### PR TITLE
Add PyYAML collections.abc compatibility shim and invoke it before YAML loading

### DIFF
--- a/merger/lenskit/core/doc_freshness.py
+++ b/merger/lenskit/core/doc_freshness.py
@@ -44,6 +44,9 @@ import re
 from typing import Iterable, Optional
 
 from merger.lenskit.core.path_security import resolve_secure_path
+from merger.lenskit.core.yaml_compat import (
+    ensure_pyyaml_collections_abc_compat,
+)
 
 # ``kind`` of evidence whose *presence* implies the work is implemented ("done").
 _DONE_KINDS = frozenset({"symbol", "test", "proof"})
@@ -474,6 +477,7 @@ def load_registry(path: Path) -> dict:
     import yaml
 
     text = path.read_text(encoding="utf-8")
+    ensure_pyyaml_collections_abc_compat()
     data = yaml.safe_load(text)
     if not isinstance(data, dict):
         raise ValueError(f"registry must be a YAML mapping: {path}")

--- a/merger/lenskit/core/merge.py
+++ b/merger/lenskit/core/merge.py
@@ -29,6 +29,7 @@ from . import clock
 from .chunker import Chunker
 from .redactor import Redactor
 from .range_resolver import build_explicit_range_ref
+from .yaml_compat import ensure_pyyaml_collections_abc_compat
 from . import __core_version__ as CORE_VERSION
 
 try:
@@ -1305,6 +1306,7 @@ def _render_augment_block(sources: List[Path], meta_density: str = "full") -> st
         return ""
 
     try:
+        ensure_pyyaml_collections_abc_compat()
         data = yaml.safe_load(raw)  # type: ignore[name-defined]
     except Exception as e:
         # If the augment file is malformed, log error and do not break the merge

--- a/merger/lenskit/core/yaml_compat.py
+++ b/merger/lenskit/core/yaml_compat.py
@@ -1,0 +1,18 @@
+"""Compatibility helpers for PyYAML on constrained or older runtimes."""
+from __future__ import annotations
+
+
+def ensure_pyyaml_collections_abc_compat() -> None:
+    """Provide legacy ``collections`` ABC aliases used by older PyYAML builds.
+
+    Some PyYAML versions still reference names such as ``collections.Hashable``
+    while modern Python exposes them under ``collections.abc``. Pythonista/iOS
+    can combine a newer standard library with an older PyYAML build, so YAML
+    loading installs these harmless aliases before calling ``yaml.safe_load``.
+    """
+    import collections
+    import collections.abc
+
+    for name in ("Hashable", "Mapping", "MutableMapping", "Sequence"):
+        if not hasattr(collections, name) and hasattr(collections.abc, name):
+            setattr(collections, name, getattr(collections.abc, name))

