### PR TITLE
Add runtime artifact metadata classification to lookup APIs

### DIFF
--- a/docs/proofs/runtime-artifact-metadata-gap-audit.md
+++ b/docs/proofs/runtime-artifact-metadata-gap-audit.md
@@ -1,0 +1,182 @@
+# Runtime Artifact Metadata Gap Audit
+
+## These / Antithese / Synthese
+
+**These:** Runtime-Artefakte (`query_trace`, `context_bundle`, `agent_query_session`) sind persistent im `QueryArtifactStore` abgelegt und über drei typsichere Lookup-APIs abrufbar. Die Infrastruktur ist vollständig.
+
+**Antithese:** Maschinenlesbare Klassifizierung fehlt. Ein Consumer der Lookup-APIs kann ohne Quelltextlektüre nicht erkennen, dass diese Artefakte `runtime_observation / observation` sind, keinen GC-Schutz haben, und dass `context_bundle` in projizierter Form gespeichert wird. `claim_boundaries` fehlt in allen drei Lookup-Schemas — obwohl es in `query-result.v1.schema.json` und `retrieval-eval.v1.schema.json` bereits vorhanden ist und die `docs/retrieval/recipes.md` die Weitergabe explizit auf einen „separaten Folge-PR" verschoben hat.
+
+**Synthese:** Der Patch ist additiv. Keine Breaking Changes. Keine neue Wahrheit, kein neues Schema-Top-Level-Dokument. Nur: was der Docstring weiß, soll auch die Maschine wissen.
+
+---
+
+## Belegter Ist-Zustand
+
+### Repo-Stand
+
+```
+Branch: claude/audit-runtime-metadata-I02Qv
+Stand:  2026-05-01
+```
+
+### Scan-Ergebnis (rg)
+
+```
+# Felder im Store (query_artifact_store.py:98-104)
+"id": artifact_id
+"artifact_type": artifact_type          # query_trace | context_bundle | agent_query_session
+"data": data
+"provenance": prov                      # source_query, timestamp, index_id, run_id
+"created_at": now                       # ISO-8601 UTC
+
+# Felder in artifact-lookup.v1.schema.json (ArtifactPayload)
+provenance: {source_query, timestamp, index_id, run_id}
+created_at
+data
+
+# Felder in trace-lookup.v1.schema.json (root)
+status, id, trace, provenance, created_at, warnings
+
+# Felder in context-lookup.v1.schema.json (root)
+status, id, context_bundle, provenance, created_at, warnings
+```
+
+**Kein Treffer für** `runtime_observation | canonicality | observation | retention_policy | artifact_shape | claim_boundaries`
+in `merger/lenskit/service/`, `merger/lenskit/contracts/artifact-lookup*`,
+`merger/lenskit/contracts/trace-lookup*`, `merger/lenskit/contracts/context-lookup*`.
+
+**Treffer vorhanden in:**
+- `merger/lenskit/contracts/bundle-manifest.v1.schema.json` — `authority: runtime_observation`, `canonicality: observation` (Zeilen 137–158)
+- `merger/lenskit/contracts/query-result.v1.schema.json` — `claim_boundaries` (Zeile 251)
+- `merger/lenskit/contracts/retrieval-eval.v1.schema.json` — `claim_boundaries` (Zeile 260)
+- `docs/retrieval/recipes.md` — explizite Aussage: „Die Weitergabe von claim_boundaries in Projektionen ist ein separater Folge-PR"
+- `docs/architecture/artifact-inventory.md` — expliziter Hinweis: „Folgepunkte (außerhalb dieser PR-Stufe): Annotation für Runtime-Artefakte (Phase 4)"
+
+---
+
+## Tabelle: Ist-Zustand je Artefakttyp
+
+| Feld | `query_trace` | `context_bundle` | `agent_query_session` | Schema-Ort | Store-Ort | Test-Ort |
+|---|---|---|---|---|---|---|
+| `artifact_type` | ✅ `query_trace` | ✅ `context_bundle` | ✅ `agent_query_session` | alle drei Lookup-Schemas | `query_artifact_store.py:99` | `test_artifact_lookup.py:127` |
+| `created_at` | ✅ ISO-8601 | ✅ ISO-8601 | ✅ ISO-8601 | alle drei Lookup-Schemas | `query_artifact_store.py:103` | `test_trace_lookup.py:125` |
+| `provenance.source_query` | ✅ | ✅ | ✅ | `artifact-lookup.v1` | `query_artifact_store.py:93` | `test_artifact_lookup.py:129` |
+| `provenance.timestamp` | ✅ | ✅ | ✅ | `artifact-lookup.v1` | `query_artifact_store.py:93` | — |
+| `provenance.index_id` | ✅ (optional) | ✅ (optional) | ✅ (optional) | `artifact-lookup.v1` | `app.py:728` | `test_artifact_lookup.py:234` |
+| `provenance.run_id` | ✅ (optional) | ✅ (optional) | ✅ (optional) | `artifact-lookup.v1` | `query_artifact_store.py:94-95` | `test_artifact_lookup.py:136` |
+| **`authority`** | ❌ absent | ❌ absent | ❌ absent | — | — | — |
+| **`canonicality`** | ❌ absent | ❌ absent | ❌ absent | — | — | — |
+| **`artifact_shape`** | ❌ absent | ❌ absent | ❌ absent | — | — | — |
+| **`retention_policy`** | ❌ absent | ❌ absent | ❌ absent | — | — | — |
+| **`claim_boundaries`** | ❌ absent | ❌ absent | ❌ absent | — | — | — |
+
+---
+
+## Kontrollfragen — Antworten
+
+**Welche Metadaten speichert `query_artifact_store.py` tatsächlich?**
+`id`, `artifact_type`, `data`, `provenance` (`source_query`, `timestamp`, `index_id`, `run_id`), `created_at`.
+
+**Welche Metadaten geben die drei Lookup-Endpoints zurück?**
+Dieselben. Keine Klassifizierungsfelder.
+
+**Sind `created_at`, `provenance`, `run_id`, `index_id` konsistent?**
+Ja — konsistent vorhanden und getestet.
+
+**Gibt es bereits `authority=runtime_observation`?**
+Nein — nur in `bundle-manifest.v1.schema.json` als erlaubter Wert, aber kein Runtime-Artefakt emittiert es.
+
+**Gibt es bereits `canonicality=observation`?**
+Nein — selbe Situation wie `authority`.
+
+**Gibt es bereits `artifact_shape`?**
+Nein. Der Store-Docstring dokumentiert: „No raw-vs-projected artifact distinction (context_bundle is stored in the projected API form, not the internal execute_query() form)." — aber dieses Wissen ist maschinenunlesbar.
+
+**Gibt es bereits `retention_policy`?**
+Nein. Der Store-Docstring dokumentiert: „No retention/GC policy: the store grows unbounded." — aber auch dies nur als Kommentar.
+
+**Gibt es Runtime-Claim-Boundaries?**
+Nein. `claim_boundaries` existiert in `query-result.v1.schema.json` (Zeile 251) und `retrieval-eval.v1.schema.json` (Zeile 260), aber nicht in den drei Artifact-Lookup-Schemas.
+
+**Sind `query_trace`, `context_bundle`, `agent_query_session` gleichartig genug?**
+Ja — alle drei werden durch `QueryArtifactStore.store()` mit identischer Schnittstelle abgelegt, alle teilen `authority=runtime_observation` und `canonicality=observation`. Sie unterscheiden sich nur in `artifact_shape`.
+
+**Gibt es bestehende Tests für Type-Mismatch / fehlenden Store?**
+Ja — `test_lookup_type_mismatch_returns_not_found`, `test_trace_lookup_type_mismatch_hides_non_trace_artifact`, `test_context_lookup_wrong_type_hides_non_bundle_artifact`. Kein Test prüft Klassifizierungsfelder.
+
+---
+
+## Entscheidung: Patch nötig
+
+Die Lücke ist real und hat benannte Belege:
+
+1. **`authority` / `canonicality`** — `artifact-inventory.md` benennt explizit „Folgepunkte: Annotation für Runtime-Artefakte (Phase 4)". Ein Consumer kann ohne Quelltextlektüre nicht erkennen, dass `query_trace` eine Beobachtung ist, keine kanonische Quelle.
+
+2. **`artifact_shape`** — `query_artifact_store.py` Docstring: „No raw-vs-projected artifact distinction (context_bundle is stored in the projected API form, not the internal execute_query() form)." Dieses maschinenunlesbare Wissen betrifft jeden Consumer, der anhand des gespeicherten Artefakts rekonstruieren möchte, ob er die interne oder die API-Form erhält. Nur `artifact_shape: "projected"` macht dies eindeutig.
+
+3. **`claim_boundaries`** — `docs/retrieval/recipes.md` (Zeile 151): „Die Weitergabe von `claim_boundaries` in Projektionen ist ein separater Folge-PR, damit das Context-Bundle-Schema nicht still erweitert wird." Dieser PR ist der angekündigte Folge-PR für die Lookup-Schemas.
+
+4. **`retention_policy`** — Documenting a known limitation as machine-readable field: store docstring says "grows unbounded", but no consumer can read this from the API.
+
+---
+
+## Minimaler Patch
+
+### Erlaubte Änderungen (alle additiv)
+
+| Datei | Änderung |
+|---|---|
+| `merger/lenskit/service/query_artifact_store.py` | `_RUNTIME_ARTIFACT_METADATA` Konstante; Injektion in `store()` |
+| `merger/lenskit/contracts/artifact-lookup.v1.schema.json` | Optionale Felder in `ArtifactPayload` |
+| `merger/lenskit/contracts/trace-lookup.v1.schema.json` | Optionale Top-Level-Felder |
+| `merger/lenskit/contracts/context-lookup.v1.schema.json` | Optionale Top-Level-Felder |
+| `merger/lenskit/service/app.py` | Durchreichen der neuen Felder in allen drei Lookup-Endpoints |
+| `merger/lenskit/tests/test_artifact_lookup.py` | Tests für Klassifizierungsfelder |
+| `merger/lenskit/tests/test_trace_lookup.py` | Tests für Klassifizierungsfelder |
+| `merger/lenskit/tests/test_context_lookup.py` | Tests für Klassifizierungsfelder |
+| `docs/service-api.md` | Aktualisierung der Response-Beispiele |
+
+### Nicht in diesem PR
+
+- Retention/GC-Implementierung
+- Agent Session v3
+- Context-Bundle-Projection-Ausweitung
+- neue Runtime-Governance-Datei
+- MCP-/Tooling-Scope
+
+---
+
+## Artifact-Shape-Werte
+
+| Artefakttyp | `artifact_shape` | Begründung |
+|---|---|---|
+| `query_trace` | `"raw"` | Internes `query_trace`-Feld aus `execute_query()`, unverändert |
+| `context_bundle` | `"projected"` | Projizierte API-Form (nach Output-Profile-Filterung), nicht die interne Form |
+| `agent_query_session` | `"wrapper"` | Wrapper-Objekt, aufgebaut aus dem projizierten Context Bundle |
+
+---
+
+## Risikoabschätzung
+
+| Klasse | Bewertung |
+|---|---|
+| Nutzen | Hoch: Runtime-Artefakte sind maschinenlesbar als `runtime_observation / observation` klassifizierbar; `artifact_shape` macht den Projektion-Status explizit; `claim_boundaries` schließt den in `recipes.md` angekündigten Folge-PR |
+| Risiko | Niedrig: alle Felder optional, kein Breaking Change, `additionalProperties: false` bleibt erhalten |
+| Hauptfehler | Doppelmodellierung: `index_id` ist bereits in `provenance` — wird nicht nach oben dupliziert |
+| Gegenmittel | Felder gehen in `ArtifactPayload` (artifact-lookup) bzw. als Top-Level-Felder (trace-/context-lookup) — konsistent mit der jeweiligen Schema-Struktur |
+
+---
+
+## Stop-Kriterium für Folge-PRs
+
+Dieser PR ist vollständig, wenn:
+1. Alle fünf Felder (`authority`, `canonicality`, `artifact_shape`, `retention_policy`, `claim_boundaries`) in Store-Einträgen vorhanden sind
+2. Alle drei Lookup-Endpoints die Felder zurückgeben
+3. Alle drei Lookup-Schemas die Felder als optional akzeptieren
+4. Tests in `test_artifact_lookup.py`, `test_trace_lookup.py`, `test_context_lookup.py` grün laufen
+5. Kein bestehender Test gebrochen ist
+
+**Außerhalb dieses PR-Scopes bleiben:**
+- Retention/GC-Implementierung (`retention_policy` dokumentiert nur den Ist-Zustand)
+- Maschinelle Durchsetzung von `artifact_shape` beim Speichern
+- `agent_query_session` Lookup-Endpoint (existiert nicht — nur `artifact_lookup` mit type=agent_query_session)

