### PR TITLE
C2.1: Add optional authority/risk_class fields to diagnostic contracts

### DIFF
--- a/docs/proofs/authority-risk-class-c2-1-proof.md
+++ b/docs/proofs/authority-risk-class-c2-1-proof.md
@@ -163,5 +163,3 @@ All checks passed!
   bewusst getrennt und nicht Teil von C2.1.
 - C2.2–C5 bleiben offen (siehe Roadmap); insbesondere `bundle-manifest.v1`-Normierung und
   `allowed_inference`/`forbidden_inference` sind ausdrücklich nicht enthalten.
-</content>
-</invoke>

--- a/docs/proofs/authority-risk-class-c2-1-proof.md
+++ b/docs/proofs/authority-risk-class-c2-1-proof.md
@@ -1,0 +1,167 @@
+# C2.1 — Additive Authority / Risk-Class Self-Declaration (Proof)
+
+**Status:** Implemented (Contract-only, additive). Proof for the lowest-risk slice of
+the Governance-Track-C contract normalization.
+**Datum:** 2026-05-24
+**Beziehung:** setzt `docs/proofs/authority-contract-gap-audit.md` (C2a) §6.1/§6.2/§6.3
+und §8 (Empfehlung C2.1) um.
+
+---
+
+## 1. Scope
+
+C2.1 ergänzt **ausschließlich additive, optionale, const** Felder `authority` und
+`risk_class` in genau drei bereits disclaimer-tragenden Diagnose-Contracts:
+
+| Contract | Neues Feld `authority` | Neues Feld `risk_class` | Ebene |
+| :--- | :--- | :--- | :--- |
+| `post-emit-health.v1.schema.json` | const `diagnostic_signal` (optional) | const `diagnostic` (optional) | top-level |
+| `agent-export-gate.v1.schema.json` | const `diagnostic_signal` (optional) | const `diagnostic` (optional) | top-level |
+| `retrieval-eval.v1.schema.json` | const `diagnostic_signal` (optional) | const `diagnostic` (optional) | top-level |
+
+Bei `retrieval-eval.v1` bleibt der bestehende verschachtelte
+`miss_taxonomy`-Block (mit seinen eigenen `authority`/`risk_class`) **unverändert**.
+Die neuen Felder sitzen auf dem Wurzelobjekt und tragen denselben const-Wert; sie sind
+semantisch konsistent mit der Taxonomie und kollidieren nicht (verschiedene JSON-Scopes).
+
+---
+
+## 2. Explizite Eigenschaften dieses Patches
+
+Dieser Patch ist bewusst minimal. Er enthält:
+
+- **additive optional fields only** — keine bestehende Property entfernt oder geändert.
+- **keine Pflichtfelder** — `authority`/`risk_class` sind in **keinem** der drei
+  `required`-Arrays; Legacy-Objekte ohne die Felder bleiben valide.
+- **keine Lockerung bestehender Constraints** — `additionalProperties: false` bleibt
+  überall erhalten; alle bestehenden `required`/`const`/`contains`/`enum`-Constraints sind
+  unverändert.
+- **keine Lints** — keine neue CI-/Lint-Stufe (C3 bleibt offen).
+- **keine Runtime-Annotation** — Producer (`core/post_emit_health.py`,
+  `core/agent_export_gate.py`, `retrieval/eval_core.py`) und CLIs **unverändert**; sie
+  emittieren die neuen Felder (noch) nicht. Das ist zulässig, weil die Felder optional sind.
+- **keine Export-Gates** — kein Eingriff in Gate-Semantik; `authority`/`risk_class` gaten
+  nichts und sind keine Wahrheits-/Safety-Verdicts.
+- **keine Federation-Normierung** — Federation-Contracts unangetastet.
+- **kein Eingriff in `output-health.v1`** — der konsumkritische Pre-Emit-Health-Contract
+  (Parity-Gates, laufende `pre_emit_health`-Naming-Migration) wird **nicht** angefasst.
+- **kein generisches `authority` neben `session_authority`** — `agent-query-session.v2`
+  wird **nicht** verändert (Ambiguitätsverbot aus dem Audit §5.F/§7).
+- **`miss_taxonomy` unverändert** — der vorhandene retrieval-eval Taxonomie-Block bleibt
+  bit-identisch (eigene `required`-Liste intakt).
+
+Explizit **nicht** Teil dieses Patches (bleibt Folgearbeit):
+`bundle-manifest.v1` (C2.2), `allowed_inference`/`forbidden_inference` (C2.3),
+Lint-Regeln (C3/C2.4), Runtime-Annotation (C4), Export-Gate-Integration (C5),
+neue Schemafamilien, neue Governance-Vokabulare.
+
+---
+
+## 3. Diagnose-Befund (vor dem Patch)
+
+- `rg "authority|risk_class" merger/lenskit/contracts/` zeigte: top-level `authority`/
+  `risk_class` fehlten in allen drei Contracts; `retrieval-eval.v1` trug die Felder nur im
+  verschachtelten `miss_taxonomy`-Block.
+- Producer-Scan (`grep -n "authority|risk_class"`): `post_emit_health.py` referenziert
+  `authority` nur im Sub-Objekt `agent_pack.authority_declared`; `agent_export_gate.py` gar
+  nicht; `eval_core.py:75-76` ausschließlich innerhalb `build_miss_taxonomy()`. → Kein
+  Producer emittiert ein **top-level** `authority`/`risk_class`.
+- Keine Testdatei assertet eine exakte Property-Key-Menge dieser Schemas.
+  `test_role_completeness.py` prüft nur `bundle-manifest`/`range-ref`.
+- Keine separaten JSON-Beispiel-/Fixture-Dateien für die drei Contracts; Instanzen werden
+  in Tests vom Producer bzw. minimal konstruiert.
+- Stop-Regeln (Audit-Anforderung) geprüft und **nicht** ausgelöst:
+  1. Root-Felder brechen Validatoren/Fixtures? **Nein** (optional + `additionalProperties:false`
+     + keine Key-Set-Asserts + Producer emittieren nichts).
+  2. `authority`/`risk_class` doppeldeutig? **Nein** (keine Vorbelegung in post-emit/export-gate;
+     in retrieval-eval identischer const-Wert wie nested).
+  3. retrieval-eval top-level kollidiert mit `miss_taxonomy`? **Nein** (getrennte JSON-Scopes,
+     identische Werte, semantisch konsistent).
+
+→ **Entscheidung: SAFE_TO_PATCH.**
+
+---
+
+## 4. Geänderte Dateien
+
+- `merger/lenskit/contracts/post-emit-health.v1.schema.json` (additive optionale Properties)
+- `merger/lenskit/contracts/agent-export-gate.v1.schema.json` (additive optionale Properties)
+- `merger/lenskit/contracts/retrieval-eval.v1.schema.json` (additive optionale top-level Properties)
+- `merger/lenskit/tests/test_post_emit_health.py` (4 additive C2.1-Tests)
+- `merger/lenskit/tests/test_agent_export_gate.py` (4 additive C2.1-Tests)
+- `merger/lenskit/tests/test_retrieval_eval.py` (4 additive C2.1-Tests)
+- `docs/proofs/authority-risk-class-c2-1-proof.md` (diese Datei)
+- `docs/roadmap/lenskit-master-roadmap.md` (Governance-Track-C: C2.1 als umgesetzt markiert)
+
+**Non-Changes (explizit unverändert):** alle Producer-/CLI-/Runtime-Module, `output-health.v1`,
+`bundle-manifest.v1`, `diagnostics-lookup.v1`, `agent-query-session.v2`, alle Federation-Contracts,
+der `miss_taxonomy`-Block in `retrieval-eval.v1`.
+
+---
+
+## 5. Test-Strategie
+
+Pro Contract drei Eigenschaften additiv abgesichert:
+
+1. **Legacy ohne neue Felder bleibt valide** — Objekt ohne `authority`/`risk_class` validiert.
+2. **korrekte Werte valide** — `authority=diagnostic_signal`, `risk_class=diagnostic` validiert.
+3. **falsche Werte invalid** — falsches `authority` bzw. `risk_class` löst `ValidationError` aus.
+
+Bestehende Tests blieben unverändert; nur additive Testfunktionen kamen hinzu.
+
+---
+
+## 6. Testkommandos + Output
+
+Baseline vor Patch:
+
+```
+$ python3 -m pytest merger/lenskit/tests/test_post_emit_health.py \
+    merger/lenskit/tests/test_agent_export_gate.py \
+    merger/lenskit/tests/test_retrieval_eval.py -q
+74 passed, 1 warning
+```
+
+Nach Patch (drei Zielsuiten, +12 additive Tests):
+
+```
+$ python3 -m pytest merger/lenskit/tests/test_post_emit_health.py \
+    merger/lenskit/tests/test_agent_export_gate.py \
+    merger/lenskit/tests/test_retrieval_eval.py -q
+86 passed, 1 warning
+```
+
+Regression (Consumer / verwandte Contracts):
+
+```
+$ python3 -m pytest merger/lenskit/tests/test_context_quality.py \
+    merger/lenskit/tests/test_cli_context_quality.py \
+    merger/lenskit/tests/test_cli_bundle_health.py \
+    merger/lenskit/tests/test_bundle_manifest_integration.py \
+    merger/lenskit/tests/test_role_completeness.py \
+    merger/lenskit/tests/test_parity.py -q
+75 passed, 1 warning
+```
+
+Lint:
+
+```
+$ ruff check --select=F401,F811 --exclude='**/fixtures/**' \
+    merger/lenskit/tests/test_post_emit_health.py \
+    merger/lenskit/tests/test_agent_export_gate.py \
+    merger/lenskit/tests/test_retrieval_eval.py
+All checks passed!
+```
+
+---
+
+## 7. Verbleibende Risiken
+
+- **Niedrig.** Die Felder sind optional und const; ohne Producer-Emission ist die einzige
+  Wirkung, dass ein Objekt die Felder tragen *darf*. Falsche Werte werden abgewiesen.
+- Producer emittieren die Felder noch nicht — eine spätere Runtime-Annotation (C4) ist
+  bewusst getrennt und nicht Teil von C2.1.
+- C2.2–C5 bleiben offen (siehe Roadmap); insbesondere `bundle-manifest.v1`-Normierung und
+  `allowed_inference`/`forbidden_inference` sind ausdrücklich nicht enthalten.
+</content>
+</invoke>

