### PR TITLE
tools: add pr-heimgewebe-commands workflow

### DIFF
--- a/.github/workflows/pr-heimgewebe-commands.yml
+++ b/.github/workflows/pr-heimgewebe-commands.yml
@@ -1,0 +1,17 @@
+name: PR Heimgewebe commands
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  dispatch:
+    if: github.event.issue.pull_request != null
+    uses: heimgewebe/metarepo/.github/workflows/heimgewebe-command-dispatch.yml@main
+    secrets:
+      HEIMGEWEBE_AUTOBOT_TOKEN: ${{ secrets.HEIMGEWEBE_AUTOBOT_TOKEN }}


### PR DESCRIPTION
Add `.github/workflows/pr-heimgewebe-commands.yml` to enable dispatching commands from PR comments to the central dispatcher in `heimgewebe/metarepo`. This allows actions like `@heimgewebe/sichter /quick` to be handled centrally.