### PR TITLE
Improve cache directory exclusion test assertions with sentinel values

### DIFF
--- a/merger/lenskit/tests/test_merge_core.py
+++ b/merger/lenskit/tests/test_merge_core.py
@@ -589,18 +589,25 @@ class TestFullSnapshotCacheExclusionParity(unittest.TestCase):
         (self.repo / ".wgx").mkdir()
         (self.repo / ".wgx" / "profile.yml").write_text("profile: default\n", encoding="utf-8")
 
+        self.cache_payloads = {
+            ".ruff_cache": "LENSKIT_TEST_SENTINEL_RUFF_CACHE_SHOULD_NOT_APPEAR\n",
+            ".pytest_cache": "LENSKIT_TEST_SENTINEL_PYTEST_CACHE_SHOULD_NOT_APPEAR\n",
+            ".mypy_cache": "LENSKIT_TEST_SENTINEL_MYPY_CACHE_SHOULD_NOT_APPEAR\n",
+            "__pycache__": "LENSKIT_TEST_SENTINEL_PYCACHE_SHOULD_NOT_APPEAR\n",
+        }
+
         (self.repo / ".ruff_cache" / "0.15.13").mkdir(parents=True)
         (self.repo / ".ruff_cache" / ".gitignore").write_text("*\n", encoding="utf-8")
-        (self.repo / ".ruff_cache" / "0.15.13" / "cache.py").write_text("# ruff cache\n", encoding="utf-8")
+        (self.repo / ".ruff_cache" / "0.15.13" / "cache.py").write_text(self.cache_payloads[".ruff_cache"], encoding="utf-8")
 
         (self.repo / ".pytest_cache" / "v").mkdir(parents=True)
-        (self.repo / ".pytest_cache" / "v" / "cache.txt").write_text("pytest cache\n", encoding="utf-8")
+        (self.repo / ".pytest_cache" / "v" / "cache.txt").write_text(self.cache_payloads[".pytest_cache"], encoding="utf-8")
 
         (self.repo / ".mypy_cache" / "3.11").mkdir(parents=True)
-        (self.repo / ".mypy_cache" / "3.11" / "cache.py").write_text("# mypy cache\n", encoding="utf-8")
+        (self.repo / ".mypy_cache" / "3.11" / "cache.py").write_text(self.cache_payloads[".mypy_cache"], encoding="utf-8")
 
         (self.repo / "__pycache__").mkdir()
-        (self.repo / "__pycache__" / "cache.py").write_text("# pycache\n", encoding="utf-8")
+        (self.repo / "__pycache__" / "cache.py").write_text(self.cache_payloads["__pycache__"], encoding="utf-8")
 
     def tearDown(self):
         shutil.rmtree(self.root)
@@ -622,6 +629,7 @@ class TestFullSnapshotCacheExclusionParity(unittest.TestCase):
         )
 
         md_text = artifacts.canonical_md.read_text(encoding="utf-8")
