### PR TITLE
Implement Context Quality Signals diagnostic projection (PR B1)

### DIFF
--- a/docs/blueprints/lenskit-anti-hallucination-output-architecture.md
+++ b/docs/blueprints/lenskit-anti-hallucination-output-architecture.md
@@ -155,18 +155,33 @@ Arbeitspaket (AP), das er härtet, oder markiert sich als **neu**.
 
 ### Milestone B — Kontextqualität und Retrieval-Realismus
 
-#### PR B1 — Context Quality Signals  (scope: Projektion, kein neuer Wahrheitslayer)
+#### PR B1 — Context Quality Signals  (scope: Projektion, kein neuer Wahrheitslayer) — **UMGESETZT**
 - **Ziel:** Kontextbedingungen transparent machen — **keine** globale Verstehensampel.
-- **Repo-Befund:** überlappt `docs/architecture/artifact-evidence-levels.md`; kein `context_quality.json`.
-- **Änderung:** `<stem>.context_quality.json` als **Projektion** vorhandener Signale
-  (Health-Checks + erreichter Evidence-Level + Retrieval-Diagnose), `authority:
-  diagnostic_signal`, `risk_class: diagnostic`, mit `agent_use_constraints` und
-  `does_not_mean: [repo_understood, retrieval_complete, …]`. **Kein**
-  `understanding_health`, **kein** Gesamt-Score.
-- **Nicht-Ziele:** Keine neue Bewertung; keine Aggregation zu einer Ampel.
-- **Akzeptanz:** Lint (C2) findet keinen globalen Verstehens-Verdict.
-- **Tests:** `test_context_quality_has_no_global_understanding_verdict`,
-  `test_context_quality_is_projection_of_existing_signals`.
+- **Repo-Befund (Stand nach B1):** `context_quality` ist umgesetzt; `<stem>.context_quality.json`
+  überlappt bewusst nicht `docs/architecture/artifact-evidence-levels.md`, sondern **projiziert**
+  den dort definierten erreichten Evidence-Level (aus `post_emit_health`) zusammen mit weiteren
+  vorhandenen Signalen. (Frühere Annahme „kein `context_quality.json`" ist überholt.)
+- **Ergebnis (PR B1 umgesetzt: Schema/Core/CLI/Tests/Proof additiv):**
+  - `merger/lenskit/contracts/context-quality.v1.schema.json` (neuer lokaler Contract).
+  - `merger/lenskit/core/context_quality.py` — `compute_context_quality` (rein) +
+    `write_context_quality` (optional persistierend, **keine** Manifest-Mutation/-Registrierung).
+  - `<stem>.context_quality.json` als **Projektion** vorhandener Signale (Manifest-Rollen +
+    `output_health`-Checks + `post_emit_health`-Status/Evidence-Level + `retrieval_eval`-Metriken
+    + optional `agent_export_gate`), `authority: diagnostic_signal`, `risk_class: diagnostic`, mit
+    `agent_use_constraints` und `does_not_mean: [repo_understood, retrieval_complete,
+    answer_safe_without_citations, claims_true]`. **Kein** `understanding_health`, **kein**
+    Gesamt-Score. Kopf-Feld ist `projection_status` (`complete|degraded|blocked`), **kein**
+    globaler Verdict.
+  - CLI `lenskit context-quality inspect <manifest> [--json] [--emit-artifact] [--output PATH]`.
+  - Tests: `merger/lenskit/tests/test_context_quality.py`,
+    `merger/lenskit/tests/test_cli_context_quality.py` (inkl. der benannten Invarianten
+    „has_no_global_understanding_verdict" und „is_projection_of_existing_signals" in
+    `test_named_blueprint_invariants`, plus Forbidden-Vocabulary-Walk).
+  - Beleg: `docs/proofs/context-quality-signals-proof.md`.
+- **Nicht-Ziele (eingehalten):** Keine neue Bewertung; keine Aggregation zu einer Ampel; keine
+  Claim-Wahrheit; **keine** B2 Miss-Klassifikation (bleibt separat).
+- **Akzeptanz:** Kein globaler Verstehens-Verdict im Artefakt (Negativtest grün); C2-Lint kann
+  später dieselbe Invariante erzwingen.
 - **Risiko:** Doppelung mit Evidence-Level — daher strikt als Projektion definiert.
 
 #### PR B2 — Retrieval Miss Taxonomy  (neu, über AP-Eval)

--- a/docs/proofs/anti-hallucination-capability-audit.md
+++ b/docs/proofs/anti-hallucination-capability-audit.md
@@ -47,7 +47,7 @@ Entscheidung: `reuse` · `harden` · `defer` · `resolve` · `delete`.
 | 17 | Anti-Hallucination Lint | MISSING (neu) | kein `anti_hallucination`/Lint-Producer im Repo | — (Schutzfehlen) | build (Kernhebel) | C2 |
 | 18 | `.lenskit/` repo-declared context | MISSING (neu) | kein `.lenskit/`-Verzeichnis | — | defer hinter A–C | D1–D3 |
 | 19 | Structural `repo_map.v1` | MISSING (neu) | `architecture_summary` existiert (Prosa/Diagnose), kein mechanischer `repo_map` | niedrig | defer | E1 |
-| 20 | Context Quality Signals (Artefakt) | MISSING (überlappt) | überlappt `docs/architecture/artifact-evidence-levels.md`; kein `context_quality.json` | mittel (globale "Verstehens"-Ampel wäre gefährlich) | defer + scope (Projektion, keine neue Wahrheit) | B1 |
+| 20 | Context Quality Signals (Artefakt) | DONE (war MISSING) | B1 umgesetzt: `merger/lenskit/core/context_quality.py` + `merger/lenskit/contracts/context-quality.v1.schema.json` erzeugen `<stem>.context_quality.json` als **Projektion** (kein neuer Wahrheitslayer). Beleg: `docs/proofs/context-quality-signals-proof.md` | mittel (globale "Verstehens"-Ampel wäre gefährlich) | umgesetzt als Projektion (kein `understanding_health`, kein Gesamt-Score) | B1 |
 | 21 | Retrieval Miss Taxonomy | MISSING (neu) | `merger/lenskit/retrieval/eval_core.py` + `merger/lenskit/contracts/retrieval-eval.v1.schema.json`; keine Miss-Taxonomie | mittel | build über bestehendem Eval | B2 |
 | 22 | Structural Architecture Signals | PARTIAL (überlappt) | `docs/blueprints/lenskit-output-optimierung-v1.md` AP G; `architecture_summary` | niedrig | in AP G falten, kein Parallelartefakt | E3 |
 | 23 | `excluded_noise` als Diagnose | MISSING | Exclusion ist heute **stumm** (`SKIP_DIRS`) | niedrig | optionales Diagnose-Artefakt | A2 |

--- a/docs/proofs/context-quality-signals-proof.md
+++ b/docs/proofs/context-quality-signals-proof.md
@@ -1,0 +1,134 @@
+# Context Quality Signals (`context_quality`) — Implementation Proof
+
+Status: Implementation note for roadmap **PR B1** (Context Quality Signals).
+Belegbasis: `docs/blueprints/lenskit-anti-hallucination-output-architecture.md` §3 (Milestone B, PR B1),
+`docs/architecture/artifact-evidence-levels.md`,
+`docs/proofs/anti-hallucination-capability-audit.md` (Zeile 20 / B1),
+`docs/proofs/post-emit-health-implementation-proof.md` (Vorbild für unregistrierte Diagnose-Artefakte).
+
+## 1. Diagnose (vor der Implementierung)
+
+- `git status --short` war sauber auf `claude/modest-bohr-SJJXj`.
+- `rg "context_quality|understanding_health|agent_use_constraints|does_not_mean|risk_class"`:
+  vor dieser PR existierten nur **Doku-Verweise** (Blueprint B1, Audit-Zeile 20), **kein**
+  `context_quality.json`, **kein** Core-Modul, **kein** Schema, **keine** CLI.
+- Bestehende Muster bestätigt und wiederverwendet: `core/output_health.py`,
+  `core/post_emit_health.py`, `core/agent_export_gate.py`, deren Schemas, `cli/cmd_bundle_health.py`,
+  `core/path_security.resolve_secure_path`, `core/post_emit_health.derive_post_health_path`.
+- Ergebnis: B1 existierte nicht — additiv neu gebaut (kein Duplikat).
+
+## 2. Kernaussage: was `context_quality` ist und was nicht
+
+`context_quality` ist eine **diagnostische Projektion** bereits vorhandener Signale
+(Manifest-Rollen-Verfügbarkeit, `output_health`-Checks, `post_emit_health`-Status / erreichter
+Evidence-Level, `retrieval_eval`-Metriken, optionales `agent_export_gate`-Ergebnis). Es ist
+ausdrücklich:
+
+- **kein** kanonischer Inhalt (kanonische Wahrheit bleibt `canonical_md`),
+- **kein** Verstehens-Verdict (kein `understanding_health`, kein Gesamt-Score),
+- **kein** Retrieval-Vollständigkeitsbeweis (Metriken sind mechanisch, nicht „complete"),
+- **kein** Antwort-Sicherheits-Gate (keine Aussage über antwort-sichere Nutzung),
+- **keine** Claim-Wahrheitsbewertung (keine Verdikte `supported/unsupported/true/false/proven`),
+- **kein** Ersatz für `output_health` oder `post_emit_health` — beide bleiben unverändert und
+  werden nur als Beobachtung projiziert.
+
+`authority` ist immer `diagnostic_signal`, `risk_class` immer `diagnostic`.
+
+## 3. Was gebaut wurde (additiv, lokal)
+
+- `merger/lenskit/contracts/context-quality.v1.schema.json` — neuer, lokaler Contract.
+- `merger/lenskit/core/context_quality.py` — Projektor: `compute_context_quality` (rein, keine
+  Writes) und `write_context_quality` (optional persistierend), plus
+  `derive_context_quality_path`.
+- `merger/lenskit/cli/cmd_context_quality.py` + Dispatch in `cli/main.py`:
+  `lenskit context-quality inspect <manifest> [--json] [--emit-artifact] [--output PATH]`.
+- Datei-Artefakt (nur bei `--emit-artifact`/`--output`): `<stem>.context_quality.json`.
+- Tests: `merger/lenskit/tests/test_context_quality.py`,
+  `merger/lenskit/tests/test_cli_context_quality.py`.
+- Diese Beweisnotiz: `docs/proofs/context-quality-signals-proof.md`.
+
+## 4. Naming-Disziplin: `projection_status`, kein globaler Verdict
+
+Das Kopf-Feld heißt **`projection_status`** mit Werten `complete | degraded | blocked`. Es
+beschreibt **ausschließlich** die Vollständigkeit der Projektion — nicht Kontextqualität, nicht
+Repository-Verstehen, nicht Antwortsicherheit:
+
+- `complete` — Manifest lesbar **und** alle projizierten Signalquellen verfügbar, ohne Warnungen.
+- `degraded` — Manifest lesbar, aber ≥1 optionale Signalquelle fehlt/ist invalide oder es gab
+  eine Warnung. Das ist der **erwartete Normalzustand** für minimale Bundles.
+- `blocked` — Manifest unlesbar/fehlend/kein JSON/kein `repolens.bundle.manifest`; es konnte
+  **keine** Projektion erstellt werden. Auch der `blocked`-Report ist schema-valide.
+
+Es gibt bewusst **kein** globales `status`-Feld. Die in der Anweisung vorgesehene Ausnahme
+(„falls top-level `status` unvermeidbar") war nicht nötig.
+
+## 5. Harte Grenzen (eingehalten)
+
+- **Reine Projektion, keine Inferenz:** `output_health.verdict` → `verdict_observed`
+  (Beobachtung). `post_emit_health.status` → `status_observed` (Projektion). Aus `output_health`
+  wird **nie** Post-Emit-Validität abgeleitet; aus `post_emit_health` **nie** Antwortsicherheit;
+  aus `retrieval_eval` **nie** Vollständigkeit; das `agent_export_gate` wird **nie** als
+  Claim-Wahrheit umgedeutet. Die Pflicht-Constraints (`agent_use_constraints`) und Disclaimer
+  (`does_not_mean`) sagen das maschinenlesbar.
+- **Verbotenes Vokabular:** keine Feldnamen/Verdikt-Werte `understanding_health`,
+  `understanding_score`, `context_score`, `agent_safe`, `agent_ready`, `safe`, `unsafe`,
+  `green`, `yellow`, `red`, `supported`, `unsupported`, `true`, `false`, `proven`, kein
+  aggregierter Score. `answer_safe_without_citations` erscheint **nur** in `does_not_mean`.
+  Negativtest: `test_no_global_understanding_or_safety_verdict` (geht den gesamten Report durch).
+- **Evidence-Vokabular wiederverwendet:** `evidence_level`/`evidence_levels_reached` stammen aus
+  `post_emit_health` und nutzen nur das bestehende Vokabular (`readable…forensic_strict`). Keine
+  neuen Level, kein `understanding_health`.
+- **Sichere Pfadauflösung:** manifest-deklarierte Artefakte werden über
+  `resolve_secure_path(manifest_dir, …)` aufgelöst (kein Directory-Traversal, keine absoluten
+  Pfade aus dem Manifest).
+- **Keine Manifest-Mutation, keine Registrierung:** `write_context_quality` schreibt nur die
+  Sidecar-Datei; das Bundle-Manifest wird **nicht** verändert und das Artefakt **nicht**
+  registriert. Tests: `test_write_persists_unregistered_without_mutating_manifest`,
+  `test_context_quality_cli_emit_artifact_does_not_mutate_manifest`. Manifest-Registrierung ist
+  in dieser PR **bewusst nicht** implementiert und bleibt einem späteren, explizit
+  registrierenden Schritt vorbehalten.
+- **B2 bleibt getrennt:** **PR B2 (Retrieval Miss Taxonomy) ist in dieser PR NICHT
+  implementiert.** Misses werden hier **nicht** klassifiziert; `retrieval_eval` wird nur
+  mechanisch projiziert. B2 bleibt ein separates, zukünftiges Arbeitspaket.
+- **Unverändert gelassen:** `output_health`, `post_emit_health`, `retrieval_eval`
+  (Scoring/Schema), `agent_export_gate`-Semantik, Redaction-Enforcement,
+  Manifest-Mutation/-Registrierung, MCP/Task-Pack/Dashboard/Monitor, Claim-Wahrheitsvokabular.
+
+## 6. Inventar / Contracts-Matrix: bewusst nicht erweitert (mit Begründung)
+
+`docs/architecture/artifact-inventory.md` und `docs/contracts/contracts-matrix.md` listen
+manifest-registrierte bzw. vertraglich getrackte Artefakte. Die unmittelbaren Vorbilder
+`post_emit_health` (PR A4) und `agent_export_gate` (PR A5) sind **unregistrierte
+Diagnose-Projektionen** und stehen **ebenfalls nicht** in diesen beiden Dokumenten. Da
+`context_quality` zur gleichen Klasse gehört (unregistriert, nicht im Manifest), folgt diese PR
+dem Präzedenzfall und erweitert Inventar/Matrix **nicht**. Das vermeidet Drift; die
+Roadmap-/Proof-Pflege bleibt der maßgebliche Tracker. (Anweisungskonform: „update inventory/matrix
+only if their current structure tracks this new artifact/contract".)
+
+## 7. Roadmap geprüft und aktualisiert
+
+- Geprüft: `docs/roadmap/lenskit-master-roadmap.md`,
+  `docs/blueprints/lenskit-anti-hallucination-output-architecture.md`,
+  `docs/architecture/artifact-evidence-levels.md`, `docs/architecture/artifact-inventory.md`,
+  `docs/contracts/contracts-matrix.md`.
+- Aktualisiert: Master-Roadmap (neuer B1-Status-Abschnitt: implementiert, Dateien, Validierung,
+  Nicht-Ziele, B2 separat) und Blueprint B1 (`UMGESETZT`, Repo-Befund nicht länger
+  „kein `context_quality.json`"). Der historische Audit-Eintrag (Zeile 20) erhält eine
+  Vorwärts-Notiz, damit kein Dokument still „kein `context_quality.json`" behauptet.
+
+## 8. Validierung
+
+```
+ruff check --select=F401,F811 --exclude='**/fixtures/**' .          # All checks passed!
+python3.11 -m pytest merger/lenskit/tests/test_context_quality.py \
+                     merger/lenskit/tests/test_cli_context_quality.py    # 24 passed
+python3.11 -m pytest merger/lenskit/tests/test_output_health.py \
+                     merger/lenskit/tests/test_post_emit_health.py \
+                     merger/lenskit/tests/test_cli_bundle_health.py \
+                     merger/lenskit/tests/test_bundle_manifest_integration.py  # 93 passed (keine Regression)
+```
+
+Forbidden-Vocabulary-Check: programmatisch über `test_no_global_understanding_or_safety_verdict`
+(walkt den gesamten Report: keine verbotenen Schlüssel/Verdikt-Werte, kein `*_score`,
+`answer_safe_without_citations` nur in `does_not_mean`) sowie per `rg` über die neuen
+Implementierungs-/Schema-/Doku-Dateien.

--- a/docs/roadmap/lenskit-master-roadmap.md
+++ b/docs/roadmap/lenskit-master-roadmap.md
@@ -292,4 +292,37 @@ PR 7 (Anti-Hallucination Output Architecture, docs-first):
 - Ziel: Output-/Beleg-Härtung risiko-getaktet vor neue Agentenintegrationen stellen; bestehende Arbeitspakete A–H härten statt duplizieren.
 - Epistemische Korrektur: keine Auto-Claim-Bewertung (`supported/unsupported`); Lenskit adressiert Belege, bewertet sie nicht (`docs/blueprints/lenskit-output-optimierung-v1.md` AP F angepasst).
 - Gate: keine neuen gated Integrationen (MCP/Task Pack/Dashboard) vor Anti-Hallucination-Lint + agent-safe Gate + `context_risk`-Pflicht.
-- Nächster Umsetzungs-PR: A1 (`TOP_FILES → TOP_CHUNK_SPANS` + `does_not_prove`-Block im Agent Reading Pack).
+- Umsetzungsstand Milestones A/B (Beleg: git log + Blueprint-Markierungen + Proofs):
+  A1 (Agent Reading Pack Begriffshärtung), A3 (Range-Ref v2), A4 (Post-emit Bundle Health),
+  A5 (Agent Export Gate / Redaction Enforcement) sind **UMGESETZT**. B1 (Context Quality
+  Signals) ist mit dieser PR **UMGESETZT** (Details unter PR 8). Nächster offener
+  Umsetzungs-PR: **B2 (Retrieval Miss Taxonomy)** — separat, nicht in B1 enthalten.
+
+PR 8 (Milestone B1 — Context Quality Signals): **UMGESETZT**
+- Scope: minimale, additive **diagnostische Projektion** vorhandener Signale; **kein** neuer
+  Wahrheitslayer. Beleg: `docs/proofs/context-quality-signals-proof.md`,
+  Blueprint `lenskit-anti-hallucination-output-architecture.md` §3 (B1).
+- Neue Dateien:
+  - `merger/lenskit/core/context_quality.py`
+  - `merger/lenskit/contracts/context-quality.v1.schema.json`
+  - `merger/lenskit/cli/cmd_context_quality.py` (Dispatch in `merger/lenskit/cli/main.py`)
+  - `merger/lenskit/tests/test_context_quality.py`
+  - `merger/lenskit/tests/test_cli_context_quality.py`
+  - `docs/proofs/context-quality-signals-proof.md`
+- Artefakt: `<stem>.context_quality.json` (`authority: diagnostic_signal`, `risk_class:
+  diagnostic`); Kopf-Feld `projection_status` (`complete|degraded|blocked`) = nur
+  Projektions-Vollständigkeit, **kein** globaler Verdict.
+- CLI: `lenskit context-quality inspect <manifest> [--json] [--emit-artifact] [--output PATH]`.
+- Nicht-Ziele (weiterhin aufrecht, bewusst aufgeschoben):
+  - **kein** globaler Verstehens-Verdict (kein `understanding_health`),
+  - **kein** aggregierter Score,
+  - **keine** Claim-Wahrheitsbewertung,
+  - **kein** Retrieval-Vollständigkeitsbeweis,
+  - **kein** Antwort-Sicherheits-Gate,
+  - **keine** Manifest-Mutation/-Registrierung (Artefakt bleibt unregistriert),
+  - **keine** B2 Retrieval Miss Taxonomy in dieser PR.
+- Validierung:
+  - `ruff check --select=F401,F811 --exclude='**/fixtures/**' .` (passed)
+  - `python3.11 -m pytest merger/lenskit/tests/test_context_quality.py merger/lenskit/tests/test_cli_context_quality.py` (24 passed)
+  - `python3.11 -m pytest merger/lenskit/tests/test_output_health.py merger/lenskit/tests/test_post_emit_health.py merger/lenskit/tests/test_cli_bundle_health.py merger/lenskit/tests/test_bundle_manifest_integration.py` (93 passed, keine Regression)
+- B2 bleibt **separates, zukünftiges** Arbeitspaket (Retrieval Miss Taxonomy; siehe Blueprint §3 B2).

--- a/merger/lenskit/cli/cmd_context_quality.py
+++ b/merger/lenskit/cli/cmd_context_quality.py
@@ -1,0 +1,123 @@
+import argparse
+import json
+import sys
+
+
+def register_context_quality_commands(subparsers) -> None:
+    cq_parser = subparsers.add_parser(
+        "context-quality",
+        help="Context quality diagnostic projection (not understanding, not answer safety)",
+    )
+    cq_subparsers = cq_parser.add_subparsers(
+        dest="context_quality_cmd", required=True, help="Context quality commands"
+    )
+
+    inspect_parser = cq_subparsers.add_parser(
+        "inspect",
+        help="Project existing context-quality signals for a bundle (diagnostic only)",
+    )
+    inspect_parser.add_argument(
+        "manifest", help="Path to the bundle manifest JSON"
+    )
+    inspect_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="emit_json",
+        help="Emit the machine-readable JSON report to stdout",
+    )
+    inspect_parser.add_argument(
+        "--emit-artifact",
+        action="store_true",
+        dest="emit_artifact",
+        help="Persist the report as <stem>.context_quality.json (unregistered; manifest is never mutated)",
+    )
+    inspect_parser.add_argument(
+        "--output",
+        dest="output_path",
+        default=None,
+        help="Explicit output path for the persisted artifact (implies --emit-artifact)",
+    )
+
+
+# degraded is a usable/expected state for minimal bundles, so it is not an error
+# exit. Only blocked (cannot project at all) returns a non-zero code.
+_EXIT_CODES = {"complete": 0, "degraded": 0, "blocked": 2}
+
+
+def run_context_quality_inspect(args: argparse.Namespace) -> int:
+    from merger.lenskit.core.context_quality import (
+        compute_context_quality,
+        write_context_quality,
+    )
+
+    manifest_path = args.manifest
+    output_path = getattr(args, "output_path", None)
+    emit_artifact = getattr(args, "emit_artifact", False) or output_path is not None
+
+    written_path = None
+    try:
+        if emit_artifact:
+            written_path, report = write_context_quality(manifest_path, output_path)
+        else:
+            report = compute_context_quality(manifest_path)
+    except Exception as e:  # noqa: BLE001 - surface unexpected failures cleanly
+        print(f"Error: unexpected failure during context-quality projection: {e}", file=sys.stderr)
+        return 2
+
+    if args.emit_json:
+        print(json.dumps(report, indent=2))
+    else:
+        _print_human_report(report, written_path)
+
+    return _EXIT_CODES.get(report["projection_status"], 1)
+
+
+def _print_human_report(report: dict, written_path=None) -> None:
+    print(f"Context Quality (diagnostic projection): {report['projection_status'].upper()}")
+    print(f"  bundle_manifest_path:    {report['bundle_manifest_path']}")
+    print(f"  bundle_run_id:           {report.get('bundle_run_id')}")
+    print(f"  run_id:                  {report['run_id']}")
+    print(f"  authority:               {report['authority']}")
+    print(f"  risk_class:              {report['risk_class']}")
+
+    signals = report.get("signals") or {}
+
+    manifest_sig = signals.get("manifest") or {}
+    key_roles = manifest_sig.get("key_roles") or {}
+    present = [role for role, ok in key_roles.items() if ok]
+    print(f"  manifest.key_roles:      {', '.join(present) or '—'}")
+
+    for name in ("output_health", "post_emit_health", "retrieval_eval", "agent_export_gate", "evidence"):
+        sig = signals.get(name) or {}
+        avail = sig.get("available")
+        extra = ""
+        if name == "output_health" and avail:
+            extra = f" verdict_observed={sig.get('verdict_observed')} (observation only)"
+        elif name == "post_emit_health" and avail:
+            extra = f" status_observed={sig.get('status_observed')} evidence_level={sig.get('evidence_level')}"
+        elif name == "agent_export_gate" and avail:
+            extra = f" status_observed={sig.get('status_observed')} (observation only)"
+        elif name == "evidence" and avail:
+            extra = f" evidence_level={sig.get('evidence_level')}"
+        print(f"  signal.{name}: available={avail}{extra}")
+
+    print(
+        "  NOTE: diagnostic projection only — NOT repository understanding, "
+        "NOT answer safety, NOT retrieval completeness, NOT claim truth."
+    )
+    print(f"  agent_use_constraints:   {', '.join(report.get('agent_use_constraints') or [])}")
+    print(f"  does_not_mean:           {', '.join(report.get('does_not_mean') or [])}")
+
+    if written_path is not None:
+        print(f"  written_artifact:        {written_path}")
+        print("  NOTE: written artifact is unregistered; manifest not mutated.")
+
+    if report.get("warnings"):
+        print(f"\nWarnings ({len(report['warnings'])}):")
+        for w in report["warnings"]:
+            print(f"  [warn] {w}")
+
+    if report.get("errors"):
+        print(f"\nErrors ({len(report['errors'])}):")
+        for e in report["errors"]:
+            print(f"  [error] {e}")

--- a/merger/lenskit/cli/main.py
+++ b/merger/lenskit/cli/main.py
@@ -30,6 +30,10 @@ def main(args: Optional[List[str]] = None) -> int:
     from .cmd_bundle_health import register_bundle_health_commands
     register_bundle_health_commands(subparsers)
 
+    # Context quality command (diagnostic projection)
+    from .cmd_context_quality import register_context_quality_commands
+    register_context_quality_commands(subparsers)
+
     # Federation command
     from .cmd_federation import register_federation_commands
     register_federation_commands(subparsers)
@@ -265,6 +269,13 @@ def main(args: Optional[List[str]] = None) -> int:
             return run_bundle_health_export_gate(parsed_args)
         else:
             parser.parse_args(["bundle-health", "--help"])
+            return 0
+    elif parsed_args.command == "context-quality":
+        from .cmd_context_quality import run_context_quality_inspect
+        if parsed_args.context_quality_cmd == "inspect":
+            return run_context_quality_inspect(parsed_args)
+        else:
+            parser.parse_args(["context-quality", "--help"])
             return 0
     elif parsed_args.command == "federation":
         from .cmd_federation import handle_federation_command

--- a/merger/lenskit/contracts/context-quality.v1.schema.json
+++ b/merger/lenskit/contracts/context-quality.v1.schema.json
@@ -1,0 +1,291 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://heimgewebe.local/schema/context-quality.v1.schema.json",
+  "title": "Context Quality Signals (context-quality v1.0)",
+  "description": "A machine-readable diagnostic PROJECTION of existing bundle, health, retrieval, and export-gate signals. It makes context conditions visible. It is not a truth source, not an understanding verdict, not a retrieval-completeness proof, not an answer-safety gate, not a global score, and not a claim judgment. authority is always diagnostic_signal and risk_class is always diagnostic.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "kind",
+    "version",
+    "run_id",
+    "checked_at",
+    "bundle_manifest_path",
+    "bundle_run_id",
+    "projection_status",
+    "authority",
+    "risk_class",
+    "signals",
+    "agent_use_constraints",
+    "does_not_mean",
+    "warnings",
+    "errors"
+  ],
+  "properties": {
+    "kind": {
+      "type": "string",
+      "const": "lenskit.context_quality"
+    },
+    "version": {
+      "type": "string",
+      "const": "1.0"
+    },
+    "run_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Unique id for this projection run (not the bundle run)."
+    },
+    "checked_at": {
+      "type": "string",
+      "description": "ISO 8601 UTC timestamp of the projection."
+    },
+    "bundle_manifest_path": {
+      "type": "string",
+      "description": "Absolute path to the projected bundle manifest."
+    },
+    "bundle_run_id": {
+      "type": ["string", "null"],
+      "description": "run_id of the projected bundle manifest, when available."
+    },
+    "projection_status": {
+      "type": "string",
+      "enum": ["complete", "degraded", "blocked"],
+      "description": "Projection completeness only; NOT context quality, NOT repository understanding, NOT answer safety. complete = manifest readable and every projected signal source was available without warnings. degraded = manifest readable but one or more optional signal sources were unavailable or produced a warning. blocked = the manifest could not be read or is not a repolens.bundle.manifest, so no projection could be made."
+    },
+    "authority": {
+      "type": "string",
+      "const": "diagnostic_signal",
+      "description": "This artifact warns; it does not prove."
+    },
+    "risk_class": {
+      "type": "string",
+      "const": "diagnostic"
+    },
+    "signals": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "manifest",
+        "output_health",
+        "post_emit_health",
+        "retrieval_eval",
+        "agent_export_gate",
+        "evidence"
+      ],
+      "properties": {
+        "manifest": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["available"],
+          "properties": {
+            "available": { "type": "boolean" },
+            "kind": { "type": ["string", "null"] },
+            "version": { "type": ["string", "null"] },
+            "run_id": { "type": ["string", "null"] },
+            "roles_present": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "key_roles": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "canonical_md",
+                "agent_reading_pack",
+                "chunk_index_jsonl",
+                "citation_map_jsonl",
+                "output_health",
+                "retrieval_eval_json",
+                "sqlite_index"
+              ],
+              "properties": {
+                "canonical_md": { "type": "boolean" },
+                "agent_reading_pack": { "type": "boolean" },
+                "chunk_index_jsonl": { "type": "boolean" },
+                "citation_map_jsonl": { "type": "boolean" },
+                "output_health": { "type": "boolean" },
+                "retrieval_eval_json": { "type": "boolean" },
+                "sqlite_index": { "type": "boolean" }
+              }
+            }
+          }
+        },
+        "output_health": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["available"],
+          "properties": {
+            "available": { "type": "boolean" },
+            "source": { "type": ["string", "null"] },
+            "reason": { "type": "string" },
+            "verdict_observed": {
+              "type": ["string", "null"],
+              "description": "Observed output_health.verdict (observation only; never inferred, never a context-quality verdict)."
+            },
+            "checks": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "canonical_md_hash_ok": { "type": ["boolean", "null"] },
+                "chunk_index_hash_ok": { "type": ["boolean", "null"] },
+                "sqlite_row_count_matches_chunk_count": { "type": ["boolean", "null"] },
+                "fts_content_non_empty": { "type": ["boolean", "null"] },
+                "range_ref_resolution_status": { "type": ["string", "null"] },
+                "redaction_status_explicit": { "type": ["boolean", "null"] },
+                "redact_secrets_enabled": { "type": ["boolean", "null"] }
+              }
+            }
+          }
+        },
+        "post_emit_health": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["available"],
+          "properties": {
+            "available": { "type": "boolean" },
+            "source": { "type": ["string", "null"] },
+            "reason": { "type": "string" },
+            "status_observed": {
+              "type": ["string", "null"],
+              "description": "Observed post_emit_health.status (projection only; never re-derived; never an answer-safety statement)."
+            },
+            "evidence_level": { "type": ["string", "null"] },
+            "evidence_levels_reached": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "does_not_mean": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          }
+        },
+        "retrieval_eval": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["available"],
+          "properties": {
+            "available": { "type": "boolean" },
+            "source": { "type": ["string", "null"] },
+            "reason": { "type": "string" },
+            "metrics": {
+              "type": ["object", "null"],
+              "additionalProperties": false,
+              "description": "Mechanical retrieval metrics projected as-is. Not a completeness proof.",
+              "properties": {
+                "recall@10": { "type": ["number", "null"] },
+                "MRR": { "type": ["number", "null"] },
+                "total_queries": { "type": ["integer", "null"] },
+                "hits": { "type": ["integer", "null"] },
+                "zero_hit_ratio": { "type": ["number", "null"] },
+                "stale_flag": { "type": ["boolean", "null"] }
+              }
+            },
+            "categories": {
+              "type": ["array", "null"],
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["category"],
+                "properties": {
+                  "category": { "type": "string" },
+                  "total_queries": { "type": ["integer", "null"] },
+                  "hits": { "type": ["integer", "null"] },
+                  "MRR": { "type": ["number", "null"] },
+                  "recall@10": { "type": ["number", "null"] }
+                }
+              }
+            }
+          }
+        },
+        "agent_export_gate": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["available"],
+          "properties": {
+            "available": { "type": "boolean" },
+            "source": { "type": ["string", "null"] },
+            "reason": { "type": "string" },
+            "status_observed": {
+              "type": ["string", "null"],
+              "description": "Observed export-gate result (observation only; never reinterpreted as claim truth or answer safety)."
+            },
+            "profile_observed": { "type": ["string", "null"] },
+            "agent_facing_observed": { "type": ["boolean", "null"] }
+          }
+        },
+        "evidence": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["available"],
+          "properties": {
+            "available": { "type": "boolean" },
+            "source": { "type": ["string", "null"] },
+            "evidence_level": {
+              "type": ["string", "null"],
+              "enum": [
+                "readable",
+                "navigable",
+                "citable",
+                "range_strict",
+                "searchable",
+                "diagnostic_full",
+                "forensic_strict",
+                null
+              ],
+              "description": "Reuses the existing evidence-level vocabulary (docs/architecture/artifact-evidence-levels.md). No new levels are invented."
+            },
+            "evidence_levels_reached": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "readable",
+                  "navigable",
+                  "citable",
+                  "range_strict",
+                  "searchable",
+                  "diagnostic_full",
+                  "forensic_strict"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "agent_use_constraints": {
+      "type": "array",
+      "items": { "type": "string" },
+      "minItems": 5,
+      "description": "How an agent must treat this projection. These are usage constraints, not verdicts.",
+      "allOf": [
+        { "contains": { "const": "verify_content_against_canonical_md" } },
+        { "contains": { "const": "cite_canonical_ranges_for_claims" } },
+        { "contains": { "const": "do_not_treat_context_quality_as_repo_understanding" } },
+        { "contains": { "const": "do_not_treat_retrieval_metrics_as_completeness_proof" } },
+        { "contains": { "const": "do_not_treat_export_gate_as_claim_truth" } }
+      ]
+    },
+    "does_not_mean": {
+      "type": "array",
+      "items": { "type": "string" },
+      "minItems": 4,
+      "description": "Disclaimers of what this projection deliberately does NOT establish. These are NOT claim verdicts.",
+      "allOf": [
+        { "contains": { "const": "repo_understood" } },
+        { "contains": { "const": "retrieval_complete" } },
+        { "contains": { "const": "answer_safe_without_citations" } },
+        { "contains": { "const": "claims_true" } }
+      ]
+    },
+    "warnings": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "errors": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/merger/lenskit/core/context_quality.py
+++ b/merger/lenskit/core/context_quality.py
@@ -80,6 +80,18 @@ _KEY_ROLES = (
     "sqlite_index",
 )
 
+# Evidence-level vocabulary from docs/architecture/artifact-evidence-levels.md.
+# Values outside this set received from optional inputs are filtered to null/dropped.
+_KNOWN_EVIDENCE_LEVELS = frozenset({
+    "readable",
+    "navigable",
+    "citable",
+    "range_strict",
+    "searchable",
+    "diagnostic_full",
+    "forensic_strict",
+})
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -105,7 +117,7 @@ def _load_json(path: Path) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
     try:
         with path.open("r", encoding="utf-8") as f:
             data = json.load(f)
-    except (OSError, json.JSONDecodeError) as e:
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError) as e:
         return None, str(e)
     if not isinstance(data, dict):
         return None, "JSON root must be an object"
