### PR TITLE
Update repo merger scripts to standalone versions

### DIFF
--- a/repomergers/hauski-merger.py
+++ b/repomergers/hauski-merger.py
@@ -2,35 +2,706 @@
 # -*- coding: utf-8 -*-
 
 """
-hauski-merger – Ruft die zentrale RepoMerger-Logik mit Hauski-spezifischen Konfigurationen auf.
+hauski-merger – Shortcuts-freundlich, Dotfiles inklusive, Basename/Env/Config-Fallbacks, keep last N merges
+
+Nutzung auf iOS (Shortcuts → "Run Pythonista Script" → Arguments):
+    – GIB GENAU EINE DER VARIANTEN, KEINE UMBRÜCHE:
+      1) --source-dir "/private/var/.../hauski"
+      2) "/private/var/.../hauski"
+      3) file:///private/var/.../hauski"
+      4) hauski   (nur Basename; Fallback-Suche aktiv)
+    – Alternativ Env: HAUSKI_SOURCE="/private/var/.../hauski"
+
+Ausgabe:
+    ./merge/hauski_DDMM.md
+    (bei Mehrfach-Merges am selben Tag: hauski_DDMM_2.md, hauski_DDMM_3.md, ...)
+    – Standard: nur die letzten 2 Merges bleiben (per Config / CLI änderbar)
+
+Konfig (optional):
+    ~/.config/hauski-merger/config.ini
+
+    [general]
+    keep = 2
+    merge_dirname = merge
+    merge_prefix  = hauski
+    max_search_depth = 4
+    encoding = utf-8
+
+    [aliases]
+    hauski = /private/var/mobile/Library/Mobile Documents/iCloud~com~omz-software~Pythonista3/Documents/hauski
 """
 
 import sys
+import os
+import argparse
+import hashlib
+import urllib.parse
+import configparser
 from pathlib import Path
+from datetime import datetime
 
-# Füge das übergeordnete Verzeichnis zum Suchpfad hinzu, um ordnermergers zu finden
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+# ===== Defaults =====
+DEF_KEEP          = 2
+DEF_MERGE_DIRNAME = "merge"
+# Basisname im Dateinamen, z. B. "hauski" -> hauski_DDMM.md
+DEF_MERGE_PREFIX  = "hauski"
+DEF_ENCODING      = "utf-8"
+DEF_SRCH_DEPTH    = 4
 
-from ordnermergers.repomerger_lib import RepoMerger  # noqa: E402
+# nur wirklich binäre Endungen (Dotfiles & .svg bleiben erhalten)
+BINARY_EXT = {
+    ".png",".jpg",".jpeg",".gif",".bmp",".ico",".webp",".heic",".heif",".psd",".ai",
+    ".mp3",".wav",".flac",".ogg",".m4a",".aac",".mp4",".mkv",".mov",".avi",".wmv",".flv",".webm",
+    ".zip",".rar",".7z",".tar",".gz",".bz2",".xz",".tgz",
+    ".ttf",".otf",".woff",".woff2",
+    ".pdf",".doc",".docx",".xls",".xlsx",".ppt",".pptx",".pages",".numbers",".key",
+    ".exe",".dll",".so",".dylib",".bin",".class",".o",".a",
+    ".db",".sqlite",".sqlite3",".realm",".mdb",".pack",".idx",
+}
+
+LANG_MAP = {
+    "py": "python","js": "javascript","ts": "typescript","html": "html","css": "css",
+    "scss": "scss","sass": "sass","json": "json","xml": "xml","yaml": "yaml","yml": "yaml",
+    "md": "markdown","sh": "bash","bat": "batch","sql": "sql","php": "php","cpp": "cpp",
+    "c": "c","java": "java","cs": "csharp","go": "go","rs": "rust","rb": "ruby",
+    "swift": "swift","kt": "kotlin","svelte": "svelte",
+}
+
+COMMON_BASES = [
+    Path("/private/var/mobile/Library/Mobile Documents/iCloud~com~omz-software~Pythonista3/Documents"),
+    Path.home() / "Library/Mobile Documents/iCloud~com~omz-software~Pythonista3/Documents",
+    Path.home() / "Documents",
+]
+
+# --- Klassifikations-Hilfen --------------------------------------------------
+
+DOC_EXTENSIONS = {".md", ".rst", ".txt"}
+
+SOURCE_EXTENSIONS = {
+    ".py", ".rs", ".ts", ".tsx", ".js", ".jsx", ".svelte",
+    ".c", ".cpp", ".h", ".hpp", ".go", ".java", ".cs",
+}
+
+CONFIG_FILENAMES = {
+    "pyproject.toml",
+    "package.json",
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "Cargo.toml",
+    "Cargo.lock",
+    "requirements.txt",
+    "Pipfile",
+    "Pipfile.lock",
+    "poetry.lock",
+    "Dockerfile",
+    "docker-compose.yml",
+    "docker-compose.yaml",
+    "Justfile",
+    "Makefile",
+    "toolchain.versions.yml",
+    ".editorconfig",
+    ".markdownlint.jsonc",
+    ".markdownlint.yaml",
+    ".yamllint",
+    ".yamllint.yml",
+    ".lychee.toml",
+    ".vale.ini",
+}
+
+# ===== Utilities ============================================================
+
+def human(n: int) -> str:
+    u = ["B", "KB", "MB", "GB", "TB"]
+    f = float(n)
+    i = 0
+    while f >= 1024 and i < len(u) - 1:
+        f /= 1024
+        i += 1
+    return f"{f:.2f} {u[i]}"
 
 
-def main():
-    """Konfiguriert und startet den Merge-Prozess für Hauski."""
+def is_text_file(p: Path, sniff: int = 4096) -> bool:
+    # harte Binär-Endungen
+    if p.suffix.lower() in BINARY_EXT:
+        return False
+    # .env / .env.* aus Sicherheitsgründen ignorieren, außer Vorlagen
+    name = p.name
+    if name.startswith(".env") and name not in (".env.example", ".env.template", ".env.sample"):
+        return False
+    try:
+        with p.open("rb") as f:
+            chunk = f.read(sniff)
+        if not chunk:
+            return True
+        if b"\x00" in chunk:
+            return False
+        try:
+            chunk.decode("utf-8")
+            return True
+        except UnicodeDecodeError:
+            chunk.decode("latin-1", errors="ignore")
+            return True
+    except Exception:
+        return False
 
