### PR TITLE
WIP: Retrieval Eval Diagnostics Calibrator - Diagnosis First, No Ranking Changes

### DIFF
--- a/docs/diagnostics/retrieval-eval-diagnostics.md
+++ b/docs/diagnostics/retrieval-eval-diagnostics.md
@@ -38,15 +38,16 @@ A miss occurs when:
 Example:
 ```json
 {
+  "metrics": {
+    "total_queries": 1
+  },
   "details": [
     {
-  "query_id": "q5",
-  "query_text": "how to configure auth",
-  "expected_target": "src/auth/setup.py",
-  "found_in_results": false,
-  "rank_in_results": null,
-  "top_k": 10,
-  "query_had_zero_hits": false
+      "query": "merge",
+      "expected": ["merge.py", "iter_report_blocks"],
+      "is_relevant": false,
+      "found_count": 1,
+      "top_results": ["merger/lenskit/core/chunker.py"]
     }
   ]
 }
@@ -313,9 +314,9 @@ combined = integrate_diagnostics_with_eval_results(
 
 # combined["eval_results"] = original metrics (unchanged)
 # combined["diagnostics_report"] = diagnostic classifications
+```
 
 The integration consumes retrieval eval objects from `details`, not `results`.
-```
 
 ## Schema Compliance
 

--- a/docs/diagnostics/retrieval-eval-diagnostics.md
+++ b/docs/diagnostics/retrieval-eval-diagnostics.md
@@ -57,7 +57,12 @@ Example:
 The calibrator asks five questions in sequence:
 
 ```
-┌─ Is target in the index?
+┌─ Has staleness or ambiguity signals?
+│  └─ Stale → "stale_expected_target"
+│  └─ Ambiguous → "query_target_ambiguous"
+│  └─ None → next
+│
+├─ Is target in the index?
 │  └─ No → "target_missing_from_index"
 │  └─ Yes → next
 │
@@ -69,14 +74,11 @@ The calibrator asks five questions in sequence:
 │  └─ No → "target_missing_from_citation_map"
 │  └─ Yes → next
 │
-├─ Is target in index but outside top-k?
+├─ Is target in index but not observed in top-k?
 │  └─ Yes → "target_exists_not_in_top_k" (not observed in top-k)
 │  └─ No → next
-│
-└─ Has staleness or ambiguity signals?
-   └─ Stale → "stale_expected_target"
-   └─ Ambiguous → "query_target_ambiguous"
-   └─ None → "diagnostic_inconclusive"
+
+└─ Else → "diagnostic_inconclusive"
 ```
 
 ### 3. Output: Diagnostic Report
@@ -114,7 +116,7 @@ The calibrator asks five questions in sequence:
         "target_found_in_index": true,
         "target_found_in_canonical": true,
         "target_found_in_citation_map": true,
-        "rank_in_results": 45,
+        "rank_in_results": null,
         "top_k": 10,
         "query_had_zero_hits": false,
         "canonical_path_check": "exact_match",
@@ -126,6 +128,21 @@ The calibrator asks five questions in sequence:
       }
     }
   ]
+}
+```
+
+Optional overfetch diagnostics example (explicitly separate from default top-k-only diagnostics):
+
+```json
+{
+  "query_id": "q5",
+  "expected_target": "src/auth/setup.py",
+  "primary_diagnosis": "target_exists_not_in_top_k",
+  "diagnosis_details": {
+    "rank_in_results": 45,
+    "top_k": 10,
+    "instrumentation_notes": "rank_in_results available from overfetch diagnostics run (k=100)"
+  }
 }
 ```
 

--- a/docs/diagnostics/retrieval-eval-diagnostics.md
+++ b/docs/diagnostics/retrieval-eval-diagnostics.md
@@ -18,7 +18,7 @@ When a retrieval evaluation miss occurs, the calibrator determines the primary r
 | Category | Meaning |
 |----------|---------|
 | **target_in_top_k** | Expected target found in top-k results (not a miss). |
-| **target_exists_not_in_top_k** | Target exists in the index but is ranked outside top-k. **Problem type:** Ranking/relevance. |
+| **target_exists_not_in_top_k** | Target exists in the index but was not observed in top-k. Without overfetch, absolute outside-top-k rank is unknown. **Problem type:** Ranking/relevance. |
 | **target_missing_from_index** | Target path/identifier not in the chunk index at all. **Problem type:** Index/ingestion. |
 | **target_missing_from_canonical** | Target path not in canonical_md artifact. **Problem type:** Artifact gap or stale reference. |
 | **target_missing_from_citation_map** | Target not reachable via citation_map_jsonl. **Problem type:** Citation gap. |
@@ -38,6 +38,8 @@ A miss occurs when:
 Example:
 ```json
 {
+  "details": [
+    {
   "query_id": "q5",
   "query_text": "how to configure auth",
   "expected_target": "src/auth/setup.py",
@@ -45,6 +47,8 @@ Example:
   "rank_in_results": null,
   "top_k": 10,
   "query_had_zero_hits": false
+    }
+  ]
 }
 ```
 
@@ -66,7 +70,7 @@ The calibrator asks five questions in sequence:
 │  └─ Yes → next
 │
 ├─ Is target in index but outside top-k?
-│  └─ Yes → "target_exists_not_in_top_k"
+│  └─ Yes → "target_exists_not_in_top_k" (not observed in top-k)
 │  └─ No → next
 │
 └─ Has staleness or ambiguity signals?
@@ -130,7 +134,9 @@ The calibrator asks five questions in sequence:
 ### target_exists_not_in_top_k
 
 **Interpretation:**  
-The target exists in the index and canonical artifacts but is ranked outside the top-k results. This is a **ranking problem**, not an indexing or artifact problem.
+The target exists in the index and canonical artifacts but was not observed in the top-k results. This is a **ranking/top-k observation problem**, not an indexing or artifact problem.
+
+Without an additional overfetch diagnostics run (for example top-50/top-100), this signal does not claim an absolute outside-top-k rank.
 
 **Next steps for remediation:**
 - Inspect the query embedding or BM25 scoring
@@ -236,10 +242,10 @@ The miss could not be conclusively classified. This typically occurs when:
 
 ```python
 from pathlib import Path
-from merger.lenskit.retrieval.eval_diagnostics import ReturnEvalDiagnosticsCalibrator
+from merger.lenskit.retrieval.eval_diagnostics import RetrievalEvalDiagnosticsCalibrator
 
 # Initialize with artifact paths
-calibrator = ReturnEvalDiagnosticsCalibrator(
+calibrator = RetrievalEvalDiagnosticsCalibrator(
     index_path=Path("data/chunks.jsonl"),
     canonical_path=Path("data/canonical.md"),
     citation_path=Path("data/citation_map.jsonl"),
@@ -290,6 +296,8 @@ combined = integrate_diagnostics_with_eval_results(
 
 # combined["eval_results"] = original metrics (unchanged)
 # combined["diagnostics_report"] = diagnostic classifications
+
+The integration consumes retrieval eval objects from `details`, not `results`.
 ```
 
 ## Schema Compliance

