### PR TITLE
Add fallback registry validator when `jsonschema` is unavailable and tests

### DIFF
--- a/merger/lenskit/core/doc_freshness.py
+++ b/merger/lenskit/core/doc_freshness.py
@@ -484,9 +484,174 @@ def load_registry(path: Path) -> dict:
     return data
 
 
+_REGISTRY_TOP_LEVEL_KEYS = frozenset(
+    {"kind", "version", "authority", "risk_class", "does_not_prove", "entries"}
+)
+_REGISTRY_ENTRY_KEYS = frozenset(
+    {
+        "id",
+        "doc",
+        "locator",
+        "claim",
+        "status",
+        "normative",
+        "owner",
+        "last_verified",
+        "evidence",
+        "notes",
+    }
+)
+_REGISTRY_EVIDENCE_KEYS = frozenset({"kind", "target", "implies"})
+_REGISTRY_ENTRY_REQUIRED = frozenset(
+    {"id", "doc", "claim", "status", "owner", "last_verified", "evidence"}
+)
+_REGISTRY_EVIDENCE_REQUIRED = frozenset({"kind", "target"})
+_REGISTRY_STATUSES = frozenset({"none", "partial", "done", "stale", "historical"})
+_REGISTRY_EVIDENCE_KINDS = frozenset(
+    {"symbol", "file", "text", "absent_text", "proof", "test"}
+)
+_REGISTRY_EVIDENCE_IMPLIES = frozenset({"done", "open"})
+_REGISTRY_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+_REGISTRY_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def _validate_registry_minimal(data: dict) -> list[str]:
+    """Return structural registry errors when ``jsonschema`` is unavailable.
+
+    This dependency-free fallback covers the contract structure required to
+    produce a claim-evidence map in constrained runtimes such as Pythonista/iOS.
+    It intentionally is not a complete JSON Schema implementation; runtimes
+    with ``jsonschema`` installed continue to perform full Draft 7 validation.
+    """
+    errors: list[str] = []
+    if not isinstance(data, dict):
+        return ["[<root>] must be an object"]
+
+    for key in sorted(set(data) - _REGISTRY_TOP_LEVEL_KEYS):
+        errors.append(f"[<root>] unknown field: {key}")
+
+    for field_name in ("kind", "version", "entries"):
+        if field_name not in data:
+            errors.append(f"[<root>] missing required field: {field_name}")
+
+    if "kind" in data and data["kind"] != "lenskit.doc_freshness_registry":
+        errors.append("[kind] must equal lenskit.doc_freshness_registry")
+    if "version" in data and data["version"] != "1.0":
+        errors.append("[version] must equal 1.0")
+    if "authority" in data and data["authority"] != "diagnostic_signal":
+        errors.append("[authority] must equal diagnostic_signal")
+    if "risk_class" in data and data["risk_class"] != "diagnostic":
+        errors.append("[risk_class] must equal diagnostic")
+
+    if "does_not_prove" in data:
+        does_not_prove = data["does_not_prove"]
+        if not isinstance(does_not_prove, list) or not all(
+            isinstance(item, str) for item in does_not_prove
+        ):
+            errors.append("[does_not_prove] must be a list of strings")
+
+    entries = data.get("entries")
+    if not isinstance(entries, list):
+        if "entries" in data:
+            errors.append("[entries] must be a list")
+        return errors
+
+    for entry_index, entry in enumerate(entries):
+        entry_path = f"entries.{entry_index}"
+        if not isinstance(entry, dict):
+            errors.append(f"[{entry_path}] must be an object")
+            continue
+
+        for key in sorted(set(entry) - _REGISTRY_ENTRY_KEYS):
+            errors.append(f"[{entry_path}] unknown field: {key}")
+        for field_name in sorted(_REGISTRY_ENTRY_REQUIRED - set(entry)):
+            errors.append(f"[{entry_path}] missing required field: {field_name}")
+
+        entry_id = entry.get("id")
+        if "id" in entry and (
+            not isinstance(entry_id, str)
+            or _REGISTRY_ID_PATTERN.fullmatch(entry_id) is None
+        ):
+            errors.append(f"[{entry_path}.id] must match ^[a-z0-9][a-z0-9-]*$")
+
+        for field_name in ("doc", "claim", "owner"):
+            if field_name in entry and (
+                not isinstance(entry[field_name], str) or not entry[field_name]
+            ):
+                errors.append(
+                    f"[{entry_path}.{field_name}] must be a non-empty string"
+                )
+
+        status = entry.get("status")
+        if "status" in entry and status not in _REGISTRY_STATUSES:
+            errors.append(f"[{entry_path}.status] invalid status: {status}")
+
+        last_verified = entry.get("last_verified")
+        if "last_verified" in entry and (
+            not isinstance(last_verified, str)
+            or _REGISTRY_DATE_PATTERN.fullmatch(last_verified) is None
+        ):
+            errors.append(f"[{entry_path}.last_verified] must match YYYY-MM-DD")
+
+        if "normative" in entry and not isinstance(entry["normative"], bool):
+            errors.append(f"[{entry_path}.normative] must be a boolean")
+        for field_name in ("locator", "notes"):
+            if field_name in entry and not isinstance(entry[field_name], str):
+                errors.append(f"[{entry_path}.{field_name}] must be a string")
+
+        evidence = entry.get("evidence")
+        if not isinstance(evidence, list):
+            if "evidence" in entry:
+                errors.append(f"[{entry_path}.evidence] must be a list")
+            continue
+        if not evidence:
+            errors.append(f"[{entry_path}.evidence] must not be empty")
+
+        for evidence_index, evidence_item in enumerate(evidence):
+            evidence_path = f"{entry_path}.evidence.{evidence_index}"
+            if not isinstance(evidence_item, dict):
+                errors.append(f"[{evidence_path}] must be an object")
+                continue
+
+            for key in sorted(set(evidence_item) - _REGISTRY_EVIDENCE_KEYS):
+                errors.append(f"[{evidence_path}] unknown field: {key}")
+            for field_name in sorted(
+                _REGISTRY_EVIDENCE_REQUIRED - set(evidence_item)
+            ):
+                errors.append(
+                    f"[{evidence_path}] missing required field: {field_name}"
+                )
+
+            kind = evidence_item.get("kind")
+            if "kind" in evidence_item and kind not in _REGISTRY_EVIDENCE_KINDS:
+                errors.append(f"[{evidence_path}.kind] invalid kind: {kind}")
+
+            target = evidence_item.get("target")
+            if "target" in evidence_item and (
+                not isinstance(target, str) or not target
+            ):
+                errors.append(f"[{evidence_path}.target] must be a non-empty string")
+
+            implies = evidence_item.get("implies")
+            if "implies" in evidence_item and implies not in _REGISTRY_EVIDENCE_IMPLIES:
+                errors.append(f"[{evidence_path}.implies] invalid implies: {implies}")
+
+    return errors
+
+
 def validate_registry(data: dict, schema_path: Path) -> list[str]:
-    """Return schema-validation errors (empty == valid)."""
-    import jsonschema
+    """Return registry-validation errors (empty means valid).
+
+    Full Draft 7 validation is used when ``jsonschema`` is available. Constrained
+    runtimes without that optional dependency use a deliberately limited,
+    dependency-free structural validator instead.
+    """
+    try:
+        import jsonschema
+    except ModuleNotFoundError as exc:
+        if exc.name != "jsonschema":
+            raise
+        return _validate_registry_minimal(data)
 
     schema = json.loads(schema_path.read_text(encoding="utf-8"))
     validator = jsonschema.Draft7Validator(schema)

--- a/merger/lenskit/core/doc_freshness.py
+++ b/merger/lenskit/core/doc_freshness.py
@@ -583,8 +583,11 @@ def _validate_registry_minimal(data: dict) -> list[str]:
                 )
 
         status = entry.get("status")
-        if "status" in entry and status not in _REGISTRY_STATUSES:
-            errors.append(f"[{entry_path}.status] invalid status: {status}")
+        if "status" in entry:
+            if not isinstance(status, str):
+                errors.append(f"[{entry_path}.status] must be a string")
+            elif status not in _REGISTRY_STATUSES:
+                errors.append(f"[{entry_path}.status] invalid status: {status}")
 
         last_verified = entry.get("last_verified")
         if "last_verified" in entry and (
@@ -623,8 +626,11 @@ def _validate_registry_minimal(data: dict) -> list[str]:
                 )
 
             kind = evidence_item.get("kind")