-    # Spezifische Konfiguration für dieses Repo
-    merger = RepoMerger(
-        config_name="hauski-merger",
-        title="Hauski-Merge",
-        env_var="HAUSKI_SOURCE",
-        merge_prefix="HAUSKI_MERGE_",
-        def_basename="hauski"
+
+def lang_for(p: Path) -> str:
+    return LANG_MAP.get(p.suffix.lower().lstrip("."), "")
+
+
+def file_md5(p: Path, block: int = 65536) -> str:
+    h = hashlib.md5()
+    with p.open("rb") as f:
+        for chunk in iter(lambda: f.read(block), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def ensure_dir(p: Path) -> Path:
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def safe_is_dir(p: Path) -> bool:
+    try:
+        return p.is_dir()
+    except Exception:
+        return False
+
+
+def _deurl(s: str) -> str:
+    if s and s.lower().startswith("file://"):
+        return urllib.parse.unquote(s[7:])
+    return s or ""
+
+
+def load_config() -> tuple[configparser.ConfigParser, Path]:
+    cfg = configparser.ConfigParser()
+    cfg_path = Path.home() / ".config" / "hauski-merger" / "config.ini"
+    try:
+        if cfg_path.exists():
+            cfg.read(cfg_path, encoding="utf-8")
+    except Exception:
+        pass
+    return cfg, cfg_path
+
+
+def cfg_get_int(cfg, section, key, default):
+    try:
+        return cfg.getint(section, key, fallback=default)
+    except Exception:
+        return default
+
+
+def cfg_get_str(cfg, section, key, default):
+    try:
+        return cfg.get(section, key, fallback=default)
+    except Exception:
+        return default
+
+# ===== Klassifikation & Statistik ===========================================
+
+def classify_category(rel: Path, ext: str) -> str:
+    """Grobe Heuristik: doc / config / source / other."""
+    name = rel.name
+    if name in CONFIG_FILENAMES:
+        return "config"
+    if ext in DOC_EXTENSIONS:
+        return "doc"
+    if ext in SOURCE_EXTENSIONS:
+        return "source"
+    parts = [p.lower() for p in rel.parts]
+    if any(p in ("config", "configs", "settings", "etc", ".github") for p in parts):
+        return "config"
+    if "docs" in parts or "doc" in parts:
+        return "doc"
+    return "other"
+
+
+def summarize_ext(manifest_rows):
+    """
+    manifest_rows: Liste von (rel:Path, size:int, md5:str, cat:str, ext:str)
+    -> (ext_counts, ext_sizes)
+    """
+    counts: dict[str, int] = {}
+    sizes: dict[str, int] = {}
+    for rel, sz, md5, cat, ext in manifest_rows:
+        key = ext or "<none>"
+        counts[key] = counts.get(key, 0) + 1
+        sizes[key] = sizes.get(key, 0) + sz
+    return counts, sizes
+
+
+def summarize_cat(manifest_rows):
+    """
+    Kleine Übersicht nach Kategorien.
+    -> dict cat -> (count, size)
+    """
+    result: dict[str, list[int]] = {}
+    for rel, sz, md5, cat, ext in manifest_rows:
+        if cat not in result:
+            result[cat] = [0, 0]
+        result[cat][0] += 1
+        result[cat][1] += sz
+    return result
+
+# ===== Basename-Fallback ====================================================
+
+def find_dir_by_basename(basename: str, aliases: dict[str, str], search_depth: int = DEF_SRCH_DEPTH) -> tuple[Path | None, list[Path]]:
+    # 0) Aliases
+    if basename in aliases:
+        p = Path(_deurl(aliases[basename]).strip('"'))
+        if safe_is_dir(p):
+            return p, []
+
+    candidates: list[Path] = []
+    for base in COMMON_BASES:
+        if not base.exists():
+            continue
+
+        # schnelle Treffer
+        pref = [
+            base / basename,
+            base / "ordnermerger" / basename,
+            base / "Obsidian" / basename,
+        ]
+        for c in pref:
+            if safe_is_dir(c):
+                candidates.append(c)
+
+        # vorsichtige Suche
+        try:
+            max_depth_abs = len(str(base).split(os.sep)) + max(1, int(search_depth))
+            for p in base.rglob(basename):
+                if p.is_dir() and p.name == basename and len(str(p).split(os.sep)) <= max_depth_abs:
+                    candidates.append(p)
+        except Exception:
+            pass
+
+    uniq: list[Path] = []
+    seen: set[str] = set()
+    for c in candidates:
+        s = str(c)
+        if s not in seen:
+            uniq.append(c)
+            seen.add(s)
+
+    if not uniq:
+        return None, []
+    best = sorted(uniq, key=lambda p: (len(str(p)), str(p)))[0]
+    others = [p for p in uniq if p != best]
+    return best, others
+
+# ===== Dateinamen-Logik =====================================================
+
+def make_output_filename(merge_dir: Path, base_name: str) -> Path:
+    """
+    Erzeugt einen Dateinamen nach Schema:
+        <base_name>_DDMM.md
+    und hängt bei Kollisionen _2, _3, ... an.
+    """
+    now = datetime.now()
+    ddmm = now.strftime("%d%m")
+    base = f"{base_name}_{ddmm}"
+    candidate = merge_dir / f"{base}.md"
+    idx = 2
+    while candidate.exists():
+        candidate = merge_dir / f"{base}_{idx}.md"
+        idx += 1
+    return candidate
+
+# ===== Manifest/Diff/Tree ===================================================
+
+def write_tree(out, root: Path, max_depth: int | None = None):
+    def lines(d: Path, lvl: int = 0):
+        if max_depth is not None and lvl >= max_depth:
+            return []
+        res: list[str] = []
+        try:
+            items = sorted(d.iterdir(), key=lambda x: (not x.is_dir(), x.name.lower()))
+            dirs = [i for i in items if i.is_dir()]
+            files = [i for i in items if i.is_file()]
+            for i, sub in enumerate(dirs):
+                pref = "└── " if (i == len(dirs) - 1 and not files) else "├── "
+                res.append("    " * lvl + f"{pref}📁 {sub.name}/")
+                res += lines(sub, lvl + 1)
+            for i, f in enumerate(files):
+                pref = "└── " if i == len(files) - 1 else "├── "
+                try:
+                    icon = "📄" if is_text_file(f) else "🔒"
+                    res.append("    " * lvl + f"{pref}{icon} {f.name} ({human(f.stat().st_size)})")
+                except Exception:
+                    res.append("    " * lvl + f"{pref}📄 {f.name}")
+        except PermissionError:
+            res.append("    " * lvl + "❌ Zugriff verweigert")
+        return res
+
+    out.write("```\n")
+    out.write(f"📁 {root.name}/\n")
+    for ln in lines(root):
+        out.write(ln + "\n")
+    out.write("```\n\n")
+
+
+def parse_manifest(md: Path) -> dict[str, tuple[str, int]]:
+    m: dict[str, tuple[str, int]] = {}
+    if not md or not md.exists():
+        return m
+    try:
+        inside = False
+        with md.open("r", encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                s = line.strip()
+                if s.startswith("## 🧾 Manifest"):
+                    inside = True
+                    continue
+                if inside:
+                    if not s.startswith("- "):
+                        if s.startswith("## "):
+                            break
+                        continue
+                    row = s[2:]
+                    parts = [p.strip() for p in row.split("|")]
+                    rel = parts[0] if parts else ""
+                    md5 = ""
+                    size = 0
+                    for p in parts[1:]:
+                        if p.startswith("md5="):
+                            md5 = p[4:].strip()
+                        elif p.startswith("size="):
+                            try:
+                                size = int(p[5:].strip())
+                            except Exception:
+                                size = 0
+                    if rel:
+                        m[rel] = (md5, size)
+    except Exception:
+        pass
+    return m
+
+
+def build_diff(current: list[tuple[Path, Path, int, str]], merge_dir: Path, merge_prefix: str):
+    # merge_prefix als Basisname: <prefix>_DDMM*.md
+    merges = sorted(merge_dir.glob(f"{merge_prefix}_*.md"))
+    if not merges:
+        return [], 0, 0, 0
+    last = merges[-1]
+    old = parse_manifest(last)
+
+    cur_paths = {str(rel) for _, rel, _, _ in current}
+    old_paths = set(old.keys())
+
+    added = sorted(cur_paths - old_paths)
+    removed = sorted(old_paths - cur_paths)
+    changed: list[str] = []
+    for _, rel, _, h in current:
+        r = str(rel)
+        old_h = old.get(r, ("", 0))[0]
+        if r in old_paths and old_h and h and old_h != h:
+            changed.append(r)
+    changed.sort()
+    diffs = [("+", p) for p in added] + [("-", p) for p in removed] + [("~", p) for p in changed]
+    return diffs, len(added), len(removed), len(changed)
+
+
+def keep_last_n(merge_dir: Path, keep: int, keep_new: Path | None = None, merge_prefix: str = DEF_MERGE_PREFIX):
+    merges = sorted(merge_dir.glob(f"{merge_prefix}_*.md"))
+    if keep_new and keep_new not in merges:
+        merges.append(keep_new)
+        merges.sort()
+    if keep <= 0 or len(merges) <= keep:
+        return
+    for old in merges[:-keep]:
+        try:
+            old.unlink()
+        except Exception:
+            pass
+
+# ===== Merge ================================================================
+
+def do_merge(
+    source: Path,
+    out_file: Path,
+    *,
+    encoding: str,
+    keep: int,
+    merge_dir: Path,
+    merge_prefix: str,
+    max_tree_depth: int | None,
+    search_info: str | None,
+):
+    included: list[tuple[Path, Path, int, str]] = []
+    manifest_rows: list[tuple[Path, int, str, str, str]] = []
+    skipped: list[str] = []
+    total = 0
+
+    for dirpath, _, files in os.walk(source):
+        d = Path(dirpath)
+        for fn in files:
+            p = d / fn
+            rel = p.relative_to(source)
+
+            if not is_text_file(p):
+                skipped.append(f"{rel} (binär/ignoriert)")
+                continue
+
+            try:
+                sz = p.stat().st_size
+            except Exception as e:
+                skipped.append(f"{rel} (stat error: {e})")
+                continue
+            try:
+                h = file_md5(p)
+            except Exception:
+                h = ""
+
+            total += sz
+            included.append((p, rel, sz, h))
+
+            ext = p.suffix.lower()
+            cat = classify_category(rel, ext)
+            manifest_rows.append((rel, sz, h, cat, ext))
+
+    included.sort(key=lambda t: str(t[1]).lower())
+    manifest_rows.sort(key=lambda t: str(t[0]).lower())
+
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+
+    base_prefix = merge_prefix.rstrip("_")
+
+    diffs, add_c, del_c, chg_c = build_diff(included, out_file.parent, base_prefix)
+    ext_counts, ext_sizes = summarize_ext(manifest_rows)
+    cat_stats = summarize_cat(manifest_rows)
+
+    with out_file.open("w", encoding=encoding) as out:
+        out.write("# HausKI-Merge\n\n")
+        out.write(f"**Zeitpunkt:** {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n")
+        out.write(f"**Quelle:** `{source}`\n")
+        if search_info:
+            out.write(f"**Quelle ermittelt:** {search_info}\n")
+        out.write(f"**Dateien (inkludiert):** {len(included)}\n")
+        out.write(f"**Gesamtgröße:** {human(total)}\n")
+        if diffs:
+            out.write(f"**Änderungen seit letztem Merge:** +{add_c} / -{del_c} / ~{chg_c}\n")
+        out.write("\n")
+
+        # KI-Hinweisblock
+        out.write("> Hinweis für KIs:\n")
+        out.write("> - Dies ist ein Schnappschuss des Dateisystems, keine vollständige Git-Historie.\n")
+        out.write("> - Die Baumstruktur findest du unter `## 📁 Struktur`.\n")
+        out.write("> - Alle aufgenommenen Dateien stehen im `## 🧾 Manifest`.\n")
+        out.write("> - Dateiinhalte stehen unter `## 📄 Dateiinhalte`.\n")
+        out.write("> - `.env` und ähnliche Dateien können bewusst fehlen (Sicherheitsfilter).\n\n")
+
+        # Plan / Übersicht
+        out.write("## 🧮 Plan\n\n")
+        out.write(f"- Textdateien im Merge: **{len(included)}**\n")
+        out.write(f"- Gesamtgröße der Quellen: **{human(total)}**\n")
+
+        if cat_stats:
+            out.write("\n**Dateien nach Kategorien:**\n\n")
+            out.write("| Kategorie | Dateien | Gesamtgröße |\n")
+            out.write("| --- | ---: | ---: |\n")
+            for cat in sorted(cat_stats.keys()):
+                cnt, sz = cat_stats[cat]
+                out.write(f"| `{cat}` | {cnt} | {human(sz)} |\n")
+            out.write("\n")
+
+        if ext_counts:
+            out.write("**Statistik nach Dateiendungen:**\n\n")
+            out.write("| Ext | Dateien | Gesamtgröße |\n")
+            out.write("| --- | ---: | ---: |\n")
+            for ext in sorted(ext_counts.keys()):
+                out.write(f"| `{ext}` | {ext_counts[ext]} | {human(ext_sizes[ext])} |\n")
+            out.write("\n")
+
+        out.write("Hinweis: Obwohl `.env`-ähnliche Dateien gefiltert werden, können sensible Daten ")
+        out.write("in anderen Dateien (z. B. JSON/YAML) vorkommen. Nutze den Merge nicht als public Dump.\n\n")
+
+        out.write("## 📁 Struktur\n\n")
+        write_tree(out, source, max_tree_depth)
+
+        if diffs:
+            out.write("## 📊 Änderungen seit letztem Merge\n\n")
+            for sym, pth in diffs:
+                out.write(f"{sym} {pth}\n")
+            out.write("\n")
+
+        if skipped:
+            out.write("## ⏭️ Übersprungen\n\n")
+            for s in skipped:
+                out.write(f"- {s}\n")
+            out.write("\n")
+
+        out.write("## 🧾 Manifest\n\n")
+        for rel, sz, h, cat, ext in manifest_rows:
+            out.write(f"- {rel} | md5={h} | size={sz} | cat={cat}\n")
+        out.write("\n")
+
+        out.write("## 📄 Dateiinhalte\n\n")
+        for p, rel, sz, h in included:
+            out.write(f"### 📄 {rel}\n\n**Größe:** {human(sz)}\n\n```{lang_for(p)}\n")
+            try:
+                txt = p.read_text(encoding=encoding, errors="replace")
+            except Exception as e:
+                txt = f"<<Lesefehler: {e}>>"
+            out.write(txt)
+            if not txt.endswith("\n"):
+                out.write("\n")
+            out.write("```\n\n")
+
+    keep_last_n(out_file.parent, keep=keep, keep_new=out_file, merge_prefix=base_prefix)
+    print(f"✅ Merge geschrieben: {out_file} ({human(out_file.stat().st_size)})")
+
+# ===== CLI ==================================================================
+
+def build_parser():
+    p = argparse.ArgumentParser(description="hauski-merger – genau ein Quellordner", add_help=False)
+    p.add_argument("--source-dir", dest="src_flag")
+    p.add_argument("--keep", type=int, dest="keep")
+    p.add_argument("--encoding", dest="encoding")
+    p.add_argument("--max-depth", type=int, dest="max_tree_depth")
+    p.add_argument("--search-depth", type=int, dest="search_depth")
+    p.add_argument("--merge-dirname", dest="merge_dirname")
+    p.add_argument("--merge-prefix", dest="merge_prefix")  # Basisname für Dateinamen (Default: hauski)
+    p.add_argument("-h", "--help", action="store_true", dest="help")
+    p.add_argument("rest", nargs="*")
+    return p
+
+
+def print_help():
+    print(__doc__.strip())
+
+
+def extract_source_path(argv: list[str], *, aliases: dict[str, str], search_depth: int) -> tuple[Path | None, str | None]:
+    """
+    Akzeptiert:
+      - --source-dir <PATH|BASENAME|file://>
+      - <PATH|BASENAME|file://>
+      - Datei → Elternordner
+      - Env: HAUSKI_SOURCE
+      - Fallback: Nur-Basename unter COMMON_BASES
+    Rückgabe: (Pfad, InfoStringFürReport)
+    """
+    # Env
+    env_src = os.environ.get("HAUSKI_SOURCE", "").strip()
+    if env_src:
+        p = Path(_deurl(env_src).strip('"'))
+        if not safe_is_dir(p) and p.exists():
+            p = p.parent
+        if safe_is_dir(p):
+            return p, "HAUSKI_SOURCE (ENV)"
+
+    # Tokens
+    tokens: list[str] = []
+    if "--source-dir" in argv:
+        idx = argv.index("--source-dir")
+        if idx + 1 < len(argv):
+            tokens.append(argv[idx + 1])
+    tokens += [t for t in argv if t != "--source-dir"]
+
+    # Direktpfad
+    for tok in tokens:
+        cand = _deurl((tok or "").strip('"'))
+        if not cand:
+            continue
+        if os.sep not in cand and not cand.lower().startswith("file://"):
+            continue
+        p = Path(cand)
+        if p.exists():
+            if p.is_file():
+                p = p.parent
+            if safe_is_dir(p):
+                return p, "direktes Argument"
+
+    # Basename/Alias
+    for tok in tokens:
+        cand = _deurl((tok or "").strip('"'))
+        if not cand:
+            continue
+        if os.sep in cand or cand.lower().startswith("file://"):
+            continue
+        base = cand
+        hit, others = find_dir_by_basename(base, aliases, search_depth=search_depth)
+        if hit:
+            info = f"Basename-Fallback ('{base}')"
+            if others:
+                others_s = " | ".join(str(p) for p in others[:5])
+                print(f"__HAUSKI_MERGER_INFO__: Mehrere Kandidaten gefunden, nehme kürzesten: {hit} | weitere: {others_s}")
+            return hit, info
+    return None, None
+
+
+def _running_in_shortcuts() -> bool:
+    return os.environ.get("HAUSKI_SHORTCUTS", "1") == "1"
+
+
+def main(argv: list[str]) -> int:
+    cfg, cfg_path = load_config()
+    args = build_parser().parse_args(argv)
+    if args.help:
+        print_help()
+        return 0
+
+    keep = args.keep if args.keep is not None else cfg_get_int(cfg, "general", "keep", DEF_KEEP)
+    merge_dirname = args.merge_dirname or cfg_get_str(cfg, "general", "merge_dirname", DEF_MERGE_DIRNAME)
+    merge_prefix = args.merge_prefix or cfg_get_str(cfg, "general", "merge_prefix", DEF_MERGE_PREFIX)
+    encoding = args.encoding or cfg_get_str(cfg, "general", "encoding", DEF_ENCODING)
+    search_depth = args.search_depth if args.search_depth is not None else cfg_get_int(cfg, "general", "max_search_depth", DEF_SRCH_DEPTH)
+    max_tree_depth = args.max_tree_depth if args.max_tree_depth is not None else None
+
+    aliases: dict[str, str] = {}
+    if cfg.has_section("aliases"):
+        for k, v in cfg.items("aliases"):
+            aliases[k] = v
+
+    src, src_info = extract_source_path(
+        [args.src_flag] + args.rest if args.src_flag else args.rest,
+        aliases=aliases,
+        search_depth=search_depth,
     )
+    if not src:
+        print("❌ Quelle fehlt/unerkannt. Übergib Pfad/URL/Basename oder setze HAUSKI_SOURCE. (-h für Hilfe)")
+        return 2
+    if not safe_is_dir(src):
+        print(f"❌ Quelle nicht gefunden oder kein Ordner: {src}")
+        return 1
 
-    # Führe den Merge-Prozess mit den übergebenen Kommandozeilenargumenten aus
-    # sys.exit wird innerhalb von run() nicht aufgerufen, daher fangen wir den Rückgabewert ab
-    return merger.run(sys.argv[1:])
+    script_root = Path(__file__).resolve().parent
+    merge_dir = ensure_dir(script_root / merge_dirname)
+
+    # Dateiname: <merge_prefix>_DDMM(.md) + Kollision-Handling
+    base_name = merge_prefix.rstrip("_")
+    out_file = make_output_filename(merge_dir, base_name=base_name)
+
+    do_merge(
+        src,
+        out_file,
+        encoding=encoding,
+        keep=keep,
+        merge_dir=merge_dir,
+        merge_prefix=merge_prefix,
+        max_tree_depth=max_tree_depth,
+        search_info=src_info,
+    )
+    return 0
+
+
+def _safe_main():
+    try:
+        rc = main(sys.argv[1:])
+    except SystemExit as e:
+        rc = int(getattr(e, "code", 1) or 0)
+    except Exception as e:
+        print(f"__HAUSKI_MERGER_ERR__: {e}")
+        rc = 1
+    if _running_in_shortcuts():
+        if rc != 0:
+            print(f"__HAUSKI_MERGER_WARN__: Exit {rc}")
+        print("__HAUSKI_MERGER_OK__")
+    else:
+        sys.exit(rc)
 
 
 if __name__ == "__main__":
-    # Beende das Skript mit dem entsprechenden Exit-Code
-    sys.exit(main())
+    _safe_main()

--- a/repomergers/repomerger.py
+++ b/repomergers/repomerger.py
@@ -1,0 +1,767 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+repomerger – Multi-Repo-Merge ohne Diff, mit Plan-Phase, Kategorien und 3 Detailstufen.
+
+Funktionen:
+- Erzeugt EIN Markdown-File mit Überblick über ein oder mehrere Repos.
+- Inhalte:
+  - Plan-Abschnitt (Metaüberblick mit Kategorien- und Endungsstatistik).
+  - Baumstruktur über alle Quellen.
+  - Manifest aller gefundenen Dateien.
+  - Je nach Detailstufe: Inhalte von Textdateien (mit Größenlimit pro Datei).
+
+Detailstufen:
+- overview: Struktur + Manifest, keine Inhalte.
+- summary:  Struktur + Manifest + Inhalte aller Textdateien <= max_file_bytes.
+- full:     Struktur + Manifest + Inhalte aller Textdateien,
+            größere Textdateien werden bis max_file_bytes gekürzt.
+
+Besonderheiten:
+- Keine Diffs zu früheren Läufen: jeder Merge ist ein eigenständiger Schnappschuss.
+- Mehrere Repos pro Lauf möglich.
+- .env / .env.* werden ignoriert, außer .env.example / .env.template / .env.sample.
+- Merge-Dateien werden IMMER in den Ordner "merges" geschrieben (neben dem Script).
+- Quellordner werden nach dem Merge gelöscht, WENN sie im gleichen Ordner wie das Script liegen
+  (und nicht der merges-Ordner sind). Abschaltbar mit --no-delete.
+"""
+
+import argparse
+import datetime
+import hashlib
+import os
+import shutil
+from pathlib import Path
+
+# --- Konfiguration / Heuristiken --------------------------------------------
+
+MERGES_DIR_NAME = "merges"
+
+# Verzeichnisse, die standardmäßig ignoriert werden (rekursiv)
+SKIP_DIRS = {
+    ".git",
+    ".idea",
+    # bewusst NICHT: ".vscode" (tasks.json etc. sind interessant)
+    "node_modules",
+    ".svelte-kit",
+    ".next",
+    "dist",
+    "build",
+    "target",
+    ".venv",
+    "venv",
+    "__pycache__",
+    ".pytest_cache",
+    ".DS_Store",
+}
+
+# Top-Level-Verzeichnisse, die bei Auto-Discovery nicht als Repos genommen werden sollen
+SKIP_ROOTS = {
+    MERGES_DIR_NAME,
+    "merge",
+    "output",
+    "out",
+}
+
+# Einzelne Dateien, die ignoriert werden
+SKIP_FILES = {
+    ".DS_Store",
+}
+
+# Erweiterungen, die sehr wahrscheinlich Text sind
+TEXT_EXTENSIONS = {
+    ".md",
+    ".txt",
+    ".rst",
+    ".py",
+    ".rs",
+    ".ts",
+    ".tsx",
+    ".js",
+    ".jsx",
+    ".json",
+    ".jsonl",
+    ".yml",
+    ".yaml",
+    ".toml",
+    ".ini",
+    ".cfg",
+    ".conf",
+    ".sh",
+    ".bash",
+    ".zsh",
+    ".fish",
+    ".dockerfile",
+    "dockerfile",
+    ".svelte",
+    ".css",
+    ".scss",
+    ".html",
+    ".htm",
+    ".xml",
+    ".csv",
+    ".log",
+    ".lock",   # z.B. Cargo.lock, pnpm-lock.yaml
+}
+
+# Dateien, die typischerweise Konfiguration sind
+CONFIG_FILENAMES = {
+    "pyproject.toml",
+    "package.json",
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "Cargo.toml",
+    "Cargo.lock",
+    "requirements.txt",
+    "Pipfile",
+    "Pipfile.lock",
+    "poetry.lock",
+    "Dockerfile",
+    "docker-compose.yml",
+    "docker-compose.yaml",
+    "Justfile",
+    "Makefile",
+    "toolchain.versions.yml",
+    ".editorconfig",
+    ".markdownlint.jsonc",
+    ".markdownlint.yaml",
+    ".yamllint",
+    ".yamllint.yml",
+    ".lychee.toml",
+    ".vale.ini",
+}
+
+DOC_EXTENSIONS = {".md", ".rst", ".txt"}
+
+SOURCE_EXTENSIONS = {
+    ".py",
+    ".rs",
+    ".ts",
+    ".tsx",
+    ".js",
+    ".jsx",
+    ".svelte",
+    ".c",
+    ".cpp",
+    ".h",
+    ".hpp",
+    ".go",
+    ".java",
+    ".cs",
+}
+
+
+class FileInfo(object):
+    """Einfache Container-Klasse für Dateimetadaten."""
+
+    def __init__(self, root_label, abs_path, rel_path, size, is_text, md5, category, ext):
+        self.root_label = root_label
+        self.abs_path = abs_path
+        self.rel_path = rel_path
+        self.size = size
+        self.is_text = is_text
+        self.md5 = md5
+        self.category = category
+        self.ext = ext
+
+
+# --- Hilfsfunktionen ---------------------------------------------------------
+
+def human_size(n):
+    """Formatierte Dateigröße, z.B. '1.23 MB'."""
+    size = float(n)
+    for unit in ("B", "KB", "MB", "GB"):
+        if size < 1024.0 or unit == "GB":
+            return "{0:.2f} {1}".format(size, unit)
+        size /= 1024.0
+    return "{0:.2f} GB".format(size)
+
+
+def is_probably_text(path, size):
+    """
+    Heuristik: Ist dies eher eine Textdatei?
+
+    - bekannte Text-Endungen -> True
+    - große unbekannte Dateien -> eher False
+    - ansonsten: 4 KiB lesen, auf NUL-Bytes prüfen.
+    """
+    name = path.name.lower()
+    base, ext = os.path.splitext(name)
+    if ext in TEXT_EXTENSIONS or name in TEXT_EXTENSIONS:
+        return True
+
+    # Sehr große unbekannte Dateien eher als binär behandeln
+    if size > 20 * 1024 * 1024:  # 20 MiB
+        return False
+
+    try:
+        with path.open("rb") as f:
+            chunk = f.read(4096)
+    except OSError:
+        return False
+
+    if not chunk:
+        return True
+    if b"\x00" in chunk:
+        return False
+
+    return True
+
+
+def compute_md5(path, limit_bytes=None):
+    """
+    MD5-Hash einer Datei.
+
+    - Wenn limit_bytes gesetzt ist, lesen wir höchstens so viele Bytes.
+    - Bei Fehlern: 'ERROR'.
+    """
+    h = hashlib.md5()
+    try:
+        with path.open("rb") as f:
+            remaining = limit_bytes
+            while True:
+                if remaining is None:
+                    chunk = f.read(65536)
+                else:
+                    chunk = f.read(min(65536, remaining))
+                if not chunk:
+                    break
+                h.update(chunk)
+                if remaining is not None:
+                    remaining -= len(chunk)
+                    if remaining <= 0:
+                        break
+        return h.hexdigest()
+    except OSError:
+        return "ERROR"
+
+
+def classify_category(rel_path, ext):
+    """
+    Grobe Einteilung in doc / config / source / other.
+    """
+    name = rel_path.name
+    if name in CONFIG_FILENAMES:
+        return "config"
+    if ext in DOC_EXTENSIONS:
+        return "doc"
+    if ext in SOURCE_EXTENSIONS:
+        return "source"
+    parts = [p.lower() for p in rel_path.parts]
+    for p in parts:
+        if p in ("config", "configs", "settings", "etc", ".github"):
+            return "config"
+    if "docs" in parts or "doc" in parts:
+        return "doc"
+    return "other"
+
+
+def summarize_extensions(file_infos):
+    """Anzahl und Gesamtgröße pro Dateiendung."""
+    counts = {}
+    sizes = {}
+    for fi in file_infos:
+        ext = fi.ext or "<none>"
+        counts[ext] = counts.get(ext, 0) + 1
+        sizes[ext] = sizes.get(ext, 0) + fi.size
+    return counts, sizes
+
+
+def summarize_categories(file_infos):
+    """Anzahl und Gesamtgröße pro Kategorie."""
+    stats = {}
+    for fi in file_infos:
+        cat = fi.category or "other"
+        if cat not in stats:
+            stats[cat] = [0, 0]
+        stats[cat][0] += 1
+        stats[cat][1] += fi.size
+    return stats
+
+
+def scan_repo(repo, md5_limit_bytes):
+    """
+    Scannt ein einzelnes Repo und erzeugt FileInfo-Einträge.
+    """
+    repo = repo.resolve()
+    root_label = repo.name
+    files = []
+
+    for dirpath, dirnames, filenames in os.walk(str(repo)):
+        # Verzeichnisse filtern
+        keep_dirs = []
+        for d in dirnames:
+            if d in SKIP_DIRS:
+                continue
+            keep_dirs.append(d)
+        dirnames[:] = keep_dirs
+
+        for fn in filenames:
+            if fn in SKIP_FILES:
+                continue
+
+            # .env und .env.* ignorieren, außer expliziten Vorlagen
+            if fn.startswith(".env") and fn not in (".env.example", ".env.template", ".env.sample"):
+                continue
+
+            abs_path = Path(dirpath) / fn
+            try:
+                st = abs_path.stat()
+            except OSError:
+                continue
+            size = st.st_size
+
+            rel = abs_path.relative_to(repo)
+            ext = abs_path.suffix.lower()
+
+            is_text = is_probably_text(abs_path, size)
+
+            if is_text or size <= md5_limit_bytes:
+                md5 = compute_md5(abs_path, md5_limit_bytes)
+            else:
+                md5 = ""
+
+            category = classify_category(rel, ext)
+
+            fi = FileInfo(
+                root_label=root_label,
+                abs_path=abs_path,
+                rel_path=rel,
+                size=size,
+                is_text=is_text,
+                md5=md5,
+                category=category,
+                ext=ext,
+            )
+            files.append(fi)
+
+    files.sort(key=lambda fi: (fi.root_label.lower(), str(fi.rel_path).lower()))
+    return files
+
+
+def build_tree(file_infos):
+    """
+    Erzeugt eine einfache Baumdarstellung pro Root.
+    """
+    by_root = {}
+    for fi in file_infos:
+        by_root.setdefault(fi.root_label, []).append(fi.rel_path)
+
+    lines = ["```"]
+    for root in sorted(by_root.keys()):
+        rels = by_root[root]
+        lines.append(u"📁 {0}/".format(root))
+
+        tree = {}
+        for r in rels:
+            parts = list(r.parts)
+            node = tree
+            for p in parts:
+                if p not in node:
+                    node[p] = {}
+                node = node[p]
+
+        def walk(node, indent):
+            dirs = []
+            files = []
+            for k, v in node.items():
+                if v:
+                    dirs.append(k)
+                else:
+                    files.append(k)
+            for d in sorted(dirs):
+                lines.append(u"{0}📁 {1}/".format(indent, d))
+                walk(node[d], indent + "    ")
+            for f in sorted(files):
+                lines.append(u"{0}📄 {1}".format(indent, f))
+
+        walk(tree, "    ")
+
+    lines.append("```")
+    return "\n".join(lines)
+
+
+def make_output_filename(sources, now):
+    """
+    Dateiname: <repo1>-<repo2>-..._<ddmm>.md
+    """
+    names = sorted(set([src.name for src in sources]))
+    joined = "-".join(names)
+    joined = joined.replace(" ", "-")
+    if len(joined) > 60:
+        joined = joined[:60]
+    date_str = now.strftime("%d%m")
+    return "{0}_{1}.md".format(joined, date_str)
+
+
+# --- Report-Erzeugung --------------------------------------------------------
+
+def write_report(files, level, max_file_bytes, output_path, sources,
+                 encoding="utf-8", plan_only=False):
+    """
+    Schreibt den Merge-Report.
+    """
+    now = datetime.datetime.now()
+
+    total_size = sum(fi.size for fi in files)
+    text_files = [fi for fi in files if fi.is_text]
+    binary_files = [fi for fi in files if not fi.is_text]
+
+    if level == "overview":
+        planned_with_content = 0
+    elif level == "summary":
+        planned_with_content = sum(1 for fi in text_files if fi.size <= max_file_bytes)
+    else:  # full
+        planned_with_content = len(text_files)
+
+    ext_counts, ext_sizes = summarize_extensions(files)
+    cat_stats = summarize_categories(files)
+
+    lines = []
+
+    # Header & Hinweise
+    lines.append("# Gewebe-Merge")
+    lines.append("")
+    lines.append("**Zeitpunkt:** {0}".format(now.strftime("%Y-%m-%d %H:%M:%S")))
+    if sources:
+        lines.append("**Quellen:**")
+        for src in sources:
+            lines.append("- `{0}`".format(src))
+    lines.append("**Detailstufe:** `{0}`".format(level))
+    lines.append("**Maximale Inhaltsgröße pro Datei:** {0}".format(human_size(max_file_bytes)))
+    lines.append("")
+    lines.append("> Hinweis für KIs:")
+    lines.append("> - Dies ist ein Schnappschuss des Dateisystems, keine vollständige Git-Historie.")
+    lines.append("> - Baumansicht: `## 📁 Struktur`.")
+    lines.append("> - Manifest: `## 🧾 Manifest`.")
+    if level == "overview":
+        lines.append("> - In dieser Detailstufe werden keine Dateiinhalte eingebettet.")
+    elif level == "summary":
+        lines.append("> - In dieser Detailstufe werden Inhalte kleiner Textdateien eingebettet;")
+        lines.append(">   größere Textdateien erscheinen nur im Manifest.")
+    else:
+        lines.append("> - In dieser Detailstufe werden Inhalte aller Textdateien eingebettet;")
+        lines.append(">   große Dateien werden nach einer einstellbaren Byte-Grenze gekürzt.")
+    lines.append("> - `.env`-ähnliche Dateien werden gefiltert; sensible Daten können trotzdem in")
+    lines.append(">   anderen Textdateien vorkommen. Nutze den Merge nicht als öffentlichen Dump.")
+    lines.append("")
+
+    # Plan
+    lines.append("## 🧮 Plan")
+    lines.append("")
+    lines.append("- Gefundene Dateien gesamt: **{0}**".format(len(files)))
+    lines.append("- Davon Textdateien: **{0}**".format(len(text_files)))
+    lines.append("- Davon Binärdateien: **{0}**".format(len(binary_files)))
+    lines.append("- Geplante Dateien mit Inhalteinbettung: **{0}**".format(planned_with_content))
+    lines.append("- Gesamtgröße der Quellen: **{0}**".format(human_size(total_size)))
+    if any(fi.size > max_file_bytes for fi in text_files):
+        lines.append(
+            "- Hinweis: Textdateien größer als {0} werden abhängig von der Detailstufe "
+            "gekürzt oder nur im Manifest aufgeführt.".format(human_size(max_file_bytes))
+        )
+    lines.append("")
+
+    if cat_stats:
+        lines.append("**Dateien nach Kategorien:**")
+        lines.append("")
+        lines.append("| Kategorie | Dateien | Gesamtgröße |")
+        lines.append("| --- | ---: | ---: |")
+        for cat in sorted(cat_stats.keys()):
+            cnt, sz = cat_stats[cat]
+            lines.append("| `{0}` | {1} | {2} |".format(cat, cnt, human_size(sz)))
+        lines.append("")
+
+    if ext_counts:
+        lines.append("**Grobe Statistik nach Dateiendungen:**")
+        lines.append("")
+        lines.append("| Ext | Dateien | Gesamtgröße |")
+        lines.append("| --- | ---: | ---: |")
+        for ext in sorted(ext_counts.keys()):
+            lines.append("| `{0}` | {1} | {2} |".format(
+                ext, ext_counts[ext], human_size(ext_sizes[ext])
+            ))
+        lines.append("")
+
+    lines.append(
+        "Da der repomerger häufig nacheinander unterschiedliche Repos verarbeitet, "
+        "werden keine Diffs zu früheren Läufen berechnet. "
+        "Jeder Merge ist ein eigenständiger Schnappschuss."
+    )
+    lines.append("")
+
+    if plan_only:
+        output_path.write_text("\n".join(lines), encoding=encoding)
+        return
+
+    # Struktur
+    lines.append("## 📁 Struktur")
+    lines.append("")
+    lines.append(build_tree(files))
+    lines.append("")
+
+    # Manifest
+    lines.append("## 🧾 Manifest")
+    lines.append("")
+    lines.append("| Root | Pfad | Kategorie | Text | Größe | MD5 |")
+    lines.append("| --- | --- | --- | --- | ---: | --- |")
+    for fi in files:
+        lines.append(
+            "| `{0}` | `{1}` | `{2}` | {3} | {4} | `{5}` |".format(
+                fi.root_label,
+                fi.rel_path,
+                fi.category,
+                "ja" if fi.is_text else "nein",
+                human_size(fi.size),
+                fi.md5,
+            )
+        )
+    lines.append("")
+
+    # Inhalte
+    if level != "overview":
+        lines.append("## 📄 Dateiinhalte")
+        lines.append("")
+        for fi in files:
+            if not fi.is_text:
+                continue
+
+            if level == "summary" and fi.size > max_file_bytes:
+                continue
+
+            lines.append("### `{0}/{1}`".format(fi.root_label, fi.rel_path))
+            lines.append("")
+            if fi.size > max_file_bytes and level == "full":
+                lines.append(
+                    "**Hinweis:** Datei ist größer als {0} – es wird nur ein Ausschnitt "
+                    "bis zu dieser Grenze gezeigt.".format(human_size(max_file_bytes))
+                )
+                lines.append("")
+
+            try:
+                with fi.abs_path.open("r", encoding=encoding, errors="replace") as f:
+                    if fi.size > max_file_bytes and level == "full":
+                        remaining = max_file_bytes
+                        collected = []
+                        for line in f:
+                            encoded = line.encode(encoding, errors="replace")
+                            if remaining <= 0:
+                                break
+                            if len(encoded) > remaining:
+                                part = encoded[:remaining].decode(encoding, errors="replace")
+                                collected.append(part + "\n[... gekürzt ...]\n")
+                                remaining = 0
+                                break
+                            collected.append(line)
+                            remaining -= len(encoded)
+                        content = "".join(collected)
+                    else:
+                        content = f.read()
+            except OSError as e:
+                lines.append("_Fehler beim Lesen der Datei: {0}_".format(e))
+                lines.append("")
+                continue
+
+            lines.append("```")
+            lines.append(content.rstrip("\n"))
+            lines.append("```")
+            lines.append("")
+
+    output_path.write_text("\n".join(lines), encoding=encoding)
+
+
+# --- CLI / Source-Erkennung / Delete-Logik ----------------------------------
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(
+        description="Erzeuge einen Gewebe-Merge-Bericht für ein oder mehrere Repos."
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help=(
+            "Quellverzeichnisse (Repos). "
+            "Wenn leer, werden alle Unterordner im Script-Ordner verwendet, "
+            "die nicht mit '.' oder '_' beginnen."
+        ),
+    )
+    parser.add_argument(
+        "--level",
+        choices=["overview", "summary", "full", "medium", "max"],
+        help=(
+            "Detailstufe: overview=Struktur+Manifest, summary=mit kleinen Inhalten, "
+            "full=maximal. medium≈summary, max≈full."
+        ),
+    )
+    parser.add_argument(
+        "--max-file-bytes",
+        type=int,
+        default=10_000_000,
+        help="Maximale Bytes pro Datei für Inhalteinbettung (Standard: 10 MiB).",
+    )
+    parser.add_argument(
+        "--encoding",
+        default="utf-8",
+        help="Encoding für Textdateien (Standard: utf-8).",
+    )
+    parser.add_argument(
+        "--plan-only",
+        action="store_true",
+        help="Nur den Plan-Teil des Berichts erzeugen (kein Manifest, keine Inhalte).",
+    )
+    parser.add_argument(
+        "--no-delete",
+        action="store_true",
+        help="Quellordner nach dem Merge NICHT löschen.",
+    )
+    return parser.parse_args(argv)
+
+
+def resolve_level(raw_level):
+    """
+    Übersetzt CLI/ENV-Level in eines der drei Kern-Level.
+    Default = full.
+    """
+    if raw_level is None:
+        return "full"
+    raw = str(raw_level).lower()
+    if raw == "overview":
+        return "overview"
+    if raw in ("summary", "medium"):
+        return "summary"
+    if raw in ("full", "max"):
+        return "full"
+    return "full"
+
+
+def discover_sources(base_dir, paths):
+    """
+    Ermittelt die zu scannenden Repos.
+    - Wenn paths angegeben: nutzt genau diese (falls Verzeichnisse).
+    - Sonst: alle Unterordner im Script-Ordner, außer '.', '_', MERGES_DIR_NAME, SKIP_ROOTS.
+    """
+    if paths:
+        sources = []
+        for p in paths:
+            path = Path(p).expanduser().resolve()
+            if path.is_dir():
+                sources.append(path)
+            else:
+                print("Warnung: Pfad ist kein Verzeichnis und wird ignoriert: {0}".format(p))
+        return sources
+
+    sources = []
+    for child in sorted(base_dir.iterdir(), key=lambda p: p.name.lower()):
+        if not child.is_dir():
+            continue
+        if child.name.startswith(".") or child.name.startswith("_"):
+            continue
+        if child.name in SKIP_ROOTS:
+            continue
+        sources.append(child.resolve())
+    return sources
+
+
+def safe_delete_source(src, base_dir, merges_dir, no_delete):
+    """
+    Löscht eine Quelle nur, wenn:
+    - sie im gleichen Ordner wie das Script liegt (parent == base_dir) UND
+    - sie nicht der merges-Ordner ist.
+    """
+    if no_delete:
+        print("Löschen deaktiviert (--no-delete): {0}".format(src))
+        return
+
+    try:
+        src = src.resolve()
+        base_dir = base_dir.resolve()
+        merges_dir = merges_dir.resolve()
+    except Exception:
+        pass
+
+    parent = src.parent
+    if parent != base_dir:
+        print("Quelle wird nicht gelöscht (liegt nicht im Script-Ordner): {0}".format(src))
+        return
+    if src == merges_dir:
+        print("Merges-Ordner wird nicht gelöscht: {0}".format(src))
+        return
+
+    try:
+        shutil.rmtree(str(src))
+        print("Quelle gelöscht: {0}".format(src))
+    except Exception as e:
+        print("Fehler beim Löschen von {0}: {1}".format(src, e))
+
+
+def main(argv=None):
+    import sys
+    import traceback
+
+    if argv is None:
+        argv = sys.argv[1:]
+
+    try:
+        script_path = Path(__file__).resolve()
+        base_dir = script_path.parent
+        merges_dir = base_dir / MERGES_DIR_NAME
+        merges_dir.mkdir(parents=True, exist_ok=True)
+
+        args = parse_args(argv)
+
+        sources = discover_sources(base_dir, args.paths)
+        if not sources:
+            print("Keine gültigen Quellverzeichnisse gefunden.", file=sys.stderr)
+            return 1
+
+        env_level = os.environ.get("REPOMERGER_LEVEL")
+        raw_level = args.level or env_level
+        level = resolve_level(raw_level)
+
+        now = datetime.datetime.now()
+        filename = make_output_filename(sources, now)
+        output_path = merges_dir / filename
+
+        md5_limit = args.max_file_bytes
+
+        all_files = []
+        for src in sources:
+            print("Scanne Quelle: {0}".format(src))
+            repo_files = scan_repo(src, md5_limit_bytes=md5_limit)
+            print("  -> {0} Dateien gefunden.".format(len(repo_files)))
+            all_files.extend(repo_files)
+
+        if not all_files:
+            print("Keine Dateien in den Quellen gefunden.", file=sys.stderr)
+            return 1
+
+        print("Erzeuge Merge-Bericht mit {0} Dateien: {1}".format(len(all_files), output_path))
+        write_report(
+            files=all_files,
+            level=level,
+            max_file_bytes=args.max_file_bytes,
+            output_path=output_path,
+            sources=sources,
+            encoding=args.encoding,
+            plan_only=args.plan_only,
+        )
+        print("Fertig.")
+
+        # Quellordner löschen (falls im gleichen Ordner wie das Script)
+        for src in sources:
+            safe_delete_source(src, base_dir, merges_dir, args.no_delete)
+
+        if args.plan_only:
+            print("Hinweis: Es wurde nur der Plan-Teil erzeugt (--plan-only).")
+        return 0
+
+    except Exception as e:
+        print("repomerger: Unbehandelter Fehler:", file=sys.stderr)
+        print(str(e), file=sys.stderr)
+        traceback.print_exc()
+        return 1
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())

--- a/repomergers/weltgewebe-merger.py
+++ b/repomergers/weltgewebe-merger.py
@@ -2,33 +2,660 @@
 # -*- coding: utf-8 -*-
 
 """
-weltgewebe-merger – Ruft die zentrale RepoMerger-Logik mit Gewebe-spezifischen Konfigurationen auf.
+repo-merger – Shortcuts-freundlich, Dotfiles inklusive, Basename/Env/Config-Fallbacks, keep last N merges
+
+Nutzung auf iOS (Shortcuts → "Run Pythonista Script" → Arguments):
+    – GIB GENAU EINE DER VARIANTEN, KEINE UMBRÜCHE:
+      1) --source-dir "/private/var/.../weltgewebe"
+      2) "/private/var/.../weltgewebe"
+      3) file:///private/var/.../weltgewebe
+      4) weltgewebe   (nur Basename; Fallback-Suche aktiv)
+    – Alternativ Env: GEWEBE_SOURCE="/private/var/.../weltgewebe"
+
+Ausgabe:
+    ./merge/weltgewebe_DDMM.md (bei Mehrfach-Merges: weltgewebe_DDMM_2.md, ...)
+    – Standard: nur die letzten 2 Merges bleiben (per Config / CLI änderbar)
+
+Konfig (optional):
+    ~/.config/repo-merger/config.ini
+
+    [general]
+    keep = 2
+    merge_dirname = merge
+    merge_prefix  = weltgewebe
+    max_search_depth = 4
+    encoding = utf-8
+
+    [aliases]
+    weltgewebe = /private/var/mobile/Library/Mobile Documents/iCloud~com~omz-software~Pythonista3/Documents/weltgewebe
+
+CLI (optional):
+    --source-dir <PATH|BASENAME|file://URL>
+    --keep <N>
+    --encoding <ENC>
+    --max-depth <N>        # Baumdarstellung im Report (None = alles)
+    --search-depth <N>     # Fallback-Suche (tiefer = langsamer)
+    --merge-dirname <NAME> # Ordner für Merges
+    --merge-prefix <STR>   # Basisname für Merge-Dateien (Default: weltgewebe)
+    -h / --help            # Minimalhelp (add_help=False, aber wir drucken selbst)
 """
 
-import sys
+import sys, os, argparse, hashlib, urllib.parse, configparser
 from pathlib import Path
+from datetime import datetime
 
-# Füge das übergeordnete Verzeichnis zum Suchpfad hinzu, um ordnermergers zu finden
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+# ===== Defaults (per Config/CLI überschreibbar) =====
+DEF_KEEP          = 2
+DEF_MERGE_DIRNAME = "merge"
+# merge_prefix = Basisname im Dateinamen, z. B. "weltgewebe" -> weltgewebe_DDMM.md
+DEF_MERGE_PREFIX  = "weltgewebe"
+DEF_ENCODING      = "utf-8"
+DEF_SRCH_DEPTH    = 4
 
-from ordnermergers.repomerger_lib import RepoMerger  # noqa: E402
+# nur wirklich binäre Endungen (Dotfiles & .svg bleiben erhalten)
+BINARY_EXT = {
+    ".png",".jpg",".jpeg",".gif",".bmp",".ico",".webp",".heic",".heif",".psd",".ai",
+    ".mp3",".wav",".flac",".ogg",".m4a",".aac",".mp4",".mkv",".mov",".avi",".wmv",".flv",".webm",
+    ".zip",".rar",".7z",".tar",".gz",".bz2",".xz",".tgz",
+    ".ttf",".otf",".woff",".woff2",
+    ".pdf",".doc",".docx",".xls",".xlsx",".ppt",".pptx",".pages",".numbers",".key",
+    ".exe",".dll",".so",".dylib",".bin",".class",".o",".a",
+    ".db",".sqlite",".sqlite3",".realm",".mdb",".pack",".idx",
+}
 
+LANG_MAP = {
+    'py':'python','js':'javascript','ts':'typescript','html':'html','css':'css','scss':'scss','sass':'sass',
+    'json':'json','xml':'xml','yaml':'yaml','yml':'yaml','md':'markdown','sh':'bash','bat':'batch',
+    'sql':'sql','php':'php','cpp':'cpp','c':'c','java':'java','cs':'csharp','go':'go','rs':'rust',
+    'rb':'ruby','swift':'swift','kt':'kotlin','svelte':'svelte'
+}
 
-def main():
-    """Konfiguriert und startet den Merge-Prozess für Weltgewebe."""
+COMMON_BASES = [
+    Path("/private/var/mobile/Library/Mobile Documents/iCloud~com~omz-software~Pythonista3/Documents"),
+    Path.home() / "Library/Mobile Documents/iCloud~com~omz-software~Pythonista3/Documents",  # iOS/macOS iCloud
+    Path.home() / "Documents",
+]
 
-    # Spezifische Konfiguration für dieses Repo
-    merger = RepoMerger(
-        config_name="weltgewebe-merger",
-        title="Gewebe-Merge",
-        env_var="GEWEBE_SOURCE",
-        merge_prefix="GEWEBE_MERGE_",
-        def_basename="weltgewebe"
+# --- Klassifikations-Hilfen --------------------------------------------------
+
+DOC_EXTENSIONS = {".md", ".rst", ".txt"}
+
+SOURCE_EXTENSIONS = {
+    ".py", ".rs", ".ts", ".tsx", ".js", ".jsx", ".svelte",
+    ".c", ".cpp", ".h", ".hpp", ".go", ".java", ".cs",
+}
+
+CONFIG_FILENAMES = {
+    "pyproject.toml",
+    "package.json",
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "Cargo.toml",
+    "Cargo.lock",
+    "requirements.txt",
+    "Pipfile",
+    "Pipfile.lock",
+    "poetry.lock",
+    "Dockerfile",
+    "docker-compose.yml",
+    "docker-compose.yaml",
+    "Justfile",
+    "Makefile",
+    "toolchain.versions.yml",
+    ".editorconfig",
+    ".markdownlint.jsonc",
+    ".markdownlint.yaml",
+    ".yamllint",
+    ".yamllint.yml",
+    ".lychee.toml",
+    ".vale.ini",
+}
+
+# ===== Utilities ============================================================
+
+def human(n: int) -> str:
+    u=["B","KB","MB","GB","TB"]; f=float(n); i=0
+    while f>=1024 and i<len(u)-1: f/=1024; i+=1
+    return f"{f:.2f} {u[i]}"
+
+def is_text_file(p: Path, sniff=4096) -> bool:
+    # harte Binär-Endungen
+    if p.suffix.lower() in BINARY_EXT:
+        return False
+    # .env / .env.* aus Sicherheitsgründen ignorieren, außer Vorlagen
+    name = p.name
+    if name.startswith(".env") and name not in (".env.example", ".env.template", ".env.sample"):
+        return False
+    try:
+        with p.open("rb") as f:
+            chunk = f.read(sniff)
+        if not chunk: return True
+        if b"\x00" in chunk: return False
+        try:
+            chunk.decode("utf-8"); return True
+        except UnicodeDecodeError:
+            chunk.decode("latin-1", errors="ignore"); return True
+    except Exception:
+        return False
+
+def lang_for(p: Path) -> str:
+    return LANG_MAP.get(p.suffix.lower().lstrip("."), "")
+
+def file_md5(p: Path, block=65536) -> str:
+    h = hashlib.md5()
+    with p.open("rb") as f:
+        for chunk in iter(lambda: f.read(block), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+def ensure_dir(p: Path) -> Path:
+    p.mkdir(parents=True, exist_ok=True); return p
+
+def safe_is_dir(p: Path) -> bool:
+    try:
+        return p.is_dir()
+    except Exception:
+        return False
+
+def _deurl(s: str) -> str:
+    if s and s.lower().startswith("file://"):
+        return urllib.parse.unquote(s[7:])
+    return s or ""
+
+def load_config():
+    cfg = configparser.ConfigParser()
+    cfg_path = Path.home() / ".config" / "repo-merger" / "config.ini"
+    try:
+        if cfg_path.exists():
+            cfg.read(cfg_path, encoding="utf-8")
+    except Exception:
+        pass
+    return cfg, cfg_path
+
+def cfg_get_int(cfg, section, key, default):
+    try:
+        return cfg.getint(section, key, fallback=default)
+    except Exception:
+        return default
+
+def cfg_get_str(cfg, section, key, default):
+    try:
+        return cfg.get(section, key, fallback=default)
+    except Exception:
+        return default
+
+# ===== Klassifikation & Statistik ===========================================
+
+def classify_category(rel: Path, ext: str) -> str:
+    """Grobe Heuristik: doc / config / source / other."""
+    name = rel.name
+    if name in CONFIG_FILENAMES:
+        return "config"
+    if ext in DOC_EXTENSIONS:
+        return "doc"
+    if ext in SOURCE_EXTENSIONS:
+        return "source"
+    parts = [p.lower() for p in rel.parts]
+    if any(p in ("config", "configs", "settings", "etc", ".github") for p in parts):
+        return "config"
+    if "docs" in parts or "doc" in parts:
+        return "doc"
+    return "other"
+
+def summarize_ext(manifest_rows):
+    """
+    manifest_rows: Liste von (rel:Path, size:int, md5:str, cat:str, ext:str)
+    -> (ext_counts, ext_sizes)
+    """
+    counts = {}
+    sizes = {}
+    for rel, sz, md5, cat, ext in manifest_rows:
+        key = ext or "<none>"
+        counts[key] = counts.get(key, 0) + 1
+        sizes[key] = sizes.get(key, 0) + sz
+    return counts, sizes
+
+def summarize_cat(manifest_rows):
+    """
+    Kleine Übersicht nach Kategorien.
+    -> dict cat -> (count, size)
+    """
+    result = {}
+    for rel, sz, md5, cat, ext in manifest_rows:
+        if cat not in result:
+            result[cat] = [0, 0]
+        result[cat][0] += 1
+        result[cat][1] += sz
+    return result
+
+# ===== Fallback-Suche nach Basename =========================================
+
+def find_dir_by_basename(basename: str, aliases, search_depth: int = DEF_SRCH_DEPTH):
+    # 0) Aliases
+    if basename in aliases:
+        p = Path(_deurl(aliases[basename]).strip('"'))
+        if safe_is_dir(p):
+            return p, []
+
+    candidates = []
+    for base in COMMON_BASES:
+        if not base.exists(): continue
+
+        # schnelle Treffer
+        pref = [
+            base / basename,
+            base / "ordnermerger" / basename,
+            base / "Obsidian" / basename,
+            base / "weltgewebe-programmierung" / basename,
+        ]
+        for c in pref:
+            if safe_is_dir(c): candidates.append(c)
+
+        # vorsichtige Suche
+        try:
+            max_depth_abs = len(str(base).split(os.sep)) + max(1, int(search_depth))
+            for p in base.rglob(basename):
+                if p.is_dir() and p.name == basename:
+                    if len(str(p).split(os.sep)) <= max_depth_abs:
+                        candidates.append(p)
+        except Exception:
+            pass
+
+    uniq = []
+    seen = set()
+    for c in candidates:
+        s = str(c)
+        if s not in seen:
+            uniq.append(c); seen.add(s)
+
+    if not uniq:
+        return None, []
+    best = sorted(uniq, key=lambda p: (len(str(p)), str(p)))[0]
+    others = [p for p in uniq if p != best]
+    return best, others
+
+# ===== Manifest/Diff/Tree ===================================================
+
+def write_tree(out, root: Path, max_depth=None):
+    def lines(d: Path, lvl=0):
+        if max_depth is not None and lvl >= max_depth:
+            return []
+        res=[]
+        try:
+            items = sorted(d.iterdir(), key=lambda x:(not x.is_dir(), x.name.lower()))
+            dirs  = [i for i in items if i.is_dir()]
+            files = [i for i in items if i.is_file()]
+            for i, sub in enumerate(dirs):
+                pref = "└── " if (i==len(dirs)-1 and not files) else "├── "
+                res.append("    "*lvl + f"{pref}📁 {sub.name}/")
+                res += lines(sub, lvl+1)
+            for i, f in enumerate(files):
+                pref = "└── " if i==len(files)-1 else "├── "
+                try:
+                    icon = "📄" if is_text_file(f) else "🔒"
+                    res.append("    "*lvl + f"{pref}{icon} {f.name} ({human(f.stat().st_size)})")
+                except Exception:
+                    res.append("    "*lvl + f"{pref}📄 {f.name}")
+        except PermissionError:
+            res.append("    "*lvl + "❌ Zugriff verweigert")
+        return res
+
+    out.write("```\n"); out.write(f"📁 {root.name}/\n")
+    for ln in lines(root): out.write(ln+"\n")
+    out.write("```\n\n")
+
+def parse_manifest(md: Path):
+    m = {}
+    if not md or not md.exists(): return m
+    try:
+        inside = False
+        with md.open("r", encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                s = line.strip()
+                if s.startswith("## 🧾 Manifest"):
+                    inside = True; continue
+                if inside:
+                    if not s.startswith("- "):
+                        if s.startswith("## "): break
+                        continue
+                    row = s[2:]
+                    parts = [p.strip() for p in row.split("|")]
+                    rel = parts[0] if parts else ""
+                    md5 = ""
+                    size = 0
+                    for p in parts[1:]:
+                        if p.startswith("md5="): md5 = p[4:].strip()
+                        elif p.startswith("size="):
+                            try: size = int(p[5:].strip())
+                            except Exception: size = 0
+                    if rel: m[rel] = (md5, size)
+    except Exception:
+        pass
+    return m
+
+def build_diff(current, merge_dir: Path, merge_prefix: str):
+    # merge_prefix als Basisname: <prefix>_DDMM*.md
+    merges = sorted(merge_dir.glob(f"{merge_prefix}_*.md"))
+    if not merges: return [], 0, 0, 0
+    last = merges[-1]
+    old = parse_manifest(last)
+
+    cur_paths = {str(rel) for _, rel, _, _ in current}
+    old_paths = set(old.keys())
+
+    added   = sorted(cur_paths - old_paths)
+    removed = sorted(old_paths - cur_paths)
+    changed = []
+    for _, rel, _, h in current:
+        r = str(rel)
+        old_h = old.get(r, ("", 0))[0]
+        if r in old_paths and old_h and h and old_h != h:
+            changed.append(r)
+    changed.sort()
+    diffs = [("+", p) for p in added] + [("-", p) for p in removed] + [("~", p) for p in changed]
+    return diffs, len(added), len(removed), len(changed)
+
+def keep_last_n(merge_dir: Path, keep: int, keep_new: Path = None, merge_prefix: str = DEF_MERGE_PREFIX):
+    merges = sorted(merge_dir.glob(f"{merge_prefix}_*.md"))
+    if keep_new and keep_new not in merges:
+        merges.append(keep_new); merges.sort()
+    if keep <= 0: return
+    if len(merges) <= keep: return
+    for old in merges[:-keep]:
+        try: old.unlink()
+        except Exception: pass
+
+# ===== Dateinamen-Logik =====================================================
+
+def make_output_filename(merge_dir: Path, base_name: str) -> Path:
+    """
+    Erzeugt einen Dateinamen nach Schema:
+        <base_name>_DDMM.md
+    und hängt bei Kollisionen _2, _3, ... an.
+    """
+    now = datetime.now()
+    ddmm = now.strftime("%d%m")
+    base = f"{base_name}_{ddmm}"
+    candidate = merge_dir / f"{base}.md"
+    idx = 2
+    while candidate.exists():
+        candidate = merge_dir / f"{base}_{idx}.md"
+        idx += 1
+    return candidate
+
+# ===== Merge ================================================================
+
+def do_merge(source: Path, out_file: Path, *,
+             encoding: str, keep: int,
+             merge_dir: Path, merge_prefix: str,
+             max_tree_depth, search_info: str):
+
+    included = []      # (p, rel, sz, h)
+    manifest_rows = [] # (rel, sz, h, cat, ext)
+    skipped = []
+    total = 0
+
+    for dirpath, _, files in os.walk(source):
+        d = Path(dirpath)
+        for fn in files:
+            p = d / fn
+            rel = p.relative_to(source)
+
+            if not is_text_file(p):
+                skipped.append(f"{rel} (binär/ignoriert)")
+                continue
+
+            try:
+                sz = p.stat().st_size
+            except Exception as e:
+                skipped.append(f"{rel} (stat error: {e})")
+                continue
+            try:
+                h = file_md5(p)
+            except Exception:
+                h = ""
+
+            total += sz
+            included.append((p, rel, sz, h))
+
+            ext = p.suffix.lower()
+            cat = classify_category(rel, ext)
+            manifest_rows.append((rel, sz, h, cat, ext))
+
+    included.sort(key=lambda t: str(t[1]).lower())
+    manifest_rows.sort(key=lambda t: str(t[0]).lower())
+
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+
+    diffs, add_c, del_c, chg_c = build_diff(included, out_file.parent, merge_prefix)
+    ext_counts, ext_sizes = summarize_ext(manifest_rows)
+    cat_stats = summarize_cat(manifest_rows)
+
+    with out_file.open("w", encoding=encoding) as out:
+        out.write("# Gewebe-Merge\n\n")
+        out.write(f"**Zeitpunkt:** {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n")
+        out.write(f"**Quelle:** `{source}`\n")
+        if search_info:
+            out.write(f"**Quelle ermittelt:** {search_info}\n")
+        out.write(f"**Dateien (inkludiert):** {len(included)}\n")
+        out.write(f"**Gesamtgröße:** {human(total)}\n")
+        if diffs:
+            out.write(f"**Änderungen seit letztem Merge:** +{add_c} / -{del_c} / ~{chg_c}\n")
+        out.write("\n")
+
+        # KI-Hinweisblock
+        out.write("> Hinweis für KIs:\n")
+        out.write("> - Dies ist ein Schnappschuss des Dateisystems, keine vollständige Git-Historie.\n")
+        out.write("> - Die Baumstruktur findest du unter `## 📁 Struktur`.\n"
+                  "> - Alle aufgenommenen Dateien stehen im `## 🧾 Manifest`.\n")
+        out.write("> - Dateiinhalte stehen unter `## 📄 Dateiinhalte`.\n")
+        out.write("> - `.env` und ähnliche Dateien können bewusst fehlen (Sicherheitsfilter).\n\n")
+
+        # Plan / Übersicht
+        out.write("## 🧮 Plan\n\n")
+        out.write(f"- Textdateien im Merge: **{len(included)}**\n")
+        out.write(f"- Gesamtgröße der Quellen: **{human(total)}**\n")
+
+        if cat_stats:
+            out.write("\n**Dateien nach Kategorien:**\n\n")
+            out.write("| Kategorie | Dateien | Gesamtgröße |\n")
+            out.write("| --- | ---: | ---: |\n")
+            for cat in sorted(cat_stats.keys()):
+                cnt, sz = cat_stats[cat]
+                out.write(f"| `{cat}` | {cnt} | {human(sz)} |\n")
+            out.write("\n")
+
+        if ext_counts:
+            out.write("**Statistik nach Dateiendungen:**\n\n")
+            out.write("| Ext | Dateien | Gesamtgröße |\n")
+            out.write("| --- | ---: | ---: |\n")
+            for ext in sorted(ext_counts.keys()):
+                out.write(f"| `{ext}` | {ext_counts[ext]} | {human(ext_sizes[ext])} |\n")
+            out.write("\n")
+
+        out.write("Hinweis: Obwohl `.env`-ähnliche Dateien gefiltert werden, können sensible Daten ")
+        out.write("in anderen Dateien (z. B. JSON/YAML) vorkommen. Nutze den Merge nicht als public Dump.\n\n")
+
+        out.write("## 📁 Struktur\n\n")
+        write_tree(out, source, max_tree_depth)
+
+        if diffs:
+            out.write("## 📊 Änderungen seit letztem Merge\n\n")
+            for sym, pth in diffs:
+                out.write(f"{sym} {pth}\n")
+            out.write("\n")
+
+        if skipped:
+            out.write("## ⏭️ Übersprungen\n\n")
+            for s in skipped:
+                out.write(f"- {s}\n")
+            out.write("\n")
+
+        out.write("## 🧾 Manifest\n\n")
+        for rel, sz, h, cat, ext in manifest_rows:
+            out.write(f"- {rel} | md5={h} | size={sz} | cat={cat}\n")
+        out.write("\n")
+
+        out.write("## 📄 Dateiinhalte\n\n")
+        for p, rel, sz, h in included:
+            out.write(f"### 📄 {rel}\n\n**Größe:** {human(sz)}\n\n```{lang_for(p)}\n")
+            try:
+                txt = p.read_text(encoding=encoding, errors="replace")
+            except Exception as e:
+                txt = f"<<Lesefehler: {e}>>"
+            out.write(txt)
+            if not txt.endswith("\n"): out.write("\n")
+            out.write("```\n\n")
+
+    keep_last_n(out_file.parent, keep=keep, keep_new=out_file, merge_prefix=merge_prefix)
+    print(f"✅ Merge geschrieben: {out_file} ({human(out_file.stat().st_size)})")
+
+# ===== CLI / ARG-PARSING ====================================================
+
+def build_parser():
+    p = argparse.ArgumentParser(description="repo-merger – genau ein Quellordner", add_help=False)
+    p.add_argument("--source-dir", dest="src_flag")
+    p.add_argument("--keep", type=int, dest="keep")
+    p.add_argument("--encoding", dest="encoding")
+    p.add_argument("--max-depth", type=int, dest="max_tree_depth")
+    p.add_argument("--search-depth", type=int, dest="search_depth")
+    p.add_argument("--merge-dirname", dest="merge_dirname")
+    p.add_argument("--merge-prefix", dest="merge_prefix")  # Basisname für Dateinamen
+    p.add_argument("-h","--help", action="store_true", dest="help")
+    p.add_argument("rest", nargs="*")  # Shortcuts liefert gern extra Tokens
+    return p
+
+def print_help():
+    print(__doc__.strip())
+
+def extract_source_path(argv, *, aliases, search_depth: int):
+    """
+    Akzeptiert:
+      - --source-dir <PATH|BASENAME|file://>
+      - <PATH|BASENAME|file://>
+      - Datei → Elternordner
+      - Env: GEWEBE_SOURCE
+      - Fallback: Nur-Basename unter COMMON_BASES
+    Rückgabe: (Pfad, InfoStringFürReport)
+    """
+    # Env-Override
+    env_src = os.environ.get("GEWEBE_SOURCE", "").strip()
+    if env_src:
+        p = Path(_deurl(env_src).strip('"'))
+        if not safe_is_dir(p) and p.exists():
+            p = p.parent
+        if safe_is_dir(p):
+            return p, "GEWEBE_SOURCE (ENV)"
+
+    # Flags + restliche Tokens
+    tokens = []
+    if "--source-dir" in argv:
+        idx = argv.index("--source-dir")
+        if idx + 1 < len(argv):
+            tokens.append(argv[idx+1])
+    tokens += [t for t in argv if t != "--source-dir"]
+
+    # Schritt 1: direkte Pfade/URLs
+    for tok in tokens:
+        cand = _deurl((tok or "").strip('"'))
+        if not cand: continue
+        # Nur-Basename?
+        if os.sep not in cand and not cand.lower().startswith("file://"):
+            continue
+        p = Path(cand)
+        if p.exists():
+            if p.is_file(): p = p.parent
+            if safe_is_dir(p):
+                return p, "direktes Argument"
+
+    # Schritt 2: Basename-Suche (inkl. Aliases)
+    for tok in tokens:
+        cand = _deurl((tok or "").strip('"'))
+        if not cand: continue
+        if os.sep in cand or cand.lower().startswith("file://"):
+            continue
+        base = cand
+        hit, others = find_dir_by_basename(base, aliases, search_depth=search_depth)
+        if hit:
+            info = f"Basename-Fallback ('{base}')"
+            if others:
+                others_s = " | ".join(str(p) for p in others[:5])
+                print(f"__REPO_MERGER_INFO__: Mehrere Kandidaten gefunden, nehme kürzesten: {hit} | weitere: {others_s}")
+            return hit, info
+
+    return None, None
+
+def _running_in_shortcuts() -> bool:
+    # Heuristik: Shortcuts defaultet auf 1, sonst env überschreiben (GEWEBE_SHORTCUTS=0)
+    return os.environ.get("GEWEBE_SHORTCUTS", "1") == "1"
+
+def main(argv):
+    cfg, cfg_path = load_config()
+    args = build_parser().parse_args(argv)
+    if args.help:
+        print_help()
+        return 0
+
+    # Konfig lesen
+    keep          = args.keep if args.keep is not None else cfg_get_int(cfg, "general", "keep", DEF_KEEP)
+    merge_dirname = args.merge_dirname or cfg_get_str(cfg, "general", "merge_dirname", DEF_MERGE_DIRNAME)
+    merge_prefix  = args.merge_prefix  or cfg_get_str(cfg, "general", "merge_prefix",  DEF_MERGE_PREFIX)
+    encoding      = args.encoding or cfg_get_str(cfg, "general", "encoding", DEF_ENCODING)
+    search_depth  = args.search_depth if args.search_depth is not None else cfg_get_int(cfg, "general", "max_search_depth", DEF_SRCH_DEPTH)
+    max_tree_depth= args.max_depth if hasattr(args, "max_depth") and args.max_depth is not None else None
+
+    # Aliases sammeln
+    aliases = {}
+    if cfg.has_section("aliases"):
+        for k,v in cfg.items("aliases"):
+            aliases[k] = v
+
+    # Pfad extrahieren
+    src, src_info = extract_source_path(
+        [args.src_flag] + args.rest if args.src_flag else args.rest,
+        aliases=aliases, search_depth=search_depth
     )
+    if not src:
+        print("❌ Quelle fehlt/unerkannt. Übergib Pfad/URL/Basename oder setze GEWEBE_SOURCE. (-h für Hilfe)")
+        return 2
+    if not safe_is_dir(src):
+        print(f"❌ Quelle nicht gefunden oder kein Ordner: {src}")
+        return 1
 
-    # Führe den Merge-Prozess mit den übergebenen Kommandozeilenargumenten aus
-    return merger.run(sys.argv[1:])
+    script_root = Path(__file__).resolve().parent
+    merge_dir   = ensure_dir(script_root / merge_dirname)
 
+    # Dateiname: <merge_prefix>_DDMM(.md) + Kollision-Handling
+    base_name = merge_prefix.rstrip("_")
+    out_file  = make_output_filename(merge_dir, base_name=base_name)
+
+    # Merge
+    do_merge(
+        src, out_file,
+        encoding=encoding,
+        keep=keep,
+        merge_dir=merge_dir,
+        merge_prefix=base_name,
+        max_tree_depth=max_tree_depth,
+        search_info=src_info
+    )
+    return 0
+
+def _safe_main():
+    try:
+        rc = main(sys.argv[1:])
+    except SystemExit as e:
+        rc = int(getattr(e, "code", 1) or 0)
+    except Exception as e:
+        print(f"__REPO_MERGER_ERR__: {e}")
+        rc = 1
+
+    if _running_in_shortcuts():
+        if rc != 0:
+            print(f"__REPO_MERGER_WARN__: Exit {rc}")
+        print("__REPO_MERGER_OK__")
+    else:
+        sys.exit(rc)
 
 if __name__ == "__main__":
-    sys.exit(main())
+    _safe_main()

--- a/repomergers/wgx-merger.py
+++ b/repomergers/wgx-merger.py
@@ -2,33 +2,708 @@
 # -*- coding: utf-8 -*-
 
 """
