### PR TITLE
Annotate retrieval_eval_json and graph_index_json authority

### DIFF
--- a/docs/architecture/artifact-inventory.md
+++ b/docs/architecture/artifact-inventory.md
@@ -21,12 +21,12 @@ Dateiendung ist Kleidung; Autorität ist Identität.
 | `<stem>.dump_index.json` | `dump_index_json` | `navigation_index` | `index_only` | `core.merge` | `retrieval.index_db` | - | Ja | Initialer Index-Bau |
 | `<stem>.json` (Sidecar) | `index_sidecar_json` | `navigation_index` | `index_only` | `core.merge` | Agents, WebUI, CLI, Lenskit Service | `bundle-manifest.v1.schema.json` | Meta | Verknüpfung der Artefakte |
 | `<base>.derived_index.json` | `derived_manifest_json` | `navigation_index` | `derived` | `core.merge` | Bundle-Konsumenten | - | Ja | Verlinkt abgeleitete Artefakte |
-| `<stem>.graph_index.json` | `graph_index_json` | _(Phase 1: nicht annotiert)_ | _(Phase 1: nicht annotiert)_ | `architecture.graph_index` | `retrieval.query_core`, `eval_core` | `architecture.graph_index.v1.schema.json` | Ja | Graph Penalty/Bonus, Semantic Eval |
-| `<stem>_architecture.md` | `architecture_summary` | _(Phase 1: nicht annotiert)_ | _(Phase 1: nicht annotiert)_ | `write_reports_v2` / `generate_architecture_summary` | Mensch, LLMs, Report-Konsumenten | - | Nein (nicht im Bundle Manifest) | Lesbare Architektur-Zusammenfassung |
+| `<stem>.graph_index.json` | `graph_index_json` | `retrieval_index` | `derived` | `architecture.graph_index` | `retrieval.query_core`, `eval_core` | `architecture.graph_index.v1.schema.json` | Ja | Graph Penalty/Bonus, Semantic Eval |
+| `<stem>_architecture.md` | `architecture_summary` | _(Schema-Zukunftsform: `diagnostic_signal`)_ | _(Schema-Zukunftsform: `diagnostic`)_ | `write_reports_v2` / `generate_architecture_summary` | Mensch, LLMs, Report-Konsumenten | - | Nein (nicht im Bundle Manifest) | Lesbare Architektur-Zusammenfassung |
 | `query_context_bundle.json`| - (Runtime Payload) | _(Phase 4)_ | _(Phase 4)_ | `retrieval.query_core` | CLI, WebUI, Agents | `query-context-bundle.v1.schema.json` | Nein (Runtime Output) | Context Expansion, UI Display |
 | `query_trace.json` | - (Runtime Payload) | _(Phase 4)_ | _(Phase 4)_ | `retrieval.query_core` | Debug CLI, Evaluatoren | extrahiert aus `query-result.v1.schema.json` | Nein (Runtime Output) | Ranking-Analyse (via `--trace`) |
-| `<stem>.retrieval_eval.json` | `retrieval_eval_json` | _(Phase 1: nicht annotiert)_ | _(Phase 1: nicht annotiert)_ | `retrieval.eval_core` | CI, Entwickler | `retrieval-eval.v1.schema.json` | Optional | Evaluierungsmetriken |
-| `pr-schau-delta.json` | `delta_json` | _(Phase 1: nicht annotiert)_ | _(Phase 1: nicht annotiert)_ | `core.pr_schau_bundle` | PR-Schau Frontends, Agents | `pr-schau-delta.v1.schema.json` | Optional | Code-Review Differentials |
+| `<stem>.retrieval_eval.json` | `retrieval_eval_json` | `diagnostic_signal` | `diagnostic` | `retrieval.eval_core` | CI, Entwickler | `retrieval-eval.v1.schema.json` | Ja (wenn vorhanden) | Evaluierungsmetriken |
+| `pr-schau-delta.json` | `delta_json` | _(Schema-Zukunftsform: `diagnostic_signal`)_ | _(Schema-Zukunftsform: `diagnostic`)_ | `core.pr_schau_bundle` (separater pr-schau-Bundle, nicht `bundle-manifest.v1`) | PR-Schau Frontends, Agents | `pr-schau-delta.v1.schema.json` | Nein (nicht im `bundle-manifest.v1`) | Code-Review Differentials |
 | `<stem>.entrypoints.json` | - (Hilfs-/Zwischenartefakt) | _(Phase 1: nicht annotiert)_ | _(Phase 1: nicht annotiert)_ | `architecture.entrypoints` | `architecture.graph_index` | `entrypoints.v1.schema.json` | Nein | Berechnung des Graph-Boosts |
 
 ## Verwandte Architekturregeln