-            if "kind" in evidence_item and kind not in _REGISTRY_EVIDENCE_KINDS:
-                errors.append(f"[{evidence_path}.kind] invalid kind: {kind}")
+            if "kind" in evidence_item:
+                if not isinstance(kind, str):
+                    errors.append(f"[{evidence_path}.kind] must be a string")
+                elif kind not in _REGISTRY_EVIDENCE_KINDS:
+                    errors.append(f"[{evidence_path}.kind] invalid kind: {kind}")
 
             target = evidence_item.get("target")
             if "target" in evidence_item and (
@@ -633,8 +639,11 @@ def _validate_registry_minimal(data: dict) -> list[str]:
                 errors.append(f"[{evidence_path}.target] must be a non-empty string")
 
             implies = evidence_item.get("implies")
-            if "implies" in evidence_item and implies not in _REGISTRY_EVIDENCE_IMPLIES:
-                errors.append(f"[{evidence_path}.implies] invalid implies: {implies}")
+            if "implies" in evidence_item:
+                if not isinstance(implies, str):
+                    errors.append(f"[{evidence_path}.implies] must be a string")
+                elif implies not in _REGISTRY_EVIDENCE_IMPLIES:
+                    errors.append(f"[{evidence_path}.implies] invalid implies: {implies}")
 
     return errors
 

--- a/merger/lenskit/tests/conftest.py
+++ b/merger/lenskit/tests/conftest.py
@@ -1,8 +1,16 @@
+from pathlib import Path
+import shutil
+import sys
+import tempfile
 
 import pytest
-import shutil
-import tempfile
-from pathlib import Path
+
+
+@pytest.fixture
+def no_jsonschema(monkeypatch):
+    """Simulate an environment where importing jsonschema fails."""
+    monkeypatch.setitem(sys.modules, "jsonschema", None)
+
 
 @pytest.fixture
 def service_client():

--- a/merger/lenskit/tests/test_claim_evidence_map.py
+++ b/merger/lenskit/tests/test_claim_evidence_map.py
@@ -226,59 +226,124 @@ entries:
     assert from_disk["claims"][0]["requires_live_check"] is True
 
 
+def test_produce_claim_evidence_map_works_without_jsonschema(
+    no_jsonschema, tmp_path
+):
+    registry_path = tmp_path / "docs" / "doc-freshness-registry.yml"
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        """
+kind: lenskit.doc_freshness_registry
+version: "1.0"
+entries:
+  - id: sample-claim
+    doc: docs/sample.md
+    claim: sample claim
+    status: done
+    owner: tests
+    last_verified: "2026-06-11"
+    evidence:
+      - kind: proof
+        target: docs/proofs/sample.md
+""".lstrip(),
+        encoding="utf-8",
+    )
+    out = tmp_path / "out" / "bundle.claim_evidence_map.json"
+
+    result = produce_claim_evidence_map(
+        registry_path, out, generated_at="2026-06-11T00:00:00Z"
+    )
+
+    assert out.exists()
+    assert [claim["id"] for claim in result["claims"]] == ["sample-claim"]
+    assert json.loads(out.read_text(encoding="utf-8")) == result
+
+
 def test_produce_claim_evidence_map_generated_at_is_deterministic_from_registry(tmp_path):
