### PR TITLE
Add machine-readable claim_boundaries and warnings to query results, populate in executor, and add tests

### DIFF
--- a/docs/retrieval/recipes.md
+++ b/docs/retrieval/recipes.md
@@ -89,3 +89,37 @@ Index neu bauen, auch wenn er aktuell scheint.
 ```bash
 python -m merger.lenskit.cli index --dump output/my_dump.json --chunk-index output/my_chunks.jsonl --rebuild
 ```
+
+## Query Claim Boundaries
+
+Das rohe Query-Ergebnis (`execute_query` / kein Output-Profile) enthält ein maschinenlesbares `claim_boundaries`-Objekt, das die epistemischen Grenzen des Treffers explizit macht.
+
+**Was ein Treffer beweist:**
+- Dieser Index lieferte unter dieser Query und diesen Filtern diese Treffer.
+
+**Was ein Treffer nicht beweist:**
+- Dass kein nicht gefundener Inhalt im Repository existiert (Abwesenheit eines Treffers ≠ Abwesenheit im Repo).
+- Dass Ranking semantische Wichtigkeit beweist.
+- Dass der Snapshot dem Live-Repository entspricht.
+- Dass Explain-Ausgaben kanonische Wahrheit sind.
+
+Das Feld `evidence_basis` listet die tatsächlich verwendeten Evidenzquellen (z.B. `query`, `fts_query`, `applied_filters`, `index`, `result_ranges`). Das Feld `requires_live_check` gibt an, ob eine autoritative Antwort einen aktuellen Repository-Zugriff erfordert.
+`result_ranges` erscheint nur, wenn Treffer tatsächlich `range_ref` oder `derived_range_ref` enthalten.
+
+Bei projizierten Output-Profilen kann die Rückgabeform ein Context Bundle oder Wrapper sein. Die Weitergabe von `claim_boundaries` in Projektionen ist ein separater Folge-PR, damit das Context-Bundle-Schema nicht still erweitert wird.
+
+```json
+{
+  "claim_boundaries": {
+    "proves": ["These hits were returned by this index under this query and these filters."],
+    "does_not_prove": [
+      "Absence of a hit does not prove absence in the repository.",
+      "Ranking does not prove semantic importance.",
+      "Snapshot query does not prove live repository state.",
+      "Best-effort explain output is diagnostic, not canonical truth."
+    ],
+    "evidence_basis": ["query", "fts_query", "applied_filters", "index"],
+    "requires_live_check": false
+  }
+}
+```

--- a/merger/lenskit/contracts/query-result.v1.schema.json
+++ b/merger/lenskit/contracts/query-result.v1.schema.json
@@ -237,9 +237,64 @@
       "description": "Diagnostic query execution trace.",
       "additionalProperties": true
     },
+    "warnings": {
+      "type": "array",
+      "description": "Non-fatal advisory messages emitted by query execution. These warnings are diagnostic and do not change result validity.",
+      "items": {
+        "type": "string"
+      }
+    },
     "context_bundle": {
       "description": "Optional portable context bundle encapsulating results and expanded textual/structural context.",
       "$ref": "query-context-bundle.v1.schema.json"
+    },
+    "claim_boundaries": {
+      "type": "object",
+      "description": "Machine-readable epistemic boundaries of this raw query result.",
+      "additionalProperties": false,
+      "required": [
+        "proves",
+        "does_not_prove",
+        "evidence_basis",
+        "requires_live_check"
+      ],
+      "properties": {
+        "proves": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Statements this result can support."
+        },
+        "does_not_prove": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Statements this result explicitly cannot support."
+        },
+        "evidence_basis": {
+          "type": "array",
+          "description": "Evidence sources actually used to produce this result.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "query",
+              "fts_query",
+              "applied_filters",
+              "index",
+              "result_ranges",
+              "bundle_manifest",
+              "graph_index",
+              "context_bundle"
+            ]
+          }
+        },
+        "requires_live_check": {
+          "type": "boolean",
+          "description": "Whether authoritative answers require a live repository check beyond this index snapshot."
+        }
+      }
     }
   }
 }

