### PR TITLE
Add machine-readable `claim_boundaries` to retrieval eval output, schema, docs, and tests

### DIFF
--- a/docs/retrieval/recipes.md
+++ b/docs/retrieval/recipes.md
@@ -90,6 +90,47 @@ Index neu bauen, auch wenn er aktuell scheint.
 python -m merger.lenskit.cli index --dump output/my_dump.json --chunk-index output/my_chunks.jsonl --rebuild
 ```
 
+## Retrieval Eval Claim Boundaries
+
+Eval-Metriken (`recall@k`, `MRR`, `zero_hit_ratio`) sind maschinenlesbar, aber sie tragen eine implizite Richterrobe. Das `claim_boundaries`-Objekt macht die epistemischen Grenzen des Eval-Outputs explizit.
+
+**Was Eval-Metriken beweisen:**
+- Die Metriken wurden für dieses Eval-Set gegen diesen Index und diese Query-Pipeline berechnet.
+
+**Was Eval-Metriken nicht beweisen:**
+- Recall auf diesem Eval-Set beweist keine allgemeine Retrieval-Qualität.
+- Zero-hit-Ratio beweist keine Abwesenheit relevanter Inhalte im Repository.
+- MRR beweist keine semantische Korrektheit.
+- Eval-Ergebnisse beweisen keinen aktuellen Live-Repository-Zustand.
+
+`requires_live_check: true` gilt immer, weil Eval-Ergebnisse auf einem Index-Snapshot basieren. Für autoritative Aussagen über den aktuellen Repo-Zustand muss das Repository selbst geprüft werden.
+
+`evidence_basis` listet die tatsächlich verwendeten Evidenzquellen. `graph_index` erscheint nur, wenn Graph-basiertes Scoring tatsächlich im Eval-Pfad verwendet wurde.
+
+```json
+{
+  "claim_boundaries": {
+    "proves": [
+      "These metrics were computed for this eval set against this index and query pipeline."
+    ],
+    "does_not_prove": [
+      "Recall on this eval set does not prove general retrieval quality.",
+      "Zero-hit ratio does not prove absence of relevant repository content.",
+      "MRR does not prove semantic correctness.",
+      "Eval results do not prove live repository state."
+    ],
+    "evidence_basis": [
+      "eval_queries",
+      "expected_targets",
+      "query_results",
+      "index",
+      "retrieval_metrics"
+    ],
+    "requires_live_check": true
+  }
+}
+```
+
 ## Query Claim Boundaries
 
 Das rohe Query-Ergebnis (`execute_query` / kein Output-Profile) enthält ein maschinenlesbares `claim_boundaries`-Objekt, das die epistemischen Grenzen des Treffers explizit macht.

--- a/docs/retrieval/retrieval_eval.example.json
+++ b/docs/retrieval/retrieval_eval.example.json
@@ -191,5 +191,24 @@
       "found_count": 1,
       "top_results": ["Dockerfile"]
     }
-  ]
+  ],
+  "claim_boundaries": {
+    "proves": [
+      "These metrics were computed for this eval set against this index and query pipeline."
+    ],
+    "does_not_prove": [
+      "Recall on this eval set does not prove general retrieval quality.",
+      "Zero-hit ratio does not prove absence of relevant repository content.",
+      "MRR does not prove semantic correctness.",
+      "Eval results do not prove live repository state."
+    ],
+    "evidence_basis": [
+      "eval_queries",
+      "expected_targets",
+      "query_results",
+      "index",
+      "retrieval_metrics"
+    ],
+    "requires_live_check": true
+  }
 }

--- a/merger/lenskit/contracts/retrieval-eval.v1.schema.json
+++ b/merger/lenskit/contracts/retrieval-eval.v1.schema.json
@@ -256,10 +256,52 @@
           "expected"
         ]
       }
+    },
+    "claim_boundaries": {
+      "type": "object",
+      "description": "Machine-readable epistemic boundaries of the evaluation output.",
+      "additionalProperties": false,
+      "required": [
+        "proves",
+        "does_not_prove",
+        "evidence_basis",
+        "requires_live_check"
+      ],
+      "properties": {
+        "proves": {
+          "type": "array",
+          "items": {"type": "string"},
+          "minItems": 1
+        },
+        "does_not_prove": {
+          "type": "array",
+          "items": {"type": "string"},
+          "minItems": 1
+        },
+        "evidence_basis": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "eval_queries",
+              "expected_targets",
+              "query_results",
+              "index",
+              "retrieval_metrics",
+              "graph_index"
+            ]
+          },
+          "minItems": 1
+        },
+        "requires_live_check": {
+          "type": "boolean"
+        }
+      }
     }
   },
   "required": [
     "metrics",
-    "details"
+    "details",
+    "claim_boundaries"
   ]
 }

--- a/merger/lenskit/retrieval/eval_core.py
+++ b/merger/lenskit/retrieval/eval_core.py
@@ -192,6 +192,7 @@ def do_eval(
     total_queries = len(gold_queries)
     results_detail = []
     category_stats: Dict[str, Dict[str, Any]] = {}
+    graph_index_used = False
 
     for q in gold_queries:
         q_text = q["query"]
@@ -216,6 +217,8 @@ def do_eval(
                     s_rel, s_match, s_why, s_paths, s_count, s_rr, s_res = evaluate_single_run(
                         q_text, filters, expected, index_path, k, embedding_policy, graph_index_path, graph_weights
                     )
+                    if "graph_index" in s_res.get("claim_boundaries", {}).get("evidence_basis", []):
+                        graph_index_used = True
                 except Exception as e:
                     # We catch a broad Exception here intentionally. This guarantees that absolutely any
                     # catastrophic failure in the semantic path (e.g. OOM, bad schema, model crash)
@@ -386,6 +389,10 @@ def do_eval(
                 print(f"  {cat} Recall@{k}: {stats[f'recall@{k}']:.1f}% | MRR: {stats['MRR']:.3f}")
         print("-" * 80 if compare_mode else "-" * 60)
 
+    evidence_basis = ["eval_queries", "expected_targets", "query_results", "index", "retrieval_metrics"]
+    if graph_index_used:
+        evidence_basis.append("graph_index")
+
     out = {
         "metrics": {
             f"recall@{k}": sem_recall_at_k if compare_mode else base_recall_at_k,
@@ -399,7 +406,20 @@ def do_eval(
             "zero_hit_ratio": zero_hit_ratio,
             "categories": category_stats
         },
-        "details": results_detail
+        "details": results_detail,
+        "claim_boundaries": {
+            "proves": [
+                "These metrics were computed for this eval set against this index and query pipeline."
+            ],
+            "does_not_prove": [
+                "Recall on this eval set does not prove general retrieval quality.",
+                "Zero-hit ratio does not prove absence of relevant repository content.",
+                "MRR does not prove semantic correctness.",
+                "Eval results do not prove live repository state."
+            ],
+            "evidence_basis": evidence_basis,
+            "requires_live_check": True
+        }
     }
 
     if compare_mode:

--- a/merger/lenskit/tests/test_retrieval_eval.py
+++ b/merger/lenskit/tests/test_retrieval_eval.py
@@ -320,6 +320,202 @@ def test_run_eval_invalid_threshold_fails(mini_index_for_eval, tmp_path, capsys)
     captured = capsys.readouterr()
     assert "Error: Invalid recall_at_5 threshold (80.0). accept_criteria must use a ratio between 0.0 and 1.0." in captured.err
 
+
+def test_retrieval_eval_claim_boundaries_present(mini_index_for_eval, tmp_path):
+    queries_json = tmp_path / "eval_queries.json"
+    queries_json.write_text(json.dumps([
+        {"query": "login", "expected_patterns": ["login.py"]}
+    ]), encoding="utf-8")
+
+    out = eval_core.do_eval(
+        index_path=Path(mini_index_for_eval),
+        queries_path=queries_json,
+        k=5,
+        is_json_mode=True,
+        is_stale=False
+    )
+
+    assert "claim_boundaries" in out
+    cb = out["claim_boundaries"]
+    assert cb["requires_live_check"] is True
+    standard_sources = {"eval_queries", "expected_targets", "query_results", "index", "retrieval_metrics"}
+    assert standard_sources.issubset(set(cb["evidence_basis"]))
+    assert "graph_index" not in cb["evidence_basis"]
+
+
+def test_retrieval_eval_claim_boundaries_schema_valid(mini_index_for_eval, tmp_path):
+    import jsonschema
+
+    queries_json = tmp_path / "eval_queries.json"
+    queries_json.write_text(json.dumps([
+        {"query": "login", "expected_patterns": ["login.py"]}
+    ]), encoding="utf-8")
+
+    out = eval_core.do_eval(
+        index_path=Path(mini_index_for_eval),
+        queries_path=queries_json,
+        k=5,
+        is_json_mode=True,
+        is_stale=False
+    )
+
+    base_dir = Path(__file__).resolve().parent.parent
+    schema_path = base_dir / "contracts" / "retrieval-eval.v1.schema.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    jsonschema.validate(instance=out, schema=schema)
+
+
+def test_retrieval_eval_claim_boundaries_reject_unknown_evidence():
+    import jsonschema
+
+    base_dir = Path(__file__).resolve().parent.parent
+    schema_path = base_dir / "contracts" / "retrieval-eval.v1.schema.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+
+    invalid_output = {
+        "metrics": {"total_queries": 1, "hits": 0, "stale_flag": False},
+        "details": [],
+        "claim_boundaries": {
+            "proves": ["x"],
+            "does_not_prove": ["y"],
+            "evidence_basis": ["not_a_valid_source"],
+            "requires_live_check": True
+        }
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=invalid_output, schema=schema)
+
+
+def test_retrieval_eval_claim_boundaries_reject_extra_field():
+    import jsonschema
+
+    base_dir = Path(__file__).resolve().parent.parent
+    schema_path = base_dir / "contracts" / "retrieval-eval.v1.schema.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+
+    invalid_output = {
+        "metrics": {"total_queries": 1, "hits": 0, "stale_flag": False},
+        "details": [],
+        "claim_boundaries": {
+            "proves": ["x"],
+            "does_not_prove": ["y"],
+            "evidence_basis": ["eval_queries"],
+            "requires_live_check": True,
+            "unknown_extra_field": "should_fail"
+        }
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=invalid_output, schema=schema)
+
+
+def test_retrieval_eval_claim_boundaries_reject_missing_required_subfield():
+    import jsonschema
+
+    base_dir = Path(__file__).resolve().parent.parent
+    schema_path = base_dir / "contracts" / "retrieval-eval.v1.schema.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+
+    invalid_output = {
+        "metrics": {"total_queries": 1, "hits": 0, "stale_flag": False},
+        "details": [],
+        "claim_boundaries": {
+            "proves": ["x"],
+            "does_not_prove": ["y"],
+            "evidence_basis": ["eval_queries"]
+            # requires_live_check missing
+        }
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=invalid_output, schema=schema)
+
+
+def test_retrieval_eval_schema_rejects_missing_claim_boundaries():
+    import jsonschema
+
+    base_dir = Path(__file__).resolve().parent.parent
+    schema_path = base_dir / "contracts" / "retrieval-eval.v1.schema.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+
+    invalid_output = {
+        "metrics": {"total_queries": 1, "hits": 0, "stale_flag": False},
+        "details": []
+    }
+
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=invalid_output, schema=schema)
+
+
+def _build_eval_env(tmp_path, graph_index_content=None, graph_invalid=False):
+    dump_path = tmp_path / "dump.json"
+    chunk_path = tmp_path / "chunks.jsonl"
+    db_path = tmp_path / "index.sqlite"
+    queries_path = tmp_path / "queries.json"
+
+    chunk_data = [
+        {"chunk_id": "c1", "repo_id": "r1", "path": "src/entry.py", "content": "def main(): pass", "start_line": 1, "end_line": 1, "layer": "core", "artifact_type": "code", "content_sha256": "h1"},
+    ]
+    with chunk_path.open("w", encoding="utf-8") as f:
+        for c in chunk_data:
+            f.write(json.dumps(c) + "\n")
+
+    dump_path.write_text(json.dumps({"dummy": "data"}), encoding="utf-8")
+    index_db.build_index(dump_path, chunk_path, db_path)
+
+    queries_path.write_text(json.dumps([
+        {"query": "main", "expected_patterns": ["entry.py"]}
+    ]), encoding="utf-8")
+
+    graph_path = None
+    if graph_invalid:
+        graph_path = tmp_path / "bad_graph.json"
+        graph_path.write_text("{bad json")
+    elif graph_index_content is not None:
+        graph_path = tmp_path / "graph_index.json"
+        graph_path.write_text(json.dumps(graph_index_content), encoding="utf-8")
+
+    return db_path, queries_path, graph_path
+
+
+def test_retrieval_eval_claim_boundaries_graph_absent_when_graph_load_fails(tmp_path):
+    db_path, queries_path, graph_path = _build_eval_env(tmp_path, graph_invalid=True)
+
+    out = eval_core.do_eval(
+        index_path=db_path,
+        queries_path=queries_path,
+        k=5,
+        is_json_mode=True,
+        is_stale=False,
+        graph_index_path=graph_path
+    )
+
+    assert out is not None
+    assert "graph_index" not in out["claim_boundaries"]["evidence_basis"]
+
+
+def test_retrieval_eval_claim_boundaries_graph_present_when_graph_actually_used(tmp_path):
+    valid_graph = {
+        "kind": "lenskit.architecture.graph_index",
+        "version": "1.0",
+        "run_id": "test",
+        "canonical_dump_index_sha256": "0" * 64,
+        "distances": {"file:src/entry.py": 0},
+        "metrics": {"entrypoint_count": 1, "nodes_reachable": 1, "unreachable_nodes": 0}
+    }
+    db_path, queries_path, graph_path = _build_eval_env(tmp_path, graph_index_content=valid_graph)
+
+    out = eval_core.do_eval(
+        index_path=db_path,
+        queries_path=queries_path,
+        k=5,
+        is_json_mode=True,
+        is_stale=False,
+        graph_index_path=graph_path
+    )
+
+    assert out is not None
+    assert "graph_index" in out["claim_boundaries"]["evidence_basis"]
+
+
 def test_run_eval_explain_always_present_on_error(mini_index_for_eval, tmp_path, capsys, monkeypatch):
     queries_json = tmp_path / "eval_queries.json"
     queries_json.write_text(json.dumps([

--- a/merger/lenskit/tests/test_retrieval_eval.py
+++ b/merger/lenskit/tests/test_retrieval_eval.py
@@ -25,6 +25,12 @@ def mini_index_for_eval(tmp_path):
     index_db.build_index(dump_path, chunk_path, db_path)
     return db_path
 
+
+def _load_retrieval_eval_schema():
+    schema_path = Path(__file__).resolve().parent.parent / "contracts" / "retrieval-eval.v1.schema.json"
+    return json.loads(schema_path.read_text(encoding="utf-8"))
+
+
 def test_parse_gold_queries_basic(tmp_path):
     md_file = tmp_path / "queries.md"
     md_content = """
@@ -158,9 +164,7 @@ def test_schema_validation(mini_index_for_eval, tmp_path):
         is_stale=False
     )
 
-    base_dir = Path(__file__).resolve().parent.parent
-    schema_path = base_dir / "contracts" / "retrieval-eval.v1.schema.json"
-    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    schema = _load_retrieval_eval_schema()
 
     jsonschema.validate(instance=out, schema=schema)
 
@@ -175,12 +179,10 @@ def test_schema_smoke():
     # target: merger/lenskit/contracts/retrieval-eval.v1.schema.json
     # ../../contracts/
 
-    base_dir = Path(__file__).resolve().parent.parent
-    schema_path = base_dir / "contracts" / "retrieval-eval.v1.schema.json"
-
+    schema_path = Path(__file__).resolve().parent.parent / "contracts" / "retrieval-eval.v1.schema.json"
     assert schema_path.exists(), f"Schema file missing at expected path: {schema_path}"
 
-    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    schema = _load_retrieval_eval_schema()
     assert "metrics" in schema["properties"]
     assert "details" in schema["properties"]
 
@@ -359,18 +361,14 @@ def test_retrieval_eval_claim_boundaries_schema_valid(mini_index_for_eval, tmp_p
         is_stale=False
     )
 
-    base_dir = Path(__file__).resolve().parent.parent
-    schema_path = base_dir / "contracts" / "retrieval-eval.v1.schema.json"
-    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    schema = _load_retrieval_eval_schema()
     jsonschema.validate(instance=out, schema=schema)
 
 
 def test_retrieval_eval_claim_boundaries_reject_unknown_evidence():
     import jsonschema
 
-    base_dir = Path(__file__).resolve().parent.parent
-    schema_path = base_dir / "contracts" / "retrieval-eval.v1.schema.json"
-    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    schema = _load_retrieval_eval_schema()
 
     invalid_output = {
         "metrics": {"total_queries": 1, "hits": 0, "stale_flag": False},
@@ -389,9 +387,7 @@ def test_retrieval_eval_claim_boundaries_reject_unknown_evidence():
 def test_retrieval_eval_claim_boundaries_reject_extra_field():
     import jsonschema
 
-    base_dir = Path(__file__).resolve().parent.parent
-    schema_path = base_dir / "contracts" / "retrieval-eval.v1.schema.json"
-    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    schema = _load_retrieval_eval_schema()
 
     invalid_output = {
         "metrics": {"total_queries": 1, "hits": 0, "stale_flag": False},
@@ -411,9 +407,7 @@ def test_retrieval_eval_claim_boundaries_reject_extra_field():
 def test_retrieval_eval_claim_boundaries_reject_missing_required_subfield():
     import jsonschema
 
-    base_dir = Path(__file__).resolve().parent.parent
-    schema_path = base_dir / "contracts" / "retrieval-eval.v1.schema.json"
-    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    schema = _load_retrieval_eval_schema()
 
     invalid_output = {
         "metrics": {"total_queries": 1, "hits": 0, "stale_flag": False},
@@ -432,9 +426,7 @@ def test_retrieval_eval_claim_boundaries_reject_missing_required_subfield():
 def test_retrieval_eval_schema_rejects_missing_claim_boundaries():
     import jsonschema
 
-    base_dir = Path(__file__).resolve().parent.parent
-    schema_path = base_dir / "contracts" / "retrieval-eval.v1.schema.json"
-    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    schema = _load_retrieval_eval_schema()
 
     invalid_output = {
         "metrics": {"total_queries": 1, "hits": 0, "stale_flag": False},


### PR DESCRIPTION
### Motivation
- Make the epistemic limits of retrieval evaluation explicit and machine-readable so consumers can understand what eval metrics do and do not prove. 
- Surface which evidence sources were used for an eval (including whether a graph index was actually used) so downstream tooling can make informed decisions.
- Ensure outputs conform to a schema and are validated by automated tests.

### Description
- Add a `claim_boundaries` object to `do_eval` output containing `proves`, `does_not_prove`, `evidence_basis`, and `requires_live_check`, and include it in the JSON eval payload. 
- Track whether a provided `graph_index` was actually used during semantic scoring and include `graph_index` in `evidence_basis` only when applicable. 
- Extend the JSON schema `merger/lenskit/contracts/retrieval-eval.v1.schema.json` to require and validate `claim_boundaries`, restrict allowed `evidence_basis` values, and forbid unknown extra fields. 
- Update documentation (`docs/retrieval/recipes.md` and `docs/retrieval/retrieval_eval.example.json`) to describe the new `claim_boundaries` semantics and show an example. 
- Add unit tests in `merger/lenskit/tests/test_retrieval_eval.py` to assert presence of `claim_boundaries`, schema validation, rejection of invalid evidence values and extra fields, and correct behavior around graph index loading and usage.

### Testing
- Ran the modified retrieval eval tests with `pytest merger/lenskit/tests/test_retrieval_eval.py`, including schema validation via `jsonschema.validate`, and all tests passed. 
- Exercise paths where a graph index is absent, present, or fails to load to confirm `evidence_basis` contains `graph_index` only when actually used, and those tests passed. 
- Ran schema validation tests that assert invalid outputs raise `jsonschema.ValidationError`, and those tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f07f7fd244832ca827443b13438b74)