### PR TITLE
Add post-emit bundle health validator (PR A4)

### DIFF
--- a/docs/proofs/post-emit-health-implementation-proof.md
+++ b/docs/proofs/post-emit-health-implementation-proof.md
@@ -88,9 +88,9 @@ Validierung, Emission und Registrierung bleiben getrennt:
 ## 6. Validierung
 
 ```
-python3.11 -m pytest merger/lenskit/tests/test_post_emit_health.py merger/lenskit/tests/test_cli_bundle_health.py   # 17 passed
+python3.11 -m pytest merger/lenskit/tests/test_post_emit_health.py merger/lenskit/tests/test_cli_bundle_health.py   # 22 passed
 python3.11 -m pytest merger/lenskit/tests/test_output_health.py merger/lenskit/tests/test_bundle_manifest_integration.py  # 68 passed (keine Regression)
-python3.11 -m pytest --ignore=merger/lenskit/tests/test_webui_payload.py  # 1330 passed, 1 skipped
+python3.11 -m pytest --ignore=merger/lenskit/tests/test_webui_payload.py  # 1335 passed, 1 skipped
 ```
 
 Voller `pytest`-Lauf ist nur durch die Browser-Tests in `test_webui_payload.py`

--- a/docs/proofs/post-emit-health-implementation-proof.md
+++ b/docs/proofs/post-emit-health-implementation-proof.md
@@ -1,0 +1,98 @@
+# Post-emit Bundle Health (`post_emit_health`) — Implementation Proof
+
+Status: Implementation note for roadmap **PR A4** (Post-hoc Bundle Validator).
+Belegbasis: `docs/blueprints/lenskit-anti-hallucination-output-architecture.md` §3 (PR A4),
+`docs/blueprints/lenskit-artifact-output-control-plane.md` §2.4 / §12,
+`docs/architecture/artifact-evidence-levels.md`.
+
+## 1. Diagnose: warum pre-emit `output_health` die Lücke nicht schließt
+
+`output_health` wird **vor** der Finalisierung des Bundles geschrieben und gegen den
+`dump_index` verankert, nicht gegen das finale `bundle_manifest`:
+
+- `merger/lenskit/core/merge.py:5988-6028` — `write_output_health(..., primary_manifest_path=final_dump_index, ...)`
+  läuft, **bevor** das Bundle-Manifest finalisiert wird.
+- `merger/lenskit/core/merge.py:6098-6123` — der `agent_reading_pack` wird **zuletzt**
+  erzeugt und erst danach ins Manifest eingetragen.
+- `merger/lenskit/core/output_health.py:424-466` — der In-Pipeline-Aufruf kennt den Pack
+  nicht (`agent_pack_present.status = "skipped"`), weil der Pack zu diesem Zeitpunkt noch
+  nicht existiert.
+
+Folge: pre-emit Health kann die **finale Bundle-Oberfläche** (inkl. `agent_reading_pack`,
+`citation_map`, finale Manifest-Hashes) strukturell nicht prüfen. Genau diese Lücke
+schließt `post_emit_health` post-hoc.
+
+Bestätigung „keine bestehenden post-emit-Hooks": `grep -rn "post_emit_health|bundle_health|bundle-health"`
+fand vor dieser PR ausschließlich Doku-Verweise, keinen Code/CLI.
+
+## 2. Was gebaut wurde (additiv, lokal)
+
+- `merger/lenskit/core/post_emit_health.py` — Validator (`compute_post_emit_health`, rein;
+  `write_post_emit_health`, optional persistierend).
+- `merger/lenskit/contracts/post-emit-health.v1.schema.json` — neuer, lokaler Contract.
+- `merger/lenskit/cli/cmd_bundle_health.py` + Dispatch in `cli/main.py` —
+  `lenskit bundle-health post <manifest> [--json] [--emit-artifact] [--output P] [--no-require-agent-pack]`.
+- Datei-Artefakt (nur bei `--emit-artifact`): `<stem>.bundle_health.post.json`.
+
+Geprüft werden: Manifest-Präsenz + Schema, Artefakt-Pfade, Artefakt-Hashes,
+`agent_reading_pack` Präsenz/Hash, Self-Role (Pack nicht als canonical/content deklariert),
+Range-Ref-Resolution (wo relevant), Redaction-Status (nur Bericht), Noise-Hygiene (falls
+vorhanden), erreichter Evidence-Level (bestehendes Vokabular), `does_not_mean`.
+
+## 3. Statusmodell
+
+Präzedenz `blocked` > `fail` > `warn` > `pass`:
+
+- `blocked` — Zertifizierung **nicht abschließbar**: erforderliche Oberfläche fehlt
+  (Manifest unlesbar / kein `repolens.bundle.manifest` / keine `artifacts`-Liste, oder eine
+  Pflichtrolle wie `canonical_md` / `agent_reading_pack` ist **nicht deklariert**).
+- `fail` — Zertifizierung abgeschlossen, aber **Defekt** gefunden: deklariertes Artefakt
+  fehlt auf Platte, Hash-Mismatch, Schema-Verstoß, Range-Ref-Resolution-Fehler, Pack als
+  canonical/content fehldeklariert.
+- `warn` — nutzbar, aber degradiert (z. B. `jsonschema` nicht verfügbar).
+- `pass` — alle Pflicht-Checks erfüllt.
+
+## 4. Harte Grenzen (eingehalten)
+
+- **Unabhängigkeit:** `output_health.verdict` ist reine **Beobachtung**
+  (`output_health_verdict`) und geht **nie** in die Statusberechnung ein. Explizit als
+  `independence_note` ausgewiesen: *„output_health.verdict=pass does not imply
+  post_emit_health.status=pass"*. Negativtest: `test_post_emit_health_independent_of_pre_health`.
+- **Kein Redaction-Enforcement:** `redaction_status.enforced` ist immer `false`;
+  `redact_secrets=false` führt nicht zu `fail` (Test:
+  `test_post_emit_health_reports_redaction_without_enforcing`). Enforcement bleibt PR A5.
+- **Kein A5/Profil/Export, kein MCP/Task-Pack/Dashboard/Monitor.**
+- **Kein `agent_ready`/`agent_safe`-Artefakt, kein Parallelvokabular** neben
+  `post_emit_health`.
+- **Keine Claim-Bewertung,** keine Verdikte `supported/unsupported/true/false/proven`.
+- **Keine globale Verstehens-Ampel:** `evidence_level` nutzt nur das bestehende
+  control-plane-Vokabular; `does_not_mean` enthält mindestens `repo_understood` und
+  `answer_safe_without_citations`.
+- **`output_health` unverändert:** keine Redefinition; Modul nur als Helper importiert
+  (`_is_jsonschema_unavailable_error`).
+- **Bundle-Erzeugung unverändert:** kein Eingriff in `merge.py`, kein Manifest-Schema-Bruch.
+
+## 5. Persistenz ist explizit (keine versteckten Seiteneffekte)
+
+Validierung, Emission und Registrierung bleiben getrennt:
+
+- Default: `bundle-health post <manifest>` validiert + druckt + Exit-Code, **ohne** Datei.
+- `--emit-artifact` (oder `--output`): schreibt `<stem>.bundle_health.post.json`.
+- Das persistierte Artefakt ist **unregistriert** — das Bundle-Manifest wird **nicht**
+  mutiert (kein Self-Hash, keine Manifest-Wahrheitsänderung). Test:
+  `test_write_post_emit_health_persists_unregistered_artifact`,
+  `test_bundle_health_post_cli_emit_artifact`.
+- `--register-artifact` (Manifest-Mutation) ist bewusst **nicht** implementiert und bleibt
+  späteren, explizit registrierenden Schritten vorbehalten.
+
+## 6. Validierung
+
+```
+python3.11 -m pytest merger/lenskit/tests/test_post_emit_health.py merger/lenskit/tests/test_cli_bundle_health.py   # 17 passed
+python3.11 -m pytest merger/lenskit/tests/test_output_health.py merger/lenskit/tests/test_bundle_manifest_integration.py  # 68 passed (keine Regression)
+python3.11 -m pytest --ignore=merger/lenskit/tests/test_webui_payload.py  # 1330 passed, 1 skipped
+```
+
+Voller `pytest`-Lauf ist nur durch die Browser-Tests in `test_webui_payload.py`
+(pytest-playwright `page`-Fixture, kein Headless-Runtime hier; `browser`-Marker in
+`pytest.ini`) blockiert — unabhängig von dieser PR.

--- a/merger/lenskit/cli/cmd_bundle_health.py
+++ b/merger/lenskit/cli/cmd_bundle_health.py
@@ -98,6 +98,9 @@ def _print_human_report(report: dict, written_path=None) -> None:
     agent_pack = report.get("agent_pack") or {}
     print(f"  agent_pack.present:      {agent_pack.get('present')}")
     print(f"  agent_pack.self_role_ok: {agent_pack.get('self_role_ok')}")
+    print(f"  agent_pack.required:     {agent_pack.get('required')}")
+    if agent_pack.get("required") is False:
+        print("  NOTE: agent_reading_pack not required for this run; this is not an agent-surface certification.")
 
     redaction = report.get("redaction_status") or {}
     print(f"  redaction (reported):    {redaction.get('redact_secrets_enabled')} (enforced={redaction.get('enforced')})")
@@ -107,6 +110,7 @@ def _print_human_report(report: dict, written_path=None) -> None:
 
     if written_path is not None:
         print(f"  written_artifact:        {written_path}")
+        print("  NOTE: written artifact is unregistered; manifest not mutated.")
 
     if report.get("warnings"):
         print(f"\nWarnings ({len(report['warnings'])}):")

