### PR TITLE
feat: Citation Map Producer with Real-Dump-Proof

### DIFF
--- a/docs/proofs/citation-map-producer-proof.md
+++ b/docs/proofs/citation-map-producer-proof.md
@@ -188,11 +188,12 @@ Dieser Dump enthält `content_range_ref` statt `canonical_range`. Die Producer-N
 ## Invarianten des Producers
 
 - Producer schreibt; validiert nichts außer dem nötigen für die Produktion.
-- Byte-Range-Hash jeder Range wird gegen `canonical_md` geprüft; Fehler → Zeile übersprungen.
+- Byte-Range-Hash jeder Range wird gegen `canonical_md` geprüft; bei Fehlern schlägt der Run fehl und es wird kein `citation_map_jsonl` geschrieben.
 - `make_citation_id(canonical_md_sha256, start_byte, end_byte, content_sha256)` wird für jede Zeile aufgerufen.
 - `citation_map_jsonl` wird nie als `canonical_content` oder `content_source` eingestuft.
 - Pfad-Traversal, absolute Pfade, Windows-Drive-Prefixe, UNC-Pfade werden abgelehnt.
-- Duplikate werden als Fehler behandelt (Zeile wird übersprungen).
+- Duplikate werden als Fehler behandelt; bei einem Duplikat schlägt der Run fehl und es wird kein `citation_map_jsonl` geschrieben.
+- `citation_map_row_count` im Report zählt ausschließlich tatsächlich geschriebene Zeilen: `0` bei `status=fail`, `N` bei `status=ok` (entspricht `valid_chunk_count` minus Duplikate, sofern kein Fehler vorliegt).
 
 ---
 

--- a/docs/proofs/citation-map-producer-proof.md
+++ b/docs/proofs/citation-map-producer-proof.md
@@ -1,6 +1,6 @@
 # Citation Map Producer — Real-Dump-Proof
 
-**Datum:** 2026-05-14  
+**Datum:** 2026-05-14 (Hardening-Patch 2026-05-14)  
 **Status: PASS**
 
 ---
@@ -195,6 +195,37 @@ Dieser Dump enthält `content_range_ref` statt `canonical_range`. Die Producer-N
 - Duplikate werden als Fehler behandelt (Zeile wird übersprungen).
 
 ---
+
+## Hardening-Patches (2026-05-14)
+
+Folgende Punkte wurden nach dem initialen Proof gepatcht:
+
+| Punkt | Patch |
+|---|---|
+| H1: Kein partieller Output bei Fehlern | Output wird nur geschrieben, wenn `errors == []`. `output_path=None` bei `status=fail`. |
+| H2: Default-Output-Pfad sicher | `_default_output_path()` prüft `.bundle.manifest.json`-Suffix; Manifest-/Artefakt-Kollision → `status=fail`. |
+| H3: `run_id` leer → Fehler | Manifest-`run_id` wird vor Nutzung als nicht-leerer String validiert. |
+| H4: `repo_id`-Konflikte → Fehler | `resolve_repo_id()` sammelt alle Quellen; unterschiedliche Werte → `CitationMapError`. |
+| H5: `start_line`/`end_line`-Semantik | Keine Code-Änderung. Dokumentation unten. |
+| H6: Registry-Tests ohne `inspect.getsource()` | `ARTIFACT_CONTRACT_REGISTRY` und `ARTIFACT_AUTHORITY_REGISTRY` auf Modulebene in `merge.py` hochgezogen; Tests importieren sie direkt. |
+
+Der Output-SHA nach Hardening ist identisch mit dem Initialwert (`304a4d22...`), da kein Chunk im echten Dump Fehler enthält.
+
+## `start_line`/`end_line`-Semantik (H5)
+
+Befund aus dem realen Dump: fünf aufeinanderfolgende Chunks mit unterschiedlichen Byte-Offsets haben alle `start_line=1`. Diese Zeilen stammen aus dem Generator-seitigen `content_range_ref`, das quell-lokale Zeilennummern innerhalb der Quelldatei enthält, nicht globale Positionen in `canonical_md`.
+
+Das Schema (`canonical_range.description`) sagt: „Position inside canonical_md" — es legt aber nicht fest, ob Zeilennummern global (canonical_md-weit) oder lokal (quellдатei-lokal) sind. Das Schema setzt `minimum: 1` und keine weiteren Constraints.
+
+**Entscheidung:** Der Producer übernimmt `start_line`/`end_line` unverändert aus dem Input-Range-Feld. Die autoritative Zitierachse sind `start_byte`, `end_byte` und `content_sha256`, deren Korrektheit gegen `canonical_md` geprüft wird. Globale Zeilennummerberechnung bleibt eigenständiges Hardening, wenn der Contract es explizit fordert.
+
+## Manifest-Wiring (H6): Registry vorbereitet — Pipeline-Integration offen
+
+`ARTIFACT_CONTRACT_REGISTRY[ArtifactRole.CITATION_MAP_JSONL]` und `ARTIFACT_AUTHORITY_REGISTRY[ArtifactRole.CITATION_MAP_JSONL]` sind in `merger/lenskit/core/merge.py` auf Modulebene definiert und werden von `write_reports_v2` referenziert.
+
+`_add_artifact(citation_map_path, ArtifactRole.CITATION_MAP_JSONL, …)` wird in der Pipeline (Merger-Lauf) **noch nicht** automatisch aufgerufen — der Producer läuft separat via CLI. Die Registries sind vorbereitet, damit ein späterer Pipeline-Integrationsschritt die korrekten Manifest-Felder erhält.
+
+Beim CLI-Lauf erzeugt der Producer die Datei, berechnet SHA256 und Bytes korrekt. Ein separater Schritt muss diese Werte ins Bundle-Manifest schreiben; das ist Phase-2-Arbeit.
 
 ## Abgrenzung zu vorherigen Proofs
 

--- a/docs/proofs/citation-map-producer-proof.md
+++ b/docs/proofs/citation-map-producer-proof.md
@@ -1,0 +1,216 @@
+# Citation Map Producer — Real-Dump-Proof
+
+**Datum:** 2026-05-14  
+**Status: PASS**
+
+---
+
+## Dump-Identität
+
+- **Dump-Stem:** `lenskit-max-260514-0409_merge`
+- **Manifest-Pfad:** `/home/alex/repos/merges/lenskit-max-260514-0409_merge.bundle.manifest.json`
+- **run_id:** `lenskit-full-max-260514-0409`
+- **created_at:** `2026-05-14T04:09:20Z`
+- **Generator:** `rlens dev`
+
+---
+
+## Manifest-Artefakte (Iststand)
+
+| Rolle | Pfad | Bytes | SHA256 |
+|---|---|---|---|
+| `canonical_md` | `lenskit-max-260514-0409_merge.md` | 3176159 | `05e38a5aadf4becaac1952eca86246429f9dd6cf57b7593f4810155525cf95df` |
+| `chunk_index_jsonl` | `lenskit-max-260514-0409_merge.chunk_index.jsonl` | 720803 | `b1849a0649c82a99e44e9235c018e8acb8f08c2f86014d434f594805e93e3086` |
+| `derived_manifest_json` | `lenskit-max-260514-0409_merge.derived_index.json` | 1182 | `2224d3f8dacaab95d69599e2929844cf152a40b26b1c84a005d13a086b6f0cc0` |
+| `dump_index_json` | `lenskit-max-260514-0409_merge.dump_index.json` | 1781 | `0b3ad60702467eb10e68b57c8b08431465d19af5c35a97053ce0a9838fd2f221` |
+| `index_sidecar_json` | `lenskit-max-260514-0409_merge.json` | 468359 | `9da8c1386fc363fa763bac4d7ca8eca6a3dfe4d71299e18b02b415af4312f6da` |
+| `retrieval_eval_json` | `lenskit-max-260514-0409_merge.retrieval_eval.json` | 18167 | `1dbdab8344a484cfdd55412fda1285020614314b77a037128e5495957cfc6888` |
+| `sqlite_index` | `lenskit-max-260514-0409_merge.chunk_index.index.sqlite` | 499712 | `f097196814472a8b5f55cc66b5a8100e5bd523766b074226fdc91c7063ae10dd` |
+
+Alle 7 Manifest-Artefakte existieren. Kein Artefakt fehlt.
+
+---
+
+## SHA256-Verifikation Manifest vs. Actual
+
+| Rolle | Manifest | Actual | Match |
+|---|---|---|---|
+| `canonical_md` | `05e38a5aadf4becaac1952eca86246429f9dd6cf57b7593f4810155525cf95df` | `05e38a5aadf4becaac1952eca86246429f9dd6cf57b7593f4810155525cf95df` | **✓** |
+| `chunk_index_jsonl` | `b1849a0649c82a99e44e9235c018e8acb8f08c2f86014d434f594805e93e3086` | `b1849a0649c82a99e44e9235c018e8acb8f08c2f86014d434f594805e93e3086` | **✓** |
+| `citation_map_jsonl` (Output) | _nicht im Manifest_ | `304a4d229217e9926d1b5b3f544720a17195932ea175af44d084364b9259ad08` | N/A (neu erzeugt) |
+
+---
+
+## Chunk-Index Scan (Iststand)
+
+| Kennzahl | Wert |
+|---|---|
+| `chunk_count` | `541` |
+| `canonical_range` vorhanden | `0` |
+| `content_range_ref` vorhanden | `541` |
+| `content_range_ref.artifact_role == "canonical_md"` | `541` |
+| `source_range` vorhanden | `0` |
+| Eindeutige `repo` (chunk-Feld) | `['lenskit']` |
+| Eindeutige `repo_id` (search_keys) | `['lenskit']` |
+
+Befund: Dieser Dump enthält ausschließlich `content_range_ref` (kein `canonical_range`). Die Normalisierungsregel greift: `content_range_ref` mit `artifact_role == "canonical_md"` wird als `canonical_range` behandelt.
+
+---
+
+## Producer-Run
+
+```bash
+python3 -m merger.lenskit.cli.main citation produce --json \
+  /home/alex/repos/merges/lenskit-max-260514-0409_merge.bundle.manifest.json
+```
+
+---
+
+## Producer-Ergebnis
+
+| Kennzahl | Wert |
+|---|---|
+| `status` | `ok` |
+| `error_kind` | `ok` |
+| `chunk_count` | `541` |
+| `valid_chunk_count` | `541` |
+| `citation_map_row_count` | `541` |
+| `citation_id_count` | `541` |
+| `citation_id_duplicate_count` | `0` |
+| `repo_id_source` | `range.repo_id` |
+| `snapshot_source` | `bundle_manifest` |
+| `output_bytes` | `313222` |
+| `output_sha256` | `304a4d229217e9926d1b5b3f544720a17195932ea175af44d084364b9259ad08` |
+
+---
+
+## Quellen
+
+| Feld | Quelle | Wert |
+|---|---|---|
+| `repo_id` | `content_range_ref.repo_id` (= `range.repo_id` nach Normalisierung) | `lenskit` |
+| `snapshot.run_id` | Bundle-Manifest `run_id` | `lenskit-full-max-260514-0409` |
+| `snapshot.canonical_md_path` | Manifest-Artefakt `role == "canonical_md"` → `path` | `lenskit-max-260514-0409_merge.md` |
+| `snapshot.canonical_md_sha256` | Manifest-Artefakt `role == "canonical_md"` → `sha256` (verifiziert gegen Actual) | `05e38a5aadf4becaac1952eca86246429f9dd6cf57b7593f4810155525cf95df` |
+
+---
+
+## Schema-Validierung
+
+Alle 541 Zeilen der erzeugten `citation_map_jsonl` wurden gegen
+`merger/lenskit/contracts/citation-map.v1.schema.json` (Draft-07) validiert.
+
+- Schema-Fehler: `0`
+- Schema-Validierung: **PASS**
+
+---
+
+## Drei Beispielzeilen
+
+```json
+{
+  "citation_id": "cit_498625f8222aaa3c",
+  "repo_id": "lenskit",
+  "snapshot": {
+    "run_id": "lenskit-full-max-260514-0409",
+    "canonical_md_path": "lenskit-max-260514-0409_merge.md",
+    "canonical_md_sha256": "05e38a5aadf4becaac1952eca86246429f9dd6cf57b7593f4810155525cf95df"
+  },
+  "canonical_range": {
+    "file_path": "lenskit-max-260514-0409_merge.md",
+    "start_byte": 123372,
+    "end_byte": 124513,
+    "start_line": 1,
+    "end_line": 57,
+    "content_sha256": "07d82137b0a8af1546a0c87ef8259c3a9da982b4e2a5d609aa790a63d6a10cb4"
+  },
+  "produced_by": "citation_map_producer/v1",
+  "chunk_id": "a5b53ec3469b019615c5"
+}
+```
+
+```json
+{
+  "citation_id": "cit_1cc6148d85771a88",
+  "repo_id": "lenskit",
+  "snapshot": {
+    "run_id": "lenskit-full-max-260514-0409",
+    "canonical_md_path": "lenskit-max-260514-0409_merge.md",
+    "canonical_md_sha256": "05e38a5aadf4becaac1952eca86246429f9dd6cf57b7593f4810155525cf95df"
+  },
+  "canonical_range": {
+    "file_path": "lenskit-max-260514-0409_merge.md",
+    "start_byte": 125550,
+    "end_byte": 127566,
+    "start_line": 1,
+    "end_line": 65,
+    "content_sha256": "770dc60e8f9a04b5596f068d6813927c573f9351ce7f08e784211b5f61d74e99"
+  },
+  "produced_by": "citation_map_producer/v1",
+  "chunk_id": "90c27c9a7c947495fd5d"
+}
+```
+
+```json
+{
+  "citation_id": "cit_d8ea672755da5920",
+  "repo_id": "lenskit",
+  "snapshot": {
+    "run_id": "lenskit-full-max-260514-0409",
+    "canonical_md_path": "lenskit-max-260514-0409_merge.md",
+    "canonical_md_sha256": "05e38a5aadf4becaac1952eca86246429f9dd6cf57b7593f4810155525cf95df"
+  },
+  "canonical_range": {
+    "file_path": "lenskit-max-260514-0409_merge.md",
+    "start_byte": 128607,
+    "end_byte": 135091,
+    "start_line": 1,
+    "end_line": 190,
+    "content_sha256": "2e2237dc13ee8ac56edb1425ad278a9671de0cd77faed1d61c151d85c19c5687"
+  },
+  "produced_by": "citation_map_producer/v1",
+  "chunk_id": "ac8037619ccf86109969"
+}
+```
+
+---
+
+## Normalisierungsregel (angewendet)
+
+Dieser Dump enthält `content_range_ref` statt `canonical_range`. Die Producer-Normalisierung:
+
+1. Prüft `chunk["canonical_range"]`: nicht vorhanden → weiter
+2. Prüft `chunk["content_range_ref"]` mit `artifact_role == "canonical_md"`: vorhanden → verwende als `canonical_range`
+3. Output-Feld heißt immer `canonical_range` (Legacy-Input `content_range_ref` ist nicht im Output)
+
+---
+
+## Invarianten des Producers
+
+- Producer schreibt; validiert nichts außer dem nötigen für die Produktion.
+- Byte-Range-Hash jeder Range wird gegen `canonical_md` geprüft; Fehler → Zeile übersprungen.
+- `make_citation_id(canonical_md_sha256, start_byte, end_byte, content_sha256)` wird für jede Zeile aufgerufen.
+- `citation_map_jsonl` wird nie als `canonical_content` oder `content_source` eingestuft.
+- Pfad-Traversal, absolute Pfade, Windows-Drive-Prefixe, UNC-Pfade werden abgelehnt.
+- Duplikate werden als Fehler behandelt (Zeile wird übersprungen).
+
+---
+
+## Abgrenzung zu vorherigen Proofs
+
+Dieser Proof ist der **Producer-Proof** (`citation_map_jsonl` erzeugen).
+
+Der **Validator-Proof** (`docs/proofs/citation-readiness-validator-proof.md`) belegt
+ausschließlich, dass `merger/lenskit/core/citation_validate.py` korrekt liest und validiert.
+Er erzeugt kein `citation_map_jsonl`.
+
+---
+
+## Ergebnis
+
+**PASS** — Real-Dump-Proof gegen `/home/alex/repos/merges/lenskit-max-260514-0409_merge.bundle.manifest.json` bestanden.
+
+- 541 Chunks verarbeitet
+- 541 schema-valide, hash-geprüfte, duplikatfreie Citation-Map-Zeilen erzeugt
+- `repo_id`-Quelle eindeutig: `range.repo_id` (`content_range_ref.repo_id`)
+- `snapshot`-Quelle eindeutig: Bundle-Manifest

--- a/docs/proofs/citation-map-producer-proof.md
+++ b/docs/proofs/citation-map-producer-proof.md
@@ -37,7 +37,7 @@ Alle 7 Manifest-Artefakte existieren. Kein Artefakt fehlt.
 |---|---|---|---|
 | `canonical_md` | `05e38a5aadf4becaac1952eca86246429f9dd6cf57b7593f4810155525cf95df` | `05e38a5aadf4becaac1952eca86246429f9dd6cf57b7593f4810155525cf95df` | **✓** |
 | `chunk_index_jsonl` | `b1849a0649c82a99e44e9235c018e8acb8f08c2f86014d434f594805e93e3086` | `b1849a0649c82a99e44e9235c018e8acb8f08c2f86014d434f594805e93e3086` | **✓** |
-| `citation_map_jsonl` (Output) | _nicht im Manifest_ | `304a4d229217e9926d1b5b3f544720a17195932ea175af44d084364b9259ad08` | N/A (neu erzeugt) |
+| `citation_map_jsonl` (Output) | _nicht im Manifest_ | `f7a7e62b01042149dfe59734e006d5ddbb876adb3d3d2cce0f42cc9d169b9c69` | N/A (neu erzeugt) |
 
 ---
 
@@ -79,8 +79,8 @@ python3 -m merger.lenskit.cli.main citation produce --json \
 | `citation_id_duplicate_count` | `0` |
 | `repo_id_source` | `range.repo_id` |
 | `snapshot_source` | `bundle_manifest` |
-| `output_bytes` | `313222` |
-| `output_sha256` | `304a4d229217e9926d1b5b3f544720a17195932ea175af44d084364b9259ad08` |
+| `output_bytes` | `316003` |
+| `output_sha256` | `f7a7e62b01042149dfe59734e006d5ddbb876adb3d3d2cce0f42cc9d169b9c69` |
 
 ---
 
@@ -120,8 +120,8 @@ Alle 541 Zeilen der erzeugten `citation_map_jsonl` wurden gegen
     "file_path": "lenskit-max-260514-0409_merge.md",
     "start_byte": 123372,
     "end_byte": 124513,
-    "start_line": 1,
-    "end_line": 57,
+    "start_line": 1445,
+    "end_line": 1501,
     "content_sha256": "07d82137b0a8af1546a0c87ef8259c3a9da982b4e2a5d609aa790a63d6a10cb4"
   },
   "produced_by": "citation_map_producer/v1",
@@ -142,8 +142,8 @@ Alle 541 Zeilen der erzeugten `citation_map_jsonl` wurden gegen
     "file_path": "lenskit-max-260514-0409_merge.md",
     "start_byte": 125550,
     "end_byte": 127566,
-    "start_line": 1,
-    "end_line": 65,
+    "start_line": 1534,
+    "end_line": 1598,
     "content_sha256": "770dc60e8f9a04b5596f068d6813927c573f9351ce7f08e784211b5f61d74e99"
   },
   "produced_by": "citation_map_producer/v1",
@@ -164,8 +164,8 @@ Alle 541 Zeilen der erzeugten `citation_map_jsonl` wurden gegen
     "file_path": "lenskit-max-260514-0409_merge.md",
     "start_byte": 128607,
     "end_byte": 135091,
-    "start_line": 1,
-    "end_line": 190,
+    "start_line": 1630,
+    "end_line": 1819,
     "content_sha256": "2e2237dc13ee8ac56edb1425ad278a9671de0cd77faed1d61c151d85c19c5687"
   },
   "produced_by": "citation_map_producer/v1",
@@ -206,18 +206,33 @@ Folgende Punkte wurden nach dem initialen Proof gepatcht:
 | H2: Default-Output-Pfad sicher | `_default_output_path()` prüft `.bundle.manifest.json`-Suffix; Manifest-/Artefakt-Kollision → `status=fail`. |
 | H3: `run_id` leer → Fehler | Manifest-`run_id` wird vor Nutzung als nicht-leerer String validiert. |
 | H4: `repo_id`-Konflikte → Fehler | `resolve_repo_id()` sammelt alle Quellen; unterschiedliche Werte → `CitationMapError`. |
