### PR TITLE
feat: emit citation map artifact from merge pipeline

### DIFF
--- a/docs/proofs/citation-map-pipeline-emission-proof.md
+++ b/docs/proofs/citation-map-pipeline-emission-proof.md
@@ -33,6 +33,19 @@
 - regenerable: true
 - staleness_sensitive: true
 
+## Designnotiz: Zweiphasige Manifest-Erzeugung
+
+Die Pipeline-Integration ist bewusst zweiphasig:
+
+1. write_reports_v2 schreibt ein provisorisches Bundle-Manifest ohne citation_map_jsonl.
+2. Der bestehende Producer produce_citation_map() liest dieses Manifest und erzeugt citation_map_jsonl.
+3. write_reports_v2 ergänzt citation_map_jsonl als Artefakt und schreibt das finale Manifest erneut atomar.
+
+Failure-Semantik:
+
+- Schlägt der Producer fehl, bricht der Run mit Fehler ab.
+- Es wird kein erfolgreicher finaler Bundle-Claim mit citation_map_jsonl erzeugt.
+
 ## Count-Konsistenz
 
 - citation_map_row_count: 613

--- a/docs/proofs/citation-map-pipeline-emission-proof.md
+++ b/docs/proofs/citation-map-pipeline-emission-proof.md
@@ -55,22 +55,35 @@ Failure-Semantik:
 
 Das Manifest paart dann repoA-Markdown mit repoB-Chunks, und der Producer schlägt mit "range.file_path does not match manifest canonical_md path" fehl.
 
-**Lösung:** Kohärenz-Guard vor Producer-Aufruf
+**Lösung:** Gehärteter Kohärenz-Guard vor Producer-Aufruf
 
-Die neue Funktion `is_manifest_coherent_for_citation_map()` in `merger/lenskit/core/citation_map.py` prüft:
+Die neue Funktion `check_manifest_coherence_for_citation_map()` in `merger/lenskit/core/citation_map.py`
+liefert ein strukturiertes Ergebnis `CitationMapCoherence` mit:
+- `coherent`
+- `skip_allowed`
+- `reason`
+
+Sie prüft:
 1. Manifest hat canonical_md und chunk_index_jsonl Artefakte
-2. Alle Chunks referenzieren denselben `canonical_range.file_path` wie das `canonical_md.path` Artefakt
-3. Wenn chunk_index_jsonl leer ist, gilt das als kohärent (keine Chunks zum Matchen)
+2. Beide Pfade sind sicher/normalisierbar
+3. Alle Chunks referenzieren denselben normalisierten `canonical_range.file_path` wie das normalisierte `canonical_md.path`
+4. Wenn chunk_index_jsonl leer ist, gilt das als kohärent (keine Chunks zum Matchen)
 
 **Verhalten:**
-- **Kohärent:** produce_citation_map() wird ausgeführt, citation_map_jsonl wird in Manifest eingetragen
-- **Inkohärent:** produce_citation_map() wird ÜBERSPRUNGEN, write_reports_v2 schlägt nicht fehl, Manifest enthält kein citation_map_jsonl
-- **Producer-Fehler bei kohärentem Manifest:** Bleibt harter Fehler (nicht pauschal verschluckt)
+- **Kohärent (`coherent=True`):** produce_citation_map() wird ausgeführt, citation_map_jsonl wird in Manifest eingetragen
+- **Inkohärent aber erlaubt (`skip_allowed=True`, `reason=range_file_path_mismatch`):** produce_citation_map() wird bewusst übersprungen
+- **Defekt (`skip_allowed=False`):** harter Fehler in write_reports_v2 (z. B. invalid JSONL, fehlende Artefakte, unsichere Pfade, unlesbare chunk_index)
+- **Producer-Fehler bei kohärentem Manifest:** bleibt harter Fehler
 
 Dies ermöglicht es:
 - Gesamt/Dual Bundles können weiterhin automatisch citation_map_jsonl erzeugen
 - Pro-repo Szenarien mit inkohärentem Manifest schlagen nicht fehl
 - Per-repo Citation Maps sind ein Folgepunkt, nicht Teil dieses PRs
+
+**Regressionstest (realer Codex-P1-Pfad):**
+- `merger/lenskit/tests/test_per_repo_cohesion.py::TestPerRepoCohesion::test_pro_repo_multi_repo_skips_citation_map_for_incoherent_manifest`
+- Führt tatsächlich `write_reports_v2(..., mode="pro-repo", output_mode="dual")` mit mehreren Repos aus
+- Verifiziert: Run ohne Exception, inkohärenter Aggregate-Manifest-Fall wird als `range_file_path_mismatch` erkannt, `citation_map_jsonl` wird für das Aggregate-Manifest nicht emittiert
 
 ## Count-Konsistenz
 

--- a/docs/proofs/citation-map-pipeline-emission-proof.md
+++ b/docs/proofs/citation-map-pipeline-emission-proof.md
@@ -44,7 +44,8 @@ Die Pipeline-Integration ist bewusst zweiphasig:
 Failure-Semantik:
 
 - Schlägt der Producer fehl, bricht der Run mit Fehler ab.
-- Es wird kein erfolgreicher finaler Bundle-Claim mit citation_map_jsonl erzeugt.
+- Ein eventuell bereits geschriebenes provisorisches Manifest gilt nicht als erfolgreicher finaler Bundle-Claim.
+- Die Service-/Job-Schicht darf Artefakte erst nach erfolgreichem write_reports_v2-Return als erfolgreich registrieren.
 
 ## Count-Konsistenz
 

--- a/docs/proofs/citation-map-pipeline-emission-proof.md
+++ b/docs/proofs/citation-map-pipeline-emission-proof.md
@@ -47,6 +47,31 @@ Failure-Semantik:
 - Ein eventuell bereits geschriebenes provisorisches Manifest gilt nicht als erfolgreicher finaler Bundle-Claim.
 - Die Service-/Job-Schicht darf Artefakte erst nach erfolgreichem write_reports_v2-Return als erfolgreich registrieren.
 
+## Kohärenz-Guard für pro-repo/multi-repo Szenarien (Codex-P1)
+
+**Problem (Codex-P1):** In `mode='pro-repo'` mit `output_mode='dual'` kann das provisorische Manifest ein inkohärentes Paar enthalten:
+- `final_canonical_md` = erstes Markdown aus `verified_md` (repoA)
+- `final_chunk_index` = letzter chunk_index (repoB oder später)
+
+Das Manifest paart dann repoA-Markdown mit repoB-Chunks, und der Producer schlägt mit "range.file_path does not match manifest canonical_md path" fehl.
+
+**Lösung:** Kohärenz-Guard vor Producer-Aufruf
+
+Die neue Funktion `is_manifest_coherent_for_citation_map()` in `merger/lenskit/core/citation_map.py` prüft:
+1. Manifest hat canonical_md und chunk_index_jsonl Artefakte
+2. Alle Chunks referenzieren denselben `canonical_range.file_path` wie das `canonical_md.path` Artefakt
+3. Wenn chunk_index_jsonl leer ist, gilt das als kohärent (keine Chunks zum Matchen)
+
+**Verhalten:**
+- **Kohärent:** produce_citation_map() wird ausgeführt, citation_map_jsonl wird in Manifest eingetragen
+- **Inkohärent:** produce_citation_map() wird ÜBERSPRUNGEN, write_reports_v2 schlägt nicht fehl, Manifest enthält kein citation_map_jsonl
+- **Producer-Fehler bei kohärentem Manifest:** Bleibt harter Fehler (nicht pauschal verschluckt)
+
+Dies ermöglicht es:
+- Gesamt/Dual Bundles können weiterhin automatisch citation_map_jsonl erzeugen
+- Pro-repo Szenarien mit inkohärentem Manifest schlagen nicht fehl
+- Per-repo Citation Maps sind ein Folgepunkt, nicht Teil dieses PRs
+
 ## Count-Konsistenz
 
 - citation_map_row_count: 613