--- a/docs/service-api.md
+++ b/docs/service-api.md
@@ -57,6 +57,17 @@ Typed read-only facade over stored `context_bundle` artifacts. Returns the conte
   "context_bundle": { "query": "main", "hits": [...] },
   "provenance": { "source_query": "main", "timestamp": "2024-01-01T00:00:00+00:00", "index_id": "test-art", "run_id": null },
   "created_at": "2024-01-01T00:00:00+00:00",
+  "authority": "runtime_observation",
+  "canonicality": "observation",
+  "artifact_shape": "projected",
+  "retention_policy": "unbounded_currently",
+  "claim_boundaries": {
+    "does_not_prove": [
+      "Artifact ID stability is limited to this store location.",
+      "Runtime artifact does not prove live repository state.",
+      "Context bundle is stored in projected API form, not raw execute_query form."
+    ]
+  },
   "warnings": []
 }
 ```
@@ -142,6 +153,16 @@ Typed read-only facade over stored `query_trace` artifacts. Returns the trace pa
   "trace": { "query_input": "...", "timings": {}, "..." : "..." },
   "provenance": { "source_query": "main", "timestamp": "2024-01-01T00:00:00+00:00", "index_id": "test-art", "run_id": null },
   "created_at": "2024-01-01T00:00:00+00:00",
+  "authority": "runtime_observation",
+  "canonicality": "observation",
+  "artifact_shape": "raw",
+  "retention_policy": "unbounded_currently",
+  "claim_boundaries": {
+    "does_not_prove": [
+      "Artifact ID stability is limited to this store location.",
+      "Runtime artifact does not prove live repository state."
+    ]
+  },
   "warnings": []
 }
 ```