--- a/merger/lenskit/retrieval/query_core.py
+++ b/merger/lenskit/retrieval/query_core.py
@@ -546,6 +546,28 @@ def execute_query(
             out.setdefault("warnings", []).append("Low result coverage")
         if fts_query_str is not None:
             out["fts_query"] = fts_query_str
+        evidence = ["query", "applied_filters", "index"]
+        if fts_query_str is not None:
+            evidence.insert(1, "fts_query")
+        has_result_ranges = any(
+            ("range_ref" in hit) or ("derived_range_ref" in hit)
+            for hit in out.get("results", [])
+        )
+        if has_result_ranges:
+            evidence.append("result_ranges")
+        out["claim_boundaries"] = {
+            "proves": [
+                "These hits were returned by this index under this query and these filters."
+            ],
+            "does_not_prove": [
+                "Absence of a hit does not prove absence in the repository.",
+                "Ranking does not prove semantic importance.",
+                "Snapshot query does not prove live repository state.",
+                "Best-effort explain output is diagnostic, not canonical truth."
+            ],
+            "evidence_basis": evidence,
+            "requires_live_check": False
+        }
 
         if explain:
             explain_block = {}

--- a/merger/lenskit/tests/test_retrieval_query.py
+++ b/merger/lenskit/tests/test_retrieval_query.py
@@ -106,6 +106,20 @@ def test_query_json_structure(mini_index):
     assert "range_ref" not in res3["results"][0]
     assert "derived_range_ref" not in res3["results"][0]
 
+def test_query_schema_allows_low_result_coverage_warning(mini_index):
+    import jsonschema
+    from pathlib import Path
+
+    res = query_core.execute_query(mini_index, query_text="hello", k=5)
+
+    assert "warnings" in res
+    assert "Low result coverage" in res["warnings"]
+
+    schema_path = Path(__file__).parent.parent / "contracts" / "query-result.v1.schema.json"
+    with schema_path.open("r", encoding="utf-8") as f:
+        schema = json.load(f)
+    jsonschema.validate(instance=res, schema=schema)
+
 def test_query_range_ref(tmp_path):
     from merger.lenskit.retrieval import index_db
     import json
@@ -683,3 +697,165 @@ def test_query_uses_stale_graph_runtime_path(mini_index, tmp_path):
     assert diagnostics["graph_used"] is True, "Graph must still be used by policy despite mismatch"
     assert diagnostics["distance"] == 0, "Graph distance must still be projected correctly"
     assert diagnostics["graph_bonus"] > 0, "Graph bonus must actually influence the score"
+
+
+# ---------------------------------------------------------------------------
+# Claim Boundaries
+# ---------------------------------------------------------------------------
+
+def test_claim_boundaries_present(mini_index):
+    import jsonschema
+    from pathlib import Path
+
+    res = query_core.execute_query(mini_index, query_text="hello", k=5)
+    assert "claim_boundaries" in res
+    cb = res["claim_boundaries"]
+    assert isinstance(cb["proves"], list)
+    assert isinstance(cb["does_not_prove"], list)
+    assert isinstance(cb["evidence_basis"], list)
+    assert isinstance(cb["requires_live_check"], bool)
+
+    schema_path = Path(__file__).parent.parent / "contracts" / "query-result.v1.schema.json"
+    with schema_path.open("r", encoding="utf-8") as f:
+        schema = json.load(f)
+    jsonschema.validate(instance=res, schema=schema)
+
+
+def test_claim_boundaries_content(mini_index):
+    res = query_core.execute_query(mini_index, query_text="hello", k=5)
+    cb = res["claim_boundaries"]
+
+    absence_stmt = "Absence of a hit does not prove absence in the repository."
+    ranking_stmt = "Ranking does not prove semantic importance."
+    snapshot_stmt = "Snapshot query does not prove live repository state."
+
+    assert any(absence_stmt in s for s in cb["does_not_prove"]), "Missing absence disclaimer"
+    assert any(ranking_stmt in s for s in cb["does_not_prove"]), "Missing ranking disclaimer"
+    assert any(snapshot_stmt in s for s in cb["does_not_prove"]), "Missing snapshot disclaimer"
+
+    assert cb["requires_live_check"] is False
+    assert "query" in cb["evidence_basis"]
+    assert "applied_filters" in cb["evidence_basis"]
+    assert "index" in cb["evidence_basis"]
+
+
+def test_claim_boundaries_fts_query_evidence(mini_index):
+    res = query_core.execute_query(mini_index, query_text="hello", k=5)
+    cb = res["claim_boundaries"]
+    assert "fts_query" in cb["evidence_basis"], "FTS query should appear in evidence_basis when fts_query is active"
+
+
+def test_claim_boundaries_no_fts_evidence_for_metadata_only(mini_index):
+    res = query_core.execute_query(mini_index, query_text="", k=5, filters={"layer": "core"})
+    cb = res["claim_boundaries"]
+    assert "fts_query" not in cb["evidence_basis"], "fts_query should not appear in evidence_basis for metadata-only queries"
+
+
+def test_claim_boundaries_result_ranges_evidence_when_present(tmp_path):
+    from merger.lenskit.retrieval import index_db
+
+    db_path = tmp_path / "index.sqlite"
+    dump_path = tmp_path / "dump.json"
+    chunk_path = tmp_path / "chunks.jsonl"
+
+    ref_obj = {
+        "artifact_role": "canonical_md",
+        "repo_id": "r1",
+        "file_path": "merged.md",
+        "start_byte": 0,
+        "end_byte": 10,
+        "start_line": 1,
+        "end_line": 1,
+        "content_sha256": "h1"
+    }
+
+    chunk_data = [
+        {
+            "chunk_id": "c1", "repo_id": "r1", "path": "src/main.py", "content": "def main(): print('hello')",
+            "start_line": 1, "end_line": 1, "layer": "core", "artifact_type": "code", "content_sha256": "h1",
+            "content_range_ref": ref_obj,
+            "start_byte": 0, "end_byte": 10, "source_file": "src/main.py"
+        }
+    ]
+    with chunk_path.open("w", encoding="utf-8") as f:
+        for c in chunk_data:
+            f.write(json.dumps(c) + "\n")
+    dump_path.write_text(json.dumps({"dummy": "data"}), encoding="utf-8")
+    index_db.build_index(dump_path, chunk_path, db_path)
+
+    res = query_core.execute_query(db_path, query_text="hello", k=1)
+    assert "result_ranges" in res["claim_boundaries"]["evidence_basis"]
+
+
+def test_claim_boundaries_result_ranges_evidence_absent_when_no_range_refs(mini_index):
+    res = query_core.execute_query(mini_index, query_text="hello", k=5)
+    assert "result_ranges" not in res["claim_boundaries"]["evidence_basis"]
+
+    zero = query_core.execute_query(mini_index, query_text="zebra", k=5)
+    assert zero["count"] == 0
+    assert "result_ranges" not in zero["claim_boundaries"]["evidence_basis"]
+
+
+def test_claim_boundaries_schema_rejects_unknown_evidence(mini_index):
+    import jsonschema
+    from pathlib import Path
+
+    schema_path = Path(__file__).parent.parent / "contracts" / "query-result.v1.schema.json"
+    with schema_path.open("r", encoding="utf-8") as f:
+        schema = json.load(f)
+
+    invalid = {
+        "query": "x", "k": 1, "engine": "fts5", "query_mode": "fts",
+        "applied_filters": {}, "count": 0, "results": [],
+        "claim_boundaries": {
+            "proves": [],
+            "does_not_prove": [],
+            "evidence_basis": ["not_a_valid_source"],
+            "requires_live_check": False
+        }
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=invalid, schema=schema)
+
+
+def test_claim_boundaries_schema_rejects_extra_field(mini_index):
+    import jsonschema
+    from pathlib import Path
+
+    schema_path = Path(__file__).parent.parent / "contracts" / "query-result.v1.schema.json"
+    with schema_path.open("r", encoding="utf-8") as f:
+        schema = json.load(f)
+
+    invalid = {
+        "query": "x", "k": 1, "engine": "fts5", "query_mode": "fts",
+        "applied_filters": {}, "count": 0, "results": [],
+        "claim_boundaries": {
+            "proves": [],
+            "does_not_prove": [],
+            "evidence_basis": ["query"],
+            "requires_live_check": False,
+            "unexpected_extra_field": True
+        }
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=invalid, schema=schema)
+
+
+def test_claim_boundaries_schema_rejects_missing_required_subfield(mini_index):
+    import jsonschema
+    from pathlib import Path
+
+    schema_path = Path(__file__).parent.parent / "contracts" / "query-result.v1.schema.json"
+    with schema_path.open("r", encoding="utf-8") as f:
+        schema = json.load(f)
+
+    invalid = {
+        "query": "x", "k": 1, "engine": "fts5", "query_mode": "fts",
+        "applied_filters": {}, "count": 0, "results": [],
+        "claim_boundaries": {
+            "proves": [],
+            "does_not_prove": []
+        }
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=invalid, schema=schema)


### PR DESCRIPTION
### Motivation
- Provide explicit, machine-readable epistemic boundaries for raw query results so callers (agents) can understand what a hit does and does not prove.
- Surface non-fatal advisory diagnostics via a `warnings` array to communicate heuristic conditions like low coverage.
- Make the behavior and schema of query responses verifiable by automated validation and tests.

### Description
- Add a `claim_boundaries` object to the query result schema (`merger/lenskit/contracts/query-result.v1.schema.json`) with required fields `proves`, `does_not_prove`, `evidence_basis`, and `requires_live_check`, and enumerate allowed evidence sources.
- Add a `warnings` array to the schema and update `execute_query` in `merger/lenskit/retrieval/query_core.py` to emit a "Low result coverage" warning and to construct the `claim_boundaries` payload (including detection of `fts_query` and `result_ranges` evidence).
- Update docs (`docs/retrieval/recipes.md`) with a new section describing the `claim_boundaries` semantics and an example JSON fragment.
- Add comprehensive tests in `merger/lenskit/tests/test_retrieval_query.py` that validate the presence, content, and schema conformance of `warnings` and `claim_boundaries`, including cases for `fts_query`, `result_ranges`, and schema rejection of invalid values or extra fields.

### Testing
- Ran the retrieval query unit tests in `merger/lenskit/tests/test_retrieval_query.py` using `pytest`, covering new `claim_boundaries` and `warnings` behaviors and JSON Schema validation.
- Tests validated that `claim_boundaries` is present with expected fields and contents for multiple scenarios and that schema validation accepts valid responses and rejects invalid ones.
- All modified and new tests passed under the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f04528b52c832c9774719af91cb87b)