### PR TITLE
docs: Add Citation-Map Producer diagnosis and stop-decision documentation

### DIFF
--- a/docs/proofs/citation-map-producer-diagnosis.md
+++ b/docs/proofs/citation-map-producer-diagnosis.md
@@ -18,7 +18,7 @@ Die Citation-Map-Producer-Komponente existiert nicht im Repo. Schema, Manifest-R
 | Beispiele | `merger/lenskit/contracts/examples/citation_map_minimal.jsonl` | 3 gültige Einträge demonstrieren source_range Varianten |
 | Schema-Test | `merger/lenskit/tests/test_citation_map_schema.py` | vorhanden |
 | Proof | `docs/proofs/citation-map-artifact-fit.md` | Rollen und Nicht-Rollen geklärt |
-| Manifest-Role | `bundle-manifest.v1.schema.json:84, 498–551` | strikt registriert mit Constraints: `contract=citation-map/v1`, `authority=navigation_index`, `canonicality=derived`, `regenerable=true`, `staleness_sensitive=true` |
+| Manifest-Role | `merger/lenskit/contracts/bundle-manifest.v1.schema.json:84, 498–551` | strikt registriert mit Constraints: `contract=citation-map/v1`, `authority=navigation_index`, `canonicality=derived`, `regenerable=true`, `staleness_sensitive=true` |
 | ArtifactRole Enum | `merger/lenskit/core/constants.py:21` | `CITATION_MAP_JSONL = "citation_map_jsonl"` |
 | Roadmap-Eintrag | `docs/roadmap/lenskit-master-roadmap.md:76` | `[ ] Citation-Map-Producer …, Real-Dump-Proof` offen |
 
@@ -71,7 +71,7 @@ Ein Producer ohne Real-Dump-Proof:
 
 ## Nächste erforderliche Vorbedingungen
 
-Bevor ein echtes `core/citation_map.py` begonnen wird, müssen diese Bedingungen erfüllt sein:
+Bevor ein echtes `merger/lenskit/core/citation_map.py` begonnen wird, müssen diese Bedingungen erfüllt sein:
 
 ### 1. Real-Dump mit dual ranges bereitstellen
 - Quelle: Ein von der aktuellen Lenskit-Pipeline erzeugter `*.bundle.manifest.json` mit zugehörigem chunk_index.jsonl, das `canonical_range`, `source_range`, `content_range_ref` enthält.

--- a/docs/proofs/citation-map-producer-diagnosis.md
+++ b/docs/proofs/citation-map-producer-diagnosis.md
@@ -122,7 +122,9 @@ Ziel: Spätere Roadmap-Reader sehen sofort, dass Producer nicht „vergessen" is
 - Beweis, dass ein Producer **könnte** funktionieren (Skizze/Pseudo-Code).
 - Beweis, dass die Blueprint-Regel richtig ist.
 - Implementierung einer der Vorbedingungen.
-- Änderung an der aktuellen Roadmap (nur Blocker-Notiz optional).
+- Änderung des Citation-Map-Producer-Status auf `[x]`.
+- Beweis, dass der spätere Producer mit Real-Dump funktioniert.
+- Weitere Roadmap-Änderungen über die Blocker-Notiz hinaus.
 
 Dieser Proof **dokumentiert die Stop-Entscheidung**, nicht die Machbarkeit des Patches.
 

--- a/docs/proofs/citation-map-producer-diagnosis.md
+++ b/docs/proofs/citation-map-producer-diagnosis.md
@@ -30,18 +30,18 @@ Die Citation-Map-Producer-Komponente existiert nicht im Repo. Schema, Manifest-R
 | Wiring in merge.py | `_add_artifact(CITATION_MAP_JSONL, …)` fehlt in Zeilen 5919–5975 (alle anderen Rollen vorhanden). Kein Contract-/Authority-Default-Eintrag für `CITATION_MAP_JSONL` in Zeilen 5825–5882. |
 | Output-Health Integration | `merger/lenskit/core/output_health.py` erwähnt `citation_map` keinmal (wäre die Stelle für geplante Citation-Health-Checks). |
 | Konsument im Code | `merger/lenskit/retrieval/query_core.py`, `service/`, `cli/` referenzieren `citation_id` nirgends. Contracts-Matrix nennt Konsumenten nur als geplant (Query/Context/Agent Evidence Pack in Phase 2/5). |
