### PR TITLE
docs: Add artifact layering architecture and drift matrix

### DIFF
--- a/docs/architecture/artifact-drift-matrix.md
+++ b/docs/architecture/artifact-drift-matrix.md
@@ -16,7 +16,7 @@ das Inventar listet Artefakte, diese Matrix beschreibt die Übergänge.
 | :--- | :--- | :--- | :--- | :--- | :--- |
 | `canonical_md` | `index_sidecar_json` | Sidecar verweist auf fehlende oder verschobene Section | `canonical_md` für Inhalt, Sidecar nur Navigation | `test_sidecar_contracts.py`, `test_report_parsing.py` | Sidecar regenerieren |
 | `bundle_manifest` | Artefakte | Manifest-SHA passt nicht zum Artefakt | Artefaktinhalt + Manifest müssen konsistent sein | `test_bundle_manifest_integration.py` | Manifest regenerieren |
-| `dump_index_json` | `derived_manifest_json` | `canonical_dump_index_sha256` mismatch | `dump_index_json` | bundle/derived manifest tests oder neuer späterer Guard | derived index regenerieren |
+| `dump_index_json` | `derived_manifest_json` | `canonical_dump_index_sha256` mismatch | `dump_index_json` | `test_bundle_manifest_integration.py` (aktuell), später dedizierter derived-manifest Guard | derived index regenerieren |
 | `chunk_index_jsonl` | `sqlite_index` | SQLite aus altem Chunk-Index | `chunk_index_jsonl` | `test_stale_check.py`, `test_sqlite_capabilities.py` | SQLite regenerieren |
 | `query_trace` | `context_bundle` | Trace beschreibt andere Treffer als Context Bundle | gemeinsame Run-ID und Query Trace | `test_artifact_lookup.py`, `test_trace_lookup.py`, `test_context_lookup.py` | Runtime-Artefakte neu erzeugen |
 | `context_bundle` | `agent_query_session` | Session verweist auf anderen Kontext | `context_bundle` + `artifact_refs` | `test_agent_session_builder.py` | Session neu erzeugen |

--- a/docs/architecture/artifact-drift-matrix.md
+++ b/docs/architecture/artifact-drift-matrix.md
@@ -1,0 +1,38 @@
+# Artifact Drift Matrix
+
+Diese Matrix dokumentiert paarweise Drift-Risiken zwischen Lenskit-Artefakten
+und ordnet jeder Paarung Autorität, Guard und Regenerationspfad zu. Sie ist
+zunächst **diagnostisch**: sie macht bestehende Ankerpunkte sichtbar, ohne
+neue Blocking-Guards einzuführen.
+
+Sie ergänzt das
+[Two-Layer Artifact Pattern](./two-layer-artifact-pattern.md) und das
+[Artefakt-Inventar](./artifact-inventory.md): das Pattern legt Schichten fest,
+das Inventar listet Artefakte, diese Matrix beschreibt die Übergänge.
+
+## Matrix
+
+| Quelle A | Quelle B | Konfliktfall | Autorität | Guard / Test | Regeneration |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| `canonical_md` | `index_sidecar_json` | Sidecar verweist auf fehlende oder verschobene Section | `canonical_md` für Inhalt, Sidecar nur Navigation | `test_sidecar_contracts.py`, `test_report_parsing.py` | Sidecar regenerieren |
+| `bundle_manifest` | Artefakte | Manifest-SHA passt nicht zum Artefakt | Artefaktinhalt + Manifest müssen konsistent sein | `test_bundle_manifest_integration.py` | Manifest regenerieren |
+| `dump_index_json` | `derived_manifest_json` | `canonical_dump_index_sha256` mismatch | `dump_index_json` | bundle/derived manifest tests oder neuer späterer Guard | derived index regenerieren |
+| `chunk_index_jsonl` | `sqlite_index` | SQLite aus altem Chunk-Index | `chunk_index_jsonl` | `test_stale_check.py`, `test_sqlite_capabilities.py` | SQLite regenerieren |
+| `query_trace` | `context_bundle` | Trace beschreibt andere Treffer als Context Bundle | gemeinsame Run-ID und Query Trace | `test_artifact_lookup.py`, `test_trace_lookup.py`, `test_context_lookup.py` | Runtime-Artefakte neu erzeugen |
+| `context_bundle` | `agent_query_session` | Session verweist auf anderen Kontext | `context_bundle` + `artifact_refs` | `test_agent_session_builder.py` | Session neu erzeugen |
+| `architecture_summary` | architecture graph / `graph_index` | Summary behauptet nicht belegte Kante | Graph Contract / Graph Index, Summary nur Diagnose | `test_graph_eval.py`, `test_graph_index.py` | Summary regenerieren |
+| PR-Schau JSON | PR-Schau Markdown | JSON meldet vollständig, Markdown fehlt oder ist unvollständig | Markdown Content + Completeness Block | `test_pr_schau_consumer_gate.py`, `pr_schau_verify` | PR-Schau Bundle neu bauen |
+
+## Rollout-Regel
+
+Diese Matrix ist zunächst diagnostisch. Neue Blocking-Guards dürfen erst
+entstehen, wenn:
+
+1. der Producer stabil emittiert,
+2. Fixtures aktualisiert sind,
+3. mindestens ein diagnostischer Lauf grün war,
+4. Consumer zusätzliche Felder tolerieren.
+
+Eine Guard-Promotion (Diagnose → Blocking) erfolgt pro Zeile getrennt, nicht
+für die gesamte Matrix auf einmal. Damit bleibt das Drift-Inventar wachsbar,
+ohne die CI in einem Schritt zu verschärfen.

