### PR TITLE
feat(pythonista): add local wc-hub fallback for Pythonista Documents

### DIFF
--- a/merger/lenskit/core/merge.py
+++ b/merger/lenskit/core/merge.py
@@ -1692,7 +1692,6 @@ def detect_hub_dir(script_path: Path, arg_base_dir: Optional[str] = None) -> Pat
     is_pythonista_like = (
         "Pythonista" in script_str
         or "/private/var/mobile/" in script_str
-        or "Mobile Documents" in script_str
     )
 
     if is_pythonista_like:
@@ -1701,7 +1700,7 @@ def detect_hub_dir(script_path: Path, arg_base_dir: Optional[str] = None) -> Pat
             candidate = local_docs / "wc-hub"
             if candidate.is_dir():
                 return candidate
-        except Exception:
+        except OSError:
             pass
 
     raise FileNotFoundError(

--- a/merger/lenskit/core/merge.py
+++ b/merger/lenskit/core/merge.py
@@ -1687,10 +1687,19 @@ def detect_hub_dir(script_path: Path, arg_base_dir: Optional[str] = None) -> Pat
     if saved is not None:
         return saved
 
+    # Pythonista local Documents fallback
+    try:
+        local_docs = Path.home() / "Documents"
+        candidate = local_docs / "wc-hub"
+        if candidate.is_dir():
+            return candidate
+    except Exception:
+        pass
+
     raise FileNotFoundError(
         "Hub-Verzeichnis nicht gefunden. "
         "Gepruefte Quellen: explizites Argument, Environment-Variable, "
-        "gespeicherter Pfad. "
+        "gespeicherter Pfad, lokales Pythonista Documents/wc-hub. "
         "Hinweis: Bei Pythonista/iCloud koennen Script und Hub in getrennten "
         "Speicherwelten liegen; in diesem Fall muss ein gueltiger Hub-Pfad "
         "explizit bereitgestellt werden."

--- a/merger/lenskit/core/merge.py
+++ b/merger/lenskit/core/merge.py
@@ -1688,18 +1688,26 @@ def detect_hub_dir(script_path: Path, arg_base_dir: Optional[str] = None) -> Pat
         return saved
 
     # Pythonista local Documents fallback
-    try:
-        local_docs = Path.home() / "Documents"
-        candidate = local_docs / "wc-hub"
-        if candidate.is_dir():
-            return candidate
-    except Exception:
-        pass
+    script_str = str(script_path)
+    is_pythonista_like = (
+        "Pythonista" in script_str
+        or "/private/var/mobile/" in script_str
+        or "Mobile Documents" in script_str
+    )
+
+    if is_pythonista_like:
+        try:
+            local_docs = Path.home() / "Documents"
+            candidate = local_docs / "wc-hub"
+            if candidate.is_dir():
+                return candidate
+        except Exception:
+            pass
 
     raise FileNotFoundError(
         "Hub-Verzeichnis nicht gefunden. "
         "Gepruefte Quellen: explizites Argument, Environment-Variable, "
-        "gespeicherter Pfad, lokales Pythonista Documents/wc-hub. "
+        "gespeicherter Pfad sowie - im Pythonista-Kontext - lokales Documents/wc-hub. "
         "Hinweis: Bei Pythonista/iCloud koennen Script und Hub in getrennten "
         "Speicherwelten liegen; in diesem Fall muss ein gueltiger Hub-Pfad "
         "explizit bereitgestellt werden."

--- a/tests/test_hub_topology.py
+++ b/tests/test_hub_topology.py
@@ -81,8 +81,8 @@ def test_is_pythonista_runtime(monkeypatch):
     assert _is_pythonista_runtime()
 
 def test_detect_hub_dir_pythonista_local_fallback(monkeypatch, tmp_path):
-    script_dir = tmp_path / "script"
-    script_dir.mkdir()
+    script_dir = tmp_path / "Pythonista" / "script"
+    script_dir.mkdir(parents=True)
     script_path = script_dir / "repolens.py"
     script_path.touch()
 
@@ -96,3 +96,23 @@ def test_detect_hub_dir_pythonista_local_fallback(monkeypatch, tmp_path):
 
     detected = detect_hub_dir(script_path)
     assert detected == hub
+
+def test_detect_hub_dir_no_pythonista_fallback(monkeypatch, tmp_path):
+    # script_path clearly outside Pythonista
+    script_dir = tmp_path / "usr" / "local" / "bin"
+    script_dir.mkdir(parents=True)
+    script_path = script_dir / "repolens.py"
+    script_path.touch()
+
+    fake_home = tmp_path / "home"
+    docs = fake_home / "Documents"
+    hub = docs / "wc-hub"
+    hub.mkdir(parents=True)
+
+    monkeypatch.setattr("pathlib.Path.home", lambda: fake_home)
+
+    import pytest
+    from merger.lenskit.core.merge import detect_hub_dir
+
+    with pytest.raises(FileNotFoundError, match="Hub-Verzeichnis"):
+        detect_hub_dir(script_path)

--- a/tests/test_hub_topology.py
+++ b/tests/test_hub_topology.py
@@ -111,8 +111,5 @@ def test_detect_hub_dir_no_pythonista_fallback(monkeypatch, tmp_path):
 
     monkeypatch.setattr("pathlib.Path.home", lambda: fake_home)
 
-    import pytest
-    from merger.lenskit.core.merge import detect_hub_dir
-
     with pytest.raises(FileNotFoundError, match="Hub-Verzeichnis"):
         detect_hub_dir(script_path)

--- a/tests/test_hub_topology.py
+++ b/tests/test_hub_topology.py
@@ -81,6 +81,7 @@ def test_is_pythonista_runtime(monkeypatch):
     assert _is_pythonista_runtime()
 
 def test_detect_hub_dir_pythonista_local_fallback(monkeypatch, tmp_path):
+    monkeypatch.delenv("REPOLENS_BASEDIR", raising=False)
     script_dir = tmp_path / "Pythonista" / "script"
     script_dir.mkdir(parents=True)
     script_path = script_dir / "repolens.py"
@@ -98,6 +99,7 @@ def test_detect_hub_dir_pythonista_local_fallback(monkeypatch, tmp_path):
     assert detected == hub
 
 def test_detect_hub_dir_no_pythonista_fallback(monkeypatch, tmp_path):
+    monkeypatch.delenv("REPOLENS_BASEDIR", raising=False)
     # script_path clearly outside Pythonista
     script_dir = tmp_path / "usr" / "local" / "bin"
     script_dir.mkdir(parents=True)

--- a/tests/test_hub_topology.py
+++ b/tests/test_hub_topology.py
@@ -79,3 +79,20 @@ def test_is_pythonista_runtime(monkeypatch):
 
     monkeypatch.setattr(sys, "executable", "/Applications/Pythonista3.app/python3")
     assert _is_pythonista_runtime()
+
+def test_detect_hub_dir_pythonista_local_fallback(monkeypatch, tmp_path):
+    script_dir = tmp_path / "script"
+    script_dir.mkdir()
+    script_path = script_dir / "repolens.py"
+    script_path.touch()
+
+    fake_home = tmp_path / "home"
+    docs = fake_home / "Documents"
+    hub = docs / "wc-hub"
+
+    hub.mkdir(parents=True)
+
+    monkeypatch.setattr("pathlib.Path.home", lambda: fake_home)
+
+    detected = detect_hub_dir(script_path)
+    assert detected == hub


### PR DESCRIPTION
Why:
In Pythonista environments, `wc-hub` is often located under the local `~/Documents/wc-hub` path. Currently, this legitimate default is not recognized, requiring explicit paths in a sandboxed, UI-first environment.

What was added:
A deterministic, single-candidate fallback for `~/Documents/wc-hub` inside `detect_hub_dir()`. It is checked only after explicit arguments, environment variables, and saved paths. An updated error message and a test case are included.

What was NOT done:
- No legacy iOS hardcodes were reintroduced.
- No recursive directory scanning or magical fallback behaviors were added.
- Existing architectures and priorites remain fully intact.

---
*PR created automatically by Jules for task [2513095179489354912](https://jules.google.com/task/2513095179489354912) started by @alexdermohr*