### PR TITLE
docs: add functional test for atlas backup-gap label resolution and update blueprint

### DIFF
--- a/docs/atlas-blaupause.md
+++ b/docs/atlas-blaupause.md
@@ -943,7 +943,7 @@ Ziel: Maschinenübergreifende Dateiwirklichkeit sichtbar und vergleichbar machen
 - [x] CLI: `atlas diff heim-pc:/home heimserver:/home`
   - *Methodische Notiz: `machine:path` löst deterministisch auf den neuesten vollständigen Snapshot auf.*
   - *Semantische Notiz: `atlas diff` leitet cross-root Anfragen intern auf `cross-root-comparison` um (statt strengem `same-root-delta`). Der aktuelle Vergleich ist ein strukturbezogener Metadatenabgleich (`rel_path`, `size_bytes`, `mtime`) und kein inhaltlich tief gehärteter Gleichheitsbeweis.*
-- [~] Backup-gap-Analyse definieren (teilweise gehärtet: als `atlas analyze backup-gap` CLI command; JSON-Output, Snapshot-ID-Auflösung und Label-Auflösung durch CLI-nahen Integrationstest abgesichert)
+- [~] Backup-gap-Analyse definieren (teilweise gehärtet: als `atlas analyze backup-gap` CLI command; JSON-Output durch funktionale CLI-Tests für Snapshot-ID-, machine:path- und Label-Auflösung abgesichert)
 - [ ] Remote-Collector-/SSH-Modell festlegen
 - [x] Konfliktfälle (gleiches root label, andere Pfade) definieren
   - *Semantische Notiz: Die label-basierte Diff-Auflösung verlangt pro Maschine Eindeutigkeit. Wenn ein Label auf einer Maschine mehrdeutig ist, muss zwingend `machine:path` oder `snapshot_id` verwendet werden.*

--- a/docs/atlas-blaupause.md
+++ b/docs/atlas-blaupause.md
@@ -943,7 +943,7 @@ Ziel: Maschinenübergreifende Dateiwirklichkeit sichtbar und vergleichbar machen
 - [x] CLI: `atlas diff heim-pc:/home heimserver:/home`
   - *Methodische Notiz: `machine:path` löst deterministisch auf den neuesten vollständigen Snapshot auf.*
   - *Semantische Notiz: `atlas diff` leitet cross-root Anfragen intern auf `cross-root-comparison` um (statt strengem `same-root-delta`). Der aktuelle Vergleich ist ein strukturbezogener Metadatenabgleich (`rel_path`, `size_bytes`, `mtime`) und kein inhaltlich tief gehärteter Gleichheitsbeweis.*
-- [~] Backup-gap-Analyse definieren (teilweise gehärtet: als `atlas analyze backup-gap` CLI command; JSON-Output und Snapshot-ID-Auflösung durch CLI-nahen Integrationstest abgesichert)
+- [~] Backup-gap-Analyse definieren (teilweise gehärtet: als `atlas analyze backup-gap` CLI command; JSON-Output, Snapshot-ID-Auflösung und Label-Auflösung durch CLI-nahen Integrationstest abgesichert)
 - [ ] Remote-Collector-/SSH-Modell festlegen
 - [x] Konfliktfälle (gleiches root label, andere Pfade) definieren
   - *Semantische Notiz: Die label-basierte Diff-Auflösung verlangt pro Maschine Eindeutigkeit. Wenn ein Label auf einer Maschine mehrdeutig ist, muss zwingend `machine:path` oder `snapshot_id` verwendet werden.*

--- a/merger/lenskit/tests/test_cli_atlas_analyze_backup_gap_functional.py
+++ b/merger/lenskit/tests/test_cli_atlas_analyze_backup_gap_functional.py
@@ -169,11 +169,12 @@ def test_cli_atlas_analyze_backup_gap_label_resolution(tmp_path, monkeypatch):
     from merger.lenskit.atlas.registry import AtlasRegistry
     with AtlasRegistry(registry_path) as reg:
         reg.register_machine("machine-a", "host-a")
+        reg.register_machine("machine-b", "host-b")
         reg.register_root("root-src", "machine-a", "abs_path", "/src", label="src-label")
-        reg.register_root("root-backup", "machine-a", "abs_path", "/backup", label="backup-label")
+        reg.register_root("root-backup", "machine-b", "abs_path", "/backup", label="backup-label")
 
         reg.create_snapshot("snap_src_1", "machine-a", "root-src", "hash1", "complete")
-        reg.create_snapshot("snap_backup_1", "machine-a", "root-backup", "hash2", "complete")
+        reg.create_snapshot("snap_backup_1", "machine-b", "root-backup", "hash2", "complete")
 
         inv_src_path = atlas_base / "inv_src.jsonl"
         with open(inv_src_path, "w", encoding="utf-8") as f:
@@ -206,7 +207,7 @@ def test_cli_atlas_analyze_backup_gap_label_resolution(tmp_path, monkeypatch):
             "analyze",
             "backup-gap",
             "machine-a:label:src-label",     # Explicit machine:label routing
-            "machine-a:label:backup-label"   # Explicit machine:label routing
+            "machine-b:label:backup-label"   # Explicit machine:label routing
         ],
         capture_output=True,
         text=True,

