### PR TITLE
Skip git subprocess probes on iOS and treat RuntimeError as git-unavailable in runtime provenance

### DIFF
--- a/merger/lenskit/core/runtime_provenance.py
+++ b/merger/lenskit/core/runtime_provenance.py
@@ -45,13 +45,22 @@ def _package_root() -> Path:
     return Path(__file__).resolve().parents[3]
 
 
+def _supports_git_subprocess_probe() -> bool:
+    """Return whether this runtime can safely attempt git subprocess probes."""
+    return sys.platform != "ios"
+
+
 def _git_state(package_root: Path) -> Tuple[Optional[str], Optional[bool]]:
     """Return ``(git_commit, git_dirty)`` for the generator working tree.
 
-    Returns ``(None, None)`` when the package root is not a git working tree or
-    git is unavailable — a service installed from a wheel legitimately has no
+    Returns ``(None, None)`` when the package root is not a git working tree,
+    git is unavailable, or subprocess execution is unsupported by the runtime —
+    a service installed from a wheel or a sandboxed runtime legitimately has no
     git state, which is itself a useful drift signal.
     """
+    if not _supports_git_subprocess_probe():
+        return None, None
+
     def _git(*args: str) -> Optional[str]:
         try:
             out = subprocess.run(
@@ -61,7 +70,7 @@ def _git_state(package_root: Path) -> Tuple[Optional[str], Optional[bool]]:
                 timeout=5,
                 check=False,
             )
-        except (OSError, subprocess.SubprocessError):
+        except (OSError, RuntimeError, subprocess.SubprocessError):
             return None
         if out.returncode != 0:
             return None

--- a/merger/lenskit/tests/test_runtime_provenance.py
+++ b/merger/lenskit/tests/test_runtime_provenance.py
@@ -65,6 +65,37 @@ def test_build_runtime_provenance_has_drift_fields():
     assert "git_dirty" in rt
 
 
+def test_runtime_provenance_skips_git_subprocess_probe_on_ios(monkeypatch):
+    from merger.lenskit.core import runtime_provenance as rp
+
+    def fail_run(*args, **kwargs):
+        raise AssertionError("subprocess.run must not be called on iOS")
+
+    monkeypatch.setattr(rp.sys, "platform", "ios")
+    monkeypatch.setattr(rp.subprocess, "run", fail_run)
+
+    runtime = rp.build_runtime_provenance(redact=False)
+
+    assert runtime["module"] == "merger.lenskit.core.merge"
+    assert runtime["python_version"]
+    assert "git_commit" in runtime
+    assert "git_dirty" in runtime
+    assert runtime["git_commit"] is None
+    assert runtime["git_dirty"] is None
+
+
+def test_git_state_treats_runtimeerror_as_git_unavailable(monkeypatch, tmp_path):
+    from merger.lenskit.core import runtime_provenance as rp
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("Subprocesses are not supported in this runtime")
+
+    monkeypatch.setattr(rp.sys, "platform", "linux")
+    monkeypatch.setattr(rp.subprocess, "run", boom)
+
+    assert rp._git_state(tmp_path) == (None, None)
+
+
 def test_generator_runtime_provenance_redacts_absolute_paths_when_redaction_enabled():
     rt = build_runtime_provenance(redact=True)
     # Absolute filesystem paths must be nulled in redacted/export mode.


### PR DESCRIPTION
### Motivation

- Prevent attempting to run `git` via subprocess in environments (notably iOS) where subprocess execution is unsupported. 
- Ensure that a runtime where `git` is unavailable or subprocesses are disallowed yields `(None, None)` for git state as a valid drift signal. 
- Treat `RuntimeError` raised by `subprocess.run` the same as other subprocess failures to avoid crashing provenance collection. 

### Description

- Added `_supports_git_subprocess_probe()` and early-return logic in `_git_state()` to skip subprocess probes on unsupported platforms. 
- Extended the `_git()` exception handling to catch `RuntimeError` in addition to `OSError` and `subprocess.SubprocessError`. 
- Updated `_git_state()` docstring to document subprocess-unavailable runtimes returning `(None, None)`. 
- Added tests `test_runtime_provenance_skips_git_subprocess_probe_on_ios` and `test_git_state_treats_runtimeerror_as_git_unavailable` to `merger/lenskit/tests/test_runtime_provenance.py`. 

### Testing

- Ran `pytest merger/lenskit/tests/test_runtime_provenance.py` which includes the new tests, and all tests passed. 
- Existing provenance tests such as `test_build_runtime_provenance_has_drift_fields` and redaction tests continued to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ab14b405c832ca362b9c186217e10)