### PR TITLE
tools: Upgrade wc-merger to match repomerger capabilities

### DIFF
--- a/wc-merger/merge_core.py
+++ b/wc-merger/merge_core.py
@@ -1,60 +1,189 @@
 # -*- coding: utf-8 -*-
+
+"""
+merge_core – Core functions for wc-merger / wc-extractor.
+Compatible with Pythonista and standard Python environments.
+"""
+
 import os
-import datetime
 import hashlib
-import fnmatch
+import datetime
 from pathlib import Path
+from typing import List, Dict, Optional, Tuple, Set
 
-# --- Constants & Configuration ---
+# --- Configuration & Heuristics (from repomerger) ---
 
+MERGES_DIR_NAME = "merges"
+DEFAULT_MAX_BYTES = 10_000_000  # 10 MB
+
+# Directories to ignore
 SKIP_DIRS = {
-    ".git", ".idea", ".vscode", "node_modules", ".svelte-kit", ".next",
-    "dist", "build", "target", ".venv", "venv", "__pycache__", ".pytest_cache",
-    ".DS_Store", "coverage", ".tox", ".mypy_cache", "site-packages"
+    ".git",
+    ".idea",
+    "node_modules",
+    ".svelte-kit",
+    ".next",
+    "dist",
+    "build",
+    "target",
+    ".venv",
+    "venv",
+    "__pycache__",
+    ".pytest_cache",
+    ".DS_Store",
 }
 
+# Top-level roots to skip in auto-discovery
+SKIP_ROOTS = {
+    MERGES_DIR_NAME,
+    "merge",
+    "output",
+    "out",
+}
+
+# Individual files to ignore
 SKIP_FILES = {
-    ".DS_Store", "Thumbs.db", ".directory"
+    ".DS_Store",
 }
 
-# Files that should be treated as sensitive and NOT embedded in content
-SENSITIVE_PATTERNS = {
-    ".env", ".env.*", "*.key", "*.pem", "*.p12", "id_rsa", "id_dsa",
-    "secrets.*", "*.kdbx", "*.pfx", ".npmrc", ".pypirc",
-    "credentials", "token", "api_key"
-}
-
-# Whitelist for .env files that are safe
-SAFE_ENV_FILES = {
-    ".env.example", ".env.template", ".env.sample", ".env.defaults"
-}
-
+# Extensions considered text
 TEXT_EXTENSIONS = {
-    ".md", ".txt", ".rst", ".py", ".rs", ".ts", ".tsx", ".js", ".jsx",
-    ".json", ".jsonl", ".yml", ".yaml", ".toml", ".ini", ".cfg", ".conf",
-    ".sh", ".bash", ".zsh", ".fish", ".dockerfile", "dockerfile",
-    ".svelte", ".css", ".scss", ".less", ".html", ".htm", ".xml", ".csv",
-    ".log", ".lock", ".properties", ".gradle", ".groovy", ".kt", ".kts",
-    ".java", ".c", ".cpp", ".h", ".hpp", ".go", ".rb", ".php", ".pl",
-    ".lua", ".sql", ".bat", ".cmd", ".ps1", ".make", "makefile", "justfile",
-    ".tf", ".hcl", ".gitignore", ".gitattributes", ".editorconfig"
+    ".md",
+    ".txt",
+    ".rst",
+    ".py",
+    ".rs",
+    ".ts",
+    ".tsx",
+    ".js",
+    ".jsx",
+    ".json",
+    ".jsonl",
+    ".yml",
+    ".yaml",
+    ".toml",
+    ".ini",
+    ".cfg",
+    ".conf",
+    ".sh",
+    ".bash",
+    ".zsh",
+    ".fish",
+    ".dockerfile",
+    "dockerfile",
+    ".svelte",
+    ".css",
+    ".scss",
+    ".html",
+    ".htm",
+    ".xml",
+    ".csv",
+    ".log",
+    ".lock",   # e.g. Cargo.lock, pnpm-lock.yaml
+    ".bats",   # added based on feedback
+    ".properties",
+    ".gradle",
+    ".groovy",
+    ".kt",
+    ".kts",
+    ".java",
+    ".c",
+    ".cpp",
+    ".h",
+    ".hpp",
+    ".go",
+    ".rb",
+    ".php",
+    ".pl",
+    ".lua",
+    ".sql",
+    ".bat",
+    ".cmd",
+    ".ps1",
+    ".make",
+    "makefile",
+    "justfile",
+    ".tf",
+    ".hcl",
+    ".gitignore",
+    ".gitattributes",
+    ".editorconfig"
 }
 
-# Mapping extensions to Markdown language identifiers
+# Files typically considered configuration
+CONFIG_FILENAMES = {
+    "pyproject.toml",
+    "package.json",
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "Cargo.toml",
+    "Cargo.lock",
+    "requirements.txt",
+    "Pipfile",
+    "Pipfile.lock",
+    "poetry.lock",
+    "Dockerfile",
+    "docker-compose.yml",
+    "docker-compose.yaml",
+    "Justfile",
+    "Makefile",
+    "toolchain.versions.yml",
+    ".editorconfig",
+    ".markdownlint.jsonc",
+    ".markdownlint.yaml",
+    ".yamllint",
+    ".yamllint.yml",
+    ".lychee.toml",
+    ".vale.ini",
+    ".pre-commit-config.yaml",
+    ".gitignore",
+    ".gitmodules",
+}
+
+DOC_EXTENSIONS = {".md", ".rst", ".txt", ".adoc"}
+
+SOURCE_EXTENSIONS = {
+    ".py",
+    ".rs",
+    ".ts",
+    ".tsx",
+    ".js",
+    ".jsx",
+    ".svelte",
+    ".c",
+    ".cpp",
+    ".h",
+    ".hpp",
+    ".go",
+    ".java",
+    ".cs",
+    ".rb",
+    ".php",
+    ".swift",
+    ".kt",
+    ".sh",
+    ".bash"
+}
+
 LANG_MAP = {
-    "py": "python", "js": "javascript", "ts": "typescript", "html": "html",
-    "css": "css", "scss": "scss", "sass": "sass", "json": "json", "xml": "xml",
-    "yaml": "yaml", "yml": "yaml", "md": "markdown", "sh": "bash", "bat": "batch",
-    "sql": "sql", "php": "php", "cpp": "cpp", "c": "c", "java": "java",
-    "cs": "csharp", "go": "go", "rs": "rust", "rb": "ruby", "swift": "swift",
-    "kt": "kotlin", "svelte": "svelte", "toml": "toml", "ini": "ini",
-    "dockerfile": "dockerfile", "tf": "hcl", "hcl": "hcl"
+    "py": "python", "js": "javascript", "ts": "typescript", "html": "html", "css": "css",
+    "scss": "scss", "sass": "sass", "json": "json", "xml": "xml", "yaml": "yaml", "yml": "yaml",
+    "md": "markdown", "sh": "bash", "bat": "batch", "sql": "sql", "php": "php", "cpp": "cpp",
+    "c": "c", "java": "java", "cs": "csharp", "go": "go", "rs": "rust", "rb": "ruby",
+    "swift": "swift", "kt": "kotlin", "svelte": "svelte", "toml": "toml", "ini": "ini",
+    "dockerfile": "dockerfile", "tf": "hcl", "hcl": "hcl", "bats": "bash"
 }
 