--- a/merger/lenskit/cli/cmd_bundle_health.py
+++ b/merger/lenskit/cli/cmd_bundle_health.py
@@ -1,0 +1,119 @@
+import argparse
+import json
+import sys
+
+
+def register_bundle_health_commands(subparsers) -> None:
+    bh_parser = subparsers.add_parser(
+        "bundle-health", help="Bundle health validation (post-emit)"
+    )
+    bh_subparsers = bh_parser.add_subparsers(
+        dest="bundle_health_cmd", required=True, help="Bundle health commands"
+    )
+
+    post_parser = bh_subparsers.add_parser(
+        "post",
+        help="Validate the final emitted bundle surface (post-emit health)",
+    )
+    post_parser.add_argument(
+        "manifest", help="Path to the bundle manifest JSON"
+    )
+    post_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="emit_json",
+        help="Emit the machine-readable JSON report to stdout",
+    )
+    post_parser.add_argument(
+        "--emit-artifact",
+        action="store_true",
+        dest="emit_artifact",
+        help="Persist the report as <stem>.bundle_health.post.json (unregistered; manifest is never mutated)",
+    )
+    post_parser.add_argument(
+        "--output",
+        dest="output_path",
+        default=None,
+        help="Explicit output path for the persisted artifact (implies --emit-artifact)",
+    )
+    post_parser.add_argument(
+        "--no-require-agent-pack",
+        action="store_false",
+        dest="agent_pack_required",
+        help="Do not treat a missing agent_reading_pack as a blocking absence",
+    )
+
+
+_EXIT_CODES = {"pass": 0, "warn": 0, "fail": 1, "blocked": 2}
+
+
+def run_bundle_health_post(args: argparse.Namespace) -> int:
+    from merger.lenskit.core.post_emit_health import (
+        compute_post_emit_health,
+        write_post_emit_health,
+    )
+
+    manifest_path = args.manifest
+    agent_pack_required = getattr(args, "agent_pack_required", True)
+    output_path = getattr(args, "output_path", None)
+    emit_artifact = getattr(args, "emit_artifact", False) or output_path is not None
+
+    written_path = None
+    try:
+        if emit_artifact:
+            written_path, report = write_post_emit_health(
+                manifest_path,
+                output_path,
+                agent_pack_required=agent_pack_required,
+            )
+        else:
+            report = compute_post_emit_health(
+                manifest_path, agent_pack_required=agent_pack_required
+            )
+    except Exception as e:  # noqa: BLE001 - surface unexpected failures cleanly
+        print(f"Error: unexpected failure during post-emit validation: {e}", file=sys.stderr)
+        return 2
+
+    if args.emit_json:
+        print(json.dumps(report, indent=2))
+    else:
+        _print_human_report(report, written_path)
+
+    return _EXIT_CODES.get(report["status"], 1)
+
+
+def _print_human_report(report: dict, written_path=None) -> None:
+    print(f"Post-emit Bundle Health: {report['status'].upper()}")
+    print(f"  bundle_manifest_path:    {report['bundle_manifest_path']}")
+    print(f"  bundle_run_id:           {report.get('bundle_run_id')}")
+    print(f"  run_id:                  {report['run_id']}")
+    print(f"  evidence_level:          {report.get('evidence_level')}")
+    print(f"  evidence_levels_reached: {', '.join(report.get('evidence_levels_reached') or []) or '—'}")
+    print(f"  output_health_verdict:   {report.get('output_health_verdict')} (observation only)")
+    print(f"  artifact_count_checked:  {report['artifact_count_checked']}")
+    print(f"  missing_artifact_count:  {report['missing_artifact_count']}")
+    print(f"  hash_mismatch_count:     {report['hash_mismatch_count']}")
+    print(f"  range_ref_resolution:    {report.get('range_ref_resolution_status')}")
+
+    agent_pack = report.get("agent_pack") or {}
+    print(f"  agent_pack.present:      {agent_pack.get('present')}")
+    print(f"  agent_pack.self_role_ok: {agent_pack.get('self_role_ok')}")
+
+    redaction = report.get("redaction_status") or {}
+    print(f"  redaction (reported):    {redaction.get('redact_secrets_enabled')} (enforced={redaction.get('enforced')})")
+
+    print(f"  {report['independence_note']}")
+    print(f"  does_not_mean:           {', '.join(report.get('does_not_mean') or [])}")
+
+    if written_path is not None:
+        print(f"  written_artifact:        {written_path}")
+
+    if report.get("warnings"):
+        print(f"\nWarnings ({len(report['warnings'])}):")
+        for w in report["warnings"]:
+            print(f"  [warn] {w}")
+
+    if report.get("errors"):
+        print(f"\nErrors ({len(report['errors'])}):")
+        for e in report["errors"]:
+            print(f"  [error] {e}")

--- a/merger/lenskit/cli/main.py
+++ b/merger/lenskit/cli/main.py
@@ -26,6 +26,10 @@ def main(args: Optional[List[str]] = None) -> int:
     from .cmd_agent_pack import register_agent_pack_commands
     register_agent_pack_commands(subparsers)
 
+    # Bundle health command (post-emit validator)
+    from .cmd_bundle_health import register_bundle_health_commands
+    register_bundle_health_commands(subparsers)
+
     # Federation command
     from .cmd_federation import register_federation_commands
     register_federation_commands(subparsers)
@@ -252,6 +256,13 @@ def main(args: Optional[List[str]] = None) -> int:
             return run_agent_pack_produce(parsed_args)
         else:
             parser.parse_args(["agent-pack", "--help"])
+            return 0
+    elif parsed_args.command == "bundle-health":
+        from .cmd_bundle_health import run_bundle_health_post
+        if parsed_args.bundle_health_cmd == "post":
+            return run_bundle_health_post(parsed_args)
+        else:
+            parser.parse_args(["bundle-health", "--help"])
             return 0
     elif parsed_args.command == "federation":
         from .cmd_federation import handle_federation_command

--- a/merger/lenskit/contracts/post-emit-health.v1.schema.json
+++ b/merger/lenskit/contracts/post-emit-health.v1.schema.json
@@ -1,0 +1,187 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://heimgewebe.local/schema/post-emit-health.v1.schema.json",
+  "title": "Post-emit Bundle Health (post-emit-health v1.0)",
+  "description": "Machine-readable validation of the final emitted Lenskit bundle surface, produced after all derived artifacts (including agent_reading_pack) are present. Independent of output_health: a green pre-emit health never implies a post-emit pass. Reports redaction status without enforcing it, and reports an achieved evidence level using the existing control-plane vocabulary (it is not a global understanding verdict).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "kind",
+    "version",
+    "run_id",
+    "checked_at",
+    "bundle_manifest_path",
+    "status",
+    "checks",
+    "errors",
+    "warnings",
+    "does_not_mean",
+    "independence_note",
+    "artifact_count_checked",
+    "hash_mismatch_count",
+    "missing_artifact_count"
+  ],
+  "properties": {
+    "kind": {
+      "type": "string",
+      "const": "lenskit.post_emit_health"
+    },
+    "version": {
+      "type": "string",
+      "const": "1.0"
+    },
+    "run_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Unique id for this post-emit validation run (not the bundle run)."
+    },
+    "bundle_run_id": {
+      "type": ["string", "null"],
+      "description": "run_id of the validated bundle manifest, when available."
+    },
+    "checked_at": {
+      "type": "string",
+      "description": "ISO 8601 UTC timestamp of validation."
+    },
+    "bundle_manifest_path": {
+      "type": "string",
+      "description": "Absolute path to the validated bundle manifest."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["pass", "warn", "fail", "blocked"],
+      "description": "blocked = certification could not complete (required surface absent). fail = certification completed but found defects. warn = usable but degraded. pass = all required checks satisfied."
+    },
+    "checks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "status"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["pass", "warn", "fail", "blocked", "skipped"]
+          },
+          "detail": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "errors": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "does_not_mean": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 2,
+      "description": "Disclaimers of what a post-emit pass deliberately does NOT establish. Always includes 'repo_understood' and 'answer_safe_without_citations'. These are NOT claim verdicts.",
+      "allOf": [
+        { "contains": { "const": "repo_understood" } },
+        { "contains": { "const": "answer_safe_without_citations" } }
+      ]
+    },
+    "independence_note": {
+      "type": "string",
+      "description": "Explicit statement that output_health.verdict=pass does not imply post_emit_health.status=pass."
+    },
+    "evidence_level": {
+      "type": ["string", "null"],
+      "enum": [
+        "readable",
+        "navigable",
+        "citable",
+        "range_strict",
+        "searchable",
+        "diagnostic_full",
+        "forensic_strict",
+        null
+      ],
+      "description": "Headline achieved evidence level on the core readable->navigable->citable->range_strict ladder, using existing vocabulary. Null when not even 'readable'."
+    },
+    "evidence_levels_reached": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "readable",
+          "navigable",
+          "citable",
+          "range_strict",
+          "searchable",
+          "diagnostic_full",
+          "forensic_strict"
+        ]
+      },
+      "description": "Full honest set of evidence levels reached (searchable/diagnostic_full may hold without the full core ladder)."
+    },
+    "output_health_verdict": {
+      "type": ["string", "null"],
+      "description": "Observed output_health verdict (input/observation only; never gates post-emit status)."
+    },
+    "redaction_status": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "available": { "type": "boolean" },
+        "redact_secrets_enabled": { "type": ["boolean", "null"] },
+        "enforced": {
+          "type": "boolean",
+          "description": "Always false in v1: post_emit_health reports redaction, it does not enforce it (enforcement is roadmap PR A5)."
+        }
+      }
+    },
+    "noise_hygiene": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "available": { "type": "boolean" },
+        "excluded_noise_count": { "type": ["integer", "null"], "minimum": 0 },
+        "source": { "type": ["string", "null"] }
+      }
+    },
+    "artifact_count_checked": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "hash_mismatch_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "missing_artifact_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "range_ref_resolution_status": {
+      "type": ["string", "null"],
+      "enum": ["ok", "fail", "environment_error", "no_range_ref", "unavailable", null]
+    },
+    "agent_pack": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "present": { "type": "boolean" },
+        "required": { "type": "boolean" },
+        "hash_ok": { "type": ["boolean", "null"] },
+        "authority_declared": { "type": ["string", "null"] },
+        "canonicality_declared": { "type": ["string", "null"] },
+        "self_role_ok": { "type": ["boolean", "null"] }
+      }
+    }
+  }
+}

