### PR TITLE
feat: add formal contract declaration to wc-merger output

### DIFF
--- a/merger/wc-merger/merge_core.py
+++ b/merger/wc-merger/merge_core.py
@@ -16,6 +16,13 @@ from typing import List, Dict, Optional, Tuple, Any, Iterator, NamedTuple
 
 SPEC_VERSION = "2.3"
 MERGES_DIR_NAME = "merges"
+
+# Formale Contract-Deklaration für alle wc-merger-Reports.
+# Name/Version können von nachgelagerten Tools verwendet werden,
+# um das Format eindeutig zu erkennen.
+MERGE_CONTRACT_NAME = "wc-merge-report"
+MERGE_CONTRACT_VERSION = SPEC_VERSION
+
 # Ab v2.3+: 0 = "kein Limit pro Datei".
 # max_file_bytes wirkt nur noch als optionales Soft-Limit / Hint,
 # nicht mehr als harte Abschneide-Grenze. Große Dateien werden
@@ -949,6 +956,8 @@ def iter_report_blocks(
         # 0 / None = kein per-File-Limit – alles wird vollständig gelesen
         header.append("- **Max File Bytes:** unlimited")
     header.append(f"- **Spec-Version:** {SPEC_VERSION}")
+    header.append(f"- **Contract:** {MERGE_CONTRACT_NAME}")
+    header.append(f"- **Contract-Version:** {MERGE_CONTRACT_VERSION}")
 
     # Semantische Use-Case-Zeile pro Profil (ergänzend zum Repo-Zweck)
     profile_usecase = PROFILE_USECASE.get(level)
@@ -992,6 +1001,8 @@ def iter_report_blocks(
     meta.append("merge:")
     meta.append(f"  spec_version: \"{SPEC_VERSION}\"")
     meta.append(f"  profile: \"{level}\"")
+    meta.append(f"  contract: \"{MERGE_CONTRACT_NAME}\"")
+    meta.append(f"  contract_version: \"{MERGE_CONTRACT_VERSION}\"")
     meta.append(f"  plan_only: {str(plan_only).lower()}")
     meta.append(f"  max_file_bytes: {max_file_bytes}")
     meta.append(f"  scope: \"{scope_desc}\"")

--- a/merger/wc-merger/wc-merger-spec.md
+++ b/merger/wc-merger/wc-merger-spec.md
@@ -57,6 +57,51 @@ Optional:
 
 ---
 
+## 3b. Merge-Contract
+
+Jeder wc-merger-Report implementiert einen formalen „Merge-Contract“.
+Ziel:
+
+- eindeutige Identifikation des Formats,
+- maschinenlesbare Versionierung,
+- Basis für externe Validatoren und CI-Checks.
+
+Pflichtfelder:
+
+Im Abschnitt **Source & Profile**:
+
+- `Contract: wc-merge-report`
+- `Contract-Version: 2.3`
+
+Im `@meta`-Block:
+
+```yaml
+merge:
+  contract: "wc-merge-report"
+  contract_version: "2.3"
+```
+
+- Es gibt **kein hartes globales Merge-Size-Limit**.
+- `max_file_bytes` begrenzt ausschließlich die **einzelne Datei**
+  (Trunkierung bzw. optionales Splitting auf Dateiebene).
+- `split_size` steuert optional die **Aufteilung des Merges in mehrere Dateien**:
+  - `split_size <= 0` → kein Split (ein einziger Merge).
+  - `split_size > 0` → Multi-File-Merge, Inhalt wird nur über mehrere Dateien verteilt,
+    aber nicht zusätzlich gekürzt.
+
+Konsequenz:
+
+> „Wenn Inhalt fehlt, liegt das an Profil-/Dateifiltern oder `max_file_bytes`, **nicht** an einem globalen Hard-Limit.“
+
+KIs dürfen davon ausgehen, dass es auf Merge-Ebene keine „unsichtbare Schere“ gibt,
+sondern nur explizit deklarierte Filter und Limits.
+
+Optional:
+
+- Spec-Checksum: <sha256>
+
+---
+
 ## 4. Kategorien
 
 Erlaubte Werte:
@@ -216,6 +261,7 @@ Jede Ausgabe wird geprüft:
 - nur erlaubte Kategorien
 - nur erlaubte Tags
 - Spec-Version vorhanden
+- Contract-Felder vorhanden (`contract`, `contract_version`)
 - keine verbotenen Schlüsselwörter oder Strukturen
 
 Fehler → kein Merge wird geschrieben.


### PR DESCRIPTION
Adds `Contract` and `Contract-Version` fields to the generated merge report header and the machine-readable YAML `@meta` block. This allows downstream tools to unambiguously identify the report format and version.

Updates the specification (`wc-merger-spec.md`) to include:
- A new section (3b) defining the Merge-Contract requirements.
- An update to the validation checklist to enforce the presence of contract fields.
- A section (3a) clarifying the "soft-limit" behavior for file sizes.

This change adheres to the v2.3 specification update request.