-# --- Data Structures ---
+# Hardcoded path for Pythonista environment (wc-hub location)
+HARDCODED_HUB_PATH = (
+    "/private/var/mobile/Containers/Data/Application/"
+    "B60D0157-973D-489A-AA59-464C3BF6D240/Documents/wc-hub"
+)
 
-class FileInfo:
-    def __init__(self, root_label, abs_path, rel_path, size, is_text, md5, category, ext, flags=None):
+
+class FileInfo(object):
+    """Container for file metadata."""
+    def __init__(self, root_label, abs_path, rel_path, size, is_text, md5, category, ext, skipped=False, reason=None, content=None):
         self.root_label = root_label
         self.abs_path = abs_path
         self.rel_path = rel_path
@@ -63,9 +192,61 @@ class FileInfo:
         self.md5 = md5
         self.category = category
         self.ext = ext
-        self.flags = flags or []
+        self.skipped = skipped
+        self.reason = reason
+        self.content = content  # Can be pre-loaded or loaded on demand
 
-# --- Core Logic ---
+
+# --- Utilities ---
+
+def detect_hub_dir(script_path: Path, arg_base_dir: Optional[str] = None) -> Path:
+    """
+    Determines the base directory (Hub) for repos.
+    Priority:
+    1. ENV WC_MERGER_BASEDIR
+    2. HARDCODED_HUB_PATH (Pythonista specific)
+    3. CLI argument
+    4. Fallback: Script's parent directory
+    """
+    # 1. ENV
+    env_base = os.environ.get("WC_MERGER_BASEDIR")
+    if env_base:
+        p = Path(env_base).expanduser()
+        try:
+            p = p.resolve()
+        except Exception:
+            pass
+        if p.is_dir():
+            return p
+
+    # 2. Hardcoded
+    p = Path(HARDCODED_HUB_PATH)
+    try:
+        p = p.expanduser().resolve()
+    except Exception:
+        pass
+    if p.is_dir():
+        return p
+
+    # 3. CLI Arg
+    if arg_base_dir:
+        p = Path(arg_base_dir).expanduser()
+        try:
+            p = p.resolve()
+        except Exception:
+            pass
+        if p.is_dir():
+            return p
+
+    # 4. Fallback
+    return script_path.parent
+
+
+def get_merges_dir(hub: Path) -> Path:
+    merges = hub / MERGES_DIR_NAME
+    merges.mkdir(parents=True, exist_ok=True)
+    return merges
+
 
 def human_size(n):
     size = float(n)
@@ -75,26 +256,14 @@ def human_size(n):
         size /= 1024.0
     return "{0:.2f} GB".format(size)
 
-def is_sensitive(filename):
-    if filename in SAFE_ENV_FILES:
-        return False
-    for pattern in SENSITIVE_PATTERNS:
-        if fnmatch.fnmatch(filename, pattern):
-            return True
-    return False
 
 def is_probably_text(path, size):
     name = path.name.lower()
-    if is_sensitive(name):
-        # Sensitive files are text-like usually, but handled separately.
-        # Here we just want to know if it's binary or text for classification.
-        pass
-
-    if path.suffix.lower() in TEXT_EXTENSIONS or name in TEXT_EXTENSIONS:
+    base, ext = os.path.splitext(name)
+    if ext in TEXT_EXTENSIONS or name in TEXT_EXTENSIONS:
         return True
 
-    # Large unknown files -> binary
-    if size > 10 * 1024 * 1024:
+    if size > 20 * 1024 * 1024:  # 20 MiB
         return False
 
     try:
@@ -108,6 +277,7 @@ def is_probably_text(path, size):
     if b"\x00" in chunk:
         return False
     return True
+
 
 def compute_md5(path, limit_bytes=None):
     h = hashlib.md5()
@@ -130,135 +300,137 @@ def compute_md5(path, limit_bytes=None):
     except OSError:
         return "ERROR"
 
-def classify_category(rel_path):
+
+def lang_for(ext):
+    return LANG_MAP.get(ext.lower().lstrip("."), "")
+
+
+def classify_category(rel_path, ext):
+    name = rel_path.name
+    if name in CONFIG_FILENAMES:
+        return "config"
+    if ext in DOC_EXTENSIONS:
+        return "doc"
+    if ext in SOURCE_EXTENSIONS:
+        return "source"
     parts = [p.lower() for p in rel_path.parts]