--- a/docs/proofs/authority-risk-class-c2-1-proof.md
+++ b/docs/proofs/authority-risk-class-c2-1-proof.md
@@ -48,7 +48,7 @@ Dieser Patch ist bewusst minimal. Er enthält:
 - **kein generisches `authority` neben `session_authority`** — `agent-query-session.v2`
   wird **nicht** verändert (Ambiguitätsverbot aus dem Audit §5.F/§7).
 - **`miss_taxonomy` unverändert** — der vorhandene retrieval-eval Taxonomie-Block bleibt
-  bit-identisch (eigene `required`-Liste intakt).
+  schema-semantisch unverändert; C2.1 ergänzt nur optionale top-level Felder im umgebenden `retrieval-eval.v1`-Schema.
 
 Explizit **nicht** Teil dieses Patches (bleibt Folgearbeit):
 `bundle-manifest.v1` (C2.2), `allowed_inference`/`forbidden_inference` (C2.3),

--- a/docs/roadmap/lenskit-master-roadmap.md
+++ b/docs/roadmap/lenskit-master-roadmap.md
@@ -180,9 +180,27 @@ und bereitet die Contract-Normierung (C2) vor — **ohne** C2 zu implementieren.
   nächster Schritt (C2.1) sind additive, optionale `authority`/`risk_class`-Felder für bereits
   disclaimer-tragende Diagnose-Contracts.
 
