### PR TITLE
docs: Add Pythonista Hub Setup documentation

### DIFF
--- a/docs/pythonista-hub-setup.md
+++ b/docs/pythonista-hub-setup.md
@@ -1,0 +1,114 @@
+# Pythonista Hub Setup (repoLens + wc-hub)
+
+## Kernproblem
+
+In Pythonista existieren getrennte Speicherwelten:
+
+- iCloud → enthält repoLens
+- Lokales Pythonista Documents → enthält wc-hub
+
+→ repoLens kann den Hub **nicht selbst finden**, da beide Welten isoliert sind.
+
+---
+
+## Prinzip
+
+Der `pathfinder.py` muss **im Kontext des Hubs ausgeführt werden**.
+
+→ Nur dort kann er den echten Pfad bestimmen.
+
+---
+
+## 🔧 Setup (verbindlich)
+
+### 1. Pathfinder in den Hub kopieren
+
+Kopiere:
+
+merger/lenskit/frontends/pythonista/pathfinder.py
+
+nach:
+
+/wc-hub/
+
+---
+
+### 2. Pathfinder im Hub ausführen
+
+In Pythonista:
+
+wc-hub/pathfinder.py starten
+
+---
+
+### 3. Was passiert intern
+
+Der Pathfinder:
+
+- erkennt den aktuellen Hub-Pfad
+- schreibt diesen in:
+
+wc-hub/.repolens-hub-path.txt
+
+und zusätzlich nach:
+
+/.repolens-hub-path.txt
+
+→ Damit entsteht ein persistenter Pfad-Contract.
+
+---
+
+### 4. repoLens neu starten
+
+Nach erfolgreichem Lauf:
+
+👉 repoLens neu starten
+
+---
+
+## ✅ Erfolgskriterium
+
+repoLens startet **ohne Fehler**.
+
+Optional prüfen:
+
+/.repolens-hub-path.txt
+
+enthält:
+
+/private/var/mobile/…/Documents/wc-hub
+
+---
+
+## ❗ Wichtige Regel
+
+> Pathfinder funktioniert nur korrekt, wenn er im Zielverzeichnis (wc-hub) ausgeführt wird.
+
+Ein Lauf aus iCloud heraus liefert falsche oder unvollständige Ergebnisse.
+
+---
+
+## 🔁 Wann erneut ausführen?
+
+- nach Verschieben des wc-hub
+- nach iOS-/App-Neuinstallation
+- wenn repoLens meldet:
+  `Hub-Verzeichnis nicht gefunden`
+
+---
+
+## 🧠 Designentscheidung
+
+repoLens nutzt bewusst **keine unsichere Auto-Erkennung**, sondern einen expliziten Pfad-Contract.
+
+→ Pathfinder ist Teil der Architektur, nicht nur ein Debug-Tool.
+
+---
+
+## 🧾 Kurzfassung
+
+Wenn repoLens den Hub nicht findet:
+
+1. Pathfinder in wc-hub kopieren
+2. dort ausführen
+3. repoLens neu starten

--- a/docs/pythonista-hub-setup.md
+++ b/docs/pythonista-hub-setup.md
@@ -15,7 +15,8 @@ Konkrete Pfade (Beispiel):
 - Lokal:
   /private/var/mobile/Containers/Data/Application/.../Documents/...
 
-→ repoLens kann den Hub **nicht selbst finden**, da beide Welten isoliert sind.
+→ repoLens kann den Hub teils automatisch erkennen (z. B. über Argument, Environment oder gespeicherten Pfad),
+  aber über die getrennten iCloud-/lokalen Documents-Welten hinweg ist diese Erkennung nicht verlässlich.
 
 ---
 
@@ -38,7 +39,7 @@ merger/lenskit/frontends/pythonista/pathfinder.py
 
 nach:
 
-<lokales Pythonista Documents>/wc-hub/
+`<lokales Pythonista Documents>/wc-hub/`
 
 ---
 
@@ -46,7 +47,7 @@ nach:
 
 In Pythonista:
 
-<lokales Pythonista Documents>/wc-hub/pathfinder.py starten
+`<lokales Pythonista Documents>/wc-hub/pathfinder.py` starten (bzw. `repolens-hub-pathfinder.py`)
 
 ---
 
@@ -57,11 +58,11 @@ Der Pathfinder:
 - erkennt den aktuellen Hub-Pfad
 - schreibt diesen in:
 
-<lokales Pythonista Documents>/wc-hub/.repolens-hub-path.txt
+`<lokales Pythonista Documents>/wc-hub/.repolens-hub-path.txt`
 
 und zusätzlich nach:
 
-<repoLens iCloud-Verzeichnis>/.repolens-hub-path.txt
+`<repoLens iCloud-Verzeichnis>/.repolens-hub-path.txt`
 
 → Damit entsteht ein persistenter Pfad-Contract.
 
@@ -82,7 +83,7 @@ repoLens startet **ohne Fehler**.
 Zusätzlich prüfen:
 
 1. Öffne:
-   <repoLens iCloud-Verzeichnis>/.repolens-hub-path.txt
+   `<repoLens iCloud-Verzeichnis>/.repolens-hub-path.txt`
 
 2. Inhalt muss exakt sein:
    /private/var/mobile/.../Documents/wc-hub
@@ -94,7 +95,7 @@ Wenn diese Datei fehlt oder leer ist → Pathfinder erneut ausführen.
 ## 🧯 Wenn es nicht funktioniert
 
 1. Prüfen:
-   Existiert <repoLens iCloud-Verzeichnis>/.repolens-hub-path.txt?
+   Existiert `<repoLens iCloud-Verzeichnis>/.repolens-hub-path.txt`?
 
 2. Wenn nein:
    → Pathfinder erneut im wc-hub ausführen
@@ -126,7 +127,9 @@ Ein Lauf aus iCloud heraus liefert falsche oder unvollständige Ergebnisse.
 
 ## 🧠 Designentscheidung
 
-repoLens nutzt bewusst **keine unsichere Auto-Erkennung**, sondern einen expliziten Pfad-Contract.
+repoLens bevorzugt bewusst einen expliziten gespeicherten Pfad-Contract
+statt sich primär auf Auto-Erkennung zu verlassen.
+Begrenzte Fallbacks existieren, können aber in getrennten Speicherwelten fehlschlagen.
 
 → Pathfinder ist Teil der Architektur, nicht nur ein Debug-Tool.
 

--- a/docs/pythonista-hub-setup.md
+++ b/docs/pythonista-hub-setup.md
@@ -7,6 +7,14 @@ In Pythonista existieren getrennte Speicherwelten:
 - iCloud → enthält repoLens
 - Lokales Pythonista Documents → enthält wc-hub
 
+Konkrete Pfade (Beispiel):
+
+- iCloud:
+  /private/var/mobile/Library/Mobile Documents/iCloud~com~omz-software~Pythonista3/Documents/...
+
+- Lokal:
+  /private/var/mobile/Containers/Data/Application/.../Documents/...
+
 → repoLens kann den Hub **nicht selbst finden**, da beide Welten isoliert sind.
 
 ---
@@ -14,6 +22,7 @@ In Pythonista existieren getrennte Speicherwelten:
 ## Prinzip
 
 Der `pathfinder.py` muss **im Kontext des Hubs ausgeführt werden**.
+Der Ausführungsort bestimmt die Sicht auf das Dateisystem.
 
 → Nur dort kann er den echten Pfad bestimmen.
 
@@ -29,7 +38,7 @@ merger/lenskit/frontends/pythonista/pathfinder.py
 
 nach:
 
-/wc-hub/
+<lokales Pythonista Documents>/wc-hub/
 
 ---
 
@@ -37,7 +46,7 @@ nach:
 
 In Pythonista:
 
-wc-hub/pathfinder.py starten
+<lokales Pythonista Documents>/wc-hub/pathfinder.py starten
 
 ---
 
@@ -48,11 +57,11 @@ Der Pathfinder:
 - erkennt den aktuellen Hub-Pfad
 - schreibt diesen in:
 
-wc-hub/.repolens-hub-path.txt
+<lokales Pythonista Documents>/wc-hub/.repolens-hub-path.txt
 
 und zusätzlich nach:
 
-/.repolens-hub-path.txt
+<repoLens iCloud-Verzeichnis>/.repolens-hub-path.txt
 
 → Damit entsteht ein persistenter Pfad-Contract.
 
@@ -70,13 +79,31 @@ Nach erfolgreichem Lauf:
 
 repoLens startet **ohne Fehler**.
 
-Optional prüfen:
+Zusätzlich prüfen:
 
-/.repolens-hub-path.txt
+1. Öffne:
+   <repoLens iCloud-Verzeichnis>/.repolens-hub-path.txt
 
-enthält:
+2. Inhalt muss exakt sein:
+   /private/var/mobile/.../Documents/wc-hub
 
-/private/var/mobile/…/Documents/wc-hub
+Wenn diese Datei fehlt oder leer ist → Pathfinder erneut ausführen.
+
+---
+
+## 🧯 Wenn es nicht funktioniert
+
+1. Prüfen:
+   Existiert <repoLens iCloud-Verzeichnis>/.repolens-hub-path.txt?
+
+2. Wenn nein:
+   → Pathfinder erneut im wc-hub ausführen
+
+3. Wenn ja:
+   → repoLens komplett neu starten
+
+4. Wenn weiterhin Fehler:
+   → falscher Script-Kontext (Pathfinder im falschen Ort ausgeführt)
 
 ---
 


### PR DESCRIPTION
Added `docs/pythonista-hub-setup.md` which thoroughly explains the rationale and setup process for running Pathfinder within the iOS Pythonista Documents context in order to securely locate the `wc-hub` directory instead of using potentially buggy "auto-discovery".

The document dictates the required execution environment and explains the resulting persistent path contract (`.repolens-hub-path.txt`).

---
*PR created automatically by Jules for task [11047536937448292839](https://jules.google.com/task/11047536937448292839) started by @alexdermohr*