-| Real-Dump | `data/` enthält nur `.gitkeep`. Kein erzeugter `*.bundle.manifest.json`, kein `*.merge.md` mit zugehörigem chunk_index. Real-Dump-Proof unmöglich. |
+| Real-Dump | `data/` enthält nur `.gitkeep`. Im Repo ist kein erzeugter `*.bundle.manifest.json`, kein `*.merge.md` mit zugehörigem chunk_index abgelegt. Real-Dump-Proof aus dem Repo-Stand heraus unmöglich. |
 | Fixture-Update | `merger/lenskit/tests/fixtures/retrieval/mini_chunk_index.jsonl` enthält keine dual ranges (`canonical_range`, `source_range`, `content_range_ref`); ein Producer würde an dieser Fixture leer laufen. |
 
 ## Epistemische Leeren
 
 Folgende Lücken verhindern einen stabilen Producer-PR:
 
-1. **Real-Dump fehlt, nötig für Real-Dump-Proof.** `data/` ist leer. Kein produzierter Lenskit-Bundle mit chunk_index dual ranges existiert im Repo oder erreichbar.
+1. **Real-Dump fehlt, nötig für Real-Dump-Proof.** `data/` ist leer. Kein produzierter Lenskit-Bundle mit chunk_index dual ranges ist im Repo als prüfbares Artefakt abgelegt.
    - Folge: Jedes Test-Fixture ist theoretisch falsch und kann nicht „Real-Dump-Proof" sein.
 
-2. **Konsument fehlt im Code, nötig für klaren Nutzen.** Kein Schema erweitert um `citation_id`, kein Validator liest citation_map_jsonl.
-   - Folge: Producer würde ein Artefakt erzeugen, das niemand im aktuellen Repo konsumiert.
+2. **Konsument fehlt im Code, nötig für klaren Nutzen.** Im Repo erweitert kein Schema `citation_id`, kein Validator liest citation_map_jsonl.
+   - Folge: Producer würde ein Artefakt erzeugen, das kein Code im Repo konsumiert.
 
 3. **Snapshot-Quelle für run_id/canonical_md_sha256 nicht zentral verdrahtet.** `merge.py` kennt diese Werte, aber nicht im Kontext eines Citation-Producers.
    - Folge: Deterministische Citation-Id-Ableitung hätte keine garantierte Quelle.

--- a/docs/proofs/citation-map-producer-diagnosis.md
+++ b/docs/proofs/citation-map-producer-diagnosis.md
@@ -6,7 +6,7 @@
 
 Die Citation-Map-Producer-Komponente existiert nicht im Repo. Schema, Manifest-Role, ArtifactRole-Enum und Beispiele sind vorhanden — aber kein Producer, kein Wiring, kein Konsument.
 
-**Stop-Kriterium erfüllt:** Kein realer Dump verfügbar; kein In-Repo-Konsument; Real-Dump-Proof daher nicht möglich.
+**Stop-Kriterium erfüllt:** Im Repo ist kein realer Dump mit dual ranges als prüfbares Artefakt abgelegt; kein In-Repo-Konsument; Real-Dump-Proof ist daher aus dem Repo-Stand heraus nicht möglich.
 
 **Keine Implementierung in diesem Diagnose-Schritt.**
 
@@ -38,7 +38,7 @@ Die Citation-Map-Producer-Komponente existiert nicht im Repo. Schema, Manifest-R
 Folgende Lücken verhindern einen stabilen Producer-PR:
 
 1. **Real-Dump fehlt, nötig für Real-Dump-Proof.** `data/` ist leer. Kein produzierter Lenskit-Bundle mit chunk_index dual ranges ist im Repo als prüfbares Artefakt abgelegt.
-   - Folge: Jedes Test-Fixture ist theoretisch falsch und kann nicht „Real-Dump-Proof" sein.
+   - Folge: Ein Test-Fixture kann Producer-Logik prüfen, aber keinen Real-Dump-Proof ersetzen.
 
 2. **Konsument fehlt im Code, nötig für klaren Nutzen.** Im Repo erweitert kein Schema `citation_id`, kein Validator liest citation_map_jsonl.
    - Folge: Producer würde ein Artefakt erzeugen, das kein Code im Repo konsumiert.
@@ -55,7 +55,7 @@ Folgende Lücken verhindern einen stabilen Producer-PR:
 |---|---|---|
 | Citation-Map-Schema fehlt oder ist nicht eindeutig | **Nein** | Schema ist eindeutig, vollständig |
 | Manifest-Role fehlt oder Semantik unklar | **Nein** | Role ist scharf constraint-belegt |
