### PR TITLE
Agent Reading Pack v1.1: add task-specific required-reading, sidecar rules, checklist and DO_NOT_CLAIM guidance

### DIFF
--- a/docs/proofs/agent-reading-pack-producer-proof.md
+++ b/docs/proofs/agent-reading-pack-producer-proof.md
@@ -1,9 +1,14 @@
 # Agent Reading Pack Producer Proof
 
-- Datum: 2026-05-20
-- Repo HEAD (Basis): b59cf653d8b06012789ec2d14cbe31c8a978d709
 - Arbeitspaket: D (PR 4) aus `docs/blueprints/lenskit-output-optimierung-v1.md`
 - Artefaktrolle: `agent_reading_pack` (`authority=navigation_index`, `canonicality=derived`, `role_only`, `text/markdown`)
+
+## Proof Basis
+
+- Original producer proof basis (v1): 2026-05-20, `b59cf653d8b06012789ec2d14cbe31c8a978d709`
+- Front-Door Hardening v1.1 verification basis: current PR commit at verification time
+- The v1.1 sentinel and sections below are verified by targeted producer/CLI tests,
+  not by the original 2026-05-20 proof run.
 
 ## Zweck
 
@@ -100,7 +105,7 @@ slice does not add schemas, sidecars, health gates, retrieval ranking,
 consumption tracing or LLM/embedding dependencies.
 
 Does not establish: answer correctness, repo understanding, claim truth, test
-sufficiency, runtime correctness, review completeness or forensic readiness.
+sufficiency, runtime correctness, review completeness, change impact or forensic readiness.
 
 Targeted verification for this slice:
 

--- a/docs/proofs/agent-reading-pack-producer-proof.md
+++ b/docs/proofs/agent-reading-pack-producer-proof.md
@@ -22,7 +22,7 @@ finalisierte Manifest re-produziert.
 python3 -m merger.lenskit.cli.main agent-pack produce <stem>.bundle.manifest.json --json
 ```
 
-## Befund (frischer Lauf, dump stem `proofrepo-max-…_merge`)
+## Befund (producer and contract verification)
 
 ### Manifest-Integration
 - `manifest_schema_valid` (gegen `bundle-manifest.v1.schema.json`): **PASS**
@@ -30,8 +30,8 @@ python3 -m merger.lenskit.cli.main agent-pack produce <stem>.bundle.manifest.jso
 - `content_type`: `text/markdown`
 - `authority` / `canonicality` / `interpretation.mode`: `navigation_index` / `derived` / `role_only`
 - `regenerable` / `staleness_sensitive`: `true` / `true`
-- `bytes` (Manifest) == Dateigröße: **true** (3990 == 3990)
-- `sha256` (Manifest) == `sha256(Datei)`: **true**
+- `bytes` (Manifest) == Dateigröße: **PASS** (covered by producer/manifest integration tests)
+- `sha256` (Manifest) == `sha256(Datei)`: **PASS** (covered by producer/manifest integration tests)
 
 ### Determinismus / Idempotenz
 - Zwei aufeinanderfolgende Produktionen über dasselbe Manifest: gleiches `output_sha256` → **PASS**
@@ -40,11 +40,13 @@ python3 -m merger.lenskit.cli.main agent-pack produce <stem>.bundle.manifest.jso
   bereits im Manifest eingetragener Pack die Ausgabe nicht.
 - `| agent_reading_pack |` erscheint nie als Tabellenzeile im Pack (`self_role_not_listed=true`).
 
-### Inhaltliche Kernsektionen (v1)
-- Sentinel: `<!-- ARTIFACT:agent_reading_pack VERSION:v1 AUTHORITY:navigation_index CANONICALITY:derived -->`
+### Inhaltliche Kernsektionen (v1.1)
+- Sentinel: `<!-- ARTIFACT:agent_reading_pack VERSION:v1.1 AUTHORITY:navigation_index CANONICALITY:derived -->`
 - Banner: `NAVIGATION, NOT TRUTH`
 - `## BUNDLE_IDENTITY`, `## READING_POLICY`, `## ARTIFACT_ROLES`, `## OUTPUT_HEALTH_SUMMARY`,