+        chunk_text = artifacts.chunk_index.read_text(encoding="utf-8")
         sidecar = json.loads(artifacts.index_json.read_text(encoding="utf-8"))
         chunk_rows = [
             json.loads(line)
@@ -645,7 +653,17 @@ class TestFullSnapshotCacheExclusionParity(unittest.TestCase):
             self.assertIn(expected, combined_sidecar_paths)
             self.assertIn(expected, chunk_paths)
 
-        for forbidden in [".ruff_cache", ".pytest_cache", ".mypy_cache", "__pycache__"]:
+        for sentinel in self.cache_payloads.values():
+            self.assertNotIn(
+                sentinel.strip(), md_text,
+                msg=f"cache file content must not appear in markdown: {sentinel.strip()!r}",
+            )
+            self.assertNotIn(
+                sentinel.strip(), chunk_text,
+                msg=f"cache file content must not appear in chunk index: {sentinel.strip()!r}",
+            )
+
+        for forbidden in self.cache_payloads:
             self.assertFalse(
                 any(forbidden in p for p in md_paths),
                 msg=f"markdown file markers must exclude {forbidden}: {md_paths}",
@@ -668,7 +686,7 @@ class TestFullSnapshotCacheExclusionParity(unittest.TestCase):
         for expected in expected_paths:
             self.assertIn(expected, rows)
 
-        for forbidden in [".ruff_cache", ".pytest_cache", ".mypy_cache", "__pycache__"]:
+        for forbidden in self.cache_payloads:
             self.assertFalse(
                 any(forbidden in p for p in rows),
                 msg=f"sqlite chunk paths must exclude {forbidden}: {rows}",

--- a/merger/lenskit/tests/test_merges_dir_drift.py
+++ b/merger/lenskit/tests/test_merges_dir_drift.py
@@ -440,15 +440,22 @@ def test_runner_full_snapshot_path_excludes_cache_dirs(temp_hub):
     (repo / ".wgx").mkdir(exist_ok=True)
     (repo / ".wgx" / "profile.yml").write_text("profile: default\n", encoding="utf-8")
 
+    cache_payloads = {
+        ".ruff_cache": "LENSKIT_TEST_SENTINEL_RUFF_CACHE_SHOULD_NOT_APPEAR\n",
+        ".pytest_cache": "LENSKIT_TEST_SENTINEL_PYTEST_CACHE_SHOULD_NOT_APPEAR\n",
+        ".mypy_cache": "LENSKIT_TEST_SENTINEL_MYPY_CACHE_SHOULD_NOT_APPEAR\n",
+        "__pycache__": "LENSKIT_TEST_SENTINEL_PYCACHE_SHOULD_NOT_APPEAR\n",
+    }
+
     (repo / ".ruff_cache" / "0.15.13").mkdir(parents=True)
     (repo / ".ruff_cache" / ".gitignore").write_text("*\n", encoding="utf-8")
-    (repo / ".ruff_cache" / "0.15.13" / "cache.py").write_text("# ruff cache\n", encoding="utf-8")
+    (repo / ".ruff_cache" / "0.15.13" / "cache.py").write_text(cache_payloads[".ruff_cache"], encoding="utf-8")
     (repo / ".pytest_cache" / "v").mkdir(parents=True)
-    (repo / ".pytest_cache" / "v" / "cache.txt").write_text("pytest cache\n", encoding="utf-8")
+    (repo / ".pytest_cache" / "v" / "cache.txt").write_text(cache_payloads[".pytest_cache"], encoding="utf-8")
     (repo / ".mypy_cache" / "3.11").mkdir(parents=True)
-    (repo / ".mypy_cache" / "3.11" / "cache.py").write_text("# mypy cache\n", encoding="utf-8")
+    (repo / ".mypy_cache" / "3.11" / "cache.py").write_text(cache_payloads[".mypy_cache"], encoding="utf-8")
     (repo / "__pycache__").mkdir(exist_ok=True)
-    (repo / "__pycache__" / "cache.py").write_text("# pycache\n", encoding="utf-8")
+    (repo / "__pycache__" / "cache.py").write_text(cache_payloads["__pycache__"], encoding="utf-8")
 
     store = JobStore(temp_hub)
     runner = JobRunner(store)
@@ -482,8 +489,9 @@ def test_runner_full_snapshot_path_excludes_cache_dirs(temp_hub):
     sqlite_path = merges_dir / artifact.paths["sqlite_index"]
 
     md_text = md_path.read_text(encoding="utf-8")
+    chunk_text = chunk_path.read_text(encoding="utf-8")
     sidecar = json.loads(json_path.read_text(encoding="utf-8"))
-    chunk_rows = [json.loads(line) for line in chunk_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    chunk_rows = [json.loads(line) for line in chunk_text.splitlines() if line.strip()]
     md_paths = [
         line.split('path="', 1)[1].split('"', 1)[0]
         for line in md_text.splitlines()
@@ -501,11 +509,19 @@ def test_runner_full_snapshot_path_excludes_cache_dirs(temp_hub):
         assert expected in combined_sidecar_paths
         assert expected in chunk_paths
 
-    forbidden_dirs = [".ruff_cache", ".pytest_cache", ".mypy_cache", "__pycache__"]
-    for forbidden in forbidden_dirs:
-        assert not any(forbidden in p for p in md_paths)
-        assert not any(forbidden in p for p in chunk_paths)
-        assert not any(forbidden in p for p in combined_sidecar_paths)
+    for sentinel in cache_payloads.values():
+        assert sentinel.strip() not in md_text, \
+            f"cache file content must not appear in markdown: {sentinel.strip()!r}"
+        assert sentinel.strip() not in chunk_text, \
+            f"cache file content must not appear in chunk index: {sentinel.strip()!r}"
+
+    for forbidden in cache_payloads:
+        assert not any(forbidden in p for p in md_paths), \
+            f"markdown file markers must exclude {forbidden}: {md_paths}"
+        assert not any(forbidden in p for p in chunk_paths), \
+            f"chunk source paths must exclude {forbidden}: {chunk_paths}"
+        assert not any(forbidden in p for p in combined_sidecar_paths), \
+            f"sidecar paths must exclude {forbidden}: {combined_sidecar_paths}"
 
     conn = sqlite3.connect(sqlite_path)
     try:
@@ -514,5 +530,6 @@ def test_runner_full_snapshot_path_excludes_cache_dirs(temp_hub):
         conn.close()
     for expected in expected_paths:
         assert expected in sqlite_paths
-    for forbidden in forbidden_dirs:
-        assert not any(forbidden in p for p in sqlite_paths)
+    for forbidden in cache_payloads:
+        assert not any(forbidden in p for p in sqlite_paths), \
+            f"sqlite chunk paths must exclude {forbidden}: {sqlite_paths}"


### PR DESCRIPTION
## Summary
Enhanced test assertions for cache directory exclusion by using distinctive sentinel values in cache file contents, enabling more robust detection of whether cache files are being incorrectly included in outputs.

## Key Changes
- **Introduced sentinel values**: Replaced generic placeholder content (e.g., "# ruff cache") with distinctive sentinel strings (e.g., "LENSKIT_TEST_SENTINEL_RUFF_CACHE_SHOULD_NOT_APPEAR") in cache files created during tests
- **Added content-based assertions**: Implemented new checks that verify cache file contents do not appear in markdown and chunk index outputs, in addition to existing path-based checks
- **Improved assertion messages**: Added descriptive error messages to all assertions to aid debugging when tests fail
- **Centralized cache payload definitions**: Moved cache file content definitions into dictionaries (`cache_payloads`) for better maintainability and consistency across test files

## Implementation Details
- Changes applied to both `test_merges_dir_drift.py` and `test_merge_core.py` test files
- New assertions check both file paths and file contents to ensure cache directories are properly excluded
- The sentinel-based approach makes it immediately obvious if cache content leaks into output artifacts
- All existing path-based exclusion checks retained alongside new content-based checks for defense-in-depth validation

https://claude.ai/code/session_015M1Av1WoyDN7JjRjaskD17