### PR TITLE
Add citation readiness validator for bundle manifests

### DIFF
--- a/docs/proofs/citation-readiness-validator-proof.md
+++ b/docs/proofs/citation-readiness-validator-proof.md
@@ -64,6 +64,7 @@ lenskit citation validate --json \
 Der Report muss enthalten:
 
 - `bundle_manifest_path`: verwendeter Pfad
+- `error_kind`: `ok` | `validation_error` | `path_read_error`
 - `bundle_run_id`: `run_id` aus dem Manifest
 - `validation_run_id`: eindeutige UUID des Validator-Laufs
 - `canonical_md_sha256`: aus Manifest

--- a/docs/proofs/citation-readiness-validator-proof.md
+++ b/docs/proofs/citation-readiness-validator-proof.md
@@ -70,9 +70,11 @@ Der Report muss enthalten:
 - `chunk_index_sha256`: aus Manifest
 - `chunk_count`: erwartet 585
 - `canonical_range_count`: erwartet 585
-- `citation_id_count`: erwartet 585 (oder kleiner bei validen Duplikat-freien Ranges)
+- `citation_id_count`: erwartet 585 (bei duplikatfreien validen Ranges)
+- Falls `citation_id_count` kleiner als `chunk_count`/`canonical_range_count` ist, signalisiert das Fehler oder übersprungene Zeilen (kein valider Duplikatfall).
 - `citation_id_duplicate_count`: erwartet 0
 - `status`: `ok` oder `fail` mit Fehlerliste
+- Zusätzlich für Hash-Diagnosen: `canonical_md_actual_sha256` und `chunk_index_actual_sha256` (berechnet aus Dateien).
 
 ---
 

--- a/docs/proofs/citation-readiness-validator-proof.md
+++ b/docs/proofs/citation-readiness-validator-proof.md
@@ -1,0 +1,88 @@
+# Citation Readiness Validator — Proof / STOP-Bericht
+
+**Datum:** 2026-05-13
+**Branch:** `claude/build-validator-consumer-1Q7p0`
+**Validator-Rolle:** Konsument / Readiness-Gate. Kein Producer.
+
+---
+
+## Status: STOP — Real-Dump lokal nicht verfügbar
+
+### Fehlende Dateien
+
+Der Real-Dump `lenskit-max-260513-0642` ist auf dem aktuellen System **nicht** vorhanden.
+
+Erwartet (alle relativ zum Dump-Verzeichnis):
+
+| Datei | Wofür benötigt |
+|-------|----------------|
+| `lenskit-max-260513-0642_merge.bundle.manifest.json` | Einstiegspunkt für Validator; enthält Artifact-Rollen und SHA256-Hashes |
+| `lenskit-max-260513-0642_merge.md` | Canonical-MD-Quelle; Byte-Ranges werden daraus gelesen und SHA256-geprüft |
+| `lenskit-max-260513-0642_chunk_index.jsonl` | 585 erwartete Chunk-Zeilen mit `canonical_range`, `source_range`, `content_range_ref` |
+
+Ohne diese drei Dateien kann der Validator nicht ausgeführt werden.
+Die Implementierung ist vollständig; der Proof-Run steht aus.
+
+---
+
+## Implementierungsstand (zum Zeitpunkt dieses Berichts)
+
+### Neue Dateien
+
+| Datei | Rolle |
+|-------|-------|
+| `merger/lenskit/core/citation_validate.py` | Core-Validator-Logik |
+| `merger/lenskit/cli/cmd_citation.py` | CLI-Befehl `lenskit citation validate` |
+| `merger/lenskit/tests/test_citation_validate.py` | Unit-Tests mit synthetischen Fixtures |
+| `merger/lenskit/tests/test_cli_citation.py` | CLI-Tests mit synthetischen Fixtures |
+
+### Geänderte Dateien
+
+| Datei | Änderung |
+|-------|----------|
+| `merger/lenskit/cli/main.py` | `citation`-Subcommand registriert |
+| `docs/roadmap/lenskit-master-roadmap.md` | Validator-Status ergänzt |
+
+---
+
+## Voraussetzungen für den Real-Dump-Proof
+
+Sobald der Dump lokal verfügbar ist:
+
+```
+lenskit citation validate \
+  /path/to/lenskit-max-260513-0642_merge.bundle.manifest.json
+```
+
+oder mit JSON-Report:
+
+```
+lenskit citation validate --json \
+  /path/to/lenskit-max-260513-0642_merge.bundle.manifest.json
+```
+
+Der Report muss enthalten:
+
+- `bundle_manifest_path`: verwendeter Pfad
+- `run_id`: eindeutige UUID des Validator-Laufs
+- `canonical_md_sha256`: aus Manifest
+- `chunk_index_sha256`: aus Manifest
+- `chunk_count`: erwartet 585
+- `canonical_range_count`: erwartet 585
+- `citation_id_count`: erwartet 585 (oder kleiner bei validen Duplikat-freien Ranges)
+- `citation_id_duplicate_count`: erwartet 0
+- `status`: `ok` oder `fail` mit Fehlerliste
+
+---
+
+## Invarianten des Validators
+
+- Validator liest; erzeugt nichts.
+- Kein `citation_map_jsonl`-Artefakt.
+- Kein Manifest-Wiring für `citation_map_jsonl`.
+- `canonical_range` ist autoritativ; `source_range` und `content_range_ref` werden nur berichtet.
+- Pfad-Traversal, absolute Pfade, Windows-Drive-Prefixe und UNC-Pfade werden abgelehnt.
+- SHA256 von `canonical_md` und `chunk_index_jsonl` wird gegen Manifest-Hashes geprüft.
+- `make_citation_id(canonical_md_sha256, start_byte, end_byte, content_sha256)` wird pro Chunk aufgerufen.
+- Duplikate werden als Fehler berichtet.
+- Exit-Code 0 = ok, 1 = Validierungsfehler, 2 = Pfad-/Lesefehler.

--- a/docs/proofs/citation-readiness-validator-proof.md
+++ b/docs/proofs/citation-readiness-validator-proof.md
@@ -70,7 +70,7 @@ Der Report muss enthalten:
 - `chunk_index_sha256`: aus Manifest
 - `chunk_count`: erwartet 585
 - `canonical_range_count`: erwartet 585
-- `citation_id_count`: erwartet 585 (bei duplikatfreien validen Ranges)
+- `citation_id_count`: erwartet 585 (bei duplikatefreien validen Ranges)
 - Falls `citation_id_count` kleiner als `chunk_count`/`canonical_range_count` ist, signalisiert das Fehler oder übersprungene Zeilen (kein valider Duplikatfall).
 - `citation_id_duplicate_count`: erwartet 0
 - `status`: `ok` oder `fail` mit Fehlerliste

--- a/docs/proofs/citation-readiness-validator-proof.md
+++ b/docs/proofs/citation-readiness-validator-proof.md
@@ -64,7 +64,8 @@ lenskit citation validate --json \
 Der Report muss enthalten:
 
 - `bundle_manifest_path`: verwendeter Pfad
-- `run_id`: eindeutige UUID des Validator-Laufs
+- `bundle_run_id`: `run_id` aus dem Manifest
+- `validation_run_id`: eindeutige UUID des Validator-Laufs
 - `canonical_md_sha256`: aus Manifest
 - `chunk_index_sha256`: aus Manifest
 - `chunk_count`: erwartet 585

--- a/docs/roadmap/lenskit-master-roadmap.md
+++ b/docs/roadmap/lenskit-master-roadmap.md
@@ -189,7 +189,7 @@ PR 3 (teilweise erledigt):
 - [x] Bundle-Manifest-Role `citation_map_jsonl`
 - [x] Chunk-Index dual range (`canonical_range`, `source_range` zusätzlich zu `content_range_ref`)
 - [ ] Citation-Map-Producer plus Real-Dump-Proof
-- [x] Citation-Readiness-Validator (`merger/lenskit/core/citation_validate.py`, CLI `lenskit citation validate`, Tests grün; Real-Dump-Proof ausstehend)
+- [x] Citation-Readiness-Validator (`merger/lenskit/core/citation_validate.py`, CLI `lenskit citation validate`, Testabdeckung in `merger/lenskit/tests/test_citation_validate.py` und `merger/lenskit/tests/test_cli_citation.py`; Real-Dump-Proof ausstehend)
 Diagnosehinweis für Priorisierung:
 - `merge.md` bleibt kanonische Vollquelle; JSON-Artefakte sind Einstieg/Index/Metadaten.
 - Ein schwacher Retrieval-Eval-Stand priorisiert Evidence-/Retrieval-Grundlagen vor Semantic/Reranking.

--- a/docs/roadmap/lenskit-master-roadmap.md
+++ b/docs/roadmap/lenskit-master-roadmap.md
@@ -83,6 +83,12 @@ Spätere PRs:
       - Real-Dump mit dual ranges bereitstellen.
       - Konsument oder Validator benennen.
     - Erledigte Vorbereitung: `merger/lenskit/core/citation_id.py` (Citation-Id-Derivationsregel als Helper, PR #652).
+  - **Citation-Readiness-Validator vorbereitet (Validator-PR):**
+    - `merger/lenskit/core/citation_validate.py` implementiert (Konsument/Readiness-Gate, kein Producer).
+    - CLI: `lenskit citation validate <bundle_manifest>` mit `--json`-Option.
+    - Tests: `test_citation_validate.py`, `test_cli_citation.py` (synthetische Fixtures, kein Real-Dump erforderlich).
+    - Real-Dump-Proof ausstehend: `lenskit-max-260513-0642` lokal nicht verfügbar; STOP-Bericht: `docs/proofs/citation-readiness-validator-proof.md`.
+    - Producer (`citation_map_jsonl` erzeugen) bleibt offen bis Real-Dump-Proof vorhanden.
 Gate:
 - `citation_map_jsonl` nie `canonical_content` oder `content_source`
 - `canonical_range` und `source_range` getrennt
@@ -183,6 +189,7 @@ PR 3 (teilweise erledigt):
 - [x] Bundle-Manifest-Role `citation_map_jsonl`
 - [x] Chunk-Index dual range (`canonical_range`, `source_range` zusätzlich zu `content_range_ref`)
 - [ ] Citation-Map-Producer plus Real-Dump-Proof
+- [x] Citation-Readiness-Validator (`merger/lenskit/core/citation_validate.py`, CLI `lenskit citation validate`, Tests grün; Real-Dump-Proof ausstehend)
 Diagnosehinweis für Priorisierung:
 - `merge.md` bleibt kanonische Vollquelle; JSON-Artefakte sind Einstieg/Index/Metadaten.
 - Ein schwacher Retrieval-Eval-Stand priorisiert Evidence-/Retrieval-Grundlagen vor Semantic/Reranking.

--- a/merger/lenskit/cli/cmd_citation.py
+++ b/merger/lenskit/cli/cmd_citation.py
@@ -43,7 +43,11 @@ def run_citation_validate(args: argparse.Namespace) -> int:
     else:
         _print_human_report(report)
 
-    return 0 if report["status"] == "ok" else 1
+    if report["status"] == "ok":
+        return 0
+    if report.get("error_kind") == "path_read_error":
+        return 2
+    return 1
 
 
 def _print_human_report(report: dict) -> None:

--- a/merger/lenskit/cli/cmd_citation.py
+++ b/merger/lenskit/cli/cmd_citation.py
@@ -1,0 +1,74 @@
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def register_citation_commands(subparsers) -> None:
+    citation_parser = subparsers.add_parser("citation", help="Citation operations")
+    citation_subparsers = citation_parser.add_subparsers(
+        dest="citation_cmd", required=True, help="Citation commands"
+    )
+
+    validate_parser = citation_subparsers.add_parser(
+        "validate", help="Validate citation readiness of a bundle manifest"
+    )
+    validate_parser.add_argument(
+        "bundle_manifest", help="Path to bundle manifest JSON"
+    )
+    validate_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="emit_json",
+        help="Emit machine-readable JSON report to stdout",
+    )
+
+
+def run_citation_validate(args: argparse.Namespace) -> int:
+    from merger.lenskit.core.citation_validate import validate_bundle
+
+    manifest_path = args.bundle_manifest
+    if not Path(manifest_path).exists():
+        print(f"Error: manifest not found: {manifest_path}", file=sys.stderr)
+        return 2
+
+    try:
+        report = validate_bundle(manifest_path)
+    except Exception as e:
+        print(f"Error: unexpected failure during validation: {e}", file=sys.stderr)
+        return 2
+
+    if args.emit_json:
+        print(json.dumps(report, indent=2))
+    else:
+        _print_human_report(report)
+
+    return 0 if report["status"] == "ok" else 1
+
+
+def _print_human_report(report: dict) -> None:
+    status = report["status"].upper()
+    print(f"Citation Readiness: {status}")
+    print(f"  run_id:                  {report['run_id']}")
+    print(f"  chunks:                  {report['chunk_count']}")
+    print(f"  canonical_range_count:   {report['canonical_range_count']}")
+    print(f"  source_range_count:      {report['source_range_count']}")
+    print(f"  content_range_ref_count: {report['content_range_ref_count']}")
+    print(f"  citation_id_count:       {report['citation_id_count']}")
+    print(f"  duplicates:              {report['citation_id_duplicate_count']}")
+    print(f"  hash_ok_count:           {report['canonical_range_hash_ok_count']}")
+
+    if report["sample_citation_ids"]:
+        print("  sample_citation_ids:")
+        for cid in report["sample_citation_ids"]:
+            print(f"    {cid}")
+
+    if report["warnings"]:
+        print(f"\nWarnings ({len(report['warnings'])}):")
+        for w in report["warnings"]:
+            print(f"  [warn] {w}")
+
+    if report["errors"]:
+        print(f"\nErrors ({len(report['errors'])}):")
+        for e in report["errors"]:
+            print(f"  [error] {e}")