--- a/docs/proofs/citation-map-pipeline-emission-proof.md
+++ b/docs/proofs/citation-map-pipeline-emission-proof.md
@@ -1,0 +1,92 @@
+# Citation Map Pipeline Emission Proof
+
+- Datum: 2026-05-15
+- Repo HEAD: 36553b82b201c3b6803ab6cb30e7809425b1b7df
+- Dump stem: lenskit-max-260515-0952_merge
+- Manifest-Pfad: /home/alex/repos/merges/lenskit-max-260515-0952_merge.bundle.manifest.json
+
+## Output Health
+
+- Datei: /home/alex/repos/merges/lenskit-max-260515-0952_merge.output_health.json
+- verdict: pass
+- errors: []
+- warnings: []
+- range_ref_resolution_status: ok
+
+## Manifest-Artefaktliste (Auszug)
+
+- canonical_md: lenskit-max-260515-0952_merge.md
+- chunk_index_jsonl: lenskit-max-260515-0952_merge.chunk_index.jsonl
+- citation_map_jsonl: lenskit-max-260515-0952_merge.citation_map.jsonl
+- dump_index_json: lenskit-max-260515-0952_merge.dump_index.json
+- derived_manifest_json: lenskit-max-260515-0952_merge.derived_index.json
+- index_sidecar_json: lenskit-max-260515-0952_merge.json
+- retrieval_eval_json: lenskit-max-260515-0952_merge.retrieval_eval.json
+- sqlite_index: lenskit-max-260515-0952_merge.chunk_index.index.sqlite
+- output_health: lenskit-max-260515-0952_merge.output_health.json
+
+## Citation Map Presence
+
+- role == citation_map_jsonl im Manifest: true
+- authority: navigation_index
+- canonicality: derived
+- regenerable: true
+- staleness_sensitive: true
+
+## Count-Konsistenz
+
+- citation_map_row_count: 613
+- chunk_index_row_count: 613
+- Ergebnis: gleich
+
+## SHA/Bytes-Proof (citation_map_jsonl)
+
+- Datei: /home/alex/repos/merges/lenskit-max-260515-0952_merge.citation_map.jsonl
+- manifest bytes: 358146
+- actual bytes: 358146
+- manifest sha256: 53e72777e00c3b2d03bec8aaa34882f623390a772a611289ba3b59e9bbc8cf33
+- actual sha256: 53e72777e00c3b2d03bec8aaa34882f623390a772a611289ba3b59e9bbc8cf33
+- Ergebnis: identisch
+
+## Canonical MD SHA Link
+
+- canonical_md manifest sha256: ab0d6aadf9421dd8b1e0fa6d4b5137ed04871d1ccdbcb8a40e0c40de962fff03
+- citation snapshot canonical_md_sha256: ab0d6aadf9421dd8b1e0fa6d4b5137ed04871d1ccdbcb8a40e0c40de962fff03
+- Ergebnis: identisch
+
+## Validator-Ergebnis
+
+Befehl:
+
+```bash
+python3 -m merger.lenskit.cli.main citation validate \
+  /home/alex/repos/merges/lenskit-max-260515-0952_merge.bundle.manifest.json --json
+```
+
+Ergebnis:
+
+- status: ok
+- error_kind: ok
+- citation_id_count: 613
+- citation_id_duplicate_count: 0
+- canonical_range_hash_ok_count: 613
+- errors: []
+
+## Schema-Validierung
+
+Befehl: Zeilenweise JSON-Schema-Validierung gegen merger/lenskit/contracts/citation-map.v1.schema.json
+
+Ergebnis:
+
+- schema_validated_rows: 613
+- Fehler: keine
+
+## Runtime-Artefakt-Regression
+
+- Prüfung: Kein strukturierter Pfad unter .claude/worktrees in Citation Map oder Manifest.
+- Ergebnis: keine Treffer.
+
+## Commit-Hygiene
+
+- Es wurden keine Dateien aus /home/alex/repos/merges committed.
+- Es wurden keine lokalen Runtime-Dateien wie .claude/settings.local.json oder .claude/worktrees committed.

--- a/merger/lenskit/core/citation_map.py
+++ b/merger/lenskit/core/citation_map.py
@@ -540,112 +540,121 @@ def _fail_report(
     }
 
 
-def is_manifest_coherent_for_citation_map(manifest_path: Path) -> bool:
+@dataclass(frozen=True, slots=True)
+class CitationMapCoherence:
+    coherent: bool
+    skip_allowed: bool
+    reason: str
+
+
+def check_manifest_coherence_for_citation_map(manifest_path: Path) -> CitationMapCoherence:
     """
-    Guard: Check if a bundle manifest's canonical_md and chunk_index_jsonl
-    reference the same canonical file path (coherent pair).
+    Validate whether manifest pairing is suitable for citation-map emission.
 
-    For pro-repo/multi-repo scenarios with output_mode='dual', the provisional
-    manifest may have an incoherent pair:
-      - canonical_md from repoA
-      - chunk_index_jsonl from repoB (or later repo)
+    Structured semantics:
+      - coherent=True: run producer (hard failures still surface)
+      - coherent=False + skip_allowed=True: known benign mismatch case
+      - coherent=False + skip_allowed=False: hard defect, caller should fail
 
-    In such cases, produce_citation_map would fail with a range.file_path mismatch.
-    This guard catches that early and allows the caller to skip citation generation
-    without failing the entire write_reports_v2 operation.
-
-    Returns True if:
-      - Manifest has canonical_md and chunk_index_jsonl artifacts
-      - Both exist and are readable
-      - All chunks reference the same file_path as the canonical_md artifact
-      - Or chunk_index_jsonl is empty (valid case)
-
-    Returns False if:
-      - Either artifact is missing or unreadable (silently skip)
-      - At least one chunk references a different file_path than canonical_md
-      - Any JSON parsing error (silently skip)
-
-    Raises nothing; failures are silent (returns False) to avoid hard errors
-    in pro-repo scenarios where skipping citation generation is acceptable.
+    In pro-repo/multi-repo aggregation, a provisional manifest may pair
+    canonical_md from repoA with chunk_index_jsonl from repoB. This must be a
+    deliberate skip, not a failure. Other defects (invalid JSON, unsafe paths,
+    missing artifacts) are hard errors and must not be silently downgraded.
     """
+    manifest_dir = manifest_path.parent
+
     try:
-        manifest_dir = manifest_path.parent
+        manifest = load_manifest(manifest_path)
+    except (json.JSONDecodeError, OSError):
+        return CitationMapCoherence(False, False, "invalid_manifest")
 
-        # Load manifest
-        try:
-            manifest = load_manifest(manifest_path)
-        except Exception:
-            return False
+    canonical_md_artifact = next(
+        (
+            a
+            for a in manifest.get("artifacts", [])
+            if isinstance(a, dict) and a.get("role") == "canonical_md"
+        ),
+        None,
+    )
+    if canonical_md_artifact is None:
+        return CitationMapCoherence(False, False, "missing_canonical_md_artifact")
 
-        # Find canonical_md artifact
-        canonical_md_artifact = next(
-            (a for a in manifest.get("artifacts", [])
-             if isinstance(a, dict) and a.get("role") == "canonical_md"),
-            None,
-        )
-        if canonical_md_artifact is None:
-            return False
+    chunk_index_artifact = next(
+        (
+            a
+            for a in manifest.get("artifacts", [])
+            if isinstance(a, dict) and a.get("role") == "chunk_index_jsonl"
+        ),
+        None,
+    )
+    if chunk_index_artifact is None:
+        return CitationMapCoherence(False, False, "missing_chunk_index_artifact")
 