--- a/merger/lenskit/contracts/artifact-lookup.v1.schema.json
+++ b/merger/lenskit/contracts/artifact-lookup.v1.schema.json
@@ -62,11 +62,11 @@
           "description": "The artifact payload. Structure depends on artifact_type."
         },
         "authority": {
-          "type": "string",
+          "const": "runtime_observation",
           "description": "Authority class of this runtime artifact. Always 'runtime_observation' for query runtime artifacts."
         },
         "canonicality": {
-          "type": "string",
+          "const": "observation",
           "description": "Canonicality class. Always 'observation' for query runtime artifacts."
         },
         "artifact_shape": {
@@ -75,7 +75,7 @@
           "description": "Shape of the stored artifact data: 'raw' = internal execute_query form (query_trace), 'projected' = API-projected form after output-profile filtering (context_bundle), 'wrapper' = session wrapper built from the projected form (agent_query_session)."
         },
         "retention_policy": {
-          "type": "string",
+          "const": "unbounded_currently",
           "description": "Retention policy for this artifact in the store. 'unbounded_currently' means no GC is applied."
         },
         "claim_boundaries": {

--- a/merger/lenskit/contracts/artifact-lookup.v1.schema.json
+++ b/merger/lenskit/contracts/artifact-lookup.v1.schema.json
@@ -60,6 +60,36 @@
           "type": "object",
           "additionalProperties": true,
           "description": "The artifact payload. Structure depends on artifact_type."
+        },
+        "authority": {
+          "type": "string",
+          "description": "Authority class of this runtime artifact. Always 'runtime_observation' for query runtime artifacts."
+        },
+        "canonicality": {
+          "type": "string",
+          "description": "Canonicality class. Always 'observation' for query runtime artifacts."
+        },
+        "artifact_shape": {
+          "type": "string",
+          "enum": ["raw", "projected", "wrapper"],
+          "description": "Shape of the stored artifact data: 'raw' = internal execute_query form (query_trace), 'projected' = API-projected form after output-profile filtering (context_bundle), 'wrapper' = session wrapper built from the projected form (agent_query_session)."
+        },
+        "retention_policy": {
+          "type": "string",
+          "description": "Retention policy for this artifact in the store. 'unbounded_currently' means no GC is applied."
+        },
+        "claim_boundaries": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["does_not_prove"],
+          "properties": {
+            "does_not_prove": {
+              "type": "array",
+              "items": {"type": "string"},
+              "description": "Statements this artifact does not prove."
+            }
+          },
+          "description": "Epistemic boundaries of this runtime artifact."
         }
       }
     }

--- a/merger/lenskit/contracts/context-lookup.v1.schema.json
+++ b/merger/lenskit/contracts/context-lookup.v1.schema.json
@@ -58,20 +58,19 @@
       "description": "Non-fatal diagnostic messages (e.g. type mismatch naming the actual artifact type, store not initialized)."
     },
     "authority": {
-      "type": "string",
+      "const": "runtime_observation",
       "description": "Authority class of this runtime artifact. Always 'runtime_observation' for context_bundle artifacts."
     },
     "canonicality": {
-      "type": "string",
+      "const": "observation",
       "description": "Canonicality class. Always 'observation' for context_bundle artifacts."
     },
     "artifact_shape": {
-      "type": "string",
-      "enum": ["raw", "projected", "wrapper"],
+      "const": "projected",
       "description": "Shape of the stored bundle data. Always 'projected' for context_bundle: API-projected form after output-profile filtering, not raw execute_query form."
     },
     "retention_policy": {
-      "type": "string",
+      "const": "unbounded_currently",
       "description": "Retention policy for this artifact in the store. 'unbounded_currently' means no GC is applied."
     },
     "claim_boundaries": {

--- a/merger/lenskit/contracts/context-lookup.v1.schema.json
+++ b/merger/lenskit/contracts/context-lookup.v1.schema.json
@@ -56,6 +56,36 @@
       "type": "array",
       "items": {"type": "string"},
       "description": "Non-fatal diagnostic messages (e.g. type mismatch naming the actual artifact type, store not initialized)."
+    },
+    "authority": {
+      "type": "string",
+      "description": "Authority class of this runtime artifact. Always 'runtime_observation' for context_bundle artifacts."
+    },
+    "canonicality": {
+      "type": "string",
+      "description": "Canonicality class. Always 'observation' for context_bundle artifacts."
+    },
+    "artifact_shape": {
+      "type": "string",
+      "enum": ["raw", "projected", "wrapper"],
+      "description": "Shape of the stored bundle data. Always 'projected' for context_bundle: API-projected form after output-profile filtering, not raw execute_query form."
+    },
+    "retention_policy": {
+      "type": "string",
+      "description": "Retention policy for this artifact in the store. 'unbounded_currently' means no GC is applied."
+    },
+    "claim_boundaries": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["does_not_prove"],
+      "properties": {
+        "does_not_prove": {
+          "type": "array",
+          "items": {"type": "string"},
+          "description": "Statements this artifact does not prove."
+        }
+      },
+      "description": "Epistemic boundaries of this runtime artifact."
     }
   }
 }

--- a/merger/lenskit/contracts/trace-lookup.v1.schema.json
+++ b/merger/lenskit/contracts/trace-lookup.v1.schema.json
@@ -58,20 +58,19 @@
       "description": "Non-fatal diagnostic messages (e.g. type mismatch naming the actual artifact type, store not initialized)."
     },
     "authority": {
-      "type": "string",
+      "const": "runtime_observation",
       "description": "Authority class of this runtime artifact. Always 'runtime_observation' for query_trace artifacts."
     },
     "canonicality": {
-      "type": "string",
+      "const": "observation",
       "description": "Canonicality class. Always 'observation' for query_trace artifacts."
     },
     "artifact_shape": {
-      "type": "string",
-      "enum": ["raw", "projected", "wrapper"],
+      "const": "raw",
       "description": "Shape of the stored trace data. Always 'raw' for query_trace: unmodified internal execute_query output."
     },
     "retention_policy": {
-      "type": "string",
+      "const": "unbounded_currently",
       "description": "Retention policy for this artifact in the store. 'unbounded_currently' means no GC is applied."
     },
     "claim_boundaries": {

--- a/merger/lenskit/contracts/trace-lookup.v1.schema.json
+++ b/merger/lenskit/contracts/trace-lookup.v1.schema.json
@@ -56,6 +56,36 @@
       "type": "array",
       "items": {"type": "string"},
       "description": "Non-fatal diagnostic messages (e.g. type mismatch naming the actual artifact type, store not initialized)."
+    },
+    "authority": {
+      "type": "string",
+      "description": "Authority class of this runtime artifact. Always 'runtime_observation' for query_trace artifacts."
+    },
+    "canonicality": {
+      "type": "string",
+      "description": "Canonicality class. Always 'observation' for query_trace artifacts."
+    },
+    "artifact_shape": {
+      "type": "string",
+      "enum": ["raw", "projected", "wrapper"],
+      "description": "Shape of the stored trace data. Always 'raw' for query_trace: unmodified internal execute_query output."
+    },
+    "retention_policy": {
+      "type": "string",
+      "description": "Retention policy for this artifact in the store. 'unbounded_currently' means no GC is applied."
+    },
+    "claim_boundaries": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["does_not_prove"],
+      "properties": {
+        "does_not_prove": {
+          "type": "array",
+          "items": {"type": "string"},
+          "description": "Statements this artifact does not prove."
+        }
+      },
+      "description": "Epistemic boundaries of this runtime artifact."
     }
   }
 }

