### PR TITLE
Implement PR A5: Agent Export Gate / Redaction Enforcement

### DIFF
--- a/docs/proofs/agent-export-gate-proof.md
+++ b/docs/proofs/agent-export-gate-proof.md
@@ -16,7 +16,8 @@ The gate additionally requires `post_emit_health` shape/binding validity before 
 - `version == 1.0`
 - valid status enum
 - schema-valid when `jsonschema` is available
-- `bundle_run_id` and `bundle_manifest_path` must match the evaluated bundle when present
+- `bundle_manifest_path` must be present, non-empty, and match the evaluated bundle manifest path
+- for `status=pass`, `bundle_run_id` must match the evaluated manifest `run_id`
 
 Invalid or mismatched post-emit reports block agent-facing export.
 

--- a/docs/proofs/agent-export-gate-proof.md
+++ b/docs/proofs/agent-export-gate-proof.md
@@ -1,0 +1,29 @@
+# Agent Export Gate Proof (A5)
+
+- Date: 2026-05-23
+- Scope: Minimal export gate for agent-facing profiles
+
+## Why output_health is insufficient
+
+`output_health` is pre-emit and observational. The gate does not treat `output_health.verdict` as sufficient evidence for export permission.
+
+## Why post_emit_health is required
+
+Agent-facing export requires a readable `post_emit_health` report with `status=pass`. Missing or unreadable post-emit health blocks agent-facing export.
+
+## Why redaction false blocks agent-facing export
+
+For agent-facing profiles with required redaction, `capabilities.redaction` must be `true`. If not, gate result is fail.
+
+## What this gate does not mean
+
+A gate pass does not mean:
+- `repo_understood`
+- `answer_safe_without_citations`
+- `claims_true`
+
+The gate is export eligibility logic, not a truth verdict.
+
+## Manifest mutation
+
+The gate reads manifest and optional health files only. It does not write to or mutate the bundle manifest.

--- a/docs/proofs/agent-export-gate-proof.md
+++ b/docs/proofs/agent-export-gate-proof.md
@@ -11,6 +11,15 @@
 
 Agent-facing export requires a readable `post_emit_health` report with `status=pass`. Missing or unreadable post-emit health blocks agent-facing export.
 
+The gate additionally requires `post_emit_health` shape/binding validity before trust:
+- `kind == lenskit.post_emit_health`
+- `version == 1.0`
+- valid status enum
+- schema-valid when `jsonschema` is available
+- `bundle_run_id` and `bundle_manifest_path` must match the evaluated bundle when present
+
+Invalid or mismatched post-emit reports block agent-facing export.
+
 ## Why redaction false blocks agent-facing export
 
 For agent-facing profiles with required redaction, `capabilities.redaction` must be `true`. If not, gate result is fail.
@@ -23,6 +32,11 @@ A gate pass does not mean:
 - `claims_true`
 
 The gate is export eligibility logic, not a truth verdict.
+
+Profile policy is fail-closed:
+- missing profile => blocked
+- unknown profile => blocked
+- only known non-agent profiles are treated as non-agent-facing
 
 ## Manifest mutation
 

--- a/merger/lenskit/cli/cmd_bundle_health.py
+++ b/merger/lenskit/cli/cmd_bundle_health.py
@@ -43,6 +43,38 @@ def register_bundle_health_commands(subparsers) -> None:
         help="Do not treat a missing agent_reading_pack as a blocking absence",
     )
 
+    export_gate_parser = bh_subparsers.add_parser(
+        "export-gate",
+        help="Evaluate export gate for a requested profile",
+    )
+    export_gate_parser.add_argument(
+        "manifest", help="Path to the bundle manifest JSON"
+    )
+    export_gate_parser.add_argument(
+        "--profile",
+        required=False,
+        default=None,
+        help="Requested export profile (agent-facing profiles enforce hard gating)",
+    )
+    export_gate_parser.add_argument(
+        "--post-health",
+        dest="post_health_path",
+        default=None,
+        help="Optional explicit path to post_emit_health JSON report",
+    )
+    export_gate_parser.add_argument(
+        "--no-require-redaction",
+        action="store_false",
+        dest="require_redaction",
+        help="Do not enforce redaction requirement even for agent-facing profiles",
+    )
+    export_gate_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="emit_json",
+        help="Emit the machine-readable JSON report to stdout",
+    )
+
 
 _EXIT_CODES = {"pass": 0, "warn": 0, "fail": 1, "blocked": 2}
 
@@ -111,6 +143,53 @@ def _print_human_report(report: dict, written_path=None) -> None:
     if written_path is not None:
         print(f"  written_artifact:        {written_path}")
         print("  NOTE: written artifact is unregistered; manifest not mutated.")
+
+    if report.get("warnings"):
+        print(f"\nWarnings ({len(report['warnings'])}):")
+        for w in report["warnings"]:
+            print(f"  [warn] {w}")
+
+    if report.get("errors"):
+        print(f"\nErrors ({len(report['errors'])}):")
+        for e in report["errors"]:
+            print(f"  [error] {e}")
+
+
+def run_bundle_health_export_gate(args: argparse.Namespace) -> int:
+    from merger.lenskit.core.agent_export_gate import evaluate_agent_export_gate
+
+    try:
+        report = evaluate_agent_export_gate(
+            manifest_path=args.manifest,
+            post_health_path=getattr(args, "post_health_path", None),
+            profile=getattr(args, "profile", None),
+            require_redaction=getattr(args, "require_redaction", True),
+        )
+    except Exception as e:  # noqa: BLE001 - surface unexpected failures cleanly
+        print(f"Error: unexpected failure during export gate evaluation: {e}", file=sys.stderr)
+        return 2
+
+    if args.emit_json:
+        print(json.dumps(report, indent=2))
+    else:
+        _print_export_gate_human(report)
+
+    return _EXIT_CODES.get(report["status"], 1)
+
+
+def _print_export_gate_human(report: dict) -> None:
+    print(f"Agent Export Gate: {report['status'].upper()}")
+    print(f"  profile:                     {report.get('profile')}")
+    print(f"  agent_facing:                {report.get('agent_facing')}")
+    print(f"  bundle_manifest_path:        {report.get('bundle_manifest_path')}")
+    print(f"  post_emit_health_status:     {report.get('post_emit_health_status')}")
+    print(f"  redaction_required:          {report.get('redaction_required')}")
+    print(f"  redaction_enabled:           {report.get('redaction_enabled')}")
+    print(
+        "  output_health_verdict:        "
+        f"{report.get('output_health_verdict_observed')} (observation only)"
+    )
+    print(f"  does_not_mean:               {', '.join(report.get('does_not_mean') or [])}")
 
     if report.get("warnings"):
         print(f"\nWarnings ({len(report['warnings'])}):")

--- a/merger/lenskit/cli/cmd_bundle_health.py
+++ b/merger/lenskit/cli/cmd_bundle_health.py
@@ -63,12 +63,6 @@ def register_bundle_health_commands(subparsers) -> None:
         help="Optional explicit path to post_emit_health JSON report",
     )
     export_gate_parser.add_argument(
-        "--no-require-redaction",
-        action="store_false",
-        dest="require_redaction",
-        help="Do not enforce redaction requirement even for agent-facing profiles",
-    )
-    export_gate_parser.add_argument(
         "--json",
         action="store_true",
         dest="emit_json",
@@ -163,7 +157,7 @@ def run_bundle_health_export_gate(args: argparse.Namespace) -> int:
             manifest_path=args.manifest,
             post_health_path=getattr(args, "post_health_path", None),
             profile=getattr(args, "profile", None),
-            require_redaction=getattr(args, "require_redaction", True),
+            require_redaction=True,
         )
     except Exception as e:  # noqa: BLE001 - surface unexpected failures cleanly
         print(f"Error: unexpected failure during export gate evaluation: {e}", file=sys.stderr)

