### PR TITLE
Refactor: Rename to OmniWandler and fix folder selection

### DIFF
--- a/merger/omniwandler/README.md
+++ b/merger/omniwandler/README.md
@@ -1,10 +1,10 @@
-# all-ein-wandler
+# OmniWandler
 
 **Der "Alles-in-einen-Topf" Wandler für generische Ordner.**
 
 ## 🎯 Zweck
 
-Der **all-ein-wandler** ist das Gegenstück zum `wc-merger`. Während `wc-merger` für Code-Repositories optimiert ist, kümmert sich der `all-ein-wandler` um **Inhalts-Ordner**:
+Der **OmniWandler** (ehemals all-ein-wandler) ist das Gegenstück zum `wc-merger`. Während `wc-merger` für Code-Repositories optimiert ist, kümmert sich der `OmniWandler` um **Inhalts-Ordner**:
 
 - Schulunterlagen / Studienmaterial
 - Projektdokumente (PDFs, Word, Bilder)
@@ -20,14 +20,15 @@ Er konvertiert einen Ordner rekursiv in eine **einzelne Markdown-Datei** (+ JSON
 - **OCR-Integration:** Nutzt iOS Shortcuts, um Text aus Bildern und (in Zukunft) PDFs zu extrahieren.
 - **Binär-Handling:** Bilder und Medien werden erkannt und im Markdown referenziert (nicht als Buchstabensalat ausgegeben).
 - **Auto-Cleanup:** Im Hub-Modus wird der Quellordner nach Erfolg gelöscht, um Speicherplatz zu sparen.
+- **Smarte Pfad-Erkennung:** Findet den `wandler-hub` auch wenn das Skript verschoben wurde.
 
 ## 🚀 Nutzung
 
 ### 1. Pythonista (iPad) - Hub Modus (Empfohlen)
 
-1.  Erstelle (oder lass erstellen) den Ordner `wandler-hub` in deinen Pythonista-Dokumenten.
+1.  Erstelle (oder lass erstellen) den Ordner `wandler-hub` in deinen Pythonista-Dokumenten (oder nutze die UI, um ihn auszuwählen).
 2.  Lege einen Ordner, den du konvertieren willst, dort hinein.
-3.  Starte `all_ein_wandler.py`.
+3.  Starte `omniwandler.py`.
 4.  Wähle den Ordner in der Liste aus.
 5.  Ergebnis landet in `wandler-hub/wandlungen`.
 
@@ -35,16 +36,16 @@ Er konvertiert einen Ordner rekursiv in eine **einzelne Markdown-Datei** (+ JSON
 
 ```bash
 # Einen spezifischen Ordner wandeln (Ausgabe im Elternverzeichnis)
-python3 merger/all-ein-wandler/all_ein_wandler.py /Pfad/zum/Ordner
+python3 merger/omniwandler/omniwandler.py /Pfad/zum/Ordner
 
 # Via Environment Variable
-export AEW_SOURCE="/Pfad/zum/Ordner"
-python3 merger/all-ein-wandler/all_ein_wandler.py
+export OMNIWANDLER_SOURCE="/Pfad/zum/Ordner"
+python3 merger/omniwandler/omniwandler.py
 ```
 
 ## ⚙️ Konfiguration
 
-Erstelle `~/.config/all-ein-wandler/config.toml` (optional):
+Erstelle `~/.config/omniwandler/config.toml` (optional):
 
 ```toml
 [general]
@@ -52,12 +53,12 @@ max_file_bytes = 10485760   # 10 MB Limit für Textdateien
 
 [ocr]
 backend = "shortcut"        # "none" oder "shortcut"
-shortcut_name = "AllEin OCR" # Name des iOS Shortcuts
+shortcut_name = "OmniWandler OCR" # Name des iOS Shortcuts
 ```
 
 ## 🤖 Unterschied zu `wc-merger`
 
-| Feature | `all-ein-wandler` | `wc-merger` |
+| Feature | `OmniWandler` | `wc-merger` |
 | :--- | :--- | :--- |
 | **Ziel** | Dokumente, PDFs, Bilder, Notizen | Code-Repositories, Software-Projekte |
 | **Output** | Fokus auf Lesbarkeit & Content | Fokus auf Struktur, Diff & Code-Kontext |


### PR DESCRIPTION
- Rename `all-ein-wandler` to `omniwandler`.
- Improve Hub detection logic (env var, relative paths, iOS standard path).
- Add UI mechanism to manually select Hub location if detection fails.
- Fix manual folder picker (avoid blocking alerts, use correct API).
- Update README.md with new name and usage instructions.