### PR TITLE
Docs: clarify rLens deployment boundaries, add bounded Omnipull and heimserver Atlas profiles, update rlens systemd template

### DIFF
--- a/docs/architecture/heimgewebe-infra-role.md
+++ b/docs/architecture/heimgewebe-infra-role.md
@@ -70,11 +70,40 @@ Lenskit bleibt Quelle innerhalb kontrollierter Heimgewebe-Pfade. Direkte externe
 
 ## 5. Deployment-Grenze
 
-Lenskit Core läuft bevorzugt auf `heim-pc`, weil dort Repos, Dumps und Atlas-Zielpfade liegen. Damit bleibt Lenskit nahe an den lokalen Quellartefakten und muss keine eigenständige öffentliche Infrastrukturrolle übernehmen.
+Der Zielzustand ist nicht mehr `heimserver = lenskit-mirror only` und auch nicht mehr `Lenskit Core läuft ausschließlich oder bevorzugt nur auf heim-pc`. Stattdessen beschreibt Lenskit zwei lokale rLens-Rollen, die jeweils nah an ihren eigenen Quellartefakten laufen:
+
+- `rlens-local` auf `heim-pc`: lokale Arbeits- und Interaktionswahrheit für lokale Repos, Dumps, Atlas-Zielpfade sowie dirty/untracked Zustände.
+- `rlens-peer-heimserver` auf `heimserver`: vollständiger Service- und Analyse-Peer für den Heimserver-Dateibaum, lokale Repos, Atlas-Snapshots, Merger-Artefakte und die lokale rLens-WebUI.
+
+`rlens-peer-heimserver` ist trotzdem keine öffentliche Control-Plane. Der Full-Peer-Status bedeutet nicht, dass externe Agents direkt auf Lenskit zugreifen dürfen, dass Lenskit eine öffentliche Runtime wird oder dass rLens Command-Ausführung übernimmt.
 
 `rLens` ist ein lokaler Service und bleibt loopback-first. Tailscale Serve darf internen Tailnet-Zugriff auf autorisierten Pfaden ermöglichen. Tailscale Funnel ist kein Lenskit-Core-Dauerpfad.
 
 Öffentlicher Zugriff darf später nur über ein getrenntes `hausmaister-agent-gateway` laufen. Dieses Gateway ist nicht Teil des Lenskit-Core und darf keine Lenskit-Runtime in eine öffentliche Control-Plane verwandeln.
+
+## 5.1 Bounded Repo-Sync / Omnipull
+
+Omnipull ist in Lenskit-Terminologie keine allgemeine Command-Ausführung, sondern eine eng begrenzte Repo-Sync-Vorbereitung für lokale Evidence- und Merger-Arbeit. Es dient dazu, lokale Repository-Bestände für Beobachtung, Atlas-Snapshots und Merger-Artefakte bereitzustellen, ohne Lenskit in einen Command-Executor zu verwandeln.
+
+Erlaubt ist ausschließlich:
+
+- `plan`: vorhandene und fehlende Repos prüfen und einen Report schreiben, ohne Repos zu verändern.
+- `apply`: fehlende Repos klonen.
+- `apply`: vorhandene Repos per fetch/prune aktualisieren.
+- `apply`: vorhandene Repos nur dann aktualisieren, wenn der Arbeitsbaum clean ist und ein Fast-Forward möglich ist.
+- ein Statusartefakt schreiben.
+
+Verboten bleibt ausdrücklich:
+
+- `reset --hard`,
+- automatisches `stash`,
+- automatisches `rebase`,
+- Branch-Wechsel,
+- Löschen untracked files,
+- Verwerfen lokaler Änderungen,
+- beliebige Shell-Commands.
+
+Ein Omnipull-Report ist Evidence. Er ist kein Command-Freibrief, kein hausmAIster-Approval und keine implizite Berechtigung für weitere Mutationen.
 
 ## 6. API-Grenze
 