-| H5: `start_line`/`end_line`-Semantik | Keine Code-Änderung. Dokumentation unten. |
+| H5: `start_line`/`end_line`-Semantik | `byte_range_to_line_range()` implementiert; Producer berechnet globale Zeilen aus `canonical_md`-Bytes. Input-Werte werden ignoriert. |
 | H6: Registry-Tests ohne `inspect.getsource()` | `ARTIFACT_CONTRACT_REGISTRY` und `ARTIFACT_AUTHORITY_REGISTRY` auf Modulebene in `merge.py` hochgezogen; Tests importieren sie direkt. |
 
-Der Output-SHA nach Hardening ist identisch mit dem Initialwert (`304a4d22...`), da kein Chunk im echten Dump Fehler enthält.
+Der Output-SHA nach H1–H4/H6-Hardening war identisch mit dem Initialwert. Nach H5-Patch ändert sich der Output-SHA, da `start_line`/`end_line` jetzt canonical_md-global sind (statt quell-lokal).
 
-## `start_line`/`end_line`-Semantik (H5)
+## `start_line`/`end_line`-Semantik (H5 — Code-Patch)
 
-Befund aus dem realen Dump: fünf aufeinanderfolgende Chunks mit unterschiedlichen Byte-Offsets haben alle `start_line=1`. Diese Zeilen stammen aus dem Generator-seitigen `content_range_ref`, das quell-lokale Zeilennummern innerhalb der Quelldatei enthält, nicht globale Positionen in `canonical_md`.
+**Contract-Entscheidung:** `canonical_range.description` im Schema lautet explizit „Position inside canonical_md. Authoritative locator for the citation." Damit sind `start_line`/`end_line` canonical_md-globale Positionen, keine quell-lokalen Werte.
 
-Das Schema (`canonical_range.description`) sagt: „Position inside canonical_md" — es legt aber nicht fest, ob Zeilennummern global (canonical_md-weit) oder lokal (quellдатei-lokal) sind. Das Schema setzt `minimum: 1` und keine weiteren Constraints.
+**Implementierung:** `byte_range_to_line_range(canonical_md_bytes, start_byte, end_byte) -> (int, int)`
 
-**Entscheidung:** Der Producer übernimmt `start_line`/`end_line` unverändert aus dem Input-Range-Feld. Die autoritative Zitierachse sind `start_byte`, `end_byte` und `content_sha256`, deren Korrektheit gegen `canonical_md` geprüft wird. Globale Zeilennummerberechnung bleibt eigenständiges Hardening, wenn der Contract es explizit fordert.
+- Zählt `b"\n"`-Bytes direkt, ohne Dekodierung.
+- `start_line = 1 + canonical_md_bytes.count(b"\n", 0, start_byte)`
+- `end_line = 1 + canonical_md_bytes.count(b"\n", 0, end_byte - 1)`
+- Ein `\n`-Byte gehört zur Zeile, die es terminiert.
+- Input-`start_line`/`end_line` werden vollständig ignoriert; Produktion schlägt auch dann nicht fehl, wenn sie fehlen.
+
+**Auswirkung auf den Real-Dump:** Der Dump `max-260514-0409` enthielt nur `content_range_ref` mit `start_line=1` bei allen 541 Chunks (quell-lokale Werte). Nach dem Patch liefern dieselben Byte-Ranges ihre kanonischen Positionen in `canonical_md`:
+
+| Beispiel | start_byte | end_byte | alt (quell-lokal) | neu (canonical_md-global) |
+|---|---|---|---|---|
+| Zeile 1 | 123372 | 124513 | `1`–`57` | `1445`–`1501` |
+| Zeile 2 | 125550 | 127566 | `1`–`65` | `1534`–`1598` |
+| Zeile 3 | 128607 | 135091 | `1`–`190` | `1630`–`1819` |
+
+Die `citation_id`-Werte sind identisch (sie hängen nicht von `start_line`/`end_line` ab).
+Output-SHA änderte sich von `304a4d22...` auf `f7a7e62b...` — ausschließlich wegen korrigierter Zeilennummern.
 
 ## Manifest-Wiring (H6): Registry vorbereitet — Pipeline-Integration offen
 

--- a/docs/roadmap/lenskit-master-roadmap.md
+++ b/docs/roadmap/lenskit-master-roadmap.md
@@ -82,7 +82,7 @@ Spätere PRs:
     - `start_line`/`end_line` werden aus `canonical_md`-Bytes berechnet (`byte_range_to_line_range()`); Input-Werte werden ignoriert. Semantik: `canonical_range` ist Position in `canonical_md` laut Contract.
     - H1–H4/H6-Hardening: kein partieller Output, sicherer Default-Pfad, `run_id`-Gate, `repo_id`-Konfliktprüfung, Module-Level-Registry.
     - `ARTIFACT_CONTRACT_REGISTRY` und `ARTIFACT_AUTHORITY_REGISTRY` auf Modulebene in `merge.py`.
-    - Tests: `test_citation_map_producer.py` (64 Tests, alle grün).
+    - Tests: `test_citation_map_producer.py` (69 Tests, alle grün).
     - Real-Dump-Proof PASS gegen Dump `lenskit-max-260514-0409_merge` (541 Chunks, 0 Fehler, 0 Duplikate, Schema-Validierung PASS); Beleg: `docs/proofs/citation-map-producer-proof.md`.
 - [x] Citation-Readiness-Validator plus Real-Dump-Proof
   - `merger/lenskit/core/citation_validate.py` implementiert (Konsument/Readiness-Gate, kein Producer).

--- a/docs/roadmap/lenskit-master-roadmap.md
+++ b/docs/roadmap/lenskit-master-roadmap.md
@@ -84,14 +84,14 @@ Spätere PRs:
     - `ARTIFACT_CONTRACT_REGISTRY` und `ARTIFACT_AUTHORITY_REGISTRY` auf Modulebene in `merge.py`.
     - Tests: `test_citation_map_producer.py` (64 Tests, alle grün).
     - Real-Dump-Proof PASS gegen Dump `lenskit-max-260514-0409_merge` (541 Chunks, 0 Fehler, 0 Duplikate, Schema-Validierung PASS); Beleg: `docs/proofs/citation-map-producer-proof.md`.
+- [x] Citation-Readiness-Validator plus Real-Dump-Proof
+  - `merger/lenskit/core/citation_validate.py` implementiert (Konsument/Readiness-Gate, kein Producer).
+  - CLI: `lenskit citation validate <bundle_manifest>` mit `--json`-Option.
+  - Tests: `test_citation_validate.py`, `test_cli_citation.py` (synthetische Fixtures, kein Real-Dump erforderlich).
+  - Real-Dump-Proof erbracht: aktueller echter Dump validiert (`594` Chunks, Status `ok`); Beleg: `docs/proofs/citation-readiness-validator-proof.md`.
 - [ ] Merger-Pipeline-Emission von `citation_map_jsonl` ins Bundle-Manifest
   - `_add_artifact(citation_map_path, ArtifactRole.CITATION_MAP_JSONL, …)` ist in `write_reports_v2()` noch nicht verdrahtet.
   - Registries sind vorbereitet; Verdrahtung ist Phase-2-Arbeit.
-  - **Citation-Readiness-Validator (Validator-PR):**
-    - `merger/lenskit/core/citation_validate.py` implementiert (Konsument/Readiness-Gate, kein Producer).
-    - CLI: `lenskit citation validate <bundle_manifest>` mit `--json`-Option.
-    - Tests: `test_citation_validate.py`, `test_cli_citation.py` (synthetische Fixtures, kein Real-Dump erforderlich).
-    - Real-Dump-Proof erbracht: aktueller echter Dump validiert (`594` Chunks, Status `ok`); Beleg: `docs/proofs/citation-readiness-validator-proof.md`.
 Gate:
 - `citation_map_jsonl` nie `canonical_content` oder `content_source`
 - `canonical_range` und `source_range` getrennt

--- a/docs/roadmap/lenskit-master-roadmap.md
+++ b/docs/roadmap/lenskit-master-roadmap.md
@@ -82,7 +82,7 @@ Spätere PRs:
     - `start_line`/`end_line` werden aus `canonical_md`-Bytes berechnet (`byte_range_to_line_range()`); Input-Werte werden ignoriert. Semantik: `canonical_range` ist Position in `canonical_md` laut Contract.
     - H1–H4/H6-Hardening: kein partieller Output, sicherer Default-Pfad, `run_id`-Gate, `repo_id`-Konfliktprüfung, Module-Level-Registry.
     - `ARTIFACT_CONTRACT_REGISTRY` und `ARTIFACT_AUTHORITY_REGISTRY` auf Modulebene in `merge.py`.
-    - Tests: `test_citation_map_producer.py` (72 Tests, alle grün).
+    - Tests: `test_citation_map_producer.py` (73 Tests, alle grün).
     - Real-Dump-Proof PASS gegen Dump `lenskit-max-260514-0409_merge` (541 Chunks, 0 Fehler, 0 Duplikate, Schema-Validierung PASS); Beleg: `docs/proofs/citation-map-producer-proof.md`.
 - [x] Citation-Readiness-Validator plus Real-Dump-Proof
   - `merger/lenskit/core/citation_validate.py` implementiert (Konsument/Readiness-Gate, kein Producer).

--- a/docs/roadmap/lenskit-master-roadmap.md
+++ b/docs/roadmap/lenskit-master-roadmap.md
@@ -82,7 +82,7 @@ Spätere PRs:
     - `start_line`/`end_line` werden aus `canonical_md`-Bytes berechnet (`byte_range_to_line_range()`); Input-Werte werden ignoriert. Semantik: `canonical_range` ist Position in `canonical_md` laut Contract.
     - H1–H4/H6-Hardening: kein partieller Output, sicherer Default-Pfad, `run_id`-Gate, `repo_id`-Konfliktprüfung, Module-Level-Registry.
     - `ARTIFACT_CONTRACT_REGISTRY` und `ARTIFACT_AUTHORITY_REGISTRY` auf Modulebene in `merge.py`.
-    - Tests: `test_citation_map_producer.py` (69 Tests, alle grün).
+    - Tests: `test_citation_map_producer.py` (72 Tests, alle grün).
     - Real-Dump-Proof PASS gegen Dump `lenskit-max-260514-0409_merge` (541 Chunks, 0 Fehler, 0 Duplikate, Schema-Validierung PASS); Beleg: `docs/proofs/citation-map-producer-proof.md`.
 - [x] Citation-Readiness-Validator plus Real-Dump-Proof
   - `merger/lenskit/core/citation_validate.py` implementiert (Konsument/Readiness-Gate, kein Producer).

--- a/docs/roadmap/lenskit-master-roadmap.md
+++ b/docs/roadmap/lenskit-master-roadmap.md
@@ -73,22 +73,20 @@ Spätere PRs:
 - [x] `citation-map.v1.schema.json` plus minimale Beispiele plus Schema-Test
 - [x] Bundle-Manifest-Role `citation_map_jsonl`
 - [x] `chunk_index` dual range mit `content_range_ref`, `canonical_range`, `source_range`
-- [ ] Citation-Map-Producer, geplante Citation-/Evidence-Health-Prüfung in separater Folge-PR, Real-Dump-Proof
-  - **Blocker (Diagnose 2026-05-12, aktualisiert 2026-05-13):**
-    - Im Repo ist kein Real-Dump mit dual ranges abgelegt.
-    - Konsument nicht im Code definiert.
-    - Citation-Id-Regel als Helper in `merger/lenskit/core/citation_id.py` vorbereitet, aber noch nicht in Producer/Validator verdrahtet.
-    - Diagnose: `docs/proofs/citation-map-producer-diagnosis.md`.
-    - Offene Vorbedingungen:
-      - Real-Dump mit dual ranges bereitstellen.
-      - Konsument oder Validator benennen.
-    - Erledigte Vorbereitung: `merger/lenskit/core/citation_id.py` (Citation-Id-Derivationsregel als Helper, PR #652).
-  - **Citation-Readiness-Validator vorbereitet (Validator-PR):**
+- [x] Citation-Map-Producer, geplante Citation-/Evidence-Health-Prüfung in separater Folge-PR, Real-Dump-Proof
+  - **Producer implementiert (2026-05-14):**
+    - `merger/lenskit/core/citation_map.py` (pure Funktionen + IO-Adapter).
+    - CLI: `lenskit citation produce <bundle_manifest>` mit `--json`- und `--output`-Option.
+    - Normalisierung: bevorzugt `canonical_range`, fällt auf `content_range_ref` zurück (beide müssen `artifact_role == "canonical_md"` haben).
+    - `make_citation_id(canonical_md_sha256, start_byte, end_byte, content_sha256)` pro Chunk.
+    - CONTRACT_REGISTRY + AUTHORITY_REGISTRY in `merge.py` ergänzt.
+    - Tests: `test_citation_map_producer.py` (40 Tests, alle grün).
+    - Real-Dump-Proof PASS gegen Dump `lenskit-max-260514-0409_merge` (541 Chunks, 0 Fehler, 0 Duplikate, Schema-Validierung PASS); Beleg: `docs/proofs/citation-map-producer-proof.md`.
+  - **Citation-Readiness-Validator (Validator-PR):**
     - `merger/lenskit/core/citation_validate.py` implementiert (Konsument/Readiness-Gate, kein Producer).
     - CLI: `lenskit citation validate <bundle_manifest>` mit `--json`-Option.
     - Tests: `test_citation_validate.py`, `test_cli_citation.py` (synthetische Fixtures, kein Real-Dump erforderlich).
     - Real-Dump-Proof erbracht: aktueller echter Dump validiert (`594` Chunks, Status `ok`); Beleg: `docs/proofs/citation-readiness-validator-proof.md`.
-    - Producer (`citation_map_jsonl` erzeugen) bleibt als separates Folge-Thema offen; der Validator-Proof ist erbracht.
 Gate:
 - `citation_map_jsonl` nie `canonical_content` oder `content_source`
 - `canonical_range` und `source_range` getrennt
@@ -188,7 +186,7 @@ PR 2:
 PR 3 (teilweise erledigt):
 - [x] Bundle-Manifest-Role `citation_map_jsonl`
 - [x] Chunk-Index dual range (`canonical_range`, `source_range` zusätzlich zu `content_range_ref`)
-- [ ] Citation-Map-Producer plus eigener Producer-Real-Dump-Proof
+- [x] Citation-Map-Producer plus eigener Producer-Real-Dump-Proof
 - [x] Citation-Readiness-Validator (`merger/lenskit/core/citation_validate.py`, CLI `lenskit citation validate`, Testabdeckung in `merger/lenskit/tests/test_citation_validate.py` und `merger/lenskit/tests/test_cli_citation.py`; Real-Dump-Proof erbracht mit aktuellem Dump, 594 Chunks, Status `ok`)
 Diagnosehinweis für Priorisierung:
 - `merge.md` bleibt kanonische Vollquelle; JSON-Artefakte sind Einstieg/Index/Metadaten.

--- a/docs/roadmap/lenskit-master-roadmap.md
+++ b/docs/roadmap/lenskit-master-roadmap.md
@@ -42,7 +42,7 @@ Diagnosebefunde für Terminologie:
 | `derived_index_json` | `derived_manifest_json` |
 | `*.derived_index.json` | Dateiname zur Role `derived_manifest_json` |
 | `output_health_json` / `output_health` | `output_health` ist als Bundle-Manifest-ArtifactRole vorhanden und wird als Diagnoseartefakt emittiert; Citation-/Evidence-Health-Erweiterung bleibt geplant |
-| `citation_map_jsonl` | Manifest-Role registriert; `derived`/`navigation_index`; kein Producer vorhanden |
+| `citation_map_jsonl` | Manifest-Role registriert; `derived`/`navigation_index`; CLI-Producer implementiert; Merger-Pipeline-Emission noch offen |
 Zusatz:
 Rollenamen folgen `bundle-manifest.v1.schema.json`, nicht älteren Blueprint-Begriffen oder Dateinamen.
 
@@ -73,15 +73,20 @@ Spätere PRs:
 - [x] `citation-map.v1.schema.json` plus minimale Beispiele plus Schema-Test
 - [x] Bundle-Manifest-Role `citation_map_jsonl`
 - [x] `chunk_index` dual range mit `content_range_ref`, `canonical_range`, `source_range`
-- [x] Citation-Map-Producer, geplante Citation-/Evidence-Health-Prüfung in separater Folge-PR, Real-Dump-Proof
-  - **Producer implementiert (2026-05-14):**
+- [x] Citation-Map-CLI-Producer plus Real-Dump-Proof
+  - **Producer implementiert und gehärtet (2026-05-14):**
     - `merger/lenskit/core/citation_map.py` (pure Funktionen + IO-Adapter).
     - CLI: `lenskit citation produce <bundle_manifest>` mit `--json`- und `--output`-Option.
     - Normalisierung: bevorzugt `canonical_range`, fällt auf `content_range_ref` zurück (beide müssen `artifact_role == "canonical_md"` haben).
     - `make_citation_id(canonical_md_sha256, start_byte, end_byte, content_sha256)` pro Chunk.
-    - CONTRACT_REGISTRY + AUTHORITY_REGISTRY in `merge.py` ergänzt.
-    - Tests: `test_citation_map_producer.py` (40 Tests, alle grün).
+    - `start_line`/`end_line` werden aus `canonical_md`-Bytes berechnet (`byte_range_to_line_range()`); Input-Werte werden ignoriert. Semantik: `canonical_range` ist Position in `canonical_md` laut Contract.
+    - H1–H4/H6-Hardening: kein partieller Output, sicherer Default-Pfad, `run_id`-Gate, `repo_id`-Konfliktprüfung, Module-Level-Registry.
+    - `ARTIFACT_CONTRACT_REGISTRY` und `ARTIFACT_AUTHORITY_REGISTRY` auf Modulebene in `merge.py`.
+    - Tests: `test_citation_map_producer.py` (64 Tests, alle grün).
     - Real-Dump-Proof PASS gegen Dump `lenskit-max-260514-0409_merge` (541 Chunks, 0 Fehler, 0 Duplikate, Schema-Validierung PASS); Beleg: `docs/proofs/citation-map-producer-proof.md`.
+- [ ] Merger-Pipeline-Emission von `citation_map_jsonl` ins Bundle-Manifest
+  - `_add_artifact(citation_map_path, ArtifactRole.CITATION_MAP_JSONL, …)` ist in `write_reports_v2()` noch nicht verdrahtet.
+  - Registries sind vorbereitet; Verdrahtung ist Phase-2-Arbeit.
   - **Citation-Readiness-Validator (Validator-PR):**
     - `merger/lenskit/core/citation_validate.py` implementiert (Konsument/Readiness-Gate, kein Producer).
     - CLI: `lenskit citation validate <bundle_manifest>` mit `--json`-Option.

--- a/merger/lenskit/cli/cmd_citation.py
+++ b/merger/lenskit/cli/cmd_citation.py
@@ -48,11 +48,7 @@ def run_citation_produce(args: argparse.Namespace) -> int:
     manifest_path = args.bundle_manifest
     output_path = getattr(args, "output_path", None)
 
-    try:
-        report = produce_citation_map(manifest_path, output_path)
-    except Exception as e:
-        print(f"Error: unexpected failure during production: {e}", file=sys.stderr)
-        return 2
+    report = produce_citation_map(manifest_path, output_path)
 
     if args.emit_json:
         print(json.dumps(report, indent=2))

--- a/merger/lenskit/cli/cmd_citation.py
+++ b/merger/lenskit/cli/cmd_citation.py
@@ -22,6 +22,49 @@ def register_citation_commands(subparsers) -> None:
         help="Emit machine-readable JSON report to stdout",
     )
 
+    produce_parser = citation_subparsers.add_parser(
+        "produce", help="Produce citation_map_jsonl from a bundle manifest"
+    )
+    produce_parser.add_argument(
+        "bundle_manifest", help="Path to bundle manifest JSON"
+    )
+    produce_parser.add_argument(
+        "--output",
+        dest="output_path",
+        default=None,
+        help="Output path for citation_map_jsonl (default: adjacent to manifest)",
+    )
+    produce_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="emit_json",
+        help="Emit machine-readable JSON report to stdout",
+    )
+
+
+def run_citation_produce(args: argparse.Namespace) -> int:
+    from merger.lenskit.core.citation_map import produce_citation_map
+
+    manifest_path = args.bundle_manifest
+    output_path = getattr(args, "output_path", None)
+
+    try:
+        report = produce_citation_map(manifest_path, output_path)
+    except Exception as e:
+        print(f"Error: unexpected failure during production: {e}", file=sys.stderr)
+        return 2
+
+    if args.emit_json:
+        print(json.dumps(report, indent=2))
+    else:
+        _print_produce_report(report)
+
+    if report["status"] == "ok":
+        return 0
+    if report.get("error_kind") == "path_read_error":
+        return 2
+    return 1
+
 
 def run_citation_validate(args: argparse.Namespace) -> int:
     from merger.lenskit.core.citation_validate import validate_bundle
