### PR TITLE
Implement Agent Consumption Trace validator and schema

### DIFF
--- a/docs/architecture/agent-consumption-contract.md
+++ b/docs/architecture/agent-consumption-contract.md
@@ -134,7 +134,7 @@ It may report:
 
 - pass: required artifacts are declared and no warning/failure condition was found.
 - warn: required artifacts are declared, but recommended artifacts are missing/unread or unknown declared artifacts were observed.
-- fail: required artifacts are missing/unread, task profiles mismatch, or required negative semantics are missing.
+- fail: required artifacts are missing/unread, task profiles mismatch, or required negative semantics are missing or invalid.
 - not_applicable: no applicable task profile could be resolved.
 
 The trace is a declaration-comparison artifact only. It does not prove actual reading, answer correctness, complete context use, runtime behavior, test sufficiency, regression absence, forensic readiness, or repo understanding.

--- a/docs/architecture/agent-consumption-contract.md
+++ b/docs/architecture/agent-consumption-contract.md
@@ -2,9 +2,10 @@
 
 ## Status
 
-PR 1 — Required Reading Protocol Core implemented.
+Required Reading Protocol Core implemented.
 Answer Compliance Contract v1 implemented.
-Agent Consumption Trace, Agent Entry Manifest, Agent Reading Pack v2, Export Safety Report, Lens Cards, Relation Cards, and Retrieval v2 are not yet implemented.
+Agent Consumption Trace v1 implemented.
+Agent Entry Manifest, Agent Reading Pack v2, Export Safety Report, Lens Cards, Relation Cards, and Retrieval v2 are not yet implemented.
 
 ---
 
@@ -122,4 +123,32 @@ does_not_establish must include the five protocol invariants on both protocol an
 The Answer Compliance Contract records what an answer declares it used.
 It is a declaration layer only. It does not prove actual reading, answer correctness, complete context use, runtime behavior, test sufficiency, regression absence, forensic readiness, or repo understanding.
 
-The later Agent Consumption Trace validator may compare Required Reading Protocol expectations against Answer Compliance declarations.
+The Agent Consumption Trace validator compares Required Reading Protocol expectations against Answer Compliance declarations (see below).
+
+---
+
+## Agent Consumption Trace
+
+The Agent Consumption Trace compares Required Reading expectations against Answer Compliance declarations.
+It may report:
+
+- pass: required artifacts are declared and no warning/failure condition was found.
+- warn: required artifacts are declared, but recommended artifacts are missing/unread or unknown declared artifacts were observed.
+- fail: required artifacts are missing/unread, task profiles mismatch, or required negative semantics are missing.
+- not_applicable: no applicable task profile could be resolved.
+
+The trace is a declaration-comparison artifact only. It does not prove actual reading, answer correctness, complete context use, runtime behavior, test sufficiency, regression absence, forensic readiness, or repo understanding.
+
+### Files
+
+| File | Role |
+|------|------|
+| `merger/lenskit/contracts/agent-consumption-trace.v1.schema.json` | JSON Schema (Draft-07) for the trace contract |
+| `merger/lenskit/core/agent_consumption_validate.py` | Pure validator: `validate_agent_consumption(required_reading_result, answer_compliance, *, available_roles=None)` |
+| `merger/lenskit/tests/test_agent_consumption_trace.py` | Schema validation and validator behaviour tests |
+
+### Scope
+
+This slice ships the contract, the pure core validator, and tests only. A CLI, strict mode, exit-code policy, Agent Entry Manifest, Output Health / Post-Emit Health integration, Bundle Manifest mutation, and Export Safety wiring are intentionally deferred. The validator performs no I/O, holds no global state, and reuses the existing Required Reading resolution rather than re-deriving it.
+
+`available_roles` is supplied explicitly. When omitted, only required and recommended roles are treated as known, and any other declared role is conservatively warned. The trace does not infer roles from the Bundle Manifest; that is later CLI / Entry Manifest work, and the `ArtifactRole` enum is not extended here.

--- a/docs/architecture/agent-consumption-contract.md
+++ b/docs/architecture/agent-consumption-contract.md
@@ -135,7 +135,7 @@ It may report:
 - pass: required artifacts are declared and no warning/failure condition was found.
 - warn: required artifacts are declared, but recommended artifacts are missing/unread or unknown declared artifacts were observed.
 - fail: required artifacts are missing/unread, task profiles mismatch, or required negative semantics are missing or invalid.
-- not_applicable: no applicable task profile could be resolved.
+- not_applicable: no applicable task profile could be resolved and no failing contract invariant was detected.
 
 The trace is a declaration-comparison artifact only. It does not prove actual reading, answer correctness, complete context use, runtime behavior, test sufficiency, regression absence, forensic readiness, or repo understanding.
 

--- a/merger/lenskit/contracts/agent-consumption-trace.v1.schema.json
+++ b/merger/lenskit/contracts/agent-consumption-trace.v1.schema.json
@@ -1,0 +1,169 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://heimgewebe.local/contracts/agent-consumption-trace.v1.schema.json",
+  "title": "Agent Consumption Trace (agent-consumption-trace v1.0)",
+  "description": "Machine-readable comparison of Required Reading Protocol expectations (the should) against Answer Compliance declarations (the declared). Comparison layer only. It does not prove actual reading, answer correctness, complete context use, runtime behavior, test sufficiency, regression absence, forensic readiness, repo understanding, or claim truth.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "kind",
+    "version",
+    "task_profile",
+    "status",
+    "required_artifacts",
+    "recommended_artifacts",
+    "declared_artifacts",
+    "missing_required_artifacts",
+    "missing_recommended_artifacts",
+    "unknown_declared_artifacts",
+    "unread_required_artifacts",
+    "unread_recommended_artifacts",
+    "declared_citations",
+    "declared_ranges",
+    "epistemic_gaps",
+    "diagnostics",
+    "does_not_establish"
+  ],
+  "properties": {
+    "kind": {
+      "type": "string",
+      "const": "lenskit.agent_consumption_trace"
+    },
+    "version": {
+      "type": "string",
+      "const": "1.0"
+    },
+    "task_profile": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Task profile against which Required Reading expectations and Answer Compliance declarations were compared."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["pass", "warn", "fail", "not_applicable"],
+      "description": "pass: required artifacts declared and no warn/fail condition. warn: recommended missing/unread or unknown declared artifacts. fail: required missing/unread, task profile mismatch, or required negative semantics missing. not_applicable: no applicable task profile could be resolved."
+    },
+    "required_artifacts": {
+      "$ref": "#/definitions/role_array",
+      "description": "Required reading expectation (the should): roles required for this task profile."
+    },
+    "recommended_artifacts": {
+      "$ref": "#/definitions/role_array",
+      "description": "Required reading expectation (the should): roles recommended for this task profile."
+    },
+    "declared_artifacts": {
+      "$ref": "#/definitions/role_array",
+      "description": "Answer Compliance declaration: roles the answer declares it checked or used. Declaration only; not proof of actual reading."
+    },
+    "missing_required_artifacts": {
+      "$ref": "#/definitions/role_array",
+      "description": "Required roles that were neither declared nor declared-unread."
+    },
+    "missing_recommended_artifacts": {
+      "$ref": "#/definitions/role_array",
+      "description": "Recommended roles that were neither declared nor declared-unread."
+    },
+    "unknown_declared_artifacts": {
+      "$ref": "#/definitions/role_array",
+      "description": "Declared roles that are not required, recommended, or in the supplied available_roles set."
+    },
+    "unread_required_artifacts": {
+      "$ref": "#/definitions/role_array",
+      "description": "Required roles the Answer Compliance declaration reports as unread or unavailable. Adopted from the declaration."
+    },
+    "unread_recommended_artifacts": {
+      "$ref": "#/definitions/role_array",
+      "description": "Recommended roles the Answer Compliance declaration reports as unread or unavailable. Adopted from the declaration."
+    },
+    "declared_citations": {
+      "type": "array",
+      "items": { "type": "object" },
+      "description": "Citation declarations adopted verbatim from the Answer Compliance declaration. Not re-validated here."
+    },
+    "declared_ranges": {
+      "type": "array",
+      "items": { "type": "object" },
+      "description": "Range declarations adopted verbatim from the Answer Compliance declaration. Not re-validated here."
+    },
+    "epistemic_gaps": {
+      "type": "array",
+      "items": { "type": "object" },
+      "description": "Epistemic gaps adopted verbatim from the Answer Compliance declaration. Not re-validated here."
+    },
+    "diagnostics": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/diagnostic" },
+      "description": "Deviations between required reading expectation and Answer Compliance declaration."
+    },
+    "does_not_establish": {
+      "$ref": "#/definitions/does_not_establish_array"
+    }
+  },
+  "definitions": {
+    "role_array": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "diagnostic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "severity", "detail"],
+      "properties": {
+        "code": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Machine-readable diagnostic code, e.g. missing_required_artifact."
+        },
+        "severity": {
+          "type": "string",
+          "enum": ["info", "warn", "fail"]
+        },
+        "detail": {
+          "type": "string",
+          "minLength": 1
+        },
+        "artifact": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional role this diagnostic refers to."
+        }
+      }
+    },
+    "does_not_establish_array": {
+      "type": "array",
+      "minItems": 9,
+      "maxItems": 9,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": [
+          "actual_reading_proven",
+          "answer_correct",
+          "repo_understood",
+          "all_relevant_context_used",
+          "claims_true",
+          "test_sufficiency",
+          "regression_absence",
+          "runtime_behavior",
+          "forensic_ready"
+        ]
+      },
+      "allOf": [
+        { "contains": { "const": "actual_reading_proven" } },
+        { "contains": { "const": "answer_correct" } },
+        { "contains": { "const": "repo_understood" } },
+        { "contains": { "const": "all_relevant_context_used" } },
+        { "contains": { "const": "claims_true" } },
+        { "contains": { "const": "test_sufficiency" } },
+        { "contains": { "const": "regression_absence" } },
+        { "contains": { "const": "runtime_behavior" } },
+        { "contains": { "const": "forensic_ready" } }
+      ],
+      "description": "Boundaries this trace does not establish. The trace is a declaration-comparison artifact only."
+    }
+  }
+}