-    name = rel_path.name.lower()
-    ext = rel_path.suffix.lower()
-
-    # CI
-    if ".github" in parts or ".gitlab" in parts or ".circleci" in parts:
-        return "ci"
-    if name in ("dockerfile", "docker-compose.yml", "docker-compose.yaml", "justfile", "makefile"):
-        return "ci"
-
-    # Config
-    if name in ("package.json", "package-lock.json", "pyproject.toml", "cargo.toml", "go.mod", "pom.xml", "requirements.txt"):
-        return "config"
-    if ext in (".ini", ".cfg", ".conf", ".toml", ".yaml", ".yml", ".json"):
-        # Could be config or data. If in 'config' dir, definitely config.
-        if "config" in parts or "conf" in parts or "settings" in parts:
+    for p in parts:
+        if p in ("config", "configs", "settings", "etc", ".github"):
             return "config"
-        # Otherwise, keep looking or default to config for now?
-        # Let's say generic json/yaml is config unless other heuristic applies.
-        return "config"
-
-    # Doc
     if "docs" in parts or "doc" in parts:
         return "doc"
-    if ext in (".md", ".rst", ".adoc", ".txt") or name.startswith("readme"):
-        return "doc"
 
-    # Test
-    if "test" in parts or "tests" in parts or "spec" in parts or "specs" in parts:
-        return "test"
-    if name.startswith("test_") or name.endswith("_test.py") or name.endswith(".test.ts") or name.endswith(".spec.ts"):
-        return "test"
-
-    # Contract
-    if "contracts" in parts or "contract" in parts or "proto" in parts or "schemas" in parts:
+    # Enhanced categorization based on feedback
+    if "contracts" in parts or "contract" in parts or "schemas" in parts:
         return "contract"
-    if ext in (".proto", ".graphql", ".gql"):
-        return "contract"
-
-    # Source
-    if ext in (".py", ".rs", ".ts", ".tsx", ".js", ".jsx", ".go", ".java", ".c", ".cpp", ".h", ".hpp", ".cs", ".rb", ".php", ".swift", ".kt", ".sh"):
-        return "source"
+    if "scripts" in parts:
+        return "source" # or 'script'? repomerger puts scripts in source if .sh
+    if "tests" in parts or "test" in parts or name.endswith("_test.py") or name.startswith("test_"):
+        return "test"
 
     return "other"
 
-def is_compact_match(rel_path, category):
-    """
-    Determines if a file should be included in 'Compact' mode.
-    Focus: Core artifacts, READMEs, Docs, Contracts, central scripts/tests.
-    """
-    parts = rel_path.parts
-    name = rel_path.name.lower()
-    path_str = str(rel_path).lower()
 
-    # Always include READMEs and key root files
-    if name.startswith("readme") or name in ("changelog.md", "contributing.md", "license"):
-        return True
+def _normalize_ext_list(ext_text: str) -> List[str]:
+    if not ext_text:
+        return []
+    parts = [p.strip() for p in ext_text.split(",")]
+    cleaned: List[str] = []
+    for p in parts:
+        if not p:
+            continue
+        if not p.startswith("."):
+            p = "." + p
+        cleaned.append(p.lower())
+    return cleaned
 
-    # Always include CI workflows
-    if ".github/workflows" in path_str:
-        return True
 
-    # Always include Contracts/Schemas
-    if category == "contract":
-        return True
-    if "contracts" in parts or "schemas" in parts:
-        return True
+# --- Repo Scan Logic ---
 
-    # Include key package definitions
-    if name in ("package.json", "cargo.toml", "pyproject.toml", "go.mod", "pom.xml"):
-        return True
-
-    # Include central scripts (but not everything)
-    if "scripts" in parts and len(parts) <= 3: # heuristics for top-level scripts
-        return True
-
-    # Runbooks / ADRs
-    if "runbook" in path_str or "adr" in path_str:
-        return True
-
-    # Entry points for tests (heuristics)
-    if category == "test":
-        if name in ("run_tests.sh", "conftest.py"):
-            return True
-
-    return False
-
-def scan_repo(repo_path, root_label, max_file_bytes):
-    repo_path = Path(repo_path).resolve()
+def scan_repo(repo_root: Path, extensions: Optional[List[str]], path_contains: Optional[str], max_bytes: int) -> Dict:
+    repo_root = repo_root.resolve()
+    root_label = repo_root.name
     files = []
 
-    for dirpath, dirnames, filenames in os.walk(str(repo_path)):
+    ext_filter = set(e.lower() for e in extensions) if extensions else None
+    path_filter = path_contains.strip() if path_contains else None
+
+    total_files = 0
+    total_bytes = 0
+    ext_hist: Dict[str, int] = {}
+    max_file_size = 0
+    max_file: Optional[str] = None
+
+    for dirpath, dirnames, filenames in os.walk(str(repo_root)):
         # Filter directories
-        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS and not d.startswith(".")]
+        keep_dirs = []
+        for d in dirnames:
+            if d in SKIP_DIRS:
+                continue
+            keep_dirs.append(d)
+        dirnames[:] = keep_dirs
 
         for fn in filenames:
             if fn in SKIP_FILES:
                 continue
 
+            # Skip .env except examples
+            if fn.startswith(".env") and fn not in (".env.example", ".env.template", ".env.sample"):
+                continue
+
             abs_path = Path(dirpath) / fn
-            rel_path = abs_path.relative_to(repo_path)
+            rel_path = abs_path.relative_to(repo_root)
+            rel_path_str = rel_path.as_posix()
+
+            # Path filter
+            if path_filter and path_filter not in rel_path_str:
+                continue
+
+            # Extension filter
+            ext = abs_path.suffix.lower()
+            if ext_filter is not None and ext not in ext_filter:
+                continue
 
             try:
                 st = abs_path.stat()
-                size = st.st_size
             except OSError:
                 continue
 
-            flags = []
+            size = st.st_size
+            total_files += 1
+            total_bytes += size
 
-            if is_sensitive(fn):
-                flags.append("sensitive")
+            ext_hist[ext] = ext_hist.get(ext, 0) + 1
+
+            if size > max_file_size:
+                max_file_size = size
+                max_file = rel_path_str
 
             is_text = is_probably_text(abs_path, size)
-            if not is_text:
-                flags.append("binary")
+            category = classify_category(rel_path, ext)
 