--- a/merger/lenskit/tests/test_cli_atlas_analyze_backup_gap_functional.py
+++ b/merger/lenskit/tests/test_cli_atlas_analyze_backup_gap_functional.py
@@ -156,3 +156,73 @@ def test_cli_atlas_analyze_backup_gap_machine_path_resolution(tmp_path, monkeypa
     assert output_json["missing"] == ["file2.txt"]
     assert output_json["outdated"] == ["file4.txt"]
     assert output_json["extraneous"] == ["file3.txt"]
+
+def test_cli_atlas_analyze_backup_gap_label_resolution(tmp_path, monkeypatch):
+    """
+    Tests the user-facing contract of providing 'machine_id:label:root_label' references
+    instead of explicit snapshot IDs.
+    """
+    registry_path = tmp_path / "atlas/registry/atlas_registry.sqlite"
+    atlas_base = tmp_path / "atlas"
+    atlas_base.mkdir(parents=True)
+
+    from merger.lenskit.atlas.registry import AtlasRegistry
+    with AtlasRegistry(registry_path) as reg:
+        reg.register_machine("machine-a", "host-a")
+        reg.register_root("root-src", "machine-a", "abs_path", "/src", label="src-label")
+        reg.register_root("root-backup", "machine-a", "abs_path", "/backup", label="backup-label")
+
+        reg.create_snapshot("snap_src_1", "machine-a", "root-src", "hash1", "complete")
+        reg.create_snapshot("snap_backup_1", "machine-a", "root-backup", "hash2", "complete")
+
+        inv_src_path = atlas_base / "inv_src.jsonl"
+        with open(inv_src_path, "w", encoding="utf-8") as f:
+            f.write(json.dumps({"rel_path": "file1.txt", "size_bytes": 100, "mtime": "2024-01-01"}) + "\n")
+            f.write(json.dumps({"rel_path": "file2.txt", "size_bytes": 200, "mtime": "2024-01-01"}) + "\n")
+            f.write(json.dumps({"rel_path": "file4.txt", "size_bytes": 400, "mtime": "2024-01-02"}) + "\n")
+
+        inv_backup_path = atlas_base / "inv_backup.jsonl"
+        with open(inv_backup_path, "w", encoding="utf-8") as f:
+            f.write(json.dumps({"rel_path": "file1.txt", "size_bytes": 100, "mtime": "2024-01-01"}) + "\n")
+            f.write(json.dumps({"rel_path": "file3.txt", "size_bytes": 300, "mtime": "2024-01-01"}) + "\n")
+            f.write(json.dumps({"rel_path": "file4.txt", "size_bytes": 400, "mtime": "2024-01-01"}) + "\n")
+
+        reg.update_snapshot_artifacts("snap_src_1", {"inventory": "inv_src.jsonl"})
+        reg.update_snapshot_artifacts("snap_backup_1", {"inventory": "inv_backup.jsonl"})
+
+    monkeypatch.chdir(tmp_path)
+
+    repo_root = Path(__file__).resolve().parent.parent.parent.parent
+    env = os.environ.copy()
+    existing_pp = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = f"{repo_root}{os.pathsep}{existing_pp}" if existing_pp else str(repo_root)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "merger.lenskit.cli.main",
+            "atlas",
+            "analyze",
+            "backup-gap",
+            "machine-a:label:src-label",     # Explicit machine:label routing
+            "machine-a:label:backup-label"   # Explicit machine:label routing
+        ],
+        capture_output=True,
+        text=True,
+        env=env
+    )
+
+    assert result.returncode == 0, f"Command failed: {result.stderr}"
+
+    output_json = json.loads(result.stdout.strip())
+
+    assert output_json["source_snapshot"] == "snap_src_1"
+    assert output_json["backup_snapshot"] == "snap_backup_1"
+    assert output_json["summary"]["missing_count"] == 1
+    assert output_json["summary"]["outdated_count"] == 1
+    assert output_json["summary"]["extraneous_count"] == 1
+
+    assert output_json["missing"] == ["file2.txt"]
+    assert output_json["outdated"] == ["file4.txt"]
+    assert output_json["extraneous"] == ["file3.txt"]

--- a/merger/lenskit/tests/test_cli_atlas_analyze_backup_gap_functional.py
+++ b/merger/lenskit/tests/test_cli_atlas_analyze_backup_gap_functional.py
@@ -5,6 +5,10 @@ import os
 from pathlib import Path
 
 def test_cli_atlas_analyze_backup_gap(tmp_path, monkeypatch):
+    """
+    Tests the user-facing contract of providing explicit 'snapshot_id' references.
+    This serves as the foundational functional CLI test for Snapshot-ID resolution.
+    """
     # Setup registry and environments
     registry_path = tmp_path / "atlas/registry/atlas_registry.sqlite"
     atlas_base = tmp_path / "atlas"


### PR DESCRIPTION
This PR addresses the epistemic gap in the `atlas-blaupause.md` blueprint. The blueprint previously claimed `[x] CLI: label-basierte Referenzauflösung in atlas diff und atlas analyze backup-gap (machine_id:label:root_label)`, but there was no explicit, dedicated functional test for this label-resolution behavior within the `backup-gap` command (the existing tests primarily covered `machine:path` fallback and direct IDs).

To rigorously prove this architectural claim:
1. Added `test_cli_atlas_analyze_backup_gap_label_resolution` to `test_cli_atlas_analyze_backup_gap_functional.py`. This test fully sets up the SQLite registry, creates explicit labels on the mock roots, and uses the `machine-a:label:src-label` syntax to run the CLI, ensuring proper fallback and JSON extraction.
2. Updated `docs/atlas-blaupause.md` to explicitly note that the Label-Auflösung is now secured by a CLI-nahen Integrationstest, confirming its full implementation state according to the Belegprinzip.

---
*PR created automatically by Jules for task [15992291938952425239](https://jules.google.com/task/15992291938952425239) started by @alexdermohr*