### PR TITLE
docs: synchronize lenskit-upgrade-blaupause with repo reality

### DIFF
--- a/docs/lenskit-upgrade-blaupause.md
+++ b/docs/lenskit-upgrade-blaupause.md
@@ -1645,7 +1645,7 @@ Priority: P0
 
 Ziel:
 - [ ] Lenskit soll als Werkzeug präzise Grenzen haben.
-  erfüllt: `/api/query` und `/api/federation/query` existieren und setzen Scope-Grenzen.
+  erfüllt: `/api/query` und `/api/federation/query` sind als begrenzte API-Pfade implementiert.
   fehlt: dedizierte Lookup-Endpunkte zur isolierten Rekonstruktion fehlen.
 
 Operationen:
@@ -1683,7 +1683,7 @@ Priority: P0
 
 Ziel:
 - [~] Jede Agent-Nutzung ist nachvollziehbar.
-  erfüllt: Architektonische Trennung zwischen CLI-Trace und API-Inline Session implementiert.
+  erfüllt: CLI-/API-Verhalten unterscheiden sich belegbar in Trace-Artefakt vs. Inline-Session.
   fehlt: Einheitlicher physischer Trace-Layer für die API.
 
 Traceability Model (aktueller repo-belegter Stand):

--- a/docs/lenskit-upgrade-blaupause.md
+++ b/docs/lenskit-upgrade-blaupause.md
@@ -1685,8 +1685,8 @@ Ziel:
   fehlt: Einheitlicher physischer Trace-Layer für die API.
 
 Traceability Model (aktueller repo-belegter Stand):
-- **v1 (CLI)**: Physisches Artefakt (`agent_query_session.v1`). Enthält `refs` + Hashes. Referenzierbar und reproduzierbar.
-- **v2 (API)**: Inline Session. Enthält keine `refs`.
+- **v1 (CLI)**: Physisches Artefakt `agent_query_session.json` (nach v1-Contract). Enthält `refs` + Hashes. Referenzierbar und reproduzierbar.
+- **v2 (API)**: Inline Session (nach v2-Contract). Enthält keine `refs`.
 *Der aktuelle API-Pfad liefert nur die Inline-v2-Session; ein physischer, referenzierbarer Artefakt-Layer ist dort derzeit nicht vorhanden.*
 
 Neues Artefakt: `agent_query_session.json`
@@ -1745,7 +1745,7 @@ Tests:
   erfüllt: Contract existiert und Validierung steht.
   fehlt: Signale aus Graph/Semantik Pfaden in den Contract leiten.
 - [~] 5. `agent_query_session.json`
-  erfüllt: CLI Artefakt (v1) und API Inline (v2) Contract aktiv.
+  erfüllt: CLI erzeugt physisches Artefakt (nach v1-Contract), API erzeugt Inline-Session (nach v2-Contract).
   fehlt: Physischer Artefakt-Layer für API-Sessions.
 - [ ] 6. service-/MCP-fähige Schnittstellenlogik
   erfüllt: API Servicepfade existieren.

--- a/docs/lenskit-upgrade-blaupause.md
+++ b/docs/lenskit-upgrade-blaupause.md
@@ -1700,7 +1700,7 @@ Priority: P0
 
 Ziel:
 - [~] Lenskit soll sich sauber an Orchestratoren oder MCP-artige Systeme andocken lassen.
-  erfüllt: HTTP-seitig repo-belegt implementiert sind aktuell `/api/query` und `/api/federation/query` (logisch: `/query`, `/federation/query`).
+  erfüllt: Basis-HTTP-Servicepfade (siehe 2.5) existieren.
   fehlt: MCP Protocol Bindings (z.B. mcp-server) fehlen gänzlich.
 
 Endpunkte logisch: `/query`, `/context`, `/trace`, `/artifact`, `/federation/query`, `/diagnostics`
@@ -1713,7 +1713,7 @@ Ziel:
 
 Guardrails:
 - **Repo-belegt implementiert**:
-  - `low_result_coverage` (emittierter Warning-String: "Low result coverage")
+  - Guardrail-Klasse: `low_result_coverage` (emittierter Warning-String: `"Low result coverage"`)
 - **Fachlich relevante, aber derzeit nicht repo-belegte Runtime-Guardrails**:
   - `stale_bundle`
   - `invalid_graph`
@@ -1738,14 +1738,14 @@ Tests:
 - [x] 1. Agent Query Contract (minimaler HTTP-Roundtrip über `/api/query` repo-belegt und getestet)
 - [x] 2. Agent Output Profiles (strukturell existierend via `output_profile` wie `agent_minimal`, `lookup_minimal`, `review_context`)
 - [~] 3. bounded API/tool surface
-  erfüllt: HTTP-seitig belegt vorhanden: `/api/query`, `/api/federation/query` (logische Endpunkte `/query`, `/federation/query`).
-  fehlt: dedizierte Lookup-Endpunkte (context/trace/artifact).
+  erfüllt: Core-Query Pfade vorhanden.
+  fehlt: dedizierte Lookup-Endpunkte.
 - [~] 4. maschinenlesbare uncertainty/provenance Felder
   erfüllt: Contract existiert und Validierung steht.
   fehlt: Signale aus Graph/Semantik Pfaden in den Contract leiten.
 - [~] 5. `agent_query_session.json`
-  erfüllt: CLI nutzt physisches Artefakt (v1), API liefert Inline-Session (v2).
-  fehlt: Einheitlicher physischer Trace-Layer für die API.
+  erfüllt: CLI nutzt Artefakt (v1), API liefert Inline-Session (v2).
+  fehlt: Physischer Trace-Layer für die API.
 - [~] 6. service-/MCP-fähige Schnittstellenlogik
   erfüllt: API Servicepfade existieren.
   fehlt: MCP Protocol Implementation.
@@ -1786,7 +1786,7 @@ Arbeitspakete:
 - [ ] **7.1 WebUI-Konsolidierung:** Bundle-Navigation, Trace-Ansicht, Explain-Ansicht, Artifact-Explorer.
 - [ ] **7.2 Diagnostic Views:** graph health, federation conflicts, bundle provenance, query trace.
 - [~] **7.3 Service-Endpunkte:** logisch vorgesehen: `/query`, `/context`, `/trace`, `/artifact`, `/federation/query`, `/diagnostics`.
-  erfüllt: repo-belegt als HTTP-Servicepfade aktuell implementiert: `/api/query` und `/api/federation/query`.
+  erfüllt: Query/Federation-Pfade implementiert.
   fehlt: dedizierte Lookup-Endpunkte fehlen.
 - [ ] **7.4 Download-/Inspection-Flows:** bundle parts, traces, context bundles, diagnostics.
 

--- a/docs/lenskit-upgrade-blaupause.md
+++ b/docs/lenskit-upgrade-blaupause.md
@@ -1700,8 +1700,8 @@ Priority: P0
 
 Ziel:
 - [~] Lenskit soll sich sauber an Orchestratoren oder MCP-artige Systeme andocken lassen.
-  erfüllt: Basis-HTTP-Servicepfade (siehe 2.5) existieren.
-  fehlt: MCP Protocol Bindings (z.B. mcp-server) fehlen gänzlich.
+  erfüllt: HTTP-Servicepfade (siehe 2.5) vorhanden.
+  fehlt: MCP Protocol Bindings (z.B. mcp-server) fehlen.
 
 Endpunkte logisch: `/query`, `/context`, `/trace`, `/artifact`, `/federation/query`, `/diagnostics`
 
@@ -1713,8 +1713,9 @@ Ziel:
 
 Guardrails:
 - **Repo-belegt implementiert**:
-  - Guardrail-Klasse: `low_result_coverage` (emittierter Warning-String: `"Low result coverage"`)
-- **Fachlich relevante, aber derzeit nicht repo-belegte Runtime-Guardrails**:
+  - Guardrail-Klasse: `low_result_coverage`
+  - emittierter Warning-String: `"Low result coverage"`
+- **Fachlich relevante Guardrail-Klassen (derzeit nicht als strukturierte Runtime-Signale repo-belegt)**:
   - `stale_bundle`
   - `invalid_graph`
   - `missing_provenance`
@@ -1738,8 +1739,8 @@ Tests:
 - [x] 1. Agent Query Contract (minimaler HTTP-Roundtrip über `/api/query` repo-belegt und getestet)
 - [x] 2. Agent Output Profiles (strukturell existierend via `output_profile` wie `agent_minimal`, `lookup_minimal`, `review_context`)
 - [~] 3. bounded API/tool surface
-  erfüllt: Core-Query Pfade vorhanden.
-  fehlt: dedizierte Lookup-Endpunkte.
+  erfüllt: Query-/Federation-Pfade vorhanden (siehe 2.5).
+  fehlt: dedizierte Lookup-Pfade.
 - [~] 4. maschinenlesbare uncertainty/provenance Felder
   erfüllt: Contract existiert und Validierung steht.
   fehlt: Signale aus Graph/Semantik Pfaden in den Contract leiten.
@@ -1785,9 +1786,9 @@ Die vorhandene Infrastruktur wird benutzbar, ohne die Architektur zu verwässern
 Arbeitspakete:
 - [ ] **7.1 WebUI-Konsolidierung:** Bundle-Navigation, Trace-Ansicht, Explain-Ansicht, Artifact-Explorer.
 - [ ] **7.2 Diagnostic Views:** graph health, federation conflicts, bundle provenance, query trace.
-- [~] **7.3 Service-Endpunkte:** logisch vorgesehen: `/query`, `/context`, `/trace`, `/artifact`, `/federation/query`, `/diagnostics`.
-  erfüllt: Query/Federation-Pfade implementiert.
-  fehlt: dedizierte Lookup-Endpunkte fehlen.
+- [~] **7.3 Service-Endpunkte:**
+  erfüllt: Query-/Federation-Pfade vorhanden.
+  fehlt: dedizierte Lookup-Pfade (Context/Trace/Artifact/Diagnostics).
 - [ ] **7.4 Download-/Inspection-Flows:** bundle parts, traces, context bundles, diagnostics.
 
 Deliverables:

