### PR TITLE
Add mini examples for helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
 # Tools – Index
+
 Kurzüberblick über Ordner:
 - `scripts/` – wiederverwendbare Helfer
 - `repomergers/` – Repo-Zusammenführungen
 - `ordnermergers/` – Ordner-Zusammenführungen
 
-## Nutzung (Beispiel)
+## Nutzung (Beispiele)
+
+Minimale Befehle, um die verfügbaren Werkzeuge aufzurufen:
+
 ```bash
-bash scripts/<tool>.sh --help
+bash scripts/jsonl-validate.sh --help
+bash scripts/jsonl-tail.sh --help
 ```
 
+Weitere Details zu den einzelnen Werkzeugen findest du in den jeweiligen README-Dateien oder mittels der `--help`-Optionen.


### PR DESCRIPTION
## Summary
- update the top-level README with explicit help-command examples for the JSONL helper scripts
- clarify that further documentation can be accessed through the individual READMEs or help flags

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f6013f9dd4832c93c062eca65949d3