--- a/merger/lenskit/cli/main.py
+++ b/merger/lenskit/cli/main.py
@@ -258,9 +258,11 @@ def main(args: Optional[List[str]] = None) -> int:
             parser.parse_args(["agent-pack", "--help"])
             return 0
     elif parsed_args.command == "bundle-health":
-        from .cmd_bundle_health import run_bundle_health_post
+        from .cmd_bundle_health import run_bundle_health_export_gate, run_bundle_health_post
         if parsed_args.bundle_health_cmd == "post":
             return run_bundle_health_post(parsed_args)
+        if parsed_args.bundle_health_cmd == "export-gate":
+            return run_bundle_health_export_gate(parsed_args)
         else:
             parser.parse_args(["bundle-health", "--help"])
             return 0

--- a/merger/lenskit/contracts/agent-export-gate.v1.schema.json
+++ b/merger/lenskit/contracts/agent-export-gate.v1.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://heimgewebe.local/schema/agent-export-gate.v1.schema.json",
+  "title": "Agent Export Gate (agent-export-gate v1.0)",
+  "description": "Machine-readable export gate for profile-scoped bundle export. This gate does not define truth semantics and treats output_health as observation only.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "kind",
+    "version",
+    "status",
+    "profile",
+    "agent_facing",
+    "checked_at",
+    "bundle_manifest_path",
+    "post_emit_health_status",
+    "output_health_verdict_observed",
+    "redaction_required",
+    "redaction_enabled",
+    "errors",
+    "warnings",
+    "does_not_mean"
+  ],
+  "properties": {
+    "kind": {
+      "type": "string",
+      "const": "lenskit.agent_export_gate"
+    },
+    "version": {
+      "type": "string",
+      "const": "1.0"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["pass", "fail", "blocked"]
+    },
+    "profile": {
+      "type": ["string", "null"]
+    },
+    "agent_facing": {
+      "type": "boolean"
+    },
+    "checked_at": {
+      "type": "string",
+      "description": "ISO 8601 UTC timestamp."
+    },
+    "bundle_manifest_path": {
+      "type": "string"
+    },
+    "post_emit_health_status": {
+      "type": ["string", "null"],
+      "enum": ["pass", "warn", "fail", "blocked", null]
+    },
+    "output_health_verdict_observed": {
+      "type": ["string", "null"]
+    },
+    "redaction_required": {
+      "type": "boolean"
+    },
+    "redaction_enabled": {
+      "type": ["boolean", "null"]
+    },
+    "errors": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "warnings": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "does_not_mean": {
+      "type": "array",
+      "items": {"type": "string"},
+      "allOf": [
+        {"contains": {"const": "repo_understood"}},
+        {"contains": {"const": "answer_safe_without_citations"}}
+      ]
+    }
+  }
+}

--- a/merger/lenskit/contracts/agent-export-gate.v1.schema.json
+++ b/merger/lenskit/contracts/agent-export-gate.v1.schema.json
@@ -73,7 +73,8 @@
       "items": {"type": "string"},
       "allOf": [
         {"contains": {"const": "repo_understood"}},
-        {"contains": {"const": "answer_safe_without_citations"}}
+        {"contains": {"const": "answer_safe_without_citations"}},
+        {"contains": {"const": "claims_true"}}
       ]
     }
   }

--- a/merger/lenskit/core/agent_export_gate.py
+++ b/merger/lenskit/core/agent_export_gate.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
 from .clock import now_utc
+from .path_security import resolve_secure_path
 from .post_emit_health import derive_post_health_path
 
 try:
@@ -40,7 +41,6 @@ _NON_AGENT_PROFILES = {
     "ui_navigation",
     "lookup_minimal",
     "review_context",
-    "local",
 }
 _KNOWN_PROFILES = _AGENT_FACING_PROFILES | _NON_AGENT_PROFILES
 
@@ -103,7 +103,11 @@ def _find_output_health_verdict(manifest: Dict[str, Any], manifest_dir: Path) ->
     if not isinstance(rel_path, str) or not rel_path:
         return None
 
-    output_path = (manifest_dir / rel_path).resolve()
+    try:
+        output_path = resolve_secure_path(manifest_dir, rel_path)
+    except ValueError:
+        return None
+
     output_doc, _ = _load_json(output_path)
     if not isinstance(output_doc, dict):
         return None
