### PR TITLE
Surface retrieval-eval miss_taxonomy as diagnostic projection

### DIFF
--- a/merger/lenskit/contracts/context-quality.v1.schema.json
+++ b/merger/lenskit/contracts/context-quality.v1.schema.json
@@ -209,6 +209,39 @@
                   "recall@10": { "type": ["number", "null"] }
                 }
               }
+            },
+            "miss_taxonomy": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["available"],
+              "description": "Optional, additive mechanical projection of the existing retrieval-eval miss_taxonomy diagnostic (see retrieval-eval.v1.schema.json). Surfaced for visibility only: diagnostic, never a truth layer. It does NOT prove repository absence, semantic irrelevance, retrieval completeness, or claim truth. Marked unavailable (without warning) when the retrieval-eval document predates or omits miss_taxonomy.",
+              "properties": {
+                "available": { "type": "boolean" },
+                "reason": { "type": "string" },
+                "aggregate": {
+                  "type": ["object", "null"],
+                  "description": "The source miss_taxonomy.aggregate block projected verbatim (existing counts only; no new aggregation and no score)."
+                },
+                "cases_sample": {
+                  "type": "array",
+                  "description": "A small, capped navigational sample of classified miss cases. Not exhaustive; read retrieval_eval_json for the full taxonomy.",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "query_index": { "type": ["integer", "null"] },
+                      "query": { "type": ["string", "null"] },
+                      "primary_miss_type": { "type": ["string", "null"] },
+                      "miss_types": { "type": "array", "items": { "type": "string" } }
+                    }
+                  }
+                },
+                "does_not_prove": {
+                  "type": "array",
+                  "items": { "type": "string" },
+                  "description": "Copied verbatim from the source miss_taxonomy to preserve its diagnostic boundary."
+                }
+              }
             }
           }
         },