--- a/merger/lenskit/cli/cmd_citation.py
+++ b/merger/lenskit/cli/cmd_citation.py
@@ -1,7 +1,6 @@
 import argparse
 import json
 import sys
-from pathlib import Path
 
 
 def register_citation_commands(subparsers) -> None:
@@ -28,9 +27,6 @@ def run_citation_validate(args: argparse.Namespace) -> int:
     from merger.lenskit.core.citation_validate import validate_bundle
 
     manifest_path = args.bundle_manifest
-    if not Path(manifest_path).exists():
-        print(f"Error: manifest not found: {manifest_path}", file=sys.stderr)
-        return 2
 
     try:
         report = validate_bundle(manifest_path)

--- a/merger/lenskit/cli/cmd_citation.py
+++ b/merger/lenskit/cli/cmd_citation.py
@@ -54,6 +54,8 @@ def _print_human_report(report: dict) -> None:
     print(f"  validation_run_id:       {report['validation_run_id']}")
     print(f"  canonical_md_sha256:     {report['canonical_md_sha256']}")
     print(f"  chunk_index_sha256:      {report['chunk_index_sha256']}")
+    print(f"  canonical_md_actual_sha256: {report['canonical_md_actual_sha256']}")
+    print(f"  chunk_index_actual_sha256:  {report['chunk_index_actual_sha256']}")
     print(f"  chunks:                  {report['chunk_count']}")
     print(f"  canonical_range_count:   {report['canonical_range_count']}")
     print(f"  source_range_count:      {report['source_range_count']}")

--- a/merger/lenskit/cli/cmd_citation.py
+++ b/merger/lenskit/cli/cmd_citation.py
@@ -49,7 +49,11 @@ def run_citation_validate(args: argparse.Namespace) -> int:
 def _print_human_report(report: dict) -> None:
     status = report["status"].upper()
     print(f"Citation Readiness: {status}")
-    print(f"  run_id:                  {report['run_id']}")
+    print(f"  bundle_manifest_path:    {report['bundle_manifest_path']}")
+    print(f"  bundle_run_id:           {report['bundle_run_id']}")
+    print(f"  validation_run_id:       {report['validation_run_id']}")
+    print(f"  canonical_md_sha256:     {report['canonical_md_sha256']}")
+    print(f"  chunk_index_sha256:      {report['chunk_index_sha256']}")
     print(f"  chunks:                  {report['chunk_count']}")
     print(f"  canonical_range_count:   {report['canonical_range_count']}")
     print(f"  source_range_count:      {report['source_range_count']}")

--- a/merger/lenskit/cli/main.py
+++ b/merger/lenskit/cli/main.py
@@ -18,6 +18,10 @@ def main(args: Optional[List[str]] = None) -> int:
     )
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
 
+    # Citation command
+    from .cmd_citation import register_citation_commands
+    register_citation_commands(subparsers)
+
     # Federation command
     from .cmd_federation import register_federation_commands
     register_federation_commands(subparsers)
@@ -220,6 +224,13 @@ def main(args: Optional[List[str]] = None) -> int:
             return cmd_atlas.run_atlas_analyze(parsed_args)
         else:
             parser.parse_args(["atlas", "--help"])
+            return 0
+    elif parsed_args.command == "citation":
+        from .cmd_citation import run_citation_validate
+        if parsed_args.citation_cmd == "validate":
+            return run_citation_validate(parsed_args)
+        else:
+            parser.parse_args(["citation", "--help"])
             return 0
     elif parsed_args.command == "federation":
         from .cmd_federation import handle_federation_command

--- a/merger/lenskit/core/citation_validate.py
+++ b/merger/lenskit/core/citation_validate.py
@@ -161,7 +161,14 @@ def validate_bundle(manifest_path_str: str) -> Dict[str, Any]:
 
     canonical_md_artifact = None
     chunk_index_artifact = None
-    for art in artifacts:
+    for index, art in enumerate(artifacts):
+        if not isinstance(art, dict):
+            return _fail_report(
+                validation_run_id,
+                [f"Manifest artifact at index {index} is not an object"],
+                bundle_manifest_path=bundle_manifest_path,
+                bundle_run_id=bundle_run_id,
+            )
         role = art.get("role", "")
         if role == "canonical_md" and canonical_md_artifact is None:
             canonical_md_artifact = art

--- a/merger/lenskit/core/citation_validate.py
+++ b/merger/lenskit/core/citation_validate.py
@@ -2,7 +2,6 @@ import hashlib
 import json
 import re
 import uuid
-import os
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -27,10 +26,10 @@ def _normalize_relative_path(raw: str, label: str) -> str:
     parts = raw.replace("\\", "/").split("/")
     if ".." in parts:
         raise ValueError(f"{label}: path traversal ('..') is forbidden")
-    normalized = os.path.normpath(raw.replace("\\", "/"))
-    if normalized in (".", ""):
+    normalized_parts = [part for part in parts if part not in ("", ".")]
+    if not normalized_parts:
         raise ValueError(f"{label}: path must not be empty")
-    return normalized
+    return "/".join(normalized_parts)
 
 
 def _sha256_file(path: Path) -> str:
@@ -349,7 +348,9 @@ def validate_bundle(manifest_path_str: str) -> Dict[str, Any]:
         if cr_file_path != canonical_md_rel:
             errors.append(
                 f"Line {lineno}: canonical_range.file_path {cr_file_path_raw!r} "
-                f"does not match manifest canonical_md path {canonical_md_rel!r}"
+                f"(normalized {cr_file_path!r}) does not match "
+                f"manifest canonical_md path {canonical_md_rel_raw!r} "
+                f"(normalized {canonical_md_rel!r})"
             )
 
         start_byte = cr.get("start_byte")

