### PR TITLE
feat: implement artifact_lookup – Phase 6 Lookup-Schicht

### DIFF
--- a/docs/lenskit-upgrade-blaupause.md
+++ b/docs/lenskit-upgrade-blaupause.md
@@ -1648,7 +1648,7 @@ Operationen:
 - [x] 1. query (logisch vorgesehen als `/query`; HTTP-seitig repo-belegt via `/api/query`)
 - [ ] 2. context_bundle (dedizierter Endpunkt fehlt)
 - [ ] 3. trace_lookup (Request/Response-Contract fehlt)
-- [ ] 4. artifact_lookup (als separater Servicepfad nicht implementiert)
+- [~] 4. artifact_lookup (`POST /api/artifact_lookup` implementiert für Query-Runtime-Artefakte: `query_trace`, `context_bundle`, `agent_query_session`; Contract `artifact-lookup.v1.schema.json`; offen: Lifecycle/Retention, raw-vs.-projizierte Artefaktform, Federation-Artefakte, MCP-Anbindung)
 - [x] 5. federation_query (logisch vorgesehen als `/federation/query`; HTTP-seitig repo-belegt via `/api/federation/query`)
 - [ ] 6. diagnostics (dedizierter Endpunkt fehlt)
 

--- a/merger/lenskit/cli/cmd_artifact.py
+++ b/merger/lenskit/cli/cmd_artifact.py
@@ -1,0 +1,55 @@
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+from ..service.query_artifact_store import QueryArtifactStore
+
+
+def _resolve_storage_dir(hub: Optional[str]) -> Optional[Path]:
+    if hub:
+        return Path(hub) / "merges" / ".rlens-service"
+    # fall back to cwd-relative convention
+    candidate = Path.cwd() / "merges" / ".rlens-service"
+    if candidate.exists():
+        return candidate
+    return None
+
+
+def run_artifact_lookup(args: argparse.Namespace) -> int:
+    storage_dir = _resolve_storage_dir(getattr(args, "hub", None))
+    if storage_dir is None:
+        print(
+            "Error: could not locate .rlens-service directory. "
+            "Pass --hub <hub_path> explicitly.",
+            file=sys.stderr,
+        )
+        return 1
+
+    store = QueryArtifactStore(storage_dir)
+    entry = store.get(args.id)
+
+    if entry is None:
+        result = {
+            "status": "not_found",
+            "id": args.id,
+            "artifact": None,
+            "warnings": [f"No artifact found with id={args.id!r}"],
+        }
+        print(json.dumps(result, indent=2))
+        return 1
+
+    result = {
+        "status": "ok",
+        "artifact_type": entry["artifact_type"],
+        "id": entry["id"],
+        "artifact": {
+            "provenance": entry["provenance"],
+            "created_at": entry["created_at"],
+            "data": entry["data"],
+        },
+        "warnings": [],
+    }
+    print(json.dumps(result, indent=2))
+    return 0

--- a/merger/lenskit/cli/cmd_artifact.py
+++ b/merger/lenskit/cli/cmd_artifact.py
@@ -4,13 +4,16 @@ import sys
 from pathlib import Path
 from typing import Optional
 
-from ..service.query_artifact_store import QueryArtifactStore
+from ..service.query_artifact_store import QueryArtifactStore, VALID_ARTIFACT_TYPES
 
 
 def _resolve_storage_dir(hub: Optional[str]) -> Optional[Path]:
     if hub:
+        # When --hub is given the service may have used a custom merges_dir.
+        # We can only probe the default path here; if a custom merges_dir was
+        # used at service start the caller should pass --hub pointing at it.
         return Path(hub) / "merges" / ".rlens-service"
-    # fall back to cwd-relative convention
+    # Fall back to cwd-relative convention.
     candidate = Path.cwd() / "merges" / ".rlens-service"
     if candidate.exists():
         return candidate
@@ -27,23 +30,41 @@ def run_artifact_lookup(args: argparse.Namespace) -> int:
         )
         return 1
 
+    artifact_type = getattr(args, "artifact_type", None)
+
     store = QueryArtifactStore(storage_dir)
     entry = store.get(args.id)
 
     if entry is None:
         result = {
-            "status": "not_found",
+            "artifact_type": artifact_type,
             "id": args.id,
+            "status": "not_found",
             "artifact": None,
             "warnings": [f"No artifact found with id={args.id!r}"],
         }
         print(json.dumps(result, indent=2))
         return 1
 