-Mögliche Folgearbeiten (separate PRs, nicht Teil von C1 oder C2a):
-- C2: Contract-Normierung (allowed/forbidden inferences als Schema-Felder) — **offen**
-- C3: Lint-Regeln (L1–L6) — **offen**
+### C2.1 — Additive Authority/Risk-Class für Diagnose-Contracts (umgesetzt)
+
+Status: **UMGESETZT** (Contract-only, additiv), Beleg
+`docs/proofs/authority-risk-class-c2-1-proof.md`.
+Scope: additive, optionale, **const** Felder `authority` (`diagnostic_signal`) und
+`risk_class` (`diagnostic`) in genau drei bereits disclaimer-tragenden Diagnose-Contracts:
+`post-emit-health.v1`, `agent-export-gate.v1` und top-level `retrieval-eval.v1`.
+
+- **Keine** Pflichtfelder, **keine** Lockerung bestehender Constraints, `additionalProperties:
+  false` bleibt erhalten.
+- **Keine** Runtime-/CLI-/Producer-Änderung, **keine** Lints, **keine** Export-Gates.
+- `miss_taxonomy` in `retrieval-eval.v1` bleibt unverändert; `output-health.v1`,
+  `bundle-manifest.v1`, `agent-query-session.v2` und die Federation-Contracts wurden **nicht**
+  angefasst.
+- Validierung: 86 passed in den drei Zielsuiten (74 Baseline + 12 additive Tests),
+  75 passed in der Consumer-Regression, ruff `F401,F811` sauber.
+
+Mögliche Folgearbeiten (separate PRs, nicht Teil von C1, C2a oder C2.1):
+- C2.2: `bundle-manifest.v1`-Normierung (per-role `risk_class`, `output_health`-Authority-Zweig) — **offen**
+- C2.3: `allowed_inference`/`forbidden_inference` als optionale Schema-Felder — **offen**
+- C3 / C2.4: Lint-Regeln (L1–L6) — **offen**
 - C4: Runtime-Annotation — **offen**
 - C5: Export-Gate-Integration — **offen**
 

