### PR TITLE
C2.5: Minimal export-gate hardening for L6 export-risk inferences

### DIFF
--- a/docs/proofs/authority-risk-class-c2-5-export-gate-proof.md
+++ b/docs/proofs/authority-risk-class-c2-5-export-gate-proof.md
@@ -1,0 +1,155 @@
+# Authority/Risk-Class C2.5 / C5 Export-Gate Inference-Boundary Proof
+
+## 1. Scope
+
+C2.5 is the **minimal** slice of Governance Track **C5** — the export-gate side of
+the C1 anti-hallucination matrix rule **L6** (export-risk), which C2.4 explicitly
+deferred (`docs/proofs/authority-risk-class-c2-4-lint-proof.md` §3;
+`merger/lenskit/core/anti_hallucination_lint.py` `OUT_OF_SCOPE_RULES["L6"]`).
+
+The existing `agent_export_gate` (roadmap A5) is **minimally hardened**, not
+replaced: it now reads the optional C2.3 `forbidden_inferences` field from the
+bundle's diagnostic artifacts and refuses to certify an **agent-facing** export
+when a diagnostic explicitly forbids a high-risk inference.
+
+Changed files:
+
+- `merger/lenskit/core/agent_export_gate.py` (additive read + gate condition)
+- `merger/lenskit/tests/test_agent_export_gate.py` (C2.5 coverage)
+- `docs/proofs/authority-risk-class-c2-5-export-gate-proof.md` (this file)
+- `docs/roadmap/lenskit-master-roadmap.md` (C2.5 / C5 status)
+
+This slice adds **no new contract**, **no runtime annotation**, **no producer
+emission**, **no claim-truth evaluation**, and **no change to `canonical_md` or
+retrieval**.
+
+## 2. The Rule (blocking, agent-facing only)
+
+For an **agent-facing** export profile, if any in-bundle diagnostic artifact
+machine-readably forbids an inference from the export-risk vocabulary (§3), the
+gate result is downgraded to `fail` (or stays `blocked` if already blocked) and
+an error names the offending inference(s).
+
+The rule exists only so that an agent-facing export does **not appear safe**
+while a diagnostic in the same bundle explicitly says that exact inference is
+forbidden. It is export-eligibility logic, not a truth verdict — consistent with
+the gate's pre-existing `does_not_mean` disclaimers
+(`repo_understood`, `answer_safe_without_citations`, `claims_true`).
+
+Non-agent-facing profiles are **not** export-risk gated: they are evaluated on
+the existing separate path and never certify the agent surface in the first
+place.
+
+## 3. Export-Risk Vocabulary (minimal, closed)
+
+`_EXPORT_RISK_FORBIDDEN_INFERENCES` in `agent_export_gate.py`:
+
+- `claims_true`
+- `repo_understood`
+- `answer_safe_without_citations`
+- `retrieval_complete`
+
+This is a deliberately small, closed set that mirrors the existing
+`context_quality.DOES_NOT_MEAN` vocabulary
+(`merger/lenskit/core/context_quality.py`). Matching is **exact** on the strings
+declared in `forbidden_inferences`; any other (free-string) forbidden inference
+is honored as a C2.3 boundary note but does **not** block export. C2.3 keeps the
+field as a free `array[string]`, so this closed vocabulary lives in the gate, not
+in the contract.
+
+## 4. Read Surface
+
+`forbidden_inferences` is read from:
+
+1. **Manifest diagnostic artifacts** that self-declare `authority ==
+   diagnostic_signal`, resolved with `resolve_secure_path` so a path escaping the
+   bundle directory is rejected (same posture as the existing `output_health`
+   observation). Artifacts that are not diagnostic, are unreadable, or are not
+   JSON objects are silently skipped.
+2. The already-loaded **`post_emit_health`** document.
+
+Both `agent-export-gate.v1`, `post-emit-health.v1`, `retrieval-eval.v1`, and
+`context-quality.v1` carry the optional C2.3 `forbidden_inferences` field; the
+gate only reads it where a diagnostic artifact is actually reachable in the
+bundle. The gate does **not** mutate the manifest or any artifact (asserted by
+`test_agent_export_gate_does_not_mutate_manifest`).
+
+## 5. Fail vs Blocked Semantics
+
+The downgrade reuses the gate's existing semantics:
+
+- `blocked` = certification could not complete (missing/unknown/non-exportable
+  profile, missing/invalid `post_emit_health`, missing `run_id`). A forbidden
+  inference does **not** override an existing `blocked`.
+- `fail` = certification completed but a defect was found. An export-risk
+  inference is exactly such a defect, so it maps to `fail` — identical to the
+  redaction-disabled branch.
+
+The report shape is unchanged: the reason is surfaced in the existing `errors`
+array, so the report still validates against `agent-export-gate.v1`
+(no schema change).
+
+## 6. Non-Changes
+
+Explicitly unchanged:
+
+- No contract schema file was modified (the C2.3 `forbidden_inferences` field
+  already existed; no new contract, no new field, no version bump).
+- No producer/runtime emission of `forbidden_inferences` — the gate **reads**
+  boundaries, it does not write them.
+- No claim-truth evaluation; no `supported`/`unsupported`/`proven`/`safe`
+  semantics introduced.
+- `evaluate_agent_export_gate` keeps its signature, so the
+  `lenskit bundle-health export-gate` CLI (`cmd_bundle_health.py`) is unaffected;
+  the `fail` status already maps to its existing exit code.
+- No change to `canonical_md`, retrieval, or any other artifact.
+- C4 (runtime annotation) and the broader C5 governance framework remain open;
+  this is only the L6 export-risk inference lever.
+
+## 7. Test Coverage
+
+`merger/lenskit/tests/test_agent_export_gate.py` (C2.5 block):
+
+1. Legacy `post_emit_health` without `forbidden_inferences` stays `pass`.
+2. A harmless free-string `forbidden_inferences` does not block.
+3. Each of the four export-risk inferences in `post_emit_health` fails an
+   agent-facing export (parametrized).
+4. A `forbidden_inferences` on an in-bundle diagnostic manifest artifact also
+   fails the export.
+5. A non-agent-facing profile (`human_review`) is **not** blocked by a forbidden
+   inference.
+6. `forbidden_inferences` on a non-`diagnostic_signal` artifact is ignored
+   (no overreach).
+7. A diagnostic path escaping the bundle is rejected and its boundary is not
+   read (security posture).
+8. The export-risk `fail` report still validates against `agent-export-gate.v1`.
+
+Existing A5 / C2.1 / C2.3 gate tests remain green.
+
+## 8. Verification Commands
+
+```bash
+python -m pytest -q \
+  merger/lenskit/tests/test_agent_export_gate.py \
+  merger/lenskit/tests/test_contract_inference_boundaries.py \
+  merger/lenskit/tests/test_anti_hallucination_lint.py
+
+python -m ruff check \
+  merger/lenskit/core/agent_export_gate.py \
+  merger/lenskit/tests/test_agent_export_gate.py \
+  --select=F401,F811,F841,E711,E712
+
+git diff --check
+```
+
+## 9. Results (local run)
+
+- Targeted trio: **107 passed**
+  (`test_agent_export_gate.py` 47, including 11 new C2.5 cases).
+- `ruff --select=F401,F811,F841,E711,E712`: clean.
+- `git diff --check`: clean.
+- Regression (`test_post_emit_health.py`, `test_context_quality.py`,
+  `test_retrieval_eval.py`, `test_contract_version_guards.py`,
+  `test_jsonschema_degradation.py`, `test_cli_bundle_health.py`): **97 passed**,
+  no regressions.
+- Python: 3.11.15 (local). CI runs 3.12.