+    # If --artifact-type is given, validate that the stored type matches.
+    if artifact_type is not None and entry["artifact_type"] != artifact_type:
+        result = {
+            "artifact_type": artifact_type,
+            "id": args.id,
+            "status": "not_found",
+            "artifact": None,
+            "warnings": [
+                f"Artifact {args.id!r} has type {entry['artifact_type']!r}, "
+                f"not {artifact_type!r}"
+            ],
+        }
+        print(json.dumps(result, indent=2))
+        return 1
+
     result = {
-        "status": "ok",
         "artifact_type": entry["artifact_type"],
         "id": entry["id"],
+        "status": "ok",
         "artifact": {
             "provenance": entry["provenance"],
             "created_at": entry["created_at"],

--- a/merger/lenskit/cli/main.py
+++ b/merger/lenskit/cli/main.py
@@ -81,6 +81,11 @@ def main(args: Optional[List[str]] = None) -> int:
     # Verify command (placeholder)
     subparsers.add_parser("verify", help="Verify artifacts or bundles")
 
+    # Artifact lookup command
+    artifact_parser = subparsers.add_parser("artifact", help="Look up a stored query artifact by ID")
+    artifact_parser.add_argument("--id", required=True, help="Artifact ID (e.g. qart-<hex>)")
+    artifact_parser.add_argument("--hub", help="Hub root path (used to locate .rlens-service store)")
+
     # Architecture command
     architecture_parser = subparsers.add_parser("architecture", help="Extract architecture views")
     architecture_parser.add_argument("--repo", default=".", help="Path to repository root")
@@ -212,6 +217,9 @@ def main(args: Optional[List[str]] = None) -> int:
     elif parsed_args.command == "federation":
         from .cmd_federation import handle_federation_command
         return handle_federation_command(parsed_args)
+    elif parsed_args.command == "artifact":
+        from . import cmd_artifact
+        return cmd_artifact.run_artifact_lookup(parsed_args)
 
     return 0
 

--- a/merger/lenskit/cli/main.py
+++ b/merger/lenskit/cli/main.py
@@ -84,6 +84,12 @@ def main(args: Optional[List[str]] = None) -> int:
     # Artifact lookup command
     artifact_parser = subparsers.add_parser("artifact", help="Look up a stored query artifact by ID")
     artifact_parser.add_argument("--id", required=True, help="Artifact ID (e.g. qart-<hex>)")
+    artifact_parser.add_argument(
+        "--artifact-type",
+        choices=["query_trace", "context_bundle", "agent_query_session"],
+        dest="artifact_type",
+        help="Optional: expected artifact type. Returns status=not_found if ID exists but type mismatches.",
+    )
     artifact_parser.add_argument("--hub", help="Hub root path (used to locate .rlens-service store)")
 
     # Architecture command

--- a/merger/lenskit/cli/main.py
+++ b/merger/lenskit/cli/main.py
@@ -88,7 +88,8 @@ def main(args: Optional[List[str]] = None) -> int:
         "--artifact-type",
         choices=["query_trace", "context_bundle", "agent_query_session"],
         dest="artifact_type",
-        help="Optional: expected artifact type. Returns status=not_found if ID exists but type mismatches.",
+        required=True,
+        help="Expected artifact type. Returns status=not_found if ID exists but type mismatches.",
     )
     artifact_parser.add_argument("--hub", help="Hub root path (used to locate .rlens-service store)")
 

--- a/merger/lenskit/contracts/artifact-lookup.v1.schema.json
+++ b/merger/lenskit/contracts/artifact-lookup.v1.schema.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://heimgewebe.local/schema/artifact-lookup.v1.schema.json",
+  "title": "Artifact Lookup (artifact-lookup v1.0)",
+  "description": "Request/response contract for the artifact_lookup endpoint. Enables first-class addressability of query runtime artifacts (query_trace, context_bundle, agent_query_session) by stable ID.",
+  "definitions": {
+    "ArtifactLookupRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["artifact_type", "id"],
+      "properties": {
+        "artifact_type": {
+          "type": "string",
+          "enum": ["query_trace", "context_bundle", "agent_query_session"],
+          "description": "The type of runtime artifact to retrieve."
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The stable artifact ID returned at query time."
+        }
+      }
+    },
+    "ArtifactProvenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_query", "timestamp"],
+      "properties": {
+        "source_query": {
+          "type": "string",
+          "description": "The query text that produced this artifact."
+        },
+        "timestamp": {
+          "type": "string",
+          "description": "ISO 8601 UTC timestamp of artifact creation."
+        },
+        "index_id": {
+          "type": ["string", "null"],
+          "description": "The build artifact ID (index) used to produce this artifact."
+        },
+        "run_id": {
+          "type": ["string", "null"],
+          "description": "Optional correlation ID linking related artifacts from the same query execution."
+        }
+      }
+    },
+    "ArtifactPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provenance", "created_at", "data"],
+      "properties": {
+        "provenance": {
+          "$ref": "#/definitions/ArtifactProvenance"
+        },
+        "created_at": {
+          "type": "string",
+          "description": "ISO 8601 UTC timestamp when this artifact was stored."
+        },
+        "data": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "The artifact payload. Structure depends on artifact_type."
+        }
+      }
+    }
+  },
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["artifact_type", "id", "status", "artifact", "warnings"],
+  "properties": {
+    "artifact_type": {
+      "type": "string",
+      "enum": ["query_trace", "context_bundle", "agent_query_session"],
+      "description": "The artifact type that was requested."
+    },
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The artifact ID that was requested."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["ok", "not_found", "error"],
+      "description": "Lookup outcome. 'ok' means artifact was found and returned. 'not_found' means no artifact exists with this id/type. 'error' means an internal failure occurred."
+    },
+    "artifact": {
+      "oneOf": [
+        {"$ref": "#/definitions/ArtifactPayload"},
+        {"type": "null"}
+      ],
+      "description": "The artifact payload including provenance. Null when status is not 'ok'."
+    },
+    "warnings": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Non-fatal diagnostic messages (e.g. type mismatch, store not initialized)."
+    }
+  }
+}

--- a/merger/lenskit/contracts/artifact-lookup.v1.schema.json
+++ b/merger/lenskit/contracts/artifact-lookup.v1.schema.json
@@ -17,7 +17,7 @@
         "id": {
           "type": "string",
           "minLength": 1,
-          "description": "The stable artifact ID returned at query time."
+          "description": "The artifact ID returned at query time. Stable within the local QueryArtifactStore for the lifetime of the store; not guaranteed across service restarts that change the store location."
         }
       }
     },

--- a/merger/lenskit/service/app.py
+++ b/merger/lenskit/service/app.py
@@ -16,8 +16,9 @@ import re
 import uuid
 from datetime import datetime, timezone
 
-from .models import JobRequest, Job, Artifact, AtlasRequest, AtlasArtifact, AtlasEffective, calculate_job_hash, PrescanRequest, PrescanResponse, FSRoot, FSRootsResponse, FederationQueryRequest, QueryRequest
+from .models import JobRequest, Job, Artifact, AtlasRequest, AtlasArtifact, AtlasEffective, calculate_job_hash, PrescanRequest, PrescanResponse, FSRoot, FSRootsResponse, FederationQueryRequest, QueryRequest, ArtifactLookupRequest
 from .jobstore import JobStore
+from .query_artifact_store import QueryArtifactStore
 from .runner import JobRunner
 from .logging_provider import LogProvider, FileLogProvider
 from .auth import verify_token
@@ -147,6 +148,7 @@ class ServiceState:
     hub: Path = None
     merges_dir: Path = None
     job_store: JobStore = None
+    query_artifact_store: QueryArtifactStore = None
     runner: JobRunner = None
     log_provider: LogProvider = None
 