--- a/docs/lenskit-upgrade-blaupause.md
+++ b/docs/lenskit-upgrade-blaupause.md
@@ -1787,7 +1787,7 @@ Arbeitspakete:
 - [ ] **7.2 Diagnostic Views:** graph health, federation conflicts, bundle provenance, query trace.
 - [ ] **7.3 Service-Endpunkte:** `/query`, `/context`, `/trace`, `/artifact`, `/federation/query`, `/diagnostics`.
   erfüllt: API für Query/Federation vorhanden.
-  fehlt: Lookup-Operationen sind noch nicht als getrennte Serviceverträge ausgebildet.
+  fehlt: dedizierte Lookup-Endpunkte fehlen.
 - [ ] **7.4 Download-/Inspection-Flows:** bundle parts, traces, context bundles, diagnostics.
 
 Deliverables:

--- a/docs/lenskit-upgrade-blaupause.md
+++ b/docs/lenskit-upgrade-blaupause.md
@@ -1648,25 +1648,11 @@ Ziel:
 
 Operationen:
 - [x] 1. query (API vorhanden)
-- [ ] 2. context_bundle
-  - Zweck: deterministische Rekonstruktion eines Bundles ohne erneutes Ranking
-  - Input: `{ "bundle_id": "string", "index_id": "string" }`
-  - Output: `ContextBundle`
-  - Abgrenzung: keine freie Suche, nur Abruf bereits gesicherter Bundles
-- [ ] 3. trace_lookup
-  - Zweck: Abruf struktureller Laufzeitmetadaten einer vergangenen Query
-  - Input: `{ "trace_id": "string" }`
-  - Output: `QueryTrace` oder `FederationTrace`
-  - Abgrenzung: reiner Status- und Path-Lookup
-- [ ] 4. artifact_lookup
-  - Zweck: Download generierter physischer Dateien
-  - Input: `{ "artifact_id": "string" }`
-  - Output: Binary / JSON Payload
-- [x] 5. federation_query (API vorhanden)
-- [ ] 6. diagnostics
-  - Zweck: Systemgesundheit und Identitätskonflikte prüfen
-  - Input: `{ "scope": "string" }`
-  - Output: `DiagnosticReport`
+- [ ] 2. context_bundle (dedizierter Lookup-Endpunkt fehlt)
+- [ ] 3. trace_lookup (Trace-Lookup ist architektonisch vorgesehen, aber Request/Response-Contract ist noch nicht festgelegt)
+- [ ] 4. artifact_lookup (Artifact-Download ist logisch erforderlich, aber als eigener Servicevertrag noch nicht definiert)
+- [x] 5. federation_query (als HTTP-Servicepfad vorhanden)
+- [ ] 6. diagnostics (dedizierter Endpunkt fehlt)
 
 Nicht direkt zulassen: freie Dateisystemnavigation ohne Scope, implizites Zusammenmischen beliebiger Bundles, ungebundene „find everything about X“-Operationen ohne Grenzen.
 
@@ -1701,7 +1687,7 @@ Ziel:
 Traceability Model (Expliziter Architektur-Entscheid):
 - **v1 (CLI)**: Physisches Artefakt (`agent_query_session.v1`). Enthält `refs` + Hashes. Referenzierbar und reproduzierbar.
 - **v2 (API)**: Inline Session. Enthält keine `refs`.
-*Die API ist aktuell bewusst nicht referenzierbar reproduzierbar, da sie als reines Transportmedium fungiert. Langfristiges Ziel: API erzeugt referenzierbare Artefakte (Storage Backing).*
+*Der aktuelle API-Pfad liefert nur die Inline-v2-Session; ein physischer, referenzierbarer Artefakt-Layer ist dort derzeit nicht vorhanden.*
 
 Neues Artefakt: `agent_query_session.json`
 
