### PR TITLE
Fix Pythonista font tuples for wc-merger labels

### DIFF
--- a/merger/wc-merger/wc-merger.py
+++ b/merger/wc-merger/wc-merger.py
@@ -396,7 +396,7 @@ class MergerUI(object):
             frame=(10, cy, 130, 24),
             text="Filter: Extensions",
             text_color="white",
-            font=ui.Font.bold_system_font_of_size(12),
+            font=("<System>", 12),
         )
         bottom_container.add_subview(ext_label)
 
@@ -412,7 +412,7 @@ class MergerUI(object):
             frame=(10, cy, 130, 24),
             text="Filter: Pfad",
             text_color="white",
-            font=ui.Font.bold_system_font_of_size(12),
+            font=("<System>", 12),
         )
         bottom_container.add_subview(path_label)
 
@@ -431,7 +431,7 @@ class MergerUI(object):
             frame=(10, cy, 130, 24),
             text="SET: Ignore",
             text_color="white",
-            font=ui.Font.bold_system_font_of_size(12),
+            font=("<System>", 12),
         )
         bottom_container.add_subview(set_ignore_label)
 


### PR DESCRIPTION
## Summary
- replace ui.Font usage with Pythonista-compatible font tuples for label definitions
- prevent AttributeError so the wc-merger UI can start normally

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693968bdfa3c832c8957668b549363a3)