--- a/merger/lenskit/core/citation_validate.py
+++ b/merger/lenskit/core/citation_validate.py
@@ -1,0 +1,341 @@
+import hashlib
+import json
+import re
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List
+
+from merger.lenskit.core.citation_id import make_citation_id
+from merger.lenskit.core.path_security import resolve_secure_path
+
+_CIT_RE = re.compile(r"^cit_[a-f0-9]{16}$")
+_SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
+_WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:[/\\]")
+_UNC_RE = re.compile(r"^\\\\")
+
+
+def _reject_unsafe_path(raw: str, label: str) -> None:
+    if not isinstance(raw, str):
+        raise ValueError(f"{label}: path must be a string")
+    if raw.startswith("/"):
+        raise ValueError(f"{label}: absolute paths are forbidden")
+    if _WINDOWS_DRIVE_RE.match(raw):
+        raise ValueError(f"{label}: Windows drive-prefixed paths are forbidden")
+    if _UNC_RE.match(raw):
+        raise ValueError(f"{label}: UNC paths are forbidden")
+    parts = raw.replace("\\", "/").split("/")
+    if ".." in parts:
+        raise ValueError(f"{label}: path traversal ('..') is forbidden")
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _fail_report(run_id: str, errors: List[str]) -> Dict[str, Any]:
+    return {
+        "status": "fail",
+        "run_id": run_id,
+        "chunk_count": 0,
+        "canonical_range_count": 0,
+        "source_range_count": 0,
+        "content_range_ref_count": 0,
+        "citation_id_count": 0,
+        "citation_id_duplicate_count": 0,
+        "canonical_range_hash_ok_count": 0,
+        "errors": errors,
+        "warnings": [],
+        "sample_citation_ids": [],
+    }
+
+
+def validate_bundle(manifest_path_str: str) -> Dict[str, Any]:
+    """
+    Validate citation readiness of a bundle manifest.
+
+    Reads the manifest, resolves canonical_md and chunk_index_jsonl artifacts,
+    verifies SHA256 hashes, and for every chunk checks canonical_range validity
+    and derives the citation_id via make_citation_id(). Nothing is written.
+
+    Returns a structured report dict.
+    """
+    run_id = str(uuid.uuid4())
+    errors: List[str] = []
+    warnings: List[str] = []
+    sample_citation_ids: List[str] = []
+
+    chunk_count = 0
+    canonical_range_count = 0
+    source_range_count = 0
+    content_range_ref_count = 0
+    citation_id_count = 0
+    citation_id_duplicate_count = 0
+    canonical_range_hash_ok_count = 0
+    seen_citation_ids: Dict[str, int] = {}
+
+    # --- resolve manifest path ---
+    manifest_path = Path(manifest_path_str)
+    if not manifest_path.is_absolute():
+        manifest_path = Path.cwd() / manifest_path
+    manifest_path = manifest_path.resolve()
+
+    if not manifest_path.exists():
+        return _fail_report(run_id, [f"Manifest not found: {manifest_path}"])
+    if not manifest_path.is_file():
+        return _fail_report(run_id, [f"Manifest path is not a file: {manifest_path}"])
+
+    manifest_dir = manifest_path.parent
+
+    # --- load manifest ---
+    try:
+        with manifest_path.open("r", encoding="utf-8") as f:
+            manifest = json.load(f)
+    except json.JSONDecodeError as e:
+        return _fail_report(run_id, [f"Manifest is not valid JSON: {e}"])
+    except OSError as e:
+        return _fail_report(run_id, [f"Cannot read manifest: {e}"])
+
+    artifacts = manifest.get("artifacts", [])
+    if not isinstance(artifacts, list):
+        return _fail_report(run_id, ["Manifest 'artifacts' field is not a list"])
+
+    canonical_md_artifact = None
+    chunk_index_artifact = None
+    for art in artifacts:
+        role = art.get("role", "")
+        if role == "canonical_md" and canonical_md_artifact is None:
+            canonical_md_artifact = art
+        elif role == "chunk_index_jsonl" and chunk_index_artifact is None:
+            chunk_index_artifact = art
+
+    if canonical_md_artifact is None:
+        return _fail_report(run_id, ["Manifest has no artifact with role 'canonical_md'"])
+    if chunk_index_artifact is None:
+        return _fail_report(run_id, ["Manifest has no artifact with role 'chunk_index_jsonl'"])
+
+    canonical_md_rel = canonical_md_artifact.get("path", "")
+    chunk_index_rel = chunk_index_artifact.get("path", "")
+    canonical_md_manifest_sha = canonical_md_artifact.get("sha256", "")
+    chunk_index_manifest_sha = chunk_index_artifact.get("sha256", "")
+
+    # --- path security ---
+    try:
+        _reject_unsafe_path(canonical_md_rel, "canonical_md path")
+        canonical_md_path = resolve_secure_path(manifest_dir, canonical_md_rel)
+    except ValueError as e:
+        return _fail_report(run_id, [f"canonical_md path rejected: {e}"])
+
+    try:
+        _reject_unsafe_path(chunk_index_rel, "chunk_index_jsonl path")
+        chunk_index_path = resolve_secure_path(manifest_dir, chunk_index_rel)
+    except ValueError as e:
+        return _fail_report(run_id, [f"chunk_index_jsonl path rejected: {e}"])
+
+    if not canonical_md_path.exists():
+        return _fail_report(run_id, [f"canonical_md file not found: {canonical_md_path}"])
+    if not chunk_index_path.exists():
+        return _fail_report(run_id, [f"chunk_index_jsonl file not found: {chunk_index_path}"])
+
+    # --- verify manifest SHAs ---
+    actual_canonical_sha = _sha256_file(canonical_md_path)
+    if canonical_md_manifest_sha and actual_canonical_sha != canonical_md_manifest_sha:
+        errors.append(
+            f"canonical_md SHA256 mismatch: manifest={canonical_md_manifest_sha!r} "
+            f"actual={actual_canonical_sha!r}"
+        )
+
+    actual_chunk_sha = _sha256_file(chunk_index_path)
+    if chunk_index_manifest_sha and actual_chunk_sha != chunk_index_manifest_sha:
+        errors.append(
+            f"chunk_index_jsonl SHA256 mismatch: manifest={chunk_index_manifest_sha!r} "
+            f"actual={actual_chunk_sha!r}"
+        )
+
+    canonical_md_sha = actual_canonical_sha
+
+    # --- read canonical_md bytes ---
+    try:
+        with canonical_md_path.open("rb") as f:
+            canonical_md_bytes = f.read()
+    except OSError as e:
+        return _fail_report(run_id, [f"Cannot read canonical_md: {e}"])
+
+    canonical_md_file_size = len(canonical_md_bytes)
+
+    # --- process chunk_index_jsonl line by line ---
+    try:
+        with chunk_index_path.open("r", encoding="utf-8") as f:
+            lines = f.readlines()
+    except OSError as e:
+        return _fail_report(run_id, [f"Cannot read chunk_index_jsonl: {e}"])
+
+    for lineno, raw_line in enumerate(lines, start=1):
+        raw_line = raw_line.strip()
+        if not raw_line:
+            continue
+
+        chunk_count += 1
+
+        try:
+            chunk = json.loads(raw_line)
+        except json.JSONDecodeError as e:
+            errors.append(f"Line {lineno}: invalid JSON: {e}")
+            continue
+
+        if not isinstance(chunk, dict):
+            errors.append(f"Line {lineno}: chunk must be a JSON object")
+            continue
+
+        if chunk.get("chunk_id") is None:
+            errors.append(f"Line {lineno}: missing 'chunk_id'")
+
+        # source_range: soft check only
+        source_range = chunk.get("source_range")
+        if source_range is not None:
+            source_range_count += 1
+            if not isinstance(source_range, dict):
+                warnings.append(f"Line {lineno}: 'source_range' is not an object")
+
+        # content_range_ref: report only
+        if chunk.get("content_range_ref") is not None:
+            content_range_ref_count += 1
+
+        # canonical_range: mandatory
+        cr = chunk.get("canonical_range")
+        if cr is None:
+            errors.append(f"Line {lineno}: missing 'canonical_range'")
+            continue
+
+        if not isinstance(cr, dict):
+            errors.append(f"Line {lineno}: 'canonical_range' must be an object")
+            continue
+
+        canonical_range_count += 1
+
+        art_role = cr.get("artifact_role")
+        if art_role != "canonical_md":
+            errors.append(
+                f"Line {lineno}: canonical_range.artifact_role must be 'canonical_md', "
+                f"got {art_role!r}"
+            )
+
+        cr_file_path = cr.get("file_path", "")
+        if cr_file_path != canonical_md_rel:
+            errors.append(
+                f"Line {lineno}: canonical_range.file_path {cr_file_path!r} "
+                f"does not match manifest canonical_md path {canonical_md_rel!r}"
+            )
+
+        start_byte = cr.get("start_byte")
+        end_byte = cr.get("end_byte")
+
+        byte_ok = True
+        if isinstance(start_byte, bool):
+            errors.append(f"Line {lineno}: canonical_range.start_byte must not be bool")
+            byte_ok = False
+        elif not isinstance(start_byte, int):
+            errors.append(f"Line {lineno}: canonical_range.start_byte must be an int")
+            byte_ok = False
+
+        if isinstance(end_byte, bool):
+            errors.append(f"Line {lineno}: canonical_range.end_byte must not be bool")
+            byte_ok = False
+        elif not isinstance(end_byte, int):
+            errors.append(f"Line {lineno}: canonical_range.end_byte must be an int")
+            byte_ok = False
+
+        if not byte_ok:
+            continue
+
+        if start_byte < 0:
+            errors.append(
+                f"Line {lineno}: canonical_range.start_byte must be >= 0, got {start_byte}"
+            )
+            continue
+
+        if end_byte <= start_byte:
+            errors.append(
+                f"Line {lineno}: canonical_range.end_byte must be > start_byte "
+                f"(start={start_byte}, end={end_byte})"
+            )
+            continue
+
+        if end_byte > canonical_md_file_size:
+            errors.append(
+                f"Line {lineno}: canonical_range end_byte={end_byte} exceeds "
+                f"file size={canonical_md_file_size}"
+            )
+            continue
+
+        range_bytes = canonical_md_bytes[start_byte:end_byte]
+        actual_range_sha = _sha256_bytes(range_bytes)
+
+        cr_content_sha = cr.get("content_sha256", "")
+        if not cr_content_sha:
+            errors.append(f"Line {lineno}: canonical_range.content_sha256 is missing")
+            continue
+
+        if not isinstance(cr_content_sha, str) or not _SHA256_RE.fullmatch(cr_content_sha):
+            errors.append(
+                f"Line {lineno}: canonical_range.content_sha256 is not a valid "
+                f"64-char lowercase hex string"
+            )
+            continue
+
+        if actual_range_sha != cr_content_sha:
+            errors.append(
+                f"Line {lineno}: canonical_range content SHA256 mismatch: "
+                f"expected={cr_content_sha!r} actual={actual_range_sha!r}"
+            )
+            continue
+
+        canonical_range_hash_ok_count += 1
+
+        try:
+            cit_id = make_citation_id(canonical_md_sha, start_byte, end_byte, actual_range_sha)
+        except (ValueError, TypeError) as e:
+            errors.append(f"Line {lineno}: make_citation_id failed: {e}")
+            continue
+
+        if not _CIT_RE.fullmatch(cit_id):
+            errors.append(
+                f"Line {lineno}: derived citation_id has invalid format: {cit_id!r}"
+            )
+            continue
+
+        citation_id_count += 1
+
+        if cit_id in seen_citation_ids:
+            citation_id_duplicate_count += 1
+            errors.append(
+                f"Line {lineno}: duplicate citation_id {cit_id!r} "
+                f"(first seen at line {seen_citation_ids[cit_id]})"
+            )
+        else:
+            seen_citation_ids[cit_id] = lineno
+            if len(sample_citation_ids) < 5:
+                sample_citation_ids.append(cit_id)
+
+    status = "ok" if not errors else "fail"
+    return {
+        "status": status,
+        "run_id": run_id,
+        "chunk_count": chunk_count,
+        "canonical_range_count": canonical_range_count,
+        "source_range_count": source_range_count,
+        "content_range_ref_count": content_range_ref_count,
+        "citation_id_count": citation_id_count,
+        "citation_id_duplicate_count": citation_id_duplicate_count,
+        "canonical_range_hash_ok_count": canonical_range_hash_ok_count,
+        "errors": errors,
+        "warnings": warnings,
+        "sample_citation_ids": sample_citation_ids,
+    }

--- a/merger/lenskit/core/citation_validate.py
+++ b/merger/lenskit/core/citation_validate.py
@@ -52,6 +52,8 @@ def _fail_report(
     bundle_run_id: Any = None,
     canonical_md_sha256: Any = None,
     chunk_index_sha256: Any = None,
+    canonical_md_actual_sha256: Any = None,
+    chunk_index_actual_sha256: Any = None,
 ) -> Dict[str, Any]:
     return {
         "status": "fail",
@@ -60,6 +62,8 @@ def _fail_report(
         "validation_run_id": validation_run_id,
         "canonical_md_sha256": canonical_md_sha256,
         "chunk_index_sha256": chunk_index_sha256,
+        "canonical_md_actual_sha256": canonical_md_actual_sha256,
+        "chunk_index_actual_sha256": chunk_index_actual_sha256,
         "chunk_count": 0,
         "canonical_range_count": 0,
         "source_range_count": 0,
@@ -175,6 +179,8 @@ def validate_bundle(manifest_path_str: str) -> Dict[str, Any]:
     chunk_index_rel_raw = chunk_index_artifact.get("path", "")
     canonical_md_manifest_sha = canonical_md_artifact.get("sha256", "")
     chunk_index_manifest_sha = chunk_index_artifact.get("sha256", "")
+    actual_canonical_sha = None
+    actual_chunk_sha = None
 
     try:
         canonical_md_rel = _normalize_relative_path(canonical_md_rel_raw, "canonical_md path")
@@ -268,6 +274,8 @@ def validate_bundle(manifest_path_str: str) -> Dict[str, Any]:
             bundle_run_id=bundle_run_id,
             canonical_md_sha256=canonical_md_manifest_sha,
             chunk_index_sha256=chunk_index_manifest_sha,
+            canonical_md_actual_sha256=actual_canonical_sha,
+            chunk_index_actual_sha256=actual_chunk_sha,
         )
 
     canonical_md_file_size = len(canonical_md_bytes)
@@ -284,6 +292,8 @@ def validate_bundle(manifest_path_str: str) -> Dict[str, Any]:
             bundle_run_id=bundle_run_id,
             canonical_md_sha256=canonical_md_manifest_sha,
             chunk_index_sha256=chunk_index_manifest_sha,
+            canonical_md_actual_sha256=actual_canonical_sha,
+            chunk_index_actual_sha256=actual_chunk_sha,
         )
 
     for lineno, raw_line in enumerate(lines, start=1):
@@ -451,6 +461,8 @@ def validate_bundle(manifest_path_str: str) -> Dict[str, Any]:
         "validation_run_id": validation_run_id,
         "canonical_md_sha256": canonical_md_manifest_sha,
         "chunk_index_sha256": chunk_index_manifest_sha,
+        "canonical_md_actual_sha256": actual_canonical_sha,
+        "chunk_index_actual_sha256": actual_chunk_sha,
         "chunk_count": chunk_count,
         "canonical_range_count": canonical_range_count,
         "source_range_count": source_range_count,

--- a/merger/lenskit/core/citation_validate.py
+++ b/merger/lenskit/core/citation_validate.py
@@ -54,9 +54,11 @@ def _fail_report(
     chunk_index_sha256: Any = None,
     canonical_md_actual_sha256: Any = None,
     chunk_index_actual_sha256: Any = None,
+    error_kind: str = "validation_error",
 ) -> Dict[str, Any]:
     return {
         "status": "fail",
+        "error_kind": error_kind,
         "bundle_manifest_path": bundle_manifest_path,
         "bundle_run_id": bundle_run_id,
         "validation_run_id": validation_run_id,
@@ -113,12 +115,14 @@ def validate_bundle(manifest_path_str: str) -> Dict[str, Any]:
             validation_run_id,
             [f"Manifest not found: {manifest_path}"],
             bundle_manifest_path=bundle_manifest_path,
+            error_kind="path_read_error",
         )
     if not manifest_path.is_file():
         return _fail_report(
             validation_run_id,
             [f"Manifest path is not a file: {manifest_path}"],
             bundle_manifest_path=bundle_manifest_path,
+            error_kind="path_read_error",
         )
 
     manifest_dir = manifest_path.parent
@@ -132,12 +136,14 @@ def validate_bundle(manifest_path_str: str) -> Dict[str, Any]:
             validation_run_id,
             [f"Manifest is not valid JSON: {e}"],
             bundle_manifest_path=bundle_manifest_path,
+            error_kind="path_read_error",
         )
     except OSError as e:
         return _fail_report(
             validation_run_id,
             [f"Cannot read manifest: {e}"],
             bundle_manifest_path=bundle_manifest_path,
+            error_kind="path_read_error",
         )
 
     bundle_run_id = manifest.get("run_id")
@@ -193,6 +199,7 @@ def validate_bundle(manifest_path_str: str) -> Dict[str, Any]:
             bundle_run_id=bundle_run_id,
             canonical_md_sha256=canonical_md_manifest_sha,
             chunk_index_sha256=chunk_index_manifest_sha,
+            error_kind="path_read_error",
         )
 
     try:
@@ -208,6 +215,7 @@ def validate_bundle(manifest_path_str: str) -> Dict[str, Any]:
             bundle_run_id=bundle_run_id,
             canonical_md_sha256=canonical_md_manifest_sha,
             chunk_index_sha256=chunk_index_manifest_sha,
+            error_kind="path_read_error",
         )
 
     if not canonical_md_path.exists():
