### PR TITLE
Add read-only `GET /api/diagnostics` endpoint, schema and tests

### DIFF
--- a/docs/lenskit-upgrade-blaupause.md
+++ b/docs/lenskit-upgrade-blaupause.md
@@ -1641,8 +1641,8 @@ Profile:
 ### 2.5 Arbeitspaket C – Bounded Tool Surface
 Ziel:
 - [~] Lenskit soll als Werkzeug präzise Grenzen haben.
-  erfüllt: HTTP-seitig repo-belegt vorhanden: `/api/query`, `/api/federation/query`, `/api/artifact_lookup`, `/api/trace_lookup`; logisch entspricht dies den Endpunkten `/query`, `/federation/query`, `/artifact`, `/trace`.
-  fehlt: dedizierter Context-Bundle-Endpunkt und Diagnostics-Endpunkt fehlen noch.
+  erfüllt: HTTP-seitig repo-belegt vorhanden: `/api/query`, `/api/federation/query`, `/api/artifact_lookup`, `/api/trace_lookup`, `/api/context_lookup`, `/api/diagnostics`; logisch entspricht dies den Endpunkten `/query`, `/federation/query`, `/artifact`, `/trace`, `/context`, `/diagnostics`.
+  fehlt: offen bleiben nachgelagerte Produktisierungsaspekte (UI/Diagnostic Views, Lifecycle/Retention, MCP-Anbindung).
 
 Operationen:
 - [x] 1. query (logisch vorgesehen als `/query`; HTTP-seitig repo-belegt via `/api/query`)
@@ -1650,7 +1650,7 @@ Operationen:
 - [~] 3. trace_lookup (`POST /api/trace_lookup` implementiert für gespeicherte `query_trace`-Artefakte; Contract `trace-lookup.v1.schema.json`; Request strict (`extra="forbid"`); offen: Federation-Trace, Retention/Lifecycle, raw-vs.-projizierte Trace-Semantik, MCP-Anbindung)
 - [~] 4. artifact_lookup (`POST /api/artifact_lookup` implementiert für Query-Runtime-Artefakte: `query_trace`, `context_bundle`, `agent_query_session`; Contract `artifact-lookup.v1.schema.json`; offen: Lifecycle/Retention, raw-vs.-projizierte Artefaktform, Federation-Artefakte, MCP-Anbindung)
 - [x] 5. federation_query (logisch vorgesehen als `/federation/query`; HTTP-seitig repo-belegt via `/api/federation/query`)
-- [ ] 6. diagnostics (dedizierter Endpunkt fehlt)
+- [x] 6. diagnostics (GET `/api/diagnostics` als read-only Snapshot-Lookup implementiert; Contract `diagnostics-lookup.v1.schema.json`; offen: UI/Diagnostic Views und ggf. tiefere Runtime-Diagnostik)
 
 Nicht direkt zulassen: freie Dateisystemnavigation ohne Scope, implizites Zusammenmischen beliebiger Bundles, ungebundene „find everything about X“-Operationen ohne Grenzen.
 
@@ -1705,7 +1705,7 @@ Tests:
 ### 2.12 Deliverables Phase 6
 - [x] 1. Agent Query Contract (minimaler HTTP-Roundtrip über `/api/query` repo-belegt und getestet)
 - [x] 2. Agent Output Profiles (strukturell existierend via `output_profile` wie `agent_minimal`, `lookup_minimal`, `review_context`)
-- [~] 3. bounded API/tool surface (Query-/Federation-Pfade vorhanden; `POST /api/artifact_lookup`, `POST /api/trace_lookup` und `POST /api/context_lookup` für gespeicherte Query-Runtime-Artefakte implementiert; Diagnostics-Pfad fehlt noch)
+- [~] 3. bounded API/tool surface (Query-/Federation-Pfade sowie `POST /api/artifact_lookup`, `POST /api/trace_lookup`, `POST /api/context_lookup` und `GET /api/diagnostics` vorhanden; offen: Lifecycle/Retention, Federation-Vertiefung, MCP-Anbindung)
 - [~] 4. maschinenlesbare uncertainty/provenance Felder (Contract existiert, komplexe Status fehlen)
 - [~] 5. `agent_query_session.json` (CLI nutzt v1 Artefakt, API liefert v2 Inline-Session)
 - [~] 6. service-/MCP-fähige Schnittstellenlogik (API Servicepfade existieren, MCP Protokoll fehlt)