--- a/merger/lenskit/service/app.py
+++ b/merger/lenskit/service/app.py
@@ -1025,15 +1025,21 @@ def api_artifact_lookup(request: ArtifactLookupRequest):
             ],
         }
 
+    _runtime_meta_fields = ("authority", "canonicality", "artifact_shape", "retention_policy", "claim_boundaries")
+    artifact_payload: Dict[str, Any] = {
+        "provenance": entry["provenance"],
+        "created_at": entry["created_at"],
+        "data": entry["data"],
+    }
+    for _field in _runtime_meta_fields:
+        if _field in entry:
+            artifact_payload[_field] = entry[_field]
+
     return {
         "artifact_type": entry["artifact_type"],
         "id": entry["id"],
         "status": "ok",
-        "artifact": {
-            "provenance": entry["provenance"],
-            "created_at": entry["created_at"],
-            "data": entry["data"],
-        },
+        "artifact": artifact_payload,
         "warnings": [],
     }
 
@@ -1082,7 +1088,8 @@ def api_trace_lookup(request: TraceLookupRequest):
             ],
         }
 
-    return {
+    _runtime_meta_fields = ("authority", "canonicality", "artifact_shape", "retention_policy", "claim_boundaries")
+    resp: Dict[str, Any] = {
         "status": "ok",
         "id": entry["id"],
         "trace": entry["data"],
@@ -1090,6 +1097,10 @@ def api_trace_lookup(request: TraceLookupRequest):
         "created_at": entry["created_at"],
         "warnings": [],
     }
+    for _field in _runtime_meta_fields:
+        if _field in entry:
+            resp[_field] = entry[_field]
+    return resp
 
 
 @app.post("/api/context_lookup", dependencies=[Depends(verify_token)])
@@ -1137,7 +1148,8 @@ def api_context_lookup(request: ContextLookupRequest):
             ],
         }
 
-    return {
+    _runtime_meta_fields = ("authority", "canonicality", "artifact_shape", "retention_policy", "claim_boundaries")
+    resp: Dict[str, Any] = {
         "status": "ok",
         "id": entry["id"],
         "context_bundle": entry["data"],
@@ -1145,6 +1157,10 @@ def api_context_lookup(request: ContextLookupRequest):
         "created_at": entry["created_at"],
         "warnings": [],
     }
+    for _field in _runtime_meta_fields:
+        if _field in entry:
+            resp[_field] = entry[_field]
+    return resp
 
 
 def _serve_file(base_dir: Path, requested_path: Union[str, Path], filename: Optional[str] = None) -> FileResponse:

--- a/merger/lenskit/service/app.py
+++ b/merger/lenskit/service/app.py
@@ -982,6 +982,27 @@ def get_artifact(id: str):
     return art
 
 
+
+# ---------------------------------------------------------------------------
+# Runtime artifact metadata helpers (shared by artifact_lookup / trace_lookup /
+# context_lookup).  Keeping the field tuple and copy helper in one place means
+# all three endpoints update automatically when the metadata schema changes.
+# ---------------------------------------------------------------------------
+
+_RUNTIME_META_FIELDS = (
+    "authority",
+    "canonicality",
+    "artifact_shape",
+    "retention_policy",
+    "claim_boundaries",
+)
+
+
+def _copy_runtime_metadata(entry: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a dict containing only the runtime metadata fields present in *entry*."""
+    return {field: entry[field] for field in _RUNTIME_META_FIELDS if field in entry}
+
+
 @app.post("/api/artifact_lookup", dependencies=[Depends(verify_token)])
 def api_artifact_lookup(request: ArtifactLookupRequest):
     """Retrieve a previously stored query runtime artifact by stable ID.
@@ -1025,15 +1046,12 @@ def api_artifact_lookup(request: ArtifactLookupRequest):
             ],
         }
 
-    _runtime_meta_fields = ("authority", "canonicality", "artifact_shape", "retention_policy", "claim_boundaries")
     artifact_payload: Dict[str, Any] = {
         "provenance": entry["provenance"],
         "created_at": entry["created_at"],
         "data": entry["data"],
+        **_copy_runtime_metadata(entry),
     }
-    for _field in _runtime_meta_fields:
-        if _field in entry:
-            artifact_payload[_field] = entry[_field]
 
     return {
         "artifact_type": entry["artifact_type"],
@@ -1088,7 +1106,6 @@ def api_trace_lookup(request: TraceLookupRequest):
             ],
         }
 
-    _runtime_meta_fields = ("authority", "canonicality", "artifact_shape", "retention_policy", "claim_boundaries")
     resp: Dict[str, Any] = {
         "status": "ok",
         "id": entry["id"],
@@ -1096,10 +1113,8 @@ def api_trace_lookup(request: TraceLookupRequest):
         "provenance": entry["provenance"],
         "created_at": entry["created_at"],
         "warnings": [],
+        **_copy_runtime_metadata(entry),
     }
-    for _field in _runtime_meta_fields:
-        if _field in entry:
-            resp[_field] = entry[_field]
     return resp
 
 
@@ -1148,7 +1163,6 @@ def api_context_lookup(request: ContextLookupRequest):
             ],
         }
 
-    _runtime_meta_fields = ("authority", "canonicality", "artifact_shape", "retention_policy", "claim_boundaries")
     resp: Dict[str, Any] = {
         "status": "ok",
         "id": entry["id"],
@@ -1156,10 +1170,8 @@ def api_context_lookup(request: ContextLookupRequest):
         "provenance": entry["provenance"],
         "created_at": entry["created_at"],
         "warnings": [],
+        **_copy_runtime_metadata(entry),
     }
-    for _field in _runtime_meta_fields:
-        if _field in entry:
-            resp[_field] = entry[_field]
     return resp
 
 

--- a/merger/lenskit/service/query_artifact_store.py
+++ b/merger/lenskit/service/query_artifact_store.py
@@ -1,4 +1,5 @@
 import json
+import copy
 import threading
 import uuid
 import logging
@@ -58,6 +59,28 @@ _RUNTIME_ARTIFACT_METADATA: Dict[str, Dict[str, Any]] = {
         },
     },
 }
+
+
+def _with_runtime_metadata(entry: Dict[str, Any]) -> Dict[str, Any]:
+    """Return entry with runtime classification fields guaranteed.
+
+    New entries written by store() already contain all fields.  Legacy entries
+    loaded from disk may predate this PR and lack authority/canonicality/
+    artifact_shape/retention_policy/claim_boundaries.  This helper backfills
+    those fields from _RUNTIME_ARTIFACT_METADATA without mutating the cached
+    dict and without overwriting any field that was already present.
+
+    Unknown artifact_types (shouldn't happen, but safe to handle) are returned
+    as-is.  deepcopy on the meta template prevents claim_boundaries list
+    aliasing across callers.
+    """
+    artifact_type = entry.get("artifact_type")
+    meta = _RUNTIME_ARTIFACT_METADATA.get(artifact_type)
+    if not meta:
+        return dict(entry)
+    merged = copy.deepcopy(meta)
+    merged.update(entry)
+    return merged
 
 
 class QueryArtifactStore:
@@ -158,14 +181,22 @@ class QueryArtifactStore:
         return artifact_id
 
     def get(self, artifact_id: str) -> Optional[Dict[str, Any]]:
-        """Return the stored entry for artifact_id, or None if not found."""
+        """Return the stored entry for artifact_id, or None if not found.
+
+        Always returns a dict with runtime classification fields present,
+        backfilling from _RUNTIME_ARTIFACT_METADATA for legacy entries that
+        predate the metadata schema addition.
+        """
         with self._lock:
-            return self._cache.get(artifact_id)
+            raw = self._cache.get(artifact_id)
+            if raw is None:
+                return None
+            return _with_runtime_metadata(raw)
 
     def get_all(self) -> List[Dict[str, Any]]:
         with self._lock:
             return sorted(
-                self._cache.values(),
+                (_with_runtime_metadata(e) for e in self._cache.values()),
                 key=lambda e: e.get("created_at", ""),
                 reverse=True,
             )

--- a/merger/lenskit/service/query_artifact_store.py
+++ b/merger/lenskit/service/query_artifact_store.py
@@ -12,6 +12,53 @@ VALID_ARTIFACT_TYPES = frozenset({"query_trace", "context_bundle", "agent_query_
 
 _STORE_FILENAME = "query_artifacts.json"
 
+# Per-type classification metadata injected into every stored entry.
+# authority/canonicality use the vocabulary from bundle-manifest.v1.schema.json.
+# artifact_shape encodes the stored data form:
+#   "raw"       — unmodified internal execute_query() output (query_trace)
+#   "projected" — API-projected form after output-profile filtering (context_bundle)
+#   "wrapper"   — session wrapper built from the projected context bundle (agent_query_session)
+# retention_policy reflects the store's current behaviour (no GC; unbounded growth).
+_RUNTIME_ARTIFACT_METADATA: Dict[str, Dict[str, Any]] = {
+    "query_trace": {
+        "authority": "runtime_observation",
+        "canonicality": "observation",
+        "artifact_shape": "raw",
+        "retention_policy": "unbounded_currently",
+        "claim_boundaries": {
+            "does_not_prove": [
+                "Artifact ID stability is limited to this store location.",
+                "Runtime artifact does not prove live repository state.",
+            ]
+        },
+    },
+    "context_bundle": {
+        "authority": "runtime_observation",
+        "canonicality": "observation",
+        "artifact_shape": "projected",
+        "retention_policy": "unbounded_currently",
+        "claim_boundaries": {
+            "does_not_prove": [
+                "Artifact ID stability is limited to this store location.",
+                "Runtime artifact does not prove live repository state.",
+                "Context bundle is stored in projected API form, not raw execute_query form.",
+            ]
+        },
+    },
+    "agent_query_session": {
+        "authority": "runtime_observation",
+        "canonicality": "observation",
+        "artifact_shape": "wrapper",
+        "retention_policy": "unbounded_currently",
+        "claim_boundaries": {
+            "does_not_prove": [
+                "Artifact ID stability is limited to this store location.",
+                "Runtime artifact does not prove live repository state.",
+            ]
+        },
+    },
+}
+
 
 class QueryArtifactStore:
     """Persistent store for query runtime artifacts.
@@ -101,6 +148,7 @@ class QueryArtifactStore:
             "data": data,
             "provenance": prov,
             "created_at": now,
+            **_RUNTIME_ARTIFACT_METADATA[artifact_type],
         }
 
         with self._lock:

--- a/merger/lenskit/service/query_artifact_store.py
+++ b/merger/lenskit/service/query_artifact_store.py
@@ -72,15 +72,17 @@ def _with_runtime_metadata(entry: Dict[str, Any]) -> Dict[str, Any]:
     dict and without overwriting any field that was already present.
 
     Unknown artifact_types (shouldn't happen, but safe to handle) are returned
-    as-is.  deepcopy on the meta template prevents claim_boundaries list
-    aliasing across callers.
+    as a deep copy.  Callers receive an independent copy of all nested
+    structures; mutations to the returned dict do not reach the cache.
     """
     artifact_type = entry.get("artifact_type")
     meta = _RUNTIME_ARTIFACT_METADATA.get(artifact_type)
+    merged = copy.deepcopy(entry)
     if not meta:
-        return dict(entry)
-    merged = copy.deepcopy(meta)
-    merged.update(entry)
+        return merged
+    for key, value in meta.items():
+        if key not in merged:
+            merged[key] = copy.deepcopy(value)
     return merged
 
 

--- a/merger/lenskit/service/query_artifact_store.py
+++ b/merger/lenskit/service/query_artifact_store.py
@@ -9,8 +9,6 @@ from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
-VALID_ARTIFACT_TYPES = frozenset({"query_trace", "context_bundle", "agent_query_session"})
-
 _STORE_FILENAME = "query_artifacts.json"
 
 # Per-type classification metadata injected into every stored entry.
@@ -59,6 +57,9 @@ _RUNTIME_ARTIFACT_METADATA: Dict[str, Dict[str, Any]] = {
         },
     },
 }
+
+# Derived from _RUNTIME_ARTIFACT_METADATA so it can never drift out of sync.
+VALID_ARTIFACT_TYPES = frozenset(_RUNTIME_ARTIFACT_METADATA.keys())
 
 
 def _with_runtime_metadata(entry: Dict[str, Any]) -> Dict[str, Any]:
@@ -165,13 +166,14 @@ class QueryArtifactStore:
             prov.setdefault("run_id", run_id)
         prov.setdefault("run_id", None)
 
+        runtime_meta = copy.deepcopy(_RUNTIME_ARTIFACT_METADATA[artifact_type])
         entry: Dict[str, Any] = {
             "id": artifact_id,
             "artifact_type": artifact_type,
             "data": data,
             "provenance": prov,
             "created_at": now,
-            **_RUNTIME_ARTIFACT_METADATA[artifact_type],
+            **runtime_meta,
         }
 
         with self._lock:

--- a/merger/lenskit/tests/test_artifact_lookup.py
+++ b/merger/lenskit/tests/test_artifact_lookup.py
@@ -172,6 +172,47 @@ class TestQueryArtifactStore:
         ids = {store.store("query_trace", {}, prov) for _ in range(5)}
         assert len(ids) == 5
 
