### PR TITLE
tools: fix silent exception handling in merger scripts

### DIFF
--- a/repomergers/hauski-merger.py
+++ b/repomergers/hauski-merger.py
@@ -181,8 +181,8 @@ def load_config() -> tuple[configparser.ConfigParser, Path]:
     try:
         if cfg_path.exists():
             cfg.read(cfg_path, encoding="utf-8")
-    except Exception:
-        pass
+    except Exception as e:
+        print(f"Warning: Failed to read config from {cfg_path}: {e}", file=sys.stderr)
     return cfg, cfg_path
 
 
@@ -275,8 +275,10 @@ def find_dir_by_basename(basename: str, aliases: dict[str, str], search_depth: i
             for p in base.rglob(basename):
                 if p.is_dir() and p.name == basename and len(str(p).split(os.sep)) <= max_depth_abs:
                     candidates.append(p)
-        except Exception:
-            pass
+        except OSError:
+            pass  # Permission denied etc.
+        except Exception as e:
+            print(f"Warning: Error searching in {base}: {e}", file=sys.stderr)
 
     uniq: list[Path] = []
     seen: set[str] = set()
@@ -375,8 +377,8 @@ def parse_manifest(md: Path) -> dict[str, tuple[str, int]]:
                                 size = 0
                     if rel:
                         m[rel] = (md5, size)
-    except Exception:
-        pass
+    except Exception as e:
+        print(f"Warning: Failed to parse manifest {md}: {e}", file=sys.stderr)
     return m
 
 
@@ -414,8 +416,8 @@ def keep_last_n(merge_dir: Path, keep: int, keep_new: Path | None = None, merge_
     for old in merges[:-keep]:
         try:
             old.unlink()
-        except Exception:
-            pass
+        except Exception as e:
+            print(f"Warning: Failed to delete old merge {old}: {e}", file=sys.stderr)
 
 # ===== Merge ================================================================
 

--- a/repomergers/weltgewebe-merger.py
+++ b/repomergers/weltgewebe-merger.py
@@ -168,8 +168,8 @@ def load_config():
     try:
         if cfg_path.exists():
             cfg.read(cfg_path, encoding="utf-8")
-    except Exception:
-        pass
+    except Exception as e:
+        print(f"Warning: Failed to read config from {cfg_path}: {e}", file=sys.stderr)
     return cfg, cfg_path
 
 def cfg_get_int(cfg, section, key, default):
@@ -258,8 +258,10 @@ def find_dir_by_basename(basename: str, aliases, search_depth: int = DEF_SRCH_DE
                 if p.is_dir() and p.name == basename:
                     if len(str(p).split(os.sep)) <= max_depth_abs:
                         candidates.append(p)
-        except Exception:
+        except OSError:
             pass
+        except Exception as e:
+            print(f"Warning: Error searching in {base}: {e}", file=sys.stderr)
 
     uniq = []
     seen = set()
@@ -329,8 +331,8 @@ def parse_manifest(md: Path):
                             try: size = int(p[5:].strip())
                             except Exception: size = 0
                     if rel: m[rel] = (md5, size)
-    except Exception:
-        pass
+    except Exception as e:
+        print(f"Warning: Failed to parse manifest {md}: {e}", file=sys.stderr)
     return m
 
 def build_diff(current, merge_dir: Path, merge_prefix: str):
@@ -363,7 +365,8 @@ def keep_last_n(merge_dir: Path, keep: int, keep_new: Path = None, merge_prefix:
     if len(merges) <= keep: return
     for old in merges[:-keep]:
         try: old.unlink()
-        except Exception: pass
+        except Exception as e:
+            print(f"Warning: Failed to delete old merge {old}: {e}", file=sys.stderr)
 
 # ===== Dateinamen-Logik =====================================================
 

--- a/repomergers/wgx-merger.py
+++ b/repomergers/wgx-merger.py
@@ -181,8 +181,8 @@ def load_config() -> tuple[configparser.ConfigParser, Path]:
     try:
         if cfg_path.exists():
             cfg.read(cfg_path, encoding="utf-8")
-    except Exception:
-        pass
+    except Exception as e:
+        print(f"Warning: Failed to read config from {cfg_path}: {e}", file=sys.stderr)
     return cfg, cfg_path
 
 
@@ -275,8 +275,10 @@ def find_dir_by_basename(basename: str, aliases: dict[str, str], search_depth: i
             for p in base.rglob(basename):
                 if p.is_dir() and p.name == basename and len(str(p).split(os.sep)) <= max_depth_abs:
                     candidates.append(p)
-        except Exception:
-            pass
+        except OSError:
+            pass  # Permission denied etc.
+        except Exception as e:
+            print(f"Warning: Error searching in {base}: {e}", file=sys.stderr)
 
     uniq: list[Path] = []
     seen: set[str] = set()
@@ -375,8 +377,8 @@ def parse_manifest(md: Path) -> dict[str, tuple[str, int]]:
                                 size = 0
                     if rel:
                         m[rel] = (md5, size)
-    except Exception:
-        pass
+    except Exception as e:
+        print(f"Warning: Failed to parse manifest {md}: {e}", file=sys.stderr)
     return m
 
 
@@ -414,8 +416,8 @@ def keep_last_n(merge_dir: Path, keep: int, keep_new: Path | None = None, merge_
     for old in merges[:-keep]:
         try:
             old.unlink()
-        except Exception:
-            pass
+        except Exception as e:
+            print(f"Warning: Failed to delete old merge {old}: {e}", file=sys.stderr)
 
 # ===== Merge ================================================================
 


### PR DESCRIPTION
- Replaces `except Exception: pass` with proper logging to stderr in `hauski-merger.py`, `wgx-merger.py`, and `weltgewebe-merger.py`.
- Addresses critical issues identified in `INCONSISTENCIES.md`.
- Ensures that configuration loading, file searching, and manifest parsing errors are visible for debugging.