-            # Checkmd5 for all files? For large files, maybe skip or limit?
-            # repomerger limits md5 to limit_bytes if text or small enough.
-            if is_text or size <= max_file_bytes:
-                md5 = compute_md5(abs_path, max_file_bytes)
+            # MD5 calculation
+            if is_text or size <= max_bytes:
+                md5 = compute_md5(abs_path, max_bytes)
             else:
                 md5 = ""
 
-            category = classify_category(rel_path)
-            ext = abs_path.suffix.lower()
+            skipped = False
+            reason = None
+            content = None
 
-            files.append(FileInfo(
+            if size > max_bytes and is_text:
+                # We will handle truncation during reporting, but mark it here?
+                # Actually repomerger logic handles content reading separately or on demand.
+                # For compatibility with wc-merger provided logic which reads content immediately (in pythonista version),
+                # we can choose strategy. But repomerger reads on demand in write_report to be cleaner.
+                # HOWEVER, the pythonista `scan_repo` in the prompt read content eagerly.
+                # "Inhalt laden" ...
+                # Let's use lazy loading (store path) for efficiency unless we need it eagerly.
+                # Given we are "merging" logic, let's stick to repomerger's robust style: store metadata, read later.
+                pass
+
+            fi = FileInfo(
                 root_label=root_label,
                 abs_path=abs_path,
                 rel_path=rel_path,
@@ -266,27 +438,58 @@ def scan_repo(repo_path, root_label, max_file_bytes):
                 is_text=is_text,
                 md5=md5,
                 category=category,
-                ext=ext,
-                flags=flags
-            ))
+                ext=ext
+            )
+            files.append(fi)
 
-    files.sort(key=lambda x: (x.root_label, str(x.rel_path)))
-    return files
+    files.sort(key=lambda fi: (fi.root_label.lower(), str(fi.rel_path).lower()))
 
-def build_tree_text(file_infos):
+    return {
+        "root": repo_root,
+        "name": root_label,
+        "files": files,
+        "total_files": total_files,
+        "total_bytes": total_bytes,
+        "ext_hist": ext_hist,
+        "max_file": max_file,
+        "max_file_size": max_file_size,
+    }
+
+
+# --- Reporting Logic (Repomerger Style) ---
+
+def summarize_extensions(file_infos):
+    counts = {}
+    sizes = {}
+    for fi in file_infos:
+        ext = fi.ext or "<none>"
+        counts[ext] = counts.get(ext, 0) + 1
+        sizes[ext] = sizes.get(ext, 0) + fi.size
+    return counts, sizes
+
+def summarize_categories(file_infos):
+    stats = {}
+    for fi in file_infos:
+        cat = fi.category or "other"
+        if cat not in stats:
+            stats[cat] = [0, 0]
+        stats[cat][0] += 1
+        stats[cat][1] += fi.size
+    return stats
+
+def build_tree(file_infos):
     by_root = {}
     for fi in file_infos:
         by_root.setdefault(fi.root_label, []).append(fi.rel_path)
 
-    lines = []
+    lines = ["```"]
     for root in sorted(by_root.keys()):
         rels = by_root[root]
         lines.append(f"📁 {root}/")
 
-        # Build a nested dict tree
         tree = {}
         for r in rels:
-            parts = r.parts
+            parts = list(r.parts)
             node = tree
             for p in parts:
                 if p not in node:
@@ -309,126 +512,197 @@ def build_tree_text(file_infos):
 
         walk(tree, "    ")
 
+    lines.append("```")
     return "\n".join(lines)
 
-def generate_report(sources, file_infos, level, max_file_bytes, encoding="utf-8"):
+def make_output_filename(merges_dir: Path, repo_names: List[str], mode: str, detail: str) -> Path:
+    ts = datetime.datetime.now().strftime("%y%m%d-%H%M%S")
+    if not repo_names:
+        base = "no-repos"
+    else:
+        base = "+".join(repo_names)
+        if len(base) > 40:
+            base = base[:37] + "..."
+    # Sanitize base
+    base = base.replace(" ", "-").replace("/", "_")
+
+    fname = f"merge_{mode}_{base}_{detail}_{ts}.md"
+    return merges_dir / fname
+
+def generate_report_content(files: List[FileInfo], level: str, max_file_bytes: int, sources: List[Path], plan_only: bool, encoding="utf-8") -> str:
     now = datetime.datetime.now()
+
+    total_size = sum(fi.size for fi in files)
+    text_files = [fi for fi in files if fi.is_text]
+    binary_files = [fi for fi in files if not fi.is_text]
+
+    if level == "overview":
+        planned_with_content = 0
+    elif level == "summary":
+        planned_with_content = sum(1 for fi in text_files if fi.size <= max_file_bytes)
+    else:  # full / max
+        planned_with_content = len(text_files)
+
+    ext_counts, ext_sizes = summarize_extensions(files)
+    cat_stats = summarize_categories(files)
+
     lines = []
 
-    # Filter logic for content inclusion
-    # Plan: No content
-    # Compact: Content for specific important files
-    # Max: Content for all text files (truncated if too large)
-
-    files_with_content = []
-    if level != "plan":
-        for fi in file_infos:
-            if not fi.is_text:
-                continue
-            if "sensitive" in fi.flags:
-                continue
-
-            if level == "compact":
-                if is_compact_match(fi.rel_path, fi.category):
-                    files_with_content.append(fi)
-            elif level == "max":
-                files_with_content.append(fi)
-
-    # Statistics
-    total_files = len(file_infos)
-    text_files_count = sum(1 for f in file_infos if f.is_text)
-    binary_files_count = total_files - text_files_count
-    total_size = sum(f.size for f in file_infos)
-
-    cat_stats = {}
-    for fi in file_infos:
-        c = fi.category
-        if c not in cat_stats:
-            cat_stats[c] = [0, 0] # count, size
-        cat_stats[c][0] += 1
-        cat_stats[c][1] += fi.size
-
-    # --- Header ---
-    lines.append("# wc-merge Report")
+    # Header
+    lines.append("# WC-Merge Report")
     lines.append("")
     lines.append(f"**Date:** {now.strftime('%Y-%m-%d %H:%M:%S')}")
