### PR TITLE
Add Required Reading Protocol core implementation

### DIFF
--- a/docs/architecture/agent-consumption-contract.md
+++ b/docs/architecture/agent-consumption-contract.md
@@ -1,0 +1,109 @@
+# Agent Consumption Contract
+
+## Status
+
+PR 1 — Required Reading Protocol Core implemented.
+Later slices (agent-consumption-trace, agent-entry-manifest, Agent Reading Pack v2, Export Safety Report, Lens Cards, Relation Cards, Retrieval v2) are not yet implemented.
+
+---
+
+## Required Reading Protocol
+
+### Purpose
+
+The Required Reading Protocol formalises the `REQUIRED_READING_BY_TASK` matrix from the Agent Reading Pack as a machine-readable, deterministic contract.
+
+An agent or test can use it to check — before answering — whether the artifacts required for a given task are present in the available bundle context.
+
+### Files
+
+| File | Role |
+|------|------|
+| `merger/lenskit/contracts/required-reading-protocol.v1.schema.json` | JSON Schema (Draft-07) for the protocol contract |
+| `merger/lenskit/core/required_reading.py` | Resolver: `default_required_reading_protocol()`, `resolve_required_reading()` |
+| `merger/lenskit/tests/test_required_reading_protocol.py` | Schema validation and resolver tests |
+
+---
+
+### Relationship to Agent Reading Pack
+
+The Agent Reading Pack (`agent_reading_pack.py`) renders `REQUIRED_READING_BY_TASK` as a Markdown table inside the pack.  The Required Reading Protocol is a direct translation of that table into a JSON contract and a Python resolver.
+
+- The Agent Reading Pack remains the **navigation layer** — it is what an agent reads to orient itself.
+- The Required Reading Protocol is the **protocol/navigation layer** — it is what a tool or test uses to check compliance programmatically.
+- Neither establishes content truth.
+
+### Relationship to canonical_md
+
+`canonical_md` is the sole content truth.  The Required Reading Protocol does not change this.
+
+The protocol tells an agent *which artifacts to read* for a task; it does not authorise any artifact to replace `canonical_md` as the source of content claims.
+
+---
+
+### Task Profiles
+
+| task_profile | required | recommended |
+|---|---|---|
+| `basic_repo_question` | `agent_reading_pack`, `canonical_md` | `citation_map_jsonl` |
+| `pr_review` | `agent_reading_pack`, `canonical_md`, `citation_map_jsonl`, `post_emit_health` | `bundle_surface_validation`, `claim_evidence_map_json` |
+| `roadmap_status_claim` | `agent_reading_pack`, `canonical_md`, `claim_evidence_map_json` | `citation_map_jsonl` |
+| `artifact_surface_review` | `bundle_manifest`, `bundle_surface_validation`, `canonical_md`, `post_emit_health` | `output_health` |
+| `retrieval_quality_review` | `canonical_md`, `chunk_index_jsonl`, `retrieval_eval_json`, `sqlite_index` | `docs/retrieval/*` |
+
+Note: `post_emit_health`, `bundle_surface_validation`, `bundle_manifest`, and `docs/retrieval/*` are protocol/surface aliases — they are not `ArtifactRole` enum values and the enum is not extended for PR 1.
+
+---
+
+### Resolver Status Values
+
+`resolve_required_reading(protocol, available_roles, task_profile)` returns one of:
+
+| status | meaning |
+|--------|---------|
+| `pass` | All required and all recommended roles present |
+| `warn` | All required roles present; at least one recommended role missing |
+| `fail` | At least one required role missing |
+| `not_applicable` | task_profile not found in protocol |
+
+### Example: pr_review
+
+```python
+from merger.lenskit.core.required_reading import (
+    default_required_reading_protocol,
+    resolve_required_reading,
+)
+
+protocol = default_required_reading_protocol()
+result = resolve_required_reading(
+    protocol,
+    available_roles={"agent_reading_pack", "canonical_md", "citation_map_jsonl", "post_emit_health"},
+    task_profile="pr_review",
+)
+# result["status"] == "warn"
+# result["missing_recommended"] == ["bundle_surface_validation", "claim_evidence_map_json"]
+```
+
+---
+
+### does_not_establish
+
+Each task profile carries a `does_not_establish` list.  These are invariants that are **not** established even when all required roles are present:
+
+- `repo_understood`
+- `answer_safe_without_citations`
+- `claims_true`
+- `all_relevant_context_used`
+- `forensic_ready`
+
+The protocol-level `does_not_establish` field repeats these for the contract as a whole.
+
+---
+
+### Invariants
+
+- `canonical_md` is the sole content truth.
+- The Required Reading Protocol is protocol/navigation, not truth.
+- Satisfying a profile does not mean claims are correct.
+- No LLMs, no embeddings, no review judgements, no patch automation.
+- No new Primary Lens IDs introduced.