--- a/merger/lenskit/core/post_emit_health.py
+++ b/merger/lenskit/core/post_emit_health.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import re
 import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -59,7 +60,7 @@ VERSION = "1.0"
 _MANIFEST_SUFFIX = ".bundle.manifest.json"
 _POST_HEALTH_SUFFIX = ".bundle_health.post.json"
 _BUNDLE_KIND = "repolens.bundle.manifest"
-_SHA256_LEN = 64
+_SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
 
 # Minimum disclaimers the artifact must always carry. These are NOT claim
 # verdicts; they declare what a post-emit pass deliberately does NOT establish.
@@ -152,9 +153,10 @@ def _range_ref_status(
     manifest_path: Path, chunk_index_path: Optional[Path]
 ) -> Tuple[str, str]:
     """
-    Resolve one ``content_range_ref`` from the chunk index against the final
-    bundle manifest. Returns (status, message) where status is one of:
-    ``ok``, ``fail``, ``environment_error``, ``no_range_ref``, ``unavailable``.
+    Resolve one range reference from the chunk index against the final bundle
+    manifest. Prefers the current ``canonical_range`` field and falls back to the
+    legacy ``content_range_ref``. Returns (status, message) where status is one
+    of: ``ok``, ``fail``, ``environment_error``, ``no_range_ref``, ``unavailable``.
     """
     if chunk_index_path is None or not chunk_index_path.exists():
         return "unavailable", "chunk_index not available for range_ref check"