-  `## HOW_TO_SEARCH`, `## TOP_CHUNK_SPANS`, `## EPISTEMIC_EMPTINESS`
+  `## HOW_TO_SEARCH`, `## REQUIRED_READING_BY_TASK`, `## WHEN_CANONICAL_MD_ONLY_IS_INSUFFICIENT`,
+  `## SIDECAR_USAGE_RULES`, `## ANSWER_COMPLIANCE_CHECKLIST`, `## DO_NOT_CLAIM`,
+  `## TOP_CHUNK_SPANS`, `## EPISTEMIC_EMPTINESS`
 - Governance-Block in `## TOP_CHUNK_SPANS`: maschinenlesbares JSON mit `applies_to: TOP_CHUNK_SPANS`,
   `risk_class: navigation`, `may_cite: false`, `must_resolve_to: role_specific_authority`,
   `does_not_prove: [semantic_importance, architecture_truth, complete_context]`
@@ -75,7 +77,7 @@ python3 -m merger.lenskit.cli.main agent-pack produce <stem>.bundle.manifest.jso
 - `HOW_TO_SEARCH` rendert `range get --manifest "<…>.bundle.manifest.json"` (nicht `dump_index`/`canonical_md`),
   da der Pack aus dem Bundle-Manifest erzeugt wird und dieses die natürliche Auflösungsbasis ist
   (Test `test_how_to_search_resolves_range_against_bundle_manifest`).
-- `OUTPUT_HEALTH_SUMMARY` weist transparent aus, dass `agent_pack_present` in v1 `skipped` sein kann.
+- `OUTPUT_HEALTH_SUMMARY` weist transparent aus, dass `agent_pack_present` in v1.1 `skipped` sein kann.
   Grund: In der Pipeline wird `output_health` **vor** der Pack-Emission berechnet — der In-Pipeline-Health-Report
   kann das Artefakt, das er zeitlich vorausläuft, strukturell **nicht** belegen (kein Hellsehen über noch nicht
   geschriebene Dateien). `pass`/`warning`/`fail` für `agent_pack_present` kann nur ein **Post-hoc-Lauf** liefern:
@@ -86,9 +88,32 @@ python3 -m merger.lenskit.cli.main agent-pack produce <stem>.bundle.manifest.jso
 - `agent-pack produce … --json` Exit-Code: **0**, `status=ok`.
 - Fehlendes Manifest: Exit-Code **2**, `error_kind=path_read_error`.
 
+## Front-Door Hardening v1.1
+
+This slice adds task-specific required reading, canonical-md-only insufficiency
+boundaries, sidecar usage rules, an answer-compliance declaration checklist and
+prohibited claim classes to the existing Agent Reading Pack.
+
+The Agent Reading Pack remains navigation only (`authority=navigation_index`,
+`canonicality=derived`). `canonical_md` remains the only content truth. This
+slice does not add schemas, sidecars, health gates, retrieval ranking,
+consumption tracing or LLM/embedding dependencies.
+
+Does not establish: answer correctness, repo understanding, claim truth, test
+sufficiency, runtime correctness, review completeness or forensic readiness.
+
+Targeted verification for this slice:
+
+```bash
+python -m pytest merger/lenskit/tests/test_agent_reading_pack.py merger/lenskit/tests/test_cli_agent_pack.py
+```
+
+Result: **50 passed**. The environment also reported one non-failing pytest
+configuration warning for the unknown `asyncio_mode` option.
+
 ## Tests
 
