### PR TITLE
Add claim boundaries to query results for epistemic transparency

### DIFF
--- a/docs/retrieval/recipes.md
+++ b/docs/retrieval/recipes.md
@@ -89,3 +89,35 @@ Index neu bauen, auch wenn er aktuell scheint.
 ```bash
 python -m merger.lenskit.cli index --dump output/my_dump.json --chunk-index output/my_chunks.jsonl --rebuild
 ```
+
+
+## Query Claim Boundaries
+
+Jedes Query-Ergebnis enthält ein maschinenlesbares `claim_boundaries`-Objekt, das die epistemischen Grenzen des Treffers explizit macht.
+
+**Was ein Treffer beweist:**
+- Dieser Index lieferte unter dieser Query und diesen Filtern diese Treffer.
+
+**Was ein Treffer nicht beweist:**
+- Dass kein nicht gefundener Inhalt im Repository existiert (Abwesenheit eines Treffers ≠ Abwesenheit im Repo).
+- Dass Ranking semantische Wichtigkeit beweist.
+- Dass der Snapshot dem Live-Repository entspricht.
+- Dass Explain-Ausgaben kanonische Wahrheit sind.
+
+Das Feld `evidence_basis` listet die tatsächlich verwendeten Evidenzquellen (z.B. `query`, `fts_query`, `applied_filters`, `index`, `result_ranges`). Das Feld `requires_live_check` gibt an, ob eine autoritative Antwort einen aktuellen Repository-Zugriff erfordert.
+
+```json
+{
+  "claim_boundaries": {
+    "proves": ["These hits were returned by this index under this query and these filters."],
+    "does_not_prove": [
+      "Absence of a hit does not prove absence in the repository.",
+      "Ranking does not prove semantic importance.",
+      "Snapshot query does not prove live repository state.",
+      "Best-effort explain output is diagnostic, not canonical truth."
+    ],
+    "evidence_basis": ["query", "fts_query", "applied_filters", "index", "result_ranges"],
+    "requires_live_check": false
+  }
+}
+```

--- a/merger/lenskit/contracts/query-result.v1.schema.json
+++ b/merger/lenskit/contracts/query-result.v1.schema.json
@@ -232,6 +232,13 @@
         }
       }
     },
+    "warnings": {
+      "type": "array",
+      "description": "Non-fatal advisory messages about query execution (e.g. low result coverage).",
+      "items": {
+        "type": "string"
+      }
+    },
     "query_trace": {
       "type": "object",
       "description": "Diagnostic query execution trace.",
@@ -240,6 +247,50 @@
     "context_bundle": {
       "description": "Optional portable context bundle encapsulating results and expanded textual/structural context.",
       "$ref": "query-context-bundle.v1.schema.json"
+    },
+    "claim_boundaries": {
+      "type": "object",
+      "description": "Machine-readable epistemic boundaries of this query result. Declares what the result proves, what it does not prove, which evidence was used, and whether a live repository check is required for authoritative answers.",
+      "additionalProperties": false,
+      "required": [
+        "proves",
+        "does_not_prove",
+        "evidence_basis",
+        "requires_live_check"
+      ],
+      "properties": {
+        "proves": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Statements this result can support."
+        },
+        "does_not_prove": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Statements this result explicitly cannot support."
+        },
+        "evidence_basis": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "query",
+              "fts_query",
+              "applied_filters",
+              "index",
+              "result_ranges",
+              "bundle_manifest",
+              "graph_index",
+              "context_bundle"
+            ]
+          },
+          "description": "Which evidence sources were used to produce this result."
+        },
+        "requires_live_check": {
+          "type": "boolean",
+          "description": "Whether authoritative answers require a live repository check beyond this index snapshot."
+        }
+      }
     }
   }
 }

