### PR TITLE
Add doc-freshness verifier: machine-readable binding of docs to code evidence

### DIFF
--- a/.github/workflows/doc-freshness.yml
+++ b/.github/workflows/doc-freshness.yml
@@ -4,9 +4,9 @@ name: Doc-Freshness (diagnostic v0)
 # (TODOs, roadmap/spec statements) to verifiable code/test/proof evidence via
 # docs/doc-freshness-registry.yml and surfaces drift, without (yet) blocking.
 # Follows the artifact-drift-matrix rollout rule (diagnose before blocking):
-# only the test suite is blocking; `inspect` and the generated-view staleness
-# check are surfaced via continue-on-error. Promotion to a blocking
-# `inspect --strict` gate is the documented next slice
+# only unit/schema tests are blocking; inspect, generated-view staleness,
+# and live-registry verification are surfaced via continue-on-error.
+# Promotion to a blocking `inspect --strict` gate is the documented next slice
 # (docs/proofs/doc-freshness-registry-v0-proof.md §7).
 
 on:
@@ -66,14 +66,6 @@ jobs:
         continue-on-error: true
         run: python -m merger.lenskit.cli.main doc-freshness inspect
 
-      - name: Generated view in sync (diagnostic, non-blocking)
-        # docs/_generated/doc-freshness.md must match a fresh regeneration from
-        # the registry. Non-blocking for v0; promotion to blocking is planned.
-        continue-on-error: true
-        run: |
-          python -m merger.lenskit.cli.main doc-freshness update --write
-          git diff --exit-code docs/_generated/doc-freshness.md
-
       - name: Doc-freshness unit/schema tests (blocking)
         run: pytest -q merger/lenskit/tests/test_doc_freshness.py -m "not doc_freshness_live"
 
@@ -85,3 +77,14 @@ jobs:
         # next slice (docs/proofs/doc-freshness-registry-v0-proof.md §7).
         continue-on-error: true
         run: pytest -q merger/lenskit/tests/test_doc_freshness.py -m doc_freshness_live
+
+      - name: Generated view in sync (diagnostic, non-blocking)
+        # docs/_generated/doc-freshness.md must match a fresh regeneration from
+        # the registry. Non-blocking for v0; promotion to blocking is planned.
+        # Note: doc-freshness update --write can mutate docs/doc-freshness-registry.yml
+        # (by stamping last_verified), so we run this after live registry tests and
+        # check both files.
+        continue-on-error: true
+        run: |
+          python -m merger.lenskit.cli.main doc-freshness update --write
+          git diff --exit-code docs/_generated/doc-freshness.md docs/doc-freshness-registry.yml

--- a/.github/workflows/doc-freshness.yml
+++ b/.github/workflows/doc-freshness.yml
@@ -1,0 +1,74 @@
+name: Doc-Freshness (diagnostic v0)
+
+# Diagnostic, NON-BLOCKING doc-freshness verifier. Couples documentation claims
+# (TODOs, roadmap/spec statements) to verifiable code/test/proof evidence via
+# docs/doc-freshness-registry.yml and surfaces drift, without (yet) blocking.
+# Follows the artifact-drift-matrix rollout rule (diagnose before blocking):
+# only the test suite is blocking; `inspect` and the generated-view staleness
+# check are surfaced via continue-on-error. Promotion to a blocking
+# `inspect --strict` gate is the documented next slice
+# (docs/proofs/doc-freshness-registry-v0-proof.md §7).
+
+on:
+  push:
+    branches: [ "main", "master" ]
+    paths:
+      - "merger/lenskit/core/doc_freshness.py"
+      - "merger/lenskit/cli/cmd_doc_freshness.py"
+      - "merger/lenskit/cli/main.py"
+      - "merger/lenskit/contracts/doc-freshness-registry.v1.schema.json"
+      - "docs/doc-freshness-registry.yml"
+      - "docs/_generated/doc-freshness.md"
+      - "merger/lenskit/tests/test_doc_freshness.py"
+      - "merger/lenskit/requirements.txt"
+      - "requirements-dev.txt"
+      - ".github/workflows/doc-freshness.yml"
+  pull_request:
+    branches: [ "main", "master" ]
+    paths:
+      - "merger/lenskit/core/doc_freshness.py"
+      - "merger/lenskit/cli/cmd_doc_freshness.py"
+      - "merger/lenskit/cli/main.py"
+      - "merger/lenskit/contracts/doc-freshness-registry.v1.schema.json"
+      - "docs/doc-freshness-registry.yml"
+      - "docs/_generated/doc-freshness.md"
+      - "merger/lenskit/tests/test_doc_freshness.py"
+      - "merger/lenskit/requirements.txt"
+      - "requirements-dev.txt"
+      - ".github/workflows/doc-freshness.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  doc-freshness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Dependencies
+        run: |
+          pip install -r merger/lenskit/requirements.txt
+          pip install -r requirements-dev.txt
+
+      - name: Doc-freshness inspect (diagnostic, non-blocking)
+        # Surfaces drift in the run log without failing the build (v0). Exit 1
+        # on findings is expected and tolerated here.
+        continue-on-error: true
+        run: python -m merger.lenskit.cli.main doc-freshness inspect
+
+      - name: Generated view in sync (diagnostic, non-blocking)
+        # docs/_generated/doc-freshness.md must match a fresh regeneration from
+        # the registry. Non-blocking for v0; promotion to blocking is planned.
+        continue-on-error: true
+        run: |
+          python -m merger.lenskit.cli.main doc-freshness update --write
+          git diff --exit-code docs/_generated/doc-freshness.md
+
+      - name: Doc-freshness test suite (blocking)
+        run: pytest -q merger/lenskit/tests/test_doc_freshness.py

--- a/.github/workflows/doc-freshness.yml
+++ b/.github/workflows/doc-freshness.yml
@@ -81,10 +81,8 @@ jobs:
       - name: Generated view in sync (diagnostic, non-blocking)
         # docs/_generated/doc-freshness.md must match a fresh regeneration from
         # the registry. Non-blocking for v0; promotion to blocking is planned.
-        # Note: doc-freshness update --write can mutate docs/doc-freshness-registry.yml
-        # (by stamping last_verified), so we run this after live registry tests and
-        # check both files.
+        # Use --no-stamp to avoid date-based registry mutations during CI sync checks.
         continue-on-error: true
         run: |
-          python -m merger.lenskit.cli.main doc-freshness update --write
+          python -m merger.lenskit.cli.main doc-freshness update --write --no-stamp
           git diff --exit-code docs/_generated/doc-freshness.md docs/doc-freshness-registry.yml

--- a/.github/workflows/doc-freshness.yml
+++ b/.github/workflows/doc-freshness.yml
@@ -23,6 +23,8 @@ on:
       - "merger/lenskit/requirements.txt"
       - "requirements-dev.txt"
       - ".github/workflows/doc-freshness.yml"
+      - "merger/lenskit/repoLens-spec.md"
+      - "docs/**.md"
   pull_request:
     branches: [ "main", "master" ]
     paths:
@@ -36,6 +38,8 @@ on:
       - "merger/lenskit/requirements.txt"
       - "requirements-dev.txt"
       - ".github/workflows/doc-freshness.yml"
+      - "merger/lenskit/repoLens-spec.md"
+      - "docs/**.md"
 
 permissions:
   contents: read
@@ -70,5 +74,14 @@ jobs:
           python -m merger.lenskit.cli.main doc-freshness update --write
           git diff --exit-code docs/_generated/doc-freshness.md
 
-      - name: Doc-freshness test suite (blocking)
-        run: pytest -q merger/lenskit/tests/test_doc_freshness.py
+      - name: Doc-freshness unit/schema tests (blocking)
+        run: pytest -q merger/lenskit/tests/test_doc_freshness.py -m "not doc_freshness_live"
+
+      - name: Live registry verification (diagnostic, non-blocking)
+        # Runs the real-registry tests against the live tree. Non-blocking for
+        # v0: these tests verify the actual checked-in registry against the
+        # actual repo state, so failures are surfaced as drift signals rather
+        # than hard build failures. Promotion to blocking is the documented
+        # next slice (docs/proofs/doc-freshness-registry-v0-proof.md §7).
+        continue-on-error: true
+        run: pytest -q merger/lenskit/tests/test_doc_freshness.py -m doc_freshness_live

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ For repolens-vs-rlens, evidence, or runtime-state changes, read in this order be
 The parity-gate terms `content_parity_pass` and `diagnostic_parity_pass` are backed by a production module (`merger/lenskit/core/parity_gates.py` + `parity_state.py`) and are enforced via the `lenskit parity enforce --require {content,diagnostic}` CLI and the `Parity Gate` CI workflow (`.github/workflows/parity-gate.yml`).
 They are not (yet) a service-runtime gate inside the rLens service; do not describe them as such. The required level is policy/profile-dependent — capability-degraded iOS/Pythonista hosts may require only `content` (see `docs/architecture/artifact-capability-matrix.md`).
 
-Do not modify generated docs (`docs/_generated/*`) or commit local runtime artifacts.
+Do not modify generated docs (`docs/_generated/*`) or commit local runtime artifacts. Changes to generated files are only permitted via the owning generator. For doc-freshness, the generator is: `python -m merger.lenskit.cli.main doc-freshness update --write`
 
 ## rLens CLI Client vs Service Launcher
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,9 @@ PRs gegen `main` müssen u. a. grün sein bei:
 
 ## Was nicht tun
 
-- Generierte Docs (`docs/_generated/*`) nicht editieren.
+- Generierte Docs (`docs/_generated/*`) nicht editieren. Änderungen sind nur
+  über den jeweiligen Generator erlaubt. Für Doc-Freshness lautet der Generator:
+  `python -m merger.lenskit.cli.main doc-freshness update --write`
 - Lokale Runtime-Artefakte nicht committen.
 - Den rLens-**Launcher** (`cli/rlens.py`) nicht still als HTTP-Client
   umdeuten — der CLI-Client ist `cli/cmd_rlens_client.py`.

--- a/docs/_generated/doc-freshness.md
+++ b/docs/_generated/doc-freshness.md
@@ -1,0 +1,18 @@
+# Doc-Freshness Status (generated)
+
+<!-- GENERATED FILE — do not edit by hand. Regenerate with: `python -m merger.lenskit.cli.main doc-freshness update --write`. Source of truth: docs/doc-freshness-registry.yml. -->
+
+- data current as of (max last_verified): 2026-05-31
+- overall: **PASS**
+- entries: 3 | findings: 0 (errors 0, warnings 0) | stale tracked: 0
+
+> Diagnostic signal. A green status does not prove the docs are complete — only that no tracked claim contradicts its declared evidence. See `docs/proofs/doc-freshness-registry-v0-proof.md`.
+
+| ID | Status | Verdict | Doc | Claim | last_verified |
+| :-- | :-- | :-- | :-- | :-- | :-- |
+| `agent-reading-pack-v2-claim-evidence-map` | partial | 🟡 partial | `docs/roadmap/lenskit-master-roadmap.md` | Agent Reading Pack v2 claim_evidence_map is produced (Arbeitspaket F) | 2026-05-31 |
+| `repolens-spec-super-merger-extras` | done | ✅ consistent | `merger/lenskit/repoLens-spec.md` | Super-Merger extras (ExtrasConfig + extras flags) are implemented | 2026-05-31 |
+| `system-map-federation-exists` | done | ✅ consistent | `docs/architecture/system-map.lenskit.md` | Federation modules exist in the source tree | 2026-05-31 |
+
+_No findings: every tracked claim matches its evidence._
+

--- a/docs/architecture/artifact-drift-matrix.md
+++ b/docs/architecture/artifact-drift-matrix.md
@@ -23,6 +23,7 @@ das Inventar listet Artefakte, diese Matrix beschreibt die Übergänge.
 | `context_bundle` | `agent_query_session` | Session verweist auf anderen Kontext | `context_bundle` + `artifact_refs` | `test_agent_session_builder.py` | Session neu erzeugen |
 | `architecture_summary` | architecture graph / `graph_index` | Summary behauptet nicht belegte Kante | Graph Contract / Graph Index, Summary nur Diagnose | Graph-Struktur-Anker: `test_graph_eval.py`, `test_graph_index.py`; dedizierter Summary-vs-Graph-Guard fehlt | Summary regenerieren |
 | PR-Schau JSON | PR-Schau Markdown | JSON meldet vollständig, Markdown fehlt oder ist unvollständig | Markdown Content + Completeness Block | `pr_schau_verify` als Verifier-Pfad; dedizierter Completeness-Test fehlt. `test_pr_schau_consumer_gate.py` prüft nur Consumer-Zugriff | PR-Schau Bundle neu bauen |