--- a/merger/lenskit/tests/test_doc_freshness.py
+++ b/merger/lenskit/tests/test_doc_freshness.py
@@ -26,6 +26,27 @@ from merger.lenskit.core.doc_freshness import (
 
 REPO_ROOT = repo_root_from_here()
 
+_PYYAML_COLLECTIONS_ALIASES = (
+    "Hashable",
+    "Mapping",
+    "MutableMapping",
+    "Sequence",
+)
+
+
+def _delete_pyyaml_collections_aliases(monkeypatch, collections_module) -> None:
+    import collections.abc
+
+    for name in _PYYAML_COLLECTIONS_ALIASES:
+        # Register even an initially missing attribute for automatic teardown.
+        monkeypatch.setattr(
+            collections_module,
+            name,
+            getattr(collections.abc, name),
+            raising=False,
+        )
+        monkeypatch.delattr(collections_module, name, raising=False)
+
 
 # --- evidence resolution -----------------------------------------------------
 
@@ -517,6 +538,28 @@ def test_verified_entry_ids_excludes_findings():
     assert "ok1" in ids
     assert "stale1" in ids  # tracked-but-ok is stampable
     assert "bad" not in ids
+
+
+def test_load_registry_installs_pyyaml_collections_compat_before_safe_load(
+    monkeypatch, tmp_path
+):
+    import collections
+    import collections.abc
+    import yaml
+
+    from merger.lenskit.core import doc_freshness
+
+    registry_path = tmp_path / "registry.yml"
+    registry_path.write_text("claims: []\n", encoding="utf-8")
+    _delete_pyyaml_collections_aliases(monkeypatch, collections)
+
+    def fake_safe_load(text):
+        assert text == "claims: []\n"
+        assert collections.Hashable is collections.abc.Hashable
+        return {"claims": []}
+
+    monkeypatch.setattr(yaml, "safe_load", fake_safe_load)
+    assert doc_freshness.load_registry(registry_path) == {"claims": []}
 
 
 # --- the REAL checked-in registry --------------------------------------------

--- a/merger/lenskit/tests/test_yaml_compat.py
+++ b/merger/lenskit/tests/test_yaml_compat.py
@@ -1,0 +1,48 @@
+"""Tests for compatibility with older PyYAML builds."""
+from __future__ import annotations
+
+import collections
+import collections.abc
+
+from merger.lenskit.core.yaml_compat import ensure_pyyaml_collections_abc_compat
+
+
+_ALIASES = ("Hashable", "Mapping", "MutableMapping", "Sequence")
+
+
+def _delete_pyyaml_collections_aliases(monkeypatch):
+    for name in _ALIASES:
+        # Register even an initially missing attribute for automatic teardown.
+        monkeypatch.setattr(
+            collections, name, getattr(collections.abc, name), raising=False
+        )
+        monkeypatch.delattr(collections, name, raising=False)
+
+
+def test_ensure_pyyaml_collections_abc_compat_installs_missing_aliases(monkeypatch):
+    _delete_pyyaml_collections_aliases(monkeypatch)
+
+    ensure_pyyaml_collections_abc_compat()
+
+    for name in _ALIASES:
+        assert getattr(collections, name) is getattr(collections.abc, name)
+
+
+def test_augment_yaml_load_installs_compat_before_safe_load(monkeypatch, tmp_path):
+    from merger.lenskit.core import merge
+
+    repo = tmp_path / "sample"
+    repo.mkdir()
+    (repo / "sample_augment.yml").write_text("augment: {}\n", encoding="utf-8")
+
+    _delete_pyyaml_collections_aliases(monkeypatch)
+
+    def fake_safe_load(text):
+        assert text == "augment: {}\n"
+        assert collections.Hashable is collections.abc.Hashable
+        return {"augment": {}}
+
+    monkeypatch.setattr(merge.yaml, "safe_load", fake_safe_load)
+    rendered = merge._render_augment_block([repo])
+
+    assert "Augment Intelligence" in rendered


### PR DESCRIPTION
### Motivation

- Some older PyYAML builds expect ABC names on the top-level `collections` module (e.g. `collections.Hashable`) while modern Python exposes them under `collections.abc`, which can break YAML parsing on constrained/older runtimes. 
- The augment-sidecar parsing and registry loading both use `yaml.safe_load`, so they need a small compatibility step to avoid runtime errors when an older PyYAML is present.

### Description

- Add a new compatibility helper `merger.lenskit.core.yaml_compat.ensure_pyyaml_collections_abc_compat` that installs harmless aliases for `Hashable`, `Mapping`, `MutableMapping`, and `Sequence` onto the `collections` module if missing. 
- Call `ensure_pyyaml_collections_abc_compat()` before any `yaml.safe_load` usage in `doc_freshness.load_registry` and `merge._render_augment_block`. 
- Add the new module import locations in `merger/lenskit/core/doc_freshness.py` and `merger/lenskit/core/merge.py`. 
- Add unit tests in `merger/lenskit/tests/test_yaml_compat.py` and extend `merger/lenskit/tests/test_doc_freshness.py` to verify the compatibility shim is installed prior to `safe_load` calls and that the augment rendering path exercises the shim.

### Testing

- Ran `pytest merger/lenskit/tests/test_yaml_compat.py` which verifies the shim installs the aliases and that the augment loader asserts the aliases are present before `safe_load`; it passed. 
- Ran the modified `test_doc_freshness::test_load_registry_installs_pyyaml_collections_compat_before_safe_load` which asserts `load_registry` invokes the compatibility helper prior to parsing; it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ad5839ef0832cb402f1b94646ba97)