--- a/docs/architecture/artifact-inventory.md
+++ b/docs/architecture/artifact-inventory.md
@@ -29,6 +29,11 @@ Dateiendung ist Kleidung; Autorität ist Identität.
 | `pr-schau-delta.json` | `delta_json` | _(Phase 1: nicht annotiert)_ | _(Phase 1: nicht annotiert)_ | `core.pr_schau_bundle` | PR-Schau Frontends, Agents | `pr-schau-delta.v1.schema.json` | Optional | Code-Review Differentials |
 | `<stem>.entrypoints.json` | - (Hilfs-/Zwischenartefakt) | _(Phase 1: nicht annotiert)_ | _(Phase 1: nicht annotiert)_ | `architecture.entrypoints` | `architecture.graph_index` | `entrypoints.v1.schema.json` | Nein | Berechnung des Graph-Boosts |
 
+## Verwandte Architekturregeln
+
+- Two-Layer Artifact Pattern: [docs/architecture/two-layer-artifact-pattern.md](./two-layer-artifact-pattern.md)
+- Artifact Drift Matrix: [docs/architecture/artifact-drift-matrix.md](./artifact-drift-matrix.md)
+
 ## Anmerkungen zur Artefaktarchitektur
 
 1. **`query_trace.json` vs. `context_bundle`:**

--- a/docs/architecture/two-layer-artifact-pattern.md
+++ b/docs/architecture/two-layer-artifact-pattern.md
@@ -1,0 +1,105 @@
+# Two-Layer Artifact Pattern
+
+## Zweck
+
+Beschreibe das Lenskit-Muster: Index Layer zeigt, Content Layer beweist.
+
+Dieses Dokument zieht eine architektonische Regel fest, die in Lenskit bereits
+implizit gelebt wird (PR-Schau JSON ↔ Markdown, Bundle Manifest ↔ canonical_md,
+Runtime-Trace ↔ Context Bundle). Es macht das Muster explizit, damit neue
+Artefakte ohne Drift in genau eine Schicht eingeordnet werden können.
+
+## Kernregel
+
+Index Layer zeigt.
+Content Layer beweist.
+Diagnose warnt.
+Cache beschleunigt.
+Runtime beobachtet.
+
+Kein Artefakt darf still als ein anderes auftreten.
+
+## Index Layer
+
+Eigenschaften:
+
+- maschinenlesbar
+- navigierend
+- enthält Integritäts-, Hash-, Range-, Rollen- oder Vollständigkeitsmetadaten
+- darf nicht als vollständiger Inhaltsbeweis gelten
+
+Beispiele:
+
+- bundle manifest
+- dump_index_json
+- index_sidecar_json
+- PR-Schau JSON
+- artifact_lookup / trace_lookup / context_lookup Oberflächen, sofern sie nur
+  verweisen
+
+## Content Layer
+
+Eigenschaften:
+
+- enthält den eigentlichen Inhalt oder einen explizit kanonischen Ausschnitt
+- darf gesplittet werden
+- darf nicht still gekürzt werden
+- muss über Range, Hash oder Completeness prüfbar bleiben
+
+Beispiele:
+
+- canonical_md
+- PR-Schau Markdown-Parts
+- query_context_bundle payload, sofern vollständig materialisiert
+
+## Diagnostic Layer
+
+Eigenschaften:
+
+- macht Zustände sichtbar
+- darf warnen
+- darf keine kanonische Inhaltsautorität beanspruchen
+
+Beispiele:
+
+- architecture_summary
+- diagnostics lookup
+- Eval-/PR-Schau-Diagnosen
+
+## Runtime Observation Layer
+
+Eigenschaften:
+
+- entsteht aus einem konkreten Lauf
+- ist nützlich für Nachvollziehbarkeit
+- beweist nicht den Live-Repository-Zustand
+
+Beispiele:
+
+- query_trace
+- context_bundle
+- agent_query_session
+
+## Verbotene Gleichsetzungen
+
+- JSON-Index als Inhaltswahrheit behandeln
+- Markdown-Vorschau als vollständigen Report verkaufen
+- Diagnose-Artefakt als canonical content verwenden
+- Cache-Artefakt als Ursprung ausgeben
+- Runtime-Spur als Live-Repo-Beweis behandeln
+
+## Abbildungen in Lenskit
+
+- PR-Schau: JSON index ↔ Markdown content
+- repoLens bundle: bundle manifest / sidecar / dump index ↔ canonical_md
+- Query Runtime: query_trace ↔ context_bundle ↔ agent_query_session
+
+## Architekturregel
+
+Neue Artefakte müssen angeben:
+
+- welche Schicht sie bedienen
+- was sie beweisen
+- was sie nicht beweisen
+- woraus sie regeneriert werden können
+- welcher Guard oder Test ihre Drift erkennt