-| **Kein realer Dump mit dual ranges verfügbar** | **Ja** | `data/` leer; keine Bundle-Manifest auf FS; Fixture hat keine dual ranges |
+| **Kein realer Dump mit dual ranges verfügbar** | **Ja** | `data/` leer; im Repo kein Bundle-Manifest abgelegt; Fixture hat keine dual ranges |
 | Producer-Status nicht eindeutig belegbar | **Nein** | H1 ist eindeutig belegt |
 | **Kein Konsument oder kein klarer Nutzen** | **Teilweise Ja** | Kein Konsument im Code; Nutzen (stable citation_id) ohne Konsument spekulativ |
 

--- a/docs/proofs/citation-map-producer-diagnosis.md
+++ b/docs/proofs/citation-map-producer-diagnosis.md
@@ -1,0 +1,134 @@
+# Citation-Map Producer — Diagnose und Stop-Entscheidung
+
+## Status
+
+**Hypothesis H1 (Producer fehlt vollständig) ist repo-belegt.**
+
+Die Citation-Map-Producer-Komponente existiert nicht im Repo. Schema, Manifest-Role, ArtifactRole-Enum und Beispiele sind vorhanden — aber kein Producer, kein Wiring, kein Konsument.
+
+**Stop-Kriterium erfüllt:** Kein realer Dump verfügbar; kein In-Repo-Konsument; Real-Dump-Proof daher nicht möglich.
+
+**Keine Implementierung in diesem Diagnose-Schritt.**
+
+## Vorhandene Bausteine (repo-belegt)
+
+| Beleg | Datei | Status |
+|---|---|---|
+| Schema | `merger/lenskit/contracts/citation-map.v1.schema.json` (5.7 KB) | vollständig, draft-07, erfordert `citation_id`, `repo_id`, `snapshot`, `canonical_range`; `source_range` optional |
+| Beispiele | `merger/lenskit/contracts/examples/citation_map_minimal.jsonl` | 3 gültige Einträge demonstrieren source_range Varianten |
+| Schema-Test | `merger/lenskit/tests/test_citation_map_schema.py` | vorhanden |
+| Proof | `docs/proofs/citation-map-artifact-fit.md` | Rollen und Nicht-Rollen geklärt |
+| Manifest-Role | `bundle-manifest.v1.schema.json:84, 498–551` | strikt registriert mit Constraints: `contract=citation-map/v1`, `authority=navigation_index`, `canonicality=derived`, `regenerable=true`, `staleness_sensitive=true` |
+| ArtifactRole Enum | `merger/lenskit/core/constants.py:21` | `CITATION_MAP_JSONL = "citation_map_jsonl"` |
+| Roadmap-Eintrag | `docs/roadmap/lenskit-master-roadmap.md:76` | `[ ] Citation-Map-Producer …, Real-Dump-Proof` offen |
+
+## Fehlende Komponenten (negativ belegt)
+
+| Komponente | Befund |
+|---|---|
+| Producer-Datei | Kein `merger/lenskit/core/citation_map.py` oder äquivalent. `find merger/lenskit -name '*citation*'` findet nur Schema, Beispiel, Test. |
+| Wiring in merge.py | `_add_artifact(CITATION_MAP_JSONL, …)` fehlt in Zeilen 5919–5975 (alle anderen Rollen vorhanden). Kein Contract-/Authority-Default-Eintrag für `CITATION_MAP_JSONL` in Zeilen 5825–5882. |
+| Output-Health Integration | `merger/lenskit/core/output_health.py` erwähnt `citation_map` keinmal (wäre die Stelle für geplante Citation-Health-Checks). |
+| Konsument im Code | `merger/lenskit/retrieval/query_core.py`, `service/`, `cli/` referenzieren `citation_id` nirgends. Contracts-Matrix nennt Konsumenten nur als geplant (Query/Context/Agent Evidence Pack in Phase 2/5). |
+| Real-Dump | `data/` enthält nur `.gitkeep`. Kein erzeugter `*.bundle.manifest.json`, kein `*.merge.md` mit zugehörigem chunk_index. Real-Dump-Proof unmöglich. |
+| Fixture-Update | `merger/lenskit/tests/fixtures/retrieval/mini_chunk_index.jsonl` enthält keine dual ranges (`canonical_range`, `source_range`, `content_range_ref`); ein Producer würde an dieser Fixture leer laufen. |
+
+## Epistemische Leeren
+
+Folgende Lücken verhindern einen stabilen Producer-PR:
+
+1. **Real-Dump fehlt, nötig für Real-Dump-Proof.** `data/` ist leer. Kein produzierter Lenskit-Bundle mit chunk_index dual ranges existiert im Repo oder erreichbar.
+   - Folge: Jedes Test-Fixture ist theoretisch falsch und kann nicht „Real-Dump-Proof" sein.
+
+2. **Konsument fehlt im Code, nötig für klaren Nutzen.** Kein Schema erweitert um `citation_id`, kein Validator liest citation_map_jsonl.
+   - Folge: Producer würde ein Artefakt erzeugen, das niemand im aktuellen Repo konsumiert.
+
+3. **Snapshot-Quelle für run_id/canonical_md_sha256 nicht zentral verdrahtet.** `merge.py` kennt diese Werte, aber nicht im Kontext eines Citation-Producers.
+   - Folge: Deterministische Citation-Id-Ableitung hätte keine garantierte Quelle.
+
+4. **Citation-Id-Derivationsregel nur in Blueprint, nicht in Code.** `docs/blueprints/lenskit-evidence-address-architecture.md:107–116` definiert die Regel; Schema erzwingt sie nicht.
+   - Folge: Producer müsste die Regel erraten oder vom Blueprint kopieren.
+
+## Stop-Kriterien (Briefing)
+
+| Kriterium | Erfüllt? | Begründung |
+|---|---|---|
+| Citation-Map-Schema fehlt oder ist nicht eindeutig | **Nein** | Schema ist eindeutig, vollständig |
+| Manifest-Role fehlt oder Semantik unklar | **Nein** | Role ist scharf constraint-belegt |
+| **Kein realer Dump mit dual ranges verfügbar** | **Ja** | `data/` leer; keine Bundle-Manifest auf FS; Fixture hat keine dual ranges |
+| Producer-Status nicht eindeutig belegbar | **Nein** | H1 ist eindeutig belegt |
+| **Kein Konsument oder kein klarer Nutzen** | **Teilweise Ja** | Kein Konsument im Code; Nutzen (stable citation_id) ohne Konsument spekulativ |
+
+**Mindestens ein hartes Stop-Kriterium ist erfüllt → Kein Patch jetzt.**
+
+## Warum jetzt nicht implementieren?
+
+Ein Producer ohne Real-Dump-Proof:
+
+1. **Verletzt die Roadmap:** `[ ] Citation-Map-Producer …, Real-Dump-Proof` definiert Gate als „Real-Dump-Proof"; ein Fixture-Test ist kein Real-Dump-Proof.
+2. **Erzeugt Phantom-Evidenz:** Artefakt ohne Konsument im Repo ist totes Inventar, erhöht nur die Komplexität.
+3. **Verstärkt die nächste Hypothese-Fallstricke:** Nachfolgende Agenten sehen einen implementierten Producer und bauen Konsumenten darauf, statt den fehlenden Real-Dump zu beheben.
+
+## Nächste erforderliche Vorbedingungen
+
+Bevor ein echtes `core/citation_map.py` begonnen wird, müssen diese Bedingungen erfüllt sein:
+
+### 1. Real-Dump mit dual ranges bereitstellen
+- Quelle: Ein von der aktuellen Lenskit-Pipeline erzeugter `*.bundle.manifest.json` mit zugehörigem chunk_index.jsonl, das `canonical_range`, `source_range`, `content_range_ref` enthält.
+- Zielort: `data/` oder dokumentierter externer Pfad.
+- Validierung: Das Bundle muss sich mit aktuellen Schemas validieren.
+- Warum: Ohne echten Dump ist kein Real-Dump-Proof möglich, nur Fixture-Proof.
+
+### 2. Mindestens einen Konsumenten benennen
+- Option A: Query-Result-Schema-Erweiterung um `citation_id` (Phase 2 geplant).
+- Option B: Explicit validator (`lenskit citation validate <bundle_manifest>`) in `merger/lenskit/cli/cmd_citation.py` (Phase 4 geplant).
+- Option C: Roadmap-gültige Placeholder wie `merger/lenskit/retrieval/citation_lookup.py` mit stub consumer.
+- Warum: Producer ohne Konsument ist unmotiviert; die nächste Lenskit-Instanz weiß nicht, warum das Artefakt existiert.
+
+### 3. Citation-Id-Derivationsregel als Code-Helper fixieren
+- Neuer PR: `merger/lenskit/core/citation_id.py` mit:
+  - `make_citation_id(canonical_md_sha256: str, start_byte: int, end_byte: int, content_sha256: str) -> str`
+  - Implementiert: `"cit_" + sha256(f"lenskit.citation-map.v1:{canonical_md_sha256}:{start_byte}:{end_byte}:{content_sha256}")[:16]`
+  - Test: Determinismus-Check (same input → same output)
+- Warum: Die Regel ist derzeit nur Blueprint-Text; sie muss Code werden, damit der Producer sie nicht erraten muss.
+
+## Roadmap-Implikation
+
+In `docs/roadmap/lenskit-master-roadmap.md` soll bleiben:
+
+```
+- [ ] Citation-Map-Producer, geplante Citation-/Evidence-Health-Prüfung in separater Folge-PR, Real-Dump-Proof
+```
+
+Nicht auf `[x]` setzen. Optional darunter kurz ergänzen:
+
+```
+  Blocker: Real-Dump nicht verfügbar, Konsument nicht definiert, Citation-Id-Regel nicht in Code; siehe docs/proofs/citation-map-producer-diagnosis.md.
+```
+
+Ziel: Spätere Roadmap-Reader sehen sofort, dass Producer nicht „vergessen" ist, sondern bewusst blockiert.
+
+## Entscheidungsgrad
+
+| Aspekt | Sicherheit |
+|---|---|
+| H1 (Producer fehlt) ist belegt | sehr hoch (0.95) |
+| Stop-Kriterium Real-Dump ist erfüllt | sehr hoch (0.95) |
+| Stop-Kriterium Konsument ist erfüllt | hoch (0.85) — teilweise, da „spekulativ" sein könnte |
+| Nächste Vorbedingungen sind sinnvoll | hoch (0.80) |
+
+## Nicht Gegenstand dieses Proofs
+
+- Beweis, dass ein Producer **könnte** funktionieren (Skizze/Pseudo-Code).
+- Beweis, dass die Blueprint-Regel richtig ist.
+- Implementierung einer der Vorbedingungen.
+- Änderung an der aktuellen Roadmap (nur Blocker-Notiz optional).
+
+Dieser Proof **dokumentiert die Stop-Entscheidung**, nicht die Machbarkeit des Patches.
+
+---
+
+**Dokument-Version:** 1.0  
+**Diagnose durchgeführt:** 2026-05-12  
+**Nächste Bewertung:** Nach Real-Dump-Verfügbarkeit und Konsumenten-Definition  
+**Status:** ✋ Stop, kein Patch, nur Dokumentation

