### PR TITLE
Simplify OmniWandler selection handling

### DIFF
--- a/merger/omniwandler/omniwandler.py
+++ b/merger/omniwandler/omniwandler.py
@@ -25,7 +25,7 @@ import time
 import traceback
 from pathlib import Path
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple, Set
+from typing import Any, Dict, List, Optional, Tuple
 
 # --- Pythonista Imports (Safe) ---
 try:
@@ -390,9 +390,7 @@ class OmniWandlerUI:
         # tilde-based inputs that may come from environment variables.
         self.hub_dir = hub_dir.expanduser()
         self.files = self._scan_hub()
-        # Merkauswahl der Zeilen (Index in self.files)
-        self.selected_rows: Set[int] = set()
-        self.ds = None  # wird in _build_view gesetzt
+        self.ds = None  # ListDataSource für die Tabelle
 
         self.view = self._build_view()
 
@@ -508,42 +506,25 @@ class OmniWandlerUI:
         ds.delete_enabled = False
         ds.move_enabled = False
 
-        # Cell-Factory mit Checkmarks
-        def make_cell(tableview, section, row, ds=ds, outer=self):
-            cell = ui.TableViewCell()
-            if 0 <= row < len(ds.items):
-                cell.text_label.text = ds.items[row]
-            else:
-                cell.text_label.text = "?"
-            cell.text_label.text_color = "white"
-            cell.background_color = "#111111"
-            try:
-                if row in outer.selected_rows:
-                    cell.accessory_type = ui.ACCESSORY_CHECKMARK
-                else:
-                    cell.accessory_type = ui.ACCESSORY_NONE
-            except Exception:
-                pass
-            return cell
-
-        ds.tableview_cell_for_row = make_cell
-
-        # Selektions-Callback direkt auf der ListDataSource
-        def did_select(tableview, section, row, ds=ds, outer=self):
-            if row < 0 or row >= len(outer.files):
-                return
-            if row in outer.selected_rows:
-                outer.selected_rows.remove(row)
-            else:
-                outer.selected_rows.add(row)
-            # Liste neu zeichnen, damit Checkmarks sichtbar werden
-            tableview.reload_data()
-
-        ds.tableview_did_select = did_select
-
         tv.data_source = ds
-        # Delegate ist wieder die ListDataSource (Pythonista-Standard)
         tv.delegate = ds
+
+        # Action: nur merken, welcher Ordner ausgewählt wurde
+        def on_row_tapped(sender):
+            sel = sender.selected_row  # (section, row) oder int
+            if sel is None:
+                return
+            if isinstance(sel, tuple):
+                _, row = sel
+            else:
+                row = sel
+            if row is None or row < 0 or row >= len(self.files):
+                return
+            # Status-Label updaten – visuelles Feedback
+            sel_name = self.files[row].name
+            self.status_lbl.text = f"Ausgewählt: {sel_name}"
+
+        ds.action = on_row_tapped
 
         v.add_subview(tv)
         self.tv = tv
@@ -611,8 +592,6 @@ class OmniWandlerUI:
 
     def _refresh(self, sender):
         self.files = self._scan_hub()
-        # Auswahl zurücksetzen, wenn sich der Inhalt geändert haben könnte
-        self.selected_rows.clear()
         if self.ds is not None:
             self.ds.items = [p.name for p in self.files]
         # TableView komplett neu zeichnen
@@ -659,82 +638,28 @@ class OmniWandlerUI:
 
     def _convert_selected(self, sender):
         """
-        Konvertiert ALLE aktuell ausgewählten Ordner in EINEM Merge.
-
-        Strategie:
-        - Jeder Ordner wird einzeln durch core.run() gejagt (damit die Logik
-          für Kategorien/OCR/etc. wiederverwendet wird).
-        - Die erzeugten Einzel-MD-Dateien werden danach zu einer großen
-          Combined-Datei zusammengeführt und wieder gelöscht.
+        Wandelt den aktuell in der Liste ausgewählten Ordner.
+        Die Auswahl erfolgt über Tipp auf die Zeile.
         """
-        if not self.selected_rows:
+        # selected_row kommt vom TableView (nicht von der DataSource)
+        sel = self.tv.selected_row
+        if sel is None:
             if console:
-                console.hud_alert("Keine Ordner ausgewählt", "error", 1.0)
+                console.hud_alert("Kein Ordner ausgewählt", "error", 1.0)
             return
 
-        rows = sorted(r for r in self.selected_rows if 0 <= r < len(self.files))
-        if not rows:
+        if isinstance(sel, tuple):
+            _, row = sel
+        else:
+            row = sel
+
+        if row is None or row < 0 or row >= len(self.files):
             if console:
-                console.hud_alert("Auswahl leer", "error", 1.0)
+                console.hud_alert("Auswahl ungültig", "error", 1.0)
             return
 
-        selected_paths = [self.files[r] for r in rows]
-
-        # Output directory
-        dest = self.hub_dir / "wandlungen"
-        dest.mkdir(exist_ok=True)
-
-        self.status_lbl.text = f"Merging {len(selected_paths)} folders…"
-
-        def worker():
-            try:
-                ts = datetime.now().strftime("%Y%m%d-%H%M")
-                stem = f"combined_{len(selected_paths)}_folders_{ts}"
-                md_path = dest / f"{stem}.md"
-
-                with md_path.open("w", encoding="utf-8", errors="replace") as out:
-                    out.write(f"# OmniWandler Combined Report\n\n")
-                    out.write("## Ordner\n\n")
-                    for p in selected_paths:
-                        out.write(f"- {p}\n")
-                    out.write("\n## Inhalte\n\n")
-
-                    for p in selected_paths:
-                        # Einzel-Wandlung (inkl. Lösch-Option)
-                        partial_md, _ = self.core.run(
-                            p,
-                            dest,
-                            delete_source=self.del_switch.value,
-                        )
-
-                        out.write(f"\n\n# --- {p.name} ---\n\n")
-                        try:
-                            with partial_md.open("r", encoding="utf-8") as f:
-                                out.write(f.read())
-                        except Exception as e:
-                            out.write(f"> Error reading partial result for {p.name}: {e}\n\n")
-
-                        # Einzel-Output wieder entfernen
-                        try:
-                            partial_md.unlink()
-                            partial_md.with_suffix(".manifest.json").unlink()
-                        except Exception:
-                            pass
-
-                if console:
-                    console.hud_alert("Combined Success!", "success", 1.0)
-
-                # Auswahl zurücksetzen
-                self.selected_rows.clear()
-                self._refresh(None)
-                self.status_lbl.text = f"Done: {md_path.name}"
-            except Exception as e:
-                traceback.print_exc()
-                if console:
-                    console.hud_alert(f"Error: {e}", "error", 2.0)
-                self.status_lbl.text = "Error occurred."
-
-        ui.delay(worker, 0.1)
+        src = self.files[row]
+        self._run_conversion(src)
 
     def _run_conversion(self, src: Path, manual_mode: bool = False):
         self.status_lbl.text = f"Processing {src.name}..."


### PR DESCRIPTION
## Summary
- restore standard ListDataSource selection handling without custom checkmarks
- update refresh and conversion logic to rely on the TableView’s built-in selected_row
- simplify conversion button to process the single highlighted folder

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939f5e84898832cace6bc874a98613c)