### PR TITLE
tools: add JSONL helpers (validate, tail)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,21 @@
+# JSONL helper scripts
+
+## `jsonl-validate.sh`
+
+Validate a JSON Lines file against a JSON Schema using [`ajv-cli`](https://github.com/ajv-validator/ajv-cli).
+
+```bash
+scripts/jsonl-validate.sh schema.json data.jsonl
+```
+
+This command will run `npx ajv-cli@5 validate -s schema.json -d data.jsonl` under the hood. Ensure `npx` is available (provided by Node.js) so that the Ajv CLI can be downloaded on demand.
+
+## `jsonl-tail.sh`
+
+Pretty-print the last entries of a JSON Lines file.
+
+```bash
+scripts/jsonl-tail.sh [-n <lines>] data.jsonl
+```
+
+The default is to display the last 10 entries. Increase or decrease the number of lines with `-n`. Each line is parsed and rendered through `jq` for readability.

--- a/scripts/jsonl-tail.sh
+++ b/scripts/jsonl-tail.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE >&2
+Usage: $(basename "$0") [-n <lines>] <file.jsonl>
+
+Pretty-print the last N entries of a JSON Lines file using jq.
+USAGE
+  exit 1
+}
+
+lines=10
+
+while getopts ":n:h" opt; do
+  case "$opt" in
+    n)
+      if [[ -z "$OPTARG" || ! "$OPTARG" =~ ^[0-9]+$ ]]; then
+        echo "-n requires a positive integer" >&2
+        usage
+      fi
+      lines=$OPTARG
+      ;;
+    h)
+      usage
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument." >&2
+      usage
+      ;;
+    \?)
+      echo "Unknown option: -$OPTARG" >&2
+      usage
+      ;;
+  esac
+done
+
+shift $((OPTIND - 1))
+
+if [[ $# -ne 1 ]]; then
+  usage
+fi
+
+file=$1
+
+if [[ ! -f "$file" ]]; then
+  echo "File not found: $file" >&2
+  exit 1
+fi
+
+tail -n "$lines" "$file" | jq -R 'select(length > 0) | fromjson'

--- a/scripts/jsonl-validate.sh
+++ b/scripts/jsonl-validate.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  cat <<USAGE >&2
+Usage: $(basename "$0") <schema.json> <data.jsonl>
+
+Validate a JSON Lines file against a JSON Schema using ajv-cli.
+USAGE
+  exit 1
+fi
+
+schema=$1
+data_file=$2
+
+if [[ ! -f "$schema" ]]; then
+  echo "Schema file not found: $schema" >&2
+  exit 1
+fi
+
+if [[ ! -f "$data_file" ]]; then
+  echo "Data file not found: $data_file" >&2
+  exit 1
+fi
+
+npx ajv-cli@5 validate -s "$schema" -d "$data_file"


### PR DESCRIPTION
## Summary
- add a script to validate JSONL files against JSON Schema via ajv-cli
- add a tail helper that pretty-prints JSONL entries with jq
- document the new helpers in scripts/README

## Testing
- bash -n scripts/jsonl-validate.sh
- bash -n scripts/jsonl-tail.sh

------
https://chatgpt.com/codex/tasks/task_e_68ee61aa7714832cbf8561c7b705b476