-- `merger/lenskit/tests/test_agent_reading_pack.py` — 24 Tests (Producer, Determinismus, Härtung, Output-Kollisionsschutz, Soft-invalid-Rendering, pure Funktionen).
+- `merger/lenskit/tests/test_agent_reading_pack.py` — 46 Tests (Producer, Determinismus, Härtung, Output-Kollisionsschutz, Soft-invalid-Rendering, pure Funktionen).
 - `merger/lenskit/tests/test_cli_agent_pack.py` — CLI-Smoke.
 - `merger/lenskit/tests/test_bundle_manifest_integration.py::test_agent_reading_pack_emitted_schema_valid_and_hashed` — Pipeline-Emission + Schema + Hash.
 - `merger/lenskit/tests/test_output_health.py` — `agent_pack_present` Parametrisierung (skipped/pass/warning).

--- a/merger/lenskit/core/agent_reading_pack.py
+++ b/merger/lenskit/core/agent_reading_pack.py
@@ -527,6 +527,9 @@ def render_agent_reading_pack(model: PackModel) -> str:
     lines.append("- `test_sufficiency` — located tests do not prove sufficient coverage.")
     lines.append("- `runtime_correctness` — static artifacts do not prove runtime behavior.")
     lines.append("- `review_complete` — reading guidance or health passes do not complete a review.")
+    lines.append(
+        "- `change_impact` — relation or path proximity alone does not prove change impact."
+    )
     lines.append("- `forensic_ready` — diagnostic passes do not establish forensic readiness.")
     lines.append("- `all_relevant_context_used` — sidecar use does not prove complete context use.")
     lines.append("- `regression_absence` — these artifacts do not prove that regressions are absent.")

--- a/merger/lenskit/core/agent_reading_pack.py
+++ b/merger/lenskit/core/agent_reading_pack.py
@@ -44,7 +44,7 @@ from .constants import ArtifactRole
 from .path_security import resolve_secure_path
 
 PRODUCED_BY = "agent_reading_pack_producer/v1"
-PACK_VERSION = "v1"
+PACK_VERSION = "v1.1"
 TOP_CHUNK_SPAN_LIMIT = 30
 
 _SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
@@ -429,6 +429,107 @@ def render_agent_reading_pack(model: PackModel) -> str:
     for role in present_roles:
         guide = _ROLE_GUIDE.get(role, "see artifact role table below")
         lines.append(f"- `{role}` — {guide}")