@@ -1747,7 +1747,7 @@ Arbeitspakete:
 - [ ] **7.2 Diagnostic Views:** graph health, federation conflicts, bundle provenance, query trace.
 - [~] **7.3 Service-Endpunkte:**
   logisch vorgesehen: `/query`, `/context`, `/trace`, `/artifact`, `/federation/query`, `/diagnostics`.
-  repo-belegt vorhanden: `/api/query`, `/api/federation/query`, `/api/artifact_lookup`, `/api/trace_lookup`, `/api/context_lookup`. (Diagnostics-Pfad fehlt noch).
+  repo-belegt vorhanden: `/api/query`, `/api/federation/query`, `/api/artifact_lookup`, `/api/trace_lookup`, `/api/context_lookup`, `/api/diagnostics`.
 - [ ] **7.4 Download-/Inspection-Flows:** bundle parts, traces, context bundles, diagnostics.
 
 Deliverables:

--- a/docs/service-api.md
+++ b/docs/service-api.md
@@ -81,6 +81,46 @@ Typed read-only facade over stored `context_bundle` artifacts. Returns the conte
 - Extra request fields are rejected with HTTP 422 (`additionalProperties: false` per contract).
 - Contract: `merger/lenskit/contracts/context-lookup.v1.schema.json`
 
+## Diagnostics
+
+### `GET /api/diagnostics`
+
+Read-only lookup facade over the persisted diagnostics snapshot.
+
+**Auth:** Standard service auth via `verify_token` (for example `Authorization: Bearer <token>`).
+
+**Behavior:**
+- Reads `.gewebe/cache/diagnostics.snapshot.json`.
+- Does **not** trigger `POST /api/diagnostics/rebuild`.
+- Does **not** modify, rewrite, or mutate the snapshot file.
+- Returns a lookup envelope (`status`, `snapshot`, `freshness`, `warnings`) instead of projecting snapshot fields to top-level.
+
+**Response shape:**
+```json
+{
+  "status": "ok",
+  "snapshot": { "schema_version": "diagnostics.snapshot.v1", "...": "..." },
+  "freshness": {
+    "generated_at": "2026-01-01T00:00:00Z",
+    "ttl_hours": 24,
+    "is_stale": false,
+    "age_seconds": 120
+  },
+  "warnings": []
+}
+```
+
+**Status semantics:**
+- `status` is the **lookup status** (`ok`, `not_found`, `error`).
+- Staleness is represented by `freshness.is_stale` (TTL exceeded).
+- The endpoint does not remap lookup status to `warn` for stale snapshots.
+
+**Notes:**
+- `not_found`: snapshot file does not exist.
+- `error`: snapshot file exists but cannot be parsed as JSON.
+- `freshness` is `null` if `generated_at` is absent/invalid or if lookup fails.
+- Contract: `merger/lenskit/contracts/diagnostics-lookup.v1.schema.json`.
+
 ## Trace Lookup
 
 ### `POST /api/trace_lookup`

--- a/docs/service-api.md
+++ b/docs/service-api.md
@@ -87,7 +87,7 @@ Typed read-only facade over stored `context_bundle` artifacts. Returns the conte
 
 Read-only lookup facade over the persisted diagnostics snapshot.
 
-**Auth:** Standard service auth via `verify_token` (for example `Authorization: Bearer <token>`).
+**Auth:** Standard service auth via `verify_token`; provide a token using either `Authorization: Bearer <token>` (preferred) or the `token` query parameter.
 
 **Behavior:**
 - Reads `.gewebe/cache/diagnostics.snapshot.json`.

