### PR TITLE
docs: Add range semantics and citation map artifact fit proofs

### DIFF
--- a/docs/architecture/range-semantics.md
+++ b/docs/architecture/range-semantics.md
@@ -48,13 +48,17 @@ interpretieren.
 
 ## Feldnamen
 
-Verwende die im Repo etablierte Terminologie:
+Verwende für Range-Objekte und Range-Refs die im Repo etablierte Terminologie:
 
 - `start_byte`
 - `end_byte`
 - `start_line`
 - `end_line`
 - `file_path`
+
+Bestehende Chunk-Records in `chunk_index_jsonl` können weiterhin `path` als Chunk-/Source-Pfadfeld
+verwenden. Diese Benennung bleibt für Chunk-Records unverändert; `file_path` meint hier
+Range-Objekte und Range-Refs wie `range-ref.v1` / `content_range_ref`.
 
 ## Invarianten
 

--- a/docs/architecture/range-semantics.md
+++ b/docs/architecture/range-semantics.md
@@ -1,0 +1,82 @@
+# Range Semantics
+
+## Zweck
+
+Definiere die Range-Begriffe für Lenskit, damit Chunking, Range-Resolver, Citation Map,
+Query Runtime und spätere Evidence-Auswertung nicht dieselben Felder unterschiedlich
+interpretieren.
+
+## Begriffe
+
+### canonical_range
+
+- Position im `canonical_md`.
+- Belegbasis für spätere `citation_map_jsonl`.
+- Hash-Prüfung bezieht sich auf den canonical byte slice.
+- Darf nicht mit source-local ranges verwechselt werden.
+
+### source_range
+
+- Position in der ursprünglichen Quelldatei.
+- Status muss sichtbar sein:
+  - `declared`: aus vorhandenen Metadaten übernommen, nicht separat validiert.
+  - `exact`: gegen eindeutig rekonstruierbare Quelle validiert.
+  - `derived`: rechnerisch abgeleitet, nicht vollständig source-verifiziert.
+  - `unavailable`: keine belastbare Source-Range verfügbar.
+
+### chunk_range
+
+- Segmentierungsbereich eines Retrieval-Chunks.
+- Hilft beim Finden.
+- Ist nicht automatisch Belegwahrheit.
+
+### content_range_ref
+
+- Bestehender legacy-kompatibler Range-Verweis.
+- Bleibt gültig.
+- Wird nicht gelöscht.
+- Reicht allein nicht als Zukunftsmodell, weil canonical/source/chunk/semantic Bedeutungen
+  getrennt werden müssen.
+- Darf später nicht blind als vollständige `canonical_range` oder `source_range` übernommen
+  werden; Producer müssen canonical/source/chunk-Bedeutungen explizit trennen und validieren.
+
+### semantic_boundary
+
+- Spätere Aussage-/Evidence-Grenze.
+- Nicht Teil von Citation Map v1.
+- Nicht in diesem PR implementieren.
+
+## Feldnamen
+
+Verwende die im Repo etablierte Terminologie:
+
+- `start_byte`
+- `end_byte`
+- `start_line`
+- `end_line`
+- `file_path`
+
+## Invarianten
+
+- `start_byte` ist inklusiv.
+- `end_byte` ist exklusiv.
+- `start_line` und `end_line` sind 1-basiert.
+- `end_line` bezeichnet die Zeile, die `end_byte - 1` enthält.
+- Empty ranges sind für spätere Citation Map v1 ungültig.
+- `canonical_range.content_sha256` bezieht sich auf den canonical byte slice.
+- `source_range.status` ist Pflicht, sobald `source_range` vorhanden ist.
+
+## Migration
+
+- `range-ref.v1` bleibt kompatibel.
+- `content_range_ref` bleibt erhalten.
+- `canonical_range` und `source_range` werden später zusätzlich erzeugt.
+- Dieser PR erzeugt keine Breaking Changes.
+
+## Nicht-Ziele
+
+- Kein `range-ref.v2`-Schema.
+- Keine Citation Map.
+- Keine Manifest-Role.
+- Kein Producer.
+- Kein Query-/UI-/Agent-Anschluss.