@@ -342,15 +354,32 @@ def _project_agent_export_gate(
     }
 
 
-def _project_evidence(post_emit_signal: Dict[str, Any]) -> Dict[str, Any]:
+def _project_evidence(post_emit_signal: Dict[str, Any], warnings: List[str]) -> Dict[str, Any]:
     # Evidence reuses the existing evidence-level vocabulary surfaced by
     # post_emit_health. It never invents new levels and never aggregates a score.
+    # Unknown values from an optional (possibly corrupted) sidecar are filtered
+    # to null/dropped with a warning to keep this report schema-valid.
     if post_emit_signal.get("available"):
+        raw_level = post_emit_signal.get("evidence_level")
+        if raw_level is not None and raw_level not in _KNOWN_EVIDENCE_LEVELS:
+            warnings.append(
+                f"post_emit_health evidence_level {raw_level!r} is not in known vocabulary; set to null"
+            )
+            raw_level = None
+
+        raw_reached = list(post_emit_signal.get("evidence_levels_reached") or [])
+        known_reached = [lvl for lvl in raw_reached if lvl in _KNOWN_EVIDENCE_LEVELS]
+        dropped = [lvl for lvl in raw_reached if lvl not in _KNOWN_EVIDENCE_LEVELS]
+        if dropped:
+            warnings.append(
+                f"post_emit_health evidence_levels_reached contained unknown values (dropped): {dropped!r}"
+            )
+
         return {
             "available": True,
             "source": "post_emit_health",
-            "evidence_level": post_emit_signal.get("evidence_level"),
-            "evidence_levels_reached": list(post_emit_signal.get("evidence_levels_reached") or []),
+            "evidence_level": raw_level,
+            "evidence_levels_reached": known_reached,
         }
     return {
         "available": False,
@@ -510,7 +539,7 @@ def compute_context_quality(
         retrieval_eval_path, by_role, manifest_dir, warnings
     )
     export_gate_signal = _project_agent_export_gate(agent_export_gate_path, warnings)
-    evidence_signal = _project_evidence(post_emit_signal)
+    evidence_signal = _project_evidence(post_emit_signal, warnings)
 
     signals = {
         "manifest": manifest_signal,

--- a/merger/lenskit/core/context_quality.py
+++ b/merger/lenskit/core/context_quality.py
@@ -1,0 +1,577 @@
+"""
+Context Quality Signals projector for Lenskit bundles (roadmap PR B1).
+
+Computes a machine-readable diagnostic PROJECTION of signals that already exist
+in and around a bundle (manifest role availability, output_health checks,
+post_emit_health status / achieved evidence level, retrieval-eval metrics, and an
+optional agent export-gate result) and writes it as
+``<stem>.context_quality.json``.
+
+Design contract (deliberately small and additive):
+- This artifact is a projection, never a new truth layer. It is not a truth
+  source, not an understanding verdict, not a retrieval-completeness proof, not
+  an answer-safety gate, not a global score, and not a claim judgment.
+- ``authority`` is always ``diagnostic_signal`` and ``risk_class`` is always
+  ``diagnostic``.
+- The headline field is ``projection_status`` (``complete | degraded | blocked``),
+  which describes PROJECTION completeness only -- never context quality, never
+  repository understanding, never answer safety. There is intentionally no global
+  ``status`` verdict.
+- ``compute_context_quality`` performs no writes. ``write_context_quality``
+  writes ``<stem>.context_quality.json`` next to the manifest unless an explicit
+  output path is given, and never mutates or registers anything in the manifest.
+- Missing optional inputs produce unavailable/degraded signal entries, never a
+  crash. Invalid optional JSON produces a warning, never a fabricated value.
+- Signals are projected as observations only. output_health verdicts are never
+  used to infer post-emit validity; post_emit_health is never used to infer
+  answer safety; retrieval metrics are never treated as completeness; the export
+  gate is never reinterpreted as claim truth.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from .clock import now_utc
+from .path_security import resolve_secure_path
+from .post_emit_health import derive_post_health_path
+
+logger = logging.getLogger(__name__)
+
+KIND = "lenskit.context_quality"
+VERSION = "1.0"
+
+_BUNDLE_KIND = "repolens.bundle.manifest"
+_MANIFEST_SUFFIX = ".bundle.manifest.json"
+_CONTEXT_QUALITY_SUFFIX = ".context_quality.json"
+
+AUTHORITY = "diagnostic_signal"
+RISK_CLASS = "diagnostic"
+
+# What this projection deliberately does NOT establish (never claim verdicts).
+DOES_NOT_MEAN = (
+    "repo_understood",
+    "retrieval_complete",
+    "answer_safe_without_citations",
+    "claims_true",
+)
+
+# How an agent must treat this projection (usage constraints, not verdicts).
+AGENT_USE_CONSTRAINTS = (
+    "verify_content_against_canonical_md",
+    "cite_canonical_ranges_for_claims",
+    "do_not_treat_context_quality_as_repo_understanding",
+    "do_not_treat_retrieval_metrics_as_completeness_proof",
+    "do_not_treat_export_gate_as_claim_truth",
+)
+
+# Manifest roles whose presence we surface as a key-role availability map.
+_KEY_ROLES = (
+    "canonical_md",
+    "agent_reading_pack",
+    "chunk_index_jsonl",
+    "citation_map_jsonl",
+    "output_health",
+    "retrieval_eval_json",
+    "sqlite_index",
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _now_iso() -> str:
+    ts = now_utc()
+    if isinstance(ts, str):
+        return ts if ts.endswith("Z") else ts + "Z"
+    return ts.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _resolve_path(path_str: str) -> Path:
+    p = Path(path_str)
+    if not p.is_absolute():
+        p = Path.cwd() / p
+    return p.resolve()
+
+
+def _load_json(path: Path) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+    if not path.exists() or not path.is_file():
+        return None, "file not found"
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        return None, str(e)
+    if not isinstance(data, dict):
+        return None, "JSON root must be an object"
+    return data, None
+
+
+def _num_or_none(value: Any) -> Optional[float]:
+    if isinstance(value, bool):
+        return None
+    return value if isinstance(value, (int, float)) else None
+
+
+def _int_or_none(value: Any) -> Optional[int]:
+    if isinstance(value, bool):
+        return None
+    return value if isinstance(value, int) else None
+
+
+def _str_or_none(value: Any) -> Optional[str]:
+    return value if isinstance(value, str) else None
+
+
+def _bool_or_none(value: Any) -> Optional[bool]:
+    return value if isinstance(value, bool) else None
+
+
+def derive_context_quality_path(manifest_path: Path) -> Path:
+    """Derive ``<stem>.context_quality.json`` adjacent to the manifest."""
+    name = manifest_path.name
+    if name.endswith(_MANIFEST_SUFFIX):
+        stem = name[: -len(_MANIFEST_SUFFIX)]
+    else:
+        stem = manifest_path.stem
+    return manifest_path.parent / (stem + _CONTEXT_QUALITY_SUFFIX)
+
+
+def _resolve_signal_path(
+    explicit_path: Optional[str],
+    by_role: Optional[Dict[str, Dict[str, Any]]],
+    role: str,
+    manifest_dir: Path,
+) -> Tuple[Optional[Path], Optional[str], Optional[str]]:
+    """
+    Resolve where a signal artifact lives.
+
+    Returns ``(path, source, note)``. ``source`` is ``explicit_path`` or
+    ``manifest_role`` when a candidate was found, else ``None``. ``note`` carries
+    a non-fatal explanation (e.g. a rejected manifest path) for the caller to warn
+    about. Manifest-declared paths are resolved securely relative to the manifest
+    directory.
+    """
+    if explicit_path:
+        return _resolve_path(explicit_path), "explicit_path", None
+    if by_role is not None:
+        entry = by_role.get(role)
+        if isinstance(entry, dict) and isinstance(entry.get("path"), str) and entry["path"]:
+            try:
+                return resolve_secure_path(manifest_dir, entry["path"]), "manifest_role", None
+            except ValueError as e:
+                return None, "manifest_role", f"path rejected: {e}"
+    return None, None, None
+
+
+# ---------------------------------------------------------------------------
+# Per-signal projectors
+# ---------------------------------------------------------------------------
+
+def _project_output_health(
+    explicit_path: Optional[str],
+    by_role: Dict[str, Dict[str, Any]],
+    manifest_dir: Path,
+    warnings: List[str],
+) -> Dict[str, Any]:
+    path, source, note = _resolve_signal_path(explicit_path, by_role, "output_health", manifest_dir)
+    if path is None:
+        if note:
+            warnings.append(f"output_health unavailable: {note}")
+            return {"available": False, "source": source, "reason": note}
+        return {
+            "available": False,
+            "source": None,
+            "reason": "not declared in manifest and no explicit path given",
+        }
+
+    doc, err = _load_json(path)
+    if doc is None:
+        warnings.append(f"output_health unavailable: {err}")
+        return {"available": False, "source": source, "reason": err}
+
+    checks = doc.get("checks") if isinstance(doc.get("checks"), dict) else {}
+    return {
+        "available": True,
+        "source": source,
+        "verdict_observed": _str_or_none(doc.get("verdict")),
+        "checks": {
+            "canonical_md_hash_ok": _bool_or_none(checks.get("canonical_md_hash_ok")),
+            "chunk_index_hash_ok": _bool_or_none(checks.get("chunk_index_hash_ok")),
+            "sqlite_row_count_matches_chunk_count": _bool_or_none(
+                checks.get("sqlite_row_count_matches_chunk_count")
+            ),
+            "fts_content_non_empty": _bool_or_none(checks.get("fts_content_non_empty")),
+            "range_ref_resolution_status": _str_or_none(checks.get("range_ref_resolution_status")),
+            "redaction_status_explicit": _bool_or_none(checks.get("redaction_status_explicit")),
+            "redact_secrets_enabled": _bool_or_none(checks.get("redact_secrets_enabled")),
+        },
+    }
+
+
+def _project_post_emit_health(
+    explicit_path: Optional[str],
+    resolved_manifest: Path,
+    warnings: List[str],
+) -> Dict[str, Any]:
+    # post_emit_health is not a manifest-declared role; it lives as the sidecar
+    # <stem>.bundle_health.post.json next to the manifest (or at an explicit path).
+    if explicit_path:
+        path: Optional[Path] = _resolve_path(explicit_path)
+        source = "explicit_path"
+    else:
+        path = derive_post_health_path(resolved_manifest)
+        source = "derived_sidecar"
+
+    if path is None or not path.exists():
+        if source == "explicit_path":
+            warnings.append("post_emit_health unavailable: file not found")
+            return {"available": False, "source": source, "reason": "file not found"}
+        return {
+            "available": False,
+            "source": None,
+            "reason": "no post_emit_health sidecar present",
+        }
+
+    doc, err = _load_json(path)
+    if doc is None:
+        warnings.append(f"post_emit_health unavailable: {err}")
+        return {"available": False, "source": source, "reason": err}
+
+    return {
+        "available": True,
+        "source": source,
+        "status_observed": _str_or_none(doc.get("status")),
+        "evidence_level": _str_or_none(doc.get("evidence_level")),
+        "evidence_levels_reached": [
+            lvl for lvl in (doc.get("evidence_levels_reached") or []) if isinstance(lvl, str)
+        ],
+        "does_not_mean": [d for d in (doc.get("does_not_mean") or []) if isinstance(d, str)],
+    }
+
+
+def _project_retrieval_eval(
+    explicit_path: Optional[str],
+    by_role: Dict[str, Dict[str, Any]],
+    manifest_dir: Path,
+    warnings: List[str],
+) -> Dict[str, Any]:
+    path, source, note = _resolve_signal_path(
+        explicit_path, by_role, "retrieval_eval_json", manifest_dir
+    )
+    if path is None:
+        if note:
+            warnings.append(f"retrieval_eval unavailable: {note}")
+            return {"available": False, "source": source, "reason": note}
+        return {
+            "available": False,
+            "source": None,
+            "reason": "not declared in manifest and no explicit path given",
+        }
+
+    doc, err = _load_json(path)
+    if doc is None:
+        warnings.append(f"retrieval_eval unavailable: {err}")
+        return {"available": False, "source": source, "reason": err}
+
+    metrics = doc.get("metrics") if isinstance(doc.get("metrics"), dict) else {}
+    projected_metrics = {
+        "recall@10": _num_or_none(metrics.get("recall@10")),
+        "MRR": _num_or_none(metrics.get("MRR")),
+        "total_queries": _int_or_none(metrics.get("total_queries")),
+        "hits": _int_or_none(metrics.get("hits")),
+        "zero_hit_ratio": _num_or_none(metrics.get("zero_hit_ratio")),
+        "stale_flag": _bool_or_none(metrics.get("stale_flag")),
+    }
+
+    categories: Optional[List[Dict[str, Any]]] = None
+    raw_categories = metrics.get("categories")
+    if isinstance(raw_categories, dict):
+        categories = []
+        for name, cat in raw_categories.items():
+            if not isinstance(cat, dict):
+                continue
+            categories.append(
+                {
+                    "category": str(name),
+                    "total_queries": _int_or_none(cat.get("total_queries")),
+                    "hits": _int_or_none(cat.get("hits")),
+                    "MRR": _num_or_none(cat.get("MRR")),
+                    "recall@10": _num_or_none(cat.get("recall@10")),
+                }
+            )
+
+    return {
+        "available": True,
+        "source": source,
+        "metrics": projected_metrics,
+        "categories": categories,
+    }
+
+
+def _project_agent_export_gate(
+    explicit_path: Optional[str],
+    warnings: List[str],
+) -> Dict[str, Any]:
+    # The export gate is computed on demand and is neither a manifest role nor a
+    # standard sidecar, so it is only projected when an explicit path is provided.
+    if not explicit_path:
+        return {
+            "available": False,
+            "source": None,
+            "reason": "no agent_export_gate path given",
+        }
+
+    path = _resolve_path(explicit_path)
+    doc, err = _load_json(path)
+    if doc is None:
+        warnings.append(f"agent_export_gate unavailable: {err}")
+        return {"available": False, "source": "explicit_path", "reason": err}
+
+    return {
+        "available": True,
+        "source": "explicit_path",
+        "status_observed": _str_or_none(doc.get("status")),
+        "profile_observed": _str_or_none(doc.get("profile")),
+        "agent_facing_observed": _bool_or_none(doc.get("agent_facing")),
+    }
+
+
+def _project_evidence(post_emit_signal: Dict[str, Any]) -> Dict[str, Any]:
+    # Evidence reuses the existing evidence-level vocabulary surfaced by
+    # post_emit_health. It never invents new levels and never aggregates a score.
+    if post_emit_signal.get("available"):
+        return {
+            "available": True,
+            "source": "post_emit_health",
+            "evidence_level": post_emit_signal.get("evidence_level"),
+            "evidence_levels_reached": list(post_emit_signal.get("evidence_levels_reached") or []),
+        }
+    return {
+        "available": False,
+        "source": None,
+        "evidence_level": None,
+        "evidence_levels_reached": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Assembly
+# ---------------------------------------------------------------------------
+
+def _blocked_signals() -> Dict[str, Any]:
+    return {
+        "manifest": {
+            "available": False,
+            "kind": None,
+            "version": None,
+            "run_id": None,
+            "roles_present": [],
+            "key_roles": {role: False for role in _KEY_ROLES},
+        },
+        "output_health": {"available": False, "source": None, "reason": "manifest blocked"},
+        "post_emit_health": {"available": False, "source": None, "reason": "manifest blocked"},
+        "retrieval_eval": {"available": False, "source": None, "reason": "manifest blocked"},
+        "agent_export_gate": {"available": False, "source": None, "reason": "manifest blocked"},
+        "evidence": {
+            "available": False,
+            "source": None,
+            "evidence_level": None,
+            "evidence_levels_reached": [],
+        },
+    }
+
+
+def _assemble(
+    *,
+    projection_status: str,
+    run_id: str,
+    bundle_run_id: Any,
+    manifest_path_str: str,
+    signals: Dict[str, Any],
+    warnings: List[str],
+    errors: List[str],
+) -> Dict[str, Any]:
+    return {
+        "kind": KIND,
+        "version": VERSION,
+        "run_id": run_id,
+        "checked_at": _now_iso(),
+        "bundle_manifest_path": manifest_path_str,
+        "bundle_run_id": bundle_run_id if isinstance(bundle_run_id, str) else None,
+        "projection_status": projection_status,
+        "authority": AUTHORITY,
+        "risk_class": RISK_CLASS,
+        "signals": signals,
+        "agent_use_constraints": list(AGENT_USE_CONSTRAINTS),
+        "does_not_mean": list(DOES_NOT_MEAN),
+        "warnings": warnings,
+        "errors": errors,
+    }
+
+
+def _blocked_report(
+    run_id: str,
+    resolved_manifest: Path,
+    error_msg: str,
+    bundle_run_id: Any,
+) -> Dict[str, Any]:
+    return _assemble(
+        projection_status="blocked",
+        run_id=run_id,
+        bundle_run_id=bundle_run_id,
+        manifest_path_str=str(resolved_manifest),
+        signals=_blocked_signals(),
+        warnings=[],
+        errors=[error_msg],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Core
+# ---------------------------------------------------------------------------
+
+def compute_context_quality(
+    manifest_path: str,
+    *,
+    output_health_path: Optional[str] = None,
+    post_emit_health_path: Optional[str] = None,
+    retrieval_eval_path: Optional[str] = None,
+    agent_export_gate_path: Optional[str] = None,
+    run_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Project the available context-quality signals for a bundle. Pure: no writes.
+
+    Returns a dict conforming to ``context-quality.v1.schema.json``. When the
+    manifest cannot be read or is not a ``repolens.bundle.manifest``, returns a
+    schema-valid report with ``projection_status == "blocked"``.
+    """
+    run_id = run_id or str(uuid.uuid4())
+    resolved_manifest = _resolve_path(manifest_path)
+
+    manifest, load_err = _load_json(resolved_manifest)
+    if manifest is None:
+        return _blocked_report(
+            run_id, resolved_manifest, f"cannot read bundle manifest: {load_err}", bundle_run_id=None
+        )
+
+    bundle_run_id = manifest.get("run_id")
+    if manifest.get("kind") != _BUNDLE_KIND:
+        return _blocked_report(
+            run_id,
+            resolved_manifest,
+            "manifest is not a repolens.bundle.manifest; cannot project context quality",
+            bundle_run_id=bundle_run_id,
+        )
+
+    manifest_dir = resolved_manifest.parent
+    warnings: List[str] = []
+    errors: List[str] = []
+
+    # ── manifest signal: role availability projection ────────────────────────
+    by_role: Dict[str, Dict[str, Any]] = {}
+    roles_present: List[str] = []
+    artifacts = manifest.get("artifacts")
+    if isinstance(artifacts, list):
+        for art in artifacts:
+            if isinstance(art, dict) and isinstance(art.get("role"), str):
+                by_role.setdefault(art["role"], art)
+                roles_present.append(art["role"])
+    else:
+        warnings.append("manifest 'artifacts' is not a list; role availability unknown")
+
+    key_roles = {role: (role in by_role) for role in _KEY_ROLES}
+    if not key_roles["canonical_md"]:
+        warnings.append("canonical_md role not declared in manifest")
+
+    manifest_signal = {
+        "available": True,
+        "kind": _str_or_none(manifest.get("kind")),
+        "version": _str_or_none(manifest.get("version")),
+        "run_id": _str_or_none(bundle_run_id),
+        "roles_present": sorted(set(roles_present)),
+        "key_roles": key_roles,
+    }
+
+    # ── projected diagnostic signals (observations only) ─────────────────────
+    output_health_signal = _project_output_health(
+        output_health_path, by_role, manifest_dir, warnings
+    )
+    post_emit_signal = _project_post_emit_health(
+        post_emit_health_path, resolved_manifest, warnings
+    )
+    retrieval_signal = _project_retrieval_eval(
+        retrieval_eval_path, by_role, manifest_dir, warnings
+    )
+    export_gate_signal = _project_agent_export_gate(agent_export_gate_path, warnings)
+    evidence_signal = _project_evidence(post_emit_signal)
+
+    signals = {
+        "manifest": manifest_signal,
+        "output_health": output_health_signal,
+        "post_emit_health": post_emit_signal,
+        "retrieval_eval": retrieval_signal,
+        "agent_export_gate": export_gate_signal,
+        "evidence": evidence_signal,
+    }
+
+    # ── projection_status: completeness of the projection, nothing more ──────
+    all_available = all(
+        signals[name].get("available") is True
+        for name in (
+            "manifest",
+            "output_health",
+            "post_emit_health",
+            "retrieval_eval",
+            "agent_export_gate",
+        )
+    )
+    if all_available and not warnings and not errors:
+        projection_status = "complete"
+    else:
+        projection_status = "degraded"
+
+    return _assemble(
+        projection_status=projection_status,
+        run_id=run_id,
+        bundle_run_id=bundle_run_id,
+        manifest_path_str=str(resolved_manifest),
+        signals=signals,
+        warnings=warnings,
+        errors=errors,
+    )
+
+
+def write_context_quality(
+    manifest_path: str,
+    output_path: Optional[str] = None,
+    **kwargs: Any,
+) -> Tuple[Path, Dict[str, Any]]:
+    """
+    Compute the context-quality projection and persist it as
+    ``<stem>.context_quality.json`` (or ``output_path`` if given).
+
+    The written artifact is intentionally NOT registered in the bundle manifest,
+    and the manifest is never mutated. Returns ``(written_path, report)``.
+    """
+    report = compute_context_quality(manifest_path, **kwargs)
+    resolved_manifest = _resolve_path(manifest_path)
+    if output_path:
+        out = Path(output_path)
+        out = out if out.is_absolute() else Path.cwd() / out
+    else:
+        out = derive_context_quality_path(resolved_manifest)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    logger.debug(
+        "context_quality written to %s (projection_status=%s)",
+        out,
+        report["projection_status"],
+    )
+    return out, report

--- a/merger/lenskit/tests/test_cli_context_quality.py
+++ b/merger/lenskit/tests/test_cli_context_quality.py
@@ -1,0 +1,127 @@
+"""
+CLI tests for `lenskit context-quality inspect`.
+"""
+import hashlib
+import json
+from pathlib import Path
+
+from merger.lenskit.cli.main import main
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+_CANONICAL = b"# repo\n\n## file: a.py\nx = 1\n"
+
+
+def _make_bundle(tmp_path: Path, *, include_pack: bool = True) -> Path:
+    (tmp_path / "demo.md").write_bytes(_CANONICAL)
+    chunk = {"chunk_id": "c0", "path": "a.py"}
+    chunk_bytes = (json.dumps(chunk) + "\n").encode("utf-8")
+    (tmp_path / "demo.chunk_index.jsonl").write_bytes(chunk_bytes)
+
+    artifacts = [
+        {
+            "role": "canonical_md", "path": "demo.md", "content_type": "text/markdown",
+            "bytes": len(_CANONICAL), "sha256": _sha256(_CANONICAL),
+            "authority": "canonical_content", "canonicality": "content_source",
+        },
+        {
+            "role": "chunk_index_jsonl", "path": "demo.chunk_index.jsonl",
+            "content_type": "application/x-ndjson", "bytes": len(chunk_bytes),
+            "sha256": _sha256(chunk_bytes),
+            "authority": "retrieval_index", "canonicality": "derived",
+        },
+    ]
+    if include_pack:
+        pack_bytes = b"# pack\nNAVIGATION, NOT TRUTH\n"
+        (tmp_path / "demo.agent_reading_pack.md").write_bytes(pack_bytes)
+        artifacts.append({
+            "role": "agent_reading_pack", "path": "demo.agent_reading_pack.md",
+            "content_type": "text/markdown", "bytes": len(pack_bytes),
+            "sha256": _sha256(pack_bytes),
+            "authority": "navigation_index", "canonicality": "derived",
+        })
+
+    manifest = {
+        "kind": "repolens.bundle.manifest", "version": "1.0", "run_id": "cli-cq-run",
+        "created_at": "2026-05-20T00:00:00Z",
+        "generator": {"name": "test", "version": "1.0", "config_sha256": "a" * 64},
+        "artifacts": artifacts, "links": {},
+        "capabilities": {"fts5_bm25": False, "redaction": False},
+    }
+    manifest_path = tmp_path / "demo.bundle.manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    return manifest_path
+
+
+def test_context_quality_cli_json(tmp_path, capsys):
+    manifest = _make_bundle(tmp_path)
+    rc = main(["context-quality", "inspect", str(manifest), "--json"])
+    assert rc == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["kind"] == "lenskit.context_quality"
+    assert report["authority"] == "diagnostic_signal"
+    assert report["risk_class"] == "diagnostic"
+    assert report["projection_status"] in {"complete", "degraded"}
+    # Default JSON invocation writes no artifact.
+    assert not (tmp_path / "demo.context_quality.json").exists()
+
+
+def test_context_quality_cli_human_states_diagnostic_only(tmp_path, capsys):
+    manifest = _make_bundle(tmp_path)
+    rc = main(["context-quality", "inspect", str(manifest)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Context Quality (diagnostic projection):" in out
+    assert "diagnostic projection only" in out
+    assert "NOT repository understanding" in out
+    assert "NOT answer safety" in out
+    # No file written by default.
+    assert not (tmp_path / "demo.context_quality.json").exists()
+
+
+def test_context_quality_cli_emit_artifact_does_not_mutate_manifest(tmp_path, capsys):
+    manifest = _make_bundle(tmp_path)
+    manifest_before = manifest.read_text(encoding="utf-8")
+
+    rc = main(["context-quality", "inspect", str(manifest), "--emit-artifact", "--json"])
+    assert rc == 0
+
+    out_file = tmp_path / "demo.context_quality.json"
+    assert out_file.exists()
+    written = json.loads(out_file.read_text(encoding="utf-8"))
+    assert written["kind"] == "lenskit.context_quality"
+    # Explicit persistence must not mutate or register anything in the manifest.
+    assert manifest.read_text(encoding="utf-8") == manifest_before
+
+
+def test_context_quality_cli_emit_artifact_unregistered_note(tmp_path, capsys):
+    manifest = _make_bundle(tmp_path)
+    rc = main(["context-quality", "inspect", str(manifest), "--emit-artifact"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert (tmp_path / "demo.context_quality.json").exists()
+    assert "written artifact is unregistered; manifest not mutated" in out
+
+
+def test_context_quality_cli_output_path(tmp_path, capsys):
+    manifest = _make_bundle(tmp_path)
+    manifest_before = manifest.read_text(encoding="utf-8")
+    target = tmp_path / "out" / "cq.json"
+
+    rc = main(["context-quality", "inspect", str(manifest), "--output", str(target)])
+    assert rc == 0
+    assert target.exists()
+    written = json.loads(target.read_text(encoding="utf-8"))
+    assert written["kind"] == "lenskit.context_quality"
+    # --output implies emission but still never mutates the manifest.
+    assert manifest.read_text(encoding="utf-8") == manifest_before
+
+
+def test_context_quality_cli_blocked_missing_manifest(tmp_path, capsys):
+    rc = main(["context-quality", "inspect", str(tmp_path / "nope.bundle.manifest.json"), "--json"])
+    assert rc == 2
+    report = json.loads(capsys.readouterr().out)
+    assert report["projection_status"] == "blocked"

--- a/merger/lenskit/tests/test_context_quality.py
+++ b/merger/lenskit/tests/test_context_quality.py
@@ -495,16 +495,12 @@ def test_docs_do_not_claim_b2_is_implemented():
     proof = (_REPO_ROOT / "docs" / "proofs" / "context-quality-signals-proof.md").read_text(encoding="utf-8")
     roadmap = (_REPO_ROOT / "docs" / "roadmap" / "lenskit-master-roadmap.md").read_text(encoding="utf-8")
 
-    # Both docs must mention B2 ...
+    # Both docs must mention B2.
     assert "B2" in proof
     assert "B2" in roadmap
-    # ... and frame it as separate / not implemented here.
-    assert any(tok in proof for tok in ("NICHT implementiert", "separat", "getrennt"))
-    assert any(tok in roadmap for tok in ("separat", "nicht in B1", "zukünftiges"))
 
-    # No line may assert B2 itself is done/implemented. Lines that frame B2 as
-    # separate / not-done (or that only mark B1 done while mentioning B2) are fine.
-    _separation_markers = ("nicht", "keine", "separat", "getrennt", "zukünftig", "future", "offen")
+    # No line may assert B2 is done/implemented without a negation/defer marker.
+    _separation_markers = ("nicht", "keine", "separat", "getrennt", "zukünftig", "future", "offen", "defer", "not ")
     for text in (proof, roadmap):
         for line in text.splitlines():
             if "B2" not in line:
@@ -514,6 +510,8 @@ def test_docs_do_not_claim_b2_is_implemented():
                 continue  # explicitly framed as separate / deferred
             assert "umgesetzt" not in lowered, f"line claims B2 done: {line!r}"
             assert "implementiert" not in lowered, f"line claims B2 implemented: {line!r}"
+            assert "done" not in lowered, f"line claims B2 done: {line!r}"
+            assert "completed" not in lowered, f"line claims B2 completed: {line!r}"
 
 
 def test_post_emit_and_evidence_projected_from_sidecar(tmp_path):
@@ -532,3 +530,68 @@ def test_post_emit_and_evidence_projected_from_sidecar(tmp_path):
     assert ev["source"] == "post_emit_health"
     assert ev["evidence_level"] == "navigable"
     assert "navigable" in ev["evidence_levels_reached"]
+
+
+# ---------------------------------------------------------------------------
+# 9. Malformed optional inputs: robustness under non-UTF-8 and invalid evidence
+# ---------------------------------------------------------------------------
+
+def test_non_utf8_optional_sidecar_degrades_with_warning(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    # Write a non-UTF-8 byte sequence as the post_emit_health sidecar.
+    sidecar = derive_post_health_path(manifest.resolve())
+    sidecar.write_bytes(b"\xff\xfe\x80\x81 bad bytes not utf-8")
+
+    report = compute_context_quality(str(manifest))
+    pe = report["signals"]["post_emit_health"]
+    assert pe["available"] is False
+    assert any("post_emit_health unavailable" in w for w in report["warnings"])
+    assert report["projection_status"] == "degraded"
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.validate(instance=report, schema=schema)
+
+
+def _write_post_emit_sidecar_with_bad_evidence(manifest_path: Path) -> None:
+    doc = {
+        "kind": "lenskit.post_emit_health", "version": "1.0", "run_id": "pe-run",
+        "bundle_run_id": "demo-run", "checked_at": "2026-05-23T00:00:00Z",
+        "bundle_manifest_path": str(manifest_path), "status": "pass",
+        "checks": [], "errors": [], "warnings": [],
+        "does_not_mean": ["repo_understood"],
+        "independence_note": "test",
+        "evidence_level": "ultra_complete",  # not in known vocabulary
+        "evidence_levels_reached": ["navigable", "exotic_level", "another_bad"],
+        "artifact_count_checked": 1, "hash_mismatch_count": 0, "missing_artifact_count": 0,
+    }
+    out = derive_post_health_path(manifest_path.resolve())
+    out.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+
+
+def test_unknown_evidence_level_is_filtered_to_null(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    _write_post_emit_sidecar_with_bad_evidence(manifest)
+
+    report = compute_context_quality(str(manifest))
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    # Must remain schema-valid even though the sidecar has an unknown evidence_level.
+    jsonschema.validate(instance=report, schema=schema)
+
+    ev = report["signals"]["evidence"]
+    assert ev["available"] is True
+    assert ev["evidence_level"] is None  # unknown level filtered to null
+    assert any("evidence_level" in w and "ultra_complete" in w for w in report["warnings"])
+
+
+def test_unknown_evidence_levels_reached_are_dropped_with_warning(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    _write_post_emit_sidecar_with_bad_evidence(manifest)
+
+    report = compute_context_quality(str(manifest))
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.validate(instance=report, schema=schema)
+
+    ev = report["signals"]["evidence"]
+    assert "exotic_level" not in ev["evidence_levels_reached"]
+    assert "another_bad" not in ev["evidence_levels_reached"]
+    assert "navigable" in ev["evidence_levels_reached"]  # known value kept
+    assert any("evidence_levels_reached" in w for w in report["warnings"])

--- a/merger/lenskit/tests/test_context_quality.py
+++ b/merger/lenskit/tests/test_context_quality.py
@@ -1,0 +1,534 @@
+"""
+Unit tests for core/context_quality.py (Context Quality Signals, PR B1).
+
+context_quality is a diagnostic PROJECTION of signals that already exist around a
+bundle. It is not a truth source, not an understanding verdict, not a
+retrieval-completeness proof, not an answer-safety gate, not a global score, and
+not a claim judgment. These tests pin those boundaries.
+"""
+import hashlib
+import json
+from pathlib import Path
+
+import jsonschema
+
+from merger.lenskit.core.context_quality import (
+    AGENT_USE_CONSTRAINTS,
+    DOES_NOT_MEAN,
+    compute_context_quality,
+    derive_context_quality_path,
+    write_context_quality,
+)
+from merger.lenskit.core.post_emit_health import derive_post_health_path
+
+_CONTRACTS_DIR = Path(__file__).parent.parent / "contracts"
+_SCHEMA_PATH = _CONTRACTS_DIR / "context-quality.v1.schema.json"
+
+_CANONICAL = b"# repo: demo\n\n## file: a.py\nx = 1\n"
+
+
+# Vocabulary that must never leak into the projection as keys or verdict values.
+# JSON booleans are fine; these are forbidden as field NAMES and as string
+# verdict VALUES. "answer_safe_without_citations" is allowed only in does_not_mean.
+_FORBIDDEN_TOKENS = {
+    "understanding_health",
+    "understanding_score",
+    "context_score",
+    "agent_safe",
+    "agent_ready",
+    "safe",
+    "unsafe",
+    "green",
+    "yellow",
+    "red",
+    "supported",
+    "unsupported",
+    "true",
+    "false",
+    "proven",
+}
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _make_bundle(
+    tmp_path: Path,
+    *,
+    include_pack: bool = True,
+    include_output_health: bool = True,
+    health_verdict: str = "pass",
+    include_retrieval_role: bool = False,
+    redaction: bool = False,
+) -> Path:
+    """Build a synthetic bundle on disk and return the manifest path."""
+    artifacts = []
+
+    (tmp_path / "demo.md").write_bytes(_CANONICAL)
+    artifacts.append({
+        "role": "canonical_md", "path": "demo.md", "content_type": "text/markdown",
+        "bytes": len(_CANONICAL), "sha256": _sha256(_CANONICAL),
+        "authority": "canonical_content", "canonicality": "content_source",
+    })
+
+    chunk = {"chunk_id": "c0", "path": "a.py"}
+    chunk_bytes = (json.dumps(chunk) + "\n").encode("utf-8")
+    (tmp_path / "demo.chunk_index.jsonl").write_bytes(chunk_bytes)
+    artifacts.append({
+        "role": "chunk_index_jsonl", "path": "demo.chunk_index.jsonl",
+        "content_type": "application/x-ndjson", "bytes": len(chunk_bytes),
+        "sha256": _sha256(chunk_bytes),
+        "authority": "retrieval_index", "canonicality": "derived",
+    })
+
+    if include_output_health:
+        health_doc = {
+            "kind": "lenskit.output_health", "version": "1.0", "run_id": "demo-run",
+            "created_at": "2026-05-20T00:00:00Z", "stem": "demo",
+            "checks": {
+                "canonical_md_hash_ok": True,
+                "chunk_index_hash_ok": True,
+                "sqlite_row_count_matches_chunk_count": None,
+                "fts_content_non_empty": None,
+                "range_ref_resolution_status": "no_range_ref",
+                "redaction_status_explicit": True,
+                "redact_secrets_enabled": redaction,
+            },
+            "diagnostic_artifacts": {}, "warnings": [], "errors": [],
+            "verdict": health_verdict,
+        }
+        health_bytes = json.dumps(health_doc, indent=2).encode("utf-8")
+        (tmp_path / "demo.output_health.json").write_bytes(health_bytes)
+        artifacts.append({
+            "role": "output_health", "path": "demo.output_health.json",
+            "content_type": "application/json", "bytes": len(health_bytes),
+            "sha256": _sha256(health_bytes),
+            "authority": "diagnostic_signal", "canonicality": "diagnostic",
+        })
+
+    if include_pack:
+        pack_bytes = b"# Pack\nNAVIGATION, NOT TRUTH\n"
+        (tmp_path / "demo.agent_reading_pack.md").write_bytes(pack_bytes)
+        artifacts.append({
+            "role": "agent_reading_pack", "path": "demo.agent_reading_pack.md",
+            "content_type": "text/markdown", "bytes": len(pack_bytes),
+            "sha256": _sha256(pack_bytes),
+            "authority": "navigation_index", "canonicality": "derived",
+        })
+
+    if include_retrieval_role:
+        re_bytes = json.dumps(_retrieval_eval_doc(), indent=2).encode("utf-8")
+        (tmp_path / "demo.retrieval_eval.json").write_bytes(re_bytes)
+        artifacts.append({
+            "role": "retrieval_eval_json", "path": "demo.retrieval_eval.json",
+            "content_type": "application/json", "bytes": len(re_bytes),
+            "sha256": _sha256(re_bytes),
+            "authority": "diagnostic_signal", "canonicality": "diagnostic",
+            "contract": {"id": "retrieval-eval", "version": "v1"},
+            "interpretation": {"mode": "contract"},
+        })
+
+    manifest = {
+        "kind": "repolens.bundle.manifest", "version": "1.0", "run_id": "demo-run",
+        "created_at": "2026-05-20T00:00:00Z",
+        "generator": {"name": "test", "version": "1.0", "config_sha256": "a" * 64},
+        "artifacts": artifacts, "links": {},
+        "capabilities": {"fts5_bm25": False, "redaction": redaction},
+    }
+    manifest_path = tmp_path / "demo.bundle.manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    return manifest_path
+
+
+def _retrieval_eval_doc() -> dict:
+    return {
+        "metrics": {
+            "recall@10": 80.0,
+            "MRR": 0.5,
+            "total_queries": 10,
+            "hits": 8,
+            "stale_flag": False,
+            "zero_hit_ratio": 0.1,
+            "categories": {
+                "symbol": {"total_queries": 4, "hits": 3, "MRR": 0.6, "recall@10": 75.0},
+            },
+        },
+        "details": [],
+        "claim_boundaries": {
+            "proves": ["index returned ranked candidates"],
+            "does_not_prove": ["semantic relevance"],
+            "evidence_basis": ["retrieval_metrics"],
+            "requires_live_check": True,
+        },
+    }
+
+
+def _write_post_emit_sidecar(manifest_path: Path, status: str = "pass") -> Path:
+    doc = {
+        "kind": "lenskit.post_emit_health", "version": "1.0", "run_id": "pe-run",
+        "bundle_run_id": "demo-run", "checked_at": "2026-05-23T00:00:00Z",
+        "bundle_manifest_path": str(manifest_path), "status": status,
+        "checks": [], "errors": [], "warnings": [],
+        "does_not_mean": ["repo_understood", "answer_safe_without_citations"],
+        "independence_note": "output_health.verdict=pass does not imply post_emit_health.status=pass",
+        "evidence_level": "navigable",
+        "evidence_levels_reached": ["readable", "navigable"],
+        "artifact_count_checked": 3, "hash_mismatch_count": 0, "missing_artifact_count": 0,
+    }
+    out = derive_post_health_path(manifest_path.resolve())
+    out.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+    return out
+
+
+def _write_export_gate(tmp_path: Path, status: str = "pass") -> Path:
+    doc = {
+        "kind": "lenskit.agent_export_gate", "version": "1.0", "status": status,
+        "profile": "agent_minimal", "agent_facing": True,
+        "checked_at": "2026-05-23T00:00:00Z", "bundle_manifest_path": "x",
+        "post_emit_health_status": "pass", "output_health_verdict_observed": "pass",
+        "redaction_required": True, "redaction_enabled": True,
+        "errors": [], "warnings": [],
+        "does_not_mean": ["repo_understood", "answer_safe_without_citations", "claims_true"],
+    }
+    out = tmp_path / "demo.export_gate.json"
+    out.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+    return out
+
+
+def _iter_strings(obj, path=""):
+    """Yield (path, key, value) for every dict key and string value in obj."""
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            yield path, k, None
+            yield from _iter_strings(v, f"{path}.{k}")
+    elif isinstance(obj, list):
+        for i, v in enumerate(obj):
+            yield from _iter_strings(v, f"{path}[{i}]")
+    elif isinstance(obj, str):
+        yield path, None, obj
+
+
+# ---------------------------------------------------------------------------
+# 1. Clean synthetic bundle produces a schema-valid report
+# ---------------------------------------------------------------------------
+
+def test_clean_bundle_is_schema_valid(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    report = compute_context_quality(str(manifest))
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.validate(instance=report, schema=schema)
+    assert report["kind"] == "lenskit.context_quality"
+    assert report["version"] == "1.0"
+
+
+def test_blocked_and_degraded_reports_are_schema_valid(tmp_path):
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+
+    # degraded (minimal bundle, optional signals unavailable)
+    (tmp_path / "min").mkdir(exist_ok=True)
+    minimal = _make_bundle(tmp_path / "min", include_output_health=False)
+    degraded = compute_context_quality(str(minimal))
+    jsonschema.validate(instance=degraded, schema=schema)
+    assert degraded["projection_status"] == "degraded"
+
+    # blocked (missing manifest)
+    blocked = compute_context_quality(str(tmp_path / "nope.bundle.manifest.json"))
+    jsonschema.validate(instance=blocked, schema=schema)
+    assert blocked["projection_status"] == "blocked"
+
+
+def test_complete_when_all_signals_available(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    _write_post_emit_sidecar(manifest)
+    re_path = tmp_path / "standalone.retrieval_eval.json"
+    re_path.write_text(json.dumps(_retrieval_eval_doc()), encoding="utf-8")
+    gate_path = _write_export_gate(tmp_path)
+
+    report = compute_context_quality(
+        str(manifest),
+        retrieval_eval_path=str(re_path),
+        agent_export_gate_path=str(gate_path),
+    )
+    assert report["projection_status"] == "complete"
+    assert report["warnings"] == []
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.validate(instance=report, schema=schema)
+
+
+# ---------------------------------------------------------------------------
+# 2. Required authority / risk_class / constraints / disclaimers
+# ---------------------------------------------------------------------------
+
+def test_report_carries_authority_risk_constraints_and_disclaimers(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    report = compute_context_quality(str(manifest))
+
+    assert report["authority"] == "diagnostic_signal"
+    assert report["risk_class"] == "diagnostic"
+
+    assert report["agent_use_constraints"]
+    assert set(AGENT_USE_CONSTRAINTS).issubset(set(report["agent_use_constraints"]))
+    for required in (
+        "verify_content_against_canonical_md",
+        "cite_canonical_ranges_for_claims",
+        "do_not_treat_context_quality_as_repo_understanding",
+        "do_not_treat_retrieval_metrics_as_completeness_proof",
+        "do_not_treat_export_gate_as_claim_truth",
+    ):
+        assert required in report["agent_use_constraints"]
+
+    for required in ("repo_understood", "retrieval_complete", "answer_safe_without_citations", "claims_true"):
+        assert required in report["does_not_mean"]
+    assert set(DOES_NOT_MEAN).issubset(set(report["does_not_mean"]))
+
+
+# ---------------------------------------------------------------------------
+# 3. No global understanding/safety verdict; no forbidden vocabulary
+# ---------------------------------------------------------------------------
+
+def test_no_global_understanding_or_safety_verdict(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    _write_post_emit_sidecar(manifest)
+    gate_path = _write_export_gate(tmp_path)
+    report = compute_context_quality(
+        str(manifest),
+        retrieval_eval_path=None,
+        agent_export_gate_path=str(gate_path),
+    )
+
+    # No top-level global verdict key — only projection_status is allowed.
+    assert "understanding_health" not in report
+    assert "status" not in report
+    assert "verdict" not in report
+    assert "agent_safe" not in report
+    assert "agent_ready" not in report
+    assert report["projection_status"] in {"complete", "degraded", "blocked"}
+
+    # Walk the whole report: no forbidden key names, no forbidden verdict values,
+    # and no aggregate score key. answer_safe_without_citations only in does_not_mean.
+    for path, key, value in _iter_strings(report):
+        if key is not None:
+            assert key.lower() not in _FORBIDDEN_TOKENS, f"forbidden key {key!r} at {path}"
+            assert not key.lower().endswith("_score"), f"aggregate score key {key!r} at {path}"
+            assert key.lower() != "score", f"aggregate score key at {path}"
+        if value is not None:
+            if value == "answer_safe_without_citations":
+                assert "does_not_mean" in path, f"answer_safe_without_citations outside does_not_mean at {path}"
+            else:
+                assert value.lower() not in _FORBIDDEN_TOKENS, f"forbidden value {value!r} at {path}"
+
+
+def test_named_blueprint_invariants(tmp_path):
+    # Mirrors the blueprint's named B1 tests for traceability.
+    manifest = _make_bundle(tmp_path)
+    report = compute_context_quality(str(manifest))
+    # test_context_quality_has_no_global_understanding_verdict
+    assert "understanding_health" not in json.dumps(report)
+    # test_context_quality_is_projection_of_existing_signals
+    assert set(report["signals"].keys()) == {
+        "manifest", "output_health", "post_emit_health",
+        "retrieval_eval", "agent_export_gate", "evidence",
+    }
+
+
+# ---------------------------------------------------------------------------
+# 4. output_health values projected as observations only
+# ---------------------------------------------------------------------------
+
+def test_output_health_projected_as_observation(tmp_path):
+    manifest = _make_bundle(tmp_path, health_verdict="warn", redaction=True)
+    report = compute_context_quality(str(manifest))
+
+    oh = report["signals"]["output_health"]
+    assert oh["available"] is True
+    assert oh["source"] == "manifest_role"
+    # verdict is surfaced verbatim as an observation, not a context-quality verdict.
+    assert oh["verdict_observed"] == "warn"
+    assert oh["checks"]["canonical_md_hash_ok"] is True
+    assert oh["checks"]["chunk_index_hash_ok"] is True
+    assert oh["checks"]["redact_secrets_enabled"] is True
+    assert oh["checks"]["range_ref_resolution_status"] == "no_range_ref"
+    # The projection must not invent post-emit validity from output_health.
+    assert report["signals"]["post_emit_health"]["available"] is False
+
+
+# ---------------------------------------------------------------------------
+# 5. retrieval_eval metrics projected mechanically
+# ---------------------------------------------------------------------------
+
+def test_retrieval_eval_metrics_projected_mechanically(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    re_path = tmp_path / "standalone.retrieval_eval.json"
+    re_path.write_text(json.dumps(_retrieval_eval_doc()), encoding="utf-8")
+
+    report = compute_context_quality(str(manifest), retrieval_eval_path=str(re_path))
+    re_sig = report["signals"]["retrieval_eval"]
+
+    assert re_sig["available"] is True
+    assert re_sig["source"] == "explicit_path"
+    assert re_sig["metrics"] == {
+        "recall@10": 80.0,
+        "MRR": 0.5,
+        "total_queries": 10,
+        "hits": 8,
+        "zero_hit_ratio": 0.1,
+        "stale_flag": False,
+    }
+    assert re_sig["categories"] == [
+        {"category": "symbol", "total_queries": 4, "hits": 3, "MRR": 0.6, "recall@10": 75.0},
+    ]
+
+
+def test_retrieval_eval_resolves_from_manifest_role(tmp_path):
+    manifest = _make_bundle(tmp_path, include_retrieval_role=True)
+    report = compute_context_quality(str(manifest))
+    re_sig = report["signals"]["retrieval_eval"]
+    assert re_sig["available"] is True
+    assert re_sig["source"] == "manifest_role"
+    assert report["signals"]["manifest"]["key_roles"]["retrieval_eval_json"] is True
+
+
+def test_invalid_retrieval_json_warns_without_fabrication(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    bad = tmp_path / "bad.retrieval_eval.json"
+    bad.write_text("{not valid json", encoding="utf-8")
+
+    report = compute_context_quality(str(manifest), retrieval_eval_path=str(bad))
+    re_sig = report["signals"]["retrieval_eval"]
+    assert re_sig["available"] is False
+    assert "metrics" not in re_sig  # nothing fabricated
+    assert any("retrieval_eval unavailable" in w for w in report["warnings"])
+    assert report["projection_status"] == "degraded"
+
+
+# ---------------------------------------------------------------------------
+# 6. Missing optional artifacts degrade availability but do not crash
+# ---------------------------------------------------------------------------
+
+def test_missing_optional_artifacts_degrade_without_crash(tmp_path):
+    manifest = _make_bundle(tmp_path, include_output_health=False)
+    report = compute_context_quality(str(manifest))
+
+    assert report["projection_status"] == "degraded"
+    assert report["signals"]["output_health"]["available"] is False
+    assert report["signals"]["post_emit_health"]["available"] is False
+    assert report["signals"]["retrieval_eval"]["available"] is False
+    assert report["signals"]["agent_export_gate"]["available"] is False
+    assert report["signals"]["evidence"]["available"] is False
+    # manifest signal is still available and surfaces role presence
+    assert report["signals"]["manifest"]["available"] is True
+    assert report["signals"]["manifest"]["key_roles"]["canonical_md"] is True
+    assert report["signals"]["manifest"]["key_roles"]["output_health"] is False
+
+
+# ---------------------------------------------------------------------------
+# 7. Unreadable / non-bundle manifest blocks
+# ---------------------------------------------------------------------------
+
+def test_missing_manifest_blocks(tmp_path):
+    report = compute_context_quality(str(tmp_path / "nope.bundle.manifest.json"))
+    assert report["projection_status"] == "blocked"
+    assert report["bundle_run_id"] is None
+    assert report["errors"]
+
+
+def test_non_bundle_manifest_blocks(tmp_path):
+    other = tmp_path / "other.json"
+    other.write_text(json.dumps({"kind": "something.else", "run_id": "x"}), encoding="utf-8")
+    report = compute_context_quality(str(other))
+    assert report["projection_status"] == "blocked"
+    assert any("not a repolens.bundle.manifest" in e for e in report["errors"])
+
+
+def test_non_json_manifest_blocks(tmp_path):
+    junk = tmp_path / "junk.bundle.manifest.json"
+    junk.write_text("not json at all", encoding="utf-8")
+    report = compute_context_quality(str(junk))
+    assert report["projection_status"] == "blocked"
+
+
+# ---------------------------------------------------------------------------
+# 8. write persists the artifact without mutating the manifest
+# ---------------------------------------------------------------------------
+
+def test_compute_does_not_write(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    compute_context_quality(str(manifest))
+    assert not derive_context_quality_path(manifest.resolve()).exists()
+
+
+def test_write_persists_unregistered_without_mutating_manifest(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    manifest_before = manifest.read_text(encoding="utf-8")
+
+    out, report = write_context_quality(str(manifest))
+
+    assert out == derive_context_quality_path(manifest.resolve())
+    assert out.exists()
+    written = json.loads(out.read_text(encoding="utf-8"))
+    assert written["projection_status"] == report["projection_status"]
+    assert written["kind"] == "lenskit.context_quality"
+
+    # Persistence must NOT mutate or register anything in the manifest.
+    assert manifest.read_text(encoding="utf-8") == manifest_before
+    data = json.loads(manifest_before)
+    assert all(a["role"] != "context_quality" for a in data["artifacts"])
+
+
+def test_write_explicit_output_path(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    target = tmp_path / "custom" / "cq.json"
+    out, _ = write_context_quality(str(manifest), str(target))
+    assert out == target.resolve() or out == target
+    assert target.exists()
+
+
+# ---------------------------------------------------------------------------
+# Evidence / post_emit projection details
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_docs_do_not_claim_b2_is_implemented():
+    proof = (_REPO_ROOT / "docs" / "proofs" / "context-quality-signals-proof.md").read_text(encoding="utf-8")
+    roadmap = (_REPO_ROOT / "docs" / "roadmap" / "lenskit-master-roadmap.md").read_text(encoding="utf-8")
+
+    # Both docs must mention B2 ...
+    assert "B2" in proof
+    assert "B2" in roadmap
+    # ... and frame it as separate / not implemented here.
+    assert any(tok in proof for tok in ("NICHT implementiert", "separat", "getrennt"))
+    assert any(tok in roadmap for tok in ("separat", "nicht in B1", "zukünftiges"))
+
+    # No line may assert B2 itself is done/implemented. Lines that frame B2 as
+    # separate / not-done (or that only mark B1 done while mentioning B2) are fine.
+    _separation_markers = ("nicht", "keine", "separat", "getrennt", "zukünftig", "future", "offen")
+    for text in (proof, roadmap):
+        for line in text.splitlines():
+            if "B2" not in line:
+                continue
+            lowered = line.lower()
+            if any(marker in lowered for marker in _separation_markers):
+                continue  # explicitly framed as separate / deferred
+            assert "umgesetzt" not in lowered, f"line claims B2 done: {line!r}"
+            assert "implementiert" not in lowered, f"line claims B2 implemented: {line!r}"
+
+
+def test_post_emit_and_evidence_projected_from_sidecar(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    _write_post_emit_sidecar(manifest, status="pass")
+
+    report = compute_context_quality(str(manifest))
+    pe = report["signals"]["post_emit_health"]
+    assert pe["available"] is True
+    assert pe["source"] == "derived_sidecar"
+    assert pe["status_observed"] == "pass"
+    assert pe["evidence_level"] == "navigable"
+
+    ev = report["signals"]["evidence"]
+    assert ev["available"] is True
+    assert ev["source"] == "post_emit_health"
+    assert ev["evidence_level"] == "navigable"
+    assert "navigable" in ev["evidence_levels_reached"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,7 @@
 pytest==8.3.4
 pytest-asyncio==0.23.8
 ruff==0.15.13
+fastapi>=0.119,<1
+pydantic>=2,<3
+uvicorn[standard]>=0.30,<1
+httpx>=0.27,<1


### PR DESCRIPTION
## Summary

Implements the Context Quality Signals diagnostic projection system (roadmap PR B1) as specified in the anti-hallucination output architecture blueprint. This adds a machine-readable projection of existing bundle signals (manifest roles, output_health checks, post_emit_health status, retrieval metrics, and optional export gate results) without creating new truth layers or global verdicts.

## Key Changes

- **Core Module** (`merger/lenskit/core/context_quality.py`):
  - `compute_context_quality()`: Pure function that projects existing signals into a diagnostic report
  - `write_context_quality()`: Optional persistence to `<stem>.context_quality.json` (unregistered artifact)
  - `derive_context_quality_path()`: Path derivation helper
  - Per-signal projectors for output_health, post_emit_health, retrieval_eval, agent_export_gate, and evidence
  - Strict naming discipline: `projection_status` (complete|degraded|blocked) describes projection completeness only, never context quality or answer safety
  - Authority always `diagnostic_signal`, risk_class always `diagnostic`

- **CLI Command** (`merger/lenskit/cli/cmd_context_quality.py`):
  - `lenskit context-quality inspect <manifest>` with `--json`, `--emit-artifact`, and `--output` options
  - Human-readable and machine-readable output modes
  - Exit codes: 0 for complete/degraded, 2 for blocked

- **JSON Schema** (`merger/lenskit/contracts/context-quality.v1.schema.json`):
  - Validates the projection structure
  - Enforces required fields: kind, version, run_id, checked_at, projection_status, authority, risk_class, signals, agent_use_constraints, does_not_mean, warnings, errors
  - Defines signal schemas for manifest, output_health, post_emit_health, retrieval_eval, agent_export_gate, and evidence

- **Comprehensive Tests** (`merger/lenskit/tests/test_context_quality.py`, `test_cli_context_quality.py`):
  - Schema validation for complete, degraded, and blocked states
  - Verification of required authority/risk_class/constraints/disclaimers
  - Enforcement of forbidden vocabulary (no `understanding_health`, `agent_safe`, `safe`, `proven`, etc.)
  - Validation that signals are projected as observations only (output_health verdicts never infer post_emit validity, etc.)
  - CLI integration tests

- **Documentation**:
  - Implementation proof (`docs/proofs/context-quality-signals-proof.md`) documenting design contract and boundaries
  - Blueprint updates marking PR B1 as implemented
  - Roadmap updates reflecting completion status

## Design Boundaries (Deliberately Enforced)

The projection explicitly does NOT:
- Establish new truth (no `repo_understood`, `retrieval_complete`, `answer_safe_without_citations`, `claims_true`)
- Infer validity across signal types (output_health verdicts never imply post_emit_health status)
- Provide a global understanding or safety verdict
- Treat retrieval metrics as completeness proof
- Reinterpret export gate results as claim truth

All signals are projected as observations only. Missing optional inputs produce unavailable/degraded entries, never crashes. Invalid optional JSON produces warnings, never fabricated values.

## Implementation Notes

- Follows existing patterns from `output_health.py`, `post_emit_health.py`, and `agent_export_gate.py`
- Reuses `path_security.resolve_secure_path()` for secure manifest-relative path resolution
- Manifest-declared signal paths resolved relative to manifest directory
- Explicit paths always take precedence over manifest-declared roles
- No manifest mutations or registrations; artifact is purely diagnostic

https://claude.ai/code/session_01GD9WMa3Czr8mvrdCH79Pv3