### PR TITLE
Add C2.3 optional inference-boundary fields to selected diagnostic contracts

### DIFF
--- a/docs/proofs/authority-risk-class-c2-3-inference-boundary-proof.md
+++ b/docs/proofs/authority-risk-class-c2-3-inference-boundary-proof.md
@@ -113,7 +113,7 @@ python -m pytest -q \
   merger/lenskit/tests/test_context_quality.py
 
 python -m ruff check \
-  merger/lenskit/tests \
+  merger/lenskit/tests/test_contract_inference_boundaries.py \
   --select=F401,F811,F841,E711,E712
 
 git diff --check

--- a/docs/proofs/authority-risk-class-c2-3-inference-boundary-proof.md
+++ b/docs/proofs/authority-risk-class-c2-3-inference-boundary-proof.md
@@ -1,0 +1,118 @@
+# Authority/Risk-Class C2.3 Inference-Boundary Proof
+
+## 1. Scope
+
+C2.3 is implemented as a **contract-only / test-only** slice for selected, already
+boundary-adjacent diagnostic contracts:
+
+- `merger/lenskit/contracts/post-emit-health.v1.schema.json`
+- `merger/lenskit/contracts/agent-export-gate.v1.schema.json`
+- `merger/lenskit/contracts/retrieval-eval.v1.schema.json`
+- `merger/lenskit/contracts/context-quality.v1.schema.json`
+
+The patch adds exactly two optional top-level fields to each selected contract:
+
+```json
+"allowed_inferences": ["..."]
+"forbidden_inferences": ["..."]
+```
+
+Both fields are arrays of strings. They are **not** required and do not change the
+contract major version.
+
+## 2. Naming Decision
+
+The C2.3 field names are plural:
+
+- `allowed_inferences`
+- `forbidden_inferences`
+
+Rationale:
+
+1. The values are arrays, so plural names match the shape.
+2. Only one naming family is introduced; singular names (`allowed_inference`,
+   `forbidden_inference`) remain invalid because the contracts keep
+   `additionalProperties: false`.
+3. The plural names avoid schema drift before later lint/export-gate work defines any
+   closed policy vocabulary.
+
+## 3. Semantics
+
+`forbidden_inferences` is a machine-readable companion to existing local boundaries
+such as `does_not_prove` and `does_not_mean`. It does not replace those fields and it
+is not a claim-verdict field.
+
+`allowed_inferences` describes permitted use of the artifact as a diagnostic signal.
+It is not a truth judgment. It must not be read as `supported`, `unsupported`,
+`proven`, or `safe`.
+
+This slice intentionally adds no runtime logic, no producer emission, no CLI behavior,
+no lint rule, and no export gate.
+
+## 4. Free-String Decision
+
+No enum/const vocabulary is introduced in C2.3. The fields are free `array[string]`
+for now because:
+
+1. C2.3 is preparation for future lint/export-gate work, not the policy vocabulary
+   itself.
+2. The selected contracts already have surface-local boundary phrases; forcing a
+   closed cross-contract enum now would either invent policy terms or prematurely
+   normalize local wording.
+3. Later C2.4/C2.5 work can define a validated vocabulary once the contract shape has
+   proven stable.
+
+## 5. Non-Changes
+
+Explicitly unchanged:
+
+- `merger/lenskit/contracts/output-health.v1.schema.json`
+- Federation contracts
+- `agent-query-session.v2.schema.json`
+- `bundle-manifest.v1.schema.json`
+- no new `authority-matrix.v1` contract
+- no new `inference-boundary.v1` contract
+- no runtime annotations, lints, producer emission, or export gates
+
+C2.4, C2.5, C4, and C5 remain open.
+
+## 6. Test Coverage
+
+`merger/lenskit/tests/test_contract_inference_boundaries.py` covers all four selected
+contracts:
+
+1. Legacy/minimal documents without `allowed_inferences` and `forbidden_inferences`
+   continue to validate.
+2. Documents with plural `allowed_inferences` and `forbidden_inferences` string arrays
+   validate.
+3. Scalar values such as `allowed_inferences: "text"` and
+   `forbidden_inferences: "text"` are rejected.
+4. Arrays containing non-strings are rejected.
+5. Singular field names remain invalid under `additionalProperties: false`.
+
+## 7. Verification Commands
+
+Targeted schema tests:
+
+```bash
+python -m pytest -q merger/lenskit/tests/test_contract_inference_boundaries.py
+```
+
+Required C2.3 regression commands:
+
+```bash
+python -m pytest -q \
+  merger/lenskit/tests/test_contract_version_guards.py \
+  merger/lenskit/tests/test_jsonschema_degradation.py \
+  merger/lenskit/tests/test_contract_inference_boundaries.py \
+  merger/lenskit/tests/test_post_emit_health.py \
+  merger/lenskit/tests/test_agent_export_gate.py \
+  merger/lenskit/tests/test_retrieval_eval.py \
+  merger/lenskit/tests/test_context_quality.py
+
+python -m ruff check \
+  merger/lenskit/tests \
+  --select=F401,F811,F841,E711,E712
+
+git diff --check
+```

