### PR TITLE
Add Lenskit CLI Operational Blueprint document

### DIFF
--- a/docs/blueprints/lenskit-cli-operational-blueprint.md
+++ b/docs/blueprints/lenskit-cli-operational-blueprint.md
@@ -21,7 +21,7 @@ python -m merger.lenskit.cli.main rlens-client --help
 
 `rlens-client` ist die CLI-Client-Oberfläche.
 
-### Optionaler rLens service launcher
+### Optionaler rLens-Service-Launcher
 
 ```bash
 python -m merger.lenskit.cli.rlens --help
@@ -83,7 +83,7 @@ Nicht aus CLI-Help ableitbar.
 
 ## 5. Nicht-Ziele
 
-- keinen `lenskit`-Wrapper anlegen
+- keinen globalen `lenskit`-Wrapper anlegen
 - keine automatische Installation
 - keine Aussage, dass rLens-Service läuft
 - keine Aussage, dass WebUI-Readiness verifiziert ist

--- a/docs/blueprints/lenskit-cli-operational-blueprint.md
+++ b/docs/blueprints/lenskit-cli-operational-blueprint.md
@@ -9,14 +9,27 @@ Er verhindert die Fehlinterpretation: Ein fehlendes globales `lenskit`-Kommando 
 
 ## 2. CLI-Oberflächen
 
-Die folgenden Modul-Aufrufe sind die maßgeblichen CLI-Oberflächen:
+### Core / Module CLI
+
+Die folgenden Modul-Aufrufe sind die maßgeblichen Core-CLI-Oberflächen:
 
 ```bash
 python -m merger.lenskit.cli --help
 python -m merger.lenskit.cli.main --help
-python -m merger.lenskit.cli.rlens --help
 python -m merger.lenskit.cli.main rlens-client --help
 ```
+
+`rlens-client` ist die CLI-Client-Oberfläche.
+
+### Optionaler rLens service launcher
+
+```bash
+python -m merger.lenskit.cli.rlens --help
+```
+
+`cli.rlens` ist der rLens-Service-Launcher und darf optional/serviceabhängig sein.
+Ein Fehlschlag von `python -m merger.lenskit.cli.rlens --help` wegen fehlender Service-Dependencies
+ist kein Gegenbeweis gegen Core-CLI-Readiness.
 
 Voraussetzung: Die Befehle werden aus einem Kontext ausgeführt, in dem das Paket importierbar ist
 (z.B. Repo-Root, aktivierte Projektumgebung, editable install oder passend gesetztes `PYTHONPATH`).
@@ -27,13 +40,15 @@ Stand: 2026-05-27.
 
 Dieser Abschnitt ist eine lokale Momentaufnahme, kein dauerhafter Contract. Nach Wechsel von Host,
 Python-Umgebung, Shell oder Installation ist §7 erneut auszuführen. Normativ bleibt die Trennung aus
-§4: Modul-CLI-Readiness, Shell-Wrapper-Readiness, Service-Readiness und WebUI-Readiness sind
-verschiedene Zustände.
+§4: Modul-CLI-Readiness, Shell-Wrapper-Readiness, rLens-Service-Launcher-Readiness,
+Service-Readiness und WebUI-Readiness sind verschiedene Zustände.
 
-- `python -m merger.lenskit.cli --help`: verifiziert
-- `python -m merger.lenskit.cli.main --help`: verifiziert
-- `python -m merger.lenskit.cli.rlens --help`: verifiziert
-- `python -m merger.lenskit.cli.main rlens-client --help`: verifiziert
+- Core / Module CLI:
+  - `python -m merger.lenskit.cli --help`: verifiziert
+  - `python -m merger.lenskit.cli.main --help`: verifiziert
+  - `python -m merger.lenskit.cli.main rlens-client --help`: verifiziert
+- rLens service launcher:
+  - `python -m merger.lenskit.cli.rlens --help`: lokal verifiziert, optional/serviceabhängig
 - globales `rlens`: vorhanden unter `/home/alex/.local/bin/rlens`
 - globales `lenskit`: nicht vorhanden
 - globale Wrapper-Aussagen beziehen sich auf den geprüften lokalen User-Kontext.
@@ -42,7 +57,15 @@ verschiedene Zustände.
 
 ### CLI readiness
 
-Die Hilfe-/Command-Surface der Modul-CLI ist erreichbar.
+CLI readiness meint Core / Module CLI.
+Die Hilfe-/Command-Surface der Core-CLI ist erreichbar. Der serviceabhängige rLens-Launcher ist dafür
+nicht zwingend erforderlich.
+
+### rLens service launcher readiness
+
+Separat von Core-CLI readiness.
+Der Help-Aufruf prüft die Launcher-Importierbarkeit inklusive service-naher Dependencies,
+aber nicht, ob der rLens-Service läuft.
 
 ### Shell wrapper readiness
 
@@ -78,11 +101,18 @@ Ein globaler `lenskit`-Wrapper darf später ergänzt werden, wenn:
 
 ## 7. Verifikationskommandos
 
+Core CLI checks:
+
 ```bash
 python -m merger.lenskit.cli --help
 python -m merger.lenskit.cli.main --help