--- a/docs/testing/test-matrix.md
+++ b/docs/testing/test-matrix.md
@@ -15,6 +15,32 @@ Diese Matrix ordnet die in `merger/lenskit/tests/` existierenden Tests nach abge
 | **Federation & Cross-Repo** | `test_federation_*.py` | Föderation-Artefakte bauen deterministisch und Query-Mechanismen greifen | **Teilweise abgedeckt.** | Tests unter `test_federation_*.py` (u. a. Add, Query, Inspect, Validate). |
 | **API/UI Integration** | `test_webui_payload.py` | Stellt sicher, dass minimale Playwright-Webseiten-Checks strukturell durchlaufen. | **Lückenhaft.** | API/UI-Strukturen sind nicht umfassend end-to-end gesichert oder als produktionsreif testbar. |
 
+## Artifact Integrity / Drift Diagnostics
+
+Architekturgrundlage:
+
+- [Two-Layer Artifact Pattern](../architecture/two-layer-artifact-pattern.md)
+- [Artifact Drift Matrix](../architecture/artifact-drift-matrix.md)
+
+Bestehende Tests als diagnostische Ankerpunkte:
+
+| Test | Drift-Paarung |
+| :--- | :--- |
+| `test_bundle_manifest_integration.py` | bundle_manifest ↔ Artefakte |
+| `test_bundle_manifest_schema.py` | bundle_manifest ↔ Artefakte |
+| `test_sidecar_contracts.py` | canonical_md ↔ index_sidecar_json |
+| `test_report_parsing.py` | canonical_md ↔ index_sidecar_json |
+| `test_stale_check.py` | chunk_index_jsonl ↔ sqlite_index |
+| `test_sqlite_capabilities.py` | chunk_index_jsonl ↔ sqlite_index |
+| `test_artifact_lookup.py` | query_trace ↔ context_bundle |
+| `test_trace_lookup.py` | query_trace ↔ context_bundle |
+| `test_context_lookup.py` | query_trace ↔ context_bundle |
+| `test_agent_session_builder.py` | context_bundle ↔ agent_query_session |
+| `test_pr_schau_consumer_gate.py` | PR-Schau JSON ↔ PR-Schau Markdown |
+
+Diese Tests sind noch keine vollständige Drift-Blocking-Matrix, sondern
+vorhandene Ankerpunkte für spätere Guards.
+
 ## Zusammenfassung der Test-Abdeckung
 
 Die Testsuite (`merger/lenskit/tests/`) belegt die Grundlagen für die Ingestion (Phase 1), die Core-Runtime (Phase 2), die Graph-Integration (Phase 3) sowie die strukturellen Erwartungen an Context-Bundles (Phase 4).