--- a/merger/lenskit/contracts/diagnostics-lookup.v1.schema.json
+++ b/merger/lenskit/contracts/diagnostics-lookup.v1.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://heimgewebe.local/schema/diagnostics-lookup.v1.schema.json",
+  "title": "Diagnostics Lookup (diagnostics-lookup v1.0)",
+  "description": "Response contract for GET /api/diagnostics. Read-only facade over persisted diagnostics.snapshot.json; does not trigger rebuild.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["status", "snapshot", "freshness", "warnings"],
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": ["ok", "not_found", "error"],
+      "description": "Lookup outcome. 'ok' means snapshot was loaded. 'not_found' means no diagnostics snapshot file exists. 'error' means snapshot file exists but could not be parsed."
+    },
+    "snapshot": {
+      "oneOf": [
+        {"type": "object", "additionalProperties": true},
+        {"type": "null"}
+      ],
+      "description": "Raw diagnostics snapshot payload from .gewebe/cache/diagnostics.snapshot.json. Null for not_found/error."
+    },
+    "freshness": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["generated_at", "ttl_hours", "is_stale", "age_seconds"],
+          "properties": {
+            "generated_at": {"type": "string"},
+            "ttl_hours": {"type": "integer", "minimum": 1},
+            "is_stale": {"type": "boolean"},
+            "age_seconds": {"type": "integer", "minimum": 0}
+          }
+        },
+        {"type": "null"}
+      ],
+      "description": "Derived freshness metadata from snapshot.generated_at and diagnostics TTL. Null when generated_at is missing/invalid or lookup failed."
+    },
+    "warnings": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Non-fatal diagnostics messages. Empty for status='ok'."
+    }
+  }
+}

--- a/merger/lenskit/service/app.py
+++ b/merger/lenskit/service/app.py
@@ -90,6 +90,22 @@ else:
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
+def _parse_iso_utc(value: Any) -> Optional[datetime]:
+    if not isinstance(value, str):
+        return None
+    raw = value.strip()
+    if not raw:
+        return None
+    normalized = raw[:-1] + "+00:00" if raw.endswith("Z") else raw
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed.astimezone(timezone.utc)
+
 app = FastAPI(title="rLens", version=SERVER_VERSION)
 
 @app.exception_handler(InvalidPathError)
@@ -308,6 +324,50 @@ def api_diagnostics_rebuild():
     except Exception:
         logger.exception("Diagnostics rebuild failed")
         raise HTTPException(status_code=500, detail="Diagnostics rebuild failed")
+
+@app.get("/api/diagnostics", dependencies=[Depends(verify_token)])
+def api_diagnostics_lookup():
+    """Read-only diagnostics lookup over the persisted snapshot."""
+    if not state.hub:
+        raise HTTPException(status_code=400, detail="Hub not configured")
+
+    diag_path = state.hub / ".gewebe" / "cache" / "diagnostics.snapshot.json"
+    if not diag_path.exists():
+        return {
+            "status": "not_found",
+            "snapshot": None,
+            "freshness": None,
+            "warnings": ["diagnostics.snapshot.json not found"],
+        }
+
+    try:
+        snapshot = json.loads(diag_path.read_text(encoding="utf-8"))
+    except Exception:
+        logger.exception("Failed to parse diagnostics snapshot")
+        return {
+            "status": "error",
+            "snapshot": None,
+            "freshness": None,
+            "warnings": ["Invalid diagnostics snapshot JSON"],
+        }
+
+    generated_at = _parse_iso_utc(snapshot.get("generated_at"))
+    freshness = None
+    if generated_at is not None:
+        age_seconds = max(int((datetime.now(timezone.utc) - generated_at).total_seconds()), 0)
+        freshness = {
+            "generated_at": snapshot.get("generated_at"),
+            "ttl_hours": diagnostics_rebuild.TTL_HOURS,
+            "is_stale": age_seconds > diagnostics_rebuild.TTL_HOURS * 3600,
+            "age_seconds": age_seconds,
+        }
+
+    return {
+        "status": "ok",
+        "snapshot": snapshot,
+        "freshness": freshness,
+        "warnings": [],
+    }
 
 @app.post("/api/extras/refresh_all", dependencies=[Depends(verify_token)])
 def api_extras_refresh_all(payload: Dict[str, Any] = Body(default_factory=dict)):

--- a/merger/lenskit/service/app.py
+++ b/merger/lenskit/service/app.py
@@ -341,14 +341,37 @@ def api_diagnostics_lookup():
         }
 
     try:
-        snapshot = json.loads(diag_path.read_text(encoding="utf-8"))
-    except Exception:
-        logger.exception("Failed to parse diagnostics snapshot")
+        snapshot_text = diag_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        logger.exception("Failed to read diagnostics snapshot")
+        return {
+            "status": "error",
+            "snapshot": None,
+            "freshness": None,
+            "warnings": ["Unable to read diagnostics snapshot"],
+        }
+
+    try:
+        snapshot = json.loads(snapshot_text)
+    except json.JSONDecodeError:
+        logger.exception("Failed to parse diagnostics snapshot JSON")
         return {
             "status": "error",
             "snapshot": None,
             "freshness": None,
             "warnings": ["Invalid diagnostics snapshot JSON"],
+        }
+
+    if not isinstance(snapshot, dict):
+        logger.warning(
+            "Diagnostics snapshot JSON must be an object, got %s",
+            type(snapshot).__name__,
+        )
+        return {
+            "status": "error",
+            "snapshot": None,
+            "freshness": None,
+            "warnings": ["Invalid diagnostics snapshot payload: expected JSON object"],
         }
 
     generated_at = _parse_iso_utc(snapshot.get("generated_at"))

--- a/merger/lenskit/tests/test_diagnostics_lookup.py
+++ b/merger/lenskit/tests/test_diagnostics_lookup.py
@@ -152,6 +152,36 @@ class TestApiDiagnosticsLookup:
         schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
         jsonschema.validate(instance=data, schema=schema)
 
+    @pytest.mark.parametrize("payload", ["[]", "\"x\"", "null", "123"])
+    def test_diagnostics_lookup_non_object_json_returns_error(self, api_client, payload):
+        client, hub_path = api_client
+        diag_path = hub_path / ".gewebe" / "cache" / "diagnostics.snapshot.json"
+        diag_path.write_text(payload, encoding="utf-8")
+
+        response = client.get("/api/diagnostics", headers=_AUTH)
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["status"] == "error"
+        assert data["snapshot"] is None
+        assert data["freshness"] is None
+        assert any("expected JSON object" in w for w in data["warnings"])
+
+    def test_diagnostics_lookup_non_object_json_conforms_to_contract(self, api_client):
+        if jsonschema is None:
+            pytest.skip("jsonschema not available")
+
+        client, hub_path = api_client
+        diag_path = hub_path / ".gewebe" / "cache" / "diagnostics.snapshot.json"
+        diag_path.write_text("[]", encoding="utf-8")
+
+        response = client.get("/api/diagnostics", headers=_AUTH)
+        assert response.status_code == 200
+
+        data = response.json()
+        schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+        jsonschema.validate(instance=data, schema=schema)
+
     def test_diagnostics_lookup_does_not_rebuild_or_mutate_snapshot(self, api_client):
         client, hub_path = api_client
         diag_path = hub_path / ".gewebe" / "cache" / "diagnostics.snapshot.json"
@@ -178,7 +208,8 @@ class TestApiDiagnosticsLookup:
         client, hub_path = api_client
         diag_path = hub_path / ".gewebe" / "cache" / "diagnostics.snapshot.json"
 
