### PR TITLE
Fix: Create JobStore state parent directory on fresh hubs

### DIFF
--- a/merger/lenskit/service/jobstore.py
+++ b/merger/lenskit/service/jobstore.py
@@ -53,12 +53,14 @@ class JobStore:
 
     def _save_jobs(self) -> None:
         tmp_file = self.jobs_file.with_suffix(".tmp")
+        tmp_file.parent.mkdir(parents=True, exist_ok=True)
         data = [j.model_dump() for j in self._jobs_cache.values()]
         tmp_file.write_text(json.dumps(data, indent=2), encoding="utf-8")
         tmp_file.rename(self.jobs_file)
 
     def _save_artifacts(self) -> None:
         tmp_file = self.artifacts_file.with_suffix(".tmp")
+        tmp_file.parent.mkdir(parents=True, exist_ok=True)
         data = [a.model_dump() for a in self._artifacts_cache.values()]
         tmp_file.write_text(json.dumps(data, indent=2), encoding="utf-8")
         tmp_file.rename(self.artifacts_file)

--- a/merger/lenskit/service/jobstore.py
+++ b/merger/lenskit/service/jobstore.py
@@ -105,6 +105,7 @@ class JobStore:
     def append_log_line(self, job_id: str, line: str):
         with self._lock:
             p = self.logs_dir / f"{job_id}.log"
+            p.parent.mkdir(parents=True, exist_ok=True)
             with p.open("a", encoding="utf-8", errors="replace") as f:
                 f.write(line + "\n")
         self._notify_log_subscribers(job_id)

--- a/merger/lenskit/tests/test_service_hardening.py
+++ b/merger/lenskit/tests/test_service_hardening.py
@@ -264,7 +264,8 @@ def test_create_job_fresh_hub_no_state_dir(client_and_hub):
     client, hub_path = client_and_hub
 
     # 1. Simulate fresh state by deleting the .rlens-service directory
-    storage_dir = state.job_store.storage_dir
+    from merger.lenskit.core.merge import MERGES_DIR_NAME
+    storage_dir = Path(hub_path) / MERGES_DIR_NAME / ".rlens-service"
 
     import shutil
     if storage_dir.exists():

--- a/merger/lenskit/tests/test_service_hardening.py
+++ b/merger/lenskit/tests/test_service_hardening.py
@@ -256,3 +256,48 @@ def test_create_job_blocks_absolute_path_repo(client_and_hub):
 
     response = client.post("/api/jobs", json=payload, headers=headers)
     assert response.status_code == 400
+
+def test_create_job_fresh_hub_no_state_dir(client_and_hub):
+    """
+    Test that a job can be created even if the `.rlens-service` directory does not exist.
+    This simulates a fresh hub or a situation where the state directory was deleted.
+    """
+    client, hub_path = client_and_hub
+
+    # 1. Simulate fresh state by deleting the .rlens-service directory
+    hub_p = Path(hub_path)
+    # The fixture already creates it in init_service, so we remove it
+    from merger.lenskit.core.merge import MERGES_DIR_NAME
+    storage_dir = hub_p / MERGES_DIR_NAME / ".rlens-service"
+
+    import shutil
+    if storage_dir.exists():
+        shutil.rmtree(storage_dir)
+
+    assert not storage_dir.exists(), "Setup failed: .rlens-service must not exist"
+
+    # 2. Re-initialize JobStore to simulate fresh start without the directory
+    # Note: init_service in the fixture already created the directory,
+    # but JobStore reads state in __init__. When we call /api/jobs, it uses
+    # the existing `state.job_store`. Since we just deleted the directory,
+    # the next write operation (save_jobs) will fail if not handled properly.
+
+    headers = {"Authorization": "Bearer test-token"}
+    payload = {
+        "repos": ["repo1"],
+        "hub": hub_path,
+        "level": "max",
+        "mode": "gesamt"
+    }
+
+    # 3. Create a job. This should trigger _save_jobs which should now recreate the parent dir.
+    response = client.post("/api/jobs", json=payload, headers=headers)
+
+    # 4. Assert that it worked and no FileNotFoundError was raised
+    assert response.status_code == 200, f"Failed to create job on fresh hub: {response.text}"
+    job_data = response.json()
+    assert "id" in job_data
+
+    # 5. Verify the directory and jobs.json were created
+    assert storage_dir.exists(), "State directory was not recreated"
+    assert (storage_dir / "jobs.json").exists(), "jobs.json was not created"