--- a/merger/lenskit/contracts/PR-SCHAU-CONTRACT.md
+++ b/merger/lenskit/contracts/PR-SCHAU-CONTRACT.md
@@ -140,7 +140,15 @@ To combat the assumption that "existence implies correctness", bundles MAY inclu
 
 *   **Decision Coverage:** A future evolution may introduce "Decision Coverage" – ensuring that while not *all* files are full, all *decision-critical* files (security, contracts, core logic) are present as `fullfiles`.
 
-## 9. Versioning
+## 9. Two-Layer Artifact Pattern
+
+PR-Schau folgt dem [Two-Layer Artifact Pattern](../../../docs/architecture/two-layer-artifact-pattern.md):
+
+- JSON beschreibt Navigation, Vollständigkeit und Integrität.
+- Markdown enthält den lesbaren Inhalt.
+- JSON darf nicht als vollständiger Inhaltsbeweis verwendet werden.
+
+## 10. Versioning
 
 This is **Version 1.0** of the PR-Schau Contract.
 Schema URI: `https://heimgewebe.local/schema/pr-schau.v1.schema.json`

--- a/merger/lenskit/contracts/PR-SCHAU-CONTRACT.md
+++ b/merger/lenskit/contracts/PR-SCHAU-CONTRACT.md
@@ -142,11 +142,11 @@ To combat the assumption that "existence implies correctness", bundles MAY inclu
 
 ## 9. Two-Layer Artifact Pattern
 
-PR-Schau folgt dem [Two-Layer Artifact Pattern](../../../docs/architecture/two-layer-artifact-pattern.md):
+PR-Schau follows the [Two-Layer Artifact Pattern](../../../docs/architecture/two-layer-artifact-pattern.md):
 
-- JSON beschreibt Navigation, Vollständigkeit und Integrität.
-- Markdown enthält den lesbaren Inhalt.
-- JSON darf nicht als vollständiger Inhaltsbeweis verwendet werden.
+- JSON describes navigation, completeness, and integrity.
+- Markdown contains the readable content.
+- JSON must not be treated as complete content proof.
 
 ## 10. Versioning
 


### PR DESCRIPTION
## Summary

This PR establishes explicit architectural rules for artifact organization in Lenskit by documenting the Two-Layer Artifact Pattern and introducing a diagnostic Artifact Drift Matrix. These documents codify patterns that were previously implicit in the codebase.

## Key Changes

- **New: Two-Layer Artifact Pattern** (`docs/architecture/two-layer-artifact-pattern.md`)
  - Defines the Index Layer (navigation, metadata) vs. Content Layer (proof, canonical content) distinction
  - Adds Diagnostic and Runtime Observation layers
  - Lists forbidden equivalences (e.g., treating JSON indices as content truth)
  - Establishes requirements for new artifacts: which layer they serve, what they prove, regeneration paths, and drift guards

- **New: Artifact Drift Matrix** (`docs/architecture/artifact-drift-matrix.md`)
  - Documents pairwise drift risks between artifact pairs (e.g., `canonical_md` ↔ `index_sidecar_json`)
  - Maps authority, guards/tests, and regeneration paths for each conflict case
  - Establishes a rollout rule: guards start diagnostic, promote to blocking only after stability and consumer tolerance
  - Covers 8 critical artifact relationships across the system

- **Updated: Test Matrix** (`docs/testing/test-matrix.md`)
  - Adds new "Artifact Integrity / Drift Diagnostics" section
  - Maps existing tests to drift-pairings they anchor (e.g., `test_bundle_manifest_integration.py` for bundle_manifest ↔ artifacts)
  - Clarifies that these are diagnostic anchors, not yet a complete blocking matrix

- **Updated: Artifact Inventory** (`docs/architecture/artifact-inventory.md`)
  - Adds cross-references to the new Two-Layer Pattern and Drift Matrix documents

- **Updated: PR-Schau Contract** (`merger/lenskit/contracts/PR-SCHAU-CONTRACT.md`)
  - Adds Section 9 documenting PR-Schau's adherence to the Two-Layer Artifact Pattern
  - Clarifies that JSON is navigation/integrity only; Markdown is canonical content

## Notable Details

- The pattern makes implicit Lenskit practices explicit (JSON ↔ Markdown in PR-Schau, Bundle Manifest ↔ canonical_md, Runtime Trace ↔ Context Bundle)
- The drift matrix is intentionally diagnostic first to avoid blocking CI prematurely
- Guards can be promoted per-row independently, allowing incremental hardening without system-wide CI impact
- All new artifacts must declare their layer, proof scope, and regeneration contract

https://claude.ai/code/session_01FH9Bv4kjoNdLfS9K3868VH