-    lines.append("**Sources:**")
-    for s in sources:
-        lines.append(f"- `{s}`")
+    if sources:
+        lines.append("**Sources:**")
+        for src in sources:
+            lines.append(f"- `{src}`")
     lines.append(f"**Level:** `{level}`")
     lines.append(f"**Max File Bytes:** {human_size(max_file_bytes)}")
     lines.append("")
 
-    # --- Plan ---
+    lines.append("> Note for AIs:")
+    lines.append("> - This is a file system snapshot.")
+    lines.append("> - Tree: `## 📁 Structure`.")
+    lines.append("> - Manifest: `## 🧾 Manifest`.")
+    if level == "overview":
+        lines.append("> - No file contents included.")
+    elif level == "summary":
+        lines.append("> - Includes content for small text files only.")
+    else:
+        lines.append("> - Includes content for all text files (truncated if too large).")
+    lines.append("")
+
+    # Plan
     lines.append("## 🧮 Plan")
     lines.append("")
-    lines.append(f"- **Total Files:** {total_files}")
-    lines.append(f"- **Text Files:** {text_files_count}")
-    lines.append(f"- **Binary Files:** {binary_files_count}")
-    lines.append(f"- **Total Size:** {human_size(total_size)}")
-    lines.append(f"- **Files with Content:** {len(files_with_content)}")
+    lines.append(f"- Total Files: **{len(files)}**")
+    lines.append(f"- Text Files: **{len(text_files)}**")
+    lines.append(f"- Binary Files: **{len(binary_files)}**")
+    lines.append(f"- Files with content: **{planned_with_content}**")
+    lines.append(f"- Total Size: **{human_size(total_size)}**")
     lines.append("")
 
-    lines.append("| Category | Files | Size |")
-    lines.append("| --- | ---: | ---: |")
-    for cat in sorted(cat_stats.keys()):
-        cnt, sz = cat_stats[cat]
-        lines.append(f"| `{cat}` | {cnt} | {human_size(sz)} |")
-    lines.append("")
+    if cat_stats:
+        lines.append("**Files by Category:**")
+        lines.append("")
+        lines.append("| Category | Files | Size |")
+        lines.append("| --- | ---: | ---: |")
+        for cat in sorted(cat_stats.keys()):
+            cnt, sz = cat_stats[cat]
+            lines.append(f"| `{cat}` | {cnt} | {human_size(sz)} |")
+        lines.append("")
 
-    # --- Structure ---
+    if ext_counts:
+        lines.append("**Extensions:**")
+        lines.append("")
+        lines.append("| Ext | Files | Size |")
+        lines.append("| --- | ---: | ---: |")
+        for ext in sorted(ext_counts.keys()):
+            lines.append(f"| `{ext}` | {ext_counts[ext]} | {human_size(ext_sizes[ext])} |")
+        lines.append("")
+
+    if plan_only:
+        return "\n".join(lines)
+
+    # Structure
     lines.append("## 📁 Structure")
     lines.append("")
-    lines.append("```")
-    lines.append(build_tree_text(file_infos))
-    lines.append("```")
+    lines.append(build_tree(files))
     lines.append("")
 
-    # --- Manifest ---
+    # Manifest
     lines.append("## 🧾 Manifest")
     lines.append("")
-    lines.append("| Root | Path | Category | Type | Size | Hash | Flags |")
-    lines.append("| --- | --- | --- | --- | ---: | --- | --- |")
-    for fi in file_infos:
-        ftype = "text" if fi.is_text else "bin"
-        flag_str = ", ".join(fi.flags) if fi.flags else "-"
-        lines.append(f"| `{fi.root_label}` | `{fi.rel_path}` | `{fi.category}` | {ftype} | {human_size(fi.size)} | `{fi.md5}` | {flag_str} |")
+    lines.append("| Root | Path | Category | Text | Size | MD5 |")
+    lines.append("| --- | --- | --- | --- | ---: | --- |")
+    for fi in files:
+        lines.append(
+            f"| `{fi.root_label}` | `{fi.rel_path}` | `{fi.category}` | {'yes' if fi.is_text else 'no'} | {human_size(fi.size)} | `{fi.md5}` |"
+        )
     lines.append("")
 
-    # --- Content ---
-    if level != "plan":
+    # Content
+    if level != "overview":
         lines.append("## 📄 Content")
         lines.append("")
-        for fi in files_with_content:
+        for fi in files:
+            if not fi.is_text:
+                continue
+
+            if level == "summary" and fi.size > max_file_bytes:
+                continue
+
             lines.append(f"### `{fi.root_label}/{fi.rel_path}`")
             lines.append("")
 
             truncated = False
             content = ""
-            try:
-                with fi.abs_path.open("r", encoding=encoding, errors="replace") as f:
-                    if fi.size > max_file_bytes:
-                        content = f.read(max_file_bytes)
-                        truncated = True
-                    else:
-                        content = f.read()
-            except Exception as e:
-                lines.append(f"_Error reading file: {e}_")
-                lines.append("")
-                continue
+
+            # If content was preloaded (Pythonista style from prompt), use it
+            if fi.content is not None:
+                content = fi.content
+                # Check length if we need to simulate truncation?
+                # The prompt logic had truncation in 'scan_repo' via max_bytes.
+                # Here we handle it display-side if possible.
+            else:
+                # Lazy load
+                try:
+                    with fi.abs_path.open("r", encoding=encoding, errors="replace") as f:
+                        if fi.size > max_file_bytes:
+                            # If level is full/max, we show up to limit.
+                            content = f.read(max_file_bytes)
+                            truncated = True
+                        else:
+                            content = f.read()
+                except OSError as e:
+                    lines.append(f"_Error reading file: {e}_")
+                    lines.append("")
+                    continue
 
             if truncated:
-                lines.append(f"> ⚠️ **Truncated**: File size ({human_size(fi.size)}) exceeds limit ({human_size(max_file_bytes)}). Content is cut off.")
-                lines.append("")
+                 lines.append(f"**Note:** File > {human_size(max_file_bytes)}, content truncated.")
+                 lines.append("")
 
