### PR TITLE
Refactor: Use robust script path detection in wc-merger tools

### DIFF
--- a/merger/wc-merger/validate_merge_meta.py
+++ b/merger/wc-merger/validate_merge_meta.py
@@ -50,6 +50,11 @@ def safe_script_path() -> Path:
         return Path.cwd().resolve()
 
 
+# Cache script path at module level for consistent behavior
+SCRIPT_PATH = safe_script_path()
+SCRIPT_DIR = SCRIPT_PATH.parent
+
+
 def extract_meta_block(markdown: str) -> dict:
     """
     Sucht den ersten @meta-Block im Markdown und parst den YAML-Inhalt.
@@ -71,8 +76,6 @@ def load_schema(path: Path) -> dict:
 
 def validate_report_meta(report_path: Path) -> None:
     # Schemas liegen neben dem Skript, nicht zwingend neben dem Report
-    script_dir = safe_script_path().parent
-
     text = report_path.read_text(encoding="utf-8")
     meta = extract_meta_block(text)
 
@@ -81,7 +84,7 @@ def validate_report_meta(report_path: Path) -> None:
         raise ValueError("Im @meta-Block fehlt der Schlüssel 'merge' oder er ist kein Objekt.")
 
     # Hauptschema laden
-    report_schema_path = (script_dir / "wc-merge-report.schema.json").resolve()
+    report_schema_path = (SCRIPT_DIR / "wc-merge-report.schema.json").resolve()
     if not report_schema_path.exists():
         raise FileNotFoundError(f"Schema nicht gefunden: {report_schema_path}")
 
@@ -102,7 +105,7 @@ def validate_report_meta(report_path: Path) -> None:
     # Optional: Delta-Contract validieren, falls vorhanden
     delta = merge_meta.get("delta")
     if isinstance(delta, dict) and delta.get("type") == "wc-merge-delta":
-        delta_schema_path = (script_dir / "wc-merge-delta.schema.json").resolve()
+        delta_schema_path = (SCRIPT_DIR / "wc-merge-delta.schema.json").resolve()
         if not delta_schema_path.exists():
             print("⚠️  Delta-Schema nicht gefunden, überspringe Delta-Validierung.")
             return

--- a/merger/wc-merger/wc-extractor.py
+++ b/merger/wc-merger/wc-extractor.py
@@ -62,6 +62,10 @@ def safe_script_path() -> Path:
         return Path.cwd().resolve()
 
 
+# Cache script path at module level for consistent behavior
+SCRIPT_PATH = safe_script_path()
+SCRIPT_DIR = SCRIPT_PATH.parent
+
 # Import from core
 try:
     from merge_core import (
@@ -70,7 +74,7 @@ try:
         get_repo_snapshot,
     )
 except ImportError:
-    sys.path.append(str(safe_script_path().parent))
+    sys.path.append(str(SCRIPT_DIR))
     from merge_core import (
         detect_hub_dir,
         get_merges_dir,
@@ -79,8 +83,7 @@ except ImportError:
 
 
 def detect_hub() -> Path:
-    script_path = safe_script_path()
-    return detect_hub_dir(script_path)
+    return detect_hub_dir(SCRIPT_PATH)
 
 
 def build_delta_meta_from_diff(
@@ -389,8 +392,7 @@ def main() -> int:
     parser.add_argument("--hub", help="Hub directory override.")
     args = parser.parse_args()
 
-    script_path = safe_script_path()
-    hub = detect_hub_dir(script_path, args.hub)
+    hub = detect_hub_dir(SCRIPT_PATH, args.hub)
 
     if not hub.exists():
          print(f"Hub directory not found: {hub}")

--- a/merger/wc-merger/wc-merger.py
+++ b/merger/wc-merger/wc-merger.py
@@ -73,6 +73,11 @@ def safe_script_path() -> Path:
         return Path.cwd().resolve()
 
 
+# Cache script path at module level for consistent behavior
+SCRIPT_PATH = safe_script_path()
+SCRIPT_DIR = SCRIPT_PATH.parent
+
+
 def force_close_files(paths: List[Path]) -> None:
     """
     Ensures generated files are not left open in the editor.
@@ -112,7 +117,7 @@ try:
         ExtrasConfig,
     )
 except ImportError:
-    sys.path.append(str(safe_script_path().parent))
+    sys.path.append(str(SCRIPT_DIR))
     from merge_core import (
         MERGES_DIR_NAME,
         DEFAULT_MAX_BYTES,
@@ -216,8 +221,7 @@ def _load_wc_extractor_module():
     import types
     import sys
 
-    script_path = safe_script_path()
-    extractor_path = script_path.with_name("wc-extractor.py")
+    extractor_path = SCRIPT_PATH.with_name("wc-extractor.py")
     if not extractor_path.exists():
         return None
     try:
@@ -1324,8 +1328,7 @@ def main_cli():
 
     args = parser.parse_args()
 
-    script_path = safe_script_path()
-    hub = detect_hub_dir(script_path, args.hub)
+    hub = detect_hub_dir(SCRIPT_PATH, args.hub)
 
     sources = []
     if args.paths:
@@ -1429,8 +1432,7 @@ def main():
 
     if use_ui:
         try:
-            script_path = safe_script_path()
-            hub = detect_hub_dir(script_path)
+            hub = detect_hub_dir(SCRIPT_PATH)
             return run_ui(hub)
         except Exception as e:
             # Fallback auf CLI (headless), falls UI trotz ui-Import nicht verfügbar ist


### PR DESCRIPTION
Replaced `Path(__file__).resolve()` with a new `safe_script_path()` helper in `wc-extractor.py`, `wc-merger.py`, and `validate_merge_meta.py`. This prevents crashes in environments where `__file__` is undefined (e.g., Pythonista, Shortcuts).