### PR TITLE
Claim boundaries: record graph evidence only when used and mark snapshot results as requiring live check

### DIFF
--- a/docs/retrieval/recipes.md
+++ b/docs/retrieval/recipes.md
@@ -103,7 +103,8 @@ Das rohe Query-Ergebnis (`execute_query` / kein Output-Profile) enthält ein mas
 - Dass der Snapshot dem Live-Repository entspricht.
 - Dass Explain-Ausgaben kanonische Wahrheit sind.
 
-Das Feld `evidence_basis` listet die tatsächlich verwendeten Evidenzquellen (z.B. `query`, `fts_query`, `applied_filters`, `index`, `result_ranges`). Das Feld `requires_live_check` gibt an, ob eine autoritative Antwort einen aktuellen Repository-Zugriff erfordert.
+Das Feld `evidence_basis` listet die tatsächlich verwendeten Evidenzquellen (z.B. `query`, `fts_query`, `applied_filters`, `index`, `result_ranges`). `graph_index` erscheint in `evidence_basis`, wenn Graph-Scoring tatsächlich verwendet wurde.
+`requires_live_check` ist bei Snapshot-basierten Query-Ergebnissen `true`, weil das Ergebnis nur den Indexzustand belegt. Für eine autoritative Aussage über den aktuellen Live-Repository-Zustand muss das Repository selbst geprüft werden.
 `result_ranges` erscheint nur, wenn Treffer tatsächlich `range_ref` oder `derived_range_ref` enthalten.
 
 Bei projizierten Output-Profilen kann die Rückgabeform ein Context Bundle oder Wrapper sein. Die Weitergabe von `claim_boundaries` in Projektionen ist ein separater Folge-PR, damit das Context-Bundle-Schema nicht still erweitert wird.
@@ -119,7 +120,7 @@ Bei projizierten Output-Profilen kann die Rückgabeform ein Context Bundle oder 
       "Best-effort explain output is diagnostic, not canonical truth."
     ],
     "evidence_basis": ["query", "fts_query", "applied_filters", "index"],