--- a/merger/lenskit/tests/test_service_hardening.py
+++ b/merger/lenskit/tests/test_service_hardening.py
@@ -264,10 +264,7 @@ def test_create_job_fresh_hub_no_state_dir(client_and_hub):
     client, hub_path = client_and_hub
 
     # 1. Simulate fresh state by deleting the .rlens-service directory
-    hub_p = Path(hub_path)
-    # The fixture already creates it in init_service, so we remove it
-    from merger.lenskit.core.merge import MERGES_DIR_NAME
-    storage_dir = hub_p / MERGES_DIR_NAME / ".rlens-service"
+    storage_dir = state.job_store.storage_dir
 
     import shutil
     if storage_dir.exists():
@@ -275,11 +272,11 @@ def test_create_job_fresh_hub_no_state_dir(client_and_hub):
 
     assert not storage_dir.exists(), "Setup failed: .rlens-service must not exist"
 
-    # 2. Re-initialize JobStore to simulate fresh start without the directory
+    # 2. Test saving with the existing JobStore instance when the state directory is gone.
     # Note: init_service in the fixture already created the directory,
-    # but JobStore reads state in __init__. When we call /api/jobs, it uses
-    # the existing `state.job_store`. Since we just deleted the directory,
-    # the next write operation (save_jobs) will fail if not handled properly.
+    # but when we call /api/jobs, it uses the existing `state.job_store`.
+    # Since we just deleted the directory, the next write operation (save_jobs)
+    # will fail if not handled properly.
 
     headers = {"Authorization": "Bearer test-token"}
     payload = {

--- a/merger/lenskit/tests/test_service_hardening.py
+++ b/merger/lenskit/tests/test_service_hardening.py
@@ -259,8 +259,7 @@ def test_create_job_blocks_absolute_path_repo(client_and_hub):
 
 def test_create_job_fresh_hub_no_state_dir(client_and_hub):
     """
-    Test that a job can be created even if the `.rlens-service` directory does not exist.
-    This simulates a fresh hub or a situation where the state directory was deleted.
+    Job creation recreates the missing .rlens-service state directory.
     """
     client, hub_path = client_and_hub
 

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,4 +1,0 @@
-Problem: Jobstart auf frischem Hub kann mit 500 scheitern, weil der JobStore in ein nicht existierendes State-Unterverzeichnis schreibt.
-Ursache: Parent-Verzeichnis für `jobs.tmp` wird vor `write_text()` nicht garantiert angelegt.
-Fix: JobStore legt das benötigte Parent-Verzeichnis vor dem Schreiben robust an.
-Test: Neuer Test `test_create_job_fresh_hub_no_state_dir` deckt frischen Hub ohne vorhandenes `.rlens-service/` ab.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,4 @@
+Problem: Jobstart auf frischem Hub kann mit 500 scheitern, weil der JobStore in ein nicht existierendes State-Unterverzeichnis schreibt.
+Ursache: Parent-Verzeichnis für `jobs.tmp` wird vor `write_text()` nicht garantiert angelegt.
+Fix: JobStore legt das benötigte Parent-Verzeichnis vor dem Schreiben robust an.
+Test: Neuer Test `test_create_job_fresh_hub_no_state_dir` deckt frischen Hub ohne vorhandenes `.rlens-service/` ab.


### PR DESCRIPTION
Problem: Jobstart auf frischem Hub kann mit 500 scheitern, weil der JobStore in ein nicht existierendes State-Unterverzeichnis schreibt.
Ursache: Parent-Verzeichnis für `jobs.tmp` wird vor `write_text()` nicht garantiert angelegt.
Fix: JobStore legt das benötigte Parent-Verzeichnis vor dem Schreiben robust an.
Test: Neuer Test `test_create_job_fresh_hub_no_state_dir` deckt frischen Hub ohne vorhandenes `.rlens-service/` ab.

---
*PR created automatically by Jules for task [16857480534567488181](https://jules.google.com/task/16857480534567488181) started by @alexdermohr*