-        canonical_md_path = canonical_md_artifact.get("path")
-        if not canonical_md_path:
-            return False
+    canonical_md_raw = canonical_md_artifact.get("path")
+    if not isinstance(canonical_md_raw, str) or not canonical_md_raw:
+        return CitationMapCoherence(False, False, "invalid_canonical_md_path")
 
-        # Find chunk_index_jsonl artifact
-        chunk_index_artifact = next(
-            (a for a in manifest.get("artifacts", [])
-             if isinstance(a, dict) and a.get("role") == "chunk_index_jsonl"),
-            None,
-        )
-        if chunk_index_artifact is None:
-            return False
+    try:
+        canonical_md_rel = _normalize_relative_path(canonical_md_raw, "canonical_md.path")
+    except ValueError:
+        return CitationMapCoherence(False, False, "unsafe_canonical_md_path")
 
-        # Resolve and check chunk_index file exists
-        try:
-            chunk_index_abs = resolve_secure_path(manifest_dir, chunk_index_artifact.get("path", ""))
-        except Exception:
-            return False
+    chunk_index_raw = chunk_index_artifact.get("path", "")
+    if not isinstance(chunk_index_raw, str) or not chunk_index_raw:
+        return CitationMapCoherence(False, False, "invalid_chunk_index_path")
 
-        if not chunk_index_abs.exists():
-            return False
+    try:
+        chunk_index_rel = _normalize_relative_path(chunk_index_raw, "chunk_index_jsonl.path")
+    except ValueError:
+        return CitationMapCoherence(False, False, "unsafe_chunk_index_path")
 
-        # Load chunk_index (NDJSON)
-        try:
-            with chunk_index_abs.open("r", encoding="utf-8") as f:
-                chunk_lines = f.readlines()
-        except Exception:
-            return False
+    try:
+        chunk_index_abs = resolve_secure_path(manifest_dir, chunk_index_rel)
+    except ValueError:
+        return CitationMapCoherence(False, False, "unsafe_chunk_index_path")
 
-        # If chunk_index is empty, it's coherent (no chunks to mismatch)
-        if not chunk_lines:
-            return True
+    if not chunk_index_abs.exists() or not chunk_index_abs.is_file():
+        return CitationMapCoherence(False, False, "missing_chunk_index_file")
 
-        # Parse and check canonical_range.file_path consistency
-        for line in chunk_lines:
-            if not line.strip():
-                continue
-            try:
-                chunk = json.loads(line)
-            except json.JSONDecodeError:
-                # Malformed line: treat as incoherent (safer to skip)
-                return False
+    saw_nonempty_line = False
+    try:
+        with chunk_index_abs.open("r", encoding="utf-8") as f:
+            for lineno, line in enumerate(f, start=1):
+                if not line.strip():
+                    continue
+                saw_nonempty_line = True
+                try:
+                    chunk = json.loads(line)
+                except json.JSONDecodeError:
+                    return CitationMapCoherence(False, False, "invalid_chunk_index_json")
 
-            # Extract canonical_range.file_path
-            normalized_range = normalize_canonical_range(chunk)
-            if normalized_range is None:
-                # No canonical_range or wrong role: treat as incoherent
-                return False
+                normalized_range = normalize_canonical_range(chunk)
+                if normalized_range is None:
+                    return CitationMapCoherence(False, False, "missing_or_invalid_canonical_range")
 
-            chunk_file_path = normalized_range.get("file_path")
-            if chunk_file_path != canonical_md_path:
-                # Mismatch: this is the incoherent case we're guarding against
-                return False
+                chunk_file_raw = normalized_range.get("file_path")
+                if not isinstance(chunk_file_raw, str) or not chunk_file_raw:
+                    return CitationMapCoherence(False, False, "missing_range_file_path")
 
-        # All chunks are coherent with canonical_md
-        return True
+                try:
+                    chunk_file_rel = _normalize_relative_path(chunk_file_raw, f"range.file_path line {lineno}")
+                except ValueError:
+                    return CitationMapCoherence(False, False, "unsafe_range_file_path")
 