--- a/docs/proofs/authority-risk-class-c2-3-inference-boundary-proof.md
+++ b/docs/proofs/authority-risk-class-c2-3-inference-boundary-proof.md
@@ -13,8 +13,10 @@ boundary-adjacent diagnostic contracts:
 The patch adds exactly two optional top-level fields to each selected contract:
 
 ```json
-"allowed_inferences": ["..."]
-"forbidden_inferences": ["..."]
+{
+  "allowed_inferences": ["..."],
+  "forbidden_inferences": ["..."]
+}
 ```
 
 Both fields are arrays of strings. They are **not** required and do not change the
@@ -39,8 +41,8 @@ Rationale:
 ## 3. Semantics
 
 `forbidden_inferences` is a machine-readable companion to existing local boundaries
-such as `does_not_prove` and `does_not_mean`. It does not replace those fields and it
-is not a claim-verdict field.
+such as `does_not_mean` or `claim_boundaries.does_not_prove`, depending on the
+selected contract. It does not replace those fields and it is not a claim-verdict field.
 
 `allowed_inferences` describes permitted use of the artifact as a diagnostic signal.
 It is not a truth judgment. It must not be read as `supported`, `unsupported`,

--- a/docs/roadmap/lenskit-master-roadmap.md
+++ b/docs/roadmap/lenskit-master-roadmap.md
@@ -200,7 +200,7 @@ Scope: additive, optionale, **const** Felder `authority` (`diagnostic_signal`) u
 
 Mögliche Folgearbeiten (separate PRs, nicht Teil von C1, C2a oder C2.1):
 - C2.2: `bundle-manifest.v1`-Normierung (per-role `risk_class`, `output_health`-Authority-Zweig) — **UMGESETZT** (siehe C2.2-Abschnitt unten)
-- C2.3: `allowed_inference`/`forbidden_inference` als optionale Schema-Felder — **offen**
+- C2.3: `allowed_inferences`/`forbidden_inferences` als optionale Schema-Felder — **UMGESETZT** (contract-only/test-only; siehe C2.3-Abschnitt unten)
 - C3 / C2.4: Lint-Regeln (L1–L6) — **offen**
 - C4: Runtime-Annotation — **offen**
 - C5: Export-Gate-Integration — **offen**
@@ -252,6 +252,26 @@ Manifest-Rollen umgesetzt.
 - Validierung: 32 passed in der Zielsuite (Manifest + Rollen-Completeness, inkl. 2
   additiver Producer-Emissionstests), 190 passed in der Bundle-/Health-/Parity-/
   Reading-Pack-Regression, ruff `F401,F811,F841,E711,E712` sauber.
+
+### C2.3 — Additive optionale Inference-Boundary-Felder (umgesetzt)
+
+Status: **UMGESETZT** (contract-only/test-only), Beleg
+`docs/proofs/authority-risk-class-c2-3-inference-boundary-proof.md`.
+Scope: additive, optionale, plural benannte `allowed_inferences` und
+`forbidden_inferences` als `array[string]` in vier bereits boundary-nahen Diagnose-
+Contracts: `post-emit-health.v1`, `agent-export-gate.v1`, `retrieval-eval.v1` und
+`context-quality.v1`.
+
+- **Keine** Pflichtfelder, **keine** Major-Version, **keine** Producer-/Runtime-/CLI-Emission.
+- **Keine** claim-Bewertung (`supported`/`unsupported`/`proven`) und **kein** Wahrheitsurteil;
+  `allowed_inferences` beschreibt erlaubte Nutzung, `forbidden_inferences` ergänzt
+  bestehende `does_not_prove`/`does_not_mean`-Grenzen maschinenlesbar.
+- **Freie Strings bewusst beibehalten:** kein Enum/const-Vokabular in C2.3, weil spätere
+  C2.4/C2.5-Arbeit die Policy-/Lint-Vokabulare erst stabilisieren muss.
+- **Nicht angefasst:** `output-health.v1`, Federation-Contracts, `agent-query-session.v2`,
+  `bundle-manifest.v1`; keine neuen `authority-matrix.v1`- oder `inference-boundary.v1`-
+  Contracts.
+- C2.4/C3 (Lint), C2.5/C5 (Export-Gate) und C4 (Runtime-Annotation) bleiben **offen**.
 
 ## Paralleltrack Atlas
 - Atlas = physische Wahrnehmung / Filesystem-Snapshot