--- a/merger/lenskit/contracts/agent-export-gate.v1.schema.json
+++ b/merger/lenskit/contracts/agent-export-gate.v1.schema.json
@@ -30,6 +30,16 @@
       "type": "string",
       "const": "1.0"
     },
+    "authority": {
+      "type": "string",
+      "const": "diagnostic_signal",
+      "description": "Optional, additive self-declaration of this artifact's authority class (C2.1). When present it MUST be the diagnostic_signal constant; it is not a truth verdict and does not gate anything."
+    },
+    "risk_class": {
+      "type": "string",
+      "const": "diagnostic",
+      "description": "Optional, additive self-declaration of this artifact's risk class (C2.1). When present it MUST be the diagnostic constant."
+    },
     "status": {
       "type": "string",
       "enum": ["pass", "fail", "blocked"]

--- a/merger/lenskit/contracts/post-emit-health.v1.schema.json
+++ b/merger/lenskit/contracts/post-emit-health.v1.schema.json
@@ -30,6 +30,16 @@
       "type": "string",
       "const": "1.0"
     },
+    "authority": {
+      "type": "string",
+      "const": "diagnostic_signal",
+      "description": "Optional, additive self-declaration of this artifact's authority class (C2.1). When present it MUST be the diagnostic_signal constant; it is not a truth verdict and does not gate anything."
+    },
+    "risk_class": {
+      "type": "string",
+      "const": "diagnostic",
+      "description": "Optional, additive self-declaration of this artifact's risk class (C2.1). When present it MUST be the diagnostic constant."
+    },
     "run_id": {
       "type": "string",
       "minLength": 1,

--- a/merger/lenskit/contracts/retrieval-eval.v1.schema.json
+++ b/merger/lenskit/contracts/retrieval-eval.v1.schema.json
@@ -6,6 +6,16 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "authority": {
+      "type": "string",
+      "const": "diagnostic_signal",
+      "description": "Optional, additive top-level self-declaration of this report's authority class (C2.1). When present it MUST be the diagnostic_signal constant. Independent of and consistent with the existing nested miss_taxonomy.authority; it is not a truth verdict and does not gate anything."
+    },
+    "risk_class": {
+      "type": "string",
+      "const": "diagnostic",
+      "description": "Optional, additive top-level self-declaration of this report's risk class (C2.1). When present it MUST be the diagnostic constant. Independent of and consistent with the existing nested miss_taxonomy.risk_class."
+    },
     "metrics": {
       "type": "object",
       "description": "Aggregate metrics for the evaluation run.",

--- a/merger/lenskit/tests/test_agent_export_gate.py
+++ b/merger/lenskit/tests/test_agent_export_gate.py
@@ -474,6 +474,52 @@ def test_schema_rejects_does_not_mean_without_claims_true(tmp_path):
         jsonschema.validate(instance=bad, schema=schema)
 
 
+# ---------------------------------------------------------------------------
+# C2.1: additive, optional authority/risk_class self-declaration
+# ---------------------------------------------------------------------------
+
+def _valid_gate_report(tmp_path) -> dict:
+    manifest = _write_manifest(tmp_path, redaction=True)
+    _write_post_health(tmp_path, "pass")
+    return evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+
+def test_c2_1_legacy_report_without_authority_stays_valid(tmp_path):
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    report = _valid_gate_report(tmp_path)
+    assert "authority" not in report
+    assert "risk_class" not in report
+    jsonschema.validate(instance=report, schema=schema)
+
+
+def test_c2_1_correct_authority_risk_class_valid(tmp_path):
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    report = _valid_gate_report(tmp_path)
+    report["authority"] = "diagnostic_signal"
+    report["risk_class"] = "diagnostic"
+    jsonschema.validate(instance=report, schema=schema)
+
+
+def test_c2_1_wrong_authority_invalid(tmp_path):
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    report = _valid_gate_report(tmp_path)
+    report["authority"] = "runtime_observation"
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=report, schema=schema)
+
+
+def test_c2_1_wrong_risk_class_invalid(tmp_path):
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    report = _valid_gate_report(tmp_path)
+    report["risk_class"] = "content"
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=report, schema=schema)
+
+
 def test_agent_export_gate_does_not_mutate_manifest(tmp_path):
     manifest = _write_manifest(tmp_path, redaction=True)
     _write_post_health(tmp_path, "pass")

