### PR TITLE
Improve wc-merger robustness

### DIFF
--- a/wc-merger/merge_core.py
+++ b/wc-merger/merge_core.py
@@ -660,8 +660,8 @@ def generate_report_content(files: List[FileInfo], level: str, max_file_bytes: i
                     continue
 
             if truncated:
-                 lines.append(f"**Note:** File > {human_size(max_file_bytes)}, content truncated.")
-                 lines.append("")
+                lines.append(f"**Note:** File > {human_size(max_file_bytes)}, content truncated.")
+                lines.append("")
 
             lang = lang_for(fi.ext)
             lines.append(f"```{lang}")

--- a/wc-merger/wc-merger.py
+++ b/wc-merger/wc-merger.py
@@ -37,6 +37,7 @@ try:
     from merge_core import (
         MERGES_DIR_NAME,
         DEFAULT_MAX_BYTES,
+        SKIP_ROOTS,
         detect_hub_dir,
         get_merges_dir,
         scan_repo,
@@ -49,6 +50,7 @@ except ImportError:
     from merge_core import (
         MERGES_DIR_NAME,
         DEFAULT_MAX_BYTES,
+        SKIP_ROOTS,
         detect_hub_dir,
         get_merges_dir,
         scan_repo,
@@ -65,6 +67,8 @@ def find_repos_in_hub(hub: Path) -> List[str]:
         return []
     for child in sorted(hub.iterdir(), key=lambda p: p.name.lower()):
         if not child.is_dir():
+            continue
+        if child.name in SKIP_ROOTS:
             continue
         if child.name == MERGES_DIR_NAME:
             continue


### PR DESCRIPTION
## Summary
- skip auto-discovered hub entries configured as skipped roots to avoid merging unwanted folders
- fix content truncation note indentation to prevent syntax errors in generated reports

## Testing
- python -m py_compile wc-merger/*.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930993c8428832c81dc05bab36bb5a9)