### PR TITLE
Reset temporary merge selections/config after successful merge in rlens + repolens

### DIFF
--- a/merger/lenskit/frontends/pythonista/repolens.py
+++ b/merger/lenskit/frontends/pythonista/repolens.py
@@ -1590,6 +1590,8 @@ class MergerUI(object):
                 self.seg_detail.selected_index = self.seg_detail.segments.index(DEFAULT_LEVEL)
             except Exception:
                 self.seg_detail.selected_index = 0
+            if hasattr(self, "on_profile_changed"):
+                self.on_profile_changed(None)
 
         if getattr(self, "seg_mode", None) is not None:
             self.seg_mode.selected_index = 1 if DEFAULT_MODE == "pro-repo" else 0

--- a/merger/lenskit/frontends/pythonista/repolens.py
+++ b/merger/lenskit/frontends/pythonista/repolens.py
@@ -1550,6 +1550,67 @@ class MergerUI(object):
                 names.append(self.repos[row])
         return names
 
+    def reset_merge_form_to_defaults_after_success(self) -> None:
+        """Reset only merge-related transient UI state after a successful merge run."""
+        self.saved_prescan_selections = {}
+
+        # Clear explicit table selection; keep the repo list and ignore set unchanged.
+        try:
+            if getattr(self, "tv", None) is not None:
+                self.tv.selected_rows = []
+                if hasattr(self.tv, "reload_data"):
+                    self.tv.reload_data()
+        except Exception:
+            pass
+
+        if getattr(self, "ext_field", None) is not None:
+            self.ext_field.text = ""
+        if getattr(self, "path_field", None) is not None:
+            self.path_field.text = ""
+
+        if getattr(self, "max_field", None) is not None:
+            self.max_field.text = "" if DEFAULT_MAX_FILE_BYTES <= 0 else str(DEFAULT_MAX_FILE_BYTES)
+
+        if getattr(self, "split_field", None) is not None:
+            split_text = ""
+            if DEFAULT_SPLIT_SIZE and str(DEFAULT_SPLIT_SIZE).strip() not in ("", "0"):
+                raw = str(DEFAULT_SPLIT_SIZE).strip()
+                if raw.isdigit():
+                    split_text = raw
+                else:
+                    try:
+                        mb = int(round(parse_human_size(raw) / (1024 * 1024)))
+                        split_text = str(mb) if mb > 0 else ""
+                    except Exception:
+                        split_text = raw
+            self.split_field.text = split_text
+
+        if getattr(self, "seg_detail", None) is not None:
+            try:
+                self.seg_detail.selected_index = self.seg_detail.segments.index(DEFAULT_LEVEL)
+            except Exception:
+                self.seg_detail.selected_index = 0
+
+        if getattr(self, "seg_mode", None) is not None:
+            self.seg_mode.selected_index = 1 if DEFAULT_MODE == "pro-repo" else 0
+
+        if getattr(self, "seg_meta", None) is not None:
+            try:
+                self.seg_meta.selected_index = self.seg_meta.segments.index(DEFAULT_META_DENSITY)
+            except Exception:
+                self.seg_meta.selected_index = 0
+
+        if getattr(self, "plan_only_switch", None) is not None:
+            self.plan_only_switch.value = False
+        if getattr(self, "code_only_switch", None) is not None:
+            self.code_only_switch.value = False
+
+        extras_defaults, _ = ExtrasConfig.from_csv(DEFAULT_EXTRAS)
+        self.extras_config = extras_defaults
+
+        self._update_repo_info()
+        self.save_last_state()
+
     def _parse_max_bytes(self) -> int:
         txt = (self.max_field.text or "").strip()
         # Leeres Feld → Standard: unbegrenzt (0 = „no limit“)
@@ -3252,6 +3313,8 @@ class MergerUI(object):
             print(f"repoLens: {msg}")
             for p in all_out_paths:
                 print(f"  - {p.name}")
+
+        self.reset_merge_form_to_defaults_after_success()
 
 
 # --- CLI Mode ---

