### PR TITLE
Validate agent_reading_pack v1.1 front-door markers in bundle surface validation

### DIFF
--- a/docs/proofs/real-dump-surface-self-check-proof.md
+++ b/docs/proofs/real-dump-surface-self-check-proof.md
@@ -257,3 +257,31 @@ Aktueller Lauf (vollständige Lenskit-Suite, ohne Playwright-`test_webui_payload
 python3 -m pytest -q --ignore=merger/lenskit/tests/test_webui_payload.py merger/lenskit/tests/
                                                           # 1754 passed, 1 skipped
 ```
+
+## Nachtrag 2026-06-11 — Agent-Pack-v1.1 Runtime Surface Guard
+
+Ein realer Dump konnte trotz eines emittierten `agent_reading_pack` mit
+`VERSION:v1` weiterhin eine grüne Bundle-Surface-Diagnose tragen. Ursache war,
+dass `agent_reading_pack_consistency` nur die Kohärenz zur Claim Evidence Map
+und den alten Claim-Map-Platzhalter prüfte. Die tatsächliche agent-facing
+Front-Door-Version und ihre Pflichtabschnitte waren kein Bestandteil der
+Surface-Diagnose.
+
+`bundle_surface_validate.py` prüft deshalb nun zusätzlich mit
+`agent_reading_pack_front_door_v1_1` die aus dem Manifest aufgelöste, emittierte
+Markdown-Datei. Verlangt werden `VERSION:v1.1`, die vier Reading-/Sidecar-/Answer-
+Abschnitte, `## DO_NOT_CLAIM`, `` `change_impact` `` und die ausdrückliche Grenze,
+dass Relation oder Pfadnähe allein keinen Change Impact beweisen. Fehlende Marker
+führen zu `fail` und werden im Detail einzeln genannt. Damit kann ein stale
+`VERSION:v1`-Pack nicht mehr in einer grünen Surface-Validation verborgen bleiben.
+Der bestehende Post-Merge-Surface-Smoke übernimmt dieses Ergebnis über
+`links.bundle_surface_validation_status`; parallele Markerlogik im Shell-Skript
+ist nicht nötig.
+
+Die Prüfung bewertet ausschließlich Aktualität und Mindestvollständigkeit der
+abgeleiteten Navigationsoberfläche (`authority=navigation_index`,
+`canonicality=derived`). Sie beweist **weder** Repo-Verständnis oder Claim-Wahrheit
+**noch** Antwortsicherheit, Review-Vollständigkeit oder Change Impact. Ein nach
+Restart beziehungsweise frischer Runtime-Ladung neu erzeugter Real-Dump bleibt
+notwendig, um zu belegen, dass die operative Service-Runtime tatsächlich den
+v1.1-Producer und den neuen Surface-Guard geladen hat.

--- a/merger/lenskit/core/bundle_surface_validate.py
+++ b/merger/lenskit/core/bundle_surface_validate.py
@@ -17,6 +17,8 @@ its internal coherence:
 - agent reading pack consistency: a present claim map MUST be summarized in the
   pack (with its artifact line), never announced as absent, and the legacy
   "not yet produced" placeholder is treated as drift;
+- agent reading pack front door: the emitted pack MUST expose the v1.1 version
+  sentinel, required navigation sections, and change-impact caution markers;
 - post-emit health: a persisted ``post_emit_health`` sidecar exists (so
   ``output_health=pass`` cannot be mistaken for forensic-readiness) AND its
   ``status`` is propagated — a present-but-failed post_emit_health drags the
@@ -65,7 +67,21 @@ _CLAIM_MAP_ROLE = ArtifactRole.CLAIM_EVIDENCE_MAP_JSON.value
 _AGENT_PACK_ROLE = ArtifactRole.AGENT_READING_PACK.value
 _OUTPUT_HEALTH_ROLE = ArtifactRole.OUTPUT_HEALTH.value
 
-# Pack markers (see core/agent_reading_pack.py: CLAIM_EVIDENCE_MAP_SUMMARY).
+# Pack markers (see core/agent_reading_pack.py). The surface validator keeps
+# these explicit because it guards the emitted runtime artifact, not merely the
+# producer's in-process version constant.
+_AGENT_PACK_V1_1_SENTINEL_PREFIX = (
+    "<!-- ARTIFACT:agent_reading_pack VERSION:v1.1 "
+)
+_AGENT_PACK_V1_1_FRONT_DOOR_MARKERS = (
+    "## REQUIRED_READING_BY_TASK",
+    "## WHEN_CANONICAL_MD_ONLY_IS_INSUFFICIENT",
+    "## SIDECAR_USAGE_RULES",
+    "## ANSWER_COMPLIANCE_CHECKLIST",
+    "## DO_NOT_CLAIM",
+    "`change_impact`",
+    "relation or path proximity alone does not prove change impact",
+)
 _PACK_SUMMARY_HEADER = "## CLAIM_EVIDENCE_MAP_SUMMARY"
 _PACK_ABSENT_PLACEHOLDER = "_No verified `claim_evidence_map_json` artifact present._"
 # Legacy placeholder emitted by stale builds that predate the claim-map wiring.
@@ -142,6 +158,46 @@ def _read_pack_text(manifest_dir: Path, pack_entry: Optional[Dict[str, Any]]) ->
         return path.read_text(encoding="utf-8")
     except (OSError, UnicodeError):
         return None
+
+
+def _pack_front_door_v1_1_check(
+    *,
+    pack_present_in_manifest: bool,
+    pack_text: Optional[str],
+) -> Dict[str, str]:
+    if not pack_present_in_manifest:
+        return _check(
+            "agent_reading_pack_front_door_v1_1",
+            "skipped",
+            "agent_reading_pack not declared in manifest",
+        )
+    if pack_text is None:
+        return _check(
+            "agent_reading_pack_front_door_v1_1",
+            "fail",
+            "agent_reading_pack declared but not readable; navigation surface "
+            "stale/incomplete",
+        )
+
+    missing = []
+    if not pack_text.startswith(_AGENT_PACK_V1_1_SENTINEL_PREFIX):
+        missing.append("ARTIFACT:agent_reading_pack VERSION:v1.1 sentinel")
+    missing.extend(
+        marker for marker in _AGENT_PACK_V1_1_FRONT_DOOR_MARKERS if marker not in pack_text
+    )
+    if missing:
+        return _check(
+            "agent_reading_pack_front_door_v1_1",
+            "fail",
+            "agent_reading_pack missing v1.1 front-door marker(s): "
+            + ", ".join(missing)
+            + "; navigation surface stale/incomplete",
+        )
+    return _check(
+        "agent_reading_pack_front_door_v1_1",
+        "pass",
+        "agent_reading_pack exposes the complete v1.1 front-door navigation surface",
+    )
 
 
 def _claim_surface_check(
@@ -457,6 +513,12 @@ def validate_bundle_surface(
             pack_text=pack_text,
             claim_present=claim_present,
             absence_reason=absence_reason,
+        )
+    )
+    checks.append(
+        _pack_front_door_v1_1_check(
+            pack_present_in_manifest=pack_entry is not None,
+            pack_text=pack_text,
         )
     )
 

--- a/merger/lenskit/core/bundle_surface_validate.py
+++ b/merger/lenskit/core/bundle_surface_validate.py
@@ -168,8 +168,8 @@ def _pack_front_door_v1_1_check(
     if not pack_present_in_manifest:
         return _check(
             "agent_reading_pack_front_door_v1_1",
-            "skipped",
-            "agent_reading_pack not declared in manifest",
+            "fail",
+            "agent_reading_pack not declared in manifest; navigation surface absent",
         )
     if pack_text is None:
         return _check(

--- a/merger/lenskit/tests/test_bundle_surface_validate.py
+++ b/merger/lenskit/tests/test_bundle_surface_validate.py
@@ -30,21 +30,34 @@ def _write_post_health(manifest_path, status="pass"):
     )
 
 
-_PACK_SUMMARY_PRESENT = (
+_PACK_V1_1_FRONT_DOOR = (
+    "<!-- ARTIFACT:agent_reading_pack VERSION:v1.1 "
+    "AUTHORITY:navigation_index CANONICALITY:derived -->\n"
+    "## REQUIRED_READING_BY_TASK\n"
+    "## WHEN_CANONICAL_MD_ONLY_IS_INSUFFICIENT\n"
+    "## SIDECAR_USAGE_RULES\n"
+    "## ANSWER_COMPLIANCE_CHECKLIST\n"
+    "## DO_NOT_CLAIM\n"
+    "- `change_impact` — relation or path proximity alone does not prove change impact.\n"
+)
+_PACK_SUMMARY_PRESENT = _PACK_V1_1_FRONT_DOOR + (
     "## CLAIM_EVIDENCE_MAP_SUMMARY\n"
     "- artifact: `x.claim_evidence_map.json`\n"
     "- claims: 3\n"
 )
-_PACK_ABSENT = (
+_PACK_ABSENT = _PACK_V1_1_FRONT_DOOR + (
     "## CLAIM_EVIDENCE_MAP_SUMMARY\n"
     "- _No verified `claim_evidence_map_json` artifact present._\n"
 )
-_PACK_ABSENT_WITH_REASON = (
+_PACK_ABSENT_WITH_REASON = _PACK_V1_1_FRONT_DOOR + (
     "## CLAIM_EVIDENCE_MAP_SUMMARY\n"
     "- _No verified `claim_evidence_map_json` artifact present._\n"
     "- reason=no_registry (registry missing)\n"
 )
-_PACK_LEGACY = "## CLAIM_EVIDENCE_MAP_SUMMARY\nclaim_evidence_map is not yet produced\n"
+_PACK_LEGACY = (
+    _PACK_V1_1_FRONT_DOOR
+    + "## CLAIM_EVIDENCE_MAP_SUMMARY\nclaim_evidence_map is not yet produced\n"
+)
 
 _DUMMY_SHA = "0" * 64
 
@@ -120,6 +133,76 @@ def _make_manifest(
 
 def _check(report, name):
     return next(c for c in report["checks"] if c["name"] == name)
+
+
+# ── agent-reading-pack v1.1 front door ─────────────────────────────────────
+
+
+def test_agent_pack_v1_1_front_door_passes(tmp_path):
+    mp = _make_manifest(tmp_path, claim_present=True)
+    report = validate_bundle_surface(mp, require_claim_evidence_map=True)
+
+    check = _check(report, "agent_reading_pack_front_door_v1_1")
+    assert check["status"] == "pass"
+    assert report["status"] == "pass"
+
+
+def test_agent_pack_v1_front_door_fails_and_names_missing_markers(tmp_path):
+    pack_text = (
+        "<!-- ARTIFACT:agent_reading_pack VERSION:v1 -->\n"
+        "## CLAIM_EVIDENCE_MAP_SUMMARY\n"
+        "- artifact: `x.claim_evidence_map.json`\n"
+    )
+    mp = _make_manifest(tmp_path, claim_present=True, pack_text=pack_text)
+    report = validate_bundle_surface(mp, require_claim_evidence_map=True)
+
+    check = _check(report, "agent_reading_pack_front_door_v1_1")
+    assert check["status"] == "fail"
+    assert report["status"] == "fail"
+    for marker in (
+        "VERSION:v1.1 sentinel",
+        "## REQUIRED_READING_BY_TASK",
+        "## DO_NOT_CLAIM",
+        "`change_impact`",
+        "relation or path proximity alone does not prove change impact",
+    ):
+        assert marker in check["detail"]
+    assert "navigation surface stale/incomplete" in check["detail"]
+
+
+def test_agent_pack_v1_10_sentinel_does_not_satisfy_v1_1(tmp_path):
+    pack_text = _PACK_SUMMARY_PRESENT.replace("VERSION:v1.1", "VERSION:v1.10")
+    mp = _make_manifest(tmp_path, claim_present=True, pack_text=pack_text)
+
+    report = validate_bundle_surface(mp, require_claim_evidence_map=True)
+
+    check = _check(report, "agent_reading_pack_front_door_v1_1")
+    assert check["status"] == "fail"
+    assert report["status"] == "fail"
+    assert "VERSION:v1.1 sentinel" in check["detail"]
+
+
+@pytest.mark.parametrize(
+    "missing_marker",
+    [
+        "## REQUIRED_READING_BY_TASK",
+        "## WHEN_CANONICAL_MD_ONLY_IS_INSUFFICIENT",
+        "## SIDECAR_USAGE_RULES",
+        "## ANSWER_COMPLIANCE_CHECKLIST",
+        "## DO_NOT_CLAIM",
+        "`change_impact`",
+        "relation or path proximity alone does not prove change impact",
+    ],
+)
+def test_agent_pack_missing_required_v1_1_marker_fails(tmp_path, missing_marker):
+    pack_text = _PACK_SUMMARY_PRESENT.replace(missing_marker, "")
+    mp = _make_manifest(tmp_path, claim_present=True, pack_text=pack_text)
+    report = validate_bundle_surface(mp, require_claim_evidence_map=True)
+
+    check = _check(report, "agent_reading_pack_front_door_v1_1")
+    assert check["status"] == "fail"
+    assert missing_marker in check["detail"]
+    assert report["status"] == "fail"
 
 
 # ── headline: claim-evidence-map surface ────────────────────────────────────

--- a/merger/lenskit/tests/test_bundle_surface_validate.py
+++ b/merger/lenskit/tests/test_bundle_surface_validate.py
@@ -147,6 +147,17 @@ def test_agent_pack_v1_1_front_door_passes(tmp_path):
     assert report["status"] == "pass"
 
 
+def test_agent_pack_front_door_fails_when_pack_missing(tmp_path):
+    mp = _make_manifest(tmp_path, claim_present=True, include_pack=False)
+    report = validate_bundle_surface(mp, require_claim_evidence_map=True)
+
+    check = _check(report, "agent_reading_pack_front_door_v1_1")
+    assert check["status"] == "fail"
+    assert report["status"] == "fail"
+    assert "not declared in manifest" in check["detail"]
+    assert "navigation surface absent" in check["detail"]
+
+
 def test_agent_pack_v1_front_door_fails_and_names_missing_markers(tmp_path):
     pack_text = (
         "<!-- ARTIFACT:agent_reading_pack VERSION:v1 -->\n"

--- a/merger/lenskit/tests/test_cli_bundle_surface.py
+++ b/merger/lenskit/tests/test_cli_bundle_surface.py
@@ -10,8 +10,25 @@ from merger.lenskit.core.post_emit_health import derive_post_health_path
 
 
 _DUMMY_SHA = "0" * 64
-_PACK_PRESENT = "## CLAIM_EVIDENCE_MAP_SUMMARY\n- artifact: `x.cem.json`\n- claims: 1\n"
-_PACK_ABSENT = "## CLAIM_EVIDENCE_MAP_SUMMARY\n- _No verified `claim_evidence_map_json` artifact present._\n"
+_AGENT_PACK_V1_1_FRONT_DOOR = (
+    "<!-- ARTIFACT:agent_reading_pack VERSION:v1.1 "
+    "AUTHORITY:navigation_index CANONICALITY:derived -->\n"
+    "## REQUIRED_READING_BY_TASK\n"
+    "## WHEN_CANONICAL_MD_ONLY_IS_INSUFFICIENT\n"
+    "## SIDECAR_USAGE_RULES\n"
+    "## ANSWER_COMPLIANCE_CHECKLIST\n"
+    "## DO_NOT_CLAIM\n"
+    "- `change_impact` — relation or path proximity alone does not prove change impact.\n"
+)
+_PACK_PRESENT = _AGENT_PACK_V1_1_FRONT_DOOR + (
+    "## CLAIM_EVIDENCE_MAP_SUMMARY\n"
+    "- artifact: `x.cem.json`\n"
+    "- claims: 1\n"
+)
+_PACK_ABSENT = _AGENT_PACK_V1_1_FRONT_DOOR + (
+    "## CLAIM_EVIDENCE_MAP_SUMMARY\n"
+    "- _No verified `claim_evidence_map_json` artifact present._\n"
+)
 
 
 def _make_bundle(tmp_path: Path, *, claim_present: bool, absence_reason=None) -> Path:
@@ -20,6 +37,8 @@ def _make_bundle(tmp_path: Path, *, claim_present: bool, absence_reason=None) ->
     artifacts.append({"role": "canonical_md", "path": "x.md", "sha256": _DUMMY_SHA, "bytes": 8})
 
     pack_text = _PACK_PRESENT if claim_present else _PACK_ABSENT
+    if not claim_present and absence_reason is not None:
+        pack_text += f"- reason={absence_reason} (declared fixture gap)\n"
     (tmp_path / "x.pack.md").write_text(pack_text, encoding="utf-8")
     artifacts.append(
         {"role": "agent_reading_pack", "path": "x.pack.md", "sha256": _DUMMY_SHA, "bytes": 1}
@@ -85,6 +104,9 @@ def test_cli_absent_without_reason_fails_exit_1(tmp_path, capsys):
     assert rc == 1
     out = json.loads(capsys.readouterr().out)
     assert out["status"] == "fail"
+    claim_check = next(c for c in out["checks"] if c["name"] == "claim_evidence_map_surface")
+    assert claim_check["status"] == "fail"
+    assert "silent absence" in claim_check["detail"]
 
 
 def test_cli_json_contains_claim_surface_check(tmp_path, capsys):


### PR DESCRIPTION
### Motivation

- Prevent a stale `agent_reading_pack` with `VERSION:v1` from producing a green bundle-surface validation by ensuring the emitted runtime-facing pack advertises the correct front-door and navigation markers.
- Make the surface validator assert minimum navigational completeness of the agent-facing pack rather than relying only on internal pack summary fields.
- Provide explicit failure details when required front-door markers are missing so stale or partial navigation surfaces cannot be hidden.

### Description

- Add constants `_AGENT_PACK_V1_1_SENTINEL_PREFIX` and `_AGENT_PACK_V1_1_FRONT_DOOR_MARKERS` and implement `_pack_front_door_v1_1_check` to validate that the emitted `agent_reading_pack` has the `VERSION:v1.1` sentinel and required front-door sections and markers. 
- Integrate the new front-door check into `validate_bundle_surface` so it is included in the overall surface validation rollup. 
- Update test fixtures and add unit tests in `merger/lenskit/tests/test_bundle_surface_validate.py` covering passing v1.1 packs, failing v1 packs, mismatched sentinels like `v1.10`, and parameterized missing-marker failure cases. 
- Document the change and rationale in `docs/proofs/real-dump-surface-self-check-proof.md` describing the runtime surface guard and its scope/limitations.

### Testing

- Ran the Lenskit test suite with `python3 -m pytest -q --ignore=merger/lenskit/tests/test_webui_payload.py merger/lenskit/tests/` and the run reported `1754 passed, 1 skipped`.
- The new unit tests in `merger/lenskit/tests/test_bundle_surface_validate.py` exercising `agent_reading_pack_front_door_v1_1` passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2aa014dfb4832ca53de6cd80c7c096)