-    except Exception:
-        # Any unexpected error: silently return False (skip citation generation)
-        return False
+                if chunk_file_rel != canonical_md_rel:
+                    return CitationMapCoherence(False, True, "range_file_path_mismatch")
+    except OSError:
+        return CitationMapCoherence(False, False, "unreadable_chunk_index")
+
+    if not saw_nonempty_line:
+        return CitationMapCoherence(True, False, "coherent_empty_chunk_index")
+
+    return CitationMapCoherence(True, False, "coherent")
+
+
+def is_manifest_coherent_for_citation_map(manifest_path: Path) -> bool:
+    """Compatibility wrapper around check_manifest_coherence_for_citation_map."""
+    return check_manifest_coherence_for_citation_map(manifest_path).coherent
 
 
 def produce_citation_map(

--- a/merger/lenskit/core/citation_map.py
+++ b/merger/lenskit/core/citation_map.py
@@ -7,8 +7,10 @@ writing NDJSON output.  IO is isolated to produce_citation_map().
 """
 import hashlib
 import json
+import os
 import re
 import uuid
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Set, Tuple
@@ -62,6 +64,30 @@ def _sha256_file(path: Path) -> str:
 
 def _sha256_bytes(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
+
+
+def _write_bytes_atomic(path: Path, data: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path: Optional[Path] = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            delete=False,
+            dir=str(path.parent),
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+        ) as tmp_file:
+            tmp_file.write(data)
+            tmp_file.flush()
+            os.fsync(tmp_file.fileno())
+            tmp_path = Path(tmp_file.name)
+        os.replace(tmp_path, path)
+    finally:
+        if tmp_path is not None and tmp_path.exists():
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
 
 
 # ---------------------------------------------------------------------------
@@ -786,7 +812,7 @@ def produce_citation_map(
             ("\n".join(output_lines) + "\n").encode("utf-8") if output_lines else b""
         )
         try:
-            output_path.write_bytes(ndjson_bytes)
+            _write_bytes_atomic(output_path, ndjson_bytes)
         except OSError as e:
             return _fail_report(
                 production_run_id,

--- a/merger/lenskit/core/citation_map.py
+++ b/merger/lenskit/core/citation_map.py
@@ -540,6 +540,114 @@ def _fail_report(
     }
 
 
+def is_manifest_coherent_for_citation_map(manifest_path: Path) -> bool:
+    """
+    Guard: Check if a bundle manifest's canonical_md and chunk_index_jsonl
+    reference the same canonical file path (coherent pair).
+
+    For pro-repo/multi-repo scenarios with output_mode='dual', the provisional
+    manifest may have an incoherent pair:
+      - canonical_md from repoA
+      - chunk_index_jsonl from repoB (or later repo)
+
+    In such cases, produce_citation_map would fail with a range.file_path mismatch.
+    This guard catches that early and allows the caller to skip citation generation
+    without failing the entire write_reports_v2 operation.
+
+    Returns True if:
+      - Manifest has canonical_md and chunk_index_jsonl artifacts
+      - Both exist and are readable
+      - All chunks reference the same file_path as the canonical_md artifact
+      - Or chunk_index_jsonl is empty (valid case)
+
+    Returns False if:
+      - Either artifact is missing or unreadable (silently skip)
+      - At least one chunk references a different file_path than canonical_md
+      - Any JSON parsing error (silently skip)
+
+    Raises nothing; failures are silent (returns False) to avoid hard errors
+    in pro-repo scenarios where skipping citation generation is acceptable.
+    """
+    try:
+        manifest_dir = manifest_path.parent
+
+        # Load manifest
+        try:
+            manifest = load_manifest(manifest_path)
+        except Exception:
+            return False
+
+        # Find canonical_md artifact
+        canonical_md_artifact = next(
+            (a for a in manifest.get("artifacts", [])
+             if isinstance(a, dict) and a.get("role") == "canonical_md"),
+            None,
+        )
+        if canonical_md_artifact is None:
+            return False
+
+        canonical_md_path = canonical_md_artifact.get("path")
+        if not canonical_md_path:
+            return False
+
+        # Find chunk_index_jsonl artifact
+        chunk_index_artifact = next(
+            (a for a in manifest.get("artifacts", [])
+             if isinstance(a, dict) and a.get("role") == "chunk_index_jsonl"),
+            None,
+        )
+        if chunk_index_artifact is None:
+            return False
+
+        # Resolve and check chunk_index file exists
+        try:
+            chunk_index_abs = resolve_secure_path(manifest_dir, chunk_index_artifact.get("path", ""))
+        except Exception:
+            return False
+
+        if not chunk_index_abs.exists():
+            return False
+
+        # Load chunk_index (NDJSON)
+        try:
+            with chunk_index_abs.open("r", encoding="utf-8") as f:
+                chunk_lines = f.readlines()
+        except Exception:
+            return False
+
+        # If chunk_index is empty, it's coherent (no chunks to mismatch)
+        if not chunk_lines:
+            return True
+
+        # Parse and check canonical_range.file_path consistency
+        for line in chunk_lines:
+            if not line.strip():
+                continue
+            try:
+                chunk = json.loads(line)
+            except json.JSONDecodeError:
+                # Malformed line: treat as incoherent (safer to skip)
+                return False
+
+            # Extract canonical_range.file_path
+            normalized_range = normalize_canonical_range(chunk)
+            if normalized_range is None:
+                # No canonical_range or wrong role: treat as incoherent
+                return False
+
+            chunk_file_path = normalized_range.get("file_path")
+            if chunk_file_path != canonical_md_path:
+                # Mismatch: this is the incoherent case we're guarding against
+                return False
+
+        # All chunks are coherent with canonical_md
+        return True
+
+    except Exception:
+        # Any unexpected error: silently return False (skip citation generation)
+        return False
+
+
 def produce_citation_map(
     manifest_path_str: str,
     output_path_str: Optional[str] = None,

--- a/merger/lenskit/core/merge.py
+++ b/merger/lenskit/core/merge.py
@@ -62,6 +62,7 @@ def _write_text_atomic(path: Path, text: str) -> None:
             except OSError:
                 pass
 
+
 def _slug_token(s: str) -> str:
     """Deterministic ASCII token suitable for heading ids across renderers."""
 
@@ -6053,13 +6054,15 @@ def write_reports_v2(
     out_paths.append(bundle_manifest_path)
 
     if final_canonical_md and final_chunk_index:
-        from .citation_map import produce_citation_map, is_manifest_coherent_for_citation_map
+        from .citation_map import (
+            produce_citation_map,
+            check_manifest_coherence_for_citation_map,
+        )
 
-        # Guard: Only emit citation_map if the manifest has a coherent canonical_md/chunk_index pair.
-        # In pro-repo/multi-repo scenarios with output_mode='dual', the provisional manifest may
-        # pair canonical_md from repoA with chunk_index from repoB (late repo), causing producer to fail
-        # with a "range.file_path does not match" error. Skip silently in that case.
-        if is_manifest_coherent_for_citation_map(bundle_manifest_path):
+        # Guard: emit citation_map only for coherent canonical_md/chunk_index pairs.
+        # Known pro-repo mismatch is a deliberate skip; malformed artifacts remain hard errors.
+        coherence = check_manifest_coherence_for_citation_map(bundle_manifest_path)
+        if coherence.coherent:
             citation_map_report = produce_citation_map(str(bundle_manifest_path))
             if citation_map_report.get("status") != "ok":
                 raise RuntimeError(
@@ -6079,6 +6082,11 @@ def write_reports_v2(
             artifacts_list.sort(key=lambda a: (a["role"], a["path"]))
             bundle_manifest["artifacts"] = artifacts_list
             _write_text_atomic(bundle_manifest_path, json.dumps(bundle_manifest, indent=2))
+        elif not coherence.skip_allowed:
+            raise RuntimeError(
+                "Cannot evaluate citation_map_jsonl coherence: "
+                f"{coherence.reason}"
+            )
 
     if extras and extras.json_sidecar:
         # JSON is primary when json_sidecar is enabled

--- a/merger/lenskit/core/merge.py
+++ b/merger/lenskit/core/merge.py
@@ -6063,6 +6063,9 @@ def write_reports_v2(
             )
 
         citation_map_path = Path(citation_map_report["output_path"])
+        out_paths.append(citation_map_path)
+        if citation_map_path not in other_paths:
+            other_paths.append(citation_map_path)
         _add_artifact(
             citation_map_path,
             ArtifactRole.CITATION_MAP_JSONL,

--- a/merger/lenskit/core/merge.py
+++ b/merger/lenskit/core/merge.py
@@ -12,6 +12,7 @@ import json
 import hashlib
 import datetime
 import re
+import tempfile
 import unicodedata
 import concurrent.futures
 from pathlib import Path
@@ -35,6 +36,31 @@ except Exception:  # pragma: no cover
 _NON_ALNUM = re.compile(r"[^a-z0-9]+")
 
 EPISTEMIC_HUMILITY_WARNING = "⚠️ **Hinweis:** Dieses Profil/Filter erlaubt keine Aussagen über das Nicht-Vorhandensein von Dateien im Repository. Fehlende Einträge bedeuten lediglich „nicht im Ausschnitt enthalten“."
+
+
+def _write_text_atomic(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path: Optional[Path] = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            delete=False,
+            dir=str(path.parent),
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+        ) as tmp_file:
+            tmp_file.write(text)
+            tmp_file.flush()
+            os.fsync(tmp_file.fileno())
+            tmp_path = Path(tmp_file.name)
+        os.replace(tmp_path, path)
+    finally:
+        if tmp_path is not None and tmp_path.exists():
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
 
 def _slug_token(s: str) -> str:
     """Deterministic ASCII token suitable for heading ids across renderers."""
@@ -6023,8 +6049,28 @@ def write_reports_v2(
             "redaction": redact_secrets
         }
     }
-    bundle_manifest_path.write_text(json.dumps(bundle_manifest, indent=2), encoding="utf-8")
+    _write_text_atomic(bundle_manifest_path, json.dumps(bundle_manifest, indent=2))
     out_paths.append(bundle_manifest_path)
+
+    if final_canonical_md and final_chunk_index:
+        from .citation_map import produce_citation_map
+
+        citation_map_report = produce_citation_map(str(bundle_manifest_path))
+        if citation_map_report.get("status") != "ok":
+            raise RuntimeError(
+                "Failed to produce citation_map_jsonl: "
+                + "; ".join(citation_map_report.get("errors", []) or ["unknown error"])
+            )
+
+        citation_map_path = Path(citation_map_report["output_path"])
+        _add_artifact(
+            citation_map_path,
+            ArtifactRole.CITATION_MAP_JSONL,
+            "application/x-ndjson",
+        )
+        artifacts_list.sort(key=lambda a: (a["role"], a["path"]))
+        bundle_manifest["artifacts"] = artifacts_list
+        _write_text_atomic(bundle_manifest_path, json.dumps(bundle_manifest, indent=2))
 
     if extras and extras.json_sidecar:
         # JSON is primary when json_sidecar is enabled

--- a/merger/lenskit/core/merge.py
+++ b/merger/lenskit/core/merge.py
@@ -6053,27 +6053,32 @@ def write_reports_v2(
     out_paths.append(bundle_manifest_path)
 
     if final_canonical_md and final_chunk_index:
-        from .citation_map import produce_citation_map
+        from .citation_map import produce_citation_map, is_manifest_coherent_for_citation_map
 
-        citation_map_report = produce_citation_map(str(bundle_manifest_path))
-        if citation_map_report.get("status") != "ok":
-            raise RuntimeError(
-                "Failed to produce citation_map_jsonl: "
-                + "; ".join(citation_map_report.get("errors", []) or ["unknown error"])
+        # Guard: Only emit citation_map if the manifest has a coherent canonical_md/chunk_index pair.
+        # In pro-repo/multi-repo scenarios with output_mode='dual', the provisional manifest may
+        # pair canonical_md from repoA with chunk_index from repoB (late repo), causing producer to fail
+        # with a "range.file_path does not match" error. Skip silently in that case.
+        if is_manifest_coherent_for_citation_map(bundle_manifest_path):
+            citation_map_report = produce_citation_map(str(bundle_manifest_path))
+            if citation_map_report.get("status") != "ok":
+                raise RuntimeError(
+                    "Failed to produce citation_map_jsonl: "
+                    + "; ".join(citation_map_report.get("errors", []) or ["unknown error"])
+                )
+
+            citation_map_path = Path(citation_map_report["output_path"])
+            out_paths.append(citation_map_path)
+            if citation_map_path not in other_paths:
+                other_paths.append(citation_map_path)
+            _add_artifact(
+                citation_map_path,
+                ArtifactRole.CITATION_MAP_JSONL,
+                "application/x-ndjson",
             )
-
-        citation_map_path = Path(citation_map_report["output_path"])
-        out_paths.append(citation_map_path)
-        if citation_map_path not in other_paths:
-            other_paths.append(citation_map_path)
-        _add_artifact(
-            citation_map_path,
-            ArtifactRole.CITATION_MAP_JSONL,
-            "application/x-ndjson",
-        )
-        artifacts_list.sort(key=lambda a: (a["role"], a["path"]))
-        bundle_manifest["artifacts"] = artifacts_list
-        _write_text_atomic(bundle_manifest_path, json.dumps(bundle_manifest, indent=2))
+            artifacts_list.sort(key=lambda a: (a["role"], a["path"]))
+            bundle_manifest["artifacts"] = artifacts_list
+            _write_text_atomic(bundle_manifest_path, json.dumps(bundle_manifest, indent=2))
 
     if extras and extras.json_sidecar:
         # JSON is primary when json_sidecar is enabled

--- a/merger/lenskit/tests/test_bundle_manifest_integration.py
+++ b/merger/lenskit/tests/test_bundle_manifest_integration.py
@@ -724,105 +724,119 @@ def test_bundle_manifest_hash_recompute_detects_artifact_drift(tmp_path):
     )
 
 
-def test_is_manifest_coherent_guard_accepts_coherent_manifest(tmp_path):
-    """The coherence guard must return True for a manifest with matching canonical_md/chunk_index."""
-    from merger.lenskit.core.citation_map import is_manifest_coherent_for_citation_map
+def test_manifest_coherence_check_accepts_coherent_manifest(tmp_path):
+    from merger.lenskit.core.citation_map import check_manifest_coherence_for_citation_map
 
-    artifacts, manifest_data, manifest_dir = _make_minimal_bundle(tmp_path)
-    # Use the actual manifest path from artifacts, not a hardcoded filename
+    artifacts, manifest_data, _ = _make_minimal_bundle(tmp_path)
     manifest_path = artifacts.bundle_manifest
     assert manifest_path is not None and manifest_path.exists()
 
-    # Verify canonical_md and chunk_index exist
     assert any(a["role"] == "canonical_md" for a in manifest_data["artifacts"])
     assert any(a["role"] == "chunk_index_jsonl" for a in manifest_data["artifacts"])
 
-    # Guard must accept this coherent manifest
-    assert is_manifest_coherent_for_citation_map(manifest_path) is True
+    coherence = check_manifest_coherence_for_citation_map(manifest_path)
+    assert coherence.coherent is True
+    assert coherence.skip_allowed is False
+    assert coherence.reason in ("coherent", "coherent_empty_chunk_index")
 
 
-def test_is_manifest_coherent_guard_rejects_incoherent_manifest(tmp_path):
-    """The coherence guard must return False when chunk ranges don't match canonical_md path."""
-    from merger.lenskit.core.citation_map import is_manifest_coherent_for_citation_map
-
-    artifacts, manifest_data, manifest_dir = _make_minimal_bundle(tmp_path)
-    manifest_path = artifacts.bundle_manifest
-    assert manifest_path is not None and manifest_path.exists()
-
-    # Find canonical_md and chunk_index entries
-    canonical_md_entry = next(
-        (a for a in manifest_data["artifacts"] if a["role"] == "canonical_md"), None
-    )
-    chunk_index_entry = next(
-        (a for a in manifest_data["artifacts"] if a["role"] == "chunk_index_jsonl"), None
-    )
-    assert canonical_md_entry is not None
-    assert chunk_index_entry is not None
-
-    # Modify chunk_index to have a mismatched file_path
-    chunk_index_path = manifest_dir / chunk_index_entry["path"]
-    assert chunk_index_path.exists()
-
-    original_chunks = []
-    with chunk_index_path.open("r", encoding="utf-8") as f:
-        for line in f:
-            if line.strip():
-                original_chunks.append(json.loads(line))
-
-    # Inject a chunk with mismatched file_path
-    if original_chunks:
-        original_chunks[0]["canonical_range"]["file_path"] = "wrong_file.md"
-
-    # Rewrite chunk_index
-    with chunk_index_path.open("w", encoding="utf-8") as f:
-        for chunk in original_chunks:
-            f.write(json.dumps(chunk) + "\n")
-
-    # Guard must reject this incoherent manifest
-    assert is_manifest_coherent_for_citation_map(manifest_path) is False
-
-
-def test_pro_repo_multi_repo_skips_citation_map_for_incoherent_manifest(tmp_path):
-    """
-    Regression test for Codex-P1: The coherence guard must correctly identify
-    incoherent manifest pairs and allow write_reports_v2 to skip citation_map generation.
-
-    This test validates the guard's ability to detect and handle the case where
-    canonical_md and chunk_index_jsonl reference different file paths
-    (as can occur in pro-repo/multi-repo mode with output_mode='dual').
-    """
-    from merger.lenskit.core.citation_map import is_manifest_coherent_for_citation_map
+def test_manifest_coherence_check_marks_path_mismatch_as_skippable(tmp_path):
+    from merger.lenskit.core.citation_map import check_manifest_coherence_for_citation_map
 
     artifacts, manifest_data, manifest_dir = _make_minimal_bundle(tmp_path)
     manifest_path = artifacts.bundle_manifest
     assert manifest_path is not None and manifest_path.exists()
 
-    # Precondition: verify the original manifest is coherent
-    assert is_manifest_coherent_for_citation_map(manifest_path) is True
-
-    # Now simulate incoherent manifest by tampering with chunk_index
     chunk_index_entry = next(
         (a for a in manifest_data["artifacts"] if a["role"] == "chunk_index_jsonl"), None
     )
     assert chunk_index_entry is not None
 
     chunk_index_path = manifest_dir / chunk_index_entry["path"]
-    original_chunks = []
+    rows = []
     with chunk_index_path.open("r", encoding="utf-8") as f:
         for line in f:
             if line.strip():
-                original_chunks.append(json.loads(line))
-
-    # Inject mismatch: change one chunk's canonical_range.file_path to simulate
-    # a scenario where repoA's markdown exists but repoB's chunk_index points elsewhere
-    if original_chunks:
-        original_chunks[0]["canonical_range"]["file_path"] = "repo_B.md"
-
+                rows.append(json.loads(line))
+    assert rows
+    rows[0]["canonical_range"]["file_path"] = "wrong_file.md"
     with chunk_index_path.open("w", encoding="utf-8") as f:
-        for chunk in original_chunks:
-            f.write(json.dumps(chunk) + "\n")
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
 
-    # Verify guard now rejects this incoherent manifest
-    assert is_manifest_coherent_for_citation_map(manifest_path) is False, (
-        "Guard must reject manifest with mismatched canonical_md/chunk_index paths"
+    coherence = check_manifest_coherence_for_citation_map(manifest_path)
+    assert coherence.coherent is False
+    assert coherence.skip_allowed is True
+    assert coherence.reason == "range_file_path_mismatch"
+
+
+def test_manifest_coherence_check_marks_invalid_json_as_hard_error(tmp_path):
+    from merger.lenskit.core.citation_map import check_manifest_coherence_for_citation_map
+
+    artifacts, manifest_data, manifest_dir = _make_minimal_bundle(tmp_path)
+    manifest_path = artifacts.bundle_manifest
+    assert manifest_path is not None and manifest_path.exists()
+
+    chunk_index_entry = next(
+        (a for a in manifest_data["artifacts"] if a["role"] == "chunk_index_jsonl"), None
     )
+    assert chunk_index_entry is not None
+
+    chunk_index_path = manifest_dir / chunk_index_entry["path"]
+    chunk_index_path.write_text("{not-json}\n", encoding="utf-8")
+
+    coherence = check_manifest_coherence_for_citation_map(manifest_path)
+    assert coherence.coherent is False
+    assert coherence.skip_allowed is False
+    assert coherence.reason == "invalid_chunk_index_json"
+
+
+def test_manifest_coherence_check_accepts_empty_chunk_index(tmp_path):
+    from merger.lenskit.core.citation_map import check_manifest_coherence_for_citation_map
+
+    artifacts, manifest_data, manifest_dir = _make_minimal_bundle(tmp_path)
+    manifest_path = artifacts.bundle_manifest
+    assert manifest_path is not None and manifest_path.exists()
+
+    chunk_index_entry = next(
+        (a for a in manifest_data["artifacts"] if a["role"] == "chunk_index_jsonl"), None
+    )
+    assert chunk_index_entry is not None
+
+    chunk_index_path = manifest_dir / chunk_index_entry["path"]
+    chunk_index_path.write_text("", encoding="utf-8")
+
+    coherence = check_manifest_coherence_for_citation_map(manifest_path)
+    assert coherence.coherent is True
+    assert coherence.skip_allowed is False
+    assert coherence.reason == "coherent_empty_chunk_index"
+
+
+def test_manifest_coherence_check_marks_unsafe_path_as_hard_error(tmp_path):
+    from merger.lenskit.core.citation_map import check_manifest_coherence_for_citation_map
+
+    artifacts, manifest_data, manifest_dir = _make_minimal_bundle(tmp_path)
+    manifest_path = artifacts.bundle_manifest
+    assert manifest_path is not None and manifest_path.exists()
+
+    chunk_index_entry = next(
+        (a for a in manifest_data["artifacts"] if a["role"] == "chunk_index_jsonl"), None
+    )
+    assert chunk_index_entry is not None
+
+    chunk_index_path = manifest_dir / chunk_index_entry["path"]
+    rows = []
+    with chunk_index_path.open("r", encoding="utf-8") as f:
+        for line in f:
+            if line.strip():
+                rows.append(json.loads(line))
+    assert rows
+    rows[0]["canonical_range"]["file_path"] = "../escape.md"
+    with chunk_index_path.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+
+    coherence = check_manifest_coherence_for_citation_map(manifest_path)
+    assert coherence.coherent is False
+    assert coherence.skip_allowed is False
+    assert coherence.reason == "unsafe_range_file_path"

--- a/merger/lenskit/tests/test_bundle_manifest_integration.py
+++ b/merger/lenskit/tests/test_bundle_manifest_integration.py
@@ -20,6 +20,7 @@ _BUNDLE_MANIFEST_SCHEMA_PATH = (
 _OUTPUT_HEALTH_SCHEMA_PATH = (
     _CONTRACTS_DIR / "output-health.v1.schema.json"
 )
+_CITATION_MAP_SCHEMA_PATH = _CONTRACTS_DIR / "citation-map.v1.schema.json"
 _SHA256_HEX_LENGTH = 64
 
 
@@ -124,6 +125,17 @@ def test_generate_bundle_manifest_integration(tmp_path):
     chunk_entry = roles_map.get(ArtifactRole.CHUNK_INDEX_JSONL.value)
     assert chunk_entry and "contract" not in chunk_entry
     assert chunk_entry["interpretation"]["mode"] == "role_only"
+
+    citation_entry = roles_map.get(ArtifactRole.CITATION_MAP_JSONL.value)
+    assert citation_entry and "contract" in citation_entry
+    assert citation_entry["contract"]["id"] == "citation-map"
+    assert citation_entry["contract"]["version"] == "v1"
+    assert citation_entry["interpretation"]["mode"] == "contract"
+    assert citation_entry["authority"] == "navigation_index"
+    assert citation_entry["canonicality"] == "derived"
+    assert citation_entry["regenerable"] is True
+    assert citation_entry["staleness_sensitive"] is True
+    assert citation_entry["path"].endswith(".citation_map.jsonl")
 
     output_health_entry = roles_map.get(ArtifactRole.OUTPUT_HEALTH.value)
     assert output_health_entry and "contract" not in output_health_entry
@@ -618,6 +630,48 @@ def test_bundle_manifest_artifact_hashes_match_files(tmp_path):
         assert _sha256_file(p) == entry["sha256"], (
             f"sha256 mismatch for {entry['path']}"
         )
+
+
+def test_citation_map_artifact_integrity_and_schema(tmp_path):
+    artifacts, data, manifest_dir = _make_minimal_bundle(tmp_path)
+
+    manifest_schema = json.loads(_BUNDLE_MANIFEST_SCHEMA_PATH.read_text(encoding="utf-8"))
+    citation_schema = json.loads(_CITATION_MAP_SCHEMA_PATH.read_text(encoding="utf-8"))
+
+    jsonschema.validate(instance=data, schema=manifest_schema)
+
+    roles_map = {item["role"]: item for item in data["artifacts"]}
+    citation_entry = roles_map[ArtifactRole.CITATION_MAP_JSONL.value]
+    chunk_entry = roles_map[ArtifactRole.CHUNK_INDEX_JSONL.value]
+    canonical_entry = roles_map[ArtifactRole.CANONICAL_MD.value]
+
+    citation_path = manifest_dir / citation_entry["path"]
+    chunk_path = manifest_dir / chunk_entry["path"]
+
+    assert citation_path.exists()
+    assert citation_entry["bytes"] == citation_path.stat().st_size
+    assert citation_entry["sha256"] == _sha256_file(citation_path)
+
+    with citation_path.open(encoding="utf-8") as f:
+        citation_rows = [json.loads(line) for line in f if line.strip()]
+    with chunk_path.open(encoding="utf-8") as f:
+        chunk_rows = [json.loads(line) for line in f if line.strip()]
+
+    assert len(citation_rows) == len(chunk_rows)
+    assert len(citation_rows) > 0
+    assert citation_entry["bytes"] == citation_path.stat().st_size
+    assert canonical_entry["sha256"] == citation_rows[0]["snapshot"]["canonical_md_sha256"]
+
+    citation_ids = set()
+    chunk_ids = {row.get("chunk_id") for row in chunk_rows if row.get("chunk_id") is not None}
+    for row in citation_rows:
+        jsonschema.validate(instance=row, schema=citation_schema)
+        assert row["citation_id"] not in citation_ids
+        citation_ids.add(row["citation_id"])
+        if "chunk_id" in row:
+            assert row["chunk_id"] in chunk_ids
+
+    assert len(citation_ids) == len(citation_rows)
 
 
 def test_bundle_manifest_canonical_dump_index_sha_matches_dump_index_artifact(tmp_path):

--- a/merger/lenskit/tests/test_bundle_manifest_integration.py
+++ b/merger/lenskit/tests/test_bundle_manifest_integration.py
@@ -722,3 +722,107 @@ def test_bundle_manifest_hash_recompute_detects_artifact_drift(tmp_path):
     assert _sha256_file(target_path) != recorded_sha, (
         "recomputed hash must differ from manifest after artifact mutation"
     )
+
+
+def test_is_manifest_coherent_guard_accepts_coherent_manifest(tmp_path):
+    """The coherence guard must return True for a manifest with matching canonical_md/chunk_index."""
+    from merger.lenskit.core.citation_map import is_manifest_coherent_for_citation_map
+
+    artifacts, manifest_data, manifest_dir = _make_minimal_bundle(tmp_path)
+    # Use the actual manifest path from artifacts, not a hardcoded filename
+    manifest_path = artifacts.bundle_manifest
+    assert manifest_path is not None and manifest_path.exists()
+
+    # Verify canonical_md and chunk_index exist
+    assert any(a["role"] == "canonical_md" for a in manifest_data["artifacts"])
+    assert any(a["role"] == "chunk_index_jsonl" for a in manifest_data["artifacts"])
+
+    # Guard must accept this coherent manifest
+    assert is_manifest_coherent_for_citation_map(manifest_path) is True
+
+
+def test_is_manifest_coherent_guard_rejects_incoherent_manifest(tmp_path):
+    """The coherence guard must return False when chunk ranges don't match canonical_md path."""
+    from merger.lenskit.core.citation_map import is_manifest_coherent_for_citation_map
+
+    artifacts, manifest_data, manifest_dir = _make_minimal_bundle(tmp_path)
+    manifest_path = artifacts.bundle_manifest
+    assert manifest_path is not None and manifest_path.exists()
+
+    # Find canonical_md and chunk_index entries
+    canonical_md_entry = next(
+        (a for a in manifest_data["artifacts"] if a["role"] == "canonical_md"), None
+    )
+    chunk_index_entry = next(
+        (a for a in manifest_data["artifacts"] if a["role"] == "chunk_index_jsonl"), None
+    )
+    assert canonical_md_entry is not None
+    assert chunk_index_entry is not None
+
+    # Modify chunk_index to have a mismatched file_path
+    chunk_index_path = manifest_dir / chunk_index_entry["path"]
+    assert chunk_index_path.exists()
+
+    original_chunks = []
+    with chunk_index_path.open("r", encoding="utf-8") as f:
+        for line in f:
+            if line.strip():
+                original_chunks.append(json.loads(line))
+
+    # Inject a chunk with mismatched file_path
+    if original_chunks:
+        original_chunks[0]["canonical_range"]["file_path"] = "wrong_file.md"
+
+    # Rewrite chunk_index
+    with chunk_index_path.open("w", encoding="utf-8") as f:
+        for chunk in original_chunks:
+            f.write(json.dumps(chunk) + "\n")
+
+    # Guard must reject this incoherent manifest
+    assert is_manifest_coherent_for_citation_map(manifest_path) is False
+
+
+def test_pro_repo_multi_repo_skips_citation_map_for_incoherent_manifest(tmp_path):
+    """
+    Regression test for Codex-P1: The coherence guard must correctly identify
+    incoherent manifest pairs and allow write_reports_v2 to skip citation_map generation.
+
+    This test validates the guard's ability to detect and handle the case where
+    canonical_md and chunk_index_jsonl reference different file paths
+    (as can occur in pro-repo/multi-repo mode with output_mode='dual').
+    """
+    from merger.lenskit.core.citation_map import is_manifest_coherent_for_citation_map
+
+    artifacts, manifest_data, manifest_dir = _make_minimal_bundle(tmp_path)
+    manifest_path = artifacts.bundle_manifest
+    assert manifest_path is not None and manifest_path.exists()
+
+    # Precondition: verify the original manifest is coherent
+    assert is_manifest_coherent_for_citation_map(manifest_path) is True
+
+    # Now simulate incoherent manifest by tampering with chunk_index
+    chunk_index_entry = next(
+        (a for a in manifest_data["artifacts"] if a["role"] == "chunk_index_jsonl"), None
+    )
+    assert chunk_index_entry is not None
+
+    chunk_index_path = manifest_dir / chunk_index_entry["path"]
+    original_chunks = []
+    with chunk_index_path.open("r", encoding="utf-8") as f:
+        for line in f:
+            if line.strip():
+                original_chunks.append(json.loads(line))
+
+    # Inject mismatch: change one chunk's canonical_range.file_path to simulate
+    # a scenario where repoA's markdown exists but repoB's chunk_index points elsewhere
+    if original_chunks:
+        original_chunks[0]["canonical_range"]["file_path"] = "repo_B.md"
+
+    with chunk_index_path.open("w", encoding="utf-8") as f:
+        for chunk in original_chunks:
+            f.write(json.dumps(chunk) + "\n")
+
+    # Verify guard now rejects this incoherent manifest
+    assert is_manifest_coherent_for_citation_map(manifest_path) is False, (
+        "Guard must reject manifest with mismatched canonical_md/chunk_index paths"
+    )

--- a/merger/lenskit/tests/test_chunk_index_dual_ranges.py
+++ b/merger/lenskit/tests/test_chunk_index_dual_ranges.py
@@ -266,12 +266,17 @@ def test_source_range_unavailable_when_redacted(tmp_path):
         )
 
 
-def test_no_citation_map_jsonl_emitted(dual_range_artifacts):
-    """No citation_map_jsonl file must be emitted by this code path."""
+def test_citation_map_jsonl_emitted(dual_range_artifacts):
+    """Dual-range bundle runs must emit citation_map_jsonl alongside the manifest."""
     artifacts, _, _ = dual_range_artifacts
-    # Check that no citation_map_jsonl files exist anywhere under the merges dir
+    assert artifacts.bundle_manifest is not None
+    manifest = json.loads(artifacts.bundle_manifest.read_text(encoding="utf-8"))
+    roles = {artifact["role"] for artifact in manifest["artifacts"]}
+    assert "citation_map_jsonl" in roles
+
     merges_dir = artifacts.chunk_index.parent
     citation_files = list(merges_dir.rglob("*.citation_map.jsonl"))
-    assert len(citation_files) == 0, (
-        f"citation_map_jsonl must not be emitted; found: {citation_files}"
+    assert len(citation_files) == 1, (
+        f"citation_map_jsonl must be emitted exactly once; found: {citation_files}"
     )
+    assert citation_files[0].exists()

--- a/merger/lenskit/tests/test_cli_citation.py
+++ b/merger/lenskit/tests/test_cli_citation.py
@@ -8,6 +8,8 @@ import json
 from pathlib import Path
 
 from merger.lenskit.cli.main import main
+from merger.lenskit.core.merge import FileInfo, write_reports_v2
+from merger.lenskit.tests._test_constants import make_generator_info
 
 
 # ---------------------------------------------------------------------------
@@ -71,6 +73,56 @@ def _make_chunk(canonical_content: bytes, start: int, end: int) -> dict:
     }
 
 
+def _make_generated_bundle(tmp_path: Path) -> Path:
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    source_file = src_dir / "file1.txt"
+    source_file.write_text("Hello World", encoding="utf-8")
+
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    hub_dir = tmp_path / "hub"
+    hub_dir.mkdir()
+
+    file_info = FileInfo(
+        root_label="test-repo",
+        abs_path=source_file,
+        rel_path=Path("file1.txt"),
+        size=11,
+        is_text=True,
+        md5="test",
+        category="docs",
+        tags=[],
+        ext=".txt",
+        skipped=False,
+    )
+
+    repo_summary = {
+        "name": "test-repo",
+        "path": str(src_dir),
+        "root": src_dir,
+        "files": [file_info],
+        "source_files": [file_info],
+    }
+
+    artifacts = write_reports_v2(
+        merges_dir=out_dir,
+        hub=hub_dir,
+        repo_summaries=[repo_summary],
+        detail="test",
+        mode="gesamt",
+        max_bytes=1000,
+        plan_only=False,
+        code_only=False,
+        output_mode="dual",
+        generator_info=make_generator_info(),
+    )
+
+    assert artifacts.bundle_manifest is not None
+    assert artifacts.bundle_manifest.exists()
+    return artifacts.bundle_manifest
+
+
 # ---------------------------------------------------------------------------
 # CLI: --json output and exit code 0 on valid fixture
 # ---------------------------------------------------------------------------
@@ -93,6 +145,20 @@ def test_cli_json_output_exit_0_on_valid_bundle(tmp_path, capsys):
     assert report["chunk_index_actual_sha256"] == report["chunk_index_sha256"]
     assert isinstance(report["errors"], list)
     assert len(report["errors"]) == 0
+
+
+def test_cli_json_output_exit_0_on_generated_bundle(tmp_path, capsys):
+    manifest_path = _make_generated_bundle(tmp_path)
+
+    rc = main(["citation", "validate", "--json", str(manifest_path)])
+
+    assert rc == 0
+    captured = capsys.readouterr()
+    report = json.loads(captured.out)
+    assert report["status"] == "ok"
+    assert report["citation_id_count"] > 0
+    assert report["canonical_md_actual_sha256"] == report["canonical_md_sha256"]
+    assert report["chunk_index_actual_sha256"] == report["chunk_index_sha256"]
 
 
 # ---------------------------------------------------------------------------

--- a/merger/lenskit/tests/test_per_repo_cohesion.py
+++ b/merger/lenskit/tests/test_per_repo_cohesion.py
@@ -11,6 +11,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.
 
 from merger.lenskit.tests._test_constants import make_generator_info
 from merger.lenskit.core.merge import write_reports_v2, ExtrasConfig, scan_repo
+from merger.lenskit.core.citation_map import check_manifest_coherence_for_citation_map
 
 # Bundle-level diagnostic/index artifacts produced alongside per-repo sidecars.
 # Extend this tuple whenever a new bundle-scoped artifact suffix is introduced.
@@ -146,6 +147,43 @@ class TestPerRepoCohesion(unittest.TestCase):
         # Hardened check: Ensure no cross-contamination in the entire artifacts object
         artifacts_dump_B = json.dumps(sidecarB["artifacts"])
         self.assertNotIn("repoA", artifacts_dump_B)
+
+    def test_pro_repo_multi_repo_skips_citation_map_for_incoherent_manifest(self):
+        """Real Codex-P1 regression: pro-repo multi-repo aggregate must not crash and must skip citation map."""
+        summaryA = scan_repo(self.repoA)
+        summaryB = scan_repo(self.repoB)
+
+        artifacts = write_reports_v2(
+            generator_info=make_generator_info(),
+            merges_dir=self.merges_dir,
+            hub=self.hub,
+            repo_summaries=[summaryA, summaryB],
+            detail="max",
+            mode="pro-repo",
+            max_bytes=1000,
+            plan_only=False,
+            output_mode="dual",
+            extras=ExtrasConfig(json_sidecar=True),
+        )
+
+        self.assertIsNotNone(artifacts.bundle_manifest)
+        self.assertTrue(artifacts.bundle_manifest.exists())
+
+        coherence = check_manifest_coherence_for_citation_map(artifacts.bundle_manifest)
+        self.assertFalse(coherence.coherent)
+        self.assertTrue(coherence.skip_allowed)
+        self.assertEqual(coherence.reason, "range_file_path_mismatch")
+
+        manifest = json.loads(artifacts.bundle_manifest.read_text(encoding="utf-8"))
+        roles = [a.get("role") for a in manifest.get("artifacts", []) if isinstance(a, dict)]
+        self.assertNotIn("citation_map_jsonl", roles)
+
+        aggregate_citation_path = artifacts.bundle_manifest.with_name(
+            artifacts.bundle_manifest.name.replace(
+                ".bundle.manifest.json", ".citation_map.jsonl"
+            )
+        )
+        self.assertFalse(aggregate_citation_path.exists())
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## These / Antithese / Synthese

**These:** Die Anweisung muss enger werden: nicht „Citation Map irgendwie erzeugen“, sondern **Pipeline-Artefakt mit Manifest-Rolle, Hash/Bytes, Validator-Gate und Real-Dump-Proof**.

**Antithese:** Zu enge Anweisung kann den Agenten lähmen, falls die interne Producer-API anders gebaut ist als erwartet.

**Synthese:** Diagnose-first, aber mit hartem Ziel: **`citation_map_jsonl` muss im normalen `rlens max`-Bundle erscheinen.** Keine Querbaustellen. Kein „ach, wir haben noch schnell Query optimiert“.

## Umsetzung

- Pipeline-Integration in `write_reports_v2()` ergänzt:
  - initiales Bundle-Manifest schreiben,
  - bestehende Producer-Logik `produce_citation_map()` intern ausführen,
  - `citation_map_jsonl` danach als Manifest-Artefakt registrieren,
  - finales Manifest deterministisch neu schreiben.
- Atomare Schreibpfade ergänzt:
  - `citation_map_jsonl` wird via temp-file + `os.replace` geschrieben,
  - Bundle-Manifest wird atomar geschrieben.
- Scope eingehalten:
  - keine Query/Context/Trace/Federation/UI/Atlas-Semantikänderungen,
  - keine lokalen Runtime-Artefakte oder Dumps im Commit.

## Tests

Ausgeführt:

```bash
python -m pytest \
  merger/lenskit/tests/test_citation_map_producer.py \
  merger/lenskit/tests/test_citation_validate.py \
  merger/lenskit/tests/test_cli_citation.py \
  merger/lenskit/tests/test_bundle_manifest_integration.py \
  merger/lenskit/tests/test_bundle_manifest_schema.py \
  merger/lenskit/tests/test_output_health.py \
  merger/lenskit/tests/test_chunk_index_dual_ranges.py \
  -q
```

Ergebnis: `215 passed, 1 warning`

## Real-Dump-Proof

Headless real run:

```bash
/bin/python3 -m merger.lenskit.frontends.pythonista.repolens \
  --headless --hub /home/alex/repos --level max /home/alex/repos/lenskit
```

Belegdump:

- stem: `lenskit-max-260515-0952_merge`
- manifest: `/home/alex/repos/merges/lenskit-max-260515-0952_merge.bundle.manifest.json`
- citation map: `/home/alex/repos/merges/lenskit-max-260515-0952_merge.citation_map.jsonl`

Nachweise:

- Manifest enthält `role == citation_map_jsonl`
- authority/canonicality: `navigation_index` / `derived`
- bytes/sha stimmen (Manifest vs Datei)
- row count konsistent: `chunk_index_jsonl == citation_map_jsonl == 613`
- `citation validate --json` liefert `status: ok`
- schema-validiert gegen `citation-map.v1.schema.json` (613/613 Zeilen)
- output health: verdict `pass`, errors `[]`, warnings `[]`

Proof-Dokument:

- `docs/proofs/citation-map-pipeline-emission-proof.md`

## Nicht-Ziele

- keine Query-/Reranking-/Federation-/UI-Optimierungen
- keine Atlas-Änderungen außerhalb bestehender Testanpassungen