@@ -75,6 +118,36 @@ def _print_human_report(report: dict) -> None:
             print(f"  [warn] {w}")
 
     if report["errors"]:
+        print(f"\nErrors ({len(report['errors'])}):")
+        for e in report["errors"]:
+            print(f"  [error] {e}")
+
+
+def _print_produce_report(report: dict) -> None:
+    status = report["status"].upper()
+    print(f"Citation Map Production: {status}")
+    print(f"  bundle_manifest_path:    {report['bundle_manifest_path']}")
+    print(f"  bundle_run_id:           {report['bundle_run_id']}")
+    print(f"  production_run_id:       {report['production_run_id']}")
+    print(f"  canonical_md_sha256:     {report['canonical_md_sha256']}")
+    print(f"  chunk_index_sha256:      {report['chunk_index_sha256']}")
+    print(f"  output_path:             {report['output_path']}")
+    print(f"  output_sha256:           {report['output_sha256']}")
+    print(f"  output_bytes:            {report['output_bytes']}")
+    print(f"  chunk_count:             {report['chunk_count']}")
+    print(f"  valid_chunk_count:       {report['valid_chunk_count']}")
+    print(f"  citation_map_row_count:  {report['citation_map_row_count']}")
+    print(f"  citation_id_count:       {report['citation_id_count']}")
+    print(f"  duplicates:              {report['citation_id_duplicate_count']}")
+    print(f"  repo_id_source:          {report['repo_id_source']}")
+    print(f"  snapshot_source:         {report['snapshot_source']}")
+
+    if report.get("warnings"):
+        print(f"\nWarnings ({len(report['warnings'])}):")
+        for w in report["warnings"]:
+            print(f"  [warn] {w}")
+
+    if report.get("errors"):
         print(f"\nErrors ({len(report['errors'])}):")
         for e in report["errors"]:
             print(f"  [error] {e}")

--- a/merger/lenskit/cli/main.py
+++ b/merger/lenskit/cli/main.py
@@ -226,9 +226,11 @@ def main(args: Optional[List[str]] = None) -> int:
             parser.parse_args(["atlas", "--help"])
             return 0
     elif parsed_args.command == "citation":
-        from .cmd_citation import run_citation_validate
+        from .cmd_citation import run_citation_produce, run_citation_validate
         if parsed_args.citation_cmd == "validate":
             return run_citation_validate(parsed_args)
+        elif parsed_args.citation_cmd == "produce":
+            return run_citation_produce(parsed_args)
         else:
             parser.parse_args(["citation", "--help"])
             return 0

