### PR TITLE
Refactor wc-merger docs and validation to match code behavior

### DIFF
--- a/merger/wc-merger/README.md
+++ b/merger/wc-merger/README.md
@@ -78,9 +78,11 @@ Jeder Report muss:
    ```
 
 2. Im `@meta`-Block die Contract-Information maschinenlesbar haben:
+   (Der Block ist in HTML-Kommentare eingebettet, um das Rendering nicht zu stören.)
 
+   ```html
+   <!-- @meta:start -->
    ```yaml
-   @meta
    merge:
      spec_version: "2.3"
      profile: "max"
@@ -93,7 +95,8 @@ Jeder Report muss:
        - tools
      path_filter: null
      ext_filter: null
-   ---
+   ```
+   <!-- @meta:end -->
    ```
 
 Das JSON Schema für diesen Block liegt hier:
@@ -127,18 +130,23 @@ Auf iPad/Pythonista können diese Pakete ebenfalls installiert werden (z. B. per
 
 ## Detailgrade (Profile)
 
-Der wc-merger v2 kennt drei optimierte Profile:
+Der wc-merger v2 kennt vier optimierte Profile:
 
 ### 1. Overview (`overview`)
 - Kopf, Plan, Strukturbaum, Manifest.
 - **Inhalte nur für Prioritätsdateien:** `README.*`, `docs/runbook.*`, `.ai-context.yml`
 - Alle anderen Dateien nur als Metadaten im Manifest (`meta-only`).
 
-### 2. Dev (`dev`)
+### 2. Summary (`summary`)
+- Fokus auf Dokumentation und Kontext.
+- **Vollständig:** `README`, Runbooks, `.ai-context`, `docs/`, `.wgx/`, `.github/workflows/`, zentrale Configs, Contracts.
+- **Meta-Only:** Der eigentliche Source-Code und Tests erscheinen nur im Manifest (außer sie sind Priority-Files).
+
+### 3. Dev (`dev`)
 - **Vollständig:** Source-Code, Docs, CI/CD, Contracts, Configs.
 - **Zusammengefasst:** Große Lockfiles.
 
-### 3. Max (`max`)
+### 4. Max (`max`)
 - Inhalte **aller Textdateien** (bis zum Limit).
 - Maximale Tiefe.
 
@@ -149,14 +157,14 @@ Der wc-merger v2 kennt drei optimierte Profile:
 ### CLI-Nutzung:
 
 ```bash
-# Overview-Profil
-python3 wc-merger.py --cli --repos repo1,repo2 --level overview
+# Overview-Profil (Scannt aktuelles Verzeichnis oder nutzt --hub)
+python3 wc-merger.py repo1 repo2 --level overview
 
-# Dev-Profil
-python3 wc-merger.py --cli --repos myrepo --level dev --mode batch
+# Dev-Profil, einzelner Merge pro Repo
+python3 wc-merger.py myrepo --level dev --mode pro-repo
 
-# Max-Profil mit Split
-python3 wc-merger.py --cli --repos myrepo --level max --split-size 20
+# Max-Profil mit Split (z. B. 20MB)
+python3 wc-merger.py myrepo --level max --split-size 20MB
 ```
 
 ### Nutzung in iOS Shortcuts (Headless)

--- a/merger/wc-merger/wc-merger-spec.md
+++ b/merger/wc-merger/wc-merger-spec.md
@@ -73,7 +73,7 @@ Im Abschnitt **Source & Profile**:
 - `Contract: wc-merge-report`
 - `Contract-Version: 2.3`
 
-Im `@meta`-Block:
+Im `@meta`-Block (eingebettet in HTML-Kommentare `<!-- @meta:start -->` ... `<!-- @meta:end -->`):
 
 ```yaml
 merge:
@@ -110,8 +110,9 @@ Erlaubte Werte:
 - config
 - test
 - contract
-- ci
 - other
+
+(Hinweis: `ci` ist als Tag implementiert, nicht als eigene Kategorie.)
 
 Neue Kategorien dürfen nicht entstehen.
 
@@ -254,14 +255,11 @@ Mindestinformationen:
 
 ## 12. Strict Validator
 
-Jede Ausgabe wird geprüft:
+Jede Ausgabe wird auf folgende strukturelle Integrität geprüft:
 - Abschnittsreihenfolge
-- vollständige Manifest-Anker
-- vollständige Content-Anker
-- nur erlaubte Kategorien
-- nur erlaubte Tags
-- Spec-Version vorhanden
-- Contract-Felder vorhanden (`contract`, `contract_version`)
-- keine verbotenen Schlüsselwörter oder Strukturen
+- Spec-Version & Contract-Header vorhanden
+- Manifest-Anker vorhanden
 
-Fehler → kein Merge wird geschrieben.
+Erweiterte Prüfungen (z.B. unbekannte Tags/Kategorien, fehlende Anker) erfolgen im **Debug-Modus** oder als Warnungen und verhindern im Standardbetrieb nicht zwingend die Ausgabe, sollten aber behoben werden.
+
+Fehler in der Grundstruktur → kein Merge wird geschrieben.


### PR DESCRIPTION
- Update `validate_merge_meta.py` to support HTML-embedded meta blocks (`<!-- @meta:start -->`) and fallback to legacy format.
- Update `README.md` to reflect the 4 existing profiles (`overview`, `summary`, `dev`, `max`), correct CLI usage, and new meta block format.
- Update `wc-merger-spec.md` to clarify strict validation scope, remove `ci` as a category (it is a tag), and document the HTML meta block.
- Ensure validation logic is robust and aligned with `merge_core.py` output.