--- a/merger/lenskit/retrieval/query_core.py
+++ b/merger/lenskit/retrieval/query_core.py
@@ -547,6 +547,23 @@ def execute_query(
         if fts_query_str is not None:
             out["fts_query"] = fts_query_str
 
+        evidence = ["query", "applied_filters", "index", "result_ranges"]
+        if fts_query_str is not None:
+            evidence.insert(1, "fts_query")
+        out["claim_boundaries"] = {
+            "proves": [
+                "These hits were returned by this index under this query and these filters."
+            ],
+            "does_not_prove": [
+                "Absence of a hit does not prove absence in the repository.",
+                "Ranking does not prove semantic importance.",
+                "Snapshot query does not prove live repository state.",
+                "Best-effort explain output is diagnostic, not canonical truth."
+            ],
+            "evidence_basis": evidence,
+            "requires_live_check": False
+        }
+
         if explain:
             explain_block = {}
             explain_block["fts_query"] = fts_query_str if fts_query_str is not None else ""

--- a/merger/lenskit/tests/test_retrieval_query.py
+++ b/merger/lenskit/tests/test_retrieval_query.py
@@ -683,3 +683,120 @@ def test_query_uses_stale_graph_runtime_path(mini_index, tmp_path):
     assert diagnostics["graph_used"] is True, "Graph must still be used by policy despite mismatch"
     assert diagnostics["distance"] == 0, "Graph distance must still be projected correctly"
     assert diagnostics["graph_bonus"] > 0, "Graph bonus must actually influence the score"
+
+
+# ---------------------------------------------------------------------------
+# Claim Boundaries
+# ---------------------------------------------------------------------------
+
+def test_claim_boundaries_present(mini_index):
+    import jsonschema
+    from pathlib import Path
+
+    res = query_core.execute_query(mini_index, query_text="hello", k=5)
+    assert "claim_boundaries" in res
+    cb = res["claim_boundaries"]
+    assert isinstance(cb["proves"], list)
+    assert isinstance(cb["does_not_prove"], list)
+    assert isinstance(cb["evidence_basis"], list)
+    assert isinstance(cb["requires_live_check"], bool)
+
+    schema_path = Path(__file__).parent.parent / "contracts" / "query-result.v1.schema.json"
+    with schema_path.open("r", encoding="utf-8") as f:
+        schema = json.load(f)
+    jsonschema.validate(instance=res, schema=schema)
+
+
+def test_claim_boundaries_content(mini_index):
+    res = query_core.execute_query(mini_index, query_text="hello", k=5)
+    cb = res["claim_boundaries"]
+
+    absence_stmt = "Absence of a hit does not prove absence in the repository."
+    ranking_stmt = "Ranking does not prove semantic importance."
+    snapshot_stmt = "Snapshot query does not prove live repository state."
+
+    assert any(absence_stmt in s for s in cb["does_not_prove"]), "Missing absence disclaimer"
+    assert any(ranking_stmt in s for s in cb["does_not_prove"]), "Missing ranking disclaimer"
+    assert any(snapshot_stmt in s for s in cb["does_not_prove"]), "Missing snapshot disclaimer"
+
+    assert cb["requires_live_check"] is False
+    assert "query" in cb["evidence_basis"]
+    assert "applied_filters" in cb["evidence_basis"]
+    assert "index" in cb["evidence_basis"]
+
+
+def test_claim_boundaries_fts_query_evidence(mini_index):
+    res = query_core.execute_query(mini_index, query_text="hello", k=5)
+    cb = res["claim_boundaries"]
+    assert "fts_query" in cb["evidence_basis"], "FTS query should appear in evidence_basis when fts_query is active"
+
+
+def test_claim_boundaries_no_fts_evidence_for_metadata_only(mini_index):
+    res = query_core.execute_query(mini_index, query_text="", k=5, filters={"layer": "core"})
+    cb = res["claim_boundaries"]
+    assert "fts_query" not in cb["evidence_basis"], "fts_query should not appear in evidence_basis for metadata-only queries"
+
+
+def test_claim_boundaries_schema_rejects_unknown_evidence(mini_index):
+    import jsonschema
+    from pathlib import Path
+
+    schema_path = Path(__file__).parent.parent / "contracts" / "query-result.v1.schema.json"
+    with schema_path.open("r", encoding="utf-8") as f:
+        schema = json.load(f)
+
+    invalid = {
+        "query": "x", "k": 1, "engine": "fts5", "query_mode": "fts",
+        "applied_filters": {}, "count": 0, "results": [],
+        "claim_boundaries": {
+            "proves": [],
+            "does_not_prove": [],
+            "evidence_basis": ["not_a_valid_source"],
+            "requires_live_check": False
+        }
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=invalid, schema=schema)
+
+
+def test_claim_boundaries_schema_rejects_extra_field(mini_index):
+    import jsonschema
+    from pathlib import Path
+
+    schema_path = Path(__file__).parent.parent / "contracts" / "query-result.v1.schema.json"
+    with schema_path.open("r", encoding="utf-8") as f:
+        schema = json.load(f)
+
+    invalid = {
+        "query": "x", "k": 1, "engine": "fts5", "query_mode": "fts",
+        "applied_filters": {}, "count": 0, "results": [],
+        "claim_boundaries": {
+            "proves": [],
+            "does_not_prove": [],
+            "evidence_basis": ["query"],
+            "requires_live_check": False,
+            "unexpected_extra_field": True
+        }
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=invalid, schema=schema)
+
+
+def test_claim_boundaries_schema_rejects_missing_required_subfield(mini_index):
+    import jsonschema
+    from pathlib import Path
+
+    schema_path = Path(__file__).parent.parent / "contracts" / "query-result.v1.schema.json"
+    with schema_path.open("r", encoding="utf-8") as f:
+        schema = json.load(f)
+
+    invalid = {
+        "query": "x", "k": 1, "engine": "fts5", "query_mode": "fts",
+        "applied_filters": {}, "count": 0, "results": [],
+        "claim_boundaries": {
+            "proves": [],
+            "does_not_prove": []
+        }
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=invalid, schema=schema)


### PR DESCRIPTION
## Summary
This PR adds machine-readable `claim_boundaries` to query results, making explicit what a query result proves, what it does not prove, which evidence sources were used, and whether a live repository check is required for authoritative answers.

## Key Changes
- **Query Core**: Modified `execute_query()` to include a `claim_boundaries` object in all query results containing:
  - `proves`: Statements the result can support (e.g., "These hits were returned by this index under this query and these filters")
  - `does_not_prove`: Explicit disclaimers about what the result cannot claim (absence, ranking semantics, live state, canonical truth)
  - `evidence_basis`: List of evidence sources actually used (query, fts_query, applied_filters, index, result_ranges)
  - `requires_live_check`: Boolean indicating if authoritative answers need live repository access

- **Schema**: Updated `query-result.v1.schema.json` to define the `claim_boundaries` structure with strict validation:
  - Enforces required fields and prevents additional properties
  - Restricts `evidence_basis` to a controlled enum of valid sources
  - Added `warnings` field for non-fatal advisory messages

- **Tests**: Added comprehensive test coverage including:
  - Presence and structure validation of claim_boundaries
  - Content validation of proves/does_not_prove statements
  - Evidence basis inclusion logic (fts_query only when active)
  - Schema validation tests for invalid evidence sources, extra fields, and missing required subfields

- **Documentation**: Added German-language documentation explaining claim boundaries, what they prove/don't prove, and example JSON structure

## Implementation Details
- The `evidence_basis` list is dynamically constructed based on query execution path (fts_query is only included when full-text search is active)
- All query results now include standardized epistemic disclaimers to prevent misinterpretation
- Schema uses `additionalProperties: false` to ensure strict compliance and catch unexpected fields

https://claude.ai/code/session_01R2wCqz1hfg3FntCyEVJYjn