-            ext_key = fi.ext.lstrip(".").lower()
-            lang = LANG_MAP.get(ext_key, "")
-
+            lang = lang_for(fi.ext)
             lines.append(f"```{lang}")
-            lines.append(content)
+            lines.append(content.rstrip("\n"))
             if truncated:
                 lines.append("\n[... truncated ...]")
             lines.append("```")
             lines.append("")
 
     return "\n".join(lines)
+
+def write_reports(merges_dir: Path, hub: Path, repo_summaries: List[Dict], detail: str, mode: str, max_bytes: int, plan_only: bool) -> List[Path]:
+    """
+    Generates report files.
+    """
+    out_paths = []
+
+    # Flatten all files for 'gesamt' mode
+    all_files = []
+    repo_names = []
+
+    for s in repo_summaries:
+        all_files.extend(s["files"])
+        repo_names.append(s["name"])
+
+    sources = [s["root"] for s in repo_summaries]
+
+    if mode == "gesamt":
+        out_path = make_output_filename(merges_dir, repo_names, mode, detail)
+        content = generate_report_content(all_files, detail, max_bytes, sources, plan_only)
+        out_path.write_text(content, encoding="utf-8")
+        out_paths.append(out_path)
+
+    else: # pro-repo
+        for s in repo_summaries:
+            s_name = s["name"]
+            s_files = s["files"]
+            s_root = s["root"]
+            out_path = make_output_filename(merges_dir, [s_name], "repo", detail)
+            content = generate_report_content(s_files, detail, max_bytes, [s_root], plan_only)
+            out_path.write_text(content, encoding="utf-8")
+            out_paths.append(out_path)
+
+    return out_paths

--- a/wc-merger/wc-merger.py
+++ b/wc-merger/wc-merger.py
@@ -2,71 +2,442 @@
 # -*- coding: utf-8 -*-
 
 """
-wc-merger CLI tool.
-Generates structured merge reports from local repositories.
+wc-merger – Working-Copy Merger for Pythonista and CLI.
+
+Features:
+- Works directly on repositories in 'wc-hub'.
+- Interactive selection (Pythonista UI) or CLI arguments.
+- Generates structured Markdown reports (Plan, Structure, Manifest, Content).
+
+Usage (CLI):
+    ./wc-merger.py [repo_paths...] --level max --max-bytes 1000000
+
+Usage (Pythonista):
+    Run script, use UI.
 """
 
-import argparse
 import sys
 import os
+import traceback
 from pathlib import Path
-from merge_core import scan_repo, generate_report
+from typing import List
 
