### PR TITLE
Add emission-consistency assertions for Agent Reading Pack v1.1 and strengthen manifest integration test

### DIFF
--- a/docs/proofs/agent-reading-pack-producer-proof.md
+++ b/docs/proofs/agent-reading-pack-producer-proof.md
@@ -116,6 +116,30 @@ python -m pytest merger/lenskit/tests/test_agent_reading_pack.py merger/lenskit/
 Result: **50 passed**. The environment also reported one non-failing pytest
 configuration warning for the unknown `asyncio_mode` option.
 
+## Bundle-emission consistency guard
+
+Producer and CLI tests prove that the v1.1 producer can render the expected front-door
+surface. They do not, by themselves, prove that the tested bundle-emission path loaded
+that producer. The manifest integration test therefore resolves the
+`agent_reading_pack` artifact from a freshly emitted bundle manifest, reads the emitted
+file, and requires the exact `VERSION:v1.1` sentinel, all five v1.1 front-door sections,
+`change_impact`, and the boundary that relation or path proximity alone does not prove
+change impact. A legacy `VERSION:v1` pack now fails this emission-level check.
+
+`post_emit_health=pass` and `bundle_surface_validation=pass` remain artifact-integrity
+and surface-coherence diagnoses. They do not automatically establish that the current
+semantic Agent Reading Pack version was emitted, and they do not prove repo
+understanding, claim truth, or answer safety. The emission-consistency assertion closes
+that regression gap in the test process without promoting either diagnostic to a truth
+gate. It does not prove that an already-running rLens service loaded the merged code;
+that requires a fresh service load and a new real-dump check.
+
+Targeted emission verification:
+
+```bash
+python -m pytest merger/lenskit/tests/test_bundle_manifest_integration.py::test_agent_reading_pack_emitted_schema_valid_and_hashed
+```
+
 ## Tests
 
 - `merger/lenskit/tests/test_agent_reading_pack.py` — 46 Tests (Producer, Determinismus, Härtung, Output-Kollisionsschutz, Soft-invalid-Rendering, pure Funktionen).

--- a/merger/lenskit/tests/test_bundle_manifest_integration.py
+++ b/merger/lenskit/tests/test_bundle_manifest_integration.py
@@ -755,7 +755,17 @@ def test_agent_reading_pack_emitted_schema_valid_and_hashed(tmp_path):
     assert pack_entry["sha256"] == _sha256_file(pack_path)
 
     body = pack_path.read_text(encoding="utf-8")
-    assert body.startswith("<!-- ARTIFACT:agent_reading_pack VERSION:v1")
+    assert body.startswith("<!-- ARTIFACT:agent_reading_pack VERSION:v1.1 ")
+    for marker in (
+        "## REQUIRED_READING_BY_TASK",
+        "## WHEN_CANONICAL_MD_ONLY_IS_INSUFFICIENT",
+        "## SIDECAR_USAGE_RULES",
+        "## ANSWER_COMPLIANCE_CHECKLIST",
+        "## DO_NOT_CLAIM",
+        "`change_impact`",
+        "relation or path proximity alone does not prove change impact",
+    ):
+        assert marker in body, f"emitted agent_reading_pack missing v1.1 marker: {marker}"
     assert "NAVIGATION, NOT TRUTH" in body
     assert data["run_id"] in body
     # The pack must never list its own role as bundle content.


### PR DESCRIPTION
### Motivation

- Ensure that the bundle-emission path actually contains the semantic Agent Reading Pack `v1.1` sentinel and the new front-door sections, closing a regression gap where producer rendering tests alone could pass while the emitted artifact was stale.

### Description

- Add a "Bundle-emission consistency guard" section to the Agent Reading Pack docs that explains the emission-level assertion and its scope.
- Strengthen `test_agent_reading_pack_emitted_schema_valid_and_hashed` to require the emitted pack to start with the header `<!-- ARTIFACT:agent_reading_pack VERSION:v1.1 ` and to contain all five v1.1 front-door section markers plus the `change_impact` marker and the boundary phrase `relation or path proximity alone does not prove change impact`.
- Preserve existing artifact-integrity checks (sha256, size, `post_emit_health`, and `bundle_surface_validation`) and clarify that the emission-consistency assertion is an additional regression guard and not a truth gate.
- Document that a legacy `VERSION:v1` pack will now fail the emission-level check.

### Testing

- Ran `pytest merger/lenskit/tests/test_agent_reading_pack.py merger/lenskit/tests/test_cli_agent_pack.py`, which reported `50 passed` and one non-failing pytest configuration warning for `asyncio_mode`.
- Ran the targeted emission test `pytest merger/lenskit/tests/test_bundle_manifest_integration.py::test_agent_reading_pack_emitted_schema_valid_and_hashed`, which passed and validates the new header and markers in the emitted artifact.
- Ran the full non-browser suite `pytest -m "not browser"`, which reported `1282 passed, 1 skipped`, and `tools/parity_guard.py` reported `PASS`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a9362b560832c82d9963e2acc1e36)