### PR TITLE
Rename TOP_FILES to TOP_CHUNK_SPANS with governance block (PR A1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,9 @@ Der Pack fasst zusammen:
 - **Reading Policy** + Artefaktrollen (welches Artefakt was aussagen darf),
 - **HOW_TO_SEARCH**: konkrete CLI-Befehle für Volltextsuche, Range-Auflösung und Citations,
 - **OUTPUT_HEALTH_SUMMARY**: Selbsttest-Verdict des Bundles,
-- **TOP_FILES**: die nach Chunk-Coverage größten aggregierten canonical Spans je
+- **TOP_CHUNK_SPANS**: die nach Chunk-Coverage größten aggregierten canonical Spans je
   Quelldatei (Navigationshilfe für präzises Zitieren in `canonical_md`) — **keine**
-  Wichtigkeitsaussage; Begriff wird zu `TOP_CHUNK_SPANS` migriert (siehe
-  `docs/blueprints/lenskit-anti-hallucination-output-architecture.md`, PR A1).
+  Wichtigkeitsaussage. (Früher: `TOP_FILES`.)
 - **EPISTEMIC_EMPTINESS**: was im Bundle fehlt.
 
 Standalone erzeugen oder regenerieren:

--- a/docs/blueprints/lenskit-anti-hallucination-output-architecture.md
+++ b/docs/blueprints/lenskit-anti-hallucination-output-architecture.md
@@ -72,12 +72,14 @@ Arbeitspaket (AP), das er härtet, oder markiert sich als **neu**.
 - **Ergebnis (PR A1 umgesetzt: Producer/Tests/Doku migriert `TOP_FILES → TOP_CHUNK_SPANS`):**
   - Heading `## TOP_FILES` → `## TOP_CHUNK_SPANS` in Producer + Tests + Proof-Doku.
   - Maschinenlesbarer Governance-JSON-Block im Pack:
-    `risk_class: navigation`, `may_cite: false`, `must_resolve_to: role_specific_authority`,
+    `applies_to: TOP_CHUNK_SPANS`, `risk_class: navigation`, `may_cite: false`,
+    `must_resolve_to: role_specific_authority`,
     `does_not_prove: [semantic_importance, architecture_truth, complete_context]`.
   - README-Beschreibung auf `TOP_CHUNK_SPANS` ohne Wichtigkeitsanspruch.
   - Neue Negativtests: `test_agent_pack_no_top_files_heading`,
     `test_agent_pack_no_important_language`, `test_agent_pack_declares_does_not_prove`,
-    `test_agent_pack_governance_block_fields`, `test_agent_pack_has_no_top_level_architecture`.
+    `test_agent_pack_governance_block_fields`, `test_agent_pack_has_no_top_level_architecture`,
+    `test_agent_pack_governance_block_is_valid_json` (JSON parsen, nicht nur strings).
 
 #### PR A2 — Output Noise Hygiene härten  (härtet #681–#683)
 - **Ziel:** Hard-Exclusion absichern + sichtbar machen; Listendrift beseitigen.

--- a/docs/blueprints/lenskit-anti-hallucination-output-architecture.md
+++ b/docs/blueprints/lenskit-anti-hallucination-output-architecture.md
@@ -67,32 +67,17 @@ Arbeitspaket (AP), das er härtet, oder markiert sich als **neu**.
 - **Nicht-Ziele:** Keine Code-/Schema-Änderung.
 - **Akzeptanz:** Jede Folge-PR referenziert eine Audit-Zeile.
 
-#### PR A1 — Agent Reading Pack Begriffshärtung  (härtet AP D)
+#### PR A1 — Agent Reading Pack Begriffshärtung  (härtet AP D) — **UMGESETZT**
 - **Ziel:** Navigationsbegriffe entschärfen; Importance-Implikation entfernen.
-- **Repo-Befund:** `merger/lenskit/core/agent_reading_pack.py:489` (`## TOP_FILES`); `README.md:35`
-  ("wichtigsten Quelldateien"); `docs/blueprints/lenskit-output-optimierung-v1.md:199-200`
-  ("wichtigste Entry-Points/Contracts" als v2-offene Punkte).
-- **Änderung:**
-  - Heading `## TOP_FILES` → `## TOP_CHUNK_SPANS` (Producer + Tests + Proof-Doku).
-    Untertitel: "größte aggregierte canonical spans nach Chunk-Coverage; **keine**
-    Wichtigkeitsaussage".
-  - Maschinenlesbarer Governance-Block im Pack (HTML-Kommentar/JSON-Fence):
-    `risk_class: navigation`, `may_cite: false`, `must_resolve_to:
-    role_specific_authority`, `does_not_prove: [semantic_importance,
-    architecture_truth, complete_context]` — wiederverwendet das Vokabular aus
-    `merger/lenskit/contracts/agent-query-session.v2.schema.json:91-110`.
-  - README-Beschreibung von TOP_FILES neutral fassen (in dieser Doku-PR vorgezogen).
-- **Nicht-Ziele:** Kein `TOP_LEVEL_ARCHITECTURE`, keine Entry-Point-/Modulzweck-Prosa,
-  keine Claim-Bewertung im Pack.
-- **Akzeptanz:** Pack enthält `TOP_CHUNK_SPANS`, kein `TOP_FILES`; kein Wort
-  "important/wichtigste" in generierten Feldern; `does_not_prove`-Block vorhanden;
-  Determinismus erhalten (byte-identischer Re-Run).
-- **Tests:** `test_agent_pack_uses_top_chunk_spans`,
-  `test_agent_pack_no_important_language`, `test_agent_pack_declares_does_not_prove`,
-  `test_agent_pack_has_no_top_level_architecture`; bestehende
-  `test_agent_reading_pack.py`/`test_cli_agent_pack.py` anpassen.
-- **Risiko:** Snapshot-Erwartungen brechen (gezielt, gewollt). v1-Leser, die nach
-  `## TOP_FILES` grep'en — Migrationsnotiz in `docs/blueprints/lenskit-output-optimierung-v1.md`.
+- **Ergebnis (PR A1 umgesetzt: Producer/Tests/Doku migriert `TOP_FILES → TOP_CHUNK_SPANS`):**
+  - Heading `## TOP_FILES` → `## TOP_CHUNK_SPANS` in Producer + Tests + Proof-Doku.
+  - Maschinenlesbarer Governance-JSON-Block im Pack:
+    `risk_class: navigation`, `may_cite: false`, `must_resolve_to: role_specific_authority`,
+    `does_not_prove: [semantic_importance, architecture_truth, complete_context]`.
+  - README-Beschreibung auf `TOP_CHUNK_SPANS` ohne Wichtigkeitsanspruch.
+  - Neue Negativtests: `test_agent_pack_no_top_files_heading`,
+    `test_agent_pack_no_important_language`, `test_agent_pack_declares_does_not_prove`,
+    `test_agent_pack_governance_block_fields`, `test_agent_pack_has_no_top_level_architecture`.
 
 #### PR A2 — Output Noise Hygiene härten  (härtet #681–#683)
 - **Ziel:** Hard-Exclusion absichern + sichtbar machen; Listendrift beseitigen.

--- a/docs/blueprints/lenskit-output-optimierung-v1.md
+++ b/docs/blueprints/lenskit-output-optimierung-v1.md
@@ -197,11 +197,9 @@
 - [x] Artefaktrollen (maschinenlesbare Tabelle aus dem Bundle-Manifest)
 - [x] Query-/Retrieval-Fluss (`HOW_TO_SEARCH` mit konkreten CLI-Befehlen: FTS-Query, `range get`, Citation-Map)
 - [x] Output-Health-Summary (Verdict + Kernchecks aus `output_health.json`)
-- [x] Top-30-Dateien mit Range-Refs (`TOP_FILES`: canonical Byte-/Zeilenspannen je Quelldatei)
-  - **Migrationsnotiz (2026-05-21):** Heading `TOP_FILES → TOP_CHUNK_SPANS` (PR A1),
-    da "TOP" Wichtigkeit impliziert; gemeint ist Chunk-Coverage, keine Wichtigkeit.
-    Bis dahin gilt `TOP_FILES` als deprecated-aber-lesbar. Siehe
-    `docs/blueprints/lenskit-anti-hallucination-output-architecture.md`.
+- [x] Top-30 nach Chunk-Coverage: `TOP_CHUNK_SPANS` (canonical Byte-/Zeilenspannen je Quelldatei)
+  - Navigationshilfe; keine Wichtigkeitsaussage. Governance-Block mit `does_not_prove` im Pack.
+  - (Früher `TOP_FILES`; migriert PR A1, 2026-05-22.)
 - [x] Epistemische Leere: fehlende/erwartete Artefakte werden explizit ausgewiesen
 
 ### Inhalt (für v2 offen, im Pack als epistemische Leere markiert)

--- a/docs/proofs/agent-reading-pack-producer-proof.md
+++ b/docs/proofs/agent-reading-pack-producer-proof.md
@@ -48,7 +48,9 @@ python3 -m merger.lenskit.cli.main agent-pack produce <stem>.bundle.manifest.jso
 - Governance-Block in `## TOP_CHUNK_SPANS`: maschinenlesbares JSON mit `applies_to: TOP_CHUNK_SPANS`,
   `risk_class: navigation`, `may_cite: false`, `must_resolve_to: role_specific_authority`,
   `does_not_prove: [semantic_importance, architecture_truth, complete_context]`
-- (Migriert aus `## TOP_FILES`, PR A1)
+- (Migriert aus `## TOP_FILES`, PR A1; interne Konstante `TOP_FILE_LIMIT → TOP_CHUNK_SPAN_LIMIT`)
+- Follow-up (post-A1): interne Legacy-Namen `top_files`, `compute_top_files`, `top_file_count`
+  bleiben in A1 unverändert (öffentliches Output-Feld / Test-API); separater Cleanup geplant.
 - `health_verdict`: `pass`
 - `top_file_count`: 3 (canonical Byte-/Zeilenspannen je Quelldatei)
 - `artifact_role_count`: 8

--- a/docs/proofs/agent-reading-pack-producer-proof.md
+++ b/docs/proofs/agent-reading-pack-producer-proof.md
@@ -45,8 +45,8 @@ python3 -m merger.lenskit.cli.main agent-pack produce <stem>.bundle.manifest.jso
 - Banner: `NAVIGATION, NOT TRUTH`
 - `## BUNDLE_IDENTITY`, `## READING_POLICY`, `## ARTIFACT_ROLES`, `## OUTPUT_HEALTH_SUMMARY`,
   `## HOW_TO_SEARCH`, `## TOP_CHUNK_SPANS`, `## EPISTEMIC_EMPTINESS`
-- Governance-Block in `## TOP_CHUNK_SPANS`: maschinenlesbares JSON mit `risk_class: navigation`,
-  `may_cite: false`, `must_resolve_to: role_specific_authority`,
+- Governance-Block in `## TOP_CHUNK_SPANS`: maschinenlesbares JSON mit `applies_to: TOP_CHUNK_SPANS`,
+  `risk_class: navigation`, `may_cite: false`, `must_resolve_to: role_specific_authority`,
   `does_not_prove: [semantic_importance, architecture_truth, complete_context]`
 - (Migriert aus `## TOP_FILES`, PR A1)
 - `health_verdict`: `pass`

--- a/docs/proofs/agent-reading-pack-producer-proof.md
+++ b/docs/proofs/agent-reading-pack-producer-proof.md
@@ -44,7 +44,11 @@ python3 -m merger.lenskit.cli.main agent-pack produce <stem>.bundle.manifest.jso
 - Sentinel: `<!-- ARTIFACT:agent_reading_pack VERSION:v1 AUTHORITY:navigation_index CANONICALITY:derived -->`
 - Banner: `NAVIGATION, NOT TRUTH`
 - `## BUNDLE_IDENTITY`, `## READING_POLICY`, `## ARTIFACT_ROLES`, `## OUTPUT_HEALTH_SUMMARY`,
-  `## HOW_TO_SEARCH`, `## TOP_FILES`, `## EPISTEMIC_EMPTINESS`
+  `## HOW_TO_SEARCH`, `## TOP_CHUNK_SPANS`, `## EPISTEMIC_EMPTINESS`
+- Governance-Block in `## TOP_CHUNK_SPANS`: maschinenlesbares JSON mit `risk_class: navigation`,
+  `may_cite: false`, `must_resolve_to: role_specific_authority`,
+  `does_not_prove: [semantic_importance, architecture_truth, complete_context]`
+- (Migriert aus `## TOP_FILES`, PR A1)
 - `health_verdict`: `pass`
 - `top_file_count`: 3 (canonical Byte-/Zeilenspannen je Quelldatei)
 - `artifact_role_count`: 8

--- a/docs/proofs/anti-hallucination-capability-audit.md
+++ b/docs/proofs/anti-hallucination-capability-audit.md
@@ -69,10 +69,12 @@ Modulzweck-Behauptungen — er hat keinen `TOP_LEVEL_ARCHITECTURE`-Abschnitt.
 ### 2.2 Erledigt (PR A1): `TOP_FILES → TOP_CHUNK_SPANS` + `does_not_prove`-Governance
 `## TOP_FILES` in Producer und Tests zu `## TOP_CHUNK_SPANS` migriert. README
 beschreibt die Sektion jetzt ohne Wichtigkeitsanspruch. Producer enthält
-maschinenlesbaren Governance-Block mit `risk_class: navigation`, `may_cite: false`,
+maschinenlesbaren Governance-Block mit `applies_to: TOP_CHUNK_SPANS`,
+`risk_class: navigation`, `may_cite: false`,
 `does_not_prove: [semantic_importance, architecture_truth, complete_context]`.
 Neue Negativtests: `test_agent_pack_no_top_files_heading`,
-`test_agent_pack_no_important_language`, `test_agent_pack_declares_does_not_prove`.
+`test_agent_pack_no_important_language`, `test_agent_pack_declares_does_not_prove`,
+`test_agent_pack_governance_block_is_valid_json` (JSON via json.loads geparst).
 
 ### 2.3 STALE: `.ruff_cache` im Output ist bereits behoben
 Der Plan-Beleg (".ruff_cache landet in canonical/chunk/sqlite", "Lenses als core")

--- a/docs/proofs/anti-hallucination-capability-audit.md
+++ b/docs/proofs/anti-hallucination-capability-audit.md
@@ -30,8 +30,8 @@ Entscheidung: `reuse` · `harden` · `defer` · `resolve` · `delete`.
 |---|---|---|---|---|---|---|
 | 1 | Reading Policy: `canonical_md` = Wahrheit, JSON = Navigation | DONE | `merger/lenskit/core/agent_reading_pack.py:13-16,411-416`; `docs/blueprints/lenskit-artifact-output-control-plane.md` §2.1; `docs/architecture/artifact-inventory.md` | niedrig | reuse | — |
 | 2 | Agent Reading Pack, `authority=navigation_index`/`derived` | DONE | `merger/lenskit/core/agent_reading_pack.py:381-394`; `merger/lenskit/core/constants.py:22`; `docs/blueprints/lenskit-output-optimierung-v1.md` AP D | niedrig | reuse | — |
-| 3 | `TOP_FILES`-Heading vorhanden | DONE | `merger/lenskit/core/agent_reading_pack.py:489` | mittel (Begriff "TOP" impliziert Wichtigkeit) | harden | A1 |
-| 4 | `TOP_FILES` als "wichtig" beschrieben | DRIFT | **README.md:35** "die wichtigsten Quelldateien"; Pack selbst sagt "by chunk coverage" (`merger/lenskit/core/agent_reading_pack.py:489-494`) | mittel | resolve (README jetzt; Heading-Rename A1) | A1 |
+| 3 | `TOP_FILES`-Heading → `TOP_CHUNK_SPANS` | **DONE (PR A1)** | `merger/lenskit/core/agent_reading_pack.py:488-489`; `merger/lenskit/tests/test_agent_reading_pack.py` (neue Negativtests) | niedrig | — | — |
+| 4 | `TOP_CHUNK_SPANS` + `does_not_prove`-Governance | **DONE (PR A1)** | Governance-JSON-Block in Producer; `README.md:35`; `docs/proofs/agent-reading-pack-producer-proof.md` | niedrig | — | — |
 | 5 | Cache/Tooling-Dirs in canonical/chunk/sqlite | DONE (exkludiert) | `merger/lenskit/core/merge.py:297-314` (`SKIP_DIRS`), Walk-Filter `merger/lenskit/core/merge.py:2277` (#681–#683) | **Plan-Beleg STALE** | reuse + harden | A2 |
 | 6 | Reading Lenses markieren Cache als `core` | PARTIAL (latent) | `merger/lenskit/core/lenses.py:87` (Ultimate-Fallback `core`, keine Exclusion) — Caches erreichen Lens aber nicht (Upstream-Skip) | niedrig-latent | harden (Guard-Test) | A2 |
 | 7 | `output_health=pass` trotz `redact_secrets=false` / `agent_pack=skipped` | DONE (bestätigt) | `merger/lenskit/core/output_health.py:468-469` (Redaction nur protokolliert), `:461-466` (skip = keine Warnung), `:486-491` (Verdict nur aus errors/warnings) | **hoch** (Schein-Agentensicherheit) | harden via separates Gate, **nicht** Health umbiegen | A4/A5 |
@@ -66,13 +66,13 @@ Entscheidung: `reuse` · `harden` · `defer` · `resolve` · `delete`.
 Modulzweck-Behauptungen — er hat keinen `TOP_LEVEL_ARCHITECTURE`-Abschnitt.
 → Diese Substanz muss **gehärtet**, nicht neu gebaut werden.
 
-### 2.2 Bestätigt: `TOP_FILES` ist Begriffsrisiko, vor allem in der README
-Der Pack-Producer beschreibt die Tabelle korrekt als "top N **by chunk coverage**"
-(`:489`) und als "Canonical spans … to read or cite a file's content precisely"
-(`:491-494`) — **keine** Wichtigkeitsaussage. Risiko ist der Heading-Begriff "TOP"
-plus die **README**, die explizit "die **wichtigsten** Quelldateien" sagt
-(`README.md:35`). Das ist die einzige aktive, repo-belegte Importance-Behauptung.
-→ README jetzt korrigieren; Heading-Rename `TOP_FILES → TOP_CHUNK_SPANS` als A1.
+### 2.2 Erledigt (PR A1): `TOP_FILES → TOP_CHUNK_SPANS` + `does_not_prove`-Governance
+`## TOP_FILES` in Producer und Tests zu `## TOP_CHUNK_SPANS` migriert. README
+beschreibt die Sektion jetzt ohne Wichtigkeitsanspruch. Producer enthält
+maschinenlesbaren Governance-Block mit `risk_class: navigation`, `may_cite: false`,
+`does_not_prove: [semantic_importance, architecture_truth, complete_context]`.
+Neue Negativtests: `test_agent_pack_no_top_files_heading`,
+`test_agent_pack_no_important_language`, `test_agent_pack_declares_does_not_prove`.
 
 ### 2.3 STALE: `.ruff_cache` im Output ist bereits behoben
 Der Plan-Beleg (".ruff_cache landet in canonical/chunk/sqlite", "Lenses als core")

--- a/merger/lenskit/core/agent_reading_pack.py
+++ b/merger/lenskit/core/agent_reading_pack.py
@@ -41,7 +41,7 @@ from .path_security import resolve_secure_path
 
 PRODUCED_BY = "agent_reading_pack_producer/v1"
 PACK_VERSION = "v1"
-TOP_FILE_LIMIT = 30
+TOP_CHUNK_SPAN_LIMIT = 30
 
 _SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
 _WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:")
@@ -204,7 +204,7 @@ def compute_top_files(
     canonical_md_bytes: bytes,
     canonical_md_rel: str,
     *,
-    limit: int = TOP_FILE_LIMIT,
+    limit: int = TOP_CHUNK_SPAN_LIMIT,
 ) -> Tuple[List[TopFile], List[str], int]:
     """
     Aggregate chunk-index entries into per-source-file canonical spans.
@@ -486,7 +486,7 @@ def render_agent_reading_pack(model: PackModel) -> str:
     lines.append("")
 
     # ── TOP_CHUNK_SPANS ──────────────────────────────────────────────────
-    lines.append(f"## TOP_CHUNK_SPANS (top {TOP_FILE_LIMIT} by chunk coverage)")
+    lines.append(f"## TOP_CHUNK_SPANS (top {TOP_CHUNK_SPAN_LIMIT} by chunk coverage)")
     lines.append(
         "```json\n"
         "{\n"

--- a/merger/lenskit/core/agent_reading_pack.py
+++ b/merger/lenskit/core/agent_reading_pack.py
@@ -485,12 +485,30 @@ def render_agent_reading_pack(model: PackModel) -> str:
         )
     lines.append("")
 
-    # ── TOP_FILES ────────────────────────────────────────────────────────
-    lines.append(f"## TOP_FILES (top {TOP_FILE_LIMIT} by chunk coverage)")
+    # ── TOP_CHUNK_SPANS ──────────────────────────────────────────────────
+    lines.append(f"## TOP_CHUNK_SPANS (top {TOP_FILE_LIMIT} by chunk coverage)")
+    lines.append(
+        "```json\n"
+        "{\n"
+        '  "artifact": "agent_reading_pack",\n'
+        '  "authority": "navigation_index",\n'
+        '  "canonicality": "derived",\n'
+        '  "risk_class": "navigation",\n'
+        '  "may_cite": false,\n'
+        '  "must_resolve_to": "role_specific_authority",\n'
+        '  "does_not_prove": [\n'
+        '    "semantic_importance",\n'
+        '    "architecture_truth",\n'
+        '    "complete_context"\n'
+        "  ]\n"
+        "}\n"
+        "```"
+    )
     if model.top_files:
         lines.append(
-            "Canonical spans point into `canonical_md`; use them to read or cite a "
-            "file's content precisely. `bytes` is `[start_byte, end_byte)`."
+            "Largest aggregated canonical spans by chunk coverage. Navigation aid only; "
+            "not an importance ranking. Canonical spans point into `canonical_md`; use "
+            "them to read or cite a file's content precisely. `bytes` is `[start_byte, end_byte)`."
         )
         lines.append("| file | repo | chunks | bytes | lines |")
         lines.append("| --- | --- | ---: | --- | --- |")

--- a/merger/lenskit/core/agent_reading_pack.py
+++ b/merger/lenskit/core/agent_reading_pack.py
@@ -491,6 +491,7 @@ def render_agent_reading_pack(model: PackModel) -> str:
         "```json\n"
         "{\n"
         '  "artifact": "agent_reading_pack",\n'
+        '  "applies_to": "TOP_CHUNK_SPANS",\n'
         '  "authority": "navigation_index",\n'
         '  "canonicality": "derived",\n'
         '  "risk_class": "navigation",\n'

--- a/merger/lenskit/tests/test_agent_reading_pack.py
+++ b/merger/lenskit/tests/test_agent_reading_pack.py
@@ -178,7 +178,7 @@ def test_pack_has_governance_and_sentinel(tmp_path):
         "## ARTIFACT_ROLES",
         "## OUTPUT_HEALTH_SUMMARY",
         "## HOW_TO_SEARCH",
-        "## TOP_FILES",
+        "## TOP_CHUNK_SPANS",
         "## EPISTEMIC_EMPTINESS",
     ):
         assert section in body, f"missing section {section}"
@@ -570,3 +570,49 @@ def test_compute_top_files_conflicting_fallback_repo_ids_are_omitted(tmp_path):
     # Both candidates are still tracked in the global repos set.
     assert "search-repo" in repos
     assert "chunk-repo" in repos
+
+
+# ---------------------------------------------------------------------------
+# A1 Begriffshärtung: TOP_FILES → TOP_CHUNK_SPANS + does_not_prove governance
+# ---------------------------------------------------------------------------
+
+def test_agent_pack_uses_top_chunk_spans(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    body = Path(produce_agent_reading_pack(str(manifest))["output_path"]).read_text()
+    assert "## TOP_CHUNK_SPANS" in body
+
+
+def test_agent_pack_no_top_files_heading(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    body = Path(produce_agent_reading_pack(str(manifest))["output_path"]).read_text()
+    assert "## TOP_FILES" not in body
+
+
+def test_agent_pack_declares_does_not_prove(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    body = Path(produce_agent_reading_pack(str(manifest))["output_path"]).read_text()
+    assert "does_not_prove" in body
+    assert "semantic_importance" in body
+    assert "architecture_truth" in body
+    assert "complete_context" in body
+
+
+def test_agent_pack_governance_block_fields(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    body = Path(produce_agent_reading_pack(str(manifest))["output_path"]).read_text()
+    assert '"risk_class": "navigation"' in body
+    assert '"may_cite": false' in body
+    assert '"must_resolve_to": "role_specific_authority"' in body
+
+
+def test_agent_pack_no_important_language(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    body = Path(produce_agent_reading_pack(str(manifest))["output_path"]).read_text()
+    for forbidden in ["most important", "wichtigste", "top-level architecture"]:
+        assert forbidden not in body.lower(), f"forbidden phrase in pack: {forbidden!r}"
+
+
+def test_agent_pack_has_no_top_level_architecture(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    body = Path(produce_agent_reading_pack(str(manifest))["output_path"]).read_text()
+    assert "top-level architecture" not in body.lower()

--- a/merger/lenskit/tests/test_agent_reading_pack.py
+++ b/merger/lenskit/tests/test_agent_reading_pack.py
@@ -7,6 +7,7 @@ test_bundle_manifest_integration.py.
 """
 import hashlib
 import json
+import re
 from pathlib import Path
 
 from merger.lenskit.core.agent_reading_pack import (
@@ -616,3 +617,23 @@ def test_agent_pack_has_no_top_level_architecture(tmp_path):
     manifest = _make_bundle(tmp_path)
     body = Path(produce_agent_reading_pack(str(manifest))["output_path"]).read_text()
     assert "top-level architecture" not in body.lower()
+
+
+def test_agent_pack_governance_block_is_valid_json(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    body = Path(produce_agent_reading_pack(str(manifest))["output_path"]).read_text()
+    match = re.search(r"```json\n(\{.*?\})\n```", body, re.DOTALL)
+    assert match, "missing governance JSON block"
+    data = json.loads(match.group(1))
+    assert data["artifact"] == "agent_reading_pack"
+    assert data["applies_to"] == "TOP_CHUNK_SPANS"
+    assert data["authority"] == "navigation_index"
+    assert data["canonicality"] == "derived"
+    assert data["risk_class"] == "navigation"
+    assert data["may_cite"] is False
+    assert data["must_resolve_to"] == "role_specific_authority"
+    assert data["does_not_prove"] == [
+        "semantic_importance",
+        "architecture_truth",
+        "complete_context",
+    ]

--- a/merger/lenskit/tests/test_bundle_manifest_integration.py
+++ b/merger/lenskit/tests/test_bundle_manifest_integration.py
@@ -709,7 +709,7 @@ def test_agent_reading_pack_emitted_schema_valid_and_hashed(tmp_path):
     assert "| agent_reading_pack |" not in body
     # It should reference the bundle's truth anchor and health verdict.
     assert "## OUTPUT_HEALTH_SUMMARY" in body
-    assert "## TOP_FILES" in body
+    assert "## TOP_CHUNK_SPANS" in body
 
 
 def test_bundle_manifest_canonical_dump_index_sha_matches_dump_index_artifact(tmp_path):


### PR DESCRIPTION
## Summary
Implements PR A1 of the anti-hallucination hardening plan: renames the `TOP_FILES` section to `TOP_CHUNK_SPANS` throughout the agent reading pack and adds a machine-readable governance block that explicitly declares what the section does *not* prove.

## Key Changes

- **Producer (`agent_reading_pack.py`):**
  - Renamed heading from `## TOP_FILES` to `## TOP_CHUNK_SPANS`
  - Added JSON governance block declaring:
    - `risk_class: "navigation"`
    - `may_cite: false`
    - `must_resolve_to: "role_specific_authority"`
    - `does_not_prove: ["semantic_importance", "architecture_truth", "complete_context"]`
  - Updated description to emphasize navigation aid only, removing any importance implication

- **Tests (`test_agent_reading_pack.py`, `test_bundle_manifest_integration.py`):**
  - Updated existing test assertion from `TOP_FILES` to `TOP_CHUNK_SPANS`
  - Added five new negative/positive tests:
    - `test_agent_pack_uses_top_chunk_spans`: verifies new heading present
    - `test_agent_pack_no_top_files_heading`: ensures old heading absent
    - `test_agent_pack_declares_does_not_prove`: validates governance block content
    - `test_agent_pack_governance_block_fields`: checks specific governance fields
    - `test_agent_pack_no_important_language`: forbids importance-implying phrases

- **Documentation:**
  - Updated `README.md` to reference `TOP_CHUNK_SPANS` without importance claims
  - Updated `lenskit-output-optimierung-v1.md` with migration note
  - Updated `lenskit-anti-hallucination-output-architecture.md` to mark PR A1 as implemented
  - Updated `anti-hallucination-capability-audit.md` to reflect completion
  - Updated `agent-reading-pack-producer-proof.md` with new section structure

## Implementation Details

The governance block is embedded as a JSON fence immediately after the section heading, making it machine-readable while remaining human-visible in the markdown output. The block reuses vocabulary from the agent-query-session schema to maintain consistency across the system.

The change addresses the conceptual risk that the term "TOP" implies importance ranking, when the section actually ranks by chunk coverage (a navigation metric, not a quality metric). The explicit `does_not_prove` declarations prevent downstream consumers from misinterpreting the data.

https://claude.ai/code/session_01GjfBHTSf9ebxQE9tjnsZ2f