### PR TITLE
Add POST /api/context_lookup endpoint for context_bundle retrieval

### DIFF
--- a/docs/lenskit-upgrade-blaupause.md
+++ b/docs/lenskit-upgrade-blaupause.md
@@ -1646,7 +1646,7 @@ Ziel:
 
 Operationen:
 - [x] 1. query (logisch vorgesehen als `/query`; HTTP-seitig repo-belegt via `/api/query`)
-- [ ] 2. context_bundle (dedizierter Endpunkt fehlt)
+- [~] 2. context_bundle (`POST /api/context_lookup` implementiert für gespeicherte `context_bundle`-Artefakte; Contract `context-lookup.v1.schema.json`; Request strict (`extra="forbid"`); offen: Lifecycle/Retention, raw-vs.-projizierte Artefaktform, Federation-Artefakte, MCP-Anbindung)
 - [~] 3. trace_lookup (`POST /api/trace_lookup` implementiert für gespeicherte `query_trace`-Artefakte; Contract `trace-lookup.v1.schema.json`; Request strict (`extra="forbid"`); offen: Federation-Trace, Retention/Lifecycle, raw-vs.-projizierte Trace-Semantik, MCP-Anbindung)
 - [~] 4. artifact_lookup (`POST /api/artifact_lookup` implementiert für Query-Runtime-Artefakte: `query_trace`, `context_bundle`, `agent_query_session`; Contract `artifact-lookup.v1.schema.json`; offen: Lifecycle/Retention, raw-vs.-projizierte Artefaktform, Federation-Artefakte, MCP-Anbindung)
 - [x] 5. federation_query (logisch vorgesehen als `/federation/query`; HTTP-seitig repo-belegt via `/api/federation/query`)
@@ -1705,7 +1705,7 @@ Tests:
 ### 2.12 Deliverables Phase 6
 - [x] 1. Agent Query Contract (minimaler HTTP-Roundtrip über `/api/query` repo-belegt und getestet)
 - [x] 2. Agent Output Profiles (strukturell existierend via `output_profile` wie `agent_minimal`, `lookup_minimal`, `review_context`)
-- [~] 3. bounded API/tool surface (Query-/Federation-Pfade vorhanden; `POST /api/artifact_lookup` und `POST /api/trace_lookup` für gespeicherte Query-Runtime-Artefakte implementiert; dedizierte Context-Bundle- und Diagnostics-Pfade fehlen noch)
+- [~] 3. bounded API/tool surface (Query-/Federation-Pfade vorhanden; `POST /api/artifact_lookup`, `POST /api/trace_lookup` und `POST /api/context_lookup` für gespeicherte Query-Runtime-Artefakte implementiert; Diagnostics-Pfad fehlt noch)
 - [~] 4. maschinenlesbare uncertainty/provenance Felder (Contract existiert, komplexe Status fehlen)
 - [~] 5. `agent_query_session.json` (CLI nutzt v1 Artefakt, API liefert v2 Inline-Session)
 - [~] 6. service-/MCP-fähige Schnittstellenlogik (API Servicepfade existieren, MCP Protokoll fehlt)
@@ -1747,7 +1747,7 @@ Arbeitspakete:
 - [ ] **7.2 Diagnostic Views:** graph health, federation conflicts, bundle provenance, query trace.
 - [~] **7.3 Service-Endpunkte:**
   logisch vorgesehen: `/query`, `/context`, `/trace`, `/artifact`, `/federation/query`, `/diagnostics`.
-  repo-belegt vorhanden: `/api/query`, `/api/federation/query`, `/api/artifact_lookup`, `/api/trace_lookup`. (Dedizierte Context-Bundle- und Diagnostics-Pfade fehlen noch).
+  repo-belegt vorhanden: `/api/query`, `/api/federation/query`, `/api/artifact_lookup`, `/api/trace_lookup`, `/api/context_lookup`. (Diagnostics-Pfad fehlt noch).
 - [ ] **7.4 Download-/Inspection-Flows:** bundle parts, traces, context bundles, diagnostics.
 
 Deliverables:

--- a/docs/service-api.md
+++ b/docs/service-api.md
@@ -42,7 +42,7 @@ Example:
 
 Typed read-only facade over stored `context_bundle` artifacts. Returns the context bundle payload for a given artifact ID without re-executing any query.
 
-**Auth:** `Authorization: Bearer <token>` required.
+**Auth:** Provide a token using either `Authorization: Bearer <token>` (preferred) or the `token` query parameter.
 
 **Request:**
 ```json
@@ -76,7 +76,8 @@ Typed read-only facade over stored `context_bundle` artifacts. Returns the conte
 **Notes:**
 - Read-only. Never recomputes, reconstructs, or re-executes a query.
 - Only returns artifacts of type `context_bundle`. If the ID exists but refers to a different artifact type, `status: "not_found"` is returned with a warning naming the actual type — no foreign artifact data is leaked.
-- Artifacts are stored automatically when `/api/query` is called with `build_context_bundle=true` or `trace=true`. The ID is returned in `artifact_ids.context_bundle` of the query response.
+- Context bundle artifacts are stored automatically when `/api/query` produces a `context_bundle`, for example via `build_context_bundle=true` or an output profile / context mode that includes a context bundle. In those cases, the ID is returned in `artifact_ids.context_bundle` of the query response.
+- `trace=true` alone stores a `query_trace`; it does not by itself guarantee `artifact_ids.context_bundle`.
 - Extra request fields are rejected with HTTP 422 (`additionalProperties: false` per contract).
 - Contract: `merger/lenskit/contracts/context-lookup.v1.schema.json`
 

--- a/docs/service-api.md
+++ b/docs/service-api.md
@@ -36,6 +36,50 @@ Example:
 }
 ```
 
+## Context Lookup
+
+### `POST /api/context_lookup`
+
+Typed read-only facade over stored `context_bundle` artifacts. Returns the context bundle payload for a given artifact ID without re-executing any query.
+
+**Auth:** `Authorization: Bearer <token>` required.
+
+**Request:**
+```json
+{ "id": "qart-<hex>" }
+```
+
+**Response (ok):**
+```json
+{
+  "status": "ok",
+  "id": "qart-abc123",
+  "context_bundle": { "query": "main", "hits": [...] },
+  "provenance": { "source_query": "main", "timestamp": "2024-01-01T00:00:00+00:00", "index_id": "test-art", "run_id": null },
+  "created_at": "2024-01-01T00:00:00+00:00",
+  "warnings": []
+}
+```
+
+**Response (not found / wrong type):**
+```json
+{
+  "status": "not_found",
+  "id": "qart-abc123",
+  "context_bundle": null,
+  "provenance": null,
+  "created_at": null,
+  "warnings": ["Artifact 'qart-abc123' has type 'query_trace', not 'context_bundle'"]
+}
+```
+
+**Notes:**
+- Read-only. Never recomputes, reconstructs, or re-executes a query.
+- Only returns artifacts of type `context_bundle`. If the ID exists but refers to a different artifact type, `status: "not_found"` is returned with a warning naming the actual type — no foreign artifact data is leaked.
+- Artifacts are stored automatically when `/api/query` is called with `build_context_bundle=true` or `trace=true`. The ID is returned in `artifact_ids.context_bundle` of the query response.
+- Extra request fields are rejected with HTTP 422 (`additionalProperties: false` per contract).
+- Contract: `merger/lenskit/contracts/context-lookup.v1.schema.json`
+
 ## Trace Lookup
 
 ### `POST /api/trace_lookup`