--- a/merger/lenskit/tests/test_post_emit_health.py
+++ b/merger/lenskit/tests/test_post_emit_health.py
@@ -11,6 +11,7 @@ import json
 from pathlib import Path
 
 import jsonschema
+import pytest
 
 from merger.lenskit.core.post_emit_health import (
     DOES_NOT_MEAN,
@@ -336,7 +337,6 @@ def test_c2_1_correct_authority_risk_class_valid(tmp_path):
 
 
 def test_c2_1_wrong_authority_invalid(tmp_path):
-    import pytest
     schema = json.loads(_POST_HEALTH_SCHEMA_PATH.read_text(encoding="utf-8"))
     report = _valid_post_emit_report(tmp_path)
     report["authority"] = "canonical_content"
@@ -345,7 +345,6 @@ def test_c2_1_wrong_authority_invalid(tmp_path):
 
 
 def test_c2_1_wrong_risk_class_invalid(tmp_path):
-    import pytest
     schema = json.loads(_POST_HEALTH_SCHEMA_PATH.read_text(encoding="utf-8"))
     report = _valid_post_emit_report(tmp_path)
     report["risk_class"] = "content"

--- a/merger/lenskit/tests/test_post_emit_health.py
+++ b/merger/lenskit/tests/test_post_emit_health.py
@@ -309,6 +309,50 @@ def test_post_emit_health_blocked_precedes_fail(tmp_path):
     assert len(report["errors"]) >= 1
 
 
+# ---------------------------------------------------------------------------
+# C2.1: additive, optional authority/risk_class self-declaration
+# ---------------------------------------------------------------------------
+
+def _valid_post_emit_report(tmp_path) -> dict:
+    manifest = _make_bundle(tmp_path)
+    return compute_post_emit_health(str(manifest))
+
+
+def test_c2_1_legacy_report_without_authority_stays_valid(tmp_path):
+    """A report that omits authority/risk_class (current producer output) is valid."""
+    schema = json.loads(_POST_HEALTH_SCHEMA_PATH.read_text(encoding="utf-8"))
+    report = _valid_post_emit_report(tmp_path)
+    assert "authority" not in report
+    assert "risk_class" not in report
+    jsonschema.validate(instance=report, schema=schema)
+
+
+def test_c2_1_correct_authority_risk_class_valid(tmp_path):
+    schema = json.loads(_POST_HEALTH_SCHEMA_PATH.read_text(encoding="utf-8"))
+    report = _valid_post_emit_report(tmp_path)
+    report["authority"] = "diagnostic_signal"
+    report["risk_class"] = "diagnostic"
+    jsonschema.validate(instance=report, schema=schema)
+
+
+def test_c2_1_wrong_authority_invalid(tmp_path):
+    import pytest
+    schema = json.loads(_POST_HEALTH_SCHEMA_PATH.read_text(encoding="utf-8"))
+    report = _valid_post_emit_report(tmp_path)
+    report["authority"] = "canonical_content"
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=report, schema=schema)
+
+
+def test_c2_1_wrong_risk_class_invalid(tmp_path):
+    import pytest
+    schema = json.loads(_POST_HEALTH_SCHEMA_PATH.read_text(encoding="utf-8"))
+    report = _valid_post_emit_report(tmp_path)
+    report["risk_class"] = "content"
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=report, schema=schema)
+
+
 def test_write_post_emit_health_persists_unregistered_artifact(tmp_path):
     manifest = _make_bundle(tmp_path)
     manifest_before = manifest.read_text(encoding="utf-8")