--- a/docs/atlas-heimserver-profiles.md
+++ b/docs/atlas-heimserver-profiles.md
@@ -1,0 +1,55 @@
+# Atlas Heimserver Profiles
+
+## Zweck
+
+Diese Profile beschreiben den Atlas-Snapshot-Rahmen für `rlens-peer-heimserver`. Ziel ist, Heimserver-Dateisystem-Snapshots agentenfähig zu machen, ohne Secret-Inhalte oder lokale forensische Rohdaten ungeprüft in Agenten-, ChatGPT- oder Export-Artefakte zu lecken.
+
+Die Profile sind Doku-/Planungsprofile. Sie ändern nicht das Atlas-Sicherheitsmodell, die loopback-first-Regel oder die bestehende Auth-Pflicht für sensible Dateisystemnavigation.
+
+## `heimserver-overview`
+
+- root: `/`
+- content_policy: `text_only` oder `inventory-first`
+- binary_policy: `metadata + hash`
+- secret_policy: `redact_content`
+- exclude content roots:
+  - `/proc`
+  - `/sys`
+  - `/dev`
+  - `/run`
+  - `/tmp`
+  - `/var/run`
+
+Dieses Profil ist für grobe Inventarisierung und Evidence-Übersicht gedacht. Inhalte werden defensiv behandelt; Binärdaten liefern nur Metadaten und Hashes.
+
+## `heimserver-deep`
+
+- root: `/`
+- content_policy: `config/scripts/text`
+- binary_policy: `metadata + hash`
+- secret_policy: `inventory_only`
+- include priority:
+  - `/etc`
+  - `/opt`
+  - `/srv`
+  - `/home/alex/repos`
+  - `/home/alex/.config/systemd`
+
+Dieses Profil ist für tieferes lokales Verständnis von Konfigurationen, Skripten, Services und Repos gedacht. Secret-nahe Bereiche bleiben inventory-only, damit Pfad-, Existenz- und Metadatenbelege nicht automatisch zu Inhaltslecks werden.
+
+## `heimserver-forensic-local`
+
+- root: `/`
+- content_policy: `broad/local`
+- secret_policy: `local_only`
+- export_allowed: `false`
+
+Dieses Profil ist nur für lokale forensische Analyse unter direkter lokaler Kontrolle gedacht. `heimserver-forensic-local` darf nicht ungeprüft in Agent-/ChatGPT-Artefakte exportiert werden. Ein Export benötigt eine explizite menschliche Prüfung und ein separates, exportfähiges Artefakt mit redigierten Inhalten.
+
+## Sicherheitsinvarianten
+
+- Atlas-Snapshot = Observation / Evidence, kein Befehl.
+- Merger = lokale Artefakterzeugung aus beobachteten oder bereitgestellten Quellen.
+- rLens = lokaler Service / UI / API, keine öffentliche Control-Plane.
+- Root-Browsing bleibt loopback- und Auth-gated; non-loopback Root-Browsing bleibt verweigert.
+- Secret-Inhalte werden nicht durch Profilnamen freigegeben.

--- a/docs/atlas-heimserver-profiles.md
+++ b/docs/atlas-heimserver-profiles.md
@@ -34,6 +34,13 @@ Dieses Profil ist für grobe Inventarisierung und Evidence-Übersicht gedacht. I
   - `/srv`
   - `/home/alex/repos`
   - `/home/alex/.config/systemd`
+- exclude content roots:
+  - `/proc`
+  - `/sys`
+  - `/dev`
+  - `/run`
+  - `/tmp`
+  - `/var/run`
 
 Dieses Profil ist für tieferes lokales Verständnis von Konfigurationen, Skripten, Services und Repos gedacht. Secret-nahe Bereiche bleiben inventory-only, damit Pfad-, Existenz- und Metadatenbelege nicht automatisch zu Inhaltslecks werden.
 