+    def test_store_contains_runtime_metadata_query_trace(self, store):
+        prov = {"source_query": "q", "timestamp": "2024-01-01T00:00:00+00:00"}
+        aid = store.store("query_trace", {}, prov)
+        entry = store.get(aid)
+        assert entry["authority"] == "runtime_observation"
+        assert entry["canonicality"] == "observation"
+        assert entry["artifact_shape"] == "raw"
+        assert entry["retention_policy"] == "unbounded_currently"
+        assert "claim_boundaries" in entry
+        assert "does_not_prove" in entry["claim_boundaries"]
+        assert len(entry["claim_boundaries"]["does_not_prove"]) >= 1
+
+    def test_context_bundle_artifact_shape_is_projected(self, store):
+        prov = {"source_query": "q", "timestamp": "2024-01-01T00:00:00+00:00"}
+        aid = store.store("context_bundle", {"query": "q", "hits": []}, prov)
+        entry = store.get(aid)
+        assert entry["artifact_shape"] == "projected"
+        assert "Context bundle is stored in projected API form" in " ".join(
+            entry["claim_boundaries"]["does_not_prove"]
+        )
+
+    def test_agent_query_session_artifact_shape_is_wrapper(self, store):
+        prov = {"source_query": "q", "timestamp": "2024-01-01T00:00:00+00:00"}
+        aid = store.store("agent_query_session", {"query": "q"}, prov)
+        entry = store.get(aid)
+        assert entry["artifact_shape"] == "wrapper"
+        assert entry["authority"] == "runtime_observation"
+
+    def test_runtime_metadata_survives_persistence_reload(self, tmp_path):
+        storage_dir = tmp_path / ".rlens-service"
+        store1 = QueryArtifactStore(storage_dir)
+        prov = {"source_query": "persist", "timestamp": "2024-01-01T00:00:00+00:00"}
+        aid = store1.store("context_bundle", {}, prov)
+
+        store2 = QueryArtifactStore(storage_dir)
+        entry = store2.get(aid)
+        assert entry is not None
+        assert entry["authority"] == "runtime_observation"
+        assert entry["artifact_shape"] == "projected"
+        assert "claim_boundaries" in entry
+
 
 # ---------------------------------------------------------------------------
 # API endpoint tests
@@ -406,6 +447,65 @@ class TestApiArtifactLookup:
         assert "context_bundle" in data["artifact_ids"], (
             "context_bundle artifact ID must be stored"
         )
+
+    def test_lookup_response_includes_runtime_metadata(self, api_client):
+        resp = api_client.post(
+            "/api/query",
+            json={
+                "index_id": "test-art",
+                "q": "main",
+                "trace": True,
+                "stale_policy": "ignore",
+            },
+            headers=_AUTH,
+        )
+        assert resp.status_code == 200
+        artifact_ids = resp.json().get("artifact_ids", {})
+        assert "query_trace" in artifact_ids
+        trace_id = artifact_ids["query_trace"]
+
+        lookup_resp = api_client.post(
+            "/api/artifact_lookup",
+            json={"artifact_type": "query_trace", "id": trace_id},
+            headers=_AUTH,
+        )
+        assert lookup_resp.status_code == 200
+        data = lookup_resp.json()
+        assert data["status"] == "ok"
+        art = data["artifact"]
+        assert art["authority"] == "runtime_observation"
+        assert art["canonicality"] == "observation"
+        assert art["artifact_shape"] == "raw"
+        assert art["retention_policy"] == "unbounded_currently"
+        assert "claim_boundaries" in art
+        assert "does_not_prove" in art["claim_boundaries"]
+
+    def test_context_bundle_lookup_includes_projected_shape(self, api_client):
+        resp = api_client.post(
+            "/api/query",
+            json={
+                "index_id": "test-art",
+                "q": "main",
+                "build_context_bundle": True,
+                "stale_policy": "ignore",
+            },
+            headers=_AUTH,
+        )
+        assert resp.status_code == 200
+        artifact_ids = resp.json().get("artifact_ids", {})
+        assert "context_bundle" in artifact_ids
+        cb_id = artifact_ids["context_bundle"]
+
+        lookup_resp = api_client.post(
+            "/api/artifact_lookup",
+            json={"artifact_type": "context_bundle", "id": cb_id},
+            headers=_AUTH,
+        )
+        assert lookup_resp.status_code == 200
+        data = lookup_resp.json()
+        assert data["status"] == "ok"
+        assert data["artifact"]["artifact_shape"] == "projected"
+        assert data["artifact"]["authority"] == "runtime_observation"
 
     def test_store_path_uses_merges_dir_when_set(self, api_client_custom_merges):
         """QueryArtifactStore must use merges_dir/.rlens-service when merges_dir is set."""

--- a/merger/lenskit/tests/test_artifact_lookup.py
+++ b/merger/lenskit/tests/test_artifact_lookup.py
@@ -213,6 +213,80 @@ class TestQueryArtifactStore:
         assert entry["artifact_shape"] == "projected"
         assert "claim_boundaries" in entry
 
+    def test_legacy_entry_without_runtime_metadata_is_backfilled(self, tmp_path):
+        """Entries written before the metadata PR are backfilled by get()."""
+        import json as _json
+        storage_dir = tmp_path / ".rlens-service"
+        storage_dir.mkdir(parents=True, exist_ok=True)
+        store_file = storage_dir / "query_artifacts.json"
+        legacy_entry = {
+            "id": "qart-legacy001",
+            "artifact_type": "query_trace",
+            "data": {"query_input": "legacy"},
+            "provenance": {"source_query": "legacy", "timestamp": "2024-01-01T00:00:00+00:00"},
+            "created_at": "2024-01-01T00:00:00+00:00",
+            # deliberately omits: authority, canonicality, artifact_shape,
+            # retention_policy, claim_boundaries
+        }
+        store_file.write_text(_json.dumps([legacy_entry]), encoding="utf-8")
+
+        store = QueryArtifactStore(storage_dir)
+        entry = store.get("qart-legacy001")
+        assert entry is not None
+        assert entry["authority"] == "runtime_observation"
+        assert entry["canonicality"] == "observation"
+        assert entry["artifact_shape"] == "raw"
+        assert entry["retention_policy"] == "unbounded_currently"
+        assert "claim_boundaries" in entry
+        assert "does_not_prove" in entry["claim_boundaries"]
+        # Original fields must be preserved
+        assert entry["data"] == {"query_input": "legacy"}
+        assert entry["provenance"]["source_query"] == "legacy"
+
+    def test_legacy_context_bundle_backfill_uses_projected_shape(self, tmp_path):
+        """Legacy context_bundle entries are backfilled with artifact_shape='projected'."""
+        import json as _json
+        storage_dir = tmp_path / ".rlens-service"
+        storage_dir.mkdir(parents=True, exist_ok=True)
+        store_file = storage_dir / "query_artifacts.json"
+        legacy_entry = {
+            "id": "qart-legacy002",
+            "artifact_type": "context_bundle",
+            "data": {"query": "q", "hits": []},
+            "provenance": {"source_query": "q", "timestamp": "2024-01-01T00:00:00+00:00"},
+            "created_at": "2024-01-01T00:00:00+00:00",
+        }
+        store_file.write_text(_json.dumps([legacy_entry]), encoding="utf-8")
+
+        store = QueryArtifactStore(storage_dir)
+        entry = store.get("qart-legacy002")
+        assert entry is not None
+        assert entry["artifact_shape"] == "projected"
+        assert entry["authority"] == "runtime_observation"
+
+    def test_backfill_does_not_overwrite_existing_fields(self, tmp_path):
+        """If a field is already in the stored entry, backfill must not overwrite it."""
+        import json as _json
+        storage_dir = tmp_path / ".rlens-service"
+        storage_dir.mkdir(parents=True, exist_ok=True)
+        store_file = storage_dir / "query_artifacts.json"
+        # Entry already has authority (e.g. from a future schema that uses a different value)
+        entry_with_authority = {
+            "id": "qart-has-auth",
+            "artifact_type": "query_trace",
+            "data": {},
+            "provenance": {"source_query": "q", "timestamp": "2024-01-01T00:00:00+00:00"},
+            "created_at": "2024-01-01T00:00:00+00:00",
+            "authority": "runtime_observation",  # already present
+            "artifact_shape": "raw",              # already present
+        }
+        store_file.write_text(_json.dumps([entry_with_authority]), encoding="utf-8")
+
+        store = QueryArtifactStore(storage_dir)
+        entry = store.get("qart-has-auth")
+        assert entry["authority"] == "runtime_observation"
+        assert entry["artifact_shape"] == "raw"
+
 
 # ---------------------------------------------------------------------------
 # API endpoint tests