--- a/merger/lenskit/tests/test_retrieval_eval.py
+++ b/merger/lenskit/tests/test_retrieval_eval.py
@@ -923,3 +923,60 @@ def test_miss_taxonomy_schema_rejects_missing_required_by_type_key():
 
     with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(instance=invalid_output, schema=schema)
+
+
+# ---------------------------------------------------------------------------
+# C2.1: additive, optional top-level authority/risk_class self-declaration
+# ---------------------------------------------------------------------------
+
+def _minimal_valid_retrieval_eval():
+    return {
+        "metrics": {"total_queries": 1, "hits": 0, "stale_flag": False},
+        "details": [],
+        "claim_boundaries": {
+            "proves": ["x"],
+            "does_not_prove": ["y"],
+            "evidence_basis": ["eval_queries"],
+            "requires_live_check": True,
+        },
+    }
+
+
+def test_c2_1_legacy_eval_without_top_level_authority_stays_valid():
+    import jsonschema
+
+    schema = _load_retrieval_eval_schema()
+    out = _minimal_valid_retrieval_eval()
+    assert "authority" not in out
+    assert "risk_class" not in out
+    jsonschema.validate(instance=out, schema=schema)
+
+
+def test_c2_1_correct_top_level_authority_risk_class_valid():
+    import jsonschema
+
+    schema = _load_retrieval_eval_schema()
+    out = _minimal_valid_retrieval_eval()
+    out["authority"] = "diagnostic_signal"
+    out["risk_class"] = "diagnostic"
+    jsonschema.validate(instance=out, schema=schema)
+
+
+def test_c2_1_wrong_top_level_authority_invalid():
+    import jsonschema
+
+    schema = _load_retrieval_eval_schema()
+    out = _minimal_valid_retrieval_eval()
+    out["authority"] = "canonical_content"
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=out, schema=schema)
+
+
+def test_c2_1_wrong_top_level_risk_class_invalid():
+    import jsonschema
+
+    schema = _load_retrieval_eval_schema()
+    out = _minimal_valid_retrieval_eval()
+    out["risk_class"] = "content"
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=out, schema=schema)