--- a/merger/lenskit/contracts/agent-consumption-trace.v1.schema.json
+++ b/merger/lenskit/contracts/agent-consumption-trace.v1.schema.json
@@ -115,8 +115,17 @@
       "properties": {
         "code": {
           "type": "string",
-          "minLength": 1,
-          "description": "Machine-readable diagnostic code, e.g. missing_required_artifact."
+          "enum": [
+            "task_profile_mismatch",
+            "task_profile_not_applicable",
+            "missing_required_artifact",
+            "unread_required_artifact",
+            "missing_recommended_artifact",
+            "unread_recommended_artifact",
+            "unknown_declared_artifact",
+            "missing_negative_semantics"
+          ],
+          "description": "Machine-readable diagnostic code."
         },
         "severity": {
           "type": "string",

--- a/merger/lenskit/contracts/agent-consumption-trace.v1.schema.json
+++ b/merger/lenskit/contracts/agent-consumption-trace.v1.schema.json
@@ -41,7 +41,7 @@
     "status": {
       "type": "string",
       "enum": ["pass", "warn", "fail", "not_applicable"],
-      "description": "pass: required artifacts declared and no warn/fail condition. warn: recommended missing/unread or unknown declared artifacts. fail: required missing/unread, task profile mismatch, or required negative semantics missing. not_applicable: no applicable task profile could be resolved."
+      "description": "pass: required artifacts declared and no warn/fail condition. warn: recommended missing/unread or unknown declared artifacts. fail: required missing/unread, task profile mismatch, or required negative semantics missing or invalid. not_applicable: no applicable task profile could be resolved."
     },
     "required_artifacts": {
       "$ref": "#/definitions/role_array",

--- a/merger/lenskit/contracts/agent-consumption-trace.v1.schema.json
+++ b/merger/lenskit/contracts/agent-consumption-trace.v1.schema.json
@@ -41,7 +41,7 @@
     "status": {
       "type": "string",
       "enum": ["pass", "warn", "fail", "not_applicable"],
-      "description": "pass: required artifacts declared and no warn/fail condition. warn: recommended missing/unread or unknown declared artifacts. fail: required missing/unread, task profile mismatch, or required negative semantics missing or invalid. not_applicable: no applicable task profile could be resolved."
+      "description": "pass: required artifacts declared and no warn/fail condition. warn: recommended missing/unread or unknown declared artifacts. fail: required missing/unread, task profile mismatch, or required negative semantics missing or invalid. not_applicable: no applicable task profile could be resolved and no failing contract invariant was detected."
     },
     "required_artifacts": {
       "$ref": "#/definitions/role_array",

--- a/merger/lenskit/core/agent_consumption_validate.py
+++ b/merger/lenskit/core/agent_consumption_validate.py
@@ -207,14 +207,13 @@ def validate_agent_consumption(
             )
 
     # ── Rule 5: negative semantics ──────────────────────────────────────────
-    ac_negatives = {str(x) for x in (ac.get("does_not_establish") or [])}
-    if not set(DOES_NOT_ESTABLISH).issubset(ac_negatives):
+    ac_negatives = [str(x) for x in (ac.get("does_not_establish") or [])]
+    if sorted(ac_negatives) != sorted(DOES_NOT_ESTABLISH):
         diagnostics.append(
             _diag(
                 "missing_negative_semantics",
                 _FAIL,
-                "Answer compliance does_not_establish is missing one or more of "
-                "the nine required boundaries.",
+                "Answer compliance does_not_establish must contain exactly the nine required boundaries.",
             )
         )
 

--- a/merger/lenskit/core/agent_consumption_validate.py
+++ b/merger/lenskit/core/agent_consumption_validate.py
@@ -98,9 +98,25 @@ def validate_agent_consumption(
 
     diagnostics: list[dict] = []
 
+    # ── Negative semantics (contract invariant) ─────────────────────────────
+    # A broken Answer Compliance artifact stays broken even when the task
+    # profile is not applicable: the nine does_not_establish boundaries are a
+    # contract invariant, not a profile question.  Evaluated before the
+    # not_applicable short-circuit so invalid boundaries are never swallowed.
+    if not _has_exact_negative_semantics(ac):
+        diagnostics.append(
+            _diag(
+                "missing_negative_semantics",
+                _FAIL,
+                "Answer compliance does_not_establish must contain exactly the "
+                "nine required boundaries.",
+            )
+        )
+
     # ── Rule 1: task profile resolution ─────────────────────────────────────
-    # not_applicable wins and stops further evaluation: there is no meaningful
-    # expectation to compare against.
+    # not_applicable stops the Soll/Ist comparison (there is no meaningful
+    # expectation to compare against), but a failing contract invariant such as
+    # invalid negative semantics still wins.
     if rr.get("status") == "not_applicable":
         diagnostics.append(
             _diag(
@@ -109,9 +125,14 @@ def validate_agent_consumption(
                 f"No applicable task profile could be resolved for '{task_profile}'.",
             )
         )
+        status = (
+            "fail"
+            if any(d["severity"] == _FAIL for d in diagnostics)
+            else "not_applicable"
+        )
         return _trace(
             task_profile=task_profile,
-            status="not_applicable",
+            status=status,
             required_artifacts=required_artifacts,
             recommended_artifacts=recommended_artifacts,
             declared_artifacts=declared_artifacts,
@@ -206,18 +227,9 @@ def validate_agent_consumption(
                 )
             )
 
-    # ── Rule 5: negative semantics ──────────────────────────────────────────
-    ac_negatives = [str(x) for x in (ac.get("does_not_establish") or [])]
-    if sorted(ac_negatives) != sorted(DOES_NOT_ESTABLISH):
-        diagnostics.append(
-            _diag(
-                "missing_negative_semantics",
-                _FAIL,
-                "Answer compliance does_not_establish must contain exactly the nine required boundaries.",
-            )
-        )
-
-    # ── Rule 6: status priority ─────────────────────────────────────────────
+    # ── Status priority ─────────────────────────────────────────────────────
+    # Negative semantics were already evaluated above, before the
+    # not_applicable short-circuit.
     if any(d["severity"] == _FAIL for d in diagnostics):
         status = "fail"
     elif any(d["severity"] == _WARN for d in diagnostics):
@@ -244,10 +256,32 @@ def validate_agent_consumption(
 
 
 def _norm_roles(value) -> list[str]:
-    """Normalise a role list deterministically: stringify, dedupe, sort."""
+    """Normalise a role list deterministically: stringify, dedupe, sort.
+
+    Defensive only: a scalar string is treated as a single role rather than
+    being decomposed into characters.  No schema validation, no exceptions.
+    """
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
     if not value:
         return []
     return sorted({str(x) for x in value})
+
+
+def _has_exact_negative_semantics(answer_compliance: dict) -> bool:
+    """True iff Answer Compliance declares exactly the nine required boundaries.
+
+    Rejects missing, extra, unknown, and duplicate values alike.
+    """
+    ac_negatives = [
+        str(x) for x in (answer_compliance.get("does_not_establish") or [])
+    ]
+    return (
+        set(ac_negatives) == set(DOES_NOT_ESTABLISH)
+        and len(ac_negatives) == len(DOES_NOT_ESTABLISH)
+    )
 
 
 def _diag(code: str, severity: str, detail: str, *, artifact: str | None = None) -> dict:
@@ -274,8 +308,14 @@ def _trace(
     epistemic_gaps: list,
     diagnostics: list[dict],
 ) -> dict:
+    severity_weight = {"fail": 0, "warn": 1, "info": 2}
     ordered_diagnostics = sorted(
-        diagnostics, key=lambda d: (d["code"], d.get("artifact", ""))
+        diagnostics,
+        key=lambda d: (
+            severity_weight.get(d.get("severity"), 3),
+            d["code"],
+            d.get("artifact", ""),
+        ),
     )
     return {
         "kind": KIND,

--- a/merger/lenskit/core/agent_consumption_validate.py
+++ b/merger/lenskit/core/agent_consumption_validate.py
@@ -1,0 +1,299 @@
+"""Agent Consumption Trace validator.
+
+Pure, deterministic comparison of Required Reading Protocol expectations (the
+"should") against an Answer Compliance declaration (what the answer claims to
+have used).  The result is a machine-readable Agent Consumption Trace.
+
+Strict separation of layers:
+
+* Required Reading Protocol = expectation: which artifacts are required or
+  recommended for a task profile.
+* Answer Compliance = declaration: what the answer claims it used, did not use,
+  or could not verify.
+* Agent Consumption Trace = comparison: does the declaration formally line up
+  with the expectation?
+
+This module performs no I/O, holds no global state, and imports nothing from the
+service / CLI layers.  It makes no truth claim.  It does not prove actual
+reading, answer correctness, repo understanding, complete context use, runtime
+behavior, test sufficiency, regression absence, forensic readiness, or claim
+truth.  It only reports whether a declared self-report formally matches the
+required-reading expectation.
+"""
+from __future__ import annotations
+
+
+KIND = "lenskit.agent_consumption_trace"
+VERSION = "1.0"
+
+# The nine boundaries this trace explicitly does not establish.
+# Mirrors answer-compliance.v1 does_not_establish exactly.
+DOES_NOT_ESTABLISH: tuple[str, ...] = (
+    "actual_reading_proven",
+    "answer_correct",
+    "repo_understood",
+    "all_relevant_context_used",
+    "claims_true",
+    "test_sufficiency",
+    "regression_absence",
+    "runtime_behavior",
+    "forensic_ready",
+)
+
+_FAIL = "fail"
+_WARN = "warn"
+_INFO = "info"
+
+
+def validate_agent_consumption(
+    required_reading_result: dict,
+    answer_compliance: dict,
+    *,
+    available_roles: set[str] | None = None,
+) -> dict:
+    """Compare a resolved Required Reading result against an Answer Compliance
+    declaration and return a deterministic Agent Consumption Trace dict.
+
+    Parameters
+    ----------
+    required_reading_result:
+        Output of ``resolve_required_reading`` (or an equivalent dict carrying
+        ``task_profile``, ``required``, ``recommended`` and ``status``).  The
+        existing Required Reading resolution is reused as-is; this validator does
+        not re-derive it.
+    answer_compliance:
+        An ``answer-compliance.v1`` declaration dict.
+    available_roles:
+        Optional set of roles known to exist in the bundle context.  When
+        provided, declared artifacts in this set are not flagged as unknown.
+        When ``None``, only required + recommended roles are treated as known and
+        any other declared role is conservatively warned.
+
+    Returns
+    -------
+    dict
+        A trace that validates against
+        ``contracts/agent-consumption-trace.v1.schema.json``.
+    """
+    rr = required_reading_result or {}
+    ac = answer_compliance or {}
+
+    rr_profile = rr.get("task_profile")
+    ac_profile = ac.get("task_profile")
+    task_profile = rr_profile if rr_profile not in (None, "") else ac_profile
+    if task_profile in (None, ""):
+        task_profile = "unknown"
+
+    required_artifacts = _norm_roles(rr.get("required"))
+    recommended_artifacts = _norm_roles(rr.get("recommended"))
+    declared_artifacts = _norm_roles(ac.get("declared_artifacts"))
+    unread_required = _norm_roles(ac.get("unread_required_artifacts"))
+    unread_recommended = _norm_roles(ac.get("unread_recommended_artifacts"))
+
+    # Pass-through declarations.  The trace is a comparison artifact, not a second
+    # Answer Compliance validator, so these are adopted verbatim.
+    declared_citations = list(ac.get("declared_citations") or [])
+    declared_ranges = list(ac.get("declared_ranges") or [])
+    epistemic_gaps = list(ac.get("epistemic_gaps") or [])
+
+    diagnostics: list[dict] = []
+
+    # ── Rule 1: task profile resolution ─────────────────────────────────────
+    # not_applicable wins and stops further evaluation: there is no meaningful
+    # expectation to compare against.
+    if rr.get("status") == "not_applicable":
+        diagnostics.append(
+            _diag(
+                "task_profile_not_applicable",
+                _INFO,
+                f"No applicable task profile could be resolved for '{task_profile}'.",
+            )
+        )
+        return _trace(
+            task_profile=task_profile,
+            status="not_applicable",
+            required_artifacts=required_artifacts,
+            recommended_artifacts=recommended_artifacts,
+            declared_artifacts=declared_artifacts,
+            missing_required_artifacts=[],
+            missing_recommended_artifacts=[],
+            unknown_declared_artifacts=[],
+            unread_required_artifacts=unread_required,
+            unread_recommended_artifacts=unread_recommended,
+            declared_citations=declared_citations,
+            declared_ranges=declared_ranges,
+            epistemic_gaps=epistemic_gaps,
+            diagnostics=diagnostics,
+        )
+
+    if ac_profile is not None and ac_profile != rr_profile:
+        diagnostics.append(
+            _diag(
+                "task_profile_mismatch",
+                _FAIL,
+                f"Answer compliance declared task profile '{ac_profile}' but "
+                f"required reading resolved '{rr_profile}'.",
+            )
+        )
+
+    declared_set = set(declared_artifacts)
+    unread_required_set = set(unread_required)
+    unread_recommended_set = set(unread_recommended)
+
+    # ── Rule 2: required artifacts ──────────────────────────────────────────
+    # Honestly declaring a required artifact as unread is good practice, but it
+    # is still a formal deviation from the expectation.
+    missing_required_artifacts: list[str] = []
+    for role in required_artifacts:
+        if role in unread_required_set:
+            diagnostics.append(
+                _diag(
+                    "unread_required_artifact",
+                    _FAIL,
+                    f"Required artifact '{role}' was declared unread.",
+                    artifact=role,
+                )
+            )
+        elif role not in declared_set:
+            missing_required_artifacts.append(role)
+            diagnostics.append(
+                _diag(
+                    "missing_required_artifact",
+                    _FAIL,
+                    f"Required artifact '{role}' was not declared.",
+                    artifact=role,
+                )
+            )
+
+    # ── Rule 3: recommended artifacts ───────────────────────────────────────
+    missing_recommended_artifacts: list[str] = []
+    for role in recommended_artifacts:
+        if role in unread_recommended_set:
+            diagnostics.append(
+                _diag(
+                    "unread_recommended_artifact",
+                    _WARN,
+                    f"Recommended artifact '{role}' was declared unread.",
+                    artifact=role,
+                )
+            )
+        elif role not in declared_set:
+            missing_recommended_artifacts.append(role)
+            diagnostics.append(
+                _diag(
+                    "missing_recommended_artifact",
+                    _WARN,
+                    f"Recommended artifact '{role}' was not declared.",
+                    artifact=role,
+                )
+            )
+
+    # ── Rule 4: unknown declared artifacts ──────────────────────────────────
+    known_roles = set(required_artifacts) | set(recommended_artifacts)
+    if available_roles is not None:
+        known_roles |= {str(x) for x in available_roles}
+    unknown_declared_artifacts: list[str] = []
+    for role in declared_artifacts:
+        if role not in known_roles:
+            unknown_declared_artifacts.append(role)
+            diagnostics.append(
+                _diag(
+                    "unknown_declared_artifact",
+                    _WARN,
+                    f"Declared artifact '{role}' is not a known required, "
+                    f"recommended, or available role.",
+                    artifact=role,
+                )
+            )
+
+    # ── Rule 5: negative semantics ──────────────────────────────────────────
+    ac_negatives = {str(x) for x in (ac.get("does_not_establish") or [])}
+    if not set(DOES_NOT_ESTABLISH).issubset(ac_negatives):
+        diagnostics.append(
+            _diag(
+                "missing_negative_semantics",
+                _FAIL,
+                "Answer compliance does_not_establish is missing one or more of "
+                "the nine required boundaries.",
+            )
+        )
+
+    # ── Rule 6: status priority ─────────────────────────────────────────────
+    if any(d["severity"] == _FAIL for d in diagnostics):
+        status = "fail"
+    elif any(d["severity"] == _WARN for d in diagnostics):
+        status = "warn"
+    else:
+        status = "pass"
+
+    return _trace(
+        task_profile=task_profile,
+        status=status,
+        required_artifacts=required_artifacts,
+        recommended_artifacts=recommended_artifacts,
+        declared_artifacts=declared_artifacts,
+        missing_required_artifacts=sorted(missing_required_artifacts),
+        missing_recommended_artifacts=sorted(missing_recommended_artifacts),
+        unknown_declared_artifacts=sorted(unknown_declared_artifacts),
+        unread_required_artifacts=unread_required,
+        unread_recommended_artifacts=unread_recommended,
+        declared_citations=declared_citations,
+        declared_ranges=declared_ranges,
+        epistemic_gaps=epistemic_gaps,
+        diagnostics=diagnostics,
+    )
+
+
+def _norm_roles(value) -> list[str]:
+    """Normalise a role list deterministically: stringify, dedupe, sort."""
+    if not value:
+        return []
+    return sorted({str(x) for x in value})
+
+
+def _diag(code: str, severity: str, detail: str, *, artifact: str | None = None) -> dict:
+    diagnostic = {"code": code, "severity": severity, "detail": detail}
+    if artifact is not None:
+        diagnostic["artifact"] = artifact
+    return diagnostic
+
+
+def _trace(
+    *,
+    task_profile: str,
+    status: str,
+    required_artifacts: list[str],
+    recommended_artifacts: list[str],
+    declared_artifacts: list[str],
+    missing_required_artifacts: list[str],
+    missing_recommended_artifacts: list[str],
+    unknown_declared_artifacts: list[str],
+    unread_required_artifacts: list[str],
+    unread_recommended_artifacts: list[str],
+    declared_citations: list,
+    declared_ranges: list,
+    epistemic_gaps: list,
+    diagnostics: list[dict],
+) -> dict:
+    ordered_diagnostics = sorted(
+        diagnostics, key=lambda d: (d["code"], d.get("artifact", ""))
+    )
+    return {
+        "kind": KIND,
+        "version": VERSION,
+        "task_profile": task_profile,
+        "status": status,
+        "required_artifacts": required_artifacts,
+        "recommended_artifacts": recommended_artifacts,
+        "declared_artifacts": declared_artifacts,
+        "missing_required_artifacts": missing_required_artifacts,
+        "missing_recommended_artifacts": missing_recommended_artifacts,
+        "unknown_declared_artifacts": unknown_declared_artifacts,
+        "unread_required_artifacts": unread_required_artifacts,
+        "unread_recommended_artifacts": unread_recommended_artifacts,
+        "declared_citations": declared_citations,
+        "declared_ranges": declared_ranges,
+        "epistemic_gaps": epistemic_gaps,
+        "diagnostics": ordered_diagnostics,
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }

--- a/merger/lenskit/tests/test_agent_consumption_trace.py
+++ b/merger/lenskit/tests/test_agent_consumption_trace.py
@@ -1,0 +1,540 @@
+import json
+from pathlib import Path
+
+import pytest
+
+try:
+    import jsonschema
+    from jsonschema import ValidationError
+except ImportError:
+    jsonschema = None
+    ValidationError = None
+
+from merger.lenskit.core.agent_consumption_validate import (
+    DOES_NOT_ESTABLISH,
+    validate_agent_consumption,
+)
+from merger.lenskit.core.required_reading import (
+    default_required_reading_protocol,
+    resolve_required_reading,
+)
+
+_SCHEMA_PATH = (
+    Path(__file__).parent.parent
+    / "contracts"
+    / "agent-consumption-trace.v1.schema.json"
+)
+
+_NINE = [
+    "actual_reading_proven",
+    "answer_correct",
+    "repo_understood",
+    "all_relevant_context_used",
+    "claims_true",
+    "test_sufficiency",
+    "regression_absence",
+    "runtime_behavior",
+    "forensic_ready",
+]
+
+
+def _require_jsonschema():
+    if jsonschema is None:
+        pytest.skip("jsonschema not installed")
+
+
+def _load_schema() -> dict:
+    return json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+def _required_reading_result(**overrides) -> dict:
+    """A resolved Required Reading result (shape of resolve_required_reading)."""
+    base = {
+        "task_profile": "pr_review",
+        "required": ["agent_reading_pack", "canonical_md"],
+        "recommended": ["citation_map_jsonl"],
+        "status": "pass",
+    }
+    base.update(overrides)
+    return base
+
+
+def _answer_compliance(**overrides) -> dict:
+    base = {
+        "kind": "lenskit.answer_compliance",
+        "version": "1.0",
+        "task_profile": "pr_review",
+        "declared_artifacts": [
+            "agent_reading_pack",
+            "canonical_md",
+            "citation_map_jsonl",
+        ],
+        "declared_citations": [],
+        "declared_ranges": [],
+        "unread_required_artifacts": [],
+        "unread_recommended_artifacts": [],
+        "epistemic_gaps": [],
+        "does_not_establish": list(_NINE),
+    }
+    base.update(overrides)
+    return base
+
+
+def _minimal_pass_trace() -> dict:
+    """Schema-level fixture: a minimal, hand-written pass trace."""
+    return {
+        "kind": "lenskit.agent_consumption_trace",
+        "version": "1.0",
+        "task_profile": "pr_review",
+        "status": "pass",
+        "required_artifacts": ["agent_reading_pack", "canonical_md"],
+        "recommended_artifacts": [],
+        "declared_artifacts": ["agent_reading_pack", "canonical_md"],
+        "missing_required_artifacts": [],
+        "missing_recommended_artifacts": [],
+        "unknown_declared_artifacts": [],
+        "unread_required_artifacts": [],
+        "unread_recommended_artifacts": [],
+        "declared_citations": [],
+        "declared_ranges": [],
+        "epistemic_gaps": [],
+        "diagnostics": [],
+        "does_not_establish": list(_NINE),
+    }
+
+
+def _codes(trace: dict) -> set[str]:
+    return {d["code"] for d in trace["diagnostics"]}
+
+
+# ── 1. Minimal pass trace is schema-valid ─────────────────────────────────────
+
+
+def test_minimal_pass_trace_is_schema_valid():
+    _require_jsonschema()
+    jsonschema.validate(instance=_minimal_pass_trace(), schema=_load_schema())
+
+
+# ── 2. kind must be lenskit.agent_consumption_trace ──────────────────────────
+
+
+def test_kind_must_be_agent_consumption_trace():
+    _require_jsonschema()
+    instance = _minimal_pass_trace()
+    instance["kind"] = "wrong_kind"
+    with pytest.raises(ValidationError, match="wrong_kind"):
+        jsonschema.validate(instance=instance, schema=_load_schema())
+
+
+# ── 3. version must be 1.0 ───────────────────────────────────────────────────
+
+
+def test_version_must_be_1_0():
+    _require_jsonschema()
+    instance = _minimal_pass_trace()
+    instance["version"] = "2.0"
+    with pytest.raises(ValidationError, match="2.0"):
+        jsonschema.validate(instance=instance, schema=_load_schema())
+
+
+# ── 4. status enum blocks unknown values ─────────────────────────────────────
+
+
+def test_status_enum_blocks_unknown_value():
+    _require_jsonschema()
+    instance = _minimal_pass_trace()
+    instance["status"] = "bogus"
+    with pytest.raises(ValidationError):
+        jsonschema.validate(instance=instance, schema=_load_schema())
+
+
+# ── 5. does_not_establish with exactly nine values is valid ──────────────────
+
+
+def test_does_not_establish_nine_values_valid():
+    _require_jsonschema()
+    instance = _minimal_pass_trace()
+    assert len(instance["does_not_establish"]) == 9
+    jsonschema.validate(instance=instance, schema=_load_schema())
+
+
+# ── 6. does_not_establish with a missing value is invalid ────────────────────
+
+
+def test_does_not_establish_missing_value_invalid():
+    _require_jsonschema()
+    instance = _minimal_pass_trace()
+    instance["does_not_establish"] = _NINE[:-1]  # eight values
+    with pytest.raises(ValidationError):
+        jsonschema.validate(instance=instance, schema=_load_schema())
+
+
+# ── 7. does_not_establish with a tenth value is invalid ──────────────────────
+
+
+def test_does_not_establish_tenth_value_invalid():
+    _require_jsonschema()
+    instance = _minimal_pass_trace()
+    instance["does_not_establish"] = _NINE + ["answer_safe_without_citations"]
+    with pytest.raises(ValidationError):
+        jsonschema.validate(instance=instance, schema=_load_schema())
+
+
+# ── 8. does_not_establish with an unknown value is invalid ───────────────────
+
+
+def test_does_not_establish_unknown_value_invalid():
+    _require_jsonschema()
+    instance = _minimal_pass_trace()
+    instance["does_not_establish"] = _NINE[:-1] + ["invented_boundary"]
+    with pytest.raises(ValidationError):
+        jsonschema.validate(instance=instance, schema=_load_schema())
+
+
+# ── 9. required artifact missing -> fail ─────────────────────────────────────
+
+
+def test_missing_required_artifact_is_fail():
+    rr = _required_reading_result(recommended=[])
+    ac = _answer_compliance(declared_artifacts=["agent_reading_pack"])
+    trace = validate_agent_consumption(rr, ac)
+    assert trace["status"] == "fail"
+    assert "missing_required_artifact" in _codes(trace)
+    assert trace["missing_required_artifacts"] == ["canonical_md"]
+
+
+# ── 10. required artifact declared unread -> fail ────────────────────────────
+
+
+def test_unread_required_artifact_is_fail():
+    rr = _required_reading_result(recommended=[])
+    ac = _answer_compliance(
+        declared_artifacts=["agent_reading_pack"],
+        unread_required_artifacts=["canonical_md"],
+    )
+    trace = validate_agent_consumption(rr, ac)
+    assert trace["status"] == "fail"
+    assert "unread_required_artifact" in _codes(trace)
+    # honest unread declaration is surfaced, not double-counted as missing
+    assert trace["unread_required_artifacts"] == ["canonical_md"]
+    assert trace["missing_required_artifacts"] == []
+
+
+# ── 11. recommended artifact missing -> warn ─────────────────────────────────
+
+
+def test_missing_recommended_artifact_is_warn():
+    rr = _required_reading_result()
+    ac = _answer_compliance(
+        declared_artifacts=["agent_reading_pack", "canonical_md"],
+    )
+    trace = validate_agent_consumption(rr, ac)
+    assert trace["status"] == "warn"
+    assert "missing_recommended_artifact" in _codes(trace)
+    assert trace["missing_recommended_artifacts"] == ["citation_map_jsonl"]
+
+
+# ── 12. recommended artifact declared unread -> warn ─────────────────────────
+
+
+def test_unread_recommended_artifact_is_warn():
+    rr = _required_reading_result()
+    ac = _answer_compliance(
+        declared_artifacts=["agent_reading_pack", "canonical_md"],
+        unread_recommended_artifacts=["citation_map_jsonl"],
+    )
+    trace = validate_agent_consumption(rr, ac)
+    assert trace["status"] == "warn"
+    assert "unread_recommended_artifact" in _codes(trace)
+    assert trace["unread_recommended_artifacts"] == ["citation_map_jsonl"]
+
+
+# ── 13. unknown declared artifact (available_roles=None) -> warn ─────────────
+
+
+def test_unknown_declared_artifact_is_warn():
+    rr = _required_reading_result(recommended=[])
+    ac = _answer_compliance(
+        declared_artifacts=["agent_reading_pack", "canonical_md", "mystery_role"],
+    )
+    trace = validate_agent_consumption(rr, ac)
+    assert trace["status"] == "warn"
+    assert "unknown_declared_artifact" in _codes(trace)
+    assert trace["unknown_declared_artifacts"] == ["mystery_role"]
+
+
+# ── 14. task_profile mismatch -> fail ────────────────────────────────────────
+
+
+def test_task_profile_mismatch_is_fail():
+    rr = _required_reading_result(task_profile="pr_review", recommended=[])
+    ac = _answer_compliance(
+        task_profile="basic_repo_question",
+        declared_artifacts=["agent_reading_pack", "canonical_md"],
+    )
+    trace = validate_agent_consumption(rr, ac)
+    assert trace["status"] == "fail"
+    assert "task_profile_mismatch" in _codes(trace)
+
+
+# ── 15. unknown / not_applicable profile -> not_applicable ───────────────────
+
+
+def test_not_applicable_profile():
+    # Real resolver naturally returns not_applicable for an unknown profile.
+    protocol = default_required_reading_protocol()
+    rr = resolve_required_reading(
+        protocol, available_roles=set(), task_profile="does_not_exist"
+    )
+    ac = _answer_compliance(task_profile="does_not_exist")
+    trace = validate_agent_consumption(rr, ac)
+    assert trace["status"] == "not_applicable"
+    assert "task_profile_not_applicable" in _codes(trace)
+    # not_applicable stops further evaluation
+    assert "missing_required_artifact" not in _codes(trace)
+    assert "task_profile_mismatch" not in _codes(trace)
+
+
+# ── 16. pass when required satisfied and no warn/fail diagnostics ─────────────
+
+
+def test_pass_when_required_satisfied():
+    rr = _required_reading_result(recommended=[])
+    ac = _answer_compliance(
+        declared_artifacts=["agent_reading_pack", "canonical_md"],
+    )
+    trace = validate_agent_consumption(rr, ac)
+    assert trace["status"] == "pass"
+    assert trace["diagnostics"] == []
+
+
+# ── 17. fail beats warn ──────────────────────────────────────────────────────
+
+
+def test_fail_beats_warn():
+    # canonical_md missing (fail) AND citation_map_jsonl missing (warn)
+    rr = _required_reading_result()
+    ac = _answer_compliance(declared_artifacts=["agent_reading_pack"])
+    trace = validate_agent_consumption(rr, ac)
+    codes = _codes(trace)
+    assert "missing_required_artifact" in codes
+    assert "missing_recommended_artifact" in codes
+    assert trace["status"] == "fail"
+
+
+# ── 18. declared_citations are adopted ───────────────────────────────────────
+
+
+def test_declared_citations_are_adopted():
+    citations = [{"citation_id": "c-1", "purpose": "support a claim"}]
+    rr = _required_reading_result(recommended=[])
+    ac = _answer_compliance(
+        declared_artifacts=["agent_reading_pack", "canonical_md"],
+        declared_citations=citations,
+    )
+    trace = validate_agent_consumption(rr, ac)
+    assert trace["declared_citations"] == citations
+
+
+# ── 19. declared_ranges are adopted ──────────────────────────────────────────
+
+
+def test_declared_ranges_are_adopted():
+    ranges = [
+        {
+            "artifact": "canonical_md",
+            "range_ref": {
+                "file_path": "lenskit-max-example_merge.md",
+                "start_line": 1,
+                "end_line": 3,
+            },
+            "purpose": "verify cited content",
+        }
+    ]
+    rr = _required_reading_result(recommended=[])
+    ac = _answer_compliance(
+        declared_artifacts=["agent_reading_pack", "canonical_md"],
+        declared_ranges=ranges,
+    )
+    trace = validate_agent_consumption(rr, ac)
+    assert trace["declared_ranges"] == ranges
+
+
+# ── 20. epistemic_gaps are adopted ───────────────────────────────────────────
+
+
+def test_epistemic_gaps_are_adopted():
+    gaps = [{"kind": "test_not_run", "detail": "No pytest run was executed."}]
+    rr = _required_reading_result(recommended=[])
+    ac = _answer_compliance(
+        declared_artifacts=["agent_reading_pack", "canonical_md"],
+        epistemic_gaps=gaps,
+    )
+    trace = validate_agent_consumption(rr, ac)
+    assert trace["epistemic_gaps"] == gaps
+
+
+# ── 21. trace makes no truth / correctness / actual-reading claim ────────────
+
+
+def test_trace_makes_no_truth_claim():
+    rr = _required_reading_result(recommended=[])
+    ac = _answer_compliance(
+        declared_artifacts=["agent_reading_pack", "canonical_md"],
+    )
+    trace = validate_agent_consumption(rr, ac)
+    # The nine boundaries only ever appear as declared non-establishment,
+    # never as a positive top-level assertion.
+    for boundary in _NINE:
+        assert boundary not in trace
+    assert trace["does_not_establish"] == list(DOES_NOT_ESTABLISH)
+    assert set(trace["does_not_establish"]) == set(_NINE)
+    # No boolean truth flags anywhere in the trace.
+    assert True not in trace.values()
+
+
+# ── 22. available_roles prevents false-positive unknown_declared_artifact ────
+
+
+def test_available_roles_prevents_false_positive_unknown():
+    rr = _required_reading_result(recommended=[])
+    ac = _answer_compliance(
+        declared_artifacts=["agent_reading_pack", "canonical_md", "mystery_role"],
+    )
+    trace = validate_agent_consumption(
+        rr, ac, available_roles={"mystery_role"}
+    )
+    assert "unknown_declared_artifact" not in _codes(trace)
+    assert trace["unknown_declared_artifacts"] == []
+    assert trace["status"] == "pass"
+
+
+# ── 23. available_roles=None warns conservatively on unknown declared role ───
+
+
+def test_available_roles_none_warns_conservatively():
+    rr = _required_reading_result(recommended=[])
+    ac = _answer_compliance(
+        declared_artifacts=["agent_reading_pack", "canonical_md", "mystery_role"],
+    )
+    trace = validate_agent_consumption(rr, ac, available_roles=None)
+    assert "unknown_declared_artifact" in _codes(trace)
+    assert trace["unknown_declared_artifacts"] == ["mystery_role"]
+
+
+# ── Negative semantics rule ──────────────────────────────────────────────────
+
+
+def test_missing_negative_semantics_is_fail():
+    rr = _required_reading_result(recommended=[])
+    ac = _answer_compliance(
+        declared_artifacts=["agent_reading_pack", "canonical_md"],
+        does_not_establish=_NINE[:-1],  # missing forensic_ready
+    )
+    trace = validate_agent_consumption(rr, ac)
+    assert trace["status"] == "fail"
+    assert "missing_negative_semantics" in _codes(trace)
+    # The trace still declares its own full set of boundaries.
+    assert trace["does_not_establish"] == list(DOES_NOT_ESTABLISH)
+
+
+# ── Validator output is schema-valid for every status ────────────────────────
+
+
+def test_validator_pass_output_is_schema_valid():
+    _require_jsonschema()
+    rr = _required_reading_result(recommended=[])
+    ac = _answer_compliance(
+        declared_artifacts=["agent_reading_pack", "canonical_md"],
+    )
+    trace = validate_agent_consumption(rr, ac)
+    assert trace["status"] == "pass"
+    jsonschema.validate(instance=trace, schema=_load_schema())
+
+
+def test_validator_warn_output_is_schema_valid():
+    _require_jsonschema()
+    rr = _required_reading_result()
+    ac = _answer_compliance(
+        declared_artifacts=["agent_reading_pack", "canonical_md"],
+    )
+    trace = validate_agent_consumption(rr, ac)
+    assert trace["status"] == "warn"
+    jsonschema.validate(instance=trace, schema=_load_schema())
+
+
+def test_validator_fail_output_is_schema_valid():
+    _require_jsonschema()
+    rr = _required_reading_result()
+    ac = _answer_compliance(declared_artifacts=["agent_reading_pack"])
+    trace = validate_agent_consumption(rr, ac)
+    assert trace["status"] == "fail"
+    jsonschema.validate(instance=trace, schema=_load_schema())
+
+
+def test_validator_not_applicable_output_is_schema_valid():
+    _require_jsonschema()
+    protocol = default_required_reading_protocol()
+    rr = resolve_required_reading(
+        protocol, available_roles=set(), task_profile="does_not_exist"
+    )
+    ac = _answer_compliance(task_profile="does_not_exist")
+    trace = validate_agent_consumption(rr, ac)
+    assert trace["status"] == "not_applicable"
+    jsonschema.validate(instance=trace, schema=_load_schema())
+
+
+# ── Reuse of the real Required Reading resolver end-to-end ───────────────────
+
+
+def test_end_to_end_with_real_resolver_is_schema_valid():
+    _require_jsonschema()
+    protocol = default_required_reading_protocol()
+    # pr_review requires agent_reading_pack, canonical_md, citation_map_jsonl,
+    # post_emit_health and recommends bundle_surface_validation,
+    # claim_evidence_map_json.
+    rr = resolve_required_reading(
+        protocol,
+        available_roles={
+            "agent_reading_pack",
+            "canonical_md",
+            "citation_map_jsonl",
+            "post_emit_health",
+            "bundle_surface_validation",
+            "claim_evidence_map_json",
+        },
+        task_profile="pr_review",
+    )
+    ac = _answer_compliance(
+        task_profile="pr_review",
+        declared_artifacts=sorted(rr["required"] + rr["recommended"]),
+    )
+    trace = validate_agent_consumption(
+        rr, ac, available_roles=set(rr["required"]) | set(rr["recommended"])
+    )
+    assert trace["status"] == "pass"
+    jsonschema.validate(instance=trace, schema=_load_schema())
+
+
+# ── Determinism ──────────────────────────────────────────────────────────────
+
+
+def test_validator_is_deterministic():
+    rr = _required_reading_result()
+    ac = _answer_compliance(declared_artifacts=["agent_reading_pack", "zzz_role"])
+    first = validate_agent_consumption(rr, ac)
+    second = validate_agent_consumption(rr, ac)
+    assert first == second
+    # lists are deterministically sorted
+    for key in (
+        "required_artifacts",
+        "recommended_artifacts",
+        "declared_artifacts",
+        "missing_required_artifacts",
+        "missing_recommended_artifacts",
+        "unknown_declared_artifacts",
+    ):
+        assert first[key] == sorted(first[key])

--- a/merger/lenskit/tests/test_agent_consumption_trace.py
+++ b/merger/lenskit/tests/test_agent_consumption_trace.py
@@ -538,3 +538,76 @@ def test_validator_is_deterministic():
         "unknown_declared_artifacts",
     ):
         assert first[key] == sorted(first[key])
+
+
+# ── Hardening: exact does_not_establish boundary check ───────────────────────
+
+
+def test_answer_compliance_extra_negative_semantics_is_fail():
+    rr = _required_reading_result(recommended=[])
+    ac = _answer_compliance(
+        declared_artifacts=["agent_reading_pack", "canonical_md"],
+        does_not_establish=_NINE + ["answer_safe_without_citations"],
+    )
+    trace = validate_agent_consumption(rr, ac)
+    assert trace["status"] == "fail"
+    assert "missing_negative_semantics" in _codes(trace)
+    # the trace still outputs its own exact nine boundaries
+    assert trace["does_not_establish"] == list(DOES_NOT_ESTABLISH)
+
+
+def test_answer_compliance_unknown_negative_semantics_is_fail():
+    rr = _required_reading_result(recommended=[])
+    ac = _answer_compliance(
+        declared_artifacts=["agent_reading_pack", "canonical_md"],
+        does_not_establish=_NINE[:-1] + ["invented_boundary"],
+    )
+    trace = validate_agent_consumption(rr, ac)
+    assert trace["status"] == "fail"
+    assert "missing_negative_semantics" in _codes(trace)
+
+
+# ── Hardening: diagnostics[].code enum in schema ─────────────────────────────
+
+
+def test_diagnostic_code_unknown_invalid():
+    _require_jsonschema()
+    instance = _minimal_pass_trace()
+    instance["diagnostics"] = [
+        {
+            "code": "invented_diagnostic_code",
+            "severity": "warn",
+            "detail": "This code is not part of the contract.",
+        }
+    ]
+    with pytest.raises(ValidationError):
+        jsonschema.validate(instance=instance, schema=_load_schema())
+
+
+@pytest.mark.parametrize(
+    "code,severity",
+    [
+        ("task_profile_mismatch", "fail"),
+        ("task_profile_not_applicable", "info"),
+        ("missing_required_artifact", "fail"),
+        ("unread_required_artifact", "fail"),
+        ("missing_recommended_artifact", "warn"),
+        ("unread_recommended_artifact", "warn"),
+        ("unknown_declared_artifact", "warn"),
+        ("missing_negative_semantics", "fail"),
+    ],
+)
+def test_known_diagnostic_codes_are_schema_valid(code, severity):
+    _require_jsonschema()
+    schema = _load_schema()
+    instance = _minimal_pass_trace()
+    if severity == "fail":
+        instance["status"] = "fail"
+    elif severity == "warn":
+        instance["status"] = "warn"
+    else:
+        instance["status"] = "not_applicable"
+    instance["diagnostics"] = [
+        {"code": code, "severity": severity, "detail": "Known diagnostic code."}
+    ]
+    jsonschema.validate(instance=instance, schema=schema)

--- a/merger/lenskit/tests/test_agent_consumption_trace.py
+++ b/merger/lenskit/tests/test_agent_consumption_trace.py
@@ -611,3 +611,82 @@ def test_known_diagnostic_codes_are_schema_valid(code, severity):
         {"code": code, "severity": severity, "detail": "Known diagnostic code."}
     ]
     jsonschema.validate(instance=instance, schema=schema)
+
+
+# ── Polish: diagnostics ordered by severity (fail > warn > info) ─────────────
+
+
+def test_diagnostics_are_sorted_by_severity_then_code():
+    # one fail (missing required) and one+ warn (unread recommended, unknown)
+    rr = _required_reading_result(
+        required=["canonical_md"],
+        recommended=["citation_map_jsonl"],
+    )
+    ac = _answer_compliance(
+        declared_artifacts=["mystery_role"],
+        unread_recommended_artifacts=["citation_map_jsonl"],
+    )
+    trace = validate_agent_consumption(rr, ac)
+    severities = [d["severity"] for d in trace["diagnostics"]]
+    assert severities == sorted(
+        severities,
+        key={"fail": 0, "warn": 1, "info": 2}.get,
+    )
+    assert trace["diagnostics"][0]["severity"] == "fail"
+
+
+# ── Polish: _norm_roles scalar string guard ──────────────────────────────────
+
+
+def test_norm_roles_treats_scalar_string_as_single_role():
+    rr = _required_reading_result(required=["canonical_md"], recommended=[])
+    ac = _answer_compliance(declared_artifacts="canonical_md")
+    trace = validate_agent_consumption(rr, ac)
+    assert trace["declared_artifacts"] == ["canonical_md"]
+    assert trace["status"] == "pass"
+
+
+# ── Polish: negative semantics evaluated before not_applicable ───────────────
+
+
+def test_answer_compliance_duplicate_negative_semantics_is_fail():
+    rr = _required_reading_result(recommended=[])
+    ac = _answer_compliance(
+        declared_artifacts=["agent_reading_pack", "canonical_md"],
+        does_not_establish=_NINE[:-1] + ["actual_reading_proven"],
+    )
+    trace = validate_agent_consumption(rr, ac)
+    assert trace["status"] == "fail"
+    assert "missing_negative_semantics" in _codes(trace)
+
+
+def test_invalid_negative_semantics_beats_not_applicable():
+    protocol = default_required_reading_protocol()
+    rr = resolve_required_reading(
+        protocol,
+        available_roles=set(),
+        task_profile="does_not_exist",
+    )
+    ac = _answer_compliance(
+        task_profile="does_not_exist",
+        does_not_establish=_NINE[:-1],
+    )
+    trace = validate_agent_consumption(rr, ac)
+    assert trace["status"] == "fail"
+    codes = _codes(trace)
+    assert "task_profile_not_applicable" in codes
+    assert "missing_negative_semantics" in codes
+
+
+def test_valid_negative_semantics_allows_not_applicable():
+    protocol = default_required_reading_protocol()
+    rr = resolve_required_reading(
+        protocol,
+        available_roles=set(),
+        task_profile="does_not_exist",
+    )
+    ac = _answer_compliance(task_profile="does_not_exist")
+    trace = validate_agent_consumption(rr, ac)
+    assert trace["status"] == "not_applicable"
+    assert "task_profile_not_applicable" in _codes(trace)
+    assert "missing_negative_semantics" not in _codes(trace)

--- a/merger/lenskit/tests/test_agent_consumption_trace.py
+++ b/merger/lenskit/tests/test_agent_consumption_trace.py
@@ -114,7 +114,6 @@ def test_core_boundaries_match_test_fixture():
     assert list(DOES_NOT_ESTABLISH) == _NINE
 
 
-
 # ── 1. Minimal pass trace is schema-valid ─────────────────────────────────────
 
 
@@ -509,7 +508,6 @@ def test_invalid_negative_semantics_not_applicable_output_is_schema_valid():
     assert "task_profile_not_applicable" in _codes(trace)
     assert "missing_negative_semantics" in _codes(trace)
     jsonschema.validate(instance=trace, schema=_load_schema())
-
 
 
 # ── Reuse of the real Required Reading resolver end-to-end ───────────────────

--- a/merger/lenskit/tests/test_agent_consumption_trace.py
+++ b/merger/lenskit/tests/test_agent_consumption_trace.py
@@ -110,6 +110,11 @@ def _codes(trace: dict) -> set[str]:
     return {d["code"] for d in trace["diagnostics"]}
 
 
+def test_core_boundaries_match_test_fixture():
+    assert list(DOES_NOT_ESTABLISH) == _NINE
+
+
+
 # ── 1. Minimal pass trace is schema-valid ─────────────────────────────────────
 
 
@@ -487,6 +492,26 @@ def test_validator_not_applicable_output_is_schema_valid():
     jsonschema.validate(instance=trace, schema=_load_schema())
 
 
+def test_invalid_negative_semantics_not_applicable_output_is_schema_valid():
+    _require_jsonschema()
+    protocol = default_required_reading_protocol()
+    rr = resolve_required_reading(
+        protocol,
+        available_roles=set(),
+        task_profile="does_not_exist",
+    )
+    ac = _answer_compliance(
+        task_profile="does_not_exist",
+        does_not_establish=_NINE[:-1],
+    )
+    trace = validate_agent_consumption(rr, ac)
+    assert trace["status"] == "fail"
+    assert "task_profile_not_applicable" in _codes(trace)
+    assert "missing_negative_semantics" in _codes(trace)
+    jsonschema.validate(instance=trace, schema=_load_schema())
+
+
+
 # ── Reuse of the real Required Reading resolver end-to-end ───────────────────
 
 
@@ -582,6 +607,21 @@ def test_diagnostic_code_unknown_invalid():
     ]
     with pytest.raises(ValidationError):
         jsonschema.validate(instance=instance, schema=_load_schema())
+
+
+def test_diagnostic_artifact_property_is_schema_valid():
+    _require_jsonschema()
+    instance = _minimal_pass_trace()
+    instance["status"] = "fail"
+    instance["diagnostics"] = [
+        {
+            "code": "missing_required_artifact",
+            "severity": "fail",
+            "detail": "Required artifact was not declared.",
+            "artifact": "canonical_md",
+        }
+    ]
+    jsonschema.validate(instance=instance, schema=_load_schema())
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

This PR implements the Agent Consumption Trace validator, a pure comparison layer that validates Answer Compliance declarations against Required Reading Protocol expectations. The implementation includes the core validator logic, comprehensive test suite, and JSON schema contract.

## Key Changes

- **Agent Consumption Trace Validator** (`merger/lenskit/core/agent_consumption_validate.py`):
  - Pure, deterministic validator with no I/O or global state
  - Compares Required Reading expectations (required/recommended artifacts) against Answer Compliance declarations
  - Implements six validation rules: task profile resolution, required artifacts, recommended artifacts, unknown declared artifacts, negative semantics, and status priority
  - Returns machine-readable trace with diagnostics, artifact lists, and pass/warn/fail/not_applicable status
  - Explicitly does not make truth claims about actual reading, answer correctness, context use, runtime behavior, test sufficiency, regression absence, forensic readiness, repo understanding, or claim truth

- **JSON Schema Contract** (`merger/lenskit/contracts/agent-consumption-trace.v1.schema.json`):
  - Validates trace structure and content
  - Enforces exactly nine `does_not_establish` boundaries
  - Defines diagnostic structure with code, severity, and optional artifact reference
  - Supports all four status values: pass, warn, fail, not_applicable

- **Comprehensive Test Suite** (`merger/lenskit/tests/test_agent_consumption_trace.py`):
  - 30+ tests covering schema validation, all validation rules, edge cases, and determinism
  - Tests for missing/unread required artifacts (fail), missing/unread recommended artifacts (warn), unknown declared artifacts (warn)
  - Tests for task profile mismatch, not_applicable handling, and negative semantics validation
  - Tests for pass-through of citations, ranges, and epistemic gaps
  - End-to-end integration test with real Required Reading resolver
  - Validates all validator outputs against schema for each status

- **Documentation Update** (`docs/architecture/agent-consumption-contract.md`):
  - Updated status to reflect Agent Consumption Trace v1 implementation
  - Added Agent Consumption Trace section describing comparison semantics and status values

## Notable Implementation Details

- **Strict Separation of Concerns**: Validator only compares declarations against expectations; makes no truth claims
- **Deterministic Output**: All lists are sorted, diagnostics are ordered by code and artifact for reproducibility
- **Conservative Unknown Handling**: When `available_roles` is None, only required+recommended roles are treated as known; other declared roles are warned
- **Status Priority**: Fail beats warn beats pass; not_applicable stops further evaluation
- **Negative Semantics**: Validates that Answer Compliance declares all nine required `does_not_establish` boundaries

https://claude.ai/code/session_01WLRzcdVLMPEXCAZYdzj6Dd