+| Doku-Aussage (Spec/Roadmap/TODO) | Code/Test/Proof-Beleg | Doku behauptet anderen Implementierungsstand als der Code (z. B. stale `TODO`, „existiert nicht") | Code/Test/Proof = Beleg; Doku nur Behauptung | `lenskit doc-freshness inspect` + `test_doc_freshness.py` (diagnostisch, nicht-blockierend); Registry `docs/doc-freshness-registry.yml` gegen `doc-freshness-registry.v1.schema.json` | `lenskit doc-freshness update --write` regeneriert `docs/_generated/doc-freshness.md` + stempelt `last_verified` |
 
 ## citation_map_jsonl — geplante Driftkanten (kein Producer vorhanden)
 

--- a/docs/doc-freshness-registry.yml
+++ b/docs/doc-freshness-registry.yml
@@ -1,0 +1,91 @@
+# Doc-Freshness Registry (doc-freshness-registry v1.0)
+#
+# Source-of-truth binding between documentation claims and the verifiable
+# code/test/proof evidence that proves or refutes them. Validated against
+# merger/lenskit/contracts/doc-freshness-registry.v1.schema.json.
+#
+# Verify:    python -m merger.lenskit.cli.main doc-freshness inspect
+# Regenerate the human view + stamp last_verified:
+#            python -m merger.lenskit.cli.main doc-freshness update --write
+#
+# Status values: none | partial | done | stale | historical
+# `historical` docs are never status-checked; `stale` declares a KNOWN, tracked
+# drift (surfaced, not suppressed — mirrors the C2.9 authority-upgrade registry).
+#
+# This file is hand-authored; docs/_generated/doc-freshness.md is generated FROM
+# it (do not hand-edit the generated view).
+
+kind: lenskit.doc_freshness_registry
+version: "1.0"
+authority: diagnostic_signal
+risk_class: diagnostic
+does_not_prove:
+  - "a green verify does not prove the docs are complete or correct, only that no tracked claim contradicts its declared evidence"
+
+entries:
+  # --- Pilot: the drift the reconciliation proof explicitly deferred to a
+  # focused PR (repoLens-spec.md still framed ExtrasConfig as a TODO though it is
+  # implemented at core/merge.py). This PR fixes the spec; the absent_text
+  # evidence asserts the stale TODO heading is gone, the symbol asserts the
+  # implementation exists. ------------------------------------------------------
+  - id: repolens-spec-super-merger-extras
+    doc: merger/lenskit/repoLens-spec.md
+    locator: "section 'Super-Merger / Extras'"
+    claim: "Super-Merger extras (ExtrasConfig + extras flags) are implemented"
+    status: done
+    normative: true
+    owner: repolens-spec
+    last_verified: "2026-05-31"
+    evidence:
+      - kind: symbol
+        target: "merger/lenskit/core/merge.py::ExtrasConfig"
+      - kind: proof
+        target: "docs/proofs/weiterentwicklungsplan-2026-05-reconciliation-proof.md"
+      - kind: absent_text
+        target: "merger/lenskit/repoLens-spec.md::### TODO: Super-Merger / Extras"
+    notes: >-
+      Reconciliation proof §6.1 flagged this exact section as drift
+      (ExtrasConfig at core/merge.py:458, spec still said "umzusetzen") and left
+      the spec edit to a focused PR. The absent_text guard keeps the TODO heading
+      from silently returning.
+
+  # --- A previously-real drift the reconciliation proof already corrected
+  # (system-map claimed federation modules "existieren derzeit nicht"). Tracked
+  # so it cannot regress. ------------------------------------------------------
+  - id: system-map-federation-exists
+    doc: docs/architecture/system-map.lenskit.md
+    locator: "section 'Bekannte Lücken' / Federation"
+    claim: "Federation modules exist in the source tree"
+    status: done
+    normative: false
+    owner: architecture
+    last_verified: "2026-05-31"
+    evidence:
+      - kind: symbol
+        target: "merger/lenskit/core/federation.py::init_federation"
+      - kind: absent_text
+        target: "docs/architecture/system-map.lenskit.md::existieren derzeit nicht im Quellbaum"
+    notes: >-
+      Corrected in the reconciliation PR (proof §6.2). The absent_text guard
+      prevents the stale "do not exist" claim from reappearing.
+
+  # --- A genuinely-open item: demonstrates that declared-`partial` work is NOT
+  # false-flagged even though related v1 symbols exist. ------------------------
+  - id: agent-reading-pack-v2-claim-evidence-map
+    doc: docs/roadmap/lenskit-master-roadmap.md
+    locator: "Phase 5 / Agent Reading Pack v2"
+    claim: "Agent Reading Pack v2 claim_evidence_map is produced (Arbeitspaket F)"
+    status: partial
+    normative: false
+    owner: roadmap
+    last_verified: "2026-05-31"
+    evidence:
+      - kind: symbol
+        target: "merger/lenskit/core/agent_reading_pack.py::produce_agent_reading_pack"
+      - kind: text
+        target: "merger/lenskit/core/agent_reading_pack.py::`claim_evidence_map` is not yet produced"
+        implies: open
+    notes: >-
+      Agent Reading Pack v1 ships; the v2 claim_evidence_map is still open
+      (agent_reading_pack.py marks it "not yet produced"). Declared partial so
+      the verifier tracks it without demanding completion.

--- a/docs/doc-freshness-registry.yml
+++ b/docs/doc-freshness-registry.yml
@@ -39,6 +39,8 @@ entries:
     evidence:
       - kind: symbol
         target: "merger/lenskit/core/merge.py::ExtrasConfig"
+      - kind: symbol
+        target: "merger/lenskit/core/merge.py::_build_extras_meta"
       - kind: proof
         target: "docs/proofs/weiterentwicklungsplan-2026-05-reconciliation-proof.md"
       - kind: absent_text

--- a/docs/proofs/doc-freshness-registry-v0-proof.md
+++ b/docs/proofs/doc-freshness-registry-v0-proof.md
@@ -51,7 +51,7 @@ deklarierte Fälle werden **sichtbar** gemacht, nicht stumm unterdrückt).
 | `merger/lenskit/cli/cmd_doc_freshness.py` | `lenskit doc-freshness inspect` / `update` |
 | `docs/_generated/doc-freshness.md` | **Generierte** Statusansicht (aus der Registry regeneriert, nicht handgepflegt) |
 | `.github/workflows/doc-freshness.yml` | **Nicht-blockierender** Diagnose-Gate + Test-Suite |
-| `merger/lenskit/tests/test_doc_freshness.py` | 27 Tests (synthetische Fixtures + reale Registry) |
+| `merger/lenskit/tests/test_doc_freshness.py` | 29 Tests (synthetische Fixtures + reale Registry) |
 
 ### Evidence-Arten (mechanisch prüfbar)
 
@@ -72,7 +72,10 @@ Pro Eintrag wird `declared status` gegen die verifizierten Belege gestellt:
   deklarierte, reproduzierbare Drift (wie C2.9 `declared_upgrades`).
 - `stale_resolved` (warn) — deklariertes `stale`, aber der Marker ist weg →
   Registry-Eintrag auf `done` heben.
-- `regressed` / `dangling` (error) — zitierter Beleg fehlt / `done` ohne Beleg.
+- `partial_maybe_resolved` (warn) — `partial`-Eintrag mit `open`-Beleg, dessen Marker
+  verschwunden ist (Hinweis: vielleicht ist die Arbeit erledigt, Registry update prüfen).
+- `regressed` / `dangling_doc` (error) — zitierter Beleg fehlt / Registry-Eintrag's
+  Doc-Datei existiert nicht.
 
 ## 3. Pilot: `repoLens-spec.md` Super-Merger / Extras
 
@@ -123,7 +126,7 @@ Zerlegung dessen, was sicher automatisierbar ist:
   stale-Drift).
 - `… doc-freshness update` → idempotent (zweiter Lauf: „up to date"; 0
   last_verified-Änderungen).
-- `pytest -q merger/lenskit/tests/test_doc_freshness.py` → **27 passed**.
+- `pytest -q merger/lenskit/tests/test_doc_freshness.py` → **29 passed**.
 - `ruff check --select=F401,F811,F841,E711,E712` → sauber.
 - Bestehende CLI unberührt: `governance lint` → exit 0.
 