-wgx-merger – Ruft die zentrale RepoMerger-Logik mit WGX-spezifischen Konfigurationen auf.
+wgx-merger – Shortcuts-freundlich, Dotfiles inklusive, Basename/Env/Config-Fallbacks, keep last N merges
+
+Nutzung auf iOS (Shortcuts → "Run Pythonista Script" → Arguments):
+    – GIB GENAU EINE DER VARIANTEN, KEINE UMBRÜCHE:
+      1) --source-dir "/private/var/.../wgx"
+      2) "/private/var/.../wgx"
+      3) file:///private/var/.../wgx
+      4) wgx   (nur Basename; Fallback-Suche aktiv)
+    – Alternativ Env: WGX_SOURCE="/private/var/.../wgx"
+
+Ausgabe:
+    ./merge/wgx_DDMM.md
+    (bei Mehrfach-Merges am selben Tag: wgx_DDMM_2.md, wgx_DDMM_3.md, ...)
+    – Standard: nur die letzten 2 Merges bleiben (per Config / CLI änderbar)
+
+Konfig (optional):
+    ~/.config/wgx-merger/config.ini
+
+    [general]
+    keep = 2
+    merge_dirname = merge
+    merge_prefix  = wgx
+    max_search_depth = 4
+    encoding = utf-8
+
+    [aliases]
+    wgx = /private/var/mobile/Library/Mobile Documents/iCloud~com~omz-software~Pythonista3/Documents/wgx
 """
 
 import sys
+import os
+import argparse
+import hashlib
+import urllib.parse
+import configparser
 from pathlib import Path
+from datetime import datetime
 
-# Füge das übergeordnete Verzeichnis zum Suchpfad hinzu, um ordnermergers zu finden
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+# ===== Defaults =====
+DEF_KEEP          = 2
+DEF_MERGE_DIRNAME = "merge"
+# Basisname im Dateinamen, z. B. "wgx" -> wgx_DDMM.md
+DEF_MERGE_PREFIX  = "wgx"
+DEF_ENCODING      = "utf-8"
+DEF_SRCH_DEPTH    = 4
 
-from ordnermergers.repomerger_lib import RepoMerger  # noqa: E402
+# nur wirklich binäre Endungen (Dotfiles & .svg bleiben erhalten)
+BINARY_EXT = {
+    ".png",".jpg",".jpeg",".gif",".bmp",".ico",".webp",".heic",".heif",".psd",".ai",
+    ".mp3",".wav",".flac",".ogg",".m4a",".aac",".mp4",".mkv",".mov",".avi",".wmv",".flv",".webm",
+    ".zip",".rar",".7z",".tar",".gz",".bz2",".xz",".tgz",
+    ".ttf",".otf",".woff",".woff2",
+    ".pdf",".doc",".docx",".xls",".xlsx",".ppt",".pptx",".pages",".numbers",".key",
+    ".exe",".dll",".so",".dylib",".bin",".class",".o",".a",
+    ".db",".sqlite",".sqlite3",".realm",".mdb",".pack",".idx",
+}
+
+LANG_MAP = {
+    "py": "python","js": "javascript","ts": "typescript","html": "html","css": "css",
+    "scss": "scss","sass": "sass","json": "json","xml": "xml","yaml": "yaml","yml": "yaml",
+    "md": "markdown","sh": "bash","bat": "batch","sql": "sql","php": "php","cpp": "cpp",
+    "c": "c","java": "java","cs": "csharp","go": "go","rs": "rust","rb": "ruby",
+    "swift": "swift","kt": "kotlin","svelte": "svelte",
+}
+
+COMMON_BASES = [
+    Path("/private/var/mobile/Library/Mobile Documents/iCloud~com~omz-software~Pythonista3/Documents"),
+    Path.home() / "Library/Mobile Documents/iCloud~com~omz-software~Pythonista3/Documents",
+    Path.home() / "Documents",
+]
+
+# --- Klassifikations-Hilfen --------------------------------------------------
+
+DOC_EXTENSIONS = {".md", ".rst", ".txt"}
+
+SOURCE_EXTENSIONS = {
+    ".py", ".rs", ".ts", ".tsx", ".js", ".jsx", ".svelte",
+    ".c", ".cpp", ".h", ".hpp", ".go", ".java", ".cs",
+}
+
+CONFIG_FILENAMES = {
+    "pyproject.toml",
+    "package.json",
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "Cargo.toml",
+    "Cargo.lock",
+    "requirements.txt",
+    "Pipfile",
+    "Pipfile.lock",
+    "poetry.lock",
+    "Dockerfile",
+    "docker-compose.yml",
+    "docker-compose.yaml",
+    "Justfile",
+    "Makefile",
+    "toolchain.versions.yml",
+    ".editorconfig",
+    ".markdownlint.jsonc",
+    ".markdownlint.yaml",
+    ".yamllint",
+    ".yamllint.yml",
+    ".lychee.toml",
+    ".vale.ini",
+}
+
+# ===== Utilities ============================================================
+
+def human(n: int) -> str:
+    u = ["B", "KB", "MB", "GB", "TB"]
+    f = float(n)
+    i = 0
+    while f >= 1024 and i < len(u) - 1:
+        f /= 1024
+        i += 1
+    return f"{f:.2f} {u[i]}"
 
 
-def main():
-    """Konfiguriert und startet den Merge-Prozess für WGX."""
+def is_text_file(p: Path, sniff: int = 4096) -> bool:
+    # harte Binär-Endungen
+    if p.suffix.lower() in BINARY_EXT:
+        return False
+    # .env / .env.* aus Sicherheitsgründen ignorieren, außer Vorlagen
+    name = p.name
+    if name.startswith(".env") and name not in (".env.example", ".env.template", ".env.sample"):
+        return False
+    try:
+        with p.open("rb") as f:
+            chunk = f.read(sniff)
+        if not chunk:
+            return True
+        if b"\x00" in chunk:
+            return False
+        try:
+            chunk.decode("utf-8")
+            return True
+        except UnicodeDecodeError:
+            chunk.decode("latin-1", errors="ignore")
+            return True
+    except Exception:
+        return False
 
-    # Spezifische Konfiguration für dieses Repo
-    merger = RepoMerger(
-        config_name="wgx-merger",
-        title="WGX-Merge",
-        env_var="WGX_SOURCE",
-        merge_prefix="WGX_MERGE_",
-        def_basename="wgx"
+
+def lang_for(p: Path) -> str:
+    return LANG_MAP.get(p.suffix.lower().lstrip("."), "")
+
+
+def file_md5(p: Path, block: int = 65536) -> str:
+    h = hashlib.md5()
+    with p.open("rb") as f:
+        for chunk in iter(lambda: f.read(block), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def ensure_dir(p: Path) -> Path:
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def safe_is_dir(p: Path) -> bool:
+    try:
+        return p.is_dir()
+    except Exception:
+        return False
+
+
+def _deurl(s: str) -> str:
+    if s and s.lower().startswith("file://"):
+        return urllib.parse.unquote(s[7:])
+    return s or ""
+
+
+def load_config() -> tuple[configparser.ConfigParser, Path]:
+    cfg = configparser.ConfigParser()
+    cfg_path = Path.home() / ".config" / "wgx-merger" / "config.ini"
+    try:
+        if cfg_path.exists():
+            cfg.read(cfg_path, encoding="utf-8")
+    except Exception:
+        pass
+    return cfg, cfg_path
+
+
+def cfg_get_int(cfg, section, key, default):
+    try:
+        return cfg.getint(section, key, fallback=default)
+    except Exception:
+        return default
+
+
+def cfg_get_str(cfg, section, key, default):
+    try:
+        return cfg.get(section, key, fallback=default)
+    except Exception:
+        return default
+
+# ===== Klassifikation & Statistik ===========================================
+
+def classify_category(rel: Path, ext: str) -> str:
+    """Grobe Heuristik: doc / config / source / other."""
+    name = rel.name
+    if name in CONFIG_FILENAMES:
+        return "config"
+    if ext in DOC_EXTENSIONS:
+        return "doc"
+    if ext in SOURCE_EXTENSIONS:
+        return "source"
+    parts = [p.lower() for p in rel.parts]
+    if any(p in ("config", "configs", "settings", "etc", ".github") for p in parts):
+        return "config"
+    if "docs" in parts or "doc" in parts:
+        return "doc"
+    return "other"
+
+
+def summarize_ext(manifest_rows):
+    """
+    manifest_rows: Liste von (rel:Path, size:int, md5:str, cat:str, ext:str)
+    -> (ext_counts, ext_sizes)
+    """
+    counts: dict[str, int] = {}
+    sizes: dict[str, int] = {}
+    for rel, sz, md5, cat, ext in manifest_rows:
+        key = ext or "<none>"
+        counts[key] = counts.get(key, 0) + 1
+        sizes[key] = sizes.get(key, 0) + sz
+    return counts, sizes
+
+
+def summarize_cat(manifest_rows):
+    """
+    Kleine Übersicht nach Kategorien.
+    -> dict cat -> (count, size)
+    """
+    result: dict[str, list[int]] = {}
+    for rel, sz, md5, cat, ext in manifest_rows:
+        if cat not in result:
+            result[cat] = [0, 0]
+        result[cat][0] += 1
+        result[cat][1] += sz
+    return result
+
+# ===== Basename-Fallback ====================================================
+
+def find_dir_by_basename(basename: str, aliases: dict[str, str], search_depth: int = DEF_SRCH_DEPTH) -> tuple[Path | None, list[Path]]:
+    # 0) Aliases
+    if basename in aliases:
+        p = Path(_deurl(aliases[basename]).strip('"'))
+        if safe_is_dir(p):
+            return p, []
+
+    candidates: list[Path] = []
+    for base in COMMON_BASES:
+        if not base.exists():
+            continue
+
+        # schnelle Treffer
+        pref = [
+            base / basename,
+            base / "ordnermerger" / basename,
+            base / "Obsidian" / basename,
+        ]
+        for c in pref:
+            if safe_is_dir(c):
+                candidates.append(c)
+
+        # vorsichtige Suche
+        try:
+            max_depth_abs = len(str(base).split(os.sep)) + max(1, int(search_depth))
+            for p in base.rglob(basename):
+                if p.is_dir() and p.name == basename and len(str(p).split(os.sep)) <= max_depth_abs:
+                    candidates.append(p)
+        except Exception:
+            pass
+
+    uniq: list[Path] = []
+    seen: set[str] = set()
+    for c in candidates:
+        s = str(c)
+        if s not in seen:
+            uniq.append(c)
+            seen.add(s)
+
+    if not uniq:
+        return None, []
+    best = sorted(uniq, key=lambda p: (len(str(p)), str(p)))[0]
+    others = [p for p in uniq if p != best]
+    return best, others
+
+# ===== Dateinamen-Logik =====================================================
+
+def make_output_filename(merge_dir: Path, base_name: str) -> Path:
+    """
+    Erzeugt einen Dateinamen nach Schema:
+        <base_name>_DDMM.md
+    und hängt bei Kollisionen _2, _3, ... an.
+    """
+    now = datetime.now()
+    ddmm = now.strftime("%d%m")
+    base = f"{base_name}_{ddmm}"
+    candidate = merge_dir / f"{base}.md"
+    idx = 2
+    while candidate.exists():
+        candidate = merge_dir / f"{base}_{idx}.md"
+        idx += 1
+    return candidate
+
+# ===== Manifest/Diff/Tree ===================================================
+
+def write_tree(out, root: Path, max_depth: int | None = None):
+    def lines(d: Path, lvl: int = 0):
+        if max_depth is not None and lvl >= max_depth:
+            return []
+        res: list[str] = []
+        try:
+            items = sorted(d.iterdir(), key=lambda x: (not x.is_dir(), x.name.lower()))
+            dirs = [i for i in items if i.is_dir()]
+            files = [i for i in items if i.is_file()]
+            for i, sub in enumerate(dirs):
+                pref = "└── " if (i == len(dirs) - 1 and not files) else "├── "
+                res.append("    " * lvl + f"{pref}📁 {sub.name}/")
+                res += lines(sub, lvl + 1)
+            for i, f in enumerate(files):
+                pref = "└── " if i == len(files) - 1 else "├── "
+                try:
+                    icon = "📄" if is_text_file(f) else "🔒"
+                    res.append("    " * lvl + f"{pref}{icon} {f.name} ({human(f.stat().st_size)})")
+                except Exception:
+                    res.append("    " * lvl + f"{pref}📄 {f.name}")
+        except PermissionError:
+            res.append("    " * lvl + "❌ Zugriff verweigert")
+        return res
+
+    out.write("```\n")
+    out.write(f"📁 {root.name}/\n")
+    for ln in lines(root):
+        out.write(ln + "\n")
+    out.write("```\n\n")
+
+
+def parse_manifest(md: Path) -> dict[str, tuple[str, int]]:
+    m: dict[str, tuple[str, int]] = {}
+    if not md or not md.exists():
+        return m
+    try:
+        inside = False
+        with md.open("r", encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                s = line.strip()
+                if s.startswith("## 🧾 Manifest"):
+                    inside = True
+                    continue
+                if inside:
+                    if not s.startswith("- "):
+                        if s.startswith("## "):
+                            break
+                        continue
+                    row = s[2:]
+                    parts = [p.strip() for p in row.split("|")]
+                    rel = parts[0] if parts else ""
+                    md5 = ""
+                    size = 0
+                    for p in parts[1:]:
+                        if p.startswith("md5="):
+                            md5 = p[4:].strip()
+                        elif p.startswith("size="):
+                            try:
+                                size = int(p[5:].strip())
+                            except Exception:
+                                size = 0
+                    if rel:
+                        m[rel] = (md5, size)
+    except Exception:
+        pass
+    return m
+
+
+def build_diff(current: list[tuple[Path, Path, int, str]], merge_dir: Path, merge_prefix: str):
+    # merge_prefix als Basisname: <prefix>_DDMM*.md
+    merges = sorted(merge_dir.glob(f"{merge_prefix}_*.md"))
+    if not merges:
+        return [], 0, 0, 0
+    last = merges[-1]
+    old = parse_manifest(last)
+
+    cur_paths = {str(rel) for _, rel, _, _ in current}
+    old_paths = set(old.keys())
+
+    added = sorted(cur_paths - old_paths)
+    removed = sorted(old_paths - cur_paths)
+    changed: list[str] = []
+    for _, rel, _, h in current:
+        r = str(rel)
+        old_h = old.get(r, ("", 0))[0]
+        if r in old_paths and old_h and h and old_h != h:
+            changed.append(r)
+    changed.sort()
+    diffs = [("+", p) for p in added] + [("-", p) for p in removed] + [("~", p) for p in changed]
+    return diffs, len(added), len(removed), len(changed)
+
+
+def keep_last_n(merge_dir: Path, keep: int, keep_new: Path | None = None, merge_prefix: str = DEF_MERGE_PREFIX):
+    merges = sorted(merge_dir.glob(f"{merge_prefix}_*.md"))
+    if keep_new and keep_new not in merges:
+        merges.append(keep_new)
+        merges.sort()
+    if keep <= 0 or len(merges) <= keep:
+        return
+    for old in merges[:-keep]:
+        try:
+            old.unlink()
+        except Exception:
+            pass
+
+# ===== Merge ================================================================
+
+def do_merge(
+    source: Path,
+    out_file: Path,
+    *,
+    encoding: str,
+    keep: int,
+    merge_dir: Path,
+    merge_prefix: str,
+    max_tree_depth: int | None,
+    search_info: str | None,
+):
+    included: list[tuple[Path, Path, int, str]] = []
+    manifest_rows: list[tuple[Path, int, str, str, str]] = []
+    skipped: list[str] = []
+    total = 0
+
+    for dirpath, _, files in os.walk(source):
+        d = Path(dirpath)
+        for fn in files:
+            p = d / fn
+            rel = p.relative_to(source)
+
+            if not is_text_file(p):
+                skipped.append(f"{rel} (binär/ignoriert)")
+                continue
+
+            try:
+                sz = p.stat().st_size
+            except Exception as e:
+                skipped.append(f"{rel} (stat error: {e})")
+                continue
+            try:
+                h = file_md5(p)
+            except Exception:
+                h = ""
+
+            total += sz
+            included.append((p, rel, sz, h))
+
+            ext = p.suffix.lower()
+            cat = classify_category(rel, ext)
+            manifest_rows.append((rel, sz, h, cat, ext))
+
+    included.sort(key=lambda t: str(t[1]).lower())
+    manifest_rows.sort(key=lambda t: str(t[0]).lower())
+
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+
+    # base_name für Diff-Logik (ohne evtl. abschließenden Unterstrich)
+    base_prefix = merge_prefix.rstrip("_")
+
+    diffs, add_c, del_c, chg_c = build_diff(included, out_file.parent, base_prefix)
+    ext_counts, ext_sizes = summarize_ext(manifest_rows)
+    cat_stats = summarize_cat(manifest_rows)
+
+    with out_file.open("w", encoding=encoding) as out:
+        out.write("# WGX-Merge\n\n")
+        out.write(f"**Zeitpunkt:** {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n")
+        out.write(f"**Quelle:** `{source}`\n")
+        if search_info:
+            out.write(f"**Quelle ermittelt:** {search_info}\n")
+        out.write(f"**Dateien (inkludiert):** {len(included)}\n")
+        out.write(f"**Gesamtgröße:** {human(total)}\n")
+        if diffs:
+            out.write(f"**Änderungen seit letztem Merge:** +{add_c} / -{del_c} / ~{chg_c}\n")
+        out.write("\n")
+
+        # KI-Hinweisblock
+        out.write("> Hinweis für KIs:\n")
+        out.write("> - Dies ist ein Schnappschuss des Dateisystems, keine vollständige Git-Historie.\n")
+        out.write("> - Die Baumstruktur findest du unter `## 📁 Struktur`.\n")
+        out.write("> - Alle aufgenommenen Dateien stehen im `## 🧾 Manifest`.\n")
+        out.write("> - Dateiinhalte stehen unter `## 📄 Dateiinhalte`.\n")
+        out.write("> - `.env` und ähnliche Dateien können bewusst fehlen (Sicherheitsfilter).\n\n")
+
+        # Plan / Übersicht
+        out.write("## 🧮 Plan\n\n")
+        out.write(f"- Textdateien im Merge: **{len(included)}**\n")
+        out.write(f"- Gesamtgröße der Quellen: **{human(total)}**\n")
+
+        if cat_stats:
+            out.write("\n**Dateien nach Kategorien:**\n\n")
+            out.write("| Kategorie | Dateien | Gesamtgröße |\n")
+            out.write("| --- | ---: | ---: |\n")
+            for cat in sorted(cat_stats.keys()):
+                cnt, sz = cat_stats[cat]
+                out.write(f"| `{cat}` | {cnt} | {human(sz)} |\n")
+            out.write("\n")
+
+        if ext_counts:
+            out.write("**Statistik nach Dateiendungen:**\n\n")
+            out.write("| Ext | Dateien | Gesamtgröße |\n")
+            out.write("| --- | ---: | ---: |\n")
+            for ext in sorted(ext_counts.keys()):
+                out.write(f"| `{ext}` | {ext_counts[ext]} | {human(ext_sizes[ext])} |\n")
+            out.write("\n")
+
+        out.write("Hinweis: Obwohl `.env`-ähnliche Dateien gefiltert werden, können sensible Daten ")
+        out.write("in anderen Dateien (z. B. JSON/YAML) vorkommen. Nutze den Merge nicht als public Dump.\n\n")
+
+        out.write("## 📁 Struktur\n\n")
+        write_tree(out, source, max_tree_depth)
+
+        if diffs:
+            out.write("## 📊 Änderungen seit letztem Merge\n\n")
+            for sym, pth in diffs:
+                out.write(f"{sym} {pth}\n")
+            out.write("\n")
+
+        if skipped:
+            out.write("## ⏭️ Übersprungen\n\n")
+            for s in skipped:
+                out.write(f"- {s}\n")
+            out.write("\n")
+
+        out.write("## 🧾 Manifest\n\n")
+        for rel, sz, h, cat, ext in manifest_rows:
+            out.write(f"- {rel} | md5={h} | size={sz} | cat={cat}\n")
+        out.write("\n")
+
+        out.write("## 📄 Dateiinhalte\n\n")
+        for p, rel, sz, h in included:
+            out.write(f"### 📄 {rel}\n\n**Größe:** {human(sz)}\n\n```{lang_for(p)}\n")
+            try:
+                txt = p.read_text(encoding=encoding, errors="replace")
+            except Exception as e:
+                txt = f"<<Lesefehler: {e}>>"
+            out.write(txt)
+            if not txt.endswith("\n"):
+                out.write("\n")
+            out.write("```\n\n")
+
+    # keep_last_n nutzt denselben Basis-Prefix (wgx)
+    keep_last_n(out_file.parent, keep=keep, keep_new=out_file, merge_prefix=base_prefix)
+    print(f"✅ Merge geschrieben: {out_file} ({human(out_file.stat().st_size)})")
+
+# ===== CLI ==================================================================
+
+def build_parser():
+    p = argparse.ArgumentParser(description="wgx-merger – genau ein Quellordner", add_help=False)
+    p.add_argument("--source-dir", dest="src_flag")
+    p.add_argument("--keep", type=int, dest="keep")
+    p.add_argument("--encoding", dest="encoding")
+    p.add_argument("--max-depth", type=int, dest="max_tree_depth")
+    p.add_argument("--search-depth", type=int, dest="search_depth")
+    p.add_argument("--merge-dirname", dest="merge_dirname")
+    p.add_argument("--merge-prefix", dest="merge_prefix")  # Basisname für Dateinamen (Default: wgx)
+    p.add_argument("-h", "--help", action="store_true", dest="help")
+    p.add_argument("rest", nargs="*")
+    return p
+
+
+def print_help():
+    print(__doc__.strip())
+
+
+def extract_source_path(argv: list[str], *, aliases: dict[str, str], search_depth: int) -> tuple[Path | None, str | None]:
+    """
+    Akzeptiert:
+      - --source-dir <PATH|BASENAME|file://>
+      - <PATH|BASENAME|file://>
+      - Datei → Elternordner
+      - Env: WGX_SOURCE
+      - Fallback: Nur-Basename unter COMMON_BASES
+    Rückgabe: (Pfad, InfoStringFürReport)
+    """
+    # Env
+    env_src = os.environ.get("WGX_SOURCE", "").strip()
+    if env_src:
+        p = Path(_deurl(env_src).strip('"'))
+        if not safe_is_dir(p) and p.exists():
+            p = p.parent
+        if safe_is_dir(p):
+            return p, "WGX_SOURCE (ENV)"
+
+    # Tokens
+    tokens: list[str] = []
+    if "--source-dir" in argv:
+        idx = argv.index("--source-dir")
+        if idx + 1 < len(argv):
+            tokens.append(argv[idx + 1])
+    tokens += [t for t in argv if t != "--source-dir"]
+
+    # Direktpfad
+    for tok in tokens:
+        cand = _deurl((tok or "").strip('"'))
+        if not cand:
+            continue
+        if os.sep not in cand and not cand.lower().startswith("file://"):
+            continue
+        p = Path(cand)
+        if p.exists():
+            if p.is_file():
+                p = p.parent
+            if safe_is_dir(p):
+                return p, "direktes Argument"
+
+    # Basename/Alias
+    for tok in tokens:
+        cand = _deurl((tok or "").strip('"'))
+        if not cand:
+            continue
+        if os.sep in cand or cand.lower().startswith("file://"):
+            continue
+        base = cand
+        hit, others = find_dir_by_basename(base, aliases, search_depth=search_depth)
+        if hit:
+            info = f"Basename-Fallback ('{base}')"
+            if others:
+                others_s = " | ".join(str(p) for p in others[:5])
+                print(f"__WGX_MERGER_INFO__: Mehrere Kandidaten gefunden, nehme kürzesten: {hit} | weitere: {others_s}")
+            return hit, info
+    return None, None
+
+
+def _running_in_shortcuts() -> bool:
+    return os.environ.get("WGX_SHORTCUTS", "1") == "1"
+
+
+def main(argv: list[str]) -> int:
+    cfg, cfg_path = load_config()
+    args = build_parser().parse_args(argv)
+    if args.help:
+        print_help()
+        return 0
+
+    keep = args.keep if args.keep is not None else cfg_get_int(cfg, "general", "keep", DEF_KEEP)
+    merge_dirname = args.merge_dirname or cfg_get_str(cfg, "general", "merge_dirname", DEF_MERGE_DIRNAME)
+    merge_prefix = args.merge_prefix or cfg_get_str(cfg, "general", "merge_prefix", DEF_MERGE_PREFIX)
+    encoding = args.encoding or cfg_get_str(cfg, "general", "encoding", DEF_ENCODING)
+    search_depth = args.search_depth if args.search_depth is not None else cfg_get_int(cfg, "general", "max_search_depth", DEF_SRCH_DEPTH)
+    max_tree_depth = args.max_tree_depth if args.max_tree_depth is not None else None
+
+    aliases: dict[str, str] = {}
+    if cfg.has_section("aliases"):
+        for k, v in cfg.items("aliases"):
+            aliases[k] = v
+
+    src, src_info = extract_source_path(
+        [args.src_flag] + args.rest if args.src_flag else args.rest,
+        aliases=aliases,
+        search_depth=search_depth,
     )
+    if not src:
+        print("❌ Quelle fehlt/unerkannt. Übergib Pfad/URL/Basename oder setze WGX_SOURCE. (-h für Hilfe)")
+        return 2
+    if not safe_is_dir(src):
+        print(f"❌ Quelle nicht gefunden oder kein Ordner: {src}")
+        return 1
 
-    # Führe den Merge-Prozess mit den übergebenen Kommandozeilenargumenten aus
-    return merger.run(sys.argv[1:])
+    script_root = Path(__file__).resolve().parent
+    merge_dir = ensure_dir(script_root / merge_dirname)
+
+    # Dateiname: <merge_prefix>_DDMM(.md) + Kollision-Handling
+    base_name = merge_prefix.rstrip("_")
+    out_file = make_output_filename(merge_dir, base_name=base_name)
+
+    do_merge(
+        src,
+        out_file,
+        encoding=encoding,
+        keep=keep,
+        merge_dir=merge_dir,
+        merge_prefix=merge_prefix,
+        max_tree_depth=max_tree_depth,
+        search_info=src_info,
+    )
+    return 0
+
+
+def _safe_main():
+    try:
+        rc = main(sys.argv[1:])
+    except SystemExit as e:
+        rc = int(getattr(e, "code", 1) or 0)
+    except Exception as e:
+        print(f"__WGX_MERGER_ERR__: {e}")
+        rc = 1
+    if _running_in_shortcuts():
+        if rc != 0:
+            print(f"__WGX_MERGER_WARN__: Exit {rc}")
+        print("__WGX_MERGER_OK__")
+    else:
+        sys.exit(rc)
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    _safe_main()


### PR DESCRIPTION
Updated `hauski-merger`, `weltgewebe-merger` (repo-merger), and `wgx-merger` to use the new standalone implementation suitable for iOS Shortcuts. Added `repomergers/repomerger.py` as a generic multi-repo merger. These scripts no longer depend on `ordnermergers` libraries.