--- a/docs/roadmap/lenskit-master-roadmap.md
+++ b/docs/roadmap/lenskit-master-roadmap.md
@@ -74,7 +74,15 @@ Spätere PRs:
 - [x] Bundle-Manifest-Role `citation_map_jsonl`
 - [x] `chunk_index` dual range mit `content_range_ref`, `canonical_range`, `source_range`
 - [ ] Citation-Map-Producer, geplante Citation-/Evidence-Health-Prüfung in separater Folge-PR, Real-Dump-Proof
-  - **Blocker (Diagnose 2026-05-12):** Im Repo ist kein Real-Dump mit dual ranges abgelegt; Konsument nicht im Code definiert; Citation-Id-Regel nicht in Code fixiert. Siehe `docs/proofs/citation-map-producer-diagnosis.md`. Nächste Vorbedingungen: 1) Real-Dump mit dual ranges bereitstellen, 2) Konsument oder Validator benennen, 3) Citation-Id-Derivation als `core/citation_id.py` implementieren.
+  - **Blocker (Diagnose 2026-05-12):**
+    - Im Repo ist kein Real-Dump mit dual ranges abgelegt.
+    - Konsument nicht im Code definiert.
+    - Citation-Id-Regel nicht in Code fixiert.
+    - Diagnose: `docs/proofs/citation-map-producer-diagnosis.md`.
+    - Nächste Vorbedingungen:
+      - Real-Dump mit dual ranges bereitstellen.
+      - Konsument oder Validator benennen.
+      - Citation-Id-Derivation als `merger/lenskit/core/citation_id.py` implementieren.
 Gate:
 - `citation_map_jsonl` nie `canonical_content` oder `content_source`
 - `canonical_range` und `source_range` getrennt