--- a/docs/proofs/doc-freshness-registry-v0-proof.md
+++ b/docs/proofs/doc-freshness-registry-v0-proof.md
@@ -1,0 +1,161 @@
+# Doc-Freshness Registry v0 — Proof
+
+> Erstellt am 2026-05-31.
+> Scope: **diagnostischer** Mechanismus, der Dokumentations-Aussagen (TODOs,
+> Roadmap-/Spec-Behauptungen) maschinell gegen Code-/Test-/Proof-**Belege**
+> koppelt und Drift sichtbar macht. Diagnose-first nach der Rollout-Regel der
+> Artifact-Drift-Matrix: **keine** neue blockierende CI-Stufe.
+
+## 0. Kernbefund (TL;DR)
+
+Lenskit hatte **Drift-Bewusstsein** (Artifact-Drift-Matrix, Two-Layer-Pattern,
+Proof-Pflicht, C2.x-Lints), aber **keine maschinenlesbare Statuskopplung**
+zwischen einer Doku-Aussage und dem Beleg, der sie stützt oder widerlegt. Genau
+diese Lücke war im gemergten Reconciliation-PR sichtbar: `repoLens-spec.md`
+führte einen `### TODO: Super-Merger / Extras`-Block, obwohl `ExtrasConfig` seit
+2026-05 in `core/merge.py:458` implementiert ist (Beleg:
+`weiterentwicklungsplan-2026-05-reconciliation-proof.md` §6.1, dort bewusst „für
+einen eigenen, fokussierten PR" zurückgestellt).
+
+**Dieser PR ist dieser fokussierte PR.** Er schließt den konkreten Drift **und**
+liefert den fehlenden Mechanismus als kleinsten, selbst-beweisenden Slice.
+
+## 1. Negativbefund (vor Implementierung verifiziert)
+
+Vor diesem PR existierte kein Doc-Freshness-Mechanismus:
+
+- `rg` über `docs/**`, `*.md` ergab **genau einen** echten stale `TODO:`-Marker
+  in einer Doku (`merger/lenskit/repoLens-spec.md:53`) — ein reiner
+  „TODO:-Scanner" hätte fast nichts zu prüfen und die eigentliche Driftklasse
+  (semantische Prosa wie „existieren derzeit nicht im Quellbaum") verfehlt.
+- `docs/architecture/artifact-drift-matrix.md` modelliert **Artefakt**-Drift,
+  nicht „Doku behauptet alten Implementierungsstand".
+- `docs/architecture/inconsistencies.md` ist eine **handgepflegte** Audit-Liste,
+  nicht maschinell verifiziert.
+- Kein CLI-Kommando, kein CI-Workflow, kein Schema zu `doc-freshness`,
+  `roadmap-lint`, `last_verified` o. ä. (`ls .github/workflows/`,
+  `cli/`-Scan).
+
+**Schlussfolgerung:** Die richtige Primitive ist **nicht** ein TODO-Text-Scanner,
+sondern eine **Beleg-Bindung** (claim → verifizierbares Artefakt → Status) mit
+einem Verifier — analog zur C2.9-Authority-Upgrade-Registry (Detektion bleibt an,
+deklarierte Fälle werden **sichtbar** gemacht, nicht stumm unterdrückt).
+
+## 2. Was dieser PR hinzufügt
+
+| Datei | Rolle |
+| --- | --- |
+| `merger/lenskit/contracts/doc-freshness-registry.v1.schema.json` | Schema (Draft-7, `additionalProperties:false`) für die Registry |
+| `docs/doc-freshness-registry.yml` | Hand-gepflegte Source-of-Truth: claim → status → evidence |
+| `merger/lenskit/core/doc_freshness.py` | Reiner Verifier (Beleg-Auflösung via `ast`/Text/Datei, Klassifikation, Report, Render, Restamp) |
+| `merger/lenskit/cli/cmd_doc_freshness.py` | `lenskit doc-freshness inspect` / `update` |
+| `docs/_generated/doc-freshness.md` | **Generierte** Statusansicht (aus der Registry regeneriert, nicht handgepflegt) |
+| `.github/workflows/doc-freshness.yml` | **Nicht-blockierender** Diagnose-Gate + Test-Suite |
+| `merger/lenskit/tests/test_doc_freshness.py` | 27 Tests (synthetische Fixtures + reale Registry) |
+
+### Evidence-Arten (mechanisch prüfbar)
+
+`symbol` (`relpath::Name`, AST-Definition in `.py`, sonst Substring), `file`,
+`text` (`relpath::needle` vorhanden), `absent_text` (needle **abwesend**),
+`proof`, `test`. `symbol`/`test`/`proof` implizieren standardmäßig „done".
+
+### Klassifikation (Drift-Logik)
+
+Pro Eintrag wird `declared status` gegen die verifizierten Belege gestellt:
+
+- `consistent` / `partial_ok` / `historical` — kein Finding.
+- `understated` (warn) — Doc sagt `none`, aber Completion-Beleg existiert (die
+  Kern-Driftklasse „Doku hinkt dem Code hinterher").
+- `stale_marker_present` (warn) — Doc sagt `done`, enthält aber noch den
+  TODO-/Alttext (der „Vorher"-Zustand des Piloten).
+- `stale_confirmed` (tracked, **kein** Finding ohne `--strict`) — bewusst
+  deklarierte, reproduzierbare Drift (wie C2.9 `declared_upgrades`).
+- `stale_resolved` (warn) — deklariertes `stale`, aber der Marker ist weg →
+  Registry-Eintrag auf `done` heben.
+- `regressed` / `dangling` (error) — zitierter Beleg fehlt / `done` ohne Beleg.
+
+## 3. Pilot: `repoLens-spec.md` Super-Merger / Extras
+
+**Aktion (der fokussierte Spec-Fix):** Der `### TODO: Super-Merger / Extras`-Block
+wurde zu `### Super-Merger / Extras — implementiert (2026-05)` umgeschrieben, mit
+Status-/Beleghinweis (kein TODO mehr). Inhalt (Extras-Contract) bleibt als
+Dokumentation erhalten.
+
+**Registry-Eintrag** `repolens-spec-super-merger-extras` (`status: done`,
+`normative: true`):
+
+- `symbol merger/lenskit/core/merge.py::ExtrasConfig` → vorhanden,
+- `proof …/weiterentwicklungsplan-2026-05-reconciliation-proof.md` → vorhanden,
+- `absent_text merger/lenskit/repoLens-spec.md::### TODO: Super-Merger / Extras`
+  → erfüllt (Heading ist weg; der Guard verhindert sein stilles Wiederkehren).
+
+**Vorher/Nachher maschinell bewiesen** (`test_verify_pilot_before_and_after`):
+mit TODO-Heading → `stale_marker_present` (warn); ohne → `consistent` (pass).
+
+Zwei weitere reale Einträge belegen das Spektrum ohne False-Positives:
+`system-map-federation-exists` (`done`; früher-realer, bereits korrigierter
+Drift, jetzt gegen Rückfall gesichert) und
+`agent-reading-pack-v2-claim-evidence-map` (`partial`; echt offen — `claim_evidence_map`
+ist laut `agent_reading_pack.py:859` „not yet produced" — wird **nicht**
+fälschlich als done geflaggt).
+
+## 4. „Automatisierte Aktualisierung" — was real automatisiert ist
+
+Das Ziel war eine automatisierte Aktualisierung der Dokumente. Ehrliche
+Zerlegung dessen, was sicher automatisierbar ist:
+
+- **Detektion** des Widerspruchs Status ↔ Beleg: vollautomatisch (✓ umgesetzt).
+- **Verifikation**, dass Belege existieren (Symbol/Datei/Test/Proof): ✓ umgesetzt.
+- **`last_verified`-Stamping** + **Regeneration der `docs/_generated/doc-freshness.md`**
+  aus der verifizierten Registry: ✓ umgesetzt (`update --write`). Die generierte
+  Ansicht ist damit ein **automatisch synchron gehaltenes Dokument**;
+  `generated_at` wird deterministisch aus den Daten abgeleitet (max
+  `last_verified`), damit Regeneration eine reine Funktion der Eingaben ist.
+- **Prosa automatisch umschreiben** (normative Spec-Texte): **bewusst NICHT**.
+  Ohne Mensch/LLM-in-the-loop nicht zuverlässig; die eine reale Prosa-Korrektur
+  (Pilot) wurde manuell und belegt durchgeführt.
+
+## 5. Validierung
+
+- `python -m merger.lenskit.cli.main doc-freshness inspect` → **PASS**
+  (3 Einträge, 0 Findings, exit 0).
+- `… doc-freshness inspect --strict` → **PASS** (kein ungelöster normativer
+  stale-Drift).
+- `… doc-freshness update` → idempotent (zweiter Lauf: „up to date"; 0
+  last_verified-Änderungen).
+- `pytest -q merger/lenskit/tests/test_doc_freshness.py` → **27 passed**.
+- `ruff check --select=F401,F811,F841,E711,E712` → sauber.
+- Bestehende CLI unberührt: `governance lint` → exit 0.
+
+## 6. STOP / bewusst nicht enthalten
+
+- **Keine** blockierende CI (diagnostisch; Promotion pro Eintrag wie die
+  Drift-Matrix). `--strict` ist der vorbereitete Enforcement-Pfad, aber im
+  Workflow nicht scharf geschaltet.
+- **Keine** automatische Prosa-Umschreibung normativer Dokumente.
+- **Keine** Semantik-/LLM-Prüfung „TODO X ist erledigt" — nur deklarierte,
+  mechanisch prüfbare Belege.
+- **Keine** Vollabdeckung aller Docs — v0 verfolgt 3 belegte Einträge; die
+  Registry wächst additiv.
+- **Keine** stumme Suppression: `stale` ist sichtbar (`stale_confirmed`).
+
+## 7. Promotionspfad (spätere Slices)
+
+1. **Diagnose** (dieser PR): Verifier + Registry + generierte Ansicht, warnend.
+2. **Enforcement normativer Specs:** `doc-freshness inspect --strict` im CI
+   blockierend schalten, sobald die Registry stabil läuft (per-Eintrag, nicht
+   global — Blueprints bleiben `historical` und werden nie blockiert).
+3. **Generierte-Ansicht-Staleness als Guard:** `update` + `git diff --exit-code`
+   blockierend, sobald etabliert.
+4. **Breitere Abdeckung:** weitere normative Specs / Master-Roadmap-Aussagen
+   additiv in die Registry aufnehmen.
+
+## 8. Belegt / plausibel / spekulativ
+
+- **Belegt:** Kein Doc-Freshness-Mechanismus existierte; der `repoLens-spec.md`-Drift
+  war real; der Verifier erkennt ihn maschinell (Tests) und der Pilot ist
+  geschlossen (live Registry PASS).
+- **Plausibel:** Beleg-Bindung schlägt einen TODO-Text-Scanner (richtige
+  Primitive, niedrige False-Positive-Fläche, passt zu C2.9/Drift-Matrix).
+- **Spekulativ:** Vollautomatische Semantikprüfung „Feature erledigt" ohne
+  deklarative Evidence-Mapping-Schicht bleibt unzuverlässig — daher nicht gebaut.

--- a/docs/roadmap/lenskit-master-roadmap.md
+++ b/docs/roadmap/lenskit-master-roadmap.md
@@ -551,6 +551,30 @@ Schließt Lücke (1) aus C2.8 §9.
   PackModel`); (2) Hebung marker-gated → inferenzbasiert mit gemessener FP-Rate vor jeder
   CI-Promotion; (3) CI-Promotion erst nach niedriger FP-Rate. C4 bleibt separat offen.
 
+## Track D — Doc-Freshness (Doku ↔ Code Drift)
+
+Dieser Track schließt die Lücke „kein maschinenlesbarer Mechanismus, der
+Roadmap-/TODO-/Spec-Aussagen gegen den realen Code-Stand aktuell hält".
+Unabhängig von A–C; blockiert nichts.
+
+### D1 — Doc-Freshness Registry / Verifier v0 (umgesetzt)
+
+Status: **UMGESETZT** (diagnostisch, nicht-blockierend), Beleg
+`docs/proofs/doc-freshness-registry-v0-proof.md`.
+Scope: declarative Registry (`docs/doc-freshness-registry.yml` gegen
+`contracts/doc-freshness-registry.v1.schema.json`) bindet Doku-Claims an
+verifizierbare Belege (`symbol`/`file`/`text`/`absent_text`/`proof`/`test`);
+`merger/lenskit/core/doc_freshness.py` + CLI `lenskit doc-freshness
+inspect|update` klassifizieren Drift und regenerieren die Ansicht
+`docs/_generated/doc-freshness.md`. Pilot: der `repoLens-spec.md`
+Super-Merger/Extras-Drift (jetzt geschlossen, gegen Rückfall gesichert).
+
+- **Diagnose vor Blocking** (wie Drift-Matrix): warnend, kein scharfer Gate.
+- **Keine** Prosa-Auto-Umschreibung; **keine** LLM-Semantikprüfung; `stale` wird
+  sichtbar getrackt (`stale_confirmed`), nicht stumm unterdrückt (wie C2.9).
+- Nächste Slices: `inspect --strict` für normative Specs blockierend schalten;
+  Generierte-Ansicht-Staleness als Guard; breitere Registry-Abdeckung.
+
 ## Paralleltrack Atlas
 - Atlas = physische Wahrnehmung / Filesystem-Snapshot
 - Lenskit = Knowledge Compiler / Evidence Runtime

--- a/merger/lenskit/cli/cmd_doc_freshness.py
+++ b/merger/lenskit/cli/cmd_doc_freshness.py
@@ -65,6 +65,14 @@ def register_doc_freshness_commands(subparsers) -> None:
         action="store_true",
         help="Persist changes (default is a dry run that prints what would change).",
     )
+    update_parser.add_argument(
+        "--no-stamp",
+        action="store_true",
+        help=(
+            "Regenerate the generated view without updating last_verified "
+            "(useful for deterministic CI sync checks)."
+        ),
+    )
 
 
 def _add_common_args(parser: argparse.ArgumentParser) -> None:
@@ -152,19 +160,19 @@ def run_doc_freshness_update(args: argparse.Namespace) -> int:
         return 2
 
     report = verify(data, repo_root, strict=False)
+    stamp = not bool(getattr(args, "no_stamp", False))
     today = date.today().isoformat()
 
     # Stamp last_verified for entries whose state is OK (never for findings).
     ok_ids = verified_entry_ids(report)
     registry_text = registry_path.read_text(encoding="utf-8")
-    new_registry_text, changed_ids = restamp_last_verified(
-        registry_text, {eid: today for eid in ok_ids}
-    )
+    stamp_updates = {eid: today for eid in ok_ids} if stamp else {}
+    new_registry_text, changed_ids = restamp_last_verified(registry_text, stamp_updates)
     registry_changed = new_registry_text != registry_text
 
     # Regenerate the human-readable view from the verified registry. Use the
     # restamped data so the view's last_verified column is consistent.
-    stamped_data = _restamp_data(data, ok_ids, today)
+    stamped_data = _restamp_data(data, ok_ids, today) if stamp else data
     # Deterministic "generated_at": derived from the data (max last_verified),
     # NOT wall-clock, so regeneration is a pure function of the registry + tree
     # and a CI "regenerate & git-diff" check does not flap across days.
@@ -179,6 +187,8 @@ def run_doc_freshness_update(args: argparse.Namespace) -> int:
     print(f"doc-freshness update — status: {report.status.upper()}")
     print(f"  verified entries (stampable): {len(ok_ids)}")
     print(f"  registry last_verified to change: {len(changed_ids)} {changed_ids or ''}")
+    if not stamp:
+        print("  stamping disabled (--no-stamp)")
     print(f"  generated view: {'WOULD CHANGE' if view_changed else 'up to date'} ({view_path})")
     if report.findings:
         print(

--- a/merger/lenskit/cli/cmd_doc_freshness.py
+++ b/merger/lenskit/cli/cmd_doc_freshness.py
@@ -1,0 +1,249 @@
+"""CLI: ``lenskit doc-freshness`` — diagnostic doc-freshness verifier (v0).
+
+Subcommands:
+
+* ``inspect`` — verify the registry against the live tree and report drift.
+  Exit 0 on pass, 1 on findings (warn/fail), 2 on a load/validation error.
+  ``--strict`` escalates a confirmed stale drift in a *normative* doc to a
+  failure (the per-entry enforcement promotion path).
+* ``update`` — regenerate the human-readable view (``docs/_generated/
+  doc-freshness.md``) and stamp ``last_verified`` for entries that verify.
+  ``--write`` persists; without it, the command is a dry run.
+
+Diagnostic-first: this is intentionally not wired as a blocking CI gate yet
+(mirrors the artifact-drift-matrix rollout rule and the experimental AST lint).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+
+def register_doc_freshness_commands(subparsers) -> None:
+    df_parser = subparsers.add_parser(
+        "doc-freshness",
+        help=(
+            "Verify documentation claims against code/test/proof evidence "
+            "(diagnostic; detects stale TODOs / roadmap drift)"
+        ),
+    )
+    df_subparsers = df_parser.add_subparsers(
+        dest="doc_freshness_cmd", required=True, help="Doc-freshness commands"
+    )
+
+    inspect_parser = df_subparsers.add_parser(
+        "inspect",
+        help="Verify the registry and report drift (exit 1 on findings).",
+    )
+    _add_common_args(inspect_parser)
+    inspect_parser.add_argument(
+        "--strict",
+        action="store_true",
+        help=(
+            "Escalate a confirmed stale drift in a normative doc to a failure "
+            "(enforcement promotion path; default is diagnostic/tracked)."
+        ),
+    )
+    inspect_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="emit_json",
+        help="Emit the machine-readable JSON report to stdout.",
+    )
+
+    update_parser = df_subparsers.add_parser(
+        "update",
+        help=(
+            "Regenerate the generated view and stamp last_verified for verified "
+            "entries (--write to persist)."
+        ),
+    )
+    _add_common_args(update_parser)
+    update_parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Persist changes (default is a dry run that prints what would change).",
+    )
+
+
+def _add_common_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--registry",
+        dest="registry",
+        default=None,
+        help="Path to the doc-freshness registry YAML (default: docs/doc-freshness-registry.yml).",
+    )
+    parser.add_argument(
+        "--repo-root",
+        dest="repo_root",
+        default=None,
+        help="Repo root used to resolve evidence (default: inferred from the package).",
+    )
+
+
+def _load_and_validate(args):
+    """Return ``(data, repo_root, registry_path)`` or raise ValueError/OSError."""
+    from pathlib import Path
+
+    from merger.lenskit.core.doc_freshness import (
+        default_registry_path,
+        default_schema_path,
+        load_registry,
+        repo_root_from_here,
+        validate_registry,
+    )
+
+    repo_root = (
+        Path(args.repo_root).resolve() if args.repo_root else repo_root_from_here()
+    )
+    registry_path = (
+        Path(args.registry).resolve()
+        if args.registry
+        else default_registry_path(repo_root)
+    )
+    if not registry_path.is_file():
+        raise OSError(f"registry not found: {registry_path}")
+
+    data = load_registry(registry_path)
+    schema_errors = validate_registry(data, default_schema_path(repo_root))
+    if schema_errors:
+        raise ValueError(
+            "registry violates doc-freshness-registry.v1 schema: "
+            + "; ".join(schema_errors)
+        )
+    return data, repo_root, registry_path
+
+
+def run_doc_freshness_inspect(args: argparse.Namespace) -> int:
+    from merger.lenskit.core.doc_freshness import verify
+
+    try:
+        data, repo_root, _ = _load_and_validate(args)
+    except (ValueError, OSError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    report = verify(data, repo_root, strict=getattr(args, "strict", False))
+
+    if getattr(args, "emit_json", False):
+        print(json.dumps(report.to_dict(), indent=2))
+    else:
+        _print_human_report(report)
+
+    return 0 if report.status == "pass" else 1
+
+
+def run_doc_freshness_update(args: argparse.Namespace) -> int:
+    from datetime import date
+
+    from merger.lenskit.core.doc_freshness import (
+        default_generated_view_path,
+        render_markdown,
+        restamp_last_verified,
+        verified_entry_ids,
+        verify,
+    )
+
+    try:
+        data, repo_root, registry_path = _load_and_validate(args)
+    except (ValueError, OSError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    report = verify(data, repo_root, strict=False)
+    today = date.today().isoformat()
+
+    # Stamp last_verified for entries whose state is OK (never for findings).
+    ok_ids = verified_entry_ids(report)
+    registry_text = registry_path.read_text(encoding="utf-8")
+    new_registry_text, changed_ids = restamp_last_verified(
+        registry_text, {eid: today for eid in ok_ids}
+    )
+    registry_changed = new_registry_text != registry_text
+
+    # Regenerate the human-readable view from the verified registry. Use the
+    # restamped data so the view's last_verified column is consistent.
+    stamped_data = _restamp_data(data, ok_ids, today)
+    # Deterministic "generated_at": derived from the data (max last_verified),
+    # NOT wall-clock, so regeneration is a pure function of the registry + tree
+    # and a CI "regenerate & git-diff" check does not flap across days.
+    generated_at = _max_last_verified(stamped_data)
+    view_text = render_markdown(stamped_data, report, generated_at) + "\n"
+    view_path = default_generated_view_path(repo_root)
+    view_changed = (
+        not view_path.is_file()
+        or view_path.read_text(encoding="utf-8") != view_text
+    )
+
+    print(f"doc-freshness update — status: {report.status.upper()}")
+    print(f"  verified entries (stampable): {len(ok_ids)}")
+    print(f"  registry last_verified to change: {len(changed_ids)} {changed_ids or ''}")
+    print(f"  generated view: {'WOULD CHANGE' if view_changed else 'up to date'} ({view_path})")
+    if report.findings:
+        print(
+            f"  NOTE: {len(report.findings)} finding(s) NOT stamped "
+            "(their declared state is contradicted by evidence)."
+        )
+
+    if not getattr(args, "write", False):
+        print("\n(dry run — pass --write to persist)")
+        return 0
+
+    if registry_changed:
+        registry_path.write_text(new_registry_text, encoding="utf-8")
+        print(f"  wrote {registry_path}")
+    if view_changed:
+        view_path.parent.mkdir(parents=True, exist_ok=True)
+        view_path.write_text(view_text, encoding="utf-8")
+        print(f"  wrote {view_path}")
+    if not registry_changed and not view_changed:
+        print("  nothing to write (already current)")
+    return 0
+
+
+def _max_last_verified(data: dict) -> str:
+    dates = [
+        e.get("last_verified")
+        for e in data.get("entries", [])
+        if e.get("last_verified")
+    ]
+    return max(dates) if dates else "—"
+
+
+def _restamp_data(data: dict, ok_ids, today: str) -> dict:
+    import copy
+
+    clone = copy.deepcopy(data)
+    ok = set(ok_ids)
+    for entry in clone.get("entries", []):
+        if entry.get("id") in ok:
+            entry["last_verified"] = today
+    return clone
+
+
+def _print_human_report(report) -> None:
+    print(f"Doc-Freshness (diagnostic v0): {report.status.upper()}")
+    print(f"  entries_scanned:  {report.entries_scanned}")
+    print(f"  findings:         {len(report.findings)} (errors {report.error_count}, warnings {report.warning_count})")
+    print(f"  stale (tracked):  {len(report.stale_confirmed)}")
+
+    findings = report.findings
+    if findings:
+        print(f"\nFindings ({len(findings)}):")
+        for r in sorted(findings, key=lambda x: (x.severity, x.entry_id)):
+            print(f"  [{r.severity}] {r.entry_id} ({r.classification}) — {r.doc}")
+            print(f"        {r.message}")
+
+    if report.stale_confirmed:
+        print(f"\nKnown drift, declared & tracked (NOT suppressed) ({len(report.stale_confirmed)}):")
+        for r in report.stale_confirmed:
+            print(f"  [{r.declared_status}] {r.entry_id} — {r.doc}")
+            print(f"        {r.message}")
+
+    print(
+        "\n  NOTE: diagnostic verifier — a pass does NOT prove the docs are "
+        "complete or correct, only that no tracked claim contradicts its "
+        "declared evidence. Not a blocking CI gate (use --strict to preview "
+        "normative-doc enforcement)."
+    )

--- a/merger/lenskit/cli/main.py
+++ b/merger/lenskit/cli/main.py
@@ -46,6 +46,10 @@ def main(args: Optional[List[str]] = None) -> int:
     from .cmd_governance import register_governance_commands
     register_governance_commands(subparsers)
 
+    # Doc-freshness command (diagnostic: docs-vs-code drift)
+    from .cmd_doc_freshness import register_doc_freshness_commands
+    register_doc_freshness_commands(subparsers)
+
     # rLens client command
     from .cmd_rlens_client import register_rlens_client_commands
     register_rlens_client_commands(subparsers)
@@ -219,6 +223,18 @@ def main(args: Optional[List[str]] = None) -> int:
             return run_governance_ast_lint(parsed_args)
         else:
             parser.parse_args(["governance", "--help"])
+            return 0
+    elif parsed_args.command == "doc-freshness":
+        from .cmd_doc_freshness import (
+            run_doc_freshness_inspect,
+            run_doc_freshness_update,
+        )
+        if parsed_args.doc_freshness_cmd == "inspect":
+            return run_doc_freshness_inspect(parsed_args)
+        elif parsed_args.doc_freshness_cmd == "update":
+            return run_doc_freshness_update(parsed_args)
+        else:
+            parser.parse_args(["doc-freshness", "--help"])
             return 0
     elif parsed_args.command == "artifact":
         from . import cmd_artifact

--- a/merger/lenskit/contracts/doc-freshness-registry.v1.schema.json
+++ b/merger/lenskit/contracts/doc-freshness-registry.v1.schema.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://heimgewebe.local/schema/doc-freshness-registry.v1.schema.json",
+  "title": "Doc-Freshness Registry (doc-freshness-registry v1.0)",
+  "description": "Machine-readable binding between documentation claims (TODOs, roadmap/spec/blueprint statements) and verifiable code/test/proof evidence. The registry is the source-of-truth layer; the verifier (lenskit doc-freshness) checks whether each declared status still matches the code reality and flags contradictions (drift). This artifact is itself a diagnostic_signal: a clean run does not prove the documentation is complete or correct, only that no declared claim contradicts its declared evidence.",
+  "type": "object",
+  "required": ["kind", "version", "entries"],
+  "properties": {
+    "kind": {
+      "type": "string",
+      "const": "lenskit.doc_freshness_registry"
+    },
+    "version": {
+      "type": "string",
+      "const": "1.0"
+    },
+    "authority": {
+      "type": "string",
+      "const": "diagnostic_signal",
+      "description": "Optional, const. The registry and its verifier report are diagnostic signals, never canonical content authority."
+    },
+    "risk_class": {
+      "type": "string",
+      "const": "diagnostic"
+    },
+    "does_not_prove": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Optional machine-readable inference boundary (L3-style). A green verify does not prove docs are complete/correct, only that declared claims do not contradict declared evidence."
+    },
+    "entries": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/entry" }
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "entry": {
+      "type": "object",
+      "required": ["id", "doc", "claim", "status", "owner", "last_verified", "evidence"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9-]*$",
+          "description": "Stable, unique slug for this tracked claim."
+        },
+        "doc": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Repo-relative path of the document that carries the claim."
+        },
+        "locator": {
+          "type": "string",
+          "description": "Optional human pointer (heading/anchor/section) to the claim inside the doc."
+        },
+        "claim": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Short statement of what the doc asserts (e.g. 'ExtrasConfig / Super-Merger extras implemented')."
+        },
+        "status": {
+          "type": "string",
+          "enum": ["none", "partial", "done", "stale", "historical"],
+          "description": "Declared status of the claim in the doc. none=not started, partial=v1 done/rest open, done=implemented and the doc reflects it, stale=known drift (doc still presents it as open though it is done), historical=explanatory/archival, not status-checked."
+        },
+        "normative": {
+          "type": "boolean",
+          "description": "True when the carrying doc is normative (spec, master-roadmap, contracts-matrix). Normative + stale is the class an enforcement promotion would block first; historical docs are never blocked.",
+          "default": false
+        },
+        "owner": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Who is accountable for keeping this claim fresh (doc/area owner, not necessarily a person)."
+        },
+        "last_verified": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+          "description": "ISO date this entry was last machine-verified. `doc-freshness update --write` stamps this for entries whose evidence verifies."
+        },
+        "evidence": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/evidence" }
+        },
+        "notes": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "evidence": {
+      "type": "object",
+      "required": ["kind", "target"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["symbol", "file", "text", "absent_text", "proof", "test"],
+          "description": "symbol: 'relpath::Name' defined (AST for .py, substring otherwise). file: path exists. text: 'relpath::needle' substring present. absent_text: 'relpath::needle' substring absent. proof: docs/proofs path exists. test: 'relpath[::test_name]' exists."
+        },
+        "target": {
+          "type": "string",
+          "minLength": 1
+        },
+        "implies": {
+          "type": "string",
+          "enum": ["done", "open"],
+          "description": "Optional. What the *presence* of this evidence implies about implementation state. symbol/test/proof default to 'done'; text/absent_text default to 'none' (no implication) unless set. 'done' evidence present while status is none triggers an understated-drift finding."
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/merger/lenskit/core/doc_freshness.py
+++ b/merger/lenskit/core/doc_freshness.py
@@ -507,7 +507,6 @@ def verify(data: dict, repo_root: Path, strict: bool = False) -> DocFreshnessRep
                 evidence=[],
             )
             report.results.append(dangling_result)
-            report.findings.append(dangling_result)
             report.entries_scanned += 1
             continue
 

--- a/merger/lenskit/core/doc_freshness.py
+++ b/merger/lenskit/core/doc_freshness.py
@@ -247,6 +247,15 @@ def _present_open_markers(results: Iterable[EvidenceResult]) -> list[EvidenceRes
     ]
 
 
+def _missing_open_markers(results: Iterable[EvidenceResult]) -> list[EvidenceResult]:
+    """text refs declared ``implies: open`` that are NOT present (open marker gone)."""
+    return [
+        r
+        for r in results
+        if r.ref.kind == "text" and r.ref.effective_implies == "open" and not r.satisfied
+    ]
+
+
 def _hard_dangling(results: Iterable[EvidenceResult]) -> list[EvidenceResult]:
     """symbol/file/proof/test refs that are not satisfied (cited but absent)."""
     return [
@@ -291,6 +300,15 @@ def classify_entry(
                 "error",
                 "partial claim cites evidence that no longer exists: "
                 + "; ".join(d.detail for d in dangling),
+            )
+        missing_open = _missing_open_markers(results)
+        if missing_open:
+            return (
+                "partial_maybe_resolved",
+                "warning",
+                "partial claim's open marker(s) are gone; implementation may be "
+                "complete — either promote to done, mark stale, or verify: "
+                + "; ".join(m.detail for m in missing_open),
             )
         return "partial_ok", "ok", "partial (mixed state asserted by owner)"
 
@@ -472,6 +490,27 @@ def verify(data: dict, repo_root: Path, strict: bool = False) -> DocFreshnessRep
     """Verify every registry entry against the live tree."""
     report = DocFreshnessReport(strict=strict)
     for entry in data.get("entries", []):
+        doc_path_rel = entry.get("doc", "")
+        doc_path = repo_root / doc_path_rel
+
+        # Check if the document exists; if not, short-circuit to dangling_doc error.
+        if not doc_path.is_file():
+            dangling_result = EntryResult(
+                entry_id=entry.get("id", "<no-id>"),
+                doc=doc_path_rel,
+                claim=entry.get("claim", ""),
+                declared_status=entry.get("status", ""),
+                normative=bool(entry.get("normative", False)),
+                classification="dangling_doc",
+                severity="error",
+                message=f"registry entry's doc does not exist: {doc_path_rel}",
+                evidence=[],
+            )
+            report.results.append(dangling_result)
+            report.findings.append(dangling_result)
+            report.entries_scanned += 1
+            continue
+
         refs = _entry_to_refs(entry)
         results = [resolve_evidence(ref, repo_root) for ref in refs]
         classification, severity, message = classify_entry(
@@ -499,12 +538,14 @@ def verify(data: dict, repo_root: Path, strict: bool = False) -> DocFreshnessRep
 _STATUS_BADGE = {
     "consistent": "✅ consistent",
     "partial_ok": "🟡 partial",
+    "partial_maybe_resolved": "🟡 partial (maybe resolved)",
     "historical": "📜 historical",
     "stale_confirmed": "⚠️ stale (tracked)",
     "stale_marker_present": "⚠️ stale marker",
     "stale_resolved": "🔧 stale resolved",
     "understated": "⬆️ understated",
     "regressed": "❌ regressed",
+    "dangling_doc": "❌ dangling doc",
 }
 
 

--- a/merger/lenskit/core/doc_freshness.py
+++ b/merger/lenskit/core/doc_freshness.py
@@ -1,0 +1,619 @@
+"""Doc-Freshness Verifier — diagnostic v0.
+
+Lenskit already has *drift awareness* (the artifact-drift-matrix, the two-layer
+artifact pattern, proof obligations, the C2.x governance lints). What it lacked
+is a machine-readable coupling between a **documentation claim** (a TODO, a
+roadmap/spec statement) and the **code/test/proof evidence** that proves or
+refutes it. Without that binding, "keep the docs current" stays a discipline
+question; a spec can keep a ``### TODO`` block for a feature that is already
+implemented (the ``ExtrasConfig`` case in ``repoLens-spec.md``) and nothing
+notices.
+
+This module closes the loop the diagnostic way the repo prefers:
+
+* A declarative registry (``docs/doc-freshness-registry.yml``, validated against
+  ``contracts/doc-freshness-registry.v1.schema.json``) binds each tracked claim
+  to its ``status`` and a list of *verifiable* ``evidence`` refs
+  (symbol/file/text/absent_text/proof/test).
+* :func:`verify` resolves every evidence ref against the live tree and
+  classifies each entry, flagging the cases where the declared status
+  *contradicts* the code reality (the drift).
+* :func:`render_markdown` regenerates a human-readable status view
+  (``docs/_generated/doc-freshness.md``) from the verified registry — a document
+  that is *automatically kept in sync*, rather than hand-maintained.
+* :func:`restamp_last_verified` stamps the machine-readable ``last_verified``
+  metadata for entries that verify, surgically (it never rewrites prose).
+
+Mirrors C2.9's stance: a ``stale`` entry is a *known, declared* drift (like a
+``declared_upgrade``) — surfaced and tracked, not silently suppressed, and not
+auto-rewritten. Detection stays on; the registry only records reviewed intent.
+
+**Out of scope (honest boundary).** This verifier does NOT rewrite normative
+prose, does NOT judge whether a feature is *correct* (only whether the declared
+status contradicts declared, mechanically checkable evidence), and introduces no
+blocking CI gate (diagnostic-first; promotion is per-entry, like the drift
+matrix). A green run does not prove the documentation is complete.
+"""
+from __future__ import annotations
+
+import ast
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Optional
+
+# ``kind`` of evidence whose *presence* implies the work is implemented ("done").
+_DONE_KINDS = frozenset({"symbol", "test", "proof"})
+
+# Classifications that are NOT findings: the declared status matches reality, or
+# is an explicitly tracked/declared state (stale_confirmed mirrors C2.9
+# declared_upgrades — known and visible, not a warning).
+_OK_CLASSIFICATIONS = frozenset(
+    {"consistent", "partial_ok", "historical", "stale_confirmed"}
+)
+
+# Per-classification severity for findings.
+_SEVERITY = {
+    "regressed": "error",
+    "dangling": "error",
+    "understated": "warning",
+    "stale_marker_present": "warning",
+    "stale_resolved": "warning",
+}
+
+
+def repo_root_from_here() -> Path:
+    """Best-effort repo root: ``merger/lenskit/core/doc_freshness.py`` → root."""
+    return Path(__file__).resolve().parents[3]
+
+
+# --- Evidence resolution ----------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EvidenceRef:
+    """One declared, mechanically checkable evidence pointer."""
+
+    kind: str
+    target: str
+    implies: Optional[str] = None
+
+    @property
+    def effective_implies(self) -> Optional[str]:
+        if self.implies is not None:
+            return self.implies
+        return "done" if self.kind in _DONE_KINDS else None
+
+    def to_dict(self) -> dict:
+        return {"kind": self.kind, "target": self.target, "implies": self.implies}
+
+
+@dataclass(frozen=True)
+class EvidenceResult:
+    ref: EvidenceRef
+    satisfied: bool
+    detail: str
+
+    def to_dict(self) -> dict:
+        return {
+            "kind": self.ref.kind,
+            "target": self.ref.target,
+            "implies": self.ref.effective_implies,
+            "satisfied": self.satisfied,
+            "detail": self.detail,
+        }
+
+
+def _split_target(target: str) -> tuple[str, Optional[str]]:
+    """Split ``relpath::needle`` into ``(relpath, needle)`` (needle optional)."""
+    if "::" in target:
+        path, _, needle = target.partition("::")
+        return path.strip(), needle
+    return target.strip(), None
+
+
+def _python_defines(source: str, name: str) -> bool:
+    """Whether ``name`` (last dotted segment) is defined anywhere in ``source``."""
+    wanted = name.split(".")[-1]
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        # Fall back to a substring probe rather than crashing on unparsable code.
+        return wanted in source
+    for node in ast.walk(tree):
+        if isinstance(
+            node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+        ):
+            if node.name == wanted:
+                return True
+        elif isinstance(node, ast.Assign):
+            for tgt in node.targets:
+                if isinstance(tgt, ast.Name) and tgt.id == wanted:
+                    return True
+        elif isinstance(node, ast.AnnAssign):
+            if isinstance(node.target, ast.Name) and node.target.id == wanted:
+                return True
+    return False
+
+
+def resolve_evidence(ref: EvidenceRef, repo_root: Path) -> EvidenceResult:
+    """Resolve a single evidence ref against the live tree.
+
+    ``satisfied`` means *the declared condition holds* (e.g. for ``absent_text``
+    it means the forbidden needle is genuinely absent).
+    """
+    rel, needle = _split_target(ref.target)
+    path = (repo_root / rel).resolve()
+
+    if ref.kind in ("file", "proof"):
+        ok = path.is_file()
+        return EvidenceResult(ref, ok, f"{'found' if ok else 'MISSING'}: {rel}")
+
+    if ref.kind == "test":
+        if not path.is_file():
+            return EvidenceResult(ref, False, f"MISSING test file: {rel}")
+        if needle:
+            text = _read(path)
+            ok = f"def {needle}" in text
+            return EvidenceResult(
+                ref, ok, f"{'found' if ok else 'MISSING'} test {needle} in {rel}"
+            )
+        return EvidenceResult(ref, True, f"found test file: {rel}")
+
+    if ref.kind == "symbol":
+        if needle is None:
+            return EvidenceResult(ref, False, f"symbol ref needs '::Name': {ref.target}")
+        if not path.is_file():
+            return EvidenceResult(ref, False, f"MISSING file for symbol: {rel}")
+        text = _read(path)
+        if rel.endswith(".py"):
+            ok = _python_defines(text, needle)
+        else:
+            ok = needle in text
+        return EvidenceResult(
+            ref, ok, f"symbol {needle} {'defined' if ok else 'NOT defined'} in {rel}"
+        )
+
+    if ref.kind in ("text", "absent_text"):
+        if needle is None:
+            return EvidenceResult(ref, False, f"{ref.kind} ref needs '::needle'")
+        if not path.is_file():
+            # A text claim about a missing file cannot hold; absent_text trivially holds.
+            present = False
+            detail = f"file MISSING: {rel}"
+        else:
+            present = needle in _read(path)
+            detail = f"needle {'present' if present else 'absent'} in {rel}"
+        satisfied = present if ref.kind == "text" else (not present)
+        return EvidenceResult(ref, satisfied, detail)
+
+    return EvidenceResult(ref, False, f"unknown evidence kind: {ref.kind}")
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+# --- Entry classification ---------------------------------------------------
+
+
+@dataclass
+class EntryResult:
+    entry_id: str
+    doc: str
+    claim: str
+    declared_status: str
+    normative: bool
+    classification: str
+    severity: str  # "ok" | "warning" | "error"
+    message: str
+    evidence: list[EvidenceResult] = field(default_factory=list)
+
+    @property
+    def is_finding(self) -> bool:
+        return self.classification not in _OK_CLASSIFICATIONS
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.entry_id,
+            "doc": self.doc,
+            "claim": self.claim,
+            "declared_status": self.declared_status,
+            "normative": self.normative,
+            "classification": self.classification,
+            "severity": self.severity,
+            "message": self.message,
+            "evidence": [e.to_dict() for e in self.evidence],
+        }
+
+
+def _has_present_done_evidence(results: Iterable[EvidenceResult]) -> bool:
+    return any(
+        r.satisfied and r.ref.effective_implies == "done" for r in results
+    )
+
+
+def _missing_done_evidence(results: Iterable[EvidenceResult]) -> list[EvidenceResult]:
+    return [
+        r for r in results if r.ref.effective_implies == "done" and not r.satisfied
+    ]
+
+
+def _unsatisfied_markers(results: Iterable[EvidenceResult]) -> list[EvidenceResult]:
+    """absent_text refs whose forbidden needle is still present (stale marker)."""
+    return [r for r in results if r.ref.kind == "absent_text" and not r.satisfied]
+
+
+def _present_open_markers(results: Iterable[EvidenceResult]) -> list[EvidenceResult]:
+    """text refs declared ``implies: open`` that are present (stale marker present)."""
+    return [
+        r
+        for r in results
+        if r.ref.kind == "text" and r.ref.effective_implies == "open" and r.satisfied
+    ]
+
+
+def _hard_dangling(results: Iterable[EvidenceResult]) -> list[EvidenceResult]:
+    """symbol/file/proof/test refs that are not satisfied (cited but absent)."""
+    return [
+        r
+        for r in results
+        if r.ref.kind in ("symbol", "file", "proof", "test") and not r.satisfied
+    ]
+
+
+def classify_entry(
+    status: str, results: list[EvidenceResult]
+) -> tuple[str, str, str]:
+    """Return ``(classification, severity, message)`` for one entry.
+
+    The core drift detection: does the *declared status* contradict the
+    *mechanically verified evidence*?
+    """
+    dangling = _hard_dangling(results)
+    stale_markers = _unsatisfied_markers(results) + _present_open_markers(results)
+    done_present = _has_present_done_evidence(results)
+
+    if status == "historical":
+        # Archival/explanatory: owner-declared, not status-checked.
+        return "historical", "ok", "historical (not status-checked)"
+
+    if status == "none":
+        if done_present:
+            return (
+                "understated",
+                "warning",
+                "doc presents this as not-started, but completion evidence exists "
+                "(code/test/proof present) — likely drift; update the doc/status.",
+            )
+        return "consistent", "ok", "no completion evidence; matches 'none'"
+
+    if status == "partial":
+        # Owner-asserted mixed state (v1 done / rest open). Never auto-flag as
+        # under/overstated; only a vanished hard evidence ref is a real problem.
+        if dangling:
+            return (
+                "regressed",
+                "error",
+                "partial claim cites evidence that no longer exists: "
+                + "; ".join(d.detail for d in dangling),
+            )
+        return "partial_ok", "ok", "partial (mixed state asserted by owner)"
+
+    if status == "done":
+        if dangling:
+            return (
+                "regressed",
+                "error",
+                "doc claims done, but cited evidence is missing: "
+                + "; ".join(d.detail for d in dangling),
+            )
+        if stale_markers:
+            return (
+                "stale_marker_present",
+                "warning",
+                "doc claims done, but still literally contains the stale/TODO "
+                "marker: " + "; ".join(m.detail for m in stale_markers),
+            )
+        return "consistent", "ok", "done and evidence verified"
+
+    if status == "stale":
+        # A known, *declared* drift (mirrors C2.9 declared_upgrades). Valid only
+        # while it still reproduces: it IS done AND the doc still shows it open.
+        reproduces = done_present and bool(stale_markers)
+        if reproduces:
+            return (
+                "stale_confirmed",
+                "ok",
+                "KNOWN drift (declared stale): implemented in code, but the doc "
+                "still presents it as open — tracked, not yet fixed.",
+            )
+        if not done_present:
+            return (
+                "regressed",
+                "error",
+                "declared stale, but no completion evidence — the premise (it is "
+                "actually done) no longer holds; re-check the entry.",
+            )
+        # done_present and no stale marker → the drift is gone.
+        return (
+            "stale_resolved",
+            "warning",
+            "declared stale, but the stale/TODO marker is gone — drift resolved; "
+            "promote this entry to status: done (or remove it).",
+        )
+
+    return "unknown_status", "error", f"unknown status: {status!r}"
+
+
+# --- Report -----------------------------------------------------------------
+
+
+@dataclass
+class DocFreshnessReport:
+    entries_scanned: int = 0
+    results: list[EntryResult] = field(default_factory=list)
+    strict: bool = False
+
+    @property
+    def findings(self) -> list[EntryResult]:
+        out = [r for r in self.results if r.is_finding]
+        if self.strict:
+            # Promotion path: under --strict, a confirmed stale drift in a
+            # normative doc is no longer merely "tracked" — it fails.
+            out += [
+                r
+                for r in self.results
+                if r.classification == "stale_confirmed" and r.normative
+            ]
+        return out
+
+    @property
+    def stale_confirmed(self) -> list[EntryResult]:
+        return [r for r in self.results if r.classification == "stale_confirmed"]
+
+    @property
+    def error_count(self) -> int:
+        return sum(1 for r in self.findings if r.severity == "error")
+
+    @property
+    def warning_count(self) -> int:
+        return sum(1 for r in self.findings if r.severity == "warning")
+
+    @property
+    def status(self) -> str:
+        if not self.findings:
+            return "pass"
+        if self.error_count:
+            return "fail"
+        # Enforcement: a KNOWN drift in a normative doc is a hard fail under
+        # --strict (severity-"ok" stale_confirmed is otherwise only tracked).
+        if self.strict and any(
+            r.classification == "stale_confirmed" and r.normative
+            for r in self.results
+        ):
+            return "fail"
+        return "warn"
+
+    def to_dict(self) -> dict:
+        return {
+            "kind": "lenskit.doc_freshness_report",
+            "version": "1.0",
+            "authority": "diagnostic_signal",
+            "risk_class": "diagnostic",
+            "blocking": False,
+            "strict": self.strict,
+            "status": self.status,
+            "entries_scanned": self.entries_scanned,
+            "finding_count": len(self.findings),
+            "error_count": self.error_count,
+            "warning_count": self.warning_count,
+            "stale_confirmed_count": len(self.stale_confirmed),
+            "does_not_prove": [
+                "a green run does not prove the documentation is complete or "
+                "correct, only that no declared claim contradicts its declared "
+                "evidence",
+                "this report is a diagnostic_signal, not canonical content",
+            ],
+            "results": [r.to_dict() for r in self.results],
+        }
+
+
+# --- Registry loading / validation ------------------------------------------
+
+
+def default_registry_path(repo_root: Path) -> Path:
+    return repo_root / "docs" / "doc-freshness-registry.yml"
+
+
+def default_schema_path(repo_root: Path) -> Path:
+    return (
+        repo_root
+        / "merger"
+        / "lenskit"
+        / "contracts"
+        / "doc-freshness-registry.v1.schema.json"
+    )
+
+
+def default_generated_view_path(repo_root: Path) -> Path:
+    return repo_root / "docs" / "_generated" / "doc-freshness.md"
+
+
+def load_registry(path: Path) -> dict:
+    import yaml
+
+    text = path.read_text(encoding="utf-8")
+    data = yaml.safe_load(text)
+    if not isinstance(data, dict):
+        raise ValueError(f"registry must be a YAML mapping: {path}")
+    return data
+
+
+def validate_registry(data: dict, schema_path: Path) -> list[str]:
+    """Return schema-validation errors (empty == valid)."""
+    import jsonschema
+
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    validator = jsonschema.Draft7Validator(schema)
+    errors = []
+    for err in sorted(validator.iter_errors(data), key=lambda e: list(e.path)):
+        loc = ".".join(str(p) for p in err.path) or "<root>"
+        errors.append(f"[{loc}] {err.message}")
+    return errors
+
+
+def _entry_to_refs(entry: dict) -> list[EvidenceRef]:
+    return [
+        EvidenceRef(
+            kind=e["kind"], target=e["target"], implies=e.get("implies")
+        )
+        for e in entry.get("evidence", [])
+    ]
+
+
+def verify(data: dict, repo_root: Path, strict: bool = False) -> DocFreshnessReport:
+    """Verify every registry entry against the live tree."""
+    report = DocFreshnessReport(strict=strict)
+    for entry in data.get("entries", []):
+        refs = _entry_to_refs(entry)
+        results = [resolve_evidence(ref, repo_root) for ref in refs]
+        classification, severity, message = classify_entry(
+            entry.get("status", ""), results
+        )
+        report.results.append(
+            EntryResult(
+                entry_id=entry.get("id", "<no-id>"),
+                doc=entry.get("doc", ""),
+                claim=entry.get("claim", ""),
+                declared_status=entry.get("status", ""),
+                normative=bool(entry.get("normative", False)),
+                classification=classification,
+                severity=severity,
+                message=message,
+                evidence=results,
+            )
+        )
+        report.entries_scanned += 1
+    return report
+
+
+# --- Generated view (automated document update) -----------------------------
+
+_STATUS_BADGE = {
+    "consistent": "✅ consistent",
+    "partial_ok": "🟡 partial",
+    "historical": "📜 historical",
+    "stale_confirmed": "⚠️ stale (tracked)",
+    "stale_marker_present": "⚠️ stale marker",
+    "stale_resolved": "🔧 stale resolved",
+    "understated": "⬆️ understated",
+    "regressed": "❌ regressed",
+}
+
+
+def render_markdown(
+    data: dict, report: DocFreshnessReport, generated_at: str
+) -> str:
+    """Render the human-readable generated view from a verified registry.
+
+    This is the *automatically maintained* document: it is regenerated from the
+    registry by ``doc-freshness update --write`` and checked in CI, so it never
+    drifts from the source-of-truth registry.
+    """
+    by_id = {e.get("id"): e for e in data.get("entries", [])}
+    lines: list[str] = []
+    lines.append("# Doc-Freshness Status (generated)")
+    lines.append("")
+    lines.append(
+        "<!-- GENERATED FILE — do not edit by hand. Regenerate with: "
+        "`python -m merger.lenskit.cli.main doc-freshness update --write`. "
+        "Source of truth: docs/doc-freshness-registry.yml. -->"
+    )
+    lines.append("")
+    lines.append(f"- data current as of (max last_verified): {generated_at}")
+    lines.append(f"- overall: **{report.status.upper()}**")
+    lines.append(
+        f"- entries: {report.entries_scanned} | findings: "
+        f"{len(report.findings)} (errors {report.error_count}, "
+        f"warnings {report.warning_count}) | stale tracked: "
+        f"{len(report.stale_confirmed)}"
+    )
+    lines.append("")
+    lines.append(
+        "> Diagnostic signal. A green status does not prove the docs are "
+        "complete — only that no tracked claim contradicts its declared "
+        "evidence. See `docs/proofs/doc-freshness-registry-v0-proof.md`."
+    )
+    lines.append("")
+    lines.append("| ID | Status | Verdict | Doc | Claim | last_verified |")
+    lines.append("| :-- | :-- | :-- | :-- | :-- | :-- |")
+    for r in sorted(report.results, key=lambda x: x.entry_id):
+        entry = by_id.get(r.entry_id, {})
+        last_verified = entry.get("last_verified", "—")
+        badge = _STATUS_BADGE.get(r.classification, r.classification)
+        claim = r.claim.replace("|", "\\|")
+        lines.append(
+            f"| `{r.entry_id}` | {r.declared_status} | {badge} | "
+            f"`{r.doc}` | {claim} | {last_verified} |"
+        )
+    lines.append("")
+
+    findings = report.findings
+    if findings:
+        lines.append("## Findings")
+        lines.append("")
+        for r in sorted(findings, key=lambda x: (x.severity, x.entry_id)):
+            lines.append(f"- **[{r.severity}] `{r.entry_id}`** ({r.classification}): {r.message}")
+        lines.append("")
+    else:
+        lines.append("_No findings: every tracked claim matches its evidence._")
+        lines.append("")
+    return "\n".join(lines)
+
+
+# --- last_verified stamping (surgical; never touches prose) ------------------
+
+
+def restamp_last_verified(
+    registry_text: str, updates: dict[str, str]
+) -> tuple[str, list[str]]:
+    """Surgically replace ``last_verified:`` values per entry id in raw YAML.
+
+    Operates on the raw text (preserves comments, order, formatting). ``updates``
+    maps entry id → ISO date. Returns ``(new_text, changed_ids)``.
+    """
+    import re
+
+    id_re = re.compile(r"^\s*-?\s*id:\s*(['\"]?)([A-Za-z0-9][A-Za-z0-9-]*)\1\s*$")
+    lv_re = re.compile(r"^(?P<indent>\s*)last_verified:\s*.*$")
+
+    out_lines: list[str] = []
+    current_id: Optional[str] = None
+    changed: list[str] = []
+    for line in registry_text.splitlines():
+        id_match = id_re.match(line)
+        if id_match:
+            current_id = id_match.group(2)
+            out_lines.append(line)
+            continue
+        lv_match = lv_re.match(line)
+        if lv_match and current_id in updates:
+            new_date = updates[current_id]
+            new_line = f"{lv_match.group('indent')}last_verified: \"{new_date}\""
+            if new_line != line:
+                changed.append(current_id)
+            out_lines.append(new_line)
+            continue
+        out_lines.append(line)
+
+    trailing_nl = "\n" if registry_text.endswith("\n") else ""
+    return "\n".join(out_lines) + trailing_nl, changed
+
+
+def verified_entry_ids(report: DocFreshnessReport) -> list[str]:
+    """Entry ids whose state is OK (safe to stamp last_verified)."""
+    return [r.entry_id for r in report.results if not r.is_finding]

--- a/merger/lenskit/core/doc_freshness.py
+++ b/merger/lenskit/core/doc_freshness.py
@@ -40,7 +40,10 @@ import ast
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
+import re
 from typing import Iterable, Optional
+
+from merger.lenskit.core.path_security import resolve_secure_path
 
 # ``kind`` of evidence whose *presence* implies the work is implemented ("done").
 _DONE_KINDS = frozenset({"symbol", "test", "proof"})
@@ -134,7 +137,10 @@ def resolve_evidence(ref: EvidenceRef, repo_root: Path) -> EvidenceResult:
     it means the forbidden needle is genuinely absent).
     """
     rel, needle = _split_target(ref.target)
-    path = (repo_root / rel).resolve()
+    try:
+        path = resolve_secure_path(repo_root, rel)
+    except ValueError as exc:
+        return EvidenceResult(ref, False, f"invalid path: {exc}")
 
     if ref.kind in ("file", "proof"):
         ok = path.is_file()
@@ -145,7 +151,8 @@ def resolve_evidence(ref: EvidenceRef, repo_root: Path) -> EvidenceResult:
             return EvidenceResult(ref, False, f"MISSING test file: {rel}")
         if needle:
             text = _read(path)
-            ok = f"def {needle}" in text
+            pattern = rf"(?m)^\s*(?:async\s+def|def)\s+{re.escape(needle)}\b"
+            ok = bool(re.search(pattern, text))
             return EvidenceResult(
                 ref, ok, f"{'found' if ok else 'MISSING'} test {needle} in {rel}"
             )
@@ -184,7 +191,7 @@ def resolve_evidence(ref: EvidenceRef, repo_root: Path) -> EvidenceResult:
 
 def _read(path: Path) -> str:
     try:
-        return path.read_text(encoding="utf-8")
+        return path.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return ""
 
@@ -500,9 +507,24 @@ def verify(data: dict, repo_root: Path, strict: bool = False) -> DocFreshnessRep
     report = DocFreshnessReport(strict=strict)
     for entry in data.get("entries", []):
         doc_path_rel = entry.get("doc", "")
-        doc_path = repo_root / doc_path_rel
+        try:
+            doc_path = resolve_secure_path(repo_root, doc_path_rel)
+        except ValueError as exc:
+            dangling_result = EntryResult(
+                entry_id=entry.get("id", "<no-id>"),
+                doc=doc_path_rel,
+                claim=entry.get("claim", ""),
+                declared_status=entry.get("status", ""),
+                normative=bool(entry.get("normative", False)),
+                classification="dangling_doc",
+                severity="error",
+                message=f"registry entry doc path is invalid: {exc}",
+                evidence=[],
+            )
+            report.results.append(dangling_result)
+            report.entries_scanned += 1
+            continue
 
-        # Check if the document exists; if not, short-circuit to dangling_doc error.
         if not doc_path.is_file():
             dangling_result = EntryResult(
                 entry_id=entry.get("id", "<no-id>"),

--- a/merger/lenskit/core/doc_freshness.py
+++ b/merger/lenskit/core/doc_freshness.py
@@ -169,12 +169,13 @@ def resolve_evidence(ref: EvidenceRef, repo_root: Path) -> EvidenceResult:
         if needle is None:
             return EvidenceResult(ref, False, f"{ref.kind} ref needs '::needle'")
         if not path.is_file():
-            # A text claim about a missing file cannot hold; absent_text trivially holds.
-            present = False
-            detail = f"file MISSING: {rel}"
-        else:
-            present = needle in _read(path)
-            detail = f"needle {'present' if present else 'absent'} in {rel}"
+            return EvidenceResult(
+                ref,
+                False,
+                f"MISSING file for {ref.kind} evidence: {rel}",
+            )
+        present = needle in _read(path)
+        detail = f"needle {'present' if present else 'absent'} in {rel}"
         satisfied = present if ref.kind == "text" else (not present)
         return EvidenceResult(ref, satisfied, detail)
 
@@ -257,11 +258,19 @@ def _missing_open_markers(results: Iterable[EvidenceResult]) -> list[EvidenceRes
 
 
 def _hard_dangling(results: Iterable[EvidenceResult]) -> list[EvidenceResult]:
-    """symbol/file/proof/test refs that are not satisfied (cited but absent)."""
+    """Evidence refs whose cited file/symbol/test/proof target is dangling."""
     return [
         r
         for r in results
-        if r.ref.kind in ("symbol", "file", "proof", "test") and not r.satisfied
+        if (
+            r.ref.kind in ("symbol", "file", "proof", "test")
+            and not r.satisfied
+        )
+        or (
+            r.ref.kind in ("text", "absent_text")
+            and not r.satisfied
+            and r.detail.startswith("MISSING file")
+        )
     ]
 
 

--- a/merger/lenskit/core/doc_freshness.py
+++ b/merger/lenskit/core/doc_freshness.py
@@ -650,7 +650,6 @@ def restamp_last_verified(
     Operates on the raw text (preserves comments, order, formatting). ``updates``
     maps entry id → ISO date. Returns ``(new_text, changed_ids)``.
     """
-    import re
 
     id_re = re.compile(r"^\s*-?\s*id:\s*(['\"]?)([A-Za-z0-9][A-Za-z0-9-]*)\1\s*$")
     lv_re = re.compile(r"^(?P<indent>\s*)last_verified:\s*.*$")

--- a/merger/lenskit/core/doc_freshness.py
+++ b/merger/lenskit/core/doc_freshness.py
@@ -52,15 +52,6 @@ _OK_CLASSIFICATIONS = frozenset(
     {"consistent", "partial_ok", "historical", "stale_confirmed"}
 )
 
-# Per-classification severity for findings.
-_SEVERITY = {
-    "regressed": "error",
-    "dangling": "error",
-    "understated": "warning",
-    "stale_marker_present": "warning",
-    "stale_resolved": "warning",
-}
-
 
 def repo_root_from_here() -> Path:
     """Best-effort repo root: ``merger/lenskit/core/doc_freshness.py`` → root."""
@@ -413,9 +404,11 @@ class DocFreshnessReport:
             "warning_count": self.warning_count,
             "stale_confirmed_count": len(self.stale_confirmed),
             "does_not_prove": [
-                "a green run does not prove the documentation is complete or "
-                "correct, only that no declared claim contradicts its declared "
-                "evidence",
+                (
+                    "a green run does not prove the documentation is complete or "
+                    + "correct, only that no declared claim contradicts its declared "
+                    + "evidence"
+                ),
                 "this report is a diagnostic_signal, not canonical content",
             ],
             "results": [r.to_dict() for r in self.results],

--- a/merger/lenskit/repoLens-spec.md
+++ b/merger/lenskit/repoLens-spec.md
@@ -50,9 +50,18 @@ Header muss enthalten:
 
 ---
 
-### TODO: Super-Merger / Extras (für google-labs-jules[bot])
+### Super-Merger / Extras — implementiert (2026-05)
 
-Die folgenden Punkte sind für die Super-Merger-Ausbaustufe umzusetzen.
+> **Status: implementiert.** `ExtrasConfig` und die Extras-Schalter sind in
+> `merger/lenskit/core/merge.py` umgesetzt (`class ExtrasConfig`,
+> `_build_extras_meta()`, Emission in den `@meta`-Block). Beleg:
+> `docs/proofs/weiterentwicklungsplan-2026-05-reconciliation-proof.md` §2 (Zeile 1)
+> und `docs/proofs/doc-freshness-registry-v0-proof.md`. Dieser Abschnitt
+> dokumentiert daher den **umgesetzten** Extras-Contract; er ist kein offenes TODO
+> mehr. Drift wird durch den Doc-Freshness-Eintrag
+> `repolens-spec-super-merger-extras` überwacht.
+
+Der Super-Merger-Ausbau umfasst die folgenden, umgesetzten Punkte:
 
 1. **Extras-Schalter in der UI implementieren**
    - Flags in `MergerUI`:

--- a/merger/lenskit/tests/test_doc_freshness.py
+++ b/merger/lenskit/tests/test_doc_freshness.py
@@ -104,6 +104,27 @@ def test_file_proof_test_evidence(tmp_path):
     ).satisfied
 
 
+def test_test_evidence_matches_async_def(tmp_path):
+    _write(tmp_path, "tests/test_async.py", "async def test_async_case():\n    assert True\n")
+    assert resolve_evidence(
+        EvidenceRef("test", "tests/test_async.py::test_async_case"), tmp_path
+    ).satisfied
+
+
+def test_resolve_evidence_rejects_path_escape(tmp_path):
+    outside = tmp_path.parent / "outside.py"
+    outside.write_text("class Hidden:\n    pass\n", encoding="utf-8")
+    res = resolve_evidence(EvidenceRef("symbol", "../outside.py::Hidden"), tmp_path)
+    assert not res.satisfied
+    assert "invalid path" in res.detail
+
+
+def test_read_replaces_invalid_utf8(tmp_path):
+    p = tmp_path / "bin.dat"
+    p.write_bytes(b"\xff\xfeTODO")
+    assert resolve_evidence(EvidenceRef("text", "bin.dat::TODO"), tmp_path).satisfied
+
+
 def test_symbol_in_non_python_file_uses_substring(tmp_path):
     _write(tmp_path, "schema.json", '{"const": "WidgetThing"}\n')
     assert resolve_evidence(
@@ -341,6 +362,26 @@ def test_verify_dangling_doc_is_error():
         assert report.error_count == 1
         assert any(r.classification == "dangling_doc" for r in report.results)
         assert any("does not exist" in r.message for r in report.results)
+
+
+def test_verify_dangling_doc_invalid_path_is_error(tmp_path):
+    data = _make_registry(
+        [
+            {
+                "id": "invalid-doc",
+                "doc": "../outside.md",
+                "claim": "test",
+                "status": "done",
+                "normative": True,
+                "evidence": [{"kind": "symbol", "target": "mod.py::Foo"}],
+            }
+        ]
+    )
+    _write(tmp_path, "mod.py", "class Foo:\n    pass\n")
+    report = verify(data, tmp_path)
+    assert report.status == "fail"
+    assert any(r.classification == "dangling_doc" for r in report.results)
+    assert any("invalid" in r.message for r in report.results)
 
 
 def test_verify_missing_absent_text_target_is_error(tmp_path):

--- a/merger/lenskit/tests/test_doc_freshness.py
+++ b/merger/lenskit/tests/test_doc_freshness.py
@@ -202,6 +202,15 @@ def test_partial_regressed_when_evidence_vanishes():
     assert cls == "regressed"
 
 
+def test_partial_maybe_resolved_when_open_marker_gone():
+    """partial entries with text implies:open should warn when marker disappears."""
+    results = [resolve_evidence_stub("text", satisfied=False, implies="open")]
+    cls, sev, msg = classify_entry("partial", results)
+    assert cls == "partial_maybe_resolved"
+    assert sev == "warning"
+    assert "open marker" in msg.lower()
+
+
 def test_historical_never_checked():
     results = [resolve_evidence_stub("symbol", satisfied=False, implies="done")]
     cls, sev, _ = classify_entry("historical", results)
@@ -297,6 +306,32 @@ def test_verify_dangling_evidence_is_error(tmp_path):
     assert report.status == "fail"
     assert report.error_count == 1
     assert report.results[0].classification == "regressed"
+
+
+def test_verify_dangling_doc_is_error():
+    """Registry entry with missing doc file should report dangling_doc error."""
+    data = _make_registry(
+        [
+            {
+                "id": "missing-doc",
+                "doc": "nonexistent.md",
+                "claim": "test",
+                "status": "done",
+                "normative": True,
+                "evidence": [{"kind": "symbol", "target": "mod.py::Foo"}],
+            }
+        ]
+    )
+    import tempfile
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir)
+        # Create the evidence file but NOT the doc file
+        _write(root, "mod.py", "class Foo:\n    pass\n")
+        report = verify(data, root)
+        assert report.status == "fail"
+        assert report.error_count == 1
+        assert any(r.classification == "dangling_doc" for r in report.results)
+        assert any("does not exist" in r.message for r in report.results)
 
 
 def test_strict_escalates_normative_stale_confirmed(tmp_path):

--- a/merger/lenskit/tests/test_doc_freshness.py
+++ b/merger/lenskit/tests/test_doc_freshness.py
@@ -1,0 +1,436 @@
+"""Tests for the diagnostic doc-freshness verifier (v0).
+
+Synthetic fixtures prove the drift detector across the classification spectrum;
+a final group asserts the *real* checked-in registry validates and verifies
+clean (i.e. the repoLens-spec ExtrasConfig drift is actually closed).
+"""
+from pathlib import Path
+
+import pytest
+
+from merger.lenskit.core.doc_freshness import (
+    DocFreshnessReport,
+    EntryResult,
+    EvidenceRef,
+    classify_entry,
+    default_schema_path,
+    load_registry,
+    render_markdown,
+    repo_root_from_here,
+    resolve_evidence,
+    restamp_last_verified,
+    validate_registry,
+    verified_entry_ids,
+    verify,
+)
+
+REPO_ROOT = repo_root_from_here()
+
+
+# --- evidence resolution -----------------------------------------------------
+
+
+def _write(root: Path, rel: str, content: str) -> None:
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+
+
+def test_symbol_evidence_present_and_absent(tmp_path):
+    _write(tmp_path, "mod.py", "class Foo:\n    pass\n\ndef bar():\n    return 1\n")
+    assert resolve_evidence(
+        EvidenceRef("symbol", "mod.py::Foo"), tmp_path
+    ).satisfied
+    assert resolve_evidence(
+        EvidenceRef("symbol", "mod.py::bar"), tmp_path
+    ).satisfied
+    assert not resolve_evidence(
+        EvidenceRef("symbol", "mod.py::Missing"), tmp_path
+    ).satisfied
+
+
+def test_symbol_evidence_assignment_and_annassign(tmp_path):
+    _write(tmp_path, "c.py", "X = 1\nY: int = 2\n")
+    assert resolve_evidence(EvidenceRef("symbol", "c.py::X"), tmp_path).satisfied
+    assert resolve_evidence(EvidenceRef("symbol", "c.py::Y"), tmp_path).satisfied
+
+
+def test_symbol_unparsable_falls_back_to_substring(tmp_path):
+    _write(tmp_path, "broken.py", "def (:\n  ExtrasConfig\n")
+    # Not valid Python; falls back to substring probe rather than crashing.
+    assert resolve_evidence(
+        EvidenceRef("symbol", "broken.py::ExtrasConfig"), tmp_path
+    ).satisfied
+
+
+def test_text_and_absent_text(tmp_path):
+    _write(tmp_path, "doc.md", "hello TODO world\n")
+    assert resolve_evidence(EvidenceRef("text", "doc.md::TODO"), tmp_path).satisfied
+    # absent_text is satisfied when the needle is genuinely absent.
+    assert resolve_evidence(
+        EvidenceRef("absent_text", "doc.md::NOPE"), tmp_path
+    ).satisfied
+    assert not resolve_evidence(
+        EvidenceRef("absent_text", "doc.md::TODO"), tmp_path
+    ).satisfied
+
+
+def test_file_proof_test_evidence(tmp_path):
+    _write(tmp_path, "docs/proofs/x-proof.md", "# proof\n")
+    _write(tmp_path, "tests/test_x.py", "def test_x():\n    assert True\n")
+    assert resolve_evidence(
+        EvidenceRef("file", "docs/proofs/x-proof.md"), tmp_path
+    ).satisfied
+    assert resolve_evidence(
+        EvidenceRef("proof", "docs/proofs/x-proof.md"), tmp_path
+    ).satisfied
+    assert resolve_evidence(
+        EvidenceRef("test", "tests/test_x.py::test_x"), tmp_path
+    ).satisfied
+    assert not resolve_evidence(
+        EvidenceRef("test", "tests/test_x.py::test_absent"), tmp_path
+    ).satisfied
+    assert not resolve_evidence(
+        EvidenceRef("proof", "docs/proofs/nope.md"), tmp_path
+    ).satisfied
+
+
+def test_symbol_in_non_python_file_uses_substring(tmp_path):
+    _write(tmp_path, "schema.json", '{"const": "WidgetThing"}\n')
+    assert resolve_evidence(
+        EvidenceRef("symbol", "schema.json::WidgetThing"), tmp_path
+    ).satisfied
+
+
+# --- classification ----------------------------------------------------------
+
+
+def _present_symbol() -> list:
+    return [resolve_evidence_stub("symbol", satisfied=True, implies="done")]
+
+
+def resolve_evidence_stub(kind, *, satisfied, implies=None):
+    from merger.lenskit.core.doc_freshness import EvidenceResult
+
+    ref = EvidenceRef(kind, f"x::{kind}", implies=implies)
+    return EvidenceResult(ref, satisfied, "stub")
+
+
+def test_none_with_completion_evidence_is_understated():
+    cls, sev, _ = classify_entry("none", _present_symbol())
+    assert cls == "understated"
+    assert sev == "warning"
+
+
+def test_none_without_evidence_is_consistent():
+    cls, sev, _ = classify_entry(
+        "none", [resolve_evidence_stub("symbol", satisfied=False, implies="done")]
+    )
+    assert cls == "consistent"
+    assert sev == "ok"
+
+
+def test_done_with_evidence_consistent():
+    results = [
+        resolve_evidence_stub("symbol", satisfied=True, implies="done"),
+        resolve_evidence_stub("absent_text", satisfied=True),
+    ]
+    cls, sev, _ = classify_entry("done", results)
+    assert cls == "consistent"
+    assert sev == "ok"
+
+
+def test_done_with_stale_marker_present_flags():
+    # The pilot "before" state: implemented, but the TODO heading is still there.
+    results = [
+        resolve_evidence_stub("symbol", satisfied=True, implies="done"),
+        resolve_evidence_stub("absent_text", satisfied=False),  # marker still present
+    ]
+    cls, sev, _ = classify_entry("done", results)
+    assert cls == "stale_marker_present"
+    assert sev == "warning"
+
+
+def test_done_with_missing_evidence_regressed():
+    results = [resolve_evidence_stub("symbol", satisfied=False, implies="done")]
+    cls, sev, _ = classify_entry("done", results)
+    assert cls == "regressed"
+    assert sev == "error"
+
+
+def test_stale_confirmed_when_reproduces():
+    # implemented (symbol present) AND doc still shows it open (text/open present).
+    results = [
+        resolve_evidence_stub("symbol", satisfied=True, implies="done"),
+        resolve_evidence_stub("text", satisfied=True, implies="open"),
+    ]
+    cls, sev, _ = classify_entry("stale", results)
+    assert cls == "stale_confirmed"
+    assert sev == "ok"  # tracked, not a finding
+
+
+def test_stale_resolved_when_marker_gone():
+    results = [
+        resolve_evidence_stub("symbol", satisfied=True, implies="done"),
+        resolve_evidence_stub("text", satisfied=False, implies="open"),
+    ]
+    cls, sev, _ = classify_entry("stale", results)
+    assert cls == "stale_resolved"
+    assert sev == "warning"
+
+
+def test_stale_regressed_when_not_actually_done():
+    results = [
+        resolve_evidence_stub("symbol", satisfied=False, implies="done"),
+        resolve_evidence_stub("text", satisfied=True, implies="open"),
+    ]
+    cls, sev, _ = classify_entry("stale", results)
+    assert cls == "regressed"
+    assert sev == "error"
+
+
+def test_partial_not_flagged_even_with_symbol():
+    results = [resolve_evidence_stub("symbol", satisfied=True, implies="done")]
+    cls, sev, _ = classify_entry("partial", results)
+    assert cls == "partial_ok"
+    assert sev == "ok"
+
+
+def test_partial_regressed_when_evidence_vanishes():
+    results = [resolve_evidence_stub("symbol", satisfied=False, implies="done")]
+    cls, sev, _ = classify_entry("partial", results)
+    assert cls == "regressed"
+
+
+def test_historical_never_checked():
+    results = [resolve_evidence_stub("symbol", satisfied=False, implies="done")]
+    cls, sev, _ = classify_entry("historical", results)
+    assert cls == "historical"
+    assert sev == "ok"
+
+
+# --- end-to-end verify on synthetic registries -------------------------------
+
+
+def _make_registry(entries):
+    return {
+        "kind": "lenskit.doc_freshness_registry",
+        "version": "1.0",
+        "entries": entries,
+    }
+
+
+def test_verify_detects_understated_drift(tmp_path):
+    _write(tmp_path, "core.py", "class Widget:\n    pass\n")
+    _write(tmp_path, "plan.md", "TODO: build Widget\n")
+    data = _make_registry(
+        [
+            {
+                "id": "widget",
+                "doc": "plan.md",
+                "claim": "Widget built",
+                "status": "none",
+                "owner": "x",
+                "last_verified": "2026-05-31",
+                "evidence": [{"kind": "symbol", "target": "core.py::Widget"}],
+            }
+        ]
+    )
+    report = verify(data, tmp_path)
+    assert report.status == "warn"
+    assert report.results[0].classification == "understated"
+
+
+def test_verify_pilot_before_and_after(tmp_path):
+    """A 'done' entry flips from stale_marker_present to consistent when the
+    stale TODO heading is removed — the exact pilot transition."""
+    _write(tmp_path, "core.py", "class ExtrasConfig:\n    pass\n")
+    _write(tmp_path, "docs/proofs/p.md", "# proof\n")
+    data = _make_registry(
+        [
+            {
+                "id": "extras",
+                "doc": "spec.md",
+                "claim": "ExtrasConfig implemented",
+                "status": "done",
+                "normative": True,
+                "owner": "spec",
+                "last_verified": "2026-05-31",
+                "evidence": [
+                    {"kind": "symbol", "target": "core.py::ExtrasConfig"},
+                    {"kind": "proof", "target": "docs/proofs/p.md"},
+                    {"kind": "absent_text", "target": "spec.md::### TODO: Extras"},
+                ],
+            }
+        ]
+    )
+
+    # BEFORE: spec still carries the TODO heading → flagged.
+    _write(tmp_path, "spec.md", "### TODO: Extras\nstuff\n")
+    before = verify(data, tmp_path)
+    assert before.status == "warn"
+    assert before.results[0].classification == "stale_marker_present"
+
+    # AFTER: TODO heading removed → consistent, clean.
+    _write(tmp_path, "spec.md", "### Extras — implemented\nstuff\n")
+    after = verify(data, tmp_path)
+    assert after.status == "pass"
+    assert after.results[0].classification == "consistent"
+
+
+def test_verify_dangling_evidence_is_error(tmp_path):
+    _write(tmp_path, "spec.md", "done\n")
+    data = _make_registry(
+        [
+            {
+                "id": "gone",
+                "doc": "spec.md",
+                "claim": "Thing done",
+                "status": "done",
+                "owner": "x",
+                "last_verified": "2026-05-31",
+                "evidence": [{"kind": "symbol", "target": "missing.py::Thing"}],
+            }
+        ]
+    )
+    report = verify(data, tmp_path)
+    assert report.status == "fail"
+    assert report.error_count == 1
+    assert report.results[0].classification == "regressed"
+
+
+def test_strict_escalates_normative_stale_confirmed(tmp_path):
+    _write(tmp_path, "core.py", "class Done:\n    pass\n")
+    _write(tmp_path, "spec.md", "### TODO: Done later\n")
+    data = _make_registry(
+        [
+            {
+                "id": "s",
+                "doc": "spec.md",
+                "claim": "Done",
+                "status": "stale",
+                "normative": True,
+                "owner": "x",
+                "last_verified": "2026-05-31",
+                "evidence": [
+                    {"kind": "symbol", "target": "core.py::Done"},
+                    {
+                        "kind": "text",
+                        "target": "spec.md::### TODO: Done later",
+                        "implies": "open",
+                    },
+                ],
+            }
+        ]
+    )
+    non_strict = verify(data, tmp_path, strict=False)
+    assert non_strict.status == "pass"  # tracked, not a finding
+    assert non_strict.stale_confirmed
+
+    strict = verify(data, tmp_path, strict=True)
+    assert strict.status == "fail"  # normative + stale_confirmed escalates
+    assert len(strict.findings) == 1
+
+
+# --- render + restamp --------------------------------------------------------
+
+
+def _ok_report():
+    r = DocFreshnessReport()
+    r.results.append(
+        EntryResult(
+            entry_id="a",
+            doc="d.md",
+            claim="c",
+            declared_status="done",
+            normative=False,
+            classification="consistent",
+            severity="ok",
+            message="ok",
+        )
+    )
+    r.entries_scanned = 1
+    return r
+
+
+def test_render_markdown_deterministic_and_tabular():
+    data = _make_registry(
+        [
+            {
+                "id": "a",
+                "doc": "d.md",
+                "claim": "c",
+                "status": "done",
+                "owner": "o",
+                "last_verified": "2026-05-31",
+                "evidence": [{"kind": "file", "target": "d.md"}],
+            }
+        ]
+    )
+    report = _ok_report()
+    out1 = render_markdown(data, report, "2026-05-31")
+    out2 = render_markdown(data, report, "2026-05-31")
+    assert out1 == out2
+    assert "GENERATED FILE" in out1
+    assert "| ID | Status | Verdict | Doc | Claim | last_verified |" in out1
+    assert "`a`" in out1
+
+
+def test_restamp_last_verified_surgical():
+    text = (
+        "# header comment\n"
+        "entries:\n"
+        "  - id: alpha\n"
+        "    last_verified: \"2020-01-01\"\n"
+        "    status: done\n"
+        "  - id: beta\n"
+        "    last_verified: \"2020-01-01\"\n"
+    )
+    new_text, changed = restamp_last_verified(text, {"alpha": "2026-05-31"})
+    assert changed == ["alpha"]
+    assert "# header comment" in new_text  # comments preserved
+    assert 'last_verified: "2026-05-31"' in new_text
+    # beta untouched
+    assert new_text.count('last_verified: "2020-01-01"') == 1
+
+
+def test_verified_entry_ids_excludes_findings():
+    r = DocFreshnessReport()
+    r.results = [
+        EntryResult("ok1", "d", "c", "done", False, "consistent", "ok", "m"),
+        EntryResult("bad", "d", "c", "done", False, "regressed", "error", "m"),
+        EntryResult("stale1", "d", "c", "stale", False, "stale_confirmed", "ok", "m"),
+    ]
+    ids = verified_entry_ids(r)
+    assert "ok1" in ids
+    assert "stale1" in ids  # tracked-but-ok is stampable
+    assert "bad" not in ids
+
+
+# --- the REAL checked-in registry --------------------------------------------
+
+
+@pytest.fixture
+def real_registry():
+    from merger.lenskit.core.doc_freshness import default_registry_path
+
+    return load_registry(default_registry_path(REPO_ROOT))
+
+
+def test_real_registry_schema_valid(real_registry):
+    errors = validate_registry(real_registry, default_schema_path(REPO_ROOT))
+    assert errors == [], f"registry schema errors: {errors}"
+
+
+def test_real_registry_verifies_clean(real_registry):
+    """The live registry must be green: every tracked claim matches its
+    evidence (proves the repoLens-spec ExtrasConfig drift is actually closed)."""
+    report = verify(real_registry, REPO_ROOT)
+    assert report.status == "pass", report.to_dict()
+    assert report.error_count == 0
+
+
+def test_real_registry_strict_clean(real_registry):
+    """No normative doc carries an unresolved stale drift."""
+    report = verify(real_registry, REPO_ROOT, strict=True)
+    assert report.status == "pass", report.to_dict()

--- a/merger/lenskit/tests/test_doc_freshness.py
+++ b/merger/lenskit/tests/test_doc_freshness.py
@@ -75,6 +75,15 @@ def test_text_and_absent_text(tmp_path):
     ).satisfied
 
 
+def test_text_and_absent_text_missing_file_are_not_satisfied(tmp_path):
+    assert not resolve_evidence(
+        EvidenceRef("text", "missing.md::TODO"), tmp_path
+    ).satisfied
+    assert not resolve_evidence(
+        EvidenceRef("absent_text", "missing.md::TODO"), tmp_path
+    ).satisfied
+
+
 def test_file_proof_test_evidence(tmp_path):
     _write(tmp_path, "docs/proofs/x-proof.md", "# proof\n")
     _write(tmp_path, "tests/test_x.py", "def test_x():\n    assert True\n")
@@ -332,6 +341,33 @@ def test_verify_dangling_doc_is_error():
         assert report.error_count == 1
         assert any(r.classification == "dangling_doc" for r in report.results)
         assert any("does not exist" in r.message for r in report.results)
+
+
+def test_verify_missing_absent_text_target_is_error(tmp_path):
+    _write(tmp_path, "spec.md", "done\n")
+    _write(tmp_path, "core.py", "class Thing:\n    pass\n")
+    data = _make_registry(
+        [
+            {
+                "id": "missing-absent-text-target",
+                "doc": "spec.md",
+                "claim": "Thing done",
+                "status": "done",
+                "owner": "x",
+                "last_verified": "2026-05-31",
+                "evidence": [
+                    {"kind": "symbol", "target": "core.py::Thing"},
+                    {"kind": "absent_text", "target": "missing.md::### TODO: Thing"},
+                ],
+            }
+        ]
+    )
+
+    report = verify(data, tmp_path)
+    assert report.status == "fail"
+    assert report.error_count == 1
+    assert report.results[0].classification == "regressed"
+    assert "MISSING file" in report.results[0].message
 
 
 def test_strict_escalates_normative_stale_confirmed(tmp_path):

--- a/merger/lenskit/tests/test_doc_freshness.py
+++ b/merger/lenskit/tests/test_doc_freshness.py
@@ -417,11 +417,13 @@ def real_registry():
     return load_registry(default_registry_path(REPO_ROOT))
 
 
+@pytest.mark.doc_freshness_live
 def test_real_registry_schema_valid(real_registry):
     errors = validate_registry(real_registry, default_schema_path(REPO_ROOT))
     assert errors == [], f"registry schema errors: {errors}"
 
 
+@pytest.mark.doc_freshness_live
 def test_real_registry_verifies_clean(real_registry):
     """The live registry must be green: every tracked claim matches its
     evidence (proves the repoLens-spec ExtrasConfig drift is actually closed)."""
@@ -430,6 +432,7 @@ def test_real_registry_verifies_clean(real_registry):
     assert report.error_count == 0
 
 
+@pytest.mark.doc_freshness_live
 def test_real_registry_strict_clean(real_registry):
     """No normative doc carries an unresolved stale drift."""
     report = verify(real_registry, REPO_ROOT, strict=True)

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,3 +6,4 @@ pythonpath = .
 asyncio_mode = auto
 markers =
     browser: tests requiring pytest-playwright/browser runtime
+    doc_freshness_live: live registry verification tests (run against actual repo tree; non-blocking in CI)


### PR DESCRIPTION
## Summary

This PR introduces a diagnostic doc-freshness verifier that closes the gap between documentation claims (TODOs, roadmap statements, spec assertions) and the code/test/proof evidence that proves or refutes them. It detects and surfaces documentation drift—such as TODO markers that remain after implementation—without blocking CI, following the artifact-drift-matrix rollout pattern (diagnose first, promote to blocking later).

The implementation is self-contained and immediately useful: it fixes the pilot case where `repoLens-spec.md` still framed `ExtrasConfig` as a TODO despite being implemented in `core/merge.py`.

## Key Changes

- **Core verifier** (`merger/lenskit/core/doc_freshness.py`): 
  - Evidence resolution engine supporting `symbol`, `file`, `text`, `absent_text`, `proof`, and `test` kinds
  - AST-based symbol detection for Python files; substring fallback for unparsable code
  - **Path-sandbox hardening**: evidence/document paths are resolved with `resolve_secure_path(...)` (prevents absolute/traversal/out-of-repo probes)
  - **Robust text reading**: UTF-8 reads use replacement semantics to avoid crashes on non-UTF8 content
  - **Test evidence matching** now supports both `def test_*` and `async def test_*` via anchored regex
  - Classification logic that detects drift: `understated` (doc lags code), `stale_marker_present` (TODO still in doc), `regressed` (cited evidence missing), `stale_confirmed` (known, tracked drift)
  - **New logic blockers**: `partial_maybe_resolved` (when `partial` entries have missing open markers) and `dangling_doc` (when registry entry's doc file doesn't exist)
  - Report generation and markdown rendering
  - Registry stamping (updates `last_verified` for verified entries)

- **Registry &amp; schema**:
  - `docs/doc-freshness-registry.yml`: Hand-authored source-of-truth binding claims to evidence
  - `merger/lenskit/contracts/doc-freshness-registry.v1.schema.json`: JSON Schema v7 validation
  - Pilot entry for the `ExtrasConfig` drift (status: `done`, with symbol + proof + absent_text guards)

- **CLI** (`merger/lenskit/cli/cmd_doc_freshness.py`):
  - `lenskit doc-freshness inspect`: Verify registry against live tree, report drift (exit 1 on findings)
  - `lenskit doc-freshness update`: Regenerate human-readable view and stamp `last_verified` (with `--write` to persist)
  - **`--no-stamp`** mode for deterministic regeneration/sync checks without mutating `last_verified`
  - `--strict` flag to escalate confirmed stale drift in normative docs to failures (enforcement promotion path)

- **CI workflow** (`.github/workflows/doc-freshness.yml`):
  - Non-blocking diagnostic gate (unit/schema tests blocking; inspect, live-registry verification, and staleness checks use `continue-on-error`)
  - Triggers on changes to verifier, registry, schema, tests, and monitored documentation (`docs/**.md`, `merger/lenskit/repoLens-spec.md`)
  - Test splitting: blocking unit/schema tests vs. non-blocking live registry verification
  - Generated-view sync check now uses `doc-freshness update --write --no-stamp` to avoid day-to-day timestamp flapping

- **Documentation**:
  - `docs/_generated/doc-freshness.md`: Auto-generated status view (never hand-edited)
  - `docs/proofs/doc-freshness-registry-v0-proof.md`: Proof document explaining the design and pilot
  - Updated `repoLens-spec.md`: Removed stale TODO heading, added implementation note with status
  - Clarified generated-docs rule in `CONTRIBUTING.md` and `AGENTS.md` with explicit generator command

- **Tests** (`merger/lenskit/tests/test_doc_freshness.py`):
  - 35 tests covering evidence resolution (symbol, text, file, proof, test kinds), classification, rendering/stamping, and end-to-end verification
  - Classification logic across all drift scenarios (understated, stale_marker_present, regressed, stale_confirmed, stale_resolved)
  - **Blocker tests**: `test_partial_maybe_resolved_when_open_marker_gone()` and `test_verify_dangling_doc_is_error()`
  - Additional hardening tests for path-escape rejection, invalid `entry.doc` path handling, async test evidence detection, and non-UTF8 read tolerance
  - End-to-end verification on synthetic and real registries
  - Pilot transition test (before/after the TODO removal)
  - Pytest marker segregation: blocking unit tests vs. non-blocking live registry verification

## Notable Implementation Details

- **Drift classification** mirrors C2.9's `declared_upgrades` pattern: `stale` entries are known, declared drifts (surfaced and tracked, not silently suppressed)
- **Evidence kinds** that imply "done" (`symbol`, `test`, `proof`) are auto-detected; custom `implies` can override
- **Logic blockers**: `partial` entries now detect when `open` evidence disappears (warning: `partial_maybe_resolved`); all entries validate doc path existence (error: `dangling_doc`)
- **Deterministic regeneration**: The generated view's `generated_at` timestamp is derived from max `last_verified` in the registry, not wall-clock, so CI diffs are stable
- **Surgical stamping**: `restamp_last_verified` only updates YAML metadata, never rewrites prose
- **Diagnostic-first**: No blocking CI gate yet; findings are surfaced and tracked; promotion to `--strict` enforcement is a documented next slice
- **Honest boundary**: The verifier does NOT rewrite normative prose, does NOT judge correctness (only declared status vs. declared evidence), and does NOT block CI