### PR TITLE
docs: update README with pythonista `repolens` frontend and improved examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,25 @@ Kurzüberblick über Ordner:
 ### repoLens (Empfohlen)
 
 Das Hauptwerkzeug, um Repositories für LLMs aufzubereiten.
+`merger.lenskit.frontends.pythonista.repolens` ist der direkte repoLens Dump-/Bundle-Emitter für lokale Modulaufrufe, insbesondere aus Pythonista/iPad-Kontexten.
+`merger.lenskit.cli.rlens` ist die rLens-Service-/Host-Surface und nicht der direkte `repoLens . --level ...`-Aufruf; rLens bleibt die operative Heim-PC/Service-Schicht.
 
 ```bash
 # Overview
-python3 -m merger.lenskit.cli.rlens . --level overview
+python3 -m merger.lenskit.frontends.pythonista.repolens . --level overview
 
-# Full Merge mit Split (20MB) und Meta-Drosselung
-python3 -m merger.lenskit.cli.rlens . --level max --split-size 20MB --meta-density standard
+# Full Merge mit Split (20MB), voller Metadichte und Dual-Output
+python3 -m merger.lenskit.frontends.pythonista.repolens . \
+  --level max \
+  --split-size 20MB \
+  --meta-density full \
+  --output-mode dual
+```
+
+Direkte Datei-Ausführung ist ebenfalls möglich, falls der Modulaufruf in einer lokalen Umgebung nicht greift:
+
+```bash
+python3 merger/lenskit/frontends/pythonista/repolens.py . --level max --split-size 20MB --meta-density full --output-mode dual
 ```
 
 Siehe [merger/lenskit/repoLens-spec.md](merger/lenskit/repoLens-spec.md) für Details.


### PR DESCRIPTION
### Motivation

- Clarify how to invoke the primary repoLens emitter from Pythonista/iPad contexts and distinguish it from the rLens CLI host/service surface.
- Provide more accurate, copy-pastable example commands for common workflows (overview and full merge) including split, meta-density, and output-mode options.

### Description

- Document the direct repoLens emitter `merger.lenskit.frontends.pythonista.repolens` and note that `merger.lenskit.cli.rlens` is the rLens host/service surface rather than the direct emitter.
- Replace the overview example call with `python3 -m merger.lenskit.frontends.pythonista.repolens . --level overview`.
- Add a full-merge example that uses `python3 -m merger.lenskit.frontends.pythonista.repolens . --level max --split-size 20MB --meta-density full --output-mode dual` and provide an alternative direct file execution example using `python3 merger/lenskit/frontends/pythonista/repolens.py`.
- Add explanatory text about direct file execution for local environments where the module call may not work.

### Testing

- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18893931fc832ca651410bf71fab66)