### PR TITLE
Add citation ID derivation helper function

### DIFF
--- a/docs/proofs/citation-map-producer-diagnosis.md
+++ b/docs/proofs/citation-map-producer-diagnosis.md
@@ -87,7 +87,7 @@ Bevor ein echtes `merger/lenskit/core/citation_map.py` begonnen wird, müssen di
 
 ### 3. Citation-Id-Derivationsregel als Code-Helper fixieren ✓ erledigt (PR #652)
 - `merger/lenskit/core/citation_id.py` implementiert `make_citation_id(...)` mit Payload-Präfix `lenskit.citation-map.v1:`, Feldreihenfolge und 16-hex-Truncation.
-- 22 Tests (Determinismus, Sensitivität, Format, Input-Guards, Golden-Vector).
+- Umfangreiche Tests zu Determinismus, Sensitivität, Format, Input-Guards und Golden-Vector.
 - **Stop-Entscheidung bleibt bestehen:** Helper ist vorbereitet, aber Real-Dump und Konsument/Validator fehlen weiterhin.
 
 ## Roadmap-Implikation

--- a/docs/proofs/citation-map-producer-diagnosis.md
+++ b/docs/proofs/citation-map-producer-diagnosis.md
@@ -85,12 +85,10 @@ Bevor ein echtes `merger/lenskit/core/citation_map.py` begonnen wird, müssen di
 - Option C: Roadmap-gültige Placeholder wie `merger/lenskit/retrieval/citation_lookup.py` mit stub consumer.
 - Warum: Producer ohne Konsument ist unmotiviert; die nächste Lenskit-Instanz weiß nicht, warum das Artefakt existiert.
 
-### 3. Citation-Id-Derivationsregel als Code-Helper fixieren
-- Neuer PR: `merger/lenskit/core/citation_id.py` mit:
-  - `make_citation_id(canonical_md_sha256: str, start_byte: int, end_byte: int, content_sha256: str) -> str`
-  - Implementiert: `"cit_" + sha256(f"lenskit.citation-map.v1:{canonical_md_sha256}:{start_byte}:{end_byte}:{content_sha256}")[:16]`
-  - Test: Determinismus-Check (same input → same output)
-- Warum: Die Regel ist derzeit nur Blueprint-Text; sie muss Code werden, damit der Producer sie nicht erraten muss.
+### 3. Citation-Id-Derivationsregel als Code-Helper fixieren ✓ erledigt (PR #652)
+- `merger/lenskit/core/citation_id.py` implementiert `make_citation_id(...)` mit Payload-Präfix `lenskit.citation-map.v1:`, Feldreihenfolge und 16-hex-Truncation.
+- 22 Tests (Determinismus, Sensitivität, Format, Input-Guards, Golden-Vector).
+- **Stop-Entscheidung bleibt bestehen:** Helper ist vorbereitet, aber Real-Dump und Konsument/Validator fehlen weiterhin.
 
 ## Roadmap-Implikation
 

--- a/docs/roadmap/lenskit-master-roadmap.md
+++ b/docs/roadmap/lenskit-master-roadmap.md
@@ -77,12 +77,12 @@ Spätere PRs:
   - **Blocker (Diagnose 2026-05-12):**
     - Im Repo ist kein Real-Dump mit dual ranges abgelegt.
     - Konsument nicht im Code definiert.
-    - Citation-Id-Regel nicht in Code fixiert.
+    - Citation-Id-Regel nicht in Code fixiert. *(Derivationsregel jetzt als Helper in `merger/lenskit/core/citation_id.py` vorbereitet; Producer bleibt blockiert durch Real-Dump-Proof und Konsument/Validator.)*
     - Diagnose: `docs/proofs/citation-map-producer-diagnosis.md`.
     - Nächste Vorbedingungen:
       - Real-Dump mit dual ranges bereitstellen.
       - Konsument oder Validator benennen.
-      - Citation-Id-Derivation als `merger/lenskit/core/citation_id.py` implementieren.
+      - ~~Citation-Id-Derivation als `merger/lenskit/core/citation_id.py` implementieren.~~ (erledigt)
 Gate:
 - `citation_map_jsonl` nie `canonical_content` oder `content_source`
 - `canonical_range` und `source_range` getrennt

