### PR TITLE
tools: Update .ai-context files for leitstand to chronik rename

### DIFF
--- a/heimgewebe-.ai-context.yml-sammlung/aussensensor.ai-context.yml
+++ b/heimgewebe-.ai-context.yml-sammlung/aussensensor.ai-context.yml
@@ -2,14 +2,14 @@ ai_context_version: 1.0
 
 project:
   name: aussensensor
-  summary: Scripted data collection pushing events to leitstand.
+  summary: Scripted data collection pushing events to chronik.
   role: sensor_event_producer
   primary_language: bash
   visibility: internal
 
 dependencies:
   internal:
-    - name: leitstand
+    - name: chronik
       relationship: uses
       interface:
         - http_ingest_aussen
@@ -30,7 +30,7 @@ architecture:
   data_flow:
     input: polling / external sensors
     processing: map to contract shape
-    output: POST to leitstand ingest
+    output: POST to chronik ingest
 
 conventions:
   branching: "main, feature/*"

--- a/heimgewebe-.ai-context.yml-sammlung/chronik.ai-context.yml
+++ b/heimgewebe-.ai-context.yml-sammlung/chronik.ai-context.yml
@@ -1,0 +1,51 @@
+ai_context_version: 1.0
+
+project:
+  name: chronik
+  summary: Event-Ingest + Persistenz/Audit (vormals leitstand)
+  role: event_ingest_persistence
+  primary_language: rust
+  visibility: internal
+
+dependencies:
+  internal:
+    - name: contracts
+      relationship: uses
+      interface:
+        - json_schema
+        - proto
+  external:
+    - name: tokio
+      version: "1.x"
+    - name: serde
+    - name: serde_json
+    - name: tracing
+
+architecture:
+  entrypoints:
+    - src/main.rs
+  key_paths:
+    - path: src/ingest/
+      purpose: HTTP ingest + validation
+    - path: src/pipeline/
+      purpose: event processing
+  data_flow:
+    input: HTTP POST /ingest/*
+    processing: JSON Schema validation + pipelines
+    output: storage + metrics
+
+conventions:
+  branching: "main, feature/*, hotfix/*"
+  commit_prefix: "chronik"
+  ci_platform: github_actions
+
+documentation:
+  adr: docs/adr/
+  runbook: docs/runbook.md
+
+ai_guidance:
+  do:
+    - pull validation rules from contracts and reject non-conforming events
+    - prefer structured logs via tracing; avoid println! in hot paths
+  dont:
+    - accept payloads without schema validation

--- a/heimgewebe-.ai-context.yml-sammlung/hauski-audio.ai-context.yml
+++ b/heimgewebe-.ai-context.yml-sammlung/hauski-audio.ai-context.yml
@@ -13,7 +13,7 @@ dependencies:
       relationship: uses
       interface:
         - audio_events_schema
-    - name: leitstand
+    - name: chronik
       relationship: uses
       interface:
         - event_ingest

--- a/heimgewebe-.ai-context.yml-sammlung/heimlern.ai-context.yml
+++ b/heimgewebe-.ai-context.yml-sammlung/heimlern.ai-context.yml
@@ -9,7 +9,7 @@ project:
 
 dependencies:
   internal:
-    - name: leitstand
+    - name: chronik
       relationship: uses
       interface:
         - event_feed
@@ -29,7 +29,7 @@ architecture:
     - path: src/scoring/
       purpose: quality scoring & policy checks
   data_flow:
-    input: events/metrics from leitstand
+    input: events/metrics from chronik
     processing: scoring + feedback
     output: reports, signals
 

--- a/heimgewebe-.ai-context.yml-sammlung/leitstand.ai-context.yml
+++ b/heimgewebe-.ai-context.yml-sammlung/leitstand.ai-context.yml
@@ -2,50 +2,28 @@ ai_context_version: 1.0
 
 project:
   name: leitstand
-  summary: Event ingest and processing hub.
-  role: central_event_store
-  primary_language: rust
+  summary: UI/Dashboard für das Heimgewebe
+  role: observability_control_room
+  primary_language: typescript
   visibility: internal
 
 dependencies:
   internal:
-    - name: contracts
+    - name: chronik
       relationship: uses
       interface:
-        - json_schema
-        - proto
+        - event_query
+        - timeline_view
+    - name: semantah
+      relationship: uses
+      interface:
+        - graph_query
+        - insight_stream
+    - name: hauski
+      relationship: uses
+      interface:
+        - trace_view
+        - action_log
   external:
-    - name: tokio
-      version: "1.x"
-    - name: serde
-    - name: serde_json
-    - name: tracing
-
-architecture:
-  entrypoints:
-    - src/main.rs
-  key_paths:
-    - path: src/ingest/
-      purpose: HTTP ingest + validation
-    - path: src/pipeline/
-      purpose: event processing
-  data_flow:
-    input: HTTP POST /ingest/*
-    processing: JSON Schema validation + pipelines
-    output: storage + metrics
-
-conventions:
-  branching: "main, feature/*, hotfix/*"
-  commit_prefix: "leitstand"
-  ci_platform: github_actions
-
-documentation:
-  adr: docs/adr/
-  runbook: docs/runbook.md
-
-ai_guidance:
-  do:
-    - pull validation rules from contracts and reject non-conforming events
-    - prefer structured logs via tracing; avoid println! in hot paths
-  dont:
-    - accept payloads without schema validation
+    - name: React
+    - name: Vite

--- a/heimgewebe-.ai-context.yml-sammlung/mitschreiber.ai-context.yml
+++ b/heimgewebe-.ai-context.yml-sammlung/mitschreiber.ai-context.yml
@@ -13,7 +13,7 @@ dependencies:
       relationship: uses
       interface:
         - jsonl_line_schema
-    - name: leitstand
+    - name: chronik
       relationship: uses
       interface:
         - http_ingest_optional

--- a/heimgewebe-.ai-context.yml-sammlung/vault-gewebe.ai-context.yml
+++ b/heimgewebe-.ai-context.yml-sammlung/vault-gewebe.ai-context.yml
@@ -14,7 +14,7 @@ dependencies:
       interface:
         - semantic_linking
         - search_integration
-    - name: leitstand
+    - name: chronik
       relationship: uses
       interface:
         - ingest_events

--- a/heimgewebe-.ai-context.yml-sammlung/wgx.ai-context.yml
+++ b/heimgewebe-.ai-context.yml-sammlung/wgx.ai-context.yml
@@ -13,7 +13,7 @@ dependencies:
       relationship: uses
       interface:
         - validation_hooks
-    - name: leitstand
+    - name: chronik
       relationship: uses
       interface:
         - ci_e2e_orchestration


### PR DESCRIPTION
- Renames leitstand.ai-context.yml to chronik.ai-context.yml and updates its content.
- Updates all references to 'leitstand' to 'chronik' in other .ai-context.yml files.
- Adds a new leitstand.ai-context.yml for the future UI repository.

This aligns with the plan to rename the backend to 'chronik' and create a new 'leitstand' UI.