### PR TITLE
🧹 Cleanup: Remove unused variables in CLI modules

### DIFF
--- a/merger/lenskit/cli/cmd_atlas.py
+++ b/merger/lenskit/cli/cmd_atlas.py
@@ -231,7 +231,7 @@ def _run_analyze_orphans(snapshot_id: str) -> int:
 
     # Load live files from the root
     live_files = set()
-    for root_dir, dirs, files in os.walk(root_path):
+    for root_dir, _, files in os.walk(root_path):
         rel_root = Path(root_dir).relative_to(root_path)
         for name in files:
             rel_file_path = rel_root / name

--- a/merger/lenskit/cli/main.py
+++ b/merger/lenskit/cli/main.py
@@ -74,7 +74,7 @@ def main(args: Optional[List[str]] = None) -> int:
     pr_explain_parser.add_argument("--delta", required=True, help="Path to delta.json file")
 
     # Verify command (placeholder)
-    verify_parser = subparsers.add_parser("verify", help="Verify artifacts or bundles")
+    subparsers.add_parser("verify", help="Verify artifacts or bundles")
 
     # Architecture command
     architecture_parser = subparsers.add_parser("architecture", help="Extract architecture views")


### PR DESCRIPTION
- Removed unused `verify_parser` assignment in `merger/lenskit/cli/main.py`.
- Renamed unused `dirs` variable to `_` in `merger/lenskit/cli/cmd_atlas.py` to follow Python conventions.
- Verified that reported unused variables in `merger/lenskit/cli/rlens.py` were already addressed.
- Confirmed CLI subcommands remain functional.