--- a/docs/roadmap/lenskit-master-roadmap.md
+++ b/docs/roadmap/lenskit-master-roadmap.md
@@ -201,9 +201,9 @@ Scope: additive, optionale, **const** Felder `authority` (`diagnostic_signal`) u
 Mögliche Folgearbeiten (separate PRs, nicht Teil von C1, C2a oder C2.1):
 - C2.2: `bundle-manifest.v1`-Normierung (per-role `risk_class`, `output_health`-Authority-Zweig) — **UMGESETZT** (siehe C2.2-Abschnitt unten)
 - C2.3: `allowed_inferences`/`forbidden_inferences` als optionale Schema-Felder — **UMGESETZT** (contract-only/test-only; siehe C2.3-Abschnitt unten)
-- C3 / C2.4: Anti-Hallucination-Contract-Lint (kontraktstatischer L3+L5-Teil) — **UMGESETZT** (siehe C2.4-Abschnitt unten). Die AST-/codepfadbasierten Regeln L1/L2/L4 und der Export-Gate-Teil L6 bleiben **offen**.
+- C3 / C2.4: Anti-Hallucination-Contract-Lint (kontraktstatischer L3+L5-Teil) — **UMGESETZT** (siehe C2.4-Abschnitt unten). Die AST-/codepfadbasierten Regeln L1/L2/L4 bleiben **offen**.
 - C4: Runtime-Annotation — **offen**