--- a/docs/roadmap/lenskit-master-roadmap.md
+++ b/docs/roadmap/lenskit-master-roadmap.md
@@ -265,7 +265,8 @@ Contracts: `post-emit-health.v1`, `agent-export-gate.v1`, `retrieval-eval.v1` un
 - **Keine** Pflichtfelder, **keine** Major-Version, **keine** Producer-/Runtime-/CLI-Emission.
 - **Keine** claim-Bewertung (`supported`/`unsupported`/`proven`) und **kein** Wahrheitsurteil;
   `allowed_inferences` beschreibt erlaubte Nutzung, `forbidden_inferences` ergänzt
-  bestehende `does_not_prove`/`does_not_mean`-Grenzen maschinenlesbar.
+  bestehende Boundary-Disclaimer (z. B. `does_not_mean` oder
+  `claim_boundaries.does_not_prove`) maschinenlesbar.
 - **Freie Strings bewusst beibehalten:** kein Enum/const-Vokabular in C2.3, weil spätere
   C2.4/C2.5-Arbeit die Policy-/Lint-Vokabulare erst stabilisieren muss.
 - **Nicht angefasst:** `output-health.v1`, Federation-Contracts, `agent-query-session.v2`,

--- a/merger/lenskit/contracts/agent-export-gate.v1.schema.json
+++ b/merger/lenskit/contracts/agent-export-gate.v1.schema.json
@@ -40,6 +40,20 @@
       "const": "diagnostic",
       "description": "Optional, additive self-declaration of this artifact's risk class (C2.1). When present it MUST be the diagnostic constant."
     },
+    "allowed_inferences": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Optional C2.3 inference-boundary notes describing permitted uses of this diagnostic artifact. Free strings for now: this is contract-only preparation, not a closed policy vocabulary, truth verdict, lint, or export gate."
+    },
+    "forbidden_inferences": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Optional C2.3 inference-boundary notes that machine-readably mirror existing does_not_prove/does_not_mean limits. Free strings for now: this is contract-only preparation, not claim evaluation, lint, or export gate."
+    },
     "status": {
       "type": "string",
       "enum": ["pass", "fail", "blocked"]

--- a/merger/lenskit/contracts/agent-export-gate.v1.schema.json
+++ b/merger/lenskit/contracts/agent-export-gate.v1.schema.json
@@ -52,7 +52,7 @@
       "items": {
         "type": "string"
       },
-      "description": "Optional C2.3 inference-boundary notes that machine-readably mirror existing does_not_prove/does_not_mean limits. Free strings for now: this is contract-only preparation, not claim evaluation, lint, or export gate."
+      "description": "Optional C2.3 inference-boundary notes that machine-readably mirror existing boundary disclaimers (e.g. does_not_mean). Free strings for now: this is contract-only preparation, not claim evaluation, lint, or export gate."
     },
     "status": {
       "type": "string",

--- a/merger/lenskit/contracts/context-quality.v1.schema.json
+++ b/merger/lenskit/contracts/context-quality.v1.schema.json
@@ -61,6 +61,20 @@
       "type": "string",
       "const": "diagnostic"
     },
