### PR TITLE
Expose validation metadata and structured range_ref_resolution in health reports

### DIFF
--- a/merger/lenskit/contracts/output-health.v1.schema.json
+++ b/merger/lenskit/contracts/output-health.v1.schema.json
@@ -122,6 +122,49 @@
           "enum": ["ok", "fail", "environment_error", "no_range_ref", "unavailable", "skipped"],
           "description": "Fine-grained status for the range_ref check. 'environment_error' means jsonschema is unavailable — the check could not run, not that data is broken. 'fail' means a real semantic/structural error was detected."
         },
+        "range_ref_resolution": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status", "required", "reason", "validation"],
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": ["ok", "fail", "environment_error", "no_range_ref", "unavailable", "skipped"]
+            },
+            "required": {
+              "type": "boolean"
+            },
+            "reason": {
+              "type": "string"
+            },
+            "validation": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["mode", "engine", "reason"],
+              "properties": {
+                "mode": {
+                  "type": "string",
+                  "enum": ["jsonschema", "minimal_fallback", "skipped_unavailable"]
+                },
+                "engine": {
+                  "type": "string",
+                  "enum": ["jsonschema", "range_resolver", "doc_freshness_minimal"]
+                },
+                "reason": {
+                  "type": "string",
+                  "enum": [
+                    "available",
+                    "dependency_unavailable",
+                    "jsonschema_unavailable",
+                    "schema_missing",
+                    "check_not_applicable",
+                    "unsupported_runtime"
+                  ]
+                }
+              }
+            }
+          }
+        },
         "sample_query_content_hit": {
           "type": "object",
           "required": ["status", "required"],

--- a/merger/lenskit/contracts/output-health.v1.schema.json
+++ b/merger/lenskit/contracts/output-health.v1.schema.json
@@ -144,7 +144,7 @@
               "properties": {
                 "mode": {
                   "type": "string",
-                  "enum": ["jsonschema", "minimal_fallback", "skipped_unavailable"]
+                  "enum": ["jsonschema", "minimal_fallback", "skipped_unavailable", "structural_precheck"]
                 },
                 "engine": {
                   "type": "string",
@@ -158,7 +158,8 @@
                     "jsonschema_unavailable",
                     "schema_missing",
                     "check_not_applicable",
-                    "unsupported_runtime"
+                    "unsupported_runtime",
+                    "malformed_range_ref"
                   ]
                 }
               }

--- a/merger/lenskit/contracts/post-emit-health.v1.schema.json
+++ b/merger/lenskit/contracts/post-emit-health.v1.schema.json
@@ -92,6 +92,32 @@
           },
           "detail": {
             "type": "string"
+          },
+          "validation": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["mode", "engine", "reason"],
+            "properties": {
+              "mode": {
+                "type": "string",
+                "enum": ["jsonschema", "minimal_fallback", "skipped_unavailable"]
+              },
+              "engine": {
+                "type": "string",
+                "enum": ["jsonschema", "range_resolver", "doc_freshness_minimal"]
+              },
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "available",
+                  "dependency_unavailable",
+                  "jsonschema_unavailable",
+                  "schema_missing",
+                  "check_not_applicable",
+                  "unsupported_runtime"
+                ]
+              }
+            }
           }
         }
       }

--- a/merger/lenskit/contracts/post-emit-health.v1.schema.json
+++ b/merger/lenskit/contracts/post-emit-health.v1.schema.json
@@ -100,7 +100,7 @@
             "properties": {
               "mode": {
                 "type": "string",
-                "enum": ["jsonschema", "minimal_fallback", "skipped_unavailable"]
+                "enum": ["jsonschema", "minimal_fallback", "skipped_unavailable", "structural_precheck"]
               },
               "engine": {
                 "type": "string",
@@ -114,7 +114,8 @@
                   "jsonschema_unavailable",
                   "schema_missing",
                   "check_not_applicable",
-                  "unsupported_runtime"
+                  "unsupported_runtime",
+                  "malformed_range_ref"
                 ]
               }
             }