-def main():
-    parser = argparse.ArgumentParser(description="wc-merger: Generate structured merge reports for AI context.")
-    parser.add_argument("paths", nargs="*", help="Paths to repositories or directories to merge.")
-    parser.add_argument("--level", choices=["plan", "compact", "max"], default="compact", help="Detail level (default: compact).")
-    parser.add_argument("--max-bytes", type=int, default=500_000, help="Max bytes per file content (default: 500KB).")
-    parser.add_argument("--output", "-o", help="Output file path (default: stdout).")
-    parser.add_argument("--hub", help="Base path for 'wc-hub' if paths are relative names.")
+# Try importing Pythonista modules
+try:
+    import ui        # type: ignore
+    import console   # type: ignore
+    import editor    # type: ignore
+except ImportError:
+    ui = None        # type: ignore
+    console = None   # type: ignore
+    editor = None    # type: ignore
+
+# Import core logic
+try:
+    from merge_core import (
+        MERGES_DIR_NAME,
+        DEFAULT_MAX_BYTES,
+        detect_hub_dir,
+        get_merges_dir,
+        scan_repo,
+        write_reports,
+        _normalize_ext_list,
+    )
+except ImportError:
+    # Fallback if running from root without proper python path
+    sys.path.append(str(Path(__file__).parent))
+    from merge_core import (
+        MERGES_DIR_NAME,
+        DEFAULT_MAX_BYTES,
+        detect_hub_dir,
+        get_merges_dir,
+        scan_repo,
+        write_reports,
+        _normalize_ext_list,
+    )
+
+
+# --- Helper ---
+
+def find_repos_in_hub(hub: Path) -> List[str]:
+    repos: List[str] = []
+    if not hub.exists():
+        return []
+    for child in sorted(hub.iterdir(), key=lambda p: p.name.lower()):
+        if not child.is_dir():
+            continue
+        if child.name == MERGES_DIR_NAME:
+            continue
+        if child.name.startswith("."):
+            continue
+        repos.append(child.name)
+    return repos
+
+
+# --- UI Class (Pythonista) ---
+
+class MergerUI(object):
+    def __init__(self, hub: Path) -> None:
+        self.hub = hub
+        self.repos = find_repos_in_hub(hub)
+
+        v = ui.View()
+        v.name = "WC-Merger"
+        v.background_color = "#111111"
+        v.frame = (0, 0, 540, 620)
+        self.view = v
+
+        y = 10
+
+        base_label = ui.Label()
+        base_label.frame = (10, y, v.width - 20, 34)
+        base_label.flex = "W"
+        base_label.number_of_lines = 2
+        base_label.text = f"Base-Dir: {hub}"
+        base_label.text_color = "white"
+        base_label.background_color = "#000000"
+        base_label.font = ("<System>", 11)
+        v.add_subview(base_label)
+        self.base_label = base_label
+        y += 40
+
+        repo_label = ui.Label()
+        repo_label.frame = (10, y, v.width - 20, 20)
+        repo_label.flex = "W"
+        repo_label.text = "Repos (Tap to select – None = All):"
+        repo_label.text_color = "white"
+        repo_label.background_color = "#111111"
+        repo_label.font = ("<System>", 13)
+        v.add_subview(repo_label)
+        y += 22
+
+        tv = ui.TableView()
+        tv.frame = (10, y, v.width - 20, 160)
+        tv.flex = "W"
+        tv.background_color = "#111111"
+        tv.row_height = 32
+        tv.allows_multiple_selection = True
+
+        ds = ui.ListDataSource(self.repos)
+        tv.data_source = ds
+        tv.delegate = ds
+        v.add_subview(tv)
+        self.tv = tv
+        self.ds = ds
+
+        y += 170
+
+        ext_field = ui.TextField()
+        ext_field.frame = (10, y, v.width - 20, 28)
+        ext_field.flex = "W"
+        # FIXED: Default is empty (all files), not restricted
+        ext_field.placeholder = ".md,.yml,.rs (empty = all)"
+        ext_field.text = ""
+        ext_field.background_color = "#222222"
+        ext_field.text_color = "white"
+        ext_field.tint_color = "white"
+        ext_field.autocorrection_type = False
+        ext_field.spellchecking_type = False
+        v.add_subview(ext_field)
+        self.ext_field = ext_field
+
+        y += 34
+
+        path_field = ui.TextField()
+        path_field.frame = (10, y, v.width - 20, 28)
+        path_field.flex = "W"
+        path_field.placeholder = "Path contains (e.g. docs/ or .github/)"
+        path_field.background_color = "#222222"
+        path_field.text_color = "white"
+        path_field.tint_color = "white"
+        path_field.autocorrection_type = False
+        path_field.spellchecking_type = False
+        v.add_subview(path_field)
+        self.path_field = path_field
+
+        y += 36
+
+        detail_label = ui.Label()
+        detail_label.text = "Detail:"
+        detail_label.text_color = "white"
+        detail_label.background_color = "#111111"
+        detail_label.frame = (10, y, 60, 22)
+        v.add_subview(detail_label)
+
+        seg_detail = ui.SegmentedControl()
+        seg_detail.segments = ["overview", "summary", "max"]
+        seg_detail.selected_index = 2  # max
+        seg_detail.frame = (70, y - 2, 220, 28)
+        seg_detail.flex = "W"
+        seg_detail.tint_color = "#ffffff"
+        v.add_subview(seg_detail)
+        self.seg_detail = seg_detail
+
+        mode_label = ui.Label()
+        mode_label.text = "Mode:"
+        mode_label.text_color = "white"
+        mode_label.background_color = "#111111"
+        mode_label.frame = (300, y, 60, 22)
+        v.add_subview(mode_label)
+
+        seg_mode = ui.SegmentedControl()
+        seg_mode.segments = ["combined", "per repo"]
+        seg_mode.selected_index = 0
+        seg_mode.frame = (360, y - 2, v.width - 370, 28)
+        seg_mode.flex = "W"
+        seg_mode.tint_color = "#ffffff"
+        v.add_subview(seg_mode)
+        self.seg_mode = seg_mode
+
+        y += 36
+
+        max_label = ui.Label()
+        max_label.text = "Max Bytes/File:"
+        max_label.text_color = "white"
+        max_label.background_color = "#111111"
+        max_label.frame = (10, y, 120, 22)
+        v.add_subview(max_label)
+
+        max_field = ui.TextField()
+        max_field.text = str(DEFAULT_MAX_BYTES)
+        max_field.frame = (130, y - 2, 140, 28)
+        max_field.flex = "W"
+        max_field.background_color = "#222222"
+        max_field.text_color = "white"
+        max_field.tint_color = "white"
+        max_field.keyboard_type = ui.KEYBOARD_NUMBER_PAD
+        v.add_subview(max_field)
+        self.max_field = max_field
+
+        plan_switch = ui.Switch()
+        plan_switch.value = False
+        plan_switch.frame = (10, y + 32, 0, 0)
+        v.add_subview(plan_switch)
+        self.plan_switch = plan_switch
+
+        plan_label = ui.Label()
+        plan_label.text = "Plan only (no content)"
+        plan_label.text_color = "white"
+        plan_label.background_color = "#111111"
+        plan_label.frame = (60, y + 32, v.width - 70, 22)
+        plan_label.flex = "W"
+        v.add_subview(plan_label)
+
+        y += 64
+
+        info_label = ui.Label()
+        info_label.text_color = "white"
+        info_label.background_color = "#111111"
+        info_label.font = ("<System>", 11)
+        info_label.number_of_lines = 1
+        info_label.frame = (10, y, v.width - 20, 18)
+        info_label.flex = "W"
+        v.add_subview(info_label)
+        self.info_label = info_label
+        self._update_repo_info()
+
+        y += 26
+
+        btn = ui.Button()
+        btn.title = "Run Merge"
+        btn.frame = (10, y, v.width - 20, 40)
+        btn.flex = "W"
+        btn.background_color = "#007aff"
+        btn.tint_color = "white"
+        btn.corner_radius = 6.0
+        btn.action = self.run_merge
+        v.add_subview(btn)
+        self.run_button = btn
+
+    def _update_repo_info(self) -> None:
+        if not self.repos:
+            self.info_label.text = "No repos found in Hub."
+        else:
+            self.info_label.text = f"{len(self.repos)} Repos found."
+
+    def _get_selected_repos(self) -> List[str]:
+        tv = self.tv
+        rows = tv.selected_rows or []
+        if not rows:
+            return list(self.repos)
+        names: List[str] = []
+        for section, row in rows:
+            if 0 <= row < len(self.repos):
+                names.append(self.repos[row])
+        return names
+
+    def _parse_max_bytes(self) -> int:
+        txt = (self.max_field.text or "").strip()
+        if not txt:
+            return DEFAULT_MAX_BYTES
+        try:
+            val = int(txt)
+            if val <= 0:
+                raise ValueError()
+            return val
+        except Exception:
+            return DEFAULT_MAX_BYTES
+
+    def run_merge(self, sender) -> None:
+        try:
+            self._run_merge_inner()
+        except Exception as e:
+            traceback.print_exc()
+            msg = f"Error: {e}"
+            if console:
+                console.alert("wc-merger", msg, "OK", hide_cancel_button=True)
+            else:
+                print(msg, file=sys.stderr)
+
+    def _run_merge_inner(self) -> None:
+        selected = self._get_selected_repos()
+        if not selected:
+            if console:
+                console.alert(
+                    "wc-merger",
+                    "No repos selected.",
+                    "OK",
+                    hide_cancel_button=True,
+                )
+            return
+
+        ext_text = (self.ext_field.text or "").strip()
+        extensions = _normalize_ext_list(ext_text)
+
+        path_contains = (self.path_field.text or "").strip()
+        if not path_contains:
+            path_contains = None
+
+        detail_idx = self.seg_detail.selected_index
+        detail = ["overview", "summary", "max"][detail_idx]
+
+        mode_idx = self.seg_mode.selected_index
+        mode = ["gesamt", "pro-repo"][mode_idx]
+
+        max_bytes = self._parse_max_bytes()
+        plan_only = bool(self.plan_switch.value)
+
+        summaries = []
+        for name in selected:
+            root = self.hub / name
+            if not root.is_dir():
+                continue
+            summary = scan_repo(root, extensions or None, path_contains, max_bytes)
+            # Add name explicitly to summary
+            summary["name"] = name
+            summaries.append(summary)
+
+        if not summaries:
+            if console:
+                console.alert(
+                    "wc-merger",
+                    "No valid repos found.",
+                    "OK",
+                    hide_cancel_button=True,
+                )
+            return
+
+        merges_dir = get_merges_dir(self.hub)
+        out_paths = write_reports(
+            merges_dir,
+            self.hub,
+            summaries,
+            detail,
+            mode,
+            max_bytes,
+            plan_only,
+        )
+
+        if not out_paths:
+            if console:
+                console.alert("wc-merger", "No report generated.", "OK", hide_cancel_button=True)
+            else:
+                print("No report generated.")
+            return
+
+        main_report = out_paths[0]
+
+        if editor is not None:
+            try:
+                editor.open_file(str(main_report))
+            except Exception:
+                print("Report:", main_report)
+        else:
+            print("Report:", main_report)
+
+        if console is not None:
+            try:
+                console.hud_alert("wc-merger: OK")
+            except Exception:
+                console.alert("wc-merger", str(main_report), "OK", hide_cancel_button=True)
+        else:
+            print("wc-merger: OK")
+
+
+# --- CLI Mode ---
+
+def main_cli():
+    import argparse
+    parser = argparse.ArgumentParser(description="wc-merger CLI")
+    parser.add_argument("paths", nargs="*", help="Repositories to merge")
+    parser.add_argument("--hub", help="Base directory (wc-hub)")
+    parser.add_argument("--level", choices=["overview", "summary", "max"], default="max")
+    parser.add_argument("--mode", choices=["gesamt", "pro-repo"], default="gesamt")
+    parser.add_argument("--max-bytes", type=int, default=DEFAULT_MAX_BYTES)
+    parser.add_argument("--plan-only", action="store_true")
 
     args = parser.parse_args()
 