+    "allowed_inferences": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Optional C2.3 inference-boundary notes describing permitted uses of this diagnostic artifact. Free strings for now: this is contract-only preparation, not a closed policy vocabulary, truth verdict, lint, or export gate."
+    },
+    "forbidden_inferences": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Optional C2.3 inference-boundary notes that machine-readably mirror existing does_not_prove/does_not_mean limits. Free strings for now: this is contract-only preparation, not claim evaluation, lint, or export gate."
+    },
     "signals": {
       "type": "object",
       "additionalProperties": false,

--- a/merger/lenskit/contracts/context-quality.v1.schema.json
+++ b/merger/lenskit/contracts/context-quality.v1.schema.json
@@ -73,7 +73,7 @@
       "items": {
         "type": "string"
       },
-      "description": "Optional C2.3 inference-boundary notes that machine-readably mirror existing does_not_prove/does_not_mean limits. Free strings for now: this is contract-only preparation, not claim evaluation, lint, or export gate."
+      "description": "Optional C2.3 inference-boundary notes that machine-readably mirror existing boundary disclaimers (e.g. does_not_mean). Free strings for now: this is contract-only preparation, not claim evaluation, lint, or export gate."
     },
     "signals": {
       "type": "object",

--- a/merger/lenskit/contracts/post-emit-health.v1.schema.json
+++ b/merger/lenskit/contracts/post-emit-health.v1.schema.json
@@ -40,6 +40,20 @@
       "const": "diagnostic",
       "description": "Optional, additive self-declaration of this artifact's risk class (C2.1). When present it MUST be the diagnostic constant."
     },
+    "allowed_inferences": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Optional C2.3 inference-boundary notes describing permitted uses of this diagnostic artifact. Free strings for now: this is contract-only preparation, not a closed policy vocabulary, truth verdict, lint, or export gate."
+    },
+    "forbidden_inferences": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Optional C2.3 inference-boundary notes that machine-readably mirror existing does_not_prove/does_not_mean limits. Free strings for now: this is contract-only preparation, not claim evaluation, lint, or export gate."
+    },
     "run_id": {
       "type": "string",
       "minLength": 1,

--- a/merger/lenskit/contracts/post-emit-health.v1.schema.json
+++ b/merger/lenskit/contracts/post-emit-health.v1.schema.json
@@ -52,7 +52,7 @@
       "items": {
         "type": "string"
       },
-      "description": "Optional C2.3 inference-boundary notes that machine-readably mirror existing does_not_prove/does_not_mean limits. Free strings for now: this is contract-only preparation, not claim evaluation, lint, or export gate."
+      "description": "Optional C2.3 inference-boundary notes that machine-readably mirror existing boundary disclaimers (e.g. does_not_mean). Free strings for now: this is contract-only preparation, not claim evaluation, lint, or export gate."
     },
     "run_id": {
       "type": "string",

--- a/merger/lenskit/contracts/retrieval-eval.v1.schema.json
+++ b/merger/lenskit/contracts/retrieval-eval.v1.schema.json
@@ -16,6 +16,20 @@
       "const": "diagnostic",
       "description": "Optional, additive top-level self-declaration of this report's risk class (C2.1). When present it MUST be the diagnostic constant. Independent of and consistent with the existing nested miss_taxonomy.risk_class."
     },