--- a/merger/lenskit/contracts/context-lookup.v1.schema.json
+++ b/merger/lenskit/contracts/context-lookup.v1.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://heimgewebe.local/schema/context-lookup.v1.schema.json",
+  "title": "Context Lookup (context-lookup v1.0)",
+  "description": "Request/response contract for POST /api/context_lookup. Typed read-only facade over stored context_bundle artifacts. Only artifacts of type 'context_bundle' are returned; all other artifact types yield status 'not_found'.",
+  "definitions": {
+    "ContextLookupRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The artifact ID returned at query time (e.g. 'qart-<hex>'). Must refer to a stored context_bundle artifact."
+        }
+      }
+    }
+  },
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["status", "id", "context_bundle", "provenance", "created_at", "warnings"],
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": ["ok", "not_found", "error"],
+      "description": "Lookup outcome. 'ok': context_bundle found. 'not_found': no artifact with this id, or artifact exists but is not context_bundle. 'error': internal failure (e.g. store not initialized)."
+    },
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The artifact ID that was requested."
+    },
+    "context_bundle": {
+      "oneOf": [
+        {"type": "object", "additionalProperties": true},
+        {"type": "null"}
+      ],
+      "description": "The context_bundle payload. Null when status is not 'ok'."
+    },
+    "provenance": {
+      "oneOf": [
+        {"type": "object", "additionalProperties": true},
+        {"type": "null"}
+      ],
+      "description": "Provenance metadata (source_query, timestamp, index_id, run_id). Null when status is not 'ok'."
+    },
+    "created_at": {
+      "oneOf": [
+        {"type": "string"},
+        {"type": "null"}
+      ],
+      "description": "ISO 8601 UTC timestamp when this artifact was stored. Null when status is not 'ok'."
+    },
+    "warnings": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Non-fatal diagnostic messages (e.g. type mismatch naming the actual artifact type, store not initialized)."
+    }
+  }
+}

--- a/merger/lenskit/service/app.py
+++ b/merger/lenskit/service/app.py
@@ -16,7 +16,7 @@ import re
 import uuid
 from datetime import datetime, timezone
 
-from .models import JobRequest, Job, Artifact, AtlasRequest, AtlasArtifact, AtlasEffective, calculate_job_hash, PrescanRequest, PrescanResponse, FSRoot, FSRootsResponse, FederationQueryRequest, QueryRequest, ArtifactLookupRequest, TraceLookupRequest
+from .models import JobRequest, Job, Artifact, AtlasRequest, AtlasArtifact, AtlasEffective, calculate_job_hash, PrescanRequest, PrescanResponse, FSRoot, FSRootsResponse, FederationQueryRequest, QueryRequest, ArtifactLookupRequest, TraceLookupRequest, ContextLookupRequest
 from .jobstore import JobStore
 from .query_artifact_store import QueryArtifactStore
 from .runner import JobRunner
@@ -1003,6 +1003,61 @@ def api_trace_lookup(request: TraceLookupRequest):
         "status": "ok",
         "id": entry["id"],
         "trace": entry["data"],
