### PR TITLE
Add test for empty artifact ID validation in lookup endpoint

### DIFF
--- a/merger/lenskit/tests/test_artifact_lookup.py
+++ b/merger/lenskit/tests/test_artifact_lookup.py
@@ -281,6 +281,15 @@ class TestApiArtifactLookup:
         )
         assert resp.status_code == 422
 
+    def test_lookup_rejects_empty_id(self, api_client):
+        """Empty id must be rejected with 422 — contract says id.minLength: 1."""
+        resp = api_client.post(
+            "/api/artifact_lookup",
+            json={"artifact_type": "query_trace", "id": ""},
+            headers=_AUTH,
+        )
+        assert resp.status_code == 422
+
     def test_no_artifact_ids_without_trace_or_build_context(self, api_client):
         resp = api_client.post(
             "/api/query",


### PR DESCRIPTION
## Summary
Added a test case to verify that the artifact lookup endpoint properly rejects requests with empty ID values, enforcing the API contract requirement that `id.minLength: 1`.

## Changes
- Added `test_lookup_rejects_empty_id()` test method to validate that POST requests to `/api/artifact_lookup` with an empty string `id` field are rejected with HTTP 422 status code
- Test verifies the endpoint enforces the schema constraint that artifact IDs must have a minimum length of 1 character

## Details
This test complements the existing `test_lookup_rejects_extra_fields()` test and ensures proper input validation for the artifact lookup API. The test confirms that empty IDs are caught at the validation layer before reaching business logic.

https://claude.ai/code/session_01GkapGNVtRGNAtdUkHRWxUk