--- a/docs/roadmap/lenskit-master-roadmap.md
+++ b/docs/roadmap/lenskit-master-roadmap.md
@@ -74,15 +74,15 @@ Spätere PRs:
 - [x] Bundle-Manifest-Role `citation_map_jsonl`
 - [x] `chunk_index` dual range mit `content_range_ref`, `canonical_range`, `source_range`
 - [ ] Citation-Map-Producer, geplante Citation-/Evidence-Health-Prüfung in separater Folge-PR, Real-Dump-Proof
-  - **Blocker (Diagnose 2026-05-12):**
+  - **Blocker (Diagnose 2026-05-12, aktualisiert 2026-05-13):**
     - Im Repo ist kein Real-Dump mit dual ranges abgelegt.
     - Konsument nicht im Code definiert.
-    - Citation-Id-Regel nicht in Code fixiert. *(Derivationsregel jetzt als Helper in `merger/lenskit/core/citation_id.py` vorbereitet; Producer bleibt blockiert durch Real-Dump-Proof und Konsument/Validator.)*
+    - Citation-Id-Regel als Helper in `merger/lenskit/core/citation_id.py` vorbereitet, aber noch nicht in Producer/Validator verdrahtet.
     - Diagnose: `docs/proofs/citation-map-producer-diagnosis.md`.
-    - Nächste Vorbedingungen:
+    - Offene Vorbedingungen:
       - Real-Dump mit dual ranges bereitstellen.
       - Konsument oder Validator benennen.