--- a/merger/lenskit/core/citation_map.py
+++ b/merger/lenskit/core/citation_map.py
@@ -555,11 +555,16 @@ def produce_citation_map(
         stem = manifest_path.name[: -len(_MANIFEST_SUFFIX)]
         output_path = manifest_path.parent / (stem + _OUTPUT_SUFFIX)
 
+    # Explicit --output paths may coincide with input artifacts not yet in
+    # protected_paths. Skip early-fail cleanup for explicit paths until both
+    # canonical_md and chunk_index_jsonl are resolved and protected.
+    output_path_is_explicit = output_path_str is not None
+
     # protected_paths grows as artifacts are resolved; at minimum contains the manifest.
     protected_paths: Set[Path] = {manifest_path.resolve()}
 
     if not manifest_path.exists() or not manifest_path.is_file():
-        _s = _remove_stale_output(output_path, protected_paths)
+        _s = _remove_stale_output(output_path, protected_paths) if not output_path_is_explicit else None
         return _fail_report(
             production_run_id,
             bundle_manifest_path_str,
@@ -573,7 +578,7 @@ def produce_citation_map(
     try:
         manifest = load_manifest(manifest_path)
     except (json.JSONDecodeError, OSError) as e:
-        _s = _remove_stale_output(output_path, protected_paths)
+        _s = _remove_stale_output(output_path, protected_paths) if not output_path_is_explicit else None
         return _fail_report(
             production_run_id,
             bundle_manifest_path_str,
@@ -585,7 +590,7 @@ def produce_citation_map(
 
     # H3: run_id must be a non-empty string — an empty snapshot.run_id is invalid.
     if not isinstance(bundle_run_id, str) or not bundle_run_id:
-        _s = _remove_stale_output(output_path, protected_paths)
+        _s = _remove_stale_output(output_path, protected_paths) if not output_path_is_explicit else None
         return _fail_report(
             production_run_id,
             bundle_manifest_path_str,
@@ -602,7 +607,7 @@ def produce_citation_map(
             resolve_artifact_by_role(manifest, "canonical_md", manifest_dir)
         )
     except CitationMapError as e:
-        _s = _remove_stale_output(output_path, protected_paths)
+        _s = _remove_stale_output(output_path, protected_paths) if not output_path_is_explicit else None
         return _fail_report(
             production_run_id,
             bundle_manifest_path_str,
@@ -620,7 +625,7 @@ def produce_citation_map(
             resolve_artifact_by_role(manifest, "chunk_index_jsonl", manifest_dir)
         )
     except CitationMapError as e:
-        _s = _remove_stale_output(output_path, protected_paths)
+        _s = _remove_stale_output(output_path, protected_paths) if not output_path_is_explicit else None
         return _fail_report(
             production_run_id,
             bundle_manifest_path_str,

--- a/merger/lenskit/core/citation_map.py
+++ b/merger/lenskit/core/citation_map.py
@@ -774,7 +774,7 @@ def produce_citation_map(
         "output_bytes": output_bytes_count,
         "chunk_count": chunk_count,
         "valid_chunk_count": valid_chunk_count,
-        "citation_map_row_count": len(output_lines),
+        "citation_map_row_count": len(output_lines) if status == "ok" else 0,
         "citation_id_count": citation_id_count,
         "citation_id_duplicate_count": citation_id_duplicate_count,
         "repo_id_source": repo_id_source,

--- a/merger/lenskit/core/citation_map.py
+++ b/merger/lenskit/core/citation_map.py
@@ -9,6 +9,7 @@ import hashlib
 import json
 import re
 import uuid
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 
@@ -117,7 +118,6 @@ def resolve_artifact_by_role(
 
 def normalize_canonical_range(
     chunk: Dict[str, Any],
-    lineno: int,
 ) -> Optional[Dict[str, Any]]:
     """
     Return the canonical range dict for a chunk, normalising legacy input.
@@ -268,18 +268,11 @@ def verify_byte_range_hash(
 # Row iterator (pure — yields structured results, never writes)
 # ---------------------------------------------------------------------------
 
+@dataclass(frozen=True, slots=True)
 class _ChunkResult:
-    __slots__ = ("row", "error", "repo_id_source")
-
-    def __init__(
-        self,
-        row: Optional[Dict[str, Any]],
-        error: Optional[str],
-        repo_id_source: Optional[str],
-    ) -> None:
-        self.row = row
-        self.error = error
-        self.repo_id_source = repo_id_source
+    row: Optional[Dict[str, Any]]
+    error: Optional[str]
+    repo_id_source: Optional[str]
 
 
 def iter_chunk_results(
@@ -320,7 +313,7 @@ def iter_chunk_results(
                 continue
 
             # --- normalise range ---
-            norm_range = normalize_canonical_range(chunk, lineno)
+            norm_range = normalize_canonical_range(chunk)
             if norm_range is None:
                 yield _ChunkResult(
                     None,
@@ -361,24 +354,13 @@ def iter_chunk_results(
             end_byte = norm_range.get("end_byte")
             content_sha256 = norm_range.get("content_sha256", "")
 
-            for name, val in (
-                ("start_byte", start_byte),
-                ("end_byte", end_byte),
-            ):
+            _int_error: Optional[str] = None
+            for name, val in (("start_byte", start_byte), ("end_byte", end_byte)):
                 if isinstance(val, bool) or not isinstance(val, int):
-                    yield _ChunkResult(
-                        None,
-                        f"Line {lineno}: range.{name} must be an int",
-                        None,
-                    )
+                    _int_error = f"Line {lineno}: range.{name} must be an int"
                     break
-            else:
-                pass  # all int checks passed — fall through
-
-            if any(
-                isinstance(v, bool) or not isinstance(v, int)
-                for v in (start_byte, end_byte)
-            ):
+            if _int_error:
+                yield _ChunkResult(None, _int_error, None)
                 continue
 
             if (
@@ -480,6 +462,7 @@ def _fail_report(
     *,
     bundle_run_id: Any = None,
     error_kind: str = "production_error",
+    snapshot_source: Optional[str] = None,
 ) -> Dict[str, Any]:
     return {
         "status": "fail",
@@ -498,7 +481,7 @@ def _fail_report(
         "citation_id_count": 0,
         "citation_id_duplicate_count": 0,
         "repo_id_source": None,
-        "snapshot_source": "bundle_manifest",
+        "snapshot_source": snapshot_source,
         "errors": errors,
         "warnings": [],
         "sample_rows": [],
@@ -514,6 +497,7 @@ def produce_citation_map(
 
     The output NDJSON file is written adjacent to the manifest unless
     output_path_str is given.  Each line is a schema-valid citation map entry.
+    An empty chunk index writes an empty file (0 bytes) with status=ok.
     """
     production_run_id = str(uuid.uuid4())
     errors: List[str] = []
@@ -734,32 +718,39 @@ def produce_citation_map(
 
     citation_id_count = len(seen_citation_ids)
 
-    # --- write output only when there are no errors (H1) ---
-    # A partial output on a failed run would be silently mistaken for a valid one.
+    # --- write output or clean up stale file ---
     output_sha256: Optional[str] = None
     output_bytes_count: Optional[int] = None
     written_output_path: Optional[str] = None
 
     if errors:
         status = "fail"
+        # B: Remove any stale output from a prior successful run at the same path.
+        # output_path is safe (collision check above ensures it is not a protected input).
+        if output_path.exists():
+            try:
+                output_path.unlink()
+            except OSError:
+                pass  # best-effort; caller sees status=fail regardless
     else:
         status = "ok"
-        if output_lines:
-            ndjson_content = "\n".join(output_lines) + "\n"
-            ndjson_bytes = ndjson_content.encode("utf-8")
-            try:
-                output_path.write_bytes(ndjson_bytes)
-            except OSError as e:
-                return _fail_report(
-                    production_run_id,
-                    bundle_manifest_path_str,
-                    [f"Cannot write output: {e}"],
-                    bundle_run_id=bundle_run_id,
-                    error_kind="path_read_error",
-                )
-            output_sha256 = _sha256_bytes(ndjson_bytes)
-            output_bytes_count = len(ndjson_bytes)
-            written_output_path = str(output_path)
+        # A: Always write, even when there are no rows (empty chunk index → empty file).
+        ndjson_bytes = (
+            ("\n".join(output_lines) + "\n").encode("utf-8") if output_lines else b""
+        )
+        try:
+            output_path.write_bytes(ndjson_bytes)
+        except OSError as e:
+            return _fail_report(
+                production_run_id,
+                bundle_manifest_path_str,
+                [f"Cannot write output: {e}"],
+                bundle_run_id=bundle_run_id,
+                error_kind="path_read_error",
+            )
+        output_sha256 = _sha256_bytes(ndjson_bytes)
+        output_bytes_count = len(ndjson_bytes)
+        written_output_path = str(output_path)
 
     return {
         "status": status,

--- a/merger/lenskit/core/citation_map.py
+++ b/merger/lenskit/core/citation_map.py
@@ -209,6 +209,26 @@ def resolve_repo_id(
 # Byte-range verification
 # ---------------------------------------------------------------------------
 
+def byte_range_to_line_range(
+    canonical_md_bytes: bytes,
+    start_byte: int,
+    end_byte: int,
+) -> Tuple[int, int]:
+    """
+    Compute 1-based global line numbers for [start_byte, end_byte) within canonical_md.
+
+    Counts b'\\n' bytes directly without decoding; does not allocate slices.
+    Assumes 0 <= start_byte < end_byte <= len(canonical_md_bytes).
+
+    start_line: line containing the byte at start_byte.
+    end_line:   line containing the last included byte (end_byte - 1).
+    A b'\\n' byte belongs to the line it terminates.
+    """
+    start_line = 1 + canonical_md_bytes.count(b"\n", 0, start_byte)
+    end_line = 1 + canonical_md_bytes.count(b"\n", 0, end_byte - 1)
+    return start_line, end_line
+
+
 def verify_byte_range_hash(
     canonical_md_bytes: bytes,
     start_byte: int,
@@ -339,15 +359,11 @@ def iter_chunk_results(
 
             start_byte = norm_range.get("start_byte")
             end_byte = norm_range.get("end_byte")
-            start_line = norm_range.get("start_line")
-            end_line = norm_range.get("end_line")
             content_sha256 = norm_range.get("content_sha256", "")
 
             for name, val in (
                 ("start_byte", start_byte),
                 ("end_byte", end_byte),
-                ("start_line", start_line),
-                ("end_line", end_line),
             ):
                 if isinstance(val, bool) or not isinstance(val, int):
                     yield _ChunkResult(
@@ -359,11 +375,9 @@ def iter_chunk_results(
             else:
                 pass  # all int checks passed — fall through
 
-            # Re-check after the loop (Python does not break out of the enclosing
-            # for-loop so we use a sentinel).
             if any(
                 isinstance(v, bool) or not isinstance(v, int)
-                for v in (start_byte, end_byte, start_line, end_line)
+                for v in (start_byte, end_byte)
             ):
                 continue
 
@@ -391,6 +405,13 @@ def iter_chunk_results(
             except CitationMapError as e:
                 yield _ChunkResult(None, str(e), None)
                 continue
+
+            # --- compute canonical_md-global line numbers (H5) ---
+            # Input start_line/end_line are ignored: they are source-file-local
+            # from the generator. Output line numbers are always canonical_md-global.
+            start_line, end_line = byte_range_to_line_range(
+                canonical_md_bytes, start_byte, end_byte
+            )
 
             # --- derive citation_id ---
             try:

--- a/merger/lenskit/core/citation_map.py
+++ b/merger/lenskit/core/citation_map.py
@@ -11,7 +11,7 @@ import re
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Set, Tuple
 
 from merger.lenskit.core.citation_id import make_citation_id
 from merger.lenskit.core.path_security import resolve_secure_path
@@ -455,6 +455,32 @@ def _default_output_path(manifest_path: Path) -> Path:
     return manifest_path.parent / (stem + _OUTPUT_SUFFIX)
 
 
+def _remove_stale_output(
+    output_path: Optional[Path],
+    protected_paths: Set[Path],
+) -> Optional[str]:
+    """
+    Remove a stale citation_map_jsonl left by a prior run, if it exists and is
+    not a protected input (manifest, canonical_md, chunk_index_jsonl).
+
+    Returns None when there is nothing to do or removal succeeds.
+    Returns an error string if removal fails — the caller includes it in errors[].
+    """
+    if output_path is None:
+        return None
+    try:
+        resolved = output_path.resolve()
+    except OSError:
+        return None
+    if resolved in protected_paths:
+        return None
+    try:
+        output_path.unlink(missing_ok=True)
+        return None
+    except OSError as e:
+        return f"Could not remove stale output {str(output_path)!r}: {e}"
+
+
 def _fail_report(
     production_run_id: str,
     manifest_path_str: str,
@@ -517,11 +543,27 @@ def produce_citation_map(
     manifest_path = manifest_path.resolve()
     bundle_manifest_path_str = str(manifest_path)
 
+    # --- determine output path as early as possible ---
+    # This allows stale-output cleanup even for pre-iteration failures (SHA mismatch,
+    # bad run_id, etc.).  output_path stays None only when the manifest suffix check
+    # fails; that error is surfaced at the normal location below.
+    output_path: Optional[Path] = None
+    if output_path_str:
+        p = Path(output_path_str)
+        output_path = p if p.is_absolute() else Path.cwd() / p
+    elif manifest_path.name.endswith(_MANIFEST_SUFFIX):
+        stem = manifest_path.name[: -len(_MANIFEST_SUFFIX)]
+        output_path = manifest_path.parent / (stem + _OUTPUT_SUFFIX)
+
+    # protected_paths grows as artifacts are resolved; at minimum contains the manifest.
+    protected_paths: Set[Path] = {manifest_path.resolve()}
+
     if not manifest_path.exists() or not manifest_path.is_file():
+        _s = _remove_stale_output(output_path, protected_paths)
         return _fail_report(
             production_run_id,
             bundle_manifest_path_str,
-            [f"Manifest not found or not a file: {manifest_path}"],
+            [f"Manifest not found or not a file: {manifest_path}"] + ([_s] if _s else []),
             error_kind="path_read_error",
         )
 
@@ -531,10 +573,11 @@ def produce_citation_map(
     try:
         manifest = load_manifest(manifest_path)
     except (json.JSONDecodeError, OSError) as e:
+        _s = _remove_stale_output(output_path, protected_paths)
         return _fail_report(
             production_run_id,
             bundle_manifest_path_str,
-            [f"Cannot load manifest: {e}"],
+            [f"Cannot load manifest: {e}"] + ([_s] if _s else []),
             error_kind="path_read_error",
         )
 
@@ -542,13 +585,14 @@ def produce_citation_map(
 
     # H3: run_id must be a non-empty string — an empty snapshot.run_id is invalid.
     if not isinstance(bundle_run_id, str) or not bundle_run_id:
+        _s = _remove_stale_output(output_path, protected_paths)
         return _fail_report(
             production_run_id,
             bundle_manifest_path_str,
             [
                 f"Manifest 'run_id' is missing or empty: {bundle_run_id!r}. "
                 "A non-empty run_id is required for snapshot identity."
-            ],
+            ] + ([_s] if _s else []),
             bundle_run_id=bundle_run_id,
         )
 
@@ -558,15 +602,17 @@ def produce_citation_map(
             resolve_artifact_by_role(manifest, "canonical_md", manifest_dir)
         )
     except CitationMapError as e:
+        _s = _remove_stale_output(output_path, protected_paths)
         return _fail_report(
             production_run_id,
             bundle_manifest_path_str,
-            [str(e)],
+            [str(e)] + ([_s] if _s else []),
             bundle_run_id=bundle_run_id,
             error_kind="path_read_error",
         )
 
     canonical_md_manifest_sha = canonical_md_art.get("sha256", "")
+    protected_paths.add(canonical_md_path.resolve())
 
     # --- resolve chunk_index_jsonl ---
     try:
@@ -574,58 +620,64 @@ def produce_citation_map(
             resolve_artifact_by_role(manifest, "chunk_index_jsonl", manifest_dir)
         )
     except CitationMapError as e:
+        _s = _remove_stale_output(output_path, protected_paths)
         return _fail_report(
             production_run_id,
             bundle_manifest_path_str,
-            [str(e)],
+            [str(e)] + ([_s] if _s else []),
             bundle_run_id=bundle_run_id,
             error_kind="path_read_error",
         )
 
     chunk_index_manifest_sha = chunk_index_art.get("sha256", "")
+    protected_paths.add(chunk_index_path.resolve())
 
     # --- verify SHAs ---
     try:
         actual_canonical_sha = _sha256_file(canonical_md_path)
     except OSError as e:
+        _s = _remove_stale_output(output_path, protected_paths)
         return _fail_report(
             production_run_id,
             bundle_manifest_path_str,
-            [f"Cannot read canonical_md: {e}"],
+            [f"Cannot read canonical_md: {e}"] + ([_s] if _s else []),
             bundle_run_id=bundle_run_id,
             error_kind="path_read_error",
         )
 
     if actual_canonical_sha != canonical_md_manifest_sha:
+        _s = _remove_stale_output(output_path, protected_paths)
         return _fail_report(
             production_run_id,
             bundle_manifest_path_str,
             [
                 f"canonical_md SHA256 mismatch: "
                 f"manifest={canonical_md_manifest_sha!r} actual={actual_canonical_sha!r}"
-            ],
+            ] + ([_s] if _s else []),
             bundle_run_id=bundle_run_id,
         )
 
     try:
         actual_chunk_sha = _sha256_file(chunk_index_path)
     except OSError as e:
+        _s = _remove_stale_output(output_path, protected_paths)
         return _fail_report(
             production_run_id,
             bundle_manifest_path_str,
-            [f"Cannot read chunk_index_jsonl: {e}"],
+            [f"Cannot read chunk_index_jsonl: {e}"] + ([_s] if _s else []),
             bundle_run_id=bundle_run_id,
             error_kind="path_read_error",
         )
 
     if actual_chunk_sha != chunk_index_manifest_sha:
+        _s = _remove_stale_output(output_path, protected_paths)
         return _fail_report(
             production_run_id,
             bundle_manifest_path_str,
             [
                 f"chunk_index_jsonl SHA256 mismatch: "
                 f"manifest={chunk_index_manifest_sha!r} actual={actual_chunk_sha!r}"
-            ],
+            ] + ([_s] if _s else []),
             bundle_run_id=bundle_run_id,
         )
 
@@ -633,36 +685,28 @@ def produce_citation_map(
     try:
         canonical_md_bytes = canonical_md_path.read_bytes()
     except OSError as e:
+        _s = _remove_stale_output(output_path, protected_paths)
         return _fail_report(
             production_run_id,
             bundle_manifest_path_str,
-            [f"Cannot read canonical_md bytes: {e}"],
+            [f"Cannot read canonical_md bytes: {e}"] + ([_s] if _s else []),
             bundle_run_id=bundle_run_id,
             error_kind="path_read_error",
         )
 
-    # --- determine output path ---
-    if output_path_str:
-        output_path = Path(output_path_str)
-        if not output_path.is_absolute():
-            output_path = Path.cwd() / output_path
-    else:
-        try:
-            output_path = _default_output_path(manifest_path)
-        except CitationMapError as e:
-            return _fail_report(
-                production_run_id,
-                bundle_manifest_path_str,
-                [str(e)],
-                bundle_run_id=bundle_run_id,
-            )
+    # If output_path is still None, the manifest filename lacks the required suffix.
+    if output_path is None:
+        return _fail_report(
+            production_run_id,
+            bundle_manifest_path_str,
+            [
+                f"Cannot derive safe output path: manifest filename {manifest_path.name!r} "
+                f"does not end with '{_MANIFEST_SUFFIX}'. Pass --output explicitly."
+            ],
+            bundle_run_id=bundle_run_id,
+        )
 
     # H2: output path must not collide with any input artifact.
-    protected_paths = {
-        manifest_path.resolve(),
-        canonical_md_path.resolve(),
-        chunk_index_path.resolve(),
-    }
     output_path_resolved = output_path.resolve()
     if output_path_resolved in protected_paths:
         return _fail_report(
@@ -725,13 +769,11 @@ def produce_citation_map(
 
     if errors:
         status = "fail"
-        # B: Remove any stale output from a prior successful run at the same path.
+        # Remove any stale output from a prior successful run at the same path.
         # output_path is safe (collision check above ensures it is not a protected input).
-        if output_path.exists():
-            try:
-                output_path.unlink()
-            except OSError:
-                pass  # best-effort; caller sees status=fail regardless
+        _s = _remove_stale_output(output_path, protected_paths)
+        if _s:
+            errors.append(_s)
     else:
         status = "ok"
         # A: Always write, even when there are no rows (empty chunk index → empty file).

--- a/merger/lenskit/core/citation_map.py
+++ b/merger/lenskit/core/citation_map.py
@@ -163,32 +163,46 @@ def resolve_repo_id(
     """
     Resolve repo_id and return (repo_id, source_description).
 
-    Priority (first non-empty wins):
+    Collects all non-empty sources in priority order:
       1. normalized_range["repo_id"]
       2. chunk["repo"]
       3. chunk["search_keys"]["repo_id"]
 
-    Raises CitationMapError when no source provides a value (hard error;
+    If all present sources agree on the same value, returns the highest-priority one.
+    If any two sources disagree, raises CitationMapError (ambiguity is a hard error;
     derivation from filenames is forbidden).
+    If no source has a value, raises CitationMapError.
     """
+    candidates: List[Tuple[str, str]] = []  # (source_label, value)
+
     v = _first_nonempty_str(normalized_range.get("repo_id"))
     if v:
-        return v, "range.repo_id"
+        candidates.append(("range.repo_id", v))
 
     v = _first_nonempty_str(chunk.get("repo"))
     if v:
-        return v, "chunk.repo"
+        candidates.append(("chunk.repo", v))
 
     sk = chunk.get("search_keys")
     if isinstance(sk, dict):
         v = _first_nonempty_str(sk.get("repo_id"))
         if v:
-            return v, "search_keys.repo_id"
+            candidates.append(("search_keys.repo_id", v))
 
-    raise CitationMapError(
-        f"Line {lineno}: no repo_id source found in chunk "
-        "(range.repo_id, chunk.repo, and search_keys.repo_id all absent or empty)"
-    )
+    if not candidates:
+        raise CitationMapError(
+            f"Line {lineno}: no repo_id source found in chunk "
+            "(range.repo_id, chunk.repo, and search_keys.repo_id all absent or empty)"
+        )
+
+    unique_values = {val for _, val in candidates}
+    if len(unique_values) > 1:
+        raise CitationMapError(
+            f"Line {lineno}: ambiguous repo_id — sources disagree: "
+            + ", ".join(f"{src}={val!r}" for src, val in candidates)
+        )
+
+    return candidates[0][1], candidates[0][0]
 
 
 # ---------------------------------------------------------------------------
@@ -415,11 +429,27 @@ def iter_chunk_results(
 # IO adapter
 # ---------------------------------------------------------------------------
 
+_MANIFEST_SUFFIX = ".bundle.manifest.json"
+_OUTPUT_SUFFIX = ".citation_map.jsonl"
+
+
 def _default_output_path(manifest_path: Path) -> Path:
-    name = manifest_path.name.replace(
-        ".bundle.manifest.json", ".citation_map.jsonl"
-    )
-    return manifest_path.parent / name
+    """
+    Derive citation map output path from manifest path.
+
+    Requires the manifest to end with '.bundle.manifest.json'.
+    Raises CitationMapError if the suffix is missing (would silently produce
+    the same filename and overwrite the manifest).
+    """
+    name = manifest_path.name
+    if not name.endswith(_MANIFEST_SUFFIX):
+        raise CitationMapError(
+            f"Cannot derive safe output path: manifest filename {name!r} "
+            f"does not end with '{_MANIFEST_SUFFIX}'. "
+            "Pass --output explicitly."
+        )
+    stem = name[: -len(_MANIFEST_SUFFIX)]
+    return manifest_path.parent / (stem + _OUTPUT_SUFFIX)
 
 
 def _fail_report(
@@ -504,6 +534,18 @@ def produce_citation_map(
         )
 
     bundle_run_id = manifest.get("run_id")
+
+    # H3: run_id must be a non-empty string — an empty snapshot.run_id is invalid.
+    if not isinstance(bundle_run_id, str) or not bundle_run_id:
+        return _fail_report(
+            production_run_id,
+            bundle_manifest_path_str,
+            [
+                f"Manifest 'run_id' is missing or empty: {bundle_run_id!r}. "
+                "A non-empty run_id is required for snapshot identity."
+            ],
+            bundle_run_id=bundle_run_id,
+        )
 
     # --- resolve canonical_md ---
     try:
@@ -600,7 +642,34 @@ def produce_citation_map(
         if not output_path.is_absolute():
             output_path = Path.cwd() / output_path
     else:
-        output_path = _default_output_path(manifest_path)
+        try:
+            output_path = _default_output_path(manifest_path)
+        except CitationMapError as e:
+            return _fail_report(
+                production_run_id,
+                bundle_manifest_path_str,
+                [str(e)],
+                bundle_run_id=bundle_run_id,
+            )
+
+    # H2: output path must not collide with any input artifact.
+    protected_paths = {
+        manifest_path.resolve(),
+        canonical_md_path.resolve(),
+        chunk_index_path.resolve(),
+    }
+    output_path_resolved = output_path.resolve()
+    if output_path_resolved in protected_paths:
+        return _fail_report(
+            production_run_id,
+            bundle_manifest_path_str,
+            [
+                f"Output path {str(output_path)!r} collides with an input artifact "
+                "(manifest, canonical_md, or chunk_index_jsonl). "
+                "Pass --output to specify a safe destination."
+            ],
+            bundle_run_id=bundle_run_id,
+        )
 
     # --- iterate rows and collect ---
     output_lines: List[str] = []
@@ -644,27 +713,32 @@ def produce_citation_map(
 
     citation_id_count = len(seen_citation_ids)
 
-    # --- write output ---
+    # --- write output only when there are no errors (H1) ---
+    # A partial output on a failed run would be silently mistaken for a valid one.
     output_sha256: Optional[str] = None
     output_bytes_count: Optional[int] = None
+    written_output_path: Optional[str] = None
 
-    if output_lines:
-        ndjson_content = "\n".join(output_lines) + "\n"
-        ndjson_bytes = ndjson_content.encode("utf-8")
-        try:
-            output_path.write_bytes(ndjson_bytes)
-        except OSError as e:
-            return _fail_report(
-                production_run_id,
-                bundle_manifest_path_str,
-                errors + [f"Cannot write output: {e}"],
-                bundle_run_id=bundle_run_id,
-                error_kind="path_read_error",
-            )
-        output_sha256 = _sha256_bytes(ndjson_bytes)
-        output_bytes_count = len(ndjson_bytes)
-
-    status = "ok" if not errors else "fail"
+    if errors:
+        status = "fail"
+    else:
+        status = "ok"
+        if output_lines:
+            ndjson_content = "\n".join(output_lines) + "\n"
+            ndjson_bytes = ndjson_content.encode("utf-8")
+            try:
+                output_path.write_bytes(ndjson_bytes)
+            except OSError as e:
+                return _fail_report(
+                    production_run_id,
+                    bundle_manifest_path_str,
+                    [f"Cannot write output: {e}"],
+                    bundle_run_id=bundle_run_id,
+                    error_kind="path_read_error",
+                )
+            output_sha256 = _sha256_bytes(ndjson_bytes)
+            output_bytes_count = len(ndjson_bytes)
+            written_output_path = str(output_path)
 
     return {
         "status": status,
@@ -674,7 +748,7 @@ def produce_citation_map(
         "production_run_id": production_run_id,
         "canonical_md_sha256": actual_canonical_sha,
         "chunk_index_sha256": actual_chunk_sha,
-        "output_path": str(output_path),
+        "output_path": written_output_path,
         "output_sha256": output_sha256,
         "output_bytes": output_bytes_count,
         "chunk_count": chunk_count,

--- a/merger/lenskit/core/citation_map.py
+++ b/merger/lenskit/core/citation_map.py
@@ -1,0 +1,690 @@
+"""
+Citation Map Producer for citation_map_jsonl.
+
+Pure functions for loading manifests, normalising chunk-index ranges,
+deriving citation identifiers, verifying byte-range hashes, and
+writing NDJSON output.  IO is isolated to produce_citation_map().
+"""
+import hashlib
+import json
+import re
+import uuid
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional, Tuple
+
+from merger.lenskit.core.citation_id import make_citation_id
+from merger.lenskit.core.path_security import resolve_secure_path
+
+
+_SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
+_WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:")
+_UNC_RE = re.compile(r"^\\\\")
+
+PRODUCED_BY = "citation_map_producer/v1"
+
+
+class CitationMapError(Exception):
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Path helpers (mirror citation_validate.py conventions)
+# ---------------------------------------------------------------------------
+
+def _normalize_relative_path(raw: str, label: str) -> str:
+    if not isinstance(raw, str):
+        raise ValueError(f"{label}: path must be a string")
+    if raw.startswith("/"):
+        raise ValueError(f"{label}: absolute paths are forbidden")
+    if _UNC_RE.match(raw):
+        raise ValueError(f"{label}: UNC paths are forbidden")
+    if raw.startswith("\\"):
+        raise ValueError(f"{label}: Windows rooted paths are forbidden")
+    if _WINDOWS_DRIVE_RE.match(raw):
+        raise ValueError(f"{label}: Windows drive-prefixed paths are forbidden")
+    parts = raw.replace("\\", "/").split("/")
+    if ".." in parts:
+        raise ValueError(f"{label}: path traversal ('..') is forbidden")
+    normalized = [p for p in parts if p not in ("", ".")]
+    if not normalized:
+        raise ValueError(f"{label}: path must not be empty")
+    return "/".join(normalized)
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for buf in iter(lambda: f.read(65536), b""):
+            h.update(buf)
+    return h.hexdigest()
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Manifest helpers
+# ---------------------------------------------------------------------------
+
+def load_manifest(manifest_path: Path) -> Dict[str, Any]:
+    """Load and parse a bundle manifest JSON file."""
+    with manifest_path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def resolve_artifact_by_role(
+    manifest: Dict[str, Any],
+    role: str,
+    manifest_dir: Path,
+) -> Tuple[Dict[str, Any], str, Path]:
+    """
+    Find artifact by role in manifest and resolve its absolute path.
+
+    Returns (artifact_dict, normalized_rel_path, resolved_abs_path).
+    Raises CitationMapError if the role is absent or the path is unsafe.
+    """
+    artifacts = manifest.get("artifacts", [])
+    artifact = next(
+        (a for a in artifacts if isinstance(a, dict) and a.get("role") == role),
+        None,
+    )
+    if artifact is None:
+        raise CitationMapError(f"Manifest has no artifact with role '{role}'")
+
+    raw_path = artifact.get("path", "")
+    try:
+        rel_path = _normalize_relative_path(raw_path, f"{role}.path")
+    except ValueError as e:
+        raise CitationMapError(f"Artifact path rejected for role '{role}': {e}")
+
+    try:
+        abs_path = resolve_secure_path(manifest_dir, rel_path)
+    except ValueError as e:
+        raise CitationMapError(f"Cannot resolve artifact path for role '{role}': {e}")
+
+    if not abs_path.exists():
+        raise CitationMapError(
+            f"Artifact file not found for role '{role}': {abs_path}"
+        )
+
+    return artifact, rel_path, abs_path
+
+
+# ---------------------------------------------------------------------------
+# Range normalisation
+# ---------------------------------------------------------------------------
+
+def normalize_canonical_range(
+    chunk: Dict[str, Any],
+    lineno: int,
+) -> Optional[Dict[str, Any]]:
+    """
+    Return the canonical range dict for a chunk, normalising legacy input.
+
+    Priority:
+      1. chunk["canonical_range"]  if artifact_role == "canonical_md"
+      2. chunk["content_range_ref"] if artifact_role == "canonical_md"
+
+    Returns None when no usable range is found.
+    content_range_ref is legacy-input only; the output always calls the result
+    canonical_range.
+    """
+    cr = chunk.get("canonical_range")
+    if cr is not None:
+        if isinstance(cr, dict) and cr.get("artifact_role") == "canonical_md":
+            return cr
+        # canonical_range present but wrong role — do not silently fall back
+        return None
+
+    crr = chunk.get("content_range_ref")
+    if crr is not None and isinstance(crr, dict):
+        if crr.get("artifact_role") == "canonical_md":
+            return crr
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# repo_id resolution
+# ---------------------------------------------------------------------------
+
+def _first_nonempty_str(value: Any) -> Optional[str]:
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+def resolve_repo_id(
+    chunk: Dict[str, Any],
+    normalized_range: Dict[str, Any],
+    lineno: int,
+) -> Tuple[str, str]:
+    """
+    Resolve repo_id and return (repo_id, source_description).
+
+    Priority (first non-empty wins):
+      1. normalized_range["repo_id"]
+      2. chunk["repo"]
+      3. chunk["search_keys"]["repo_id"]
+
+    Raises CitationMapError when no source provides a value (hard error;
+    derivation from filenames is forbidden).
+    """
+    v = _first_nonempty_str(normalized_range.get("repo_id"))
+    if v:
+        return v, "range.repo_id"
+
+    v = _first_nonempty_str(chunk.get("repo"))
+    if v:
+        return v, "chunk.repo"
+
+    sk = chunk.get("search_keys")
+    if isinstance(sk, dict):
+        v = _first_nonempty_str(sk.get("repo_id"))
+        if v:
+            return v, "search_keys.repo_id"
+
+    raise CitationMapError(
+        f"Line {lineno}: no repo_id source found in chunk "
+        "(range.repo_id, chunk.repo, and search_keys.repo_id all absent or empty)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Byte-range verification
+# ---------------------------------------------------------------------------
+
+def verify_byte_range_hash(
+    canonical_md_bytes: bytes,
+    start_byte: int,
+    end_byte: int,
+    expected_sha256: str,
+    lineno: int,
+) -> str:
+    """
+    Verify the byte slice [start_byte, end_byte) against expected_sha256.
+
+    Returns the actual SHA256 on success.
+    Raises CitationMapError on bounds violation or hash mismatch.
+    """
+    file_size = len(canonical_md_bytes)
+    if start_byte < 0:
+        raise CitationMapError(
+            f"Line {lineno}: start_byte={start_byte} must be >= 0"
+        )
+    if end_byte <= start_byte:
+        raise CitationMapError(
+            f"Line {lineno}: end_byte={end_byte} must be > start_byte={start_byte}"
+        )
+    if end_byte > file_size:
+        raise CitationMapError(
+            f"Line {lineno}: end_byte={end_byte} exceeds file size={file_size}"
+        )
+    actual_sha = _sha256_bytes(canonical_md_bytes[start_byte:end_byte])
+    if actual_sha != expected_sha256:
+        raise CitationMapError(
+            f"Line {lineno}: byte-range SHA256 mismatch: "
+            f"expected={expected_sha256!r} actual={actual_sha!r}"
+        )
+    return actual_sha
+
+
+# ---------------------------------------------------------------------------
+# Row iterator (pure — yields structured results, never writes)
+# ---------------------------------------------------------------------------
+
+class _ChunkResult:
+    __slots__ = ("row", "error", "repo_id_source")
+
+    def __init__(
+        self,
+        row: Optional[Dict[str, Any]],
+        error: Optional[str],
+        repo_id_source: Optional[str],
+    ) -> None:
+        self.row = row
+        self.error = error
+        self.repo_id_source = repo_id_source
+
+
+def iter_chunk_results(
+    chunk_index_path: Path,
+    canonical_md_bytes: bytes,
+    canonical_md_rel: str,
+    canonical_md_sha256: str,
+    run_id: str,
+) -> Iterator[_ChunkResult]:
+    """
+    Yield one _ChunkResult per non-empty line of the chunk index.
+
+    On success: result.row is a schema-valid citation map entry dict.
+    On error:   result.row is None; result.error describes the problem.
+    """
+    snapshot = {
+        "run_id": run_id,
+        "canonical_md_path": canonical_md_rel,
+        "canonical_md_sha256": canonical_md_sha256,
+    }
+
+    with chunk_index_path.open("r", encoding="utf-8") as f:
+        for lineno, raw_line in enumerate(f, start=1):
+            raw_line = raw_line.strip()
+            if not raw_line:
+                continue
+
+            try:
+                chunk = json.loads(raw_line)
+            except json.JSONDecodeError as e:
+                yield _ChunkResult(None, f"Line {lineno}: invalid JSON: {e}", None)
+                continue
+
+            if not isinstance(chunk, dict):
+                yield _ChunkResult(
+                    None, f"Line {lineno}: chunk must be a JSON object", None
+                )
+                continue
+
+            # --- normalise range ---
+            norm_range = normalize_canonical_range(chunk, lineno)
+            if norm_range is None:
+                yield _ChunkResult(
+                    None,
+                    f"Line {lineno}: no valid canonical range found "
+                    "(need canonical_range or content_range_ref with artifact_role='canonical_md')",
+                    None,
+                )
+                continue
+
+            # --- resolve repo_id ---
+            try:
+                repo_id, repo_id_src = resolve_repo_id(chunk, norm_range, lineno)
+            except CitationMapError as e:
+                yield _ChunkResult(None, str(e), None)
+                continue
+
+            # --- validate range fields ---
+            raw_fp = norm_range.get("file_path", "")
+            try:
+                norm_fp = _normalize_relative_path(raw_fp, "range.file_path")
+            except ValueError as e:
+                yield _ChunkResult(
+                    None, f"Line {lineno}: range.file_path rejected: {e}", None
+                )
+                continue
+
+            if norm_fp != canonical_md_rel:
+                yield _ChunkResult(
+                    None,
+                    f"Line {lineno}: range.file_path {raw_fp!r} "
+                    f"(normalized {norm_fp!r}) does not match "
+                    f"manifest canonical_md path {canonical_md_rel!r}",
+                    None,
+                )
+                continue
+
+            start_byte = norm_range.get("start_byte")
+            end_byte = norm_range.get("end_byte")
+            start_line = norm_range.get("start_line")
+            end_line = norm_range.get("end_line")
+            content_sha256 = norm_range.get("content_sha256", "")
+
+            for name, val in (
+                ("start_byte", start_byte),
+                ("end_byte", end_byte),
+                ("start_line", start_line),
+                ("end_line", end_line),
+            ):
+                if isinstance(val, bool) or not isinstance(val, int):
+                    yield _ChunkResult(
+                        None,
+                        f"Line {lineno}: range.{name} must be an int",
+                        None,
+                    )
+                    break
+            else:
+                pass  # all int checks passed — fall through
+
+            # Re-check after the loop (Python does not break out of the enclosing
+            # for-loop so we use a sentinel).
+            if any(
+                isinstance(v, bool) or not isinstance(v, int)
+                for v in (start_byte, end_byte, start_line, end_line)
+            ):
+                continue
+
+            if (
+                not content_sha256
+                or not isinstance(content_sha256, str)
+                or not _SHA256_RE.fullmatch(content_sha256)
+            ):
+                yield _ChunkResult(
+                    None,
+                    f"Line {lineno}: range.content_sha256 is missing or invalid",
+                    None,
+                )
+                continue
+
+            # --- verify byte range hash ---
+            try:
+                actual_sha = verify_byte_range_hash(
+                    canonical_md_bytes,
+                    start_byte,
+                    end_byte,
+                    content_sha256,
+                    lineno,
+                )
+            except CitationMapError as e:
+                yield _ChunkResult(None, str(e), None)
+                continue
+
+            # --- derive citation_id ---
+            try:
+                citation_id = make_citation_id(
+                    canonical_md_sha256, start_byte, end_byte, actual_sha
+                )
+            except (ValueError, TypeError) as e:
+                yield _ChunkResult(
+                    None, f"Line {lineno}: make_citation_id failed: {e}", None
+                )
+                continue
+
+            row: Dict[str, Any] = {
+                "citation_id": citation_id,
+                "repo_id": repo_id,
+                "snapshot": snapshot,
+                "canonical_range": {
+                    "file_path": canonical_md_rel,
+                    "start_byte": start_byte,
+                    "end_byte": end_byte,
+                    "start_line": start_line,
+                    "end_line": end_line,
+                    "content_sha256": actual_sha,
+                },
+                "produced_by": PRODUCED_BY,
+            }
+
+            chunk_id = chunk.get("chunk_id")
+            if chunk_id is not None:
+                row["chunk_id"] = str(chunk_id)
+
+            yield _ChunkResult(row, None, repo_id_src)
+
+
+# ---------------------------------------------------------------------------
+# IO adapter
+# ---------------------------------------------------------------------------
+
+def _default_output_path(manifest_path: Path) -> Path:
+    name = manifest_path.name.replace(
+        ".bundle.manifest.json", ".citation_map.jsonl"
+    )
+    return manifest_path.parent / name
+
+
+def _fail_report(
+    production_run_id: str,
+    manifest_path_str: str,
+    errors: List[str],
+    *,
+    bundle_run_id: Any = None,
+    error_kind: str = "production_error",
+) -> Dict[str, Any]:
+    return {
+        "status": "fail",
+        "error_kind": error_kind,
+        "bundle_manifest_path": manifest_path_str,
+        "bundle_run_id": bundle_run_id,
+        "production_run_id": production_run_id,
+        "canonical_md_sha256": None,
+        "chunk_index_sha256": None,
+        "output_path": None,
+        "output_sha256": None,
+        "output_bytes": None,
+        "chunk_count": 0,
+        "valid_chunk_count": 0,
+        "citation_map_row_count": 0,
+        "citation_id_count": 0,
+        "citation_id_duplicate_count": 0,
+        "repo_id_source": None,
+        "snapshot_source": "bundle_manifest",
+        "errors": errors,
+        "warnings": [],
+        "sample_rows": [],
+    }
+
+
+def produce_citation_map(
+    manifest_path_str: str,
+    output_path_str: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Produce a citation_map_jsonl from a bundle manifest and return a report dict.
+
+    The output NDJSON file is written adjacent to the manifest unless
+    output_path_str is given.  Each line is a schema-valid citation map entry.
+    """
+    production_run_id = str(uuid.uuid4())
+    errors: List[str] = []
+    warnings: List[str] = []
+
+    chunk_count = 0
+    valid_chunk_count = 0
+    citation_id_duplicate_count = 0
+    seen_citation_ids: Dict[str, int] = {}
+    sample_rows: List[Dict[str, Any]] = []
+    repo_id_source: Optional[str] = None
+
+    # --- resolve manifest path ---
+    manifest_path = Path(manifest_path_str)
+    if not manifest_path.is_absolute():
+        manifest_path = Path.cwd() / manifest_path
+    manifest_path = manifest_path.resolve()
+    bundle_manifest_path_str = str(manifest_path)
+
+    if not manifest_path.exists() or not manifest_path.is_file():
+        return _fail_report(
+            production_run_id,
+            bundle_manifest_path_str,
+            [f"Manifest not found or not a file: {manifest_path}"],
+            error_kind="path_read_error",
+        )
+
+    manifest_dir = manifest_path.parent
+
+    # --- load manifest ---
+    try:
+        manifest = load_manifest(manifest_path)
+    except (json.JSONDecodeError, OSError) as e:
+        return _fail_report(
+            production_run_id,
+            bundle_manifest_path_str,
+            [f"Cannot load manifest: {e}"],
+            error_kind="path_read_error",
+        )
+
+    bundle_run_id = manifest.get("run_id")
+
+    # --- resolve canonical_md ---
+    try:
+        canonical_md_art, canonical_md_rel, canonical_md_path = (
+            resolve_artifact_by_role(manifest, "canonical_md", manifest_dir)
+        )
+    except CitationMapError as e:
+        return _fail_report(
+            production_run_id,
+            bundle_manifest_path_str,
+            [str(e)],
+            bundle_run_id=bundle_run_id,
+            error_kind="path_read_error",
+        )
+
+    canonical_md_manifest_sha = canonical_md_art.get("sha256", "")
+
+    # --- resolve chunk_index_jsonl ---
+    try:
+        chunk_index_art, chunk_index_rel, chunk_index_path = (
+            resolve_artifact_by_role(manifest, "chunk_index_jsonl", manifest_dir)
+        )
+    except CitationMapError as e:
+        return _fail_report(
+            production_run_id,
+            bundle_manifest_path_str,
+            [str(e)],
+            bundle_run_id=bundle_run_id,
+            error_kind="path_read_error",
+        )
+
+    chunk_index_manifest_sha = chunk_index_art.get("sha256", "")
+
+    # --- verify SHAs ---
+    try:
+        actual_canonical_sha = _sha256_file(canonical_md_path)
+    except OSError as e:
+        return _fail_report(
+            production_run_id,
+            bundle_manifest_path_str,
+            [f"Cannot read canonical_md: {e}"],
+            bundle_run_id=bundle_run_id,
+            error_kind="path_read_error",
+        )
+
+    if actual_canonical_sha != canonical_md_manifest_sha:
+        return _fail_report(
+            production_run_id,
+            bundle_manifest_path_str,
+            [
+                f"canonical_md SHA256 mismatch: "
+                f"manifest={canonical_md_manifest_sha!r} actual={actual_canonical_sha!r}"
+            ],
+            bundle_run_id=bundle_run_id,
+        )
+
+    try:
+        actual_chunk_sha = _sha256_file(chunk_index_path)
+    except OSError as e:
+        return _fail_report(
+            production_run_id,
+            bundle_manifest_path_str,
+            [f"Cannot read chunk_index_jsonl: {e}"],
+            bundle_run_id=bundle_run_id,
+            error_kind="path_read_error",
+        )
+
+    if actual_chunk_sha != chunk_index_manifest_sha:
+        return _fail_report(
+            production_run_id,
+            bundle_manifest_path_str,
+            [
+                f"chunk_index_jsonl SHA256 mismatch: "
+                f"manifest={chunk_index_manifest_sha!r} actual={actual_chunk_sha!r}"
+            ],
+            bundle_run_id=bundle_run_id,
+        )
+
+    # --- read canonical_md bytes ---
+    try:
+        canonical_md_bytes = canonical_md_path.read_bytes()
+    except OSError as e:
+        return _fail_report(
+            production_run_id,
+            bundle_manifest_path_str,
+            [f"Cannot read canonical_md bytes: {e}"],
+            bundle_run_id=bundle_run_id,
+            error_kind="path_read_error",
+        )
+
+    # --- determine output path ---
+    if output_path_str:
+        output_path = Path(output_path_str)
+        if not output_path.is_absolute():
+            output_path = Path.cwd() / output_path
+    else:
+        output_path = _default_output_path(manifest_path)
+
+    # --- iterate rows and collect ---
+    output_lines: List[str] = []
+
+    for result in iter_chunk_results(
+        chunk_index_path,
+        canonical_md_bytes,
+        canonical_md_rel,
+        actual_canonical_sha,
+        bundle_run_id or "",
+    ):
+        chunk_count += 1
+
+        if result.error is not None:
+            errors.append(result.error)
+            continue
+
+        row = result.row
+
+        # Track repo_id_source from first valid chunk
+        if repo_id_source is None and result.repo_id_source is not None:
+            repo_id_source = result.repo_id_source
+
+        citation_id = row["citation_id"]
+
+        if citation_id in seen_citation_ids:
+            citation_id_duplicate_count += 1
+            errors.append(
+                f"duplicate citation_id {citation_id!r} "
+                f"(first at row {seen_citation_ids[citation_id]})"
+            )
+            continue
+
+        seen_citation_ids[citation_id] = valid_chunk_count + 1
+        valid_chunk_count += 1
+
+        if len(sample_rows) < 3:
+            sample_rows.append(row)
+
+        output_lines.append(json.dumps(row, ensure_ascii=False))
+
+    citation_id_count = len(seen_citation_ids)
+
+    # --- write output ---
+    output_sha256: Optional[str] = None
+    output_bytes_count: Optional[int] = None
+
+    if output_lines:
+        ndjson_content = "\n".join(output_lines) + "\n"
+        ndjson_bytes = ndjson_content.encode("utf-8")
+        try:
+            output_path.write_bytes(ndjson_bytes)
+        except OSError as e:
+            return _fail_report(
+                production_run_id,
+                bundle_manifest_path_str,
+                errors + [f"Cannot write output: {e}"],
+                bundle_run_id=bundle_run_id,
+                error_kind="path_read_error",
+            )
+        output_sha256 = _sha256_bytes(ndjson_bytes)
+        output_bytes_count = len(ndjson_bytes)
+
+    status = "ok" if not errors else "fail"
+
+    return {
+        "status": status,
+        "error_kind": "ok" if status == "ok" else "production_error",
+        "bundle_manifest_path": bundle_manifest_path_str,
+        "bundle_run_id": bundle_run_id,
+        "production_run_id": production_run_id,
+        "canonical_md_sha256": actual_canonical_sha,
+        "chunk_index_sha256": actual_chunk_sha,
+        "output_path": str(output_path),
+        "output_sha256": output_sha256,
+        "output_bytes": output_bytes_count,
+        "chunk_count": chunk_count,
+        "valid_chunk_count": valid_chunk_count,
+        "citation_map_row_count": len(output_lines),
+        "citation_id_count": citation_id_count,
+        "citation_id_duplicate_count": citation_id_duplicate_count,
+        "repo_id_source": repo_id_source,
+        "snapshot_source": "bundle_manifest",
+        "errors": errors,
+        "warnings": warnings,
+        "sample_rows": sample_rows,
+    }

--- a/merger/lenskit/core/merge.py
+++ b/merger/lenskit/core/merge.py
@@ -5826,6 +5826,7 @@ def write_reports_v2(
         ArtifactRole.RETRIEVAL_EVAL_JSON: {"id": "retrieval-eval", "version": "v1"},
         ArtifactRole.GRAPH_INDEX_JSON: {"id": "architecture.graph_index", "version": "v1"},
         ArtifactRole.PR_DELTA_JSON: {"id": "pr-schau-delta", "version": "1.0"},
+        ArtifactRole.CITATION_MAP_JSONL: {"id": "citation-map", "version": "v1"},
     }
 
     # Authority/canonicality mapping (bundle-manifest.v1, optional fields).
@@ -5881,6 +5882,12 @@ def write_reports_v2(
         },
         ArtifactRole.GRAPH_INDEX_JSON: {
             "authority": "retrieval_index",
+            "canonicality": "derived",
+            "regenerable": True,
+            "staleness_sensitive": True,
+        },
+        ArtifactRole.CITATION_MAP_JSONL: {
+            "authority": "navigation_index",
             "canonicality": "derived",
             "regenerable": True,
             "staleness_sensitive": True,

--- a/merger/lenskit/core/merge.py
+++ b/merger/lenskit/core/merge.py
@@ -184,6 +184,79 @@ DEBUG_CONFIG = DebugConfig.defaults()
 AGENT_CONTRACT_NAME = "repolens-agent"
 AGENT_CONTRACT_VERSION = "v2"
 
+# Module-level registries so tests can import them without calling write_reports_v2.
+# write_reports_v2 references these via local aliases (CONTRACT_REGISTRY / AUTHORITY_REGISTRY).
+ARTIFACT_CONTRACT_REGISTRY = {
+    ArtifactRole.INDEX_SIDECAR_JSON: {"id": AGENT_CONTRACT_NAME, "version": AGENT_CONTRACT_VERSION},
+    ArtifactRole.RETRIEVAL_EVAL_JSON: {"id": "retrieval-eval", "version": "v1"},
+    ArtifactRole.GRAPH_INDEX_JSON: {"id": "architecture.graph_index", "version": "v1"},
+    ArtifactRole.PR_DELTA_JSON: {"id": "pr-schau-delta", "version": "1.0"},
+    ArtifactRole.CITATION_MAP_JSONL: {"id": "citation-map", "version": "v1"},
+}
+
+ARTIFACT_AUTHORITY_REGISTRY = {
+    ArtifactRole.CANONICAL_MD: {
+        "authority": "canonical_content",
+        "canonicality": "content_source",
+        "regenerable": True,
+        "staleness_sensitive": False,
+    },
+    ArtifactRole.INDEX_SIDECAR_JSON: {
+        "authority": "navigation_index",
+        "canonicality": "index_only",
+        "regenerable": True,
+        "staleness_sensitive": True,
+    },
+    ArtifactRole.DUMP_INDEX_JSON: {
+        "authority": "navigation_index",
+        "canonicality": "index_only",
+        "regenerable": True,
+        "staleness_sensitive": True,
+    },
+    ArtifactRole.DERIVED_MANIFEST_JSON: {
+        "authority": "navigation_index",
+        "canonicality": "derived",
+        "regenerable": True,
+        "staleness_sensitive": True,
+    },
+    ArtifactRole.CHUNK_INDEX_JSONL: {
+        "authority": "retrieval_index",
+        "canonicality": "derived",
+        "regenerable": True,
+        "staleness_sensitive": True,
+    },
+    ArtifactRole.SQLITE_INDEX: {
+        "authority": "runtime_cache",
+        "canonicality": "cache",
+        "regenerable": True,
+        "staleness_sensitive": True,
+    },
+    ArtifactRole.RETRIEVAL_EVAL_JSON: {
+        "authority": "diagnostic_signal",
+        "canonicality": "diagnostic",
+        "regenerable": True,
+        "staleness_sensitive": True,
+    },
+    ArtifactRole.OUTPUT_HEALTH: {
+        "authority": "diagnostic_signal",
+        "canonicality": "diagnostic",
+        "regenerable": True,
+        "staleness_sensitive": True,
+    },
+    ArtifactRole.GRAPH_INDEX_JSON: {
+        "authority": "retrieval_index",
+        "canonicality": "derived",
+        "regenerable": True,
+        "staleness_sensitive": True,
+    },
+    ArtifactRole.CITATION_MAP_JSONL: {
+        "authority": "navigation_index",
+        "canonicality": "derived",
+        "regenerable": True,
+        "staleness_sensitive": True,
+    },
+}
+
 # Delta Report configuration
 MAX_DELTA_FILES = 10  # Maximum number of files to show in each delta section
 
@@ -5820,79 +5893,9 @@ def write_reports_v2(
         meta_none=meta_none,
         ).with_suffix(".bundle.manifest.json")
 
-    # Contract mappings for structured roles to support deterministic downstream interpretation.
-    CONTRACT_REGISTRY = {
-        ArtifactRole.INDEX_SIDECAR_JSON: {"id": AGENT_CONTRACT_NAME, "version": AGENT_CONTRACT_VERSION},
-        ArtifactRole.RETRIEVAL_EVAL_JSON: {"id": "retrieval-eval", "version": "v1"},
-        ArtifactRole.GRAPH_INDEX_JSON: {"id": "architecture.graph_index", "version": "v1"},
-        ArtifactRole.PR_DELTA_JSON: {"id": "pr-schau-delta", "version": "1.0"},
-        ArtifactRole.CITATION_MAP_JSONL: {"id": "citation-map", "version": "v1"},
-    }
-
-    # Authority/canonicality mapping (bundle-manifest.v1, optional fields).
-    # Roles not present here remain unannotated for now (Phase 1 scope).
-    AUTHORITY_REGISTRY = {
-        ArtifactRole.CANONICAL_MD: {
-            "authority": "canonical_content",
-            "canonicality": "content_source",
-            "regenerable": True,
-            "staleness_sensitive": False,
-        },
-        ArtifactRole.INDEX_SIDECAR_JSON: {
-            "authority": "navigation_index",
-            "canonicality": "index_only",
-            "regenerable": True,
-            "staleness_sensitive": True,
-        },
-        ArtifactRole.DUMP_INDEX_JSON: {
-            "authority": "navigation_index",
-            "canonicality": "index_only",
-            "regenerable": True,
-            "staleness_sensitive": True,
-        },
-        ArtifactRole.DERIVED_MANIFEST_JSON: {
-            "authority": "navigation_index",
-            "canonicality": "derived",
-            "regenerable": True,
-            "staleness_sensitive": True,
-        },
-        ArtifactRole.CHUNK_INDEX_JSONL: {
-            "authority": "retrieval_index",
-            "canonicality": "derived",
-            "regenerable": True,
-            "staleness_sensitive": True,
-        },
-        ArtifactRole.SQLITE_INDEX: {
-            "authority": "runtime_cache",
-            "canonicality": "cache",
-            "regenerable": True,
-            "staleness_sensitive": True,
-        },
-        ArtifactRole.RETRIEVAL_EVAL_JSON: {
-            "authority": "diagnostic_signal",
-            "canonicality": "diagnostic",
-            "regenerable": True,
-            "staleness_sensitive": True,
-        },
-        ArtifactRole.OUTPUT_HEALTH: {
-            "authority": "diagnostic_signal",
-            "canonicality": "diagnostic",
-            "regenerable": True,
-            "staleness_sensitive": True,
-        },
-        ArtifactRole.GRAPH_INDEX_JSON: {
-            "authority": "retrieval_index",
-            "canonicality": "derived",
-            "regenerable": True,
-            "staleness_sensitive": True,
-        },
-        ArtifactRole.CITATION_MAP_JSONL: {
-            "authority": "navigation_index",
-            "canonicality": "derived",
-            "regenerable": True,
-            "staleness_sensitive": True,
-        },
-    }
+    # Aliases into module-level registries (ARTIFACT_CONTRACT_REGISTRY / ARTIFACT_AUTHORITY_REGISTRY).
+    CONTRACT_REGISTRY = ARTIFACT_CONTRACT_REGISTRY
+    AUTHORITY_REGISTRY = ARTIFACT_AUTHORITY_REGISTRY
 
     artifacts_list = []
     def _add_artifact(p: Optional[Path], role: ArtifactRole, content_type: str):

--- a/merger/lenskit/tests/test_citation_map_producer.py
+++ b/merger/lenskit/tests/test_citation_map_producer.py
@@ -766,6 +766,7 @@ class TestNoPartialOutputOnErrors:
         assert not expected_output.exists(), "Partial output must not be written on failure"
         assert report["output_path"] is None
         assert report["output_sha256"] is None
+        assert report["citation_map_row_count"] == 0, "No rows written means count must be 0"
 
     def test_no_output_on_duplicate_citation_id(self, tmp_path):
         content = b"Duplicate test content XYZ"

--- a/merger/lenskit/tests/test_citation_map_producer.py
+++ b/merger/lenskit/tests/test_citation_map_producer.py
@@ -7,7 +7,7 @@ is in docs/proofs/citation-map-producer-proof.md.
 import hashlib
 import json
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import pytest
 
@@ -39,8 +39,8 @@ def _make_bundle(
     canonical_content: bytes,
     chunks: List[Dict[str, Any]],
     *,
-    canonical_sha_override: str = None,
-    chunk_index_sha_override: str = None,
+    canonical_sha_override: Optional[str] = None,
+    chunk_index_sha_override: Optional[str] = None,
     stem: str = "test_merge",
 ) -> Path:
     canonical_md_path = tmp_path / f"{stem}.md"
@@ -158,26 +158,26 @@ class TestNormalizeCanonicalRange:
         canonical = {"artifact_role": "canonical_md", "file_path": "a.md", "start_byte": 0, "end_byte": 10}
         fallback = {"artifact_role": "canonical_md", "file_path": "b.md", "start_byte": 0, "end_byte": 10}
         chunk = {"canonical_range": canonical, "content_range_ref": fallback}
-        result = normalize_canonical_range(chunk, lineno=1)
+        result = normalize_canonical_range(chunk)
         assert result is canonical
 
     def test_falls_back_to_content_range_ref_when_no_canonical_range(self):
         fallback = {"artifact_role": "canonical_md", "file_path": "a.md"}
         chunk = {"content_range_ref": fallback}
-        result = normalize_canonical_range(chunk, lineno=1)
+        result = normalize_canonical_range(chunk)
         assert result is fallback
 
     def test_returns_none_when_neither_present(self):
         chunk = {"chunk_id": "x"}
-        assert normalize_canonical_range(chunk, lineno=1) is None
+        assert normalize_canonical_range(chunk) is None
 
     def test_returns_none_when_canonical_range_wrong_role(self):
         chunk = {"canonical_range": {"artifact_role": "source_file", "file_path": "x"}}
-        assert normalize_canonical_range(chunk, lineno=1) is None
+        assert normalize_canonical_range(chunk) is None
 
     def test_returns_none_when_content_range_ref_wrong_role(self):
         chunk = {"content_range_ref": {"artifact_role": "index_sidecar_json", "file_path": "x"}}
-        assert normalize_canonical_range(chunk, lineno=1) is None
+        assert normalize_canonical_range(chunk) is None
 
     def test_does_not_fall_back_when_canonical_range_wrong_role(self):
         # canonical_range with wrong role should NOT fall back to content_range_ref
@@ -185,7 +185,7 @@ class TestNormalizeCanonicalRange:
             "canonical_range": {"artifact_role": "source_file"},
             "content_range_ref": {"artifact_role": "canonical_md", "file_path": "a.md"},
         }
-        assert normalize_canonical_range(chunk, lineno=1) is None
+        assert normalize_canonical_range(chunk) is None
 
     def test_content_range_ref_fallback_with_all_fields(self):
         crr = {
@@ -198,7 +198,7 @@ class TestNormalizeCanonicalRange:
             "content_sha256": "a" * 64,
         }
         chunk = {"content_range_ref": crr}
-        result = normalize_canonical_range(chunk, lineno=1)
+        result = normalize_canonical_range(chunk)
         assert result["start_byte"] == 10
         assert result["end_byte"] == 20
 
@@ -733,6 +733,119 @@ class TestManifestWiring:
 
         assert actual_sha == report["output_sha256"]
         assert report["output_bytes"] == len(output_bytes)
+
+
+# ---------------------------------------------------------------------------
+# A: Zero-row run writes empty artifact
+# ---------------------------------------------------------------------------
+
+class TestEmptyChunkIndex:
+    def test_empty_chunk_index_writes_empty_file(self, tmp_path):
+        content = b"some canonical content"
+        manifest_path = _make_bundle(tmp_path, content, [])
+        report = produce_citation_map(str(manifest_path))
+
+        assert report["status"] == "ok", report["errors"]
+        assert report["citation_map_row_count"] == 0
+        assert report["chunk_count"] == 0
+        assert report["output_bytes"] == 0
+        assert report["output_sha256"] == _sha256(b"")
+        assert report["output_path"] is not None
+        assert Path(report["output_path"]).exists()
+        assert Path(report["output_path"]).read_bytes() == b""
+
+    def test_blank_lines_only_chunk_index_writes_empty_file(self, tmp_path):
+        content = b"canonical content"
+        # Build a manifest but then overwrite chunk_index with blank lines only
+        manifest_path = _make_bundle(tmp_path, content, [])
+        # Rewrite chunk_index with whitespace lines and update manifest SHA
+        chunk_index_path = tmp_path / "test_merge.chunk_index.jsonl"
+        blank_bytes = b"\n\n   \n"
+        chunk_index_path.write_bytes(blank_bytes)
+
+        # Update manifest so SHA matches
+        manifest = json.loads((tmp_path / "test_merge.bundle.manifest.json").read_text())
+        for art in manifest["artifacts"]:
+            if art["role"] == "chunk_index_jsonl":
+                art["sha256"] = _sha256(blank_bytes)
+                art["bytes"] = len(blank_bytes)
+        (tmp_path / "test_merge.bundle.manifest.json").write_text(json.dumps(manifest))
+
+        report = produce_citation_map(str(manifest_path))
+
+        assert report["status"] == "ok", report["errors"]
+        assert report["citation_map_row_count"] == 0
+        assert report["output_bytes"] == 0
+        assert report["output_sha256"] == _sha256(b"")
+        assert Path(report["output_path"]).read_bytes() == b""
+
+
+# ---------------------------------------------------------------------------
+# B: Stale output removed on fail rerun
+# ---------------------------------------------------------------------------
+
+class TestStaleOutputCleanup:
+    def test_stale_output_removed_on_fail_rerun(self, tmp_path):
+        content = b"Valid content for first run\nSecond line here\n"
+        valid_chunk = _canonical_range_chunk(content, 0, 5, "test_merge.md", chunk_id="c1")
+
+        # First run: success — output file is created
+        manifest_path = _make_bundle(tmp_path, content, [valid_chunk])
+        report1 = produce_citation_map(str(manifest_path))
+        assert report1["status"] == "ok", report1["errors"]
+        output_path = Path(report1["output_path"])
+        assert output_path.exists()
+
+        # Modify chunk_index to introduce an error (bad SHA), keeping manifest consistent
+        bad_sha = "b" * 64
+        invalid_chunk = {
+            "chunk_id": "c2",
+            "repo": "testrepo",
+            "canonical_range": {
+                "artifact_role": "canonical_md",
+                "file_path": "test_merge.md",
+                "start_byte": 6,
+                "end_byte": 11,
+                "content_sha256": bad_sha,
+            },
+        }
+        chunk_lines = json.dumps(invalid_chunk) + "\n"
+        chunk_index_bytes = chunk_lines.encode("utf-8")
+        (tmp_path / "test_merge.chunk_index.jsonl").write_bytes(chunk_index_bytes)
+
+        # Update manifest SHA to match new chunk_index
+        manifest = json.loads((tmp_path / "test_merge.bundle.manifest.json").read_text())
+        for art in manifest["artifacts"]:
+            if art["role"] == "chunk_index_jsonl":
+                art["sha256"] = _sha256(chunk_index_bytes)
+                art["bytes"] = len(chunk_index_bytes)
+        (tmp_path / "test_merge.bundle.manifest.json").write_text(json.dumps(manifest))
+
+        # Second run: fail — stale output must be removed
+        report2 = produce_citation_map(str(manifest_path))
+        assert report2["status"] == "fail"
+        assert report2["output_path"] is None
+        assert report2["citation_map_row_count"] == 0
+        assert not output_path.exists(), "Stale output from first run must be removed"
+
+
+# ---------------------------------------------------------------------------
+# D: snapshot_source precision
+# ---------------------------------------------------------------------------
+
+class TestSnapshotSource:
+    def test_snapshot_source_none_on_missing_manifest(self, tmp_path):
+        report = produce_citation_map(str(tmp_path / "nonexistent.bundle.manifest.json"))
+        assert report["status"] == "fail"
+        assert report["snapshot_source"] is None
+
+    def test_snapshot_source_bundle_manifest_on_success(self, tmp_path):
+        content = b"snapshot source test"
+        chunk = _canonical_range_chunk(content, 0, 7, "test_merge.md")
+        manifest_path = _make_bundle(tmp_path, content, [chunk])
+        report = produce_citation_map(str(manifest_path))
+        assert report["status"] == "ok", report["errors"]
+        assert report["snapshot_source"] == "bundle_manifest"
 
 
 # ---------------------------------------------------------------------------

--- a/merger/lenskit/tests/test_citation_map_producer.py
+++ b/merger/lenskit/tests/test_citation_map_producer.py
@@ -1093,3 +1093,41 @@ class TestRunIdValidation:
         manifest_path = self._make_bundle_no_run_id(tmp_path, content, [chunk], "valid-run-123")
         report = produce_citation_map(str(manifest_path))
         assert report["status"] == "ok", report["errors"]
+
+
+# ---------------------------------------------------------------------------
+# Explicit --output protection before artifact resolution
+# ---------------------------------------------------------------------------
+
+class TestExplicitOutputProtectionBeforeArtifactResolution:
+    def test_bad_run_id_does_not_delete_explicit_output(self, tmp_path):
+        """Explicit --output must survive early fail before artifact paths are in protected_paths."""
+        canonical_md = tmp_path / "test_merge.md"
+        canonical_md.write_bytes(b"canonical content\n")
+        chunk_index = tmp_path / "test_merge.chunk_index.jsonl"
+        chunk_index.write_bytes(b"")
+
+        manifest = {
+            "run_id": "",  # triggers early fail before canonical_md is resolved
+            "artifacts": [
+                {
+                    "role": "canonical_md",
+                    "path": "test_merge.md",
+                    "sha256": _sha256(b"canonical content\n"),
+                },
+                {
+                    "role": "chunk_index_jsonl",
+                    "path": "test_merge.chunk_index.jsonl",
+                    "sha256": _sha256(b""),
+                },
+            ],
+        }
+        manifest_path = tmp_path / "test_merge.bundle.manifest.json"
+        manifest_path.write_text(json.dumps(manifest))
+
+        report = produce_citation_map(str(manifest_path), output_path_str=str(canonical_md))
+        assert report["status"] == "fail"
+        assert any("run_id" in e for e in report["errors"])
+        assert canonical_md.exists(), (
+            "Explicit --output must not be deleted before artifact protection is complete"
+        )

--- a/merger/lenskit/tests/test_citation_map_producer.py
+++ b/merger/lenskit/tests/test_citation_map_producer.py
@@ -1,0 +1,613 @@
+"""
+Tests for merger.lenskit.core.citation_map (Citation Map Producer).
+
+All unit tests use synthetic in-memory fixtures; the real-dump proof
+is in docs/proofs/citation-map-producer-proof.md.
+"""
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+from merger.lenskit.core.citation_id import make_citation_id
+from merger.lenskit.core.citation_map import (
+    CitationMapError,
+    PRODUCED_BY,
+    iter_chunk_results,
+    normalize_canonical_range,
+    produce_citation_map,
+    resolve_artifact_by_role,
+    resolve_repo_id,
+    verify_byte_range_hash,
+)
+from merger.lenskit.core.constants import ArtifactRole
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _make_bundle(
+    tmp_path: Path,
+    canonical_content: bytes,
+    chunks: List[Dict[str, Any]],
+    *,
+    canonical_sha_override: str = None,
+    chunk_index_sha_override: str = None,
+    stem: str = "test_merge",
+) -> Path:
+    canonical_md_path = tmp_path / f"{stem}.md"
+    canonical_md_path.write_bytes(canonical_content)
+
+    chunk_lines = "\n".join(json.dumps(c) for c in chunks) + "\n"
+    chunk_index_bytes = chunk_lines.encode("utf-8")
+    chunk_index_path = tmp_path / f"{stem}.chunk_index.jsonl"
+    chunk_index_path.write_bytes(chunk_index_bytes)
+
+    actual_canonical_sha = _sha256(canonical_content)
+    actual_chunk_sha = _sha256(chunk_index_bytes)
+
+    manifest = {
+        "kind": "repolens.bundle.manifest",
+        "version": "1.0",
+        "run_id": "test-run-001",
+        "created_at": "2026-05-14T00:00:00Z",
+        "generator": {
+            "name": "test",
+            "version": "0.0.1",
+            "config_sha256": "a" * 64,
+        },
+        "artifacts": [
+            {
+                "role": "canonical_md",
+                "path": f"{stem}.md",
+                "content_type": "text/markdown",
+                "bytes": len(canonical_content),
+                "sha256": canonical_sha_override or actual_canonical_sha,
+                "authority": "canonical_content",
+                "canonicality": "content_source",
+                "regenerable": True,
+                "staleness_sensitive": False,
+                "interpretation": {"mode": "role_only"},
+            },
+            {
+                "role": "chunk_index_jsonl",
+                "path": f"{stem}.chunk_index.jsonl",
+                "content_type": "application/x-ndjson",
+                "bytes": len(chunk_index_bytes),
+                "sha256": chunk_index_sha_override or actual_chunk_sha,
+                "authority": "retrieval_index",
+                "canonicality": "derived",
+                "regenerable": True,
+                "staleness_sensitive": True,
+                "interpretation": {"mode": "role_only"},
+            },
+        ],
+        "links": {},
+        "capabilities": {"fts5_bm25": False, "redaction": False},
+    }
+
+    manifest_path = tmp_path / f"{stem}.bundle.manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    return manifest_path
+
+
+def _canonical_range_chunk(
+    canonical_content: bytes,
+    start_byte: int,
+    end_byte: int,
+    md_path: str,
+    repo_id: str = "testrepo",
+    chunk_id: str = "chunk001",
+) -> Dict[str, Any]:
+    content_sha = _sha256(canonical_content[start_byte:end_byte])
+    return {
+        "chunk_id": chunk_id,
+        "repo": repo_id,
+        "canonical_range": {
+            "artifact_role": "canonical_md",
+            "repo_id": repo_id,
+            "file_path": md_path,
+            "start_byte": start_byte,
+            "end_byte": end_byte,
+            "start_line": 1,
+            "end_line": 2,
+            "content_sha256": content_sha,
+        },
+    }
+
+
+def _content_range_ref_chunk(
+    canonical_content: bytes,
+    start_byte: int,
+    end_byte: int,
+    md_path: str,
+    repo_id: str = "testrepo",
+    chunk_id: str = "chunk001",
+) -> Dict[str, Any]:
+    content_sha = _sha256(canonical_content[start_byte:end_byte])
+    return {
+        "chunk_id": chunk_id,
+        "repo": repo_id,
+        "content_range_ref": {
+            "artifact_role": "canonical_md",
+            "repo_id": repo_id,
+            "file_path": md_path,
+            "start_byte": start_byte,
+            "end_byte": end_byte,
+            "start_line": 1,
+            "end_line": 2,
+            "content_sha256": content_sha,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# normalize_canonical_range
+# ---------------------------------------------------------------------------
+
+class TestNormalizeCanonicalRange:
+    def test_prefers_canonical_range_when_present(self):
+        canonical = {"artifact_role": "canonical_md", "file_path": "a.md", "start_byte": 0, "end_byte": 10}
+        fallback = {"artifact_role": "canonical_md", "file_path": "b.md", "start_byte": 0, "end_byte": 10}
+        chunk = {"canonical_range": canonical, "content_range_ref": fallback}
+        result = normalize_canonical_range(chunk, lineno=1)
+        assert result is canonical
+
+    def test_falls_back_to_content_range_ref_when_no_canonical_range(self):
+        fallback = {"artifact_role": "canonical_md", "file_path": "a.md"}
+        chunk = {"content_range_ref": fallback}
+        result = normalize_canonical_range(chunk, lineno=1)
+        assert result is fallback
+
+    def test_returns_none_when_neither_present(self):
+        chunk = {"chunk_id": "x"}
+        assert normalize_canonical_range(chunk, lineno=1) is None
+
+    def test_returns_none_when_canonical_range_wrong_role(self):
+        chunk = {"canonical_range": {"artifact_role": "source_file", "file_path": "x"}}
+        assert normalize_canonical_range(chunk, lineno=1) is None
+
+    def test_returns_none_when_content_range_ref_wrong_role(self):
+        chunk = {"content_range_ref": {"artifact_role": "index_sidecar_json", "file_path": "x"}}
+        assert normalize_canonical_range(chunk, lineno=1) is None
+
+    def test_does_not_fall_back_when_canonical_range_wrong_role(self):
+        # canonical_range with wrong role should NOT fall back to content_range_ref
+        chunk = {
+            "canonical_range": {"artifact_role": "source_file"},
+            "content_range_ref": {"artifact_role": "canonical_md", "file_path": "a.md"},
+        }
+        assert normalize_canonical_range(chunk, lineno=1) is None
+
+    def test_content_range_ref_fallback_with_all_fields(self):
+        crr = {
+            "artifact_role": "canonical_md",
+            "file_path": "merge.md",
+            "start_byte": 10,
+            "end_byte": 20,
+            "start_line": 1,
+            "end_line": 1,
+            "content_sha256": "a" * 64,
+        }
+        chunk = {"content_range_ref": crr}
+        result = normalize_canonical_range(chunk, lineno=1)
+        assert result["start_byte"] == 10
+        assert result["end_byte"] == 20
+
+
+# ---------------------------------------------------------------------------
+# resolve_repo_id
+# ---------------------------------------------------------------------------
+
+class TestResolveRepoId:
+    def test_prefers_range_repo_id(self):
+        norm_range = {"repo_id": "from_range", "file_path": "x"}
+        chunk = {"repo": "from_chunk"}
+        repo_id, src = resolve_repo_id(chunk, norm_range, lineno=1)
+        assert repo_id == "from_range"
+        assert src == "range.repo_id"
+
+    def test_falls_back_to_chunk_repo(self):
+        norm_range = {"file_path": "x"}
+        chunk = {"repo": "from_chunk"}
+        repo_id, src = resolve_repo_id(chunk, norm_range, lineno=1)
+        assert repo_id == "from_chunk"
+        assert src == "chunk.repo"
+
+    def test_falls_back_to_search_keys_repo_id(self):
+        norm_range = {"file_path": "x"}
+        chunk = {"search_keys": {"repo_id": "from_sk"}}
+        repo_id, src = resolve_repo_id(chunk, norm_range, lineno=1)
+        assert repo_id == "from_sk"
+        assert src == "search_keys.repo_id"
+
+    def test_raises_when_no_source(self):
+        norm_range = {"file_path": "x"}
+        chunk = {}
+        with pytest.raises(CitationMapError, match="no repo_id source"):
+            resolve_repo_id(chunk, norm_range, lineno=1)
+
+    def test_range_repo_id_beats_chunk_repo_without_error(self):
+        # Different values across priority levels — the higher-priority one wins silently
+        norm_range = {"repo_id": "repo_a"}
+        chunk = {"repo": "repo_b"}
+        repo_id, src = resolve_repo_id(chunk, norm_range, lineno=5)
+        assert repo_id == "repo_a"
+        assert src == "range.repo_id"
+
+    def test_no_ambiguity_when_values_agree(self):
+        norm_range = {"repo_id": "lenskit"}
+        chunk = {"repo": "lenskit", "search_keys": {"repo_id": "lenskit"}}
+        repo_id, src = resolve_repo_id(chunk, norm_range, lineno=1)
+        assert repo_id == "lenskit"
+        assert src == "range.repo_id"
+
+    def test_ignores_empty_string_sources(self):
+        norm_range = {"repo_id": ""}
+        chunk = {"repo": "lenskit"}
+        repo_id, src = resolve_repo_id(chunk, norm_range, lineno=1)
+        assert repo_id == "lenskit"
+        assert src == "chunk.repo"
+
+
+# ---------------------------------------------------------------------------
+# verify_byte_range_hash
+# ---------------------------------------------------------------------------
+
+class TestVerifyByteRangeHash:
+    def test_valid_range(self):
+        content = b"hello world"
+        sha = _sha256(content[0:5])
+        actual = verify_byte_range_hash(content, 0, 5, sha, lineno=1)
+        assert actual == sha
+
+    def test_mismatch_raises(self):
+        content = b"hello world"
+        with pytest.raises(CitationMapError, match="SHA256 mismatch"):
+            verify_byte_range_hash(content, 0, 5, "a" * 64, lineno=1)
+
+    def test_end_exceeds_size_raises(self):
+        content = b"abc"
+        sha = _sha256(content)
+        with pytest.raises(CitationMapError, match="exceeds file size"):
+            verify_byte_range_hash(content, 0, 100, sha, lineno=1)
+
+    def test_end_lte_start_raises(self):
+        content = b"abc"
+        with pytest.raises(CitationMapError, match="end_byte"):
+            verify_byte_range_hash(content, 5, 3, "a" * 64, lineno=1)
+
+    def test_negative_start_raises(self):
+        content = b"abc"
+        with pytest.raises(CitationMapError, match="start_byte"):
+            verify_byte_range_hash(content, -1, 2, "a" * 64, lineno=1)
+
+
+# ---------------------------------------------------------------------------
+# snapshot derivation from manifest
+# ---------------------------------------------------------------------------
+
+class TestSnapshotFromManifest:
+    def test_snapshot_fields_come_from_manifest(self, tmp_path):
+        content = b"Hello snapshot world"
+        chunk = _canonical_range_chunk(content, 0, 5, "test_merge.md")
+        manifest_path = _make_bundle(tmp_path, content, [chunk])
+
+        report = produce_citation_map(str(manifest_path))
+        assert report["status"] == "ok", report["errors"]
+
+        row = report["sample_rows"][0]
+        snap = row["snapshot"]
+        assert snap["run_id"] == "test-run-001"
+        assert snap["canonical_md_path"] == "test_merge.md"
+        assert snap["canonical_md_sha256"] == _sha256(content)
+
+    def test_snapshot_source_is_bundle_manifest(self, tmp_path):
+        content = b"snapshot source test"
+        chunk = _canonical_range_chunk(content, 0, 5, "test_merge.md")
+        manifest_path = _make_bundle(tmp_path, content, [chunk])
+        report = produce_citation_map(str(manifest_path))
+        assert report["snapshot_source"] == "bundle_manifest"
+
+
+# ---------------------------------------------------------------------------
+# make_citation_id is used
+# ---------------------------------------------------------------------------
+
+class TestCitationIdDerivation:
+    def test_citation_id_matches_make_citation_id(self, tmp_path):
+        content = b"Citation ID test content"
+        chunk = _canonical_range_chunk(content, 0, 8, "test_merge.md")
+        manifest_path = _make_bundle(tmp_path, content, [chunk])
+
+        report = produce_citation_map(str(manifest_path))
+        assert report["status"] == "ok", report["errors"]
+
+        row = report["sample_rows"][0]
+        canonical_sha = _sha256(content)
+        slice_sha = _sha256(content[0:8])
+        expected_cit_id = make_citation_id(canonical_sha, 0, 8, slice_sha)
+        assert row["citation_id"] == expected_cit_id
+
+    def test_citation_id_format(self, tmp_path):
+        content = b"format test content here"
+        chunk = _canonical_range_chunk(content, 0, 4, "test_merge.md")
+        manifest_path = _make_bundle(tmp_path, content, [chunk])
+
+        report = produce_citation_map(str(manifest_path))
+        assert report["status"] == "ok", report["errors"]
+
+        cit_id = report["sample_rows"][0]["citation_id"]
+        assert cit_id.startswith("cit_")
+        assert len(cit_id) == 20  # "cit_" + 16 hex chars
+
+
+# ---------------------------------------------------------------------------
+# Range normalisation: canonical_range preferred over content_range_ref
+# ---------------------------------------------------------------------------
+
+class TestRangeNormalisation:
+    def test_canonical_range_preferred(self, tmp_path):
+        content = b"ABCDEFGHIJ"
+        canonical_sha = _sha256(content[0:5])
+        fallback_sha = _sha256(content[5:10])
+        chunk = {
+            "chunk_id": "c1",
+            "repo": "testrepo",
+            "canonical_range": {
+                "artifact_role": "canonical_md",
+                "repo_id": "testrepo",
+                "file_path": "test_merge.md",
+                "start_byte": 0,
+                "end_byte": 5,
+                "start_line": 1,
+                "end_line": 1,
+                "content_sha256": canonical_sha,
+            },
+            "content_range_ref": {
+                "artifact_role": "canonical_md",
+                "repo_id": "testrepo",
+                "file_path": "test_merge.md",
+                "start_byte": 5,
+                "end_byte": 10,
+                "start_line": 2,
+                "end_line": 2,
+                "content_sha256": fallback_sha,
+            },
+        }
+        manifest_path = _make_bundle(tmp_path, content, [chunk])
+        report = produce_citation_map(str(manifest_path))
+        assert report["status"] == "ok", report["errors"]
+        row = report["sample_rows"][0]
+        assert row["canonical_range"]["start_byte"] == 0
+        assert row["canonical_range"]["end_byte"] == 5
+
+    def test_content_range_ref_fallback(self, tmp_path):
+        content = b"ABCDEFGHIJ"
+        chunk = _content_range_ref_chunk(content, 2, 7, "test_merge.md")
+        manifest_path = _make_bundle(tmp_path, content, [chunk])
+        report = produce_citation_map(str(manifest_path))
+        assert report["status"] == "ok", report["errors"]
+        row = report["sample_rows"][0]
+        assert row["canonical_range"]["start_byte"] == 2
+        assert row["canonical_range"]["end_byte"] == 7
+
+    def test_error_when_no_range(self, tmp_path):
+        content = b"ABCDEFGHIJ"
+        chunk = {"chunk_id": "c1", "repo": "testrepo"}
+        manifest_path = _make_bundle(tmp_path, content, [chunk])
+        report = produce_citation_map(str(manifest_path))
+        assert report["status"] == "fail"
+        assert any("no valid canonical range" in e for e in report["errors"])
+
+    def test_error_when_canonical_range_wrong_role_no_fallback(self, tmp_path):
+        content = b"ABCDEFGHIJ"
+        chunk = {
+            "chunk_id": "c1",
+            "repo": "testrepo",
+            "canonical_range": {"artifact_role": "source_file"},
+        }
+        manifest_path = _make_bundle(tmp_path, content, [chunk])
+        report = produce_citation_map(str(manifest_path))
+        assert report["status"] == "fail"
+
+
+# ---------------------------------------------------------------------------
+# Byte-range hash verification in producer
+# ---------------------------------------------------------------------------
+
+class TestProducerByteRangeVerification:
+    def test_hash_mismatch_causes_error(self, tmp_path):
+        content = b"Hello world test"
+        bad_sha = "b" * 64
+        chunk = {
+            "chunk_id": "c1",
+            "repo": "testrepo",
+            "canonical_range": {
+                "artifact_role": "canonical_md",
+                "file_path": "test_merge.md",
+                "start_byte": 0,
+                "end_byte": 5,
+                "start_line": 1,
+                "end_line": 1,
+                "content_sha256": bad_sha,
+            },
+        }
+        manifest_path = _make_bundle(tmp_path, content, [chunk])
+        report = produce_citation_map(str(manifest_path))
+        assert report["status"] == "fail"
+        assert any("SHA256 mismatch" in e for e in report["errors"])
+
+    def test_valid_hash_produces_row(self, tmp_path):
+        content = b"Hello world test"
+        chunk = _canonical_range_chunk(content, 0, 5, "test_merge.md")
+        manifest_path = _make_bundle(tmp_path, content, [chunk])
+        report = produce_citation_map(str(manifest_path))
+        assert report["status"] == "ok", report["errors"]
+        assert report["citation_map_row_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Integration: produce_citation_map correctness
+# ---------------------------------------------------------------------------
+
+class TestProduceCitationMap:
+    def test_produces_valid_output_file(self, tmp_path):
+        content = b"Line 1 content\nLine 2 content\n"
+        chunks = [
+            _canonical_range_chunk(content, 0, 14, "test_merge.md", chunk_id="c1"),
+            _canonical_range_chunk(content, 15, 29, "test_merge.md", chunk_id="c2"),
+        ]
+        manifest_path = _make_bundle(tmp_path, content, chunks)
+        report = produce_citation_map(str(manifest_path))
+
+        assert report["status"] == "ok", report["errors"]
+        assert report["chunk_count"] == 2
+        assert report["citation_map_row_count"] == 2
+        assert report["citation_id_count"] == 2
+        assert report["citation_id_duplicate_count"] == 0
+
+        output_path = Path(report["output_path"])
+        assert output_path.exists()
+        lines = [json.loads(l) for l in output_path.read_text().strip().splitlines()]
+        assert len(lines) == 2
+        for row in lines:
+            assert "citation_id" in row
+            assert "repo_id" in row
+            assert "snapshot" in row
+            assert "canonical_range" in row
+            assert row["produced_by"] == PRODUCED_BY
+
+    def test_no_duplicate_citation_ids(self, tmp_path):
+        content = b"unique content abc"
+        chunks = [
+            _canonical_range_chunk(content, 0, 6, "test_merge.md", chunk_id="c1"),
+            _canonical_range_chunk(content, 7, 14, "test_merge.md", chunk_id="c2"),
+        ]
+        manifest_path = _make_bundle(tmp_path, content, chunks)
+        report = produce_citation_map(str(manifest_path))
+        assert report["citation_id_duplicate_count"] == 0
+
+    def test_sha256_mismatch_fails(self, tmp_path):
+        content = b"some content"
+        chunk = _canonical_range_chunk(content, 0, 4, "test_merge.md")
+        manifest_path = _make_bundle(
+            tmp_path, content, [chunk],
+            canonical_sha_override="c" * 64,
+        )
+        report = produce_citation_map(str(manifest_path))
+        assert report["status"] == "fail"
+        assert any("SHA256 mismatch" in e for e in report["errors"])
+
+    def test_missing_manifest_fails(self, tmp_path):
+        report = produce_citation_map(str(tmp_path / "nonexistent.bundle.manifest.json"))
+        assert report["status"] == "fail"
+        assert report["error_kind"] == "path_read_error"
+
+    def test_output_sha256_matches_file(self, tmp_path):
+        content = b"sha256 output check"
+        chunk = _canonical_range_chunk(content, 0, 6, "test_merge.md")
+        manifest_path = _make_bundle(tmp_path, content, [chunk])
+        report = produce_citation_map(str(manifest_path))
+        assert report["status"] == "ok", report["errors"]
+
+        output_path = Path(report["output_path"])
+        actual_sha = _sha256(output_path.read_bytes())
+        assert actual_sha == report["output_sha256"]
+
+    def test_custom_output_path(self, tmp_path):
+        content = b"custom output path test"
+        chunk = _canonical_range_chunk(content, 0, 6, "test_merge.md")
+        manifest_path = _make_bundle(tmp_path, content, [chunk])
+        custom_output = str(tmp_path / "custom.citation_map.jsonl")
+        report = produce_citation_map(str(manifest_path), custom_output)
+        assert report["status"] == "ok", report["errors"]
+        assert report["output_path"] == custom_output
+        assert Path(custom_output).exists()
+
+    def test_repo_id_source_reported(self, tmp_path):
+        content = b"repo_id source test"
+        chunk = _content_range_ref_chunk(content, 0, 5, "test_merge.md", repo_id="lenskit")
+        manifest_path = _make_bundle(tmp_path, content, [chunk])
+        report = produce_citation_map(str(manifest_path))
+        assert report["status"] == "ok", report["errors"]
+        assert report["repo_id_source"] == "range.repo_id"
+
+
+# ---------------------------------------------------------------------------
+# Integration: manifest wiring (CONTRACT_REGISTRY / AUTHORITY_REGISTRY)
+# ---------------------------------------------------------------------------
+
+class TestManifestWiring:
+    def test_citation_map_role_exists_in_constants(self):
+        assert ArtifactRole.CITATION_MAP_JSONL.value == "citation_map_jsonl"
+
+    def test_contract_registry_has_citation_map(self):
+        from merger.lenskit.core.merge import write_reports_v2
+        import inspect, textwrap
+        src = inspect.getsource(write_reports_v2)
+        assert "citation-map" in src
+        assert '"v1"' in src or "'v1'" in src
+
+    def test_authority_registry_has_citation_map(self):
+        from merger.lenskit.core.merge import write_reports_v2
+        import inspect
+        src = inspect.getsource(write_reports_v2)
+        assert "navigation_index" in src
+        # Must have both the canonical_md entry (canonical_content) and
+        # the citation_map entry (navigation_index / derived) — just
+        # check the citation_map values appear after the CITATION_MAP_JSONL key
+        assert "CITATION_MAP_JSONL" in src
+
+    def test_citation_map_artifact_written_to_manifest(self, tmp_path):
+        """Produce a citation map file, then verify _add_artifact logic produces
+        the correct manifest entry when invoked with the CITATION_MAP_JSONL role."""
+        import hashlib
+        from merger.lenskit.core.constants import ArtifactRole
+
+        content = b"Manifest wiring test content"
+        chunk = _canonical_range_chunk(content, 0, 7, "test_merge.md")
+        manifest_path = _make_bundle(tmp_path, content, [chunk])
+        report = produce_citation_map(str(manifest_path))
+        assert report["status"] == "ok", report["errors"]
+
+        output_path = Path(report["output_path"])
+        assert output_path.exists()
+
+        # Simulate what _add_artifact would write by checking the produced file
+        output_bytes = output_path.read_bytes()
+        actual_sha = hashlib.sha256(output_bytes).hexdigest()
+
+        assert actual_sha == report["output_sha256"]
+        assert report["output_bytes"] == len(output_bytes)
+
+        # Verify the produced entry would satisfy bundle-manifest.v1 role constraints
+        expected_entry = {
+            "role": ArtifactRole.CITATION_MAP_JSONL.value,
+            "path": output_path.name,
+            "content_type": "application/x-ndjson",
+            "bytes": len(output_bytes),
+            "sha256": actual_sha,
+            "contract": {"id": "citation-map", "version": "v1"},
+            "interpretation": {"mode": "contract"},
+            "authority": "navigation_index",
+            "canonicality": "derived",
+            "regenerable": True,
+            "staleness_sensitive": True,
+        }
+        assert expected_entry["role"] == "citation_map_jsonl"
+        assert expected_entry["content_type"] == "application/x-ndjson"
+        assert expected_entry["contract"] == {"id": "citation-map", "version": "v1"}
+        assert expected_entry["authority"] == "navigation_index"
+        assert expected_entry["canonicality"] == "derived"
+        assert expected_entry["regenerable"] is True
+        assert expected_entry["staleness_sensitive"] is True
+        assert expected_entry["sha256"] == actual_sha
+        assert expected_entry["bytes"] == len(output_bytes)

--- a/merger/lenskit/tests/test_citation_map_producer.py
+++ b/merger/lenskit/tests/test_citation_map_producer.py
@@ -15,6 +15,7 @@ from merger.lenskit.core.citation_id import make_citation_id
 from merger.lenskit.core.citation_map import (
     CitationMapError,
     PRODUCED_BY,
+    byte_range_to_line_range,
     iter_chunk_results,
     normalize_canonical_range,
     produce_citation_map,
@@ -301,6 +302,138 @@ class TestVerifyByteRangeHash:
         content = b"abc"
         with pytest.raises(CitationMapError, match="start_byte"):
             verify_byte_range_hash(content, -1, 2, "a" * 64, lineno=1)
+
+
+# ---------------------------------------------------------------------------
+# byte_range_to_line_range
+# ---------------------------------------------------------------------------
+
+class TestByteRangeToLineRange:
+    def test_range_in_line_1(self):
+        content = b"hello world"
+        assert byte_range_to_line_range(content, 0, 5) == (1, 1)
+
+    def test_range_in_line_2(self):
+        content = b"line1\nhello world"
+        # range starts at byte 6 ('h'), ends at byte 11 (exclusive)
+        assert byte_range_to_line_range(content, 6, 11) == (2, 2)
+
+    def test_range_spans_lines_2_and_3(self):
+        content = b"line1\nline2\nline3"
+        # range [6, 13): bytes 6-12 = "line2\nli"
+        # start_byte=6 → line 2; last byte=12 ('i' in line3) → line 3
+        assert byte_range_to_line_range(content, 6, 13) == (2, 3)
+
+    def test_range_ends_on_newline_byte(self):
+        # The '\n' byte terminates the line it belongs to; end_line is that line
+        content = b"line1\nline2\n"
+        # range [0, 6): last included byte = index 5 = '\n'
+        # '\n' at 5 belongs to line 1
+        assert byte_range_to_line_range(content, 0, 6) == (1, 1)
+
+    def test_range_starts_after_newline_ends_on_next_newline(self):
+        content = b"line1\nline2\nline3\n"
+        # range [6, 12): bytes 6-11 = "line2\n", last byte 11 = '\n' → line 2
+        assert byte_range_to_line_range(content, 6, 12) == (2, 2)
+
+    def test_single_byte_range(self):
+        content = b"x"
+        assert byte_range_to_line_range(content, 0, 1) == (1, 1)
+
+    def test_first_byte_of_second_line(self):
+        content = b"\nfoo"
+        # byte 0 = '\n' (line 1 terminator), byte 1 = 'f' (start of line 2)
+        assert byte_range_to_line_range(content, 1, 2) == (2, 2)
+
+    def test_whole_file_range(self):
+        content = b"a\nb\nc"
+        assert byte_range_to_line_range(content, 0, len(content)) == (1, 3)
+
+
+# ---------------------------------------------------------------------------
+# H5: input start_line/end_line are ignored; output is computed from bytes
+# ---------------------------------------------------------------------------
+
+class TestInputLineRangeIgnored:
+    def test_missing_input_start_end_line_does_not_prevent_production(self, tmp_path):
+        """Chunk with no start_line/end_line in range still produces a row."""
+        content = b"Line one\nLine two\n"
+        content_sha = _sha256(content[0:8])
+        chunk = {
+            "chunk_id": "c1",
+            "repo": "testrepo",
+            "canonical_range": {
+                "artifact_role": "canonical_md",
+                "repo_id": "testrepo",
+                "file_path": "test_merge.md",
+                "start_byte": 0,
+                "end_byte": 8,
+                "content_sha256": content_sha,
+                # deliberately no start_line / end_line
+            },
+        }
+        manifest_path = _make_bundle(tmp_path, content, [chunk])
+        report = produce_citation_map(str(manifest_path))
+        assert report["status"] == "ok", report["errors"]
+        assert report["citation_map_row_count"] == 1
+        row = report["sample_rows"][0]
+        assert row["canonical_range"]["start_line"] == 1
+        assert row["canonical_range"]["end_line"] == 1
+
+    def test_wrong_input_line_numbers_are_not_passed_through(self, tmp_path):
+        """Input start_line=99/end_line=99 must NOT appear in output."""
+        content = b"Line one\nLine two\n"
+        content_sha = _sha256(content[0:8])
+        chunk = {
+            "chunk_id": "c1",
+            "repo": "testrepo",
+            "canonical_range": {
+                "artifact_role": "canonical_md",
+                "repo_id": "testrepo",
+                "file_path": "test_merge.md",
+                "start_byte": 0,
+                "end_byte": 8,
+                "start_line": 99,  # wrong — must be ignored
+                "end_line": 99,    # wrong — must be ignored
+                "content_sha256": content_sha,
+            },
+        }
+        manifest_path = _make_bundle(tmp_path, content, [chunk])
+        report = produce_citation_map(str(manifest_path))
+        assert report["status"] == "ok", report["errors"]
+        row = report["sample_rows"][0]
+        assert row["canonical_range"]["start_line"] != 99
+        assert row["canonical_range"]["end_line"] != 99
+        assert row["canonical_range"]["start_line"] == 1
+        assert row["canonical_range"]["end_line"] == 1
+
+    def test_output_line_numbers_match_byte_range_function(self, tmp_path):
+        """Output start_line/end_line must equal byte_range_to_line_range result."""
+        content = b"first\nsecond\nthird\n"
+        # range in second line: bytes 6-11 = "second"
+        start_byte, end_byte = 6, 12
+        content_sha = _sha256(content[start_byte:end_byte])
+        chunk = {
+            "chunk_id": "c1",
+            "repo": "testrepo",
+            "canonical_range": {
+                "artifact_role": "canonical_md",
+                "repo_id": "testrepo",
+                "file_path": "test_merge.md",
+                "start_byte": start_byte,
+                "end_byte": end_byte,
+                "start_line": 1,   # wrong input — source-local
+                "end_line": 1,     # wrong input — source-local
+                "content_sha256": content_sha,
+            },
+        }
+        manifest_path = _make_bundle(tmp_path, content, [chunk])
+        report = produce_citation_map(str(manifest_path))
+        assert report["status"] == "ok", report["errors"]
+        row = report["sample_rows"][0]
+        expected_start, expected_end = byte_range_to_line_range(content, start_byte, end_byte)
+        assert row["canonical_range"]["start_line"] == expected_start
+        assert row["canonical_range"]["end_line"] == expected_end
 
 
 # ---------------------------------------------------------------------------

--- a/merger/lenskit/tests/test_citation_map_producer.py
+++ b/merger/lenskit/tests/test_citation_map_producer.py
@@ -207,14 +207,14 @@ class TestNormalizeCanonicalRange:
 # ---------------------------------------------------------------------------
 
 class TestResolveRepoId:
-    def test_prefers_range_repo_id(self):
-        norm_range = {"repo_id": "from_range", "file_path": "x"}
-        chunk = {"repo": "from_chunk"}
+    def test_single_source_range_repo_id(self):
+        norm_range = {"repo_id": "only_source", "file_path": "x"}
+        chunk = {}
         repo_id, src = resolve_repo_id(chunk, norm_range, lineno=1)
-        assert repo_id == "from_range"
+        assert repo_id == "only_source"
         assert src == "range.repo_id"
 
-    def test_falls_back_to_chunk_repo(self):
+    def test_falls_back_to_chunk_repo_when_range_absent(self):
         norm_range = {"file_path": "x"}
         chunk = {"repo": "from_chunk"}
         repo_id, src = resolve_repo_id(chunk, norm_range, lineno=1)
@@ -234,15 +234,21 @@ class TestResolveRepoId:
         with pytest.raises(CitationMapError, match="no repo_id source"):
             resolve_repo_id(chunk, norm_range, lineno=1)
 
-    def test_range_repo_id_beats_chunk_repo_without_error(self):
-        # Different values across priority levels — the higher-priority one wins silently
+    def test_raises_on_conflicting_values(self):
+        # Different values in different sources → hard error (H4)
         norm_range = {"repo_id": "repo_a"}
         chunk = {"repo": "repo_b"}
-        repo_id, src = resolve_repo_id(chunk, norm_range, lineno=5)
-        assert repo_id == "repo_a"
-        assert src == "range.repo_id"
+        with pytest.raises(CitationMapError, match="ambiguous repo_id"):
+            resolve_repo_id(chunk, norm_range, lineno=5)
 
-    def test_no_ambiguity_when_values_agree(self):
+    def test_raises_on_conflict_range_vs_search_keys(self):
+        norm_range = {"repo_id": "repo_x"}
+        chunk = {"search_keys": {"repo_id": "repo_y"}}
+        with pytest.raises(CitationMapError, match="ambiguous repo_id"):
+            resolve_repo_id(chunk, norm_range, lineno=3)
+
+    def test_no_error_when_all_sources_agree(self):
+        # All present sources have the same value → ok, return highest-priority
         norm_range = {"repo_id": "lenskit"}
         chunk = {"repo": "lenskit", "search_keys": {"repo_id": "lenskit"}}
         repo_id, src = resolve_repo_id(chunk, norm_range, lineno=1)
@@ -254,6 +260,13 @@ class TestResolveRepoId:
         chunk = {"repo": "lenskit"}
         repo_id, src = resolve_repo_id(chunk, norm_range, lineno=1)
         assert repo_id == "lenskit"
+        assert src == "chunk.repo"
+
+    def test_two_sources_same_value_no_conflict(self):
+        norm_range = {"file_path": "x"}
+        chunk = {"repo": "myrepo", "search_keys": {"repo_id": "myrepo"}}
+        repo_id, src = resolve_repo_id(chunk, norm_range, lineno=1)
+        assert repo_id == "myrepo"
         assert src == "chunk.repo"
 
 
@@ -542,35 +555,36 @@ class TestProduceCitationMap:
 
 
 # ---------------------------------------------------------------------------
-# Integration: manifest wiring (CONTRACT_REGISTRY / AUTHORITY_REGISTRY)
+# Integration: manifest wiring (MODULE-LEVEL registries, not inspect.getsource)
 # ---------------------------------------------------------------------------
 
 class TestManifestWiring:
     def test_citation_map_role_exists_in_constants(self):
         assert ArtifactRole.CITATION_MAP_JSONL.value == "citation_map_jsonl"
 
-    def test_contract_registry_has_citation_map(self):
-        from merger.lenskit.core.merge import write_reports_v2
-        import inspect, textwrap
-        src = inspect.getsource(write_reports_v2)
-        assert "citation-map" in src
-        assert '"v1"' in src or "'v1'" in src
+    def test_contract_registry_has_citation_map_entry(self):
+        from merger.lenskit.core.merge import ARTIFACT_CONTRACT_REGISTRY
+        entry = ARTIFACT_CONTRACT_REGISTRY[ArtifactRole.CITATION_MAP_JSONL]
+        assert entry["id"] == "citation-map"
+        assert entry["version"] == "v1"
 
-    def test_authority_registry_has_citation_map(self):
-        from merger.lenskit.core.merge import write_reports_v2
-        import inspect
-        src = inspect.getsource(write_reports_v2)
-        assert "navigation_index" in src
-        # Must have both the canonical_md entry (canonical_content) and
-        # the citation_map entry (navigation_index / derived) — just
-        # check the citation_map values appear after the CITATION_MAP_JSONL key
-        assert "CITATION_MAP_JSONL" in src
+    def test_authority_registry_has_citation_map_entry(self):
+        from merger.lenskit.core.merge import ARTIFACT_AUTHORITY_REGISTRY
+        entry = ARTIFACT_AUTHORITY_REGISTRY[ArtifactRole.CITATION_MAP_JSONL]
+        assert entry["authority"] == "navigation_index"
+        assert entry["canonicality"] == "derived"
+        assert entry["regenerable"] is True
+        assert entry["staleness_sensitive"] is True
 
-    def test_citation_map_artifact_written_to_manifest(self, tmp_path):
-        """Produce a citation map file, then verify _add_artifact logic produces
-        the correct manifest entry when invoked with the CITATION_MAP_JSONL role."""
+    def test_citation_map_not_canonical_content(self):
+        from merger.lenskit.core.merge import ARTIFACT_AUTHORITY_REGISTRY
+        entry = ARTIFACT_AUTHORITY_REGISTRY[ArtifactRole.CITATION_MAP_JSONL]
+        assert entry["authority"] != "canonical_content"
+        assert entry["canonicality"] != "content_source"
+
+    def test_citation_map_artifact_file_sha_and_bytes(self, tmp_path):
+        """Produce a citation map and verify sha256 / bytes match the file on disk."""
         import hashlib
-        from merger.lenskit.core.constants import ArtifactRole
 
         content = b"Manifest wiring test content"
         chunk = _canonical_range_chunk(content, 0, 7, "test_merge.md")
@@ -581,33 +595,184 @@ class TestManifestWiring:
         output_path = Path(report["output_path"])
         assert output_path.exists()
 
-        # Simulate what _add_artifact would write by checking the produced file
         output_bytes = output_path.read_bytes()
         actual_sha = hashlib.sha256(output_bytes).hexdigest()
 
         assert actual_sha == report["output_sha256"]
         assert report["output_bytes"] == len(output_bytes)
 
-        # Verify the produced entry would satisfy bundle-manifest.v1 role constraints
-        expected_entry = {
-            "role": ArtifactRole.CITATION_MAP_JSONL.value,
-            "path": output_path.name,
-            "content_type": "application/x-ndjson",
-            "bytes": len(output_bytes),
-            "sha256": actual_sha,
-            "contract": {"id": "citation-map", "version": "v1"},
-            "interpretation": {"mode": "contract"},
-            "authority": "navigation_index",
-            "canonicality": "derived",
-            "regenerable": True,
-            "staleness_sensitive": True,
+
+# ---------------------------------------------------------------------------
+# Hardening: H1 — no partial output on errors
+# ---------------------------------------------------------------------------
+
+class TestNoPartialOutputOnErrors:
+    def test_no_output_file_when_chunk_errors_exist(self, tmp_path):
+        content = b"Valid and invalid chunks"
+        valid_chunk = _canonical_range_chunk(content, 0, 5, "test_merge.md", chunk_id="c1")
+        bad_sha = "b" * 64
+        invalid_chunk = {
+            "chunk_id": "c2",
+            "repo": "testrepo",
+            "canonical_range": {
+                "artifact_role": "canonical_md",
+                "file_path": "test_merge.md",
+                "start_byte": 6,
+                "end_byte": 11,
+                "start_line": 1,
+                "end_line": 1,
+                "content_sha256": bad_sha,  # wrong hash → error
+            },
         }
-        assert expected_entry["role"] == "citation_map_jsonl"
-        assert expected_entry["content_type"] == "application/x-ndjson"
-        assert expected_entry["contract"] == {"id": "citation-map", "version": "v1"}
-        assert expected_entry["authority"] == "navigation_index"
-        assert expected_entry["canonicality"] == "derived"
-        assert expected_entry["regenerable"] is True
-        assert expected_entry["staleness_sensitive"] is True
-        assert expected_entry["sha256"] == actual_sha
-        assert expected_entry["bytes"] == len(output_bytes)
+        manifest_path = _make_bundle(tmp_path, content, [valid_chunk, invalid_chunk])
+        expected_output = tmp_path / "test_merge.citation_map.jsonl"
+
+        report = produce_citation_map(str(manifest_path))
+
+        assert report["status"] == "fail"
+        assert not expected_output.exists(), "Partial output must not be written on failure"
+        assert report["output_path"] is None
+        assert report["output_sha256"] is None
+
+    def test_no_output_on_duplicate_citation_id(self, tmp_path):
+        content = b"Duplicate test content XYZ"
+        # Two chunks with identical byte ranges → same citation_id → duplicate
+        chunk_a = _canonical_range_chunk(content, 0, 5, "test_merge.md", chunk_id="c1")
+        chunk_b = _canonical_range_chunk(content, 0, 5, "test_merge.md", chunk_id="c2")
+        manifest_path = _make_bundle(tmp_path, content, [chunk_a, chunk_b])
+        expected_output = tmp_path / "test_merge.citation_map.jsonl"
+
+        report = produce_citation_map(str(manifest_path))
+
+        assert report["status"] == "fail"
+        assert any("duplicate" in e for e in report["errors"])
+        assert not expected_output.exists()
+
+    def test_output_path_is_none_on_fail(self, tmp_path):
+        content = b"test"
+        invalid_chunk = {"chunk_id": "c1", "repo": "r"}  # no range
+        manifest_path = _make_bundle(tmp_path, content, [invalid_chunk])
+        report = produce_citation_map(str(manifest_path))
+        assert report["status"] == "fail"
+        assert report["output_path"] is None
+
+
+# ---------------------------------------------------------------------------
+# Hardening: H2 — default output path safety
+# ---------------------------------------------------------------------------
+
+class TestDefaultOutputPathSafety:
+    def test_standard_manifest_name_produces_correct_path(self, tmp_path):
+        content = b"path safety test"
+        chunk = _canonical_range_chunk(content, 0, 4, "test_merge.md")
+        manifest_path = _make_bundle(tmp_path, content, [chunk])
+        report = produce_citation_map(str(manifest_path))
+        assert report["status"] == "ok", report["errors"]
+        assert report["output_path"] == str(tmp_path / "test_merge.citation_map.jsonl")
+
+    def test_non_standard_manifest_name_fails_safely(self, tmp_path):
+        # Manifest doesn't end with .bundle.manifest.json → cannot derive safe output path
+        content = b"path safety test"
+        chunk = _canonical_range_chunk(content, 0, 4, "test_merge.md")
+        manifest_path = _make_bundle(tmp_path, content, [chunk])
+
+        # Rename manifest to a non-standard name
+        bad_manifest = tmp_path / "manifest.json"
+        manifest_path.rename(bad_manifest)
+
+        # Also fix the manifest content to not reference the standard name
+        # (re-write with all paths intact — the manifest content itself doesn't need to change
+        # because _default_output_path checks the manifest file's own name)
+        report = produce_citation_map(str(bad_manifest))
+        assert report["status"] == "fail"
+        assert any("cannot derive safe output path" in e.lower() or
+                   "bundle.manifest.json" in e for e in report["errors"])
+        # Must not create a file named "manifest.json" (collision)
+        assert not (tmp_path / "manifest.json.citation_map.jsonl").exists()
+
+    def test_output_does_not_collide_with_manifest(self, tmp_path):
+        content = b"collision test"
+        chunk = _canonical_range_chunk(content, 0, 4, "test_merge.md")
+        manifest_path = _make_bundle(tmp_path, content, [chunk])
+        # Explicitly pass manifest path as output → must fail
+        report = produce_citation_map(str(manifest_path), str(manifest_path))
+        assert report["status"] == "fail"
+        assert any("collides" in e for e in report["errors"])
+
+    def test_output_does_not_collide_with_canonical_md(self, tmp_path):
+        content = b"collision test 2"
+        chunk = _canonical_range_chunk(content, 0, 4, "test_merge.md")
+        manifest_path = _make_bundle(tmp_path, content, [chunk])
+        canonical_md = tmp_path / "test_merge.md"
+        report = produce_citation_map(str(manifest_path), str(canonical_md))
+        assert report["status"] == "fail"
+        assert any("collides" in e for e in report["errors"])
+
+
+# ---------------------------------------------------------------------------
+# Hardening: H3 — run_id must be non-empty
+# ---------------------------------------------------------------------------
+
+class TestRunIdValidation:
+    def _make_bundle_no_run_id(self, tmp_path, canonical_content, chunks, run_id_value):
+        from pathlib import Path as P
+        canonical_md_path = tmp_path / "test_merge.md"
+        canonical_md_path.write_bytes(canonical_content)
+        chunk_lines = "\n".join(json.dumps(c) for c in chunks) + "\n"
+        chunk_index_bytes = chunk_lines.encode("utf-8")
+        chunk_index_path = tmp_path / "test_merge.chunk_index.jsonl"
+        chunk_index_path.write_bytes(chunk_index_bytes)
+        manifest = {
+            "kind": "repolens.bundle.manifest",
+            "version": "1.0",
+            "created_at": "2026-05-14T00:00:00Z",
+            "generator": {"name": "test", "version": "0.0.1", "config_sha256": "a" * 64},
+            "artifacts": [
+                {
+                    "role": "canonical_md",
+                    "path": "test_merge.md",
+                    "content_type": "text/markdown",
+                    "bytes": len(canonical_content),
+                    "sha256": _sha256(canonical_content),
+                    "interpretation": {"mode": "role_only"},
+                },
+                {
+                    "role": "chunk_index_jsonl",
+                    "path": "test_merge.chunk_index.jsonl",
+                    "content_type": "application/x-ndjson",
+                    "bytes": len(chunk_index_bytes),
+                    "sha256": _sha256(chunk_index_bytes),
+                    "interpretation": {"mode": "role_only"},
+                },
+            ],
+            "links": {},
+            "capabilities": {},
+        }
+        if run_id_value is not None:
+            manifest["run_id"] = run_id_value
+        manifest_path = tmp_path / "test_merge.bundle.manifest.json"
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        return manifest_path
+
+    def test_missing_run_id_fails(self, tmp_path):
+        content = b"run_id test"
+        chunk = _canonical_range_chunk(content, 0, 5, "test_merge.md")
+        manifest_path = self._make_bundle_no_run_id(tmp_path, content, [chunk], None)
+        report = produce_citation_map(str(manifest_path))
+        assert report["status"] == "fail"
+        assert any("run_id" in e for e in report["errors"])
+
+    def test_empty_run_id_fails(self, tmp_path):
+        content = b"run_id test"
+        chunk = _canonical_range_chunk(content, 0, 5, "test_merge.md")
+        manifest_path = self._make_bundle_no_run_id(tmp_path, content, [chunk], "")
+        report = produce_citation_map(str(manifest_path))
+        assert report["status"] == "fail"
+        assert any("run_id" in e for e in report["errors"])
+
+    def test_valid_run_id_succeeds(self, tmp_path):
+        content = b"run_id valid test"
+        chunk = _canonical_range_chunk(content, 0, 5, "test_merge.md")
+        manifest_path = self._make_bundle_no_run_id(tmp_path, content, [chunk], "valid-run-123")
+        report = produce_citation_map(str(manifest_path))
+        assert report["status"] == "ok", report["errors"]

--- a/merger/lenskit/tests/test_citation_map_producer.py
+++ b/merger/lenskit/tests/test_citation_map_producer.py
@@ -830,6 +830,76 @@ class TestStaleOutputCleanup:
 
 
 # ---------------------------------------------------------------------------
+# B (extended): Stale cleanup on early failures (SHA mismatch, bad run_id)
+# ---------------------------------------------------------------------------
+
+class TestEarlyFailStaleCleanup:
+    def test_canonical_md_sha_mismatch_removes_stale_output(self, tmp_path):
+        content = b"First run content\nWith two lines\n"
+        chunk = _canonical_range_chunk(content, 0, 5, "test_merge.md")
+        manifest_path = _make_bundle(tmp_path, content, [chunk])
+
+        # First run succeeds and writes output.
+        report1 = produce_citation_map(str(manifest_path))
+        assert report1["status"] == "ok", report1["errors"]
+        stale_path = Path(report1["output_path"])
+        assert stale_path.exists()
+
+        # Tamper canonical_md bytes so its SHA no longer matches the manifest.
+        (tmp_path / "test_merge.md").write_bytes(b"tampered")
+
+        # Second run: SHA mismatch → fail; stale output must be removed.
+        report2 = produce_citation_map(str(manifest_path))
+        assert report2["status"] == "fail"
+        assert any("SHA256 mismatch" in e for e in report2["errors"])
+        assert report2["output_path"] is None
+        assert not stale_path.exists(), "Stale output must be removed on canonical_md SHA mismatch"
+
+    def test_chunk_index_sha_mismatch_removes_stale_output(self, tmp_path):
+        content = b"Content for chunk index SHA test\n"
+        chunk = _canonical_range_chunk(content, 0, 7, "test_merge.md")
+        manifest_path = _make_bundle(tmp_path, content, [chunk])
+
+        # First run succeeds.
+        report1 = produce_citation_map(str(manifest_path))
+        assert report1["status"] == "ok", report1["errors"]
+        stale_path = Path(report1["output_path"])
+        assert stale_path.exists()
+
+        # Tamper chunk_index so its SHA no longer matches the manifest.
+        (tmp_path / "test_merge.chunk_index.jsonl").write_bytes(b"tampered chunk index\n")
+
+        # Second run: chunk_index SHA mismatch → fail; stale output must be removed.
+        report2 = produce_citation_map(str(manifest_path))
+        assert report2["status"] == "fail"
+        assert any("SHA256 mismatch" in e for e in report2["errors"])
+        assert report2["output_path"] is None
+        assert not stale_path.exists(), "Stale output must be removed on chunk_index SHA mismatch"
+
+    def test_cleanup_failure_reported_in_errors(self, tmp_path):
+        from unittest.mock import patch as mock_patch
+
+        content = b"Content for cleanup failure test\n"
+        chunk = _canonical_range_chunk(content, 0, 7, "test_merge.md")
+        manifest_path = _make_bundle(tmp_path, content, [chunk])
+
+        # First run succeeds.
+        report1 = produce_citation_map(str(manifest_path))
+        assert report1["status"] == "ok", report1["errors"]
+
+        # Tamper canonical_md to trigger SHA mismatch on second run.
+        (tmp_path / "test_merge.md").write_bytes(b"tampered")
+
+        # Simulate unlink permission failure.
+        with mock_patch.object(Path, "unlink", side_effect=OSError("Permission denied (mocked)")):
+            report2 = produce_citation_map(str(manifest_path))
+
+        assert report2["status"] == "fail"
+        assert report2["output_path"] is None
+        assert any("Could not remove stale output" in e for e in report2["errors"])
+
+
+# ---------------------------------------------------------------------------
 # D: snapshot_source precision
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Implements `merger/lenskit/core/citation_map.py` — Citation Map Producer with pure functions for manifest loading, range normalisation (`canonical_range` preferred, `content_range_ref` fallback), byte-range hash verification, citation-id derivation via `make_citation_id()`, and NDJSON output
- Adds CLI subcommand `lenskit citation produce <bundle_manifest> [--output] [--json]`
- Adds `CITATION_MAP_JSONL` entries to `CONTRACT_REGISTRY` and `AUTHORITY_REGISTRY` in `merge.py`
- 40 unit and integration tests in `test_citation_map_producer.py` (all green, no regressions in 125 total tests)
- Real-Dump-Proof PASS: 541 chunks, 0 errors, 0 duplicates, schema-validated against `citation-map.v1.schema.json`
- Roadmap Phase 1 Citation-Map-Producer gate set to `[x]`
- Proof: `docs/proofs/citation-map-producer-proof.md`

## Key design decisions

- Range normalisation: dump `lenskit-max-260514-0409` contains only `content_range_ref` (no `canonical_range`); the producer normalises `content_range_ref` with `artifact_role == "canonical_md"` to `canonical_range` output — no STOP triggered
- `repo_id` resolved by priority: `range.repo_id` > `chunk.repo` > `search_keys.repo_id`; no filename derivation
- `snapshot` sourced exclusively from bundle manifest (`run_id`, `canonical_md.path`, `canonical_md.sha256`)
- `citation_map_jsonl` is never `canonical_content` or `content_source`; always `navigation_index` / `derived`

## Test plan

- [x] `python -m pytest merger/lenskit/tests/test_citation_map_producer.py` — 40 tests, all pass
- [x] `python -m pytest merger/lenskit/tests/test_citation_validate.py merger/lenskit/tests/test_bundle_manifest_schema.py merger/lenskit/tests/test_bundle_manifest_integration.py` — 85 tests, all pass, no regressions
- [x] Real-dump proof: `lenskit citation produce --json <manifest>` against `/home/alex/repos/merges/lenskit-max-260514-0409_merge.bundle.manifest.json` → status ok, 541 rows, 0 duplicates, schema PASS
- [x] Roadmap updated, proof document written

🤖 Generated with [Claude Code](https://claude.com/claude-code)