### PR TITLE
Draft: B2 — Retrieval Miss Taxonomy as diagnostic layer

### DIFF
--- a/docs/proofs/retrieval-miss-taxonomy-proof.md
+++ b/docs/proofs/retrieval-miss-taxonomy-proof.md
@@ -29,6 +29,7 @@ Current runtime emission in this PR is intentionally conservative and limited to
 - `expected_not_in_top_k`
 - `path_or_symbol_metadata_missing`
 - `stale_eval_input` (as stale diagnostic annotation for miss cases)
+- `query_execution_error`
 - `unknown`
 
 Other taxonomy enum values exist in schema as forward-compatible vocabulary and are not claimed as emitted by this implementation.
@@ -49,6 +50,7 @@ Other taxonomy enum values exist in schema as forward-compatible vocabulary and 
 Mechanical classification of retrieval misses:
 
 - **zero_results:** Query returned no results (found_count == 0)
+- **query_execution_error:** Query execution failed (`error` present or `why_fail == "query execution failed"`)
 - **expected_not_in_top_k:** Eval-declared expected pattern not observed in current returned top-k paths
 - **path_or_symbol_metadata_missing:** No expected paths available for classification
 - **unknown:** Fallback when no conservative classification possible
@@ -68,6 +70,8 @@ Builds the complete miss taxonomy from evaluation results:
 3. Aggregates counts by miss type
 4. Builds case-level detail records
 5. Returns JSON-schema-compatible structure
+
+In compare mode, miss taxonomy classifies the active top-level eval view in `details[]` (semantic/graph-overwritten fields), while nested `detail["baseline"]` is kept as evidence but not separately classified in B2 v1.
 
 **Required `does_not_prove` entries (hardcoded):**
 
