### PR TITLE
Add surface-local context_risk hints to query context bundle

### DIFF
--- a/docs/proofs/context-risk-hardening-plan.md
+++ b/docs/proofs/context-risk-hardening-plan.md
@@ -5,8 +5,8 @@ Scope: Phase-B-Härtung — Context Risk & Agent-facing Output Safety.
 Revision: rev2 — Scope nach Review präzisiert auf **strikte Surface-Lokalität** (kein
 globaler Epistemik-Layer, keine Cross-Artifact-Normalisierung, kein Shared-`$ref`/-
 Registry, kein agent-safe-Verdikt, kein Scoring). Siehe §6a.
-Diese Notiz beschreibt die **minimale additive** Härtung; die Phase-2-Umsetzung folgt
-als kleiner PR B3 entlang dieser Notiz.
+Diese Notiz beschreibt die **minimale additive** Härtung; die Phase-2-Umsetzung erfolgt
+in diesem PR als kleiner B3-Schritt entlang dieser Notiz.
 
 Beziehung zu bestehenden Docs (ersetzt nichts):
 - Reihenfolge/Gates: `docs/roadmap/lenskit-master-roadmap.md`
@@ -418,6 +418,7 @@ Zusätzlich (Review-rev2, siehe §6a): **kein** Cross-Artifact-Normalisierungs-L
 ## 11. Nächster Schritt
 
 rev1 wurde reviewt; Scope auf strikte Surface-Lokalität präzisiert (rev2, §6a). Die
-additive Phase-2-Umsetzung (§5, §8) erfolgt als kleiner, gezielter PR B3 entlang dieser
-Notiz: optionales `context_risk` im Bundle-Schema + konstanter, inline definierter Block
-im Producer + die vier benannten Tests (§9). Keine anderen Contracts werden angefasst.
+additive Phase-2-Umsetzung (§5, §8) ist in diesem PR als kleiner, gezielter B3-Schritt
+entlang dieser Notiz enthalten: optionales `context_risk` im Bundle-Schema + konstanter,
+inline definierter Block im Producer + die vier benannten Tests (§9). Keine anderen
+Contracts werden angefasst.

