### PR TITLE
tools(wc-merger): Align code, spec, and README for v2.3 consistency

### DIFF
--- a/merger/wc-merger/README.md
+++ b/merger/wc-merger/README.md
@@ -41,7 +41,7 @@ Für die Weiterentwicklung (und speziell für Agenten wie Jules) gelten folgende
 
 4.  **KI-Safety:**
     *   Timestamps immer in UTC (`YYYY-MM-DD HH:MM:SS (UTC)`).
-    *   `Spec-Version: 2.1` Header immer setzen.
+    *   `Spec-Version: 2.3` Header immer setzen.
 
 ---
 
@@ -90,7 +90,7 @@ Jeder Report muss:
      contract_version: "2.3"
      plan_only: false
      max_file_bytes: 0
-     scope: "single repo: `tools`"
+     scope: "single repo `tools`"
      source_repos:
        - tools
      path_filter: null
@@ -143,12 +143,14 @@ Der wc-merger v2 kennt vier optimierte Profile:
 - **Meta-Only:** Der eigentliche Source-Code und Tests erscheinen nur im Manifest (außer sie sind Priority-Files).
 
 ### 3. Dev (`dev`)
-- **Vollständig:** Source-Code, Docs, CI/CD, Contracts, Configs.
-- **Zusammengefasst:** Große Lockfiles.
+- **Vollständig:** Source-Code, Tests, zentrale Configs, CI/CD, Contracts, ai-context, `.wgx/profile`.
+- **Vollständig bei Doku:** nur README, Runbooks und `.ai-context`-Dateien.
+- **Zusammengefasst:** große Lockfiles (nur Manifest).
 
 ### 4. Max (`max`)
 - Inhalte **aller Textdateien** (bis zum Limit).
 - Maximale Tiefe.
+- Keine Kürzung auf Merge-Ebene, nur optionaler Split in mehrere Dateien.
 
 ---
 

--- a/merger/wc-merger/merge_core.py
+++ b/merger/wc-merger/merge_core.py
@@ -819,8 +819,10 @@ def iter_report_blocks(
         fi.anchor = anchor
 
         # Debug checks
-        if fi.category == "other" or fi.category not in ["source", "doc", "config", "test", "contract", "ci", "other"]:
-             unknown_categories.add(fi.category)
+        # Kategorien strikt gemäß Spec v2.3:
+        # {source, doc, config, test, contract, other}
+        if fi.category == "other" or fi.category not in ["source", "doc", "config", "test", "contract", "other"]:
+            unknown_categories.add(fi.category)
 
         status = "omitted"
         if fi.is_text:
@@ -1137,11 +1139,13 @@ def iter_report_blocks(
     index_blocks.append("## Index")
 
     # List of categories to index
-    cats_to_idx = ["source", "doc", "config", "contract", "test", "ci"]
+    # CI ist ein Tag, keine eigene Kategorie – wird separat indiziert.
+    cats_to_idx = ["source", "doc", "config", "contract", "test"]
     for c in cats_to_idx:
         index_blocks.append(f"- [{c.capitalize()}](#cat-{c})")
 
     # Tags can be indexed too if needed, e.g. wgx-profile
+    index_blocks.append("- [CI Pipelines](#tag-ci)")
     index_blocks.append("- [WGX Profiles](#tag-wgx-profile)")
     index_blocks.append("")
 
@@ -1153,6 +1157,14 @@ def iter_report_blocks(
             for f in cat_files:
                 index_blocks.append(f"- [`{f.rel_path}`](#{f.anchor})")
             index_blocks.append("")
+
+    # Tag Lists – CI-Pipelines
+    ci_files = [f for f in files if "ci" in (f.tags or [])]
+    if ci_files:
+        index_blocks.append("## Tag: ci {#tag-ci}")
+        for f in ci_files:
+            index_blocks.append(f"- [`{f.rel_path}`](#{f.anchor})")
+        index_blocks.append("")
 
     # Tag Lists (example)
     wgx_files = [f for f in files if "wgx-profile" in f.tags]

--- a/merger/wc-merger/wc-merger-spec.md
+++ b/merger/wc-merger/wc-merger-spec.md
@@ -201,7 +201,7 @@ Vor dem Manifest:
 - [Config](#cat-config)
 - [Contracts](#cat-contract)
 - [Tests](#cat-test)
-- [CI](#cat-ci)
+- [CI Pipelines](#tag-ci)
 - [WGX Profiles](#tag-wgx-profile)
 ```
 
@@ -209,6 +209,13 @@ Für jede Kategorie:
 
 ```markdown
 ## Category: source {#cat-source}
+- [file](#file-...)
+```
+
+Für Tags (z. B. CI):
+
+```markdown
+## Tag: ci {#tag-ci}
 - [file](#file-...)
 ```
 


### PR DESCRIPTION
- Core: Strictly enforce categories (source, doc, config, test, contract, other) excluding `ci`.
- Core: Treat `ci` purely as a tag and update Index generation to list "CI Pipelines" separately under tags.
- Readme: Update Spec-Version to 2.3 and refine `dev` and `max` profile descriptions.
- Spec: Update Index section examples to reflect `ci` as a tag.
- Bump Spec-Version header to 2.3.