### PR TITLE
feat(wgx): Integrate heimgewebe/tools with WGX v1 guard

### DIFF
--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -1,0 +1,28 @@
+name: wgx-guard
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - ".wgx/**"
+      - ".github/workflows/**"
+      - "scripts/**"
+  push:
+    branches: [ main ]
+    paths:
+      - ".wgx/**"
+      - ".github/workflows/**"
+      - "scripts/**"
+  workflow_dispatch:
+
+jobs:
+  guard:
+    name: "WGX guard (central)"
+    uses: heimgewebe/wgx/.github/workflows/wgx-guard.yml@main
+    secrets: inherit
+
+    # Hinweis:
+    # - Die eigentliche Logik (Profilvalidierung, Task-Aufruf etc.) liegt im zentralen WGX-Repo.
+    # - Dieses Repo stellt das Profil (.wgx/profile.yml) und die konkreten Tasks bereit.

--- a/.wgx/profile.example.yml
+++ b/.wgx/profile.example.yml
@@ -1,16 +1,34 @@
+---
+# Beispiel-WGX-Profil für heimgewebe/tools (WGX v1-Stil)
+profile: tools-example
+description: "Beispielprofil für WGX v1 in heimgewebe/tools"
+
+wgx-version: ">=1.0.0"
+
+class: bash-tooling
+
 wgx:
   apiVersion: v1
-  requiredWgx: "^2.0.0"
-  repoKind: generic
 
-  tooling:
-    shell:
-      default: bash
+lang:
+  - shell
 
-  tasks:
-    up: "echo bootstrap"
-    lint: "bash -n $(git ls-files '*.sh' '*.bash') && echo lint ok"
-    test: "echo test"
-    build: "echo build"
-    smoke: "echo smoke"
-    metrics: "scripts/wgx-metrics-snapshot.sh --output metrics.json"
+meta:
+  org: heimgewebe
+  repo: heimgewebe/tools
+  maintainer: alexdermohr@gmail.com
+  tags:
+    - tools
+    - metrics
+    - wgx
+  ci: true
+
+tasks:
+  smoke: |
+    echo "[wgx.smoke] tools-example – Profil geladen"
+  guard: |
+    echo "[wgx.guard] tools-example – keine echten Checks (nur Beispielprofil)"
+  metrics: |
+    echo "[wgx.metrics] tools-example – Beispiel, bitte im echten Profil anpassen"
+  snapshot: |
+    echo "[wgx.snapshot] tools-example – Beispieltask"

--- a/.wgx/profile.yml
+++ b/.wgx/profile.yml
@@ -1,0 +1,67 @@
+---
+# WGX Profil für heimgewebe/tools
+profile: heimgewebe-tools
+description: "Host- und CI-Hilfsskripte für Heimgewebe"
+
+# Semantische Version des hauski-/WGX-Profils (nicht dasselbe wie wgx CLI-Version)
+wgx-version: ">=1.0.0"
+
+# Fleet-Klasse dieses Repos – dient als Oberflächen-Typ für Tools
+class: bash-tooling
+
+wgx:
+  apiVersion: v1
+
+lang:
+  - shell
+
+meta:
+  org: heimgewebe
+  repo: heimgewebe/tools
+  maintainer: alexdermohr@gmail.com
+  tags:
+    - tools
+    - metrics
+    - host
+    - wgx
+  ci: true
+
+env:
+  WGX_METRICS_OUTPUT: "metrics.json"
+
+tasks:
+  smoke: |
+    echo "[wgx.smoke] tools – schneller Grundcheck"
+    if [ -f scripts/wgx-metrics-snapshot.sh ]; then
+      bash scripts/wgx-metrics-snapshot.sh --json || echo "[wgx.smoke] metrics-snapshot optional fehlgeschlagen"
+    else
+      echo "[wgx.smoke] kein scripts/wgx-metrics-snapshot.sh gefunden – skip."
+    fi
+
+  guard: |
+    set -euo pipefail
+    echo "[wgx.guard] tools – Shell-Skripte prüfen…"
+    if [ -f scripts/wgx-metrics-snapshot.sh ]; then
+      bash -n scripts/wgx-metrics-snapshot.sh
+      if command -v shellcheck >/dev/null 2>&1; then
+        shellcheck scripts/wgx-metrics-snapshot.sh
+      else
+        echo "[wgx.guard] shellcheck nicht installiert – nur bash -n ausgeführt."
+      fi
+    else
+      echo "[wgx.guard] scripts/wgx-metrics-snapshot.sh fehlt – nichts zu prüfen."
+    fi
+
+  metrics: |
+    echo "[wgx.metrics] tools – metrics-Snapshot (best effort)…"
+    if [ -f scripts/wgx-metrics-snapshot.sh ]; then
+      bash scripts/wgx-metrics-snapshot.sh --json || echo "[wgx.metrics] metrics-snapshot fehlgeschlagen."
+    else
+      echo "[wgx.metrics] kein metrics-Skript vorhanden – skip."
+    fi
+
+  snapshot: |
+    echo "[wgx.snapshot] tools – Snapshot (best effort)…"
+    if [ -f scripts/wgx-metrics-snapshot.sh ]; then
+      bash scripts/wgx-metrics-snapshot.sh --json || true
+    fi


### PR DESCRIPTION
This change connects the tools repo to the fleet-wide WGX v1 guard and aligns the local WGX profile format with the current v1 conventions.

- Converts `.wgx/profile.example.yml` to a WGX v1-style example profile.
- Introduces a concrete `.wgx/profile.yml` for heimgewebe/tools with a `bash-tooling` class and meaningful `smoke`, `guard`, `metrics` and snapshot tasks.
- Adds a lightweight `wgx-guard` workflow that delegates to the central reusable workflow in `heimgewebe/wgx`.

The guard task validates the metrics script with `bash -n` and uses `shellcheck` when available, while metrics/snapshot remain best-effort to avoid unnecessary CI-Fails.