### PR TITLE
tools: Refine wc-merger v2.3 and add headless support

### DIFF
--- a/merger/wc-merger/README.md
+++ b/merger/wc-merger/README.md
@@ -90,4 +90,26 @@ python3 wc-merger.py --cli --repos myrepo --detail dev --mode batch
 python3 wc-merger.py --cli --repos myrepo --detail max --split-size 20
 ```
 
+### Nutzung in iOS Shortcuts (Headless)
+
+Shortcuts startet Pythonista oft als **App-Extension** mit stark eingeschränkten Rechten.
+In dieser Umgebung sind die Pythonista-Module `editor`, `ui`, `console` u. a. nicht verfügbar.
+
+Der wc-merger unterstützt deshalb einen **Headless-Modus**:
+
+```bash
+# Variante 1: per Flag
+python3 wc-merger.py --headless --level dev --mode gesamt
+
+# Variante 2: per Umgebungsvariable
+WC_HEADLESS=1 python3 wc-merger.py --level dev --mode gesamt
+```
+
+**Tipp:** Soll ein Shortcut Pythonista *voll* starten (mit UI/editor),
+nutze das URL-Scheme:
+
+```
+pythonista3://merger/wc-merger/wc-merger.py?action=run
+```
+
 Weitere Details siehe [wc-merger-spec.md](./wc-merger-spec.md).

--- a/merger/wc-merger/merge_core.py
+++ b/merger/wc-merger/merge_core.py
@@ -237,6 +237,8 @@ def extract_purpose(repo_root: Path) -> str:
                     txt = f.read().strip()
                     # First paragraph is content until double newline
                     first = txt.split("\n\n")[0].strip()
+                    # Markdown-Überschrift (#, ##, …) vorne abschneiden
+                    first = first.lstrip("#").strip()
                     return first
             except Exception:
                 return ""
@@ -276,8 +278,6 @@ def classify_file_v2(rel_path: Path, ext: str) -> Tuple[str, List[str]]:
         tags.append("feed")
     if "lock" in name: # *lock* pattern
         tags.append("lockfile")
-    if "tools" in parts and "src" in parts:
-        tags.append("cli")
     if name == "readme.md":
         tags.append("readme")
     if ".wgx" in parts and name.startswith("profile"):
@@ -696,7 +696,7 @@ def iter_report_blocks(files: List[FileInfo], level: str, max_file_bytes: int, s
     elif level == "max":
         header.append("`max`")
         header.append("- alle Textdateien → voll")
-        header.append("- nur > Max Bytes → BITECHT truncated")
+        header.append("- nur Dateien > Max Bytes → truncated")
     else:
         header.append(f"`{level}` (custom)")
     header.append("")
@@ -835,6 +835,8 @@ def iter_report_blocks(files: List[FileInfo], level: str, max_file_bytes: int, s
 
 def generate_report_content(files: List[FileInfo], level: str, max_file_bytes: int, sources: List[Path], plan_only: bool, debug: bool = False) -> str:
     report = "".join(iter_report_blocks(files, level, max_file_bytes, sources, plan_only, debug))
+    if plan_only:
+        return report
     try:
         validate_report_structure(report)
     except ValueError as e:


### PR DESCRIPTION
- Remove `cli` tag logic from `merge_core.py` to maintain a clean tag ontology.
- Fix typo in `max` profile description: "BITECHT" -> "truncated".
- Update `extract_purpose` to strip Markdown headings from the extracted text.
- Update `wc-merger.py` to support headless execution (iOS Shortcuts) by handling missing `ui` modules and adding `--headless` flag.
- Skip strict report structure validation when running in `--plan-only` mode.
- Update `README.md` with headless usage instructions.