### PR TITLE
Federation Trace Telemetry Hardening (Phase-5 Follow-up)

### DIFF
--- a/merger/lenskit/cli/cmd_federation.py
+++ b/merger/lenskit/cli/cmd_federation.py
@@ -123,6 +123,7 @@ def handle_federation_command(args: argparse.Namespace) -> int:
 
                 status_map = res["federation_trace"].get("bundle_status", {})
                 error_map = res["federation_trace"].get("bundle_errors", {})
+                latency_map = res["federation_trace"].get("bundle_latency_ms", {})
 
                 for b in fed_data.get("bundles", []):
                     repo_id = b["repo_id"]
@@ -133,12 +134,10 @@ def handle_federation_command(args: argparse.Namespace) -> int:
                     }
                     if "last_fingerprint" in b:
                         b_obj["fingerprint"] = b["last_fingerprint"]
+                    if repo_id in latency_map:
+                        b_obj["latency_ms"] = float(latency_map[repo_id])
                     if repo_id in error_map:
                         b_obj["error_message"] = error_map[repo_id]
-
-                    # Omitting latency_ms as it is not currently accurately tracked per bundle in execution.
-                    # We avoid putting 0.0 fake telemetry here; if the schema requires it, the schema should be relaxed
-                    # or true latency telemetry integrated into execution logic.
 
                     trace_obj["bundles"].append(b_obj)
 

--- a/merger/lenskit/retrieval/federation_query.py
+++ b/merger/lenskit/retrieval/federation_query.py
@@ -1,4 +1,5 @@
 import json
+import time
 from pathlib import Path
 from typing import Dict, Any, List, Optional
 