@@ -218,6 +226,7 @@ def validate_bundle(manifest_path_str: str) -> Dict[str, Any]:
             bundle_run_id=bundle_run_id,
             canonical_md_sha256=canonical_md_manifest_sha,
             chunk_index_sha256=chunk_index_manifest_sha,
+            error_kind="path_read_error",
         )
     if not chunk_index_path.exists():
         return _fail_report(
@@ -227,10 +236,22 @@ def validate_bundle(manifest_path_str: str) -> Dict[str, Any]:
             bundle_run_id=bundle_run_id,
             canonical_md_sha256=canonical_md_manifest_sha,
             chunk_index_sha256=chunk_index_manifest_sha,
+            error_kind="path_read_error",
         )
 
     # --- verify manifest SHAs ---
-    actual_canonical_sha = _sha256_file(canonical_md_path)
+    try:
+        actual_canonical_sha = _sha256_file(canonical_md_path)
+    except OSError as e:
+        return _fail_report(
+            validation_run_id,
+            [f"Cannot read canonical_md: {e}"],
+            bundle_manifest_path=bundle_manifest_path,
+            bundle_run_id=bundle_run_id,
+            canonical_md_sha256=canonical_md_manifest_sha,
+            chunk_index_sha256=chunk_index_manifest_sha,
+            error_kind="path_read_error",
+        )
     if not canonical_md_manifest_sha:
         errors.append("canonical_md sha256 is missing in manifest")
     elif not isinstance(canonical_md_manifest_sha, str) or not _SHA256_RE.fullmatch(
@@ -245,7 +266,19 @@ def validate_bundle(manifest_path_str: str) -> Dict[str, Any]:
             f"actual={actual_canonical_sha!r}"
         )
 
-    actual_chunk_sha = _sha256_file(chunk_index_path)
+    try:
+        actual_chunk_sha = _sha256_file(chunk_index_path)
+    except OSError as e:
+        return _fail_report(
+            validation_run_id,
+            [f"Cannot read chunk_index_jsonl: {e}"],
+            bundle_manifest_path=bundle_manifest_path,
+            bundle_run_id=bundle_run_id,
+            canonical_md_sha256=canonical_md_manifest_sha,
+            chunk_index_sha256=chunk_index_manifest_sha,
+            canonical_md_actual_sha256=actual_canonical_sha,
+            error_kind="path_read_error",
+        )
     if not chunk_index_manifest_sha:
         errors.append("chunk_index_jsonl sha256 is missing in manifest")
     elif not isinstance(chunk_index_manifest_sha, str) or not _SHA256_RE.fullmatch(
@@ -276,6 +309,7 @@ def validate_bundle(manifest_path_str: str) -> Dict[str, Any]:
             chunk_index_sha256=chunk_index_manifest_sha,
             canonical_md_actual_sha256=actual_canonical_sha,
             chunk_index_actual_sha256=actual_chunk_sha,
+            error_kind="path_read_error",
         )
 
     canonical_md_file_size = len(canonical_md_bytes)
@@ -294,6 +328,7 @@ def validate_bundle(manifest_path_str: str) -> Dict[str, Any]:
             chunk_index_sha256=chunk_index_manifest_sha,
             canonical_md_actual_sha256=actual_canonical_sha,
             chunk_index_actual_sha256=actual_chunk_sha,
+            error_kind="path_read_error",
         )
 
     for lineno, raw_line in enumerate(lines, start=1):
@@ -362,6 +397,7 @@ def validate_bundle(manifest_path_str: str) -> Dict[str, Any]:
                 f"manifest canonical_md path {canonical_md_rel_raw!r} "
                 f"(normalized {canonical_md_rel!r})"
             )
+            continue
 
         start_byte = cr.get("start_byte")
         end_byte = cr.get("end_byte")
@@ -456,6 +492,7 @@ def validate_bundle(manifest_path_str: str) -> Dict[str, Any]:
     status = "ok" if not errors else "fail"
     return {
         "status": status,
+        "error_kind": "ok" if status == "ok" else "validation_error",
         "bundle_manifest_path": bundle_manifest_path,
         "bundle_run_id": bundle_run_id,
         "validation_run_id": validation_run_id,

--- a/merger/lenskit/core/citation_validate.py
+++ b/merger/lenskit/core/citation_validate.py
@@ -19,10 +19,12 @@ def _normalize_relative_path(raw: str, label: str) -> str:
         raise ValueError(f"{label}: path must be a string")
     if raw.startswith("/"):
         raise ValueError(f"{label}: absolute paths are forbidden")
+    if raw.startswith("\\"):
+        if _UNC_RE.match(raw):
+            raise ValueError(f"{label}: UNC paths are forbidden")
+        raise ValueError(f"{label}: Windows rooted paths are forbidden")
     if _WINDOWS_DRIVE_RE.match(raw):
         raise ValueError(f"{label}: Windows drive-prefixed paths are forbidden")
-    if _UNC_RE.match(raw):
-        raise ValueError(f"{label}: UNC paths are forbidden")
     parts = raw.replace("\\", "/").split("/")
     if ".." in parts:
         raise ValueError(f"{label}: path traversal ('..') is forbidden")

--- a/merger/lenskit/core/citation_validate.py
+++ b/merger/lenskit/core/citation_validate.py
@@ -19,9 +19,9 @@ def _normalize_relative_path(raw: str, label: str) -> str:
         raise ValueError(f"{label}: path must be a string")
     if raw.startswith("/"):
         raise ValueError(f"{label}: absolute paths are forbidden")
+    if _UNC_RE.match(raw):
+        raise ValueError(f"{label}: UNC paths are forbidden")
     if raw.startswith("\\"):
-        if _UNC_RE.match(raw):
-            raise ValueError(f"{label}: UNC paths are forbidden")
         raise ValueError(f"{label}: Windows rooted paths are forbidden")
     if _WINDOWS_DRIVE_RE.match(raw):
         raise ValueError(f"{label}: Windows drive-prefixed paths are forbidden")

--- a/merger/lenskit/core/citation_validate.py
+++ b/merger/lenskit/core/citation_validate.py
@@ -2,6 +2,7 @@ import hashlib
 import json
 import re
 import uuid
+import os
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -10,11 +11,11 @@ from merger.lenskit.core.path_security import resolve_secure_path
 
 _CIT_RE = re.compile(r"^cit_[a-f0-9]{16}$")
 _SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
-_WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:[/\\]")
+_WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:")
 _UNC_RE = re.compile(r"^\\\\")
 
 
-def _reject_unsafe_path(raw: str, label: str) -> None:
+def _normalize_relative_path(raw: str, label: str) -> str:
     if not isinstance(raw, str):
         raise ValueError(f"{label}: path must be a string")
     if raw.startswith("/"):
@@ -26,6 +27,10 @@ def _reject_unsafe_path(raw: str, label: str) -> None:
     parts = raw.replace("\\", "/").split("/")
     if ".." in parts:
         raise ValueError(f"{label}: path traversal ('..') is forbidden")
+    normalized = os.path.normpath(raw.replace("\\", "/"))
+    if normalized in (".", ""):
+        raise ValueError(f"{label}: path must not be empty")
+    return normalized
 
 
 def _sha256_file(path: Path) -> str:
@@ -40,10 +45,22 @@ def _sha256_bytes(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
-def _fail_report(run_id: str, errors: List[str]) -> Dict[str, Any]:
+def _fail_report(
+    validation_run_id: str,
+    errors: List[str],
+    *,
+    bundle_manifest_path: str = "",
+    bundle_run_id: Any = None,
+    canonical_md_sha256: Any = None,
+    chunk_index_sha256: Any = None,
+) -> Dict[str, Any]:
     return {
         "status": "fail",
-        "run_id": run_id,
+        "bundle_manifest_path": bundle_manifest_path,
+        "bundle_run_id": bundle_run_id,
+        "validation_run_id": validation_run_id,
+        "canonical_md_sha256": canonical_md_sha256,
+        "chunk_index_sha256": chunk_index_sha256,
         "chunk_count": 0,
         "canonical_range_count": 0,
         "source_range_count": 0,
@@ -67,7 +84,7 @@ def validate_bundle(manifest_path_str: str) -> Dict[str, Any]:
 
     Returns a structured report dict.
     """
-    run_id = str(uuid.uuid4())
+    validation_run_id = str(uuid.uuid4())
     errors: List[str] = []
     warnings: List[str] = []
     sample_citation_ids: List[str] = []
@@ -86,11 +103,20 @@ def validate_bundle(manifest_path_str: str) -> Dict[str, Any]:
     if not manifest_path.is_absolute():
         manifest_path = Path.cwd() / manifest_path
     manifest_path = manifest_path.resolve()
+    bundle_manifest_path = str(manifest_path)
 
     if not manifest_path.exists():
-        return _fail_report(run_id, [f"Manifest not found: {manifest_path}"])
+        return _fail_report(
+            validation_run_id,
+            [f"Manifest not found: {manifest_path}"],
+            bundle_manifest_path=bundle_manifest_path,
+        )
     if not manifest_path.is_file():
-        return _fail_report(run_id, [f"Manifest path is not a file: {manifest_path}"])
+        return _fail_report(
+            validation_run_id,
+            [f"Manifest path is not a file: {manifest_path}"],
+            bundle_manifest_path=bundle_manifest_path,
+        )
 
     manifest_dir = manifest_path.parent
 
@@ -99,13 +125,28 @@ def validate_bundle(manifest_path_str: str) -> Dict[str, Any]:
         with manifest_path.open("r", encoding="utf-8") as f:
             manifest = json.load(f)
     except json.JSONDecodeError as e:
-        return _fail_report(run_id, [f"Manifest is not valid JSON: {e}"])
+        return _fail_report(
+            validation_run_id,
+            [f"Manifest is not valid JSON: {e}"],
+            bundle_manifest_path=bundle_manifest_path,
+        )
     except OSError as e:
-        return _fail_report(run_id, [f"Cannot read manifest: {e}"])
+        return _fail_report(
+            validation_run_id,
+            [f"Cannot read manifest: {e}"],
+            bundle_manifest_path=bundle_manifest_path,
+        )
+
+    bundle_run_id = manifest.get("run_id")
 
     artifacts = manifest.get("artifacts", [])
     if not isinstance(artifacts, list):
-        return _fail_report(run_id, ["Manifest 'artifacts' field is not a list"])
+        return _fail_report(
+            validation_run_id,
+            ["Manifest 'artifacts' field is not a list"],
+            bundle_manifest_path=bundle_manifest_path,
+            bundle_run_id=bundle_run_id,
+        )
 
     canonical_md_artifact = None
     chunk_index_artifact = None
@@ -117,43 +158,98 @@ def validate_bundle(manifest_path_str: str) -> Dict[str, Any]:
             chunk_index_artifact = art
 
     if canonical_md_artifact is None:
-        return _fail_report(run_id, ["Manifest has no artifact with role 'canonical_md'"])
+        return _fail_report(
+            validation_run_id,
+            ["Manifest has no artifact with role 'canonical_md'"],
+            bundle_manifest_path=bundle_manifest_path,
+            bundle_run_id=bundle_run_id,
+        )
     if chunk_index_artifact is None:
-        return _fail_report(run_id, ["Manifest has no artifact with role 'chunk_index_jsonl'"])
+        return _fail_report(
+            validation_run_id,
+            ["Manifest has no artifact with role 'chunk_index_jsonl'"],
+            bundle_manifest_path=bundle_manifest_path,
+            bundle_run_id=bundle_run_id,
+        )
 
-    canonical_md_rel = canonical_md_artifact.get("path", "")
-    chunk_index_rel = chunk_index_artifact.get("path", "")
+    canonical_md_rel_raw = canonical_md_artifact.get("path", "")
+    chunk_index_rel_raw = chunk_index_artifact.get("path", "")
     canonical_md_manifest_sha = canonical_md_artifact.get("sha256", "")
     chunk_index_manifest_sha = chunk_index_artifact.get("sha256", "")
 
-    # --- path security ---
     try:
-        _reject_unsafe_path(canonical_md_rel, "canonical_md path")
+        canonical_md_rel = _normalize_relative_path(canonical_md_rel_raw, "canonical_md path")
         canonical_md_path = resolve_secure_path(manifest_dir, canonical_md_rel)
     except ValueError as e:
-        return _fail_report(run_id, [f"canonical_md path rejected: {e}"])
+        return _fail_report(
+            validation_run_id,
+            [f"canonical_md path rejected: {e}"],
+            bundle_manifest_path=bundle_manifest_path,
+            bundle_run_id=bundle_run_id,
+            canonical_md_sha256=canonical_md_manifest_sha,
+            chunk_index_sha256=chunk_index_manifest_sha,
+        )
 
     try:
-        _reject_unsafe_path(chunk_index_rel, "chunk_index_jsonl path")
+        chunk_index_rel = _normalize_relative_path(
+            chunk_index_rel_raw, "chunk_index_jsonl path"
+        )
         chunk_index_path = resolve_secure_path(manifest_dir, chunk_index_rel)
     except ValueError as e:
-        return _fail_report(run_id, [f"chunk_index_jsonl path rejected: {e}"])
+        return _fail_report(
+            validation_run_id,
+            [f"chunk_index_jsonl path rejected: {e}"],
+            bundle_manifest_path=bundle_manifest_path,
+            bundle_run_id=bundle_run_id,
+            canonical_md_sha256=canonical_md_manifest_sha,
+            chunk_index_sha256=chunk_index_manifest_sha,
+        )
 
     if not canonical_md_path.exists():
-        return _fail_report(run_id, [f"canonical_md file not found: {canonical_md_path}"])
+        return _fail_report(
+            validation_run_id,
+            [f"canonical_md file not found: {canonical_md_path}"],
+            bundle_manifest_path=bundle_manifest_path,
+            bundle_run_id=bundle_run_id,
+            canonical_md_sha256=canonical_md_manifest_sha,
+            chunk_index_sha256=chunk_index_manifest_sha,
+        )
     if not chunk_index_path.exists():
-        return _fail_report(run_id, [f"chunk_index_jsonl file not found: {chunk_index_path}"])
+        return _fail_report(
+            validation_run_id,
+            [f"chunk_index_jsonl file not found: {chunk_index_path}"],
+            bundle_manifest_path=bundle_manifest_path,
+            bundle_run_id=bundle_run_id,
+            canonical_md_sha256=canonical_md_manifest_sha,
+            chunk_index_sha256=chunk_index_manifest_sha,
+        )
 
     # --- verify manifest SHAs ---
     actual_canonical_sha = _sha256_file(canonical_md_path)
-    if canonical_md_manifest_sha and actual_canonical_sha != canonical_md_manifest_sha:
+    if not canonical_md_manifest_sha:
+        errors.append("canonical_md sha256 is missing in manifest")
+    elif not isinstance(canonical_md_manifest_sha, str) or not _SHA256_RE.fullmatch(
+        canonical_md_manifest_sha
+    ):
+        errors.append(
+            "canonical_md sha256 must be a 64-char lowercase hex string in manifest"
+        )
+    elif actual_canonical_sha != canonical_md_manifest_sha:
         errors.append(
             f"canonical_md SHA256 mismatch: manifest={canonical_md_manifest_sha!r} "
             f"actual={actual_canonical_sha!r}"
         )
 
     actual_chunk_sha = _sha256_file(chunk_index_path)
-    if chunk_index_manifest_sha and actual_chunk_sha != chunk_index_manifest_sha:
+    if not chunk_index_manifest_sha:
+        errors.append("chunk_index_jsonl sha256 is missing in manifest")
+    elif not isinstance(chunk_index_manifest_sha, str) or not _SHA256_RE.fullmatch(
+        chunk_index_manifest_sha
+    ):
+        errors.append(
+            "chunk_index_jsonl sha256 must be a 64-char lowercase hex string in manifest"
+        )
+    elif actual_chunk_sha != chunk_index_manifest_sha:
         errors.append(
             f"chunk_index_jsonl SHA256 mismatch: manifest={chunk_index_manifest_sha!r} "
             f"actual={actual_chunk_sha!r}"
@@ -166,7 +262,14 @@ def validate_bundle(manifest_path_str: str) -> Dict[str, Any]:
         with canonical_md_path.open("rb") as f:
             canonical_md_bytes = f.read()
     except OSError as e:
-        return _fail_report(run_id, [f"Cannot read canonical_md: {e}"])
+        return _fail_report(
+            validation_run_id,
+            [f"Cannot read canonical_md: {e}"],
+            bundle_manifest_path=bundle_manifest_path,
+            bundle_run_id=bundle_run_id,
+            canonical_md_sha256=canonical_md_manifest_sha,
+            chunk_index_sha256=chunk_index_manifest_sha,
+        )
 
     canonical_md_file_size = len(canonical_md_bytes)
 
@@ -175,7 +278,14 @@ def validate_bundle(manifest_path_str: str) -> Dict[str, Any]:
         with chunk_index_path.open("r", encoding="utf-8") as f:
             lines = f.readlines()
     except OSError as e:
-        return _fail_report(run_id, [f"Cannot read chunk_index_jsonl: {e}"])
+        return _fail_report(
+            validation_run_id,
+            [f"Cannot read chunk_index_jsonl: {e}"],
+            bundle_manifest_path=bundle_manifest_path,
+            bundle_run_id=bundle_run_id,
+            canonical_md_sha256=canonical_md_manifest_sha,
+            chunk_index_sha256=chunk_index_manifest_sha,
+        )
 
     for lineno, raw_line in enumerate(lines, start=1):
         raw_line = raw_line.strip()
@@ -227,10 +337,18 @@ def validate_bundle(manifest_path_str: str) -> Dict[str, Any]:
                 f"got {art_role!r}"
             )
 
-        cr_file_path = cr.get("file_path", "")
+        cr_file_path_raw = cr.get("file_path", "")
+        try:
+            cr_file_path = _normalize_relative_path(
+                cr_file_path_raw, "canonical_range.file_path"
+            )
+        except ValueError as e:
+            errors.append(f"Line {lineno}: canonical_range.file_path rejected: {e}")
+            continue
+
         if cr_file_path != canonical_md_rel:
             errors.append(
-                f"Line {lineno}: canonical_range.file_path {cr_file_path!r} "
+                f"Line {lineno}: canonical_range.file_path {cr_file_path_raw!r} "
                 f"does not match manifest canonical_md path {canonical_md_rel!r}"
             )
 
@@ -327,7 +445,11 @@ def validate_bundle(manifest_path_str: str) -> Dict[str, Any]:
     status = "ok" if not errors else "fail"
     return {
         "status": status,
-        "run_id": run_id,
+        "bundle_manifest_path": bundle_manifest_path,
+        "bundle_run_id": bundle_run_id,
+        "validation_run_id": validation_run_id,
+        "canonical_md_sha256": canonical_md_manifest_sha,
+        "chunk_index_sha256": chunk_index_manifest_sha,
         "chunk_count": chunk_count,
         "canonical_range_count": canonical_range_count,
         "source_range_count": source_range_count,

--- a/merger/lenskit/tests/test_citation_validate.py
+++ b/merger/lenskit/tests/test_citation_validate.py
@@ -5,11 +5,7 @@ All tests use synthetic in-memory fixtures — no real dump required.
 """
 import hashlib
 import json
-import os
-import tempfile
 from pathlib import Path
-
-import pytest
 
 from merger.lenskit.core.citation_validate import validate_bundle
 
@@ -375,7 +371,7 @@ def test_path_traversal_in_canonical_md_path_fails(tmp_path):
         "capabilities": [],
     }
     manifest_path = tmp_path / "bundle.manifest.json"
-    manifest_path.write_text(json.dumps(manifest))
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
 
     report = validate_bundle(str(manifest_path))
 
@@ -412,7 +408,7 @@ def test_absolute_canonical_md_path_fails(tmp_path):
         "capabilities": [],
     }
     manifest_path = tmp_path / "bundle.manifest.json"
-    manifest_path.write_text(json.dumps(manifest))
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
 
     report = validate_bundle(str(manifest_path))
 
@@ -485,7 +481,7 @@ def test_manifest_missing_canonical_md_role_fails(tmp_path):
         "capabilities": [],
     }
     manifest_path = tmp_path / "bundle.manifest.json"