+        "provenance": entry["provenance"],
+        "created_at": entry["created_at"],
+        "warnings": [],
+    }
+
+
+@app.post("/api/context_lookup", dependencies=[Depends(verify_token)])
+def api_context_lookup(request: ContextLookupRequest):
+    """Retrieve a previously stored context_bundle artifact by stable ID.
+
+    Typed read-only facade over the QueryArtifactStore. Only artifacts of
+    type 'context_bundle' are returned. If the ID exists but refers to a
+    different artifact type, status 'not_found' is returned with a warning
+    naming the actual type — no foreign artifact data is leaked.
+
+    This endpoint is read-only and never recomputes or re-executes a query.
+    """
+    if state.query_artifact_store is None:
+        return {
+            "status": "error",
+            "id": request.id,
+            "context_bundle": None,
+            "provenance": None,
+            "created_at": None,
+            "warnings": ["Query artifact store not initialized"],
+        }
+
+    entry = state.query_artifact_store.get(request.id)
+
+    if entry is None:
+        return {
+            "status": "not_found",
+            "id": request.id,
+            "context_bundle": None,
+            "provenance": None,
+            "created_at": None,
+            "warnings": [f"No artifact found with id={request.id!r}"],
+        }
+
+    if entry["artifact_type"] != "context_bundle":
+        return {
+            "status": "not_found",
+            "id": request.id,
+            "context_bundle": None,
+            "provenance": None,
+            "created_at": None,
+            "warnings": [
+                f"Artifact {request.id!r} has type {entry['artifact_type']!r}, not 'context_bundle'"
+            ],
+        }
+
+    return {
+        "status": "ok",
+        "id": entry["id"],
+        "context_bundle": entry["data"],
         "provenance": entry["provenance"],
         "created_at": entry["created_at"],
         "warnings": [],

--- a/merger/lenskit/service/models.py
+++ b/merger/lenskit/service/models.py
@@ -296,3 +296,9 @@ class TraceLookupRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     id: str = Field(min_length=1)
+
+
+class ContextLookupRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(min_length=1)

--- a/merger/lenskit/tests/test_context_lookup.py
+++ b/merger/lenskit/tests/test_context_lookup.py
@@ -1,0 +1,246 @@
+"""Tests for POST /api/context_lookup: typed read-only facade over context_bundle artifacts.
+
+Auth convention (confirmed via merger/lenskit/service/auth.py):
+  verify_token accepts HTTPBearer credentials only.
+  Canonical header: "Authorization": "Bearer <token>"
+"""
+import json
+import pytest
+from pathlib import Path
+
+try:
+    import jsonschema
+except ImportError:
+    jsonschema = None
+
+try:
+    from fastapi.testclient import TestClient
+    from merger.lenskit.service.app import app
+    from merger.lenskit.service import app as service_app
+    from merger.lenskit.retrieval import index_db
+    _HAS_FASTAPI = True
+except ImportError:
+    _HAS_FASTAPI = False
+
+requires_fastapi = pytest.mark.skipif(not _HAS_FASTAPI, reason="fastapi not installed")
+
+_AUTH = {"Authorization": "Bearer test_token"}
+
+_SCHEMA_PATH = Path(__file__).parent.parent / "contracts" / "context-lookup.v1.schema.json"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mini_index(tmp_path):
+    if not _HAS_FASTAPI:
+        pytest.skip("fastapi not installed")
+    dump_path = tmp_path / "dump.json"
+    chunk_path = tmp_path / "chunks.jsonl"
+    db_path = tmp_path / ".index.sqlite"
+
+    chunk_data = [
+        {
+            "chunk_id": "c1", "repo_id": "r1", "path": "src/main.py",
+            "content": "def main():\n    return 0",
+            "start_line": 1, "end_line": 2, "layer": "core",
+            "artifact_type": "code", "content_sha256": "h1",
+        },
+    ]
+    with chunk_path.open("w", encoding="utf-8") as f:
+        for c in chunk_data:
+            f.write(json.dumps(c) + "\n")
+    dump_path.write_text(json.dumps({"dummy": "data"}), encoding="utf-8")
+    index_db.build_index(dump_path, chunk_path, db_path)
+    return db_path
+
+
+@pytest.fixture
+def api_client(tmp_path, mini_index):
+    hub_path = mini_index.parent.parent
+    service_app.init_service(hub_path=hub_path, token="test_token")
+
+    from merger.lenskit.service.models import Artifact, JobRequest
+    from merger.lenskit.service.app import state
+
+    req = JobRequest(repos=["repo"], level="max", mode="gesamt")
+    art = Artifact(
+        id="test-art", job_id="test-job", hub=str(hub_path), repos=["repo"],
+        created_at="2024-01-01T00:00:00+00:00",
+        paths={"sqlite_index": mini_index.name},
+        params=req,
+        merges_dir=str(mini_index.parent),
+    )
+    state.job_store.add_artifact(art)
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@requires_fastapi
+class TestApiContextLookup:
+
+    def test_context_lookup_after_query_with_build_context_bundle(self, api_client):
+        resp = api_client.post(
+            "/api/query",
+            json={
+                "index_id": "test-art",
+                "q": "main",
+                "k": 5,
+                "build_context_bundle": True,
+                "stale_policy": "ignore",
+            },
+            headers=_AUTH,
+        )
+        assert resp.status_code == 200
+        query_result = resp.json()
+
+        assert "artifact_ids" in query_result, (
+            "artifact_ids missing from query response — store integration failed"
+        )
+        artifact_ids = query_result["artifact_ids"]
+        assert "context_bundle" in artifact_ids, (
+            "context_bundle not stored despite build_context_bundle=True"
+        )
+        cb_id = artifact_ids["context_bundle"]
+        assert cb_id.startswith("qart-")
+
+        lookup_resp = api_client.post(
+            "/api/context_lookup",
+            json={"id": cb_id},
+            headers=_AUTH,
+        )
+        assert lookup_resp.status_code == 200
+        data = lookup_resp.json()
+        assert data["status"] == "ok"
+        assert data["id"] == cb_id
+        assert data["context_bundle"] is not None
+        assert data["provenance"] is not None
+        assert data["provenance"]["source_query"] == "main"
+        assert data["created_at"] is not None
+        assert data["warnings"] == []
+
+    def test_context_lookup_not_found(self, api_client):
+        resp = api_client.post(
+            "/api/context_lookup",
+            json={"id": "qart-doesnotexist"},
+            headers=_AUTH,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "not_found"
+        assert data["context_bundle"] is None
+        assert data["provenance"] is None
+        assert data["created_at"] is None
+        assert len(data["warnings"]) > 0
+
+    def test_context_lookup_wrong_type_hides_non_bundle_artifact(self, api_client):
+        """Looking up a query_trace ID via /api/context_lookup must return not_found."""
+        resp = api_client.post(
+            "/api/query",
+            json={
+                "index_id": "test-art",
+                "q": "main",
+                "trace": True,
+                "stale_policy": "ignore",
+            },
+            headers=_AUTH,
+        )
+        assert resp.status_code == 200
+        artifact_ids = resp.json().get("artifact_ids", {})
+        assert "query_trace" in artifact_ids, (
+            "query_trace not stored despite trace=True"
+        )
+        trace_id = artifact_ids["query_trace"]
+
+        lookup_resp = api_client.post(
+            "/api/context_lookup",
+            json={"id": trace_id},
+            headers=_AUTH,
+        )
+        assert lookup_resp.status_code == 200
+        data = lookup_resp.json()
+        assert data["status"] == "not_found"
+        assert data["context_bundle"] is None
+        assert data["provenance"] is None
+        assert len(data["warnings"]) > 0
+        # Warning names the actual type; no foreign artifact data is leaked.
+        assert "query_trace" in data["warnings"][0]
+
+    def test_context_lookup_requires_auth(self, api_client):
+        resp = api_client.post(
+            "/api/context_lookup",
+            json={"id": "qart-test"},
+        )
+        assert resp.status_code == 401
+
+    def test_context_lookup_rejects_empty_id(self, api_client):
+        """Empty id must be rejected with 422 — contract says id.minLength: 1."""
+        resp = api_client.post(
+            "/api/context_lookup",
+            json={"id": ""},
+            headers=_AUTH,
+        )
+        assert resp.status_code == 422
+
+    def test_context_lookup_rejects_extra_fields(self, api_client):
+        """Extra fields must be rejected with 422 — contract says additionalProperties: false."""
+        resp = api_client.post(
+            "/api/context_lookup",
+            json={"id": "qart-test", "unexpected": True},
+            headers=_AUTH,
+        )
+        assert resp.status_code == 422
+
+    def test_context_lookup_ok_response_conforms_to_contract(self, api_client):
+        """ok response must validate against context-lookup.v1.schema.json."""
+        if jsonschema is None:
+            pytest.skip("jsonschema not available")
+
+        resp = api_client.post(
+            "/api/query",
+            json={
+                "index_id": "test-art",
+                "q": "main",
+                "build_context_bundle": True,
+                "stale_policy": "ignore",
+            },
+            headers=_AUTH,
+        )
+        assert resp.status_code == 200
+        artifact_ids = resp.json().get("artifact_ids", {})
+        assert "context_bundle" in artifact_ids, (
+            "context_bundle not stored despite build_context_bundle=True"
+        )
+        cb_id = artifact_ids["context_bundle"]
+
+        lookup_resp = api_client.post(
+            "/api/context_lookup",
+            json={"id": cb_id},
+            headers=_AUTH,
+        )
+        assert lookup_resp.status_code == 200
+        data = lookup_resp.json()
+
+        schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+        jsonschema.validate(instance=data, schema=schema)
+
+    def test_context_lookup_not_found_conforms_to_contract(self, api_client):
+        """not_found response must also validate against the contract schema."""
+        if jsonschema is None:
+            pytest.skip("jsonschema not available")
+
+        resp = api_client.post(
+            "/api/context_lookup",
+            json={"id": "qart-nonexistent"},
+            headers=_AUTH,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+
+        schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+        jsonschema.validate(instance=data, schema=schema)

--- a/merger/lenskit/tests/test_context_lookup.py
+++ b/merger/lenskit/tests/test_context_lookup.py
@@ -1,8 +1,8 @@
 """Tests for POST /api/context_lookup: typed read-only facade over context_bundle artifacts.
 
 Auth convention (confirmed via merger/lenskit/service/auth.py):
-  verify_token accepts HTTPBearer credentials only.
-  Canonical header: "Authorization": "Bearer <token>"
+  verify_token accepts either HTTPBearer credentials or a token query parameter.
+  Canonical test path here: "Authorization": "Bearer <token>".
 """
 import json
 import pytest
@@ -60,7 +60,9 @@ def mini_index(tmp_path):
 @pytest.fixture
 def api_client(tmp_path, mini_index):
     hub_path = mini_index.parent.parent
-    service_app.init_service(hub_path=hub_path, token="test_token")
+    merges_dir = tmp_path / "merges"
+    merges_dir.mkdir(parents=True, exist_ok=True)
+    service_app.init_service(hub_path=hub_path, token="test_token", merges_dir=merges_dir)
 
     from merger.lenskit.service.models import Artifact, JobRequest
     from merger.lenskit.service.app import state


### PR DESCRIPTION
## Summary
Implements a new typed read-only API endpoint `/api/context_lookup` that retrieves previously stored `context_bundle` artifacts by stable ID. This provides a dedicated facade for accessing context bundles without re-executing queries.

## Key Changes

- **New endpoint `POST /api/context_lookup`** (`merger/lenskit/service/app.py`)
  - Accepts a request with an artifact ID (e.g., `qart-<hex>`)
  - Returns the stored context bundle payload, provenance metadata, and creation timestamp
  - Returns `status: "not_found"` if the artifact doesn't exist or is not a `context_bundle` type
  - Type-safe: artifacts of other types (e.g., `query_trace`) are hidden with a warning naming the actual type — no foreign artifact data is leaked
  - Requires Bearer token authentication
  - Read-only: never recomputes or re-executes queries

- **Request model `ContextLookupRequest`** (`merger/lenskit/service/models.py`)
  - Strict validation with `extra="forbid"` to reject unexpected fields
  - Required field: `id` (non-empty string)

- **JSON Schema contract** (`merger/lenskit/contracts/context-lookup.v1.schema.json`)
  - Defines request and response structure
  - Response includes: `status`, `id`, `context_bundle`, `provenance`, `created_at`, `warnings`
  - Supports three status values: `ok`, `not_found`, `error`

- **Comprehensive test suite** (`merger/lenskit/tests/test_context_lookup.py`)
  - Tests successful lookup after query with `build_context_bundle=True`
  - Tests not-found cases (missing artifact, wrong artifact type)
  - Tests authentication requirement
  - Tests input validation (empty ID, extra fields)
  - Tests schema compliance for both success and not-found responses
  - Verifies type-safety: looking up a `query_trace` ID returns `not_found` with a warning

- **Documentation** (`docs/service-api.md`)
  - Added endpoint documentation with request/response examples
  - Clarified read-only semantics and type-safety guarantees
  - Noted contract location and validation rules

- **Upgrade tracking** (`docs/lenskit-upgrade-blaupause.md`)
  - Updated status of context_bundle operation from unimplemented to implemented

## Implementation Details

- Endpoint checks `state.query_artifact_store` and returns `status: "error"` if uninitialized
- Type filtering is explicit: only `artifact_type == "context_bundle"` returns `status: "ok"`
- Warnings are always included in response (empty array on success, diagnostic messages on failure)
- All responses conform to the JSON Schema contract and validate successfully

https://claude.ai/code/session_01Ftyc4hugPUTGJ7xizvq28r