--- a/merger/lenskit/core/output_health.py
+++ b/merger/lenskit/core/output_health.py
@@ -406,6 +406,32 @@ def compute_output_health(
         rr_ok, rr_msgs, rr_status = _range_ref_check(dump_index_path, chunk_index_path)
         checks["range_ref_resolution_ok"] = rr_ok
         checks["range_ref_resolution_status"] = rr_status
+        # mode names the validation capability used by this check; engine names
+        # the local component consuming that capability, not a schema engine.
+        if rr_status == "environment_error":
+            rr_validation = {
+                "mode": "skipped_unavailable",
+                "engine": "range_resolver",
+                "reason": "dependency_unavailable",
+            }
+        elif rr_status in {"ok", "fail"}:
+            rr_validation = {
+                "mode": "jsonschema",
+                "engine": "range_resolver",
+                "reason": "available",
+            }
+        else:
+            rr_validation = {
+                "mode": "skipped_unavailable",
+                "engine": "range_resolver",
+                "reason": "check_not_applicable",
+            }
+        checks["range_ref_resolution"] = {
+            "status": rr_status,
+            "required": True,
+            "reason": rr_msgs[0] if rr_msgs else "range_ref validation completed",
+            "validation": rr_validation,
+        }
         if rr_ok is False:
             errors.extend(rr_msgs)
         else:
@@ -414,6 +440,16 @@ def compute_output_health(
     else:
         checks["range_ref_resolution_ok"] = None
         checks["range_ref_resolution_status"] = "skipped"
+        checks["range_ref_resolution"] = {
+            "status": "skipped",
+            "required": False,
+            "reason": "chunk_index not required; range_ref check not applicable",
+            "validation": {
+                "mode": "skipped_unavailable",
+                "engine": "range_resolver",
+                "reason": "check_not_applicable",
+            },
+        }
 
     # ── non-blocking optional checks ────────────────────────────────────────
     checks["sample_query_content_hit"] = {

--- a/merger/lenskit/core/output_health.py
+++ b/merger/lenskit/core/output_health.py
@@ -195,13 +195,14 @@ def _range_ref_check(
     chunk_index_path: Optional[Path],
 ) -> Tuple[Optional[bool], List[str], str, Dict[str, str]]:
     """
-    Find one chunk with content_range_ref and attempt resolution.
+    Find one chunk with canonical_range (or legacy content_range_ref) and attempt
+    resolution.
 
     Returns (ok, messages, status, validation) where:
       ok=True,  status="ok"               — at least one ref resolved successfully
       ok=False, status="fail"             — real semantic / structural failure
       ok=None,  status="environment_error"— jsonschema not installed; check not executable
-      ok=None,  status="no_range_ref"     — no content_range_ref found (inline-only bundle)
+      ok=None,  status="no_range_ref"     — no range reference found (inline-only bundle)
       ok=None,  status="unavailable"      — required input file missing
 
     messages go to errors when ok=False, to warnings otherwise.
@@ -226,7 +227,9 @@ def _range_ref_check(
                     continue
                 if not isinstance(chunk, dict):
                     continue
-                raw_ref = chunk.get("content_range_ref")
+                raw_ref = chunk.get("canonical_range")
+                if raw_ref is None:
+                    raw_ref = chunk.get("content_range_ref")
                 if raw_ref is not None:
                     if isinstance(raw_ref, str):
                         try:
@@ -234,7 +237,7 @@ def _range_ref_check(
                         except json.JSONDecodeError as e:
                             return (
                                 False,
-                                [f"invalid content_range_ref JSON string: {e}"],
+                                [f"invalid range reference JSON string: {e}"],
                                 "fail",
                                 _range_ref_validation(
                                     "structural_precheck", "malformed_range_ref"
@@ -243,7 +246,7 @@ def _range_ref_check(
                     if not isinstance(raw_ref, dict):
                         return (
                             False,
-                            [f"content_range_ref must be an object, got {type(raw_ref).__name__}"],
+                            [f"range reference must be an object, got {type(raw_ref).__name__}"],
                             "fail",
                             _range_ref_validation(
                                 "structural_precheck", "malformed_range_ref"
@@ -257,7 +260,7 @@ def _range_ref_check(
     if sample_ref is None:
         # No range_ref present in any chunk; this is normal for inline-only bundles
         # but should be flagged as a non-blocking issue
-        return None, ["no content_range_ref found; range_ref check skipped"], "no_range_ref", not_applicable
+        return None, ["no range reference found; range_ref check skipped"], "no_range_ref", not_applicable
 
     try:
         from .range_resolver import resolve_range_ref

--- a/merger/lenskit/core/output_health.py
+++ b/merger/lenskit/core/output_health.py
@@ -186,14 +186,18 @@ def _is_jsonschema_unavailable_error(exc: Exception) -> bool:
     return isinstance(exc, RuntimeError) and any(m in msg for m in _JSONSCHEMA_UNAVAILABLE_MARKERS)
 
 
+def _range_ref_validation(mode: str, reason: str) -> Dict[str, str]:
+    return {"mode": mode, "engine": "range_resolver", "reason": reason}
+
+
 def _range_ref_check(
     dump_index_path: Optional[Path],
     chunk_index_path: Optional[Path],
-) -> Tuple[Optional[bool], List[str], str]:
+) -> Tuple[Optional[bool], List[str], str, Dict[str, str]]:
     """
     Find one chunk with content_range_ref and attempt resolution.
 
-    Returns (ok, messages, status) where:
+    Returns (ok, messages, status, validation) where:
       ok=True,  status="ok"               — at least one ref resolved successfully
       ok=False, status="fail"             — real semantic / structural failure
       ok=None,  status="environment_error"— jsonschema not installed; check not executable
@@ -202,10 +206,13 @@ def _range_ref_check(
 
     messages go to errors when ok=False, to warnings otherwise.
     """
+    not_applicable = _range_ref_validation(
+        "skipped_unavailable", "check_not_applicable"
+    )
     if not chunk_index_path or not chunk_index_path.exists():
-        return None, ["chunk_index not available for range_ref check"], "unavailable"
+        return None, ["chunk_index not available for range_ref check"], "unavailable", not_applicable
     if not dump_index_path or not dump_index_path.exists():
-        return None, ["dump_index not available for range_ref check"], "unavailable"
+        return None, ["dump_index not available for range_ref check"], "unavailable", not_applicable
 
     sample_ref = None
     try:
@@ -225,31 +232,62 @@ def _range_ref_check(
                         try:
                             raw_ref = json.loads(raw_ref)
                         except json.JSONDecodeError as e:
-                            return False, [f"invalid content_range_ref JSON string: {e}"], "fail"
+                            return (
+                                False,
+                                [f"invalid content_range_ref JSON string: {e}"],
+                                "fail",
+                                _range_ref_validation(
+                                    "structural_precheck", "malformed_range_ref"
+                                ),
+                            )
                     if not isinstance(raw_ref, dict):
-                        return False, [
-                            f"content_range_ref must be an object, got {type(raw_ref).__name__}"
-                        ], "fail"
+                        return (
+                            False,
+                            [f"content_range_ref must be an object, got {type(raw_ref).__name__}"],
+                            "fail",
+                            _range_ref_validation(
+                                "structural_precheck", "malformed_range_ref"
+                            ),
+                        )
                     sample_ref = raw_ref
                     break
     except (OSError, UnicodeError) as e:
-        return None, [f"Could not read chunk_index: {e}"], "unavailable"
+        return None, [f"Could not read chunk_index: {e}"], "unavailable", not_applicable
 
     if sample_ref is None:
         # No range_ref present in any chunk; this is normal for inline-only bundles
         # but should be flagged as a non-blocking issue
-        return None, ["no content_range_ref found; range_ref check skipped"], "no_range_ref"
+        return None, ["no content_range_ref found; range_ref check skipped"], "no_range_ref", not_applicable
 
     try:
         from .range_resolver import resolve_range_ref
         resolve_range_ref(dump_index_path, sample_ref)
-        return True, [], "ok"
+        return True, [], "ok", _range_ref_validation("jsonschema", "available")
     except Exception as e:
         if _is_jsonschema_unavailable_error(e):
             # jsonschema is an optional runtime dependency; its absence means the check
             # cannot be executed — this is epistemic emptiness, not proof of broken data.
-            return None, ["range_ref schema validation skipped: jsonschema unavailable"], "environment_error"
-        return False, [f"range_ref resolution failed: {e}"], "fail"
+            return (
+                None,
+                ["range_ref schema validation skipped: jsonschema unavailable"],
+                "environment_error",
+                _range_ref_validation(
+                    "skipped_unavailable", "dependency_unavailable"
+                ),
+            )
+        if "schema file not found" in str(e).lower():
+            return (
+                False,
+                [f"range_ref resolution failed: {e}"],
+                "fail",
+                _range_ref_validation("skipped_unavailable", "schema_missing"),
+            )
+        return (
+            False,
+            [f"range_ref resolution failed: {e}"],
+            "fail",
+            _range_ref_validation("jsonschema", "available"),
+        )
 
 
 def compute_output_health(
@@ -403,29 +441,11 @@ def compute_output_health(
 
     # ── range_ref_resolution_ok ─────────────────────────────────────────────
     if chunk_index_required:
-        rr_ok, rr_msgs, rr_status = _range_ref_check(dump_index_path, chunk_index_path)
+        rr_ok, rr_msgs, rr_status, rr_validation = _range_ref_check(
+            dump_index_path, chunk_index_path
+        )
         checks["range_ref_resolution_ok"] = rr_ok
         checks["range_ref_resolution_status"] = rr_status
-        # mode names the validation capability used by this check; engine names
-        # the local component consuming that capability, not a schema engine.
-        if rr_status == "environment_error":
-            rr_validation = {
-                "mode": "skipped_unavailable",
-                "engine": "range_resolver",
-                "reason": "dependency_unavailable",
-            }
-        elif rr_status in {"ok", "fail"}:
-            rr_validation = {
-                "mode": "jsonschema",
-                "engine": "range_resolver",
-                "reason": "available",
-            }
-        else:
-            rr_validation = {
-                "mode": "skipped_unavailable",
-                "engine": "range_resolver",
-                "reason": "check_not_applicable",
-            }
         checks["range_ref_resolution"] = {
             "status": rr_status,
             "required": True,

--- a/merger/lenskit/core/post_emit_health.py
+++ b/merger/lenskit/core/post_emit_health.py
@@ -130,11 +130,30 @@ def _now_iso() -> str:
     return ts.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def _check(name: str, status: str, detail: Optional[str] = None) -> Dict[str, Any]:
+def _check(
+    name: str,
+    status: str,
+    detail: Optional[str] = None,
+    validation: Optional[Dict[str, str]] = None,
+) -> Dict[str, Any]:
     out: Dict[str, Any] = {"name": name, "status": status}
     if detail:
         out["detail"] = detail
+    if validation is not None:
+        out["validation"] = validation
     return out
+
+
+def _validation(mode: str, engine: str, reason: str) -> Dict[str, str]:
+    return {"mode": mode, "engine": engine, "reason": reason}
+
+
+def _schema_skip_reason(message: str) -> str:
+    if "schema not found" in message:
+        return "schema_missing"
+    if "jsonschema unavailable" in message:
+        return "dependency_unavailable"
+    return "unsupported_runtime"
 
 
 def _resolve_manifest_path(manifest_path_str: str) -> Path:
@@ -418,12 +437,34 @@ def compute_post_emit_health(
     # ── manifest schema ──────────────────────────────────────────────────────
     schema_status, schema_msg = _validate_manifest_schema(manifest)
     if schema_status == "pass":
-        checks.append(_check("manifest_schema_valid", "pass"))
+        checks.append(
+            _check(
+                "manifest_schema_valid",
+                "pass",
+                validation=_validation("jsonschema", "jsonschema", "available"),
+            )
+        )
     elif schema_status == "fail":
-        checks.append(_check("manifest_schema_valid", "fail", schema_msg))
+        checks.append(
+            _check(
+                "manifest_schema_valid",
+                "fail",
+                detail=schema_msg,
+                validation=_validation("jsonschema", "jsonschema", "available"),
+            )
+        )
         errors.append(schema_msg)
     else:  # environment_error
-        checks.append(_check("manifest_schema_valid", "skipped", schema_msg))
+        checks.append(
+            _check(
+                "manifest_schema_valid",
+                "skipped",
+                detail=schema_msg,
+                validation=_validation(
+                    "skipped_unavailable", "jsonschema", _schema_skip_reason(schema_msg)
+                ),
+            )
+        )
         warnings.append(schema_msg)
 
     # ── per-artifact existence + hash ────────────────────────────────────────
@@ -549,15 +590,47 @@ def compute_post_emit_health(
 
     rr_status, rr_msg = _range_ref_status(manifest_path, chunk_index_path)
     if rr_status == "ok":
-        checks.append(_check("range_ref_resolution", "pass", rr_msg))
+        checks.append(
+            _check(
+                "range_ref_resolution",
+                "pass",
+                detail=rr_msg,
+                validation=_validation("jsonschema", "range_resolver", "available"),
+            )
+        )
     elif rr_status == "fail":
-        checks.append(_check("range_ref_resolution", "fail", rr_msg))
+        checks.append(
+            _check(
+                "range_ref_resolution",
+                "fail",
+                detail=rr_msg,
+                validation=_validation("jsonschema", "range_resolver", "available"),
+            )
+        )
         errors.append(rr_msg)
     elif rr_status == "environment_error":
-        checks.append(_check("range_ref_resolution", "skipped", rr_msg))
+        checks.append(
+            _check(
+                "range_ref_resolution",
+                "skipped",
+                detail=rr_msg,
+                validation=_validation(
+                    "skipped_unavailable", "range_resolver", "dependency_unavailable"
+                ),
+            )
+        )
         warnings.append(rr_msg)
     else:  # no_range_ref / unavailable — nothing to certify, non-blocking
-        checks.append(_check("range_ref_resolution", "skipped", rr_msg))
+        checks.append(
+            _check(
+                "range_ref_resolution",
+                "skipped",
+                detail=rr_msg,
+                validation=_validation(
+                    "skipped_unavailable", "range_resolver", "check_not_applicable"
+                ),
+            )
+        )
 
     # ── claim_evidence_map: optional globally, required for forensic_strict preflight ──
     claim_entry = by_role.get(_CLAIM_EVIDENCE_MAP)
@@ -588,7 +661,10 @@ def compute_post_emit_health(
             _check(
                 "claim_evidence_map_schema_valid",
                 "skipped",
-                "claim_evidence_map_json absent" + reason_suffix,
+                detail="claim_evidence_map_json absent" + reason_suffix,
+                validation=_validation(
+                    "skipped_unavailable", "jsonschema", "check_not_applicable"
+                ),
             )
         )
     else:
@@ -606,7 +682,10 @@ def compute_post_emit_health(
                 _check(
                     "claim_evidence_map_schema_valid",
                     "skipped",
-                    "schema validation skipped because claim_evidence_map_json hash is unverified",
+                    detail="schema validation skipped because claim_evidence_map_json hash is unverified",
+                    validation=_validation(
+                        "skipped_unavailable", "jsonschema", "check_not_applicable"
+                    ),
                 )
             )
             errors.append("claim_evidence_map_json is declared but hash is missing/invalid")
@@ -629,12 +708,40 @@ def compute_post_emit_health(
                 else:
                     claim_schema_status, claim_schema_msg = _validate_claim_evidence_map_schema(claim_doc)
                     if claim_schema_status == "pass":
-                        checks.append(_check("claim_evidence_map_schema_valid", "pass"))
+                        checks.append(
+                            _check(
+                                "claim_evidence_map_schema_valid",
+                                "pass",
+                                validation=_validation(
+                                    "jsonschema", "jsonschema", "available"
+                                ),
+                            )
+                        )
                     elif claim_schema_status == "fail":
-                        checks.append(_check("claim_evidence_map_schema_valid", "fail", claim_schema_msg))
+                        checks.append(
+                            _check(
+                                "claim_evidence_map_schema_valid",
+                                "fail",
+                                detail=claim_schema_msg,
+                                validation=_validation(
+                                    "jsonschema", "jsonschema", "available"
+                                ),
+                            )
+                        )
                         errors.append(claim_schema_msg)
                     else:
-                        checks.append(_check("claim_evidence_map_schema_valid", "skipped", claim_schema_msg))
+                        checks.append(
+                            _check(
+                                "claim_evidence_map_schema_valid",
+                                "skipped",
+                                detail=claim_schema_msg,
+                                validation=_validation(
+                                    "skipped_unavailable",
+                                    "jsonschema",
+                                    _schema_skip_reason(claim_schema_msg),
+                                ),
+                            )
+                        )
                         warnings.append(claim_schema_msg)
 
     # ── redaction: reported, never enforced (enforcement is PR A5) ───────────

--- a/merger/lenskit/core/post_emit_health.py
+++ b/merger/lenskit/core/post_emit_health.py
@@ -175,15 +175,19 @@ def derive_post_health_path(manifest_path: Path) -> Path:
 
 def _range_ref_status(
     manifest_path: Path, chunk_index_path: Optional[Path]
-) -> Tuple[str, str]:
+) -> Tuple[str, str, Dict[str, str]]:
     """
     Resolve one range reference from the chunk index against the final bundle
     manifest. Prefers the current ``canonical_range`` field and falls back to the
-    legacy ``content_range_ref``. Returns (status, message) where status is one
-    of: ``ok``, ``fail``, ``environment_error``, ``no_range_ref``, ``unavailable``.
+    legacy ``content_range_ref``. Returns (status, message, validation) where
+    status is one of: ``ok``, ``fail``, ``environment_error``, ``no_range_ref``,
+    ``unavailable``.
     """
+    not_applicable = _validation(
+        "skipped_unavailable", "range_resolver", "check_not_applicable"
+    )
     if chunk_index_path is None or not chunk_index_path.exists():
-        return "unavailable", "chunk_index not available for range_ref check"
+        return "unavailable", "chunk_index not available for range_ref check", not_applicable
 
     sample_ref: Optional[Dict[str, Any]] = None
     try:
@@ -206,26 +210,62 @@ def _range_ref_status(
                     try:
                         raw = json.loads(raw)
                     except json.JSONDecodeError as e:
-                        return "fail", f"invalid range reference JSON string: {e}"
+                        return (
+                            "fail",
+                            f"invalid range reference JSON string: {e}",
+                            _validation(
+                                "structural_precheck",
+                                "range_resolver",
+                                "malformed_range_ref",
+                            ),
+                        )
                 if not isinstance(raw, dict):
-                    return "fail", "range reference must be an object"
+                    return (
+                        "fail",
+                        "range reference must be an object",
+                        _validation(
+                            "structural_precheck",
+                            "range_resolver",
+                            "malformed_range_ref",
+                        ),
+                    )
                 sample_ref = raw
                 break
     except (OSError, UnicodeError) as e:
-        return "unavailable", f"could not read chunk_index: {e}"
+        return "unavailable", f"could not read chunk_index: {e}", not_applicable
 
     if sample_ref is None:
-        return "no_range_ref", "no range reference found; range_ref check skipped"
+        return "no_range_ref", "no range reference found; range_ref check skipped", not_applicable
 
     try:
         from .range_resolver import resolve_range_ref
 
         resolve_range_ref(manifest_path, sample_ref)
-        return "ok", "range reference resolved against bundle manifest"
+        return (
+            "ok",
+            "range reference resolved against bundle manifest",
+            _validation("jsonschema", "range_resolver", "available"),
+        )
     except Exception as e:  # noqa: BLE001 - classify below
         if _is_jsonschema_unavailable_error(e):
-            return "environment_error", "range_ref validation skipped: jsonschema unavailable"
-        return "fail", f"range_ref resolution failed: {e}"
+            return (
+                "environment_error",
+                "range_ref validation skipped: jsonschema unavailable",
+                _validation(
+                    "skipped_unavailable", "range_resolver", "dependency_unavailable"
+                ),
+            )
+        if "schema file not found" in str(e).lower():
+            return (
+                "fail",
+                f"range_ref resolution failed: {e}",
+                _validation("skipped_unavailable", "range_resolver", "schema_missing"),
+            )
+        return (
+            "fail",
+            f"range_ref resolution failed: {e}",
+            _validation("jsonschema", "range_resolver", "available"),
+        )
 
 
 def _compute_evidence(
@@ -588,14 +628,16 @@ def compute_post_emit_health(
         except ValueError:
             chunk_index_path = None
 
-    rr_status, rr_msg = _range_ref_status(manifest_path, chunk_index_path)
+    rr_status, rr_msg, rr_validation = _range_ref_status(
+        manifest_path, chunk_index_path
+    )
     if rr_status == "ok":
         checks.append(
             _check(
                 "range_ref_resolution",
                 "pass",
                 detail=rr_msg,
-                validation=_validation("jsonschema", "range_resolver", "available"),
+                validation=rr_validation,
             )
         )
     elif rr_status == "fail":
@@ -604,7 +646,7 @@ def compute_post_emit_health(
                 "range_ref_resolution",
                 "fail",
                 detail=rr_msg,
-                validation=_validation("jsonschema", "range_resolver", "available"),
+                validation=rr_validation,
             )
         )
         errors.append(rr_msg)
@@ -614,9 +656,7 @@ def compute_post_emit_health(
                 "range_ref_resolution",
                 "skipped",
                 detail=rr_msg,
-                validation=_validation(
-                    "skipped_unavailable", "range_resolver", "dependency_unavailable"
-                ),
+                validation=rr_validation,
             )
         )
         warnings.append(rr_msg)
@@ -626,9 +666,7 @@ def compute_post_emit_health(
                 "range_ref_resolution",
                 "skipped",
                 detail=rr_msg,
-                validation=_validation(
-                    "skipped_unavailable", "range_resolver", "check_not_applicable"
-                ),
+                validation=rr_validation,
             )
         )
 

--- a/merger/lenskit/tests/test_output_health.py
+++ b/merger/lenskit/tests/test_output_health.py
@@ -931,6 +931,14 @@ def test_range_ref_jsonschema_unavailable_is_warn_not_fail(tmp_path):
     )
     assert result["checks"]["range_ref_resolution_ok"] is None
     assert result["checks"]["range_ref_resolution_status"] == "environment_error"
+    assert result["checks"]["range_ref_resolution"]["status"] == "environment_error"
+    assert result["checks"]["range_ref_resolution"]["validation"] == {
+        "mode": "skipped_unavailable",
+        "engine": "range_resolver",
+        "reason": "dependency_unavailable",
+    }
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.validate(instance=result, schema=schema)
     assert any("jsonschema" in w.lower() for w in result["warnings"])
     assert not any("jsonschema" in e.lower() for e in result["errors"])
 
@@ -990,6 +998,13 @@ def test_range_ref_status_ok_on_intact_path(tmp_path):
 
     assert result["checks"]["range_ref_resolution_ok"] is True
     assert result["checks"]["range_ref_resolution_status"] == "ok"
+    assert result["checks"]["range_ref_resolution"]["validation"] == {
+        "mode": "jsonschema",
+        "engine": "range_resolver",
+        "reason": "available",
+    }
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.validate(instance=result, schema=schema)
     assert result["verdict"] == "pass"
 
 

--- a/merger/lenskit/tests/test_output_health.py
+++ b/merger/lenskit/tests/test_output_health.py
@@ -473,7 +473,15 @@ def test_verdict_fail_invalid_content_range_ref_json_string(tmp_path):
 
     assert result["verdict"] == "fail"
     assert result["checks"]["range_ref_resolution_ok"] is False
+    assert result["checks"]["range_ref_resolution_status"] == "fail"
+    assert result["checks"]["range_ref_resolution"]["validation"] == {
+        "mode": "structural_precheck",
+        "engine": "range_resolver",
+        "reason": "malformed_range_ref",
+    }
     assert any("invalid range reference json" in e.lower() for e in result["errors"])
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.validate(instance=result, schema=schema)
 
 
 def test_verdict_fail_content_range_ref_wrong_type(tmp_path):
@@ -560,7 +568,7 @@ def test_range_ref_precheck_prefers_malformed_canonical_range(tmp_path):
     jsonschema.validate(instance=result, schema=schema)
 
 
-def test_no_content_range_ref_is_warn_not_pass(tmp_path):
+def test_no_range_reference_is_warn_not_pass(tmp_path):
     kwargs = _base_kwargs(tmp_path=tmp_path, with_sqlite=False)
     result = compute_output_health(**kwargs)
 

--- a/merger/lenskit/tests/test_output_health.py
+++ b/merger/lenskit/tests/test_output_health.py
@@ -473,7 +473,7 @@ def test_verdict_fail_invalid_content_range_ref_json_string(tmp_path):
 
     assert result["verdict"] == "fail"
     assert result["checks"]["range_ref_resolution_ok"] is False
-    assert any("invalid content_range_ref json" in e.lower() for e in result["errors"])
+    assert any("invalid range reference json" in e.lower() for e in result["errors"])
 
 
 def test_verdict_fail_content_range_ref_wrong_type(tmp_path):
@@ -511,8 +511,51 @@ def test_verdict_fail_content_range_ref_wrong_type(tmp_path):
         "reason": "malformed_range_ref",
     }
     assert any(
-        "content_range_ref" in e and "object" in e for e in result["errors"]
+        "range reference" in e.lower() and "object" in e for e in result["errors"]
     )
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.validate(instance=result, schema=schema)
+
+
+def test_range_ref_precheck_prefers_malformed_canonical_range(tmp_path):
+    canonical_md_path, canonical_md_sha = _make_canonical_md(tmp_path)
+    valid_legacy_ref = _build_range_ref_for_canonical(canonical_md_path, 0, 8)
+    chunks = [
+        {
+            "id": "c1",
+            "content": "x",
+            "path": "a.md",
+            "canonical_range": ["not", "an", "object"],
+            "content_range_ref": valid_legacy_ref,
+        }
+    ]
+    chunk_index_path, chunk_sha = _make_chunk_jsonl(tmp_path, chunks)
+    dump_index_path = _make_dump_index(
+        tmp_path, canonical_md_path.name, chunk_index_path.name
+    )
+
+    result = compute_output_health(
+        run_id="run-malformed-canonical-range",
+        stem="test",
+        primary_manifest_path=dump_index_path,
+        canonical_md_path=canonical_md_path,
+        chunk_index_path=chunk_index_path,
+        dump_index_path=dump_index_path,
+        sqlite_index_path=None,
+        sqlite_index_required=False,
+        redact_secrets=False,
+        expected_canonical_md_sha256=canonical_md_sha,
+        expected_chunk_index_sha256=chunk_sha,
+    )
+
+    assert result["verdict"] == "fail"
+    assert result["checks"]["range_ref_resolution_ok"] is False
+    assert result["checks"]["range_ref_resolution_status"] == "fail"
+    assert result["checks"]["range_ref_resolution"]["validation"] == {
+        "mode": "structural_precheck",
+        "engine": "range_resolver",
+        "reason": "malformed_range_ref",
+    }
     schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
     jsonschema.validate(instance=result, schema=schema)
 
@@ -1014,6 +1057,48 @@ def test_range_ref_status_ok_on_intact_path(tmp_path):
     schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
     jsonschema.validate(instance=result, schema=schema)
     assert result["verdict"] == "pass"
+
+
+def test_range_ref_status_ok_on_canonical_range_without_legacy_ref(tmp_path):
+    canonical_md_path, canonical_md_sha = _make_canonical_md(tmp_path)
+    rr = _build_range_ref_for_canonical(canonical_md_path, 0, 8)
+    chunks = [
+        {
+            "id": "c1",
+            "content": "hello world",
+            "path": "test/a.md",
+            "canonical_range": rr,
+        }
+    ]
+    chunk_index_path, chunk_sha = _make_chunk_jsonl(tmp_path, chunks)
+    dump_index_path = _make_dump_index(
+        tmp_path, canonical_md_path.name, chunk_index_path.name
+    )
+
+    result = compute_output_health(
+        run_id="run-canonical-range-only",
+        stem="test",
+        primary_manifest_path=dump_index_path,
+        canonical_md_path=canonical_md_path,
+        chunk_index_path=chunk_index_path,
+        dump_index_path=dump_index_path,
+        sqlite_index_path=None,
+        sqlite_index_required=False,
+        redact_secrets=False,
+        expected_canonical_md_sha256=canonical_md_sha,
+        expected_chunk_index_sha256=chunk_sha,
+    )
+
+    assert result["checks"]["range_ref_resolution_ok"] is True
+    assert result["checks"]["range_ref_resolution_status"] == "ok"
+    assert result["checks"]["range_ref_resolution"]["validation"] == {
+        "mode": "jsonschema",
+        "engine": "range_resolver",
+        "reason": "available",
+    }
+    assert result["verdict"] == "pass"
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.validate(instance=result, schema=schema)
 
 
 def test_range_ref_status_fail_on_real_semantic_error(tmp_path):

--- a/merger/lenskit/tests/test_output_health.py
+++ b/merger/lenskit/tests/test_output_health.py
@@ -504,9 +504,17 @@ def test_verdict_fail_content_range_ref_wrong_type(tmp_path):
 
     assert result["verdict"] == "fail"
     assert result["checks"]["range_ref_resolution_ok"] is False
+    assert result["checks"]["range_ref_resolution_status"] == "fail"
+    assert result["checks"]["range_ref_resolution"]["validation"] == {
+        "mode": "structural_precheck",
+        "engine": "range_resolver",
+        "reason": "malformed_range_ref",
+    }
     assert any(
         "content_range_ref" in e and "object" in e for e in result["errors"]
     )
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.validate(instance=result, schema=schema)
 
 
 def test_no_content_range_ref_is_warn_not_pass(tmp_path):

--- a/merger/lenskit/tests/test_post_emit_health.py
+++ b/merger/lenskit/tests/test_post_emit_health.py
@@ -13,6 +13,8 @@ from pathlib import Path
 import jsonschema
 import pytest
 
+from merger.lenskit.core import post_emit_health
+from merger.lenskit.core import range_resolver
 from merger.lenskit.core.post_emit_health import (
     DOES_NOT_MEAN,
     compute_post_emit_health,
@@ -324,6 +326,17 @@ def test_post_emit_health_clean_bundle_passes(tmp_path):
     assert report["agent_pack"]["self_role_ok"] is True
     # A clean bundle whose chunks carry canonical_range resolves a real range path.
     assert report["range_ref_resolution_status"] == "ok"
+    by_name = {item["name"]: item for item in report["checks"]}
+    assert by_name["manifest_schema_valid"]["validation"] == {
+        "mode": "jsonschema",
+        "engine": "jsonschema",
+        "reason": "available",
+    }
+    assert by_name["range_ref_resolution"]["validation"] == {
+        "mode": "jsonschema",
+        "engine": "range_resolver",
+        "reason": "available",
+    }
     assert "repo_understood" in report["does_not_mean"]
     assert "answer_safe_without_citations" in report["does_not_mean"]
     assert set(DOES_NOT_MEAN).issubset(set(report["does_not_mean"]))
@@ -363,6 +376,61 @@ def test_post_emit_health_checks_claim_evidence_map_when_present(tmp_path):
     assert by_name["claim_evidence_map_present"]["status"] == "pass"
     assert by_name["claim_evidence_map_hash_ok"]["status"] == "pass"
     assert by_name["claim_evidence_map_schema_valid"]["status"] == "pass"
+    assert by_name["claim_evidence_map_schema_valid"]["validation"] == {
+        "mode": "jsonschema",
+        "engine": "jsonschema",
+        "reason": "available",
+    }
+
+
+def test_post_emit_health_reports_jsonschema_degradation_machine_readably(
+    tmp_path, monkeypatch
+):
+    manifest = _make_bundle(tmp_path, include_claim_map=True, include_citation=True)
+    monkeypatch.setattr(post_emit_health, "jsonschema", None)
+    monkeypatch.setattr(range_resolver, "jsonschema", None)
+
+    report = compute_post_emit_health(str(manifest))
+
+    assert report["status"] == "warn"
+    by_name = {item["name"]: item for item in report["checks"]}
+    for check_name, engine in (
+        ("manifest_schema_valid", "jsonschema"),
+        ("range_ref_resolution", "range_resolver"),
+        ("claim_evidence_map_schema_valid", "jsonschema"),
+    ):
+        check = by_name[check_name]
+        assert check["status"] == "skipped"
+        assert "jsonschema unavailable" in check["detail"]
+        assert check["validation"] == {
+            "mode": "skipped_unavailable",
+            "engine": engine,
+            "reason": "dependency_unavailable",
+        }
+
+
+def test_post_emit_health_reports_missing_claim_schema_machine_readably(
+    tmp_path, monkeypatch
+):
+    manifest = _make_bundle(tmp_path, include_claim_map=True, include_citation=True)
+    monkeypatch.setattr(
+        post_emit_health,
+        "_validate_claim_evidence_map_schema",
+        lambda _doc: (
+            "environment_error",
+            "claim_evidence_map schema not found: claim-evidence-map.v1.schema.json",
+        ),
+    )
+
+    report = compute_post_emit_health(str(manifest))
+
+    assert report["status"] == "warn"
+    by_name = {item["name"]: item for item in report["checks"]}
+    assert by_name["claim_evidence_map_schema_valid"]["validation"] == {
+        "mode": "skipped_unavailable",
+        "engine": "jsonschema",
+        "reason": "schema_missing",
+    }
 
 
 def test_post_emit_health_fails_on_invalid_claim_map_schema(tmp_path):

--- a/merger/lenskit/tests/test_post_emit_health.py
+++ b/merger/lenskit/tests/test_post_emit_health.py
@@ -351,6 +351,42 @@ def test_post_emit_health_range_ref_legacy_content_range_ref(tmp_path):
     assert report["range_ref_resolution_status"] == "ok"
 
 
+def test_post_emit_health_range_ref_precheck_reports_actual_provenance(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    chunk_bytes = (
+        json.dumps(
+            {
+                "chunk_id": "c0",
+                "path": "a.py",
+                "canonical_range": ["not", "an", "object"],
+            }
+        )
+        + "\n"
+    ).encode("utf-8")
+    (tmp_path / "demo.chunk_index.jsonl").write_bytes(chunk_bytes)
+
+    manifest_doc = json.loads(manifest.read_text(encoding="utf-8"))
+    for artifact in manifest_doc["artifacts"]:
+        if artifact.get("role") == "chunk_index_jsonl":
+            artifact["bytes"] = len(chunk_bytes)
+            artifact["sha256"] = _sha256(chunk_bytes)
+            break
+    manifest.write_text(json.dumps(manifest_doc, indent=2), encoding="utf-8")
+
+    report = compute_post_emit_health(str(manifest))
+
+    assert report["status"] == "fail"
+    assert report["range_ref_resolution_status"] == "fail"
+    by_name = {item["name"]: item for item in report["checks"]}
+    assert by_name["range_ref_resolution"]["validation"] == {
+        "mode": "structural_precheck",
+        "engine": "range_resolver",
+        "reason": "malformed_range_ref",
+    }
+    schema = json.loads(_POST_HEALTH_SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.validate(instance=report, schema=schema)
+
+
 def test_post_emit_health_output_health_must_be_validated_not_declared(tmp_path):
     """A declared but tampered output_health must not be trusted nor boost coverage."""
     manifest = _make_bundle(tmp_path)  # includes a declared, hash-valid output_health


### PR DESCRIPTION
### Motivation
- Make schema-driven checks machine-readable by emitting structured validation metadata (`mode`, `engine`, `reason`) and richer status details for range-ref resolution. 
- Surface why a check was skipped (e.g. missing schema or unavailable runtime) in a standardized way so downstream consumers can make programmatic decisions. 

### Description
- Add a new `range_ref_resolution` object to the output health contract and add a `validation` property to per-check items in the post-emit health contract to carry `mode`, `engine`, and `reason` fields. 
- In `merger/lenskit/core/output_health.py` produce `checks["range_ref_resolution"]` with `status`, `required`, `reason`, and `validation` populated according to the resolution result. 
- In `merger/lenskit/core/post_emit_health.py` extend `_check` to accept an optional `validation` payload, add helpers `_validation` and `_schema_skip_reason`, and attach validation metadata to `manifest_schema_valid`, `range_ref_resolution`, and `claim_evidence_map_schema_valid` checks (including explicit handling when `jsonschema` is unavailable or a schema is missing). 
- Update JSON schema files `output-health.v1.schema.json` and `post-emit-health.v1.schema.json` to include the new structures and enums, and update unit tests in `tests/test_output_health.py` and `tests/test_post_emit_health.py` to assert the new fields and behavior (including cases where `jsonschema` is unavailable or a schema is missing).

### Testing
- Ran the unit test suite with `pytest` including modified and new tests in `merger/lenskit/tests/test_output_health.py` and `merger/lenskit/tests/test_post_emit_health.py`. 
- Tests validate that `range_ref_resolution` and `validation` fields are present and contain the expected `mode`/`engine`/`reason` values in success, failure, and degraded (`jsonschema` missing / schema missing) scenarios. 
- Schema checks in tests using `jsonschema.validate` were also exercised to ensure produced reports conform to the updated contracts. 
- All automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b954d018c832cb3ad401deaf5dc1d)