@@ -162,9 +166,12 @@ def _validate_post_health_binding(
     if resolved_post_manifest != resolved_manifest:
         return "post_emit_health bundle_manifest_path does not match the evaluated manifest"
 
-    status = post_doc.get("status")
     post_bundle_run_id = post_doc.get("bundle_run_id")
-    if status == "pass" and isinstance(manifest_run_id, str) and manifest_run_id:
+    if status == "pass":
+        if not isinstance(manifest_run_id, str) or not manifest_run_id.strip():
+            return "manifest run_id is missing or empty; cannot bind post_emit_health"
+        if not isinstance(post_bundle_run_id, str) or not post_bundle_run_id.strip():
+            return "post_emit_health bundle_run_id is missing or empty"
         if post_bundle_run_id != manifest_run_id:
             return "post_emit_health bundle_run_id does not match manifest run_id"
 
@@ -229,7 +236,9 @@ def evaluate_agent_export_gate(
         }
 
     manifest_dir = resolved_manifest.parent
-    manifest_run_id = manifest.get("run_id") if isinstance(manifest.get("run_id"), str) else None
+    manifest_run_id_raw = manifest.get("run_id")
+    manifest_run_id = manifest_run_id_raw if isinstance(manifest_run_id_raw, str) else None
+    manifest_run_id_valid = isinstance(manifest_run_id, str) and bool(manifest_run_id.strip())
 
     profile_missing = profile is None
     profile_unknown = isinstance(profile, str) and profile not in _KNOWN_PROFILES
@@ -280,6 +289,10 @@ def evaluate_agent_export_gate(
         errors.append(f"unknown export profile: {profile!r}")
 
     if agent_facing:
+        if not manifest_run_id_valid:
+            status = "blocked"
+            errors.append("agent-facing export requires non-empty manifest run_id")
+
         if not post_health_valid:
             status = "blocked"
             errors.append("agent-facing export requires valid post_emit_health")

--- a/merger/lenskit/core/agent_export_gate.py
+++ b/merger/lenskit/core/agent_export_gate.py
@@ -1,0 +1,245 @@
+"""
+Agent export gate for bundle-facing export profiles (roadmap PR A5).
+
+This module enforces a small, explicit export gate for agent-facing profiles:
+- post_emit_health must be available and pass on the final bundle surface,
+- redaction policy must be acceptable for the requested profile,
+- output_health.verdict is observation-only and never sufficient evidence.
+
+Design constraints:
+- No manifest mutation.
+- No global truth verdicts (no safe/unsafe/agent_ready semantics).
+- Deterministic machine-readable result shape.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+from .clock import now_utc
+from .post_emit_health import derive_post_health_path
+
+KIND = "lenskit.agent_export_gate"
+VERSION = "1.0"
+
+_BUNDLE_KIND = "repolens.bundle.manifest"
+_POST_STATUSES = {"pass", "warn", "fail", "blocked"}
+_AGENT_FACING_PROFILES = {
+    "agent_minimal",
+    "agent_facing",
+    "agent",
+}
+
+_DOES_NOT_MEAN = [
+    "repo_understood",
+    "answer_safe_without_citations",
+    "claims_true",
+]
+
+
+def _now_iso() -> str:
+    ts = now_utc()
+    if isinstance(ts, str):
+        return ts if ts.endswith("Z") else ts + "Z"
+    return ts.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _resolve_path(path_str: str) -> Path:
+    p = Path(path_str)
+    if not p.is_absolute():
+        p = Path.cwd() / p
+    return p.resolve()
+
+
+def _load_json(path: Path) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+    if not path.exists() or not path.is_file():
+        return None, "file not found"
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        return None, str(e)
+    if not isinstance(data, dict):
+        return None, "JSON root must be an object"
+    return data, None
+
+
+def _is_agent_facing(profile: Optional[str]) -> bool:
+    if not profile:
+        return False
+    return profile in _AGENT_FACING_PROFILES
+
+
+def _find_output_health_verdict(manifest: Dict[str, Any], manifest_dir: Path) -> Optional[str]:
+    artifacts = manifest.get("artifacts")
+    if not isinstance(artifacts, list):
+        return None
+
+    output_entry = None
+    for art in artifacts:
+        if not isinstance(art, dict):
+            continue
+        if art.get("role") == "output_health":
+            output_entry = art
+            break
+
+    if not isinstance(output_entry, dict):
+        return None
+    rel_path = output_entry.get("path")
+    if not isinstance(rel_path, str) or not rel_path:
+        return None
+
+    output_path = (manifest_dir / rel_path).resolve()
+    output_doc, _ = _load_json(output_path)
+    if not isinstance(output_doc, dict):
+        return None
+
+    verdict = output_doc.get("verdict")
+    if isinstance(verdict, str):
+        return verdict
+    return None
+
+
+def evaluate_agent_export_gate(
+    manifest_path: str,
+    post_health_path: Optional[str] = None,
+    profile: Optional[str] = None,
+    require_redaction: bool = True,
+) -> Dict[str, Any]:
+    """
+    Evaluate whether export is permitted for the requested profile.
+
+    Returns a deterministic machine-readable gate report.
+    """
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    resolved_manifest = _resolve_path(manifest_path)
+
+    manifest, manifest_err = _load_json(resolved_manifest)
+    if manifest is None:
+        return {
+            "kind": KIND,
+            "version": VERSION,
+            "status": "blocked",
+            "profile": profile,
+            "agent_facing": _is_agent_facing(profile),
+            "checked_at": _now_iso(),
+            "bundle_manifest_path": str(resolved_manifest),
+            "post_emit_health_status": None,
+            "output_health_verdict_observed": None,
+            "redaction_required": bool(require_redaction and _is_agent_facing(profile)),
+            "redaction_enabled": None,
+            "errors": [f"cannot read bundle manifest: {manifest_err}"],
+            "warnings": [],
+            "does_not_mean": list(_DOES_NOT_MEAN),
+        }
+
+    if manifest.get("kind") != _BUNDLE_KIND:
+        return {
+            "kind": KIND,
+            "version": VERSION,
+            "status": "blocked",
+            "profile": profile,
+            "agent_facing": _is_agent_facing(profile),
+            "checked_at": _now_iso(),
+            "bundle_manifest_path": str(resolved_manifest),
+            "post_emit_health_status": None,
+            "output_health_verdict_observed": None,
+            "redaction_required": bool(require_redaction and _is_agent_facing(profile)),
+            "redaction_enabled": None,
+            "errors": ["manifest is not a repolens.bundle.manifest"],
+            "warnings": [],
+            "does_not_mean": list(_DOES_NOT_MEAN),
+        }
+
+    manifest_dir = resolved_manifest.parent
+    agent_facing = _is_agent_facing(profile)
+    redaction_required = bool(require_redaction and agent_facing)
+
+    capabilities = manifest.get("capabilities") if isinstance(manifest.get("capabilities"), dict) else {}
+    redaction_value = capabilities.get("redaction")
+    redaction_enabled = redaction_value if isinstance(redaction_value, bool) else None
+
+    output_health_verdict_observed: Optional[str] = _find_output_health_verdict(manifest, manifest_dir)
+
+    if post_health_path:
+        resolved_post_health = _resolve_path(post_health_path)
+    else:
+        resolved_post_health = derive_post_health_path(resolved_manifest)
+
+    post_doc, post_err = _load_json(resolved_post_health)
+    post_emit_health_status: Optional[str] = None
+    if isinstance(post_doc, dict):
+        raw_status = post_doc.get("status")
+        if isinstance(raw_status, str) and raw_status in _POST_STATUSES:
+            post_emit_health_status = raw_status
+        else:
+            warnings.append("post_emit_health report has no recognized status")
+        observed = post_doc.get("output_health_verdict")
+        if isinstance(observed, str):
+            output_health_verdict_observed = observed
+    else:
+        if post_err is not None:
+            warnings.append(f"post_emit_health unavailable: {post_err}")
+
+    status = "pass"
+
+    if agent_facing:
+        if post_doc is None:
+            status = "blocked"
+            errors.append("agent-facing export requires readable post_emit_health")
+        elif post_emit_health_status == "blocked":
+            status = "blocked"
+            errors.append("post_emit_health status is blocked")
+        elif post_emit_health_status == "fail":
+            status = "fail"
+            errors.append("post_emit_health status is fail")
+        elif post_emit_health_status != "pass":
+            status = "fail"
+            errors.append("agent-facing export requires post_emit_health status pass")
+
+        if redaction_required and redaction_enabled is not True:
+            status = "fail" if status != "blocked" else status
+            errors.append("agent-facing export requires capabilities.redaction=true")
+    else:
+        if profile is None:
+            warnings.append("no profile provided; treated as non-agent-facing")
+        elif profile not in _AGENT_FACING_PROFILES and profile not in {
+            "human_review",
+            "ui_navigation",
+            "lookup_minimal",
+            "review_context",
+            "local",
+        }:
+            warnings.append(f"unknown profile '{profile}' treated as non-agent-facing")
+
+        warnings.append(
+            "non-agent-facing profile result does not certify agent-surface export"
+        )
+
+    if output_health_verdict_observed == "pass" and (
+        post_doc is None or post_emit_health_status != "pass"
+    ):
+        warnings.append(
+            "output_health.verdict=pass observed but not sufficient for export gate"
+        )
+
+    return {
+        "kind": KIND,
+        "version": VERSION,
+        "status": status,
+        "profile": profile,
+        "agent_facing": agent_facing,
+        "checked_at": _now_iso(),
+        "bundle_manifest_path": str(resolved_manifest),
+        "post_emit_health_status": post_emit_health_status,
+        "output_health_verdict_observed": output_health_verdict_observed,
+        "redaction_required": redaction_required,
+        "redaction_enabled": redaction_enabled,
+        "errors": errors,
+        "warnings": warnings,
+        "does_not_mean": list(_DOES_NOT_MEAN),
+    }

--- a/merger/lenskit/core/agent_export_gate.py
+++ b/merger/lenskit/core/agent_export_gate.py
@@ -155,20 +155,18 @@ def _validate_post_health_binding(
         return f"post_emit_health has invalid status: {status!r}"
 
     manifest_path_value = post_doc.get("bundle_manifest_path")
-    if isinstance(manifest_path_value, str) and manifest_path_value:
-        resolved_post_manifest = _resolve_path(manifest_path_value)
-        if resolved_post_manifest != resolved_manifest:
-            return "post_emit_health bundle_manifest_path does not match the evaluated manifest"
+    if not isinstance(manifest_path_value, str) or not manifest_path_value.strip():
+        return "post_emit_health bundle_manifest_path is missing or empty"
 
+    resolved_post_manifest = _resolve_path(manifest_path_value.strip())
+    if resolved_post_manifest != resolved_manifest:
+        return "post_emit_health bundle_manifest_path does not match the evaluated manifest"
+
+    status = post_doc.get("status")
     post_bundle_run_id = post_doc.get("bundle_run_id")
-    if (
-        isinstance(manifest_run_id, str)
-        and manifest_run_id
-        and isinstance(post_bundle_run_id, str)
-        and post_bundle_run_id
-        and post_bundle_run_id != manifest_run_id
-    ):
-        return "post_emit_health bundle_run_id does not match manifest run_id"
+    if status == "pass" and isinstance(manifest_run_id, str) and manifest_run_id:
+        if post_bundle_run_id != manifest_run_id:
+            return "post_emit_health bundle_run_id does not match manifest run_id"
 
     schema_error = _validate_post_health_schema(post_doc)
     if schema_error is not None:

--- a/merger/lenskit/core/agent_export_gate.py
+++ b/merger/lenskit/core/agent_export_gate.py
@@ -21,16 +21,28 @@ from typing import Any, Dict, Optional, Tuple
 from .clock import now_utc
 from .post_emit_health import derive_post_health_path
 
+try:
+    import jsonschema
+except ImportError:  # optional runtime dependency
+    jsonschema = None
+
 KIND = "lenskit.agent_export_gate"
 VERSION = "1.0"
 
 _BUNDLE_KIND = "repolens.bundle.manifest"
+_POST_HEALTH_KIND = "lenskit.post_emit_health"
+_POST_HEALTH_VERSION = "1.0"
 _POST_STATUSES = {"pass", "warn", "fail", "blocked"}
-_AGENT_FACING_PROFILES = {
-    "agent_minimal",
-    "agent_facing",
-    "agent",
+# A5-local profile policy derived from repository output_profile vocabulary.
+_AGENT_FACING_PROFILES = {"agent_minimal"}
+_NON_AGENT_PROFILES = {
+    "human_review",
+    "ui_navigation",
+    "lookup_minimal",
+    "review_context",
+    "local",
 }
+_KNOWN_PROFILES = _AGENT_FACING_PROFILES | _NON_AGENT_PROFILES
 
 _DOES_NOT_MEAN = [
     "repo_understood",
@@ -102,6 +114,69 @@ def _find_output_health_verdict(manifest: Dict[str, Any], manifest_dir: Path) ->
     return None
 
 
+def _validate_post_health_schema(post_doc: Dict[str, Any]) -> Optional[str]:
+    if jsonschema is None:
+        return None
+
+    schema_path = Path(__file__).parent.parent / "contracts" / "post-emit-health.v1.schema.json"
+    if not schema_path.exists():
+        return f"post_emit_health schema not found: {schema_path.name}"
+
+    try:
+        with schema_path.open("r", encoding="utf-8") as f:
+            schema = json.load(f)
+        jsonschema.validate(instance=post_doc, schema=schema)
+    except jsonschema.ValidationError as e:  # type: ignore[union-attr]
+        return f"post_emit_health schema validation failed: {e.message}"
+    except (OSError, json.JSONDecodeError) as e:
+        return f"could not load post_emit_health schema: {e}"
+    return None
+
+
+def _validate_post_health_binding(
+    post_doc: Dict[str, Any],
+    *,
+    resolved_manifest: Path,
+    manifest_run_id: Optional[str],
+) -> Optional[str]:
+    kind = post_doc.get("kind")
+    if kind != _POST_HEALTH_KIND:
+        return f"post_emit_health kind mismatch: expected {_POST_HEALTH_KIND!r} got {kind!r}"
+
+    version = post_doc.get("version")
+    if version != _POST_HEALTH_VERSION:
+        return (
+            "post_emit_health version mismatch: "
+            f"expected {_POST_HEALTH_VERSION!r} got {version!r}"
+        )
+
+    status = post_doc.get("status")
+    if not isinstance(status, str) or status not in _POST_STATUSES:
+        return f"post_emit_health has invalid status: {status!r}"
+
+    manifest_path_value = post_doc.get("bundle_manifest_path")
+    if isinstance(manifest_path_value, str) and manifest_path_value:
+        resolved_post_manifest = _resolve_path(manifest_path_value)
+        if resolved_post_manifest != resolved_manifest:
+            return "post_emit_health bundle_manifest_path does not match the evaluated manifest"
+
+    post_bundle_run_id = post_doc.get("bundle_run_id")
+    if (
+        isinstance(manifest_run_id, str)
+        and manifest_run_id
+        and isinstance(post_bundle_run_id, str)
+        and post_bundle_run_id
+        and post_bundle_run_id != manifest_run_id
+    ):
+        return "post_emit_health bundle_run_id does not match manifest run_id"
+
+    schema_error = _validate_post_health_schema(post_doc)
+    if schema_error is not None:
+        return schema_error
+
+    return None
+
+
 def evaluate_agent_export_gate(
     manifest_path: str,
     post_health_path: Optional[str] = None,
@@ -156,8 +231,12 @@ def evaluate_agent_export_gate(
         }
 
     manifest_dir = resolved_manifest.parent
+    manifest_run_id = manifest.get("run_id") if isinstance(manifest.get("run_id"), str) else None
+
+    profile_missing = profile is None
+    profile_unknown = isinstance(profile, str) and profile not in _KNOWN_PROFILES
     agent_facing = _is_agent_facing(profile)
-    redaction_required = bool(require_redaction and agent_facing)
+    redaction_required = True if agent_facing else False
 
     capabilities = manifest.get("capabilities") if isinstance(manifest.get("capabilities"), dict) else {}
     redaction_value = capabilities.get("redaction")
@@ -172,25 +251,40 @@ def evaluate_agent_export_gate(
 
     post_doc, post_err = _load_json(resolved_post_health)
     post_emit_health_status: Optional[str] = None
+    post_health_valid = False
     if isinstance(post_doc, dict):
-        raw_status = post_doc.get("status")
-        if isinstance(raw_status, str) and raw_status in _POST_STATUSES:
-            post_emit_health_status = raw_status
+        binding_error = _validate_post_health_binding(
+            post_doc,
+            resolved_manifest=resolved_manifest,
+            manifest_run_id=manifest_run_id,
+        )
+        if binding_error is not None:
+            warnings.append(binding_error)
         else:
-            warnings.append("post_emit_health report has no recognized status")
-        observed = post_doc.get("output_health_verdict")
-        if isinstance(observed, str):
-            output_health_verdict_observed = observed
+            post_health_valid = True
+            raw_status = post_doc.get("status")
+            if isinstance(raw_status, str):
+                post_emit_health_status = raw_status
+            observed = post_doc.get("output_health_verdict")
+            if isinstance(observed, str):
+                output_health_verdict_observed = observed
     else:
         if post_err is not None:
             warnings.append(f"post_emit_health unavailable: {post_err}")
 
     status = "pass"
 
+    if profile_missing:
+        status = "blocked"
+        errors.append("export gate requires an explicit profile")
+    elif profile_unknown:
+        status = "blocked"
+        errors.append(f"unknown export profile: {profile!r}")
+
     if agent_facing:
-        if post_doc is None:
+        if not post_health_valid:
             status = "blocked"
-            errors.append("agent-facing export requires readable post_emit_health")
+            errors.append("agent-facing export requires valid post_emit_health")
         elif post_emit_health_status == "blocked":
             status = "blocked"
             errors.append("post_emit_health status is blocked")
@@ -205,17 +299,6 @@ def evaluate_agent_export_gate(
             status = "fail" if status != "blocked" else status
             errors.append("agent-facing export requires capabilities.redaction=true")
     else:
-        if profile is None:
-            warnings.append("no profile provided; treated as non-agent-facing")
-        elif profile not in _AGENT_FACING_PROFILES and profile not in {
-            "human_review",
-            "ui_navigation",
-            "lookup_minimal",
-            "review_context",
-            "local",
-        }:
-            warnings.append(f"unknown profile '{profile}' treated as non-agent-facing")
-
         warnings.append(
             "non-agent-facing profile result does not certify agent-surface export"
         )

--- a/merger/lenskit/tests/test_agent_export_gate.py
+++ b/merger/lenskit/tests/test_agent_export_gate.py
@@ -262,6 +262,22 @@ def test_agent_facing_post_emit_pass_empty_bundle_manifest_path_is_blocked(tmp_p
     assert report["status"] == "blocked"
 
 
+def test_agent_facing_post_emit_pass_mismatched_bundle_manifest_path_is_blocked(tmp_path):
+    manifest = _write_manifest(tmp_path, redaction=True)
+    post = _write_post_health(tmp_path, "pass")
+    doc = json.loads(post.read_text(encoding="utf-8"))
+    doc["bundle_manifest_path"] = str(tmp_path / "other.bundle.manifest.json")
+    post.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    assert report["status"] == "blocked"
+
+
 def test_agent_facing_post_emit_pass_missing_bundle_run_id_is_blocked(tmp_path):
     manifest = _write_manifest(tmp_path, redaction=True)
     post = _write_post_health(tmp_path, "pass")

--- a/merger/lenskit/tests/test_agent_export_gate.py
+++ b/merger/lenskit/tests/test_agent_export_gate.py
@@ -1,0 +1,214 @@
+import hashlib
+import json
+from pathlib import Path
+
+import jsonschema
+
+from merger.lenskit.core.agent_export_gate import evaluate_agent_export_gate
+
+
+_CONTRACTS_DIR = Path(__file__).parent.parent / "contracts"
+_SCHEMA_PATH = _CONTRACTS_DIR / "agent-export-gate.v1.schema.json"
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _write_manifest(
+    tmp_path: Path,
+    *,
+    redaction: bool,
+    include_output_health: bool = True,
+    output_health_verdict: str = "pass",
+) -> Path:
+    canonical = b"# repo: demo\n\nhello\n"
+    (tmp_path / "demo.md").write_bytes(canonical)
+
+    artifacts = [
+        {
+            "role": "canonical_md",
+            "path": "demo.md",
+            "content_type": "text/markdown",
+            "bytes": len(canonical),
+            "sha256": _sha256(canonical),
+            "authority": "canonical_content",
+            "canonicality": "content_source",
+            "interpretation": {"mode": "role_only"},
+        }
+    ]
+
+    if include_output_health:
+        output_doc = {
+            "kind": "lenskit.output_health",
+            "version": "1.0",
+            "run_id": "run-1",
+            "created_at": "2026-05-23T00:00:00Z",
+            "stem": "demo",
+            "checks": {},
+            "diagnostic_artifacts": {},
+            "warnings": [],
+            "errors": [],
+            "verdict": output_health_verdict,
+        }
+        output_bytes = json.dumps(output_doc, indent=2).encode("utf-8")
+        (tmp_path / "demo.output_health.json").write_bytes(output_bytes)
+        artifacts.append(
+            {
+                "role": "output_health",
+                "path": "demo.output_health.json",
+                "content_type": "application/json",
+                "bytes": len(output_bytes),
+                "sha256": _sha256(output_bytes),
+                "authority": "diagnostic_signal",
+                "canonicality": "diagnostic",
+                "interpretation": {"mode": "role_only"},
+            }
+        )
+
+    manifest = {
+        "kind": "repolens.bundle.manifest",
+        "version": "1.0",
+        "run_id": "demo-run",
+        "created_at": "2026-05-23T00:00:00Z",
+        "generator": {"name": "test", "version": "1.0", "config_sha256": "a" * 64},
+        "artifacts": artifacts,
+        "links": {},
+        "capabilities": {"fts5_bm25": False, "redaction": redaction},
+    }
+    path = tmp_path / "demo.bundle.manifest.json"
+    path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    return path
+
+
+def _write_post_health(tmp_path: Path, status: str, *, observed_output_health: str = "pass") -> Path:
+    report = {
+        "kind": "lenskit.post_emit_health",
+        "version": "1.0",
+        "run_id": "post-run",
+        "bundle_run_id": "demo-run",
+        "checked_at": "2026-05-23T00:00:00Z",
+        "bundle_manifest_path": str(tmp_path / "demo.bundle.manifest.json"),
+        "status": status,
+        "checks": [],
+        "errors": [],
+        "warnings": [],
+        "does_not_mean": ["repo_understood", "answer_safe_without_citations"],
+        "independence_note": "output_health.verdict=pass does not imply post_emit_health.status=pass",
+        "artifact_count_checked": 0,
+        "hash_mismatch_count": 0,
+        "missing_artifact_count": 0,
+        "output_health_verdict": observed_output_health,
+    }
+    path = tmp_path / "demo.bundle_health.post.json"
+    path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    return path
+
+
+def test_agent_facing_pass_when_post_emit_pass_and_redaction_true(tmp_path):
+    manifest = _write_manifest(tmp_path, redaction=True)
+    _write_post_health(tmp_path, "pass")
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    assert report["status"] == "pass"
+    assert report["agent_facing"] is True
+    assert report["post_emit_health_status"] == "pass"
+    assert report["redaction_required"] is True
+    assert report["redaction_enabled"] is True
+
+
+def test_agent_facing_output_health_pass_but_missing_post_emit_not_pass(tmp_path):
+    manifest = _write_manifest(
+        tmp_path,
+        redaction=True,
+        include_output_health=True,
+        output_health_verdict="pass",
+    )
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    assert report["output_health_verdict_observed"] == "pass"
+    assert report["status"] in {"blocked", "fail"}
+    assert report["status"] != "pass"
+
+
+def test_agent_facing_fails_when_post_emit_fail(tmp_path):
+    manifest = _write_manifest(tmp_path, redaction=True)
+    _write_post_health(tmp_path, "fail")
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    assert report["status"] == "fail"
+    assert report["post_emit_health_status"] == "fail"
+
+
+def test_agent_facing_fails_when_redaction_required_but_disabled(tmp_path):
+    manifest = _write_manifest(tmp_path, redaction=False)
+    _write_post_health(tmp_path, "pass")
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    assert report["status"] == "fail"
+    assert report["redaction_required"] is True
+    assert report["redaction_enabled"] is False
+
+
+def test_non_agent_local_profile_does_not_claim_agent_certification(tmp_path):
+    manifest = _write_manifest(tmp_path, redaction=False)
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="local",
+        require_redaction=True,
+    )
+
+    assert report["status"] == "pass"
+    assert report["agent_facing"] is False
+    assert report["redaction_required"] is False
+    assert any("does not certify agent-surface export" in w for w in report["warnings"])
+
+
+def test_agent_export_gate_validates_against_schema(tmp_path):
+    manifest = _write_manifest(tmp_path, redaction=True)
+    _write_post_health(tmp_path, "pass")
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.validate(instance=report, schema=schema)
+
+
+def test_agent_export_gate_does_not_mutate_manifest(tmp_path):
+    manifest = _write_manifest(tmp_path, redaction=True)
+    _write_post_health(tmp_path, "pass")
+    before = manifest.read_text(encoding="utf-8")
+
+    _ = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    after = manifest.read_text(encoding="utf-8")
+    assert after == before

--- a/merger/lenskit/tests/test_agent_export_gate.py
+++ b/merger/lenskit/tests/test_agent_export_gate.py
@@ -22,6 +22,8 @@ def _write_manifest(
     redaction: bool,
     include_output_health: bool = True,
     output_health_verdict: str = "pass",
+    output_health_path: str = "demo.output_health.json",
+    run_id: object = "demo-run",
 ) -> Path:
     canonical = b"# repo: demo\n\nhello\n"
     (tmp_path / "demo.md").write_bytes(canonical)
@@ -53,11 +55,13 @@ def _write_manifest(
             "verdict": output_health_verdict,
         }
         output_bytes = json.dumps(output_doc, indent=2).encode("utf-8")
-        (tmp_path / "demo.output_health.json").write_bytes(output_bytes)
+        output_file = tmp_path / output_health_path
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        output_file.write_bytes(output_bytes)
         artifacts.append(
             {
                 "role": "output_health",
-                "path": "demo.output_health.json",
+            "path": output_health_path,
                 "content_type": "application/json",
                 "bytes": len(output_bytes),
                 "sha256": _sha256(output_bytes),
@@ -70,19 +74,22 @@ def _write_manifest(
     manifest = {
         "kind": "repolens.bundle.manifest",
         "version": "1.0",
-        "run_id": "demo-run",
         "created_at": "2026-05-23T00:00:00Z",
         "generator": {"name": "test", "version": "1.0", "config_sha256": "a" * 64},
         "artifacts": artifacts,
         "links": {},
         "capabilities": {"fts5_bm25": False, "redaction": redaction},
     }
+    if run_id is not ...:
+        manifest["run_id"] = run_id
     path = tmp_path / "demo.bundle.manifest.json"
     path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
     return path
 
 
-def _write_post_health(tmp_path: Path, status: str, *, observed_output_health: str = "pass") -> Path:
+def _write_post_health(
+    tmp_path: Path, status: str, *, observed_output_health: str | None = "pass"
+) -> Path:
     report = {
         "kind": "lenskit.post_emit_health",
         "version": "1.0",
@@ -99,8 +106,9 @@ def _write_post_health(tmp_path: Path, status: str, *, observed_output_health: s
         "artifact_count_checked": 0,
         "hash_mismatch_count": 0,
         "missing_artifact_count": 0,
-        "output_health_verdict": observed_output_health,
     }
+    if observed_output_health is not None:
+        report["output_health_verdict"] = observed_output_health
     path = tmp_path / "demo.bundle_health.post.json"
     path.write_text(json.dumps(report, indent=2), encoding="utf-8")
     return path
@@ -165,6 +173,34 @@ def test_unknown_profile_is_blocked(tmp_path):
     assert any("unknown export profile" in e for e in report["errors"])
 
 
+def test_agent_facing_blocks_when_manifest_run_id_missing(tmp_path):
+    manifest = _write_manifest(tmp_path, redaction=True, run_id=...)
+    _write_post_health(tmp_path, "pass")
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    assert report["status"] == "blocked"
+    assert any("manifest run_id" in e for e in report["errors"])
+
+
+def test_agent_facing_blocks_when_manifest_run_id_empty(tmp_path):
+    manifest = _write_manifest(tmp_path, redaction=True, run_id="")
+    _write_post_health(tmp_path, "pass")
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    assert report["status"] == "blocked"
+    assert any("manifest run_id" in e for e in report["errors"])
+
+
 def test_agent_facing_output_health_pass_but_missing_post_emit_not_pass(tmp_path):
     manifest = _write_manifest(
         tmp_path,
@@ -182,6 +218,32 @@ def test_agent_facing_output_health_pass_but_missing_post_emit_not_pass(tmp_path
     assert report["output_health_verdict_observed"] == "pass"
     assert report["status"] in {"blocked", "fail"}
     assert report["status"] != "pass"
+
+
+def test_output_health_observation_does_not_read_outside_bundle(tmp_path):
+    outside_doc = {
+        "kind": "lenskit.output_health",
+        "version": "1.0",
+        "verdict": "pass",
+    }
+    outside_path = tmp_path.parent / "outside.output_health.json"
+    outside_path.write_text(json.dumps(outside_doc, indent=2), encoding="utf-8")
+
+    manifest = _write_manifest(
+        tmp_path,
+        redaction=True,
+        output_health_path="../outside.output_health.json",
+    )
+    _write_post_health(tmp_path, "pass", observed_output_health=None)
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    assert report["status"] == "pass"
+    assert report["output_health_verdict_observed"] is None
 
 
 def test_agent_facing_fails_when_post_emit_fail(tmp_path):
@@ -357,12 +419,12 @@ def test_agent_facing_fails_when_redaction_required_but_disabled(tmp_path):
     assert report["redaction_enabled"] is False
 
 
-def test_non_agent_local_profile_does_not_claim_agent_certification(tmp_path):
+def test_non_agent_human_review_profile_does_not_claim_agent_certification(tmp_path):
     manifest = _write_manifest(tmp_path, redaction=False)
 
     report = evaluate_agent_export_gate(
         manifest_path=str(manifest),
-        profile="local",
+        profile="human_review",
         require_redaction=True,
     )
 
@@ -372,11 +434,11 @@ def test_non_agent_local_profile_does_not_claim_agent_certification(tmp_path):
     assert any("does not certify agent-surface export" in w for w in report["warnings"])
 
 
-def test_non_agent_local_profile_stays_pass_when_require_redaction_false(tmp_path):
+def test_non_agent_human_review_stays_pass_when_require_redaction_false(tmp_path):
     manifest = _write_manifest(tmp_path, redaction=False)
     report = evaluate_agent_export_gate(
         manifest_path=str(manifest),
-        profile="local",
+        profile="human_review",
         require_redaction=False,
     )
     assert report["status"] == "pass"

--- a/merger/lenskit/tests/test_agent_export_gate.py
+++ b/merger/lenskit/tests/test_agent_export_gate.py
@@ -3,6 +3,7 @@ import json
 from pathlib import Path
 
 import jsonschema
+import pytest
 
 from merger.lenskit.core.agent_export_gate import evaluate_agent_export_gate
 
@@ -122,6 +123,34 @@ def test_agent_facing_pass_when_post_emit_pass_and_redaction_true(tmp_path):
     assert report["redaction_enabled"] is True
 
 
+def test_missing_profile_is_blocked(tmp_path):
+    manifest = _write_manifest(tmp_path, redaction=True)
+    _write_post_health(tmp_path, "pass")
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile=None,
+        require_redaction=True,
+    )
+
+    assert report["status"] == "blocked"
+    assert any("explicit profile" in e for e in report["errors"])
+
+
+def test_unknown_profile_is_blocked(tmp_path):
+    manifest = _write_manifest(tmp_path, redaction=True)
+    _write_post_health(tmp_path, "pass")
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_portable",
+        require_redaction=True,
+    )
+
+    assert report["status"] == "blocked"
+    assert any("unknown export profile" in e for e in report["errors"])
+
+
 def test_agent_facing_output_health_pass_but_missing_post_emit_not_pass(tmp_path):
     manifest = _write_manifest(
         tmp_path,
@@ -155,6 +184,70 @@ def test_agent_facing_fails_when_post_emit_fail(tmp_path):
     assert report["post_emit_health_status"] == "fail"
 
 
+def test_agent_facing_invalid_post_emit_kind_is_blocked(tmp_path):
+    manifest = _write_manifest(tmp_path, redaction=True)
+    post = _write_post_health(tmp_path, "pass")
+    doc = json.loads(post.read_text(encoding="utf-8"))
+    doc["kind"] = "lenskit.output_health"
+    post.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    assert report["status"] == "blocked"
+
+
+def test_agent_facing_invalid_post_emit_version_is_blocked(tmp_path):
+    manifest = _write_manifest(tmp_path, redaction=True)
+    post = _write_post_health(tmp_path, "pass")
+    doc = json.loads(post.read_text(encoding="utf-8"))
+    doc["version"] = "2.0"
+    post.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    assert report["status"] == "blocked"
+
+
+def test_agent_facing_invalid_post_emit_schema_is_blocked(tmp_path):
+    manifest = _write_manifest(tmp_path, redaction=True)
+    post = _write_post_health(tmp_path, "pass")
+    doc = json.loads(post.read_text(encoding="utf-8"))
+    doc["does_not_mean"] = ["repo_understood"]
+    post.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    assert report["status"] == "blocked"
+
+
+def test_agent_facing_post_emit_bundle_run_id_mismatch_is_blocked(tmp_path):
+    manifest = _write_manifest(tmp_path, redaction=True)
+    post = _write_post_health(tmp_path, "pass")
+    doc = json.loads(post.read_text(encoding="utf-8"))
+    doc["bundle_run_id"] = "different-run"
+    post.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    assert report["status"] == "blocked"
+
+
 def test_agent_facing_fails_when_redaction_required_but_disabled(tmp_path):
     manifest = _write_manifest(tmp_path, redaction=False)
     _write_post_health(tmp_path, "pass")
@@ -185,6 +278,16 @@ def test_non_agent_local_profile_does_not_claim_agent_certification(tmp_path):
     assert any("does not certify agent-surface export" in w for w in report["warnings"])
 
 
+def test_non_agent_local_profile_stays_pass_when_require_redaction_false(tmp_path):
+    manifest = _write_manifest(tmp_path, redaction=False)
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="local",
+        require_redaction=False,
+    )
+    assert report["status"] == "pass"
+
+
 def test_agent_export_gate_validates_against_schema(tmp_path):
     manifest = _write_manifest(tmp_path, redaction=True)
     _write_post_health(tmp_path, "pass")
@@ -197,6 +300,22 @@ def test_agent_export_gate_validates_against_schema(tmp_path):
 
     schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
     jsonschema.validate(instance=report, schema=schema)
+
+
+def test_schema_rejects_does_not_mean_without_claims_true(tmp_path):
+    manifest = _write_manifest(tmp_path, redaction=True)
+    _write_post_health(tmp_path, "pass")
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    bad = dict(report)
+    bad["does_not_mean"] = ["repo_understood", "answer_safe_without_citations"]
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=bad, schema=schema)
 
 
 def test_agent_export_gate_does_not_mutate_manifest(tmp_path):

--- a/merger/lenskit/tests/test_agent_export_gate.py
+++ b/merger/lenskit/tests/test_agent_export_gate.py
@@ -123,6 +123,20 @@ def test_agent_facing_pass_when_post_emit_pass_and_redaction_true(tmp_path):
     assert report["redaction_enabled"] is True
 
 
+def test_agent_facing_post_emit_pass_bound_manifest_and_run_id_passes(tmp_path):
+    manifest = _write_manifest(tmp_path, redaction=True)
+    _write_post_health(tmp_path, "pass")
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    assert report["status"] == "pass"
+    assert report["post_emit_health_status"] == "pass"
+
+
 def test_missing_profile_is_blocked(tmp_path):
     manifest = _write_manifest(tmp_path, redaction=True)
     _write_post_health(tmp_path, "pass")
@@ -221,6 +235,70 @@ def test_agent_facing_invalid_post_emit_schema_is_blocked(tmp_path):
     post = _write_post_health(tmp_path, "pass")
     doc = json.loads(post.read_text(encoding="utf-8"))
     doc["does_not_mean"] = ["repo_understood"]
+    post.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    assert report["status"] == "blocked"
+
+
+def test_agent_facing_post_emit_pass_empty_bundle_manifest_path_is_blocked(tmp_path):
+    manifest = _write_manifest(tmp_path, redaction=True)
+    post = _write_post_health(tmp_path, "pass")
+    doc = json.loads(post.read_text(encoding="utf-8"))
+    doc["bundle_manifest_path"] = ""
+    post.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    assert report["status"] == "blocked"
+
+
+def test_agent_facing_post_emit_pass_missing_bundle_run_id_is_blocked(tmp_path):
+    manifest = _write_manifest(tmp_path, redaction=True)
+    post = _write_post_health(tmp_path, "pass")
+    doc = json.loads(post.read_text(encoding="utf-8"))
+    doc.pop("bundle_run_id", None)
+    post.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    assert report["status"] == "blocked"
+
+
+def test_agent_facing_post_emit_pass_null_bundle_run_id_is_blocked(tmp_path):
+    manifest = _write_manifest(tmp_path, redaction=True)
+    post = _write_post_health(tmp_path, "pass")
+    doc = json.loads(post.read_text(encoding="utf-8"))
+    doc["bundle_run_id"] = None
+    post.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    assert report["status"] == "blocked"
+
+
+def test_agent_facing_post_emit_pass_empty_bundle_run_id_is_blocked(tmp_path):
+    manifest = _write_manifest(tmp_path, redaction=True)
+    post = _write_post_health(tmp_path, "pass")
+    doc = json.loads(post.read_text(encoding="utf-8"))
+    doc["bundle_run_id"] = ""
     post.write_text(json.dumps(doc, indent=2), encoding="utf-8")
 
     report = evaluate_agent_export_gate(

--- a/merger/lenskit/tests/test_cli_bundle_health.py
+++ b/merger/lenskit/tests/test_cli_bundle_health.py
@@ -56,6 +56,30 @@ def _make_bundle(tmp_path: Path, *, include_pack: bool = True) -> Path:
     return manifest_path
 
 
+def _write_post_health(tmp_path: Path, status: str = "pass") -> Path:
+    report = {
+        "kind": "lenskit.post_emit_health",
+        "version": "1.0",
+        "run_id": "post-run",
+        "bundle_run_id": "cli-bh-run",
+        "checked_at": "2026-05-23T00:00:00Z",
+        "bundle_manifest_path": str(tmp_path / "demo.bundle.manifest.json"),
+        "status": status,
+        "checks": [],
+        "errors": [],
+        "warnings": [],
+        "does_not_mean": ["repo_understood", "answer_safe_without_citations"],
+        "independence_note": "output_health.verdict=pass does not imply post_emit_health.status=pass",
+        "artifact_count_checked": 0,
+        "hash_mismatch_count": 0,
+        "missing_artifact_count": 0,
+        "output_health_verdict": "pass",
+    }
+    out = tmp_path / "demo.bundle_health.post.json"
+    out.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    return out
+
+
 def test_bundle_health_post_cli_json(tmp_path, capsys):
     manifest = _make_bundle(tmp_path)
     rc = main(["bundle-health", "post", str(manifest), "--json"])
@@ -129,3 +153,48 @@ def test_bundle_health_post_cli_fail_hash_mismatch(tmp_path, capsys):
     report = json.loads(capsys.readouterr().out)
     assert report["status"] == "fail"
     assert report["hash_mismatch_count"] >= 1
+
+
+def test_bundle_health_export_gate_cli_json(tmp_path, capsys):
+    manifest = _make_bundle(tmp_path)
+    _write_post_health(tmp_path, status="pass")
+
+    # Flip manifest capability redaction to true so strict agent gate can pass.
+    data = json.loads(manifest.read_text(encoding="utf-8"))
+    data["capabilities"]["redaction"] = True
+    manifest.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+    rc = main(
+        [
+            "bundle-health",
+            "export-gate",
+            str(manifest),
+            "--profile",
+            "agent_minimal",
+            "--json",
+        ]
+    )
+    assert rc == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["kind"] == "lenskit.agent_export_gate"
+    assert report["status"] == "pass"
+    assert report["agent_facing"] is True
+
+
+def test_bundle_health_export_gate_cli_human_states_observation_only(tmp_path, capsys):
+    manifest = _make_bundle(tmp_path)
+
+    rc = main(
+        [
+            "bundle-health",
+            "export-gate",
+            str(manifest),
+            "--profile",
+            "agent_minimal",
+        ]
+    )
+    out = capsys.readouterr().out
+    assert rc in (1, 2)
+    assert "Agent Export Gate:" in out
+    assert "output_health_verdict:" in out
+    assert "(observation only)" in out

--- a/merger/lenskit/tests/test_cli_bundle_health.py
+++ b/merger/lenskit/tests/test_cli_bundle_health.py
@@ -5,6 +5,8 @@ import hashlib
 import json
 from pathlib import Path
 
+import pytest
+
 from merger.lenskit.cli.main import main
 
 
@@ -198,3 +200,18 @@ def test_bundle_health_export_gate_cli_human_states_observation_only(tmp_path, c
     assert "Agent Export Gate:" in out
     assert "output_health_verdict:" in out
     assert "(observation only)" in out
+
+
+def test_bundle_health_export_gate_cli_has_no_redaction_bypass_flag(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    with pytest.raises(SystemExit):
+        main(
+            [
+                "bundle-health",
+                "export-gate",
+                str(manifest),
+                "--profile",
+                "agent_minimal",
+                "--no-require-redaction",
+            ]
+        )


### PR DESCRIPTION
## These / Antithese / Synthese

**These:** Der Agent soll jetzt A5 als klar begrenztes Export-Gate umsetzen.
**Antithese:** Er darf daraus keine neue Agent-Safe-Wahrheitsmaschine bauen.
**Synthese:** Auftrag: **Gate vor Export**, nicht **Verdikt über Wahrheit**.

Kopierbare Anweisung:

```text
Implement PR A5: Agent Export Gate / Redaction Enforcement as a small, contract-first, diagnose-first PR.

Context:
A3/B3/A4 are already merged. The next step is not another evidence surface, but a hard guard preventing agent-facing export from relying on pre-emit output_health alone or from exporting unredacted bundles.

Goal:
Add a minimal export gate for agent-facing bundle/export profiles. The gate must enforce that agent-facing exports are only allowed when:
1. the final bundle surface has a passing post_emit_health result,
2. redaction/export policy is acceptable for the requested profile,
3. output_health.verdict is treated only as an observation and never as sufficient proof,
4. no manifest mutation or hidden registration happens as a side effect.

Important non-goals:
- Do not create an `agent_safe`, `agent_ready`, `safe`, or `unsafe` truth verdict.
- Do not redefine output_health.
- Do not implement A5 as redaction scanning itself unless a minimal policy check already has exact repo support.
- Do not implement claim_evidence_map.
- Do not add MCP, task packs, dashboard, monitor, agent handoff, or export packaging.
- Do not introduce supported/unsupported/true/false/proven claim language.
- Do not create a global epistemic/risk ontology.
- Do not mutate the bundle manifest as part of validation.

Diagnosis first:
Before coding, inspect and cite exact repo locations for:
- existing post_emit_health core and CLI,
- bundle manifest capability fields / redaction capability,
- output_health redaction reporting,
- profile/export vocabulary if any,
- existing tests around post_emit_health, output_health, bundle manifest, and agent pack.

Stop if the repo lacks enough concrete surface for a safe implementation. In that case, write a short proof note explaining the missing surface instead of guessing.

Preferred implementation shape:
1. Add a small core module, for example:
   `merger/lenskit/core/agent_export_gate.py`

2. Add a pure function, roughly:
   `evaluate_agent_export_gate(manifest_path, post_health_path=None, profile=None, require_redaction=True) -> dict`

3. The returned dict should be deterministic and machine-readable. Suggested fields:
   - kind: `lenskit.agent_export_gate`
   - version: `1.0`
   - status: `pass | fail | blocked`
   - profile
   - agent_facing: boolean
   - checked_at
   - bundle_manifest_path
   - post_emit_health_status
   - output_health_verdict_observed
   - redaction_required
   - redaction_enabled
   - errors
   - warnings
   - does_not_mean

4. Required semantics:
   - If profile is agent-facing and post_emit_health is missing or unreadable: `blocked`.
   - If post_emit_health.status is `blocked` or `fail`: `fail` or `blocked` according to the same precedence already used in post_emit_health. Keep this explicit and tested.
   - If output_health.verdict is `pass` but post_emit_health is absent/failing: gate must not pass.
   - If agent-facing and redaction is required but manifest capabilities show `redaction: false`: gate must fail.
   - If profile is non-agent-facing/local, redaction may be reported but must not silently imply agent-surface certification.
   - The result must clearly say that a pass does not mean `repo_understood`, `answer_safe_without_citations`, or `claims_true`.

5. CLI:
   Add a minimal CLI command only if it fits existing CLI patterns:
   `lenskit bundle-health export-gate <manifest> --profile <profile> [--post-health <path>] [--json]`

   Human output must visibly distinguish:
   - gate status,
   - profile,
   - whether profile is agent-facing,
   - redaction required/enabled,
   - post_emit_health status,
   - output_health verdict as observation only.

6. Schema:
   Add `agent-export-gate.v1.schema.json` only if the repo pattern supports this cleanly. Keep it local. No shared global risk schema.

Tests required:
- agent-facing profile + post_emit_health pass + redaction true => pass
- agent-facing profile + output_health pass but missing post_emit_health => blocked/fail, not pass
- agent-facing profile + post_emit_health fail => fail
- agent-facing profile + redaction false while required => fail
- non-agent/local profile + redaction false does not claim agent-surface certification
- result validates against schema if schema is added
- CLI JSON output is parseable if CLI is added
- CLI human output states output_health is observation only
- no manifest mutation

Validation commands:
Run at minimum:
ruff check --select=F401,F811 --exclude='**/fixtures/**' .
python3.11 -m pytest merger/lenskit/tests/test_post_emit_health.py merger/lenskit/tests/test_cli_bundle_health.py

Also run any new targeted tests added for the export gate.

If feasible, also run:
python3.11 -m pytest merger/lenskit/tests/test_output_health.py merger/lenskit/tests/test_bundle_manifest_integration.py

Documentation:
Add a short proof note only if useful, for example:
`docs/proofs/agent-export-gate-proof.md`

It must state:
- why output_health is insufficient,
- why post_emit_health is required,
- why redaction false blocks agent-facing export,
- what the gate does not mean,
- that no manifest mutation occurs.

Do not over-document. The PR should stay small.

Expected PR summary:
“Adds a minimal agent export gate that blocks agent-facing export unless final post_emit_health and redaction policy are acceptable, while preserving output_health as observation-only and avoiding any agent-safe truth verdict or manifest mutation.”
```

## Essenz

**Hebel:** Export wird blockierbar, ohne Wahrheit zu behaupten.
**Entscheidung:** A5 als kleiner Gate-PR.
**Nächste Aktion:** Agent mit obigem Prompt starten; bei fehlender Profiloberfläche erst Diagnose-Proof statt Patch.