@@ -156,6 +158,8 @@ def init_service(hub_path: Path, token: Optional[str] = None, host: str = "127.0
     state.hub = hub_path
     state.merges_dir = merges_dir
     state.job_store = JobStore(hub_path)
+    _rlens_service_dir = hub_path / "merges" / ".rlens-service"
+    state.query_artifact_store = QueryArtifactStore(_rlens_service_dir)
     state.runner = JobRunner(state.job_store)
     state.log_provider = FileLogProvider(state.job_store)
 
@@ -627,6 +631,44 @@ def api_query(request: QueryRequest):
     if request.trace and isinstance(projected, dict) and "context_bundle" in projected:
         session = build_agent_query_session_v2(request.q, projected.get("context_bundle"))
         projected["agent_query_session"] = session
+
+    # Store query runtime artifacts so they can be retrieved via artifact_lookup.
+    # Triggered when trace=True or build_context_bundle=True to keep storage opt-in.
+    _should_store = request.trace or request.build_context_bundle
+    if _should_store and state.query_artifact_store is not None and isinstance(projected, dict):
+        from datetime import datetime, timezone as _tz
+        _run_id = uuid.uuid4().hex
+        _provenance = {
+            "source_query": request.q,
+            "timestamp": datetime.now(_tz.utc).isoformat(),
+            "index_id": request.index_id,
+        }
+        _artifact_ids: dict = {}
+
+        # query_trace: always in the raw result when trace=True
+        if "query_trace" in result:
+            _artifact_ids["query_trace"] = state.query_artifact_store.store(
+                "query_trace", result["query_trace"], _provenance, run_id=_run_id
+            )
+
+        # context_bundle: prefer projected form (profile-stripped if applicable)
+        _cb = projected.get("context_bundle")
+        if _cb is None and "hits" in projected:
+            _cb = projected  # direct bundle format (no-wrapper profile path)
+        if _cb is not None:
+            _artifact_ids["context_bundle"] = state.query_artifact_store.store(
+                "context_bundle", _cb, _provenance, run_id=_run_id
+            )
+
+        # agent_query_session: built above when trace=True
+        if "agent_query_session" in projected:
+            _artifact_ids["agent_query_session"] = state.query_artifact_store.store(
+                "agent_query_session", projected["agent_query_session"], _provenance, run_id=_run_id
+            )
+
+        if _artifact_ids:
+            projected["artifact_ids"] = _artifact_ids
+
     return projected
 
 @app.post("/api/jobs", response_model=Job, dependencies=[Depends(verify_token)])
@@ -838,6 +880,62 @@ def get_artifact(id: str):
     if not art:
         raise HTTPException(status_code=404, detail="Artifact not found")
     return art
+
+
+@app.post("/api/artifact_lookup", dependencies=[Depends(verify_token)])
+def api_artifact_lookup(request: ArtifactLookupRequest):
+    """Retrieve a previously stored query runtime artifact by stable ID.
+
+    Artifacts (query_trace, context_bundle, agent_query_session) are stored
+    automatically when a query is executed with trace=True or
+    build_context_bundle=True. The artifact_ids map is included in the query
+    response so callers can extract the IDs for subsequent lookups.
+
+    This endpoint is read-only and never recomputes anything.
+    """
+    if state.query_artifact_store is None:
+        return {
+            "artifact_type": request.artifact_type,
+            "id": request.id,
+            "status": "error",
+            "artifact": None,
+            "warnings": ["Query artifact store not initialized"],
+        }
+
+    entry = state.query_artifact_store.get(request.id)
+
+    if entry is None:
+        return {
+            "artifact_type": request.artifact_type,
+            "id": request.id,
+            "status": "not_found",
+            "artifact": None,
+            "warnings": [f"No artifact found with id={request.id!r}"],
+        }
+
+    if entry["artifact_type"] != request.artifact_type:
+        return {
+            "artifact_type": request.artifact_type,
+            "id": request.id,
+            "status": "not_found",
+            "artifact": None,
+            "warnings": [
+                f"Artifact {request.id!r} has type {entry['artifact_type']!r}, "
+                f"not {request.artifact_type!r}"
+            ],
+        }
+
+    return {
+        "artifact_type": entry["artifact_type"],
+        "id": entry["id"],
+        "status": "ok",
+        "artifact": {
+            "provenance": entry["provenance"],
+            "created_at": entry["created_at"],
+            "data": entry["data"],
+        },
+        "warnings": [],
+    }
 
 def _serve_file(base_dir: Path, requested_path: Union[str, Path], filename: Optional[str] = None) -> FileResponse:
     """

--- a/merger/lenskit/service/app.py
+++ b/merger/lenskit/service/app.py
@@ -158,8 +158,11 @@ def init_service(hub_path: Path, token: Optional[str] = None, host: str = "127.0
     state.hub = hub_path
     state.merges_dir = merges_dir
     state.job_store = JobStore(hub_path)
-    _rlens_service_dir = hub_path / "merges" / ".rlens-service"
-    state.query_artifact_store = QueryArtifactStore(_rlens_service_dir)
+    # Co-locate QueryArtifactStore with the effective merges dir so query artifacts
+    # land alongside the outputs they reference.  JobStore uses hub_path/merges
+    # unconditionally; QueryArtifactStore follows state.merges_dir when set.
+    _effective_merges = merges_dir if merges_dir else get_merges_dir(hub_path)
+    state.query_artifact_store = QueryArtifactStore(_effective_merges / ".rlens-service")
     state.runner = JobRunner(state.job_store)
     state.log_provider = FileLogProvider(state.job_store)
 
@@ -651,7 +654,11 @@ def api_query(request: QueryRequest):
                 "query_trace", result["query_trace"], _provenance, run_id=_run_id
             )
 
-        # context_bundle: prefer projected form (profile-stripped if applicable)
+        # context_bundle: stored in the projected (profile-stripped) form as returned
+        # by the API — not the raw internal state from execute_query().  An artifact
+        # lookup will therefore return the same shape a client received, which may have
+        # had explain blocks or graph_context removed by the output_profile.  Known
+        # limitation: the raw pre-projection bundle is not separately addressable.
         _cb = projected.get("context_bundle")
         if _cb is None and "hits" in projected:
             _cb = projected  # direct bundle format (no-wrapper profile path)

--- a/merger/lenskit/service/app.py
+++ b/merger/lenskit/service/app.py
@@ -674,7 +674,17 @@ def api_query(request: QueryRequest):
             )
 
         if _artifact_ids:
-            projected["artifact_ids"] = _artifact_ids
+            # artifact_ids must not be injected into a direct context bundle because
+            # query-context-bundle.v1.schema.json has additionalProperties: false.
+            # Three projected shapes are possible (see project_output docstring):
+            #   1. No profile → raw result dict (no schema restriction on extra keys).
+            #   2. Profile + wrapper → {"context_bundle": ..., ...} (wrapper accepts extras).
+            #   3. Profile, no wrapper → direct bundle at top level (hits key, strict schema).
+            # Only case 3 requires wrapping.
+            if "hits" in projected and "context_bundle" not in projected:
+                projected = {"context_bundle": projected, "artifact_ids": _artifact_ids}
+            else:
+                projected["artifact_ids"] = _artifact_ids
 
     return projected
 

--- a/merger/lenskit/service/models.py
+++ b/merger/lenskit/service/models.py
@@ -283,3 +283,8 @@ class QueryRequest(BaseModel):
     stale_policy: Literal["fail", "warn", "ignore"] = "fail"
     test_penalty: float = 0.75
     overmatch_guard: bool = False
+
+
+class ArtifactLookupRequest(BaseModel):
+    artifact_type: Literal["query_trace", "context_bundle", "agent_query_session"]
+    id: str

--- a/merger/lenskit/service/models.py
+++ b/merger/lenskit/service/models.py
@@ -287,4 +287,4 @@ class QueryRequest(BaseModel):
 
 class ArtifactLookupRequest(BaseModel):
     artifact_type: Literal["query_trace", "context_bundle", "agent_query_session"]
-    id: str
+    id: str = Field(min_length=1)

--- a/merger/lenskit/service/query_artifact_store.py
+++ b/merger/lenskit/service/query_artifact_store.py
@@ -1,0 +1,113 @@
+import json
+import threading
+import uuid
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+VALID_ARTIFACT_TYPES = frozenset({"query_trace", "context_bundle", "agent_query_session"})
+
+_STORE_FILENAME = "query_artifacts.json"
+
+
+class QueryArtifactStore:
+    """Persistent store for query runtime artifacts.
+
+    Artifacts (query_trace, context_bundle, agent_query_session) are produced
+    ephemerally during execute_query(). This store assigns stable IDs and
+    persists them so they can be retrieved via artifact_lookup without
+    re-executing any query.
+
+    Storage format: JSON list at {storage_dir}/query_artifacts.json.
+    All writes are atomic (tmp-rename).
+    """
+
+    def __init__(self, storage_dir: Path):
+        self.storage_dir = storage_dir
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+        self._store_file = self.storage_dir / _STORE_FILENAME
+        self._cache: Dict[str, Dict[str, Any]] = {}
+        self._lock = threading.RLock()
+        self._load()
+
+    def _load(self) -> None:
+        with self._lock:
+            if not self._store_file.exists():
+                return
+            try:
+                data = json.loads(self._store_file.read_text(encoding="utf-8"))
+                for entry in data:
+                    self._cache[entry["id"]] = entry
+            except Exception as e:
+                logger.error("Failed to load query artifacts from %s: %s", self._store_file, e)
+
+    def _save(self) -> None:
+        tmp = self._store_file.with_suffix(".tmp")
+        tmp.parent.mkdir(parents=True, exist_ok=True)
+        tmp.write_text(
+            json.dumps(list(self._cache.values()), indent=2),
+            encoding="utf-8",
+        )
+        tmp.rename(self._store_file)
+
+    def store(
+        self,
+        artifact_type: str,
+        data: Dict[str, Any],
+        provenance: Dict[str, Any],
+        run_id: Optional[str] = None,
+    ) -> str:
+        """Store a query artifact and return its stable artifact_id.
+
+        Args:
+            artifact_type: One of "query_trace", "context_bundle", "agent_query_session".
+            data: The artifact payload (must be JSON-serialisable).
+            provenance: Dict with at minimum "source_query" and "timestamp".
+            run_id: Optional correlation ID linking artifacts from the same execution.
+
+        Returns:
+            A stable artifact_id string (e.g. "qart-<hex>").
+        """
+        if artifact_type not in VALID_ARTIFACT_TYPES:
+            raise ValueError(
+                f"Invalid artifact_type {artifact_type!r}. "
+                f"Must be one of: {sorted(VALID_ARTIFACT_TYPES)}"
+            )
+
+        artifact_id = f"qart-{uuid.uuid4().hex}"
+        now = datetime.now(timezone.utc).isoformat()
+
+        prov = dict(provenance)
+        if run_id is not None:
+            prov.setdefault("run_id", run_id)
+        prov.setdefault("run_id", None)
+
+        entry: Dict[str, Any] = {
+            "id": artifact_id,
+            "artifact_type": artifact_type,
+            "data": data,
+            "provenance": prov,
+            "created_at": now,
+        }
+
+        with self._lock:
+            self._cache[artifact_id] = entry
+            self._save()
+
+        return artifact_id
+
+    def get(self, artifact_id: str) -> Optional[Dict[str, Any]]:
+        """Return the stored entry for artifact_id, or None if not found."""
+        with self._lock:
+            return self._cache.get(artifact_id)
+
+    def get_all(self) -> List[Dict[str, Any]]:
+        with self._lock:
+            return sorted(
+                self._cache.values(),
+                key=lambda e: e.get("created_at", ""),
+                reverse=True,
+            )

--- a/merger/lenskit/service/query_artifact_store.py
+++ b/merger/lenskit/service/query_artifact_store.py
@@ -61,7 +61,7 @@ class QueryArtifactStore:
             json.dumps(list(self._cache.values()), indent=2),
             encoding="utf-8",
         )
-        tmp.rename(self._store_file)
+        tmp.replace(self._store_file)
 
     def store(
         self,

--- a/merger/lenskit/service/query_artifact_store.py
+++ b/merger/lenskit/service/query_artifact_store.py
@@ -17,9 +17,19 @@ class QueryArtifactStore:
     """Persistent store for query runtime artifacts.
 
     Artifacts (query_trace, context_bundle, agent_query_session) are produced
-    ephemerally during execute_query(). This store assigns stable IDs and
-    persists them so they can be retrieved via artifact_lookup without
-    re-executing any query.
+    ephemerally during execute_query(). This store assigns IDs and persists
+    them so they can be retrieved via artifact_lookup without re-executing any
+    query.
+
+    ID stability: IDs are stable within this store instance for the lifetime
+    of the underlying JSON file.  They are not guaranteed to be resolvable
+    after the store location changes (e.g. different merges_dir).
+
+    Known limitations (open, not in scope for this PR):
+    - No retention/GC policy: the store grows unbounded.
+    - No federation artifact support.
+    - No raw-vs-projected artifact distinction (context_bundle is stored in
+      the projected API form, not the internal execute_query() form).
 
     Storage format: JSON list at {storage_dir}/query_artifacts.json.
     All writes are atomic (tmp-rename).

--- a/merger/lenskit/service/query_artifact_store.py
+++ b/merger/lenskit/service/query_artifact_store.py
@@ -32,7 +32,7 @@ class QueryArtifactStore:
       the projected API form, not the internal execute_query() form).
 
     Storage format: JSON list at {storage_dir}/query_artifacts.json.