--- a/docs/diagnostics/retrieval-eval-diagnostics.md
+++ b/docs/diagnostics/retrieval-eval-diagnostics.md
@@ -86,6 +86,8 @@ The calibrator asks five questions in sequence:
 
 ```json
 {
+  "authority": "diagnostic_signal",
+  "risk_class": "diagnostic",
   "metadata": {
     "version": "1.0",
     "timestamp": "2026-05-26T12:00:00Z",

--- a/docs/diagnostics/retrieval-eval-diagnostics.md
+++ b/docs/diagnostics/retrieval-eval-diagnostics.md
@@ -1,0 +1,370 @@
+# Retrieval Evaluation Diagnostics
+
+## Purpose
+
+**What it does:** Classifies retrieval evaluation misses into diagnostic categories to explain why queries did not find expected targets.
+
+**What it does NOT do:**
+- ❌ Fix ranking scores or rerank results
+- ❌ Modify retrieval metrics (recall, MRR, etc.)
+- ❌ Change the gold set or query definitions
+- ❌ Propose improvements to the index, BM25, or chunking
+- ❌ Claim that a "fix" has been applied
+
+## Diagnostic Categories
+
+When a retrieval evaluation miss occurs, the calibrator determines the primary root cause:
+
+| Category | Meaning |
+|----------|---------|
+| **target_in_top_k** | Expected target found in top-k results (not a miss). |
+| **target_exists_not_in_top_k** | Target exists in the index but is ranked outside top-k. **Problem type:** Ranking/relevance. |
+| **target_missing_from_index** | Target path/identifier not in the chunk index at all. **Problem type:** Index/ingestion. |
+| **target_missing_from_canonical** | Target path not in canonical_md artifact. **Problem type:** Artifact gap or stale reference. |
+| **target_missing_from_citation_map** | Target not reachable via citation_map_jsonl. **Problem type:** Citation gap. |
+| **stale_expected_target** | Expected target has staleness indicators (e.g., `/tmp/`, obsolete naming). **Problem type:** Gold set stale. |
+| **query_target_ambiguous** | Query or target definition is ambiguous or malformed. **Problem type:** Input quality. |
+| **diagnostic_inconclusive** | Miss could not be conclusively classified (e.g., all artifacts unavailable). **Problem type:** Instrumentation gap. |
+
+## How It Works
+
+### 1. Input: Query Miss
+
+A miss occurs when:
+- A query was executed
+- An expected target was in the gold set
+- The target was **not** found in the top-k results
+
+Example:
+```json
+{
+  "query_id": "q5",
+  "query_text": "how to configure auth",
+  "expected_target": "src/auth/setup.py",
+  "found_in_results": false,
+  "rank_in_results": null,
+  "top_k": 10,
+  "query_had_zero_hits": false
+}
+```
+
+### 2. Diagnostic Check
+
+The calibrator asks five questions in sequence:
+
+```
+┌─ Is target in the index?
+│  └─ No → "target_missing_from_index"
+│  └─ Yes → next
+│
+├─ Is target in canonical_md?
+│  └─ No → "target_missing_from_canonical"
+│  └─ Yes → next
+│
+├─ Is target in citation_map?
+│  └─ No → "target_missing_from_citation_map"
+│  └─ Yes → next
+│
+├─ Is target in index but outside top-k?
+│  └─ Yes → "target_exists_not_in_top_k"
+│  └─ No → next
+│
+└─ Has staleness or ambiguity signals?
+   └─ Stale → "stale_expected_target"
+   └─ Ambiguous → "query_target_ambiguous"
+   └─ None → "diagnostic_inconclusive"
+```
+
+### 3. Output: Diagnostic Report
+
+```json
+{
+  "metadata": {
+    "version": "1.0",
+    "timestamp": "2026-05-26T12:00:00Z",
+    "total_misses": 47,
+    "diagnostic_breakdowns": {
+      "target_in_top_k": 0,
+      "target_exists_not_in_top_k": 12,
+      "target_missing_from_index": 5,
+      "target_missing_from_canonical": 2,
+      "target_missing_from_citation_map": 0,
+      "stale_expected_target": 3,
+      "query_target_ambiguous": 1,
+      "diagnostic_inconclusive": 24
+    },
+    "index_stats": {
+      "total_chunks": 1250,
+      "total_paths": 412,
+      "canonical_md_exists": true,
+      "citation_map_exists": true
+    }
+  },
+  "diagnostics": [
+    {
+      "query_id": "q5",
+      "query_text": "how to configure auth",
+      "expected_target": "src/auth/setup.py",
+      "primary_diagnosis": "target_exists_not_in_top_k",
+      "diagnosis_details": {
+        "target_found_in_index": true,
+        "target_found_in_canonical": true,
+        "target_found_in_citation_map": true,
+        "rank_in_results": 45,
+        "top_k": 10,
+        "query_had_zero_hits": false,
+        "canonical_path_check": "exact_match",
+        "possible_path_variants": [],
+        "staleness_indicator": "none",
+        "secondary_diagnoses": ["low_query_specificity"],
+        "confidence": "high",
+        "instrumentation_notes": null
+      }
+    }
+  ]
+}
+```
+
+## Decision Framework: What Each Diagnosis Means
+
+### target_exists_not_in_top_k
+
+**Interpretation:**  
+The target exists in the index and canonical artifacts but is ranked outside the top-k results. This is a **ranking problem**, not an indexing or artifact problem.
+
+**Next steps for remediation:**
+- Inspect the query embedding or BM25 scoring
+- Check if the target matches the query semantically
+- Consider if query vocabulary differs from target content
+- Analyze if filter criteria are too restrictive
+
+**NOT a fix target:** Index, chunking, canonicalization, citation mapping
+
+---
+
+### target_missing_from_index
+
+**Interpretation:**  
+The expected target path does not exist in the chunk index. The content was not ingested or was filtered out.
+
+**Next steps:**
+- Check if the path was in the source repository during indexing
+- Verify path_filter or include_paths_by_repo settings
+- Check if the file was skipped due to file size or format
+- Verify if the chunking step has a bug
+
+**NOT a fix target:** Query, ranking, reranking
+
+---
+
+### target_missing_from_canonical
+
+**Interpretation:**  
+The target is in the index but not in canonical_md. This indicates an artifact consistency gap.
+
+**Next steps:**
+- Verify that canonical_md is up-to-date with the index
+- Check if canonical_md was created before the index
+- Inspect citation_map_jsonl for the target's cross-references
+- May indicate a CI/build ordering issue
+
+**NOT a fix target:** Ranking, query
+
+---
+
+### target_missing_from_citation_map
+
+**Interpretation:**  
+The target is in the index and canonical but not reachable via the citation map.
+
+**Next steps:**
+- Check citation_map generation logic
+- Verify if citation_validate passes
+- Inspect if the target has citation_id conflicts
+
+**NOT a fix target:** Ranking, query
+
+---
+
+### stale_expected_target
+
+**Interpretation:**  
+The expected target has staleness indicators (e.g., path in `/tmp/`, old date formats, deprecated naming). The gold set may refer to historical snapshots.
+
+**Next steps:**
+- Review the gold set for outdated expected paths
+- Check if the query is still relevant
+- Verify if the target was renamed or moved
+- Consider if the query should target a newer path instead
+
+**NOT a fix target:** Ranking, index
+
+---
+
+### query_target_ambiguous
+
+**Interpretation:**  
+The query or target definition is malformed or ambiguous.
+
+**Next steps:**
+- Review the query definition in the gold set
+- Check if the expected_target is well-formed (non-empty, valid path)
+- Verify if there are special characters or encoding issues
+
+**NOT a fix target:** Ranking, index
+
+---
+
+### diagnostic_inconclusive
+
+**Interpretation:**  
+The miss could not be conclusively classified. This typically occurs when:
+- Artifacts are unavailable (canonical_md, citation_map, index)
+- Multiple conflicting signals exist
+- Instrumentation is incomplete
+
+**Next steps:**
+- Ensure all required artifacts (index, canonical_md, citation_map) are available
+- Check diagnostic logs for instrumentation gaps
+- Re-run diagnostics after artifact repair
+
+---
+
+## Integration
+
+### Standalone Usage
+
+```python
+from pathlib import Path
+from merger.lenskit.retrieval.eval_diagnostics import ReturnEvalDiagnosticsCalibrator
+
+# Initialize with artifact paths
+calibrator = ReturnEvalDiagnosticsCalibrator(
+    index_path=Path("data/chunks.jsonl"),
+    canonical_path=Path("data/canonical.md"),
+    citation_path=Path("data/citation_map.jsonl"),
+)
+
+# Define misses
+misses = [
+    {
+        "query_id": "q1",
+        "query_text": "find auth setup",
+        "expected_target": "src/auth/setup.py",
+        "found_in_results": False,
+        "rank_in_results": None,
+        "top_k": 10,
+        "query_had_zero_hits": False,
+    },
+]
+
+# Generate report
+report = calibrator.generate_report(misses)
+
+# Save to file
+calibrator.save_report(report, Path("diagnostics_report.json"))
+```
+
+### Integration with eval_core
+
+```python
+from merger.lenskit.retrieval.eval_diagnostics_integration import (
+    integrate_diagnostics_with_eval_results,
+)
+
+# Run existing evaluation
+eval_results = do_eval(
+    index_path=Path("data/index.sqlite"),
+    queries_path=Path("queries.md"),
+    k=10,
+)
+
+# Attach diagnostics
+combined = integrate_diagnostics_with_eval_results(
+    eval_results,
+    index_path=Path("data/chunks.jsonl"),
+    canonical_path=Path("data/canonical.md"),
+    citation_path=Path("data/citation_map.jsonl"),
+    output_path=Path("combined_results.json"),
+)
+
+# combined["eval_results"] = original metrics (unchanged)
+# combined["diagnostics_report"] = diagnostic classifications
+```
+
+## Schema Compliance
+
+The diagnostics output conforms to `retrieval-eval-diagnostics.v1.schema.json`:
+
+```bash
+# Validate a generated report
+python3 -c "
+import json
+import jsonschema
+from pathlib import Path
+
+report = json.loads(Path('diagnostics_report.json').read_text())
+schema = json.loads(Path('merger/lenskit/contracts/retrieval-eval-diagnostics.v1.schema.json').read_text())
+
+jsonschema.validate(instance=report, schema=schema)
+print('✓ Report valid')
+"
+```
+
+## Testing
+
+Run the diagnostic test suite:
+
+```bash
+python -m pytest merger/lenskit/tests/test_retrieval_eval_diagnostics.py -v
+```
+
+Key test scenarios:
+- ✓ target_in_top_k (hit, not a miss)
+- ✓ target_exists_not_in_top_k (ranking problem)
+- ✓ target_missing_from_index (indexing problem)
+- ✓ target_missing_from_canonical (artifact gap)
+- ✓ stale_expected_target (gold set stale)
+- ✓ query_target_ambiguous (input quality)
+- ✓ schema compliance
+- ✓ deterministic sorting
+- ✓ artifact availability graceful degradation
+
+## Limitations & Caveats
+
+1. **Requires artifacts:** If index, canonical_md, or citation_map are unavailable, diagnostics default to `diagnostic_inconclusive`.
+
+2. **Partial path matching:** The calibrator uses substring matching for path comparisons. Exact matching may require additional metadata.
+
+3. **Secondary diagnoses are informational:** Only `primary_diagnosis` represents the root cause. Secondary diagnoses provide context but are not definitive.
+
+4. **No semantic analysis:** The calibrator does not evaluate query/target semantic similarity. Ranking problems require separate semantic evaluation.
+
+5. **Gold set assumed correct:** Diagnostics do not validate the gold set itself. Stale or incorrect expected targets are flagged as "stale" or "ambiguous" but not audited.
+
+## Authority & Risk Classification
+
+Per the schema:
+- **authority:** `diagnostic_signal` (diagnostic only, not authoritative)
+- **risk_class:** `diagnostic` (informational, not a decision gate)
+
+Diagnostics do **not**:
+- Prove absence of content in the repository
+- Prove semantic relevance or ranking correctness
+- Justify fixing ranking, reranking, or synonym tables
+- Supersede manual review or authority decision-making
+
+They **do**:
+- Separate indexing from ranking problems
+- Guide the next investigation step
+- Enable targeted root-cause analysis
+- Reduce false diagnoses
+
+## Future Enhancements
+
+Potential additions (not in v1.0):
+- Semantic similarity scoring for ranking analysis
+- Path variance detection (file renames, refactoring)
+- Citation cycle detection
+- Gold set completeness audit
+- Query vocabulary/embedding analysis

--- a/merger/lenskit/contracts/retrieval-eval-diagnostics.v1.schema.json
+++ b/merger/lenskit/contracts/retrieval-eval-diagnostics.v1.schema.json
@@ -208,7 +208,7 @@
                 "description": "Confidence level in the diagnosis classification."
               },
               "instrumentation_notes": {
-                "type": "string",
+                "type": ["string", "null"],
                 "description": "Optional notes if diagnosis is inconclusive or requires manual review."
               }
             }

--- a/merger/lenskit/contracts/retrieval-eval-diagnostics.v1.schema.json
+++ b/merger/lenskit/contracts/retrieval-eval-diagnostics.v1.schema.json
@@ -41,7 +41,7 @@
             "target_exists_not_in_top_k": {
               "type": "integer",
               "minimum": 0,
-              "description": "Target exists in index/canonical but ranked outside top-k."
+              "description": "Target exists in index/canonical but was not observed in top-k results. Absolute rank outside top-k is unknown unless overfetch diagnostics are run."
             },
             "target_missing_from_index": {
               "type": "integer",
@@ -157,12 +157,12 @@
               },
               "target_found_in_citation_map": {
                 "type": "boolean",
-                "description": "Is the target reachable via citation_map_jsonl?"
+                "description": "Is the target reachable via citation_map_jsonl through chunk_index path->chunk_id bridge?"
               },
               "rank_in_results": {
                 "type": ["integer", "null"],
                 "minimum": 1,
-                "description": "If found, rank position in unfiltered results (1-indexed). null if not found."
+                "description": "If observed in returned results, rank position (1-indexed). null when not observed or when no overfetch rank is available."
               },
               "top_k": {
                 "type": ["integer", "null"],

--- a/merger/lenskit/contracts/retrieval-eval-diagnostics.v1.schema.json
+++ b/merger/lenskit/contracts/retrieval-eval-diagnostics.v1.schema.json
@@ -5,8 +5,18 @@
   "description": "Diagnostic classification of retrieval evaluation misses. Provides per-miss root-cause analysis without modifying existing metrics or ranking behavior. Categorizes why each expected target was not found in top-k results.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["metadata", "diagnostics"],
+  "required": ["authority", "risk_class", "metadata", "diagnostics"],
   "properties": {
+    "authority": {
+      "type": "string",
+      "const": "diagnostic_signal",
+      "description": "Top-level self-declaration of authority class for this diagnostics artifact."
+    },
+    "risk_class": {
+      "type": "string",
+      "const": "diagnostic",
+      "description": "Top-level self-declaration of risk class for this diagnostics artifact."
+    },
     "metadata": {
       "type": "object",
       "description": "Metadata about the diagnostic run.",

--- a/merger/lenskit/contracts/retrieval-eval-diagnostics.v1.schema.json
+++ b/merger/lenskit/contracts/retrieval-eval-diagnostics.v1.schema.json
@@ -1,0 +1,220 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://lenskit.merger/schemas/retrieval-eval-diagnostics.v1.json",
+  "title": "Lenskit Retrieval Evaluation Diagnostics Report",
+  "description": "Diagnostic classification of retrieval evaluation misses. Provides per-miss root-cause analysis without modifying existing metrics or ranking behavior. Categorizes why each expected target was not found in top-k results.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["metadata", "diagnostics"],
+  "properties": {
+    "metadata": {
+      "type": "object",
+      "description": "Metadata about the diagnostic run.",
+      "additionalProperties": false,
+      "required": ["version", "timestamp", "total_misses"],
+      "properties": {
+        "version": {
+          "type": "string",
+          "const": "1.0",
+          "description": "Schema version."
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp of diagnostic generation."
+        },
+        "total_misses": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total number of misses (expected targets not found in top-k)."
+        },
+        "diagnostic_breakdowns": {
+          "type": "object",
+          "description": "Count of misses by primary diagnosis category.",
+          "additionalProperties": false,
+          "properties": {
+            "target_in_top_k": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Expected target found in top-k (not a miss)."
+            },
+            "target_exists_not_in_top_k": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Target exists in index/canonical but ranked outside top-k."
+            },
+            "target_missing_from_index": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Target path/identifier not in current chunk index."
+            },
+            "target_missing_from_canonical": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Target path not found in canonical_md artifact."
+            },
+            "target_missing_from_citation_map": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Target not reachable via citation_map_jsonl."
+            },
+            "stale_expected_target": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Expected target path indicates stale snapshot (historical identifier)."
+            },
+            "query_target_ambiguous": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Query or target definition is ambiguous or malformed."
+            },
+            "diagnostic_inconclusive": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Miss could not be conclusively classified (instrumentation gap)."
+            }
+          }
+        },
+        "index_stats": {
+          "type": "object",
+          "description": "Statistics about the index and canonical artifacts.",
+          "additionalProperties": false,
+          "properties": {
+            "total_chunks": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Total number of chunks in the index."
+            },
+            "total_paths": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Unique paths in the index."
+            },
+            "canonical_md_exists": {
+              "type": "boolean",
+              "description": "Whether canonical_md artifact exists and is readable."
+            },
+            "citation_map_exists": {
+              "type": "boolean",
+              "description": "Whether citation_map_jsonl artifact exists and is readable."
+            }
+          }
+        }
+      }
+    },
+    "diagnostics": {
+      "type": "array",
+      "description": "Array of diagnostic records, one per query miss.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "query_id",
+          "query_text",
+          "expected_target",
+          "primary_diagnosis",
+          "diagnosis_details"
+        ],
+        "properties": {
+          "query_id": {
+            "type": "string",
+            "description": "Unique identifier for the query (from queries.md or gold set)."
+          },
+          "query_text": {
+            "type": "string",
+            "description": "The query string as executed."
+          },
+          "expected_target": {
+            "type": "string",
+            "description": "The expected target path or identifier from the gold set."
+          },
+          "primary_diagnosis": {
+            "type": "string",
+            "enum": [
+              "target_in_top_k",
+              "target_exists_not_in_top_k",
+              "target_missing_from_index",
+              "target_missing_from_canonical",
+              "target_missing_from_citation_map",
+              "stale_expected_target",
+              "query_target_ambiguous",
+              "diagnostic_inconclusive"
+            ],
+            "description": "Primary root cause of the miss."
+          },
+          "diagnosis_details": {
+            "type": "object",
+            "description": "Detailed information supporting the diagnosis.",
+            "additionalProperties": false,
+            "properties": {
+              "target_found_in_index": {
+                "type": "boolean",
+                "description": "Was the expected target path found in the chunk index?"
+              },
+              "target_found_in_canonical": {
+                "type": "boolean",
+                "description": "Was the expected target found in canonical_md?"
+              },
+              "target_found_in_citation_map": {
+                "type": "boolean",
+                "description": "Is the target reachable via citation_map_jsonl?"
+              },
+              "rank_in_results": {
+                "type": ["integer", "null"],
+                "minimum": 1,
+                "description": "If found, rank position in unfiltered results (1-indexed). null if not found."
+              },
+              "top_k": {
+                "type": ["integer", "null"],
+                "minimum": 1,
+                "description": "The k value used for top-k evaluation. null if not applicable."
+              },
+              "query_had_zero_hits": {
+                "type": "boolean",
+                "description": "Did the query return 0 total results from the search?"
+              },
+              "canonical_path_check": {
+                "type": "string",
+                "description": "Status of path lookup in canonical_md ('exact_match', 'variant_found', 'not_found', 'canonical_unavailable')."
+              },
+              "possible_path_variants": {
+                "type": "array",
+                "description": "If target not found exactly, list of similar or related paths in index.",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "staleness_indicator": {
+                "type": "string",
+                "description": "Evidence of target being stale (e.g., 'path_format_obsolete', 'timestamp_mismatch', 'none')."
+              },
+              "secondary_diagnoses": {
+                "type": "array",
+                "description": "Additional contributing factors (informational, not primary cause).",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "low_query_specificity",
+                    "partial_match_outside_top_k",
+                    "index_stale",
+                    "citation_gap",
+                    "ambiguous_target_definition"
+                  ]
+                }
+              },
+              "confidence": {
+                "type": "string",
+                "enum": ["high", "medium", "low"],
+                "description": "Confidence level in the diagnosis classification."
+              },
+              "instrumentation_notes": {
+                "type": "string",
+                "description": "Optional notes if diagnosis is inconclusive or requires manual review."
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/merger/lenskit/retrieval/eval_diagnostics.py
+++ b/merger/lenskit/retrieval/eval_diagnostics.py
@@ -571,6 +571,8 @@ class RetrievalEvalDiagnosticsCalibrator:
 
         # Build report
         report = {
+            "authority": "diagnostic_signal",
+            "risk_class": "diagnostic",
             "metadata": {
                 "version": "1.0",
                 "timestamp": datetime.now(timezone.utc).isoformat(),

--- a/merger/lenskit/retrieval/eval_diagnostics.py
+++ b/merger/lenskit/retrieval/eval_diagnostics.py
@@ -21,12 +21,12 @@ from datetime import datetime, timezone
 import re
 
 
-class ReturnEvalDiagnosticsError(Exception):
+class RetrievalEvalDiagnosticsError(Exception):
     """Base exception for diagnostics module."""
     pass
 
 
-class MissingArtifactError(ReturnEvalDiagnosticsError):
+class MissingArtifactError(RetrievalEvalDiagnosticsError):
     """Raised when required diagnostic artifacts are unavailable."""
     pass
 
@@ -97,6 +97,7 @@ class IndexInspector:
         """
         self.index_path = index_path
         self._index_paths_cache: Optional[set] = None
+        self._path_to_chunk_ids_cache: Optional[Dict[str, set]] = None
         self._canonical_md_content: Optional[str] = None
         self._citation_map_cache: Optional[Dict[str, Any]] = None
 
@@ -139,6 +140,53 @@ class IndexInspector:
 
         self._index_paths_cache = paths
         return paths
+
+    def load_path_to_chunk_ids(self, force_reload: bool = False) -> Dict[str, set]:
+        """
+        Load mapping of path -> set(chunk_id) from chunk index JSONL.
+
+        This is required to bridge path-based expectations to citation_map entries,
+        which are keyed by citation_id and reference chunk_id.
+        """
+        if self._path_to_chunk_ids_cache is not None and not force_reload:
+            return self._path_to_chunk_ids_cache
+
+        mapping: Dict[str, set] = {}
+        if self.index_path is None:
+            self._path_to_chunk_ids_cache = mapping
+            return mapping
+
+        if self.index_path.suffix != ".jsonl":
+            self._path_to_chunk_ids_cache = mapping
+            return mapping
+
+        try:
+            with open(self.index_path, "r", encoding="utf-8") as f:
+                for line in f:
+                    if not line.strip():
+                        continue
+                    try:
+                        chunk = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    path = chunk.get("path")
+                    chunk_id = chunk.get("chunk_id")
+                    if isinstance(path, str) and isinstance(chunk_id, str):
+                        mapping.setdefault(path, set()).add(chunk_id)
+        except (IOError, OSError) as e:
+            raise MissingArtifactError(
+                f"Failed to read chunk index from {self.index_path}: {e}"
+            )
+
+        self._path_to_chunk_ids_cache = mapping
+        return mapping
+
+    @staticmethod
+    def find_matching_paths(expected_target: str, index_paths: set) -> List[str]:
+        """Return index paths that contain the expected target as substring."""
+        if not isinstance(expected_target, str) or not expected_target:
+            return []
+        return sorted([p for p in index_paths if expected_target in p or p in expected_target])
 
     def load_canonical_md(self, canonical_path: Path) -> str:
         """
@@ -235,7 +283,7 @@ class IndexInspector:
         return citation_map
 
 
-class ReturnEvalDiagnosticsCalibrator:
+class RetrievalEvalDiagnosticsCalibrator:
     """
     Diagnostic calibrator for retrieval evaluation misses.
 
@@ -263,16 +311,20 @@ class ReturnEvalDiagnosticsCalibrator:
 
         # Load artifacts once
         self._index_paths: Optional[set] = None
+        self._path_to_chunk_ids: Optional[Dict[str, set]] = None
         self._canonical_md: Optional[str] = None
         self._citation_map: Optional[Dict[str, Any]] = None
+        self._citation_chunk_ids: Optional[set] = None
 
     def _load_artifacts(self) -> None:
         """Load and cache required artifacts."""
         if self.index_path:
             try:
                 self._index_paths = self.inspector.load_index_paths()
+                self._path_to_chunk_ids = self.inspector.load_path_to_chunk_ids()
             except MissingArtifactError:
                 self._index_paths = set()
+                self._path_to_chunk_ids = {}
 
         if self.canonical_path:
             try:
@@ -283,8 +335,14 @@ class ReturnEvalDiagnosticsCalibrator:
         if self.citation_path:
             try:
                 self._citation_map = self.inspector.load_citation_map(self.citation_path)
+                self._citation_chunk_ids = {
+                    rec.get("chunk_id")
+                    for rec in self._citation_map.values()
+                    if isinstance(rec, dict) and isinstance(rec.get("chunk_id"), str)
+                }
             except MissingArtifactError:
                 self._citation_map = None
+                self._citation_chunk_ids = None
 
     def diagnose_miss(
         self,
@@ -341,9 +399,12 @@ class ReturnEvalDiagnosticsCalibrator:
             details["confidence"] = "high"
             return record
 
-        # Check if target is in the index
+        matching_paths: List[str] = []
+
+        # Check if target is in the index by substring match against indexed paths.
         if self._index_paths:
-            details["target_found_in_index"] = expected_target in self._index_paths
+            matching_paths = self.inspector.find_matching_paths(expected_target, self._index_paths)
+            details["target_found_in_index"] = bool(matching_paths)
 
         # Check if target is in canonical_md
         if self._canonical_md:
@@ -355,12 +416,21 @@ class ReturnEvalDiagnosticsCalibrator:
             if variants:
                 details["possible_path_variants"] = variants
 
-        # Check if target is in citation_map
-        if self._citation_map:
-            details["target_found_in_citation_map"] = expected_target in self._citation_map
+        # Check citation linkage via chunk_id bridge: expected_target -> index path(s) -> chunk_id(s) -> citation_map.chunk_id
+        if self._citation_chunk_ids is not None and self._path_to_chunk_ids is not None:
+            chunk_ids_for_target = set()
+            for path in matching_paths:
+                chunk_ids_for_target.update(self._path_to_chunk_ids.get(path, set()))
+            details["target_found_in_citation_map"] = bool(chunk_ids_for_target & self._citation_chunk_ids)
 
         # Now determine primary diagnosis based on what we found
-        primary_diagnosis = self._classify_miss(expected_target, rank_in_results, top_k, details)
+        primary_diagnosis = self._classify_miss(
+            expected_target,
+            found_in_results,
+            rank_in_results,
+            top_k,
+            details,
+        )
 
         # Detect staleness if applicable
         if self._is_stale_indicator(expected_target):
@@ -381,6 +451,7 @@ class ReturnEvalDiagnosticsCalibrator:
     def _classify_miss(
         self,
         expected_target: str,
+        found_in_results: bool,
         rank_in_results: Optional[int],
         top_k: Optional[int],
         details: Dict[str, Any],
@@ -393,7 +464,7 @@ class ReturnEvalDiagnosticsCalibrator:
         2. If target not in index -> target_missing_from_index
         3. If target not in canonical -> target_missing_from_canonical
         4. If target not in citation_map -> target_missing_from_citation_map
-        5. If target in index but outside top-k -> target_exists_not_in_top_k
+        5. If target in index but not observed in top-k -> target_exists_not_in_top_k
         6. Else -> diagnostic_inconclusive
         """
         # Check for staleness indicators first (before index check)
@@ -404,8 +475,12 @@ class ReturnEvalDiagnosticsCalibrator:
         if self._is_ambiguous_target(expected_target):
             return "query_target_ambiguous"
 
-        # Check index
-        if self._index_paths is not None and expected_target not in self._index_paths:
+        # Non path-like targets cannot be proven against path-only index keys.
+        if not self._target_looks_path_like(expected_target):
+            return "query_target_ambiguous"
+
+        # Check index with substring semantics.
+        if self._index_paths is not None and not details["target_found_in_index"]:
             return "target_missing_from_index"
 
         # Check canonical_md
@@ -413,14 +488,13 @@ class ReturnEvalDiagnosticsCalibrator:
             return "target_missing_from_canonical"
 
         # Check citation_map
-        if self._citation_map is not None and not details["target_found_in_citation_map"]:
+        if self._citation_map is not None and details["target_found_in_index"] and not details["target_found_in_citation_map"]:
             return "target_missing_from_citation_map"
 
-        # If target is in index but not in results -> ranking issue
-        if self._index_paths is not None and expected_target in self._index_paths:
-            if rank_in_results is not None and top_k is not None:
-                if rank_in_results > top_k:
-                    return "target_exists_not_in_top_k"
+        # If target exists in index but is not observed in top-k results,
+        # classify as top-k/ranking signal without claiming absolute rank.
+        if details["target_found_in_index"] and not found_in_results:
+            return "target_exists_not_in_top_k"
 
         # Fallback
         return "diagnostic_inconclusive"
@@ -439,6 +513,12 @@ class ReturnEvalDiagnosticsCalibrator:
         # Check for suspicious patterns
         suspicious = [r"^[^a-zA-Z0-9/._-]+$", r"^<.+>$"]
         return any(re.match(pat, target) for pat in suspicious)
+
+    def _target_looks_path_like(self, target: str) -> bool:
+        """Heuristic: expected target behaves like a path/path-substring token."""
+        if not isinstance(target, str) or not target:
+            return False
+        return "/" in target or "." in target
 
     def generate_report(
         self,

--- a/merger/lenskit/retrieval/eval_diagnostics.py
+++ b/merger/lenskit/retrieval/eval_diagnostics.py
@@ -570,6 +570,13 @@ class RetrievalEvalDiagnosticsCalibrator:
             breakdowns[record.primary_diagnosis] += 1
 
         # Build report
+        total_paths = len(self._index_paths) if self._index_paths else 0
+        total_chunks = (
+            sum(len(ids) for ids in self._path_to_chunk_ids.values())
+            if self._path_to_chunk_ids
+            else 0
+        )
+
         report = {
             "authority": "diagnostic_signal",
             "risk_class": "diagnostic",
@@ -579,8 +586,8 @@ class RetrievalEvalDiagnosticsCalibrator:
                 "total_misses": len(misses),
                 "diagnostic_breakdowns": breakdowns,
                 "index_stats": {
-                    "total_chunks": len(self._index_paths) if self._index_paths else 0,
-                    "total_paths": len(self._index_paths) if self._index_paths else 0,
+                    "total_chunks": total_chunks,
+                    "total_paths": total_paths,
                     "canonical_md_exists": self._canonical_md is not None,
                     "citation_map_exists": self._citation_map is not None,
                 },

--- a/merger/lenskit/retrieval/eval_diagnostics.py
+++ b/merger/lenskit/retrieval/eval_diagnostics.py
@@ -312,6 +312,7 @@ class RetrievalEvalDiagnosticsCalibrator:
         # Load artifacts once
         self._index_paths: Optional[set] = None
         self._path_to_chunk_ids: Optional[Dict[str, set]] = None
+        self._index_unavailable: bool = False
         self._canonical_md: Optional[str] = None
         self._citation_map: Optional[Dict[str, Any]] = None
         self._citation_chunk_ids: Optional[set] = None
@@ -322,9 +323,11 @@ class RetrievalEvalDiagnosticsCalibrator:
             try:
                 self._index_paths = self.inspector.load_index_paths()
                 self._path_to_chunk_ids = self.inspector.load_path_to_chunk_ids()
+                self._index_unavailable = False
             except MissingArtifactError:
-                self._index_paths = set()
-                self._path_to_chunk_ids = {}
+                self._index_paths = None
+                self._path_to_chunk_ids = None
+                self._index_unavailable = True
 
         if self.canonical_path:
             try:
@@ -385,7 +388,12 @@ class RetrievalEvalDiagnosticsCalibrator:
             "staleness_indicator": "none",
             "secondary_diagnoses": [],
             "confidence": "medium",
+            "instrumentation_notes": None,
         }
+
+        if self._index_unavailable:
+            details["instrumentation_notes"] = "index artifact unavailable"
+            details["confidence"] = "low"
 
         # If found in results, that's the primary diagnosis
         if found_in_results:
@@ -478,6 +486,10 @@ class RetrievalEvalDiagnosticsCalibrator:
         # Non path-like targets cannot be proven against path-only index keys.
         if not self._target_looks_path_like(expected_target):
             return "query_target_ambiguous"
+
+        # If an index path was configured but could not be read, do not infer absence.
+        if self._index_unavailable or self._index_paths is None:
+            return "diagnostic_inconclusive"
 
         # Check index with substring semantics.
         if self._index_paths is not None and not details["target_found_in_index"]:

--- a/merger/lenskit/retrieval/eval_diagnostics.py
+++ b/merger/lenskit/retrieval/eval_diagnostics.py
@@ -117,24 +117,25 @@ class IndexInspector:
         if self.index_path is None:
             return set()
 
-        paths = set()
+        if self.index_path.suffix != ".jsonl":
+            raise MissingArtifactError(f"Unsupported chunk index format: {self.index_path}")
 
-        if self.index_path.suffix == ".jsonl":
-            try:
-                with open(self.index_path, "r", encoding="utf-8") as f:
-                    for line in f:
-                        if not line.strip():
-                            continue
-                        try:
-                            chunk = json.loads(line)
-                            if "path" in chunk:
-                                paths.add(chunk["path"])
-                        except (json.JSONDecodeError, KeyError):
-                            continue
-            except (IOError, OSError) as e:
-                raise MissingArtifactError(
-                    f"Failed to read chunk index from {self.index_path}: {e}"
-                )
+        paths = set()
+        try:
+            with open(self.index_path, "r", encoding="utf-8") as f:
+                for line in f:
+                    if not line.strip():
+                        continue
+                    try:
+                        chunk = json.loads(line)
+                        if "path" in chunk:
+                            paths.add(chunk["path"])
+                    except (json.JSONDecodeError, KeyError):
+                        continue
+        except (IOError, OSError) as e:
+            raise MissingArtifactError(
+                f"Failed to read chunk index from {self.index_path}: {e}"
+            )
         # For SQLite index, would need similar logic
         # For now, assume JSONL format
 
@@ -157,8 +158,7 @@ class IndexInspector:
             return mapping
 
         if self.index_path.suffix != ".jsonl":
-            self._path_to_chunk_ids_cache = mapping
-            return mapping
+            raise MissingArtifactError(f"Unsupported chunk index format: {self.index_path}")
 
         try:
             with open(self.index_path, "r", encoding="utf-8") as f:
@@ -392,11 +392,16 @@ class RetrievalEvalDiagnosticsCalibrator:
         }
 
         if self._index_unavailable:
-            details["instrumentation_notes"] = "index artifact unavailable"
+            details["instrumentation_notes"] = "index artifact unavailable or unsupported format"
             details["confidence"] = "low"
 
-        # If found in results, that's the primary diagnosis
-        if found_in_results:
+        # Found-in-results only proves a top-k hit when rank metadata confirms rank <= top_k.
+        if (
+            found_in_results
+            and rank_in_results is not None
+            and top_k is not None
+            and rank_in_results <= top_k
+        ):
             record = DiagnosticsRecord(
                 query_id=query_id,
                 query_text=query_text,
@@ -505,7 +510,15 @@ class RetrievalEvalDiagnosticsCalibrator:
 
         # If target exists in index but is not observed in top-k results,
         # classify as top-k/ranking signal without claiming absolute rank.
-        if details["target_found_in_index"] and not found_in_results:
+        if details["target_found_in_index"] and (
+            not found_in_results
+            or (
+                found_in_results
+                and rank_in_results is not None
+                and top_k is not None
+                and rank_in_results > top_k
+            )
+        ):
             return "target_exists_not_in_top_k"
 
         # Fallback

--- a/merger/lenskit/retrieval/eval_diagnostics.py
+++ b/merger/lenskit/retrieval/eval_diagnostics.py
@@ -1,0 +1,522 @@
+"""
+Retrieval Evaluation Diagnostics Calibrator
+
+Classifies retrieval evaluation misses into diagnostic categories without modifying
+existing metrics or ranking behavior. Provides per-miss root-cause analysis by checking:
+
+1. Does the expected target exist in the index?
+2. Does it exist in canonical_md?
+3. Is it reachable via citation_map?
+4. Is it ranked outside top-k (ranking problem)?
+5. Is the expected target stale or ambiguous?
+
+This module is diagnostic only - it does not propose fixes, rerank results, or modify
+the gold set. It answers "why" a miss occurred, enabling targeted remediation decisions.
+"""
+
+import json
+from pathlib import Path
+from typing import Dict, List, Optional, Any, Tuple
+from datetime import datetime, timezone
+import re
+
+
+class ReturnEvalDiagnosticsError(Exception):
+    """Base exception for diagnostics module."""
+    pass
+
+
+class MissingArtifactError(ReturnEvalDiagnosticsError):
+    """Raised when required diagnostic artifacts are unavailable."""
+    pass
+
+
+class DiagnosticsRecord:
+    """Single diagnostic record for a query miss."""
+
+    PRIMARY_DIAGNOSES = {
+        "target_in_top_k",
+        "target_exists_not_in_top_k",
+        "target_missing_from_index",
+        "target_missing_from_canonical",
+        "target_missing_from_citation_map",
+        "stale_expected_target",
+        "query_target_ambiguous",
+        "diagnostic_inconclusive",
+    }
+
+    SECONDARY_DIAGNOSES = {
+        "low_query_specificity",
+        "partial_match_outside_top_k",
+        "index_stale",
+        "citation_gap",
+        "ambiguous_target_definition",
+    }
+
+    def __init__(
+        self,
+        query_id: str,
+        query_text: str,
+        expected_target: str,
+        primary_diagnosis: str,
+        diagnosis_details: Dict[str, Any],
+    ):
+        """Initialize a diagnostics record."""
+        if primary_diagnosis not in self.PRIMARY_DIAGNOSES:
+            raise ValueError(
+                f"Invalid primary_diagnosis '{primary_diagnosis}'. "
+                f"Must be one of {sorted(self.PRIMARY_DIAGNOSES)}"
+            )
+
+        self.query_id = query_id
+        self.query_text = query_text
+        self.expected_target = expected_target
+        self.primary_diagnosis = primary_diagnosis
+        self.diagnosis_details = diagnosis_details
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert record to dictionary (for JSON serialization)."""
+        return {
+            "query_id": self.query_id,
+            "query_text": self.query_text,
+            "expected_target": self.expected_target,
+            "primary_diagnosis": self.primary_diagnosis,
+            "diagnosis_details": self.diagnosis_details,
+        }
+
+
+class IndexInspector:
+    """Inspects index and canonical artifacts to support diagnostics."""
+
+    def __init__(self, index_path: Optional[Path] = None):
+        """
+        Initialize inspector.
+
+        Args:
+            index_path: Path to chunk index (e.g., chunks.jsonl or index.sqlite).
+        """
+        self.index_path = index_path
+        self._index_paths_cache: Optional[set] = None
+        self._canonical_md_content: Optional[str] = None
+        self._citation_map_cache: Optional[Dict[str, Any]] = None
+
+    def load_index_paths(self, force_reload: bool = False) -> set:
+        """
+        Load all unique paths from the index (chunk_index).
+
+        Args:
+            force_reload: Force reload from disk.
+
+        Returns:
+            Set of all unique paths in the index.
+        """
+        if self._index_paths_cache is not None and not force_reload:
+            return self._index_paths_cache
+
+        if self.index_path is None:
+            return set()
+
+        paths = set()
+
+        if self.index_path.suffix == ".jsonl":
+            try:
+                with open(self.index_path, "r", encoding="utf-8") as f:
+                    for line in f:
+                        if not line.strip():
+                            continue
+                        try:
+                            chunk = json.loads(line)
+                            if "path" in chunk:
+                                paths.add(chunk["path"])
+                        except (json.JSONDecodeError, KeyError):
+                            continue
+            except (IOError, OSError) as e:
+                raise MissingArtifactError(
+                    f"Failed to read chunk index from {self.index_path}: {e}"
+                )
+        # For SQLite index, would need similar logic
+        # For now, assume JSONL format
+
+        self._index_paths_cache = paths
+        return paths
+
+    def load_canonical_md(self, canonical_path: Path) -> str:
+        """
+        Load canonical markdown content.
+
+        Args:
+            canonical_path: Path to canonical_md artifact.
+
+        Returns:
+            Full content of canonical_md.
+        """
+        if self._canonical_md_content is not None:
+            return self._canonical_md_content
+
+        if not canonical_path.exists():
+            raise MissingArtifactError(f"canonical_md not found: {canonical_path}")
+
+        try:
+            with open(canonical_path, "r", encoding="utf-8") as f:
+                self._canonical_md_content = f.read()
+        except (IOError, OSError) as e:
+            raise MissingArtifactError(
+                f"Failed to read canonical_md from {canonical_path}: {e}"
+            )
+
+        return self._canonical_md_content
+
+    def check_target_in_canonical(self, target: str, canonical_md: str) -> Tuple[bool, str, List[str]]:
+        """
+        Check if target exists in canonical_md.
+
+        Args:
+            target: Expected target path/identifier.
+            canonical_md: Content of canonical_md artifact.
+
+        Returns:
+            (exists, check_status, similar_paths)
+            - exists: Whether exact match found
+            - check_status: 'exact_match' | 'variant_found' | 'not_found'
+            - similar_paths: List of paths that might be related
+        """
+        # Exact match search
+        if f"`{target}`" in canonical_md or f"/{target}" in canonical_md:
+            return True, "exact_match", []
+
+        # Look for variants (path separators, file extensions)
+        similar = []
+        # Extract all code blocks and paths from markdown
+        code_blocks = re.findall(r"`([^`]+)`", canonical_md)
+        for block in code_blocks:
+            if target in block or block in target:
+                similar.append(block)
+
+        if similar:
+            return False, "variant_found", similar[:5]
+
+        return False, "not_found", []
+
+    def load_citation_map(self, citation_path: Path) -> Dict[str, Any]:
+        """
+        Load citation_map_jsonl for cross-referencing.
+
+        Args:
+            citation_path: Path to citation_map_jsonl.
+
+        Returns:
+            Dict mapping citation IDs to citation records.
+        """
+        if self._citation_map_cache is not None:
+            return self._citation_map_cache
+
+        if not citation_path.exists():
+            raise MissingArtifactError(f"citation_map_jsonl not found: {citation_path}")
+
+        citation_map = {}
+        try:
+            with open(citation_path, "r", encoding="utf-8") as f:
+                for line in f:
+                    if not line.strip():
+                        continue
+                    try:
+                        record = json.loads(line)
+                        # Assume citation_id is the key
+                        if "citation_id" in record:
+                            citation_map[record["citation_id"]] = record
+                    except json.JSONDecodeError:
+                        continue
+        except (IOError, OSError) as e:
+            raise MissingArtifactError(
+                f"Failed to read citation_map from {citation_path}: {e}"
+            )
+
+        self._citation_map_cache = citation_map
+        return citation_map
+
+
+class ReturnEvalDiagnosticsCalibrator:
+    """
+    Diagnostic calibrator for retrieval evaluation misses.
+
+    Classifies why each miss occurred without modifying ranking, metrics, or gold set.
+    """
+
+    def __init__(
+        self,
+        index_path: Optional[Path] = None,
+        canonical_path: Optional[Path] = None,
+        citation_path: Optional[Path] = None,
+    ):
+        """
+        Initialize the calibrator.
+
+        Args:
+            index_path: Path to chunk_index.jsonl
+            canonical_path: Path to canonical_md artifact
+            citation_path: Path to citation_map_jsonl
+        """
+        self.index_path = index_path
+        self.canonical_path = canonical_path
+        self.citation_path = citation_path
+        self.inspector = IndexInspector(index_path)
+
+        # Load artifacts once
+        self._index_paths: Optional[set] = None
+        self._canonical_md: Optional[str] = None
+        self._citation_map: Optional[Dict[str, Any]] = None
+
+    def _load_artifacts(self) -> None:
+        """Load and cache required artifacts."""
+        if self.index_path:
+            try:
+                self._index_paths = self.inspector.load_index_paths()
+            except MissingArtifactError:
+                self._index_paths = set()
+
+        if self.canonical_path:
+            try:
+                self._canonical_md = self.inspector.load_canonical_md(self.canonical_path)
+            except MissingArtifactError:
+                self._canonical_md = None
+
+        if self.citation_path:
+            try:
+                self._citation_map = self.inspector.load_citation_map(self.citation_path)
+            except MissingArtifactError:
+                self._citation_map = None
+
+    def diagnose_miss(
+        self,
+        query_id: str,
+        query_text: str,
+        expected_target: str,
+        found_in_results: bool,
+        rank_in_results: Optional[int] = None,
+        top_k: Optional[int] = None,
+        query_had_zero_hits: bool = False,
+    ) -> DiagnosticsRecord:
+        """
+        Diagnose why a query miss occurred.
+
+        Args:
+            query_id: Unique query identifier.
+            query_text: The query string as executed.
+            expected_target: Expected target path/identifier from gold set.
+            found_in_results: Was the target found in results?
+            rank_in_results: Rank position in results (1-indexed), or None.
+            top_k: The k value used for top-k evaluation.
+            query_had_zero_hits: Did the query return 0 total results?
+
+        Returns:
+            DiagnosticsRecord with primary diagnosis and details.
+        """
+        # Load artifacts if not already loaded
+        if self._index_paths is None:
+            self._load_artifacts()
+
+        details: Dict[str, Any] = {
+            "target_found_in_index": False,
+            "target_found_in_canonical": False,
+            "target_found_in_citation_map": False,
+            "rank_in_results": rank_in_results,
+            "top_k": top_k,
+            "query_had_zero_hits": query_had_zero_hits,
+            "canonical_path_check": "unavailable",
+            "possible_path_variants": [],
+            "staleness_indicator": "none",
+            "secondary_diagnoses": [],
+            "confidence": "medium",
+        }
+
+        # If found in results, that's the primary diagnosis
+        if found_in_results:
+            record = DiagnosticsRecord(
+                query_id=query_id,
+                query_text=query_text,
+                expected_target=expected_target,
+                primary_diagnosis="target_in_top_k",
+                diagnosis_details=details,
+            )
+            details["confidence"] = "high"
+            return record
+
+        # Check if target is in the index
+        if self._index_paths:
+            details["target_found_in_index"] = expected_target in self._index_paths
+
+        # Check if target is in canonical_md
+        if self._canonical_md:
+            canonical_exists, check_status, variants = self.inspector.check_target_in_canonical(
+                expected_target, self._canonical_md
+            )
+            details["target_found_in_canonical"] = canonical_exists
+            details["canonical_path_check"] = check_status
+            if variants:
+                details["possible_path_variants"] = variants
+
+        # Check if target is in citation_map
+        if self._citation_map:
+            details["target_found_in_citation_map"] = expected_target in self._citation_map
+
+        # Now determine primary diagnosis based on what we found
+        primary_diagnosis = self._classify_miss(expected_target, rank_in_results, top_k, details)
+
+        # Detect staleness if applicable
+        if self._is_stale_indicator(expected_target):
+            details["staleness_indicator"] = "path_format_obsolete"
+            if primary_diagnosis != "stale_expected_target":
+                details["secondary_diagnoses"].append("index_stale")
+
+        record = DiagnosticsRecord(
+            query_id=query_id,
+            query_text=query_text,
+            expected_target=expected_target,
+            primary_diagnosis=primary_diagnosis,
+            diagnosis_details=details,
+        )
+
+        return record
+
+    def _classify_miss(
+        self,
+        expected_target: str,
+        rank_in_results: Optional[int],
+        top_k: Optional[int],
+        details: Dict[str, Any],
+    ) -> str:
+        """
+        Classify the primary diagnosis based on diagnostic checks.
+
+        Decision tree (in priority order):
+        1. Check for staleness or ambiguity indicators first
+        2. If target not in index -> target_missing_from_index
+        3. If target not in canonical -> target_missing_from_canonical
+        4. If target not in citation_map -> target_missing_from_citation_map
+        5. If target in index but outside top-k -> target_exists_not_in_top_k
+        6. Else -> diagnostic_inconclusive
+        """
+        # Check for staleness indicators first (before index check)
+        if self._is_stale_indicator(expected_target):
+            return "stale_expected_target"
+
+        # Check for ambiguity (before index check)
+        if self._is_ambiguous_target(expected_target):
+            return "query_target_ambiguous"
+
+        # Check index
+        if self._index_paths is not None and expected_target not in self._index_paths:
+            return "target_missing_from_index"
+
+        # Check canonical_md
+        if self._canonical_md is not None and not details["target_found_in_canonical"]:
+            return "target_missing_from_canonical"
+
+        # Check citation_map
+        if self._citation_map is not None and not details["target_found_in_citation_map"]:
+            return "target_missing_from_citation_map"
+
+        # If target is in index but not in results -> ranking issue
+        if self._index_paths is not None and expected_target in self._index_paths:
+            if rank_in_results is not None and top_k is not None:
+                if rank_in_results > top_k:
+                    return "target_exists_not_in_top_k"
+
+        # Fallback
+        return "diagnostic_inconclusive"
+
+    def _is_stale_indicator(self, target: str) -> bool:
+        """Check if target has staleness indicators (e.g., obsolete path format)."""
+        # Examples: very old date patterns, deprecated naming
+        stale_patterns = [r"^\d{4}-\d{2}-\d{2}/", r"^/tmp/", r"^\.git/"]
+        return any(re.match(pat, target) for pat in stale_patterns)
+
+    def _is_ambiguous_target(self, target: str) -> bool:
+        """Check if target is ambiguous or malformed."""
+        # Examples: empty, special characters, non-file-like
+        if not target or len(target) < 2:
+            return True
+        # Check for suspicious patterns
+        suspicious = [r"^[^a-zA-Z0-9/._-]+$", r"^<.+>$"]
+        return any(re.match(pat, target) for pat in suspicious)
+
+    def generate_report(
+        self,
+        misses: List[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        """
+        Generate a complete diagnostics report from a list of misses.
+
+        Args:
+            misses: List of miss dictionaries, each with keys:
+                - query_id: str
+                - query_text: str
+                - expected_target: str
+                - found_in_results: bool
+                - rank_in_results: Optional[int]
+                - top_k: Optional[int]
+                - query_had_zero_hits: bool
+
+        Returns:
+            Complete diagnostics report conforming to schema.
+        """
+        # Load artifacts once
+        self._load_artifacts()
+
+        diagnostics_records = []
+        breakdowns = {
+            "target_in_top_k": 0,
+            "target_exists_not_in_top_k": 0,
+            "target_missing_from_index": 0,
+            "target_missing_from_canonical": 0,
+            "target_missing_from_citation_map": 0,
+            "stale_expected_target": 0,
+            "query_target_ambiguous": 0,
+            "diagnostic_inconclusive": 0,
+        }
+
+        for miss in misses:
+            record = self.diagnose_miss(
+                query_id=miss.get("query_id", ""),
+                query_text=miss.get("query_text", ""),
+                expected_target=miss.get("expected_target", ""),
+                found_in_results=miss.get("found_in_results", False),
+                rank_in_results=miss.get("rank_in_results"),
+                top_k=miss.get("top_k"),
+                query_had_zero_hits=miss.get("query_had_zero_hits", False),
+            )
+
+            diagnostics_records.append(record.to_dict())
+            breakdowns[record.primary_diagnosis] += 1
+
+        # Build report
+        report = {
+            "metadata": {
+                "version": "1.0",
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "total_misses": len(misses),
+                "diagnostic_breakdowns": breakdowns,
+                "index_stats": {
+                    "total_chunks": len(self._index_paths) if self._index_paths else 0,
+                    "total_paths": len(self._index_paths) if self._index_paths else 0,
+                    "canonical_md_exists": self._canonical_md is not None,
+                    "citation_map_exists": self._citation_map is not None,
+                },
+            },
+            "diagnostics": sorted(
+                diagnostics_records,
+                key=lambda x: (x["query_id"], x["expected_target"]),
+            ),
+        }
+
+        return report
+
+    def to_json(self, report: Dict[str, Any]) -> str:
+        """Convert report to JSON string."""
+        return json.dumps(report, indent=2, ensure_ascii=False)
+
+    def save_report(self, report: Dict[str, Any], output_path: Path) -> None:
+        """Save report to JSON file."""
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(output_path, "w", encoding="utf-8") as f:
+            f.write(self.to_json(report))

--- a/merger/lenskit/retrieval/eval_diagnostics_integration.py
+++ b/merger/lenskit/retrieval/eval_diagnostics_integration.py
@@ -10,7 +10,7 @@ It only explains why misses occurred.
 
 from pathlib import Path
 from typing import Dict, List, Any, Optional
-from .eval_diagnostics import ReturnEvalDiagnosticsCalibrator
+from .eval_diagnostics import RetrievalEvalDiagnosticsCalibrator
 
 
 def integrate_diagnostics_with_eval_results(
@@ -37,7 +37,7 @@ def integrate_diagnostics_with_eval_results(
     Returns:
         Dictionary with original eval results and added diagnostics report.
     """
-    calibrator = ReturnEvalDiagnosticsCalibrator(
+    calibrator = RetrievalEvalDiagnosticsCalibrator(
         index_path=index_path,
         canonical_path=canonical_path,
         citation_path=citation_path,
@@ -70,48 +70,63 @@ def _extract_misses_from_eval(eval_results: Dict[str, Any]) -> List[Dict[str, An
     Expected structure:
     {
         "metrics": {...},
-        "results": [
+        "details": [
             {
-                "query_index": 0,
                 "query": "...",
                 "expected": ["path1", "path2"],
                 "is_relevant": false,  # Miss if false
-                "observed_top_k_count": 0,  # Number of results found
+                "found_count": 0,  # Number of results found
                 ...
             }
         ]
     }
     """
-    misses = []
-    results = eval_results.get("results", [])
+    misses: List[Dict[str, Any]] = []
+    if "details" not in eval_results:
+        if "results" in eval_results:
+            raise ValueError("Expected retrieval_eval field 'details', found unsupported legacy key 'results'.")
+        return misses
 
-    for result in results:
+    details = eval_results.get("details", [])
+    if not isinstance(details, list):
+        raise ValueError("Expected retrieval_eval['details'] to be a list.")
+
+    for detail_idx, detail in enumerate(details):
         # Only process misses (is_relevant=false)
-        if result.get("is_relevant", False):
+        if detail.get("is_relevant", False):
             continue
 
-        query_index = result.get("query_index", 0)
-        query_text = result.get("query", "")
-        expected = result.get("expected", [])
-        found_count = result.get("observed_top_k_count", 0)
-        top_k = result.get("top_k", 10)
+        query_text = detail.get("query", "")
+        expected = detail.get("expected", [])
+        if not isinstance(expected, list):
+            expected = [str(expected)]
+        found_count = detail.get("found_count", 0)
+        if not isinstance(found_count, int):
+            found_count = 0
+
+        top_results = detail.get("top_results", [])
+        if not isinstance(top_results, list):
+            top_results = []
+        top_k = len(top_results) if len(top_results) > 0 else None
 
         # For each expected target, create a miss record
         for expected_target in expected:
+            if not isinstance(expected_target, str):
+                expected_target = str(expected_target)
+
             # Try to determine if target was in results
             found_in_results = False
             rank_in_results = None
 
             # Check if target was found (substring match in results)
-            top_results = result.get("top_results", [])
-            for idx, res_path in enumerate(top_results):
-                if expected_target in res_path or res_path in expected_target:
+            for rank_idx, res_path in enumerate(top_results):
+                if isinstance(res_path, str) and (expected_target in res_path or res_path in expected_target):
                     found_in_results = True
-                    rank_in_results = idx + 1
+                    rank_in_results = rank_idx + 1
                     break
 
             miss = {
-                "query_id": f"q{query_index}",
+                "query_id": f"q{detail_idx}",
                 "query_text": query_text,
                 "expected_target": expected_target,
                 "found_in_results": found_in_results,

--- a/merger/lenskit/retrieval/eval_diagnostics_integration.py
+++ b/merger/lenskit/retrieval/eval_diagnostics_integration.py
@@ -85,7 +85,7 @@ def _extract_misses_from_eval(eval_results: Dict[str, Any]) -> List[Dict[str, An
     if "details" not in eval_results:
         if "results" in eval_results:
             raise ValueError("Expected retrieval_eval field 'details', found unsupported legacy key 'results'.")
-        return misses
+        raise ValueError("Expected retrieval_eval field 'details'.")
 
     details = eval_results.get("details", [])
     if not isinstance(details, list):

--- a/merger/lenskit/retrieval/eval_diagnostics_integration.py
+++ b/merger/lenskit/retrieval/eval_diagnostics_integration.py
@@ -1,0 +1,124 @@
+"""
+Integration example: Using retrieval_eval_diagnostics in the eval pipeline.
+
+This module shows how to integrate the diagnostics calibrator with existing
+evaluation results to generate diagnostic reports.
+
+NOTE: The calibrator does not modify retrieval behavior, metrics, or the gold set.
+It only explains why misses occurred.
+"""
+
+from pathlib import Path
+from typing import Dict, List, Any, Optional
+from .eval_diagnostics import ReturnEvalDiagnosticsCalibrator
+
+
+def integrate_diagnostics_with_eval_results(
+    eval_results: Dict[str, Any],
+    index_path: Optional[Path] = None,
+    canonical_path: Optional[Path] = None,
+    citation_path: Optional[Path] = None,
+    output_path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """
+    Integrate diagnostics calibrator with existing eval results.
+
+    This function takes the output from a standard retrieval evaluation
+    (from eval_core.do_eval) and generates diagnostic classifications
+    for all misses without modifying the original evaluation.
+
+    Args:
+        eval_results: Results from eval_core.do_eval()
+        index_path: Path to chunk_index.jsonl
+        canonical_path: Path to canonical_md artifact
+        citation_path: Path to citation_map_jsonl
+        output_path: Optional path to save diagnostics report
+
+    Returns:
+        Dictionary with original eval results and added diagnostics report.
+    """
+    calibrator = ReturnEvalDiagnosticsCalibrator(
+        index_path=index_path,
+        canonical_path=canonical_path,
+        citation_path=citation_path,
+    )
+
+    # Extract misses from eval results
+    misses = _extract_misses_from_eval(eval_results)
+
+    # Generate diagnostic report
+    diagnostics_report = calibrator.generate_report(misses)
+
+    # Optionally save report
+    if output_path:
+        calibrator.save_report(diagnostics_report, output_path)
+
+    # Combine original results with diagnostics
+    combined = {
+        "eval_results": eval_results,
+        "diagnostics_report": diagnostics_report,
+        "note": "Diagnostics are diagnostic-only signals and do not modify evaluation metrics.",
+    }
+
+    return combined
+
+
+def _extract_misses_from_eval(eval_results: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """
+    Extract misses from standard eval results format.
+
+    Expected structure:
+    {
+        "metrics": {...},
+        "results": [
+            {
+                "query_index": 0,
+                "query": "...",
+                "expected": ["path1", "path2"],
+                "is_relevant": false,  # Miss if false
+                "observed_top_k_count": 0,  # Number of results found
+                ...
+            }
+        ]
+    }
+    """
+    misses = []
+    results = eval_results.get("results", [])
+
+    for result in results:
+        # Only process misses (is_relevant=false)
+        if result.get("is_relevant", False):
+            continue
+
+        query_index = result.get("query_index", 0)
+        query_text = result.get("query", "")
+        expected = result.get("expected", [])
+        found_count = result.get("observed_top_k_count", 0)
+        top_k = result.get("top_k", 10)
+
+        # For each expected target, create a miss record
+        for expected_target in expected:
+            # Try to determine if target was in results
+            found_in_results = False
+            rank_in_results = None
+
+            # Check if target was found (substring match in results)
+            top_results = result.get("top_results", [])
+            for idx, res_path in enumerate(top_results):
+                if expected_target in res_path or res_path in expected_target:
+                    found_in_results = True
+                    rank_in_results = idx + 1
+                    break
+
+            miss = {
+                "query_id": f"q{query_index}",
+                "query_text": query_text,
+                "expected_target": expected_target,
+                "found_in_results": found_in_results,
+                "rank_in_results": rank_in_results,
+                "top_k": top_k,
+                "query_had_zero_hits": found_count == 0,
+            }
+            misses.append(miss)
+
+    return misses

--- a/merger/lenskit/tests/test_retrieval_eval_diagnostics.py
+++ b/merger/lenskit/tests/test_retrieval_eval_diagnostics.py
@@ -148,6 +148,11 @@ class TestIntegrationExtraction:
         with pytest.raises(ValueError):
             _extract_misses_from_eval(eval_results)
 
+    def test_extract_rejects_missing_details_field(self):
+        eval_results = {"metrics": {"total_queries": 1}}
+        with pytest.raises(ValueError, match="Expected retrieval_eval field 'details'\\."):
+            _extract_misses_from_eval(eval_results)
+
 
 class TestRetrievalEvalDiagnosticsCalibrator:
     def test_all_good_hit(self, tmp_artifacts):
@@ -182,6 +187,45 @@ class TestRetrievalEvalDiagnosticsCalibrator:
         )
         assert record.primary_diagnosis == "target_exists_not_in_top_k"
         assert record.diagnosis_details["rank_in_results"] is None
+
+    def test_mixed_expected_path_and_symbol_pattern(self, tmp_artifacts):
+        eval_results = {
+            "metrics": {"total_queries": 1},
+            "details": [
+                {
+                    "query": "merge",
+                    "expected": ["merge.py", "iter_report_blocks"],
+                    "is_relevant": False,
+                    "found_count": 1,
+                    "top_results": ["merger/lenskit/core/chunker.py"],
+                }
+            ],
+        }
+
+        misses = _extract_misses_from_eval(eval_results)
+        assert len(misses) == 2
+
+        calibrator = RetrievalEvalDiagnosticsCalibrator(
+            index_path=tmp_artifacts["index"],
+            canonical_path=tmp_artifacts["canonical"],
+            citation_path=tmp_artifacts["citation"],
+        )
+
+        by_target = {}
+        for miss in misses:
+            rec = calibrator.diagnose_miss(**miss)
+            by_target[miss["expected_target"]] = rec.primary_diagnosis
+
+        assert by_target["merge.py"] in {
+            "target_exists_not_in_top_k",
+            "target_missing_from_citation_map",
+            "target_missing_from_canonical",
+        }
+        assert by_target["iter_report_blocks"] in {
+            "query_target_ambiguous",
+            "diagnostic_inconclusive",
+        }
+        assert by_target["iter_report_blocks"] != "target_missing_from_index"
 
     def test_target_missing_from_index(self, tmp_artifacts):
         calibrator = RetrievalEvalDiagnosticsCalibrator(

--- a/merger/lenskit/tests/test_retrieval_eval_diagnostics.py
+++ b/merger/lenskit/tests/test_retrieval_eval_diagnostics.py
@@ -341,3 +341,20 @@ class TestRetrievalEvalDiagnosticsCalibrator:
             ]
         )
         assert [d["query_id"] for d in report["diagnostics"]] == ["q1", "q3"]
+
+    def test_index_stats_total_chunks_vs_total_paths(self, tmp_path):
+        index_file = tmp_path / "chunks.jsonl"
+        chunks = [
+            {"chunk_id": "c1", "path": "merger/lenskit/core/merge.py", "content": "part 1"},
+            {"chunk_id": "c2", "path": "merger/lenskit/core/merge.py", "content": "part 2"},
+        ]
+        with index_file.open("w", encoding="utf-8") as f:
+            for chunk in chunks:
+                f.write(json.dumps(chunk) + "\n")
+
+        calibrator = RetrievalEvalDiagnosticsCalibrator(index_path=index_file)
+        report = calibrator.generate_report([])
+
+        stats = report["metadata"]["index_stats"]
+        assert stats["total_paths"] == 1
+        assert stats["total_chunks"] == 2

--- a/merger/lenskit/tests/test_retrieval_eval_diagnostics.py
+++ b/merger/lenskit/tests/test_retrieval_eval_diagnostics.py
@@ -1,56 +1,67 @@
-"""
-Tests for retrieval evaluation diagnostics calibrator.
-
-Tests all diagnostic categories without modifying retrieval behavior.
-"""
+"""Tests for retrieval evaluation diagnostics calibrator."""
 
 import json
-import pytest
 from pathlib import Path
+
+import jsonschema
+import pytest
+
 from merger.lenskit.retrieval.eval_diagnostics import (
-    ReturnEvalDiagnosticsCalibrator,
     DiagnosticsRecord,
     IndexInspector,
     MissingArtifactError,
+    RetrievalEvalDiagnosticsCalibrator,
 )
-import jsonschema
+from merger.lenskit.retrieval.eval_diagnostics_integration import _extract_misses_from_eval
 
 
 @pytest.fixture
 def tmp_artifacts(tmp_path):
-    """Create temporary index and canonical artifacts for testing."""
-    # Create chunk_index.jsonl
+    """Create temporary index/canonical/citation artifacts using real citation semantics."""
     index_file = tmp_path / "chunks.jsonl"
     chunks = [
-        {"chunk_id": "c1", "path": "src/auth/login.py", "content": "def login(): pass"},
-        {"chunk_id": "c2", "path": "src/config/settings.py", "content": "SECRET = 'x'"},
-        {"chunk_id": "c3", "path": "docs/api.md", "content": "# API"},
-        {"chunk_id": "c4", "path": "src/utils/helpers.py", "content": "def help(): pass"},
+        {"chunk_id": "c1", "path": "merger/lenskit/core/merge.py", "content": "def iter_report_blocks(): pass"},
+        {"chunk_id": "c2", "path": "merger/lenskit/core/chunker.py", "content": "class Chunker: pass"},
+        {"chunk_id": "c3", "path": "merger/lenskit/retrieval/index_db.py", "content": "def build_index(): pass"},
+        {"chunk_id": "c4", "path": "merger/lenskit/core/missing_citation.py", "content": "x = 1"},
     ]
-    with open(index_file, "w", encoding="utf-8") as f:
+    with index_file.open("w", encoding="utf-8") as f:
         for chunk in chunks:
             f.write(json.dumps(chunk) + "\n")
 
-    # Create canonical_md
     canonical_file = tmp_path / "canonical.md"
-    canonical_content = """# Canonical Content
+    canonical_file.write_text(
+        "\n".join(
+            [
+                "# Canonical Content",
+                "- `merger/lenskit/core/merge.py`",
+                "- `merger/lenskit/core/chunker.py`",
+                "- `merger/lenskit/retrieval/index_db.py`",
+                "- `merger/lenskit/core/missing_citation.py`",
+            ]
+        ),
+        encoding="utf-8",
+    )
 
-## Files
-- `src/auth/login.py`: Authentication module
-- `src/config/settings.py`: Configuration settings
-- `docs/api.md`: API documentation
-- `src/utils/helpers.py`: Helper utilities
-"""
-    canonical_file.write_text(canonical_content, encoding="utf-8")
-
-    # Create citation_map_jsonl
     citation_file = tmp_path / "citation_map.jsonl"
     citations = [
-        {"citation_id": "src/auth/login.py", "path": "src/auth/login.py", "refs": []},
-        {"citation_id": "src/config/settings.py", "path": "src/config/settings.py", "refs": []},
-        {"citation_id": "docs/api.md", "path": "docs/api.md", "refs": []},
+        {
+            "citation_id": "cit-1",
+            "chunk_id": "c1",
+            "canonical_range": {"start_byte": 0, "end_byte": 10},
+        },
+        {
+            "citation_id": "cit-2",
+            "chunk_id": "c2",
+            "canonical_range": {"start_byte": 11, "end_byte": 20},
+        },
+        {
+            "citation_id": "cit-3",
+            "chunk_id": "c3",
+            "canonical_range": {"start_byte": 21, "end_byte": 30},
+        },
     ]
-    with open(citation_file, "w", encoding="utf-8") as f:
+    with citation_file.open("w", encoding="utf-8") as f:
         for citation in citations:
             f.write(json.dumps(citation) + "\n")
 
@@ -63,405 +74,226 @@ def tmp_artifacts(tmp_path):
 
 
 class TestDiagnosticsRecord:
-    """Test DiagnosticsRecord class."""
-
     def test_valid_record(self):
-        """Test creating a valid diagnostics record."""
         record = DiagnosticsRecord(
             query_id="q1",
-            query_text="find login",
-            expected_target="src/auth/login.py",
-            primary_diagnosis="target_in_top_k",
-            diagnosis_details={"confidence": "high", "rank_in_results": 1},
-        )
-        assert record.query_id == "q1"
-        assert record.primary_diagnosis == "target_in_top_k"
-
-    def test_invalid_diagnosis(self):
-        """Test that invalid diagnosis raises error."""
-        with pytest.raises(ValueError):
-            DiagnosticsRecord(
-                query_id="q1",
-                query_text="find login",
-                expected_target="src/auth/login.py",
-                primary_diagnosis="invalid_diagnosis",
-                diagnosis_details={},
-            )
-
-    def test_to_dict(self):
-        """Test converting record to dict."""
-        record = DiagnosticsRecord(
-            query_id="q1",
-            query_text="find login",
-            expected_target="src/auth/login.py",
+            query_text="find merge",
+            expected_target="merge.py",
             primary_diagnosis="target_in_top_k",
             diagnosis_details={"confidence": "high"},
         )
-        d = record.to_dict()
-        assert d["query_id"] == "q1"
-        assert d["primary_diagnosis"] == "target_in_top_k"
+        assert record.to_dict()["primary_diagnosis"] == "target_in_top_k"
+
+    def test_invalid_diagnosis(self):
+        with pytest.raises(ValueError):
+            DiagnosticsRecord(
+                query_id="q1",
+                query_text="find merge",
+                expected_target="merge.py",
+                primary_diagnosis="invalid",
+                diagnosis_details={},
+            )
 
 
 class TestIndexInspector:
-    """Test IndexInspector class."""
-
     def test_load_index_paths(self, tmp_artifacts):
-        """Test loading paths from chunk index."""
         inspector = IndexInspector(tmp_artifacts["index"])
         paths = inspector.load_index_paths()
-        assert "src/auth/login.py" in paths
-        assert "src/config/settings.py" in paths
-        assert len(paths) >= 3
+        assert "merger/lenskit/core/merge.py" in paths
 
-    def test_load_index_paths_missing_file(self):
-        """Test loading non-existent index file."""
-        inspector = IndexInspector(Path("/nonexistent/file.jsonl"))
+    def test_load_index_paths_missing(self):
+        inspector = IndexInspector(Path("/does/not/exist.jsonl"))
         with pytest.raises(MissingArtifactError):
             inspector.load_index_paths()
 
-    def test_load_canonical_md(self, tmp_artifacts):
-        """Test loading canonical_md content."""
-        inspector = IndexInspector()
-        content = inspector.load_canonical_md(tmp_artifacts["canonical"])
-        assert "Canonical Content" in content
-        assert "src/auth/login.py" in content
-
-    def test_load_canonical_md_missing(self):
-        """Test loading non-existent canonical_md."""
-        inspector = IndexInspector()
-        with pytest.raises(MissingArtifactError):
-            inspector.load_canonical_md(Path("/nonexistent/canonical.md"))
-
-    def test_check_target_in_canonical_exact_match(self, tmp_artifacts):
-        """Test exact target match in canonical_md."""
-        inspector = IndexInspector()
-        content = inspector.load_canonical_md(tmp_artifacts["canonical"])
-        exists, status, variants = inspector.check_target_in_canonical(
-            "src/auth/login.py", content
-        )
-        assert exists is True
-        assert status == "exact_match"
-
-    def test_check_target_in_canonical_not_found(self, tmp_artifacts):
-        """Test target not in canonical_md."""
-        inspector = IndexInspector()
-        content = inspector.load_canonical_md(tmp_artifacts["canonical"])
-        exists, status, variants = inspector.check_target_in_canonical(
-            "src/nonexistent.py", content
-        )
-        assert exists is False
-        assert status == "not_found"
-
-    def test_load_citation_map(self, tmp_artifacts):
-        """Test loading citation_map."""
-        inspector = IndexInspector()
-        citation_map = inspector.load_citation_map(tmp_artifacts["citation"])
-        assert "src/auth/login.py" in citation_map
+    def test_path_to_chunk_ids(self, tmp_artifacts):
+        inspector = IndexInspector(tmp_artifacts["index"])
+        mapping = inspector.load_path_to_chunk_ids()
+        assert mapping["merger/lenskit/core/merge.py"] == {"c1"}
 
 
-class TestReturnEvalDiagnosticsCalibrator:
-    """Test ReturnEvalDiagnosticsCalibrator class."""
+class TestIntegrationExtraction:
+    def test_extract_uses_details_structure(self):
+        eval_results = {
+            "metrics": {"total_queries": 2},
+            "details": [
+                {
+                    "query": "merge",
+                    "expected": ["merge.py", "iter_report_blocks"],
+                    "is_relevant": False,
+                    "found_count": 2,
+                    "top_results": ["merger/lenskit/core/merge.py", "merger/lenskit/core/chunker.py"],
+                },
+                {
+                    "query": "chunk",
+                    "expected": ["chunker.py"],
+                    "is_relevant": True,
+                    "found_count": 1,
+                    "top_results": ["merger/lenskit/core/chunker.py"],
+                },
+            ],
+        }
 
-    def test_init_with_artifacts(self, tmp_artifacts):
-        """Test initializing calibrator with artifact paths."""
-        calibrator = ReturnEvalDiagnosticsCalibrator(
+        misses = _extract_misses_from_eval(eval_results)
+        assert len(misses) == 2
+        assert misses[0]["query_id"] == "q0"
+        assert misses[0]["query_had_zero_hits"] is False
+        assert misses[0]["top_k"] == 2
+
+    def test_extract_rejects_legacy_results_key(self):
+        eval_results = {
+            "metrics": {},
+            "results": [{"query": "x", "is_relevant": False, "expected": ["a"], "top_results": [], "found_count": 0}],
+        }
+        with pytest.raises(ValueError):
+            _extract_misses_from_eval(eval_results)
+
+
+class TestRetrievalEvalDiagnosticsCalibrator:
+    def test_all_good_hit(self, tmp_artifacts):
+        calibrator = RetrievalEvalDiagnosticsCalibrator(
             index_path=tmp_artifacts["index"],
             canonical_path=tmp_artifacts["canonical"],
             citation_path=tmp_artifacts["citation"],
         )
-        assert calibrator.index_path == tmp_artifacts["index"]
-
-    def test_diagnose_target_in_top_k(self, tmp_artifacts):
-        """Test diagnosis when target is found in results."""
-        calibrator = ReturnEvalDiagnosticsCalibrator(
-            index_path=tmp_artifacts["index"],
-            canonical_path=tmp_artifacts["canonical"],
-        )
         record = calibrator.diagnose_miss(
             query_id="q1",
-            query_text="find login",
-            expected_target="src/auth/login.py",
+            query_text="find merge",
+            expected_target="merge.py",
             found_in_results=True,
             rank_in_results=1,
             top_k=10,
         )
         assert record.primary_diagnosis == "target_in_top_k"
-        assert record.diagnosis_details["confidence"] == "high"
 
-    def test_diagnose_target_missing_from_index(self, tmp_artifacts):
-        """Test diagnosis when target missing from index."""
-        calibrator = ReturnEvalDiagnosticsCalibrator(
+    def test_target_exists_not_observed_in_top_k_without_rank_claim(self, tmp_artifacts):
+        calibrator = RetrievalEvalDiagnosticsCalibrator(
             index_path=tmp_artifacts["index"],
             canonical_path=tmp_artifacts["canonical"],
+            citation_path=tmp_artifacts["citation"],
         )
         record = calibrator.diagnose_miss(
             query_id="q2",
-            query_text="find missing",
-            expected_target="src/nonexistent/missing.py",
+            query_text="find merge",
+            expected_target="merge.py",
+            found_in_results=False,
+            rank_in_results=None,
+            top_k=10,
+        )
+        assert record.primary_diagnosis == "target_exists_not_in_top_k"
+        assert record.diagnosis_details["rank_in_results"] is None
+
+    def test_target_missing_from_index(self, tmp_artifacts):
+        calibrator = RetrievalEvalDiagnosticsCalibrator(
+            index_path=tmp_artifacts["index"],
+            canonical_path=tmp_artifacts["canonical"],
+            citation_path=tmp_artifacts["citation"],
+        )
+        record = calibrator.diagnose_miss(
+            query_id="q3",
+            query_text="find nope",
+            expected_target="does/not/exist.py",
             found_in_results=False,
             rank_in_results=None,
             top_k=10,
         )
         assert record.primary_diagnosis == "target_missing_from_index"
-        assert record.diagnosis_details["target_found_in_index"] is False
 
-    def test_diagnose_target_exists_not_in_top_k(self, tmp_artifacts):
-        """Test diagnosis when target in index but outside top-k."""
-        calibrator = ReturnEvalDiagnosticsCalibrator(
+    def test_stale_expected_target(self, tmp_artifacts):
+        calibrator = RetrievalEvalDiagnosticsCalibrator(
             index_path=tmp_artifacts["index"],
             canonical_path=tmp_artifacts["canonical"],
+            citation_path=tmp_artifacts["citation"],
         )
-        record = calibrator.diagnose_miss(
-            query_id="q3",
-            query_text="find helpers",
-            expected_target="src/utils/helpers.py",
-            found_in_results=False,
-            rank_in_results=15,
-            top_k=10,
-        )
-        assert record.primary_diagnosis == "target_exists_not_in_top_k"
-        assert record.diagnosis_details["target_found_in_index"] is True
-
-    def test_diagnose_target_missing_from_canonical(self, tmp_artifacts):
-        """Test diagnosis when target missing from canonical_md."""
-        calibrator = ReturnEvalDiagnosticsCalibrator(
-            index_path=tmp_artifacts["index"],
-            canonical_path=tmp_artifacts["canonical"],
-        )
-        # Add a chunk to index that's not in canonical
-        with open(tmp_artifacts["index"], "a", encoding="utf-8") as f:
-            f.write(json.dumps({
-                "chunk_id": "c_extra",
-                "path": "src/extra/new.py",
-                "content": "new code"
-            }) + "\n")
-
         record = calibrator.diagnose_miss(
             query_id="q4",
-            query_text="find new",
-            expected_target="src/extra/new.py",
-            found_in_results=False,
-            rank_in_results=None,
-            top_k=10,
-        )
-        # Target is in index but not in canonical
-        assert record.primary_diagnosis == "target_missing_from_canonical"
-
-    def test_diagnose_stale_expected_target(self, tmp_artifacts):
-        """Test diagnosis of stale expected targets."""
-        calibrator = ReturnEvalDiagnosticsCalibrator(
-            index_path=tmp_artifacts["index"],
-            canonical_path=tmp_artifacts["canonical"],
-        )
-        record = calibrator.diagnose_miss(
-            query_id="q5",
             query_text="find old",
-            expected_target="/tmp/old_snapshot.py",  # Stale indicator
+            expected_target="/tmp/old_snapshot.py",
             found_in_results=False,
             rank_in_results=None,
             top_k=10,
         )
         assert record.primary_diagnosis == "stale_expected_target"
 
-    def test_diagnose_ambiguous_query(self, tmp_artifacts):
-        """Test diagnosis of ambiguous targets."""
-        calibrator = ReturnEvalDiagnosticsCalibrator(
-            index_path=tmp_artifacts["index"],
-            canonical_path=tmp_artifacts["canonical"],
-        )
-        record = calibrator.diagnose_miss(
-            query_id="q6",
-            query_text="find it",
-            expected_target="",  # Empty target
-            found_in_results=False,
-            rank_in_results=None,
-            top_k=10,
-        )
-        assert record.primary_diagnosis == "query_target_ambiguous"
-
-    def test_diagnose_zero_hits(self, tmp_artifacts):
-        """Test diagnosis when query returns zero hits."""
-        calibrator = ReturnEvalDiagnosticsCalibrator(
-            index_path=tmp_artifacts["index"],
-            canonical_path=tmp_artifacts["canonical"],
-        )
-        record = calibrator.diagnose_miss(
-            query_id="q7",
-            query_text="find xyz",
-            expected_target="src/xyz/file.py",
-            found_in_results=False,
-            rank_in_results=None,
-            top_k=10,
-            query_had_zero_hits=True,
-        )
-        assert record.diagnosis_details["query_had_zero_hits"] is True
-
-    def test_generate_report(self, tmp_artifacts):
-        """Test generating a complete diagnostic report."""
-        calibrator = ReturnEvalDiagnosticsCalibrator(
+    def test_ambiguous_empty_expected_target(self, tmp_artifacts):
+        calibrator = RetrievalEvalDiagnosticsCalibrator(
             index_path=tmp_artifacts["index"],
             canonical_path=tmp_artifacts["canonical"],
             citation_path=tmp_artifacts["citation"],
         )
-        misses = [
-            {
-                "query_id": "q1",
-                "query_text": "find login",
-                "expected_target": "src/auth/login.py",
-                "found_in_results": True,
-                "rank_in_results": 1,
-                "top_k": 10,
-                "query_had_zero_hits": False,
-            },
-            {
-                "query_id": "q2",
-                "query_text": "find missing",
-                "expected_target": "src/nonexistent.py",
-                "found_in_results": False,
-                "rank_in_results": None,
-                "top_k": 10,
-                "query_had_zero_hits": False,
-            },
-            {
-                "query_id": "q3",
-                "query_text": "find helpers",
-                "expected_target": "src/utils/helpers.py",
-                "found_in_results": False,
-                "rank_in_results": 15,
-                "top_k": 10,
-                "query_had_zero_hits": False,
-            },
-        ]
-        report = calibrator.generate_report(misses)
-        
-        # Verify report structure
-        assert "metadata" in report
-        assert "diagnostics" in report
-        assert report["metadata"]["total_misses"] == 3
-        assert report["metadata"]["version"] == "1.0"
-        assert "timestamp" in report["metadata"]
+        record = calibrator.diagnose_miss(
+            query_id="q5",
+            query_text="find ???",
+            expected_target="",
+            found_in_results=False,
+            rank_in_results=None,
+            top_k=None,
+        )
+        assert record.primary_diagnosis == "query_target_ambiguous"
 
-        # Verify diagnostic breakdowns
-        breakdowns = report["metadata"]["diagnostic_breakdowns"]
-        # q1: found in results -> target_in_top_k
-        # q2: not in index -> target_missing_from_index
-        # q3: in index and canonical, but not in citation_map -> target_missing_from_citation_map
-        assert breakdowns["target_in_top_k"] == 1, f"Expected 1 target_in_top_k, got {breakdowns}"
-        assert breakdowns["target_missing_from_index"] == 1, f"Expected 1 target_missing_from_index, got {breakdowns}"
-        # src/utils/helpers.py is not in citation_map, so it gets that diagnosis instead of ranking
-        assert breakdowns["target_missing_from_citation_map"] == 1, f"Expected 1 target_missing_from_citation_map, got {breakdowns}"
-
-        # Verify diagnostics array
-        assert len(report["diagnostics"]) == 3
-        # Verify sorting is by query_id + expected_target
-        assert report["diagnostics"][0]["query_id"] == "q1"
-
-    def test_save_report(self, tmp_artifacts):
-        """Test saving report to file."""
-        output_file = tmp_artifacts["tmp_path"] / "diagnostics_report.json"
-        calibrator = ReturnEvalDiagnosticsCalibrator(
+    def test_citation_map_checked_via_chunk_id_bridge(self, tmp_artifacts):
+        calibrator = RetrievalEvalDiagnosticsCalibrator(
             index_path=tmp_artifacts["index"],
             canonical_path=tmp_artifacts["canonical"],
+            citation_path=tmp_artifacts["citation"],
         )
-        misses = [
-            {
-                "query_id": "q1",
-                "query_text": "find login",
-                "expected_target": "src/auth/login.py",
-                "found_in_results": True,
-                "rank_in_results": 1,
-                "top_k": 10,
-                "query_had_zero_hits": False,
-            },
-        ]
-        report = calibrator.generate_report(misses)
-        calibrator.save_report(report, output_file)
-        
-        assert output_file.exists()
-        saved_data = json.loads(output_file.read_text(encoding="utf-8"))
-        assert saved_data["metadata"]["total_misses"] == 1
+        record = calibrator.diagnose_miss(
+            query_id="q6",
+            query_text="find merge",
+            expected_target="merge.py",
+            found_in_results=False,
+            rank_in_results=None,
+            top_k=10,
+        )
+        assert record.diagnosis_details["target_found_in_citation_map"] is True
+        assert record.primary_diagnosis != "target_missing_from_citation_map"
 
-    def test_report_conforms_to_schema(self, tmp_artifacts):
-        """Test that generated report conforms to schema."""
-        calibrator = ReturnEvalDiagnosticsCalibrator(
+    def test_missing_citation_detected_when_chunk_has_no_citation(self, tmp_artifacts):
+        calibrator = RetrievalEvalDiagnosticsCalibrator(
             index_path=tmp_artifacts["index"],
             canonical_path=tmp_artifacts["canonical"],
+            citation_path=tmp_artifacts["citation"],
         )
-        misses = [
-            {
-                "query_id": "q1",
-                "query_text": "find login",
-                "expected_target": "src/auth/login.py",
-                "found_in_results": True,
-                "rank_in_results": 1,
-                "top_k": 10,
-                "query_had_zero_hits": False,
-            },
-        ]
-        report = calibrator.generate_report(misses)
-        
-        # Load the schema
+        record = calibrator.diagnose_miss(
+            query_id="q7",
+            query_text="find missing citation",
+            expected_target="missing_citation.py",
+            found_in_results=False,
+            rank_in_results=None,
+            top_k=10,
+        )
+        assert record.primary_diagnosis == "target_missing_from_citation_map"
+
+    def test_schema_validation(self, tmp_artifacts):
+        calibrator = RetrievalEvalDiagnosticsCalibrator(
+            index_path=tmp_artifacts["index"],
+            canonical_path=tmp_artifacts["canonical"],
+            citation_path=tmp_artifacts["citation"],
+        )
+        report = calibrator.generate_report(
+            [
+                {
+                    "query_id": "q9",
+                    "query_text": "find merge",
+                    "expected_target": "merge.py",
+                    "found_in_results": False,
+                    "rank_in_results": None,
+                    "top_k": 2,
+                    "query_had_zero_hits": False,
+                }
+            ]
+        )
+
         schema_path = Path(__file__).resolve().parent.parent / "contracts" / "retrieval-eval-diagnostics.v1.schema.json"
         schema = json.loads(schema_path.read_text(encoding="utf-8"))
-        
-        # Validate report against schema
-        try:
-            jsonschema.validate(instance=report, schema=schema)
-        except jsonschema.ValidationError as e:
-            pytest.fail(f"Report does not conform to schema: {e.message}")
+        jsonschema.validate(instance=report, schema=schema)
 
     def test_deterministic_sorting(self, tmp_artifacts):
-        """Test that diagnostics are deterministically sorted."""
-        calibrator = ReturnEvalDiagnosticsCalibrator(
-            index_path=tmp_artifacts["index"],
-            canonical_path=tmp_artifacts["canonical"],
+        calibrator = RetrievalEvalDiagnosticsCalibrator(index_path=tmp_artifacts["index"])
+        report = calibrator.generate_report(
+            [
+                {"query_id": "q3", "query_text": "z", "expected_target": "b.py", "found_in_results": False, "rank_in_results": None, "top_k": None, "query_had_zero_hits": True},
+                {"query_id": "q1", "query_text": "a", "expected_target": "a.py", "found_in_results": False, "rank_in_results": None, "top_k": None, "query_had_zero_hits": True},
+            ]
         )
-        misses = [
-            {
-                "query_id": "q3",
-                "query_text": "z query",
-                "expected_target": "z target",
-                "found_in_results": False,
-                "rank_in_results": None,
-                "top_k": 10,
-                "query_had_zero_hits": False,
-            },
-            {
-                "query_id": "q1",
-                "query_text": "a query",
-                "expected_target": "a target",
-                "found_in_results": False,
-                "rank_in_results": None,
-                "top_k": 10,
-                "query_had_zero_hits": False,
-            },
-            {
-                "query_id": "q2",
-                "query_text": "m query",
-                "expected_target": "m target",
-                "found_in_results": False,
-                "rank_in_results": None,
-                "top_k": 10,
-                "query_had_zero_hits": False,
-            },
-        ]
-        report = calibrator.generate_report(misses)
-        
-        # Check ordering by query_id
-        query_ids = [d["query_id"] for d in report["diagnostics"]]
-        assert query_ids == sorted(query_ids)
-
-
-def test_secondary_diagnoses():
-    """Test that secondary diagnoses are correctly set."""
-    record = DiagnosticsRecord(
-        query_id="q1",
-        query_text="find login",
-        expected_target="src/auth/login.py",
-        primary_diagnosis="target_exists_not_in_top_k",
-        diagnosis_details={
-            "confidence": "medium",
-            "secondary_diagnoses": ["low_query_specificity", "index_stale"],
-        },
-    )
-    assert len(record.diagnosis_details["secondary_diagnoses"]) == 2
+        assert [d["query_id"] for d in report["diagnostics"]] == ["q1", "q3"]

--- a/merger/lenskit/tests/test_retrieval_eval_diagnostics.py
+++ b/merger/lenskit/tests/test_retrieval_eval_diagnostics.py
@@ -1,0 +1,467 @@
+"""
+Tests for retrieval evaluation diagnostics calibrator.
+
+Tests all diagnostic categories without modifying retrieval behavior.
+"""
+
+import json
+import pytest
+from pathlib import Path
+from merger.lenskit.retrieval.eval_diagnostics import (
+    ReturnEvalDiagnosticsCalibrator,
+    DiagnosticsRecord,
+    IndexInspector,
+    MissingArtifactError,
+)
+import jsonschema
+
+
+@pytest.fixture
+def tmp_artifacts(tmp_path):
+    """Create temporary index and canonical artifacts for testing."""
+    # Create chunk_index.jsonl
+    index_file = tmp_path / "chunks.jsonl"
+    chunks = [
+        {"chunk_id": "c1", "path": "src/auth/login.py", "content": "def login(): pass"},
+        {"chunk_id": "c2", "path": "src/config/settings.py", "content": "SECRET = 'x'"},
+        {"chunk_id": "c3", "path": "docs/api.md", "content": "# API"},
+        {"chunk_id": "c4", "path": "src/utils/helpers.py", "content": "def help(): pass"},
+    ]
+    with open(index_file, "w", encoding="utf-8") as f:
+        for chunk in chunks:
+            f.write(json.dumps(chunk) + "\n")
+
+    # Create canonical_md
+    canonical_file = tmp_path / "canonical.md"
+    canonical_content = """# Canonical Content
+
+## Files
+- `src/auth/login.py`: Authentication module
+- `src/config/settings.py`: Configuration settings
+- `docs/api.md`: API documentation
+- `src/utils/helpers.py`: Helper utilities
+"""
+    canonical_file.write_text(canonical_content, encoding="utf-8")
+
+    # Create citation_map_jsonl
+    citation_file = tmp_path / "citation_map.jsonl"
+    citations = [
+        {"citation_id": "src/auth/login.py", "path": "src/auth/login.py", "refs": []},
+        {"citation_id": "src/config/settings.py", "path": "src/config/settings.py", "refs": []},
+        {"citation_id": "docs/api.md", "path": "docs/api.md", "refs": []},
+    ]
+    with open(citation_file, "w", encoding="utf-8") as f:
+        for citation in citations:
+            f.write(json.dumps(citation) + "\n")
+
+    return {
+        "index": index_file,
+        "canonical": canonical_file,
+        "citation": citation_file,
+        "tmp_path": tmp_path,
+    }
+
+
+class TestDiagnosticsRecord:
+    """Test DiagnosticsRecord class."""
+
+    def test_valid_record(self):
+        """Test creating a valid diagnostics record."""
+        record = DiagnosticsRecord(
+            query_id="q1",
+            query_text="find login",
+            expected_target="src/auth/login.py",
+            primary_diagnosis="target_in_top_k",
+            diagnosis_details={"confidence": "high", "rank_in_results": 1},
+        )
+        assert record.query_id == "q1"
+        assert record.primary_diagnosis == "target_in_top_k"
+
+    def test_invalid_diagnosis(self):
+        """Test that invalid diagnosis raises error."""
+        with pytest.raises(ValueError):
+            DiagnosticsRecord(
+                query_id="q1",
+                query_text="find login",
+                expected_target="src/auth/login.py",
+                primary_diagnosis="invalid_diagnosis",
+                diagnosis_details={},
+            )
+
+    def test_to_dict(self):
+        """Test converting record to dict."""
+        record = DiagnosticsRecord(
+            query_id="q1",
+            query_text="find login",
+            expected_target="src/auth/login.py",
+            primary_diagnosis="target_in_top_k",
+            diagnosis_details={"confidence": "high"},
+        )
+        d = record.to_dict()
+        assert d["query_id"] == "q1"
+        assert d["primary_diagnosis"] == "target_in_top_k"
+
+
+class TestIndexInspector:
+    """Test IndexInspector class."""
+
+    def test_load_index_paths(self, tmp_artifacts):
+        """Test loading paths from chunk index."""
+        inspector = IndexInspector(tmp_artifacts["index"])
+        paths = inspector.load_index_paths()
+        assert "src/auth/login.py" in paths
+        assert "src/config/settings.py" in paths
+        assert len(paths) >= 3
+
+    def test_load_index_paths_missing_file(self):
+        """Test loading non-existent index file."""
+        inspector = IndexInspector(Path("/nonexistent/file.jsonl"))
+        with pytest.raises(MissingArtifactError):
+            inspector.load_index_paths()
+
+    def test_load_canonical_md(self, tmp_artifacts):
+        """Test loading canonical_md content."""
+        inspector = IndexInspector()
+        content = inspector.load_canonical_md(tmp_artifacts["canonical"])
+        assert "Canonical Content" in content
+        assert "src/auth/login.py" in content
+
+    def test_load_canonical_md_missing(self):
+        """Test loading non-existent canonical_md."""
+        inspector = IndexInspector()
+        with pytest.raises(MissingArtifactError):
+            inspector.load_canonical_md(Path("/nonexistent/canonical.md"))
+
+    def test_check_target_in_canonical_exact_match(self, tmp_artifacts):
+        """Test exact target match in canonical_md."""
+        inspector = IndexInspector()
+        content = inspector.load_canonical_md(tmp_artifacts["canonical"])
+        exists, status, variants = inspector.check_target_in_canonical(
+            "src/auth/login.py", content
+        )
+        assert exists is True
+        assert status == "exact_match"
+
+    def test_check_target_in_canonical_not_found(self, tmp_artifacts):
+        """Test target not in canonical_md."""
+        inspector = IndexInspector()
+        content = inspector.load_canonical_md(tmp_artifacts["canonical"])
+        exists, status, variants = inspector.check_target_in_canonical(
+            "src/nonexistent.py", content
+        )
+        assert exists is False
+        assert status == "not_found"
+
+    def test_load_citation_map(self, tmp_artifacts):
+        """Test loading citation_map."""
+        inspector = IndexInspector()
+        citation_map = inspector.load_citation_map(tmp_artifacts["citation"])
+        assert "src/auth/login.py" in citation_map
+
+
+class TestReturnEvalDiagnosticsCalibrator:
+    """Test ReturnEvalDiagnosticsCalibrator class."""
+
+    def test_init_with_artifacts(self, tmp_artifacts):
+        """Test initializing calibrator with artifact paths."""
+        calibrator = ReturnEvalDiagnosticsCalibrator(
+            index_path=tmp_artifacts["index"],
+            canonical_path=tmp_artifacts["canonical"],
+            citation_path=tmp_artifacts["citation"],
+        )
+        assert calibrator.index_path == tmp_artifacts["index"]
+
+    def test_diagnose_target_in_top_k(self, tmp_artifacts):
+        """Test diagnosis when target is found in results."""
+        calibrator = ReturnEvalDiagnosticsCalibrator(
+            index_path=tmp_artifacts["index"],
+            canonical_path=tmp_artifacts["canonical"],
+        )
+        record = calibrator.diagnose_miss(
+            query_id="q1",
+            query_text="find login",
+            expected_target="src/auth/login.py",
+            found_in_results=True,
+            rank_in_results=1,
+            top_k=10,
+        )
+        assert record.primary_diagnosis == "target_in_top_k"
+        assert record.diagnosis_details["confidence"] == "high"
+
+    def test_diagnose_target_missing_from_index(self, tmp_artifacts):
+        """Test diagnosis when target missing from index."""
+        calibrator = ReturnEvalDiagnosticsCalibrator(
+            index_path=tmp_artifacts["index"],
+            canonical_path=tmp_artifacts["canonical"],
+        )
+        record = calibrator.diagnose_miss(
+            query_id="q2",
+            query_text="find missing",
+            expected_target="src/nonexistent/missing.py",
+            found_in_results=False,
+            rank_in_results=None,
+            top_k=10,
+        )
+        assert record.primary_diagnosis == "target_missing_from_index"
+        assert record.diagnosis_details["target_found_in_index"] is False
+
+    def test_diagnose_target_exists_not_in_top_k(self, tmp_artifacts):
+        """Test diagnosis when target in index but outside top-k."""
+        calibrator = ReturnEvalDiagnosticsCalibrator(
+            index_path=tmp_artifacts["index"],
+            canonical_path=tmp_artifacts["canonical"],
+        )
+        record = calibrator.diagnose_miss(
+            query_id="q3",
+            query_text="find helpers",
+            expected_target="src/utils/helpers.py",
+            found_in_results=False,
+            rank_in_results=15,
+            top_k=10,
+        )
+        assert record.primary_diagnosis == "target_exists_not_in_top_k"
+        assert record.diagnosis_details["target_found_in_index"] is True
+
+    def test_diagnose_target_missing_from_canonical(self, tmp_artifacts):
+        """Test diagnosis when target missing from canonical_md."""
+        calibrator = ReturnEvalDiagnosticsCalibrator(
+            index_path=tmp_artifacts["index"],
+            canonical_path=tmp_artifacts["canonical"],
+        )
+        # Add a chunk to index that's not in canonical
+        with open(tmp_artifacts["index"], "a", encoding="utf-8") as f:
+            f.write(json.dumps({
+                "chunk_id": "c_extra",
+                "path": "src/extra/new.py",
+                "content": "new code"
+            }) + "\n")
+
+        record = calibrator.diagnose_miss(
+            query_id="q4",
+            query_text="find new",
+            expected_target="src/extra/new.py",
+            found_in_results=False,
+            rank_in_results=None,
+            top_k=10,
+        )
+        # Target is in index but not in canonical
+        assert record.primary_diagnosis == "target_missing_from_canonical"
+
+    def test_diagnose_stale_expected_target(self, tmp_artifacts):
+        """Test diagnosis of stale expected targets."""
+        calibrator = ReturnEvalDiagnosticsCalibrator(
+            index_path=tmp_artifacts["index"],
+            canonical_path=tmp_artifacts["canonical"],
+        )
+        record = calibrator.diagnose_miss(
+            query_id="q5",
+            query_text="find old",
+            expected_target="/tmp/old_snapshot.py",  # Stale indicator
+            found_in_results=False,
+            rank_in_results=None,
+            top_k=10,
+        )
+        assert record.primary_diagnosis == "stale_expected_target"
+
+    def test_diagnose_ambiguous_query(self, tmp_artifacts):
+        """Test diagnosis of ambiguous targets."""
+        calibrator = ReturnEvalDiagnosticsCalibrator(
+            index_path=tmp_artifacts["index"],
+            canonical_path=tmp_artifacts["canonical"],
+        )
+        record = calibrator.diagnose_miss(
+            query_id="q6",
+            query_text="find it",
+            expected_target="",  # Empty target
+            found_in_results=False,
+            rank_in_results=None,
+            top_k=10,
+        )
+        assert record.primary_diagnosis == "query_target_ambiguous"
+
+    def test_diagnose_zero_hits(self, tmp_artifacts):
+        """Test diagnosis when query returns zero hits."""
+        calibrator = ReturnEvalDiagnosticsCalibrator(
+            index_path=tmp_artifacts["index"],
+            canonical_path=tmp_artifacts["canonical"],
+        )
+        record = calibrator.diagnose_miss(
+            query_id="q7",
+            query_text="find xyz",
+            expected_target="src/xyz/file.py",
+            found_in_results=False,
+            rank_in_results=None,
+            top_k=10,
+            query_had_zero_hits=True,
+        )
+        assert record.diagnosis_details["query_had_zero_hits"] is True
+
+    def test_generate_report(self, tmp_artifacts):
+        """Test generating a complete diagnostic report."""
+        calibrator = ReturnEvalDiagnosticsCalibrator(
+            index_path=tmp_artifacts["index"],
+            canonical_path=tmp_artifacts["canonical"],
+            citation_path=tmp_artifacts["citation"],
+        )
+        misses = [
+            {
+                "query_id": "q1",
+                "query_text": "find login",
+                "expected_target": "src/auth/login.py",
+                "found_in_results": True,
+                "rank_in_results": 1,
+                "top_k": 10,
+                "query_had_zero_hits": False,
+            },
+            {
+                "query_id": "q2",
+                "query_text": "find missing",
+                "expected_target": "src/nonexistent.py",
+                "found_in_results": False,
+                "rank_in_results": None,
+                "top_k": 10,
+                "query_had_zero_hits": False,
+            },
+            {
+                "query_id": "q3",
+                "query_text": "find helpers",
+                "expected_target": "src/utils/helpers.py",
+                "found_in_results": False,
+                "rank_in_results": 15,
+                "top_k": 10,
+                "query_had_zero_hits": False,
+            },
+        ]
+        report = calibrator.generate_report(misses)
+        
+        # Verify report structure
+        assert "metadata" in report
+        assert "diagnostics" in report
+        assert report["metadata"]["total_misses"] == 3
+        assert report["metadata"]["version"] == "1.0"
+        assert "timestamp" in report["metadata"]
+
+        # Verify diagnostic breakdowns
+        breakdowns = report["metadata"]["diagnostic_breakdowns"]
+        # q1: found in results -> target_in_top_k
+        # q2: not in index -> target_missing_from_index
+        # q3: in index and canonical, but not in citation_map -> target_missing_from_citation_map
+        assert breakdowns["target_in_top_k"] == 1, f"Expected 1 target_in_top_k, got {breakdowns}"
+        assert breakdowns["target_missing_from_index"] == 1, f"Expected 1 target_missing_from_index, got {breakdowns}"
+        # src/utils/helpers.py is not in citation_map, so it gets that diagnosis instead of ranking
+        assert breakdowns["target_missing_from_citation_map"] == 1, f"Expected 1 target_missing_from_citation_map, got {breakdowns}"
+
+        # Verify diagnostics array
+        assert len(report["diagnostics"]) == 3
+        # Verify sorting is by query_id + expected_target
+        assert report["diagnostics"][0]["query_id"] == "q1"
+
+    def test_save_report(self, tmp_artifacts):
+        """Test saving report to file."""
+        output_file = tmp_artifacts["tmp_path"] / "diagnostics_report.json"
+        calibrator = ReturnEvalDiagnosticsCalibrator(
+            index_path=tmp_artifacts["index"],
+            canonical_path=tmp_artifacts["canonical"],
+        )
+        misses = [
+            {
+                "query_id": "q1",
+                "query_text": "find login",
+                "expected_target": "src/auth/login.py",
+                "found_in_results": True,
+                "rank_in_results": 1,
+                "top_k": 10,
+                "query_had_zero_hits": False,
+            },
+        ]
+        report = calibrator.generate_report(misses)
+        calibrator.save_report(report, output_file)
+        
+        assert output_file.exists()
+        saved_data = json.loads(output_file.read_text(encoding="utf-8"))
+        assert saved_data["metadata"]["total_misses"] == 1
+
+    def test_report_conforms_to_schema(self, tmp_artifacts):
+        """Test that generated report conforms to schema."""
+        calibrator = ReturnEvalDiagnosticsCalibrator(
+            index_path=tmp_artifacts["index"],
+            canonical_path=tmp_artifacts["canonical"],
+        )
+        misses = [
+            {
+                "query_id": "q1",
+                "query_text": "find login",
+                "expected_target": "src/auth/login.py",
+                "found_in_results": True,
+                "rank_in_results": 1,
+                "top_k": 10,
+                "query_had_zero_hits": False,
+            },
+        ]
+        report = calibrator.generate_report(misses)
+        
+        # Load the schema
+        schema_path = Path(__file__).resolve().parent.parent / "contracts" / "retrieval-eval-diagnostics.v1.schema.json"
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        
+        # Validate report against schema
+        try:
+            jsonschema.validate(instance=report, schema=schema)
+        except jsonschema.ValidationError as e:
+            pytest.fail(f"Report does not conform to schema: {e.message}")
+
+    def test_deterministic_sorting(self, tmp_artifacts):
+        """Test that diagnostics are deterministically sorted."""
+        calibrator = ReturnEvalDiagnosticsCalibrator(
+            index_path=tmp_artifacts["index"],
+            canonical_path=tmp_artifacts["canonical"],
+        )
+        misses = [
+            {
+                "query_id": "q3",
+                "query_text": "z query",
+                "expected_target": "z target",
+                "found_in_results": False,
+                "rank_in_results": None,
+                "top_k": 10,
+                "query_had_zero_hits": False,
+            },
+            {
+                "query_id": "q1",
+                "query_text": "a query",
+                "expected_target": "a target",
+                "found_in_results": False,
+                "rank_in_results": None,
+                "top_k": 10,
+                "query_had_zero_hits": False,
+            },
+            {
+                "query_id": "q2",
+                "query_text": "m query",
+                "expected_target": "m target",
+                "found_in_results": False,
+                "rank_in_results": None,
+                "top_k": 10,
+                "query_had_zero_hits": False,
+            },
+        ]
+        report = calibrator.generate_report(misses)
+        
+        # Check ordering by query_id
+        query_ids = [d["query_id"] for d in report["diagnostics"]]
+        assert query_ids == sorted(query_ids)
+
+
+def test_secondary_diagnoses():
+    """Test that secondary diagnoses are correctly set."""
+    record = DiagnosticsRecord(
+        query_id="q1",
+        query_text="find login",
+        expected_target="src/auth/login.py",
+        primary_diagnosis="target_exists_not_in_top_k",
+        diagnosis_details={
+            "confidence": "medium",
+            "secondary_diagnoses": ["low_query_specificity", "index_stale"],
+        },
+    )
+    assert len(record.diagnosis_details["secondary_diagnoses"]) == 2

--- a/merger/lenskit/tests/test_retrieval_eval_diagnostics.py
+++ b/merger/lenskit/tests/test_retrieval_eval_diagnostics.py
@@ -390,3 +390,40 @@ class TestRetrievalEvalDiagnosticsCalibrator:
             top_k=10,
         )
         assert record.primary_diagnosis == "target_missing_from_index"
+
+    def test_unsupported_index_format_is_inconclusive_not_missing(self, tmp_path):
+        sqlite_like_index = tmp_path / "chunk_index.index.sqlite"
+        sqlite_like_index.write_text("not-a-jsonl-index", encoding="utf-8")
+
+        calibrator = RetrievalEvalDiagnosticsCalibrator(index_path=sqlite_like_index)
+        record = calibrator.diagnose_miss(
+            query_id="q_sqlite_index",
+            query_text="find merge",
+            expected_target="merge.py",
+            found_in_results=False,
+            rank_in_results=None,
+            top_k=10,
+        )
+        assert record.primary_diagnosis == "diagnostic_inconclusive"
+        assert record.primary_diagnosis != "target_missing_from_index"
+        note = record.diagnosis_details.get("instrumentation_notes")
+        assert isinstance(note, str)
+        assert "index" in note.lower() or "unsupported" in note.lower()
+
+    def test_found_outside_top_k_not_classified_as_top_k_hit(self, tmp_artifacts):
+        calibrator = RetrievalEvalDiagnosticsCalibrator(
+            index_path=tmp_artifacts["index"],
+            canonical_path=tmp_artifacts["canonical"],
+            citation_path=tmp_artifacts["citation"],
+        )
+        record = calibrator.diagnose_miss(
+            query_id="q_overfetch",
+            query_text="find merge",
+            expected_target="merge.py",
+            found_in_results=True,
+            rank_in_results=45,
+            top_k=10,
+        )
+        assert record.primary_diagnosis == "target_exists_not_in_top_k"
+        assert record.primary_diagnosis != "target_in_top_k"
+        assert record.diagnosis_details["rank_in_results"] == 45

--- a/merger/lenskit/tests/test_retrieval_eval_diagnostics.py
+++ b/merger/lenskit/tests/test_retrieval_eval_diagnostics.py
@@ -358,3 +358,35 @@ class TestRetrievalEvalDiagnosticsCalibrator:
         stats = report["metadata"]["index_stats"]
         assert stats["total_paths"] == 1
         assert stats["total_chunks"] == 2
+
+    def test_unreadable_index_is_inconclusive_not_missing(self):
+        calibrator = RetrievalEvalDiagnosticsCalibrator(index_path=Path("/does/not/exist.jsonl"))
+        record = calibrator.diagnose_miss(
+            query_id="q_missing_index",
+            query_text="find merge",
+            expected_target="merge.py",
+            found_in_results=False,
+            rank_in_results=None,
+            top_k=10,
+        )
+        assert record.primary_diagnosis == "diagnostic_inconclusive"
+        assert record.primary_diagnosis != "target_missing_from_index"
+        note = record.diagnosis_details.get("instrumentation_notes")
+        assert isinstance(note, str)
+        assert "index" in note.lower()
+        assert "unavailable" in note.lower()
+
+    def test_readable_empty_index_can_be_missing_from_index(self, tmp_path):
+        index_file = tmp_path / "empty_chunks.jsonl"
+        index_file.write_text("", encoding="utf-8")
+
+        calibrator = RetrievalEvalDiagnosticsCalibrator(index_path=index_file)
+        record = calibrator.diagnose_miss(
+            query_id="q_empty_index",
+            query_text="find merge",
+            expected_target="merge.py",
+            found_in_results=False,
+            rank_in_results=None,
+            top_k=10,
+        )
+        assert record.primary_diagnosis == "target_missing_from_index"


### PR DESCRIPTION
## Summary

Implements a diagnostic-only retrieval evaluation calibrator that classifies misses without modifying ranking behavior, metrics, or the gold set.

## Purpose

**What it does:** Explains WHY each retrieval miss occurred by checking if the target:
- Exists in the index?
- Exists in canonical_md?
- Is reachable via citation_map?
- Is ranked outside top-k (ranking problem)?
- Shows staleness or ambiguity signals?

**What it does NOT do:**
- ❌ Fix ranking or rerank results
- ❌ Modify retrieval metrics
- ❌ Change the gold set
- ❌ Propose fixes (diagnostic-only)

## Diagnostic Categories

1. **target_in_top_k** - Hit (not a miss)
2. **target_exists_not_in_top_k** - Ranking problem
3. **target_missing_from_index** - Indexing/ingestion problem
4. **target_missing_from_canonical** - Artifact gap
5. **target_missing_from_citation_map** - Citation gap
6. **stale_expected_target** - Gold set stale
7. **query_target_ambiguous** - Input quality issue
8. **diagnostic_inconclusive** - Instrumentation gap

## Changes

### New Files
- `merger/lenskit/retrieval/eval_diagnostics.py` - Main calibrator module
- `merger/lenskit/retrieval/eval_diagnostics_integration.py` - Integration example
- `merger/lenskit/contracts/retrieval-eval-diagnostics.v1.schema.json` - Output schema
- `merger/lenskit/tests/test_retrieval_eval_diagnostics.py` - 23 test cases
- `docs/diagnostics/retrieval-eval-diagnostics.md` - Complete documentation

### Unchanged
- No changes to `eval_core.py`
- No changes to ranking, BM25, or query engine
- No changes to existing metrics or gold set
- Existing retrieval behavior unaffected

## Test Results

✅ 23 tests pass
✅ All diagnostic categories covered
✅ Schema compliance validated
✅ Deterministic sorting verified
✅ Artifact degradation handled gracefully
✅ Code quality checks pass (ruff)

## Usage Example

```python
from merger.lenskit.retrieval.eval_diagnostics import ReturnEvalDiagnosticsCalibrator

calibrator = ReturnEvalDiagnosticsCalibrator(
    index_path=Path('data/chunks.jsonl'),
    canonical_path=Path('data/canonical.md'),
    citation_path=Path('data/citation_map.jsonl'),
)

misses = [
    {
        'query_id': 'q1',
        'query_text': 'find auth setup',
        'expected_target': 'src/auth/setup.py',
        'found_in_results': False,
        'rank_in_results': None,
        'top_k': 10,
        'query_had_zero_hits': False,
    },
]

report = calibrator.generate_report(misses)
calibrator.save_report(report, Path('diagnostics.json'))
```

## Key Principle

> **Diagnose first, remediate second.**
> 
> This calibrator separates indexing, ranking, and artifact problems without proposing fixes. Use the diagnostics to make informed decisions about where to investigate next.

## Acceptance Criteria

- [x] Diagnostic categories explain each miss with single primary cause
- [x] Existing retrieval metrics unchanged
- [x] JSON schema validated output
- [x] Deterministically sorted output
- [x] No ranking behavior changes
- [x] Tests cover all diagnostic categories
- [x] Documentation clarifies diagnostic-only nature
- [x] Code quality checks pass

---

**Status:** Draft - Ready for review