--- a/docs/proofs/citation-map-artifact-fit.md
+++ b/docs/proofs/citation-map-artifact-fit.md
@@ -1,0 +1,74 @@
+# Citation Map Artifact Fit
+
+## Zweck
+
+Klärt, welche vorhandenen Artefakte eine spätere `citation_map_jsonl` nutzen darf und
+welche Rollen sie nicht übernehmen darf.
+
+## Belegter Ist-Zustand
+
+- `canonical_md` ist Inhaltsträger und kanonische Vollquelle.
+- `chunk_index_jsonl` ist abgeleiteter Retrieval-Index.
+- `bundle_manifest` ist die stärkste Registry-Basis.
+- `dump_index_json` ist Navigation/View.
+- `derived_manifest_json` ist Derived-/Cache-View.
+- `sqlite_index` ist Runtime-Cache.
+- `citation_map_jsonl` ist geplant, aber noch nicht implementiert.
+
+## Entscheidung
+
+`citation_map_jsonl` wird später ein neues abgeleitetes Belegadress-Artefakt.
+
+Sie ersetzt nicht:
+
+- `canonical_md`
+- `chunk_index_jsonl`
+- `range-ref.v1`
+- `sqlite_index`
+- `bundle_manifest`
+
+## Geplante Rolle
+
+`citation_map_jsonl` darf später nur:
+
+- `authority: navigation_index`
+- `canonicality: derived`
+
+Sie darf nie behaupten:
+
+- `canonical_content`
+- `content_source`
+- `runtime_cache`
+
+## Inputs für spätere Citation Map
+
+- `canonical_md`
+- `chunk_index_jsonl`
+- `bundle_manifest`
+
+## Nicht voraussetzen
+
+- Inline-`content` im Chunk ist nicht Pflicht.
+- SQLite ist keine Citation-Wahrheit.
+- `source_range.status = exact` ist nicht garantiert.
+- Query-Ergebnisse dürfen Citations später referenzieren, aber nicht selbst erzeugen.
+- Evidence Use / Claim-Bewertung gehört nicht in Citation Map v1.
+
+## Offene Folge-PRs
+
+1. `citation-map.v1.schema.json`
+2. Minimale Beispiele
+3. Schema-Test
+4. Bundle-Manifest-Role `citation_map_jsonl`
+5. Chunk-Index dual range
+6. Citation-Map-Producer
+7. Citation-/Evidence-Health-Prüfung
+8. Real-Dump-Proof
+
+## Stop-Kriterium für diesen Proof
+
+Der Proof ist ausreichend, wenn klar ist:
+
+- Welche Artefakte genutzt werden.
+- Welche Artefakte nicht ersetzt werden.
+- Welche Semantik vor Contract/Producer geklärt sein muss.

--- a/docs/proofs/citation-map-artifact-fit.md
+++ b/docs/proofs/citation-map-artifact-fit.md
@@ -9,7 +9,7 @@ welche Rollen sie nicht übernehmen darf.
 
 - `canonical_md` ist Inhaltsträger und kanonische Vollquelle.
 - `chunk_index_jsonl` ist abgeleiteter Retrieval-Index.
-- `bundle_manifest` ist die stärkste Registry-Basis.
+- Das Bundle Manifest (`*.bundle.manifest.json`, `kind: repolens.bundle.manifest`) ist das stärkste Registry-Root-Dokument; es ist keine ArtifactRole und darf nicht mit ArtifactRole-Strings wie `canonical_md` oder `chunk_index_jsonl` verwechselt werden.
 - `dump_index_json` ist Navigation/View.
 - `derived_manifest_json` ist Derived-/Cache-View.
 - `sqlite_index` ist Runtime-Cache.
@@ -36,9 +36,9 @@ Sie ersetzt nicht:
 
 Sie darf nie behaupten:
 
-- `canonical_content`
-- `content_source`
-- `runtime_cache`
+- `authority: canonical_content`
+- `authority: runtime_cache`
+- `canonicality: content_source`
 
 ## Inputs für spätere Citation Map
 


### PR DESCRIPTION
## Summary

This PR adds two foundational documentation artifacts that establish semantic clarity for range handling and citation map architecture in Lenskit. These proofs define terminology and constraints that will guide future implementation of citation mapping and evidence resolution features.

## Changes

- **docs/architecture/range-semantics.md**: Defines four distinct range concepts (`canonical_range`, `source_range`, `chunk_range`, `content_range_ref`) with clear invariants and field naming conventions. Establishes that ranges use inclusive `start_byte`, exclusive `end_byte`, and 1-based line numbers. Clarifies that this is a semantic specification document, not a breaking schema change.

- **docs/proofs/citation-map-artifact-fit.md**: Clarifies the planned role of `citation_map_jsonl` as a derived navigation index artifact. Documents which existing artifacts it will depend on (`canonical_md`, `chunk_index_jsonl`, `bundle_manifest`) and which it will not replace. Establishes that source range status tracking and semantic boundaries are out of scope for Citation Map v1.

## Implementation Details

Both documents are written in German (matching the project's documentation language) and serve as architectural proofs rather than executable code. They establish:

- **Range invariants**: Byte ranges are half-open intervals [start, end); lines are 1-based
- **Status tracking**: Source ranges must declare their validation status (declared, exact, derived, unavailable)
- **Non-goals**: Explicitly excludes range-ref.v2 schema, manifest roles, producers, and query/UI integration from current scope
- **Migration path**: Confirms backward compatibility with existing `range-ref.v1` and `content_range_ref`

These proofs provide the semantic foundation needed before implementing the citation map producer and schema in follow-up PRs.

https://claude.ai/code/session_01FTvLFLT973bboKbkFsUysG