--- a/merger/lenskit/contracts/required-reading-protocol.v1.schema.json
+++ b/merger/lenskit/contracts/required-reading-protocol.v1.schema.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://heimgewebe.local/contracts/required-reading-protocol.v1.schema.json",
+  "title": "Required Reading Protocol (required-reading-protocol v1.0)",
+  "description": "Machine-readable contract for task-specific required reading. Protocol and navigation layer only — not content truth. canonical_md remains the sole content truth.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "kind",
+    "version",
+    "default_profile",
+    "task_profiles",
+    "does_not_establish"
+  ],
+  "properties": {
+    "kind": {
+      "type": "string",
+      "const": "lenskit.required_reading_protocol"
+    },
+    "version": {
+      "type": "string",
+      "const": "1.0"
+    },
+    "default_profile": {
+      "type": "string",
+      "description": "Profile name used when no explicit task_profile is specified."
+    },
+    "task_profiles": {
+      "type": "object",
+      "description": "Map of task profile names to their reading requirements.",
+      "additionalProperties": {
+        "$ref": "#/definitions/task_profile"
+      }
+    },
+    "does_not_establish": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Protocol-level invariants this contract does not establish, regardless of which profiles are satisfied."
+    }
+  },
+  "definitions": {
+    "task_profile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "required",
+        "recommended",
+        "insufficient",
+        "citation_required",
+        "answer_checklist_required",
+        "does_not_establish"
+      ],
+      "properties": {
+        "required": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Artifact roles or surface aliases that must be present for this task profile. Includes both ArtifactRole values and protocol aliases such as post_emit_health, bundle_surface_validation, bundle_manifest, and docs/retrieval/*."
+        },
+        "recommended": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Artifact roles or surface aliases whose presence improves answer quality for this task."
+        },
+        "insufficient": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Anti-patterns: approaches or artifact subsets that are insufficient for this task."
+        },
+        "citation_required": {
+          "type": "boolean",
+          "description": "Whether this task requires citations to canonical ranges."
+        },
+        "answer_checklist_required": {
+          "type": "boolean",
+          "description": "Whether this task requires completing the ANSWER_COMPLIANCE_CHECKLIST."
+        },
+        "does_not_establish": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Invariants this profile does not establish even when all required roles are present."
+        }
+      }
+    }
+  }
+}

--- a/merger/lenskit/core/required_reading.py
+++ b/merger/lenskit/core/required_reading.py
@@ -1,0 +1,165 @@
+"""Required Reading Protocol resolver.
+
+Formalises the REQUIRED_READING_BY_TASK matrix from the Agent Reading Pack as a
+deterministic, machine-readable protocol.  The Agent Reading Pack remains the
+navigation layer; canonical_md remains the sole content truth.
+"""
+from __future__ import annotations
+
+
+_DOES_NOT_ESTABLISH = [
+    "all_relevant_context_used",
+    "answer_safe_without_citations",
+    "claims_true",
+    "forensic_ready",
+    "repo_understood",
+]
+
+_PROFILES: dict[str, dict] = {
+    "basic_repo_question": {
+        "required": ["agent_reading_pack", "canonical_md"],
+        "recommended": ["citation_map_jsonl"],
+        "insufficient": ["sidecar-only claims without canonical verification"],
+        "citation_required": True,
+        "answer_checklist_required": True,
+        "does_not_establish": _DOES_NOT_ESTABLISH,
+    },
+    "pr_review": {
+        "required": [
+            "agent_reading_pack",
+            "canonical_md",
+            "citation_map_jsonl",
+            "post_emit_health",
+        ],
+        "recommended": ["bundle_surface_validation", "claim_evidence_map_json"],
+        "insufficient": [
+            "only reading canonical_md linearly",
+            "treating health pass as review completeness",
+        ],
+        "citation_required": True,
+        "answer_checklist_required": True,
+        "does_not_establish": _DOES_NOT_ESTABLISH,
+    },
+    "roadmap_status_claim": {
+        "required": ["agent_reading_pack", "canonical_md", "claim_evidence_map_json"],
+        "recommended": ["citation_map_jsonl"],
+        "insufficient": [
+            "roadmap status without Claim Evidence Map",
+            "roadmap status without canonical check",
+        ],
+        "citation_required": True,
+        "answer_checklist_required": True,
+        "does_not_establish": _DOES_NOT_ESTABLISH,
+    },
+    "artifact_surface_review": {
+        "required": [
+            "bundle_manifest",
+            "bundle_surface_validation",
+            "canonical_md",
+            "post_emit_health",
+        ],
+        "recommended": ["output_health"],
+        "insufficient": [
+            "output_health alone",
+            "treating health pass as claim truth",
+        ],
+        "citation_required": True,
+        "answer_checklist_required": True,
+        "does_not_establish": _DOES_NOT_ESTABLISH,
+    },
+    "retrieval_quality_review": {
+        "required": [
+            "canonical_md",
+            "chunk_index_jsonl",
+            "retrieval_eval_json",
+            "sqlite_index",
+        ],
+        "recommended": ["docs/retrieval/*"],
+        "insufficient": ["impressionistic retrieval claims without metrics"],
+        "citation_required": True,
+        "answer_checklist_required": True,
+        "does_not_establish": _DOES_NOT_ESTABLISH,
+    },
+}
+
+
+def default_required_reading_protocol() -> dict:
+    """Return the canonical Required Reading Protocol dict.
+
+    Deterministic: no timestamps, no I/O, no external state.
+    Directly mirrors the REQUIRED_READING_BY_TASK matrix in agent_reading_pack.py.
+    """
+    task_profiles = {}
+    for name, profile in _PROFILES.items():
+        task_profiles[name] = {
+            "required": sorted(profile["required"]),
+            "recommended": sorted(profile["recommended"]),
+            "insufficient": sorted(profile["insufficient"]),
+            "citation_required": profile["citation_required"],
+            "answer_checklist_required": profile["answer_checklist_required"],
+            "does_not_establish": sorted(profile["does_not_establish"]),
+        }
+    return {
+        "kind": "lenskit.required_reading_protocol",
+        "version": "1.0",
+        "default_profile": "basic_repo_question",
+        "task_profiles": task_profiles,
+        "does_not_establish": sorted(_DOES_NOT_ESTABLISH),
+    }
+
+
+def resolve_required_reading(
+    protocol: dict,
+    available_roles: set[str],
+    task_profile: str,
+) -> dict:
+    """Resolve required reading status for a given task profile and available roles.
+
+    Returns a deterministic dict with sorted lists and one of four status values:
+      pass           — all required and all recommended roles present
+      warn           — all required present, at least one recommended missing
+      fail           — at least one required role missing
+      not_applicable — task_profile not found in protocol
+    """
+    profiles = protocol.get("task_profiles", {})
+    if task_profile not in profiles:
+        return {
+            "task_profile": task_profile,
+            "required": [],
+            "recommended": [],
+            "insufficient": [],
+            "available_required": [],
+            "missing_required": [],
+            "available_recommended": [],
+            "missing_recommended": [],
+            "status": "not_applicable",
+        }
+
+    p = profiles[task_profile]
+    required = sorted(p.get("required", []))
+    recommended = sorted(p.get("recommended", []))
+    insufficient = sorted(p.get("insufficient", []))
+
+    available_required = sorted(r for r in required if r in available_roles)
+    missing_required = sorted(r for r in required if r not in available_roles)
+    available_recommended = sorted(r for r in recommended if r in available_roles)
+    missing_recommended = sorted(r for r in recommended if r not in available_roles)
+
+    if missing_required:
+        status = "fail"
+    elif missing_recommended:
+        status = "warn"
+    else:
+        status = "pass"
+
+    return {
+        "task_profile": task_profile,
+        "required": required,
+        "recommended": recommended,
+        "insufficient": insufficient,
+        "available_required": available_required,
+        "missing_required": missing_required,
+        "available_recommended": available_recommended,
+        "missing_recommended": missing_recommended,
+        "status": status,
+    }

--- a/merger/lenskit/tests/test_required_reading_protocol.py
+++ b/merger/lenskit/tests/test_required_reading_protocol.py
@@ -1,0 +1,182 @@
+import json
+import pytest
+from pathlib import Path
+
+try:
+    import jsonschema
+    from jsonschema import ValidationError
+except ImportError:
+    jsonschema = None
+    ValidationError = None
+
+from merger.lenskit.core.required_reading import (
+    default_required_reading_protocol,
+    resolve_required_reading,
+)
+
+_SCHEMA_PATH = (
+    Path(__file__).parent.parent / "contracts" / "required-reading-protocol.v1.schema.json"
+)
+_EXPECTED_PROFILES = {
+    "basic_repo_question",
+    "pr_review",
+    "roadmap_status_claim",
+    "artifact_surface_review",
+    "retrieval_quality_review",
+}
+_EXPECTED_PROFILE_KEYS = {
+    "required",
+    "recommended",
+    "insufficient",
+    "citation_required",
+    "answer_checklist_required",
+    "does_not_establish",
+}
+
+
+def _require_jsonschema():
+    if jsonschema is None:
+        pytest.skip("jsonschema not installed")
+
+
+def _load_schema() -> dict:
+    return json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+# ── 1. default_required_reading_protocol() is schema-valid ──────────────────
+
+def test_default_protocol_is_schema_valid():
+    _require_jsonschema()
+    schema = _load_schema()
+    protocol = default_required_reading_protocol()
+    jsonschema.validate(instance=protocol, schema=schema)
+
+
+# ── 2. All expected profiles present ────────────────────────────────────────
+
+def test_all_agent_pack_profiles_present():
+    protocol = default_required_reading_protocol()
+    assert _EXPECTED_PROFILES <= set(protocol["task_profiles"].keys())
+
+
+# ── 3. Each profile has the required keys ───────────────────────────────────
+
+def test_each_profile_has_required_keys():
+    protocol = default_required_reading_protocol()
+    for name, profile in protocol["task_profiles"].items():
+        missing = _EXPECTED_PROFILE_KEYS - set(profile.keys())
+        assert not missing, f"Profile '{name}' missing keys: {missing}"
+
+
+# ── 4. basic_repo_question: all roles present → pass ────────────────────────
+
+def test_basic_repo_question_all_present_is_pass():
+    protocol = default_required_reading_protocol()
+    result = resolve_required_reading(
+        protocol,
+        available_roles={"agent_reading_pack", "canonical_md", "citation_map_jsonl"},
+        task_profile="basic_repo_question",
+    )
+    assert result["status"] == "pass"
+    assert result["missing_required"] == []
+    assert result["missing_recommended"] == []
+
+
+# ── 5. basic_repo_question: required present, recommended missing → warn ────
+
+def test_basic_repo_question_missing_recommended_is_warn():
+    protocol = default_required_reading_protocol()
+    result = resolve_required_reading(
+        protocol,
+        available_roles={"agent_reading_pack", "canonical_md"},
+        task_profile="basic_repo_question",
+    )
+    assert result["status"] == "warn"
+    assert result["missing_required"] == []
+    assert "citation_map_jsonl" in result["missing_recommended"]
+
+
+# ── 6. pr_review: required role missing → fail ──────────────────────────────
+
+def test_pr_review_missing_required_is_fail():
+    protocol = default_required_reading_protocol()
+    # citation_map_jsonl is required for pr_review
+    result = resolve_required_reading(
+        protocol,
+        available_roles={"agent_reading_pack", "canonical_md", "post_emit_health"},
+        task_profile="pr_review",
+    )
+    assert result["status"] == "fail"
+    assert "citation_map_jsonl" in result["missing_required"]
+
+
+# ── 7. pr_review: all required present, recommended missing → warn ───────────
+
+def test_pr_review_all_required_missing_recommended_is_warn():
+    protocol = default_required_reading_protocol()
+    result = resolve_required_reading(
+        protocol,
+        available_roles={
+            "agent_reading_pack",
+            "canonical_md",
+            "citation_map_jsonl",
+            "post_emit_health",
+        },
+        task_profile="pr_review",
+    )
+    assert result["status"] == "warn"
+    assert result["missing_required"] == []
+    assert len(result["missing_recommended"]) > 0
+
+
+# ── 8. Unknown task_profile → not_applicable ────────────────────────────────
+
+def test_unknown_task_profile_is_not_applicable():
+    protocol = default_required_reading_protocol()
+    result = resolve_required_reading(
+        protocol,
+        available_roles={"canonical_md"},
+        task_profile="nonexistent_profile",
+    )
+    assert result["status"] == "not_applicable"
+    assert result["required"] == []
+    assert result["recommended"] == []
+
+
+# ── 9. Output lists are deterministically sorted ────────────────────────────
+
+def test_output_lists_are_sorted():
+    protocol = default_required_reading_protocol()
+    result = resolve_required_reading(
+        protocol,
+        available_roles={"canonical_md", "agent_reading_pack"},
+        task_profile="pr_review",
+    )
+    for key in ("required", "recommended", "insufficient",
+                "available_required", "missing_required",
+                "available_recommended", "missing_recommended"):
+        lst = result[key]
+        assert lst == sorted(lst), f"List '{key}' is not sorted: {lst}"
+
+
+# ── 10. does_not_establish missing from task_profile → schema invalid ────────
+
+def test_schema_invalid_when_does_not_establish_missing():
+    _require_jsonschema()
+    schema = _load_schema()
+    protocol = default_required_reading_protocol()
+    # Remove does_not_establish from one profile
+    del protocol["task_profiles"]["basic_repo_question"]["does_not_establish"]
+    with pytest.raises(ValidationError):
+        jsonschema.validate(instance=protocol, schema=schema)
+
+
+# ── 11. Extra field in task_profile → schema invalid (additionalProperties:false) ──
+
+def test_schema_invalid_when_extra_field_in_profile():
+    _require_jsonschema()
+    schema = _load_schema()
+    protocol = default_required_reading_protocol()
+    protocol["task_profiles"]["basic_repo_question"]["unexpected_field"] = "should_fail"
+    with pytest.raises(ValidationError):
+        jsonschema.validate(instance=protocol, schema=schema)


### PR DESCRIPTION
## Summary

Implements the Required Reading Protocol as a machine-readable, deterministic contract that formalises the `REQUIRED_READING_BY_TASK` matrix from the Agent Reading Pack. This enables programmatic validation of whether required artifacts are present before answering a task.

## Key Changes

- **Protocol Definition** (`merger/lenskit/core/required_reading.py`):
  - `default_required_reading_protocol()`: Returns the canonical protocol dict with 5 task profiles (basic_repo_question, pr_review, roadmap_status_claim, artifact_surface_review, retrieval_quality_review)
  - `resolve_required_reading()`: Resolver that checks available roles against a task profile and returns deterministic status (pass/warn/fail/not_applicable) with sorted lists of required, recommended, available, and missing artifacts

- **JSON Schema** (`merger/lenskit/contracts/required-reading-protocol.v1.schema.json`):
  - Draft-07 schema defining the protocol contract structure
  - Enforces required fields: kind, version, default_profile, task_profiles, does_not_establish
  - Defines task_profile schema with required/recommended/insufficient lists and boolean flags
  - Uses `additionalProperties: false` to prevent schema drift

- **Comprehensive Tests** (`merger/lenskit/tests/test_required_reading_protocol.py`):
  - Schema validation tests (11 test cases)
  - Validates all expected profiles are present
  - Tests resolver status transitions (pass → warn → fail)
  - Verifies output lists are deterministically sorted
  - Tests edge cases (unknown profiles, missing fields, extra fields)

- **Architecture Documentation** (`docs/architecture/agent-consumption-contract.md`):
  - Clarifies relationship to Agent Reading Pack (navigation layer) and canonical_md (content truth)
  - Documents all 5 task profiles with their required/recommended roles
  - Explains resolver status values and does_not_establish invariants
  - Includes usage example

## Notable Implementation Details

- All output lists are deterministically sorted for reproducibility
- Protocol is deterministic (no timestamps, I/O, or external state)
- Supports protocol/surface aliases (post_emit_health, bundle_surface_validation, etc.) alongside ArtifactRole values
- `does_not_establish` list captures invariants not established even with all required roles present
- Schema validation is optional (jsonschema import is gracefully skipped if unavailable)

https://claude.ai/code/session_01MHbF1SXDDTYBSQa67DAV9t