+    lines.append("")
+
+    # ── REQUIRED_READING_BY_TASK ─────────────────────────────────────────
+    lines.append("## REQUIRED_READING_BY_TASK")
+    lines.append(
+        "Choose the task profile that matches the claim. Required artifacts are "
+        "profile-specific; sidecars remain navigation or diagnosis, not content truth."
+    )
+    lines.append("| task_profile | required | recommended | insufficient |")
+    lines.append("| --- | --- | --- | --- |")
+    lines.append(
+        "| `basic_repo_question` | `agent_reading_pack`, `canonical_md` | "
+        "`citation_map_jsonl` when making specific cited claims | "
+        "sidecar-only claims without canonical verification |"
+    )
+    lines.append(
+        "| `pr_review` | `agent_reading_pack`, `canonical_md`, `citation_map_jsonl`, "
+        "`post_emit_health` | `claim_evidence_map_json` when roadmap/status claims are "
+        "involved; `bundle_surface_validation` when bundle/surface claims are involved | "
+        "only reading `canonical_md` linearly; relying on a health pass as review completeness |"
+    )
+    lines.append(
+        "| `roadmap_status_claim` | `agent_reading_pack`, `canonical_md`, "
+        "`claim_evidence_map_json` | `citation_map_jsonl` | roadmap status without the "
+        "Claim Evidence Map or a canonical check |"
+    )
+    lines.append(
+        "| `artifact_surface_review` | `bundle_manifest`, `post_emit_health`, "
+        "`bundle_surface_validation`, `canonical_md` | `output_health` | "
+        "`output_health` alone; any health pass treated as claim truth |"
+    )
+    lines.append(
+        "| `retrieval_quality_review` | `retrieval_eval_json`, `chunk_index_jsonl`, "
+        "`sqlite_index`, `canonical_md` | `docs/retrieval/*` | impressionistic retrieval "
+        "claims without metrics |"
+    )
+    lines.append("")
+
+    # ── WHEN_CANONICAL_MD_ONLY_IS_INSUFFICIENT ───────────────────────────
+    lines.append("## WHEN_CANONICAL_MD_ONLY_IS_INSUFFICIENT")
+    lines.append(
+        "`canonical_md` contains the content truth, but some tasks require sidecars to "
+        "locate, validate or diagnose the relevant evidence surface."
+    )
+    lines.append("Additional role-appropriate artifacts are needed for:")
+    lines.append("- PR review with evidence requirements.")
+    lines.append("- Roadmap or status claims.")
+    lines.append("- Bundle or surface health assessment.")
+    lines.append("- Retrieval quality assessment.")
+    lines.append("- Citation or range readiness claims.")
+    lines.append("- Claims about present or missing sidecars.")
+    lines.append("- Claims about artifact authority, canonicality or risk class.")
+    lines.append("")
+
+    # ── SIDECAR_USAGE_RULES ──────────────────────────────────────────────
+    lines.append("## SIDECAR_USAGE_RULES")
+    lines.append("- Sidecars are navigation, diagnostic signals, indexes or caches; they are not content truth.")
+    lines.append("- Content claims must resolve back to `canonical_md`, the only content truth.")
+    lines.append("- `citation_map_jsonl` maps stable citation IDs to canonical ranges.")
+    lines.append("- `claim_evidence_map_json` is an evidence-navigation index, not truth.")
+    lines.append("- `post_emit_health` is post-emit surface diagnosis, not repo understanding.")
+    lines.append("- `bundle_surface_validation` is surface coherence validation, not claim truth.")
+    lines.append(
+        "- `output_health` is a pre-/emit diagnostic signal and must not be read as "
+        "forensic readiness."
+    )
+    lines.append("- `sqlite_index` is runtime cache/search support, not authority.")
+    lines.append("")
+
+    # ── ANSWER_COMPLIANCE_CHECKLIST ──────────────────────────────────────
+    lines.append("## ANSWER_COMPLIANCE_CHECKLIST")
+    lines.append("```text")
+    lines.append("Lenskit consumption:")
+    lines.append("- task_profile:")
+    lines.append("- required_artifacts_checked:")
+    lines.append("- sidecars_used:")
+    lines.append("- canonical_ranges_or_citations_used:")
+    lines.append("- sidecars_not_used_and_why:")
+    lines.append("- epistemic_gaps:")
+    lines.append("- does_not_establish:")
+    lines.append("```")
+    lines.append(
+        "This checklist is a declaration aid, not proof that the agent actually read or "
+        "understood the artifacts."
+    )
+    lines.append("")
+
+    # ── DO_NOT_CLAIM ─────────────────────────────────────────────────────
+    lines.append("## DO_NOT_CLAIM")
+    lines.append("The Agent Reading Pack, health reports, surface validation and sidecars do not prove:")
+    lines.append("- `repo_understood` — navigation or a health pass does not prove repo understanding.")
+    lines.append("- `claims_true` — indexes and surface checks do not prove content claims true.")
+    lines.append(
+        "- `answer_safe_without_citations` — artifact presence does not make citations unnecessary."
+    )
+    lines.append("- `test_sufficiency` — located tests do not prove sufficient coverage.")
+    lines.append("- `runtime_correctness` — static artifacts do not prove runtime behavior.")
+    lines.append("- `review_complete` — reading guidance or health passes do not complete a review.")
+    lines.append("- `forensic_ready` — diagnostic passes do not establish forensic readiness.")
+    lines.append("- `all_relevant_context_used` — sidecar use does not prove complete context use.")
+    lines.append("- `regression_absence` — these artifacts do not prove that regressions are absent.")
     lines.append("")
 
     # ── ARTIFACT_ROLES ───────────────────────────────────────────────────

--- a/merger/lenskit/tests/test_agent_reading_pack.py
+++ b/merger/lenskit/tests/test_agent_reading_pack.py
@@ -340,6 +340,7 @@ def test_pack_do_not_claim_lists_prohibited_claim_classes(tmp_path):
         "test_sufficiency",
         "runtime_correctness",
         "review_complete",