@@ -506,6 +580,80 @@ class TestApiArtifactLookup:
         assert data["status"] == "ok"
         assert data["artifact"]["artifact_shape"] == "projected"
         assert data["artifact"]["authority"] == "runtime_observation"
+
+    def test_artifact_lookup_ok_with_runtime_metadata_conforms_to_contract(self, api_client):
+        """ok response including runtime metadata must validate against artifact-lookup.v1.schema.json."""
+        if jsonschema is None:
+            pytest.skip("jsonschema not available")
+
+        resp = api_client.post(
+            "/api/query",
+            json={
+                "index_id": "test-art",
+                "q": "main",
+                "trace": True,
+                "stale_policy": "ignore",
+            },
+            headers=_AUTH,
+        )
+        assert resp.status_code == 200
+        trace_id = resp.json().get("artifact_ids", {}).get("query_trace")
+        assert trace_id is not None, "query_trace not stored despite trace=True"
+
+        lookup_resp = api_client.post(
+            "/api/artifact_lookup",
+            json={"artifact_type": "query_trace", "id": trace_id},
+            headers=_AUTH,
+        )
+        assert lookup_resp.status_code == 200
+        data = lookup_resp.json()
+        assert data["status"] == "ok"
+        assert "authority" in data["artifact"], "runtime metadata missing from artifact payload"
+
+        schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+        jsonschema.validate(instance=data, schema=schema)
+
+    def test_schema_rejects_wrong_authority_value(self):
+        """Schema const enforcement: authority must be 'runtime_observation'."""
+        if jsonschema is None:
+            pytest.skip("jsonschema not available")
+
+        schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+        bad_payload = {
+            "artifact_type": "query_trace",
+            "id": "qart-test",
+            "status": "ok",
+            "artifact": {
+                "provenance": {"source_query": "q", "timestamp": "2024-01-01T00:00:00+00:00"},
+                "created_at": "2024-01-01T00:00:00+00:00",
+                "data": {},
+                "authority": "canonical_content",  # wrong value — must fail
+            },
+            "warnings": [],
+        }
+        with pytest.raises(Exception):  # jsonschema.ValidationError
+            jsonschema.validate(instance=bad_payload, schema=schema)
+
+    def test_schema_rejects_unknown_artifact_shape(self):
+        """Schema enum enforcement: artifact_shape must be raw|projected|wrapper."""
+        if jsonschema is None:
+            pytest.skip("jsonschema not available")
+
+        schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+        bad_payload = {
+            "artifact_type": "query_trace",
+            "id": "qart-test",
+            "status": "ok",
+            "artifact": {
+                "provenance": {"source_query": "q", "timestamp": "2024-01-01T00:00:00+00:00"},
+                "created_at": "2024-01-01T00:00:00+00:00",
+                "data": {},
+                "artifact_shape": "unknown_shape",  # not in enum — must fail
+            },
+            "warnings": [],
+        }
+        with pytest.raises(Exception):  # jsonschema.ValidationError
+            jsonschema.validate(instance=bad_payload, schema=schema)
 
     def test_store_path_uses_merges_dir_when_set(self, api_client_custom_merges):
         """QueryArtifactStore must use merges_dir/.rlens-service when merges_dir is set."""

--- a/merger/lenskit/tests/test_artifact_lookup.py
+++ b/merger/lenskit/tests/test_artifact_lookup.py
@@ -302,6 +302,15 @@ class TestQueryArtifactStore:
         third = store.get(third_id)
         assert "MUTATION_SENTINEL" not in third["claim_boundaries"]["does_not_prove"]
 
+    def test_get_returns_deepcopy_not_mutable_cache_entry(self, store):
+        """Mutating a get() return value must not affect subsequent get() calls for the same id."""
+        prov = {"source_query": "q", "timestamp": "2024-01-01T00:00:00+00:00"}
+        aid = store.store("query_trace", {}, prov)
+        first = store.get(aid)
+        first["claim_boundaries"]["does_not_prove"].append("MUTATION_SENTINEL")
+        again = store.get(aid)
+        assert "MUTATION_SENTINEL" not in again["claim_boundaries"]["does_not_prove"]
+
 
 # ---------------------------------------------------------------------------
 # API endpoint tests

--- a/merger/lenskit/tests/test_artifact_lookup.py
+++ b/merger/lenskit/tests/test_artifact_lookup.py
@@ -287,6 +287,21 @@ class TestQueryArtifactStore:
         assert entry["authority"] == "runtime_observation"
         assert entry["artifact_shape"] == "raw"
 
+    def test_runtime_metadata_claim_boundaries_are_not_shared_between_entries(self, store):
+        """claim_boundaries lists must not be shared between independently stored artifacts."""
+        prov = {"source_query": "q", "timestamp": "2024-01-01T00:00:00+00:00"}
+        first_id = store.store("query_trace", {}, prov)
+        second_id = store.store("query_trace", {}, prov)
+        first = store.get(first_id)
+        # Mutate the returned entry's claim_boundaries in-place.
+        first["claim_boundaries"]["does_not_prove"].append("MUTATION_SENTINEL")
+        second = store.get(second_id)
+        assert "MUTATION_SENTINEL" not in second["claim_boundaries"]["does_not_prove"]
+        # A third entry stored after the mutation must also be clean.
+        third_id = store.store("query_trace", {}, prov)
+        third = store.get(third_id)
+        assert "MUTATION_SENTINEL" not in third["claim_boundaries"]["does_not_prove"]
+
 
 # ---------------------------------------------------------------------------
 # API endpoint tests
@@ -631,7 +646,7 @@ class TestApiArtifactLookup:
             },
             "warnings": [],
         }
-        with pytest.raises(Exception):  # jsonschema.ValidationError
+        with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(instance=bad_payload, schema=schema)
 
     def test_schema_rejects_unknown_artifact_shape(self):
@@ -652,7 +667,7 @@ class TestApiArtifactLookup:
             },
             "warnings": [],
         }
-        with pytest.raises(Exception):  # jsonschema.ValidationError
+        with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(instance=bad_payload, schema=schema)
 
     def test_store_path_uses_merges_dir_when_set(self, api_client_custom_merges):

--- a/merger/lenskit/tests/test_context_lookup.py
+++ b/merger/lenskit/tests/test_context_lookup.py
@@ -246,3 +246,69 @@ class TestApiContextLookup:
 
         schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
         jsonschema.validate(instance=data, schema=schema)
