### PR TITLE
docs: add missing disk.json artifact to atlas-blaupause.md

### DIFF
--- a/docs/atlas-blaupause.md
+++ b/docs/atlas-blaupause.md
@@ -958,6 +958,7 @@ Ziel: Atlas wird diagnostisch.
   - hardening: partial (Echtzeit-/Online-Erkennung fehlt)
 - [x] duplicates.json definieren (Wird generiert, als Artefakt im Snapshot abgelegt und formell in der Registry unter duplicates_ref hinterlegt)
 - [x] orphans.json definieren (Wird generiert, als Artefakt im Snapshot abgelegt und formell in der Registry unter orphans_ref hinterlegt)
+- [x] disk.json definieren (Wird generiert, als Artefakt im Snapshot abgelegt und formell in der Registry unter disk_ref hinterlegt)
 - [~] analyze disk standardisieren
   - implementation: done (CLI Output und Disk-Artifact)
   - tests: present


### PR DESCRIPTION
This update accurately documents the generation of the `disk.json` artifact in Phase 6 of the `atlas-blaupause.md` blueprint. 

The change reflects the verified repository state where `disk.json` is generated (in `cmd_atlas.py: _run_analyze_disk`) and registered as `disk_ref` (in `registry.py`), maintaining structural symmetry with other analyzed artifacts like duplicates and orphans. 

The update closes an epistemic gap without making functional assumptions, matching the exact state of the system according to the existing tests and integration checks.

---
*PR created automatically by Jules for task [17947447227303238525](https://jules.google.com/task/17947447227303238525) started by @alexdermohr*