-    sources = []
+    script_path = Path(__file__).resolve()
+    hub = detect_hub_dir(script_path, args.hub)
 
     # Resolve sources
-    if not args.paths:
-        # Default to current directory if no paths provided
-        sources.append(Path.cwd())
-    else:
+    sources = []
+    if args.paths:
         for p in args.paths:
             path = Path(p)
-            if not path.exists() and args.hub:
-                hub_path = Path(args.hub) / p
-                if hub_path.exists():
-                    path = hub_path
-
+            if not path.exists():
+                # Try relative to hub
+                path = hub / p
             if path.exists() and path.is_dir():
-                sources.append(path.resolve())
+                sources.append(path)
             else:
-                print(f"Warning: Path '{p}' not found or is not a directory.", file=sys.stderr)
+                print(f"Warning: {path} not found.")
+    else:
+        # Scan hub for repos
+        repos = find_repos_in_hub(hub)
+        for r in repos:
+            sources.append(hub / r)
 
     if not sources:
-        print("Error: No valid sources found.", file=sys.stderr)
+        print("No sources found.")
         sys.exit(1)
 
-    all_files = []
+    print(f"Hub: {hub}")
+    print(f"Sources: {[s.name for s in sources]}")
+
+    summaries = []
     for src in sources:
-        print(f"Scanning {src}...", file=sys.stderr)
-        root_label = src.name
-        files = scan_repo(src, root_label, args.max_bytes)
-        all_files.extend(files)
+        print(f"Scanning {src.name}...")
+        summary = scan_repo(src, None, None, args.max_bytes)
+        summary["name"] = src.name
+        summaries.append(summary)
 
-    print(f"Generating report (Level: {args.level})...", file=sys.stderr)
-    report = generate_report(
-        sources=[str(s) for s in sources],
-        file_infos=all_files,
-        level=args.level,
-        max_file_bytes=args.max_bytes
-    )
+    merges_dir = get_merges_dir(hub)
+    out_paths = write_reports(merges_dir, hub, summaries, args.level, args.mode, args.max_bytes, args.plan_only)
 
-    if args.output:
-        out_path = Path(args.output)
-        out_path.parent.mkdir(parents=True, exist_ok=True)
-        out_path.write_text(report, encoding="utf-8")
-        print(f"Report written to {out_path}", file=sys.stderr)
+    for p in out_paths:
+        print(f"Report generated: {p}")
+
+
+def main():
+    if ui is not None:
+        script_path = Path(__file__).resolve()
+        hub = detect_hub_dir(script_path)
+        ui_obj = MergerUI(hub)
+        ui_obj.view.present("sheet")
     else:
-        print(report)
+        main_cli()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
- Port core logic from `repomerger.py` to `wc-merger/merge_core.py`.
- Update `wc-merger/wc-merger.py` to use expanded file detection and categorization.
- Ensure `wc-merger` includes scripts, tests, and config files by default.
- Implement comprehensive Markdown report structure (Plan, Structure, Manifest, Content).
- Update `wc-extractor.py` to use shared core logic and generate import diffs.
- Fix default extension filter in `wc-merger.py` to be inclusive (empty = all files).