### PR TITLE
Fix Ajv import in jsonl validator

### DIFF
--- a/scripts/jsonl-validate.sh
+++ b/scripts/jsonl-validate.sh
@@ -39,7 +39,7 @@ SCHEMA_PATH="$WORK_DIR/schema.json"
 # Create the JS validator script
 cat <<'JS' > "$WORK_DIR/validate.js"
 const fs = require('fs');
-const Ajv2020 = require('ajv/dist/2020');
+const Ajv2020 = require('ajv/dist/2020').default;
 const addFormats = require('ajv-formats');
 
 const schemaPath = process.argv[2];


### PR DESCRIPTION
## Summary
- fix Ajv 2020 import in the JSONL validator script to use the module default export and avoid constructor failures

## Testing
- bash scripts/jsonl-validate.sh /tmp/sample.ndjson /tmp/schema.json

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69391d913abc832c9c4e214b4a3d95be)