### PR TITLE
fix: handle rLens SSE end events and correct running_jobs count

### DIFF
--- a/merger/lenskit/frontends/webui/app.js
+++ b/merger/lenskit/frontends/webui/app.js
@@ -1189,22 +1189,31 @@ function streamLogs(jobId) {
     const es = new EventSource(url);
     activeEventSource = es;
 
+    let streamClosed = false;
+
+    function closeStream(reason) {
+        if (streamClosed) return;
+        streamClosed = true;
+        es.close();
+        activeEventSource = null;
+        pre.innerText += `\n${reason}\n`;
+        pre.scrollTop = pre.scrollHeight;
+    }
+
+    // Named SSE event "end" — sent by backend as "event: end\ndata: end\n\n"
+    // onmessage does NOT receive named events; addEventListener is required.
+    es.addEventListener("end", () => {
+        closeStream("[Job Finished]");
+        loadArtifacts();
+    });
+
     es.onmessage = (event) => {
-        if (event.data === 'end') {
-            es.close();
-            activeEventSource = null;
-            pre.innerText += "\n[Job Finished]\n";
-            loadArtifacts(); // Refresh artifacts
-            return;
-        }
         pre.innerText += event.data + "\n";
         pre.scrollTop = pre.scrollHeight;
     };
 
     es.onerror = () => {
-        pre.innerText += "\n[Connection Lost]\n";
-        es.close();
-        activeEventSource = null;
+        closeStream("[Connection Lost]");
     };
 }
 

--- a/merger/lenskit/service/app.py
+++ b/merger/lenskit/service/app.py
@@ -90,6 +90,8 @@ else:
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+ACTIVE_JOB_STATUSES = {"queued", "running", "canceling"}
+
 
 def _parse_iso_utc(value: Any) -> Optional[datetime]:
     if not isinstance(value, str):
@@ -105,6 +107,31 @@ def _parse_iso_utc(value: Any) -> Optional[datetime]:
     if parsed.tzinfo is None:
         return None
     return parsed.astimezone(timezone.utc)
+
+
+def _mark_persisted_active_jobs_terminal(job_store: JobStore) -> int:
+    now = datetime.now(timezone.utc).isoformat()
+    interrupted_error = "interrupted by service restart; job was not resumed"
+    system_log_line = (
+        "[system] Job marked failed on service startup because rLens does not "
+        "resume persisted active jobs."
+    )
+
+    reconciled = 0
+    for job in job_store.get_all_jobs():
+        if job.status not in ACTIVE_JOB_STATUSES:
+            continue
+
+        job.status = "failed"
+        job.error = interrupted_error
+        job.finished_at = now
+
+        # Preserve a useful trace in the job log before saving the terminal state.
+        job_store.append_log_line(job.id, system_log_line)
+        job_store.update_job(job)
+        reconciled += 1
+
+    return reconciled
 
 app = FastAPI(title="rLens", version=SERVER_VERSION)
 