@@ -171,29 +173,31 @@ def _range_ref_status(
                     continue
                 if not isinstance(chunk, dict):
                     continue
-                raw = chunk.get("content_range_ref")
+                raw = chunk.get("canonical_range")
+                if raw is None:
+                    raw = chunk.get("content_range_ref")
                 if raw is None:
                     continue
                 if isinstance(raw, str):
                     try:
                         raw = json.loads(raw)
                     except json.JSONDecodeError as e:
-                        return "fail", f"invalid content_range_ref JSON string: {e}"
+                        return "fail", f"invalid range reference JSON string: {e}"
                 if not isinstance(raw, dict):
-                    return "fail", "content_range_ref must be an object"
+                    return "fail", "range reference must be an object"
                 sample_ref = raw
                 break
     except (OSError, UnicodeError) as e:
         return "unavailable", f"could not read chunk_index: {e}"
 
     if sample_ref is None:
-        return "no_range_ref", "no content_range_ref found; range_ref check skipped"
+        return "no_range_ref", "no range reference found; range_ref check skipped"
 
     try:
         from .range_resolver import resolve_range_ref
 
         resolve_range_ref(manifest_path, sample_ref)
-        return "ok", "content_range_ref resolved against bundle manifest"
+        return "ok", "range reference resolved against bundle manifest"
     except Exception as e:  # noqa: BLE001 - classify below
         if _is_jsonschema_unavailable_error(e):
             return "environment_error", "range_ref validation skipped: jsonschema unavailable"
@@ -205,7 +209,7 @@ def _compute_evidence(
     range_ref_status: str,
     jsonschema_available: bool,
     sqlite_ok: Optional[bool],
-    output_health_present: bool,
+    output_health_valid: bool,
 ) -> Tuple[Optional[str], List[str]]:
     """
     Report achieved evidence levels using the existing vocabulary. Each level
@@ -233,7 +237,7 @@ def _compute_evidence(
     if navigable and _SQLITE_INDEX in valid_roles and bool(sqlite_ok):
         reached.add("searchable")
 
-    if navigable and output_health_present and _DEBUG_ROLES.issubset(valid_roles):
+    if navigable and output_health_valid and _DEBUG_ROLES.issubset(valid_roles):
         reached.add("diagnostic_full")
 
     headline: Optional[str] = None
@@ -434,7 +438,7 @@ def compute_post_emit_health(
         if actual is None:
             errors.append(f"artifact '{role}' could not be read for hashing: {raw_path}")
             continue
-        if isinstance(expected_sha, str) and len(expected_sha) == _SHA256_LEN:
+        if isinstance(expected_sha, str) and _SHA256_RE.fullmatch(expected_sha):
             if actual != expected_sha:
                 hash_mismatch_count += 1
                 errors.append(
@@ -548,13 +552,17 @@ def compute_post_emit_health(
     )
 
     # ── output_health: OBSERVATION ONLY (never gates post-emit status) ───────
+    # Coverage is based on a *validated* artifact, not a bare manifest declaration:
+    # a declared-but-missing/hash-mismatched output_health is not trusted and must
+    # not boost evidence (e.g. diagnostic_full) or supply a verdict.
     output_health_verdict: Optional[str] = None
-    output_health_present = _OUTPUT_HEALTH in by_role
+    output_health_declared = _OUTPUT_HEALTH in by_role
+    output_health_valid = _OUTPUT_HEALTH in valid_roles
     sqlite_ok: Optional[bool] = None
     noise_hygiene: Dict[str, Any] = {"available": False, "excluded_noise_count": None, "source": None}
 
     oh_entry = by_role.get(_OUTPUT_HEALTH)
-    if isinstance(oh_entry, dict) and isinstance(oh_entry.get("path"), str):
+    if output_health_valid and isinstance(oh_entry, dict) and isinstance(oh_entry.get("path"), str):
         try:
             oh_path = resolve_secure_path(manifest_dir, oh_entry["path"])
         except ValueError:
@@ -585,14 +593,18 @@ def compute_post_emit_health(
                         "source": "output_health",
                     }
 
-    checks.append(
-        _check(
-            "output_health_observed",
-            "pass" if output_health_present else "skipped",
+    if output_health_valid:
+        oh_obs_status, oh_obs_detail = "pass", (
             f"output_health.verdict={output_health_verdict!r} (observation only; "
-            "does not imply post_emit_health.status=pass)",
+            "does not imply post_emit_health.status=pass)"
         )
-    )
+    elif output_health_declared:
+        oh_obs_status, oh_obs_detail = "skipped", (
+            "output_health is declared but not hash-validated; verdict not trusted"
+        )
+    else:
+        oh_obs_status, oh_obs_detail = "skipped", "output_health not declared in manifest"
+    checks.append(_check("output_health_observed", oh_obs_status, oh_obs_detail))
 
     # ── evidence level (existing vocabulary; not an understanding verdict) ────
     evidence_level, evidence_levels_reached = _compute_evidence(
@@ -600,7 +612,7 @@ def compute_post_emit_health(
         rr_status,
         jsonschema_available=jsonschema is not None,
         sqlite_ok=sqlite_ok,
-        output_health_present=output_health_present,
+        output_health_valid=output_health_valid,
     )
     checks.append(
         _check(

--- a/merger/lenskit/core/post_emit_health.py
+++ b/merger/lenskit/core/post_emit_health.py
@@ -1,0 +1,674 @@
+"""
+Post-emit Bundle Health validator for Lenskit bundles (roadmap PR A4).
+
+Validates the FINAL emitted bundle surface *after* every derived artifact is
+present — in particular the ``agent_reading_pack``, which the in-pipeline
+``output_health`` (pre-emit) cannot see because the pack is produced *after*
+``output_health`` is written (see ``core/merge.py``: output_health is anchored to
+``dump_index`` and emitted before the manifest is finalized; the pack is emitted
+last). This module closes that gap.
+
+Design contract:
+- Independent from ``output_health``: ``output_health.verdict`` is recorded as an
+  OBSERVATION only and NEVER causes a post-emit pass. A green pre-emit health does
+  not imply a green post-emit status.
+- No self-hash circularity: the post-emit report is a separate file
+  (``<stem>.bundle_health.post.json``) that is intentionally NOT registered in the
+  bundle manifest, so it never verifies its own hash and never mutates manifest
+  truth.
+- Redaction status is REPORTED but NOT enforced (enforcement is roadmap PR A5).
+- The achieved evidence level is reported using the existing control-plane
+  vocabulary (``docs/architecture/artifact-evidence-levels.md``). It is NOT a
+  global understanding verdict.
+
+Status model (precedence ``blocked`` > ``fail`` > ``warn`` > ``pass``):
+- ``blocked`` — certification could not complete: a required certification surface
+  is absent (manifest unreadable / not a bundle manifest / no artifact list, or a
+  required role such as ``canonical_md`` / ``agent_reading_pack`` is not declared).
+- ``fail``    — certification completed but found defects: a manifest-declared
+  artifact file is missing, a hash mismatch, an invalid manifest schema, a
+  range-ref resolution failure, or the pack mis-declares itself as canonical.
+- ``warn``    — usable but degraded (e.g. jsonschema unavailable for strict checks).
+- ``pass``    — all required checks satisfied.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from .clock import now_utc
+from .constants import ArtifactRole
+from .output_health import _is_jsonschema_unavailable_error
+from .path_security import resolve_secure_path
+
+try:
+    import jsonschema
+except ImportError:  # optional runtime dependency
+    jsonschema = None
+
+logger = logging.getLogger(__name__)
+
+KIND = "lenskit.post_emit_health"
+VERSION = "1.0"
+
+_MANIFEST_SUFFIX = ".bundle.manifest.json"
+_POST_HEALTH_SUFFIX = ".bundle_health.post.json"
+_BUNDLE_KIND = "repolens.bundle.manifest"
+_SHA256_LEN = 64
+
+# Minimum disclaimers the artifact must always carry. These are NOT claim
+# verdicts; they declare what a post-emit pass deliberately does NOT establish.
+DOES_NOT_MEAN = (
+    "repo_understood",
+    "answer_safe_without_citations",
+)
+
+# The artifact must explicitly state the pre-/post-health independence.
+INDEPENDENCE_NOTE = (
+    "output_health.verdict=pass does not imply post_emit_health.status=pass"
+)
+
+# Existing evidence-level vocabulary (docs/architecture/artifact-evidence-levels.md).
+_EVIDENCE_ORDER = (
+    "readable",
+    "navigable",
+    "citable",
+    "range_strict",
+    "searchable",
+    "diagnostic_full",
+    "forensic_strict",
+)
+# The strict linear chain used to pick a single conservative headline level.
+_CORE_LADDER = ("readable", "navigable", "citable", "range_strict")
+
+_CANONICAL_MD = ArtifactRole.CANONICAL_MD.value
+_CHUNK_INDEX = ArtifactRole.CHUNK_INDEX_JSONL.value
+_CITATION_MAP = ArtifactRole.CITATION_MAP_JSONL.value
+_SQLITE_INDEX = ArtifactRole.SQLITE_INDEX.value
+_OUTPUT_HEALTH = ArtifactRole.OUTPUT_HEALTH.value
+_AGENT_PACK = ArtifactRole.AGENT_READING_PACK.value
+_DEBUG_ROLES = frozenset(
+    {
+        ArtifactRole.DUMP_INDEX_JSON.value,
+        ArtifactRole.DERIVED_MANIFEST_JSON.value,
+        ArtifactRole.INDEX_SIDECAR_JSON.value,
+        ArtifactRole.ARCHITECTURE_SUMMARY.value,
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _sha256_file(path: Path) -> Optional[str]:
+    h = hashlib.sha256()
+    try:
+        with path.open("rb") as f:
+            for buf in iter(lambda: f.read(65536), b""):
+                h.update(buf)
+        return h.hexdigest()
+    except OSError:
+        return None
+
+
+def _now_iso() -> str:
+    ts = now_utc()
+    if isinstance(ts, str):
+        return ts if ts.endswith("Z") else ts + "Z"
+    return ts.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _check(name: str, status: str, detail: Optional[str] = None) -> Dict[str, Any]:
+    out: Dict[str, Any] = {"name": name, "status": status}
+    if detail:
+        out["detail"] = detail
+    return out
+
+
+def _resolve_manifest_path(manifest_path_str: str) -> Path:
+    p = Path(manifest_path_str)
+    if not p.is_absolute():
+        p = Path.cwd() / p
+    return p.resolve()
+
+
+def derive_post_health_path(manifest_path: Path) -> Path:
+    """Derive ``<stem>.bundle_health.post.json`` adjacent to the manifest."""
+    name = manifest_path.name
+    if name.endswith(_MANIFEST_SUFFIX):
+        stem = name[: -len(_MANIFEST_SUFFIX)]
+    else:
+        stem = manifest_path.stem
+    return manifest_path.parent / (stem + _POST_HEALTH_SUFFIX)
+
+
+def _range_ref_status(
+    manifest_path: Path, chunk_index_path: Optional[Path]
+) -> Tuple[str, str]:
+    """
+    Resolve one ``content_range_ref`` from the chunk index against the final
+    bundle manifest. Returns (status, message) where status is one of:
+    ``ok``, ``fail``, ``environment_error``, ``no_range_ref``, ``unavailable``.
+    """
+    if chunk_index_path is None or not chunk_index_path.exists():
+        return "unavailable", "chunk_index not available for range_ref check"
+
+    sample_ref: Optional[Dict[str, Any]] = None
+    try:
+        with chunk_index_path.open("r", encoding="utf-8") as f:
+            for line in f:
+                if not line.strip():
+                    continue
+                try:
+                    chunk = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(chunk, dict):
+                    continue
+                raw = chunk.get("content_range_ref")
+                if raw is None:
+                    continue
+                if isinstance(raw, str):
+                    try:
+                        raw = json.loads(raw)
+                    except json.JSONDecodeError as e:
+                        return "fail", f"invalid content_range_ref JSON string: {e}"
+                if not isinstance(raw, dict):
+                    return "fail", "content_range_ref must be an object"
+                sample_ref = raw
+                break
+    except (OSError, UnicodeError) as e:
+        return "unavailable", f"could not read chunk_index: {e}"
+
+    if sample_ref is None:
+        return "no_range_ref", "no content_range_ref found; range_ref check skipped"
+
+    try:
+        from .range_resolver import resolve_range_ref
+
+        resolve_range_ref(manifest_path, sample_ref)
+        return "ok", "content_range_ref resolved against bundle manifest"
+    except Exception as e:  # noqa: BLE001 - classify below
+        if _is_jsonschema_unavailable_error(e):
+            return "environment_error", "range_ref validation skipped: jsonschema unavailable"
+        return "fail", f"range_ref resolution failed: {e}"
+
+
+def _compute_evidence(
+    valid_roles: set[str],
+    range_ref_status: str,
+    jsonschema_available: bool,
+    sqlite_ok: Optional[bool],
+    output_health_present: bool,
+) -> Tuple[Optional[str], List[str]]:
+    """
+    Report achieved evidence levels using the existing vocabulary. Each level
+    encodes its own prerequisites, so this never overstates what was reached.
+    ``forensic_strict`` requires ``claim_evidence_map`` (which does not exist) and
+    is therefore never reached.
+    """
+    reached: set[str] = set()
+
+    readable = _CANONICAL_MD in valid_roles
+    if readable:
+        reached.add("readable")
+
+    navigable = readable and _AGENT_PACK in valid_roles and _CHUNK_INDEX in valid_roles
+    if navigable:
+        reached.add("navigable")
+
+    citable = navigable and _CITATION_MAP in valid_roles
+    if citable:
+        reached.add("citable")
+
+    if citable and range_ref_status == "ok" and jsonschema_available:
+        reached.add("range_strict")
+
+    if navigable and _SQLITE_INDEX in valid_roles and bool(sqlite_ok):
+        reached.add("searchable")
+
+    if navigable and output_health_present and _DEBUG_ROLES.issubset(valid_roles):
+        reached.add("diagnostic_full")
+
+    headline: Optional[str] = None
+    for lvl in _CORE_LADDER:
+        if lvl in reached:
+            headline = lvl
+        else:
+            break
+
+    ordered = [lvl for lvl in _EVIDENCE_ORDER if lvl in reached]
+    return headline, ordered
+
+
+def _assemble(
+    *,
+    status: str,
+    run_id: str,
+    bundle_run_id: Any,
+    manifest_path_str: str,
+    checks: List[Dict[str, Any]],
+    errors: List[str],
+    warnings: List[str],
+    evidence_level: Optional[str] = None,
+    evidence_levels_reached: Optional[List[str]] = None,
+    output_health_verdict: Optional[str] = None,
+    redaction_status: Optional[Dict[str, Any]] = None,
+    noise_hygiene: Optional[Dict[str, Any]] = None,
+    artifact_count_checked: int = 0,
+    hash_mismatch_count: int = 0,
+    missing_artifact_count: int = 0,
+    range_ref_resolution_status: Optional[str] = None,
+    agent_pack: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    return {
+        "kind": KIND,
+        "version": VERSION,
+        "run_id": run_id,
+        "bundle_run_id": bundle_run_id,
+        "checked_at": _now_iso(),
+        "bundle_manifest_path": manifest_path_str,
+        "status": status,
+        "checks": checks,
+        "errors": errors,
+        "warnings": warnings,
+        "does_not_mean": list(DOES_NOT_MEAN),
+        "independence_note": INDEPENDENCE_NOTE,
+        "evidence_level": evidence_level,
+        "evidence_levels_reached": evidence_levels_reached or [],
+        "output_health_verdict": output_health_verdict,
+        "redaction_status": redaction_status,
+        "noise_hygiene": noise_hygiene,
+        "artifact_count_checked": artifact_count_checked,
+        "hash_mismatch_count": hash_mismatch_count,
+        "missing_artifact_count": missing_artifact_count,
+        "range_ref_resolution_status": range_ref_resolution_status,
+        "agent_pack": agent_pack,
+    }
+
+
+def _validate_manifest_schema(manifest: Dict[str, Any]) -> Tuple[str, str]:
+    """Returns (status, message): pass | fail | environment_error."""
+    schema_path = Path(__file__).parent.parent / "contracts" / "bundle-manifest.v1.schema.json"
+    if jsonschema is None:
+        return "environment_error", "manifest schema validation skipped: jsonschema unavailable"
+    if not schema_path.exists():
+        return "environment_error", f"bundle manifest schema not found: {schema_path.name}"
+    try:
+        with schema_path.open("r", encoding="utf-8") as f:
+            schema = json.load(f)
+        jsonschema.validate(instance=manifest, schema=schema)
+        return "pass", "manifest validates against bundle-manifest.v1"
+    except jsonschema.ValidationError as e:  # type: ignore[union-attr]
+        return "fail", f"manifest schema validation failed: {e.message}"
+    except (OSError, json.JSONDecodeError) as e:
+        return "environment_error", f"could not load bundle manifest schema: {e}"
+
+
+# ---------------------------------------------------------------------------
+# Core
+# ---------------------------------------------------------------------------
+
+def compute_post_emit_health(
+    manifest_path_str: str,
+    *,
+    agent_pack_required: bool = True,
+    run_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Validate the final emitted bundle surface. Pure: performs no writes.
+
+    Returns a dict conforming to ``post-emit-health.v1.schema.json``.
+    """
+    run_id = run_id or str(uuid.uuid4())
+    manifest_path = _resolve_manifest_path(manifest_path_str)
+    manifest_path_str = str(manifest_path)
+    manifest_dir = manifest_path.parent
+
+    # ── blocked: cannot even enumerate the surface ───────────────────────────
+    if not manifest_path.exists() or not manifest_path.is_file():
+        return _assemble(
+            status="blocked",
+            run_id=run_id,
+            bundle_run_id=None,
+            manifest_path_str=manifest_path_str,
+            checks=[_check("manifest_present", "blocked", "bundle manifest not found")],
+            errors=["bundle manifest not found or not a file"],
+            warnings=[],
+        )
+
+    try:
+        with manifest_path.open("r", encoding="utf-8") as f:
+            manifest = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        return _assemble(
+            status="blocked",
+            run_id=run_id,
+            bundle_run_id=None,
+            manifest_path_str=manifest_path_str,
+            checks=[_check("manifest_present", "blocked", f"cannot read manifest: {e}")],
+            errors=[f"cannot read bundle manifest: {e}"],
+            warnings=[],
+        )
+
+    bundle_run_id = manifest.get("run_id") if isinstance(manifest, dict) else None
+
+    if not isinstance(manifest, dict) or manifest.get("kind") != _BUNDLE_KIND:
+        return _assemble(
+            status="blocked",
+            run_id=run_id,
+            bundle_run_id=bundle_run_id,
+            manifest_path_str=manifest_path_str,
+            checks=[_check("manifest_present", "blocked", "not a repolens.bundle.manifest")],
+            errors=["manifest is not a repolens.bundle.manifest; cannot certify bundle surface"],
+            warnings=[],
+        )
+
+    artifacts = manifest.get("artifacts")
+    if not isinstance(artifacts, list):
+        return _assemble(
+            status="blocked",
+            run_id=run_id,
+            bundle_run_id=bundle_run_id,
+            manifest_path_str=manifest_path_str,
+            checks=[_check("manifest_present", "blocked", "manifest 'artifacts' is not a list")],
+            errors=["manifest 'artifacts' is not a list; no inspectable artifact surface"],
+            warnings=[],
+        )
+
+    checks: List[Dict[str, Any]] = [_check("manifest_present", "pass")]
+    errors: List[str] = []
+    warnings: List[str] = []
+    blocking: List[str] = []
+
+    # ── manifest schema ──────────────────────────────────────────────────────
+    schema_status, schema_msg = _validate_manifest_schema(manifest)
+    if schema_status == "pass":
+        checks.append(_check("manifest_schema_valid", "pass"))
+    elif schema_status == "fail":
+        checks.append(_check("manifest_schema_valid", "fail", schema_msg))
+        errors.append(schema_msg)
+    else:  # environment_error
+        checks.append(_check("manifest_schema_valid", "skipped", schema_msg))
+        warnings.append(schema_msg)
+
+    # ── per-artifact existence + hash ────────────────────────────────────────
+    artifact_count_checked = 0
+    missing_artifact_count = 0
+    hash_mismatch_count = 0
+    valid_roles: set[str] = set()
+    by_role: Dict[str, Dict[str, Any]] = {}
+
+    for index, art in enumerate(artifacts):
+        if not isinstance(art, dict):
+            errors.append(f"artifact at index {index} is not an object")
+            continue
+        artifact_count_checked += 1
+        role = art.get("role") if isinstance(art.get("role"), str) else f"<index {index}>"
+        if isinstance(art.get("role"), str):
+            by_role.setdefault(art["role"], art)
+        raw_path = art.get("path")
+        expected_sha = art.get("sha256")
+
+        if not isinstance(raw_path, str) or not raw_path:
+            errors.append(f"artifact '{role}' has no path")
+            continue
+        try:
+            target = resolve_secure_path(manifest_dir, raw_path)
+        except ValueError as e:
+            errors.append(f"artifact '{role}' path rejected: {e}")
+            continue
+
+        if not target.exists() or not target.is_file():
+            missing_artifact_count += 1
+            errors.append(f"artifact '{role}' is declared in the manifest but the file is missing: {raw_path}")
+            continue
+
+        actual = _sha256_file(target)
+        if actual is None:
+            errors.append(f"artifact '{role}' could not be read for hashing: {raw_path}")
+            continue
+        if isinstance(expected_sha, str) and len(expected_sha) == _SHA256_LEN:
+            if actual != expected_sha:
+                hash_mismatch_count += 1
+                errors.append(
+                    f"artifact '{role}' hash mismatch: manifest={expected_sha} actual={actual}"
+                )
+                continue
+            valid_roles.add(art["role"]) if isinstance(art.get("role"), str) else None
+        else:
+            warnings.append(f"artifact '{role}' has no usable sha256 in manifest; integrity unverified")
+
+    checks.append(
+        _check(
+            "artifact_paths_exist",
+            "fail" if missing_artifact_count else "pass",
+            f"{missing_artifact_count} of {artifact_count_checked} declared artifact file(s) missing",
+        )
+    )
+    checks.append(
+        _check(
+            "artifact_hashes_match",
+            "fail" if hash_mismatch_count else "pass",
+            f"{hash_mismatch_count} hash mismatch(es) across {artifact_count_checked} artifact(s)",
+        )
+    )
+
+    # ── canonical_md must be declared (truth-source surface) ─────────────────
+    if _CANONICAL_MD not in by_role:
+        blocking.append("canonical_md is not declared in the manifest; cannot certify a truth source")
+        checks.append(_check("canonical_md_present", "blocked", "canonical_md absent from manifest"))
+    else:
+        checks.append(_check("canonical_md_present", "pass"))
+
+    # ── agent_reading_pack: the defining post-emission certification surface ──
+    pack_entry = by_role.get(_AGENT_PACK)
+    pack_present = pack_entry is not None
+    pack_authority = pack_entry.get("authority") if isinstance(pack_entry, dict) else None
+    pack_canonicality = pack_entry.get("canonicality") if isinstance(pack_entry, dict) else None
+    pack_hash_ok: Optional[bool] = _AGENT_PACK in valid_roles if pack_present else None
+    pack_self_role_ok: Optional[bool] = None
+
+    if not pack_present:
+        if agent_pack_required:
+            blocking.append("agent_reading_pack is not declared in the manifest; agent surface cannot be certified")
+            checks.append(_check("agent_pack_present", "blocked", "agent_reading_pack absent from manifest"))
+        else:
+            checks.append(_check("agent_pack_present", "skipped", "agent_reading_pack not required for this run"))
+    else:
+        checks.append(_check("agent_pack_present", "pass"))
+        # The pack is navigation, never content/canonical truth. A mis-declared
+        # self-role is a defect (a navigation artifact claiming to be the source
+        # of truth). This is the manifest-level form of "the pack does not list
+        # itself as a canonical/content source incorrectly".
+        mis_declared = (
+            pack_authority == "canonical_content" or pack_canonicality == "content_source"
+        )
+        if mis_declared:
+            pack_self_role_ok = False
+            errors.append(
+                "agent_reading_pack mis-declares itself as a canonical/content source "
+                f"(authority={pack_authority!r}, canonicality={pack_canonicality!r})"
+            )
+            checks.append(_check("agent_pack_self_role", "fail", "pack declared as canonical/content"))
+        else:
+            pack_self_role_ok = True
+            checks.append(_check("agent_pack_self_role", "pass", "pack declared as navigation/derived"))
+
+    agent_pack = {
+        "present": pack_present,
+        "required": bool(agent_pack_required),
+        "hash_ok": pack_hash_ok,
+        "authority_declared": pack_authority,
+        "canonicality_declared": pack_canonicality,
+        "self_role_ok": pack_self_role_ok,
+    }
+
+    # ── range-ref / citation resolution (checkable where relevant) ───────────
+    chunk_entry = by_role.get(_CHUNK_INDEX)
+    chunk_index_path: Optional[Path] = None
+    if isinstance(chunk_entry, dict) and isinstance(chunk_entry.get("path"), str):
+        try:
+            chunk_index_path = resolve_secure_path(manifest_dir, chunk_entry["path"])
+        except ValueError:
+            chunk_index_path = None
+
+    rr_status, rr_msg = _range_ref_status(manifest_path, chunk_index_path)
+    if rr_status == "ok":
+        checks.append(_check("range_ref_resolution", "pass", rr_msg))
+    elif rr_status == "fail":
+        checks.append(_check("range_ref_resolution", "fail", rr_msg))
+        errors.append(rr_msg)
+    elif rr_status == "environment_error":
+        checks.append(_check("range_ref_resolution", "skipped", rr_msg))
+        warnings.append(rr_msg)
+    else:  # no_range_ref / unavailable — nothing to certify, non-blocking
+        checks.append(_check("range_ref_resolution", "skipped", rr_msg))
+
+    # ── redaction: reported, never enforced (enforcement is PR A5) ───────────
+    capabilities = manifest.get("capabilities") if isinstance(manifest.get("capabilities"), dict) else {}
+    redact_value = capabilities.get("redaction")
+    redaction_status = {
+        "available": isinstance(redact_value, bool),
+        "redact_secrets_enabled": redact_value if isinstance(redact_value, bool) else None,
+        "enforced": False,
+    }
+    checks.append(
+        _check(
+            "redaction_status_reported",
+            "pass",
+            f"redaction={redact_value!r} (reported only; not enforced in post_emit_health)",
+        )
+    )
+
+    # ── output_health: OBSERVATION ONLY (never gates post-emit status) ───────
+    output_health_verdict: Optional[str] = None
+    output_health_present = _OUTPUT_HEALTH in by_role
+    sqlite_ok: Optional[bool] = None
+    noise_hygiene: Dict[str, Any] = {"available": False, "excluded_noise_count": None, "source": None}
+
+    oh_entry = by_role.get(_OUTPUT_HEALTH)
+    if isinstance(oh_entry, dict) and isinstance(oh_entry.get("path"), str):
+        try:
+            oh_path = resolve_secure_path(manifest_dir, oh_entry["path"])
+        except ValueError:
+            oh_path = None
+        if oh_path is not None and oh_path.exists():
+            try:
+                with oh_path.open("r", encoding="utf-8") as f:
+                    oh_doc = json.load(f)
+            except (OSError, json.JSONDecodeError):
+                oh_doc = None
+            if isinstance(oh_doc, dict):
+                v = oh_doc.get("verdict")
+                output_health_verdict = v if isinstance(v, str) else None
+                oh_checks = oh_doc.get("checks") if isinstance(oh_doc.get("checks"), dict) else {}
+                rc_match = oh_checks.get("sqlite_row_count_matches_chunk_count")
+                fts_ok = oh_checks.get("fts_content_non_empty")
+                if rc_match is not None or fts_ok is not None:
+                    sqlite_ok = bool(rc_match) and bool(fts_ok)
+                # Noise-hygiene signals are surfaced only where already available
+                # (e.g. a future A2 excluded_noise diagnostic). Never synthesized.
+                excluded = oh_checks.get("excluded_noise")
+                if excluded is None:
+                    excluded = oh_doc.get("excluded_noise")
+                if isinstance(excluded, list):
+                    noise_hygiene = {
+                        "available": True,
+                        "excluded_noise_count": len(excluded),
+                        "source": "output_health",
+                    }
+
+    checks.append(
+        _check(
+            "output_health_observed",
+            "pass" if output_health_present else "skipped",
+            f"output_health.verdict={output_health_verdict!r} (observation only; "
+            "does not imply post_emit_health.status=pass)",
+        )
+    )
+
+    # ── evidence level (existing vocabulary; not an understanding verdict) ────
+    evidence_level, evidence_levels_reached = _compute_evidence(
+        valid_roles,
+        rr_status,
+        jsonschema_available=jsonschema is not None,
+        sqlite_ok=sqlite_ok,
+        output_health_present=output_health_present,
+    )
+    checks.append(
+        _check(
+            "evidence_level_reported",
+            "pass",
+            f"achieved evidence_level={evidence_level!r}",
+        )
+    )
+
+    # ── status (blocked > fail > warn > pass) ────────────────────────────────
+    if blocking:
+        status = "blocked"
+        # surface blocking reasons in errors for visibility without losing the
+        # blocked headline
+        errors = list(errors) + blocking
+    elif errors:
+        status = "fail"
+    elif warnings:
+        status = "warn"
+    else:
+        status = "pass"
+
+    return _assemble(
+        status=status,
+        run_id=run_id,
+        bundle_run_id=bundle_run_id,
+        manifest_path_str=manifest_path_str,
+        checks=checks,
+        errors=errors,
+        warnings=warnings,
+        evidence_level=evidence_level,
+        evidence_levels_reached=evidence_levels_reached,
+        output_health_verdict=output_health_verdict,
+        redaction_status=redaction_status,
+        noise_hygiene=noise_hygiene,
+        artifact_count_checked=artifact_count_checked,
+        hash_mismatch_count=hash_mismatch_count,
+        missing_artifact_count=missing_artifact_count,
+        range_ref_resolution_status=rr_status,
+        agent_pack=agent_pack,
+    )
+
+
+def write_post_emit_health(
+    manifest_path_str: str,
+    output_path_str: Optional[str] = None,
+    *,
+    agent_pack_required: bool = True,
+    run_id: Optional[str] = None,
+) -> Tuple[Path, Dict[str, Any]]:
+    """
+    Compute the post-emit health report and persist it as
+    ``<stem>.bundle_health.post.json`` (or ``output_path_str`` if given).
+
+    The written artifact is intentionally NOT registered in the bundle manifest:
+    persistence does not mutate manifest truth, and the report never verifies its
+    own hash. Returns ``(written_path, report)``.
+    """
+    report = compute_post_emit_health(
+        manifest_path_str, agent_pack_required=agent_pack_required, run_id=run_id
+    )
+    manifest_path = _resolve_manifest_path(manifest_path_str)
+    if output_path_str:
+        out = Path(output_path_str)
+        out = out if out.is_absolute() else Path.cwd() / out
+    else:
+        out = derive_post_health_path(manifest_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    logger.debug("post_emit_health written to %s (status=%s)", out, report["status"])
+    return out, report

--- a/merger/lenskit/tests/test_cli_bundle_health.py
+++ b/merger/lenskit/tests/test_cli_bundle_health.py
@@ -1,0 +1,110 @@
+"""
+CLI tests for `lenskit bundle-health post`.
+"""
+import hashlib
+import json
+from pathlib import Path
+
+from merger.lenskit.cli.main import main
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+_CANONICAL = b"# repo\n\n## file: a.py\nx = 1\n"
+
+
+def _make_bundle(tmp_path: Path, *, include_pack: bool = True) -> Path:
+    (tmp_path / "demo.md").write_bytes(_CANONICAL)
+    chunk = {"chunk_id": "c0", "path": "a.py"}
+    chunk_bytes = (json.dumps(chunk) + "\n").encode("utf-8")
+    (tmp_path / "demo.chunk_index.jsonl").write_bytes(chunk_bytes)
+
+    artifacts = [
+        {
+            "role": "canonical_md", "path": "demo.md", "content_type": "text/markdown",
+            "bytes": len(_CANONICAL), "sha256": _sha256(_CANONICAL),
+            "authority": "canonical_content", "canonicality": "content_source",
+        },
+        {
+            "role": "chunk_index_jsonl", "path": "demo.chunk_index.jsonl",
+            "content_type": "application/x-ndjson", "bytes": len(chunk_bytes),
+            "sha256": _sha256(chunk_bytes),
+            "authority": "retrieval_index", "canonicality": "derived",
+        },
+    ]
+    if include_pack:
+        pack_bytes = b"# pack\nNAVIGATION, NOT TRUTH\n"
+        (tmp_path / "demo.agent_reading_pack.md").write_bytes(pack_bytes)
+        artifacts.append({
+            "role": "agent_reading_pack", "path": "demo.agent_reading_pack.md",
+            "content_type": "text/markdown", "bytes": len(pack_bytes),
+            "sha256": _sha256(pack_bytes),
+            "authority": "navigation_index", "canonicality": "derived",
+        })
+
+    manifest = {
+        "kind": "repolens.bundle.manifest", "version": "1.0", "run_id": "cli-bh-run",
+        "created_at": "2026-05-20T00:00:00Z",
+        "generator": {"name": "test", "version": "1.0", "config_sha256": "a" * 64},
+        "artifacts": artifacts, "links": {},
+        "capabilities": {"fts5_bm25": False, "redaction": False},
+    }
+    manifest_path = tmp_path / "demo.bundle.manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    return manifest_path
+
+
+def test_bundle_health_post_cli_json(tmp_path, capsys):
+    manifest = _make_bundle(tmp_path)
+    rc = main(["bundle-health", "post", str(manifest), "--json"])
+    assert rc == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["kind"] == "lenskit.post_emit_health"
+    assert report["status"] == "pass"
+    assert report["evidence_level"] == "navigable"
+    # Default invocation has no side effects: no artifact file is written.
+    assert not (tmp_path / "demo.bundle_health.post.json").exists()
+
+
+def test_bundle_health_post_cli_human_ok(tmp_path, capsys):
+    manifest = _make_bundle(tmp_path)
+    rc = main(["bundle-health", "post", str(manifest)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Post-emit Bundle Health: PASS" in out
+    assert "does not imply post_emit_health.status=pass" in out
+
+
+def test_bundle_health_post_cli_emit_artifact(tmp_path, capsys):
+    manifest = _make_bundle(tmp_path)
+    manifest_before = manifest.read_text(encoding="utf-8")
+
+    rc = main(["bundle-health", "post", str(manifest), "--emit-artifact", "--json"])
+    assert rc == 0
+
+    out_file = tmp_path / "demo.bundle_health.post.json"
+    assert out_file.exists()
+    written = json.loads(out_file.read_text(encoding="utf-8"))
+    assert written["status"] == "pass"
+    # Explicit persistence must not mutate the manifest (no registration).
+    assert manifest.read_text(encoding="utf-8") == manifest_before
+
+
+def test_bundle_health_post_cli_blocked_missing_pack(tmp_path, capsys):
+    manifest = _make_bundle(tmp_path, include_pack=False)
+    rc = main(["bundle-health", "post", str(manifest), "--json"])
+    assert rc == 2
+    report = json.loads(capsys.readouterr().out)
+    assert report["status"] == "blocked"
+
+
+def test_bundle_health_post_cli_fail_hash_mismatch(tmp_path, capsys):
+    manifest = _make_bundle(tmp_path)
+    (tmp_path / "demo.md").write_bytes(_CANONICAL + b"DRIFT\n")
+    rc = main(["bundle-health", "post", str(manifest), "--json"])
+    assert rc == 1
+    report = json.loads(capsys.readouterr().out)
+    assert report["status"] == "fail"
+    assert report["hash_mismatch_count"] >= 1

--- a/merger/lenskit/tests/test_cli_bundle_health.py
+++ b/merger/lenskit/tests/test_cli_bundle_health.py
@@ -100,6 +100,27 @@ def test_bundle_health_post_cli_blocked_missing_pack(tmp_path, capsys):
     assert report["status"] == "blocked"
 
 
+def test_bundle_health_post_cli_no_require_pack_note(tmp_path, capsys):
+    manifest = _make_bundle(tmp_path, include_pack=False)
+    rc = main(["bundle-health", "post", str(manifest), "--no-require-agent-pack"])
+    out = capsys.readouterr().out
+    assert "agent_pack.required:     False" in out
+    assert "agent_reading_pack not required for this run; this is not an agent-surface certification" in out
+    assert rc == 0
+
+
+def test_bundle_health_post_cli_emit_artifact_unregistered_note(tmp_path, capsys):
+    manifest = _make_bundle(tmp_path)
+    manifest_before = manifest.read_text(encoding="utf-8")
+    rc = main(["bundle-health", "post", str(manifest), "--emit-artifact"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    out_file = tmp_path / "demo.bundle_health.post.json"
+    assert out_file.exists()
+    assert manifest.read_text(encoding="utf-8") == manifest_before
+    assert "written artifact is unregistered; manifest not mutated" in out
+
+
 def test_bundle_health_post_cli_fail_hash_mismatch(tmp_path, capsys):
     manifest = _make_bundle(tmp_path)
     (tmp_path / "demo.md").write_bytes(_CANONICAL + b"DRIFT\n")

--- a/merger/lenskit/tests/test_post_emit_health.py
+++ b/merger/lenskit/tests/test_post_emit_health.py
@@ -11,7 +11,6 @@ import json
 from pathlib import Path
 
 import jsonschema
-import pytest
 
 from merger.lenskit.core.post_emit_health import (
     DOES_NOT_MEAN,
@@ -40,6 +39,7 @@ def _make_bundle(
     redaction: bool = False,
     pack_authority: str = "navigation_index",
     pack_canonicality: str = "derived",
+    range_key: str = "canonical_range",
 ) -> Path:
     """Build a synthetic bundle on disk and return the manifest path."""
     artifacts = []
@@ -51,15 +51,19 @@ def _make_bundle(
         "authority": "canonical_content", "canonicality": "content_source",
     })
 
+    _start = _CANONICAL.index(b"x = 1")
     chunk = {
         "chunk_id": "c0",
         "path": "a.py",
-        "canonical_range": {
+        range_key: {
             "artifact_role": "canonical_md",
+            "repo_id": "demo",
             "file_path": "demo.md",
-            "start_byte": _CANONICAL.index(b"x = 1"),
+            "start_byte": _start,
             "end_byte": len(_CANONICAL),
-            "content_sha256": _sha256(_CANONICAL[_CANONICAL.index(b"x = 1"):]),
+            "start_line": 4,
+            "end_line": 4,
+            "content_sha256": _sha256(_CANONICAL[_start:]),
         },
     }
     chunk_bytes = (json.dumps(chunk) + "\n").encode("utf-8")
@@ -205,9 +209,38 @@ def test_post_emit_health_clean_bundle_passes(tmp_path):
     assert report["status"] == "pass"
     assert report["errors"] == []
     assert report["agent_pack"]["self_role_ok"] is True
+    # A clean bundle whose chunks carry canonical_range resolves a real range path.
+    assert report["range_ref_resolution_status"] == "ok"
     assert "repo_understood" in report["does_not_mean"]
     assert "answer_safe_without_citations" in report["does_not_mean"]
     assert set(DOES_NOT_MEAN).issubset(set(report["does_not_mean"]))
+
+
+def test_post_emit_health_range_ref_legacy_content_range_ref(tmp_path):
+    """Legacy chunks using content_range_ref still resolve via the fallback."""
+    manifest = _make_bundle(tmp_path, range_key="content_range_ref")
+    report = compute_post_emit_health(str(manifest))
+
+    assert report["status"] == "pass"
+    assert report["range_ref_resolution_status"] == "ok"
+
+
+def test_post_emit_health_output_health_must_be_validated_not_declared(tmp_path):
+    """A declared but tampered output_health must not be trusted nor boost coverage."""
+    manifest = _make_bundle(tmp_path)  # includes a declared, hash-valid output_health
+    # Tamper the file after the manifest (and its recorded hash) were written.
+    (tmp_path / "demo.output_health.json").write_bytes(
+        b'{"kind":"lenskit.output_health","verdict":"pass","tampered":true}\n'
+    )
+
+    report = compute_post_emit_health(str(manifest))
+
+    assert report["status"] == "fail"
+    assert report["hash_mismatch_count"] >= 1
+    # The verdict must NOT be read from the hash-mismatched artifact.
+    assert report["output_health_verdict"] is None
+    # A corrupted output_health must not contribute diagnostic coverage.
+    assert "diagnostic_full" not in report["evidence_levels_reached"]
 
 
 def test_post_emit_health_output_validates_against_schema(tmp_path):

--- a/merger/lenskit/tests/test_post_emit_health.py
+++ b/merger/lenskit/tests/test_post_emit_health.py
@@ -1,0 +1,277 @@
+"""
+Unit tests for core/post_emit_health.py (the post-emit bundle validator, PR A4).
+
+Uses self-contained synthetic bundle manifests so the tests do not depend on the
+full merge pipeline. The defining property: post_emit_health validates the FINAL
+bundle surface (including the agent_reading_pack, which the in-pipeline
+output_health cannot see) and is independent of the pre-emit output_health verdict.
+"""
+import hashlib
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from merger.lenskit.core.post_emit_health import (
+    DOES_NOT_MEAN,
+    compute_post_emit_health,
+    derive_post_health_path,
+    write_post_emit_health,
+)
+
+_CONTRACTS_DIR = Path(__file__).parent.parent / "contracts"
+_POST_HEALTH_SCHEMA_PATH = _CONTRACTS_DIR / "post-emit-health.v1.schema.json"
+
+_CANONICAL = b"# repo: demo\n\n## file: a.py\nx = 1\n"
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _make_bundle(
+    tmp_path: Path,
+    *,
+    include_pack: bool = True,
+    include_health: bool = True,
+    include_citation: bool = False,
+    health_verdict: str = "pass",
+    redaction: bool = False,
+    pack_authority: str = "navigation_index",
+    pack_canonicality: str = "derived",
+) -> Path:
+    """Build a synthetic bundle on disk and return the manifest path."""
+    artifacts = []
+
+    (tmp_path / "demo.md").write_bytes(_CANONICAL)
+    artifacts.append({
+        "role": "canonical_md", "path": "demo.md", "content_type": "text/markdown",
+        "bytes": len(_CANONICAL), "sha256": _sha256(_CANONICAL),
+        "authority": "canonical_content", "canonicality": "content_source",
+    })
+
+    chunk = {
+        "chunk_id": "c0",
+        "path": "a.py",
+        "canonical_range": {
+            "artifact_role": "canonical_md",
+            "file_path": "demo.md",
+            "start_byte": _CANONICAL.index(b"x = 1"),
+            "end_byte": len(_CANONICAL),
+            "content_sha256": _sha256(_CANONICAL[_CANONICAL.index(b"x = 1"):]),
+        },
+    }
+    chunk_bytes = (json.dumps(chunk) + "\n").encode("utf-8")
+    (tmp_path / "demo.chunk_index.jsonl").write_bytes(chunk_bytes)
+    artifacts.append({
+        "role": "chunk_index_jsonl", "path": "demo.chunk_index.jsonl",
+        "content_type": "application/x-ndjson", "bytes": len(chunk_bytes),
+        "sha256": _sha256(chunk_bytes),
+        "authority": "retrieval_index", "canonicality": "derived",
+    })
+
+    if include_health:
+        health_doc = {
+            "kind": "lenskit.output_health", "version": "1.0", "run_id": "demo-run",
+            "created_at": "2026-05-20T00:00:00Z", "stem": "demo",
+            "checks": {"chunk_count": 1}, "diagnostic_artifacts": {},
+            "warnings": [], "errors": [], "verdict": health_verdict,
+        }
+        health_bytes = json.dumps(health_doc, indent=2).encode("utf-8")
+        (tmp_path / "demo.output_health.json").write_bytes(health_bytes)
+        artifacts.append({
+            "role": "output_health", "path": "demo.output_health.json",
+            "content_type": "application/json", "bytes": len(health_bytes),
+            "sha256": _sha256(health_bytes),
+            "authority": "diagnostic_signal", "canonicality": "diagnostic",
+        })
+
+    if include_pack:
+        pack_bytes = b"<!-- ARTIFACT:agent_reading_pack VERSION:v1 -->\n# Pack\nNAVIGATION, NOT TRUTH\n"
+        (tmp_path / "demo.agent_reading_pack.md").write_bytes(pack_bytes)
+        artifacts.append({
+            "role": "agent_reading_pack", "path": "demo.agent_reading_pack.md",
+            "content_type": "text/markdown", "bytes": len(pack_bytes),
+            "sha256": _sha256(pack_bytes),
+            "authority": pack_authority, "canonicality": pack_canonicality,
+        })
+
+    if include_citation:
+        cit_bytes = b'{"citation_id":"cit_0000000000000000"}\n'
+        (tmp_path / "demo.citation_map.jsonl").write_bytes(cit_bytes)
+        artifacts.append({
+            "role": "citation_map_jsonl", "path": "demo.citation_map.jsonl",
+            "content_type": "application/x-ndjson", "bytes": len(cit_bytes),
+            "sha256": _sha256(cit_bytes),
+            "authority": "navigation_index", "canonicality": "derived",
+            "regenerable": True, "staleness_sensitive": True,
+            "contract": {"id": "citation-map", "version": "v1"},
+        })
+
+    manifest = {
+        "kind": "repolens.bundle.manifest", "version": "1.0", "run_id": "demo-run",
+        "created_at": "2026-05-20T00:00:00Z",
+        "generator": {"name": "test", "version": "1.0", "config_sha256": "a" * 64},
+        "artifacts": artifacts, "links": {},
+        "capabilities": {"fts5_bm25": False, "redaction": redaction},
+    }
+    manifest_path = tmp_path / "demo.bundle.manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    return manifest_path
+
+
+# ---------------------------------------------------------------------------
+# Required tests
+# ---------------------------------------------------------------------------
+
+def test_post_emit_health_requires_agent_pack(tmp_path):
+    """A bundle without an agent_reading_pack must not silently pass."""
+    manifest = _make_bundle(tmp_path, include_pack=False)
+    report = compute_post_emit_health(str(manifest))
+
+    assert report["status"] == "blocked"
+    assert report["status"] != "pass"
+    assert report["agent_pack"]["present"] is False
+    pack_check = next(c for c in report["checks"] if c["name"] == "agent_pack_present")
+    assert pack_check["status"] == "blocked"
+
+
+def test_post_emit_health_independent_of_pre_health(tmp_path):
+    """output_health.verdict=pass must never imply post_emit_health.status=pass."""
+    manifest = _make_bundle(tmp_path, health_verdict="pass")
+    # Introduce a post-emit-only defect: corrupt the pack so its hash mismatches.
+    (tmp_path / "demo.agent_reading_pack.md").write_bytes(b"tampered content not in manifest hash\n")
+
+    report = compute_post_emit_health(str(manifest))
+
+    # The pre-emit verdict is recorded as an observation ...
+    assert report["output_health_verdict"] == "pass"
+    # ... but the post-emit status is computed independently and fails.
+    assert report["status"] == "fail"
+    assert report["hash_mismatch_count"] >= 1
+    assert report["independence_note"] == (
+        "output_health.verdict=pass does not imply post_emit_health.status=pass"
+    )
+
+
+def test_post_emit_health_reports_evidence_level(tmp_path):
+    """Evidence level is reported using the existing vocabulary."""
+    manifest = _make_bundle(tmp_path)
+    report = compute_post_emit_health(str(manifest))
+
+    assert report["status"] == "pass"
+    # canonical_md + agent_reading_pack + chunk_index => navigable (no citation_map).
+    assert report["evidence_level"] == "navigable"
+    assert "readable" in report["evidence_levels_reached"]
+    assert "navigable" in report["evidence_levels_reached"]
+    assert "citable" not in report["evidence_levels_reached"]
+
+
+def test_post_emit_health_detects_missing_artifact(tmp_path):
+    """A manifest-declared artifact whose file is missing => fail."""
+    manifest = _make_bundle(tmp_path)
+    (tmp_path / "demo.chunk_index.jsonl").unlink()
+
+    report = compute_post_emit_health(str(manifest))
+
+    assert report["status"] == "fail"
+    assert report["missing_artifact_count"] >= 1
+    paths_check = next(c for c in report["checks"] if c["name"] == "artifact_paths_exist")
+    assert paths_check["status"] == "fail"
+
+
+def test_post_emit_health_detects_hash_mismatch(tmp_path):
+    """A file whose content no longer matches the manifest hash => fail."""
+    manifest = _make_bundle(tmp_path)
+    (tmp_path / "demo.md").write_bytes(_CANONICAL + b"DRIFT\n")
+
+    report = compute_post_emit_health(str(manifest))
+
+    assert report["status"] == "fail"
+    assert report["hash_mismatch_count"] >= 1
+    hashes_check = next(c for c in report["checks"] if c["name"] == "artifact_hashes_match")
+    assert hashes_check["status"] == "fail"
+
+
+# ---------------------------------------------------------------------------
+# Supporting coverage
+# ---------------------------------------------------------------------------
+
+def test_post_emit_health_clean_bundle_passes(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    report = compute_post_emit_health(str(manifest))
+
+    assert report["status"] == "pass"
+    assert report["errors"] == []
+    assert report["agent_pack"]["self_role_ok"] is True
+    assert "repo_understood" in report["does_not_mean"]
+    assert "answer_safe_without_citations" in report["does_not_mean"]
+    assert set(DOES_NOT_MEAN).issubset(set(report["does_not_mean"]))
+
+
+def test_post_emit_health_output_validates_against_schema(tmp_path):
+    schema = json.loads(_POST_HEALTH_SCHEMA_PATH.read_text(encoding="utf-8"))
+    # Build distinct bundles in fresh dirs and validate each report against schema.
+    for i, kwargs in enumerate(({}, {"include_pack": False}, {"include_citation": True})):
+        sub = tmp_path / f"bundle_{i}"
+        sub.mkdir()
+        manifest = _make_bundle(sub, **kwargs)
+        report = compute_post_emit_health(str(manifest))
+        jsonschema.validate(instance=report, schema=schema)
+
+
+def test_post_emit_health_reports_redaction_without_enforcing(tmp_path):
+    """redaction=false must be reported but must NOT cause a fail (no enforcement)."""
+    manifest = _make_bundle(tmp_path, redaction=False)
+    report = compute_post_emit_health(str(manifest))
+
+    assert report["status"] == "pass"
+    assert report["redaction_status"]["redact_secrets_enabled"] is False
+    assert report["redaction_status"]["enforced"] is False
+
+
+def test_post_emit_health_blocked_on_missing_manifest(tmp_path):
+    report = compute_post_emit_health(str(tmp_path / "nope.bundle.manifest.json"))
+    assert report["status"] == "blocked"
+    assert report["bundle_run_id"] is None
+    # Even the early-exit blocked report must be a schema-valid artifact.
+    schema = json.loads(_POST_HEALTH_SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.validate(instance=report, schema=schema)
+
+
+def test_post_emit_health_self_role_misdeclared_fails(tmp_path):
+    """A pack that declares itself as a canonical/content source is a defect."""
+    manifest = _make_bundle(
+        tmp_path, pack_authority="canonical_content", pack_canonicality="content_source"
+    )
+    report = compute_post_emit_health(str(manifest))
+
+    assert report["status"] == "fail"
+    assert report["agent_pack"]["self_role_ok"] is False
+
+
+def test_post_emit_health_no_require_agent_pack_relaxes_block(tmp_path):
+    manifest = _make_bundle(tmp_path, include_pack=False)
+    report = compute_post_emit_health(str(manifest), agent_pack_required=False)
+
+    # Without the pack requirement the absence is not blocking; the rest is clean.
+    assert report["status"] != "blocked"
+    assert report["agent_pack"]["present"] is False
+
+
+def test_write_post_emit_health_persists_unregistered_artifact(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    manifest_before = manifest.read_text(encoding="utf-8")
+
+    out, report = write_post_emit_health(str(manifest))
+
+    assert out == derive_post_health_path(manifest.resolve())
+    assert out.exists()
+    written = json.loads(out.read_text(encoding="utf-8"))
+    assert written["status"] == report["status"] == "pass"
+
+    # Persistence must NOT mutate the bundle manifest (no registration).
+    assert manifest.read_text(encoding="utf-8") == manifest_before
+    data = json.loads(manifest_before)
+    assert all(a["role"] != "post_emit_health" for a in data["artifacts"])

--- a/merger/lenskit/tests/test_post_emit_health.py
+++ b/merger/lenskit/tests/test_post_emit_health.py
@@ -260,6 +260,22 @@ def test_post_emit_health_no_require_agent_pack_relaxes_block(tmp_path):
     assert report["agent_pack"]["present"] is False
 
 
+def test_post_emit_health_blocked_precedes_fail(tmp_path):
+    """blocked takes precedence over fail: even when an inspectable defect exists,
+    the absence of agent_reading_pack from the manifest makes the status blocked."""
+    # Build without pack; also corrupt canonical so a hash defect is detectable.
+    manifest = _make_bundle(tmp_path, include_pack=False)
+    (tmp_path / "demo.md").write_bytes(_CANONICAL + b"CORRUPTION\n")
+
+    report = compute_post_emit_health(str(manifest))
+
+    # The hash defect is inspectable but the required certification surface is absent.
+    assert report["status"] == "blocked"
+    # The hash mismatch should still be captured in errors for transparency.
+    assert report["hash_mismatch_count"] >= 1
+    assert len(report["errors"]) >= 1
+
+
 def test_write_post_emit_health_persists_unregistered_artifact(tmp_path):
     manifest = _make_bundle(tmp_path)
     manifest_before = manifest.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Implements the post-emit bundle health validator (`post_emit_health`) that validates the final emitted Lenskit bundle surface **after** all derived artifacts are present, particularly the `agent_reading_pack` which the in-pipeline `output_health` cannot see. This closes a critical gap in bundle certification by validating the complete final manifest state.

## Key Changes

- **Core validator module** (`merger/lenskit/core/post_emit_health.py`):
  - `compute_post_emit_health()`: Pure function that validates bundle manifest, artifact existence, hash integrity, and structural requirements
  - `write_post_emit_health()`: Optional persistence to `<stem>.bundle_health.post.json` (intentionally unregistered in manifest to avoid self-hash circularity)
  - Comprehensive checks: manifest schema validation, per-artifact existence/hash verification, `agent_reading_pack` presence and self-role validation, range-ref resolution, redaction status reporting, evidence level computation
  - Status model with precedence: `blocked` > `fail` > `warn` > `pass`

- **Contract definition** (`merger/lenskit/contracts/post-emit-health.v1.schema.json`):
  - JSON Schema v7 defining the post-emit health report structure
  - Enforces required disclaimers (`does_not_mean`, `independence_note`)
  - Validates evidence level vocabulary and agent pack metadata

- **CLI integration** (`merger/lenskit/cli/cmd_bundle_health.py`):
  - New `lenskit bundle-health post` command with options:
    - `--json`: Machine-readable JSON output
    - `--emit-artifact`: Persist report to disk
    - `--output`: Explicit output path
    - `--no-require-agent-pack`: Make pack optional
  - Human-readable report formatting with status-based exit codes

- **Tests** (`merger/lenskit/tests/test_post_emit_health.py`, `test_cli_bundle_health.py`):
  - Synthetic bundle fixtures for isolated testing
  - Coverage of required scenarios: missing pack detection, pre/post-health independence, evidence level reporting, artifact integrity checks
  - Schema validation tests

- **Documentation** (`docs/proofs/post-emit-health-implementation-proof.md`):
  - Implementation rationale and design decisions
  - Proof of gap closure (why pre-emit health is insufficient)

## Notable Design Decisions

- **Independence by design**: `output_health.verdict` is recorded as an observation only and never gates post-emit status. A green pre-emit verdict does not imply a green post-emit status.
- **No manifest mutation**: Post-emit report is a separate file intentionally NOT registered in the bundle manifest, preventing self-hash circularity and manifest truth mutation.
- **Evidence level reporting**: Uses existing control-plane vocabulary (`readable`, `navigable`, `citable`, `range_strict`, etc.) to report achieved evidence levels without claiming global understanding.
- **Redaction reporting without enforcement**: Redaction status is reported but not enforced (enforcement deferred to PR A5).
- **Comprehensive surface validation**: Validates manifest schema, artifact paths, SHA256 hashes, agent pack presence/role correctness, range-ref resolution, and noise hygiene where available.

https://claude.ai/code/session_01Abh1neQ4XZJAaBZF4XP8eM