### PR TITLE
tools: Fix repomerger syntax highlighting and jsonl-validate performance

### DIFF
--- a/repomergers/repomerger.py
+++ b/repomergers/repomerger.py
@@ -134,6 +134,14 @@ CONFIG_FILENAMES = {
 
 DOC_EXTENSIONS = {".md", ".rst", ".txt"}
 
+LANG_MAP = {
+    "py": "python", "js": "javascript", "ts": "typescript", "html": "html", "css": "css",
+    "scss": "scss", "sass": "sass", "json": "json", "xml": "xml", "yaml": "yaml", "yml": "yaml",
+    "md": "markdown", "sh": "bash", "bat": "batch", "sql": "sql", "php": "php", "cpp": "cpp",
+    "c": "c", "java": "java", "cs": "csharp", "go": "go", "rs": "rust", "rb": "ruby",
+    "swift": "swift", "kt": "kotlin", "svelte": "svelte",
+}
+
 SOURCE_EXTENSIONS = {
     ".py",
     ".rs",
@@ -235,6 +243,11 @@ def compute_md5(path, limit_bytes=None):
         return h.hexdigest()
     except OSError:
         return "ERROR"
+
+
+def lang_for(ext):
+    """Ermittelt die Sprache für Markdown-Blöcke anhand der Endung."""
+    return LANG_MAP.get(ext.lower().lstrip("."), "")
 
 
 def classify_category(rel_path, ext):
@@ -562,7 +575,7 @@ def write_report(files, level, max_file_bytes, output_path, sources,
                 lines.append("")
                 continue
 
-            lines.append("```")
+            lines.append("```{0}".format(lang_for(fi.ext)))
             lines.append(content.rstrip("\n"))
             lines.append("```")
             lines.append("")

--- a/scripts/jsonl-validate.sh
+++ b/scripts/jsonl-validate.sh
@@ -5,7 +5,7 @@ usage() {
 jsonl-validate.sh
 
 Validates every non-empty line as standalone JSON object against a JSON Schema (draft 2020-12).
-Requires: node + npx (ajv-cli@5)
+Requires: node + npm
 USAGE
 }
 [[ $# -ge 2 ]] || { usage >&2; exit 2; }
@@ -20,26 +20,87 @@ while [[ $# -gt 0 ]]; do
  esac
  shift
 done
+
 command -v node >/dev/null || { echo "node required" >&2; exit 127; }
-CMD="npx --yes ajv-cli@5 validate --spec=draft2020 --all-errors"
-[[ "$STRICT" == "true" ]] && CMD="$CMD --strict=true" || CMD="$CMD --strict=false"
-[[ "$FORMATS" == "true" ]] && CMD="$CMD --validate-formats=true" || CMD="$CMD --validate-formats=false"
+command -v npm >/dev/null || { echo "npm required" >&2; exit 127; }
+
 shopt -s nullglob
 mapfile -t FILES < <(compgen -G "$PATTERN" || true)
 (( ${#FILES[@]} )) || { echo "no files match: $PATTERN" >&2; exit 1; }
-fails=0
-for f in "${FILES[@]}"; do
- echo "==> $f"
- line=0
- while IFS= read -r ln || [[ -n "$ln" ]]; do
- line=$((line+1))
- [[ -n "${ln//[[:space:]]/}" ]] || continue
- tmp="$(mktemp -t ajv-XXXX.json)"; printf '%s\n' "$ln" >"$tmp"
- if ! bash -c "$CMD -s \"$SCHEMA\" -d \"$tmp\" >/dev/null"; then
- echo "::error file=$f,line=$line::validation failed"
- fails=1
- fi
- rm -f "$tmp"
- done < "$f"
-done
-exit $fails
+
+# Setup temporary environment for validation script
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# Copy schema to work dir to avoid path issues
+cp "$SCHEMA" "$WORK_DIR/schema.json"
+SCHEMA_PATH="$WORK_DIR/schema.json"
+
+# Create the JS validator script
+cat <<'JS' > "$WORK_DIR/validate.js"
+const fs = require('fs');
+const Ajv2020 = require('ajv/dist/2020');
+const addFormats = require('ajv-formats');
+
+const schemaPath = process.argv[2];
+const strictMode = process.argv[3] === 'true';
+const validateFormats = process.argv[4] === 'true';
+const files = process.argv.slice(5);
+
+try {
+    const schemaContent = fs.readFileSync(schemaPath, 'utf8');
+    const schema = JSON.parse(schemaContent);
+
+    const ajv = new Ajv2020({ allErrors: true, strict: strictMode });
+    if (validateFormats) {
+        addFormats(ajv);
+    }
+    const validate = ajv.compile(schema);
+
+    let fails = 0;
+
+    files.forEach(file => {
+        console.log("==> " + file);
+        try {
+            const content = fs.readFileSync(file, 'utf8');
+            const lines = content.split('\n');
+            lines.forEach((line, index) => {
+                if (!line.trim()) return;
+                try {
+                    const data = JSON.parse(line);
+                    const valid = validate(data);
+                    if (!valid) {
+                        console.error(`::error file=${file},line=${index + 1}::validation failed`);
+                        validate.errors.forEach(err => {
+                             console.error(`  ${err.instancePath} ${err.message}`);
+                        });
+                        fails = 1;
+                    }
+                } catch (e) {
+                    console.error(`::error file=${file},line=${index + 1}::invalid json: ${e.message}`);
+                    fails = 1;
+                }
+            });
+        } catch (e) {
+             console.error(`::error file=${file}::could not read file: ${e.message}`);
+             fails = 1;
+        }
+    });
+
+    process.exit(fails);
+} catch (e) {
+    console.error("Fatal error:", e);
+    process.exit(1);
+}
+JS
+
+# Install dependencies quietly
+pushd "$WORK_DIR" >/dev/null
+# Initialize package.json to avoid warnings
+echo '{}' > package.json
+# Install ajv and ajv-formats
+npm install --silent --no-audit --no-fund ajv ajv-formats >/dev/null 2>&1
+popd >/dev/null
+
+# Run the validation
+NODE_PATH="$WORK_DIR/node_modules" node "$WORK_DIR/validate.js" "$SCHEMA_PATH" "$STRICT" "$FORMATS" "${FILES[@]}"


### PR DESCRIPTION
- Add missing `LANG_MAP` to `repomergers/repomerger.py` to enable syntax highlighting in generated markdown reports.
- Optimize `scripts/jsonl-validate.sh` by using a temporary Node.js environment with `ajv` installed once, instead of `npx` per line, reducing runtime from O(N) overhead to O(1) setup.