@@ -1723,8 +1709,17 @@ Priority: P1
 Ziel:
 - [~] Lenskit soll problematische Zustände aktiv markieren. (teilweise: Warnungen wie conflict oder stale werden generiert, Guardrail \"low result coverage\" ist in `test_api_query.py` belegt; Guardrails für invalid graph, missing provenance, cross-repo conflict bleiben offen)
 
-Warnungen: stale bundle, invalid graph, missing provenance, derived fallback only, cross-repo conflict, incomplete scope, low result coverage.
-Reaktion: Nicht blockieren, aber markieren.
+Guardrails:
+- **low_result_coverage**:
+  - signal: `warning.low_coverage` (als belegter Output-Warning Mechanismus implementiert)
+- **stale_bundle**:
+  - für diese Guardrail existiert noch keine repo-belegte strukturierte Runtime-Markierung
+- **invalid_graph**:
+  - für diese Guardrail existiert noch keine repo-belegte strukturierte Runtime-Markierung
+- **missing_provenance**:
+  - für diese Guardrail existiert noch keine repo-belegte strukturierte Runtime-Markierung
+- **cross_repo_conflict**:
+  - für diese Guardrail existiert noch keine repo-belegte strukturierte Runtime-Markierung
 
 ### 2.11 Arbeitspaket I – Evaluierung der Agent-Nutzung
 Priority: P1
@@ -1751,7 +1746,7 @@ Tests:
   fehlt: Signale aus Graph/Semantik Pfaden in den Contract leiten.
 - [~] 5. `agent_query_session.json`
   erfüllt: CLI Artefakt (v1) und API Inline (v2) Contract aktiv.
-  fehlt: Konsolidierung der API hin zu physischen Artefakten (Storage Backing).
+  fehlt: Physischer Artefakt-Layer für API-Sessions.
 - [ ] 6. service-/MCP-fähige Schnittstellenlogik
   erfüllt: API Servicepfade existieren.
   fehlt: MCP Protocol Implementation.

--- a/docs/lenskit-upgrade-blaupause.md
+++ b/docs/lenskit-upgrade-blaupause.md
@@ -1713,7 +1713,7 @@ Ziel:
 
 Guardrails:
 - **Repo-belegt implementiert**:
-  - `low_result_coverage` (Runtime-Warning-Output belegt)
+  - `low_result_coverage` (emittierter Warning-String: "Low result coverage")
 - **Fachlich relevante, aber derzeit nicht repo-belegte Runtime-Guardrails**:
   - `stale_bundle`
   - `invalid_graph`

--- a/docs/lenskit-upgrade-blaupause.md
+++ b/docs/lenskit-upgrade-blaupause.md
@@ -1641,22 +1641,22 @@ Profile:
 ### 2.5 Arbeitspaket C – Bounded Tool Surface
 
 Ziel:
-- [ ] Lenskit soll als Werkzeug präzise Grenzen haben.
+- [~] Lenskit soll als Werkzeug präzise Grenzen haben. (teilweise: `/api/query` und `/api/federation/query` setzen Scope-Grenzen, dedizierte Lookup-Endpunkte fehlen)
 
 Operationen:
-1. query
-2. context_bundle
-3. trace_lookup
-4. artifact_lookup
-5. federation_query
-6. diagnostics
+- [x] 1. query (vorhanden via `/api/query`)
+- [ ] 2. context_bundle (offen: dedizierter Endpunkt fehlt in `app.py`)
+- [ ] 3. trace_lookup (offen: dedizierter Endpunkt fehlt in `app.py`)
+- [ ] 4. artifact_lookup (offen: dedizierter Endpunkt fehlt in `app.py`)
+- [x] 5. federation_query (vorhanden via `/api/federation/query`)
+- [ ] 6. diagnostics (offen: dedizierter Endpunkt fehlt in `app.py`)
 
 Nicht direkt zulassen: freie Dateisystemnavigation ohne Scope, implizites Zusammenmischen beliebiger Bundles, ungebundene „find everything about X“-Operationen ohne Grenzen.
 
 ### 2.6 Arbeitspaket D – Uncertainty / Provenance maschinenlesbar machen
 
 Ziel:
-- [ ] Agenten sollen nicht nur Ergebnisse, sondern auch deren epistemischen Status sehen. (teilweise: `epistemics` Contract definiert, Status wie `semantic_status` oder `graph_status` werden strikt konservativ aus Runtime-Logik abgeleitet)
+- [~] Agenten sollen nicht nur Ergebnisse, sondern auch deren epistemischen Status sehen. (teilweise: `epistemics` Contract definiert und in `test_api_query.py` getestet, jedoch bleiben komplexe Status wie `semantic_status` oft `unknown`, da Interpolation/Guardrails nicht vollständig durchgereicht werden)
 
 Felder: provenance_type, bundle_origin, resolver_status, graph_status, semantic_status, federation_status, uncertainty, interpolation.
 
@@ -1672,7 +1672,7 @@ Trennung:
 ### 2.8 Arbeitspaket F – Agent Traceability
 
 Ziel:
-- [~] Jede Agent-Nutzung ist nachvollziehbar (teilweise: CLI-Traceability über das Artefakt `agent_query_session.json` ist implementiert und testbelegt; der API-Trace-Pfad liefert eine Inline-v2-Session, aber nicht das vollständige Artefakt mit `refs`).
+- [~] Jede Agent-Nutzung ist nachvollziehbar (teilweise: CLI erzeugt physisches Artefakt `agent_query_session.v1` inkl. Hashes in `refs`; API liefert in `/api/query` eine Inline `agent_query_session.v2` ohne physische Trace-Referenzen).
 
 Neues Artefakt: `agent_query_session.json`
 
@@ -1681,14 +1681,14 @@ Inhalt: request contract, resolved bundle set, query trace refs, context bundle 
 ### 2.9 Arbeitspaket G – Service-Endpunkte / MCP-fähige Form
 
 Ziel:
-- [ ] Lenskit soll sich sauber an Orchestratoren oder MCP-artige Systeme andocken lassen (HTTP /api/query existiert strukturell, aber MCP-Schnittstellen an sich fehlen).
+- [~] Lenskit soll sich sauber an Orchestratoren oder MCP-artige Systeme andocken lassen (teilweise: HTTP `/api/query` und `/api/federation/query` existieren in `app.py`, jedoch fehlen MCP Protocol Bindings vollständig).
 
 Endpunkte logisch: `/query`, `/context`, `/trace`, `/artifact`, `/federation/query`, `/diagnostics`
 
 ### 2.10 Arbeitspaket H – Guardrails für Agenten
 
 Ziel:
-- [~] Lenskit soll problematische Zustände aktiv markieren. (teilweise: Warnungen wie conflict oder stale werden generiert, einfache Guardrail-Heuristik auf Basis geringer Trefferabdeckung ("low result coverage") ist umgesetzt; weitergehende Guardrails fehlen noch)
+- [~] Lenskit soll problematische Zustände aktiv markieren. (teilweise: Warnungen wie conflict oder stale werden generiert, Guardrail \"low result coverage\" ist in `test_api_query.py` belegt; Guardrails für invalid graph, missing provenance, cross-repo conflict bleiben offen)
 
 Warnungen: stale bundle, invalid graph, missing provenance, derived fallback only, cross-repo conflict, incomplete scope, low result coverage.
 Reaktion: Nicht blockieren, aber markieren.
@@ -1709,11 +1709,11 @@ Tests:
 ### 2.12 Deliverables Phase 6
 - [x] 1. Agent Query Contract (für /api/query im API-Roundtrip minimal belegt und getestet)
 - [x] 2. Agent Output Profiles (strukturell existierend via `output_profile` wie `agent_minimal`, `lookup_minimal`, `review_context`)
-- [ ] 3. bounded API/tool surface
-- [ ] 4. maschinenlesbare uncertainty/provenance Felder (teilweise: strukturierter Contract verifiziert, aber einzelne Aspekte wie `semantic_status` bleiben bewusst `unknown` zur Wahrung der epistemischen Integrität)
+- [~] 3. bounded API/tool surface (teilweise: query/federation existieren, isolierte Lookups für context/trace/artifact fehlen)
+- [~] 4. maschinenlesbare uncertainty/provenance Felder (teilweise: strukturierter Contract verifiziert, aber einzelne Aspekte wie `semantic_status` bleiben bewusst `unknown` zur Wahrung der epistemischen Integrität)
 - [~] 5. `agent_query_session.json` (teilweise: Das CLI erzeugt das vollständige physische Artefakt inkl. Trace-Referenzen; die API erzeugt stattdessen ein Inline-Feld `agent_query_session` v2 und kein separates JSON-Artefakt).
-- [ ] 6. service-/MCP-fähige Schnittstellenlogik (offen: reiner Servicepfad /api/federation/query vorhanden, MCP-Protokoll fehlt gänzlich)
-- [~] 7. Agent-Guardrails (teilweise: einfache Guardrail-Heuristik für "low result coverage" verifiziert, vollständige Liste und tiefergehende Guardrails offen)
+- [~] 6. service-/MCP-fähige Schnittstellenlogik (teilweise: Servicepfad `/api/federation/query` und `/api/query` vorhanden, MCP-Protokoll fehlt gänzlich)
+- [~] 7. Agent-Guardrails (teilweise: Guardrail-Heuristik \"low result coverage\" belegt, strukturelle Härtung für fehlende Provenance etc. offen)
 
 ### 2.13 Gate für Phase 6
 - [ ] Phase 6 ist fertig, wenn:
@@ -1749,7 +1749,7 @@ Die vorhandene Infrastruktur wird benutzbar, ohne die Architektur zu verwässern
 Arbeitspakete:
 - [ ] **7.1 WebUI-Konsolidierung:** Bundle-Navigation, Trace-Ansicht, Explain-Ansicht, Artifact-Explorer.
 - [ ] **7.2 Diagnostic Views:** graph health, federation conflicts, bundle provenance, query trace.
-- [ ] **7.3 Service-Endpunkte:** /query, /context, /trace, /artifact, /federation/query, /diagnostics. (teilweise: /api/federation/query vorhanden, restliche Endpunkte offen)
+- [~] **7.3 Service-Endpunkte:** `/query`, `/context`, `/trace`, `/artifact`, `/federation/query`, `/diagnostics`. (teilweise: `/api/query` und `/api/federation/query` in `app.py` vorhanden, Lookup-Endpunkte fehlen)
 - [ ] **7.4 Download-/Inspection-Flows:** bundle parts, traces, context bundles, diagnostics.
 
 Deliverables:

--- a/docs/lenskit-upgrade-blaupause.md
+++ b/docs/lenskit-upgrade-blaupause.md
@@ -1662,7 +1662,7 @@ Nicht direkt zulassen: freie Dateisystemnavigation ohne Scope, implizites Zusamm
 Priority: P1
 
 Ziel:
-- [ ] Agenten sollen nicht nur Ergebnisse, sondern auch deren epistemischen Status sehen.
+- [~] Agenten sollen nicht nur Ergebnisse, sondern auch deren epistemischen Status sehen.
   erfüllt: `epistemics` Contract definiert und für lokale Basisdaten getestet.
   fehlt: Komplexe Status werden noch nicht durchgängig aus allen Pfaden in den Contract überführt (z.B. `semantic_status` bleibt konservativ `unknown`).
 

--- a/docs/lenskit-upgrade-blaupause.md
+++ b/docs/lenskit-upgrade-blaupause.md
@@ -1651,8 +1651,8 @@ Ziel:
 Operationen:
 - [x] 1. query (API vorhanden)
 - [ ] 2. context_bundle (dedizierter Lookup-Endpunkt fehlt)
-- [ ] 3. trace_lookup (als getrennte Operation vorgesehen, aber Request/Response-Contract ist noch nicht festgelegt)
-- [ ] 4. artifact_lookup (als getrennte Lookup-Operation naheliegend, aber als eigener Servicevertrag noch nicht definiert)
+- [ ] 3. trace_lookup (Request/Response-Contract ist nicht repo-belegt festgelegt)
+- [ ] 4. artifact_lookup (als separater Servicepfad nicht implementiert)
 - [x] 5. federation_query (als HTTP-Servicepfad vorhanden)
 - [ ] 6. diagnostics (dedizierter Endpunkt fehlt)
 
@@ -1687,8 +1687,8 @@ Ziel:
   fehlt: Einheitlicher physischer Trace-Layer für die API.
 
 Traceability Model (aktueller repo-belegter Stand):
-- CLI-Pfad: physisches Artefakt `agent_query_session.json` nach v1-Contract. Enthält `refs` + Hashes. Referenzierbar und reproduzierbar.
-- API-Pfad: Inline Session nach v2-Contract. Enthält keine `refs`.
+- CLI nutzt aktuell das physische Artefakt `agent_query_session.json` nach v1-Contract. Enthält `refs` + Hashes.
+- API liefert aktuell eine Inline-Session nach v2-Contract. Enthält keine `refs`.
 *Der aktuelle API-Pfad liefert nur die Inline-v2-Session; ein physischer, referenzierbarer Artefakt-Layer ist dort derzeit nicht vorhanden.*
 
 Physisches CLI-Artefakt: `agent_query_session.json`
@@ -1712,16 +1712,13 @@ Ziel:
 - [~] Lenskit soll problematische Zustände aktiv markieren. (teilweise: Warnungen wie conflict oder stale werden generiert, Guardrail "low result coverage" ist in `test_api_query.py` belegt; Guardrails für invalid graph, missing provenance, cross-repo conflict bleiben offen)
 
 Guardrails:
-- **low_result_coverage**:
-  - belegter Runtime-Warning-Output: "Low result coverage"
-- **stale_bundle**:
-  - für diese Guardrail existiert noch keine repo-belegte strukturierte Runtime-Markierung
-- **invalid_graph**:
-  - für diese Guardrail existiert noch keine repo-belegte strukturierte Runtime-Markierung
-- **missing_provenance**:
-  - für diese Guardrail existiert noch keine repo-belegte strukturierte Runtime-Markierung
-- **cross_repo_conflict**:
-  - für diese Guardrail existiert noch keine repo-belegte strukturierte Runtime-Markierung
+- **Repo-belegt implementiert**:
+  - `low_result_coverage` (belegter Runtime-Warning-Output: "Low result coverage")
+- **Fachlich relevante, aber derzeit nicht repo-belegte Runtime-Guardrails**:
+  - `stale_bundle`
+  - `invalid_graph`
+  - `missing_provenance`
+  - `cross_repo_conflict`
 
 ### 2.11 Arbeitspaket I – Evaluierung der Agent-Nutzung
 Priority: P1
@@ -1747,8 +1744,8 @@ Tests:
   erfüllt: Contract existiert und Validierung steht.
   fehlt: Signale aus Graph/Semantik Pfaden in den Contract leiten.
 - [~] 5. `agent_query_session.json`
-  erfüllt: CLI erzeugt physisches Artefakt (nach v1-Contract), API erzeugt Inline-Session (nach v2-Contract).
-  fehlt: Physischer Artefakt-Layer für API-Sessions.
+  erfüllt: CLI nutzt physisches Artefakt (v1), API liefert Inline-Session (v2).
+  fehlt: Einheitlicher physischer Trace-Layer für die API.
 - [ ] 6. service-/MCP-fähige Schnittstellenlogik
   erfüllt: API Servicepfade existieren.
   fehlt: MCP Protocol Implementation.

--- a/docs/lenskit-upgrade-blaupause.md
+++ b/docs/lenskit-upgrade-blaupause.md
@@ -1638,6 +1638,8 @@ Profile:
 * federated_search
 * debug_trace
 
+Priority-Hinweis: P0 = kurzfristig architekturkritisch / blocker-nah, P1 = wichtig, aber nachgeordnet.
+
 ### 2.5 Arbeitspaket C – Bounded Tool Surface
 Priority: P0
 
@@ -1649,8 +1651,8 @@ Ziel:
 Operationen:
 - [x] 1. query (API vorhanden)
 - [ ] 2. context_bundle (dedizierter Lookup-Endpunkt fehlt)
-- [ ] 3. trace_lookup (Trace-Lookup ist architektonisch vorgesehen, aber Request/Response-Contract ist noch nicht festgelegt)
-- [ ] 4. artifact_lookup (Artifact-Download ist logisch erforderlich, aber als eigener Servicevertrag noch nicht definiert)
+- [ ] 3. trace_lookup (als getrennte Operation vorgesehen, aber Request/Response-Contract ist noch nicht festgelegt)
+- [ ] 4. artifact_lookup (Roadmap-seitig erforderlich, aber als eigener Servicevertrag noch nicht definiert)
 - [x] 5. federation_query (als HTTP-Servicepfad vorhanden)
 - [ ] 6. diagnostics (dedizierter Endpunkt fehlt)
 
@@ -1689,7 +1691,7 @@ Traceability Model (aktueller repo-belegter Stand):
 - **v2 (API)**: Inline Session (nach v2-Contract). Enthält keine `refs`.
 *Der aktuelle API-Pfad liefert nur die Inline-v2-Session; ein physischer, referenzierbarer Artefakt-Layer ist dort derzeit nicht vorhanden.*
 
-Neues Artefakt: `agent_query_session.json`
+Physisches CLI-Artefakt: `agent_query_session.json`
 
 Inhalt: request contract, resolved bundle set, query trace refs, context bundle refs, diagnostics refs, warnings.
 

--- a/docs/lenskit-upgrade-blaupause.md
+++ b/docs/lenskit-upgrade-blaupause.md
@@ -1638,11 +1638,7 @@ Profile:
 * federated_search
 * debug_trace
 
-Priority-Hinweis: P0 = kurzfristig architekturkritisch / blocker-nah, P1 = wichtig, aber nachgeordnet. (Die Prioritäten sind redaktionelle Planungsgewichtungen dieser Blaupause, keine direkten Repo-Statusangaben.)
-
 ### 2.5 Arbeitspaket C – Bounded Tool Surface
-Priority: P0
-
 Ziel:
 - [~] Lenskit soll als Werkzeug präzise Grenzen haben.
   erfüllt: HTTP-seitig repo-belegt vorhanden: `/api/query`, `/api/federation/query`; logisch entspricht dies den Endpunkten `/query` und `/federation/query`.
@@ -1659,8 +1655,6 @@ Operationen:
 Nicht direkt zulassen: freie Dateisystemnavigation ohne Scope, implizites Zusammenmischen beliebiger Bundles, ungebundene „find everything about X“-Operationen ohne Grenzen.
 
 ### 2.6 Arbeitspaket D – Uncertainty / Provenance maschinenlesbar machen
-Priority: P1
-
 Ziel:
 - [~] Agenten sollen nicht nur Ergebnisse, sondern auch deren epistemischen Status sehen.
   erfüllt: `epistemics` Contract definiert und für lokale Basisdaten getestet.
@@ -1669,8 +1663,6 @@ Ziel:
 Felder: provenance_type, bundle_origin, resolver_status, graph_status, semantic_status, federation_status, uncertainty, interpolation.
 
 ### 2.7 Arbeitspaket E – Decision-Support von Retrieval trennen
-Priority: P1
-
 Ziel:
 - [ ] Lenskit bleibt Retrieval- und Evidenzsystem, kein Entscheidungsautomat.
 
@@ -1679,8 +1671,6 @@ Trennung:
 * Agent / Orchestrator entscheidet: was relevant ist, welche Handlung folgt, welche Synthese gebildet wird.
 
 ### 2.8 Arbeitspaket F – Agent Traceability
-Priority: P0
-
 Ziel:
 - [~] Jede Agent-Nutzung ist nachvollziehbar.
   erfüllt: CLI-/API-Verhalten unterscheiden sich belegbar in Trace-Artefakt vs. Inline-Session.
@@ -1696,16 +1686,12 @@ Physisches CLI-Artefakt: `agent_query_session.json`
 Inhalt: request contract, resolved bundle set, query trace refs, context bundle refs, diagnostics refs, warnings.
 
 ### 2.9 Arbeitspaket G – Service-Endpunkte / MCP-fähige Form
-Priority: P0
-
 Ziel:
 - [~] Lenskit soll sich sauber an Orchestratoren oder MCP-artige Systeme andocken lassen.
   erfüllt: HTTP-Servicepfade (siehe 2.5) vorhanden.
   fehlt: MCP Protocol Bindings (z.B. mcp-server) fehlen.
 
 ### 2.10 Arbeitspaket H – Guardrails für Agenten
-Priority: P1
-
 Ziel:
 - [~] Lenskit soll problematische Zustände aktiv markieren. (teilweise: Guardrail "low result coverage" ist als Runtime-Warning belegt; Guardrails für stale bundle, invalid graph, missing provenance und cross-repo conflict bleiben als strukturierte Runtime-Signale noch offen)
 
@@ -1720,8 +1706,6 @@ Guardrails:
   - `cross_repo_conflict`
 
 ### 2.11 Arbeitspaket I – Evaluierung der Agent-Nutzung
-Priority: P1
-
 Ziel:
 - [ ] Nicht nur Query-Qualität, sondern Agent-Tauglichkeit prüfen.
 
@@ -1736,19 +1720,11 @@ Tests:
 ### 2.12 Deliverables Phase 6
 - [x] 1. Agent Query Contract (minimaler HTTP-Roundtrip über `/api/query` repo-belegt und getestet)
 - [x] 2. Agent Output Profiles (strukturell existierend via `output_profile` wie `agent_minimal`, `lookup_minimal`, `review_context`)
-- [~] 3. bounded API/tool surface
-  erfüllt: Query-/Federation-Pfade vorhanden (siehe 2.5).
-  fehlt: dedizierte Lookup-Pfade.
-- [~] 4. maschinenlesbare uncertainty/provenance Felder
-  erfüllt: Contract existiert und Validierung steht.
-  fehlt: Signale aus Graph/Semantik Pfaden in den Contract leiten.
-- [~] 5. `agent_query_session.json`
-  erfüllt: CLI nutzt Artefakt (v1), API liefert Inline-Session (v2).
-  fehlt: Physischer Trace-Layer für die API.
-- [~] 6. service-/MCP-fähige Schnittstellenlogik
-  erfüllt: API Servicepfade existieren.
-  fehlt: MCP Protocol Implementation.
-- [~] 7. Agent-Guardrails (teilweise: Guardrail-Heuristik "low result coverage" belegt, strukturelle Härtung für fehlende Provenance etc. offen)
+- [~] 3. bounded API/tool surface (Query-/Federation-Pfade vorhanden, dedizierte Lookup-Pfade fehlen)
+- [~] 4. maschinenlesbare uncertainty/provenance Felder (Contract existiert, komplexe Status fehlen)
+- [~] 5. `agent_query_session.json` (CLI nutzt v1 Artefakt, API liefert v2 Inline-Session)
+- [~] 6. service-/MCP-fähige Schnittstellenlogik (API Servicepfade existieren, MCP Protokoll fehlt)
+- [~] 7. Agent-Guardrails (teilweise: Guardrail-Heuristik "low result coverage" belegt, Härtung offen)
 
 ### 2.13 Gate für Phase 6
 - [ ] Phase 6 ist fertig, wenn:
@@ -1784,9 +1760,7 @@ Die vorhandene Infrastruktur wird benutzbar, ohne die Architektur zu verwässern
 Arbeitspakete:
 - [ ] **7.1 WebUI-Konsolidierung:** Bundle-Navigation, Trace-Ansicht, Explain-Ansicht, Artifact-Explorer.
 - [ ] **7.2 Diagnostic Views:** graph health, federation conflicts, bundle provenance, query trace.
-- [~] **7.3 Service-Endpunkte:** `/query`, `/context`, `/trace`, `/artifact`, `/federation/query`, `/diagnostics`
-  erfüllt: Query-/Federation-Pfade vorhanden.
-  fehlt: dedizierte Lookup-Pfade.
+- [~] **7.3 Service-Endpunkte:** logisch vorgesehen: `/query`, `/context`, `/trace`, `/artifact`, `/federation/query`, `/diagnostics`. repo-belegt vorhanden: `/api/query`, `/api/federation/query`. dedizierte Lookup-Pfade fehlen.
 - [ ] **7.4 Download-/Inspection-Flows:** bundle parts, traces, context bundles, diagnostics.
 
 Deliverables:

--- a/docs/lenskit-upgrade-blaupause.md
+++ b/docs/lenskit-upgrade-blaupause.md
@@ -1645,7 +1645,7 @@ Priority: P0
 
 Ziel:
 - [ ] Lenskit soll als Werkzeug präzise Grenzen haben.
-  erfüllt: `/api/query` und `/api/federation/query` sind als begrenzte API-Pfade implementiert.
+  erfüllt: HTTP-seitig repo-belegt vorhanden: `/api/query`, `/api/federation/query`; logisch entspricht dies den Endpunkten `/query` und `/federation/query`.
   fehlt: dedizierte Lookup-Endpunkte zur isolierten Rekonstruktion fehlen.
 
 Operationen:
@@ -1700,7 +1700,7 @@ Priority: P0
 
 Ziel:
 - [ ] Lenskit soll sich sauber an Orchestratoren oder MCP-artige Systeme andocken lassen.
-  erfüllt: HTTP API für `/query` und `/federation/query` implementiert.
+  erfüllt: HTTP-seitig repo-belegt implementiert sind aktuell `/api/query` und `/api/federation/query` (logisch: `/query`, `/federation/query`).
   fehlt: MCP Protocol Bindings (z.B. mcp-server) fehlen gänzlich.
 
 Endpunkte logisch: `/query`, `/context`, `/trace`, `/artifact`, `/federation/query`, `/diagnostics`
@@ -1738,7 +1738,7 @@ Tests:
 - [x] 1. Agent Query Contract (für /api/query im API-Roundtrip minimal belegt und getestet)
 - [x] 2. Agent Output Profiles (strukturell existierend via `output_profile` wie `agent_minimal`, `lookup_minimal`, `review_context`)
 - [ ] 3. bounded API/tool surface
-  erfüllt: query/federation Servicepfade vorhanden.
+  erfüllt: HTTP-seitig belegt vorhanden: `/api/query`, `/api/federation/query` (logische Endpunkte `/query`, `/federation/query`).
   fehlt: dedizierte Lookup-Endpunkte (context/trace/artifact).
 - [ ] 4. maschinenlesbare uncertainty/provenance Felder
   erfüllt: Contract existiert und Validierung steht.
@@ -1785,8 +1785,8 @@ Die vorhandene Infrastruktur wird benutzbar, ohne die Architektur zu verwässern
 Arbeitspakete:
 - [ ] **7.1 WebUI-Konsolidierung:** Bundle-Navigation, Trace-Ansicht, Explain-Ansicht, Artifact-Explorer.
 - [ ] **7.2 Diagnostic Views:** graph health, federation conflicts, bundle provenance, query trace.
-- [ ] **7.3 Service-Endpunkte:** `/query`, `/context`, `/trace`, `/artifact`, `/federation/query`, `/diagnostics`.
-  erfüllt: API für Query/Federation vorhanden.
+- [ ] **7.3 Service-Endpunkte:** logisch vorgesehen: `/query`, `/context`, `/trace`, `/artifact`, `/federation/query`, `/diagnostics`.
+  erfüllt: repo-belegt als HTTP-Servicepfade aktuell implementiert: `/api/query` und `/api/federation/query`.
   fehlt: dedizierte Lookup-Endpunkte fehlen.
 - [ ] **7.4 Download-/Inspection-Flows:** bundle parts, traces, context bundles, diagnostics.
 

--- a/docs/lenskit-upgrade-blaupause.md
+++ b/docs/lenskit-upgrade-blaupause.md
@@ -1673,7 +1673,7 @@ Trennung:
 ### 2.8 Arbeitspaket F – Agent Traceability
 Ziel:
 - [~] Jede Agent-Nutzung ist nachvollziehbar.
-  CLI: nutzt physisches Artefakt `agent_query_session.json` (v1-Contract).
+  CLI: nutzt physisches Artefakt `agent_query_session.json` (v1-Contract). Es bündelt Request-, Bundle-, Trace- und Diagnose-Bezüge.
   API: liefert Inline-Session (v2-Contract); ein referenzierbarer, physischer Trace-Layer fehlt hier derzeit.
 
 ### 2.9 Arbeitspaket G – Service-Endpunkte / MCP-fähige Form
@@ -1745,7 +1745,9 @@ Die vorhandene Infrastruktur wird benutzbar, ohne die Architektur zu verwässern
 Arbeitspakete:
 - [ ] **7.1 WebUI-Konsolidierung:** Bundle-Navigation, Trace-Ansicht, Explain-Ansicht, Artifact-Explorer.
 - [ ] **7.2 Diagnostic Views:** graph health, federation conflicts, bundle provenance, query trace.
-- [~] **7.3 Service-Endpunkte:** logisch vorgesehen: `/query`, `/context`, `/trace`, `/artifact`, `/federation/query`, `/diagnostics`. repo-belegt vorhanden: `/api/query`, `/api/federation/query`. dedizierte Lookup-Pfade fehlen.
+- [~] **7.3 Service-Endpunkte:**
+  logisch vorgesehen: `/query`, `/context`, `/trace`, `/artifact`, `/federation/query`, `/diagnostics`.
+  repo-belegt vorhanden: `/api/query`, `/api/federation/query`. (Dedizierte Lookup-Pfade fehlen).
 - [ ] **7.4 Download-/Inspection-Flows:** bundle parts, traces, context bundles, diagnostics.
 
 Deliverables:

--- a/docs/lenskit-upgrade-blaupause.md
+++ b/docs/lenskit-upgrade-blaupause.md
@@ -1651,7 +1651,7 @@ Ziel:
 Operationen:
 - [x] 1. query (API vorhanden)
 - [ ] 2. context_bundle (dedizierter Lookup-Endpunkt fehlt)
-- [ ] 3. trace_lookup (Request/Response-Contract fehlt)
+- [ ] 3. trace_lookup (als repo-belegter Request/Response-Contract noch nicht festgelegt)
 - [ ] 4. artifact_lookup (als separater Servicepfad nicht implementiert)
 - [x] 5. federation_query (als HTTP-Servicepfad vorhanden)
 - [ ] 6. diagnostics (dedizierter Endpunkt fehlt)
@@ -1714,7 +1714,7 @@ Ziel:
 Guardrails:
 - **Repo-belegt implementiert**:
   - `low_result_coverage` (Runtime-Warning-Output belegt)
-- **Fachlich relevante, aber derzeit nicht repo-belegte Runtime-Guardrails**:
+- **Fachlich relevante Guardrail-Klassen (derzeit nicht als strukturierte Runtime-Signale repo-belegt)**:
   - `stale_bundle`
   - `invalid_graph`
   - `missing_provenance`

--- a/docs/lenskit-upgrade-blaupause.md
+++ b/docs/lenskit-upgrade-blaupause.md
@@ -1652,7 +1652,7 @@ Operationen:
 - [x] 1. query (API vorhanden)
 - [ ] 2. context_bundle (dedizierter Lookup-Endpunkt fehlt)
 - [ ] 3. trace_lookup (als getrennte Operation vorgesehen, aber Request/Response-Contract ist noch nicht festgelegt)
-- [ ] 4. artifact_lookup (Roadmap-seitig erforderlich, aber als eigener Servicevertrag noch nicht definiert)
+- [ ] 4. artifact_lookup (als getrennte Lookup-Operation naheliegend, aber als eigener Servicevertrag noch nicht definiert)
 - [x] 5. federation_query (als HTTP-Servicepfad vorhanden)
 - [ ] 6. diagnostics (dedizierter Endpunkt fehlt)
 
@@ -1687,8 +1687,8 @@ Ziel:
   fehlt: Einheitlicher physischer Trace-Layer für die API.
 
 Traceability Model (aktueller repo-belegter Stand):
-- **v1 (CLI)**: Physisches Artefakt `agent_query_session.json` (nach v1-Contract). Enthält `refs` + Hashes. Referenzierbar und reproduzierbar.
-- **v2 (API)**: Inline Session (nach v2-Contract). Enthält keine `refs`.
+- CLI-Pfad: physisches Artefakt `agent_query_session.json` nach v1-Contract. Enthält `refs` + Hashes. Referenzierbar und reproduzierbar.
+- API-Pfad: Inline Session nach v2-Contract. Enthält keine `refs`.
 *Der aktuelle API-Pfad liefert nur die Inline-v2-Session; ein physischer, referenzierbarer Artefakt-Layer ist dort derzeit nicht vorhanden.*
 
 Physisches CLI-Artefakt: `agent_query_session.json`
@@ -1709,7 +1709,7 @@ Endpunkte logisch: `/query`, `/context`, `/trace`, `/artifact`, `/federation/que
 Priority: P1
 
 Ziel:
-- [~] Lenskit soll problematische Zustände aktiv markieren. (teilweise: Warnungen wie conflict oder stale werden generiert, Guardrail \"low result coverage\" ist in `test_api_query.py` belegt; Guardrails für invalid graph, missing provenance, cross-repo conflict bleiben offen)
+- [~] Lenskit soll problematische Zustände aktiv markieren. (teilweise: Warnungen wie conflict oder stale werden generiert, Guardrail "low result coverage" ist in `test_api_query.py` belegt; Guardrails für invalid graph, missing provenance, cross-repo conflict bleiben offen)
 
 Guardrails:
 - **low_result_coverage**:
@@ -1752,7 +1752,7 @@ Tests:
 - [ ] 6. service-/MCP-fähige Schnittstellenlogik
   erfüllt: API Servicepfade existieren.
   fehlt: MCP Protocol Implementation.
-- [~] 7. Agent-Guardrails (teilweise: Guardrail-Heuristik \"low result coverage\" belegt, strukturelle Härtung für fehlende Provenance etc. offen)
+- [~] 7. Agent-Guardrails (teilweise: Guardrail-Heuristik "low result coverage" belegt, strukturelle Härtung für fehlende Provenance etc. offen)
 
 ### 2.13 Gate für Phase 6
 - [ ] Phase 6 ist fertig, wenn:

--- a/docs/lenskit-upgrade-blaupause.md
+++ b/docs/lenskit-upgrade-blaupause.md
@@ -1709,7 +1709,7 @@ Endpunkte logisch: `/query`, `/context`, `/trace`, `/artifact`, `/federation/que
 Priority: P1
 
 Ziel:
-- [~] Lenskit soll problematische Zustände aktiv markieren. (teilweise: Warnungen wie conflict oder stale werden generiert, Guardrail "low result coverage" ist in `test_api_query.py` belegt; Guardrails für invalid graph, missing provenance, cross-repo conflict bleiben offen)
+- [~] Lenskit soll problematische Zustände aktiv markieren. (teilweise: Guardrail "low result coverage" ist als Runtime-Warning belegt; Guardrails für stale bundle, invalid graph, missing provenance und cross-repo conflict bleiben als strukturierte Runtime-Signale noch offen)
 
 Guardrails:
 - **Repo-belegt implementiert**:

--- a/docs/lenskit-upgrade-blaupause.md
+++ b/docs/lenskit-upgrade-blaupause.md
@@ -1644,14 +1644,14 @@ Priority-Hinweis: P0 = kurzfristig architekturkritisch / blocker-nah, P1 = wicht
 Priority: P0
 
 Ziel:
-- [ ] Lenskit soll als Werkzeug präzise Grenzen haben.
+- [~] Lenskit soll als Werkzeug präzise Grenzen haben.
   erfüllt: HTTP-seitig repo-belegt vorhanden: `/api/query`, `/api/federation/query`; logisch entspricht dies den Endpunkten `/query` und `/federation/query`.
   fehlt: dedizierte Lookup-Endpunkte zur isolierten Rekonstruktion fehlen.
 
 Operationen:
 - [x] 1. query (logisch vorgesehen als `/query`; HTTP-seitig repo-belegt via `/api/query`)
-- [ ] 2. context_bundle (dedizierter Lookup-Endpunkt fehlt)
-- [ ] 3. trace_lookup (als repo-belegter Request/Response-Contract noch nicht festgelegt)
+- [ ] 2. context_bundle (dedizierter Endpunkt fehlt)
+- [ ] 3. trace_lookup (Request/Response-Contract fehlt)
 - [ ] 4. artifact_lookup (als separater Servicepfad nicht implementiert)
 - [x] 5. federation_query (logisch vorgesehen als `/federation/query`; HTTP-seitig repo-belegt via `/api/federation/query`)
 - [ ] 6. diagnostics (dedizierter Endpunkt fehlt)
@@ -1687,8 +1687,8 @@ Ziel:
   fehlt: Einheitlicher physischer Trace-Layer für die API.
 
 Traceability Model (aktueller repo-belegter Stand):
-- CLI-Pfad: nutzt aktuell das physische Artefakt `agent_query_session.json` nach v1-Contract. Enthält `refs` + Hashes.
-- API-Pfad: liefert aktuell eine Inline-Session nach v2-Contract. Enthält keine `refs`.
+- CLI nutzt aktuell das physische Artefakt `agent_query_session.json` nach v1-Contract.
+- API liefert aktuell eine Inline-Session nach v2-Contract.
 *Der aktuelle API-Pfad liefert nur die Inline-v2-Session; ein physischer, referenzierbarer Artefakt-Layer ist dort derzeit nicht vorhanden.*
 
 Physisches CLI-Artefakt: `agent_query_session.json`
@@ -1699,7 +1699,7 @@ Inhalt: request contract, resolved bundle set, query trace refs, context bundle 
 Priority: P0
 
 Ziel:
-- [ ] Lenskit soll sich sauber an Orchestratoren oder MCP-artige Systeme andocken lassen.
+- [~] Lenskit soll sich sauber an Orchestratoren oder MCP-artige Systeme andocken lassen.
   erfüllt: HTTP-seitig repo-belegt implementiert sind aktuell `/api/query` und `/api/federation/query` (logisch: `/query`, `/federation/query`).
   fehlt: MCP Protocol Bindings (z.B. mcp-server) fehlen gänzlich.
 
@@ -1714,7 +1714,7 @@ Ziel:
 Guardrails:
 - **Repo-belegt implementiert**:
   - `low_result_coverage` (Runtime-Warning-Output belegt)
-- **Fachlich relevante Guardrail-Klassen (derzeit nicht als strukturierte Runtime-Signale repo-belegt)**:
+- **Fachlich relevante, aber derzeit nicht repo-belegte Runtime-Guardrails**:
   - `stale_bundle`
   - `invalid_graph`
   - `missing_provenance`
@@ -1737,16 +1737,16 @@ Tests:
 ### 2.12 Deliverables Phase 6
 - [x] 1. Agent Query Contract (minimaler HTTP-Roundtrip über `/api/query` repo-belegt und getestet)
 - [x] 2. Agent Output Profiles (strukturell existierend via `output_profile` wie `agent_minimal`, `lookup_minimal`, `review_context`)
-- [ ] 3. bounded API/tool surface
+- [~] 3. bounded API/tool surface
   erfüllt: HTTP-seitig belegt vorhanden: `/api/query`, `/api/federation/query` (logische Endpunkte `/query`, `/federation/query`).
   fehlt: dedizierte Lookup-Endpunkte (context/trace/artifact).
-- [ ] 4. maschinenlesbare uncertainty/provenance Felder
+- [~] 4. maschinenlesbare uncertainty/provenance Felder
   erfüllt: Contract existiert und Validierung steht.
   fehlt: Signale aus Graph/Semantik Pfaden in den Contract leiten.
 - [~] 5. `agent_query_session.json`
-  erfüllt: CLI-Pfad nutzt physisches Artefakt (v1), API-Pfad liefert Inline-Session (v2).
+  erfüllt: CLI nutzt physisches Artefakt (v1), API liefert Inline-Session (v2).
   fehlt: Einheitlicher physischer Trace-Layer für die API.
-- [ ] 6. service-/MCP-fähige Schnittstellenlogik
+- [~] 6. service-/MCP-fähige Schnittstellenlogik
   erfüllt: API Servicepfade existieren.
   fehlt: MCP Protocol Implementation.
 - [~] 7. Agent-Guardrails (teilweise: Guardrail-Heuristik "low result coverage" belegt, strukturelle Härtung für fehlende Provenance etc. offen)
@@ -1785,7 +1785,7 @@ Die vorhandene Infrastruktur wird benutzbar, ohne die Architektur zu verwässern
 Arbeitspakete:
 - [ ] **7.1 WebUI-Konsolidierung:** Bundle-Navigation, Trace-Ansicht, Explain-Ansicht, Artifact-Explorer.
 - [ ] **7.2 Diagnostic Views:** graph health, federation conflicts, bundle provenance, query trace.
-- [ ] **7.3 Service-Endpunkte:** logisch vorgesehen: `/query`, `/context`, `/trace`, `/artifact`, `/federation/query`, `/diagnostics`.
+- [~] **7.3 Service-Endpunkte:** logisch vorgesehen: `/query`, `/context`, `/trace`, `/artifact`, `/federation/query`, `/diagnostics`.
   erfüllt: repo-belegt als HTTP-Servicepfade aktuell implementiert: `/api/query` und `/api/federation/query`.
   fehlt: dedizierte Lookup-Endpunkte fehlen.
 - [ ] **7.4 Download-/Inspection-Flows:** bundle parts, traces, context bundles, diagnostics.

--- a/docs/lenskit-upgrade-blaupause.md
+++ b/docs/lenskit-upgrade-blaupause.md
@@ -1649,11 +1649,11 @@ Ziel:
   fehlt: dedizierte Lookup-Endpunkte zur isolierten Rekonstruktion fehlen.
 
 Operationen:
-- [x] 1. query (API vorhanden)
+- [x] 1. query (logisch vorgesehen als `/query`; HTTP-seitig repo-belegt via `/api/query`)
 - [ ] 2. context_bundle (dedizierter Lookup-Endpunkt fehlt)
 - [ ] 3. trace_lookup (als repo-belegter Request/Response-Contract noch nicht festgelegt)
 - [ ] 4. artifact_lookup (als separater Servicepfad nicht implementiert)
-- [x] 5. federation_query (als HTTP-Servicepfad vorhanden)
+- [x] 5. federation_query (logisch vorgesehen als `/federation/query`; HTTP-seitig repo-belegt via `/api/federation/query`)
 - [ ] 6. diagnostics (dedizierter Endpunkt fehlt)
 
 Nicht direkt zulassen: freie Dateisystemnavigation ohne Scope, implizites Zusammenmischen beliebiger Bundles, ungebundene „find everything about X“-Operationen ohne Grenzen.
@@ -1735,7 +1735,7 @@ Tests:
 - [x] 6. test_agent_federated_conflict_warning
 
 ### 2.12 Deliverables Phase 6
-- [x] 1. Agent Query Contract (für /api/query im API-Roundtrip minimal belegt und getestet)
+- [x] 1. Agent Query Contract (minimaler HTTP-Roundtrip über `/api/query` repo-belegt und getestet)
 - [x] 2. Agent Output Profiles (strukturell existierend via `output_profile` wie `agent_minimal`, `lookup_minimal`, `review_context`)
 - [ ] 3. bounded API/tool surface
   erfüllt: HTTP-seitig belegt vorhanden: `/api/query`, `/api/federation/query` (logische Endpunkte `/query`, `/federation/query`).

--- a/docs/lenskit-upgrade-blaupause.md
+++ b/docs/lenskit-upgrade-blaupause.md
@@ -1639,28 +1639,49 @@ Profile:
 * debug_trace
 
 ### 2.5 Arbeitspaket C – Bounded Tool Surface
+Priority: P0
 
 Ziel:
-- [~] Lenskit soll als Werkzeug präzise Grenzen haben. (teilweise: `/api/query` und `/api/federation/query` setzen Scope-Grenzen, dedizierte Lookup-Endpunkte fehlen)
+- [ ] Lenskit soll als Werkzeug präzise Grenzen haben.
+  erfüllt: `/api/query` und `/api/federation/query` existieren und setzen Scope-Grenzen.
+  fehlt: dedizierte Lookup-Endpunkte zur isolierten Rekonstruktion fehlen.
 
 Operationen:
-- [x] 1. query (vorhanden via `/api/query`)
-- [ ] 2. context_bundle (offen: dedizierter Endpunkt fehlt in `app.py`)
-- [ ] 3. trace_lookup (offen: dedizierter Endpunkt fehlt in `app.py`)
-- [ ] 4. artifact_lookup (offen: dedizierter Endpunkt fehlt in `app.py`)
-- [x] 5. federation_query (vorhanden via `/api/federation/query`)
-- [ ] 6. diagnostics (offen: dedizierter Endpunkt fehlt in `app.py`)
+- [x] 1. query (API vorhanden)
+- [ ] 2. context_bundle
+  - Zweck: deterministische Rekonstruktion eines Bundles ohne erneutes Ranking
+  - Input: `{ "bundle_id": "string", "index_id": "string" }`
+  - Output: `ContextBundle`
+  - Abgrenzung: keine freie Suche, nur Abruf bereits gesicherter Bundles
+- [ ] 3. trace_lookup
+  - Zweck: Abruf struktureller Laufzeitmetadaten einer vergangenen Query
+  - Input: `{ "trace_id": "string" }`
+  - Output: `QueryTrace` oder `FederationTrace`
+  - Abgrenzung: reiner Status- und Path-Lookup
+- [ ] 4. artifact_lookup
+  - Zweck: Download generierter physischer Dateien
+  - Input: `{ "artifact_id": "string" }`
+  - Output: Binary / JSON Payload
+- [x] 5. federation_query (API vorhanden)
+- [ ] 6. diagnostics
+  - Zweck: Systemgesundheit und Identitätskonflikte prüfen
+  - Input: `{ "scope": "string" }`
+  - Output: `DiagnosticReport`
 
 Nicht direkt zulassen: freie Dateisystemnavigation ohne Scope, implizites Zusammenmischen beliebiger Bundles, ungebundene „find everything about X“-Operationen ohne Grenzen.
 
 ### 2.6 Arbeitspaket D – Uncertainty / Provenance maschinenlesbar machen
+Priority: P1
 
 Ziel:
-- [~] Agenten sollen nicht nur Ergebnisse, sondern auch deren epistemischen Status sehen. (teilweise: `epistemics` Contract definiert und in `test_api_query.py` getestet, jedoch bleiben komplexe Status wie `semantic_status` oft `unknown`, da Interpolation/Guardrails nicht vollständig durchgereicht werden)
+- [ ] Agenten sollen nicht nur Ergebnisse, sondern auch deren epistemischen Status sehen.
+  erfüllt: `epistemics` Contract definiert und für lokale Basisdaten getestet.
+  fehlt: Durchgängige Interpolation und Fallback-Signale für komplexe Status (z.B. `semantic_status` bleibt meist `unknown`).
 
 Felder: provenance_type, bundle_origin, resolver_status, graph_status, semantic_status, federation_status, uncertainty, interpolation.
 
 ### 2.7 Arbeitspaket E – Decision-Support von Retrieval trennen
+Priority: P1
 
 Ziel:
 - [ ] Lenskit bleibt Retrieval- und Evidenzsystem, kein Entscheidungsautomat.
@@ -1670,22 +1691,34 @@ Trennung:
 * Agent / Orchestrator entscheidet: was relevant ist, welche Handlung folgt, welche Synthese gebildet wird.
 
 ### 2.8 Arbeitspaket F – Agent Traceability
+Priority: P0
 
 Ziel:
-- [~] Jede Agent-Nutzung ist nachvollziehbar (teilweise: CLI erzeugt physisches Artefakt `agent_query_session.v1` inkl. Hashes in `refs`; API liefert in `/api/query` eine Inline `agent_query_session.v2` ohne physische Trace-Referenzen).
+- [~] Jede Agent-Nutzung ist nachvollziehbar.
+  erfüllt: Architektonische Trennung zwischen CLI-Trace und API-Inline Session implementiert.
+  fehlt: Einheitlicher physischer Trace-Layer für die API.
+
+Traceability Model (Expliziter Architektur-Entscheid):
+- **v1 (CLI)**: Physisches Artefakt (`agent_query_session.v1`). Enthält `refs` + Hashes. Referenzierbar und reproduzierbar.
+- **v2 (API)**: Inline Session. Enthält keine `refs`.
+*Die API ist aktuell bewusst nicht referenzierbar reproduzierbar, da sie als reines Transportmedium fungiert. Langfristiges Ziel: API erzeugt referenzierbare Artefakte (Storage Backing).*
 
 Neues Artefakt: `agent_query_session.json`
 
 Inhalt: request contract, resolved bundle set, query trace refs, context bundle refs, diagnostics refs, warnings.
 
 ### 2.9 Arbeitspaket G – Service-Endpunkte / MCP-fähige Form
+Priority: P0
 
 Ziel:
-- [~] Lenskit soll sich sauber an Orchestratoren oder MCP-artige Systeme andocken lassen (teilweise: HTTP `/api/query` und `/api/federation/query` existieren in `app.py`, jedoch fehlen MCP Protocol Bindings vollständig).
+- [ ] Lenskit soll sich sauber an Orchestratoren oder MCP-artige Systeme andocken lassen.
+  erfüllt: HTTP API für `/query` und `/federation/query` implementiert.
+  fehlt: MCP Protocol Bindings (z.B. mcp-server) fehlen gänzlich.
 
 Endpunkte logisch: `/query`, `/context`, `/trace`, `/artifact`, `/federation/query`, `/diagnostics`
 
 ### 2.10 Arbeitspaket H – Guardrails für Agenten
+Priority: P1
 
 Ziel:
 - [~] Lenskit soll problematische Zustände aktiv markieren. (teilweise: Warnungen wie conflict oder stale werden generiert, Guardrail \"low result coverage\" ist in `test_api_query.py` belegt; Guardrails für invalid graph, missing provenance, cross-repo conflict bleiben offen)
@@ -1694,6 +1727,7 @@ Warnungen: stale bundle, invalid graph, missing provenance, derived fallback onl
 Reaktion: Nicht blockieren, aber markieren.
 
 ### 2.11 Arbeitspaket I – Evaluierung der Agent-Nutzung
+Priority: P1
 
 Ziel:
 - [ ] Nicht nur Query-Qualität, sondern Agent-Tauglichkeit prüfen.
@@ -1709,10 +1743,18 @@ Tests:
 ### 2.12 Deliverables Phase 6
 - [x] 1. Agent Query Contract (für /api/query im API-Roundtrip minimal belegt und getestet)
 - [x] 2. Agent Output Profiles (strukturell existierend via `output_profile` wie `agent_minimal`, `lookup_minimal`, `review_context`)
-- [~] 3. bounded API/tool surface (teilweise: query/federation existieren, isolierte Lookups für context/trace/artifact fehlen)
-- [~] 4. maschinenlesbare uncertainty/provenance Felder (teilweise: strukturierter Contract verifiziert, aber einzelne Aspekte wie `semantic_status` bleiben bewusst `unknown` zur Wahrung der epistemischen Integrität)
-- [~] 5. `agent_query_session.json` (teilweise: Das CLI erzeugt das vollständige physische Artefakt inkl. Trace-Referenzen; die API erzeugt stattdessen ein Inline-Feld `agent_query_session` v2 und kein separates JSON-Artefakt).
-- [~] 6. service-/MCP-fähige Schnittstellenlogik (teilweise: Servicepfad `/api/federation/query` und `/api/query` vorhanden, MCP-Protokoll fehlt gänzlich)
+- [ ] 3. bounded API/tool surface
+  erfüllt: query/federation Servicepfade vorhanden.
+  fehlt: isolierte Lookups für context/trace/artifact.
+- [ ] 4. maschinenlesbare uncertainty/provenance Felder
+  erfüllt: Contract existiert und Validierung steht.
+  fehlt: Signale aus Graph/Semantik Pfaden in den Contract leiten.
+- [~] 5. `agent_query_session.json`
+  erfüllt: CLI Artefakt (v1) und API Inline (v2) Contract aktiv.
+  fehlt: Konsolidierung der API hin zu physischen Artefakten (Storage Backing).
+- [ ] 6. service-/MCP-fähige Schnittstellenlogik
+  erfüllt: API Servicepfade existieren.
+  fehlt: MCP Protocol Implementation.
 - [~] 7. Agent-Guardrails (teilweise: Guardrail-Heuristik \"low result coverage\" belegt, strukturelle Härtung für fehlende Provenance etc. offen)
 
 ### 2.13 Gate für Phase 6
@@ -1749,7 +1791,9 @@ Die vorhandene Infrastruktur wird benutzbar, ohne die Architektur zu verwässern
 Arbeitspakete:
 - [ ] **7.1 WebUI-Konsolidierung:** Bundle-Navigation, Trace-Ansicht, Explain-Ansicht, Artifact-Explorer.
 - [ ] **7.2 Diagnostic Views:** graph health, federation conflicts, bundle provenance, query trace.
-- [~] **7.3 Service-Endpunkte:** `/query`, `/context`, `/trace`, `/artifact`, `/federation/query`, `/diagnostics`. (teilweise: `/api/query` und `/api/federation/query` in `app.py` vorhanden, Lookup-Endpunkte fehlen)
+- [ ] **7.3 Service-Endpunkte:** `/query`, `/context`, `/trace`, `/artifact`, `/federation/query`, `/diagnostics`.
+  erfüllt: API für Query/Federation vorhanden.
+  fehlt: Echte REST-Trennung für Lookups.
 - [ ] **7.4 Download-/Inspection-Flows:** bundle parts, traces, context bundles, diagnostics.
 
 Deliverables:

--- a/docs/lenskit-upgrade-blaupause.md
+++ b/docs/lenskit-upgrade-blaupause.md
@@ -1673,17 +1673,8 @@ Trennung:
 ### 2.8 Arbeitspaket F – Agent Traceability
 Ziel:
 - [~] Jede Agent-Nutzung ist nachvollziehbar.
-  erfüllt: CLI-/API-Verhalten unterscheiden sich belegbar in Trace-Artefakt vs. Inline-Session.
-  fehlt: Einheitlicher physischer Trace-Layer für die API.
-
-Traceability Model (aktueller repo-belegter Stand):
-- CLI nutzt aktuell das physische Artefakt `agent_query_session.json` nach v1-Contract.
-- API liefert aktuell eine Inline-Session nach v2-Contract.
-*Der aktuelle API-Pfad liefert nur die Inline-v2-Session; ein physischer, referenzierbarer Artefakt-Layer ist dort derzeit nicht vorhanden.*
-
-Physisches CLI-Artefakt: `agent_query_session.json`
-
-Inhalt: request contract, resolved bundle set, query trace refs, context bundle refs, diagnostics refs, warnings.
+  CLI: nutzt physisches Artefakt `agent_query_session.json` (v1-Contract).
+  API: liefert Inline-Session (v2-Contract); ein referenzierbarer, physischer Trace-Layer fehlt hier derzeit.
 
 ### 2.9 Arbeitspaket G – Service-Endpunkte / MCP-fähige Form
 Ziel:
@@ -1691,19 +1682,13 @@ Ziel:
   erfüllt: HTTP-Servicepfade (siehe 2.5) vorhanden.
   fehlt: MCP Protocol Bindings (z.B. mcp-server) fehlen.
 
+Endpunkte logisch: `/query`, `/context`, `/trace`, `/artifact`, `/federation/query`, `/diagnostics`
+
 ### 2.10 Arbeitspaket H – Guardrails für Agenten
 Ziel:
-- [~] Lenskit soll problematische Zustände aktiv markieren. (teilweise: Guardrail "low result coverage" ist als Runtime-Warning belegt; Guardrails für stale bundle, invalid graph, missing provenance und cross-repo conflict bleiben als strukturierte Runtime-Signale noch offen)
-
-Guardrails:
-- **Repo-belegt implementiert**:
-  - Guardrail-Klasse: `low_result_coverage`
-  - emittierter Warning-String: `"Low result coverage"`
-- **Fachlich relevante Guardrail-Klassen (derzeit nicht als strukturierte Runtime-Signale repo-belegt)**:
-  - `stale_bundle`
-  - `invalid_graph`
-  - `missing_provenance`
-  - `cross_repo_conflict`
+- [~] Lenskit soll problematische Zustände aktiv markieren.
+  repo-belegt: Guardrail-Klasse `low_result_coverage` (emittiert `"Low result coverage"`).
+  noch offen (nicht strukturell belegt): `stale_bundle`, `invalid_graph`, `missing_provenance`, `cross_repo_conflict`.
 
 ### 2.11 Arbeitspaket I – Evaluierung der Agent-Nutzung
 Ziel:

--- a/docs/lenskit-upgrade-blaupause.md
+++ b/docs/lenskit-upgrade-blaupause.md
@@ -1638,7 +1638,7 @@ Profile:
 * federated_search
 * debug_trace
 
-Priority-Hinweis: P0 = kurzfristig architekturkritisch / blocker-nah, P1 = wichtig, aber nachgeordnet.
+Priority-Hinweis: P0 = kurzfristig architekturkritisch / blocker-nah, P1 = wichtig, aber nachgeordnet. (Die Prioritäten sind redaktionelle Planungsgewichtungen dieser Blaupause, keine direkten Repo-Statusangaben.)
 
 ### 2.5 Arbeitspaket C – Bounded Tool Surface
 Priority: P0
@@ -1651,7 +1651,7 @@ Ziel:
 Operationen:
 - [x] 1. query (API vorhanden)
 - [ ] 2. context_bundle (dedizierter Lookup-Endpunkt fehlt)
-- [ ] 3. trace_lookup (Request/Response-Contract ist nicht repo-belegt festgelegt)
+- [ ] 3. trace_lookup (Request/Response-Contract fehlt)
 - [ ] 4. artifact_lookup (als separater Servicepfad nicht implementiert)
 - [x] 5. federation_query (als HTTP-Servicepfad vorhanden)
 - [ ] 6. diagnostics (dedizierter Endpunkt fehlt)
@@ -1687,8 +1687,8 @@ Ziel:
   fehlt: Einheitlicher physischer Trace-Layer für die API.
 
 Traceability Model (aktueller repo-belegter Stand):
-- CLI nutzt aktuell das physische Artefakt `agent_query_session.json` nach v1-Contract. Enthält `refs` + Hashes.
-- API liefert aktuell eine Inline-Session nach v2-Contract. Enthält keine `refs`.
+- CLI-Pfad: nutzt aktuell das physische Artefakt `agent_query_session.json` nach v1-Contract. Enthält `refs` + Hashes.
+- API-Pfad: liefert aktuell eine Inline-Session nach v2-Contract. Enthält keine `refs`.
 *Der aktuelle API-Pfad liefert nur die Inline-v2-Session; ein physischer, referenzierbarer Artefakt-Layer ist dort derzeit nicht vorhanden.*
 
 Physisches CLI-Artefakt: `agent_query_session.json`
@@ -1713,7 +1713,7 @@ Ziel:
 
 Guardrails:
 - **Repo-belegt implementiert**:
-  - `low_result_coverage` (belegter Runtime-Warning-Output: "Low result coverage")
+  - `low_result_coverage` (Runtime-Warning-Output belegt)
 - **Fachlich relevante, aber derzeit nicht repo-belegte Runtime-Guardrails**:
   - `stale_bundle`
   - `invalid_graph`
@@ -1744,7 +1744,7 @@ Tests:
   erfüllt: Contract existiert und Validierung steht.
   fehlt: Signale aus Graph/Semantik Pfaden in den Contract leiten.
 - [~] 5. `agent_query_session.json`
-  erfüllt: CLI nutzt physisches Artefakt (v1), API liefert Inline-Session (v2).
+  erfüllt: CLI-Pfad nutzt physisches Artefakt (v1), API-Pfad liefert Inline-Session (v2).
   fehlt: Einheitlicher physischer Trace-Layer für die API.
 - [ ] 6. service-/MCP-fähige Schnittstellenlogik
   erfüllt: API Servicepfade existieren.

--- a/docs/lenskit-upgrade-blaupause.md
+++ b/docs/lenskit-upgrade-blaupause.md
@@ -1662,7 +1662,7 @@ Priority: P1
 Ziel:
 - [ ] Agenten sollen nicht nur Ergebnisse, sondern auch deren epistemischen Status sehen.
   erfüllt: `epistemics` Contract definiert und für lokale Basisdaten getestet.
-  fehlt: Durchgängige Interpolation und Fallback-Signale für komplexe Status (z.B. `semantic_status` bleibt meist `unknown`).
+  fehlt: Komplexe Status werden noch nicht durchgängig aus allen Pfaden in den Contract überführt (z.B. `semantic_status` bleibt konservativ `unknown`).
 
 Felder: provenance_type, bundle_origin, resolver_status, graph_status, semantic_status, federation_status, uncertainty, interpolation.
 
@@ -1684,7 +1684,7 @@ Ziel:
   erfüllt: Architektonische Trennung zwischen CLI-Trace und API-Inline Session implementiert.
   fehlt: Einheitlicher physischer Trace-Layer für die API.
 
-Traceability Model (Expliziter Architektur-Entscheid):
+Traceability Model (aktueller repo-belegter Stand):
 - **v1 (CLI)**: Physisches Artefakt (`agent_query_session.v1`). Enthält `refs` + Hashes. Referenzierbar und reproduzierbar.
 - **v2 (API)**: Inline Session. Enthält keine `refs`.
 *Der aktuelle API-Pfad liefert nur die Inline-v2-Session; ein physischer, referenzierbarer Artefakt-Layer ist dort derzeit nicht vorhanden.*
@@ -1711,7 +1711,7 @@ Ziel:
 
 Guardrails:
 - **low_result_coverage**:
-  - signal: `warning.low_coverage` (als belegter Output-Warning Mechanismus implementiert)
+  - belegter Runtime-Warning-Output: "Low result coverage"
 - **stale_bundle**:
   - für diese Guardrail existiert noch keine repo-belegte strukturierte Runtime-Markierung
 - **invalid_graph**:
@@ -1740,7 +1740,7 @@ Tests:
 - [x] 2. Agent Output Profiles (strukturell existierend via `output_profile` wie `agent_minimal`, `lookup_minimal`, `review_context`)
 - [ ] 3. bounded API/tool surface
   erfüllt: query/federation Servicepfade vorhanden.
-  fehlt: isolierte Lookups für context/trace/artifact.
+  fehlt: dedizierte Lookup-Endpunkte (context/trace/artifact).
 - [ ] 4. maschinenlesbare uncertainty/provenance Felder
   erfüllt: Contract existiert und Validierung steht.
   fehlt: Signale aus Graph/Semantik Pfaden in den Contract leiten.
@@ -1788,7 +1788,7 @@ Arbeitspakete:
 - [ ] **7.2 Diagnostic Views:** graph health, federation conflicts, bundle provenance, query trace.
 - [ ] **7.3 Service-Endpunkte:** `/query`, `/context`, `/trace`, `/artifact`, `/federation/query`, `/diagnostics`.
   erfüllt: API für Query/Federation vorhanden.
-  fehlt: Echte REST-Trennung für Lookups.
+  fehlt: Lookup-Operationen sind noch nicht als getrennte Serviceverträge ausgebildet.
 - [ ] **7.4 Download-/Inspection-Flows:** bundle parts, traces, context bundles, diagnostics.
 
 Deliverables:

--- a/docs/lenskit-upgrade-blaupause.md
+++ b/docs/lenskit-upgrade-blaupause.md
@@ -1703,8 +1703,6 @@ Ziel:
   erfüllt: HTTP-Servicepfade (siehe 2.5) vorhanden.
   fehlt: MCP Protocol Bindings (z.B. mcp-server) fehlen.
 
-Endpunkte logisch: `/query`, `/context`, `/trace`, `/artifact`, `/federation/query`, `/diagnostics`
-
 ### 2.10 Arbeitspaket H – Guardrails für Agenten
 Priority: P1
 
@@ -1786,9 +1784,9 @@ Die vorhandene Infrastruktur wird benutzbar, ohne die Architektur zu verwässern
 Arbeitspakete:
 - [ ] **7.1 WebUI-Konsolidierung:** Bundle-Navigation, Trace-Ansicht, Explain-Ansicht, Artifact-Explorer.
 - [ ] **7.2 Diagnostic Views:** graph health, federation conflicts, bundle provenance, query trace.
-- [~] **7.3 Service-Endpunkte:**
+- [~] **7.3 Service-Endpunkte:** `/query`, `/context`, `/trace`, `/artifact`, `/federation/query`, `/diagnostics`
   erfüllt: Query-/Federation-Pfade vorhanden.
-  fehlt: dedizierte Lookup-Pfade (Context/Trace/Artifact/Diagnostics).
+  fehlt: dedizierte Lookup-Pfade.
 - [ ] **7.4 Download-/Inspection-Flows:** bundle parts, traces, context bundles, diagnostics.
 
 Deliverables:


### PR DESCRIPTION
This PR executes an epistemically strict update to the `docs/lenskit-upgrade-blaupause.md` blueprint along the Retrieval-/Service-/Agent-track.

Modifications reflect an exact gap analysis against the existing repository implementation (`merger/lenskit/service/app.py`, `test_api_query.py`, `test_cli_agent_session.py`).

### Key Adjustments:
* **Agent Traceability (2.8):** Demarcates the boundary between the fully implemented CLI trace artifact (`agent_query_session.v1` w/ refs) and the API's explicitly abbreviated inline session (`v2`).
* **Service Endpoints (2.9, 7.3):** Identifies the missing dedicated lookup paths (`/context`, `/trace`, `/artifact`, `/diagnostics`) while affirming the presence of `/api/query` and `/api/federation/query`.
* **Guardrails (2.10):** Tempers completion claims to what is explicitly backed by tests (the 'low result coverage' guardrail), marking structural hardening for other aspects as open.
* **MCP Capabilities (2.9):** Explicitly denotes the absence of Model Context Protocol bindings.

These changes bring the roadmap's status checkboxes and descriptions perfectly in sync with the codebase's operational truth.

---
*PR created automatically by Jules for task [1083908643688244122](https://jules.google.com/task/1083908643688244122) started by @alexdermohr*