--- a/merger/lenskit/contracts/context-quality.v1.schema.json
+++ b/merger/lenskit/contracts/context-quality.v1.schema.json
@@ -217,7 +217,10 @@
               "description": "Optional, additive mechanical projection of the existing retrieval-eval miss_taxonomy diagnostic (see retrieval-eval.v1.schema.json). Surfaced for visibility only: diagnostic, never a truth layer. It does NOT prove repository absence, semantic irrelevance, retrieval completeness, or claim truth. Marked unavailable (without warning) when the retrieval-eval document predates or omits miss_taxonomy.",
               "properties": {
                 "available": { "type": "boolean" },
-                "reason": { "type": "string" },
+                "reason": {
+                  "type": "string",
+                  "description": "Machine-readable reason why the miss_taxonomy projection is unavailable, e.g. missing_from_retrieval_eval when the source retrieval_eval document omits miss_taxonomy, or invalid_miss_taxonomy_shape when miss_taxonomy is present but is not an object."
+                },
                 "aggregate": {
                   "type": ["object", "null"],
                   "description": "The source miss_taxonomy.aggregate block projected verbatim (existing counts only; no new aggregation and no score)."

--- a/merger/lenskit/core/agent_reading_pack.py
+++ b/merger/lenskit/core/agent_reading_pack.py
@@ -496,6 +496,13 @@ def render_agent_reading_pack(model: PackModel) -> str:
         "forensic readiness."
     )
     lines.append("- `sqlite_index` is runtime cache/search support, not authority.")
+    lines.append(
+        "- `retrieval_eval_json` is a diagnostic retrieval-quality signal; for "
+        "retrieval quality reviews inspect its `miss_taxonomy` to see why expected "
+        "targets were missed. Miss taxonomy is diagnostic only and does not prove "
+        "retrieval completeness, target absence in the repository, semantic "
+        "irrelevance, claim truth or repo understanding."
+    )
     lines.append("")
 
     # ── ANSWER_COMPLIANCE_CHECKLIST ──────────────────────────────────────

--- a/merger/lenskit/core/context_quality.py
+++ b/merger/lenskit/core/context_quality.py
@@ -25,7 +25,10 @@ Design contract (deliberately small and additive):
 - Signals are projected as observations only. output_health verdicts are never
   used to infer post-emit validity; post_emit_health is never used to infer
   answer safety; retrieval metrics are never treated as completeness; the export
-  gate is never reinterpreted as claim truth.
+  gate is never reinterpreted as claim truth. The retrieval-eval miss_taxonomy is
+  surfaced verbatim as an existing diagnostic classification, never as proof of
+  repository absence, semantic (ir)relevance, retrieval completeness, or claim
+  truth.
 """
 
 from __future__ import annotations
@@ -91,6 +94,11 @@ _KNOWN_EVIDENCE_LEVELS = frozenset({
     "diagnostic_full",
     "forensic_strict",
 })
+
+# Cap on how many miss cases we surface in the projection. The full taxonomy
+# lives in retrieval_eval_json; the context-quality projection only carries a
+# small navigational sample so it stays compact.
+_MISS_TAXONOMY_CASE_SAMPLE_LIMIT = 5
 
 
 # ---------------------------------------------------------------------------
@@ -267,6 +275,43 @@ def _project_post_emit_health(
     }
 
 
+def _project_miss_taxonomy(raw: Any) -> Dict[str, Any]:
+    """
+    Mechanically project the existing retrieval-eval ``miss_taxonomy`` diagnostic.
+
+    The already-computed aggregate counts and the ``does_not_prove`` boundary are
+    copied verbatim, plus a small capped navigational sample of cases. This invents
+    no new aggregation, no score, and no verdict. When the retrieval-eval document
+    predates or omits ``miss_taxonomy`` the projection is marked unavailable WITHOUT
+    a warning, so older eval files never degrade or fail the projection.
+    """
+    if not isinstance(raw, dict):
+        return {"available": False, "reason": "missing_from_retrieval_eval"}
+
+    aggregate = raw.get("aggregate")
+    aggregate = aggregate if isinstance(aggregate, dict) else None
+
+    cases_sample: List[Dict[str, Any]] = []
+    raw_cases = raw.get("cases")
+    if isinstance(raw_cases, list):
+        for case in raw_cases[:_MISS_TAXONOMY_CASE_SAMPLE_LIMIT]:
+            if not isinstance(case, dict):
+                continue
+            cases_sample.append({
+                "query_index": _int_or_none(case.get("query_index")),
+                "query": _str_or_none(case.get("query")),
+                "primary_miss_type": _str_or_none(case.get("primary_miss_type")),
+                "miss_types": [m for m in (case.get("miss_types") or []) if isinstance(m, str)],
+            })
+
+    return {
+        "available": True,
+        "aggregate": aggregate,
+        "cases_sample": cases_sample,
+        "does_not_prove": [d for d in (raw.get("does_not_prove") or []) if isinstance(d, str)],
+    }
+
+
 def _project_retrieval_eval(
     explicit_path: Optional[str],
     by_role: Dict[str, Dict[str, Any]],
@@ -323,6 +368,7 @@ def _project_retrieval_eval(
         "source": source,
         "metrics": projected_metrics,
         "categories": categories,
+        "miss_taxonomy": _project_miss_taxonomy(doc.get("miss_taxonomy")),
     }
 
 

--- a/merger/lenskit/core/context_quality.py
+++ b/merger/lenskit/core/context_quality.py
@@ -152,6 +152,17 @@ def _bool_or_none(value: Any) -> Optional[bool]:
     return value if isinstance(value, bool) else None
 
 
+def _string_list(value: Any) -> List[str]:
+    """Return only the string items of a JSON list; [] for any non-list value.
+
+    Defensive against untrusted/older JSON: a truthy non-list scalar (e.g. ``True``,
+    ``404``, ``"broken"``) or a dict must never raise or iterate unexpectedly.
+    """
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
 def derive_context_quality_path(manifest_path: Path) -> Path:
     """Derive ``<stem>.context_quality.json`` adjacent to the manifest."""
     name = manifest_path.name
@@ -284,31 +295,41 @@ def _project_miss_taxonomy(raw: Any) -> Dict[str, Any]:
     no new aggregation, no score, and no verdict. When the retrieval-eval document
     predates or omits ``miss_taxonomy`` the projection is marked unavailable WITHOUT
     a warning, so older eval files never degrade or fail the projection.
+
+    Defensive against untrusted/older JSON: list-typed fields (``does_not_prove``,
+    ``cases``, ``case.miss_types``) are read only when they are actually lists, so a
+    truthy non-list value never raises. Cases are validated as dicts BEFORE the
+    sample limit is applied, so leading malformed entries cannot starve later valid
+    cases out of the sample.
     """
-    if not isinstance(raw, dict):
+    if raw is None:
         return {"available": False, "reason": "missing_from_retrieval_eval"}
+    if not isinstance(raw, dict):
+        return {"available": False, "reason": "invalid_miss_taxonomy_shape"}
 
     aggregate = raw.get("aggregate")
     aggregate = aggregate if isinstance(aggregate, dict) else None
 
-    cases_sample: List[Dict[str, Any]] = []
     raw_cases = raw.get("cases")
-    if isinstance(raw_cases, list):
-        for case in raw_cases[:_MISS_TAXONOMY_CASE_SAMPLE_LIMIT]:
-            if not isinstance(case, dict):
-                continue
-            cases_sample.append({
-                "query_index": _int_or_none(case.get("query_index")),
-                "query": _str_or_none(case.get("query")),
-                "primary_miss_type": _str_or_none(case.get("primary_miss_type")),
-                "miss_types": [m for m in (case.get("miss_types") or []) if isinstance(m, str)],
-            })
+    cases = raw_cases if isinstance(raw_cases, list) else []
+    cases_sample: List[Dict[str, Any]] = []
+    for case in cases:
+        if not isinstance(case, dict):
+            continue
+        if len(cases_sample) >= _MISS_TAXONOMY_CASE_SAMPLE_LIMIT:
+            break
+        cases_sample.append({
+            "query_index": _int_or_none(case.get("query_index")),
+            "query": _str_or_none(case.get("query")),
+            "primary_miss_type": _str_or_none(case.get("primary_miss_type")),
+            "miss_types": _string_list(case.get("miss_types")),
+        })
 
     return {
         "available": True,
         "aggregate": aggregate,
         "cases_sample": cases_sample,
-        "does_not_prove": [d for d in (raw.get("does_not_prove") or []) if isinstance(d, str)],
+        "does_not_prove": _string_list(raw.get("does_not_prove")),
     }
 
 

--- a/merger/lenskit/tests/test_agent_reading_pack.py
+++ b/merger/lenskit/tests/test_agent_reading_pack.py
@@ -328,6 +328,25 @@ def test_pack_front_door_preserves_authority_boundaries(tmp_path):
     assert "`sqlite_index` is runtime cache/search support, not authority" in body
 
 
+def test_agent_pack_retrieval_quality_review_mentions_miss_taxonomy(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    body = Path(produce_agent_reading_pack(str(manifest))["output_path"]).read_text()
+
+    # The retrieval-quality-review profile and its required eval artifact stay intact.
+    assert "`retrieval_quality_review`" in body
+    required_section = _section(body, "REQUIRED_READING_BY_TASK")
+    assert "`retrieval_quality_review`" in required_section
+    assert "`retrieval_eval_json`" in required_section
+
+    # The pack now points reviewers at the existing miss_taxonomy diagnostic and
+    # keeps its boundary: the taxonomy is diagnostic only, not proof.
+    rules = _section(body, "SIDECAR_USAGE_RULES")
+    assert "`retrieval_eval_json`" in rules
+    assert "miss_taxonomy" in rules
+    assert "diagnostic only" in rules
+    assert "does not prove" in rules
+
+
 def test_pack_do_not_claim_lists_prohibited_claim_classes(tmp_path):
     manifest = _make_bundle(tmp_path)
     body = Path(produce_agent_reading_pack(str(manifest))["output_path"]).read_text()

--- a/merger/lenskit/tests/test_context_quality.py
+++ b/merger/lenskit/tests/test_context_quality.py
@@ -164,6 +164,81 @@ def _retrieval_eval_doc() -> dict:
     }
 
 
+def _miss_taxonomy(case_count: int = 2) -> dict:
+    """A retrieval-eval miss_taxonomy block, shaped like eval_core.build_miss_taxonomy."""
+    cases = [
+        {
+            "query_index": 0,
+            "query": "where is auth handled",
+            "expected": ["src/auth.py"],
+            "is_relevant": False,
+            "observed_top_k_count": 0,
+            "miss_types": ["zero_results"],
+            "primary_miss_type": "zero_results",
+            "classification_basis": ["retrieval_eval_expectations"],
+        },
+        {
+            "query_index": 1,
+            "query": "token refresh logic",
+            "expected": ["src/token.py"],
+            "is_relevant": False,
+            "observed_top_k_count": 5,
+            "miss_types": ["expected_not_in_top_k"],
+            "primary_miss_type": "expected_not_in_top_k",
+            "classification_basis": ["retrieval_eval_expectations", "returned_hit_paths"],
+        },
+    ]
+    # Synthesize extra padding cases when a larger sample is requested.
+    while len(cases) < case_count:
+        i = len(cases)
+        cases.append({
+            "query_index": i,
+            "query": f"padding query {i}",
+            "expected": [],
+            "is_relevant": False,
+            "observed_top_k_count": 0,
+            "miss_types": ["unknown"],
+            "primary_miss_type": "unknown",
+            "classification_basis": ["query_metadata"],
+        })
+    return {
+        "version": "1.0",
+        "authority": "diagnostic_signal",
+        "risk_class": "diagnostic",
+        "classification_basis": [
+            "retrieval_eval_expectations",
+            "returned_hit_paths",
+            "query_metadata",
+        ],
+        "does_not_prove": [
+            "absence_of_retrieval_hit_does_not_prove_absence_in_repository",
+            "miss_type_does_not_prove_claim_truth_or_falsehood",
+            "ranking_position_does_not_prove_semantic_importance",
+            "retrieval_eval_does_not_prove_retrieval_completeness",
+            "taxonomy_is_diagnostic_not_authoritative",
+        ],
+        "aggregate": {
+            "total_cases_classified": case_count + 1,
+            "total_misses": case_count,
+            "by_type": {
+                "zero_results": 1,
+                "expected_not_in_top_k": 1,
+                "expected_rank_below_k": 0,
+                "expected_path_not_indexed": 0,
+                "expected_symbol_not_indexed": 0,
+                "path_or_symbol_metadata_missing": 0,
+                "possible_query_vocabulary_gap": 0,
+                "possible_filter_scope_gap": 0,
+                "noise_or_fixture_hit": 0,
+                "stale_eval_input": 0,
+                "query_execution_error": 0,
+                "unknown": max(0, case_count - 2),
+            },
+        },
+        "cases": cases[:case_count],
+    }
+
+
 def _write_post_emit_sidecar(manifest_path: Path, status: str = "pass") -> Path:
     doc = {
         "kind": "lenskit.post_emit_health", "version": "1.0", "run_id": "pe-run",
@@ -398,8 +473,91 @@ def test_invalid_retrieval_json_warns_without_fabrication(tmp_path):
     re_sig = report["signals"]["retrieval_eval"]
     assert re_sig["available"] is False
     assert "metrics" not in re_sig  # nothing fabricated
+    assert "miss_taxonomy" not in re_sig  # nothing fabricated when eval is unavailable
     assert any("retrieval_eval unavailable" in w for w in report["warnings"])
     assert report["projection_status"] == "degraded"
+
+
+# ---------------------------------------------------------------------------
+# 5b. retrieval_eval miss_taxonomy projected mechanically (existing diagnostic)
+# ---------------------------------------------------------------------------
+
+def test_retrieval_eval_miss_taxonomy_projected_mechanically(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    doc = _retrieval_eval_doc()
+    doc["miss_taxonomy"] = _miss_taxonomy()
+    re_path = tmp_path / "standalone.retrieval_eval.json"
+    re_path.write_text(json.dumps(doc), encoding="utf-8")
+
+    report = compute_context_quality(str(manifest), retrieval_eval_path=str(re_path))
+    re_sig = report["signals"]["retrieval_eval"]
+    assert re_sig["available"] is True
+
+    mt = re_sig["miss_taxonomy"]
+    assert mt["available"] is True
+    # The aggregate block is copied verbatim — no new aggregation/score invented.
+    assert mt["aggregate"] == _miss_taxonomy()["aggregate"]
+    assert mt["aggregate"]["by_type"]["zero_results"] == 1
+    # The does_not_prove boundary is preserved verbatim.
+    assert mt["does_not_prove"] == _miss_taxonomy()["does_not_prove"]
+    # A small navigational sample of cases is surfaced (not the full taxonomy).
+    assert len(mt["cases_sample"]) == 2
+    assert mt["cases_sample"][0]["primary_miss_type"] == "zero_results"
+    assert mt["cases_sample"][0]["miss_types"] == ["zero_results"]
+    assert mt["cases_sample"][1]["primary_miss_type"] == "expected_not_in_top_k"
+    # The projection introduces no truth/completeness/score field of its own.
+    assert set(mt.keys()) == {"available", "aggregate", "cases_sample", "does_not_prove"}
+
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.validate(instance=report, schema=schema)
+
+
+def test_retrieval_eval_miss_taxonomy_cases_sample_is_capped(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    doc = _retrieval_eval_doc()
+    doc["miss_taxonomy"] = _miss_taxonomy(case_count=12)
+    re_path = tmp_path / "standalone.retrieval_eval.json"
+    re_path.write_text(json.dumps(doc), encoding="utf-8")
+
+    report = compute_context_quality(str(manifest), retrieval_eval_path=str(re_path))
+    mt = report["signals"]["retrieval_eval"]["miss_taxonomy"]
+    # Many cases collapse to a small capped navigational sample.
+    assert len(mt["cases_sample"]) == 5
+    # Aggregate counts still reflect the full set, copied verbatim.
+    assert mt["aggregate"]["total_misses"] == 12
+
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.validate(instance=report, schema=schema)
+
+
+def test_retrieval_eval_without_miss_taxonomy_stays_valid(tmp_path):
+    # An older retrieval-eval document without miss_taxonomy must remain fully
+    # valid: it must not warn, must not degrade, and must not raise.
+    manifest = _make_bundle(tmp_path)
+    _write_post_emit_sidecar(manifest)
+    re_path = tmp_path / "standalone.retrieval_eval.json"
+    re_path.write_text(json.dumps(_retrieval_eval_doc()), encoding="utf-8")  # no miss_taxonomy
+    gate_path = _write_export_gate(tmp_path)
+
+    report = compute_context_quality(
+        str(manifest),
+        retrieval_eval_path=str(re_path),
+        agent_export_gate_path=str(gate_path),
+    )
+    # Missing miss_taxonomy is silent: no warning, projection still complete.
+    assert report["warnings"] == []
+    assert report["projection_status"] == "complete"
+    assert not any("miss_taxonomy" in w for w in report["warnings"])
+
+    re_sig = report["signals"]["retrieval_eval"]
+    assert re_sig["available"] is True
+    assert re_sig["metrics"]["total_queries"] == 10  # metrics still projected
+    mt = re_sig["miss_taxonomy"]
+    assert mt["available"] is False
+    assert mt["reason"] == "missing_from_retrieval_eval"
+
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.validate(instance=report, schema=schema)
 
 
 # ---------------------------------------------------------------------------

--- a/merger/lenskit/tests/test_context_quality.py
+++ b/merger/lenskit/tests/test_context_quality.py
@@ -484,8 +484,9 @@ def test_invalid_retrieval_json_warns_without_fabrication(tmp_path):
 
 def test_retrieval_eval_miss_taxonomy_projected_mechanically(tmp_path):
     manifest = _make_bundle(tmp_path)
+    expected_mt = _miss_taxonomy()
     doc = _retrieval_eval_doc()
-    doc["miss_taxonomy"] = _miss_taxonomy()
+    doc["miss_taxonomy"] = expected_mt
     re_path = tmp_path / "standalone.retrieval_eval.json"
     re_path.write_text(json.dumps(doc), encoding="utf-8")
 
@@ -496,10 +497,10 @@ def test_retrieval_eval_miss_taxonomy_projected_mechanically(tmp_path):
     mt = re_sig["miss_taxonomy"]
     assert mt["available"] is True
     # The aggregate block is copied verbatim — no new aggregation/score invented.
-    assert mt["aggregate"] == _miss_taxonomy()["aggregate"]
+    assert mt["aggregate"] == expected_mt["aggregate"]
     assert mt["aggregate"]["by_type"]["zero_results"] == 1
     # The does_not_prove boundary is preserved verbatim.
-    assert mt["does_not_prove"] == _miss_taxonomy()["does_not_prove"]
+    assert mt["does_not_prove"] == expected_mt["does_not_prove"]
     # A small navigational sample of cases is surfaced (not the full taxonomy).
     assert len(mt["cases_sample"]) == 2
     assert mt["cases_sample"][0]["primary_miss_type"] == "zero_results"
@@ -525,6 +526,107 @@ def test_retrieval_eval_miss_taxonomy_cases_sample_is_capped(tmp_path):
     assert len(mt["cases_sample"]) == 5
     # Aggregate counts still reflect the full set, copied verbatim.
     assert mt["aggregate"]["total_misses"] == 12
+
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.validate(instance=report, schema=schema)
+
+
+# ---------------------------------------------------------------------------
+# 5c. miss_taxonomy projection is robust against malformed / older JSON shapes
+# ---------------------------------------------------------------------------
+
+def _write_eval_with_miss_taxonomy(tmp_path: Path, miss_taxonomy: object) -> Path:
+    doc = _retrieval_eval_doc()
+    doc["miss_taxonomy"] = miss_taxonomy
+    re_path = tmp_path / "standalone.retrieval_eval.json"
+    re_path.write_text(json.dumps(doc), encoding="utf-8")
+    return re_path
+
+
+def test_retrieval_eval_miss_taxonomy_ignores_non_list_does_not_prove(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    mt = _miss_taxonomy()
+    mt["does_not_prove"] = True  # truthy non-list must not raise
+    re_path = _write_eval_with_miss_taxonomy(tmp_path, mt)
+
+    report = compute_context_quality(str(manifest), retrieval_eval_path=str(re_path))
+    projected = report["signals"]["retrieval_eval"]["miss_taxonomy"]
+    assert projected["available"] is True
+    assert projected["does_not_prove"] == []  # degrades to empty, no crash
+
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.validate(instance=report, schema=schema)
+
+
+def test_retrieval_eval_miss_taxonomy_ignores_non_list_case_miss_types(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    mt = _miss_taxonomy()
+    mt["cases"][0]["miss_types"] = 404  # truthy non-list must not raise
+    re_path = _write_eval_with_miss_taxonomy(tmp_path, mt)
+
+    report = compute_context_quality(str(manifest), retrieval_eval_path=str(re_path))
+    projected = report["signals"]["retrieval_eval"]["miss_taxonomy"]
+    assert projected["available"] is True
+    # The affected case is still projected; only miss_types degrades to [].
+    assert projected["cases_sample"][0]["primary_miss_type"] == "zero_results"
+    assert projected["cases_sample"][0]["miss_types"] == []
+
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.validate(instance=report, schema=schema)
+
+
+def test_retrieval_eval_miss_taxonomy_ignores_non_list_cases(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    mt = _miss_taxonomy()
+    mt["cases"] = True  # truthy non-list must not raise
+    re_path = _write_eval_with_miss_taxonomy(tmp_path, mt)
+
+    report = compute_context_quality(str(manifest), retrieval_eval_path=str(re_path))
+    projected = report["signals"]["retrieval_eval"]["miss_taxonomy"]
+    assert projected["available"] is True
+    assert projected["cases_sample"] == []
+
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.validate(instance=report, schema=schema)
+
+
+def test_retrieval_eval_miss_taxonomy_samples_valid_cases_after_invalid_entries(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    mt = _miss_taxonomy()
+    # Leading invalid entries must not starve later valid cases from the sample.
+    mt["cases"] = [
+        None,
+        "broken",
+        123,
+        {"query": "q1", "primary_miss_type": "zero_results", "miss_types": ["zero_results"]},
+        {"query": "q2", "primary_miss_type": "expected_not_in_top_k", "miss_types": ["expected_not_in_top_k"]},
+        {"query": "q3", "primary_miss_type": "unknown", "miss_types": ["unknown"]},
+    ]
+    re_path = _write_eval_with_miss_taxonomy(tmp_path, mt)
+
+    report = compute_context_quality(str(manifest), retrieval_eval_path=str(re_path))
+    sample = report["signals"]["retrieval_eval"]["miss_taxonomy"]["cases_sample"]
+    # All three valid dict cases are collected; the limit is applied AFTER filtering,
+    # so slicing the first N raw entries (3 of which are invalid) would have missed q3.
+    assert [c["query"] for c in sample] == ["q1", "q2", "q3"]
+    assert all(isinstance(c["miss_types"], list) for c in sample)
+
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.validate(instance=report, schema=schema)
+
+
+def test_retrieval_eval_miss_taxonomy_non_dict_shape_is_unavailable(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    re_path = _write_eval_with_miss_taxonomy(tmp_path, "TODO")  # present but not an object
+
+    report = compute_context_quality(str(manifest), retrieval_eval_path=str(re_path))
+    re_sig = report["signals"]["retrieval_eval"]
+    # retrieval_eval metrics stay available; only the taxonomy projection is unavailable.
+    assert re_sig["available"] is True
+    mt = re_sig["miss_taxonomy"]
+    assert mt["available"] is False
+    assert mt["reason"] == "invalid_miss_taxonomy_shape"
+    assert not any("miss_taxonomy" in w for w in report["warnings"])  # no warning inflation
 
     schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
     jsonschema.validate(instance=report, schema=schema)


### PR DESCRIPTION
## Summary
Add mechanical projection of the existing `miss_taxonomy` diagnostic from retrieval-eval documents into context-quality reports. The miss_taxonomy is surfaced as a read-only diagnostic signal with its aggregate counts and a capped sample of cases, preserving its boundary that it does not prove repository absence, semantic relevance, retrieval completeness, or claim truth.

## Key Changes

- **Test fixtures and cases** (`test_context_quality.py`):
  - Added `_miss_taxonomy()` helper to generate realistic miss_taxonomy test data with configurable case counts
  - Added three new test cases:
    - `test_retrieval_eval_miss_taxonomy_projected_mechanically`: Verifies miss_taxonomy is projected with aggregate and cases_sample
    - `test_retrieval_eval_miss_taxonomy_cases_sample_is_capped`: Confirms large case sets are capped to 5 samples while preserving full aggregate counts
    - `test_retrieval_eval_without_miss_taxonomy_stays_valid`: Ensures backward compatibility—older retrieval-eval documents without miss_taxonomy remain valid without warnings or degradation
  - Updated `test_invalid_retrieval_json_warns_without_fabrication` to verify miss_taxonomy is not fabricated when eval is unavailable

- **Core projection logic** (`context_quality.py`):
  - Added `_project_miss_taxonomy()` function that mechanically projects the diagnostic:
    - Copies `aggregate` and `does_not_prove` blocks verbatim (no new aggregation or scoring)
    - Extracts a small navigational sample of cases (capped at 5) with query_index, query, primary_miss_type, and miss_types
    - Marks unavailable silently (no warning) when missing from older retrieval-eval documents
  - Integrated miss_taxonomy projection into `_project_retrieval_eval()` output
  - Added `_MISS_TAXONOMY_CASE_SAMPLE_LIMIT = 5` constant to cap sample size
  - Updated module docstring to clarify miss_taxonomy is diagnostic only

- **Schema** (`context-quality.v1.schema.json`):
  - Added `miss_taxonomy` object definition under retrieval_eval signals with:
    - `available` (required boolean)
    - `reason` (optional string for unavailability)
    - `aggregate` (optional object, copied verbatim)
    - `cases_sample` (array of case objects with query_index, query, primary_miss_type, miss_types)
    - `does_not_prove` (array of boundary statements, copied verbatim)
  - Includes descriptive notes that this is diagnostic only and does not prove absence, relevance, completeness, or truth

- **Agent reading pack** (`agent_reading_pack.py`, `test_agent_reading_pack.py`):
  - Updated sidecar usage rules to mention `retrieval_eval_json` miss_taxonomy as a diagnostic signal
  - Added guidance that miss_taxonomy is diagnostic only and does not prove retrieval completeness, target absence, semantic irrelevance, or claim truth
  - Added test `test_agent_pack_retrieval_quality_review_mentions_miss_taxonomy` to verify the pack documents miss_taxonomy appropriately

## Notable Implementation Details

- **Backward compatibility**: Missing miss_taxonomy is handled silently without warnings or projection degradation, allowing older retrieval-eval documents to remain fully valid
- **Compact projection**: Only a 5-case sample is surfaced in context-quality reports; the full taxonomy remains in the source retrieval_eval_json document
- **Boundary preservation**: The `does_not_prove` statements from the source miss_taxonomy are copied verbatim to maintain the diagnostic boundary
- **No fabrication**: The projection invents no new aggregation, scoring, or verdicts—it is purely mechanical and additive

https://claude.ai/code/session_01Pxs5jy5nX8tJfj6jDR7R4s