-- C5: Export-Gate-Integration (inkl. L6) — **offen**
+- C2.5 / C5: Export-Gate-Integration für L6-Export-Risk-Inferenzen — **MINIMAL UMGESETZT** (siehe C2.5-Abschnitt unten). Das breitere C5-Governance-Framework bleibt **offen**.
 
 ### C2.2 — Additive per-role Risk-Class + output_health-Authority im Bundle-Manifest (umgesetzt)
 
@@ -273,8 +273,9 @@ Contracts: `post-emit-health.v1`, `agent-export-gate.v1`, `retrieval-eval.v1` un
   `bundle-manifest.v1`; keine neuen `authority-matrix.v1`- oder `inference-boundary.v1`-
   Contracts.
 - C2.4/C3 (kontraktstatischer Lint) ist mit dem nächsten Abschnitt **UMGESETZT**;
-  die AST-Regeln (L1/L2/L4) und C2.5/C5 (Export-Gate inkl. L6) sowie C4
-  (Runtime-Annotation) bleiben **offen**.
+  C2.5/C5 (Export-Gate, L6-Export-Risk-Inferenzen) ist **minimal umgesetzt**
+  (siehe C2.5-Abschnitt). Die AST-Regeln (L1/L2/L4) und C4 (Runtime-Annotation)
+  bleiben **offen**.
 
 ### C2.4 — Anti-Hallucination-Contract-Lint (kontraktstatischer L3+L5-Teil, umgesetzt)
 
@@ -309,7 +310,8 @@ Contract-Migration zu erzwingen.
 - **STOP / Out of Scope (dokumentiert, nicht implementiert):**
   - **L1/L2/L4** erfordern Python-**AST-/Codepfad**-Analyse (hohe False-Positive-Fläche
     laut Blueprint §6) → spätere AST-Lint-Stufe.
-  - **L6** (Export-Risk) = Export-Gate-Integration = **C5**.
+  - **L6** (Export-Risk) = Export-Gate-Integration = **C5** (inzwischen minimal
+    umgesetzt für die Export-Risk-Inferenzen: siehe C2.5-Abschnitt).
   - Die Out-of-Scope-Regeln werden maschinenlesbar im Report (`rules_out_of_scope`)
     geführt.
 - **Deferral-Registry (getrackt, nicht-blockierend):** genau
@@ -326,6 +328,45 @@ Contract-Migration zu erzwingen.
   `test_anti_hallucination_lint.py` 32 passed; Regression
   (contracts/health/quality/eval/cli) ohne Regression; ruff
   `F401,F811,F841,E711,E712` sauber.