@@ -47,5 +47,17 @@ Dateiendung ist Kleidung; Autorität ist Identität.
    - `index.sqlite` wird systemintern als `sqlite_index` geführt (statt `chunk_index_sqlite`).
    - `architecture_graph.json` und `architecture_summary` sind getrennt zu behandeln: `architecture_graph.json` bezeichnet Graph-/Importdaten, `architecture_summary` die lesbare `_architecture.md`-Zusammenfassung.
    - `pr-schau-delta.json` wird als `delta_json` deklariert.
-5. **Authority/Canonicality-Felder (Phase 1):**
-   Die Felder `authority`, `canonicality`, `regenerable` und `staleness_sensitive` sind in `bundle-manifest.v1.schema.json` optional. `authority` und `canonicality` sind pro Rolle wertbeschränkt (z.B. darf `sqlite_index` keine `canonical_content`-Autorität tragen, `architecture_summary` keinen `content_source`-Status). `regenerable` und `staleness_sensitive` werden in Phase 1 vom Producer emittiert und bleiben zunächst typgeprüft. `staleness_sensitive` beschreibt Bundle-interne Drift, nicht Aktualität gegenüber dem Live-Repository. Der Producer (`merger/lenskit/core/merge.py`, `AUTHORITY_REGISTRY`) emittiert diese Felder aktuell für sechs Rollen: `canonical_md`, `index_sidecar_json`, `dump_index_json`, `derived_manifest_json`, `chunk_index_jsonl`, `sqlite_index`. Für `retrieval_eval_json`, `delta_json`, `graph_index_json`, `architecture_summary` und Runtime-Artefakte folgen die Annotationen in späteren Phasen (3, 4, 5). `architecture_summary` wird vom aktuellen Producer (`write_reports_v2`) nicht in das Bundle Manifest aufgenommen; der entsprechende Schema-Constraint bleibt als zulässige Zukunftsform stehen.
+5. **Authority/Canonicality-Felder (Phase 1 + 3.5):**
+   Die Felder `authority`, `canonicality`, `regenerable` und `staleness_sensitive` sind in `bundle-manifest.v1.schema.json` optional. `authority` und `canonicality` sind pro Rolle wertbeschränkt (z.B. darf `sqlite_index` keine `canonical_content`-Autorität tragen, `architecture_summary` keinen `content_source`-Status). `regenerable` und `staleness_sensitive` werden vom Producer emittiert und bleiben typgeprüft. `staleness_sensitive` beschreibt Bundle-interne Drift, nicht Aktualität gegenüber dem Live-Repository.
+
+   **Vom Producer (`merger/lenskit/core/merge.py`, `AUTHORITY_REGISTRY`) aktiv emittiert (acht Rollen):**
+   `canonical_md`, `index_sidecar_json`, `dump_index_json`, `derived_manifest_json`, `chunk_index_jsonl`, `sqlite_index`, `retrieval_eval_json` (Phase 3.5), `graph_index_json` (Phase 3.5).
+
+   **Im Schema als Zukunftsform per-role-constrained, aber nicht vom `bundle-manifest.v1`-Producer emittiert:**
+   - `architecture_summary` — wird von `write_reports_v2` *nicht* als Manifest-Artefakt aufgenommen; der `_write_architecture_summary`-Pfad schreibt die Datei, aber `_add_artifact` wird für diese Rolle nicht aufgerufen. Schema-Constraint (`diagnostic_signal` / `diagnostic`) bleibt als zulässige Zukunftsform.
+   - `delta_json` — lebt im pr-schau-Bundle (`core.pr_schau_bundle`), das ein **eigenes** Manifest gemäß `pr-schau.v1.schema.json` produziert. Im `bundle-manifest.v1`-Pfad gibt es keinen `_add_artifact(... ArtifactRole.PR_DELTA_JSON ...)`-Aufruf. Schema-Constraint (`diagnostic_signal` / `diagnostic`) verhindert, dass extern gebaute Manifeste delta_json fälschlich als kanonischen Inhalt deklarieren.
+
+   **Außerhalb des Bundle-Manifest-Pfads (keine Schema-Constraints):**
+   `query_context_bundle.json`, `query_trace.json` — Runtime-Payloads. `entrypoints.json`, `architecture_graph.json` — Zwischenartefakte für `build_derived_artifacts`. `source_file` — Range-Resolver-Konzept (`core.range_resolver`), nicht im Manifest.
+
+   Folgepunkte (außerhalb dieser PR-Stufe): Annotation für Runtime-Artefakte (Phase 4) und föderierte Artefakte (Phase 5).