--- a/docs/roadmap/lenskit-master-roadmap.md
+++ b/docs/roadmap/lenskit-master-roadmap.md
@@ -74,6 +74,7 @@ Spätere PRs:
 - [x] Bundle-Manifest-Role `citation_map_jsonl`
 - [x] `chunk_index` dual range mit `content_range_ref`, `canonical_range`, `source_range`
 - [ ] Citation-Map-Producer, geplante Citation-/Evidence-Health-Prüfung in separater Folge-PR, Real-Dump-Proof
+  - **Blocker (Diagnose 2026-05-12):** Real-Dump nicht verfügbar; Konsument nicht im Code definiert; Citation-Id-Regel nicht in Code fixiert. Siehe `docs/proofs/citation-map-producer-diagnosis.md`. Nächste Vorbedingungen: 1) Real-Dump mit dual ranges bereitstellen, 2) Konsument oder Validator benennen, 3) Citation-Id-Derivation als `core/citation_id.py` implementieren.
 Gate:
 - `citation_map_jsonl` nie `canonical_content` oder `content_source`
 - `canonical_range` und `source_range` getrennt

--- a/docs/roadmap/lenskit-master-roadmap.md
+++ b/docs/roadmap/lenskit-master-roadmap.md
@@ -74,7 +74,7 @@ Spätere PRs:
 - [x] Bundle-Manifest-Role `citation_map_jsonl`
 - [x] `chunk_index` dual range mit `content_range_ref`, `canonical_range`, `source_range`
 - [ ] Citation-Map-Producer, geplante Citation-/Evidence-Health-Prüfung in separater Folge-PR, Real-Dump-Proof