-        registry_path = tmp_path / "docs" / "doc-freshness-registry.yml"
-        registry_path.parent.mkdir(parents=True)
-        registry_path.write_text(
-                (
-                        "kind: lenskit.doc_freshness_registry\n"
-                        "version: \"1.0\"\n"
-                        "entries:\n"
-                        "  - id: a\n"
-                        "    doc: docs/a.md\n"
-                        "    locator: a\n"
-                        "    claim: a\n"
-                        "    status: done\n"
-                        "    normative: false\n"
-                        "    owner: o\n"
-                        "    last_verified: \"2026-05-30\"\n"
-                        "    evidence:\n"
-                        "      - kind: file\n"
-                        "        target: docs/a.md\n"
-                        "  - id: b\n"
-                        "    doc: docs/b.md\n"
-                        "    locator: b\n"
-                        "    claim: b\n"
-                        "    status: done\n"
-                        "    normative: false\n"
-                        "    owner: o\n"
-                        "    last_verified: \"2026-05-31\"\n"
-                        "    evidence:\n"
-                        "      - kind: file\n"
-                        "        target: docs/b.md\n"
-                ),
-                encoding="utf-8",
-        )
+    registry_path = tmp_path / "docs" / "doc-freshness-registry.yml"
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        (
+            "kind: lenskit.doc_freshness_registry\n"
+            "version: \"1.0\"\n"
+            "entries:\n"
+            "  - id: a\n"
+            "    doc: docs/a.md\n"
+            "    locator: a\n"
+            "    claim: a\n"
+            "    status: done\n"
+            "    normative: false\n"
+            "    owner: o\n"
+            "    last_verified: \"2026-05-30\"\n"
+            "    evidence:\n"
+            "      - kind: file\n"
+            "        target: docs/a.md\n"
+            "  - id: b\n"
+            "    doc: docs/b.md\n"
+            "    locator: b\n"
+            "    claim: b\n"
+            "    status: done\n"
+            "    normative: false\n"
+            "    owner: o\n"
+            "    last_verified: \"2026-05-31\"\n"
+            "    evidence:\n"
+            "      - kind: file\n"
+            "        target: docs/b.md\n"
+        ),
+        encoding="utf-8",
+    )
 