-      - ~~Citation-Id-Derivation als `merger/lenskit/core/citation_id.py` implementieren.~~ (erledigt)
+    - Erledigte Vorbereitung: `merger/lenskit/core/citation_id.py` (Citation-Id-Derivationsregel als Helper, PR #652).
 Gate:
 - `citation_map_jsonl` nie `canonical_content` oder `content_source`
 - `canonical_range` und `source_range` getrennt

--- a/merger/lenskit/core/citation_id.py
+++ b/merger/lenskit/core/citation_id.py
@@ -1,0 +1,36 @@
+import hashlib
+import re
+
+_SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
+
+
+def make_citation_id(
+    canonical_md_sha256: str,
+    start_byte: int,
+    end_byte: int,
+    content_sha256: str,
+) -> str:
+    """Derive a stable citation ID from a canonical range's identifying fields."""
+    if not isinstance(canonical_md_sha256, str) or not _SHA256_RE.match(canonical_md_sha256):
+        raise ValueError(
+            "canonical_md_sha256 must be a 64-character lowercase hex string"
+        )
+    if not isinstance(content_sha256, str) or not _SHA256_RE.match(content_sha256):
+        raise ValueError(
+            "content_sha256 must be a 64-character lowercase hex string"
+        )
+    if isinstance(start_byte, bool) or not isinstance(start_byte, int):
+        raise TypeError("start_byte must be an int, not bool or other type")
+    if isinstance(end_byte, bool) or not isinstance(end_byte, int):
+        raise TypeError("end_byte must be an int, not bool or other type")
+    if start_byte < 0:
+        raise ValueError("start_byte must be >= 0")
+    if end_byte <= start_byte:
+        raise ValueError("end_byte must be > start_byte")
+
+    payload = (
+        f"lenskit.citation-map.v1:"
+        f"{canonical_md_sha256}:{start_byte}:{end_byte}:{content_sha256}"
+    )
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+    return f"cit_{digest}"

--- a/merger/lenskit/core/citation_id.py
+++ b/merger/lenskit/core/citation_id.py
@@ -11,11 +11,11 @@ def make_citation_id(
     content_sha256: str,
 ) -> str:
     """Derive a stable citation ID from a canonical range's identifying fields."""
-    if not isinstance(canonical_md_sha256, str) or not _SHA256_RE.match(canonical_md_sha256):
+    if not isinstance(canonical_md_sha256, str) or not _SHA256_RE.fullmatch(canonical_md_sha256):
         raise ValueError(
             "canonical_md_sha256 must be a 64-character lowercase hex string"
         )
-    if not isinstance(content_sha256, str) or not _SHA256_RE.match(content_sha256):
+    if not isinstance(content_sha256, str) or not _SHA256_RE.fullmatch(content_sha256):
         raise ValueError(
             "content_sha256 must be a 64-character lowercase hex string"
         )

--- a/merger/lenskit/tests/test_citation_id.py
+++ b/merger/lenskit/tests/test_citation_id.py
@@ -1,0 +1,157 @@
+import re
+import pytest
+
+from merger.lenskit.core.citation_id import make_citation_id
+
+SHA_A = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+SHA_B = "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+SHA_C = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+CIT_RE = re.compile(r"^cit_[a-f0-9]{16}$")
+
+
+# ---------------------------------------------------------------------------
+# Format
+# ---------------------------------------------------------------------------
+
+def test_format_matches_pattern():
+    result = make_citation_id(SHA_A, 0, 100, SHA_B)
+    assert CIT_RE.match(result), f"Unexpected format: {result!r}"
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+def test_deterministic_same_inputs():
+    a = make_citation_id(SHA_A, 0, 100, SHA_B)
+    b = make_citation_id(SHA_A, 0, 100, SHA_B)
+    assert a == b
+
+
+# ---------------------------------------------------------------------------
+# Sensitivity
+# ---------------------------------------------------------------------------
+
+def test_sensitive_to_canonical_md_sha256():
+    a = make_citation_id(SHA_A, 0, 100, SHA_B)
+    b = make_citation_id(SHA_C, 0, 100, SHA_B)
+    assert a != b
+
+
+def test_sensitive_to_start_byte():
+    a = make_citation_id(SHA_A, 0, 100, SHA_B)
+    b = make_citation_id(SHA_A, 1, 100, SHA_B)
+    assert a != b
+
+
+def test_sensitive_to_end_byte():
+    a = make_citation_id(SHA_A, 0, 100, SHA_B)
+    b = make_citation_id(SHA_A, 0, 101, SHA_B)
+    assert a != b
+
+
+def test_sensitive_to_content_sha256():
+    a = make_citation_id(SHA_A, 0, 100, SHA_B)
+    b = make_citation_id(SHA_A, 0, 100, SHA_C)
+    assert a != b
+
+
+# ---------------------------------------------------------------------------
+# Invalid SHA values
+# ---------------------------------------------------------------------------
+
+def test_invalid_canonical_md_sha256_too_short():
+    with pytest.raises(ValueError, match="canonical_md_sha256"):
+        make_citation_id("abc", 0, 100, SHA_B)
+
+
+def test_invalid_canonical_md_sha256_uppercase():
+    bad = SHA_A.upper()
+    with pytest.raises(ValueError, match="canonical_md_sha256"):
+        make_citation_id(bad, 0, 100, SHA_B)
+
+
+def test_invalid_canonical_md_sha256_not_hex():
+    bad = "z" * 64
+    with pytest.raises(ValueError, match="canonical_md_sha256"):
+        make_citation_id(bad, 0, 100, SHA_B)
+
+
+def test_invalid_content_sha256_too_short():
+    with pytest.raises(ValueError, match="content_sha256"):
+        make_citation_id(SHA_A, 0, 100, "abc")
+
+
+def test_invalid_content_sha256_uppercase():
+    bad = SHA_B.upper()
+    with pytest.raises(ValueError, match="content_sha256"):
+        make_citation_id(SHA_A, 0, 100, bad)
+
+
+def test_invalid_content_sha256_not_hex():
+    bad = "g" * 64
+    with pytest.raises(ValueError, match="content_sha256"):
+        make_citation_id(SHA_A, 0, 100, bad)
+
+
+# ---------------------------------------------------------------------------
+# Invalid start_byte / end_byte types
+# ---------------------------------------------------------------------------
+
+def test_start_byte_bool_rejected():
+    with pytest.raises(TypeError, match="start_byte"):
+        make_citation_id(SHA_A, True, 100, SHA_B)
+
+
+def test_end_byte_bool_rejected():
+    with pytest.raises(TypeError, match="end_byte"):
+        make_citation_id(SHA_A, 0, True, SHA_B)
+
+
+def test_start_byte_float_rejected():
+    with pytest.raises(TypeError, match="start_byte"):
+        make_citation_id(SHA_A, 0.0, 100, SHA_B)  # type: ignore[arg-type]
+
+
+def test_end_byte_float_rejected():
+    with pytest.raises(TypeError, match="end_byte"):
+        make_citation_id(SHA_A, 0, 100.0, SHA_B)  # type: ignore[arg-type]
+
+
+def test_start_byte_string_rejected():
+    with pytest.raises(TypeError, match="start_byte"):
+        make_citation_id(SHA_A, "0", 100, SHA_B)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Invalid start_byte / end_byte values
+# ---------------------------------------------------------------------------
+
+def test_start_byte_negative_rejected():
+    with pytest.raises(ValueError, match="start_byte"):
+        make_citation_id(SHA_A, -1, 100, SHA_B)
+
+
+def test_end_byte_equal_start_rejected():
+    with pytest.raises(ValueError, match="end_byte"):
+        make_citation_id(SHA_A, 50, 50, SHA_B)
+
+
+def test_end_byte_less_than_start_rejected():
+    with pytest.raises(ValueError, match="end_byte"):
+        make_citation_id(SHA_A, 100, 50, SHA_B)
+
+
+# ---------------------------------------------------------------------------
+# Edge cases that should succeed
+# ---------------------------------------------------------------------------
+
+def test_start_byte_zero_is_valid():
+    result = make_citation_id(SHA_A, 0, 1, SHA_B)
+    assert CIT_RE.match(result)
+
+
+def test_large_byte_offsets_are_valid():
+    result = make_citation_id(SHA_A, 0, 10_000_000, SHA_B)
+    assert CIT_RE.match(result)

--- a/merger/lenskit/tests/test_citation_id.py
+++ b/merger/lenskit/tests/test_citation_id.py
@@ -144,6 +144,14 @@ def test_end_byte_less_than_start_rejected():
 
 
 # ---------------------------------------------------------------------------
+# Golden vector — freezes payload prefix, field order, and 16-hex truncation
+# ---------------------------------------------------------------------------
+
+def test_known_vector_freezes_payload_contract():
+    assert make_citation_id(SHA_A, 0, 100, SHA_B) == "cit_e9bf24db57165d03"
+
+
+# ---------------------------------------------------------------------------
 # Edge cases that should succeed
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Implements the citation ID derivation rule as a reusable helper function in the codebase, unblocking the citation map producer implementation path.

## Changes
- **New module**: `merger/lenskit/core/citation_id.py`
  - Implements `make_citation_id()` function that derives stable citation IDs from canonical range identifying fields
  - Takes `canonical_md_sha256`, `start_byte`, `end_byte`, and `content_sha256` as inputs
  - Returns a deterministic ID in the format `cit_<16-char-hex>`
  - Uses SHA256 hashing of a versioned payload string for stability
  - Includes comprehensive input validation for SHA256 format and byte offset constraints

- **Comprehensive test suite**: `merger/lenskit/tests/test_citation_id.py`
  - Format validation tests
  - Determinism verification
  - Sensitivity tests for all input parameters
  - SHA256 validation (length, case, hex format)
  - Byte offset type and value validation
  - Edge case coverage

- **Documentation update**: Updated roadmap to reflect completion of citation ID derivation rule implementation

## Implementation Details
- Citation IDs are derived from a versioned payload: `lenskit.citation-map.v1:{canonical_md_sha256}:{start_byte}:{end_byte}:{content_sha256}`
- Only the first 16 characters of the SHA256 digest are used for the ID
- Strict input validation rejects non-lowercase hex strings, invalid types (bool, float), and invalid byte ranges
- The function is deterministic and sensitive to all input parameters

https://claude.ai/code/session_01RD8gpBb8ZBPuagVdLSA8LV