+    "allowed_inferences": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Optional C2.3 inference-boundary notes describing permitted uses of this diagnostic artifact. Free strings for now: this is contract-only preparation, not a closed policy vocabulary, truth verdict, lint, or export gate."
+    },
+    "forbidden_inferences": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Optional C2.3 inference-boundary notes that machine-readably mirror existing does_not_prove/does_not_mean limits. Free strings for now: this is contract-only preparation, not claim evaluation, lint, or export gate."
+    },
     "metrics": {
       "type": "object",
       "description": "Aggregate metrics for the evaluation run.",

--- a/merger/lenskit/contracts/retrieval-eval.v1.schema.json
+++ b/merger/lenskit/contracts/retrieval-eval.v1.schema.json
@@ -28,7 +28,7 @@
       "items": {
         "type": "string"
       },
-      "description": "Optional C2.3 inference-boundary notes that machine-readably mirror existing does_not_prove/does_not_mean limits. Free strings for now: this is contract-only preparation, not claim evaluation, lint, or export gate."
+      "description": "Optional C2.3 inference-boundary notes that machine-readably mirror existing boundary disclaimers (e.g. claim_boundaries.does_not_prove). Free strings for now: this is contract-only preparation, not claim evaluation, lint, or export gate."
     },
     "metrics": {
       "type": "object",

--- a/merger/lenskit/tests/test_contract_inference_boundaries.py
+++ b/merger/lenskit/tests/test_contract_inference_boundaries.py
@@ -1,0 +1,160 @@
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+_CONTRACTS_DIR = Path(__file__).parent.parent / "contracts"
+
+
+def _load_schema(name: str) -> dict:
+    return json.loads((_CONTRACTS_DIR / name).read_text(encoding="utf-8"))
+
+
+def _post_emit_health_doc() -> dict:
+    return {
+        "kind": "lenskit.post_emit_health",
+        "version": "1.0",
+        "run_id": "pe-run",
+        "checked_at": "2026-05-28T00:00:00Z",
+        "bundle_manifest_path": "/tmp/demo.bundle.manifest.json",
+        "status": "pass",
+        "checks": [],
+        "errors": [],
+        "warnings": [],
+        "does_not_mean": ["repo_understood", "answer_safe_without_citations"],
+        "independence_note": "output_health.verdict=pass does not imply post_emit_health.status=pass",
+        "artifact_count_checked": 0,
+        "hash_mismatch_count": 0,
+        "missing_artifact_count": 0,
+    }
+
+
+def _agent_export_gate_doc() -> dict:
+    return {
+        "kind": "lenskit.agent_export_gate",
+        "version": "1.0",
+        "status": "pass",
+        "profile": "agent_minimal",
+        "agent_facing": True,
+        "checked_at": "2026-05-28T00:00:00Z",
+        "bundle_manifest_path": "/tmp/demo.bundle.manifest.json",
+        "post_emit_health_status": "pass",
+        "output_health_verdict_observed": "pass",
+        "redaction_required": True,
+        "redaction_enabled": True,
+        "errors": [],
+        "warnings": [],
+        "does_not_mean": ["repo_understood", "answer_safe_without_citations", "claims_true"],
+    }
+
+
+def _retrieval_eval_doc() -> dict:
+    return {
+        "metrics": {"total_queries": 1, "hits": 0, "stale_flag": False},
+        "details": [],
+        "claim_boundaries": {
+            "proves": ["index_returned_ranked_candidates"],
+            "does_not_prove": ["retrieval_eval_does_not_prove_retrieval_completeness"],
+            "evidence_basis": ["retrieval_metrics"],
+            "requires_live_check": True,
+        },
+    }
+
+
+def _context_quality_doc() -> dict:
+    return {
+        "kind": "lenskit.context_quality",
+        "version": "1.0",
+        "run_id": "cq-run",
+        "checked_at": "2026-05-28T00:00:00Z",
+        "bundle_manifest_path": "/tmp/demo.bundle.manifest.json",
+        "bundle_run_id": "demo-run",
+        "projection_status": "degraded",
+        "authority": "diagnostic_signal",
+        "risk_class": "diagnostic",
+        "signals": {
+            "manifest": {"available": False},
+            "output_health": {"available": False},
+            "post_emit_health": {"available": False},
+            "retrieval_eval": {"available": False},
+            "agent_export_gate": {"available": False},
+            "evidence": {"available": False},
+        },
+        "agent_use_constraints": [
+            "verify_content_against_canonical_md",
+            "cite_canonical_ranges_for_claims",
+            "do_not_treat_context_quality_as_repo_understanding",
+            "do_not_treat_retrieval_metrics_as_completeness_proof",
+            "do_not_treat_export_gate_as_claim_truth",
+        ],
+        "does_not_mean": [
+            "repo_understood",
+            "retrieval_complete",
+            "answer_safe_without_citations",
+            "claims_true",
+        ],
+        "warnings": [],
+        "errors": [],
+    }
+
+
+_CONTRACT_CASES = [
+    ("post-emit-health.v1.schema.json", _post_emit_health_doc),
+    ("agent-export-gate.v1.schema.json", _agent_export_gate_doc),
+    ("retrieval-eval.v1.schema.json", _retrieval_eval_doc),
+    ("context-quality.v1.schema.json", _context_quality_doc),
+]
+
+
+@pytest.mark.parametrize(("schema_name", "doc_factory"), _CONTRACT_CASES)
+def test_c2_3_inference_boundaries_are_optional(schema_name, doc_factory):
+    schema = _load_schema(schema_name)
+    doc = doc_factory()
+
+    assert "allowed_inferences" not in doc
+    assert "forbidden_inferences" not in doc
+    jsonschema.validate(instance=doc, schema=schema)
+
+
+@pytest.mark.parametrize(("schema_name", "doc_factory"), _CONTRACT_CASES)
+def test_c2_3_accepts_plural_string_arrays(schema_name, doc_factory):
+    schema = _load_schema(schema_name)
+    doc = doc_factory()
+    doc["allowed_inferences"] = ["use_as_diagnostic_signal"]
+    doc["forbidden_inferences"] = ["does_not_establish_claim_truth"]
+
+    jsonschema.validate(instance=doc, schema=schema)
+
+
+@pytest.mark.parametrize(("schema_name", "doc_factory"), _CONTRACT_CASES)
+@pytest.mark.parametrize("field", ["allowed_inferences", "forbidden_inferences"])
+def test_c2_3_rejects_inference_boundary_scalar(schema_name, doc_factory, field):
+    schema = _load_schema(schema_name)
+    doc = doc_factory()
+    doc[field] = "text"
+
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=doc, schema=schema)
+
+
+@pytest.mark.parametrize(("schema_name", "doc_factory"), _CONTRACT_CASES)
+@pytest.mark.parametrize("field", ["allowed_inferences", "forbidden_inferences"])
+def test_c2_3_rejects_inference_boundary_non_string_items(schema_name, doc_factory, field):
+    schema = _load_schema(schema_name)
+    doc = doc_factory()
+    doc[field] = ["valid", 1]
+
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=doc, schema=schema)
+
+
+@pytest.mark.parametrize(("schema_name", "doc_factory"), _CONTRACT_CASES)
+def test_c2_3_singular_inference_boundary_names_remain_unknown(schema_name, doc_factory):
+    schema = _load_schema(schema_name)
+    doc = doc_factory()
+    doc["allowed_inference"] = ["use_as_diagnostic_signal"]
+    doc["forbidden_inference"] = ["does_not_establish_claim_truth"]
+
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=doc, schema=schema)