--- a/merger/lenskit/contracts/bundle-manifest.v1.schema.json
+++ b/merger/lenskit/contracts/bundle-manifest.v1.schema.json
@@ -426,6 +426,72 @@
                 }
               }
             }
+          },
+          {
+            "if": {
+              "properties": {
+                "role": {
+                  "const": "retrieval_eval_json"
+                }
+              },
+              "required": [
+                "role"
+              ]
+            },
+            "then": {
+              "properties": {
+                "authority": {
+                  "const": "diagnostic_signal"
+                },
+                "canonicality": {
+                  "const": "diagnostic"
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "role": {
+                  "const": "graph_index_json"
+                }
+              },
+              "required": [
+                "role"
+              ]
+            },
+            "then": {
+              "properties": {
+                "authority": {
+                  "const": "retrieval_index"
+                },
+                "canonicality": {
+                  "const": "derived"
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "role": {
+                  "const": "delta_json"
+                }
+              },
+              "required": [
+                "role"
+              ]
+            },
+            "then": {
+              "properties": {
+                "authority": {
+                  "const": "diagnostic_signal"
+                },
+                "canonicality": {
+                  "const": "diagnostic"
+                }
+              }
+            }
           }
         ]
       }

--- a/merger/lenskit/core/merge.py
+++ b/merger/lenskit/core/merge.py
@@ -5803,6 +5803,18 @@ def write_reports_v2(
             "regenerable": True,
             "staleness_sensitive": True,
         },
+        ArtifactRole.RETRIEVAL_EVAL_JSON: {
+            "authority": "diagnostic_signal",
+            "canonicality": "diagnostic",
+            "regenerable": True,
+            "staleness_sensitive": True,
+        },
+        ArtifactRole.GRAPH_INDEX_JSON: {
+            "authority": "retrieval_index",
+            "canonicality": "derived",
+            "regenerable": True,
+            "staleness_sensitive": True,
+        },
     }
 
     artifacts_list = []

--- a/merger/lenskit/tests/test_bundle_manifest_schema.py
+++ b/merger/lenskit/tests/test_bundle_manifest_schema.py
@@ -345,3 +345,133 @@ def test_canonicality_unknown_value_rejected(schema):
     }
     with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(instance=_wrap_artifact(artifact), schema=schema)