-    All writes are atomic (tmp-rename).
+    All writes use tmp-file replacement.
     """
 
     def __init__(self, storage_dir: Path):

--- a/merger/lenskit/tests/test_artifact_lookup.py
+++ b/merger/lenskit/tests/test_artifact_lookup.py
@@ -1,9 +1,21 @@
-"""Tests for artifact_lookup: QueryArtifactStore + /api/artifact_lookup endpoint."""
+"""Tests for artifact_lookup: QueryArtifactStore + /api/artifact_lookup endpoint.
+
+Auth convention (confirmed via merger/lenskit/service/auth.py):
+  verify_token accepts HTTPBearer credentials only.
+  Canonical header: "Authorization": "Bearer <token>"
+  "x-rlens-token" appears in CORS allow_headers but is NOT read by verify_token.
+"""
 import json
 import pytest
 from pathlib import Path
 
 from merger.lenskit.service.query_artifact_store import QueryArtifactStore, VALID_ARTIFACT_TYPES
+
+# jsonschema is an optional dependency; tests that need it skip gracefully.
+try:
+    import jsonschema
+except ImportError:
+    jsonschema = None
 
 try:
     from fastapi.testclient import TestClient
@@ -15,6 +27,12 @@ except ImportError:
     _HAS_FASTAPI = False
 
 requires_fastapi = pytest.mark.skipif(not _HAS_FASTAPI, reason="fastapi not installed")
+
+# Canonical auth header — matches HTTPBearer in verify_token.
+_AUTH = {"Authorization": "Bearer test_token"}
+
+# Path to the artifact-lookup schema for contract validation.
+_SCHEMA_PATH = Path(__file__).parent.parent / "contracts" / "artifact-lookup.v1.schema.json"
 
 
 # ---------------------------------------------------------------------------
@@ -70,6 +88,29 @@ def api_client(tmp_path, mini_index):
     return TestClient(app)
 
 
+@pytest.fixture
+def api_client_custom_merges(tmp_path, mini_index):
+    """Fixture that uses an explicit merges_dir to verify store-path drift fix."""
+    hub_path = mini_index.parent.parent
+    custom_merges = tmp_path / "custom_merges"
+    custom_merges.mkdir(parents=True, exist_ok=True)
+    service_app.init_service(hub_path=hub_path, token="test_token", merges_dir=custom_merges)
+
+    from merger.lenskit.service.models import Artifact, JobRequest
+    from merger.lenskit.service.app import state
+
+    req = JobRequest(repos=["repo"], level="max", mode="gesamt")
+    art = Artifact(
+        id="test-art", job_id="test-job", hub=str(hub_path), repos=["repo"],
+        created_at="2024-01-01T00:00:00+00:00",
+        paths={"sqlite_index": mini_index.name},
+        params=req,
+        merges_dir=str(mini_index.parent),
+    )
+    state.job_store.add_artifact(art)
+    return TestClient(app), custom_merges
+
+
 # ---------------------------------------------------------------------------
 # QueryArtifactStore unit tests
 # ---------------------------------------------------------------------------
@@ -123,14 +164,13 @@ class TestQueryArtifactStore:
         ids = [store.store("query_trace", {}, prov) for _ in range(3)]
         all_entries = store.get_all()
         assert len(all_entries) == 3
-        # stored IDs should all be present
         stored_ids = {e["id"] for e in all_entries}
         assert stored_ids == set(ids)
 
     def test_id_is_stable_and_unique(self, store):
         prov = {"source_query": "q", "timestamp": "2024-01-01T00:00:00+00:00"}
         ids = {store.store("query_trace", {}, prov) for _ in range(5)}
-        assert len(ids) == 5  # all unique
+        assert len(ids) == 5
 
 
 # ---------------------------------------------------------------------------
@@ -143,7 +183,7 @@ class TestApiArtifactLookup:
         resp = api_client.post(
             "/api/artifact_lookup",
             json={"artifact_type": "query_trace", "id": "qart-doesnotexist"},
-            headers={"x-rlens-token": "test_token"},
+            headers=_AUTH,
         )
         assert resp.status_code == 200
         data = resp.json()
@@ -151,7 +191,7 @@ class TestApiArtifactLookup:
         assert data["artifact"] is None
         assert len(data["warnings"]) > 0
 
-    def test_lookup_after_query_with_trace(self, api_client, mini_index):
+    def test_lookup_after_query_with_trace(self, api_client):
         resp = api_client.post(
             "/api/query",
             json={
@@ -162,16 +202,19 @@ class TestApiArtifactLookup:
                 "build_context_bundle": True,
                 "stale_policy": "ignore",
             },
-            headers={"x-rlens-token": "test_token"},
+            headers=_AUTH,
         )
         assert resp.status_code == 200
         query_result = resp.json()
 
         assert "artifact_ids" in query_result, (
-            "artifact_ids not in query response — store integration failed"
+            "artifact_ids missing from query response — store integration failed"
         )
         artifact_ids = query_result["artifact_ids"]
-        assert "query_trace" in artifact_ids
+        # trace=True must always produce a query_trace artifact — no skip allowed here.
+        assert "query_trace" in artifact_ids, (
+            "query_trace not stored despite trace=True"
+        )
 
         trace_id = artifact_ids["query_trace"]
         assert trace_id.startswith("qart-")
@@ -179,7 +222,7 @@ class TestApiArtifactLookup:
         lookup_resp = api_client.post(
             "/api/artifact_lookup",
             json={"artifact_type": "query_trace", "id": trace_id},
-            headers={"x-rlens-token": "test_token"},
+            headers=_AUTH,
         )
         assert lookup_resp.status_code == 200
         lookup_data = lookup_resp.json()
@@ -189,46 +232,47 @@ class TestApiArtifactLookup:
         assert "provenance" in lookup_data["artifact"]
         assert lookup_data["artifact"]["provenance"]["source_query"] == "main"
         assert lookup_data["artifact"]["provenance"]["index_id"] == "test-art"
-        # Determinism: lookup returns same object, no recomputing
         assert "data" in lookup_data["artifact"]
 
-    def test_lookup_type_mismatch_returns_not_found(self, api_client, mini_index):
-        # Store a query_trace artifact, try to look it up as context_bundle
+    def test_lookup_type_mismatch_returns_not_found(self, api_client):
         resp = api_client.post(
             "/api/query",
             json={
                 "index_id": "test-art",
-                "q": "helper",
+                "q": "main",
                 "trace": True,
                 "stale_policy": "ignore",
             },
-            headers={"x-rlens-token": "test_token"},
+            headers=_AUTH,
         )
         assert resp.status_code == 200
         artifact_ids = resp.json().get("artifact_ids", {})
-        trace_id = artifact_ids.get("query_trace")
-        if not trace_id:
-            pytest.skip("No query_trace artifact was stored")
+        # trace=True must always store query_trace — no skip here.
+        assert "query_trace" in artifact_ids, (
+            "query_trace not stored despite trace=True"
+        )
+        trace_id = artifact_ids["query_trace"]
 
+        # Look up a query_trace ID under the wrong type.
         lookup_resp = api_client.post(
             "/api/artifact_lookup",
             json={"artifact_type": "context_bundle", "id": trace_id},
-            headers={"x-rlens-token": "test_token"},
+            headers=_AUTH,
         )
         assert lookup_resp.status_code == 200
         data = lookup_resp.json()
         assert data["status"] == "not_found"
         assert len(data["warnings"]) > 0
+        assert "query_trace" in data["warnings"][0]  # warning names the actual type
 
     def test_lookup_requires_auth(self, api_client):
         resp = api_client.post(
             "/api/artifact_lookup",
             json={"artifact_type": "query_trace", "id": "qart-test"},
         )
-        # Without token, should be 401 or 403
-        assert resp.status_code in (401, 403)
+        assert resp.status_code == 401
 
-    def test_no_artifact_ids_without_trace_flag(self, api_client, mini_index):
+    def test_no_artifact_ids_without_trace_or_build_context(self, api_client):
         resp = api_client.post(
             "/api/query",
             json={
@@ -239,15 +283,15 @@ class TestApiArtifactLookup:
                 "build_context_bundle": False,
                 "stale_policy": "ignore",
             },
-            headers={"x-rlens-token": "test_token"},
+            headers=_AUTH,
         )
         assert resp.status_code == 200
         result = resp.json()
         assert "artifact_ids" not in result, (
-            "artifact_ids should not appear when trace=False and build_context_bundle=False"
+            "artifact_ids must not appear when trace=False and build_context_bundle=False"
         )
 
-    def test_context_bundle_lookup_roundtrip(self, api_client, mini_index):
+    def test_context_bundle_lookup_roundtrip(self, api_client):
         resp = api_client.post(
             "/api/query",
             json={
@@ -256,28 +300,32 @@ class TestApiArtifactLookup:
                 "build_context_bundle": True,
                 "stale_policy": "ignore",
             },
-            headers={"x-rlens-token": "test_token"},
+            headers=_AUTH,
         )
         assert resp.status_code == 200
         query_result = resp.json()
 
         artifact_ids = query_result.get("artifact_ids", {})
-        cb_id = artifact_ids.get("context_bundle")
-        if not cb_id:
-            pytest.skip("No context_bundle artifact was stored (no hits or bundle not built)")
+        assert "context_bundle" in artifact_ids, (
+            "context_bundle not stored despite build_context_bundle=True"
+        )
+        cb_id = artifact_ids["context_bundle"]
 
         lookup_resp = api_client.post(
             "/api/artifact_lookup",
             json={"artifact_type": "context_bundle", "id": cb_id},
-            headers={"x-rlens-token": "test_token"},
+            headers=_AUTH,
         )
         assert lookup_resp.status_code == 200
         data = lookup_resp.json()
         assert data["status"] == "ok"
         assert data["artifact"]["data"]["query"] == "main"
 
-    def test_lookup_response_conforms_to_contract(self, api_client, mini_index):
-        # After a trace query, check the full response shape matches artifact-lookup.v1 schema
+    def test_lookup_response_conforms_to_contract(self, api_client):
+        """Response must validate against artifact-lookup.v1.schema.json."""
+        if jsonschema is None:
+            pytest.skip("jsonschema not available")
+
         resp = api_client.post(
             "/api/query",
             json={
@@ -286,32 +334,48 @@ class TestApiArtifactLookup:
                 "trace": True,
                 "stale_policy": "ignore",
             },
-            headers={"x-rlens-token": "test_token"},
+            headers=_AUTH,
         )
         assert resp.status_code == 200
         artifact_ids = resp.json().get("artifact_ids", {})
-        trace_id = artifact_ids.get("query_trace")
-        if not trace_id:
-            pytest.skip("No query_trace stored")
+        # trace=True must always store query_trace.
+        assert "query_trace" in artifact_ids, (
+            "query_trace not stored despite trace=True"
+        )
+        trace_id = artifact_ids["query_trace"]
 
         lookup_resp = api_client.post(
             "/api/artifact_lookup",
             json={"artifact_type": "query_trace", "id": trace_id},
-            headers={"x-rlens-token": "test_token"},
+            headers=_AUTH,
         )
+        assert lookup_resp.status_code == 200
         data = lookup_resp.json()
-        # Validate required top-level fields per artifact-lookup.v1 schema
-        assert "artifact_type" in data
-        assert "id" in data
-        assert "status" in data
-        assert "artifact" in data
-        assert "warnings" in data
-        assert isinstance(data["warnings"], list)
-        assert data["status"] in ("ok", "not_found", "error")
-        if data["status"] == "ok":
-            artifact = data["artifact"]
-            assert "provenance" in artifact
-            assert "created_at" in artifact
-            assert "data" in artifact
-            assert "source_query" in artifact["provenance"]
-            assert "timestamp" in artifact["provenance"]
+
+        schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+        jsonschema.validate(instance=data, schema=schema)
+
+    def test_store_path_uses_merges_dir_when_set(self, api_client_custom_merges):
+        """QueryArtifactStore must use merges_dir/.rlens-service when merges_dir is set."""
+        client, custom_merges = api_client_custom_merges
+        resp = client.post(
+            "/api/query",
+            json={
+                "index_id": "test-art",
+                "q": "main",
+                "trace": True,
+                "stale_policy": "ignore",
+            },
+            headers=_AUTH,
+        )
+        assert resp.status_code == 200
+        artifact_ids = resp.json().get("artifact_ids", {})
+        assert "query_trace" in artifact_ids, (
+            "query_trace not stored despite trace=True"
+        )
+
+        # The query_artifacts.json must exist inside the custom merges dir.
+        store_file = custom_merges / ".rlens-service" / "query_artifacts.json"
+        assert store_file.exists(), (
+            f"QueryArtifactStore did not write to custom merges_dir: {store_file}"
+        )

--- a/merger/lenskit/tests/test_artifact_lookup.py
+++ b/merger/lenskit/tests/test_artifact_lookup.py
@@ -1,0 +1,317 @@
+"""Tests for artifact_lookup: QueryArtifactStore + /api/artifact_lookup endpoint."""
+import json
+import pytest
+from pathlib import Path
+
+from merger.lenskit.service.query_artifact_store import QueryArtifactStore, VALID_ARTIFACT_TYPES
+
+try:
+    from fastapi.testclient import TestClient
+    from merger.lenskit.service.app import app
+    from merger.lenskit.service import app as service_app
+    from merger.lenskit.retrieval import index_db
+    _HAS_FASTAPI = True
+except ImportError:
+    _HAS_FASTAPI = False
+
+requires_fastapi = pytest.mark.skipif(not _HAS_FASTAPI, reason="fastapi not installed")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def store(tmp_path):
+    return QueryArtifactStore(tmp_path / ".rlens-service")
+
+
+@pytest.fixture
+def mini_index(tmp_path):
+    if not _HAS_FASTAPI:
+        pytest.skip("fastapi not installed")
+    dump_path = tmp_path / "dump.json"
+    chunk_path = tmp_path / "chunks.jsonl"
+    db_path = tmp_path / ".index.sqlite"
+
+    chunk_data = [
+        {
+            "chunk_id": "c1", "repo_id": "r1", "path": "src/main.py",
+            "content": "def main():\n    return 0",
+            "start_line": 1, "end_line": 2, "layer": "core",
+            "artifact_type": "code", "content_sha256": "h1",
+        },
+    ]
+    with chunk_path.open("w", encoding="utf-8") as f:
+        for c in chunk_data:
+            f.write(json.dumps(c) + "\n")
+    dump_path.write_text(json.dumps({"dummy": "data"}), encoding="utf-8")
+    index_db.build_index(dump_path, chunk_path, db_path)
+    return db_path
+
+
+@pytest.fixture
+def api_client(tmp_path, mini_index):
+    hub_path = mini_index.parent.parent
+    service_app.init_service(hub_path=hub_path, token="test_token")
+
+    from merger.lenskit.service.models import Artifact, JobRequest
+    from merger.lenskit.service.app import state
+
+    req = JobRequest(repos=["repo"], level="max", mode="gesamt")
+    art = Artifact(
+        id="test-art", job_id="test-job", hub=str(hub_path), repos=["repo"],
+        created_at="2024-01-01T00:00:00+00:00",
+        paths={"sqlite_index": mini_index.name},
+        params=req,
+        merges_dir=str(mini_index.parent),
+    )
+    state.job_store.add_artifact(art)
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# QueryArtifactStore unit tests
+# ---------------------------------------------------------------------------
+
+class TestQueryArtifactStore:
+    def test_store_and_get_roundtrip(self, store):
+        data = {"query_input": "hello", "timings": {}}
+        provenance = {"source_query": "hello", "timestamp": "2024-01-01T00:00:00+00:00"}
+        artifact_id = store.store("query_trace", data, provenance)
+
+        assert artifact_id.startswith("qart-")
+        entry = store.get(artifact_id)
+        assert entry is not None
+        assert entry["artifact_type"] == "query_trace"
+        assert entry["data"] == data
+        assert entry["provenance"]["source_query"] == "hello"
+        assert entry["provenance"]["run_id"] is None
+
+    def test_store_with_run_id(self, store):
+        provenance = {"source_query": "q", "timestamp": "2024-01-01T00:00:00+00:00"}
+        aid = store.store("context_bundle", {"query": "q", "hits": []}, provenance, run_id="abc123")
+        entry = store.get(aid)
+        assert entry["provenance"]["run_id"] == "abc123"
+
+    def test_get_missing_returns_none(self, store):
+        assert store.get("qart-nonexistent") is None
+
+    def test_invalid_artifact_type_raises(self, store):
+        with pytest.raises(ValueError, match="Invalid artifact_type"):
+            store.store("federation_trace", {}, {"source_query": "q", "timestamp": "t"})
+
+    def test_all_valid_types_accepted(self, store):
+        prov = {"source_query": "q", "timestamp": "2024-01-01T00:00:00+00:00"}
+        for art_type in VALID_ARTIFACT_TYPES:
+            aid = store.store(art_type, {}, prov)
+            assert store.get(aid) is not None
+
+    def test_persistence_survives_reload(self, tmp_path):
+        storage_dir = tmp_path / ".rlens-service"
+        store1 = QueryArtifactStore(storage_dir)
+        prov = {"source_query": "persist test", "timestamp": "2024-01-01T00:00:00+00:00"}
+        aid = store1.store("query_trace", {"data": "value"}, prov)
+
+        store2 = QueryArtifactStore(storage_dir)
+        entry = store2.get(aid)
+        assert entry is not None
+        assert entry["data"] == {"data": "value"}
+
+    def test_get_all_returns_most_recent_first(self, store):
+        prov = {"source_query": "q", "timestamp": "2024-01-01T00:00:00+00:00"}
+        ids = [store.store("query_trace", {}, prov) for _ in range(3)]
+        all_entries = store.get_all()
+        assert len(all_entries) == 3
+        # stored IDs should all be present
+        stored_ids = {e["id"] for e in all_entries}
+        assert stored_ids == set(ids)
+
+    def test_id_is_stable_and_unique(self, store):
+        prov = {"source_query": "q", "timestamp": "2024-01-01T00:00:00+00:00"}
+        ids = {store.store("query_trace", {}, prov) for _ in range(5)}
+        assert len(ids) == 5  # all unique
+
+
+# ---------------------------------------------------------------------------
+# API endpoint tests
+# ---------------------------------------------------------------------------
+
+@requires_fastapi
+class TestApiArtifactLookup:
+    def test_lookup_not_found(self, api_client):
+        resp = api_client.post(
+            "/api/artifact_lookup",
+            json={"artifact_type": "query_trace", "id": "qart-doesnotexist"},
+            headers={"x-rlens-token": "test_token"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "not_found"
+        assert data["artifact"] is None
+        assert len(data["warnings"]) > 0
+
+    def test_lookup_after_query_with_trace(self, api_client, mini_index):
+        resp = api_client.post(
+            "/api/query",
+            json={
+                "index_id": "test-art",
+                "q": "main",
+                "k": 5,
+                "trace": True,
+                "build_context_bundle": True,
+                "stale_policy": "ignore",
+            },
+            headers={"x-rlens-token": "test_token"},
+        )
+        assert resp.status_code == 200
+        query_result = resp.json()
+
+        assert "artifact_ids" in query_result, (
+            "artifact_ids not in query response — store integration failed"
+        )
+        artifact_ids = query_result["artifact_ids"]
+        assert "query_trace" in artifact_ids
+
+        trace_id = artifact_ids["query_trace"]
+        assert trace_id.startswith("qart-")
+
+        lookup_resp = api_client.post(
+            "/api/artifact_lookup",
+            json={"artifact_type": "query_trace", "id": trace_id},
+            headers={"x-rlens-token": "test_token"},
+        )
+        assert lookup_resp.status_code == 200
+        lookup_data = lookup_resp.json()
+        assert lookup_data["status"] == "ok"
+        assert lookup_data["id"] == trace_id
+        assert lookup_data["artifact"] is not None
+        assert "provenance" in lookup_data["artifact"]
+        assert lookup_data["artifact"]["provenance"]["source_query"] == "main"
+        assert lookup_data["artifact"]["provenance"]["index_id"] == "test-art"
+        # Determinism: lookup returns same object, no recomputing
+        assert "data" in lookup_data["artifact"]
+
+    def test_lookup_type_mismatch_returns_not_found(self, api_client, mini_index):
+        # Store a query_trace artifact, try to look it up as context_bundle
+        resp = api_client.post(
+            "/api/query",
+            json={
+                "index_id": "test-art",
+                "q": "helper",
+                "trace": True,
+                "stale_policy": "ignore",
+            },
+            headers={"x-rlens-token": "test_token"},
+        )
+        assert resp.status_code == 200
+        artifact_ids = resp.json().get("artifact_ids", {})
+        trace_id = artifact_ids.get("query_trace")
+        if not trace_id:
+            pytest.skip("No query_trace artifact was stored")
+
+        lookup_resp = api_client.post(
+            "/api/artifact_lookup",
+            json={"artifact_type": "context_bundle", "id": trace_id},
+            headers={"x-rlens-token": "test_token"},
+        )
+        assert lookup_resp.status_code == 200
+        data = lookup_resp.json()
+        assert data["status"] == "not_found"
+        assert len(data["warnings"]) > 0
+
+    def test_lookup_requires_auth(self, api_client):
+        resp = api_client.post(
+            "/api/artifact_lookup",
+            json={"artifact_type": "query_trace", "id": "qart-test"},
+        )
+        # Without token, should be 401 or 403
+        assert resp.status_code in (401, 403)
+
+    def test_no_artifact_ids_without_trace_flag(self, api_client, mini_index):
+        resp = api_client.post(
+            "/api/query",
+            json={
+                "index_id": "test-art",
+                "q": "main",
+                "k": 5,
+                "trace": False,
+                "build_context_bundle": False,
+                "stale_policy": "ignore",
+            },
+            headers={"x-rlens-token": "test_token"},
+        )
+        assert resp.status_code == 200
+        result = resp.json()
+        assert "artifact_ids" not in result, (
+            "artifact_ids should not appear when trace=False and build_context_bundle=False"
+        )
+
+    def test_context_bundle_lookup_roundtrip(self, api_client, mini_index):
+        resp = api_client.post(
+            "/api/query",
+            json={
+                "index_id": "test-art",
+                "q": "main",
+                "build_context_bundle": True,
+                "stale_policy": "ignore",
+            },
+            headers={"x-rlens-token": "test_token"},
+        )
+        assert resp.status_code == 200
+        query_result = resp.json()
+
+        artifact_ids = query_result.get("artifact_ids", {})
+        cb_id = artifact_ids.get("context_bundle")
+        if not cb_id:
+            pytest.skip("No context_bundle artifact was stored (no hits or bundle not built)")
+
+        lookup_resp = api_client.post(
+            "/api/artifact_lookup",
+            json={"artifact_type": "context_bundle", "id": cb_id},
+            headers={"x-rlens-token": "test_token"},
+        )
+        assert lookup_resp.status_code == 200
+        data = lookup_resp.json()
+        assert data["status"] == "ok"
+        assert data["artifact"]["data"]["query"] == "main"
+
+    def test_lookup_response_conforms_to_contract(self, api_client, mini_index):
+        # After a trace query, check the full response shape matches artifact-lookup.v1 schema
+        resp = api_client.post(
+            "/api/query",
+            json={
+                "index_id": "test-art",
+                "q": "main",
+                "trace": True,
+                "stale_policy": "ignore",
+            },
+            headers={"x-rlens-token": "test_token"},
+        )
+        assert resp.status_code == 200
+        artifact_ids = resp.json().get("artifact_ids", {})
+        trace_id = artifact_ids.get("query_trace")
+        if not trace_id:
+            pytest.skip("No query_trace stored")
+
+        lookup_resp = api_client.post(
+            "/api/artifact_lookup",
+            json={"artifact_type": "query_trace", "id": trace_id},
+            headers={"x-rlens-token": "test_token"},
+        )
+        data = lookup_resp.json()
+        # Validate required top-level fields per artifact-lookup.v1 schema
+        assert "artifact_type" in data
+        assert "id" in data
+        assert "status" in data
+        assert "artifact" in data
+        assert "warnings" in data
+        assert isinstance(data["warnings"], list)
+        assert data["status"] in ("ok", "not_found", "error")
+        if data["status"] == "ok":
+            artifact = data["artifact"]
+            assert "provenance" in artifact
+            assert "created_at" in artifact
+            assert "data" in artifact
+            assert "source_query" in artifact["provenance"]
+            assert "timestamp" in artifact["provenance"]

--- a/merger/lenskit/tests/test_artifact_lookup.py
+++ b/merger/lenskit/tests/test_artifact_lookup.py
@@ -355,6 +355,40 @@ class TestApiArtifactLookup:
         schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
         jsonschema.validate(instance=data, schema=schema)
 
+    def test_direct_bundle_artifact_ids_wrapping(self, api_client):
+        """artifact_ids must not be injected into a bare context bundle.
+
+        When output_profile produces a direct bundle (hits at top level, no
+        context_bundle wrapper), the app must wrap it:
+          {"context_bundle": <bundle>, "artifact_ids": {...}}
+
+        Regression guard for the additionalProperties: false contract break.
+        """
+        resp = api_client.post(
+            "/api/query",
+            json={
+                "index_id": "test-art",
+                "q": "main",
+                "build_context_bundle": True,
+                "output_profile": "agent_minimal",
+                "stale_policy": "ignore",
+            },
+            headers=_AUTH,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+
+        assert "artifact_ids" in data, "artifact_ids missing despite build_context_bundle=True"
+        assert "context_bundle" in data, (
+            "Direct bundle must be wrapped under 'context_bundle' key when artifact_ids are present"
+        )
+        assert "hits" not in data, (
+            "Top-level 'hits' must not appear — injecting into a strict context bundle violates schema"
+        )
+        assert "context_bundle" in data["artifact_ids"], (
+            "context_bundle artifact ID must be stored"
+        )
+
     def test_store_path_uses_merges_dir_when_set(self, api_client_custom_merges):
         """QueryArtifactStore must use merges_dir/.rlens-service when merges_dir is set."""
         client, custom_merges = api_client_custom_merges


### PR DESCRIPTION
Introduces first-class addressability for query runtime artifacts
(query_trace, context_bundle, agent_query_session) via stable IDs,
following the contract-first + Diagnose-Gate approach prescribed in
the Retrieval Upgrade Blueprint (Phase 6 / Bounded Tool Surface).

Diagnose-Gate findings (documented in commit context):
- Build artifacts (Artifact model) are already persistently stored in
  JobStore; accessible via existing /api/artifacts/{id}.
- Query runtime artifacts were fully ephemeral – returned inline, no
  stable IDs, no registry. → Option B extended: new QueryArtifactStore.

Changes:
- contracts/artifact-lookup.v1.schema.json: new contract schema with
  ArtifactLookupRequest, ArtifactProvenance, ArtifactPayload definitions
- service/query_artifact_store.py: thread-safe, atomically persisted
  store for query runtime artifacts; assigns stable qart-<hex> IDs
- service/models.py: ArtifactLookupRequest pydantic model
- service/app.py: QueryArtifactStore wired into ServiceState;
  /api/query stores artifacts on trace=True / build_context_bundle=True
  and returns artifact_ids map; new POST /api/artifact_lookup endpoint
- cli/cmd_artifact.py + cli/main.py: lenskit artifact --id <id> command
- tests/test_artifact_lookup.py: 8 unit tests for QueryArtifactStore
  (store/get roundtrip, persistence, run_id, type guard, uniqueness);
  7 API integration tests guarded behind requires_fastapi skip marker

https://claude.ai/code/session_01KQ1YXZuDcdhzWevB5Ggqg3