-        contracts_dir = tmp_path / "merger" / "lenskit" / "contracts"
-        contracts_dir.mkdir(parents=True)
-        source_schema = (
-                Path(__file__).parent.parent / "contracts" / "doc-freshness-registry.v1.schema.json"
-        )
-        (contracts_dir / "doc-freshness-registry.v1.schema.json").write_text(
-                source_schema.read_text(encoding="utf-8"),
-                encoding="utf-8",
-        )
+    contracts_dir = tmp_path / "merger" / "lenskit" / "contracts"
+    contracts_dir.mkdir(parents=True)
+    source_schema = (
+        Path(__file__).parent.parent
+        / "contracts"
+        / "doc-freshness-registry.v1.schema.json"
+    )
+    (contracts_dir / "doc-freshness-registry.v1.schema.json").write_text(
+        source_schema.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
 
-        out1 = tmp_path / "out" / "a.claim_evidence_map.json"
-        out2 = tmp_path / "out" / "b.claim_evidence_map.json"
+    out1 = tmp_path / "out" / "a.claim_evidence_map.json"
+    out2 = tmp_path / "out" / "b.claim_evidence_map.json"
 
-        first = produce_claim_evidence_map(registry_path, out1)
-        second = produce_claim_evidence_map(registry_path, out2)
+    first = produce_claim_evidence_map(registry_path, out1)
+    second = produce_claim_evidence_map(registry_path, out2)
 
-        assert first["source"]["generated_at"] == "2026-05-31T00:00:00Z"
-        assert first["source"]["generated_at"] == second["source"]["generated_at"]
-        assert out1.read_text(encoding="utf-8") == out2.read_text(encoding="utf-8")
+    assert first["source"]["generated_at"] == "2026-05-31T00:00:00Z"
+    assert first["source"]["generated_at"] == second["source"]["generated_at"]
+    assert out1.read_text(encoding="utf-8") == out2.read_text(encoding="utf-8")
+
+
+def test_produce_claim_evidence_map_rejects_fallback_validation_errors(
+    no_jsonschema, tmp_path
+):
+    registry_path = tmp_path / "docs" / "doc-freshness-registry.yml"
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        """
+kind: lenskit.doc_freshness_registry
+version: "1.0"
+entries:
+  - id: Bad ID
+    doc: docs/sample.md
+    claim: sample claim
+    status: banana
+    owner: tests
+    last_verified: "2026-06-11"
+    evidence:
+      - kind: proof
+        target: docs/proofs/sample.md
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    out = tmp_path / "out" / "bundle.claim_evidence_map.json"
+    with pytest.raises(ValueError, match="validation failed.*invalid status: banana"):
+        produce_claim_evidence_map(registry_path, out)
+
+    assert not out.exists()
 
 
 def test_produce_claim_evidence_map_raises_for_invalid_registry(tmp_path):

--- a/merger/lenskit/tests/test_claim_evidence_map.py
+++ b/merger/lenskit/tests/test_claim_evidence_map.py
@@ -1,7 +1,6 @@
 import json
 from pathlib import Path
 
-import jsonschema
 import pytest
 
 from merger.lenskit.core.claim_evidence_map import (
@@ -72,6 +71,7 @@ def _collect_field_names(value):
 
 
 def test_claim_evidence_map_schema_accepts_minimal_valid_document():
+    jsonschema = pytest.importorskip("jsonschema")
     doc = {
         "kind": "lenskit.claim_evidence_map",
         "version": "1.0",
@@ -176,6 +176,7 @@ def test_claim_evidence_map_has_no_truth_verdict_fields():
 
 
 def test_produce_claim_evidence_map_from_doc_freshness_registry(tmp_path):
+    jsonschema = pytest.importorskip("jsonschema")
     registry_path = tmp_path / "docs" / "doc-freshness-registry.yml"
     registry_path.parent.mkdir(parents=True)
     registry_path.write_text(
@@ -340,9 +341,12 @@ entries:
     )
 
     out = tmp_path / "out" / "bundle.claim_evidence_map.json"
-    with pytest.raises(ValueError, match="validation failed.*invalid status: banana"):
+    with pytest.raises(ValueError) as excinfo:
         produce_claim_evidence_map(registry_path, out)
 
+    message = str(excinfo.value)
+    assert "validation failed" in message
+    assert "invalid status: banana" in message
     assert not out.exists()
 
 

--- a/merger/lenskit/tests/test_doc_freshness.py
+++ b/merger/lenskit/tests/test_doc_freshness.py
@@ -562,6 +562,57 @@ def test_load_registry_installs_pyyaml_collections_compat_before_safe_load(
     assert doc_freshness.load_registry(registry_path) == {"claims": []}
 
 
+def test_validate_registry_falls_back_when_jsonschema_missing(no_jsonschema, tmp_path):
+    valid = {
+        "kind": "lenskit.doc_freshness_registry",
+        "version": "1.0",
+        "entries": [
+            {
+                "id": "sample-claim",
+                "doc": "docs/sample.md",
+                "claim": "sample claim",
+                "status": "done",
+                "owner": "tests",
+                "last_verified": "2026-06-11",
+                "evidence": [
+                    {"kind": "proof", "target": "docs/proofs/sample.md"}
+                ],
+            }
+        ],
+    }
+
+    assert validate_registry(valid, tmp_path / "unused.schema.json") == []
+
+
+def test_validate_registry_fallback_reports_structural_errors(
+    no_jsonschema, tmp_path
+):
+    invalid = {
+        "kind": "lenskit.doc_freshness_registry",
+        "version": "1.0",
+        "entries": [
+            {
+                "id": "Bad ID",
+                "doc": "",
+                "claim": "sample claim",
+                "status": "banana",
+                "owner": "tests",
+                "last_verified": "not-a-date",
+                "evidence": [{"kind": "banana", "target": ""}],
+            }
+        ],
+    }
+
+    errors = validate_registry(invalid, tmp_path / "unused.schema.json")
+
+    assert "[entries.0.id] must match ^[a-z0-9][a-z0-9-]*$" in errors
+    assert "[entries.0.doc] must be a non-empty string" in errors
+    assert "[entries.0.status] invalid status: banana" in errors
+    assert "[entries.0.last_verified] must match YYYY-MM-DD" in errors
+    assert "[entries.0.evidence.0.kind] invalid kind: banana" in errors
+    assert "[entries.0.evidence.0.target] must be a non-empty string" in errors
+
+
 # --- the REAL checked-in registry --------------------------------------------
 
 

--- a/merger/lenskit/tests/test_doc_freshness.py
+++ b/merger/lenskit/tests/test_doc_freshness.py
@@ -613,6 +613,38 @@ def test_validate_registry_fallback_reports_structural_errors(
     assert "[entries.0.evidence.0.target] must be a non-empty string" in errors
 
 
+def test_validate_registry_fallback_reports_type_errors_for_enum_fields(
+    no_jsonschema, tmp_path
+):
+    invalid = {
+        "kind": "lenskit.doc_freshness_registry",
+        "version": "1.0",
+        "entries": [
+            {
+                "id": "sample-claim",
+                "doc": "docs/sample.md",
+                "claim": "sample claim",
+                "status": ["done"],
+                "owner": "tests",
+                "last_verified": "2026-06-11",
+                "evidence": [
+                    {
+                        "kind": {"bad": "value"},
+                        "target": "docs/proofs/sample.md",
+                        "implies": ["open"],
+                    }
+                ],
+            }
+        ],
+    }
+
+    errors = validate_registry(invalid, tmp_path / "unused.schema.json")
+
+    assert "[entries.0.status] must be a string" in errors
+    assert "[entries.0.evidence.0.kind] must be a string" in errors
+    assert "[entries.0.evidence.0.implies] must be a string" in errors
+
+
 # --- the REAL checked-in registry --------------------------------------------
 
 


### PR DESCRIPTION
### Motivation
- Allow registry validation to work in constrained environments where the optional `jsonschema` package is not installed by providing a minimal, dependency-free structural validator.
- Ensure `produce_claim_evidence_map` and related flows behave predictably when `jsonschema` is missing, returning informative errors rather than raising import errors.
- Add tests that simulate missing `jsonschema` and validate both successful and failing fallback validation scenarios.

### Description
- Introduce a minimal validator `_validate_registry_minimal` in `merger/lenskit/core/doc_freshness.py` that enforces the expected registry structure, required fields, allowed keys, ID/date patterns, allowed statuses, and evidence constraints without external dependencies.
- Add constants for allowed registry keys, entry/evidence fields, patterns, and enumerations to centralize validation rules in `doc_freshness.py`.
- Update `validate_registry` to attempt full Draft 7 validation using `jsonschema` and fall back to `_validate_registry_minimal` when `jsonschema` is not importable, with a clear docstring explaining the behavior.
- Add a `no_jsonschema` pytest fixture in `merger/lenskit/tests/conftest.py` that simulates the absence of `jsonschema` by inserting `None` into `sys.modules`.
- Add tests to `merger/lenskit/tests/test_claim_evidence_map.py` and `merger/lenskit/tests/test_doc_freshness.py` to verify that `produce_claim_evidence_map` and `validate_registry` work with and without `jsonschema`, and that the fallback reports structural errors and causes `produce_claim_evidence_map` to raise on invalid input.

### Testing
- Ran the lenskit unit tests in `merger/lenskit/tests` with `pytest`, including `test_produce_claim_evidence_map_works_without_jsonschema`, `test_produce_claim_evidence_map_rejects_fallback_validation_errors`, `test_validate_registry_falls_back_when_jsonschema_missing`, and `test_validate_registry_fallback_reports_structural_errors`, and all passed.
- Verified that `produce_claim_evidence_map` writes the expected output file when `jsonschema` is missing and that it raises `ValueError` for registries failing the fallback validation. 
- Confirmed that when `jsonschema` is present, `validate_registry` continues to use full Draft 7 validation and returns no errors for a valid real registry via `test_real_registry_schema_valid`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ae5cf3b7c832cbc5633d25d265a15)