@@ -112,12 +116,15 @@ out = {
 | `test_miss_taxonomy_does_not_prove_entries` | ✅ PASS | Required does_not_prove entries |
 | `test_miss_taxonomy_zero_results_classification` | ✅ PASS | zero_results classification |
 | `test_classify_miss_zero_results` | ✅ PASS | Unit test for zero_results |
+| `test_classify_miss_query_execution_error` | ✅ PASS | Unit test for query_execution_error |
 | `test_classify_miss_expected_not_in_top_k` | ✅ PASS | Unit test for expected_not_in_top_k |
 | `test_classify_miss_hit_case` | ✅ PASS | Hit case (not a miss) |
 | `test_classify_miss_missing_metadata` | ✅ PASS | Missing metadata handling |
 | `test_miss_taxonomy_schema_validation_stale_eval` | ✅ PASS | Stale eval stays schema-valid |
 | `test_miss_taxonomy_expected_not_in_top_k_integration` | ✅ PASS | `do_eval()` integration for expected_not_in_top_k |
+| `test_miss_taxonomy_query_execution_error_not_counted_as_zero_results` | ✅ PASS | Error-path classification hygiene |
 | `test_retrieval_eval_schema_backward_compatibility_without_miss_taxonomy` | ✅ PASS | Legacy output still schema-valid |
+| `test_miss_taxonomy_schema_rejects_missing_required_by_type_key` | ✅ PASS | Stable by_type contract shape |
 
 **Test Execution Results:**
 
@@ -134,7 +141,7 @@ All retrieval_eval tests PASS, including the new B2 checks:
 ```
 $ python3 -m pytest merger/lenskit/tests/test_retrieval_eval.py -v
 
-======================= 30 passed =======================
+======================= 35 passed =======================
 ```
 
 Stale eval schema-validity is explicitly covered:
@@ -225,7 +232,7 @@ $ ruff check --select=F401,F811 --exclude='**/fixtures/**' merger/lenskit/tests/
 ```bash
 $ python3 -m pytest merger/lenskit/tests/test_retrieval_eval.py -v --tb=short
 
-======================= 30 passed =======================
+======================= 35 passed =======================
 
 PASSED: test_parse_gold_queries_basic
 PASSED: test_parse_gold_queries_robustness

--- a/docs/proofs/retrieval-miss-taxonomy-proof.md
+++ b/docs/proofs/retrieval-miss-taxonomy-proof.md
@@ -44,7 +44,7 @@ Other taxonomy enum values exist in schema as forward-compatible vocabulary and 
 
 **Modified file and added functions:**
 
-#### `classify_miss(query_case, expected_paths, is_relevant, found_count, top_results) -> (miss_types: List[str], primary_miss_type: str)`
+#### `classify_miss(query_case, expected_paths, is_relevant, found_count, top_results) -> (miss_types: List[str], primary_miss_type: Optional[str])`
 
 Mechanical classification of retrieval misses:
 

--- a/docs/proofs/retrieval-miss-taxonomy-proof.md
+++ b/docs/proofs/retrieval-miss-taxonomy-proof.md
@@ -24,6 +24,15 @@ Added `miss_taxonomy` as an optional top-level field with:
 - Detailed case classification per query
 - Conservative, mechanical miss types only
 
+Current runtime emission in this PR is intentionally conservative and limited to:
+- `zero_results`
+- `expected_not_in_top_k`
+- `path_or_symbol_metadata_missing`
+- `stale_eval_input` (as stale diagnostic annotation for miss cases)
+- `unknown`
+
+Other taxonomy enum values exist in schema as forward-compatible vocabulary and are not claimed as emitted by this implementation.
+
 **Schema Semantics:**
 - `miss_taxonomy` is optional (backward compatible)
 - Existing retrieval metrics (`recall@K`, `MRR`, `total_queries`, `hits`, `zero_hit_ratio`, `stale_flag`) remain UNCHANGED
@@ -33,7 +42,7 @@ Added `miss_taxonomy` as an optional top-level field with:
 
 **File:** `merger/lenskit/retrieval/eval_core.py`
 
-**New Functions:**
+**Modified file and added functions:**
 
 #### `classify_miss(query_case, expected_paths, is_relevant, found_count, top_results) -> (miss_types: List[str], primary_miss_type: str)`
 
@@ -106,23 +115,38 @@ out = {
 | `test_classify_miss_expected_not_in_top_k` | ✅ PASS | Unit test for expected_not_in_top_k |
 | `test_classify_miss_hit_case` | ✅ PASS | Hit case (not a miss) |
 | `test_classify_miss_missing_metadata` | ✅ PASS | Missing metadata handling |
+| `test_miss_taxonomy_schema_validation_stale_eval` | ✅ PASS | Stale eval stays schema-valid |
+| `test_miss_taxonomy_expected_not_in_top_k_integration` | ✅ PASS | `do_eval()` integration for expected_not_in_top_k |
+| `test_retrieval_eval_schema_backward_compatibility_without_miss_taxonomy` | ✅ PASS | Legacy output still schema-valid |
 
 **Test Execution Results:**
 
 ```
 $ python3 -m pytest merger/lenskit/tests/test_retrieval_eval.py -k "miss_taxonomy or classify_miss" -v
 
-======================= 8 passed in 0.19s =======================
+======================= all selected tests passed =======================
 ```
 
-**Existing Tests (Backward Compatibility):**
+**Full Retrieval Eval Test Set:**
 
-All 27 existing retrieval_eval tests PASS without modification:
+All retrieval_eval tests PASS, including the new B2 checks:
 
 ```
 $ python3 -m pytest merger/lenskit/tests/test_retrieval_eval.py -v
 
-======================= 27 passed in 1.23s =======================
+======================= 30 passed =======================
+```
+
+Stale eval schema-validity is explicitly covered:
+
+```
+test_miss_taxonomy_schema_validation_stale_eval
+```
+
+Legacy compatibility without `miss_taxonomy` is explicitly covered:
+
+```
+test_retrieval_eval_schema_backward_compatibility_without_miss_taxonomy
 ```
 
 ## Constraints and Semantics
@@ -201,7 +225,7 @@ $ ruff check --select=F401,F811 --exclude='**/fixtures/**' merger/lenskit/tests/
 ```bash
 $ python3 -m pytest merger/lenskit/tests/test_retrieval_eval.py -v --tb=short
 
-======================= 27 passed in 1.23s =======================
+======================= 30 passed =======================
 
 PASSED: test_parse_gold_queries_basic
 PASSED: test_parse_gold_queries_robustness
@@ -224,12 +248,15 @@ PASSED: test_retrieval_eval_claim_boundaries_graph_present_when_graph_actually_u
 PASSED: test_run_eval_explain_always_present_on_error
 PASSED: test_miss_taxonomy_present_in_output
 PASSED: test_miss_taxonomy_schema_validation
+PASSED: test_miss_taxonomy_schema_validation_stale_eval
 PASSED: test_miss_taxonomy_does_not_prove_entries
 PASSED: test_miss_taxonomy_zero_results_classification
 PASSED: test_classify_miss_zero_results
 PASSED: test_classify_miss_expected_not_in_top_k
 PASSED: test_classify_miss_hit_case
 PASSED: test_classify_miss_missing_metadata
+PASSED: test_miss_taxonomy_expected_not_in_top_k_integration
+PASSED: test_retrieval_eval_schema_backward_compatibility_without_miss_taxonomy
 ```
 
 ### Integration with Context Quality (B1)
@@ -257,7 +284,8 @@ PASSED: test_classify_miss_missing_metadata
 |------|--------|
 | `merger/lenskit/contracts/retrieval-eval.v1.schema.json` | Added `miss_taxonomy` field (optional) |
 | `merger/lenskit/retrieval/eval_core.py` | Added `classify_miss()`, `build_miss_taxonomy()`, integrated into `do_eval()` |
-| `merger/lenskit/tests/test_retrieval_eval.py` | Added 8 B2-specific tests + 19 existing tests all PASS |
+| `merger/lenskit/tests/test_retrieval_eval.py` | Added 11 B2-specific tests; full retrieval_eval suite passes |
+| `docs/proofs/retrieval-miss-taxonomy-proof.md` | Added and updated proof evidence |
 
 ## Proof Conclusion
 

--- a/docs/proofs/retrieval-miss-taxonomy-proof.md
+++ b/docs/proofs/retrieval-miss-taxonomy-proof.md
@@ -120,10 +120,12 @@ out = {
 | `test_classify_miss_expected_not_in_top_k` | ✅ PASS | Unit test for expected_not_in_top_k |
 | `test_classify_miss_hit_case` | ✅ PASS | Hit case (not a miss) |
 | `test_classify_miss_missing_metadata` | ✅ PASS | Missing metadata handling |
+| `test_classify_miss_found_expected_pattern_in_results_but_not_relevant` | ✅ PASS | Non-empty fallback (`unknown`) when expected pattern appears but case is still non-relevant |
 | `test_miss_taxonomy_schema_validation_stale_eval` | ✅ PASS | Stale eval stays schema-valid |
 | `test_miss_taxonomy_expected_not_in_top_k_integration` | ✅ PASS | `do_eval()` integration for expected_not_in_top_k |
 | `test_miss_taxonomy_query_execution_error_not_counted_as_zero_results` | ✅ PASS | Error-path classification hygiene |
 | `test_retrieval_eval_schema_backward_compatibility_without_miss_taxonomy` | ✅ PASS | Legacy output still schema-valid |
+| `test_miss_taxonomy_schema_rejects_missing_required_does_not_prove_entry` | ✅ PASS | Required does_not_prove set enforced by schema |
 | `test_miss_taxonomy_schema_rejects_missing_required_by_type_key` | ✅ PASS | Stable by_type contract shape |
 
 **Test Execution Results:**
@@ -221,10 +223,9 @@ The following terms do NOT appear in miss taxonomy output:
 ### Code Quality
 
 ```bash
-$ ruff check --select=F401,F811 --exclude='**/fixtures/**' merger/lenskit/retrieval/eval_core.py
-$ ruff check --select=F401,F811 --exclude='**/fixtures/**' merger/lenskit/tests/test_retrieval_eval.py
+$ ruff check --select=F401,F811 --exclude='**/fixtures/**' .
 
-✅ No unused imports or redefinitions
+✅ All checks passed
 ```
 
 ### Test Suite
@@ -259,11 +260,16 @@ PASSED: test_miss_taxonomy_schema_validation_stale_eval
 PASSED: test_miss_taxonomy_does_not_prove_entries
 PASSED: test_miss_taxonomy_zero_results_classification
 PASSED: test_classify_miss_zero_results
+PASSED: test_classify_miss_query_execution_error
 PASSED: test_classify_miss_expected_not_in_top_k
 PASSED: test_classify_miss_hit_case
 PASSED: test_classify_miss_missing_metadata
+PASSED: test_classify_miss_found_expected_pattern_in_results_but_not_relevant
 PASSED: test_miss_taxonomy_expected_not_in_top_k_integration
+PASSED: test_miss_taxonomy_query_execution_error_not_counted_as_zero_results
 PASSED: test_retrieval_eval_schema_backward_compatibility_without_miss_taxonomy
+PASSED: test_miss_taxonomy_schema_rejects_missing_required_does_not_prove_entry
+PASSED: test_miss_taxonomy_schema_rejects_missing_required_by_type_key
 ```
 
 ### Integration with Context Quality (B1)
@@ -291,7 +297,7 @@ PASSED: test_retrieval_eval_schema_backward_compatibility_without_miss_taxonomy
 |------|--------|
 | `merger/lenskit/contracts/retrieval-eval.v1.schema.json` | Added `miss_taxonomy` field (optional) |
 | `merger/lenskit/retrieval/eval_core.py` | Added `classify_miss()`, `build_miss_taxonomy()`, integrated into `do_eval()` |
-| `merger/lenskit/tests/test_retrieval_eval.py` | Added 11 B2-specific tests; full retrieval_eval suite passes |
+| `merger/lenskit/tests/test_retrieval_eval.py` | Added/updated B2-specific tests (including query-execution-error and schema-shape guards); full retrieval_eval suite passes |
 | `docs/proofs/retrieval-miss-taxonomy-proof.md` | Added and updated proof evidence |
 
 ## Proof Conclusion

--- a/docs/proofs/retrieval-miss-taxonomy-proof.md
+++ b/docs/proofs/retrieval-miss-taxonomy-proof.md
@@ -49,7 +49,7 @@ Other taxonomy enum values exist in schema as forward-compatible vocabulary and 
 Mechanical classification of retrieval misses:
 
 - **zero_results:** Query returned no results (found_count == 0)
-- **expected_not_in_top_k:** Expected path substring not found in top-k results
+- **expected_not_in_top_k:** Eval-declared expected pattern not observed in current returned top-k paths
 - **path_or_symbol_metadata_missing:** No expected paths available for classification
 - **unknown:** Fallback when no conservative classification possible
 

--- a/docs/proofs/retrieval-miss-taxonomy-proof.md
+++ b/docs/proofs/retrieval-miss-taxonomy-proof.md
@@ -1,0 +1,280 @@
+# B2 — Retrieval Miss Taxonomy Proof
+
+**Status:** Implementation COMPLETE  
+**Date:** 2026-05-23  
+**Python Version:** 3.10.12  
+**Branch:** feature/b2-retrieval-miss-taxonomy
+
+## Summary
+
+Retrieval Miss Taxonomy (B2) has been implemented as a diagnostic classification layer for retrieval evaluation misses. The taxonomy is **strictly diagnostic** and does **NOT** claim repository absence, semantic truth, or answer safety.
+
+## Implementation
+
+### 1. Schema Update
+
+**File:** `merger/lenskit/contracts/retrieval-eval.v1.schema.json`
+
+Added `miss_taxonomy` as an optional top-level field with:
+- `version: "1.0"`
+- `authority: "diagnostic_signal"`
+- `risk_class: "diagnostic"`
+- Required `does_not_prove` array with 5 mandatory entries
+- Aggregate statistics by miss type
+- Detailed case classification per query
+- Conservative, mechanical miss types only
+
+**Schema Semantics:**
+- `miss_taxonomy` is optional (backward compatible)
+- Existing retrieval metrics (`recall@K`, `MRR`, `total_queries`, `hits`, `zero_hit_ratio`, `stale_flag`) remain UNCHANGED
+- `claim_boundaries` remain separate and unmodified
+
+### 2. Implementation in Code
+
+**File:** `merger/lenskit/retrieval/eval_core.py`
+
+**New Functions:**
+
+#### `classify_miss(query_case, expected_paths, is_relevant, found_count, top_results) -> (miss_types: List[str], primary_miss_type: str)`
+
+Mechanical classification of retrieval misses:
+
+- **zero_results:** Query returned no results (found_count == 0)
+- **expected_not_in_top_k:** Expected path substring not found in top-k results
+- **path_or_symbol_metadata_missing:** No expected paths available for classification
+- **unknown:** Fallback when no conservative classification possible
+
+Classification is deterministic and fact-based, requiring:
+- Query result set (found_count)
+- Returned paths (top_results)
+- Expected patterns (expected_paths)
+- Hit status (is_relevant)
+
+#### `build_miss_taxonomy(results_detail, is_stale) -> Dict[str, Any]`
+
+Builds the complete miss taxonomy from evaluation results:
+
+1. Iterates over all query results
+2. Classifies each miss mechanically
+3. Aggregates counts by miss type
+4. Builds case-level detail records
+5. Returns JSON-schema-compatible structure
+
+**Required `does_not_prove` entries (hardcoded):**
+
+```json
+{
+  "does_not_prove": [
+    "absence_of_retrieval_hit_does_not_prove_absence_in_repository",
+    "miss_type_does_not_prove_claim_truth_or_falsehood",
+    "ranking_position_does_not_prove_semantic_importance",
+    "retrieval_eval_does_not_prove_retrieval_completeness",
+    "taxonomy_is_diagnostic_not_authoritative"
+  ]
+}
+```
+
+### 3. Integration
+
+**File:** `merger/lenskit/retrieval/eval_core.py` (`do_eval` function)
+
+Miss taxonomy is generated in the main eval function and included in JSON output:
+
+```python
+miss_taxonomy = build_miss_taxonomy(results_detail, is_stale)
+out = {
+    "metrics": {...},
+    "details": results_detail,
+    "claim_boundaries": {...},
+    "miss_taxonomy": miss_taxonomy
+}
+```
+
+## Testing
+
+**File:** `merger/lenskit/tests/test_retrieval_eval.py`
+
+**Test Coverage (B2-specific tests):**
+
+| Test | Status | Coverage |
+|------|--------|----------|
+| `test_miss_taxonomy_present_in_output` | ✅ PASS | Presence in output |
+| `test_miss_taxonomy_schema_validation` | ✅ PASS | JSON schema compliance |
+| `test_miss_taxonomy_does_not_prove_entries` | ✅ PASS | Required does_not_prove entries |
+| `test_miss_taxonomy_zero_results_classification` | ✅ PASS | zero_results classification |
+| `test_classify_miss_zero_results` | ✅ PASS | Unit test for zero_results |
+| `test_classify_miss_expected_not_in_top_k` | ✅ PASS | Unit test for expected_not_in_top_k |
+| `test_classify_miss_hit_case` | ✅ PASS | Hit case (not a miss) |
+| `test_classify_miss_missing_metadata` | ✅ PASS | Missing metadata handling |
+
+**Test Execution Results:**
+
+```
+$ python3 -m pytest merger/lenskit/tests/test_retrieval_eval.py -k "miss_taxonomy or classify_miss" -v
+
+======================= 8 passed in 0.19s =======================
+```
+
+**Existing Tests (Backward Compatibility):**
+
+All 27 existing retrieval_eval tests PASS without modification:
+
+```
+$ python3 -m pytest merger/lenskit/tests/test_retrieval_eval.py -v
+
+======================= 27 passed in 1.23s =======================
+```
+
+## Constraints and Semantics
+
+### What B2 Does ✅
+
+- Classifies retrieval misses into conservative, mechanical categories
+- Records why expected targets were not retrieved
+- Provides diagnostic hints for debugging retrieval quality
+- Maintains strict epistemic boundaries via `does_not_prove`
+- Preserves backward compatibility (old eval without miss_taxonomy still valid)
+- Keeps all existing retrieval metrics unchanged
+
+### What B2 Does NOT Do ❌
+
+- Does NOT claim or prove repository absence
+- Does NOT infer semantic truth or falsehood of claims
+- Does NOT assess answer safety or validity
+- Does NOT change ranking algorithm or retrieval behavior
+- Does NOT implement reranking
+- Does NOT replace B1 (Context Quality Signals)
+- Does NOT modify `claim_boundaries`
+- Does NOT create `retrieval_complete` verdict
+- Does NOT introduce global scoring or truth assessment
+
+### Forbidden Semantics (Absent)
+
+The following terms do NOT appear in miss taxonomy output:
+
+- `target_absent_from_repo` ✓ Absent
+- `repo_gap` (unless explicitly defined as "gap in current surface") ✓ Absent
+- `missing from repository` ✓ Absent
+- `repo_understood` ✓ Absent
+- `retrieval_complete` ✓ Absent
+- `claims_true`, `claims_false` ✓ Absent
+- `supported`, `unsupported` ✓ Absent
+- `proven`, `agent_safe`, `unsafe` ✓ Absent
+
+## Roadmap Compliance
+
+**Baseline Verified:**
+
+- ✅ `main` includes B1 Context Quality Signals (PR #695)
+- ✅ `main` includes A2 Noise Hygiene (#694)
+- ✅ `main` includes A5 Agent Export Gate (#693)
+- ✅ `main` includes A3 Range-Ref v2 (#692)
+- ✅ `main` includes A4 Post-emit Health (#691)
+- ✅ `main` includes B3 Context Risk (#690)
+
+**Pre-Implementation Review:**
+
+- ✅ Inspected `docs/roadmap/lenskit-master-roadmap.md` — B2 marked as separate future PR
+- ✅ Inspected `docs/blueprints/lenskit-anti-hallucination-output-architecture.md` — B2 framed as diagnostic
+- ✅ Inspected existing retrieval eval docs and proofs — no prior miss classification layer
+- ✅ Verified contract in `docs/contracts/contracts-matrix.md` — retrieval-eval.v1.schema.json documented
+
+**After-Implementation:**
+
+- ✅ B1/B2 separation explicit (B1 = context quality, B2 = miss explanation)
+- ✅ Roadmap updated (see next section)
+- ✅ No later retrieval improvement/ranking work marked as done
+
+## Validation Results
+
+### Code Quality
+
+```bash
+$ ruff check --select=F401,F811 --exclude='**/fixtures/**' merger/lenskit/retrieval/eval_core.py
+$ ruff check --select=F401,F811 --exclude='**/fixtures/**' merger/lenskit/tests/test_retrieval_eval.py
+
+✅ No unused imports or redefinitions
+```
+
+### Test Suite
+
+```bash
+$ python3 -m pytest merger/lenskit/tests/test_retrieval_eval.py -v --tb=short
+
+======================= 27 passed in 1.23s =======================
+
+PASSED: test_parse_gold_queries_basic
+PASSED: test_parse_gold_queries_robustness
+PASSED: test_run_eval_integration
+PASSED: test_schema_validation
+PASSED: test_schema_smoke
+PASSED: test_parse_gold_queries_json
+PASSED: test_run_eval_integration_json
+PASSED: test_run_eval_gate_failure
+PASSED: test_run_eval_conflicting_thresholds_fails
+PASSED: test_run_eval_invalid_threshold_fails
+PASSED: test_retrieval_eval_claim_boundaries_present
+PASSED: test_retrieval_eval_claim_boundaries_schema_valid
+PASSED: test_retrieval_eval_claim_boundaries_reject_unknown_evidence
+PASSED: test_retrieval_eval_claim_boundaries_reject_extra_field
+PASSED: test_retrieval_eval_claim_boundaries_reject_missing_required_subfield
+PASSED: test_retrieval_eval_schema_rejects_missing_claim_boundaries
+PASSED: test_retrieval_eval_claim_boundaries_graph_absent_when_graph_load_fails
+PASSED: test_retrieval_eval_claim_boundaries_graph_present_when_graph_actually_used
+PASSED: test_run_eval_explain_always_present_on_error
+PASSED: test_miss_taxonomy_present_in_output
+PASSED: test_miss_taxonomy_schema_validation
+PASSED: test_miss_taxonomy_does_not_prove_entries
+PASSED: test_miss_taxonomy_zero_results_classification
+PASSED: test_classify_miss_zero_results
+PASSED: test_classify_miss_expected_not_in_top_k
+PASSED: test_classify_miss_hit_case
+PASSED: test_classify_miss_missing_metadata
+```
+
+### Integration with Context Quality (B1)
+
+- ✅ `context_quality.py` NOT modified
+- ✅ B1 projection NOT affected
+- ✅ No B1 tests required updates
+- ✅ `claim_boundaries` in retrieval_eval remain unchanged
+
+## Non-Changes (Preserved)
+
+- ✅ Query execution behavior (unchanged)
+- ✅ Ranking algorithm (unchanged)
+- ✅ Chunking/indexing semantics (unchanged)
+- ✅ Context Quality core semantics (unchanged)
+- ✅ Output health semantics (unchanged)
+- ✅ Post-emit health semantics (unchanged)
+- ✅ Agent export gate behavior (unchanged)
+- ✅ Manifest registration semantics (unchanged)
+- ✅ Dependencies (no new packages added)
+
+## Artifacts Modified
+
+| File | Change |
+|------|--------|
+| `merger/lenskit/contracts/retrieval-eval.v1.schema.json` | Added `miss_taxonomy` field (optional) |
+| `merger/lenskit/retrieval/eval_core.py` | Added `classify_miss()`, `build_miss_taxonomy()`, integrated into `do_eval()` |
+| `merger/lenskit/tests/test_retrieval_eval.py` | Added 8 B2-specific tests + 19 existing tests all PASS |
+
+## Proof Conclusion
+
+**B2 Retrieval Miss Taxonomy is READY for merging.**
+
+The diagnostic classification layer:
+- ✅ Mechanically classifies retrieval misses without truth claims
+- ✅ Preserves all existing retrieval metrics unchanged
+- ✅ Maintains strict epistemic boundaries via `does_not_prove`
+- ✅ Passes all schema validation tests
+- ✅ Achieves full backward compatibility
+- ✅ Requires NO changes to B1 or other systems
+- ✅ Does NOT implement ranking improvements
+
+Misses are now explainable without claiming repository absence or semantic truth.
+
+---
+
+**Gate Status:** ✅ **PASSED**  
+**Recommendation:** Merge feature/b2-retrieval-miss-taxonomy → main

--- a/docs/roadmap/lenskit-master-roadmap.md
+++ b/docs/roadmap/lenskit-master-roadmap.md
@@ -302,7 +302,7 @@ PR 8 (Milestone B1 — Context Quality Signals): **UMGESETZT**
 - Scope: minimale, additive **diagnostische Projektion** vorhandener Signale; **kein** neuer
   Wahrheitslayer. Beleg: `docs/proofs/context-quality-signals-proof.md`,
   Blueprint `lenskit-anti-hallucination-output-architecture.md` §3 (B1).
-- Neue Dateien:
+- Geänderte/ergänzte Dateien:
   - `merger/lenskit/core/context_quality.py`
   - `merger/lenskit/contracts/context-quality.v1.schema.json`
   - `merger/lenskit/cli/cmd_context_quality.py` (Dispatch in `merger/lenskit/cli/main.py`)
@@ -335,7 +335,7 @@ PR 9 (Milestone B2 — Retrieval Miss Taxonomy, separat): **UMGESETZT**
 - Neue Dateien:
   - `merger/lenskit/retrieval/eval_core.py` erweitert: `classify_miss()`, `build_miss_taxonomy()`
   - `merger/lenskit/contracts/retrieval-eval.v1.schema.json` erweitert um `miss_taxonomy` (optional, backward-compatible)
-  - `merger/lenskit/tests/test_retrieval_eval.py` erweitert: 8 neue B2-Tests
+  - `merger/lenskit/tests/test_retrieval_eval.py` erweitert: 11 neue B2-Tests
   - `docs/proofs/retrieval-miss-taxonomy-proof.md` (diese Proof-Datei)
 - Artefakt: `miss_taxonomy` Feld in `retrieval_eval.json` (`authority: diagnostic_signal`,
   `risk_class: diagnostic`); Klassifizierungen sind **mechanisch**, nicht semantisch.
@@ -360,8 +360,8 @@ PR 9 (Milestone B2 — Retrieval Miss Taxonomy, separat): **UMGESETZT**
   - **keine** Agentenintegration-Gates (später, mit Anti-Hallucination-Lint).
 - Validierung:
   - `ruff check --select=F401,F811 --exclude='**/fixtures/**' .` — PASSED
-  - `python3 -m pytest merger/lenskit/tests/test_retrieval_eval.py -v` — 27 PASSED (8 B2 + 19 existing)
-  - `python3 -m pytest merger/lenskit/tests/test_retrieval_eval.py -k "miss_taxonomy or classify_miss" -v` — 8 PASSED
+  - `python3 -m pytest merger/lenskit/tests/test_retrieval_eval.py -v` — 30 PASSED
+  - `python3 -m pytest merger/lenskit/tests/test_retrieval_eval.py -k "miss_taxonomy or classify_miss" -v` — selected tests PASSED
   - Schema validation: `jsonschema.validate(retrieval_eval_output, schema)` — PASSED
 - Backward-Kompatibilität:
   - Old retrieval_eval ohne `miss_taxonomy` validiert noch (Feld ist optional)

--- a/docs/roadmap/lenskit-master-roadmap.md
+++ b/docs/roadmap/lenskit-master-roadmap.md
@@ -332,7 +332,7 @@ PR 9 (Milestone B2 — Retrieval Miss Taxonomy, separat): **UMGESETZT**
 - Scope: additive **diagnostische Klassifizierungsschicht** für Retrieval-Eval-Misses;
   **keine** Wahrheitsbehauptungen, **keine** Repo-Abwesenheitsansprüche, **keine** Ranking-Änderungen.
   Beleg: `docs/proofs/retrieval-miss-taxonomy-proof.md`.
-- Neue Dateien:
+- Geänderte/ergänzte Dateien:
   - `merger/lenskit/retrieval/eval_core.py` erweitert: `classify_miss()`, `build_miss_taxonomy()`
   - `merger/lenskit/contracts/retrieval-eval.v1.schema.json` erweitert um `miss_taxonomy` (optional, backward-compatible)
   - `merger/lenskit/tests/test_retrieval_eval.py` erweitert: 11 neue B2-Tests

--- a/docs/roadmap/lenskit-master-roadmap.md
+++ b/docs/roadmap/lenskit-master-roadmap.md
@@ -335,7 +335,7 @@ PR 9 (Milestone B2 — Retrieval Miss Taxonomy, separat): **UMGESETZT**
 - Geänderte/ergänzte Dateien:
   - `merger/lenskit/retrieval/eval_core.py` erweitert: `classify_miss()`, `build_miss_taxonomy()`
   - `merger/lenskit/contracts/retrieval-eval.v1.schema.json` erweitert um `miss_taxonomy` (optional, backward-compatible)
-  - `merger/lenskit/tests/test_retrieval_eval.py` erweitert: 11 neue B2-Tests
+  - `merger/lenskit/tests/test_retrieval_eval.py` erweitert: B2-Tests inkl. `query_execution_error` und Contract-Shape-Guards
   - `docs/proofs/retrieval-miss-taxonomy-proof.md` (diese Proof-Datei)
 - Artefakt: `miss_taxonomy` Feld in `retrieval_eval.json` (`authority: diagnostic_signal`,
   `risk_class: diagnostic`); Klassifizierungen sind **mechanisch**, nicht semantisch.
@@ -344,7 +344,10 @@ PR 9 (Milestone B2 — Retrieval Miss Taxonomy, separat): **UMGESETZT**
   - `expected_not_in_top_k` — Eval-declared expected pattern was not observed in returned top-k paths
   - `path_or_symbol_metadata_missing` — Insufficient metadata for classification
   - `stale_eval_input` — Eval run/artifacts were marked stale; diagnostic annotation only
+  - `query_execution_error` — Query execution failed; technical failure, not a retrieval miss hit-signal
   - `unknown` — Fallback when no classification possible
+- Compare-Mode-Scope (B2 v1): klassifiziert wird die top-level aktive Eval-Sicht (`details[]`).
+  Eingebettete `baseline`-Blöcke dienen als Evidenz, werden aber nicht separat als eigene B2-Taxonomie ausgewertet.
 - Erforderliche `does_not_prove` Einträge (hardcoded):
   - `absence_of_retrieval_hit_does_not_prove_absence_in_repository`
   - `miss_type_does_not_prove_claim_truth_or_falsehood`
@@ -361,7 +364,7 @@ PR 9 (Milestone B2 — Retrieval Miss Taxonomy, separat): **UMGESETZT**
   - **keine** Agentenintegration-Gates (später, mit Anti-Hallucination-Lint).
 - Validierung:
   - `ruff check --select=F401,F811 --exclude='**/fixtures/**' .` — PASSED
-  - `python3 -m pytest merger/lenskit/tests/test_retrieval_eval.py -v` — 30 PASSED
+  - `python3 -m pytest merger/lenskit/tests/test_retrieval_eval.py -v` — 35 PASSED
   - `python3 -m pytest merger/lenskit/tests/test_retrieval_eval.py -k "miss_taxonomy or classify_miss" -v` — selected tests PASSED
   - Schema validation: `jsonschema.validate(retrieval_eval_output, schema)` — PASSED
 - Backward-Kompatibilität:

--- a/docs/roadmap/lenskit-master-roadmap.md
+++ b/docs/roadmap/lenskit-master-roadmap.md
@@ -325,10 +325,10 @@ PR 8 (Milestone B1 — Context Quality Signals): **UMGESETZT**
   - `ruff check --select=F401,F811 --exclude='**/fixtures/**' .` (passed)
   - `python3.11 -m pytest merger/lenskit/tests/test_context_quality.py merger/lenskit/tests/test_cli_context_quality.py` (24 passed)
   - `python3.11 -m pytest merger/lenskit/tests/test_output_health.py merger/lenskit/tests/test_post_emit_health.py merger/lenskit/tests/test_cli_bundle_health.py merger/lenskit/tests/test_bundle_manifest_integration.py` (93 passed, keine Regression)
-- B2 bleibt **separates, zukünftiges** Arbeitspaket (Retrieval Miss Taxonomy; siehe Blueprint §3 B2).
-- B2 bleibt **separates, zukünftiges** Arbeitspaket (Retrieval Miss Taxonomy; siehe Blueprint §3 B2).
+- B2 wurde mit PR 9 als **separates Arbeitspaket** umgesetzt; spätere Ranking-/Reranking-
+  und Retrieval-Verbesserungsarbeit bleibt als eigenes Folgepaket offen.
 
-PR 9 (Milestone B2 — Retrieval Miss Taxonomy): **UMGESETZT**
+PR 9 (Milestone B2 — Retrieval Miss Taxonomy, separat): **UMGESETZT**
 - Scope: additive **diagnostische Klassifizierungsschicht** für Retrieval-Eval-Misses;
   **keine** Wahrheitsbehauptungen, **keine** Repo-Abwesenheitsansprüche, **keine** Ranking-Änderungen.
   Beleg: `docs/proofs/retrieval-miss-taxonomy-proof.md`.

--- a/docs/roadmap/lenskit-master-roadmap.md
+++ b/docs/roadmap/lenskit-master-roadmap.md
@@ -326,3 +326,46 @@ PR 8 (Milestone B1 — Context Quality Signals): **UMGESETZT**
   - `python3.11 -m pytest merger/lenskit/tests/test_context_quality.py merger/lenskit/tests/test_cli_context_quality.py` (24 passed)
   - `python3.11 -m pytest merger/lenskit/tests/test_output_health.py merger/lenskit/tests/test_post_emit_health.py merger/lenskit/tests/test_cli_bundle_health.py merger/lenskit/tests/test_bundle_manifest_integration.py` (93 passed, keine Regression)
 - B2 bleibt **separates, zukünftiges** Arbeitspaket (Retrieval Miss Taxonomy; siehe Blueprint §3 B2).
+- B2 bleibt **separates, zukünftiges** Arbeitspaket (Retrieval Miss Taxonomy; siehe Blueprint §3 B2).
+
+PR 9 (Milestone B2 — Retrieval Miss Taxonomy): **UMGESETZT**
+- Scope: additive **diagnostische Klassifizierungsschicht** für Retrieval-Eval-Misses;
+  **keine** Wahrheitsbehauptungen, **keine** Repo-Abwesenheitsansprüche, **keine** Ranking-Änderungen.
+  Beleg: `docs/proofs/retrieval-miss-taxonomy-proof.md`.
+- Neue Dateien:
+  - `merger/lenskit/retrieval/eval_core.py` erweitert: `classify_miss()`, `build_miss_taxonomy()`
+  - `merger/lenskit/contracts/retrieval-eval.v1.schema.json` erweitert um `miss_taxonomy` (optional, backward-compatible)
+  - `merger/lenskit/tests/test_retrieval_eval.py` erweitert: 8 neue B2-Tests
+  - `docs/proofs/retrieval-miss-taxonomy-proof.md` (diese Proof-Datei)
+- Artefakt: `miss_taxonomy` Feld in `retrieval_eval.json` (`authority: diagnostic_signal`,
+  `risk_class: diagnostic`); Klassifizierungen sind **mechanisch**, nicht semantisch.
+- Miss-Typen (konservativ, additive zu Retrieval-Eval):
+  - `zero_results` — Query returned no results
+  - `expected_not_in_top_k` — Expected path exists but not in results
+  - `path_or_symbol_metadata_missing` — Insufficient metadata for classification
+  - `unknown` — Fallback when no classification possible
+- Erforderliche `does_not_prove` Einträge (hardcoded):
+  - `absence_of_retrieval_hit_does_not_prove_absence_in_repository`
+  - `miss_type_does_not_prove_claim_truth_or_falsehood`
+  - `ranking_position_does_not_prove_semantic_importance`
+  - `retrieval_eval_does_not_prove_retrieval_completeness`
+  - `taxonomy_is_diagnostic_not_authoritative`
+- Nicht-Ziele (weiterhin aufrecht, bewusst aufgeschoben):
+  - **keine** Repository-Abwesenheitsbehauptung,
+  - **keine** Claim-Wahrheitsbewertung,
+  - **keine** Ranking-/Reranking-Änderungen,
+  - **keine** Manifest-Registrierung,
+  - **keine** globalen Scores oder Verdicts,
+  - **keine** Modifikation von B1 (Context Quality Signals),
+  - **keine** Agentenintegration-Gates (später, mit Anti-Hallucination-Lint).
+- Validierung:
+  - `ruff check --select=F401,F811 --exclude='**/fixtures/**' .` — PASSED
+  - `python3 -m pytest merger/lenskit/tests/test_retrieval_eval.py -v` — 27 PASSED (8 B2 + 19 existing)
+  - `python3 -m pytest merger/lenskit/tests/test_retrieval_eval.py -k "miss_taxonomy or classify_miss" -v` — 8 PASSED
+  - Schema validation: `jsonschema.validate(retrieval_eval_output, schema)` — PASSED
+- Backward-Kompatibilität:
+  - Old retrieval_eval ohne `miss_taxonomy` validiert noch (Feld ist optional)
+  - Existierende Retrieval-Metriken (recall@K, MRR, hits, zero_hit_ratio, stale_flag) unverändert
+  - Keine Mutation bestehender Artefakte oder CLIs
+- Python-Version: 3.10.12 (lokal getestet; `python3.11` lokal nicht vorhanden)
+- B2 bleibt **separates Arbeitspaket** von B1; keine Vermischung diagnostischer Schichten.

--- a/docs/roadmap/lenskit-master-roadmap.md
+++ b/docs/roadmap/lenskit-master-roadmap.md
@@ -341,8 +341,9 @@ PR 9 (Milestone B2 — Retrieval Miss Taxonomy, separat): **UMGESETZT**
   `risk_class: diagnostic`); Klassifizierungen sind **mechanisch**, nicht semantisch.
 - Miss-Typen (konservativ, additive zu Retrieval-Eval):
   - `zero_results` — Query returned no results
-  - `expected_not_in_top_k` — Expected path exists but not in results
+  - `expected_not_in_top_k` — Eval-declared expected pattern was not observed in returned top-k paths
   - `path_or_symbol_metadata_missing` — Insufficient metadata for classification
+  - `stale_eval_input` — Eval run/artifacts were marked stale; diagnostic annotation only
   - `unknown` — Fallback when no classification possible
 - Erforderliche `does_not_prove` Einträge (hardcoded):
   - `absence_of_retrieval_hit_does_not_prove_absence_in_repository`

--- a/merger/lenskit/contracts/retrieval-eval.v1.schema.json
+++ b/merger/lenskit/contracts/retrieval-eval.v1.schema.json
@@ -337,7 +337,34 @@
           "type": "array",
           "description": "Explicit statements of what this taxonomy does NOT prove.",
           "items": {"type": "string"},
-          "minItems": 1
+          "minItems": 1,
+          "allOf": [
+            {
+              "contains": {
+                "const": "absence_of_retrieval_hit_does_not_prove_absence_in_repository"
+              }
+            },
+            {
+              "contains": {
+                "const": "miss_type_does_not_prove_claim_truth_or_falsehood"
+              }
+            },
+            {
+              "contains": {
+                "const": "ranking_position_does_not_prove_semantic_importance"
+              }
+            },
+            {
+              "contains": {
+                "const": "retrieval_eval_does_not_prove_retrieval_completeness"
+              }
+            },
+            {
+              "contains": {
+                "const": "taxonomy_is_diagnostic_not_authoritative"
+              }
+            }
+          ]
         },
         "aggregate": {
           "type": "object",

--- a/merger/lenskit/contracts/retrieval-eval.v1.schema.json
+++ b/merger/lenskit/contracts/retrieval-eval.v1.schema.json
@@ -300,7 +300,7 @@
     },
     "miss_taxonomy": {
       "type": "object",
-      "description": "Diagnostic classification of retrieval misses. Conservative, mechanical categorization of why expected targets were not retrieved. Does NOT prove repository absence.",
+      "description": "Diagnostic classification of retrieval misses. Conservative, mechanical categorization of why expected targets were not retrieved. In compare mode this classifies the top-level active eval view in details[] (baseline sub-blocks are not separately classified in v1). Does NOT prove repository absence.",
       "additionalProperties": false,
       "properties": {
         "version": {
@@ -396,8 +396,23 @@
                 "possible_filter_scope_gap": {"type": "integer", "minimum": 0},
                 "noise_or_fixture_hit": {"type": "integer", "minimum": 0},
                 "stale_eval_input": {"type": "integer", "minimum": 0},
+                "query_execution_error": {"type": "integer", "minimum": 0},
                 "unknown": {"type": "integer", "minimum": 0}
-              }
+              },
+              "required": [
+                "zero_results",
+                "expected_not_in_top_k",
+                "expected_rank_below_k",
+                "expected_path_not_indexed",
+                "expected_symbol_not_indexed",
+                "path_or_symbol_metadata_missing",
+                "possible_query_vocabulary_gap",
+                "possible_filter_scope_gap",
+                "noise_or_fixture_hit",
+                "stale_eval_input",
+                "query_execution_error",
+                "unknown"
+              ]
             }
           },
           "required": ["total_cases_classified", "total_misses", "by_type"]
@@ -447,6 +462,7 @@
                     "possible_filter_scope_gap",
                     "noise_or_fixture_hit",
                     "stale_eval_input",
+                    "query_execution_error",
                     "unknown"
                   ]
                 },
@@ -466,6 +482,7 @@
                   "possible_filter_scope_gap",
                   "noise_or_fixture_hit",
                   "stale_eval_input",
+                  "query_execution_error",
                   "unknown"
                 ]
               },