-    manifest_path.write_text(json.dumps(manifest))
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
 
     report = validate_bundle(str(manifest_path))
 
@@ -517,7 +513,7 @@ def test_manifest_missing_chunk_index_role_fails(tmp_path):
         "capabilities": [],
     }
     manifest_path = tmp_path / "bundle.manifest.json"
-    manifest_path.write_text(json.dumps(manifest))
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
 
     report = validate_bundle(str(manifest_path))
 

--- a/merger/lenskit/tests/test_citation_validate.py
+++ b/merger/lenskit/tests/test_citation_validate.py
@@ -1,0 +1,488 @@
+"""
+Tests for merger.lenskit.core.citation_validate.
+
+All tests use synthetic in-memory fixtures — no real dump required.
+"""
+import hashlib
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from merger.lenskit.core.citation_validate import validate_bundle
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _make_bundle(
+    tmp_path: Path,
+    canonical_content: bytes,
+    chunks: list,
+    *,
+    canonical_sha_override: str = None,
+    chunk_index_sha_override: str = None,
+) -> Path:
+    """
+    Write a minimal synthetic bundle into tmp_path and return the manifest path.
+
+    Each item in `chunks` is a dict that will be written as a JSONL line.
+    The caller is responsible for constructing valid or intentionally broken entries.
+    """
+    canonical_md_path = tmp_path / "merge.md"
+    canonical_md_path.write_bytes(canonical_content)
+
+    chunk_lines = "\n".join(json.dumps(c) for c in chunks) + "\n"
+    chunk_index_bytes = chunk_lines.encode("utf-8")
+    chunk_index_path = tmp_path / "chunk_index.jsonl"
+    chunk_index_path.write_bytes(chunk_index_bytes)
+
+    actual_canonical_sha = _sha256(canonical_content)
+    actual_chunk_sha = _sha256(chunk_index_bytes)
+
+    manifest = {
+        "kind": "repolens.bundle.manifest",
+        "version": "1.0",
+        "run_id": "test-run-001",
+        "created_at": "2026-05-13T00:00:00Z",
+        "generator": {
+            "name": "test",
+            "version": "0.0.1",
+            "config_sha256": "a" * 64,
+        },
+        "artifacts": [
+            {
+                "role": "canonical_md",
+                "path": "merge.md",
+                "content_type": "text/markdown",
+                "bytes": len(canonical_content),
+                "sha256": canonical_sha_override or actual_canonical_sha,
+            },
+            {
+                "role": "chunk_index_jsonl",
+                "path": "chunk_index.jsonl",
+                "content_type": "application/x-ndjson",
+                "bytes": len(chunk_index_bytes),
+                "sha256": chunk_index_sha_override or actual_chunk_sha,
+            },
+        ],
+        "links": [],
+        "capabilities": [],
+    }
+
+    manifest_path = tmp_path / "bundle.manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    return manifest_path
+
+
+def _make_chunk(canonical_content: bytes, canonical_md_rel: str, start: int, end: int) -> dict:
+    """Build a valid chunk entry for the given byte range."""
+    range_bytes = canonical_content[start:end]
+    content_sha = _sha256(range_bytes)
+    return {
+        "chunk_id": f"chunk-{start}-{end}",
+        "canonical_range": {
+            "artifact_role": "canonical_md",
+            "file_path": canonical_md_rel,
+            "start_byte": start,
+            "end_byte": end,
+            "content_sha256": content_sha,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+def test_valid_bundle_reports_ok(tmp_path):
+    content = b"Hello world this is canonical markdown content for testing purposes."
+    chunk = _make_chunk(content, "merge.md", 0, 20)
+    manifest_path = _make_bundle(tmp_path, content, [chunk])
+
+    report = validate_bundle(str(manifest_path))
+
+    assert report["status"] == "ok"
+    assert report["chunk_count"] == 1
+    assert report["canonical_range_count"] == 1
+    assert report["citation_id_count"] == 1
+    assert report["canonical_range_hash_ok_count"] == 1
+    assert report["citation_id_duplicate_count"] == 0
+    assert len(report["errors"]) == 0
+    assert len(report["sample_citation_ids"]) == 1
+
+
+def test_valid_bundle_multiple_chunks(tmp_path):
+    content = b"AAAA BBBB CCCC DDDD EEEE FFFF GGGG HHHH IIII JJJJ"
+    chunks = [
+        _make_chunk(content, "merge.md", 0, 5),
+        _make_chunk(content, "merge.md", 5, 10),
+        _make_chunk(content, "merge.md", 10, 15),
+    ]
+    manifest_path = _make_bundle(tmp_path, content, chunks)
+
+    report = validate_bundle(str(manifest_path))
+
+    assert report["status"] == "ok"
+    assert report["chunk_count"] == 3
+    assert report["citation_id_count"] == 3
+    assert report["citation_id_duplicate_count"] == 0
+
+
+def test_sample_citation_ids_capped_at_five(tmp_path):
+    content = bytes(range(100))
+    chunks = [_make_chunk(content, "merge.md", i, i + 10) for i in range(0, 70, 10)]
+    manifest_path = _make_bundle(tmp_path, content, chunks)
+
+    report = validate_bundle(str(manifest_path))
+
+    assert report["status"] == "ok"
+    assert len(report["sample_citation_ids"]) == 5
+
+
+def test_source_range_and_content_range_ref_counted(tmp_path):
+    content = b"Source and ref test content abcdefghijklmnop"
+    chunk = _make_chunk(content, "merge.md", 0, 10)
+    chunk["source_range"] = {"file_path": "original.py", "start_line": 1, "end_line": 5}
+    chunk["content_range_ref"] = {"artifact_role": "chunk_index_jsonl", "start_byte": 0, "end_byte": 10}
+    manifest_path = _make_bundle(tmp_path, content, [chunk])
+
+    report = validate_bundle(str(manifest_path))
+
+    assert report["status"] == "ok"
+    assert report["source_range_count"] == 1
+    assert report["content_range_ref_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Hash mismatch
+# ---------------------------------------------------------------------------
+
+def test_canonical_md_sha_mismatch_fails(tmp_path):
+    content = b"canonical content"
+    chunk = _make_chunk(content, "merge.md", 0, 9)
+    manifest_path = _make_bundle(tmp_path, content, [chunk], canonical_sha_override="b" * 64)
+
+    report = validate_bundle(str(manifest_path))
+
+    assert report["status"] == "fail"
+    assert any("canonical_md SHA256 mismatch" in e for e in report["errors"])
+
+
+def test_chunk_index_sha_mismatch_fails(tmp_path):
+    content = b"canonical content"
+    chunk = _make_chunk(content, "merge.md", 0, 9)
+    manifest_path = _make_bundle(tmp_path, content, [chunk], chunk_index_sha_override="c" * 64)
+
+    report = validate_bundle(str(manifest_path))
+
+    assert report["status"] == "fail"
+    assert any("chunk_index_jsonl SHA256 mismatch" in e for e in report["errors"])
+
+
+def test_range_content_sha_mismatch_fails(tmp_path):
+    content = b"Hello world range test"
+    chunk = _make_chunk(content, "merge.md", 0, 10)
+    # corrupt the content_sha256 in the canonical_range
+    chunk["canonical_range"]["content_sha256"] = "d" * 64
+    manifest_path = _make_bundle(tmp_path, content, [chunk])
+
+    report = validate_bundle(str(manifest_path))
+
+    assert report["status"] == "fail"
+    assert any("content SHA256 mismatch" in e for e in report["errors"])
+
+
+# ---------------------------------------------------------------------------
+# Byte range errors
+# ---------------------------------------------------------------------------
+
+def test_out_of_bounds_end_byte_fails(tmp_path):
+    content = b"short"
+    chunk = _make_chunk(content, "merge.md", 0, 3)
+    chunk["canonical_range"]["end_byte"] = 999  # beyond file size
+    # also fix content_sha256 to avoid hash mismatch masking this error
+    chunk["canonical_range"]["content_sha256"] = "e" * 64
+    manifest_path = _make_bundle(tmp_path, content, [chunk])
+
+    report = validate_bundle(str(manifest_path))
+
+    assert report["status"] == "fail"
+    assert any("exceeds" in e or "end_byte" in e for e in report["errors"])
+
+
+def test_empty_range_end_equals_start_fails(tmp_path):
+    content = b"empty range test"
+    chunk = _make_chunk(content, "merge.md", 5, 10)
+    chunk["canonical_range"]["end_byte"] = 5  # equal to start_byte
+    chunk["canonical_range"]["content_sha256"] = "f" * 64
+    manifest_path = _make_bundle(tmp_path, content, [chunk])
+
+    report = validate_bundle(str(manifest_path))
+
+    assert report["status"] == "fail"
+    assert any("end_byte must be > start_byte" in e for e in report["errors"])
+
+
+def test_negative_start_byte_fails(tmp_path):
+    content = b"negative byte test"
+    chunk = _make_chunk(content, "merge.md", 0, 5)
+    chunk["canonical_range"]["start_byte"] = -1
+    chunk["canonical_range"]["content_sha256"] = "a" * 64
+    manifest_path = _make_bundle(tmp_path, content, [chunk])
+
+    report = validate_bundle(str(manifest_path))
+
+    assert report["status"] == "fail"
+    assert any("start_byte must be >= 0" in e for e in report["errors"])
+
+
+# ---------------------------------------------------------------------------
+# Bool byte offsets
+# ---------------------------------------------------------------------------
+
+def test_bool_start_byte_fails(tmp_path):
+    content = b"bool test content"
+    chunk = _make_chunk(content, "merge.md", 0, 5)
+    chunk["canonical_range"]["start_byte"] = True  # bool is subclass of int in Python
+    manifest_path = _make_bundle(tmp_path, content, [chunk])
+
+    report = validate_bundle(str(manifest_path))
+
+    assert report["status"] == "fail"
+    assert any("start_byte must not be bool" in e for e in report["errors"])
+
+
+def test_bool_end_byte_fails(tmp_path):
+    content = b"bool test content"
+    chunk = _make_chunk(content, "merge.md", 0, 5)
+    chunk["canonical_range"]["end_byte"] = True
+    manifest_path = _make_bundle(tmp_path, content, [chunk])
+
+    report = validate_bundle(str(manifest_path))
+
+    assert report["status"] == "fail"
+    assert any("end_byte must not be bool" in e for e in report["errors"])
+
+
+# ---------------------------------------------------------------------------
+# Missing canonical_range
+# ---------------------------------------------------------------------------
+
+def test_missing_canonical_range_fails(tmp_path):
+    content = b"no canonical range here"
+    chunk = {
+        "chunk_id": "chunk-no-range",
+        "source_range": {"file_path": "src.py", "start_line": 1, "end_line": 3},
+    }
+    manifest_path = _make_bundle(tmp_path, content, [chunk])
+
+    report = validate_bundle(str(manifest_path))
+
+    assert report["status"] == "fail"
+    assert any("missing 'canonical_range'" in e for e in report["errors"])
+
+
+# ---------------------------------------------------------------------------
+# Duplicate citation_id
+# ---------------------------------------------------------------------------
+
+def test_duplicate_citation_id_reported_as_error(tmp_path):
+    content = b"duplicate range content test"
+    # Two identical ranges → same citation_id
+    chunk1 = _make_chunk(content, "merge.md", 0, 10)
+    chunk2 = _make_chunk(content, "merge.md", 0, 10)
+    chunk2["chunk_id"] = "chunk-dup"
+    manifest_path = _make_bundle(tmp_path, content, [chunk1, chunk2])
+
+    report = validate_bundle(str(manifest_path))
+
+    assert report["status"] == "fail"
+    assert report["citation_id_duplicate_count"] == 1
+    assert any("duplicate citation_id" in e for e in report["errors"])
+
+
+# ---------------------------------------------------------------------------
+# Path traversal / unsafe paths
+# ---------------------------------------------------------------------------
+
+def test_path_traversal_in_canonical_md_path_fails(tmp_path):
+    content = b"traversal test"
+    chunk = _make_chunk(content, "merge.md", 0, 5)
+
+    manifest = {
+        "kind": "repolens.bundle.manifest",
+        "version": "1.0",
+        "run_id": "test-traversal",
+        "created_at": "2026-05-13T00:00:00Z",
+        "generator": {"name": "test", "version": "0", "config_sha256": "a" * 64},
+        "artifacts": [
+            {
+                "role": "canonical_md",
+                "path": "../evil.md",  # traversal attempt
+                "content_type": "text/markdown",
+                "bytes": len(content),
+                "sha256": _sha256(content),
+            },
+            {
+                "role": "chunk_index_jsonl",
+                "path": "chunk_index.jsonl",
+                "content_type": "application/x-ndjson",
+                "bytes": 0,
+                "sha256": _sha256(b""),
+            },
+        ],
+        "links": [],
+        "capabilities": [],
+    }
+    manifest_path = tmp_path / "bundle.manifest.json"
+    manifest_path.write_text(json.dumps(manifest))
+
+    report = validate_bundle(str(manifest_path))
+
+    assert report["status"] == "fail"
+    assert any("traversal" in e or "forbidden" in e for e in report["errors"])
+
+
+def test_absolute_canonical_md_path_fails(tmp_path):
+    content = b"absolute path test"
+
+    manifest = {
+        "kind": "repolens.bundle.manifest",
+        "version": "1.0",
+        "run_id": "test-abs",
+        "created_at": "2026-05-13T00:00:00Z",
+        "generator": {"name": "test", "version": "0", "config_sha256": "a" * 64},
+        "artifacts": [
+            {
+                "role": "canonical_md",
+                "path": "/etc/passwd",  # absolute path
+                "content_type": "text/markdown",
+                "bytes": 0,
+                "sha256": _sha256(b""),
+            },
+            {
+                "role": "chunk_index_jsonl",
+                "path": "chunk_index.jsonl",
+                "content_type": "application/x-ndjson",
+                "bytes": 0,
+                "sha256": _sha256(b""),
+            },
+        ],
+        "links": [],
+        "capabilities": [],
+    }
+    manifest_path = tmp_path / "bundle.manifest.json"
+    manifest_path.write_text(json.dumps(manifest))
+
+    report = validate_bundle(str(manifest_path))
+
+    assert report["status"] == "fail"
+    assert any("absolute" in e or "forbidden" in e for e in report["errors"])
+
+
+# ---------------------------------------------------------------------------
+# Missing manifest / artifact roles
+# ---------------------------------------------------------------------------
+
+def test_manifest_not_found_fails():
+    report = validate_bundle("/nonexistent/path/bundle.manifest.json")
+    assert report["status"] == "fail"
+    assert any("not found" in e for e in report["errors"])
+
+
+def test_manifest_missing_canonical_md_role_fails(tmp_path):
+    manifest = {
+        "kind": "repolens.bundle.manifest",
+        "version": "1.0",
+        "run_id": "test-no-canonical",
+        "created_at": "2026-05-13T00:00:00Z",
+        "generator": {"name": "test", "version": "0", "config_sha256": "a" * 64},
+        "artifacts": [
+            {
+                "role": "chunk_index_jsonl",
+                "path": "chunk_index.jsonl",
+                "content_type": "application/x-ndjson",
+                "bytes": 0,
+                "sha256": _sha256(b""),
+            }
+        ],
+        "links": [],
+        "capabilities": [],
+    }
+    manifest_path = tmp_path / "bundle.manifest.json"
+    manifest_path.write_text(json.dumps(manifest))
+
+    report = validate_bundle(str(manifest_path))
+
+    assert report["status"] == "fail"
+    assert any("canonical_md" in e for e in report["errors"])
+
+
+def test_manifest_missing_chunk_index_role_fails(tmp_path):
+    content = b"content"
+    (tmp_path / "merge.md").write_bytes(content)
+
+    manifest = {
+        "kind": "repolens.bundle.manifest",
+        "version": "1.0",
+        "run_id": "test-no-chunk",
+        "created_at": "2026-05-13T00:00:00Z",
+        "generator": {"name": "test", "version": "0", "config_sha256": "a" * 64},
+        "artifacts": [
+            {
+                "role": "canonical_md",
+                "path": "merge.md",
+                "content_type": "text/markdown",
+                "bytes": len(content),
+                "sha256": _sha256(content),
+            }
+        ],
+        "links": [],
+        "capabilities": [],
+    }
+    manifest_path = tmp_path / "bundle.manifest.json"
+    manifest_path.write_text(json.dumps(manifest))
+
+    report = validate_bundle(str(manifest_path))
+
+    assert report["status"] == "fail"
+    assert any("chunk_index_jsonl" in e for e in report["errors"])
+
+
+# ---------------------------------------------------------------------------
+# Report structure completeness
+# ---------------------------------------------------------------------------
+
+def test_report_has_all_required_keys(tmp_path):
+    content = b"structure test"
+    chunk = _make_chunk(content, "merge.md", 0, 7)
+    manifest_path = _make_bundle(tmp_path, content, [chunk])
+
+    report = validate_bundle(str(manifest_path))
+
+    required_keys = {
+        "status", "run_id", "chunk_count", "canonical_range_count",
+        "source_range_count", "content_range_ref_count", "citation_id_count",
+        "citation_id_duplicate_count", "canonical_range_hash_ok_count",
+        "errors", "warnings", "sample_citation_ids",
+    }
+    assert required_keys.issubset(report.keys())
+
+
+def test_run_id_is_unique_per_call(tmp_path):
+    content = b"unique run id test"
+    chunk = _make_chunk(content, "merge.md", 0, 6)
+    manifest_path = _make_bundle(tmp_path, content, [chunk])
+
+    r1 = validate_bundle(str(manifest_path))
+    r2 = validate_bundle(str(manifest_path))
+
+    assert r1["run_id"] != r2["run_id"]

--- a/merger/lenskit/tests/test_citation_validate.py
+++ b/merger/lenskit/tests/test_citation_validate.py
@@ -532,6 +532,27 @@ def test_manifest_missing_chunk_index_role_fails(tmp_path):
     assert any("chunk_index_jsonl" in e for e in report["errors"])
 
 
+def test_manifest_artifact_entry_not_object_fails(tmp_path):
+    manifest = {
+        "kind": "repolens.bundle.manifest",
+        "version": "1.0",
+        "run_id": "test-bad-artifact-entry",
+        "created_at": "2026-05-13T00:00:00Z",
+        "generator": {"name": "test", "version": "0", "config_sha256": "a" * 64},
+        "artifacts": ["not-an-object"],
+        "links": [],
+        "capabilities": [],
+    }
+    manifest_path = tmp_path / "bundle.manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    report = validate_bundle(str(manifest_path))
+
+    assert report["status"] == "fail"
+    assert report["error_kind"] == "validation_error"
+    assert any("artifact at index 0 is not an object" in e for e in report["errors"])
+
+
 # ---------------------------------------------------------------------------
 # Report structure completeness
 # ---------------------------------------------------------------------------

--- a/merger/lenskit/tests/test_citation_validate.py
+++ b/merger/lenskit/tests/test_citation_validate.py
@@ -438,6 +438,17 @@ def test_canonical_range_file_path_with_windows_drive_prefix_fails(tmp_path):
         assert any("Windows drive-prefixed paths are forbidden" in e for e in report["errors"])
 
 
+def test_canonical_range_file_path_with_windows_root_prefix_fails(tmp_path):
+    content = b"windows rooted path"
+    chunk = _make_chunk(content, r"\merge.md", 0, 5)
+    manifest_path = _make_bundle(tmp_path, content, [chunk])
+
+    report = validate_bundle(str(manifest_path))
+
+    assert report["status"] == "fail"
+    assert any("Windows rooted paths are forbidden" in e for e in report["errors"])
+
+
 def test_canonical_range_file_path_mismatch_does_not_increment_hash_or_citation_counts(tmp_path):
     content = b"path mismatch counter guard"
     chunk = _make_chunk(content, "different.md", 0, 10)

--- a/merger/lenskit/tests/test_citation_validate.py
+++ b/merger/lenskit/tests/test_citation_validate.py
@@ -110,6 +110,7 @@ def test_valid_bundle_reports_ok(tmp_path):
     report = validate_bundle(str(manifest_path))
 
     assert report["status"] == "ok"
+    assert report["error_kind"] == "ok"
     assert report["chunk_count"] == 1
     assert report["canonical_range_count"] == 1
     assert report["citation_id_count"] == 1
@@ -441,6 +442,18 @@ def test_canonical_range_file_path_with_windows_drive_prefix_fails(tmp_path):
         assert any("Windows drive-prefixed paths are forbidden" in e for e in report["errors"])
 
 
+def test_canonical_range_file_path_mismatch_does_not_increment_hash_or_citation_counts(tmp_path):
+    content = b"path mismatch counter guard"
+    chunk = _make_chunk(content, "different.md", 0, 10)
+    manifest_path = _make_bundle(tmp_path, content, [chunk])
+
+    report = validate_bundle(str(manifest_path))
+
+    assert report["status"] == "fail"
+    assert report["canonical_range_hash_ok_count"] == 0
+    assert report["citation_id_count"] == 0
+
+
 # ---------------------------------------------------------------------------
 # Missing manifest / artifact roles
 # ---------------------------------------------------------------------------
@@ -448,6 +461,7 @@ def test_canonical_range_file_path_with_windows_drive_prefix_fails(tmp_path):
 def test_manifest_not_found_fails():
     report = validate_bundle("/nonexistent/path/bundle.manifest.json")
     assert report["status"] == "fail"
+    assert report["error_kind"] == "path_read_error"
     assert any("not found" in e for e in report["errors"])
 
 
@@ -476,6 +490,7 @@ def test_manifest_missing_canonical_md_role_fails(tmp_path):
     report = validate_bundle(str(manifest_path))
 
     assert report["status"] == "fail"
+    assert report["error_kind"] == "validation_error"
     assert any("canonical_md" in e for e in report["errors"])
 
 
@@ -522,7 +537,7 @@ def test_report_has_all_required_keys(tmp_path):
     report = validate_bundle(str(manifest_path))
 
     required_keys = {
-        "status", "bundle_manifest_path", "bundle_run_id", "validation_run_id",
+        "status", "error_kind", "bundle_manifest_path", "bundle_run_id", "validation_run_id",
         "canonical_md_sha256", "chunk_index_sha256",
         "canonical_md_actual_sha256", "chunk_index_actual_sha256",
         "chunk_count", "canonical_range_count",

--- a/merger/lenskit/tests/test_citation_validate.py
+++ b/merger/lenskit/tests/test_citation_validate.py
@@ -117,6 +117,8 @@ def test_valid_bundle_reports_ok(tmp_path):
     assert report["citation_id_duplicate_count"] == 0
     assert len(report["errors"]) == 0
     assert len(report["sample_citation_ids"]) == 1
+    assert report["canonical_md_actual_sha256"] == report["canonical_md_sha256"]
+    assert report["chunk_index_actual_sha256"] == report["chunk_index_sha256"]
 
 
 def test_valid_bundle_multiple_chunks(tmp_path):
@@ -185,6 +187,18 @@ def test_chunk_index_sha_mismatch_fails(tmp_path):
 
     assert report["status"] == "fail"
     assert any("chunk_index_jsonl SHA256 mismatch" in e for e in report["errors"])
+
+
+def test_report_contains_actual_sha_on_manifest_mismatch(tmp_path):
+    content = b"canonical content"
+    chunk = _make_chunk(content, "merge.md", 0, 9)
+    manifest_path = _make_bundle(tmp_path, content, [chunk], canonical_sha_override="b" * 64)
+
+    report = validate_bundle(str(manifest_path))
+
+    assert report["status"] == "fail"
+    assert report["canonical_md_sha256"] == "b" * 64
+    assert report["canonical_md_actual_sha256"] == _sha256(content)
 
 
 def test_missing_manifest_sha256_fails(tmp_path):
@@ -509,7 +523,9 @@ def test_report_has_all_required_keys(tmp_path):
 
     required_keys = {
         "status", "bundle_manifest_path", "bundle_run_id", "validation_run_id",
-        "canonical_md_sha256", "chunk_index_sha256", "chunk_count", "canonical_range_count",
+        "canonical_md_sha256", "chunk_index_sha256",
+        "canonical_md_actual_sha256", "chunk_index_actual_sha256",
+        "chunk_count", "canonical_range_count",
         "source_range_count", "content_range_ref_count", "citation_id_count",
         "citation_id_duplicate_count", "canonical_range_hash_ok_count",
         "errors", "warnings", "sample_citation_ids",

--- a/merger/lenskit/tests/test_citation_validate.py
+++ b/merger/lenskit/tests/test_citation_validate.py
@@ -192,8 +192,9 @@ def test_missing_manifest_sha256_fails(tmp_path):
     chunk = _make_chunk(content, "merge.md", 0, 9)
     manifest_path = _make_bundle(tmp_path, content, [chunk])
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    manifest["artifacts"][0].pop("sha256", None)
-    manifest["artifacts"][1].pop("sha256", None)
+    for artifact in manifest["artifacts"]:
+        if artifact.get("role") in ("canonical_md", "chunk_index_jsonl"):
+            artifact.pop("sha256", None)
     manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
 
     report = validate_bundle(str(manifest_path))
@@ -412,6 +413,18 @@ def test_canonical_range_file_path_with_dot_slash_is_accepted(tmp_path):
     report = validate_bundle(str(manifest_path))
 
     assert report["status"] == "ok"
+
+
+def test_canonical_range_file_path_with_windows_drive_prefix_fails(tmp_path):
+    content = b"windows drive path"
+    for windows_path in ("C:merge.md", "C:/merge.md", r"C:\merge.md"):
+        chunk = _make_chunk(content, windows_path, 0, 5)
+        manifest_path = _make_bundle(tmp_path, content, [chunk])
+
+        report = validate_bundle(str(manifest_path))
+
+        assert report["status"] == "fail"
+        assert any("Windows drive-prefixed paths are forbidden" in e for e in report["errors"])
 
 
 # ---------------------------------------------------------------------------

--- a/merger/lenskit/tests/test_citation_validate.py
+++ b/merger/lenskit/tests/test_citation_validate.py
@@ -187,6 +187,22 @@ def test_chunk_index_sha_mismatch_fails(tmp_path):
     assert any("chunk_index_jsonl SHA256 mismatch" in e for e in report["errors"])
 
 
+def test_missing_manifest_sha256_fails(tmp_path):
+    content = b"canonical content"
+    chunk = _make_chunk(content, "merge.md", 0, 9)
+    manifest_path = _make_bundle(tmp_path, content, [chunk])
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["artifacts"][0].pop("sha256", None)
+    manifest["artifacts"][1].pop("sha256", None)
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    report = validate_bundle(str(manifest_path))
+
+    assert report["status"] == "fail"
+    assert any("canonical_md sha256 is missing" in e for e in report["errors"])
+    assert any("chunk_index_jsonl sha256 is missing" in e for e in report["errors"])
+
+
 def test_range_content_sha_mismatch_fails(tmp_path):
     content = b"Hello world range test"
     chunk = _make_chunk(content, "merge.md", 0, 10)
@@ -388,6 +404,16 @@ def test_absolute_canonical_md_path_fails(tmp_path):
     assert any("absolute" in e or "forbidden" in e for e in report["errors"])
 
 
+def test_canonical_range_file_path_with_dot_slash_is_accepted(tmp_path):
+    content = b"dot slash canonical path"
+    chunk = _make_chunk(content, "./merge.md", 0, 10)
+    manifest_path = _make_bundle(tmp_path, content, [chunk])
+
+    report = validate_bundle(str(manifest_path))
+
+    assert report["status"] == "ok"
+
+
 # ---------------------------------------------------------------------------
 # Missing manifest / artifact roles
 # ---------------------------------------------------------------------------
@@ -469,7 +495,8 @@ def test_report_has_all_required_keys(tmp_path):
     report = validate_bundle(str(manifest_path))
 
     required_keys = {
-        "status", "run_id", "chunk_count", "canonical_range_count",
+        "status", "bundle_manifest_path", "bundle_run_id", "validation_run_id",
+        "canonical_md_sha256", "chunk_index_sha256", "chunk_count", "canonical_range_count",
         "source_range_count", "content_range_ref_count", "citation_id_count",
         "citation_id_duplicate_count", "canonical_range_hash_ok_count",
         "errors", "warnings", "sample_citation_ids",
@@ -477,7 +504,7 @@ def test_report_has_all_required_keys(tmp_path):
     assert required_keys.issubset(report.keys())
 
 
-def test_run_id_is_unique_per_call(tmp_path):
+def test_report_separates_bundle_run_id_and_validation_run_id(tmp_path):
     content = b"unique run id test"
     chunk = _make_chunk(content, "merge.md", 0, 6)
     manifest_path = _make_bundle(tmp_path, content, [chunk])
@@ -485,4 +512,6 @@ def test_run_id_is_unique_per_call(tmp_path):
     r1 = validate_bundle(str(manifest_path))
     r2 = validate_bundle(str(manifest_path))
 
-    assert r1["run_id"] != r2["run_id"]
+    assert r1["bundle_run_id"] == "test-run-001"
+    assert r2["bundle_run_id"] == "test-run-001"
+    assert r1["validation_run_id"] != r2["validation_run_id"]

--- a/merger/lenskit/tests/test_cli_citation.py
+++ b/merger/lenskit/tests/test_cli_citation.py
@@ -7,8 +7,6 @@ import hashlib
 import json
 from pathlib import Path
 
-import pytest
-
 from merger.lenskit.cli.main import main
 
 
@@ -54,7 +52,7 @@ def _make_bundle(tmp_path: Path, canonical_content: bytes, chunks: list) -> Path
         "capabilities": [],
     }
     manifest_path = tmp_path / "bundle.manifest.json"
-    manifest_path.write_text(json.dumps(manifest))
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
     return manifest_path
 
 
@@ -88,6 +86,7 @@ def test_cli_json_output_exit_0_on_valid_bundle(tmp_path, capsys):
     captured = capsys.readouterr()
     report = json.loads(captured.out)
     assert report["status"] == "ok"
+    assert report["error_kind"] == "ok"
     assert report["chunk_count"] == 2
     assert report["citation_id_count"] == 2
     assert report["canonical_md_actual_sha256"] == report["canonical_md_sha256"]
@@ -113,6 +112,7 @@ def test_cli_exit_1_on_invalid_bundle(tmp_path, capsys):
     captured = capsys.readouterr()
     report = json.loads(captured.out)
     assert report["status"] == "fail"
+    assert report["error_kind"] == "validation_error"
     assert len(report["errors"]) > 0
 
 
@@ -123,6 +123,59 @@ def test_cli_exit_1_on_invalid_bundle(tmp_path, capsys):
 def test_cli_exit_2_on_missing_manifest(tmp_path, capsys):
     rc = main(["citation", "validate", str(tmp_path / "nonexistent.manifest.json")])
     assert rc == 2
+
+
+def test_cli_exit_2_on_manifest_path_directory(tmp_path, capsys):
+    manifest_dir = tmp_path / "manifest_dir"
+    manifest_dir.mkdir()
+
+    rc = main(["citation", "validate", "--json", str(manifest_dir)])
+
+    assert rc == 2
+    captured = capsys.readouterr()
+    report = json.loads(captured.out)
+    assert report["status"] == "fail"
+    assert report["error_kind"] == "path_read_error"
+
+
+def test_cli_exit_2_on_missing_canonical_md_artifact_file(tmp_path, capsys):
+    content = b"missing canonical md file"
+    chunk = _make_chunk(content, 0, 7)
+    manifest_path = _make_bundle(tmp_path, content, [chunk])
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    for artifact in manifest["artifacts"]:
+        if artifact["role"] == "canonical_md":
+            artifact["path"] = "missing-merge.md"
+            break
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    rc = main(["citation", "validate", "--json", str(manifest_path)])
+
+    assert rc == 2
+    captured = capsys.readouterr()
+    report = json.loads(captured.out)
+    assert report["status"] == "fail"
+    assert report["error_kind"] == "path_read_error"
+
+
+def test_cli_exit_2_on_missing_chunk_index_artifact_file(tmp_path, capsys):
+    content = b"missing chunk index file"
+    chunk = _make_chunk(content, 0, 7)
+    manifest_path = _make_bundle(tmp_path, content, [chunk])
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    for artifact in manifest["artifacts"]:
+        if artifact["role"] == "chunk_index_jsonl":
+            artifact["path"] = "missing-chunk-index.jsonl"
+            break
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    rc = main(["citation", "validate", "--json", str(manifest_path)])
+
+    assert rc == 2
+    captured = capsys.readouterr()
+    report = json.loads(captured.out)
+    assert report["status"] == "fail"
+    assert report["error_kind"] == "path_read_error"
 
 
 # ---------------------------------------------------------------------------

--- a/merger/lenskit/tests/test_cli_citation.py
+++ b/merger/lenskit/tests/test_cli_citation.py
@@ -90,6 +90,8 @@ def test_cli_json_output_exit_0_on_valid_bundle(tmp_path, capsys):
     assert report["status"] == "ok"
     assert report["chunk_count"] == 2
     assert report["citation_id_count"] == 2
+    assert report["canonical_md_actual_sha256"] == report["canonical_md_sha256"]
+    assert report["chunk_index_actual_sha256"] == report["chunk_index_sha256"]
     assert isinstance(report["errors"], list)
     assert len(report["errors"]) == 0
 

--- a/merger/lenskit/tests/test_cli_citation.py
+++ b/merger/lenskit/tests/test_cli_citation.py
@@ -1,0 +1,156 @@
+"""
+CLI tests for `lenskit citation validate`.
+
+Uses the same synthetic fixture helpers as test_citation_validate.py.
+"""
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from merger.lenskit.cli.main import main
+
+
+# ---------------------------------------------------------------------------
+# Helpers (duplicated locally to keep tests self-contained)
+# ---------------------------------------------------------------------------
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _make_bundle(tmp_path: Path, canonical_content: bytes, chunks: list) -> Path:
+    canonical_md_path = tmp_path / "merge.md"
+    canonical_md_path.write_bytes(canonical_content)
+
+    chunk_lines = "\n".join(json.dumps(c) for c in chunks) + "\n"
+    chunk_index_bytes = chunk_lines.encode("utf-8")
+    (tmp_path / "chunk_index.jsonl").write_bytes(chunk_index_bytes)
+
+    manifest = {
+        "kind": "repolens.bundle.manifest",
+        "version": "1.0",
+        "run_id": "cli-test-run",
+        "created_at": "2026-05-13T00:00:00Z",
+        "generator": {"name": "test", "version": "0.0.1", "config_sha256": "a" * 64},
+        "artifacts": [
+            {
+                "role": "canonical_md",
+                "path": "merge.md",
+                "content_type": "text/markdown",
+                "bytes": len(canonical_content),
+                "sha256": _sha256(canonical_content),
+            },
+            {
+                "role": "chunk_index_jsonl",
+                "path": "chunk_index.jsonl",
+                "content_type": "application/x-ndjson",
+                "bytes": len(chunk_index_bytes),
+                "sha256": _sha256(chunk_index_bytes),
+            },
+        ],
+        "links": [],
+        "capabilities": [],
+    }
+    manifest_path = tmp_path / "bundle.manifest.json"
+    manifest_path.write_text(json.dumps(manifest))
+    return manifest_path
+
+
+def _make_chunk(canonical_content: bytes, start: int, end: int) -> dict:
+    range_bytes = canonical_content[start:end]
+    content_sha = _sha256(range_bytes)
+    return {
+        "chunk_id": f"chunk-{start}-{end}",
+        "canonical_range": {
+            "artifact_role": "canonical_md",
+            "file_path": "merge.md",
+            "start_byte": start,
+            "end_byte": end,
+            "content_sha256": content_sha,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI: --json output and exit code 0 on valid fixture
+# ---------------------------------------------------------------------------
+
+def test_cli_json_output_exit_0_on_valid_bundle(tmp_path, capsys):
+    content = b"CLI test canonical content abcdefghij"
+    chunks = [_make_chunk(content, 0, 10), _make_chunk(content, 10, 20)]
+    manifest_path = _make_bundle(tmp_path, content, chunks)
+
+    rc = main(["citation", "validate", "--json", str(manifest_path)])
+
+    assert rc == 0
+    captured = capsys.readouterr()
+    report = json.loads(captured.out)
+    assert report["status"] == "ok"
+    assert report["chunk_count"] == 2
+    assert report["citation_id_count"] == 2
+    assert isinstance(report["errors"], list)
+    assert len(report["errors"]) == 0
+
+
+# ---------------------------------------------------------------------------
+# CLI: exit code 1 on invalid fixture (hash mismatch)
+# ---------------------------------------------------------------------------
+
+def test_cli_exit_1_on_invalid_bundle(tmp_path, capsys):
+    content = b"Invalid bundle test content"
+    chunk = _make_chunk(content, 0, 10)
+    # corrupt the content_sha256
+    chunk["canonical_range"]["content_sha256"] = "b" * 64
+    manifest_path = _make_bundle(tmp_path, content, [chunk])
+
+    rc = main(["citation", "validate", "--json", str(manifest_path)])
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    report = json.loads(captured.out)
+    assert report["status"] == "fail"
+    assert len(report["errors"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# CLI: exit code 2 on missing manifest path
+# ---------------------------------------------------------------------------
+
+def test_cli_exit_2_on_missing_manifest(tmp_path, capsys):
+    rc = main(["citation", "validate", str(tmp_path / "nonexistent.manifest.json")])
+    assert rc == 2
+
+
+# ---------------------------------------------------------------------------
+# CLI: human-readable output (no --json)
+# ---------------------------------------------------------------------------
+
+def test_cli_human_output_shows_status(tmp_path, capsys):
+    content = b"Human readable output test content xyz"
+    chunk = _make_chunk(content, 0, 15)
+    manifest_path = _make_bundle(tmp_path, content, [chunk])
+
+    rc = main(["citation", "validate", str(manifest_path)])
+
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "Citation Readiness: OK" in captured.out
+    assert "citation_id_count" in captured.out
+
+
+def test_cli_human_output_shows_errors_on_fail(tmp_path, capsys):
+    content = b"error output test"
+    chunk = {
+        "chunk_id": "no-range",
+        # no canonical_range
+    }
+    manifest_path = _make_bundle(tmp_path, content, [chunk])
+
+    rc = main(["citation", "validate", str(manifest_path)])
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "Citation Readiness: FAIL" in captured.out
+    assert "[error]" in captured.out

--- a/merger/lenskit/tests/test_cli_citation.py
+++ b/merger/lenskit/tests/test_cli_citation.py
@@ -121,8 +121,14 @@ def test_cli_exit_1_on_invalid_bundle(tmp_path, capsys):
 # ---------------------------------------------------------------------------
 
 def test_cli_exit_2_on_missing_manifest(tmp_path, capsys):
-    rc = main(["citation", "validate", str(tmp_path / "nonexistent.manifest.json")])
+    rc = main(
+        ["citation", "validate", "--json", str(tmp_path / "nonexistent.manifest.json")]
+    )
     assert rc == 2
+    captured = capsys.readouterr()
+    report = json.loads(captured.out)
+    assert report["status"] == "fail"
+    assert report["error_kind"] == "path_read_error"
 
 
 def test_cli_exit_2_on_manifest_path_directory(tmp_path, capsys):

--- a/merger/lenskit/tests/test_cli_citation.py
+++ b/merger/lenskit/tests/test_cli_citation.py
@@ -126,6 +126,7 @@ def test_cli_exit_2_on_missing_manifest(tmp_path, capsys):
     )
     assert rc == 2
     captured = capsys.readouterr()
+    assert captured.out.strip()
     report = json.loads(captured.out)
     assert report["status"] == "fail"
     assert report["error_kind"] == "path_read_error"


### PR DESCRIPTION
## Summary

Implements a citation readiness validator that checks bundle manifests for citation integrity. The validator verifies SHA256 hashes, validates byte ranges, derives citation IDs, and detects duplicates. Includes comprehensive unit tests with synthetic fixtures and a CLI interface.

## Key Changes

- **Core validator** (`merger/lenskit/core/citation_validate.py`):
  - `validate_bundle()` function that reads a manifest, resolves artifacts, and validates all chunks
  - Verifies SHA256 hashes for `canonical_md` and `chunk_index_jsonl` artifacts
  - Validates byte ranges (non-negative, non-empty, within file bounds)
  - Rejects unsafe paths (absolute, traversal, Windows drive, UNC)
  - Derives citation IDs via `make_citation_id()` and detects duplicates
  - Returns structured report with counts, errors, warnings, and sample citation IDs
  - Generates unique `run_id` per validation run

- **CLI command** (`merger/lenskit/cli/cmd_citation.py`):
  - New `lenskit citation validate` subcommand
  - Supports `--json` flag for machine-readable output
  - Human-readable report with status, counts, and error details
  - Exit codes: 0 (ok), 1 (validation failure), 2 (file/path error)

- **Tests** (`merger/lenskit/tests/test_citation_validate.py`):
  - 40+ unit tests covering happy path, hash mismatches, byte range errors, bool type checks, missing fields, path traversal, and report structure
  - Synthetic in-memory fixtures with helper functions for bundle creation
  - No real dump required

- **CLI tests** (`merger/lenskit/tests/test_cli_citation.py`):
  - Integration tests for CLI output (JSON and human-readable)
  - Exit code validation
  - Error reporting

- **Integration**:
  - Registered `citation` subcommand in `merger/lenskit/cli/main.py`
  - Updated roadmap documentation

## Notable Implementation Details

- Validator is read-only; produces no artifacts or manifest modifications
- `canonical_range` is authoritative; `source_range` and `content_range_ref` are counted but not validated
- Path security enforced via `resolve_secure_path()` and custom traversal checks
- Byte offset validation explicitly rejects `bool` type (since `bool` is a subclass of `int` in Python)
- Sample citation IDs capped at 5 for report brevity
- Comprehensive error messages include line numbers and expected vs. actual values

https://claude.ai/code/session_01UCY24kZcjMcgQhNqmDgCt2