@@ -116,6 +117,7 @@ def execute_federated_query(
     bundle_traces = {}
     bundle_status = {}
     bundle_errors = {}
+    bundle_latency_ms = {}
 
     queried_bundles_total = len(bundles)
     queried_bundles_effective = 0
@@ -130,26 +132,27 @@ def execute_federated_query(
     for b in bundles:
         repo_id = b["repo_id"]
         bundle_path_str = b["bundle_path"]
+        bundle_start = time.perf_counter()
 
-        if filters and filters.get("repo") and filters["repo"] != repo_id:
-            bundle_status[repo_id] = "filtered_out"
-            continue
-
-        if "://" in bundle_path_str:
-            bundle_status[repo_id] = "bundle_path_unsupported"
-            continue
-
-        bundle_path = Path(bundle_path_str)
-        if not bundle_path.is_absolute():
-            bundle_path = federation_index_path.parent / bundle_path
-
-        db_path = _find_bundle_index(bundle_path)
-        if not db_path:
-            bundle_status[repo_id] = "index_missing"
-            continue
-
-        import sqlite3
         try:
+            if filters and filters.get("repo") and filters["repo"] != repo_id:
+                bundle_status[repo_id] = "filtered_out"
+                continue
+
+            if "://" in bundle_path_str:
+                bundle_status[repo_id] = "bundle_path_unsupported"
+                continue
+
+            bundle_path = Path(bundle_path_str)
+            if not bundle_path.is_absolute():
+                bundle_path = federation_index_path.parent / bundle_path
+
+            db_path = _find_bundle_index(bundle_path)
+            if not db_path:
+                bundle_status[repo_id] = "index_missing"
+                continue
+
+            import sqlite3
             # Check for staleness using fingerprint (last_fingerprint from federation index vs DB)
             # Note: staleness detection is strictly best-effort and must never fail the federated query.
             expected_fingerprint = b.get("last_fingerprint")
@@ -206,6 +209,8 @@ def execute_federated_query(
         except Exception as e:
             bundle_status[repo_id] = "query_error"
             bundle_errors[repo_id] = str(e)
+        finally:
+            bundle_latency_ms[repo_id] = (time.perf_counter() - bundle_start) * 1000.0
 
     # Conflict Detection Heuristic (Minimal)
     # Group results by filename (`Path.name`) as a primitive heuristic.
@@ -302,7 +307,8 @@ def execute_federated_query(
             "queried_bundles_effective": queried_bundles_effective,
             "bundle_status": bundle_status,
             "bundle_errors": bundle_errors,
-            "bundle_traces": bundle_traces
+            "bundle_traces": bundle_traces,
+            "bundle_latency_ms": bundle_latency_ms,
         }
 
     return out

--- a/merger/lenskit/retrieval/federation_query.py
+++ b/merger/lenskit/retrieval/federation_query.py
@@ -132,6 +132,8 @@ def execute_federated_query(
     for b in bundles:
         repo_id = b["repo_id"]
         bundle_path_str = b["bundle_path"]
+        # Per-bundle processing latency, including validation and early exits;
+        # not a pure DB query benchmark.
         bundle_start = time.perf_counter()
 
         try:

--- a/merger/lenskit/tests/test_federation_cli.py
+++ b/merger/lenskit/tests/test_federation_cli.py
@@ -229,6 +229,10 @@ def test_federation_query_cli_trace_projection(tmp_path: Path, monkeypatch):
 
     # Check bundle projection
     assert len(trace_data["bundles"]) == 2
+    for bundle in trace_data["bundles"]:
+        assert "latency_ms" in bundle
+        assert isinstance(bundle["latency_ms"], float)
+        assert bundle["latency_ms"] >= 0.0
 
     # Hard schema validation — skip only if jsonschema is not installed
     try:
@@ -240,6 +244,61 @@ def test_federation_query_cli_trace_projection(tmp_path: Path, monkeypatch):
     with schema_path.open("r", encoding="utf-8") as sf:
         schema = json.load(sf)
     jsonschema.validate(instance=trace_data, schema=schema)
+
+
+def test_federation_query_cli_trace_projection_includes_latency_on_index_missing(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    out_path = tmp_path / "fed.json"
+    init_federation("trace-fed-missing", out_path)
+
+    from merger.lenskit.retrieval import index_db
+    bundle_path = tmp_path / "b1"
+    bundle_path.mkdir()
+    b_dump = bundle_path / "dump.json"
+    b_chunks = bundle_path / "chunks.jsonl"
+    db_path = bundle_path / "chunk_index.index.sqlite"
+
+    chunk_data = [
+        {
+            "chunk_id": "c1",
+            "repo_id": "repo1",
+            "path": "src/main.py",
+            "content": "hello repo1",
+            "start_line": 1,
+            "end_line": 1,
+            "layer": "core",
+            "artifact_type": "code",
+            "content_sha256": "h1",
+            "source_file": "src/main.py",
+            "start_byte": 0,
+            "end_byte": 100,
+        }
+    ]
+    with b_chunks.open("w", encoding="utf-8") as f:
+        for c in chunk_data:
+            f.write(json.dumps(c) + "\n")
+    b_dump.write_text(json.dumps({"dummy": "data"}), encoding="utf-8")
+    index_db.build_index(b_dump, b_chunks, db_path)
+    add_bundle(out_path, "repo1", str(bundle_path))
+
+    # Force index_missing status for the bundle.
+    db_path.unlink()
+
+    from merger.lenskit.cli import main
+    ret = main.main(["federation", "query", "--index", str(out_path), "-q", "hello", "--trace"])
+    assert ret == 0
+
+    trace_file = tmp_path / "federation_trace.json"
+    assert trace_file.exists()
+    trace_data = json.loads(trace_file.read_text(encoding="utf-8"))
+
+    assert len(trace_data["bundles"]) == 1
+    b0 = trace_data["bundles"][0]
+    assert b0["status"] == "index_missing"
+    assert "latency_ms" in b0
+    assert isinstance(b0["latency_ms"], float)
+    assert b0["latency_ms"] >= 0.0
 
 def test_federation_query_trace_writes_conflicts_json(tmp_path: Path, monkeypatch):
     # Isolate execution to tmp_path to verify file creation safely

--- a/merger/lenskit/tests/test_federation_query.py
+++ b/merger/lenskit/tests/test_federation_query.py
@@ -97,6 +97,11 @@ def test_execute_federated_query_with_trace(federated_setup):
     assert "bundle_traces" in trace
     assert "repo1" in trace["bundle_traces"]
     assert "repo2" in trace["bundle_traces"]
+    assert "bundle_latency_ms" in trace
+    assert isinstance(trace["bundle_latency_ms"]["repo1"], float)
+    assert isinstance(trace["bundle_latency_ms"]["repo2"], float)
+    assert trace["bundle_latency_ms"]["repo1"] >= 0.0
+    assert trace["bundle_latency_ms"]["repo2"] >= 0.0
 
 def test_execute_federated_query_is_deterministic_on_tie(federated_setup):
     # 'hello' will yield score ties.
@@ -470,7 +475,11 @@ def test_execute_federated_query_handles_query_error(federated_setup, monkeypatc
     trace = res["federation_trace"]
     assert trace["bundle_status"]["repo1"] == "query_error"
     assert "Database corruption" in trace["bundle_errors"]["repo1"]
+    assert isinstance(trace["bundle_latency_ms"]["repo1"], float)
+    assert trace["bundle_latency_ms"]["repo1"] >= 0.0
     assert trace["bundle_status"]["repo2"] == "ok"
+    assert isinstance(trace["bundle_latency_ms"]["repo2"], float)
+    assert trace["bundle_latency_ms"]["repo2"] >= 0.0
     assert trace["queried_bundles_effective"] == 1
     # Ein Bundle liefert Ergebnisse
     assert res["count"] > 0


### PR DESCRIPTION
## Aufgabe
Federation Trace Telemetry Hardening (Phase-5-Follow-up): bestehende Federation-Traces diagnostisch härten, ohne neue Föderationsarchitektur einzuführen.

## Diagnose (vor Patch)
### Dokumentationsbefund
- In Roadmap/Blueprints/Contracts ist die Restlücke explizit dokumentiert: per-Bundle Latenz-Telemetrie fehlt in der Runtime-Trace-Form.
- `federation-trace.v1.schema.json` erlaubt bereits `latency_ms` auf Bundle-Ebene für das CLI-Dateiartefakt.
- Runtime-Inline-Form (`queried_bundles_total`, `bundle_status`, `bundle_errors`, `bundle_traces`) war vorhanden, aber ohne strukturierte per-Bundle-Latenz.

### Code-Verifikation
- Federation-Runtime (`execute_federated_query`) hatte keine monotonic per-Bundle-Latenz-Erfassung.
- Status-Emission war bereits vorhanden über `bundle_status` mit u.a. `ok`, `stale`, `filtered_out`, `index_missing`, `bundle_path_unsupported`, `query_error`.
- CLI-Projektion (`cmd_federation.py`) hat `latency_ms` bisher absichtlich nicht geschrieben.

### Test-Verifikation
- Vorhandene Tests deckten Statuspfade und Trace-Erhalt gut ab (Runtime/CLI/API), aber keine Pflichtprüfung für `latency_ms` in Success-/Fehlerpfaden.

## Umsetzung
### A) Federation Runtime Trace Telemetry
- In `merger/lenskit/retrieval/federation_query.py` pro Bundle monotonic Timing via `time.perf_counter()` ergänzt.
- Neue strukturierte Runtime-Trace-Map: `bundle_latency_ms` (float in Millisekunden).
- Erfassung erfolgt in allen Pfaden (inkl. `continue`- und `except`-Pfaden) via `finally`.
- Bestehende Status-/Ranking-/Aggregation-Semantik unverändert.

### B) CLI Projection
- In `merger/lenskit/cli/cmd_federation.py` wird `bundle_latency_ms` in das CLI-Dateiartefakt `federation_trace.json` auf Bundle-Ebene als `latency_ms` projiziert.
- Keine neue Top-Level-Architektur, nur Ergänzung bestehender Trace-Projektion.

## Tests
Erweitert:
- `merger/lenskit/tests/test_federation_query.py`
  - Success-Trace enthält `bundle_latency_ms` mit float-Werten.
  - Fehlerpfad (`query_error`) enthält ebenfalls `bundle_latency_ms`.
- `merger/lenskit/tests/test_federation_cli.py`
  - `federation_trace.json` enthält `latency_ms` pro Bundle.
  - `index_missing`-Fehlerpfad enthält ebenfalls `latency_ms`.

Ausgeführt:
- `python -m pytest -q merger/lenskit/tests/test_federation_query.py` ✅
- `python -m pytest -q merger/lenskit/tests/test_federation_cli.py` ✅
- Zusätzlich betroffen/angrenzend:
  - `python -m pytest -q merger/lenskit/tests/test_api_federation.py` ✅
  - `python -m pytest -q merger/lenskit/tests/test_agent_profiles.py::test_agent_profile_agent_minimal_preserves_runtime_federation_trace merger/lenskit/tests/test_agent_session_builder.py` ✅

## Risikoanalyse
- Niedriges Regressionsrisiko: additive Telemetriefelder, keine Änderung an Ranking oder Föderationslogik.
- Kompatibilität: bestehende Konsumenten von `bundle_status` bleiben intakt; neue Latenzwerte sind ergänzend.
- Architekturgrenzen bleiben unverändert (keine Identity-/Trust-/Ranking-Neuentwicklung).

## Nicht-Ziele
- Keine neue Federation-Architektur.
- Keine Identity-/Trust-/Ranking-Features.
- Keine spekulativen Erweiterungen über Telemetrie hinaus.