+
+
+# Phase 3.5: per-role authority/canonicality constraints for additional
+# bundle-manifest roles. Producer-emitted roles (retrieval_eval_json,
+# graph_index_json) are now annotated by the producer; delta_json carries
+# its constraint as a future-form so that any external manifest builder
+# cannot misrepresent it as canonical content.
+
+def test_retrieval_eval_json_authority_accepted_when_correct(schema):
+    artifact = {
+        "role": "retrieval_eval_json",
+        "path": "out.retrieval_eval.json",
+        "content_type": "application/json",
+        "bytes": 2048,
+        "sha256": TEST_ARTIFACT_SHA256,
+        "contract": {"id": "retrieval-eval", "version": "v1"},
+        "interpretation": {"mode": "contract"},
+        "authority": "diagnostic_signal",
+        "canonicality": "diagnostic",
+        "regenerable": True,
+        "staleness_sensitive": True
+    }
+    jsonschema.validate(instance=_wrap_artifact(artifact), schema=schema)
+
+
+def test_retrieval_eval_json_cannot_claim_content_source(schema):
+    artifact = {
+        "role": "retrieval_eval_json",
+        "path": "out.retrieval_eval.json",
+        "content_type": "application/json",
+        "bytes": 2048,
+        "sha256": TEST_ARTIFACT_SHA256,
+        "contract": {"id": "retrieval-eval", "version": "v1"},
+        "interpretation": {"mode": "contract"},
+        "canonicality": "content_source"  # forbidden: diagnostic, not content
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=_wrap_artifact(artifact), schema=schema)
+
+
+def test_retrieval_eval_json_cannot_claim_canonical_content(schema):
+    artifact = {
+        "role": "retrieval_eval_json",
+        "path": "out.retrieval_eval.json",
+        "content_type": "application/json",
+        "bytes": 2048,
+        "sha256": TEST_ARTIFACT_SHA256,
+        "contract": {"id": "retrieval-eval", "version": "v1"},
+        "interpretation": {"mode": "contract"},
+        "authority": "canonical_content"  # forbidden: eval is diagnostic, not canonical
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=_wrap_artifact(artifact), schema=schema)
+
+
+def test_graph_index_json_authority_accepted_when_correct(schema):
+    artifact = {
+        "role": "graph_index_json",
+        "path": "out.graph_index.json",
+        "content_type": "application/json",
+        "bytes": 2048,
+        "sha256": TEST_ARTIFACT_SHA256,
+        "contract": {"id": "architecture.graph_index", "version": "v1"},
+        "interpretation": {"mode": "contract"},
+        "authority": "retrieval_index",
+        "canonicality": "derived",
+        "regenerable": True,
+        "staleness_sensitive": True
+    }
+    jsonschema.validate(instance=_wrap_artifact(artifact), schema=schema)
+
+
+def test_graph_index_json_cannot_claim_canonical_content(schema):
+    artifact = {
+        "role": "graph_index_json",
+        "path": "out.graph_index.json",
+        "content_type": "application/json",
+        "bytes": 2048,
+        "sha256": TEST_ARTIFACT_SHA256,
+        "contract": {"id": "architecture.graph_index", "version": "v1"},
+        "interpretation": {"mode": "contract"},
+        "authority": "canonical_content"  # forbidden: derived index, not canonical content
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=_wrap_artifact(artifact), schema=schema)
+
+
+def test_graph_index_json_cannot_claim_content_source(schema):
+    artifact = {
+        "role": "graph_index_json",
+        "path": "out.graph_index.json",
+        "content_type": "application/json",
+        "bytes": 2048,
+        "sha256": TEST_ARTIFACT_SHA256,
+        "contract": {"id": "architecture.graph_index", "version": "v1"},
+        "interpretation": {"mode": "contract"},
+        "canonicality": "content_source"  # forbidden: graph index does not contain content
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=_wrap_artifact(artifact), schema=schema)
+
+
+def test_delta_json_cannot_claim_content_source(schema):
+    artifact = {
+        "role": "delta_json",
+        "path": "delta.json",
+        "content_type": "application/json",
+        "bytes": 1024,
+        "sha256": TEST_ARTIFACT_SHA256,
+        "contract": {"id": "pr-schau-delta", "version": "1.0"},
+        "interpretation": {"mode": "contract"},
+        "canonicality": "content_source"  # forbidden: delta is diagnostic, not content
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=_wrap_artifact(artifact), schema=schema)
+
+
+def test_delta_json_cannot_claim_canonical_content(schema):
+    artifact = {
+        "role": "delta_json",
+        "path": "delta.json",
+        "content_type": "application/json",
+        "bytes": 1024,
+        "sha256": TEST_ARTIFACT_SHA256,
+        "contract": {"id": "pr-schau-delta", "version": "1.0"},
+        "interpretation": {"mode": "contract"},
+        "authority": "canonical_content"  # forbidden: delta is diagnostic, not canonical
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=_wrap_artifact(artifact), schema=schema)