@@ -174,6 +201,9 @@ def init_service(hub_path: Path, token: Optional[str] = None, host: str = "127.0
     state.hub = hub_path
     state.merges_dir = merges_dir
     state.job_store = JobStore(hub_path)
+    reconciled_jobs = _mark_persisted_active_jobs_terminal(state.job_store)
+    if reconciled_jobs:
+        logger.info("Reconciled %s persisted active job(s) on startup.", reconciled_jobs)
     # Co-locate QueryArtifactStore with the effective merges dir so query artifacts
     # land alongside the outputs they reference.  JobStore uses hub_path/merges
     # unconditionally; QueryArtifactStore follows state.merges_dir when set.
@@ -481,8 +511,6 @@ def api_version():
 
 @app.get("/api/health")
 def health():
-    ACTIVE_JOB_STATUSES = {"queued", "running", "canceling"}
-
     return {
         "status": "ok",
         "version": SPEC_VERSION,

--- a/merger/lenskit/service/app.py
+++ b/merger/lenskit/service/app.py
@@ -481,6 +481,8 @@ def api_version():
 
 @app.get("/api/health")
 def health():
+    ACTIVE_JOB_STATUSES = {"queued", "running", "canceling"}
+
     return {
         "status": "ok",
         "version": SPEC_VERSION,
@@ -490,7 +492,7 @@ def health():
         "auth_enabled": bool(get_security_config().token),
         "running_jobs": sum(
             1 for j in state.job_store.get_all_jobs()
-            if j.status in ("queued", "running", "canceling")
+            if j.status in ACTIVE_JOB_STATUSES
         ) if state.job_store else 0
     }
 

--- a/merger/lenskit/service/app.py
+++ b/merger/lenskit/service/app.py
@@ -488,7 +488,10 @@ def health():
         "hub": str(state.hub),
         "merges_dir": str(state.merges_dir) if state.merges_dir else None,
         "auth_enabled": bool(get_security_config().token),
-        "running_jobs": len(state.runner.futures) if state.runner else 0
+        "running_jobs": sum(
+            1 for j in state.job_store.get_all_jobs()
+            if j.status in ("queued", "running", "canceling")
+        ) if state.job_store else 0
     }
 
 @app.get("/api/repos", dependencies=[Depends(verify_token)])

--- a/merger/lenskit/tests/test_service_health.py
+++ b/merger/lenskit/tests/test_service_health.py
@@ -1,0 +1,68 @@
+"""Tests for /api/health endpoint — specifically running_jobs correctness."""
+import pytest
+from merger.lenskit.service.app import app, init_service, state
+from merger.lenskit.service.models import Job, JobRequest
+
+
+@pytest.fixture
+def health_client(tmp_path):
+    hub = tmp_path / "hub"
+    hub.mkdir()
+    (hub / "repo1").mkdir()
+
+    import os
+    os.environ["RLENS_TOKEN"] = "test-health-token"
+
+    app.middleware_stack = None
+    init_service(hub, token="test-health-token")
+
+    from fastapi.testclient import TestClient
+    with TestClient(app) as client:
+        yield client, state.job_store
+
+
+def _add_job(store, status: str) -> Job:
+    req = JobRequest(repos=["repo1"])
+    job = Job.create(request=req)
+    job.status = status
+    store.add_job(job)
+    return job
+
+
+def test_health_running_jobs_zero_when_all_succeeded(health_client):
+    client, store = health_client
+
+    _add_job(store, "succeeded")
+    _add_job(store, "succeeded")
+    _add_job(store, "failed")
+    _add_job(store, "canceled")
+
+    resp = client.get("/api/health", headers={"Authorization": "Bearer test-health-token"})
+    assert resp.status_code == 200
+    assert resp.json()["running_jobs"] == 0
+
+
+def test_health_running_jobs_counts_active_statuses(health_client):
+    client, store = health_client
+
+    _add_job(store, "succeeded")
+    _add_job(store, "running")
+    _add_job(store, "queued")
+    _add_job(store, "canceling")
+    _add_job(store, "failed")
+
+    resp = client.get("/api/health", headers={"Authorization": "Bearer test-health-token"})
+    assert resp.status_code == 200
+    # running + queued + canceling = 3
+    assert resp.json()["running_jobs"] == 3
+
+
+def test_health_running_jobs_excludes_terminal(health_client):
+    client, store = health_client
+
+    for status in ("succeeded", "failed", "canceled"):
+        _add_job(store, status)
+
+    resp = client.get("/api/health", headers={"Authorization": "Bearer test-health-token"})
+    assert resp.status_code == 200
+    assert resp.json()["running_jobs"] == 0

--- a/merger/lenskit/tests/test_service_startup_reconciliation.py
+++ b/merger/lenskit/tests/test_service_startup_reconciliation.py
@@ -1,0 +1,109 @@
+"""Tests for startup reconciliation of persisted active jobs."""
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from merger.lenskit.service.app import ACTIVE_JOB_STATUSES, app, init_service, state
+from merger.lenskit.service.models import Job, JobRequest
+
+
+@pytest.fixture
+def persisted_jobs_hub(tmp_path):
+    hub = tmp_path / "hub"
+    hub.mkdir()
+    (hub / "repo1").mkdir()
+
+    storage_dir = hub / "merges" / ".rlens-service"
+    storage_dir.mkdir(parents=True)
+
+    return hub
+
+
+def _make_job(job_id: str, status: str) -> Job:
+    request = JobRequest(repos=["repo1"])
+    job = Job.create(request=request)
+    job.id = job_id
+    job.status = status
+    job.created_at = "2026-05-15T00:00:00+00:00"
+    if status in {"running", "canceling"}:
+        job.started_at = "2026-05-15T00:01:00+00:00"
+    return job
+
+
+def _write_jobs_file(hub: Path, jobs: list[Job]) -> None:
+    jobs_file = hub / "merges" / ".rlens-service" / "jobs.json"
+    jobs_file.write_text(
+        json.dumps([job.model_dump() for job in jobs], indent=2),
+        encoding="utf-8",
+    )
+
+
+def test_init_service_reconciles_persisted_active_jobs(persisted_jobs_hub):
+    jobs = [
+        _make_job("queued-job", "queued"),
+        _make_job("running-job", "running"),
+        _make_job("canceling-job", "canceling"),
+        _make_job("succeeded-job", "succeeded"),
+        _make_job("failed-job", "failed"),
+        _make_job("canceled-job", "canceled"),
+    ]
+    _write_jobs_file(persisted_jobs_hub, jobs)
+
+    app.middleware_stack = None
+    init_service(persisted_jobs_hub, token="test-token")
+
+    store = state.job_store
+    assert store is not None
+
+    active_after_restart = [job for job in store.get_all_jobs() if job.status in ACTIVE_JOB_STATUSES]
+    assert active_after_restart == []
+
+    for job_id in ("queued-job", "running-job", "canceling-job"):
+        job = store.get_job(job_id)
+        assert job is not None
+        assert job.status == "failed"
+        assert job.error == "interrupted by service restart; job was not resumed"
+        assert job.finished_at is not None
+        assert any("service startup" in line for line in store.read_log_lines(job_id))
+
+    for job_id, expected_status in (
+        ("succeeded-job", "succeeded"),
+        ("failed-job", "failed"),
+        ("canceled-job", "canceled"),
+    ):
+        job = store.get_job(job_id)
+        assert job is not None
+        assert job.status == expected_status
+        assert job.error is None
+
+    with TestClient(app) as client:
+        response = client.get("/api/health", headers={"Authorization": "Bearer test-token"})
+        assert response.status_code == 200
+        assert response.json()["running_jobs"] == 0
+
+
+def test_init_service_leaves_terminal_jobs_unchanged(persisted_jobs_hub):
+    jobs = [
+        _make_job("succeeded-job", "succeeded"),
+        _make_job("failed-job", "failed"),
+        _make_job("canceled-job", "canceled"),
+    ]
+    _write_jobs_file(persisted_jobs_hub, jobs)
+
+    app.middleware_stack = None
+    init_service(persisted_jobs_hub, token="test-token")
+
+    store = state.job_store
+    assert store is not None
+
+    for job_id, expected_status in (
+        ("succeeded-job", "succeeded"),
+        ("failed-job", "failed"),
+        ("canceled-job", "canceled"),
+    ):
+        job = store.get_job(job_id)
+        assert job is not None
+        assert job.status == expected_status
+        assert job.error is None

--- a/merger/lenskit/tests/test_webui_appjs_sse.py
+++ b/merger/lenskit/tests/test_webui_appjs_sse.py
@@ -1,0 +1,59 @@
+"""Static regression tests for the rLens webui app.js SSE end-event fix.
+
+These checks verify that the correct EventSource API is used to handle
+the named SSE 'end' event emitted by the backend. No browser/JS runtime needed.
+"""
+import os
+import re
+
+APP_JS = os.path.join(
+    os.path.dirname(__file__),
+    "..", "frontends", "webui", "app.js"
+)
+
+
+def _load_appjs() -> str:
+    with open(APP_JS, encoding="utf-8") as f:
+        return f.read()
+
+
+def test_appjs_has_named_end_listener():
+    """app.js must handle the named SSE 'end' event via addEventListener."""
+    src = _load_appjs()
+    assert 'addEventListener("end"' in src or "addEventListener('end'" in src, (
+        "streamLogs() must use es.addEventListener('end', ...) to handle the named SSE end event. "
+        "onmessage does not fire for named events."
+    )
+
+
+def test_appjs_onmessage_has_no_data_end_guard():
+    """onmessage must no longer check event.data === 'end' as the sole end-path."""
+    src = _load_appjs()
+    # The old pattern was the only termination path inside onmessage
+    assert "event.data === 'end'" not in src and 'event.data === "end"' not in src, (
+        "onmessage must not check event.data === 'end'. "
+        "The 'end' event is a named SSE event and is not delivered to onmessage."
+    )
+
+
+def test_appjs_stream_closed_guard_present():
+    """A re-entrance guard (streamClosed) must prevent duplicate end/error messages."""
+    src = _load_appjs()
+    assert "streamClosed" in src, (
+        "streamLogs() must declare a streamClosed flag (or equivalent closeStream helper) "
+        "to prevent onerror from appending '[Connection Lost]' after an intentional close."
+    )
+
+
+def test_appjs_load_artifacts_called_on_end():
+    """loadArtifacts() must be called after the stream ends."""
+    src = _load_appjs()
+    # Find the addEventListener("end") block
+    match = re.search(
+        r'addEventListener\(["\']end["\'].*?loadArtifacts\(\)',
+        src,
+        re.DOTALL,
+    )
+    assert match, (
+        "loadArtifacts() must be called inside the 'end' event listener of streamLogs()."
+    )


### PR DESCRIPTION
## Befund & Diagnose

Zwei unabhängige Bugs, beide ohne Berührung von Merge-/Citation-/Dump-Code behoben.

---

### Issue A — Frontend: SSE `end`-Event wurde nie verarbeitet

**Ursache:** Das Backend sendet das Streamende als _named SSE event_:
```
event: end
data: end
```
`EventSource.onmessage` empfängt **keine** named events — dafür ist `addEventListener("end", ...)` erforderlich. Der bisherige Check `event.data === 'end'` in `onmessage` konnte niemals feuern, deshalb blieb der Stream im Browser offen und `[Job Finished]` erschien nie.

**Fix in `merger/lenskit/frontends/webui/app.js`:**
- `es.addEventListener("end", ...)` für das named end-event
- `closeStream(reason)`-Hilfsfunktion mit `streamClosed`-Guard — verhindert, dass `onerror` nach einem intentionalen Close noch `[Connection Lost]` anhängt
- `onmessage` verarbeitet nur noch normale Logzeilen

---

### Issue B — Backend: `running_jobs` in `/api/health` stale

**Ursache:** `runner.futures` ist ein Dict, das beim Submit befüllt wird, **aber nie bereinigt**. Nach 5 abgeschlossenen Jobs steht `len(state.runner.futures) == 5` für immer — unabhängig vom tatsächlichen Jobstatus.

**Fix in `merger/lenskit/service/app.py`:**
```python
# vorher
"running_jobs": len(state.runner.futures) if state.runner else 0

# nachher
"running_jobs": sum(
    1 for j in state.job_store.get_all_jobs()
    if j.status in ("queued", "running", "canceling")
) if state.job_store else 0
```
Zählt jetzt aus dem Job-Store — konsistent mit der activeSet-Definition in `jobstore.py`.

---

## Geänderte Dateien

| Datei | Änderung |
|---|---|
| `merger/lenskit/frontends/webui/app.js` | `addEventListener("end")`, `closeStream()`-Guard, `onmessage` bereinigt |
| `merger/lenskit/service/app.py` | `running_jobs` aus job_store statt `runner.futures` |
| `merger/lenskit/tests/test_webui_appjs_sse.py` | Statische Regressionstests für SSE-Fix (kein JS-Framework) |
| `merger/lenskit/tests/test_service_health.py` | Tests für `running_jobs`-Semantik: succeeded/failed/canceled=0, running/queued/canceling zählen |

---

## Testbefund

```
merger/lenskit/tests/test_service_health.py::test_health_running_jobs_zero_when_all_succeeded PASSED
merger/lenskit/tests/test_service_health.py::test_health_running_jobs_counts_active_statuses PASSED
merger/lenskit/tests/test_service_health.py::test_health_running_jobs_excludes_terminal PASSED
merger/lenskit/tests/test_webui_appjs_sse.py::test_appjs_has_named_end_listener PASSED
merger/lenskit/tests/test_webui_appjs_sse.py::test_appjs_onmessage_has_no_data_end_guard PASSED
merger/lenskit/tests/test_webui_appjs_sse.py::test_appjs_stream_closed_guard_present PASSED
merger/lenskit/tests/test_webui_appjs_sse.py::test_appjs_load_artifacts_called_on_end PASSED
7 passed
```

**Pre-existing failures** (pytest-asyncio nicht installiert, unberührt von diesem PR):
- `test_service_sse_lifecycle.py` — 4 async-Tests schlagen wegen fehlendem `pytest-asyncio` fehl

---

## Runtime-Proof

- `rlens.service` nach Patch neu gestartet
- Job `6b8f22d6` (level=overview, repo=lenskit) gestartet, durchgelaufen
- SSE-Stream liefert `event: end\ndata: end` am Ende bestätigt via `curl -N`
- `/api/health` meldet `running_jobs: 0` nach Jobabschluss ✓
- `/api/health` meldet `running_jobs: 0` im Leerlauf ✓

---

## Nicht geändert

Citation Producer, Merge-Output, Chunking, FTS, Atlas, Dump-Proofs — unberührt.