### PR TITLE
feat(retrieval): add typed trace lookup endpoint

### DIFF
--- a/docs/lenskit-upgrade-blaupause.md
+++ b/docs/lenskit-upgrade-blaupause.md
@@ -1647,7 +1647,7 @@ Ziel:
 Operationen:
 - [x] 1. query (logisch vorgesehen als `/query`; HTTP-seitig repo-belegt via `/api/query`)
 - [ ] 2. context_bundle (dedizierter Endpunkt fehlt)
-- [ ] 3. trace_lookup (Request/Response-Contract fehlt)
+- [~] 3. trace_lookup (`POST /api/trace_lookup` implementiert für gespeicherte `query_trace`-Artefakte; Contract `trace-lookup.v1.schema.json`; offen: Federation-Trace, physischer API-Trace-Layer)
 - [~] 4. artifact_lookup (`POST /api/artifact_lookup` implementiert für Query-Runtime-Artefakte: `query_trace`, `context_bundle`, `agent_query_session`; Contract `artifact-lookup.v1.schema.json`; offen: Lifecycle/Retention, raw-vs.-projizierte Artefaktform, Federation-Artefakte, MCP-Anbindung)
 - [x] 5. federation_query (logisch vorgesehen als `/federation/query`; HTTP-seitig repo-belegt via `/api/federation/query`)
 - [ ] 6. diagnostics (dedizierter Endpunkt fehlt)
@@ -1705,7 +1705,7 @@ Tests:
 ### 2.12 Deliverables Phase 6
 - [x] 1. Agent Query Contract (minimaler HTTP-Roundtrip über `/api/query` repo-belegt und getestet)
 - [x] 2. Agent Output Profiles (strukturell existierend via `output_profile` wie `agent_minimal`, `lookup_minimal`, `review_context`)
-- [~] 3. bounded API/tool surface (Query-/Federation-Pfade vorhanden, dedizierte Lookup-Pfade fehlen)
+- [~] 3. bounded API/tool surface (Query-/Federation-Pfade vorhanden; `POST /api/trace_lookup` für `query_trace`-Artefakte implementiert; dedizierte Context-Bundle- und Diagnostics-Pfade fehlen noch)
 - [~] 4. maschinenlesbare uncertainty/provenance Felder (Contract existiert, komplexe Status fehlen)
 - [~] 5. `agent_query_session.json` (CLI nutzt v1 Artefakt, API liefert v2 Inline-Session)
 - [~] 6. service-/MCP-fähige Schnittstellenlogik (API Servicepfade existieren, MCP Protokoll fehlt)
@@ -1747,7 +1747,7 @@ Arbeitspakete:
 - [ ] **7.2 Diagnostic Views:** graph health, federation conflicts, bundle provenance, query trace.
 - [~] **7.3 Service-Endpunkte:**
   logisch vorgesehen: `/query`, `/context`, `/trace`, `/artifact`, `/federation/query`, `/diagnostics`.
-  repo-belegt vorhanden: `/api/query`, `/api/federation/query`. (Dedizierte Lookup-Pfade fehlen).
+  repo-belegt vorhanden: `/api/query`, `/api/federation/query`, `/api/trace_lookup`. (Dedizierte Context-Bundle- und Diagnostics-Pfade fehlen noch).
 - [ ] **7.4 Download-/Inspection-Flows:** bundle parts, traces, context bundles, diagnostics.
 
 Deliverables:

--- a/docs/lenskit-upgrade-blaupause.md
+++ b/docs/lenskit-upgrade-blaupause.md
@@ -1641,13 +1641,13 @@ Profile:
 ### 2.5 Arbeitspaket C – Bounded Tool Surface
 Ziel:
 - [~] Lenskit soll als Werkzeug präzise Grenzen haben.
-  erfüllt: HTTP-seitig repo-belegt vorhanden: `/api/query`, `/api/federation/query`; logisch entspricht dies den Endpunkten `/query` und `/federation/query`.
-  fehlt: dedizierte Lookup-Endpunkte zur isolierten Rekonstruktion fehlen.
+  erfüllt: HTTP-seitig repo-belegt vorhanden: `/api/query`, `/api/federation/query`, `/api/artifact_lookup`, `/api/trace_lookup`; logisch entspricht dies den Endpunkten `/query`, `/federation/query`, `/artifact`, `/trace`.
+  fehlt: dedizierter Context-Bundle-Endpunkt und Diagnostics-Endpunkt fehlen noch.
 
 Operationen:
 - [x] 1. query (logisch vorgesehen als `/query`; HTTP-seitig repo-belegt via `/api/query`)
 - [ ] 2. context_bundle (dedizierter Endpunkt fehlt)