+        "change_impact",
         "forensic_ready",
         "all_relevant_context_used",
         "regression_absence",
@@ -349,6 +350,8 @@ def test_pack_do_not_claim_lists_prohibited_claim_classes(tmp_path):
     assert "health reports" in section
     assert "surface validation" in section
     assert "sidecars do not prove" in section
+    assert "relation or path proximity" in section
+    assert "change impact" in section
 
 
 def test_pack_answer_compliance_checklist_is_declarative(tmp_path):

--- a/merger/lenskit/tests/test_agent_reading_pack.py
+++ b/merger/lenskit/tests/test_agent_reading_pack.py
@@ -25,6 +25,16 @@ def _sha256(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
+def _section(body: str, heading: str) -> str:
+    match = re.search(
+        rf"^## {re.escape(heading)}\n(.*?)(?=^## |\Z)",
+        body,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match is not None, f"missing section {heading}"
+    return match.group(1)
+
+
 _CANONICAL = (
     b"<!-- merge -->\n"
     b"# repo: demo\n\n"
@@ -258,11 +268,16 @@ def test_pack_has_governance_and_sentinel(tmp_path):
     report = produce_agent_reading_pack(str(manifest))
     body = Path(report["output_path"]).read_text(encoding="utf-8")
 
-    assert body.startswith("<!-- ARTIFACT:agent_reading_pack VERSION:v1")
+    assert body.startswith("<!-- ARTIFACT:agent_reading_pack VERSION:v1.1")
     assert "NAVIGATION, NOT TRUTH" in body
     for section in (
         "## BUNDLE_IDENTITY",
         "## READING_POLICY",
+        "## REQUIRED_READING_BY_TASK",
+        "## WHEN_CANONICAL_MD_ONLY_IS_INSUFFICIENT",
+        "## SIDECAR_USAGE_RULES",
+        "## ANSWER_COMPLIANCE_CHECKLIST",
+        "## DO_NOT_CLAIM",
         "## ARTIFACT_ROLES",
         "## OUTPUT_HEALTH_SUMMARY",
         "## HOW_TO_SEARCH",
@@ -270,6 +285,88 @@ def test_pack_has_governance_and_sentinel(tmp_path):
         "## EPISTEMIC_EMPTINESS",
     ):
         assert section in body, f"missing section {section}"
+
+
+def test_pack_front_door_task_profiles_and_artifact_roles(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    body = Path(produce_agent_reading_pack(str(manifest))["output_path"]).read_text()
+
+    for task_profile in (
+        "basic_repo_question",
+        "pr_review",
+        "roadmap_status_claim",
+        "artifact_surface_review",
+        "retrieval_quality_review",
+    ):
+        assert f"`{task_profile}`" in body
+
+    for role in (
+        "canonical_md",
+        "citation_map_jsonl",
+        "claim_evidence_map_json",
+        "post_emit_health",
+        "bundle_surface_validation",
+        "output_health",
+        "retrieval_eval_json",
+        "chunk_index_jsonl",
+        "sqlite_index",
+    ):
+        assert f"`{role}`" in body
+
+
+def test_pack_front_door_preserves_authority_boundaries(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    body = Path(produce_agent_reading_pack(str(manifest))["output_path"]).read_text()
+
+    assert "The only source of truth is `canonical_md`" in body
+    assert "authority=navigation_index" in body
+    assert "canonicality=derived" in body
+    assert "`claim_evidence_map_json` is an evidence-navigation index, not truth" in body
+    assert "`post_emit_health` is post-emit surface diagnosis, not repo understanding" in body
+    assert "`bundle_surface_validation` is surface coherence validation, not claim truth" in body
+    assert "`output_health` is a pre-/emit diagnostic signal" in body
+    assert "`sqlite_index` is runtime cache/search support, not authority" in body
+
+
+def test_pack_do_not_claim_lists_prohibited_claim_classes(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    body = Path(produce_agent_reading_pack(str(manifest))["output_path"]).read_text()
+    section = _section(body, "DO_NOT_CLAIM")
+
+    for claim_class in (
+        "repo_understood",
+        "claims_true",
+        "answer_safe_without_citations",
+        "test_sufficiency",
+        "runtime_correctness",
+        "review_complete",
+        "forensic_ready",
+        "all_relevant_context_used",
+        "regression_absence",
+    ):
+        assert f"`{claim_class}`" in section
+
+    assert "health reports" in section
+    assert "surface validation" in section
+    assert "sidecars do not prove" in section
+
+
+def test_pack_answer_compliance_checklist_is_declarative(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    body = Path(produce_agent_reading_pack(str(manifest))["output_path"]).read_text()
+
+    assert "Lenskit consumption:" in body
+    for field in (
+        "task_profile",
+        "required_artifacts_checked",
+        "sidecars_used",
+        "canonical_ranges_or_citations_used",
+        "sidecars_not_used_and_why",
+        "epistemic_gaps",
+        "does_not_establish",
+    ):
+        assert f"- {field}:" in body
+    assert "declaration aid, not proof" in body
 
 
 def test_pack_lists_present_artifact_roles(tmp_path):

--- a/merger/lenskit/tests/test_cli_agent_pack.py
+++ b/merger/lenskit/tests/test_cli_agent_pack.py
@@ -67,7 +67,17 @@ def test_cli_agent_pack_json_ok(tmp_path, capsys):
     assert rc == 0
     report = json.loads(capsys.readouterr().out)
     assert report["status"] == "ok"
-    assert Path(report["output_path"]).exists()
+    output_path = Path(report["output_path"])
+    assert output_path.exists()
+    body = output_path.read_text(encoding="utf-8")
+    for section in (
+        "## REQUIRED_READING_BY_TASK",
+        "## WHEN_CANONICAL_MD_ONLY_IS_INSUFFICIENT",
+        "## SIDECAR_USAGE_RULES",
+        "## ANSWER_COMPLIANCE_CHECKLIST",
+        "## DO_NOT_CLAIM",
+    ):
+        assert section in body
 
 
 def test_cli_agent_pack_human_ok(tmp_path, capsys):


### PR DESCRIPTION
### Motivation
- Provide a front-door "hardening" slice to the Agent Reading Pack that guides which artifacts are required or recommended for different task profiles and to prevent sidecars/health reports from being mistaken for content truth. 
- Make the pack explicit about authority boundaries by preserving `canonical_md` as the single content truth while documenting when sidecars are necessary for locating, diagnosing or validating claims. 
- Improve consumer declarations and risk-limiting language so consumers can declare what they checked and what the pack does not establish. 

### Description
- Bumps the pack version from `v1` to `v1.1` by changing `PACK_VERSION = "v1.1"` and updates the sentinel in the emitted pack. 
- Extends `render_agent_reading_pack` with new sections: `## REQUIRED_READING_BY_TASK`, `## WHEN_CANONICAL_MD_ONLY_IS_INSUFFICIENT`, `## SIDECAR_USAGE_RULES`, `## ANSWER_COMPLIANCE_CHECKLIST`, and `## DO_NOT_CLAIM`, plus associated explanatory content and table rows. 
- Updates documentation proof `docs/proofs/agent-reading-pack-producer-proof.md` to reflect v1.1 semantics and verification notes. 
- Adds and updates unit tests in `merger/lenskit/tests/test_agent_reading_pack.py` and adjusts CLI assertions in `merger/lenskit/tests/test_cli_agent_pack.py` to validate the new sections and textual constraints. 

### Testing
- Ran targeted verification with `python -m pytest merger/lenskit/tests/test_agent_reading_pack.py merger/lenskit/tests/test_cli_agent_pack.py` which succeeded with `50 passed` and a non-failing pytest configuration warning about `asyncio_mode`. 
- The wider non-browser test suite `pytest -m "not browser"` reported `1282 passed, 1 skipped`. 
- `tools/parity_guard.py` also passed in the verification environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a73dd410c832c853564afa2e234ed)