-        stale_generated_at = (datetime.now(timezone.utc) - timedelta(hours=72)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        ttl_hours = service_app.diagnostics_rebuild.TTL_HOURS
+        stale_generated_at = (datetime.now(timezone.utc) - timedelta(hours=ttl_hours + 1)).strftime("%Y-%m-%dT%H:%M:%SZ")
         diag_path.write_text(
             json.dumps(
                 {

--- a/merger/lenskit/tests/test_diagnostics_lookup.py
+++ b/merger/lenskit/tests/test_diagnostics_lookup.py
@@ -209,7 +209,9 @@ class TestApiDiagnosticsLookup:
         diag_path = hub_path / ".gewebe" / "cache" / "diagnostics.snapshot.json"
 
         ttl_hours = service_app.diagnostics_rebuild.TTL_HOURS
-        stale_generated_at = (datetime.now(timezone.utc) - timedelta(hours=ttl_hours + 1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        stale_generated_at = (
+            datetime.now(timezone.utc) - timedelta(hours=ttl_hours + 1)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
         diag_path.write_text(
             json.dumps(
                 {

--- a/merger/lenskit/tests/test_diagnostics_lookup.py
+++ b/merger/lenskit/tests/test_diagnostics_lookup.py
@@ -1,0 +1,206 @@
+"""Tests for GET /api/diagnostics: read-only lookup of diagnostics snapshot."""
+import json
+from pathlib import Path
+from datetime import datetime, timezone, timedelta
+
+import pytest
+
+try:
+    import jsonschema
+except ImportError:
+    jsonschema = None
+
+try:
+    from fastapi.testclient import TestClient
+    from merger.lenskit.service.app import app
+    from merger.lenskit.service import app as service_app
+    _HAS_FASTAPI = True
+except ImportError:
+    _HAS_FASTAPI = False
+
+requires_fastapi = pytest.mark.skipif(not _HAS_FASTAPI, reason="fastapi not installed")
+
+_AUTH = {"Authorization": "Bearer test_token"}
+_SCHEMA_PATH = Path(__file__).parent.parent / "contracts" / "diagnostics-lookup.v1.schema.json"
+
+
+@pytest.fixture
+def api_client(tmp_path):
+    hub_path = tmp_path / "hub"
+    cache_dir = hub_path / ".gewebe" / "cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    merges_dir = tmp_path / "merges"
+    merges_dir.mkdir(parents=True, exist_ok=True)
+    service_app.init_service(hub_path=hub_path, token="test_token", merges_dir=merges_dir)
+    return TestClient(app), hub_path
+
+
+@requires_fastapi
+class TestApiDiagnosticsLookup:
+
+    @pytest.mark.parametrize(
+        "generated_at",
+        [
+            "2026-01-01T00:00:00Z",
+            "2026-01-01T00:00:00+00:00",
+        ],
+    )
+    def test_diagnostics_lookup_ok_reads_snapshot(self, api_client, generated_at):
+        client, hub_path = api_client
+        diag_path = hub_path / ".gewebe" / "cache" / "diagnostics.snapshot.json"
+        diag_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "diagnostics.snapshot.v1",
+                    "status": "ok",
+                    "generated_at": generated_at,
+                    "summary": {"ok": 1, "issue": 0, "missing": 0, "issues_total": 0},
+                    "data": {},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        response = client.get("/api/diagnostics", headers=_AUTH)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ok"
+        assert data["snapshot"]["schema_version"] == "diagnostics.snapshot.v1"
+        assert data["freshness"] is not None
+        assert data["freshness"]["generated_at"] == generated_at
+        assert isinstance(data["freshness"]["is_stale"], bool)
+        assert data["warnings"] == []
+
+    def test_diagnostics_lookup_not_found(self, api_client):
+        client, _ = api_client
+        response = client.get("/api/diagnostics", headers=_AUTH)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "not_found"
+        assert data["snapshot"] is None
+        assert data["freshness"] is None
+        assert len(data["warnings"]) > 0
+
+    def test_diagnostics_lookup_invalid_json(self, api_client):
+        client, hub_path = api_client
+        diag_path = hub_path / ".gewebe" / "cache" / "diagnostics.snapshot.json"
+        diag_path.write_text("{this is not json", encoding="utf-8")
+
+        response = client.get("/api/diagnostics", headers=_AUTH)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "error"
+        assert data["snapshot"] is None
+        assert data["freshness"] is None
+        assert len(data["warnings"]) > 0
+
+    def test_diagnostics_lookup_requires_auth(self, api_client):
+        client, _ = api_client
+        response = client.get("/api/diagnostics")
+        assert response.status_code == 401
+
+    def test_diagnostics_lookup_response_conforms_to_contract(self, api_client):
+        if jsonschema is None:
+            pytest.skip("jsonschema not available")
+
+        client, hub_path = api_client
+        diag_path = hub_path / ".gewebe" / "cache" / "diagnostics.snapshot.json"
+        diag_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "diagnostics.snapshot.v1",
+                    "status": "ok",
+                    "generated_at": "2026-01-01T00:00:00Z",
+                    "summary": {"ok": 1, "issue": 0, "missing": 0, "issues_total": 0},
+                    "data": {},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        response = client.get("/api/diagnostics", headers=_AUTH)
+        assert response.status_code == 200
+        data = response.json()
+
+        schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+        jsonschema.validate(instance=data, schema=schema)
+
+    def test_diagnostics_lookup_not_found_conforms_to_contract(self, api_client):
+        if jsonschema is None:
+            pytest.skip("jsonschema not available")
+
+        client, _ = api_client
+        response = client.get("/api/diagnostics", headers=_AUTH)
+        assert response.status_code == 200
+
+        data = response.json()
+        schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+        jsonschema.validate(instance=data, schema=schema)
+
+    def test_diagnostics_lookup_error_conforms_to_contract(self, api_client):
+        if jsonschema is None:
+            pytest.skip("jsonschema not available")
+
+        client, hub_path = api_client
+        diag_path = hub_path / ".gewebe" / "cache" / "diagnostics.snapshot.json"
+        diag_path.write_text("{invalid", encoding="utf-8")
+
+        response = client.get("/api/diagnostics", headers=_AUTH)
+        assert response.status_code == 200
+
+        data = response.json()
+        schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+        jsonschema.validate(instance=data, schema=schema)
+
+    def test_diagnostics_lookup_does_not_rebuild_or_mutate_snapshot(self, api_client):
+        client, hub_path = api_client
+        diag_path = hub_path / ".gewebe" / "cache" / "diagnostics.snapshot.json"
+        diag_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "diagnostics.snapshot.v1",
+                    "status": "ok",
+                    "generated_at": "2026-01-01T00:00:00Z",
+                    "summary": {"ok": 1, "issue": 0, "missing": 0, "issues_total": 0},
+                    "data": {},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        before_mtime = diag_path.stat().st_mtime_ns
+        response = client.get("/api/diagnostics", headers=_AUTH)
+        assert response.status_code == 200
+        after_mtime = diag_path.stat().st_mtime_ns
+        assert before_mtime == after_mtime
+
+    def test_diagnostics_lookup_stale_snapshot_sets_freshness_without_mutation(self, api_client):
+        client, hub_path = api_client
+        diag_path = hub_path / ".gewebe" / "cache" / "diagnostics.snapshot.json"
+
+        stale_generated_at = (datetime.now(timezone.utc) - timedelta(hours=72)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        diag_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "diagnostics.snapshot.v1",
+                    "status": "ok",
+                    "generated_at": stale_generated_at,
+                    "summary": {"ok": 1, "issue": 0, "missing": 0, "issues_total": 0},
+                    "data": {},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        before_mtime = diag_path.stat().st_mtime_ns
+        response = client.get("/api/diagnostics", headers=_AUTH)
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data["status"] == "ok"
+        assert data["freshness"] is not None
+        assert data["freshness"]["is_stale"] is True
+        assert data["freshness"]["ttl_hours"] > 0
+
+        after_mtime = diag_path.stat().st_mtime_ns
+        assert before_mtime == after_mtime


### PR DESCRIPTION
### Motivation
- Provide a read-only lookup for the persisted diagnostics snapshot that does not trigger rebuilds and exposes freshness metadata.
- Surface diagnostics through the service API and update docs/roadmap to reflect the bounded API surface.

### Description
- Implemented `GET /api/diagnostics` in `merger/lenskit/service/app.py` that reads `.gewebe/cache/diagnostics.snapshot.json` and returns a lookup envelope with `status`, `snapshot`, `freshness`, and `warnings`.
- Added `_parse_iso_utc` helper and freshness calculation using `generated_at` and `diagnostics_rebuild.TTL_HOURS` to compute `age_seconds` and `is_stale`.
- Added JSON Schema contract at `merger/lenskit/contracts/diagnostics-lookup.v1.schema.json` and updated `docs/service-api.md` and `docs/lenskit-upgrade-blaupause.md` to document the endpoint.
- Added tests in `merger/lenskit/tests/test_diagnostics_lookup.py` covering successful lookup, missing snapshot, invalid JSON, auth, contract conformance, non-mutation of the file, and stale snapshot handling.

### Testing
- Ran `pytest merger/lenskit/tests/test_diagnostics_lookup.py` and the test suite for the diagnostics lookup passed; contract validation tests are skipped if `jsonschema` is not installed.
- Verified the endpoint returns `status: not_found` when the snapshot file is absent and `status: error` when the snapshot contains invalid JSON.
- Verified the endpoint does not mutate or rebuild the snapshot file and correctly marks stale snapshots using the configured TTL.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edeca241e0832c9a26af8ee5a832bc)