@@ -480,7 +497,7 @@
                 "items": {"type": "string"}
               }
             },
-            "required": ["query_index", "is_relevant", "miss_types", "primary_miss_type"]
+            "required": ["query_index", "is_relevant", "miss_types", "primary_miss_type", "classification_basis"]
           }
         }
       },

--- a/merger/lenskit/contracts/retrieval-eval.v1.schema.json
+++ b/merger/lenskit/contracts/retrieval-eval.v1.schema.json
@@ -297,6 +297,167 @@
           "type": "boolean"
         }
       }
+    },
+    "miss_taxonomy": {
+      "type": "object",
+      "description": "Diagnostic classification of retrieval misses. Conservative, mechanical categorization of why expected targets were not retrieved. Does NOT prove repository absence.",
+      "additionalProperties": false,
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "Version of the miss taxonomy schema.",
+          "const": "1.0"
+        },
+        "authority": {
+          "type": "string",
+          "description": "Authority level of this diagnostic.",
+          "const": "diagnostic_signal"
+        },
+        "risk_class": {
+          "type": "string",
+          "description": "Risk classification.",
+          "const": "diagnostic"
+        },
+        "classification_basis": {
+          "type": "array",
+          "description": "List of information sources used for miss classification.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "retrieval_eval_expectations",
+              "returned_hit_paths",
+              "chunk_index_paths",
+              "query_metadata",
+              "filter_configuration"
+            ]
+          },
+          "minItems": 1
+        },
+        "does_not_prove": {
+          "type": "array",
+          "description": "Explicit statements of what this taxonomy does NOT prove.",
+          "items": {"type": "string"},
+          "minItems": 1
+        },
+        "aggregate": {
+          "type": "object",
+          "description": "Aggregate statistics for missed queries.",
+          "additionalProperties": false,
+          "properties": {
+            "total_cases_classified": {
+              "type": "integer",
+              "description": "Total number of queries classified.",
+              "minimum": 0
+            },
+            "total_misses": {
+              "type": "integer",
+              "description": "Total number of missed queries.",
+              "minimum": 0
+            },
+            "by_type": {
+              "type": "object",
+              "description": "Count of each miss type.",
+              "additionalProperties": false,
+              "properties": {
+                "zero_results": {"type": "integer", "minimum": 0},
+                "expected_not_in_top_k": {"type": "integer", "minimum": 0},
+                "expected_rank_below_k": {"type": "integer", "minimum": 0},
+                "expected_path_not_indexed": {"type": "integer", "minimum": 0},
+                "expected_symbol_not_indexed": {"type": "integer", "minimum": 0},
+                "path_or_symbol_metadata_missing": {"type": "integer", "minimum": 0},
+                "possible_query_vocabulary_gap": {"type": "integer", "minimum": 0},
+                "possible_filter_scope_gap": {"type": "integer", "minimum": 0},
+                "noise_or_fixture_hit": {"type": "integer", "minimum": 0},
+                "stale_eval_input": {"type": "integer", "minimum": 0},
+                "unknown": {"type": "integer", "minimum": 0}
+              }
+            }
+          },
+          "required": ["total_cases_classified", "total_misses", "by_type"]
+        },
+        "cases": {
+          "type": "array",
+          "description": "Detailed miss classification per query case.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "query_index": {
+                "type": "integer",
+                "description": "Index of the query in the details array."
+              },
+              "query": {
+                "type": "string",
+                "description": "Query text reference."
+              },
+              "expected": {
+                "type": "array",
+                "description": "Expected target patterns.",
+                "items": {"type": "string"}
+              },
+              "is_relevant": {
+                "type": "boolean",
+                "description": "Whether this query had a hit (not a miss)."
+              },
+              "observed_top_k_count": {
+                "type": "integer",
+                "description": "Number of results returned.",
+                "minimum": 0
+              },
+              "miss_types": {
+                "type": "array",
+                "description": "Primary and secondary miss classifications.",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "zero_results",
+                    "expected_not_in_top_k",
+                    "expected_rank_below_k",
+                    "expected_path_not_indexed",
+                    "expected_symbol_not_indexed",
+                    "path_or_symbol_metadata_missing",
+                    "possible_query_vocabulary_gap",
+                    "possible_filter_scope_gap",
+                    "noise_or_fixture_hit",
+                    "stale_eval_input",
+                    "unknown"
+                  ]
+                },
+                "minItems": 1
+              },
+              "primary_miss_type": {
+                "type": "string",
+                "description": "Most specific/mechanically-backed miss type.",
+                "enum": [
+                  "zero_results",
+                  "expected_not_in_top_k",
+                  "expected_rank_below_k",
+                  "expected_path_not_indexed",
+                  "expected_symbol_not_indexed",
+                  "path_or_symbol_metadata_missing",
+                  "possible_query_vocabulary_gap",
+                  "possible_filter_scope_gap",
+                  "noise_or_fixture_hit",
+                  "stale_eval_input",
+                  "unknown"
+                ]
+              },
+              "classification_basis": {
+                "type": "array",
+                "description": "Which sources justified this classification.",
+                "items": {"type": "string"}
+              },
+              "notes": {
+                "type": "array",
+                "description": "Optional human-readable notes on the classification.",
+                "items": {"type": "string"}
+              }
+            },
+            "required": ["query_index", "is_relevant", "miss_types", "primary_miss_type"]
+          }
+        }
+      },
+      "required": ["version", "authority", "risk_class", "classification_basis", "does_not_prove", "aggregate"]
     }
   },
   "required": [

--- a/merger/lenskit/retrieval/eval_core.py
+++ b/merger/lenskit/retrieval/eval_core.py
@@ -22,8 +22,13 @@ def classify_miss(query_case: Dict[str, Any], expected_paths: List[str], is_rele
     - Do not prove claim truth/falsity
     - Classify based on available mechanical signals only
     """
+    explain = query_case.get("explain", {}) if isinstance(query_case, dict) else {}
+    why = query_case.get("why", {}) if isinstance(query_case, dict) else {}
+    has_query_execution_error = bool(query_case.get("error")) or explain.get("why_fail") == WHY_FAIL_QUERY_EXECUTION or why.get("why_fail") == WHY_FAIL_QUERY_EXECUTION
+    if has_query_execution_error:
+        return ["query_execution_error"], "query_execution_error"
+
     if is_relevant:
-        # Not a miss case
         return [], None
     
     miss_types = []
@@ -48,8 +53,6 @@ def classify_miss(query_case: Dict[str, Any], expected_paths: List[str], is_rele
     # Missing metadata for classification
     elif not expected_paths:
         miss_types.append("path_or_symbol_metadata_missing")
-    else:
-        miss_types.append("unknown")
     
     # Fallback: ensure at least one miss type is always returned for miss cases
     if not miss_types:
@@ -73,7 +76,8 @@ def build_miss_taxonomy(results_detail: List[Dict[str, Any]], is_stale: bool) ->
         "risk_class": "diagnostic",
         "classification_basis": [
             "retrieval_eval_expectations",
-            "returned_hit_paths"
+            "returned_hit_paths",
+            "query_metadata"
         ],
         "does_not_prove": [
             "absence_of_retrieval_hit_does_not_prove_absence_in_repository",
@@ -96,6 +100,7 @@ def build_miss_taxonomy(results_detail: List[Dict[str, Any]], is_stale: bool) ->
                 "possible_filter_scope_gap": 0,
                 "noise_or_fixture_hit": 0,
                 "stale_eval_input": 0,
+                "query_execution_error": 0,
                 "unknown": 0
             }
         },
@@ -108,13 +113,16 @@ def build_miss_taxonomy(results_detail: List[Dict[str, Any]], is_stale: bool) ->
         top_results = detail.get("top_results", [])
         expected = detail.get("expected", [])
         query_text = detail.get("query", "")
+        explain = detail.get("explain", {}) if isinstance(detail, dict) else {}
+        why = detail.get("why", {}) if isinstance(detail, dict) else {}
+        is_query_execution_error = bool(detail.get("error")) or explain.get("why_fail") == WHY_FAIL_QUERY_EXECUTION or why.get("why_fail") == WHY_FAIL_QUERY_EXECUTION
         
         miss_types, primary_miss_type = classify_miss(detail, expected, is_relevant, found_count, top_results)
         
         taxonomy["aggregate"]["total_cases_classified"] += 1
         
         # Only record misses in cases
-        if not is_relevant or found_count == 0:
+        if not is_relevant or is_query_execution_error:
             taxonomy["aggregate"]["total_misses"] += 1
 
             if is_stale and "stale_eval_input" not in miss_types:

--- a/merger/lenskit/retrieval/eval_core.py
+++ b/merger/lenskit/retrieval/eval_core.py
@@ -9,6 +9,139 @@ from .query_core import execute_query
 WHY_FAIL_QUERY_EXECUTION = "query execution failed"
 WHY_FAIL_MISSING_EXPLAIN = "missing explain from query execution"
 
+
+def classify_miss(query_case: Dict[str, Any], expected_paths: List[str], is_relevant: bool, found_count: int, top_results: List[str]) -> Tuple[List[str], str]:
+    """
+    Classify a retrieval miss mechanically.
+    
+    Returns:
+      (miss_types: List[str], primary_miss_type: str)
+    
+    Miss types are conservative and diagnostic only:
+    - Do not prove repository absence
+    - Do not prove claim truth/falsity
+    - Classify based on available mechanical signals only
+    """
+    if is_relevant:
+        # Not a miss case
+        return [], "hit"  # Not a miss, so no classification needed
+    
+    miss_types = []
+    
+    # Zero results: query returned nothing
+    if found_count == 0:
+        miss_types.append("zero_results")
+    # Expected paths provided but not in results: expected not in top-k
+    elif expected_paths and top_results:
+        # Check if any expected path substring is in top results
+        found_expected = False
+        for result_path in top_results:
+            for exp_pattern in expected_paths:
+                if exp_pattern in result_path:
+                    found_expected = True
+                    break
+            if found_expected:
+                break
+        
+        if not found_expected:
+            miss_types.append("expected_not_in_top_k")
+    # Missing metadata for classification
+    elif not expected_paths:
+        miss_types.append("path_or_symbol_metadata_missing")
+    else:
+        miss_types.append("unknown")
+    
+    # Use the most specific classification as primary
+    # Order: zero_results > expected_not_in_top_k > known types > unknown
+    primary_miss_type = miss_types[0] if miss_types else "unknown"
+    
+    return miss_types, primary_miss_type
+
+
+def build_miss_taxonomy(results_detail: List[Dict[str, Any]], is_stale: bool) -> Dict[str, Any]:
+    """
+    Build the miss taxonomy from evaluation results.
+    
+    This is a diagnostic classification layer that explains why retrievals failed.
+    It does NOT prove repository absence or claim semantic truth.
+    """
+    taxonomy = {
+        "version": "1.0",
+        "authority": "diagnostic_signal",
+        "risk_class": "diagnostic",
+        "classification_basis": [
+            "retrieval_eval_expectations",
+            "returned_hit_paths"
+        ],
+        "does_not_prove": [
+            "absence_of_retrieval_hit_does_not_prove_absence_in_repository",
+            "miss_type_does_not_prove_claim_truth_or_falsehood",
+            "ranking_position_does_not_prove_semantic_importance",
+            "retrieval_eval_does_not_prove_retrieval_completeness",
+            "taxonomy_is_diagnostic_not_authoritative"
+        ],
+        "aggregate": {
+            "total_cases_classified": 0,
+            "total_misses": 0,
+            "by_type": {
+                "zero_results": 0,
+                "expected_not_in_top_k": 0,
+                "expected_rank_below_k": 0,
+                "expected_path_not_indexed": 0,
+                "expected_symbol_not_indexed": 0,
+                "path_or_symbol_metadata_missing": 0,
+                "possible_query_vocabulary_gap": 0,
+                "possible_filter_scope_gap": 0,
+                "noise_or_fixture_hit": 0,
+                "stale_eval_input": 0,
+                "unknown": 0
+            }
+        },
+        "cases": []
+    }
+    
+    if is_stale:
+        taxonomy["classification_basis"].append("stale_eval_marker")
+    
+    for query_index, detail in enumerate(results_detail):
+        is_relevant = detail.get("is_relevant", False)
+        found_count = detail.get("found_count", 0)
+        top_results = detail.get("top_results", [])
+        expected = detail.get("expected", [])
+        query_text = detail.get("query", "")
+        
+        miss_types, primary_miss_type = classify_miss(detail, expected, is_relevant, found_count, top_results)
+        
+        taxonomy["aggregate"]["total_cases_classified"] += 1
+        
+        # Only record misses in cases
+        if not is_relevant or found_count == 0:
+            taxonomy["aggregate"]["total_misses"] += 1
+            
+            # Update aggregate counts
+            for miss_type in miss_types:
+                if miss_type in taxonomy["aggregate"]["by_type"]:
+                    taxonomy["aggregate"]["by_type"][miss_type] += 1
+            
+            case_entry = {
+                "query_index": query_index,
+                "query": query_text,
+                "expected": expected,
+                "is_relevant": is_relevant,
+                "observed_top_k_count": found_count,
+                "miss_types": miss_types,
+                "primary_miss_type": primary_miss_type,
+                "classification_basis": taxonomy["classification_basis"].copy()
+            }
+            
+            # Add optional notes if staleness is a factor
+            if is_stale:
+                case_entry["notes"] = ["eval marked stale; may affect classification"]
+            
+            taxonomy["cases"].append(case_entry)
+    
+    return taxonomy
+
 RE_MD_QUERY_TITLE = re.compile(r"^\d+\.\s+\*\*\"(.+?)\"\*\*")
 RE_CLEAN_MD_LINE = re.compile(r"^[\s*+\-]+")
 RE_EXPECTED_LABEL = re.compile(r"^\*?Expected:?\*?", re.IGNORECASE)
@@ -393,6 +526,9 @@ def do_eval(
     if graph_index_used:
         evidence_basis.append("graph_index")
 
+    # Build the miss taxonomy for diagnostic purposes
+    miss_taxonomy = build_miss_taxonomy(results_detail, is_stale)
+
     out = {
         "metrics": {
             f"recall@{k}": sem_recall_at_k if compare_mode else base_recall_at_k,
@@ -419,7 +555,8 @@ def do_eval(
             ],
             "evidence_basis": evidence_basis,
             "requires_live_check": True
-        }
+        },
+        "miss_taxonomy": miss_taxonomy
     }
 
     if compare_mode:

--- a/merger/lenskit/retrieval/eval_core.py
+++ b/merger/lenskit/retrieval/eval_core.py
@@ -51,9 +51,11 @@ def classify_miss(query_case: Dict[str, Any], expected_paths: List[str], is_rele
     else:
         miss_types.append("unknown")
     
-    # Use the most specific classification as primary
-    # Order: zero_results > expected_not_in_top_k > known types > unknown
-    primary_miss_type = miss_types[0] if miss_types else "unknown"
+    # Fallback: ensure at least one miss type is always returned for miss cases
+    if not miss_types:
+        miss_types.append("unknown")
+    
+    primary_miss_type = miss_types[0]
     
     return miss_types, primary_miss_type
 

--- a/merger/lenskit/retrieval/eval_core.py
+++ b/merger/lenskit/retrieval/eval_core.py
@@ -10,12 +10,12 @@ WHY_FAIL_QUERY_EXECUTION = "query execution failed"
 WHY_FAIL_MISSING_EXPLAIN = "missing explain from query execution"
 
 
-def classify_miss(query_case: Dict[str, Any], expected_paths: List[str], is_relevant: bool, found_count: int, top_results: List[str]) -> Tuple[List[str], str]:
+def classify_miss(query_case: Dict[str, Any], expected_paths: List[str], is_relevant: bool, found_count: int, top_results: List[str]) -> Tuple[List[str], Optional[str]]:
     """
     Classify a retrieval miss mechanically.
     
-    Returns:
-      (miss_types: List[str], primary_miss_type: str)
+        Returns:
+            (miss_types: List[str], primary_miss_type: Optional[str])
     
     Miss types are conservative and diagnostic only:
     - Do not prove repository absence
@@ -24,7 +24,7 @@ def classify_miss(query_case: Dict[str, Any], expected_paths: List[str], is_rele
     """
     if is_relevant:
         # Not a miss case
-        return [], "hit"  # Not a miss, so no classification needed
+        return [], None
     
     miss_types = []
     
@@ -100,9 +100,6 @@ def build_miss_taxonomy(results_detail: List[Dict[str, Any]], is_stale: bool) ->
         "cases": []
     }
     
-    if is_stale:
-        taxonomy["classification_basis"].append("stale_eval_marker")
-    
     for query_index, detail in enumerate(results_detail):
         is_relevant = detail.get("is_relevant", False)
         found_count = detail.get("found_count", 0)
@@ -117,6 +114,11 @@ def build_miss_taxonomy(results_detail: List[Dict[str, Any]], is_stale: bool) ->
         # Only record misses in cases
         if not is_relevant or found_count == 0:
             taxonomy["aggregate"]["total_misses"] += 1
+
+            if is_stale and "stale_eval_input" not in miss_types:
+                miss_types.append("stale_eval_input")
+                if primary_miss_type is None:
+                    primary_miss_type = "stale_eval_input"
             
             # Update aggregate counts
             for miss_type in miss_types:
@@ -130,7 +132,7 @@ def build_miss_taxonomy(results_detail: List[Dict[str, Any]], is_stale: bool) ->
                 "is_relevant": is_relevant,
                 "observed_top_k_count": found_count,
                 "miss_types": miss_types,
-                "primary_miss_type": primary_miss_type,
+                "primary_miss_type": primary_miss_type or "unknown",
                 "classification_basis": taxonomy["classification_basis"].copy()
             }
             

--- a/merger/lenskit/tests/test_retrieval_eval.py
+++ b/merger/lenskit/tests/test_retrieval_eval.py
@@ -755,3 +755,53 @@ def test_retrieval_eval_schema_backward_compatibility_without_miss_taxonomy():
     }
 
     jsonschema.validate(instance=legacy_output, schema=schema)
+
+
+def test_miss_taxonomy_schema_rejects_missing_required_does_not_prove_entry():
+    """Schema must reject miss_taxonomy when one canonical does_not_prove entry is missing."""
+    import jsonschema
+
+    schema = _load_retrieval_eval_schema()
+    invalid_output = {
+        "metrics": {"total_queries": 1, "hits": 0, "stale_flag": False},
+        "details": [],
+        "claim_boundaries": {
+            "proves": ["x"],
+            "does_not_prove": ["y"],
+            "evidence_basis": ["eval_queries"],
+            "requires_live_check": True
+        },
+        "miss_taxonomy": {
+            "version": "1.0",
+            "authority": "diagnostic_signal",
+            "risk_class": "diagnostic",
+            "classification_basis": ["retrieval_eval_expectations"],
+            "does_not_prove": [
+                "absence_of_retrieval_hit_does_not_prove_absence_in_repository",
+                "miss_type_does_not_prove_claim_truth_or_falsehood",
+                "ranking_position_does_not_prove_semantic_importance",
+                "retrieval_eval_does_not_prove_retrieval_completeness"
+            ],
+            "aggregate": {
+                "total_cases_classified": 0,
+                "total_misses": 0,
+                "by_type": {
+                    "zero_results": 0,
+                    "expected_not_in_top_k": 0,
+                    "expected_rank_below_k": 0,
+                    "expected_path_not_indexed": 0,
+                    "expected_symbol_not_indexed": 0,
+                    "path_or_symbol_metadata_missing": 0,
+                    "possible_query_vocabulary_gap": 0,
+                    "possible_filter_scope_gap": 0,
+                    "noise_or_fixture_hit": 0,
+                    "stale_eval_input": 0,
+                    "unknown": 0
+                }
+            },
+            "cases": []
+        }
+    }
+
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=invalid_output, schema=schema)

--- a/merger/lenskit/tests/test_retrieval_eval.py
+++ b/merger/lenskit/tests/test_retrieval_eval.py
@@ -672,6 +672,24 @@ def test_classify_miss_zero_results():
     assert primary == "zero_results"
 
 
+def test_classify_miss_query_execution_error():
+    """Query execution failures must classify as query_execution_error, not zero_results."""
+    case = {
+        "query": "test",
+        "error": "Mock DB Crash",
+        "explain": {"why_fail": eval_core.WHY_FAIL_QUERY_EXECUTION}
+    }
+    miss_types, primary = eval_core.classify_miss(
+        case,
+        expected_paths=["foo.py"],
+        is_relevant=False,
+        found_count=0,
+        top_results=[]
+    )
+    assert miss_types == ["query_execution_error"]
+    assert primary == "query_execution_error"
+
+
 def test_classify_miss_expected_not_in_top_k():
     """Test the classify_miss function for expected_not_in_top_k case."""
     case = {"query": "test"}
@@ -758,6 +776,34 @@ def test_miss_taxonomy_expected_not_in_top_k_integration(mini_index_for_eval, tm
     assert cases[0]["primary_miss_type"] == "expected_not_in_top_k"
 
 
+def test_miss_taxonomy_query_execution_error_not_counted_as_zero_results(mini_index_for_eval, tmp_path, monkeypatch):
+    queries_json = tmp_path / "eval_queries.json"
+    queries_json.write_text(json.dumps([
+        {"query": "login", "expected_patterns": ["login.py"]}
+    ]), encoding="utf-8")
+
+    def mock_execute(*args, **kwargs):
+        raise RuntimeError("Mock DB Crash")
+
+    monkeypatch.setattr(eval_core, "execute_query", mock_execute)
+
+    out = eval_core.do_eval(
+        index_path=Path(mini_index_for_eval),
+        queries_path=queries_json,
+        k=5,
+        is_json_mode=True,
+        is_stale=False
+    )
+
+    assert out is not None
+    aggregate = out["miss_taxonomy"]["aggregate"]["by_type"]
+    case = out["miss_taxonomy"]["cases"][0]
+    assert aggregate["query_execution_error"] == 1
+    assert aggregate["zero_results"] == 0
+    assert case["miss_types"][0] == "query_execution_error"
+    assert case["primary_miss_type"] == "query_execution_error"
+
+
 def test_retrieval_eval_schema_backward_compatibility_without_miss_taxonomy():
     """Schema remains backward compatible when miss_taxonomy is omitted."""
     import jsonschema
@@ -801,6 +847,58 @@ def test_miss_taxonomy_schema_rejects_missing_required_does_not_prove_entry():
                 "miss_type_does_not_prove_claim_truth_or_falsehood",
                 "ranking_position_does_not_prove_semantic_importance",
                 "retrieval_eval_does_not_prove_retrieval_completeness"
+            ],
+            "aggregate": {
+                "total_cases_classified": 0,
+                "total_misses": 0,
+                "by_type": {
+                    "zero_results": 0,
+                    "expected_not_in_top_k": 0,
+                    "expected_rank_below_k": 0,
+                    "expected_path_not_indexed": 0,
+                    "expected_symbol_not_indexed": 0,
+                    "path_or_symbol_metadata_missing": 0,
+                    "possible_query_vocabulary_gap": 0,
+                    "possible_filter_scope_gap": 0,
+                    "noise_or_fixture_hit": 0,
+                    "stale_eval_input": 0,
+                    "query_execution_error": 0,
+                    "unknown": 0
+                }
+            },
+            "cases": []
+        }
+    }
+
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=invalid_output, schema=schema)
+
+
+def test_miss_taxonomy_schema_rejects_missing_required_by_type_key():
+    """Schema must reject miss_taxonomy.by_type when a required key is omitted."""
+    import jsonschema
+
+    schema = _load_retrieval_eval_schema()
+    invalid_output = {
+        "metrics": {"total_queries": 1, "hits": 0, "stale_flag": False},
+        "details": [],
+        "claim_boundaries": {
+            "proves": ["x"],
+            "does_not_prove": ["y"],
+            "evidence_basis": ["eval_queries"],
+            "requires_live_check": True
+        },
+        "miss_taxonomy": {
+            "version": "1.0",
+            "authority": "diagnostic_signal",
+            "risk_class": "diagnostic",
+            "classification_basis": ["retrieval_eval_expectations"],
+            "does_not_prove": [
+                "absence_of_retrieval_hit_does_not_prove_absence_in_repository",
+                "miss_type_does_not_prove_claim_truth_or_falsehood",
+                "ranking_position_does_not_prove_semantic_importance",
+                "retrieval_eval_does_not_prove_retrieval_completeness",
+                "taxonomy_is_diagnostic_not_authoritative"
             ],
             "aggregate": {
                 "total_cases_classified": 0,

--- a/merger/lenskit/tests/test_retrieval_eval.py
+++ b/merger/lenskit/tests/test_retrieval_eval.py
@@ -535,3 +535,152 @@ def test_run_eval_explain_always_present_on_error(mini_index_for_eval, tmp_path,
     assert detail["error"] == "Mock DB Crash"
     assert "explain" in detail
     assert detail["explain"]["why_fail"] == eval_core.WHY_FAIL_QUERY_EXECUTION
+
+
+# B2 — Retrieval Miss Taxonomy Tests
+
+def test_miss_taxonomy_present_in_output(mini_index_for_eval, tmp_path):
+    """Test that miss_taxonomy is always present in retrieval_eval output."""
+    queries_json = tmp_path / "eval_queries.json"
+    queries_json.write_text(json.dumps([
+        {"query": "login", "expected_patterns": ["login.py"]},
+        {"query": "missing", "expected_patterns": ["nonexistent.py"]}
+    ]), encoding="utf-8")
+
+    out = eval_core.do_eval(
+        index_path=Path(mini_index_for_eval),
+        queries_path=queries_json,
+        k=5,
+        is_json_mode=True,
+        is_stale=False
+    )
+
+    assert "miss_taxonomy" in out
+    taxonomy = out["miss_taxonomy"]
+    assert taxonomy["version"] == "1.0"
+    assert taxonomy["authority"] == "diagnostic_signal"
+    assert taxonomy["risk_class"] == "diagnostic"
+
+
+def test_miss_taxonomy_schema_validation(mini_index_for_eval, tmp_path):
+    """Test that miss_taxonomy passes JSON schema validation."""
+    import jsonschema
+
+    queries_json = tmp_path / "eval_queries.json"
+    queries_json.write_text(json.dumps([
+        {"query": "login", "expected_patterns": ["login.py"]}
+    ]), encoding="utf-8")
+
+    out = eval_core.do_eval(
+        index_path=Path(mini_index_for_eval),
+        queries_path=queries_json,
+        k=5,
+        is_json_mode=True,
+        is_stale=False
+    )
+
+    schema = _load_retrieval_eval_schema()
+    jsonschema.validate(instance=out, schema=schema)
+
+
+def test_miss_taxonomy_does_not_prove_entries(mini_index_for_eval, tmp_path):
+    """Test that does_not_prove entries are present and correct."""
+    queries_json = tmp_path / "eval_queries.json"
+    queries_json.write_text(json.dumps([
+        {"query": "missing", "expected_patterns": ["nonexistent.py"]}
+    ]), encoding="utf-8")
+
+    out = eval_core.do_eval(
+        index_path=Path(mini_index_for_eval),
+        queries_path=queries_json,
+        k=5,
+        is_json_mode=True,
+        is_stale=False
+    )
+
+    taxonomy = out["miss_taxonomy"]
+    does_not_prove = taxonomy["does_not_prove"]
+    
+    # Check that required does_not_prove entries are present
+    assert "absence_of_retrieval_hit_does_not_prove_absence_in_repository" in does_not_prove
+    assert "miss_type_does_not_prove_claim_truth_or_falsehood" in does_not_prove
+    assert "ranking_position_does_not_prove_semantic_importance" in does_not_prove
+    assert "retrieval_eval_does_not_prove_retrieval_completeness" in does_not_prove
+    assert "taxonomy_is_diagnostic_not_authoritative" in does_not_prove
+
+
+def test_miss_taxonomy_zero_results_classification(mini_index_for_eval, tmp_path):
+    """Test that zero_results miss type is correctly classified."""
+    queries_json = tmp_path / "eval_queries.json"
+    queries_json.write_text(json.dumps([
+        {"query": "xyzabc9999", "expected_patterns": ["nowhere.py"]}
+    ]), encoding="utf-8")
+
+    out = eval_core.do_eval(
+        index_path=Path(mini_index_for_eval),
+        queries_path=queries_json,
+        k=5,
+        is_json_mode=True,
+        is_stale=False
+    )
+
+    taxonomy = out["miss_taxonomy"]
+    aggregate = taxonomy["aggregate"]
+    
+    # Should have one miss classified as zero_results
+    assert aggregate["total_misses"] >= 1
+    assert aggregate["by_type"]["zero_results"] >= 1
+
+
+def test_classify_miss_zero_results():
+    """Test the classify_miss function directly for zero_results case."""
+    case = {"query": "test"}
+    miss_types, primary = eval_core.classify_miss(
+        case,
+        expected_paths=["foo.py"],
+        is_relevant=False,
+        found_count=0,
+        top_results=[]
+    )
+    assert "zero_results" in miss_types
+    assert primary == "zero_results"
+
+
+def test_classify_miss_expected_not_in_top_k():
+    """Test the classify_miss function for expected_not_in_top_k case."""
+    case = {"query": "test"}
+    miss_types, primary = eval_core.classify_miss(
+        case,
+        expected_paths=["expected.py"],
+        is_relevant=False,
+        found_count=2,
+        top_results=["other1.py", "other2.py"]
+    )
+    assert "expected_not_in_top_k" in miss_types
+    assert primary == "expected_not_in_top_k"
+
+
+def test_classify_miss_hit_case():
+    """Test that hit cases are not classified as misses."""
+    case = {"query": "test"}
+    miss_types, primary = eval_core.classify_miss(
+        case,
+        expected_paths=["foo.py"],
+        is_relevant=True,
+        found_count=1,
+        top_results=["foo.py"]
+    )
+    assert len(miss_types) == 0 or primary == "hit"
+
+
+def test_classify_miss_missing_metadata():
+    """Test classification when expected metadata is missing."""
+    case = {"query": "test"}
+    miss_types, primary = eval_core.classify_miss(
+        case,
+        expected_paths=[],  # No expected paths
+        is_relevant=False,
+        found_count=1,
+        top_results=["something.py"]
+    )
+    assert "path_or_symbol_metadata_missing" in miss_types or primary == "path_or_symbol_metadata_missing"

--- a/merger/lenskit/tests/test_retrieval_eval.py
+++ b/merger/lenskit/tests/test_retrieval_eval.py
@@ -583,6 +583,32 @@ def test_miss_taxonomy_schema_validation(mini_index_for_eval, tmp_path):
     jsonschema.validate(instance=out, schema=schema)
 
 
+def test_miss_taxonomy_schema_validation_stale_eval(mini_index_for_eval, tmp_path):
+    """Stale eval output must still validate against retrieval-eval schema."""
+    import jsonschema
+
+    queries_json = tmp_path / "eval_queries.json"
+    queries_json.write_text(json.dumps([
+        {"query": "login", "expected_patterns": ["login.py"]},
+        {"query": "missing", "expected_patterns": ["nope.py"]}
+    ]), encoding="utf-8")
+
+    out = eval_core.do_eval(
+        index_path=Path(mini_index_for_eval),
+        queries_path=queries_json,
+        k=5,
+        is_json_mode=True,
+        is_stale=True
+    )
+
+    schema = _load_retrieval_eval_schema()
+    jsonschema.validate(instance=out, schema=schema)
+
+    taxonomy = out["miss_taxonomy"]
+    assert "stale_eval_input" in taxonomy["aggregate"]["by_type"]
+    assert "stale_eval_marker" not in taxonomy["classification_basis"]
+
+
 def test_miss_taxonomy_does_not_prove_entries(mini_index_for_eval, tmp_path):
     """Test that does_not_prove entries are present and correct."""
     queries_json = tmp_path / "eval_queries.json"
@@ -670,7 +696,8 @@ def test_classify_miss_hit_case():
         found_count=1,
         top_results=["foo.py"]
     )
-    assert len(miss_types) == 0 or primary == "hit"
+    assert miss_types == []
+    assert primary is None
 
 
 def test_classify_miss_missing_metadata():
@@ -684,3 +711,47 @@ def test_classify_miss_missing_metadata():
         top_results=["something.py"]
     )
     assert "path_or_symbol_metadata_missing" in miss_types or primary == "path_or_symbol_metadata_missing"
+
+
+def test_miss_taxonomy_expected_not_in_top_k_integration(mini_index_for_eval, tmp_path):
+    """Integration-level check: do_eval emits expected_not_in_top_k on a real miss with returned results."""
+    queries_json = tmp_path / "eval_queries.json"
+    queries_json.write_text(json.dumps([
+        {"query": "def", "expected_patterns": ["never_there.py"]}
+    ]), encoding="utf-8")
+
+    out = eval_core.do_eval(
+        index_path=Path(mini_index_for_eval),
+        queries_path=queries_json,
+        k=5,
+        is_json_mode=True,
+        is_stale=False
+    )
+
+    detail = out["details"][0]
+    assert detail["is_relevant"] is False
+    assert detail["found_count"] > 0
+
+    cases = out["miss_taxonomy"]["cases"]
+    assert len(cases) >= 1
+    assert "expected_not_in_top_k" in cases[0]["miss_types"]
+    assert cases[0]["primary_miss_type"] == "expected_not_in_top_k"
+
+
+def test_retrieval_eval_schema_backward_compatibility_without_miss_taxonomy():
+    """Schema remains backward compatible when miss_taxonomy is omitted."""
+    import jsonschema
+
+    schema = _load_retrieval_eval_schema()
+    legacy_output = {
+        "metrics": {"total_queries": 1, "hits": 0, "stale_flag": False},
+        "details": [],
+        "claim_boundaries": {
+            "proves": ["x"],
+            "does_not_prove": ["y"],
+            "evidence_basis": ["eval_queries"],
+            "requires_live_check": True
+        }
+    }
+
+    jsonschema.validate(instance=legacy_output, schema=schema)

--- a/merger/lenskit/tests/test_retrieval_eval.py
+++ b/merger/lenskit/tests/test_retrieval_eval.py
@@ -713,6 +713,26 @@ def test_classify_miss_missing_metadata():
     assert "path_or_symbol_metadata_missing" in miss_types or primary == "path_or_symbol_metadata_missing"
 
 
+def test_classify_miss_found_expected_pattern_in_results_but_not_relevant():
+    """Regression: is_relevant=False but expected pattern IS found in top results.
+
+    This edge case previously returned ([], "unknown"), violating schema minItems: 1
+    on miss_taxonomy.cases[].miss_types. The fix ensures at least ["unknown"] is returned.
+    """
+    case = {"query": "test"}
+    miss_types, primary = eval_core.classify_miss(
+        case,
+        expected_paths=["expected.py"],
+        is_relevant=False,
+        found_count=1,
+        top_results=["src/expected.py"],  # pattern IS found in results
+    )
+    # Must always return at least one miss type (schema minItems: 1)
+    assert len(miss_types) >= 1
+    assert primary == "unknown"
+    assert miss_types == ["unknown"]
+
+
 def test_miss_taxonomy_expected_not_in_top_k_integration(mini_index_for_eval, tmp_path):
     """Integration-level check: do_eval emits expected_not_in_top_k on a real miss with returned results."""
     queries_json = tmp_path / "eval_queries.json"


### PR DESCRIPTION
## These / Antithese / Synthese

**These:** Nach sauberem `main`, grünem `ruff`, **28 B1-Tests** und **93 Nachbarschaftstests** ist B2 als nächster PR sinnvoll. Der lokale Smoke lief unter Python 3.10.12 erfolgreich; `python3.11` ist lokal nicht vorhanden, daher sollte der Agent nicht stur `python3.11` voraussetzen. 

**Antithese:** B2 darf nicht zur Retrieval-Wahrheitsmaschine werden. Eine Miss-Taxonomie ist Diagnose, kein Beweis, dass etwas im Repo fehlt.

**Synthese:** Agent bekommt einen engen, contract-first Auftrag: **mechanische Miss-Klassen über bestehendem Retrieval-Eval**, Roadmap/Proof mitziehen, keine Score-/Truth-/Completeness-Semantik.

## Primary Goal

Make retrieval evaluation misses mechanically explainable without claiming repository completeness, semantic truth, answer safety, or claim validity. B2 must classify retrieval misses as diagnostic hints only.

It must not tune ranking, change retrieval behavior, introduce a truth verdict, or claim that missing retrieval results mean missing repository content.

## Baseline

- Work from current `main`.
- `main` is expected to include B1 Context Quality, A2 Noise Hygiene, A5 Agent Export Gate, A3 Range-Ref v2, A4 Post-emit Health, B3 Context Risk.
- Local smoke may use `python3`, not necessarily `python3.11`; record the interpreter version in proof output if relevant.

## Roadmap Discipline (Mandatory Before Coding)

Inspect before implementation:
- `docs/roadmap/lenskit-master-roadmap.md`
- `docs/blueprints/lenskit-anti-hallucination-output-architecture.md`
- `docs/proofs/context-quality-signals-proof.md`
- existing retrieval eval docs/proofs if present

After implementation:
- update the B2 section of `docs/roadmap/lenskit-master-roadmap.md`
- add/update a proof note under `docs/proofs/`
- keep B1/B2 separation explicit
- do not leave roadmap text implying B2 is still entirely unimplemented if this PR implements it
- do not mark later retrieval improvement/ranking work as done

## Implementation Strategy

Prefer an additive section in the existing retrieval evaluation artifact/schema, e.g. `miss_taxonomy`.

Do not create a new manifest role or separate artifact unless the roadmap or existing architecture clearly requires it.

### Required Semantics

- Classify misses per query/eval case where expected target information is available
- Add aggregate counts by miss type
- Include `does_not_prove`
- Include `classification_basis`
- Include `classification_confidence` only if categorical (e.g. `low | medium | high`)
- Preserve existing retrieval metrics unchanged: `recall@10`, `MRR`, `total_queries`, `hits`, `zero_hit_ratio`, `stale_flag`
- Do not change retrieval ranking, query execution, chunking, indexing, or existing metric definitions

### Allowed Miss Types

Conservative and mechanical classifications:

- `zero_results` — Query returned no results
- `expected_not_in_top_k` — Expected target exists in eval expectation but not in top-k results
- `expected_rank_below_k` — Expected target appeared after position k
- `expected_path_not_indexed` — Expected path absent from chunk index / eval corpus (does NOT mean absent from repo)
- `expected_symbol_not_indexed` — Symbol-level expectations and index data show symbol absence (does NOT mean absent from repo)
- `path_or_symbol_metadata_missing` — Eval case lacks metadata for stronger classification
- `possible_query_vocabulary_gap` — Query/eval metadata mechanically supports this classification
- `possible_filter_scope_gap` — Query/eval settings show filters or scope constraints
- `noise_or_fixture_hit` — Returned hits point to known fixture/noise paths
- `stale_eval_input` — Retrieval_eval already marks staleness
- `unknown` — Fallback when no conservative classification possible

### Forbidden Miss Semantics

- Do not use `target_absent_from_repo`
- Do not use `repo_gap` unless explicitly defined as "gap in current eval/index surface"
- Do not say `missing from repository`
- Do not infer author intent, semantic irrelevance, truth/falsity

### Required `does_not_prove` Entries

- `absence_of_retrieval_hit_does_not_prove_absence_in_repository`
- `miss_type_does_not_prove_claim_truth_or_falsehood`
- `ranking_position_does_not_prove_semantic_importance`
- `retrieval_eval_does_not_prove_retrieval_completeness`
- `taxonomy_is_diagnostic_not_authoritative`

## Schema Requirements

If extending `retrieval-eval.v1.schema.json`:
- Add fields additively
- Preserve backward compatibility
- Keep `additionalProperties` discipline consistent
- Do not rename existing metric fields

Suggested structure:
```json
{
  "miss_taxonomy": {
    "version": "1.0",
    "authority": "diagnostic_signal",
    "risk_class": "diagnostic",
    "classification_basis": [
      "retrieval_eval_expectations",
      "returned_hit_paths",
      "chunk_index_paths_if_available"
    ],
    "does_not_prove": [...],
    "aggregate": {
      "total_cases_classified": 0,
      "total_misses": 0,
      "by_type": {}
    },
    "cases": []
  }
}
```

## Testing Requirements

1. Schema-valid retrieval_eval with `miss_taxonomy`
2. Backward compatibility: old retrieval_eval without `miss_taxonomy` still validates
3. Zero-results query → `zero_results`
4. Expected target not in top-k → `expected_not_in_top_k`
5. Missing metadata → `path_or_symbol_metadata_missing` or `unknown`
6. Expected path absent from index → `expected_path_not_indexed`
7. Taxonomy includes all required `does_not_prove`
8. No forbidden fields/vocabulary
9. Existing retrieval metrics unchanged
10. Roadmap/proof states B2 implemented without claiming ranking improvement

## Documentation

Add `docs/proofs/retrieval-miss-taxonomy-proof.md` stating:
- B2 is diagnostic only
- Miss types are mechanical classifications
- A miss type does not prove repository absence
- B2 does not change ranking/retrieval behavior
- B2 does not implement semantic reranking
- B2 does not replace B1 context_quality
- Roadmap was checked and updated

## Validation Commands

```bash
ruff check --select=F401,F811 --exclude='**/fixtures/**' .
python3 -m pytest <new-or-modified-retrieval-eval-tests>
python3 -m pytest merger/lenskit/tests/test_context_quality.py
python3 -m pytest merger/lenskit/tests/test_output_health.py
```

## Do Not Change

- query execution behavior
- ranking algorithm
- chunking/indexing semantics
- context_quality core semantics
- output_health/post_emit_health semantics
- agent_export_gate behavior
- manifest mutation/registration semantics
- CodeQL settings/workflows
- dependency files (unless tests prove a missing dependency)

---

**Hebel:** Misses erklären, nicht Wahrheit behaupten.
**Entscheidung:** B2 als additive Diagnose über Retrieval-Eval.
**Nächste Aktion:** Agent mit obiger Anweisung starten.