--- a/merger/lenskit/tests/test_graph_bundle_integration.py
+++ b/merger/lenskit/tests/test_graph_bundle_integration.py
@@ -155,6 +155,23 @@ def test_graph_in_bundle_manifest_positive(tmp_path, monkeypatch):
     assert manifest_entry["contract"]["version"] == "v1"
     assert manifest_entry["interpretation"]["mode"] == "contract"
 
+    # Phase 3.5: producer must annotate graph_index_json as a derived retrieval
+    # index, never as canonical content.
+    assert manifest_entry["authority"] == "retrieval_index"
+    assert manifest_entry["canonicality"] == "derived"
+    assert manifest_entry["regenerable"] is True
+    assert manifest_entry["staleness_sensitive"] is True
+
+    # Phase 3.5: when build_derived_artifacts produces a retrieval_eval.json
+    # alongside the graph index, it must also carry diagnostic authority.
+    eval_artifacts = [a for a in data.get("artifacts", []) if a.get("role") == ArtifactRole.RETRIEVAL_EVAL_JSON.value]
+    if eval_artifacts:
+        eval_entry = eval_artifacts[0]
+        assert eval_entry["authority"] == "diagnostic_signal"
+        assert eval_entry["canonicality"] == "diagnostic"
+        assert eval_entry["regenerable"] is True
+        assert eval_entry["staleness_sensitive"] is True
+
 
 def test_graph_bundle_integration_fallback(tmp_path):
     """

--- a/merger/lenskit/tests/test_graph_bundle_integration.py
+++ b/merger/lenskit/tests/test_graph_bundle_integration.py
@@ -162,15 +162,20 @@ def test_graph_in_bundle_manifest_positive(tmp_path, monkeypatch):
     assert manifest_entry["regenerable"] is True
     assert manifest_entry["staleness_sensitive"] is True
 
-    # Phase 3.5: when build_derived_artifacts produces a retrieval_eval.json
-    # alongside the graph index, it must also carry diagnostic authority.
+    # Phase 3.5: build_derived_artifacts produces a retrieval_eval.json
+    # alongside the graph index whenever queries.md is present (as set up
+    # above). The producer must annotate it with diagnostic authority.
     eval_artifacts = [a for a in data.get("artifacts", []) if a.get("role") == ArtifactRole.RETRIEVAL_EVAL_JSON.value]
-    if eval_artifacts:
-        eval_entry = eval_artifacts[0]
-        assert eval_entry["authority"] == "diagnostic_signal"
-        assert eval_entry["canonicality"] == "diagnostic"
-        assert eval_entry["regenerable"] is True
-        assert eval_entry["staleness_sensitive"] is True
+    assert len(eval_artifacts) == 1, "retrieval_eval_json missing from bundle manifest"
+    eval_entry = eval_artifacts[0]
+    assert eval_entry["path"].endswith(".retrieval_eval.json")
+    assert eval_entry["contract"]["id"] == "retrieval-eval"
+    assert eval_entry["contract"]["version"] == "v1"
+    assert eval_entry["interpretation"]["mode"] == "contract"
+    assert eval_entry["authority"] == "diagnostic_signal"
+    assert eval_entry["canonicality"] == "diagnostic"
+    assert eval_entry["regenerable"] is True
+    assert eval_entry["staleness_sensitive"] is True
 
 
 def test_graph_bundle_integration_fallback(tmp_path):


### PR DESCRIPTION
Phase 3.5 of the Artifact Integrity blueprint extends the bundle-manifest
authority coverage to the two remaining roles that the producer actually
emits via write_reports_v2._add_artifact: retrieval_eval_json (diagnostic)
and graph_index_json (retrieval index, derived). Also adds schema-level
per-role constraints for retrieval_eval_json, graph_index_json and
delta_json so external manifest builders cannot misrepresent diagnostic
or derived artifacts as canonical content.

architecture_summary, delta_json (pr-schau bundle), source_file and
runtime payloads remain deliberately unannotated in AUTHORITY_REGISTRY
because the bundle-manifest.v1 producer does not emit them.

Producer integration test now asserts the new fields end-to-end; schema
tests cover positive and negative aufwertung across the three new roles.