--- a/merger/lenskit/tests/test_retrieval_eval.py
+++ b/merger/lenskit/tests/test_retrieval_eval.py
@@ -3,6 +3,7 @@ import pytest
 from pathlib import Path
 from merger.lenskit.cli import cmd_eval
 from merger.lenskit.retrieval import index_db, eval_core
+import jsonschema
 
 @pytest.fixture
 def mini_index_for_eval(tmp_path):
@@ -943,8 +944,6 @@ def _minimal_valid_retrieval_eval():
 
 
 def test_c2_1_legacy_eval_without_top_level_authority_stays_valid():
-    import jsonschema
-
     schema = _load_retrieval_eval_schema()
     out = _minimal_valid_retrieval_eval()
     assert "authority" not in out
@@ -953,8 +952,6 @@ def test_c2_1_legacy_eval_without_top_level_authority_stays_valid():
 
 
 def test_c2_1_correct_top_level_authority_risk_class_valid():
-    import jsonschema
-
     schema = _load_retrieval_eval_schema()
     out = _minimal_valid_retrieval_eval()
     out["authority"] = "diagnostic_signal"
@@ -963,8 +960,6 @@ def test_c2_1_correct_top_level_authority_risk_class_valid():
 
 
 def test_c2_1_wrong_top_level_authority_invalid():
-    import jsonschema
-
     schema = _load_retrieval_eval_schema()
     out = _minimal_valid_retrieval_eval()
     out["authority"] = "canonical_content"
@@ -973,8 +968,6 @@ def test_c2_1_wrong_top_level_authority_invalid():
 
 
 def test_c2_1_wrong_top_level_risk_class_invalid():
-    import jsonschema
-
     schema = _load_retrieval_eval_schema()
     out = _minimal_valid_retrieval_eval()
     out["risk_class"] = "content"


### PR DESCRIPTION
## Summary

Implements C2.1 from the Governance-Track-C audit by adding optional, additive `authority` and `risk_class` fields to three diagnostic contracts. This is a minimal, contract-only change with no runtime or producer modifications.

## Changes

### Schema Updates
- **`post-emit-health.v1.schema.json`**: Added optional top-level `authority` (const: `diagnostic_signal`) and `risk_class` (const: `diagnostic`) fields
- **`agent-export-gate.v1.schema.json`**: Added optional top-level `authority` and `risk_class` fields with identical const values
- **`retrieval-eval.v1.schema.json`**: Added optional top-level `authority` and `risk_class` fields; existing nested `miss_taxonomy` block remains unchanged

### Test Coverage
- **`test_post_emit_health.py`**: Added 4 tests validating legacy compatibility, correct values, and rejection of invalid values
- **`test_agent_export_gate.py`**: Added 4 tests with same validation pattern
- **`test_retrieval_eval.py`**: Added 4 tests with same validation pattern

All new tests pass; baseline test count increased from 74 to 86 passed tests across the three target suites.

### Documentation
- Added `docs/proofs/authority-risk-class-c2-1-proof.md` with detailed audit trail, risk analysis, and test results
- Updated `docs/roadmap/lenskit-master-roadmap.md` to mark C2.1 as implemented and clarify remaining work (C2.2, C2.3, C3/C2.4, C4, C5)

## Implementation Details

- **Additive only**: No existing properties removed or modified; `additionalProperties: false` preserved
- **Optional fields**: Neither `authority` nor `risk_class` are in any `required` array; legacy objects without these fields remain valid
- **No producer changes**: Current producers do not emit these fields; they remain optional to allow gradual adoption
- **No runtime impact**: No CLI, export gate, or runtime annotation changes; fields are purely declarative
- **Consistent semantics**: In `retrieval-eval.v1`, top-level fields use identical const values as the existing nested `miss_taxonomy` block, avoiding ambiguity
- **No constraint relaxation**: All existing validation rules (`const`, `enum`, `contains`, `required`) remain intact

## Verification

- Consumer regression tests (context quality, bundle health, role completeness, parity): 75 passed
- Lint checks (ruff F401, F811): All passed
- No breaking changes to downstream contracts or federation schemas

https://claude.ai/code/session_01UhCkyVrYrvvRf9T1TeH3xx