--- a/docs/proofs/context-risk-hardening-plan.md
+++ b/docs/proofs/context-risk-hardening-plan.md
@@ -1,0 +1,329 @@
+# Context Risk Hardening Plan (Diagnose + Design)
+
+Status: Diagnose-/Design-Notiz (diagnose-first, docs-first).
+Scope: Phase-B-Härtung — Context Risk & Agent-facing Output Safety.
+Diese Notiz **baut nichts**. Sie belegt den Ist-Zustand, isoliert die **eine** reale,
+repo-belegte Lücke und beschreibt die **minimale additive** Härtung, bevor Code
+geändert wird.
+
+Beziehung zu bestehenden Docs (ersetzt nichts):
+- Reihenfolge/Gates: `docs/roadmap/lenskit-master-roadmap.md`
+- Reconciled Roadmap (PR B3): `docs/blueprints/lenskit-anti-hallucination-output-architecture.md`
+- Befund/Falsifikation: `docs/proofs/anti-hallucination-capability-audit.md`
+- Runtime-Boundary-Befund: `docs/proofs/runtime-artifact-metadata-gap-audit.md`
+- Transfer-Boundary: `docs/proofs/vibe-lab-transfer-falsification.md`
+- Profile/Evidence/Health: `docs/blueprints/lenskit-artifact-output-control-plane.md`
+
+---
+
+## 0. Auftrag in einem Satz
+
+Agent-facing Output Safety **operationalisieren**, ohne eine neue Wahrheits- oder
+Governance-Schicht zu bauen: Agenten sollen am **Bundle selbst** erkennen, dass es eine
+Retrieval-/Projektions-Fläche ist (kein vollständiger Repo-Kontext, keine
+Inhaltswahrheit) — als deterministische Risk-Hints, **nicht** als Wahrheitsampel.
+
+Leitsatz: Lenskit erzeugt Bedingungen für bessere Interpretation. Lenskit entscheidet
+nicht Wahrheit.
+
+## 1. Methode
+
+`git status`/`rg`/`test -f` plus vollständiges Lesen der Kern-Contracts, Producer,
+Consumer und Tests im aktuellen Branch-Stand (`claude/nifty-albattani-QKFo0`,
+Stand 2026-05-22). Kein Planpunkt wurde ohne Code-/Contract-/Test-Beleg übernommen.
+Baseline der direkt betroffenen Testfläche grün (`133 passed`, siehe §9).
+
+Leitbefund (wie im Auftrag erwartet): Der lokale Contract-/Teststand ist **weiter** als
+der Bundle-Eindruck. Mehrere im Auftrag genannte „Zielideen" (Runtime-Observation-Warnung,
+`cache_not_truth`, `non_canonical_surface`, `artifact_shape`) sind bereits **umgesetzt** —
+am Lookup-/Envelope-Layer. Genau **eine** Fläche bleibt ungehärtet: das
+`query-context-bundle.v1` selbst.
+
+---
+
+## 2. Belegter Ist-Zustand — was bereits existiert
+
+### 2.1 Runtime-Lookup-Artefakte klassifizieren sich bereits (Gap geschlossen)
+
+Der `runtime-artifact-metadata-gap-audit.md` (Branch `claude/audit-runtime-metadata`,
+2026-05-01) beschrieb fehlende Klassifizierung. **Dieser Patch ist gelandet.** Die drei
+Lookup-Contracts tragen heute alle Klassifizierungsfelder:
+
+- `merger/lenskit/contracts/artifact-lookup.v1.schema.json:50,64-103` — `ArtifactPayload`
+  required: `authority` (const `runtime_observation`), `canonicality` (const
+  `observation`), `artifact_shape` (`raw|projected|wrapper`), `retention_policy`
+  (const `unbounded_currently`), `lifecycle_status` (const `active`), `expires_at`,
+  `claim_boundaries.does_not_prove`.
+- `merger/lenskit/contracts/context-lookup.v1.schema.json:23-104` — `if status==ok then
+  required [authority, canonicality, artifact_shape (const projected), retention_policy,
+  lifecycle_status, expires_at, claim_boundaries]`.
+- `merger/lenskit/contracts/trace-lookup.v1.schema.json:23-104` — analog, `artifact_shape`
+  const `raw`.
+
+→ **Konsequenz:** Focus B („Beobachtung ≠ Wahrheit", `runtime_observation_warning`,
+`cache_not_truth`, `non_canonical_surface`, `artifact_shape`) ist am **Lookup-Layer
+bereits operationalisiert**. Hier ist **nichts** neu zu bauen.
+
+### 2.2 `query-result.v1` hat Claim-Boundaries
+
+`merger/lenskit/contracts/query-result.v1.schema.json:251-298` definiert `claim_boundaries`
+(`proves`, `does_not_prove`, `evidence_basis`, `requires_live_check`). Producer:
+`merger/lenskit/retrieval/query_core.py:564-576` setzt sie deterministisch auf das
+**Query-Result** (u. a. „Absence of a hit does not prove absence in the repository.",
+„Ranking does not prove semantic importance.", „Snapshot query does not prove live
+repository state.").
+
+### 2.3 `agent-query-session.v2` hat Authority + Claim-Boundaries
+
+`merger/lenskit/contracts/agent-query-session.v2.schema.json:57-61` — `session_authority`
+const `agent_context_projection` („not canonical repository content"); `:91-110`
+`claim_boundaries.{proves,does_not_prove}` (beide required, `minItems:1`). Producer:
+`merger/lenskit/retrieval/session.py:127-149` (`build_agent_query_session_v2`) emittiert
+sie deterministisch.
+
+### 2.4 Agent Reading Pack ist begriffsgehärtet (PR A1, #688)
+
+`TOP_FILES → TOP_CHUNK_SPANS` + maschinenlesbarer Governance-Block (`risk_class:
+navigation`, `may_cite: false`, `must_resolve_to: role_specific_authority`,
+`does_not_prove: [...]`). Beleg: Audit §2.2; Roadmap A1.
+
+### 2.5 Per-Hit-`epistemics` im Bundle existieren
+
+`merger/lenskit/retrieval/query_core.py:729-745` (`build_context_bundle`) setzt je Hit
+einen `epistemics`-Block (`provenance_type`, `bundle_origin`, `resolver_status`,
+`graph_status`, `semantic_status`, `federation_status`, `uncertainty`, `interpolation`);
+Schema `query-context-bundle.v1.schema.json:81-140`. Strenge Grammatik-Tests:
+`test_api_query.py:530-576`.
+
+### Vokabular bereits im Repo (keine Erfindung nötig)
+
+| Begriff | Bereits vorhanden in |
+|---|---|
+| `authority: runtime_observation` / `canonicality: observation` | artifact-/context-/trace-lookup, bundle-manifest |
+| `artifact_shape` (raw/projected/wrapper) | artifact-/context-/trace-lookup |
+| `claim_boundaries` / `does_not_prove` | query-result, agent-query-session, lookups |
+| `session_authority: agent_context_projection` | agent-query-session.v2 |
+| `risk_class` / `must_resolve_to` / `may_cite` | Agent-Reading-Pack-Governance (A1) |
+| per-Hit `resolver_status` / `uncertainty` / `interpolation` | query-context-bundle.v1 |
+
+→ Eine `context_risk`-Härtung **wiederverwendet** dieses Vokabular; sie führt keine neue
+Meta-Sprache ein.
+
+---
+
+## 3. Die eine reale, repo-belegte Lücke
+
+### 3.1 Das Bundle selbst trägt keine Top-Level-Risk-/Claim-Fläche
+
+`merger/lenskit/contracts/query-context-bundle.v1.schema.json:6-12` —
+`additionalProperties: false`, `required: [query, hits]`. **Kein** `context_risk`,
+**keine** `claim_boundaries` auf Bundle-Ebene. Producer
+`query_core.py:686-779` gibt `{"query": ..., "hits": [...]}` zurück — sonst nichts.
+(Deckt sich mit Audit-Zeile 14 und Audit §4 Punkt 4: additive Erweiterbarkeit „noch
+nicht durch einen Consumer-Test belegt".)
+
+### 3.2 Konkreter, code-belegter Schaden: die Projektion verliert die Claim-Boundaries
+
+`merger/lenskit/retrieval/output_projection.py:31-86`: Bei gesetztem `output_profile`
+(z. B. `agent_minimal`, `ui_navigation`) und ohne Wrapper-Trigger gibt `project_output`
+**das nackte Bundle** zurück (`return bundle`, Zeile 86). Die auf dem Query-Result
+gesetzten `claim_boundaries` (§2.2) liegen in `res`, werden aber **nicht** ins Bundle
+kopiert; der Wrapper-Pfad (`:60-84`) hängt nur `federation_trace`/`query_trace`/
+`federation_conflicts`/`cross_repo_links`/`warnings` an — **nicht** `claim_boundaries`.
+
+Ergebnis: Ein Agent, der mit `output_profile=agent_minimal` arbeitet, erhält
+`hits[].resolved_code_snippet` **ohne jede** Bundle-Boundary. Nichts im Bundle sagt:
+„dies ist eine Retrieval-Teilmenge", „Belege auflösen gegen `canonical_md`", „Abwesenheit
+eines Treffers beweist keine Abwesenheit im Repo". Das ist genau die Stelle, an der ein
+Agent Query-Hits mit Repo-Wahrheit verwechseln kann.
+
+### 3.3 Warum die Per-Hit-`epistemics` das nicht abdecken
+
+Die `epistemics` (§2.5) beschreiben **die Auflösung des einzelnen Treffers**
+(resolver_status, interpolation). Sie sagen **nichts** über die **Vollständigkeit der
+TrefferMENGE**: Das Bundle ist eine `results[:k]`-Scheibe
+(`query_core.py:605-613`) — ein gefiltertes Top-k-Subset. „Was fehlt" ist per
+Konstruktion nicht in den Hits sichtbar. Die fehlende Aussage ist eine **Mengen-/
+Projektions-Eigenschaft**, kein Per-Hit-Attribut.
+
+---
+
+## 4. Fehlklassen-Abgleich (Auftrag „Zielideen" vs. Belege)
+
+Nur dump-/repo-belegte Fehlklassen adressieren; nicht alles bauen.
+
+| Zielidee (Auftrag) | Status | Beleg / Begründung | Aktion |
+|---|---|---|---|
+| `context_risk` (Bundle-Ebene) | **GAP** | §3.1, Audit #14/#4, B3 | **ADRESSIEREN** |
+| `retrieval_based_subset` / `retrieval_incompleteness` | **GAP** | Bundle = `results[:k]`, `query_core.py:605-613` | **ADRESSIEREN** (Teil von `context_risk`) |
+| `may_answer_from_this_directly:false` + Resolve-Map | **GAP** | §3.2 (Projektion verliert Boundaries) | **ADRESSIEREN** (Teil von `context_risk`) |
+| stärkere `does_not_prove` (Bundle) | **GAP** | Bundle hat keine; Vokabular existiert §2.2 | **ADRESSIEREN** (in `context_risk`, Vokabular wiederverwenden) |
+| `runtime_observation_warning` / `cache_not_truth` / `non_canonical_surface` | **DONE** | §2.1 (Lookup-Layer) | **NICHT bauen** (referenzieren) |
+| `artifact_shape` | **DONE** | §2.1 | **NICHT bauen** |
+| `coverage_hints` (numerischer Score) | **NICHT bauen** | Score-Risiko = „Verstehensampel"; verboten | **NICHT bauen** |
+| `citation_resolution_gap` (Bundle-Aggregat aus per-Hit `resolver_status`) | **OPTIONAL/DEFER** | wäre deterministische Projektion bestehender per-Hit-Daten; erhöht aber Fläche | **NICHT in Erst-PR** (separat erwägen) |
+
+---
+
+## 5. Minimale additive Härtung (Design)
+
+Entspricht exakt **PR B3** der reconciled Roadmap („Context Bundle Resolve Discipline").
+Ein einziger neuer additiver Block in **einem** bestehenden Contract + dessen Producer +
+Tests.
+
+### 5.1 Schema (additiv, optional)
+
+In `query-context-bundle.v1.schema.json` ein **optionales** Top-Level-`context_risk`
+ergänzen (zu `properties`, **nicht** zu `required`):
+
+```jsonc
+"context_risk": {
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "retrieval_based_subset",
+    "missing_relevant_context_possible",
+    "may_answer_from_this_directly",
+    "claims_resolve_to",
+    "does_not_prove"
+  ],
+  "properties": {
+    "retrieval_based_subset":          { "type": "boolean" },
+    "missing_relevant_context_possible": { "type": "boolean" },
+    "may_answer_from_this_directly":   { "type": "boolean" },
+    "claims_resolve_to": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["content", "metadata", "schema", "runtime"],
+      "properties": {
+        "content":  { "const": "canonical_md" },
+        "metadata": { "const": "bundle_manifest" },
+        "schema":   { "const": "schema" },
+        "runtime":  { "const": "query_trace" }
+      }
+    },
+    "does_not_prove": { "type": "array", "items": { "type": "string" } }
+  }
+}
+```
+
+`additionalProperties: false` am Bundle bleibt erhalten; durch die Aufnahme in
+`properties` validieren **sowohl** neue Bundles (mit Feld) **als auch** alte Bundles
+(ohne Feld). Kein Pflichtfeld-Bruch.
+
+### 5.2 Producer (deterministische Konstante)
+
+In `build_context_bundle()` (`query_core.py:691-779`) am Bundle-Top-Level einen
+**konstanten** Block emittieren (kein Inhalts-/Heuristik-Bezug → deterministisch):
+
+```python
+bundle["context_risk"] = {
+    "retrieval_based_subset": True,
+    "missing_relevant_context_possible": True,
+    "may_answer_from_this_directly": False,
+    "claims_resolve_to": {
+        "content": "canonical_md",
+        "metadata": "bundle_manifest",
+        "schema": "schema",
+        "runtime": "query_trace",
+    },
+    "does_not_prove": [
+        "Absence of a hit does not prove absence in the repository.",
+        "These retrieved snippets do not prove complete or sufficient context.",
+        "Ranking does not prove semantic importance.",
+        "This bundle is an agent context projection, not canonical repository content.",
+    ],
+}
+```
+
+Die `does_not_prove`-Strings spiegeln die bestehenden Boundaries aus
+`query_core.py:564-576` / `session.py:139-149` — ein Vokabular, keine zweite Sprache.
+
+### 5.3 Determinismus + Migration
+
+- **Deterministisch:** Der Block ist eine Konstante; identisch bei jedem Lauf,
+  unabhängig von Hits/Query. Bricht keine Determinismus-/Byte-Identität-Belege.
+- **Projektions-überlebend:** `project_output` strippt nur **Hit-Felder**
+  (`explain`/`graph_context`/`surrounding_context`, `output_projection.py:35-49`); ein
+  Top-Level-`context_risk` bleibt in **allen** Profilen erhalten — genau dort, wo der
+  Schaden aus §3.2 entsteht.
+- **Lookup unberührt:** `context-lookup.v1` speichert das Bundle als
+  `context_bundle` mit `additionalProperties: true` (`:41-46`) — das Zusatzfeld wird
+  ohne Schema-Änderung akzeptiert. **Kein** Eingriff in die Lookup-Contracts nötig.
+- **Alte Bundles:** bleiben gültig (Feld optional). Ein Consumer liest „Feld fehlt" =
+  Legacy/unbekannt, nicht „kein Risk".
+
+### 5.4 Optional-im-Schema, immer-emittiert
+
+Die Roadmap-Zielgröße `runtime_outputs_with_context_risk: 100%` wird dadurch erfüllt,
+dass der **Producer das Feld immer emittiert**, während das **Schema es optional** lässt
+(Backcompat). Das Feld später `required` zu machen wäre ein **separater, breaking-naher**
+Schritt (würde Alt-Bundles abweisen) → **defer**, konsistent mit „keine Breaking Schema
+Changes ohne Migrationspfad".
+
+---
+
+## 6. Warum keine neue Governance nötig ist
+
+- Das gesamte Vokabular existiert bereits (§2-Tabelle). `context_risk` **leitet ab/
+  projiziert**, es bewertet nicht.
+- Kein neues Top-Level-Artefakt, keine neue Schema-Datei, kein neuer CLI-Command, keine
+  neue Control-Plane, keine Wahrheitsmaschine.
+- Genau **ein** Contract wird additiv erweitert; sein Producer emittiert eine Konstante.
+- Die bestehende Pre/Post-Health-Trennung, die Parity-Gate-Semantik und die
+  Authority-Registry bleiben unangetastet.
+
+## 7. Harte Nicht-Ziele (repo-spezifisch bekräftigt)
+
+Nicht gebaut wird: automatische Claim-Wahrheitsbewertung; `supported/unsupported/true/
+false/proven`; Truth-/Confidence-Score; globale Verstehens-/Risk-Ampel; numerische
+`coverage`-Scores; neue globale Meta-Artefakte; zweites Generated-Artifact-Register;
+Promotion-Readiness-Control-Plane; Agent-Command-Chain; `write_change`/`validate_change`;
+generisches Handoff-System; Vibe-Lab-Replik. (Konsistent mit
+`vibe-lab-transfer-falsification.md` und Anti-Hallucination-Blueprint §6.)
+
+## 8. Blast Radius (unter Abbruchschwelle ~10 Dateien)
+
+| Datei | Änderung |
+|---|---|
+| `merger/lenskit/contracts/query-context-bundle.v1.schema.json` | additiv optionales `context_risk` |
+| `merger/lenskit/retrieval/query_core.py` | konstanten Block in `build_context_bundle` emittieren |
+| `merger/lenskit/tests/test_context_bundle.py` | neue Tests (declares / backwards-compat / deterministisch / projektion-überlebt) |
+| `docs/proofs/context-risk-hardening-plan.md` | diese Notiz (Phase 1) |
+| (optional) `docs/contracts/contracts-matrix.md` / `docs/architecture/artifact-inventory.md` | Doku-Sync-Notiz |
+
+→ 2 Code-/Contract-Dateien + 1 Testdatei + Doku. Keine globalen Umbenennungen.
+
+## 9. Validierung (Plan; Baseline bereits grün)
+
+- Baseline (Stand jetzt, `python3.11 -m pytest`): `test_context_bundle.py`,
+  `test_agent_session_builder.py`, `test_agent_session_schema.py`, `test_context_lookup.py`,
+  `test_trace_lookup.py`, `test_artifact_lookup.py`, `test_api_query.py` → **133 passed**.
+- Neue Tests (entsprechen B3-Namen):
+  - `test_context_bundle_declares_context_risk` — Producer emittiert Block mit exakter
+    deterministischer Form + Resolve-Map.
+  - `test_context_bundle_v1_backwards_compatible` — Bundle **ohne** `context_risk`
+    validiert weiter (Beleg für additive Sicherheit; schließt Audit-§4-Punkt-4).
+  - `test_context_risk_block_is_deterministic` — zwei Läufe → identischer Block.
+  - `test_context_risk_survives_agent_minimal_projection` — Block überlebt
+    `project_output(..., "agent_minimal")` (Beleg gegen §3.2-Schaden).
+- Bestehende Schema-Validierung in `test_context_bundle.py:54-70` muss grün bleiben
+  (Bundle **und** Query-Result gegen Schemas, via Registry).
+- Pflicht vor Merge: vollständiges `pytest` grün; keine Determinismus-Regression.
+
+## 10. Risiken / Unsicherheit
+
+- **Hauptrisiko:** Scope-Drift zur „Universal-Risk-Engine". Gegenmittel: §7-Nicht-Ziele,
+  ein konstanter Block, ein Contract.
+- **Designoffene Kleinentscheidung (für Review):** `does_not_prove` **innerhalb**
+  `context_risk` (eine neue Top-Level-Eigenschaft, Empfehlung) **vs.** separate
+  Bundle-`claim_boundaries` (zweite neue Eigenschaft, mehr Symmetrie zu
+  query-result/session). Empfehlung: in `context_risk` halten → minimalste Fläche.
+- **Unsicherheit ~0,2:** Ob ein Consumer außerhalb des gelesenen Surfaces das Bundle
+  strikt re-validiert; mitigiert durch Optional-Feld + Backcompat-Test.
+
+## 11. Nächster Schritt
+
+Diese Diagnose-/Design-Notiz **zuerst reviewen** (Phase-1-Stop-Kriterium: max. eine kleine
+neue Proof-Datei, keine Roadmap-Neuerfindung — erfüllt). Erst nach Review die additive
+Phase-2-Implementierung (§5, §8) angehen — als kleiner, gezielter PR B3.

--- a/docs/proofs/context-risk-hardening-plan.md
+++ b/docs/proofs/context-risk-hardening-plan.md
@@ -2,9 +2,11 @@
 
 Status: Diagnose-/Design-Notiz (diagnose-first, docs-first).
 Scope: Phase-B-Härtung — Context Risk & Agent-facing Output Safety.
-Diese Notiz **baut nichts**. Sie belegt den Ist-Zustand, isoliert die **eine** reale,
-repo-belegte Lücke und beschreibt die **minimale additive** Härtung, bevor Code
-geändert wird.
+Revision: rev2 — Scope nach Review präzisiert auf **strikte Surface-Lokalität** (kein
+globaler Epistemik-Layer, keine Cross-Artifact-Normalisierung, kein Shared-`$ref`/-
+Registry, kein agent-safe-Verdikt, kein Scoring). Siehe §6a.
+Diese Notiz beschreibt die **minimale additive** Härtung; die Phase-2-Umsetzung folgt
+als kleiner PR B3 entlang dieser Notiz.
 
 Beziehung zu bestehenden Docs (ersetzt nichts):
 - Reihenfolge/Gates: `docs/roadmap/lenskit-master-roadmap.md`
@@ -211,6 +213,13 @@ ergänzen (zu `properties`, **nicht** zu `required`):
 `properties` validieren **sowohl** neue Bundles (mit Feld) **als auch** alte Bundles
 (ohne Feld). Kein Pflichtfeld-Bruch.
 
+Der `context_risk`-Block wird **inline** in genau diesem Contract definiert — **kein**
+`$ref` auf ein geteiltes Definitions-Dokument, **keine** wiederverwendbare
+`definitions/context_risk`-Abstraktion, die andere Contracts importieren könnten (siehe
+§6a). `context_risk` ist die **lokale Risk-Hint-Fläche des Context-Bundles**:
+Retrieval-/Projektions-/Incompleteness-Hinweise plus surface-lokale Resolve-Pointer und
+surface-lokale `does_not_prove`-Aussagen — **kein** generalisierter Epistemik-Container.
+
 ### 5.2 Producer (deterministische Konstante)
 
 In `build_context_bundle()` (`query_core.py:691-779`) am Bundle-Top-Level einen
@@ -236,8 +245,11 @@ bundle["context_risk"] = {
 }
 ```
 
-Die `does_not_prove`-Strings spiegeln die bestehenden Boundaries aus
-`query_core.py:564-576` / `session.py:139-149` — ein Vokabular, keine zweite Sprache.
+**Surface-Lokalität (verbindlich, siehe §6a):** Die `does_not_prove`-Strings werden
+**lokal in `build_context_bundle` inline** definiert. Sie dürfen Formulierungen aus
+`query_core.py:564-576` / `session.py:139-149` **wörtlich wiederholen**, aber es entsteht
+**keine** geteilte Konstante, **kein** exportiertes Modul-Symbol und **kein** Shared-`$ref`.
+Eigentum bleibt bei dieser Surface. Gleiche Phrase ≠ geteiltes Vokabular.
 
 ### 5.3 Determinismus + Migration
 
@@ -273,6 +285,78 @@ Changes ohne Migrationspfad".
 - Die bestehende Pre/Post-Health-Trennung, die Parity-Gate-Semantik und die
   Authority-Registry bleiben unangetastet.
 
+## 6a. Surface-Lokalität — keine globale Epistemik-Schicht
+
+Verbindliche Leitplanke (Review-Vorgabe): `context_risk`/`does_not_prove` bleiben
+**artefakt-lokal, contract-lokal, additiv, nicht-autoritativ, nicht-aggregiert,
+nicht-scorend**. Sie werden **nicht** zu einem globalen Epistemik-Layer, einer
+Truth-Engine oder einer normierten Risk-Ontologie ausgebaut.
+
+### 6a.1 `does_not_prove` je Surface — Eigentum bleibt lokal
+
+Jede Surface besitzt ihre **eigene, inline definierte** Boundary. Es gibt **keine**
+geteilte Definition, die mehrere Contracts importieren.
+
+| Surface | Boundary-Feld (lokal definiert) | Eigentümer-Contract |
+|---|---|---|
+| Query Result | `claim_boundaries` (proves/does_not_prove/evidence_basis/requires_live_check) | `query-result.v1` |
+| Agent Query Session | `session_authority` + `claim_boundaries` (Projektions-Semantik) | `agent-query-session.v2` |
+| **Context Bundle** | **`context_risk` (Retrieval/Projektion/Incompleteness + Resolve-Pointer + lokale `does_not_prove`)** | **`query-context-bundle.v1`** ← diese Härtung |
+| Runtime Lookup (artifact/context/trace) | `authority`/`canonicality`/`artifact_shape` + lokales `claim_boundaries.does_not_prove` | `artifact-/context-/trace-lookup.v1` |
+| Output Health | lokale Integritäts-/Diagnose-Limits (verdict, checks) | `output-health.v1` |
+
+### 6a.2 Warum `does_not_prove` surface-owned bleibt
+
+Beweisgrenzen sind **kontextabhängig**: Was ein Query-Result nicht beweist, ist nicht
+deckungsgleich mit dem, was ein Context-Bundle (gefiltertes Top-k-Subset) oder ein
+Runtime-Trace (Beobachtung) nicht beweist. Eine generische, geteilte Liste würde diese
+Unterschiede verwischen und müsste zwangsläufig in eine **Ontologie erlaubter Aussagen**
+wachsen — genau der zu vermeidende Drift. Lokale Eigentümerschaft hält jede Aussage
+**präzise an ihrer Surface** und vermeidet eine zweite Buchhaltung.
+
+### 6a.3 Warum `context_risk` **kein** generalisiertes Register ist
+
+`context_risk` ist die lokale Risk-Hint-Fläche **nur** des Context-Bundles. Es ist
+**kein** Container für allgemeine Epistemik-Semantik, der nach und nach von einem
+„Risk-Hint-Surface" zu einer versteckten globalen Interpretationsschicht aufstiege.
+Konkrete technische Selbstbindung:
+- **kein** `$ref` / keine `definitions/*`, die andere Contracts referenzieren;
+- **keine** exportierte Producer-Konstante, die mehrere Producer teilen;
+- **kein** Enum/Vokabular „erlaubter" `does_not_prove`-Strings;
+- **keine** Aggregation über Artefakte; **keine** numerischen Scores.
+
+Gleiche **Phrase** darf mehrfach auftauchen (z. B. „Absence of a hit does not prove
+absence in the repository."); geteilt wird die **Phrase**, nie die **Definition** oder
+die **Autorität**.
+
+### 6a.4 Warum Symmetrie bewusst **partiell** bleibt
+
+Es wird **kein** normiertes Top-Level-`claim_boundaries` nur um der Symmetrie willen
+über alle Artefakte gezogen. Jede Surface formuliert ihre Grenzen in **ihrer eigenen
+Form** (Query-Result: `claim_boundaries`; Session: `session_authority`+`claim_boundaries`;
+Bundle: `context_risk`; Lookups: `claim_boundaries.does_not_prove`; Health: Integritäts-
+Limits). Diese gewollte **Asymmetrie** ist die Schutzmaßnahme gegen „eine Ontologie für
+alle epistemischen Grenzen".
+
+### 6a.5 Migrations-/Kompatibilitätswirkung
+
+- **Schema:** additiv, optional → alte Bundles **ohne** `context_risk` bleiben gültig;
+  neue Bundles validieren ebenso (§5.1, §5.3). Kein Bruch von `additionalProperties:
+  false`.
+- **Andere Contracts:** **unverändert.** `context-lookup.v1` akzeptiert das Bundle bereits
+  via `additionalProperties: true` (§5.3); query-result/session/lookups/health werden
+  **nicht** angefasst.
+- **Consumer:** lesen „Feld fehlt" als Legacy/unbekannt, nicht als „kein Risk". Per-Hit-
+  `epistemics` bleiben unverändert.
+- **Determinismus:** konstanter Block (§5.3) → keine Golden-/Byte-Identitäts-Regression.
+
+### 6a.6 Expliziter Nicht-Ziel: keine agent-safe-Verdikt-Schicht
+
+`context_risk` liefert **Hinweise**, **kein Urteil**. Es entsteht **kein**
+`agent_safe`/`safe`/`unsafe`-Feld, kein `output_health=pass ⇒ agent-safe`-Schluss und
+keine Verdikt-Aggregation. Agent-Safe bleibt ausschließlich Sache des separaten Gates
+(A4/A5 `post_emit_health`), nicht dieser Surface.
+
 ## 7. Harte Nicht-Ziele (repo-spezifisch bekräftigt)
 
 Nicht gebaut wird: automatische Claim-Wahrheitsbewertung; `supported/unsupported/true/
@@ -281,6 +365,11 @@ false/proven`; Truth-/Confidence-Score; globale Verstehens-/Risk-Ampel; numerisc
 Promotion-Readiness-Control-Plane; Agent-Command-Chain; `write_change`/`validate_change`;
 generisches Handoff-System; Vibe-Lab-Replik. (Konsistent mit
 `vibe-lab-transfer-falsification.md` und Anti-Hallucination-Blueprint §6.)
+
+Zusätzlich (Review-rev2, siehe §6a): **kein** Cross-Artifact-Normalisierungs-Layer;
+**kein** geteilter `$ref`/`definitions`-Block für `context_risk`/`does_not_prove`;
+**kein** universelles Epistemik-Metadatenmodell; **keine** Cross-Artifact-Authority;
+**keine** Aggregation; **keine** agent-safe-Verdikt-Schicht.
 
 ## 8. Blast Radius (unter Abbruchschwelle ~10 Dateien)
 
@@ -315,15 +404,20 @@ generisches Handoff-System; Vibe-Lab-Replik. (Konsistent mit
 
 - **Hauptrisiko:** Scope-Drift zur „Universal-Risk-Engine". Gegenmittel: §7-Nicht-Ziele,
   ein konstanter Block, ein Contract.
-- **Designoffene Kleinentscheidung (für Review):** `does_not_prove` **innerhalb**
-  `context_risk` (eine neue Top-Level-Eigenschaft, Empfehlung) **vs.** separate
-  Bundle-`claim_boundaries` (zweite neue Eigenschaft, mehr Symmetrie zu
-  query-result/session). Empfehlung: in `context_risk` halten → minimalste Fläche.
+- **Entschieden (rev2, Review):** `does_not_prove` lebt **surface-lokal** im
+  `context_risk`-Block des Bundles, **inline** definiert, **nicht** als geteiltes/
+  normiertes `claim_boundaries`. Keine Cross-Artifact-Symmetrie erzwungen (§6a.4).
+- **Zu prüfender Einzelpunkt (rev2):** Die `claims_resolve_to`-Map ist ein
+  **surface-lokaler Resolve-/Navigations-Pointer**, der die bestehende Reading-Policy
+  (Invariante 10) wiederholt — **kein** neues Authority-Modell, **nicht** geteilt. Falls
+  der Review selbst das als zu nah an einem Authority-Modell bewertet, ist es trivial
+  entfernbar (die drei Booleans + lokales `does_not_prove` tragen den Kern allein).
 - **Unsicherheit ~0,2:** Ob ein Consumer außerhalb des gelesenen Surfaces das Bundle
   strikt re-validiert; mitigiert durch Optional-Feld + Backcompat-Test.
 
 ## 11. Nächster Schritt
 
-Diese Diagnose-/Design-Notiz **zuerst reviewen** (Phase-1-Stop-Kriterium: max. eine kleine
-neue Proof-Datei, keine Roadmap-Neuerfindung — erfüllt). Erst nach Review die additive
-Phase-2-Implementierung (§5, §8) angehen — als kleiner, gezielter PR B3.
+rev1 wurde reviewt; Scope auf strikte Surface-Lokalität präzisiert (rev2, §6a). Die
+additive Phase-2-Umsetzung (§5, §8) erfolgt als kleiner, gezielter PR B3 entlang dieser
+Notiz: optionales `context_risk` im Bundle-Schema + konstanter, inline definierter Block
+im Producer + die vier benannten Tests (§9). Keine anderen Contracts werden angefasst.

--- a/merger/lenskit/contracts/query-context-bundle.v1.schema.json
+++ b/merger/lenskit/contracts/query-context-bundle.v1.schema.json
@@ -143,7 +143,7 @@
     },
     "context_risk": {
       "type": "object",
-      "description": "Surface-local risk hints for this context bundle. Retrieval/projection/incompleteness signals only — not a truth verdict, not a score, not an aggregated or shared epistemic layer. Optional for backwards compatibility; emitted by build_context_bundle for all new bundles.",
+      "description": "Surface-local risk hints for this context bundle. Retrieval/projection/incompleteness signals only — not a truth verdict, not a score, not an aggregated or shared epistemic layer. Optional for backwards compatibility; included in all newly produced bundles.",
       "additionalProperties": false,
       "required": [
         "retrieval_based_subset",
@@ -167,14 +167,14 @@
         },
         "claims_resolve_to": {
           "type": "object",
-          "description": "Surface-local resolve pointers restating the existing reading policy (where each claim kind is authoritative). Not a new authority model and not shared across contracts.",
+          "description": "Surface-local resolve pointers restating the existing reading policy. Not a new authority model and not shared across contracts. The runtime surface resolves to query_trace when present.",
           "additionalProperties": false,
           "required": ["content", "metadata", "schema", "runtime"],
           "properties": {
             "content": { "const": "canonical_md" },
             "metadata": { "const": "bundle_manifest" },
             "schema": { "const": "schema" },
-            "runtime": { "const": "query_trace_if_present" }
+            "runtime": { "const": "query_trace" }
           }
         },
         "does_not_prove": {

--- a/merger/lenskit/contracts/query-context-bundle.v1.schema.json
+++ b/merger/lenskit/contracts/query-context-bundle.v1.schema.json
@@ -163,7 +163,7 @@
         },
         "may_answer_from_this_directly": {
           "type": "boolean",
-          "description": "False: this bundle is a navigation/projection surface; answers must be resolved against the authoritative surfaces in claims_resolve_to."
+          "description": "False: this bundle alone is not sufficient as canonical proof; answers must qualify retrieval/projection limits and resolve claims against the authoritative surfaces in claims_resolve_to."
         },
         "claims_resolve_to": {
           "type": "object",
@@ -174,7 +174,7 @@
             "content": { "const": "canonical_md" },
             "metadata": { "const": "bundle_manifest" },
             "schema": { "const": "schema" },
-            "runtime": { "const": "query_trace" }
+            "runtime": { "const": "query_trace_if_present" }
           }
         },
         "does_not_prove": {

--- a/merger/lenskit/contracts/query-context-bundle.v1.schema.json
+++ b/merger/lenskit/contracts/query-context-bundle.v1.schema.json
@@ -140,6 +140,49 @@
           }
         }
       }
+    },
+    "context_risk": {
+      "type": "object",
+      "description": "Surface-local risk hints for this context bundle. Retrieval/projection/incompleteness signals only — not a truth verdict, not a score, not an aggregated or shared epistemic layer. Optional for backwards compatibility; emitted by build_context_bundle for all new bundles.",
+      "additionalProperties": false,
+      "required": [
+        "retrieval_based_subset",
+        "missing_relevant_context_possible",
+        "may_answer_from_this_directly",
+        "claims_resolve_to",
+        "does_not_prove"
+      ],
+      "properties": {
+        "retrieval_based_subset": {
+          "type": "boolean",
+          "description": "True: these hits are a retrieval-selected top-k subset, not the complete repository context."
+        },
+        "missing_relevant_context_possible": {
+          "type": "boolean",
+          "description": "True: relevant context may exist outside this bundle and is not guaranteed to be present."
+        },
+        "may_answer_from_this_directly": {
+          "type": "boolean",
+          "description": "False: this bundle is a navigation/projection surface; answers must be resolved against the authoritative surfaces in claims_resolve_to."
+        },
+        "claims_resolve_to": {
+          "type": "object",
+          "description": "Surface-local resolve pointers restating the existing reading policy (where each claim kind is authoritative). Not a new authority model and not shared across contracts.",
+          "additionalProperties": false,
+          "required": ["content", "metadata", "schema", "runtime"],
+          "properties": {
+            "content": { "const": "canonical_md" },
+            "metadata": { "const": "bundle_manifest" },
+            "schema": { "const": "schema" },
+            "runtime": { "const": "query_trace" }
+          }
+        },
+        "does_not_prove": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Surface-local statements this bundle does not prove. Owned by this contract; phrases may echo other surfaces but are not a shared vocabulary."
+        }
+      }
     }
   }
 }

--- a/merger/lenskit/retrieval/query_core.py
+++ b/merger/lenskit/retrieval/query_core.py
@@ -789,7 +789,7 @@ def build_context_bundle(query_text: str, results: List[Dict[str, Any]], raw_con
             "content": "canonical_md",
             "metadata": "bundle_manifest",
             "schema": "schema",
-            "runtime": "query_trace_if_present",
+            "runtime": "query_trace",
         },
         "does_not_prove": [
             "Absence of a hit does not prove absence in the repository.",

--- a/merger/lenskit/retrieval/query_core.py
+++ b/merger/lenskit/retrieval/query_core.py
@@ -789,7 +789,7 @@ def build_context_bundle(query_text: str, results: List[Dict[str, Any]], raw_con
             "content": "canonical_md",
             "metadata": "bundle_manifest",
             "schema": "schema",
-            "runtime": "query_trace",
+            "runtime": "query_trace_if_present",
         },
         "does_not_prove": [
             "Absence of a hit does not prove absence in the repository.",

--- a/merger/lenskit/retrieval/query_core.py
+++ b/merger/lenskit/retrieval/query_core.py
@@ -776,4 +776,27 @@ def build_context_bundle(query_text: str, results: List[Dict[str, Any]], raw_con
 
         bundle["hits"].append(hit_ctx)
 
+    # Surface-local context risk hints (query-context-bundle.v1 context_risk).
+    # Deterministic constant: this bundle is always a retrieval-selected projection,
+    # never complete repository context. Defined inline here on purpose — these strings
+    # may echo other surfaces' boundaries but are owned by this surface only (no shared
+    # constant, no shared $ref). This is a navigation/projection hint, not a truth verdict.
+    bundle["context_risk"] = {
+        "retrieval_based_subset": True,
+        "missing_relevant_context_possible": True,
+        "may_answer_from_this_directly": False,
+        "claims_resolve_to": {
+            "content": "canonical_md",
+            "metadata": "bundle_manifest",
+            "schema": "schema",
+            "runtime": "query_trace",
+        },
+        "does_not_prove": [
+            "Absence of a hit does not prove absence in the repository.",
+            "These retrieved snippets do not prove complete or sufficient context.",
+            "Ranking does not prove semantic importance.",
+            "This bundle is an agent context projection, not canonical repository content.",
+        ],
+    }
+
     return bundle

--- a/merger/lenskit/tests/test_context_bundle.py
+++ b/merger/lenskit/tests/test_context_bundle.py
@@ -330,7 +330,7 @@ _EXPECTED_CONTEXT_RISK = {
         "content": "canonical_md",
         "metadata": "bundle_manifest",
         "schema": "schema",
-        "runtime": "query_trace_if_present",
+        "runtime": "query_trace",
     },
     "does_not_prove": [
         "Absence of a hit does not prove absence in the repository.",

--- a/merger/lenskit/tests/test_context_bundle.py
+++ b/merger/lenskit/tests/test_context_bundle.py
@@ -330,7 +330,7 @@ _EXPECTED_CONTEXT_RISK = {
         "content": "canonical_md",
         "metadata": "bundle_manifest",
         "schema": "schema",
-        "runtime": "query_trace",
+        "runtime": "query_trace_if_present",
     },
     "does_not_prove": [
         "Absence of a hit does not prove absence in the repository.",

--- a/merger/lenskit/tests/test_context_bundle.py
+++ b/merger/lenskit/tests/test_context_bundle.py
@@ -318,3 +318,81 @@ def test_cli_rejects_window_lines_without_window_mode(mini_index, capsys):
     assert ret == 1
     captured = capsys.readouterr()
     assert "--context-window-lines requires --context-mode window" in captured.err
+
+
+# --- PR B3: surface-local context_risk hardening ---
+
+_EXPECTED_CONTEXT_RISK = {
+    "retrieval_based_subset": True,
+    "missing_relevant_context_possible": True,
+    "may_answer_from_this_directly": False,
+    "claims_resolve_to": {
+        "content": "canonical_md",
+        "metadata": "bundle_manifest",
+        "schema": "schema",
+        "runtime": "query_trace",
+    },
+    "does_not_prove": [
+        "Absence of a hit does not prove absence in the repository.",
+        "These retrieved snippets do not prove complete or sufficient context.",
+        "Ranking does not prove semantic importance.",
+        "This bundle is an agent context projection, not canonical repository content.",
+    ],
+}
+
+
+def test_context_bundle_declares_context_risk(mini_index):
+    # The producer emits a surface-local context_risk block, and the resulting
+    # bundle still validates against the (additively extended) bundle schema.
+    res = query_core.execute_query(
+        mini_index, query_text="hello", k=5, build_context=True, context_mode="exact"
+    )
+    bundle = res["context_bundle"]
+
+    assert bundle["context_risk"] == _EXPECTED_CONTEXT_RISK
+    # The safety-critical semantics specifically:
+    assert bundle["context_risk"]["may_answer_from_this_directly"] is False
+    assert bundle["context_risk"]["claims_resolve_to"]["content"] == "canonical_md"
+
+    bundle_schema_path = (
+        Path(__file__).parent.parent / "contracts" / "query-context-bundle.v1.schema.json"
+    )
+    bundle_schema = json.loads(bundle_schema_path.read_text(encoding="utf-8"))
+    jsonschema.validate(instance=bundle, schema=bundle_schema)
+
+
+def test_context_bundle_v1_backwards_compatible():
+    # A legacy bundle WITHOUT context_risk must still validate: the field is optional,
+    # so adding it is a non-breaking, additive change for existing consumers/bundles.
+    bundle_schema_path = (
+        Path(__file__).parent.parent / "contracts" / "query-context-bundle.v1.schema.json"
+    )
+    bundle_schema = json.loads(bundle_schema_path.read_text(encoding="utf-8"))
+
+    legacy_bundle = {"query": "hello", "hits": []}
+    jsonschema.validate(instance=legacy_bundle, schema=bundle_schema)
+
+
+def test_context_risk_block_is_deterministic(mini_index):
+    # The block is a constant: two independent runs produce an identical context_risk.
+    res_a = query_core.execute_query(mini_index, query_text="hello", k=5, build_context=True)
+    res_b = query_core.execute_query(mini_index, query_text="hello", k=5, build_context=True)
+    assert res_a["context_bundle"]["context_risk"] == res_b["context_bundle"]["context_risk"]
+
+
+def test_context_risk_survives_agent_minimal_projection(mini_index):
+    # The concrete harm B3 closes: agent_minimal returns the bare bundle, dropping the
+    # query-result-level claim_boundaries. The bundle-level context_risk must survive
+    # the projection so the agent still sees the projection/resolve boundary.
+    from merger.lenskit.retrieval.output_projection import project_output
+
+    res = query_core.execute_query(mini_index, query_text="hello", k=5, build_context=True)
+    projected = project_output(res, "agent_minimal")
+
+    # project_output returns either the bare bundle (direct form) or a wrapper.
+    bundle = projected["context_bundle"] if "context_bundle" in projected else projected
+
+    assert "context_risk" in bundle
+    assert bundle["context_risk"] == _EXPECTED_CONTEXT_RISK
+    # agent_minimal still strips per-hit explain (sanity: we projected the right profile).
+    assert all("explain" not in hit for hit in bundle["hits"])


### PR DESCRIPTION
## Summary

This PR implements Phase B3 of the context risk hardening plan by adding a deterministic, surface-local `context_risk` block to the query context bundle. This addresses the gap where agent-facing output loses critical projection/incompleteness signals during output profile filtering.

## Changes

- **Schema (`query-context-bundle.v1.schema.json`)**: Added optional top-level `context_risk` object containing:
  - `retrieval_based_subset` (boolean): signals this is a top-k subset, not complete context
  - `missing_relevant_context_possible` (boolean): indicates relevant context may exist outside bundle
  - `may_answer_from_this_directly` (boolean): false, requiring resolution against authoritative sources
  - `claims_resolve_to`: surface-local resolve pointers (content→canonical_md, metadata→bundle_manifest, schema→schema, runtime→query_trace)
  - `does_not_prove`: array of deterministic boundary statements

- **Producer (`query_core.py`)**: Modified `build_context_bundle()` to emit a constant `context_risk` block for all bundles. The block is defined inline (not shared) to maintain surface-local ownership and prevent drift toward a global epistemic layer.

- **Tests (`test_context_bundle.py`)**: Added four new tests:
  - `test_context_bundle_declares_context_risk`: validates producer emits correct block and bundle validates against schema
  - `test_context_bundle_v1_backwards_compatible`: confirms legacy bundles without field remain valid (additive safety)
  - `test_context_risk_block_is_deterministic`: verifies block is constant across runs
  - `test_context_risk_survives_agent_minimal_projection`: confirms block survives output profile filtering (closes the concrete harm where agent_minimal projection dropped claim boundaries)

- **Documentation (`context-risk-hardening-plan.md`)**: Added comprehensive design document covering diagnosis, existing state, the specific gap, design rationale, and surface-locality constraints.

## Implementation Details

- **Additive & Non-Breaking**: The `context_risk` field is optional in the schema, allowing legacy bundles without it to remain valid while new bundles always emit it.

- **Deterministic**: The block is a constant (not computed from hits or query content), preserving byte-identity guarantees and determinism properties.

- **Surface-Local**: Strings are defined inline in `build_context_bundle()` with no shared constants, `$ref` definitions, or cross-contract imports. This prevents the risk of drift toward a global epistemic layer or truth-scoring system.

- **Projection-Surviving**: Unlike query-result-level `claim_boundaries` which were lost during `agent_minimal` projection, the bundle-level `context_risk` survives all output profiles, ensuring agents always see the projection/resolve boundary.

- **Scope-Bounded**: Addresses only the documented gap (§3 of design doc); does not build coverage scores, truth verdicts, agent-safe gates, or cross-artifact normalization.

https://claude.ai/code/session_01HHVYe5JNxBXRKbxtA2pfwP