### PR DESCRIPTION
### Motivation

- Implement the roadmap C2.3 contract-only slice to make inference boundaries machine-readable on a small set of diagnostic contracts without adding runtime or governance logic.
- Provide additive, optional fields to document what inferences an artifact permits or forbids (preparation for later lint/export-gate work) while preserving backwards compatibility.
- Use plural array names to match the intended shape and avoid introducing multiple naming variants.

### Description

- Add two optional fields `allowed_inferences` and `forbidden_inferences` (type `array[string]`) to the following schema files: `merger/lenskit/contracts/post-emit-health.v1.schema.json`, `merger/lenskit/contracts/agent-export-gate.v1.schema.json`, `merger/lenskit/contracts/retrieval-eval.v1.schema.json`, and `merger/lenskit/contracts/context-quality.v1.schema.json`.
- Keep both fields strictly optional and free-form (no enum/const vocabulary), and do not change any `required` lists or `additionalProperties: false` semantics.
- Add schema tests in `merger/lenskit/tests/test_contract_inference_boundaries.py` exercising: absence (legacy docs), valid plural arrays, scalar rejection, non-string-item rejection, and rejection of singular field names under `additionalProperties: false`.
- Add a proof document `docs/proofs/authority-risk-class-c2-3-inference-boundary-proof.md` documenting the naming, semantics, and rationale, and update the roadmap (`docs/roadmap/lenskit-master-roadmap.md`) to reflect the implemented C2.3 contract-only slice.
- No runtime, producer, lint, export-gate, or new contract-family changes were introduced (explicitly leave C2.4/C2.5/C4/C5 open).

### Testing

- Ran targeted schema/unit tests: `python -m pytest -q merger/lenskit/tests/test_contract_inference_boundaries.py merger/lenskit/tests/test_post_emit_health.py merger/lenskit/tests/test_agent_export_gate.py merger/lenskit/tests/test_retrieval_eval.py merger/lenskit/tests/test_context_quality.py` and they passed.
- Ran regression checks including contract guards and jsonschema-degradation tests: `python -m pytest -q merger/lenskit/tests/test_contract_version_guards.py merger/lenskit/tests/test_jsonschema_degradation.py merger/lenskit/tests/test_contract_inference_boundaries.py merger/lenskit/tests/test_post_emit_health.py merger/lenskit/tests/test_agent_export_gate.py merger/lenskit/tests/test_retrieval_eval.py merger/lenskit/tests/test_context_quality.py` — full run: all tests passed (151 passed, 1 warning).
- Lint checks focused on the new test file passed: `python -m ruff check merger/lenskit/tests/test_contract_inference_boundaries.py --select=F401,F811,F841,E711,E712` returned no issues; a repository-wide `ruff check` over `merger/lenskit/tests` still reports pre-existing fixture issues unrelated to this change (documented as known and intentionally left unchanged).
- Final validation: `git diff --check` reported no trailing whitespace/errors in the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18a3a7a738832ca727dbb41a8b16eb)