### PR TITLE
Add contracts validation workflow

### DIFF
--- a/.github/workflows/contracts-validate.yml
+++ b/.github/workflows/contracts-validate.yml
@@ -173,7 +173,7 @@ jobs:
               D)  blocked+=("DELETE: $p1") ;;
               R*) blocked+=("RENAME: $p1 → ${p2:-(unknown destination)}") ;;
             esac
-          done < <(git diff --name-status --diff-filter=DR "${base}...HEAD")
+          done < <(git diff --name-status --diff-filter=DR "${base}...HEAD") # three-dot: only changes unique to this branch/PR
 
           if (( ${#blocked[@]} )); then
             echo "::group::❌ Protected file deletions blocked"


### PR DESCRIPTION
## Summary
- add contracts validation workflow that runs on contract-related changes
- enforce reusable workflow pinning and prevent protected deletions before validation
- invoke the shared contracts reusable workflow for fixture validation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69089c32c198832cb550ef5e068b0855