--- a/docs/service-api.md
+++ b/docs/service-api.md
@@ -240,15 +240,16 @@ All runtime artifacts stored in the `QueryArtifactStore` (`query_trace`, `contex
 
 ## Mutation Boundary Classification
 
-Lenskit API documentation distinguishes three classes for mutation-near buttons or paths. This is a contract boundary, not an implementation of new endpoints:
+Lenskit API documentation distinguishes four classes for mutation-near buttons or paths. This is a contract boundary, not an implementation of new endpoints:
 
 | Class | Meaning | Agent exposure |
 |---|---|---|
-| `read-only observation` | Lookup, query, diagnostics, trace, context, artifact, Atlas snapshot, or inventory access that reads or reports evidence without changing source repos or host state. | May be consumed through authorized read-only adapters. |
+| `read-only observation` | Lookup, query, diagnostics, trace, or context access that reads or reports evidence without mutating source repos, working trees, user files, or derived artifact outputs. | May be consumed through authorized read-only adapters. |
+| `local artifact generation` | Snapshot, inventory, report, or merge-artifact generation that may write derived files locally, for example under a merges or artifact directory, while still avoiding source-repo or working-tree mutation. | May be exposed only where local artifact writes are explicitly documented, bounded, and authorized; it must not be presented as side-effect-free read-only access. |
 | `bounded repo-sync mutation` | Narrow Omnipull-style repo preparation: plan/report, clone missing repos, fetch/prune existing repos, and clean fast-forward only. | Must remain locally authorized, report-producing, and unavailable as a general external Agent tool. |
 | `local-only forensic operation` | Broad local filesystem or forensic inspection, especially profiles marked non-exportable. | Must remain local-only unless a reviewed, redacted export artifact is produced. |
 
-Omnipull-shaped paths, if added later, must be documented and tested as `bounded repo-sync mutation`. They are not generic command execution and must not provide arbitrary shell command, branch switching, reset, stash, rebase, untracked-file deletion, or local-change discard semantics. Snapshot and Merger controls must similarly state whether they are pure observation, local artifact generation, or local-only forensic work before they are exposed beyond the local rLens peer.
+Omnipull-shaped paths, if added later, must be documented and tested as `bounded repo-sync mutation`. They are not generic command execution and must not provide arbitrary shell command, branch switching, reset, stash, rebase, untracked-file deletion, or local-change discard semantics. Snapshot and Merger controls must similarly state whether they are read-only observation, local artifact generation, or local-only forensic work before they are exposed beyond the local rLens peer.
 
 ## Job Submission & Dispatch
 

--- a/docs/service-api.md
+++ b/docs/service-api.md
@@ -238,6 +238,18 @@ All runtime artifacts stored in the `QueryArtifactStore` (`query_trace`, `contex
 - Legacy entries missing these fields are transparently backfilled on read.
 - These fields are groundwork for future Retention, MCP, and Agent-Orchestration logic.
 
+## Mutation Boundary Classification
+
+Lenskit API documentation distinguishes three classes for mutation-near buttons or paths. This is a contract boundary, not an implementation of new endpoints:
+
+| Class | Meaning | Agent exposure |
+|---|---|---|
+| `read-only observation` | Lookup, query, diagnostics, trace, context, artifact, Atlas snapshot, or inventory access that reads or reports evidence without changing source repos or host state. | May be consumed through authorized read-only adapters. |
+| `bounded repo-sync mutation` | Narrow Omnipull-style repo preparation: plan/report, clone missing repos, fetch/prune existing repos, and clean fast-forward only. | Must remain locally authorized, report-producing, and unavailable as a general external Agent tool. |
+| `local-only forensic operation` | Broad local filesystem or forensic inspection, especially profiles marked non-exportable. | Must remain local-only unless a reviewed, redacted export artifact is produced. |
+
+Omnipull-shaped paths, if added later, must be documented and tested as `bounded repo-sync mutation`. They are not generic command execution and must not provide arbitrary shell command, branch switching, reset, stash, rebase, untracked-file deletion, or local-change discard semantics. Snapshot and Merger controls must similarly state whether they are pure observation, local artifact generation, or local-only forensic work before they are exposed beyond the local rLens peer.
+
 ## Job Submission & Dispatch
 
 ### `include_paths_by_repo` Semantics

--- a/docs/systemd/rlens.service
+++ b/docs/systemd/rlens.service
@@ -1,13 +1,17 @@
 [Unit]
-Description=rLens Web UI (rlens)
+Description=rLens Web UI (rlens example/template)
 After=network.target
 
 [Service]
 Type=simple
 Environment=RLENS_HUB=/home/alex/repos
+Environment=RLENS_MERGES=/home/alex/lenskit-out
 Environment=RLENS_HOST=127.0.0.1
 Environment=RLENS_PORT=8787
-Environment=RLENS_TOKEN=heimgewebe-local
+# Required local file; do not commit secrets.
+# Expected keys include RLENS_TOKEN and/or RLENS_FS_TOKEN_SECRET.
+# Missing file intentionally fails the unit for full-peer deployments.
+EnvironmentFile=%h/.config/rlens/env
 WorkingDirectory=/home/alex/repos/lenskit
 ExecStart=/usr/bin/python3 -m merger.lenskit.cli.rlens
 Restart=on-failure

--- a/docs/systemd/rlens.service
+++ b/docs/systemd/rlens.service
@@ -1,18 +1,19 @@
 [Unit]
-Description=rLens Web UI (rlens example/template)
+Description=rLens Web UI (rlens user-unit example/template)
 After=network.target
 
 [Service]
 Type=simple
-Environment=RLENS_HUB=/home/alex/repos
-Environment=RLENS_MERGES=/home/alex/lenskit-out
+Environment=RLENS_HUB=%h/repos
+Environment=RLENS_MERGES=%h/lenskit-out
 Environment=RLENS_HOST=127.0.0.1
 Environment=RLENS_PORT=8787
 # Required local file; do not commit secrets.
-# Expected keys include RLENS_TOKEN and/or RLENS_FS_TOKEN_SECRET.
+# RLENS_TOKEN is required for API auth.
+# RLENS_FS_TOKEN_SECRET is separate and optional for filesystem-token signing.
 # Missing file intentionally fails the unit for full-peer deployments.
 EnvironmentFile=%h/.config/rlens/env
-WorkingDirectory=/home/alex/repos/lenskit
+WorkingDirectory=%h/repos/lenskit
 ExecStart=/usr/bin/python3 -m merger.lenskit.cli.rlens
 Restart=on-failure
 RestartSec=2

--- a/docs/systemd/rlens.service
+++ b/docs/systemd/rlens.service
@@ -13,6 +13,7 @@ Environment=RLENS_PORT=8787
 # RLENS_FS_TOKEN_SECRET is separate and optional for filesystem-token signing.
 # Missing file intentionally fails the unit for full-peer deployments.
 EnvironmentFile=%h/.config/rlens/env
+ExecStartPre=/bin/sh -c 'test -n "$RLENS_TOKEN" || { echo "RLENS_TOKEN is required" >&2; exit 1; }'
 WorkingDirectory=%h/repos/lenskit
 ExecStart=/usr/bin/python3 -m merger.lenskit.cli.rlens
 Restart=on-failure

--- a/docs/testing/test-matrix.md
+++ b/docs/testing/test-matrix.md
@@ -55,3 +55,16 @@ Die Testsuite (`merger/lenskit/tests/`) belegt die Grundlagen für die Ingestion
 Diese Belege sichern spezifische Teilziele methodisch ab, decken jedoch weder die API-Sicherheit weitreichend ab, noch prüfen sie die tatsächliche Agent-Tauglichkeit der ausgegebenen Kontexte qualitativ.
 
 Die Test-Matrix verifiziert, dass für die Single-Repo/Single-Bundle Use Cases eine solide Grundlage herrscht. **Phase 5 (Cross-Repo-Knowledge-Layer)** ist durch Tests unter `test_federation_*.py` **teilweise abgedeckt**, bleibt aber insbesondere bei vollständigen End-to-End-Pfaden über mehrere Repositories unvollständig. **Phase 6 (Agent Control Surface / Provenienz):** `agent_query_session`-Provenienz-Härtung ist durch Crosscheck-Tests belegt (artifact_refs-Konsistenz, null-Self-ID, Roundtrip-Lookup, Schema-Rejection); Agent-Orchestrierung, Feedback-Schleifen und MCP-Anbindung sind noch offen.
+
+
+## Open Deployment / Boundary Test Points
+
+These items are intentionally listed as open guards for future work; this documentation-only change does not implement the tested behavior.
+
+| Area | Desired guard | Status | Notes |
+| :--- | :--- | :--- | :--- |
+| rLens systemd template | Template includes `RLENS_MERGES` and loads secrets from `EnvironmentFile`, not a static `RLENS_TOKEN`. | **Open.** | Prevents secret drift in example deployment units. |
+| Bounded repo-sync / Omnipull | Any future repo-sync action is report-producing and restricted to plan, clone missing, fetch/prune, and clean fast-forward. | **Open.** | Must reject generic shell command semantics. |
+| Secure FS navigation | Root-browsing remains loopback/auth-gated and non-loopback root browsing remains refused. | **Existing security invariant; guard should remain explicit.** | See secure FS navigation ADR and service tests. |
+| Atlas heimserver profiles | Heimserver overview/deep profiles exclude pseudo/volatile roots such as `/proc`, `/sys`, `/dev`, and `/run`. | **Open.** | Prevents host pseudo-filesystems from becoming content evidence. |
+| Forensic profile export | `heimserver-forensic-local` cannot be exported into Agent/ChatGPT artifacts without human review and redaction. | **Open.** | Protects local-only forensic evidence from accidental externalization. |

--- a/docs/testing/test-matrix.md
+++ b/docs/testing/test-matrix.md
@@ -57,14 +57,14 @@ Diese Belege sichern spezifische Teilziele methodisch ab, decken jedoch weder di
 Die Test-Matrix verifiziert, dass für die Single-Repo/Single-Bundle Use Cases eine solide Grundlage herrscht. **Phase 5 (Cross-Repo-Knowledge-Layer)** ist durch Tests unter `test_federation_*.py` **teilweise abgedeckt**, bleibt aber insbesondere bei vollständigen End-to-End-Pfaden über mehrere Repositories unvollständig. **Phase 6 (Agent Control Surface / Provenienz):** `agent_query_session`-Provenienz-Härtung ist durch Crosscheck-Tests belegt (artifact_refs-Konsistenz, null-Self-ID, Roundtrip-Lookup, Schema-Rejection); Agent-Orchestrierung, Feedback-Schleifen und MCP-Anbindung sind noch offen.
 
 
-## Open Deployment / Boundary Test Points
+## Offene Deployment-/Boundary-Testpunkte
 
-These items are intentionally listed as open guards for future work; this documentation-only change does not implement the tested behavior.
+Diese Punkte sind bewusst als offene Guards für Folgearbeiten aufgeführt; diese reine Doku-Änderung implementiert das geprüfte Verhalten nicht.
 
-| Area | Desired guard | Status | Notes |
+| Bereich | Gewünschter Guard | Status | Hinweise |
 | :--- | :--- | :--- | :--- |
-| rLens systemd template | Template includes `RLENS_MERGES` and loads secrets from `EnvironmentFile`, not a static `RLENS_TOKEN`. | **Open.** | Prevents secret drift in example deployment units. |
-| Bounded repo-sync / Omnipull | Any future repo-sync action is report-producing and restricted to plan, clone missing, fetch/prune, and clean fast-forward. | **Open.** | Must reject generic shell command semantics. |
-| Secure FS navigation | Root-browsing remains loopback/auth-gated and non-loopback root browsing remains refused. | **Existing security invariant; guard should remain explicit.** | See secure FS navigation ADR and service tests. |
-| Atlas heimserver profiles | Heimserver overview/deep profiles exclude pseudo/volatile roots such as `/proc`, `/sys`, `/dev`, and `/run`. | **Open.** | Prevents host pseudo-filesystems from becoming content evidence. |
-| Forensic profile export | `heimserver-forensic-local` cannot be exported into Agent/ChatGPT artifacts without human review and redaction. | **Open.** | Protects local-only forensic evidence from accidental externalization. |
+| rLens-systemd-Template | Template enthält `RLENS_MERGES` und lädt Secrets über `EnvironmentFile`, nicht über einen statischen `RLENS_TOKEN`. | **Open.** | Verhindert Secret-Drift in Beispiel-Deployment-Units. |
+| Bounded Repo-Sync / Omnipull | Jede künftige Repo-Sync-Aktion schreibt Reports und ist auf Plan, Clone fehlender Repos, Fetch/Prune sowie Clean-Fast-Forward beschränkt. | **Open.** | Muss generische Shell-Command-Semantik ablehnen. |
+| Secure FS Navigation | Root-Browsing bleibt loopback/auth-gated und non-loopback Root-Browsing bleibt verweigert. | **Bestehende Sicherheitsinvariante; Guard soll explizit bleiben.** | Siehe Secure-FS-Navigation-ADR und Service-Tests. |
+| Atlas-Heimserver-Profile | Heimserver-Overview/Deep-Profile schließen Pseudo-/volatile Roots wie `/proc`, `/sys`, `/dev` und `/run` aus. | **Open.** | Verhindert, dass Host-Pseudo-Dateisysteme zu Content-Evidence werden. |
+| Forensic-Profil-Export | `heimserver-forensic-local` kann ohne menschliche Prüfung und Redaction nicht in Agent-/ChatGPT-Artefakte exportiert werden. | **Open.** | Schützt local-only forensische Evidence vor versehentlicher Externalisierung. |


### PR DESCRIPTION
### Motivation

- Präzisiert die Grenze zwischen Lenskit/rLens als lokaler Knowledge-Service und einer möglichen öffentlichen Control‑Plane, um unbeabsichtigte Agent- oder Shell-Execution-Exposition zu verhindern. 
- Definiert eingeschränkte Repo-Sync-Operationen („Omnipull“) als evidenz-/report-produzierende Aktionen statt als generelle Command-Execution. 
- Stellt sichere Atlas-Snapshot-Profile für `rlens-peer-heimserver` bereit, um forensische/secret-sensitive Bereiche zu behandeln, ohne Inhalte ungeprüft zu exportieren. 

### Description

- Überarbeitet `docs/architecture/heimgewebe-infra-role.md` um zwei rLens-Rollen (`rlens-local`, `rlens-peer-heimserver`), die loopback-first Regel, und eine klare Deployment-Grenze sowie die neue Sektion „Bounded Repo-Sync / Omnipull“. 
- Fügt `docs/atlas-heimserver-profiles.md` hinzu mit drei Snapshot-Profilen (`heimserver-overview`, `heimserver-deep`, `heimserver-forensic-local`) und zugehörigen Sicherheitsinvarianten. 
- Erweitert `docs/service-api.md` um eine „Mutation Boundary Classification“, die drei Klassen von API‑Pfaden (read-only observation, bounded repo-sync mutation, local-only forensic operation) beschreibt. 
- Aktualisiert `docs/systemd/rlens.service` Template um `RLENS_MERGES`, ein `EnvironmentFile=%h/.config/rlens/env` für lokale Secrets und erklärende Kommentare, statt eines festen `RLENS_TOKEN`. 
- Ergänzt `docs/testing/test-matrix.md` um offene Deployment-/Boundary-Testpunkte und dokumentiert die verbleibenden Guards und Verantwortlichkeiten. 

### Testing

- Diese Änderung ist rein dokumentarisch mit einer kleine systemd-Unit-Vorlage-Anpassung und enthält keine produktiven Codepfade, weshalb keine modifizierten Unit-Tests erforderlich waren. 
- Es wurden keine automatisierten unit/integration tests in diesem PR geändert oder ausgeführt. 
- Die Änderungen sind für die bestehende CI/test-Suite neutral; die reguläre CI kann die Standardsuite (`pytest`) wie gewohnt ausführen.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a033329a478832c8c5b47c5c46309a0)