-- [~] 3. trace_lookup (`POST /api/trace_lookup` implementiert für gespeicherte `query_trace`-Artefakte; Contract `trace-lookup.v1.schema.json`; offen: Federation-Trace, physischer API-Trace-Layer)
+- [~] 3. trace_lookup (`POST /api/trace_lookup` implementiert für gespeicherte `query_trace`-Artefakte; Contract `trace-lookup.v1.schema.json`; Request strict (`extra="forbid"`); offen: Federation-Trace, Retention/Lifecycle, raw-vs.-projizierte Trace-Semantik, MCP-Anbindung)
 - [~] 4. artifact_lookup (`POST /api/artifact_lookup` implementiert für Query-Runtime-Artefakte: `query_trace`, `context_bundle`, `agent_query_session`; Contract `artifact-lookup.v1.schema.json`; offen: Lifecycle/Retention, raw-vs.-projizierte Artefaktform, Federation-Artefakte, MCP-Anbindung)
 - [x] 5. federation_query (logisch vorgesehen als `/federation/query`; HTTP-seitig repo-belegt via `/api/federation/query`)
 - [ ] 6. diagnostics (dedizierter Endpunkt fehlt)
@@ -1705,7 +1705,7 @@ Tests:
 ### 2.12 Deliverables Phase 6
 - [x] 1. Agent Query Contract (minimaler HTTP-Roundtrip über `/api/query` repo-belegt und getestet)
 - [x] 2. Agent Output Profiles (strukturell existierend via `output_profile` wie `agent_minimal`, `lookup_minimal`, `review_context`)
-- [~] 3. bounded API/tool surface (Query-/Federation-Pfade vorhanden; `POST /api/trace_lookup` für `query_trace`-Artefakte implementiert; dedizierte Context-Bundle- und Diagnostics-Pfade fehlen noch)
+- [~] 3. bounded API/tool surface (Query-/Federation-Pfade vorhanden; `POST /api/artifact_lookup` und `POST /api/trace_lookup` für gespeicherte Query-Runtime-Artefakte implementiert; dedizierte Context-Bundle- und Diagnostics-Pfade fehlen noch)
 - [~] 4. maschinenlesbare uncertainty/provenance Felder (Contract existiert, komplexe Status fehlen)
 - [~] 5. `agent_query_session.json` (CLI nutzt v1 Artefakt, API liefert v2 Inline-Session)
 - [~] 6. service-/MCP-fähige Schnittstellenlogik (API Servicepfade existieren, MCP Protokoll fehlt)
@@ -1747,7 +1747,7 @@ Arbeitspakete:
 - [ ] **7.2 Diagnostic Views:** graph health, federation conflicts, bundle provenance, query trace.
 - [~] **7.3 Service-Endpunkte:**
   logisch vorgesehen: `/query`, `/context`, `/trace`, `/artifact`, `/federation/query`, `/diagnostics`.
-  repo-belegt vorhanden: `/api/query`, `/api/federation/query`, `/api/trace_lookup`. (Dedizierte Context-Bundle- und Diagnostics-Pfade fehlen noch).
+  repo-belegt vorhanden: `/api/query`, `/api/federation/query`, `/api/artifact_lookup`, `/api/trace_lookup`. (Dedizierte Context-Bundle- und Diagnostics-Pfade fehlen noch).
 - [ ] **7.4 Download-/Inspection-Flows:** bundle parts, traces, context bundles, diagnostics.
 
 Deliverables:

--- a/docs/service-api.md
+++ b/docs/service-api.md
@@ -36,6 +36,49 @@ Example:
 }
 ```
 
+## Trace Lookup
+
+### `POST /api/trace_lookup`
+
+Typed read-only facade over stored `query_trace` artifacts. Returns the trace payload for a given artifact ID without re-executing any query.
+
+**Auth:** `Authorization: Bearer <token>` required.
+
+**Request:**
+```json
+{ "id": "qart-<hex>" }
+```
+
+**Response (ok):**
+```json
+{
+  "status": "ok",
+  "id": "qart-abc123",
+  "trace": { "query_input": "...", "timings": {}, "..." : "..." },
+  "provenance": { "source_query": "main", "timestamp": "2024-01-01T00:00:00+00:00", "index_id": "test-art", "run_id": null },
+  "created_at": "2024-01-01T00:00:00+00:00",
+  "warnings": []
+}
+```
+
+**Response (not found / wrong type):**
+```json
+{
+  "status": "not_found",
+  "id": "qart-abc123",
+  "trace": null,
+  "provenance": null,
+  "created_at": null,
+  "warnings": ["Artifact 'qart-abc123' has type 'context_bundle', not 'query_trace'"]
+}
+```
+
+**Notes:**
+- Read-only. Never recomputes or re-executes a query.
+- Only returns artifacts of type `query_trace`. If the ID exists but refers to a different artifact type, `status: "not_found"` is returned with a warning naming the actual type — no foreign artifact data is leaked.
+- Artifacts are stored automatically when `/api/query` is called with `trace=true`. The ID is returned in `artifact_ids.query_trace` of the query response.
+- Contract: `merger/lenskit/contracts/trace-lookup.v1.schema.json`
+
 ## Job Submission & Dispatch
 
 ### `include_paths_by_repo` Semantics

--- a/docs/service-api.md
+++ b/docs/service-api.md
@@ -77,6 +77,7 @@ Typed read-only facade over stored `query_trace` artifacts. Returns the trace pa
 - Read-only. Never recomputes or re-executes a query.
 - Only returns artifacts of type `query_trace`. If the ID exists but refers to a different artifact type, `status: "not_found"` is returned with a warning naming the actual type — no foreign artifact data is leaked.
 - Artifacts are stored automatically when `/api/query` is called with `trace=true`. The ID is returned in `artifact_ids.query_trace` of the query response.
+- Extra request fields are rejected with HTTP 422 (`additionalProperties: false` per contract).
 - Contract: `merger/lenskit/contracts/trace-lookup.v1.schema.json`
 
 ## Job Submission & Dispatch

--- a/merger/lenskit/contracts/trace-lookup.v1.schema.json
+++ b/merger/lenskit/contracts/trace-lookup.v1.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://heimgewebe.local/schema/trace-lookup.v1.schema.json",
+  "title": "Trace Lookup (trace-lookup v1.0)",
+  "description": "Request/response contract for POST /api/trace_lookup. Typed read-only facade over stored query_trace artifacts. Only artifacts of type 'query_trace' are returned; all other artifact types yield status 'not_found'.",
+  "definitions": {
+    "TraceLookupRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The artifact ID returned at query time (e.g. 'qart-<hex>'). Must refer to a stored query_trace artifact."
+        }
+      }
+    }
+  },
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["status", "id", "trace", "provenance", "created_at", "warnings"],
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": ["ok", "not_found", "error"],
+      "description": "Lookup outcome. 'ok': trace found. 'not_found': no artifact with this id, or artifact exists but is not query_trace. 'error': internal failure (e.g. store not initialized)."
+    },
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The artifact ID that was requested."
+    },
+    "trace": {
+      "oneOf": [
+        {"type": "object", "additionalProperties": true},
+        {"type": "null"}
+      ],
+      "description": "The query_trace payload. Null when status is not 'ok'."
+    },
+    "provenance": {
+      "oneOf": [
+        {"type": "object", "additionalProperties": true},
+        {"type": "null"}
+      ],
+      "description": "Provenance metadata (source_query, timestamp, index_id, run_id). Null when status is not 'ok'."
+    },
+    "created_at": {
+      "oneOf": [
+        {"type": "string"},
+        {"type": "null"}
+      ],
+      "description": "ISO 8601 UTC timestamp when this artifact was stored. Null when status is not 'ok'."
+    },
+    "warnings": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Non-fatal diagnostic messages (e.g. type mismatch naming the actual artifact type, store not initialized)."
+    }
+  }
+}

--- a/merger/lenskit/service/app.py
+++ b/merger/lenskit/service/app.py
@@ -16,7 +16,7 @@ import re
 import uuid
 from datetime import datetime, timezone
 
-from .models import JobRequest, Job, Artifact, AtlasRequest, AtlasArtifact, AtlasEffective, calculate_job_hash, PrescanRequest, PrescanResponse, FSRoot, FSRootsResponse, FederationQueryRequest, QueryRequest, ArtifactLookupRequest
+from .models import JobRequest, Job, Artifact, AtlasRequest, AtlasArtifact, AtlasEffective, calculate_job_hash, PrescanRequest, PrescanResponse, FSRoot, FSRootsResponse, FederationQueryRequest, QueryRequest, ArtifactLookupRequest, TraceLookupRequest
 from .jobstore import JobStore
 from .query_artifact_store import QueryArtifactStore
 from .runner import JobRunner
@@ -953,6 +953,61 @@ def api_artifact_lookup(request: ArtifactLookupRequest):
         },
         "warnings": [],
     }
+
+@app.post("/api/trace_lookup", dependencies=[Depends(verify_token)])
+def api_trace_lookup(request: TraceLookupRequest):
+    """Retrieve a previously stored query_trace artifact by stable ID.
+
+    Typed read-only facade over the QueryArtifactStore. Only artifacts of
+    type 'query_trace' are returned. If the ID exists but refers to a
+    different artifact type, status 'not_found' is returned with a warning
+    naming the actual type — no foreign artifact data is leaked.
+
+    This endpoint is read-only and never recomputes anything.
+    """
+    if state.query_artifact_store is None:
+        return {
+            "status": "error",
+            "id": request.id,
+            "trace": None,
+            "provenance": None,
+            "created_at": None,
+            "warnings": ["Query artifact store not initialized"],
+        }
+
+    entry = state.query_artifact_store.get(request.id)
+
+    if entry is None:
+        return {
+            "status": "not_found",
+            "id": request.id,
+            "trace": None,
+            "provenance": None,
+            "created_at": None,
+            "warnings": [f"No artifact found with id={request.id!r}"],
+        }
+
+    if entry["artifact_type"] != "query_trace":
+        return {
+            "status": "not_found",
+            "id": request.id,
+            "trace": None,
+            "provenance": None,
+            "created_at": None,
+            "warnings": [
+                f"Artifact {request.id!r} has type {entry['artifact_type']!r}, not 'query_trace'"
+            ],
+        }
+
+    return {
+        "status": "ok",
+        "id": entry["id"],
+        "trace": entry["data"],
+        "provenance": entry["provenance"],
+        "created_at": entry["created_at"],
+        "warnings": [],
+    }
+
 
 def _serve_file(base_dir: Path, requested_path: Union[str, Path], filename: Optional[str] = None) -> FileResponse:
     """

--- a/merger/lenskit/service/models.py
+++ b/merger/lenskit/service/models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from typing import List, Optional, Literal, Dict, Any
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 import uuid
 import hashlib
 import json
@@ -286,9 +286,13 @@ class QueryRequest(BaseModel):
 
 
 class ArtifactLookupRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     artifact_type: Literal["query_trace", "context_bundle", "agent_query_session"]
     id: str = Field(min_length=1)
 
 
 class TraceLookupRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     id: str = Field(min_length=1)

--- a/merger/lenskit/service/models.py
+++ b/merger/lenskit/service/models.py
@@ -288,3 +288,7 @@ class QueryRequest(BaseModel):
 class ArtifactLookupRequest(BaseModel):
     artifact_type: Literal["query_trace", "context_bundle", "agent_query_session"]
     id: str = Field(min_length=1)
+
+
+class TraceLookupRequest(BaseModel):
+    id: str = Field(min_length=1)

--- a/merger/lenskit/tests/test_artifact_lookup.py
+++ b/merger/lenskit/tests/test_artifact_lookup.py
@@ -272,6 +272,15 @@ class TestApiArtifactLookup:
         )
         assert resp.status_code == 401
 
+    def test_lookup_rejects_extra_fields(self, api_client):
+        """Extra fields must be rejected with 422 — contract says additionalProperties: false."""
+        resp = api_client.post(
+            "/api/artifact_lookup",
+            json={"artifact_type": "query_trace", "id": "qart-test", "unexpected": True},
+            headers=_AUTH,
+        )
+        assert resp.status_code == 422
+
     def test_no_artifact_ids_without_trace_or_build_context(self, api_client):
         resp = api_client.post(
             "/api/query",

--- a/merger/lenskit/tests/test_trace_lookup.py
+++ b/merger/lenskit/tests/test_trace_lookup.py
@@ -1,0 +1,237 @@
+"""Tests for POST /api/trace_lookup: typed read-only facade over query_trace artifacts.
+
+Auth convention (confirmed via merger/lenskit/service/auth.py):
+  verify_token accepts HTTPBearer credentials only.
+  Canonical header: "Authorization": "Bearer <token>"
+"""
+import json
+import pytest
+from pathlib import Path
+
+try:
+    import jsonschema
+except ImportError:
+    jsonschema = None
+
+try:
+    from fastapi.testclient import TestClient
+    from merger.lenskit.service.app import app
+    from merger.lenskit.service import app as service_app
+    from merger.lenskit.retrieval import index_db
+    _HAS_FASTAPI = True
+except ImportError:
+    _HAS_FASTAPI = False
+
+requires_fastapi = pytest.mark.skipif(not _HAS_FASTAPI, reason="fastapi not installed")
+
+_AUTH = {"Authorization": "Bearer test_token"}
+
+_SCHEMA_PATH = Path(__file__).parent.parent / "contracts" / "trace-lookup.v1.schema.json"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (mirrored from test_artifact_lookup.py)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mini_index(tmp_path):
+    if not _HAS_FASTAPI:
+        pytest.skip("fastapi not installed")
+    dump_path = tmp_path / "dump.json"
+    chunk_path = tmp_path / "chunks.jsonl"
+    db_path = tmp_path / ".index.sqlite"
+
+    chunk_data = [
+        {
+            "chunk_id": "c1", "repo_id": "r1", "path": "src/main.py",
+            "content": "def main():\n    return 0",
+            "start_line": 1, "end_line": 2, "layer": "core",
+            "artifact_type": "code", "content_sha256": "h1",
+        },
+    ]
+    with chunk_path.open("w", encoding="utf-8") as f:
+        for c in chunk_data:
+            f.write(json.dumps(c) + "\n")
+    dump_path.write_text(json.dumps({"dummy": "data"}), encoding="utf-8")
+    index_db.build_index(dump_path, chunk_path, db_path)
+    return db_path
+
+
+@pytest.fixture
+def api_client(tmp_path, mini_index):
+    hub_path = mini_index.parent.parent
+    service_app.init_service(hub_path=hub_path, token="test_token")
+
+    from merger.lenskit.service.models import Artifact, JobRequest
+    from merger.lenskit.service.app import state
+
+    req = JobRequest(repos=["repo"], level="max", mode="gesamt")
+    art = Artifact(
+        id="test-art", job_id="test-job", hub=str(hub_path), repos=["repo"],
+        created_at="2024-01-01T00:00:00+00:00",
+        paths={"sqlite_index": mini_index.name},
+        params=req,
+        merges_dir=str(mini_index.parent),
+    )
+    state.job_store.add_artifact(art)
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@requires_fastapi
+class TestApiTraceLookup:
+
+    def test_trace_lookup_after_query_with_trace(self, api_client):
+        resp = api_client.post(
+            "/api/query",
+            json={
+                "index_id": "test-art",
+                "q": "main",
+                "k": 5,
+                "trace": True,
+                "stale_policy": "ignore",
+            },
+            headers=_AUTH,
+        )
+        assert resp.status_code == 200
+        query_result = resp.json()
+
+        assert "artifact_ids" in query_result, (
+            "artifact_ids missing from query response"
+        )
+        artifact_ids = query_result["artifact_ids"]
+        assert "query_trace" in artifact_ids, (
+            "query_trace not stored despite trace=True"
+        )
+
+        trace_id = artifact_ids["query_trace"]
+        assert trace_id.startswith("qart-")
+
+        lookup_resp = api_client.post(
+            "/api/trace_lookup",
+            json={"id": trace_id},
+            headers=_AUTH,
+        )
+        assert lookup_resp.status_code == 200
+        data = lookup_resp.json()
+        assert data["status"] == "ok"
+        assert data["id"] == trace_id
+        assert data["trace"] is not None
+        assert data["provenance"] is not None
+        assert data["provenance"]["source_query"] == "main"
+        assert data["created_at"] is not None
+        assert data["warnings"] == []
+
+    def test_trace_lookup_not_found(self, api_client):
+        resp = api_client.post(
+            "/api/trace_lookup",
+            json={"id": "qart-doesnotexist"},
+            headers=_AUTH,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "not_found"
+        assert data["trace"] is None
+        assert data["provenance"] is None
+        assert data["created_at"] is None
+        assert len(data["warnings"]) > 0
+
+    def test_trace_lookup_type_mismatch_hides_non_trace_artifact(self, api_client):
+        """Looking up a context_bundle ID via /api/trace_lookup must return not_found."""
+        resp = api_client.post(
+            "/api/query",
+            json={
+                "index_id": "test-art",
+                "q": "main",
+                "build_context_bundle": True,
+                "stale_policy": "ignore",
+            },
+            headers=_AUTH,
+        )
+        assert resp.status_code == 200
+        artifact_ids = resp.json().get("artifact_ids", {})
+        assert "context_bundle" in artifact_ids, (
+            "context_bundle not stored despite build_context_bundle=True"
+        )
+        cb_id = artifact_ids["context_bundle"]
+
+        lookup_resp = api_client.post(
+            "/api/trace_lookup",
+            json={"id": cb_id},
+            headers=_AUTH,
+        )
+        assert lookup_resp.status_code == 200
+        data = lookup_resp.json()
+        assert data["status"] == "not_found"
+        assert data["trace"] is None
+        assert data["provenance"] is None
+        assert len(data["warnings"]) > 0
+        # Warning must name the actual type, not expose the artifact data.
+        assert "context_bundle" in data["warnings"][0]
+
+    def test_trace_lookup_requires_auth(self, api_client):
+        resp = api_client.post(
+            "/api/trace_lookup",
+            json={"id": "qart-test"},
+        )
+        assert resp.status_code == 401
+
+    def test_trace_lookup_rejects_empty_id(self, api_client):
+        resp = api_client.post(
+            "/api/trace_lookup",
+            json={"id": ""},
+            headers=_AUTH,
+        )
+        assert resp.status_code == 422
+
+    def test_trace_lookup_response_conforms_to_contract(self, api_client):
+        """Response must validate against trace-lookup.v1.schema.json."""
+        if jsonschema is None:
+            pytest.skip("jsonschema not available")
+
+        resp = api_client.post(
+            "/api/query",
+            json={
+                "index_id": "test-art",
+                "q": "main",
+                "trace": True,
+                "stale_policy": "ignore",
+            },
+            headers=_AUTH,
+        )
+        assert resp.status_code == 200
+        artifact_ids = resp.json().get("artifact_ids", {})
+        assert "query_trace" in artifact_ids, (
+            "query_trace not stored despite trace=True"
+        )
+        trace_id = artifact_ids["query_trace"]
+
+        lookup_resp = api_client.post(
+            "/api/trace_lookup",
+            json={"id": trace_id},
+            headers=_AUTH,
+        )
+        assert lookup_resp.status_code == 200
+        data = lookup_resp.json()
+
+        schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+        jsonschema.validate(instance=data, schema=schema)
+
+    def test_trace_lookup_not_found_conforms_to_contract(self, api_client):
+        """not_found response must also validate against the contract schema."""
+        if jsonschema is None:
+            pytest.skip("jsonschema not available")
+
+        resp = api_client.post(
+            "/api/trace_lookup",
+            json={"id": "qart-nonexistent"},
+            headers=_AUTH,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+
+        schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+        jsonschema.validate(instance=data, schema=schema)

--- a/merger/lenskit/tests/test_trace_lookup.py
+++ b/merger/lenskit/tests/test_trace_lookup.py
@@ -187,6 +187,15 @@ class TestApiTraceLookup:
         )
         assert resp.status_code == 422
 
+    def test_trace_lookup_rejects_extra_fields(self, api_client):
+        """Extra fields must be rejected with 422 — contract says additionalProperties: false."""
+        resp = api_client.post(
+            "/api/trace_lookup",
+            json={"id": "qart-test", "unexpected": True},
+            headers=_AUTH,
+        )
+        assert resp.status_code == 422
+
     def test_trace_lookup_response_conforms_to_contract(self, api_client):
         """Response must validate against trace-lookup.v1.schema.json."""
         if jsonschema is None:


### PR DESCRIPTION
Adds POST /api/trace_lookup as a dedicated typed facade over stored
query_trace artifacts in the QueryArtifactStore. The generic
artifact_lookup endpoint is unchanged.

Scope:
- New JSON Schema contract: trace-lookup.v1.schema.json
- New Pydantic model: TraceLookupRequest (id: str, min_length=1)
- New endpoint: POST /api/trace_lookup (read-only, auth-required)
  - Returns query_trace artifacts only; non-trace IDs yield status
    "not_found" with a warning naming the actual type (no data leak)
  - Returns error when store is not initialised
- New tests: test_trace_lookup.py (7 tests, all green)
  - after-query roundtrip, not_found, type mismatch, auth, empty-id
    (422), and schema-contract validation via jsonschema
- Blaupause: trace_lookup item C.3 promoted [ ] → [~], deliverable 3
  and Phase 7.3 updated; Phase 6 gate remains open
- service-api.md: POST /api/trace_lookup section added

No storage semantics changed. No retention/GC, no federation
artifacts, no MCP, no raw/projected changes, no artifact_lookup
contract changes.

https://claude.ai/code/session_01XzkAnHxqgLLuXJyMisAR6K