+
+### C2.5 — Export-Gate liest L6-Export-Risk-Inferenzen (minimal umgesetzt)
+
+Status: **MINIMAL UMGESETZT** (additive Gate-Härtung, keine Contract-Änderung),
+Beleg `docs/proofs/authority-risk-class-c2-5-export-gate-proof.md`.
+Scope: der **Export-Gate-Teil** der C1-Regel **L6**, den C2.4 ausdrücklich nach
+C5 verschoben hat. Das bestehende `agent_export_gate` (A5) wird **minimal
+gehärtet**, nicht ersetzt: es liest jetzt das optionale C2.3-Feld
+`forbidden_inferences` aus den Diagnoseartefakten des Bundles.
+
+- Geänderte/ergänzte Dateien:
+  - `merger/lenskit/core/agent_export_gate.py` (additives Lesen + Gate-Bedingung)
+  - `merger/lenskit/tests/test_agent_export_gate.py` (C2.5-Tests)
+  - `docs/proofs/authority-risk-class-c2-5-export-gate-proof.md`
+- Regel (blockierend, **nur agent-facing**): Wenn ein Diagnoseartefakt im Bundle
+  maschinenlesbar eine Inferenz aus dem geschlossenen Export-Risk-Vokabular
+  verbietet, wird ein **agent-facing** Export auf `fail` herabgestuft (bzw. bleibt
+  `blocked`) und ein Fehler benennt die Inferenz. Nicht-agent-facing Profile
+  werden weiterhin getrennt geprüft und sind **nicht** export-risk-gegated.
+- Export-Risk-Vokabular (klein, geschlossen, exakt; spiegelt
+  `context_quality.DOES_NOT_MEAN`): `claims_true`, `repo_understood`,
+  `answer_safe_without_citations`, `retrieval_complete`. Freie C2.3-Strings
+  außerhalb dieses Vokabulars blockieren **nicht**.
+- Lesefläche: Manifest-Artefakte mit `authority == diagnostic_signal` (sicher via
+  `resolve_secure_path`, bundle-intern) plus das bereits geladene
+  `post_emit_health`-Dokument. Kein Lesen außerhalb des Bundles.
+- **STOP / bewusst nicht enthalten:** **kein** neuer Contract, **keine**
+  Runtime-Annotation, **keine** Producer-Emission von `forbidden_inferences`,
+  **keine** Wahrheitsermittlung, **keine** Manifest-Mutation, **keine** Änderung
+  an `canonical_md` oder am Retrieval. Report-Form unverändert (Grund in
+  bestehendem `errors`-Array → weiterhin schema-valide gegen
+  `agent-export-gate.v1`). Die `evaluate_agent_export_gate`-Signatur bleibt
+  gleich; die `bundle-health export-gate`-CLI ist unverändert. C4
+  (Runtime-Annotation) und das breitere C5-Governance-Framework bleiben **offen**.
+- Validierung: Zieltrio (`test_agent_export_gate.py`,
+  `test_contract_inference_boundaries.py`, `test_anti_hallucination_lint.py`) →
+  **107 passed** (`test_agent_export_gate.py` 47, davon 11 neue C2.5-Fälle);
+  Regression (health/quality/eval/contract-guards/cli) 97 passed, keine
+  Regression; ruff `F401,F811,F841,E711,E712` sauber; `git diff --check` sauber.
 
 ## Paralleltrack Atlas
 - Atlas = physische Wahrnehmung / Filesystem-Snapshot

--- a/merger/lenskit/core/agent_export_gate.py
+++ b/merger/lenskit/core/agent_export_gate.py
@@ -62,6 +62,23 @@ _DOES_NOT_MEAN = [
     "claims_true",
 ]
 
+# C2.5 / C5 minimal (anti-hallucination matrix §6 L6): export-risk inference
+# vocabulary. A diagnostic artifact may machine-readably forbid an inference via
+# the optional C2.3 ``forbidden_inferences`` field. If a bundle's diagnostics
+# forbid one of these high-risk inferences, an agent-facing export must not look
+# clean: an agent could otherwise read the bundle as establishing claim truth,
+# repository understanding, citation-free answer safety, or retrieval
+# completeness. This is an export-eligibility boundary, not a truth verdict, and
+# it mirrors the context_quality DOES_NOT_MEAN vocabulary.
+_EXPORT_RISK_FORBIDDEN_INFERENCES = frozenset(
+    {
+        "claims_true",
+        "repo_understood",
+        "answer_safe_without_citations",
+        "retrieval_complete",
+    }
+)
+
 
 def _now_iso() -> str:
     ts = now_utc()
@@ -128,6 +145,56 @@ def _find_output_health_verdict(manifest: Dict[str, Any], manifest_dir: Path) ->
     if isinstance(verdict, str):
         return verdict
     return None