-    "requires_live_check": false
+    "requires_live_check": true
   }
 }
 ```

--- a/merger/lenskit/retrieval/query_core.py
+++ b/merger/lenskit/retrieval/query_core.py
@@ -555,6 +555,12 @@ def execute_query(
         )
         if has_result_ranges:
             evidence.append("result_ranges")
+        graph_used_in_results = any(
+            hit.get("why", {}).get("diagnostics", {}).get("graph", {}).get("graph_used") is True
+            for hit in out.get("results", [])
+        )
+        if graph_used_in_results:
+            evidence.append("graph_index")
         out["claim_boundaries"] = {
             "proves": [
                 "These hits were returned by this index under this query and these filters."
@@ -566,7 +572,7 @@ def execute_query(
                 "Best-effort explain output is diagnostic, not canonical truth."
             ],
             "evidence_basis": evidence,
-            "requires_live_check": False
+            "requires_live_check": True
         }
 
         if explain:

--- a/merger/lenskit/tests/test_retrieval_query.py
+++ b/merger/lenskit/tests/test_retrieval_query.py
@@ -697,6 +697,8 @@ def test_query_uses_stale_graph_runtime_path(mini_index, tmp_path):
     assert diagnostics["graph_used"] is True, "Graph must still be used by policy despite mismatch"
     assert diagnostics["distance"] == 0, "Graph distance must still be projected correctly"
     assert diagnostics["graph_bonus"] > 0, "Graph bonus must actually influence the score"
+    assert "graph_index" in res["claim_boundaries"]["evidence_basis"], "Claim boundaries must record graph evidence usage"
+    assert res["claim_boundaries"]["requires_live_check"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -733,7 +735,7 @@ def test_claim_boundaries_content(mini_index):
     assert any(ranking_stmt in s for s in cb["does_not_prove"]), "Missing ranking disclaimer"
     assert any(snapshot_stmt in s for s in cb["does_not_prove"]), "Missing snapshot disclaimer"
 
-    assert cb["requires_live_check"] is False
+    assert cb["requires_live_check"] is True
     assert "query" in cb["evidence_basis"]
     assert "applied_filters" in cb["evidence_basis"]
     assert "index" in cb["evidence_basis"]
@@ -794,6 +796,52 @@ def test_claim_boundaries_result_ranges_evidence_absent_when_no_range_refs(mini_
     zero = query_core.execute_query(mini_index, query_text="zebra", k=5)
     assert zero["count"] == 0
     assert "result_ranges" not in zero["claim_boundaries"]["evidence_basis"]
+
+
+def test_claim_boundaries_graph_index_evidence_when_graph_used(mini_index, tmp_path, monkeypatch):
+    graph_index_path = tmp_path / "graph_index.json"
+    graph_index = {
+        "distances": {
+            "file:tests/test_main.py": 0,
+            "file:src/main.py": 1
+        }
+    }
+    graph_index_path.write_text(json.dumps(graph_index), encoding="utf-8")
+
+    def mock_load(path, expected_sha256=None):
+        return {"status": "ok", "graph": graph_index}
+
+    monkeypatch.setattr(query_core, "load_graph_index", mock_load)
+
+    res = query_core.execute_query(
+        mini_index,
+        query_text="def",
+        k=2,
+        explain=True,
+        graph_index_path=graph_index_path,
+    )
+
+    assert "graph_index" in res["claim_boundaries"]["evidence_basis"]
+
+
+def test_claim_boundaries_no_graph_index_evidence_when_graph_not_used(mini_index, tmp_path, monkeypatch):
+    graph_index_path = tmp_path / "graph_index.json"
+    graph_index_path.write_text("{}", encoding="utf-8")
+
+    def mock_load(path, expected_sha256=None):
+        return {"status": "invalid_schema", "graph": None}
+
+    monkeypatch.setattr(query_core, "load_graph_index", mock_load)
+
+    res = query_core.execute_query(
+        mini_index,
+        query_text="def",
+        k=2,
+        explain=True,
+        graph_index_path=graph_index_path,
+    )
+
+    assert "graph_index" not in res["claim_boundaries"]["evidence_basis"]
 
 
 def test_claim_boundaries_schema_rejects_unknown_evidence(mini_index):


### PR DESCRIPTION
### Motivation
- Make raw query results include a machine-readable `claim_boundaries` object that accurately records which evidence sources were actually used.  
- Ensure `graph_index` is only listed in `evidence_basis` when graph scoring was actually applied to returned hits.  
- Treat snapshot/index-based query outputs as requiring a live repository check for authoritative answers.  
- Align documentation and tests with the runtime behavior so consumers and guards can rely on the schema.

### Description
- Update `merger/lenskit/retrieval/query_core.py` to build an `evidence` list, detect `result_ranges` and whether any returned hit used graph scoring (`graph_used`), append `graph_index` only when used, and set `claim_boundaries.requires_live_check` to `true`.  
- Update retrieval docs `docs/retrieval/recipes.md` to mention `graph_index` appears only when graph-scoring is used and to show `requires_live_check: true` for snapshot results.  
- Extend and adjust tests in `merger/lenskit/tests/test_retrieval_query.py` to assert presence/absence of `graph_index` in `claim_boundaries.evidence_basis`, to validate `requires_live_check` semantics, and to keep the schema and warning checks (including the low-result-coverage warning).  
- No changes to public JSON contract files in this patchset beyond aligning behavior/tests/docs (runtime code and tests were the primary edits).

### Testing
- Ran targeted tests with `PYTHONPATH=. pytest -q merger/lenskit/tests/test_retrieval_query.py -k 'claim_boundaries or low_result_coverage_warning or stale_graph_runtime_path'` which succeeded.  
- An initial run without `PYTHONPATH` failed during collection with `ModuleNotFoundError: No module named 'merger'`, which is an environment invocation issue rather than a code failure.  
- Final test run produced `13 passed, 22 deselected` for the selected test subset.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0726dbe44832ca0539b9af4311a8a)