### PR TITLE
Fix citation-map coherence for split-mode noncanonical chunks

### DIFF
--- a/merger/lenskit/core/citation_map.py
+++ b/merger/lenskit/core/citation_map.py
@@ -171,6 +171,32 @@ def normalize_canonical_range(
     return None
 
 
+def _is_split_mode_noncanonical_chunk(chunk: Dict[str, Any]) -> bool:
+        """
+        Return True only for split-mode non-canonical chunks that are intentionally
+        excluded from citation-map coherence and production.
+
+        Required conditions:
+            - source_range is present (dict)
+            - source_status == "full"
+            - canonical_range is absent
+            - content_range_ref is absent
+        """
+        source_range = chunk.get("source_range")
+        source_status = chunk.get("source_status")
+
+        has_source_range = isinstance(source_range, dict)
+        has_canonical_range = chunk.get("canonical_range") is not None
+        has_content_range_ref = chunk.get("content_range_ref") is not None
+
+        return (
+                has_source_range
+                and source_status == "full"
+                and not has_canonical_range
+                and not has_content_range_ref
+        )
+
+
 # ---------------------------------------------------------------------------
 # repo_id resolution
 # ---------------------------------------------------------------------------
@@ -341,6 +367,8 @@ def iter_chunk_results(
             # --- normalise range ---
             norm_range = normalize_canonical_range(chunk)
             if norm_range is None:
+                if _is_split_mode_noncanonical_chunk(chunk):
+                    continue
                 yield _ChunkResult(
                     None,
                     f"Line {lineno}: no valid canonical range found "
@@ -630,6 +658,8 @@ def check_manifest_coherence_for_citation_map(manifest_path: Path) -> CitationMa
 
                 normalized_range = normalize_canonical_range(chunk)
                 if normalized_range is None:
+                    if _is_split_mode_noncanonical_chunk(chunk):
+                        continue
                     return CitationMapCoherence(False, False, "missing_or_invalid_canonical_range")
 
                 chunk_file_raw = normalized_range.get("file_path")

--- a/merger/lenskit/core/citation_map.py
+++ b/merger/lenskit/core/citation_map.py
@@ -172,29 +172,52 @@ def normalize_canonical_range(
 
 
 def _is_split_mode_noncanonical_chunk(chunk: Dict[str, Any]) -> bool:
-        """
-        Return True only for split-mode non-canonical chunks that are intentionally
-        excluded from citation-map coherence and production.
+    """
+    Return True only for split-mode non-canonical chunks that are intentionally
+    excluded from citation-map coherence and production.
 
-        Required conditions:
-            - source_range is present (dict)
-            - source_status == "full"
-            - canonical_range is absent
-            - content_range_ref is absent
-        """
-        source_range = chunk.get("source_range")
-        source_status = chunk.get("source_status")
+    Required conditions:
+      - source_range is present (dict)
+      - source_status == "full"
+      - canonical_range is absent
+      - content_range_ref is absent
 
-        has_source_range = isinstance(source_range, dict)
-        has_canonical_range = chunk.get("canonical_range") is not None
-        has_content_range_ref = chunk.get("content_range_ref") is not None
+    Conservative positive split-shape signals:
+      - content_artifact == "merge_md"
+      - content_range is present (dict)
+      - chunk.path matches source_range.file_path
+      - source_range.status == "declared"
+    """
+    source_range = chunk.get("source_range")
+    source_status = chunk.get("source_status")
 
-        return (
-                has_source_range
-                and source_status == "full"
-                and not has_canonical_range
-                and not has_content_range_ref
-        )
+    if not isinstance(source_range, dict):
+        return False
+    if source_status != "full":
+        return False
+    if chunk.get("canonical_range") is not None:
+        return False
+    if chunk.get("content_range_ref") is not None:
+        return False
+
+    if chunk.get("content_artifact") != "merge_md":
+        return False
+    if not isinstance(chunk.get("content_range"), dict):
+        return False
+
+    chunk_path = chunk.get("path")
+    source_file_path = source_range.get("file_path")
+    if not isinstance(chunk_path, str) or not chunk_path:
+        return False
+    if not isinstance(source_file_path, str) or not source_file_path:
+        return False
+    if chunk_path != source_file_path:
+        return False
+
+    if source_range.get("status") != "declared":
+        return False
+
+    return True
 
 
 # ---------------------------------------------------------------------------

--- a/merger/lenskit/tests/test_citation_map_producer.py
+++ b/merger/lenskit/tests/test_citation_map_producer.py
@@ -16,6 +16,7 @@ from merger.lenskit.core.citation_map import (
     CitationMapError,
     PRODUCED_BY,
     byte_range_to_line_range,
+    check_manifest_coherence_for_citation_map,
     normalize_canonical_range,
     produce_citation_map,
     resolve_repo_id,
@@ -683,6 +684,101 @@ class TestProduceCitationMap:
         report = produce_citation_map(str(manifest_path))
         assert report["status"] == "ok", report["errors"]
         assert report["repo_id_source"] == "range.repo_id"
+
+
+class TestSplitModeCoherence:
+    def test_split_mode_noncanonical_chunks_skip_coherence(self, tmp_path):
+        content = b"split mode content\n"
+        chunk = {
+            "chunk_id": "split_only",
+            "repo": "testrepo",
+            "source_status": "full",
+            "source_range": {
+                "file_path": "src.txt",
+                "repo_id": "testrepo",
+                "start_byte": 0,
+                "end_byte": 10,
+                "status": "declared",
+            },
+        }
+        manifest_path = _make_bundle(tmp_path, content, [chunk])
+
+        coherence = check_manifest_coherence_for_citation_map(manifest_path)
+        assert coherence.coherent is True
+
+        report = produce_citation_map(str(manifest_path))
+        assert report["status"] == "ok", report["errors"]
+        assert report["citation_map_row_count"] == 0
+
+    def test_canonical_chunks_still_checked_for_coherence(self, tmp_path):
+        content = b"canonical content\n"
+        chunk = {
+            "chunk_id": "bad",
+            "repo": "testrepo",
+        }
+        manifest_path = _make_bundle(tmp_path, content, [chunk])
+
+        coherence = check_manifest_coherence_for_citation_map(manifest_path)
+        assert coherence.coherent is False
+        assert coherence.reason == "missing_or_invalid_canonical_range"
+
+        report = produce_citation_map(str(manifest_path))
+        assert report["status"] == "fail"
+        assert any("no valid canonical range" in e for e in report["errors"])
+
+    def test_mixed_canonical_and_split_mode_chunks(self, tmp_path):
+        content = b"ABCDEFGHIJ"
+        canonical_chunk = _canonical_range_chunk(content, 0, 5, "test_merge.md", chunk_id="c1")
+        split_chunk = {
+            "chunk_id": "split_only",
+            "repo": "testrepo",
+            "source_status": "full",
+            "source_range": {
+                "file_path": "src.txt",
+                "repo_id": "testrepo",
+                "start_byte": 0,
+                "end_byte": 4,
+                "status": "declared",
+            },
+        }
+        manifest_path = _make_bundle(tmp_path, content, [canonical_chunk, split_chunk])
+
+        coherence = check_manifest_coherence_for_citation_map(manifest_path)
+        assert coherence.coherent is True
+
+        report = produce_citation_map(str(manifest_path))
+        assert report["status"] == "ok", report["errors"]
+        assert report["citation_map_row_count"] == 1
+
+    @pytest.mark.parametrize(
+        "chunk",
+        [
+            {
+                "chunk_id": "missing_source_range",
+                "repo": "testrepo",
+                "source_status": "full",
+            },
+            {
+                "chunk_id": "wrong_status",
+                "repo": "testrepo",
+                "source_status": "truncated",
+                "source_range": {
+                    "file_path": "src.txt",
+                    "repo_id": "testrepo",
+                    "start_byte": 0,
+                    "end_byte": 1,
+                    "status": "unavailable",
+                },
+            },
+        ],
+    )
+    def test_split_mode_chunk_requires_source_range_and_full_status(self, tmp_path, chunk):
+        content = b"content\n"
+        manifest_path = _make_bundle(tmp_path, content, [chunk])
+
+        coherence = check_manifest_coherence_for_citation_map(manifest_path)
+        assert coherence.coherent is False
+        assert coherence.reason == "missing_or_invalid_canonical_range"
 
 
 # ---------------------------------------------------------------------------

--- a/merger/lenskit/tests/test_citation_map_producer.py
+++ b/merger/lenskit/tests/test_citation_map_producer.py
@@ -692,7 +692,15 @@ class TestSplitModeCoherence:
         chunk = {
             "chunk_id": "split_only",
             "repo": "testrepo",
+            "path": "src.txt",
             "source_status": "full",
+            "content_artifact": "merge_md",
+            "content_range": {
+                "start_byte": 0,
+                "end_byte": 10,
+                "start_line": 1,
+                "end_line": 1,
+            },
             "source_range": {
                 "file_path": "src.txt",
                 "repo_id": "testrepo",
@@ -732,7 +740,15 @@ class TestSplitModeCoherence:
         split_chunk = {
             "chunk_id": "split_only",
             "repo": "testrepo",
+            "path": "src.txt",
             "source_status": "full",
+            "content_artifact": "merge_md",
+            "content_range": {
+                "start_byte": 0,
+                "end_byte": 4,
+                "start_line": 1,
+                "end_line": 1,
+            },
             "source_range": {
                 "file_path": "src.txt",
                 "repo_id": "testrepo",
@@ -779,6 +795,38 @@ class TestSplitModeCoherence:
         coherence = check_manifest_coherence_for_citation_map(manifest_path)
         assert coherence.coherent is False
         assert coherence.reason == "missing_or_invalid_canonical_range"
+
+    def test_canonical_looking_chunk_without_canonical_ranges_still_fails(self, tmp_path):
+        content = b"canonical-looking content\n"
+        chunk = {
+            "chunk_id": "canonical_like_missing_ranges",
+            "repo": "testrepo",
+            "path": "src.txt",
+            "source_status": "full",
+            "content_artifact": "canonical_md",
+            "content_range": {
+                "start_byte": 0,
+                "end_byte": 10,
+                "start_line": 1,
+                "end_line": 1,
+            },
+            "source_range": {
+                "file_path": "src.txt",
+                "repo_id": "testrepo",
+                "start_byte": 0,
+                "end_byte": 10,
+                "status": "declared",
+            },
+        }
+        manifest_path = _make_bundle(tmp_path, content, [chunk])
+
+        coherence = check_manifest_coherence_for_citation_map(manifest_path)
+        assert coherence.coherent is False
+        assert coherence.reason == "missing_or_invalid_canonical_range"
+
+        report = produce_citation_map(str(manifest_path))
+        assert report["status"] == "fail"
+        assert any("no valid canonical range" in e for e in report["errors"])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a conservative `_is_split_mode_noncanonical_chunk` helper in `citation_map.py`
- exclude only valid split-mode non-canonical chunks from citation-map coherence/production
- preserve hard-fail behavior for canonical chunks missing/invalid `canonical_range`
- add focused regression coverage in `test_citation_map_producer.py`

## Why
Current `main` failed target tests with `missing_or_invalid_canonical_range` because split-mode non-canonical chunks were treated as hard coherence failures.

## Validation
- `ruff check --select=F401,F811 --exclude='**/fixtures/**' .`
- `pytest merger/lenskit/tests/test_range_propagation.py::test_range_propagation_split_mode -vv`
- `pytest merger/lenskit/tests/test_split_mode_contract.py::test_split_mode_contract_range_refs -vv`
- `pytest merger/lenskit/tests/test_streaming_report_header.py::test_write_reports_v2_single_file_enforces_part_1_1_header -vv`
- `pytest merger/lenskit/tests/test_citation_map_producer.py -vv`
- `pytest merger/lenskit/tests/test_output_health.py -vv`
- `pytest -m "not browser" -q --tb=line`