+
+    def test_context_lookup_ok_includes_runtime_metadata(self, api_client):
+        resp = api_client.post(
+            "/api/query",
+            json={
+                "index_id": "test-art",
+                "q": "main",
+                "build_context_bundle": True,
+                "stale_policy": "ignore",
+            },
+            headers=_AUTH,
+        )
+        assert resp.status_code == 200
+        artifact_ids = resp.json().get("artifact_ids", {})
+        assert "context_bundle" in artifact_ids
+        cb_id = artifact_ids["context_bundle"]
+
+        lookup_resp = api_client.post(
+            "/api/context_lookup",
+            json={"id": cb_id},
+            headers=_AUTH,
+        )
+        assert lookup_resp.status_code == 200
+        data = lookup_resp.json()
+        assert data["status"] == "ok"
+        assert data["authority"] == "runtime_observation"
+        assert data["canonicality"] == "observation"
+        assert data["artifact_shape"] == "projected"
+        assert data["retention_policy"] == "unbounded_currently"
+        assert "claim_boundaries" in data
+        assert "does_not_prove" in data["claim_boundaries"]
+        # context_bundle specifically notes projected form in claim_boundaries
+        assert any(
+            "projected" in s.lower()
+            for s in data["claim_boundaries"]["does_not_prove"]
+        )
+
+    def test_context_lookup_runtime_metadata_conforms_to_contract(self, api_client):
+        """ok response with runtime metadata must validate against schema."""
+        if jsonschema is None:
+            pytest.skip("jsonschema not available")
+
+        resp = api_client.post(
+            "/api/query",
+            json={
+                "index_id": "test-art",
+                "q": "main",
+                "build_context_bundle": True,
+                "stale_policy": "ignore",
+            },
+            headers=_AUTH,
+        )
+        assert resp.status_code == 200
+        cb_id = resp.json().get("artifact_ids", {}).get("context_bundle")
+        assert cb_id is not None
+
+        lookup_resp = api_client.post(
+            "/api/context_lookup",
+            json={"id": cb_id},
+            headers=_AUTH,
+        )
+        assert lookup_resp.status_code == 200
+        data = lookup_resp.json()
+
+        schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+        jsonschema.validate(instance=data, schema=schema)

--- a/merger/lenskit/tests/test_trace_lookup.py
+++ b/merger/lenskit/tests/test_trace_lookup.py
@@ -244,3 +244,64 @@ class TestApiTraceLookup:
 
         schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
         jsonschema.validate(instance=data, schema=schema)
+
+    def test_trace_lookup_ok_includes_runtime_metadata(self, api_client):
+        resp = api_client.post(
+            "/api/query",
+            json={
+                "index_id": "test-art",
+                "q": "main",
+                "trace": True,
+                "stale_policy": "ignore",
+            },
+            headers=_AUTH,
+        )
+        assert resp.status_code == 200
+        artifact_ids = resp.json().get("artifact_ids", {})
+        assert "query_trace" in artifact_ids
+        trace_id = artifact_ids["query_trace"]
+
+        lookup_resp = api_client.post(
+            "/api/trace_lookup",
+            json={"id": trace_id},
+            headers=_AUTH,
+        )
+        assert lookup_resp.status_code == 200
+        data = lookup_resp.json()
+        assert data["status"] == "ok"
+        assert data["authority"] == "runtime_observation"
+        assert data["canonicality"] == "observation"
+        assert data["artifact_shape"] == "raw"
+        assert data["retention_policy"] == "unbounded_currently"
+        assert "claim_boundaries" in data
+        assert "does_not_prove" in data["claim_boundaries"]
+
+    def test_trace_lookup_runtime_metadata_conforms_to_contract(self, api_client):
+        """ok response with runtime metadata must validate against schema."""
+        if jsonschema is None:
+            pytest.skip("jsonschema not available")
+
+        resp = api_client.post(
+            "/api/query",
+            json={
+                "index_id": "test-art",
+                "q": "main",
+                "trace": True,
+                "stale_policy": "ignore",
+            },
+            headers=_AUTH,
+        )
+        assert resp.status_code == 200
+        trace_id = resp.json().get("artifact_ids", {}).get("query_trace")
+        assert trace_id is not None
+
+        lookup_resp = api_client.post(
+            "/api/trace_lookup",
+            json={"id": trace_id},
+            headers=_AUTH,
+        )
+        assert lookup_resp.status_code == 200
+        data = lookup_resp.json()
+
+        schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+        jsonschema.validate(instance=data, schema=schema)


### PR DESCRIPTION
## Summary

This PR adds machine-readable classification metadata to runtime artifacts stored in `QueryArtifactStore` and returned by the three lookup endpoints (`artifact_lookup`, `trace_lookup`, `context_lookup`). Previously, this metadata existed only as docstring comments; now it is explicitly modeled in schemas and API responses.

## Key Changes

- **Store metadata injection**: Added `_RUNTIME_ARTIFACT_METADATA` constant in `query_artifact_store.py` that injects five fields into every stored artifact:
  - `authority`: Always `"runtime_observation"` for runtime artifacts
  - `canonicality`: Always `"observation"` for runtime artifacts
  - `artifact_shape`: Distinguishes storage form (`"raw"` for query_trace, `"projected"` for context_bundle, `"wrapper"` for agent_query_session)
  - `retention_policy`: Documents current behavior (`"unbounded_currently"` — no GC applied)
  - `claim_boundaries`: Epistemic boundaries with `does_not_prove` statements specific to each artifact type

- **Schema updates**: Extended three lookup contract schemas to accept the new optional fields:
  - `artifact-lookup.v1.schema.json`: Added fields to `ArtifactPayload`
  - `trace-lookup.v1.schema.json`: Added top-level fields
  - `context-lookup.v1.schema.json`: Added top-level fields

- **API endpoint updates**: Modified `app.py` to pass through the new metadata fields in all three lookup endpoints, conditionally including them if present in the stored entry.

- **Test coverage**: Added comprehensive tests in `test_artifact_lookup.py`, `test_trace_lookup.py`, and `test_context_lookup.py` to verify:
  - Metadata is correctly stored and retrieved
  - Artifact-specific values (e.g., `artifact_shape` differs by type)
  - Metadata survives persistence/reload cycles
  - API responses include metadata and conform to schema

- **Documentation**: Updated `docs/service-api.md` with example responses showing the new metadata fields.

## Implementation Details

- All changes are **additive and backward-compatible**: new fields are optional in schemas, no breaking changes to existing APIs
- `artifact_shape` explicitly documents the projection status of `context_bundle` (stored in API-projected form, not raw internal form), addressing a known limitation previously only documented in code comments
- `claim_boundaries` includes artifact-type-specific disclaimers (e.g., context_bundle notes it is in projected form)
- Metadata is injected at store time via dictionary unpacking, ensuring consistency across all three artifact types
- No retention/GC implementation changes; `retention_policy` documents current unbounded behavior

This PR fulfills the "Phase 4" annotation mentioned in `docs/architecture/artifact-inventory.md` and completes the follow-up PR for `claim_boundaries` propagation announced in `docs/retrieval/recipes.md`.

https://claude.ai/code/session_01PUxx3TKtHRHGC9auMag5MC