--- a/merger/lenskit/frontends/pythonista/repolens.py
+++ b/merger/lenskit/frontends/pythonista/repolens.py
@@ -3316,7 +3316,8 @@ class MergerUI(object):
             for p in all_out_paths:
                 print(f"  - {p.name}")
 
-        self.reset_merge_form_to_defaults_after_success()
+        if all_out_paths:
+            self.reset_merge_form_to_defaults_after_success()
 
 
 # --- CLI Mode ---

--- a/merger/lenskit/frontends/webui/app.js
+++ b/merger/lenskit/frontends/webui/app.js
@@ -638,11 +638,17 @@ function resetMergeFormToDefaultsAfterSuccessfulSubmit() {
         cb.checked = false;
     });
 
+    const hubPathEl = document.getElementById('hubPath');
+    const mergesPathEl = document.getElementById('mergesPath');
+
     // Clear selection pool without touching unrelated localStorage keys.
     savedPrescanSelections.clear();
     persistSavedPrescanSelections();
     if (typeof renderSelectionPool === 'function') {
         renderSelectionPool();
+    }
+    if (typeof fetchRepos === 'function') {
+        fetchRepos((hubPathEl && hubPathEl.value) || '');
     }
 
     const profileEl = document.getElementById('profile');
@@ -654,8 +660,6 @@ function resetMergeFormToDefaultsAfterSuccessfulSubmit() {
     const extFilterEl = document.getElementById('extFilter');
     const planOnlyEl = document.getElementById('planOnly');
     const codeOnlyEl = document.getElementById('codeOnly');
-    const hubPathEl = document.getElementById('hubPath');
-    const mergesPathEl = document.getElementById('mergesPath');
 
     if (profileEl) profileEl.value = defaults.profile;
     if (modeEl) modeEl.value = defaults.mode;

--- a/merger/lenskit/frontends/webui/app.js
+++ b/merger/lenskit/frontends/webui/app.js
@@ -619,6 +619,93 @@ function saveConfig() {
     setTimeout(() => btn.innerText = oldText, 1000);
 }
 
+function resetMergeFormToDefaultsAfterSuccessfulSubmit() {
+    const defaults = {
+        profile: 'max',
+        mode: 'gesamt',
+        splitSize: '25MB',
+        maxBytes: '0',
+        metaDensity: 'auto',
+        pathFilter: '',
+        extFilter: '',
+        planOnly: false,
+        codeOnly: false,
+        extras: [...DEFAULT_EXTRAS]
+    };
+
+    // Clear explicit repo selection only; keep repository list and environment untouched.
+    document.querySelectorAll('input[name="repos"]').forEach(cb => {
+        cb.checked = false;
+    });
+
+    // Clear selection pool without touching unrelated localStorage keys.
+    savedPrescanSelections.clear();
+    persistSavedPrescanSelections();
+    if (typeof renderSelectionPool === 'function') {
+        renderSelectionPool();
+    }
+
+    const profileEl = document.getElementById('profile');
+    const modeEl = document.getElementById('mode');
+    const splitSizeEl = document.getElementById('splitSize');
+    const maxBytesEl = document.getElementById('maxBytes');
+    const metaDensityEl = document.getElementById('metaDensity');
+    const pathFilterEl = document.getElementById('pathFilter');
+    const extFilterEl = document.getElementById('extFilter');
+    const planOnlyEl = document.getElementById('planOnly');
+    const codeOnlyEl = document.getElementById('codeOnly');
+    const hubPathEl = document.getElementById('hubPath');
+    const mergesPathEl = document.getElementById('mergesPath');
+
+    if (profileEl) profileEl.value = defaults.profile;
+    if (modeEl) modeEl.value = defaults.mode;
+    if (splitSizeEl) splitSizeEl.value = defaults.splitSize;
+    if (maxBytesEl) maxBytesEl.value = defaults.maxBytes;
+    if (metaDensityEl) metaDensityEl.value = defaults.metaDensity;
+    if (pathFilterEl) pathFilterEl.value = defaults.pathFilter;
+    if (extFilterEl) extFilterEl.value = defaults.extFilter;
+    if (planOnlyEl) planOnlyEl.checked = defaults.planOnly;
+    if (codeOnlyEl) codeOnlyEl.checked = defaults.codeOnly;
+
+    const defaultExtras = new Set(defaults.extras);
+    document.querySelectorAll('input[name="extras"]').forEach(cb => {
+        cb.checked = defaultExtras.has(cb.value);
+    });
+
+    // Keep persisted environment fields (hub/merges) and unrelated keys; only refresh merge-form defaults.
+    try {
+        const raw = localStorage.getItem(CONFIG_KEY);
+        const existingConfig = raw ? JSON.parse(raw) : {};
+        const nextConfig = (existingConfig && typeof existingConfig === 'object')
+            ? { ...existingConfig }
+            : {};
+
+        nextConfig.profile = defaults.profile;
+        nextConfig.mode = defaults.mode;
+        nextConfig.splitSize = defaults.splitSize;
+        nextConfig.maxBytes = defaults.maxBytes;
+        nextConfig.planOnly = defaults.planOnly;
+        nextConfig.codeOnly = defaults.codeOnly;
+        nextConfig.metaDensity = defaults.metaDensity;
+        nextConfig.pathFilter = defaults.pathFilter;
+        nextConfig.extFilter = defaults.extFilter;
+        nextConfig.extras = defaults.extras;
+
+        if (nextConfig.hubPath === undefined && hubPathEl) {
+            nextConfig.hubPath = hubPathEl.value;
+        }
+        if (nextConfig.mergesPath === undefined && mergesPathEl) {
+            nextConfig.mergesPath = mergesPathEl.value;
+        }
+
+        localStorage.setItem(CONFIG_KEY, JSON.stringify(nextConfig));
+    } catch (e) {
+        console.warn('Failed to persist reset merge defaults', e);
+    }
+
+    showNotification('Merge started; form reset to defaults', 'info');
+}
+
 function restoreConfig() {
     try {
         const config = JSON.parse(localStorage.getItem(CONFIG_KEY));
@@ -1161,6 +1248,8 @@ async function startJob(e) {
             const job = await res.json();
             streamLogs(job.id); // This will connect to the last one, acceptable for now
         }
+
+        resetMergeFormToDefaultsAfterSuccessfulSubmit();
 
         btn.disabled = false;
         btn.innerText = "Start Job";

--- a/merger/lenskit/frontends/webui/app.js
+++ b/merger/lenskit/frontends/webui/app.js
@@ -707,7 +707,7 @@ function resetMergeFormToDefaultsAfterSuccessfulSubmit() {
         console.warn('Failed to persist reset merge defaults', e);
     }
 
-    showNotification('Merge started; form reset to defaults', 'info');
+    showNotification('Job submitted; form reset to defaults', 'info');
 }
 
 function restoreConfig() {

--- a/merger/lenskit/tests/test_prescan_pool.py
+++ b/merger/lenskit/tests/test_prescan_pool.py
@@ -2,7 +2,7 @@ import unittest
 import sys
 from pathlib import Path
 
-PYTHONISTA_FRONTEND_DIR = Path("merger/lenskit/frontends/pythonista").resolve()
+PYTHONISTA_FRONTEND_DIR = Path(__file__).resolve().parents[1] / "frontends" / "pythonista"
 if str(PYTHONISTA_FRONTEND_DIR) not in sys.path:
     sys.path.insert(0, str(PYTHONISTA_FRONTEND_DIR))
 
@@ -215,6 +215,12 @@ class TestRepoLensResetAfterSuccess(unittest.TestCase):
 
                 self.saved_state = None
                 self.repo_info_updated = False
+                self.profile_hint = DummyField("stale")
+
+            def on_profile_changed(self, _sender):
+                idx = self.seg_detail.selected_index
+                seg = self.seg_detail.segments[idx]
+                self.profile_hint.text = repolens.PROFILE_DESCRIPTIONS.get(seg, "")
 
             def _update_repo_info(self):
                 self.repo_info_updated = True
@@ -247,6 +253,10 @@ class TestRepoLensResetAfterSuccess(unittest.TestCase):
         self.assertEqual(dummy.seg_meta.selected_index, 0)  # auto
         self.assertFalse(dummy.plan_only_switch.value)
         self.assertFalse(dummy.code_only_switch.value)
+        self.assertEqual(
+            dummy.profile_hint.text,
+            repolens.PROFILE_DESCRIPTIONS["max"],
+        )
 
         self.assertTrue(dummy.extras_config.augment_sidecar)
         self.assertTrue(dummy.extras_config.json_sidecar)

--- a/merger/lenskit/tests/test_prescan_pool.py
+++ b/merger/lenskit/tests/test_prescan_pool.py
@@ -1,6 +1,14 @@
 import unittest
+import sys
+from pathlib import Path
+
+PYTHONISTA_FRONTEND_DIR = Path("merger/lenskit/frontends/pythonista").resolve()
+if str(PYTHONISTA_FRONTEND_DIR) not in sys.path:
+    sys.path.insert(0, str(PYTHONISTA_FRONTEND_DIR))
+
 from merger.lenskit.frontends.pythonista.repolens_utils import normalize_path, normalize_repo_id
 from merger.lenskit.frontends.pythonista.repolens_helpers import resolve_pool_include_paths, deserialize_prescan_pool, _sanitize_list
+from merger.lenskit.frontends.pythonista import repolens
 
 class TestSanitizeListInternal(unittest.TestCase):
     def test_sanitize_list_mixed(self):
@@ -157,6 +165,98 @@ class TestPrescanPool(unittest.TestCase):
         res_structured = deserialize_prescan_pool(data_structured)
         self.assertEqual(res_structured["repo_structured"]["raw"], ["a", ".", "b"])
         self.assertEqual(res_structured["repo_structured"]["compressed"], ["x", ".", "y"])
+
+
+class TestRepoLensResetAfterSuccess(unittest.TestCase):
+    def test_reset_merge_form_to_defaults_after_success(self):
+        class DummyField:
+            def __init__(self, text=""):
+                self.text = text
+
+        class DummySwitch:
+            def __init__(self, value=False):
+                self.value = value
+
+        class DummySegment:
+            def __init__(self, segments, selected_index):
+                self.segments = segments
+                self.selected_index = selected_index
+
+        class DummyTable:
+            def __init__(self):
+                self.selected_rows = [(0, 0), (0, 1)]
+                self.reloaded = False
+
+            def reload_data(self):
+                self.reloaded = True
+
+        class DummyUI:
+            def __init__(self):
+                self.saved_prescan_selections = {
+                    "repoa": {"raw": ["a.py"], "compressed": ["a.py"]}
+                }
+                self.ignored_repos = {"keep-me"}
+
+                self.ext_field = DummyField(".py")
+                self.path_field = DummyField("src/")
+                self.max_field = DummyField("1234")
+                self.split_field = DummyField("7")
+
+                self.seg_detail = DummySegment(["overview", "summary", "dev", "max"], 0)
+                self.seg_mode = DummySegment(["combined", "per repo"], 1)
+                self.seg_meta = DummySegment(["auto", "min", "standard", "full"], 3)
+
+                self.plan_only_switch = DummySwitch(True)
+                self.code_only_switch = DummySwitch(True)
+                self.tv = DummyTable()
+
+                extras_cfg, _ = repolens.ExtrasConfig.from_csv("health,heatmap")
+                self.extras_config = extras_cfg
+
+                self.saved_state = None
+                self.repo_info_updated = False
+
+            def _update_repo_info(self):
+                self.repo_info_updated = True
+
+            def save_last_state(self):
+                selected_repos = []
+                for section, row in (self.tv.selected_rows or []):
+                    if section == 0:
+                        selected_repos.append(f"repo-{row}")
+                self.saved_state = {
+                    "prescan_pool": self.saved_prescan_selections,
+                    "selected_repos": selected_repos,
+                    "ignored_repos": sorted(self.ignored_repos),
+                }
+
+        dummy = DummyUI()
+        repolens.MergerUI.reset_merge_form_to_defaults_after_success(dummy)
+
+        self.assertEqual(dummy.saved_prescan_selections, {})
+        self.assertEqual(dummy.tv.selected_rows, [])
+        self.assertTrue(dummy.tv.reloaded)
+
+        self.assertEqual(dummy.ext_field.text, "")
+        self.assertEqual(dummy.path_field.text, "")
+        self.assertEqual(dummy.max_field.text, "")
+        self.assertEqual(dummy.split_field.text, "25")
+
+        self.assertEqual(dummy.seg_detail.selected_index, 3)  # max
+        self.assertEqual(dummy.seg_mode.selected_index, 0)  # gesamt/combined
+        self.assertEqual(dummy.seg_meta.selected_index, 0)  # auto
+        self.assertFalse(dummy.plan_only_switch.value)
+        self.assertFalse(dummy.code_only_switch.value)
+
+        self.assertTrue(dummy.extras_config.augment_sidecar)
+        self.assertTrue(dummy.extras_config.json_sidecar)
+        self.assertFalse(dummy.extras_config.health)
+        self.assertFalse(dummy.extras_config.heatmap)
+
+        self.assertTrue(dummy.repo_info_updated)
+        self.assertEqual(dummy.saved_state["prescan_pool"], {})
+        self.assertEqual(dummy.saved_state["selected_repos"], [])
+        self.assertEqual(dummy.saved_state["ignored_repos"], ["keep-me"])
 
 if __name__ == '__main__':
     unittest.main()

--- a/merger/lenskit/tests/test_webui_payload.py
+++ b/merger/lenskit/tests/test_webui_payload.py
@@ -460,6 +460,10 @@ def test_run_merge_resets_form_and_pool_after_success(page_with_static: Page):
     """)
     assert pool_after == {}
 
+    page_with_static.wait_for_function("""
+        () => !document.querySelector('#repoList')?.innerText.includes('POOL')
+    """)
+
     assert page_with_static.input_value("#profile") == "max"
     assert page_with_static.input_value("#mode") == "gesamt"
     assert page_with_static.input_value("#splitSize") == "25MB"

--- a/merger/lenskit/tests/test_webui_payload.py
+++ b/merger/lenskit/tests/test_webui_payload.py
@@ -522,7 +522,14 @@ def test_run_merge_does_not_reset_on_job_error(page_with_static: Page):
     )
 
     page_with_static.click("#jobForm button[type='submit']")
-    page_with_static.wait_for_timeout(300)
+    page_with_static.wait_for_function(
+        """
+        () => {
+            const submitBtn = document.querySelector("#jobForm button[type='submit']");
+            return submitBtn && submitBtn.disabled === false && submitBtn.innerText === "Start Job";
+        }
+        """
+    )
 
     assert any("Failed to start job" in m for m in dialog_messages)
     assert page_with_static.is_checked("input[name='repos'][value='repoA']") is True
@@ -582,7 +589,18 @@ def test_run_merge_success_keeps_environment_storage(page_with_static: Page):
     )
 
     page_with_static.click("#jobForm button[type='submit']")
-    page_with_static.wait_for_timeout(300)
+    page_with_static.wait_for_function(
+        """
+        () => {
+            const profileOk = document.querySelector('#profile')?.value === 'max';
+            const reposUnchecked = Array.from(document.querySelectorAll('input[name="repos"]')).every(b => !b.checked);
+            const poolBadgeGone = !document.querySelector('#repoList')?.innerText.includes('POOL');
+            const cfg = JSON.parse(localStorage.getItem('rlens_config') || '{}');
+            const cfgProfileOk = cfg.profile === 'max';
+            return profileOk && reposUnchecked && poolBadgeGone && cfgProfileOk;
+        }
+        """
+    )
 
     token = page_with_static.evaluate("() => localStorage.getItem('rlens_token')")
     state_version = page_with_static.evaluate("() => localStorage.getItem('rlens_state_version')")

--- a/merger/lenskit/tests/test_webui_payload.py
+++ b/merger/lenskit/tests/test_webui_payload.py
@@ -377,6 +377,220 @@ def test_run_merge_plan_only_omits_force_new(page_with_static: Page):
     assert p["plan_only"] is True
     assert "force_new" not in p, "force_new should be omitted for plan_only jobs"
 
+
+def test_run_merge_resets_form_and_pool_after_success(page_with_static: Page):
+    pool_state = {
+        "repoA": {"raw": ["src/a.py"], "compressed": ["src/a.py"]},
+        "repoB": {"raw": None, "compressed": None},
+    }
+
+    page_with_static.add_init_script("window.__RLENS_TEST__ = true;")
+    page_with_static.goto("http://localhost:8000/")
+
+    page_with_static.evaluate(f"""
+        localStorage.setItem("lenskit.prescan.savedSelections.v1", JSON.stringify({json.dumps(pool_state)}));
+    """)
+    page_with_static.reload()
+    page_with_static.wait_for_function("() => window.__rlens_pool_ready === true")
+    page_with_static.wait_for_selector("#repoList input[name='repos']")
+
+    page_with_static.evaluate("""
+        document.querySelectorAll('input[name="repos"]').forEach(b => {
+            if (b.value === 'repoA' || b.value === 'repoB') b.checked = true;
+        });
+    """)
+
+    page_with_static.select_option("#profile", "overview")
+    page_with_static.select_option("#mode", "gesamt")
+    page_with_static.fill("#splitSize", "10MB")
+    page_with_static.fill("#maxBytes", "2048")
+    page_with_static.select_option("#metaDensity", "full")
+    page_with_static.fill("#pathFilter", "src/")
+    page_with_static.fill("#extFilter", ".py,.md")
+    page_with_static.check("#planOnly")
+    page_with_static.check("#codeOnly")
+
+    page_with_static.evaluate("""
+        document.querySelectorAll('input[name="extras"]').forEach(b => {
+            b.checked = (b.value === 'health' || b.value === 'heatmap');
+        });
+    """)
+
+    payloads = []
+
+    def handle_jobs(route: Route):
+        if route.request.method == "POST":
+            data = route.request.post_data_json or json.loads(route.request.post_data)
+            payloads.append(data)
+            route.fulfill(json={"id": "job-reset", "status": "queued"})
+        else:
+            route.continue_()
+
+    page_with_static.route("**/api/jobs", handle_jobs)
+    page_with_static.click("#jobForm button[type='submit']")
+
+    start = time.time()
+    while len(payloads) == 0 and time.time() - start < 5:
+        page_with_static.wait_for_timeout(50)
+
+    assert len(payloads) == 1
+    sent = payloads[0]
+    assert sent["level"] == "overview"
+    assert sent["split_size"] == "10MB"
+    assert sent["max_bytes"] == "2048"
+    assert sent["path_filter"] is None
+    assert sent["extensions"] is None
+    assert sent["include_paths_by_repo"]["repoA"] == ["src/a.py"]
+    assert sent["include_paths_by_repo"]["repoB"] is None
+    assert sent["plan_only"] is True
+    assert sent["code_only"] is True
+    assert sent["extras"] == "health,heatmap"
+
+    page_with_static.wait_for_function("""
+        () => Array.from(document.querySelectorAll('input[name="repos"]')).every(b => b.checked === false)
+    """)
+
+    checked_count = page_with_static.evaluate("""
+        () => Array.from(document.querySelectorAll('input[name="repos"]')).filter(b => b.checked).length
+    """)
+    assert checked_count == 0
+
+    pool_after = page_with_static.evaluate("""
+        () => JSON.parse(localStorage.getItem('lenskit.prescan.savedSelections.v1') || '{}')
+    """)
+    assert pool_after == {}
+
+    assert page_with_static.input_value("#profile") == "max"
+    assert page_with_static.input_value("#mode") == "gesamt"
+    assert page_with_static.input_value("#splitSize") == "25MB"
+    assert page_with_static.input_value("#maxBytes") == "0"
+    assert page_with_static.input_value("#metaDensity") == "auto"
+    assert page_with_static.input_value("#pathFilter") == ""
+    assert page_with_static.input_value("#extFilter") == ""
+    assert page_with_static.is_checked("#planOnly") is False
+    assert page_with_static.is_checked("#codeOnly") is False
+
+    checked_extras = page_with_static.evaluate("""
+        () => Array.from(document.querySelectorAll('input[name="extras"]'))
+            .filter(b => b.checked)
+            .map(b => b.value)
+            .sort()
+    """)
+    assert checked_extras == ["augment_sidecar", "json_sidecar"]
+
+
+def test_run_merge_does_not_reset_on_job_error(page_with_static: Page):
+    pool_state = {
+        "repoA": {"raw": ["src/a.py"], "compressed": ["src/a.py"]}
+    }
+
+    page_with_static.add_init_script("window.__RLENS_TEST__ = true;")
+    page_with_static.goto("http://localhost:8000/")
+
+    page_with_static.evaluate(f"""
+        localStorage.setItem("lenskit.prescan.savedSelections.v1", JSON.stringify({json.dumps(pool_state)}));
+    """)
+    page_with_static.reload()
+    page_with_static.wait_for_function("() => window.__rlens_pool_ready === true")
+    page_with_static.wait_for_selector("#repoList input[name='repos']")
+
+    page_with_static.check("input[name='repos'][value='repoA']")
+    page_with_static.select_option("#profile", "dev")
+    page_with_static.fill("#splitSize", "5MB")
+    page_with_static.fill("#maxBytes", "1234")
+    page_with_static.fill("#pathFilter", "pkg/")
+    page_with_static.fill("#extFilter", ".py")
+    page_with_static.check("#planOnly")
+    page_with_static.evaluate("""
+        document.querySelectorAll('input[name="extras"]').forEach(b => {
+            b.checked = (b.value === 'health');
+        });
+    """)
+
+    dialog_messages = []
+    page_with_static.on("dialog", lambda dialog: (dialog_messages.append(dialog.message), dialog.accept()))
+
+    page_with_static.route(
+        "**/api/jobs",
+        lambda route: route.fulfill(status=500, json={"detail": "boom"})
+        if route.request.method == "POST"
+        else route.continue_(),
+    )
+
+    page_with_static.click("#jobForm button[type='submit']")
+    page_with_static.wait_for_timeout(300)
+
+    assert any("Failed to start job" in m for m in dialog_messages)
+    assert page_with_static.is_checked("input[name='repos'][value='repoA']") is True
+    assert page_with_static.input_value("#profile") == "dev"
+    assert page_with_static.input_value("#splitSize") == "5MB"
+    assert page_with_static.input_value("#maxBytes") == "1234"
+    assert page_with_static.input_value("#pathFilter") == "pkg/"
+    assert page_with_static.input_value("#extFilter") == ".py"
+    assert page_with_static.is_checked("#planOnly") is True
+
+    checked_extras = page_with_static.evaluate("""
+        () => Array.from(document.querySelectorAll('input[name="extras"]'))
+            .filter(b => b.checked)
+            .map(b => b.value)
+    """)
+    assert checked_extras == ["health"]
+
+    pool_after = page_with_static.evaluate("""
+        () => JSON.parse(localStorage.getItem('lenskit.prescan.savedSelections.v1') || '{}')
+    """)
+    assert pool_after == pool_state
+
+
+def test_run_merge_success_keeps_environment_storage(page_with_static: Page):
+    page_with_static.add_init_script("window.__RLENS_TEST__ = true;")
+    page_with_static.goto("http://localhost:8000/")
+    page_with_static.wait_for_selector("#repoList input[name='repos']")
+
+    page_with_static.evaluate("""
+        localStorage.setItem('rlens_token', 'token-keep');
+        localStorage.setItem('rlens_state_version', 'state-keep');
+        localStorage.setItem('rlens_atlas_config_v2', JSON.stringify({version: 2, root: 'hub', token: 'atlas-keep'}));
+        localStorage.setItem('rlens_config', JSON.stringify({
+            profile: 'dev',
+            mode: 'pro-repo',
+            splitSize: '8MB',
+            maxBytes: '1024',
+            pathFilter: 'x/',
+            extFilter: '.py',
+            planOnly: true,
+            codeOnly: true,
+            extras: ['health'],
+            hubPath: '/env/hub',
+            mergesPath: '/env/merges'
+        }));
+        document.getElementById('hubPath').value = '/env/hub';
+        document.getElementById('mergesPath').value = '/env/merges';
+    """)
+
+    page_with_static.check("input[name='repos'][value='repoA']")
+
+    page_with_static.route(
+        "**/api/jobs",
+        lambda route: route.fulfill(json={"id": "job-env", "status": "queued"})
+        if route.request.method == "POST"
+        else route.continue_(),
+    )
+
+    page_with_static.click("#jobForm button[type='submit']")
+    page_with_static.wait_for_timeout(300)
+
+    token = page_with_static.evaluate("() => localStorage.getItem('rlens_token')")
+    state_version = page_with_static.evaluate("() => localStorage.getItem('rlens_state_version')")
+    atlas = page_with_static.evaluate("() => localStorage.getItem('rlens_atlas_config_v2')")
+    cfg = page_with_static.evaluate("() => JSON.parse(localStorage.getItem('rlens_config'))")
+
+    assert token == "token-keep"
+    assert state_version == "state-keep"
+    assert json.loads(atlas) == {"version": 2, "root": "hub", "token": "atlas-keep"}
+    assert cfg["hubPath"] == "/env/hub"
+    assert cfg["mergesPath"] == "/env/merges"
+
 def test_query_tab_submits_payload(page_with_static: Page):
     from playwright.sync_api import expect
 


### PR DESCRIPTION
## Ziel
Nach erfolgreichem Merge werden temporaere Merge-Auswahlen und Merge-Konfigurationen in beiden Frontends auf Defaults zurueckgesetzt.

## Scope
- Keine Backend-Aenderung
- Kein globales Storage-Clear
- Keine Aenderungen an scan_repo / write_reports_v2 / Prescan-Materialisierung

## Aenderungen
### rLens WebUI
- Neuer Helper: resetMergeFormToDefaultsAfterSuccessfulSubmit()
- Reset nur im erfolgreichen Submit-Pfad in startJob(e)
- Reset-Inhalt:
  - Repo-Checkboxes uncheck
  - Selection Pool (lenskit.prescan.savedSelections.v1) gezielt leeren
  - Merge-Form auf Defaults zurueck
  - Extras zurueck auf DEFAULT_EXTRAS
  - Persistierte Merge-Form-Felder in rlens_config aktualisiert, ohne Umgebungswerte (hubPath/mergesPath) oder andere Storage-Keys zu loeschen

### repoLens / Pythonista
- Neue Methode: reset_merge_form_to_defaults_after_success()
- Aufruf erst nach erfolgreicher Artefakterzeugung in _run_merge_inner()
- Reset-Inhalt:
  - saved_prescan_selections = {}
  - explizite Repo-Auswahl leeren
  - Filter/Schalter/Segmente auf Startdefaults
  - Extras zurueck auf Initial-Defaults
  - _update_repo_info() + save_last_state()
- ignored_repos bleibt erhalten

### Tests
- WebUI-Tests erweitert:
  - Reset nach Erfolg
  - Kein Reset bei Job-Fehler
  - Umgebungs-Storage bleibt erhalten
- Pythonista helper-naher Test ergaenzt:
  - Pool/Selection leer gespeichert
  - ignored_repos bleibt erhalten

## Verifikation
- python -m pytest merger/lenskit/tests/test_webui_payload.py
- python -m pytest merger/lenskit/tests/test_prescan_pool.py
- python -m ruff check merger/lenskit/frontends/webui merger/lenskit/frontends/pythonista merger/lenskit/tests/test_prescan_pool.py --select=F401,F811,F841,E711,E712
- python -m py_compile merger/lenskit/frontends/pythonista/repolens.py
- python3 tools/parity_guard.py
