### PR TITLE
tools: wc-merger v2.4 UI and Filename Patch

### DIFF
--- a/merger/wc-merger/merge_core.py
+++ b/merger/wc-merger/merge_core.py
@@ -487,14 +487,19 @@ def build_tree(file_infos: List[FileInfo]) -> str:
     return "\n".join(lines)
 
 def make_output_filename(merges_dir: Path, repo_names: List[str], mode: str, detail: str, part: Optional[int] = None) -> Path:
-    ts = datetime.datetime.now().strftime("%y%m%d-%H%M%S")
+    # Zeitstempel ohne Sekunden, damit die Namen ruhiger werden
+    ts = datetime.datetime.now().strftime("%y%m%d-%H%M")
     base = "+".join(repo_names) if repo_names else "no-repos"
     if len(base) > 40:
         base = base[:37] + "..."
     base = base.replace(" ", "-").replace("/", "_")
 
     part_suffix = f"_part{part}" if part else ""
-    return merges_dir / f"merge_v2_{mode}_{base}_{detail}_{ts}{part_suffix}.md"
+    # Neues Schema:
+    #   <repos>_<detail>_<mode>_<YYMMDD-HHMM>[_partX]_merge.md
+    # Beispiel:
+    #   hausKI+wgx_dev_multi_251205-1457_merge.md
+    return merges_dir / f"{base}_{detail}_{mode}_{ts}{part_suffix}_merge.md"
 
 def read_smart_content(fi: FileInfo, max_bytes: int, encoding="utf-8") -> Tuple[str, bool, str]:
     """
@@ -952,8 +957,8 @@ def write_reports_v2(
             sources.append(s["root"])
 
         # kosmetisches Label im Dateinamen:
-        # nur ein Repo → "single", mehrere → "gesamt"
-        mode_label = "single" if len(repo_names) == 1 else "gesamt"
+        # nur ein Repo → "single", mehrere → "multi"
+        mode_label = "single" if len(repo_names) == 1 else "multi"
         process_and_write(
             all_files,
             sources,

--- a/merger/wc-merger/wc-merger.py
+++ b/merger/wc-merger/wc-merger.py
@@ -211,13 +211,26 @@ class MergerUI(object):
         y += 40
 
         repo_label = ui.Label()
-        repo_label.frame = (10, y, v.width - 20, 20)
+        # Platz lassen für „Alle auswählen“-Button rechts
+        repo_label.frame = (10, y, v.width - 110, 20)
         repo_label.flex = "W"
         repo_label.text = "Repos (Tap to select – None = All):"
         repo_label.text_color = "white"
         repo_label.background_color = "#111111"
         repo_label.font = ("<System>", 13)
         v.add_subview(repo_label)
+
+        select_all_btn = ui.Button()
+        select_all_btn.title = "All"
+        select_all_btn.frame = (v.width - 90, y - 2, 80, 24)
+        select_all_btn.flex = "WL"
+        select_all_btn.background_color = "#333333"
+        select_all_btn.tint_color = "white"
+        select_all_btn.corner_radius = 4.0
+        select_all_btn.action = self.select_all_repos
+        v.add_subview(select_all_btn)
+        self.select_all_button = select_all_btn
+
         y += 22
 
         tv = ui.TableView()
@@ -234,7 +247,8 @@ class MergerUI(object):
 
         ds = ui.ListDataSource(self.repos)
         ds.text_color = "white"
-        ds.highlight_color = "#333333"
+        # deutliche Selektion: kräftiges Blau statt „grau auf schwarz“
+        ds.highlight_color = "#0050ff"
         ds.tableview_cell_for_row = self._tableview_cell
         tv.data_source = ds
         tv.delegate = ds
@@ -383,6 +397,15 @@ class MergerUI(object):
         else:
             self.info_label.text = f"{len(self.repos)} Repos found."
 
+    def select_all_repos(self, sender) -> None:
+        """Markiert alle Repos in der Liste als ausgewählt."""
+        if not self.repos:
+            return
+        tv = self.tv
+        tv.selected_rows = [(0, i) for i in range(len(self.repos))]
+        # Refresh, damit die Highlight-Farbe überall sichtbar wird
+        tv.reload()
+
     def _tableview_cell(self, tableview, section, row):
         cell = ui.TableViewCell()
         cell.background_color = "#111111"
@@ -392,7 +415,8 @@ class MergerUI(object):
         cell.text_label.background_color = "#111111"
 
         selected_bg = ui.View()
-        selected_bg.background_color = "#333333"
+        # gut sichtbarer Selected-Hintergrund
+        selected_bg.background_color = "#0050ff"
         cell.selected_background_view = selected_bg
         return cell
 
@@ -487,8 +511,9 @@ class MergerUI(object):
             max_bytes,
             plan_only,
             split_size,
-            path_contains,
-            extensions or None,
+            debug=False,
+            path_filter=path_contains,
+            ext_filter=extensions or None,
         )
 
         if not out_paths:


### PR DESCRIPTION
- Updated filename schema: removed seconds, moved 'merge' suffix to end, implemented 'multi' label for aggregated repos.
- Enhanced Pythonista UI:
  - Added 'Select All' button for repositories.
  - Improved selection visibility with high-contrast blue (#0050ff).
- Bugfix: Corrected `write_reports_v2` call in UI mode to pass filters correctly (fixed silent parameter misalignment).