### PR TITLE
Fix wc-merger UI layout and refine dev profile logic

### DIFF
--- a/merger/wc-merger/merge_core.py
+++ b/merger/wc-merger/merge_core.py
@@ -840,13 +840,26 @@ def iter_report_blocks(
                     else:
                         status = "meta-only"
             elif level == "dev":
+                # Dev-Profil: Fokus auf arbeitsrelevante Dateien.
+                # - Source/Tests/Config/CI/Contracts → voll
+                # - Lockfiles: ab bestimmter Größe nur Manifest
+                # - Doku: nur Prioritätsdateien (README, Runbooks, ai-context) voll,
+                #         Rest Manifest
+                # - Sonstiges: Manifest
                 if "lockfile" in fi.tags:
-                    if fi.size > 20000:
+                    if fi.size > 20_000:
                         status = "meta-only"
                     else:
                         status = "full"
-                else:
+                elif fi.category in ["source", "test", "config", "ci", "contract"]:
                     status = "full"
+                elif fi.category == "doc":
+                    if is_priority_file(fi):
+                        status = "full"
+                    else:
+                        status = "meta-only"
+                else:
+                    status = "meta-only"
             elif level == "max":
                 status = "full"
             else:
@@ -978,8 +991,9 @@ def iter_report_blocks(
         header.append("- Code & Tests: Manifest + Struktur; nur Prioritätsdateien (README, Runbooks, ai-context) voll")
     elif level == "dev":
         header.append("`dev`")
-        header.append("- Alles relevante (Code, Tests, CI, Contracts, ai-context, wgx-profile) → voll")
-        header.append("- Lockfiles / Artefakte: truncated oder meta-only")
+        header.append("- Code, Tests, Config, CI, Contracts, ai-context, wgx-profile → voll")
+        header.append("- Doku nur für Prioritätsdateien voll (README, Runbooks, ai-context), sonst Manifest")
+        header.append("- Lockfiles / Artefakte: ab bestimmter Größe truncated oder meta-only")
     elif level == "max":
         header.append("`max`")
         header.append("- alle Textdateien → voll")

--- a/merger/wc-merger/wc-merger.py
+++ b/merger/wc-merger/wc-merger.py
@@ -547,7 +547,14 @@ class MergerUI(object):
 
         btn = ui.Button()
         btn.title = "Run Merge"
-        btn.frame = (10, y, v.width - 20, 40)
+        # Button nicht direkt an den unteren Rand kleben, damit er
+        # vom iOS-Home-Handle nicht halb verdeckt wird.
+        bottom_margin = 24
+        button_height = 40
+        safe_y = v.height - bottom_margin - button_height
+        if safe_y < y:
+            y = safe_y
+        btn.frame = (10, y, v.width - 20, button_height)
         btn.flex = "W"
         btn.background_color = "#007aff"
         btn.tint_color = "white"


### PR DESCRIPTION
- Adjusted `wc-merger.py` to add a bottom margin to the "Run Merge" button, preventing overlap with the iOS home indicator.
- Updated `merge_core.py` to refine the `dev` profile logic:
    - Now focuses on `source`, `test`, `config`, `ci`, and `contract` categories.
    - Limits documentation to priority files only (README, Runbooks, ai-context).
    - Truncates or omits lockfiles and artifacts to reduce noise.
    - Explicitly differentiates `dev` (working set) from `max` (full dump).
- Updated profile descriptions in the report header to reflect these changes.