-  - **Blocker (Diagnose 2026-05-12):** Real-Dump nicht verfügbar; Konsument nicht im Code definiert; Citation-Id-Regel nicht in Code fixiert. Siehe `docs/proofs/citation-map-producer-diagnosis.md`. Nächste Vorbedingungen: 1) Real-Dump mit dual ranges bereitstellen, 2) Konsument oder Validator benennen, 3) Citation-Id-Derivation als `core/citation_id.py` implementieren.
+  - **Blocker (Diagnose 2026-05-12):** Im Repo ist kein Real-Dump mit dual ranges abgelegt; Konsument nicht im Code definiert; Citation-Id-Regel nicht in Code fixiert. Siehe `docs/proofs/citation-map-producer-diagnosis.md`. Nächste Vorbedingungen: 1) Real-Dump mit dual ranges bereitstellen, 2) Konsument oder Validator benennen, 3) Citation-Id-Derivation als `core/citation_id.py` implementieren.
 Gate:
 - `citation_map_jsonl` nie `canonical_content` oder `content_source`
 - `canonical_range` und `source_range` getrennt


### PR DESCRIPTION
## Summary

This PR adds comprehensive diagnostic documentation for the Citation-Map Producer component, establishing that implementation should be blocked until critical preconditions are met. The diagnosis confirms that the Producer component is entirely missing from the codebase while supporting infrastructure (schema, manifest role, examples) exists.

## Changes

- **New diagnostic document** (`docs/proofs/citation-map-producer-diagnosis.md`):
  - Confirms Hypothesis H1: Citation-Map Producer component is completely absent from the repository
  - Documents all existing supporting infrastructure (schema, examples, tests, manifest role definitions)
  - Catalogs missing components (producer implementation, merge.py wiring, output health integration, real dump data)
  - Identifies epistemological gaps preventing stable implementation
  - Establishes hard stop criteria: no real dump with dual ranges available, no consumer in codebase
  - Specifies three required preconditions before implementation can proceed:
    1. Real dump with dual ranges must be provided
    2. At least one consumer must be defined
    3. Citation-ID derivation rule must be extracted to code helper
  - Provides decision confidence levels for each finding (0.80–0.95)

- **Updated roadmap** (`docs/roadmap/lenskit-master-roadmap.md`):
  - Adds blocker notation to Citation-Map-Producer roadmap item
  - References the diagnostic document for context
  - Clarifies that the feature is intentionally blocked, not forgotten

## Rationale

The diagnosis prevents premature implementation that would:
- Violate the roadmap's "Real-Dump-Proof" gate requirement
- Create phantom evidence (artifact with no consumer)
- Increase complexity without clear utility
- Set traps for subsequent work that might build on incomplete infrastructure

This is a documentation-only change that establishes decision rationale and unblocks future work by clearly stating what must be done first.

https://claude.ai/code/session_01XGHVE9BAh5eRZt2gKpiMgY