-python -m merger.lenskit.cli.rlens --help
 python -m merger.lenskit.cli.main rlens-client --help
+```
+
+Optional service launcher / wrapper checks:
+
+```bash
+python -m merger.lenskit.cli.rlens --help
 command -v lenskit || true
 command -v rlens || true
 ```

--- a/docs/blueprints/lenskit-cli-operational-blueprint.md
+++ b/docs/blueprints/lenskit-cli-operational-blueprint.md
@@ -8,10 +8,11 @@ Dieser Blueprint definiert, wie Lenskit über CLI betrieben wird.
 Er verhindert die Fehlinterpretation: Ein fehlendes globales `lenskit`-Kommando im `PATH` bedeutet **nicht**, dass die Modul-CLI nicht funktioniert.
 
 
-## Beziehung zu bestehender rLens-Client-Doku
+## 1.1 Beziehung zu bestehender rLens-Client-Doku
 
 Dieses Dokument ist ein operativer Readiness-Blueprint. Es ersetzt nicht
 `docs/blueprints/rlens-cli-client-blueprint.md`.
+
 - `docs/blueprints/rlens-cli-client-blueprint.md` beschreibt Client-API,
   Sicherheitsmodell, Profile und rLens-Client-Produktpfad.
 - Dieses Dokument beschreibt, welche lokalen CLI-/Wrapper-/Service-Zustände
@@ -52,8 +53,7 @@ Dieser Abschnitt ist eine lokale Momentaufnahme, kein dauerhafter Contract.
 Die lokalen Wrapper-Angaben sind kein Contract und kein CI-Nachweis.
 Sie dienen nur dazu, den geprüften Host-/User-Zustand nicht mit Modul-CLI-Readiness
 zu verwechseln.
-Nach Wechsel von Host,
-Python-Umgebung, Shell oder Installation ist §7 erneut auszuführen. Normativ bleibt die Trennung aus
+Nach Wechsel von Host, Python-Umgebung, Shell oder Installation ist §7 erneut auszuführen. Normativ bleibt die Trennung aus
 §4: Modul-CLI-Readiness, Shell-Wrapper-Readiness, rLens-Service-Launcher-Readiness,
 Service-Readiness und WebUI-Readiness sind verschiedene Zustände.
 

--- a/docs/blueprints/lenskit-cli-operational-blueprint.md
+++ b/docs/blueprints/lenskit-cli-operational-blueprint.md
@@ -1,0 +1,88 @@
+# Lenskit CLI Operational Blueprint
+
+Stand: 2026-05-27
+
+## 1. Zweck
+
+Dieser Blueprint definiert, wie Lenskit über CLI betrieben wird.
+Er verhindert die Fehlinterpretation: Ein fehlendes globales `lenskit`-Kommando im `PATH` bedeutet **nicht**, dass die Modul-CLI nicht funktioniert.
+
+## 2. CLI-Oberflächen
+
+Die folgenden Modul-Aufrufe sind die maßgeblichen CLI-Oberflächen:
+
+```bash
+python -m merger.lenskit.cli --help
+python -m merger.lenskit.cli.main --help
+python -m merger.lenskit.cli.rlens --help
+python -m merger.lenskit.cli.main rlens-client --help
+```
+
+Voraussetzung: Die Befehle werden aus einem Kontext ausgeführt, in dem das Paket importierbar ist
+(z.B. Repo-Root, aktivierte Projektumgebung, editable install oder passend gesetztes `PYTHONPATH`).
+
+## 3. Aktueller bekannter Status
+
+Stand: 2026-05-27.
+
+Dieser Abschnitt ist eine lokale Momentaufnahme, kein dauerhafter Contract. Nach Wechsel von Host,
+Python-Umgebung, Shell oder Installation ist §7 erneut auszuführen. Normativ bleibt die Trennung aus
+§4: Modul-CLI-Readiness, Shell-Wrapper-Readiness, Service-Readiness und WebUI-Readiness sind
+verschiedene Zustände.
+
+- `python -m merger.lenskit.cli --help`: verifiziert
+- `python -m merger.lenskit.cli.main --help`: verifiziert
+- `python -m merger.lenskit.cli.rlens --help`: verifiziert
+- `python -m merger.lenskit.cli.main rlens-client --help`: verifiziert
+- globales `rlens`: vorhanden unter `/home/alex/.local/bin/rlens`
+- globales `lenskit`: nicht vorhanden
+- globale Wrapper-Aussagen beziehen sich auf den geprüften lokalen User-Kontext.
+
+## 4. Readiness-Modell
+
+### CLI readiness
+
+Die Hilfe-/Command-Surface der Modul-CLI ist erreichbar.
+
+### Shell wrapper readiness
+
+Separater Komfortstatus.
+Fehlt `lenskit` im `PATH`, ist das ein Packaging-/Convenience-Gap, kein CLI-Funktionsfehler.
+
+### Service readiness
+
+Separat von CLI readiness.
+`rlens-client health` kann fehlschlagen, wenn kein rLens-Service läuft oder Base-URL/Token fehlen.
+
+### WebUI readiness
+
+Nicht aus CLI-Help ableitbar.
+
+## 5. Nicht-Ziele
+
+- keinen `lenskit`-Wrapper anlegen
+- keine automatische Installation
+- keine Aussage, dass rLens-Service läuft
+- keine Aussage, dass WebUI-Readiness verifiziert ist
+- keine vollständige CLI-Referenz schreiben
+- keine Runtime-Proof-Datei anlegen, außer ausdrücklich nötig
+
+## 6. Optionaler späterer Promotion-Pfad für globales `lenskit`
+
+Ein globaler `lenskit`-Wrapper darf später ergänzt werden, wenn:
+
+- er auf die beabsichtigte Python-Umgebung zeigt
+- er user-lokal bleibt
+- `lenskit --help` funktional der Modul-CLI entspricht
+- Drift zwischen Wrapper und Modulaufruf prüfbar bleibt
+
+## 7. Verifikationskommandos
+
+```bash
+python -m merger.lenskit.cli --help
+python -m merger.lenskit.cli.main --help
+python -m merger.lenskit.cli.rlens --help
+python -m merger.lenskit.cli.main rlens-client --help
+command -v lenskit || true
+command -v rlens || true
+```

--- a/docs/blueprints/lenskit-cli-operational-blueprint.md
+++ b/docs/blueprints/lenskit-cli-operational-blueprint.md
@@ -7,6 +7,16 @@ Stand: 2026-05-27
 Dieser Blueprint definiert, wie Lenskit über CLI betrieben wird.
 Er verhindert die Fehlinterpretation: Ein fehlendes globales `lenskit`-Kommando im `PATH` bedeutet **nicht**, dass die Modul-CLI nicht funktioniert.
 
+
+## Beziehung zu bestehender rLens-Client-Doku
+
+Dieses Dokument ist ein operativer Readiness-Blueprint. Es ersetzt nicht
+`docs/blueprints/rlens-cli-client-blueprint.md`.
+- `docs/blueprints/rlens-cli-client-blueprint.md` beschreibt Client-API,
+  Sicherheitsmodell, Profile und rLens-Client-Produktpfad.
+- Dieses Dokument beschreibt, welche lokalen CLI-/Wrapper-/Service-Zustände
+  nicht miteinander verwechselt werden dürfen.
+
 ## 2. CLI-Oberflächen
 
 ### Core / Module CLI
@@ -38,7 +48,11 @@ Voraussetzung: Die Befehle werden aus einem Kontext ausgeführt, in dem das Pake
 
 Stand: 2026-05-27.
 
-Dieser Abschnitt ist eine lokale Momentaufnahme, kein dauerhafter Contract. Nach Wechsel von Host,
+Dieser Abschnitt ist eine lokale Momentaufnahme, kein dauerhafter Contract.
+Die lokalen Wrapper-Angaben sind kein Contract und kein CI-Nachweis.
+Sie dienen nur dazu, den geprüften Host-/User-Zustand nicht mit Modul-CLI-Readiness
+zu verwechseln.
+Nach Wechsel von Host,
 Python-Umgebung, Shell oder Installation ist §7 erneut auszuführen. Normativ bleibt die Trennung aus
 §4: Modul-CLI-Readiness, Shell-Wrapper-Readiness, rLens-Service-Launcher-Readiness,
 Service-Readiness und WebUI-Readiness sind verschiedene Zustände.


### PR DESCRIPTION
### Motivation

- Provide an operational blueprint that documents how Lenskit is operated via the Python-module CLI and to avoid misinterpretation when a global `lenskit` wrapper is missing.
- Capture the current local verification status, clarify readiness categories (CLI, shell wrapper, service, WebUI) and define verification commands for reproducible checks.

### Description

- Add a new documentation blueprint at `docs/blueprints/lenskit-cli-operational-blueprint.md` that defines the purpose, supported CLI surfaces, current known status snapshot, a readiness model, non-goals, an optional promotion path for a global `lenskit` wrapper, and verification commands.
- Document the canonical module invocation examples such as `python -m merger.lenskit.cli --help` and `python -m merger.lenskit.cli.main rlens-client --help` and provide the set of commands to re-run the local checks.
- State explicit non-goals to avoid accidental scope creep, including that this change does not create or install a global wrapper or verify service/WebUI runtime.

### Testing

- No automated tests were added or executed for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16e0d0cdb0832cb66bc76c2ed1770c)