+
+
+def _doc_forbidden_inferences(doc: Dict[str, Any]) -> set[str]:
+    """Return the optional C2.3 ``forbidden_inferences`` strings of a diagnostic doc."""
+    values = doc.get("forbidden_inferences")
+    if not isinstance(values, list):
+        return set()
+    return {v for v in values if isinstance(v, str)}
+
+
+def _collect_forbidden_inferences(
+    manifest: Dict[str, Any],
+    manifest_dir: Path,
+    post_doc: Optional[Dict[str, Any]],
+) -> set[str]:
+    """Collect ``forbidden_inferences`` declared by in-bundle diagnostic artifacts.
+
+    Sources:
+    - manifest artifacts that self-declare ``authority == diagnostic_signal``,
+      resolved securely within the bundle directory, and
+    - the already-loaded ``post_emit_health`` document.
+
+    Reads only the optional C2.3 ``forbidden_inferences`` field. It performs no
+    truth evaluation, mutates nothing, and silently skips artifacts that cannot
+    be securely resolved or read as JSON objects.
+    """
+    found: set[str] = set()
+
+    artifacts = manifest.get("artifacts")
+    if isinstance(artifacts, list):
+        for art in artifacts:
+            if not isinstance(art, dict):
+                continue
+            if art.get("authority") != "diagnostic_signal":
+                continue
+            rel_path = art.get("path")
+            if not isinstance(rel_path, str) or not rel_path:
+                continue
+            try:
+                art_path = resolve_secure_path(manifest_dir, rel_path)
+            except ValueError:
+                continue
+            doc, _ = _load_json(art_path)
+            if isinstance(doc, dict):
+                found |= _doc_forbidden_inferences(doc)
+
+    if isinstance(post_doc, dict):
+        found |= _doc_forbidden_inferences(post_doc)
+
+    return found
 
 
 def _validate_post_health_schema(post_doc: Dict[str, Any]) -> Optional[str]:
@@ -340,6 +407,22 @@ def evaluate_agent_export_gate(
         warnings.append(
             "output_health.verdict=pass observed but not sufficient for export gate"
         )
+
+    # C2.5 / C5 (L6) minimal: honor explicit export-risk inference boundaries.
+    # Only agent-facing export is constrained here; non-agent-facing results are
+    # checked separately above and never certify the agent surface anyway, so the
+    # diagnostic boundaries are read only when they can actually gate the export.
+    if agent_facing:
+        blocking_inferences = sorted(
+            _collect_forbidden_inferences(manifest, manifest_dir, post_doc)
+            & _EXPORT_RISK_FORBIDDEN_INFERENCES
+        )
+        if blocking_inferences:
+            status = "fail" if status != "blocked" else status
+            errors.append(
+                "agent-facing export blocked by forbidden inference(s): "
+                + ", ".join(blocking_inferences)
+            )
 
     return {
         "kind": KIND,

--- a/merger/lenskit/core/agent_export_gate.py
+++ b/merger/lenskit/core/agent_export_gate.py
@@ -185,9 +185,9 @@ def _collect_forbidden_inferences(
                 continue
             try:
                 art_path = resolve_secure_path(manifest_dir, rel_path)
-            except ValueError:
+                doc, _ = _load_json(art_path)
+            except (ValueError, UnicodeDecodeError):
                 continue
-            doc, _ = _load_json(art_path)
             if isinstance(doc, dict):
                 found |= _doc_forbidden_inferences(doc)
 

--- a/merger/lenskit/tests/test_agent_export_gate.py
+++ b/merger/lenskit/tests/test_agent_export_gate.py
@@ -88,7 +88,11 @@ def _write_manifest(
 
 
 def _write_post_health(
-    tmp_path: Path, status: str, *, observed_output_health: str | None = "pass"
+    tmp_path: Path,
+    status: str,
+    *,
+    observed_output_health: str | None = "pass",
+    forbidden_inferences: list[str] | None = None,
 ) -> Path:
     report = {
         "kind": "lenskit.post_emit_health",
@@ -109,9 +113,44 @@ def _write_post_health(
     }
     if observed_output_health is not None:
         report["output_health_verdict"] = observed_output_health
+    if forbidden_inferences is not None:
+        report["forbidden_inferences"] = list(forbidden_inferences)
     path = tmp_path / "demo.bundle_health.post.json"
     path.write_text(json.dumps(report, indent=2), encoding="utf-8")
     return path
+
+
+def _attach_diagnostic_artifact(
+    manifest_path: Path,
+    tmp_path: Path,
+    *,
+    forbidden_inferences: list[str],
+    filename: str = "demo.retrieval_eval.json",
+    authority: str = "diagnostic_signal",
+) -> None:
+    """Append an in-bundle diagnostic artifact carrying forbidden_inferences."""
+    doc = {
+        "metrics": {"total_queries": 0, "hits": 0, "stale_flag": False},
+        "details": [],
+        "forbidden_inferences": list(forbidden_inferences),
+    }
+    blob = json.dumps(doc, indent=2).encode("utf-8")
+    (tmp_path / filename).write_bytes(blob)
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["artifacts"].append(
+        {
+            "role": "retrieval_eval_json",
+            "path": filename,
+            "content_type": "application/json",
+            "bytes": len(blob),
+            "sha256": _sha256(blob),
+            "authority": authority,
+            "canonicality": "diagnostic",
+            "interpretation": {"mode": "role_only"},
+        }
+    )
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
 
 
 def test_agent_facing_pass_when_post_emit_pass_and_redaction_true(tmp_path):
@@ -595,3 +634,174 @@ def test_agent_export_gate_does_not_mutate_manifest(tmp_path):
 
     after = manifest.read_text(encoding="utf-8")
     assert after == before
+
+
+# ---------------------------------------------------------------------------
+# C2.5 / C5 (L6): export-risk inference boundaries
+# ---------------------------------------------------------------------------
+
+_BLOCKING_INFERENCES = [
+    "claims_true",
+    "repo_understood",
+    "answer_safe_without_citations",
+    "retrieval_complete",
+]
+
+
+def test_c2_5_legacy_post_health_without_forbidden_inferences_passes(tmp_path):
+    """Legacy documents that never declare forbidden_inferences stay clean."""
+    manifest = _write_manifest(tmp_path, redaction=True)
+    _write_post_health(tmp_path, "pass", forbidden_inferences=None)
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    assert report["status"] == "pass"
+    assert not any("forbidden inference" in e for e in report["errors"])
+
+
+def test_c2_5_harmless_forbidden_inference_does_not_block(tmp_path):
+    """A free-string forbidden inference outside the export-risk vocabulary is harmless."""
+    manifest = _write_manifest(tmp_path, redaction=True)
+    _write_post_health(
+        tmp_path,
+        "pass",
+        forbidden_inferences=["does_not_establish_claim_truth", "use_only_as_signal"],
+    )
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    assert report["status"] == "pass"
+    assert not any("forbidden inference" in e for e in report["errors"])
+
+
+@pytest.mark.parametrize("inference", _BLOCKING_INFERENCES)
+def test_c2_5_blocking_inference_in_post_health_fails_agent_export(tmp_path, inference):
+    """An export-risk inference forbidden by a diagnostic blocks agent-facing export."""
+    manifest = _write_manifest(tmp_path, redaction=True)
+    _write_post_health(tmp_path, "pass", forbidden_inferences=[inference])
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    assert report["status"] == "fail"
+    assert report["agent_facing"] is True
+    assert any(
+        "forbidden inference" in e and inference in e for e in report["errors"]
+    )
+
+
+def test_c2_5_blocking_inference_in_manifest_diagnostic_fails_agent_export(tmp_path):
+    """forbidden_inferences on an in-bundle diagnostic artifact also blocks export."""
+    manifest = _write_manifest(tmp_path, redaction=True)
+    _write_post_health(tmp_path, "pass")
+    _attach_diagnostic_artifact(
+        manifest, tmp_path, forbidden_inferences=["retrieval_complete"]
+    )
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    assert report["status"] == "fail"
+    assert any("retrieval_complete" in e for e in report["errors"])
+
+
+def test_c2_5_non_agent_facing_not_blocked_by_forbidden_inference(tmp_path):
+    """Non-agent-facing profiles are evaluated separately and are not export-risk gated."""
+    manifest = _write_manifest(tmp_path, redaction=False)
+    _attach_diagnostic_artifact(
+        manifest, tmp_path, forbidden_inferences=["claims_true"]
+    )
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="human_review",
+        require_redaction=True,
+    )
+
+    assert report["status"] == "pass"
+    assert report["agent_facing"] is False
+    assert not any("forbidden inference" in e for e in report["errors"])
+
+
+def test_c2_5_non_diagnostic_authority_forbidden_inference_is_ignored(tmp_path):
+    """forbidden_inferences are only read from diagnostic_signal artifacts (no overreach)."""
+    manifest = _write_manifest(tmp_path, redaction=True)
+    _write_post_health(tmp_path, "pass")
+    _attach_diagnostic_artifact(
+        manifest,
+        tmp_path,
+        forbidden_inferences=["claims_true"],
+        authority="navigation_index",
+    )
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    assert report["status"] == "pass"
+    assert not any("forbidden inference" in e for e in report["errors"])
+
+
+def test_c2_5_out_of_bundle_diagnostic_forbidden_inference_not_read(tmp_path):
+    """A diagnostic path escaping the bundle is rejected, so its boundary is not read."""
+    outside_doc = {"forbidden_inferences": ["claims_true"]}
+    outside_blob = json.dumps(outside_doc, indent=2).encode("utf-8")
+    (tmp_path.parent / "outside.retrieval_eval.json").write_bytes(outside_blob)
+
+    manifest_path = _write_manifest(tmp_path, redaction=True)
+    _write_post_health(tmp_path, "pass")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["artifacts"].append(
+        {
+            "role": "retrieval_eval_json",
+            "path": "../outside.retrieval_eval.json",
+            "content_type": "application/json",
+            "bytes": len(outside_blob),
+            "sha256": _sha256(outside_blob),
+            "authority": "diagnostic_signal",
+            "canonicality": "diagnostic",
+            "interpretation": {"mode": "role_only"},
+        }
+    )
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest_path),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    assert report["status"] == "pass"
+    assert not any("forbidden inference" in e for e in report["errors"])
+
+
+def test_c2_5_blocked_report_validates_against_schema(tmp_path):
+    """The export-risk failure path still emits a schema-valid gate report."""
+    manifest = _write_manifest(tmp_path, redaction=True)
+    _write_post_health(tmp_path, "pass", forbidden_inferences=["claims_true"])
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    assert report["status"] == "fail"
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.validate(instance=report, schema=schema)

--- a/merger/lenskit/tests/test_agent_export_gate.py
+++ b/merger/lenskit/tests/test_agent_export_gate.py
@@ -758,6 +758,40 @@ def test_c2_5_non_diagnostic_authority_forbidden_inference_is_ignored(tmp_path):
     assert not any("forbidden inference" in e for e in report["errors"])
 
 
+def test_c2_5_invalid_utf8_diagnostic_artifact_is_skipped(tmp_path):
+    """A corrupt diagnostic artifact must not abort export-gate certification."""
+    manifest = _write_manifest(tmp_path, redaction=True)
+    _write_post_health(tmp_path, "pass")
+
+    bad_path = tmp_path / "bad.retrieval_eval.json"
+    bad_blob = b"\xff\xfe\x00not-valid-utf8"
+    bad_path.write_bytes(bad_blob)
+
+    manifest_doc = json.loads(manifest.read_text(encoding="utf-8"))
+    manifest_doc["artifacts"].append(
+        {
+            "role": "retrieval_eval_json",
+            "path": bad_path.name,
+            "content_type": "application/json",
+            "bytes": len(bad_blob),
+            "sha256": _sha256(bad_blob),
+            "authority": "diagnostic_signal",
+            "canonicality": "diagnostic",
+            "interpretation": {"mode": "role_only"},
+        }
+    )
+    manifest.write_text(json.dumps(manifest_doc, indent=2), encoding="utf-8")
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    assert report["status"] == "pass"
+    assert not any("forbidden inference" in e for e in report["errors"])
+
+
 def test_c2_5_out_of_bundle_diagnostic_forbidden_inference_not_read(tmp_path):
     """A diagnostic path escaping the bundle is rejected, so its boundary is not read."""
     outside_doc = {"forbidden_inferences": ["claims_true"]}


### PR DESCRIPTION
## Summary

This PR implements C2.5, a minimal hardening of the agent export gate to honor explicit export-risk inference boundaries declared in bundle diagnostics. The gate now reads the optional C2.3 `forbidden_inferences` field from in-bundle diagnostic artifacts and refuses to certify an agent-facing export when a diagnostic forbids a high-risk inference from the export-risk vocabulary.

This is an **additive, non-breaking change** that adds no new contract, no runtime annotation, and no producer emission — only gate-side read logic.

## Key Changes

- **`merger/lenskit/core/agent_export_gate.py`**
  - Added `_EXPORT_RISK_FORBIDDEN_INFERENCES`: a closed, minimal vocabulary (`claims_true`, `repo_understood`, `answer_safe_without_citations`, `retrieval_complete`) that mirrors `context_quality.DOES_NOT_MEAN`
  - Added `_doc_forbidden_inferences()`: extracts the optional C2.3 `forbidden_inferences` field from a diagnostic document
  - Added `_collect_forbidden_inferences()`: securely reads `forbidden_inferences` from manifest artifacts with `authority == diagnostic_signal` (using `resolve_secure_path` to prevent bundle escape) and from the already-loaded `post_emit_health` document
    - Robustly handles both `ValueError` (path traversal) and `UnicodeDecodeError` (invalid UTF-8), silently skipping artifacts that cannot be read
  - Modified `evaluate_agent_export_gate()`: for agent-facing exports, downgrades status to `fail` if any blocking inference is found, appending an error message naming the offending inference(s)

- **`merger/lenskit/tests/test_agent_export_gate.py`**
  - Added `_write_post_health()` parameter `forbidden_inferences` to support test scenarios
  - Added `_attach_diagnostic_artifact()`: helper to create in-bundle diagnostic artifacts with `forbidden_inferences` for testing
  - Added 9 new test cases covering:
    - Legacy documents without `forbidden_inferences` remain `pass`
    - Harmless free-string `forbidden_inferences` do not block
    - Each of the four export-risk inferences blocks agent-facing export (parametrized)
    - In-bundle diagnostic artifacts also trigger the block
    - Non-agent-facing profiles are not export-risk gated
    - Non-`diagnostic_signal` artifacts are ignored (no overreach)
    - Out-of-bundle diagnostic paths are rejected (security posture)
    - Invalid UTF-8 diagnostic artifacts are gracefully skipped without aborting certification
    - Export-risk `fail` reports validate against schema

- **`docs/proofs/authority-risk-class-c2-5-export-gate-proof.md`** (new)
  - Formal proof document covering scope, rule semantics, vocabulary, read surface, fail vs. blocked semantics, non-changes, test coverage, and verification commands

- **`docs/roadmap/lenskit-master-roadmap.md`**
  - Updated C2.5 / C5 status from "open" to "minimally implemented"
  - Clarified that L6 export-risk is now handled; broader C5 governance framework remains open

## Implementation Details

- **Export-risk vocabulary is closed and exact**: only the four strings in `_EXPORT_RISK_FORBIDDEN_INFERENCES` block export; any other free-string `forbidden_inferences` are honored as C2.3 boundary notes but do not gate
- **Agent-facing only**: non-agent-facing profiles (`human_review`, etc.) are evaluated on a separate path and are never export-risk gated
- **Secure path resolution**: diagnostic artifacts are read only if their path resolves securely within the bundle directory; paths escaping the bundle are silently skipped
- **Robust artifact parsing**: corrupt diagnostic artifacts (non-UTF-8, invalid JSON) are silently skipped rather than aborting certification, ensuring resilience to malformed in-bundle artifacts
- **No mutation**: the gate reads boundaries but does not write them; the manifest and all artifacts remain unchanged
- **Schema-compatible**: the report shape is unchanged; errors are surfaced in the existing `errors` array, so the report still validates against `agent-export-gate.v1` without schema changes
- **Fail vs. blocked semantics**: a forbidden inference maps to `fail` (a defect found during certification), not `blocked` (certification could not complete); an existing `blocked` status is not overridden

## Testing

All 9 new test cases pass, covering legacy compatibility, blocking logic, security boundaries, and robustness to malformed artifacts.