### PR TITLE
feat(agent): add agent entry manifest v1

### DIFF
--- a/merger/lenskit/contracts/agent-entry-manifest.v1.schema.json
+++ b/merger/lenskit/contracts/agent-entry-manifest.v1.schema.json
@@ -1,0 +1,235 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://heimgewebe.local/schema/agent-entry-manifest.v1.schema.json",
+  "title": "Lenskit Agent Entry Manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "kind",
+    "version",
+    "bundle_run_id",
+    "created_at",
+    "authority",
+    "canonicality",
+    "risk_class",
+    "canonical_source",
+    "read_first",
+    "task_profiles_ref",
+    "available_surfaces",
+    "unavailable_surfaces",
+    "does_not_establish"
+  ],
+  "properties": {
+    "kind": {
+      "type": "string",
+      "const": "lenskit.agent_entry_manifest"
+    },
+    "version": {
+      "type": "string",
+      "const": "1.0"
+    },
+    "bundle_run_id": {
+      "type": "string"
+    },
+    "created_at": {
+      "type": "string"
+    },
+    "authority": {
+      "type": "string",
+      "const": "navigation_index"
+    },
+    "canonicality": {
+      "type": "string",
+      "const": "derived"
+    },
+    "risk_class": {
+      "type": "string",
+      "const": "navigation"
+    },
+    "canonical_source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "role",
+        "path",
+        "sha256",
+        "authority",
+        "canonicality"
+      ],
+      "properties": {
+        "role": {
+          "type": "string",
+          "const": "canonical_md"
+        },
+        "path": {
+          "type": "string"
+        },
+        "sha256": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "authority": {
+          "type": "string",
+          "const": "canonical_content"
+        },
+        "canonicality": {
+          "type": "string",
+          "const": "content_source"
+        }
+      }
+    },
+    "read_first": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/surface_ref"
+      }
+    },
+    "task_profiles_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "version",
+        "source"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "const": "lenskit.required_reading_protocol"
+        },
+        "version": {
+          "type": "string",
+          "const": "1.0"
+        },
+        "source": {
+          "type": "string"
+        }
+      }
+    },
+    "available_surfaces": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/surface_ref"
+      }
+    },
+    "unavailable_surfaces": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/unavailable_surface"
+      }
+    },
+    "does_not_establish": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "allOf": [
+        {
+          "contains": {
+            "const": "repo_understood"
+          }
+        },
+        {
+          "contains": {
+            "const": "answer_safe_without_citations"
+          }
+        },
+        {
+          "contains": {
+            "const": "claims_true"
+          }
+        },
+        {
+          "contains": {
+            "const": "forensic_ready"
+          }
+        },
+        {
+          "contains": {
+            "const": "all_relevant_context_used"
+          }
+        }
+      ]
+    }
+  },
+  "definitions": {
+    "surface_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "role",
+        "path",
+        "authority",
+        "canonicality"
+      ],
+      "properties": {
+        "role": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "sha256": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "authority": {
+          "type": "string"
+        },
+        "canonicality": {
+          "type": "string"
+        },
+        "risk_class": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "required_for": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "recommended_for": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "unavailable_surface": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "role",
+        "reason"
+      ],
+      "properties": {
+        "role": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "required_for": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "recommended_for": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/merger/lenskit/contracts/agent-entry-manifest.v1.schema.json
+++ b/merger/lenskit/contracts/agent-entry-manifest.v1.schema.json
@@ -122,8 +122,18 @@
     },
     "does_not_establish": {
       "type": "array",
+      "minItems": 5,
+      "maxItems": 5,
+      "uniqueItems": true,
       "items": {
-        "type": "string"
+        "type": "string",
+        "enum": [
+          "repo_understood",
+          "answer_safe_without_citations",
+          "claims_true",
+          "forensic_ready",
+          "all_relevant_context_used"
+        ]
       },
       "allOf": [
         {

--- a/merger/lenskit/core/agent_entry_manifest.py
+++ b/merger/lenskit/core/agent_entry_manifest.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+
+_DOES_NOT_ESTABLISH = [
+    "repo_understood",
+    "answer_safe_without_citations",
+    "claims_true",
+    "forensic_ready",
+    "all_relevant_context_used",
+]
+
+_READ_FIRST_PRIORITY = [
+    "agent_reading_pack",
+    "post_emit_health",
+    "canonical_md",
+]
+
+_EXPECTED_SURFACES = [
+    "canonical_md",
+    "agent_reading_pack",
+    "post_emit_health",
+    "claim_evidence_map_json",
+    "citation_map_jsonl",
+    "bundle_surface_validation",
+    "output_health",
+    "export_safety_report",
+]
+
+
+def _as_dict(value: Any) -> Dict[str, Any] | None:
+    if isinstance(value, dict):
+        return value
+    return None
+
+
+def _as_list(value: Any) -> List[Any]:
+    if isinstance(value, list):
+        return value
+    return []
+
+
+def _str_or_none(value: Any) -> str | None:
+    if isinstance(value, str):
+        return value
+    return None
+
+
+def _artifact_role(artifact: Dict[str, Any]) -> str | None:
+    return _str_or_none(artifact.get("role"))
+
+
+def _artifact_path(artifact: Dict[str, Any]) -> str | None:
+    return _str_or_none(artifact.get("path"))
+
+
+def _artifact_sha256(artifact: Dict[str, Any]) -> str | None:
+    return _str_or_none(artifact.get("sha256"))
+
+
+def _artifact_authority(artifact: Dict[str, Any]) -> str | None:
+    return _str_or_none(artifact.get("authority"))
+
+
+def _artifact_canonicality(artifact: Dict[str, Any]) -> str | None:
+    return _str_or_none(artifact.get("canonicality"))
+
+
+def build_agent_entry_manifest(
+    bundle_manifest: Dict[str, Any],
+    *,
+    created_at: Optional[str] = None,
+) -> Dict[str, Any]:
+    # Determine bundle run id
+    bundle_run_id = (
+        _str_or_none(bundle_manifest.get("run_id"))
+        or _str_or_none(bundle_manifest.get("bundle_run_id"))
+        or _str_or_none(bundle_manifest.get("id"))
+    )
+    if not bundle_run_id:
+        raise ValueError("bundle_run_id missing")
+
+    # Determine created at
+    if created_at is not None:
+        final_created_at = created_at
+    else:
+        manifest_created_at = _str_or_none(bundle_manifest.get("created_at"))
+        final_created_at = manifest_created_at if manifest_created_at else "unknown"
+
+    artifacts = _as_list(bundle_manifest.get("artifacts"))
+
+    canonical_source: Dict[str, Any] | None = None
+    available_surfaces: List[Dict[str, Any]] = []
+    available_roles: set[str] = set()
+
+    for artifact_raw in artifacts:
+        artifact = _as_dict(artifact_raw)
+        if not artifact:
+            continue
+
+        role = _artifact_role(artifact)
+        path = _artifact_path(artifact)
+
+        if role == "canonical_md" and not path:
+            raise ValueError("canonical_md path missing")
+
+        if not role or not path:
+            continue
+
+        authority = _artifact_authority(artifact) or "unknown"
+        canonicality = _artifact_canonicality(artifact) or "unknown"
+        sha256 = _artifact_sha256(artifact)
+        risk_class = _str_or_none(artifact.get("risk_class"))
+
+        surface_ref: Dict[str, Any] = {
+            "role": role,
+            "path": path,
+            "sha256": sha256,
+            "authority": authority,
+            "canonicality": canonicality,
+            "risk_class": risk_class,
+            "required_for": [],
+            "recommended_for": [],
+        }
+
+        available_surfaces.append(surface_ref)
+        available_roles.add(role)
+
+        if role == "canonical_md":
+            canonical_source = {
+                "role": role,
+                "path": path,
+                "sha256": sha256,
+                "authority": authority,
+                "canonicality": canonicality,
+            }
+
+    if not canonical_source:
+        raise ValueError("canonical_md artifact missing")
+
+    if canonical_source["authority"] != "canonical_content":
+        raise ValueError("canonical_md authority must be canonical_content")
+
+    if canonical_source["canonicality"] != "content_source":
+        raise ValueError("canonical_md canonicality must be content_source")
+
+    read_first: List[Dict[str, Any]] = []
+    for priority_role in _READ_FIRST_PRIORITY:
+        for surface in available_surfaces:
+            if surface["role"] == priority_role:
+                read_first.append(surface)
+                break
+
+    unavailable_surfaces: List[Dict[str, Any]] = []
+    for expected_role in _EXPECTED_SURFACES:
+        if expected_role not in available_roles:
+            unavailable_surfaces.append(
+                {
+                    "role": expected_role,
+                    "reason": "not_present_in_bundle_manifest",
+                    "required_for": [],
+                    "recommended_for": [],
+                }
+            )
+
+    task_profiles_ref = {
+        "kind": "lenskit.required_reading_protocol",
+        "version": "1.0",
+        "source": "merger.lenskit.core.required_reading",
+    }
+
+    return {
+        "kind": "lenskit.agent_entry_manifest",
+        "version": "1.0",
+        "bundle_run_id": bundle_run_id,
+        "created_at": final_created_at,
+        "authority": "navigation_index",
+        "canonicality": "derived",
+        "risk_class": "navigation",
+        "canonical_source": canonical_source,
+        "read_first": read_first,
+        "task_profiles_ref": task_profiles_ref,
+        "available_surfaces": available_surfaces,
+        "unavailable_surfaces": unavailable_surfaces,
+        "does_not_establish": list(_DOES_NOT_ESTABLISH),
+    }

--- a/merger/lenskit/core/agent_entry_manifest.py
+++ b/merger/lenskit/core/agent_entry_manifest.py
@@ -67,6 +67,47 @@ def _artifact_canonicality(artifact: Dict[str, Any]) -> str | None:
     return _str_or_none(artifact.get("canonicality"))
 
 
+def _links(bundle_manifest: Dict[str, Any]) -> Dict[str, Any]:
+    links = _as_dict(bundle_manifest.get("links"))
+    return links or {}
+
+
+def _linked_sidecar_surfaces(bundle_manifest: Dict[str, Any]) -> List[Dict[str, Any]]:
+    links = _links(bundle_manifest)
+    surfaces: List[Dict[str, Any]] = []
+    
+    post_emit_path = _str_or_none(links.get("post_emit_health_path"))
+    if post_emit_path:
+        surfaces.append(
+            {
+                "role": "post_emit_health",
+                "path": post_emit_path,
+                "sha256": None,
+                "authority": "diagnostic_signal",
+                "canonicality": "diagnostic",
+                "risk_class": "diagnostic",
+                "required_for": [],
+                "recommended_for": [],
+            }
+        )
+        
+    surface_path = _str_or_none(links.get("bundle_surface_validation_path"))
+    if surface_path:
+        surfaces.append(
+            {
+                "role": "bundle_surface_validation",
+                "path": surface_path,
+                "sha256": None,
+                "authority": "diagnostic_signal",
+                "canonicality": "diagnostic",
+                "risk_class": "diagnostic",
+                "required_for": [],
+                "recommended_for": [],
+            }
+        )
+    return surfaces
+
+
 def build_agent_entry_manifest(
     bundle_manifest: Dict[str, Any],
     *,
@@ -108,8 +149,15 @@ def build_agent_entry_manifest(
         if not role or not path:
             continue
 
-        authority = _artifact_authority(artifact) or "unknown"
-        canonicality = _artifact_canonicality(artifact) or "unknown"
+        authority = _artifact_authority(artifact)
+        canonicality = _artifact_canonicality(artifact)
+
+        if role == "canonical_md":
+            authority = authority or "canonical_content"
+            canonicality = canonicality or "content_source"
+        else:
+            authority = authority or "unknown"
+            canonicality = canonicality or "unknown"
         sha256 = _artifact_sha256(artifact)
         risk_class = _str_or_none(artifact.get("risk_class"))
 
@@ -135,6 +183,11 @@ def build_agent_entry_manifest(
                 "authority": authority,
                 "canonicality": canonicality,
             }
+
+    for linked_surface in _linked_sidecar_surfaces(bundle_manifest):
+        if linked_surface["role"] not in available_roles:
+            available_surfaces.append(linked_surface)
+            available_roles.add(linked_surface["role"])
 
     if not canonical_source:
         raise ValueError("canonical_md artifact missing")

--- a/merger/lenskit/core/agent_entry_manifest.py
+++ b/merger/lenskit/core/agent_entry_manifest.py
@@ -1,23 +1,26 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Iterator
 
 
-_DOES_NOT_ESTABLISH = [
+_DOES_NOT_ESTABLISH = (
     "repo_understood",
     "answer_safe_without_citations",
     "claims_true",
     "forensic_ready",
     "all_relevant_context_used",
-]
+)
 
-_READ_FIRST_PRIORITY = [
+_READ_FIRST_PRIORITY = (
     "agent_reading_pack",
     "post_emit_health",
     "canonical_md",
-]
+)
 
-_EXPECTED_SURFACES = [
+# V1 agent-entry expected surfaces. Broader bundle inventory roles
+# (chunk indexes, sqlite index, retrieval eval, derived/dump indexes)
+# are surfaced when present but are not reported as unavailable in v1.
+_EXPECTED_SURFACES = (
     "canonical_md",
     "agent_reading_pack",
     "post_emit_health",
@@ -26,7 +29,7 @@ _EXPECTED_SURFACES = [
     "bundle_surface_validation",
     "output_health",
     "export_safety_report",
-]
+)
 
 
 def _as_dict(value: Any) -> Dict[str, Any] | None:
@@ -72,40 +75,34 @@ def _links(bundle_manifest: Dict[str, Any]) -> Dict[str, Any]:
     return links or {}
 
 
-def _linked_sidecar_surfaces(bundle_manifest: Dict[str, Any]) -> List[Dict[str, Any]]:
+def _linked_sidecar_surfaces(bundle_manifest: Dict[str, Any]) -> Iterator[Dict[str, Any]]:
     links = _links(bundle_manifest)
-    surfaces: List[Dict[str, Any]] = []
     
     post_emit_path = _str_or_none(links.get("post_emit_health_path"))
     if post_emit_path:
-        surfaces.append(
-            {
-                "role": "post_emit_health",
-                "path": post_emit_path,
-                "sha256": None,
-                "authority": "diagnostic_signal",
-                "canonicality": "diagnostic",
-                "risk_class": "diagnostic",
-                "required_for": [],
-                "recommended_for": [],
-            }
-        )
+        yield {
+            "role": "post_emit_health",
+            "path": post_emit_path,
+            "sha256": None,
+            "authority": "diagnostic_signal",
+            "canonicality": "diagnostic",
+            "risk_class": "diagnostic",
+            "required_for": [],
+            "recommended_for": [],
+        }
         
     surface_path = _str_or_none(links.get("bundle_surface_validation_path"))
     if surface_path:
-        surfaces.append(
-            {
-                "role": "bundle_surface_validation",
-                "path": surface_path,
-                "sha256": None,
-                "authority": "diagnostic_signal",
-                "canonicality": "diagnostic",
-                "risk_class": "diagnostic",
-                "required_for": [],
-                "recommended_for": [],
-            }
-        )
-    return surfaces
+        yield {
+            "role": "bundle_surface_validation",
+            "path": surface_path,
+            "sha256": None,
+            "authority": "diagnostic_signal",
+            "canonicality": "diagnostic",
+            "risk_class": "diagnostic",
+            "required_for": [],
+            "recommended_for": [],
+        }
 
 
 def build_agent_entry_manifest(
@@ -176,6 +173,8 @@ def build_agent_entry_manifest(
         available_roles.add(role)
 
         if role == "canonical_md":
+            if canonical_source is not None:
+                raise ValueError("multiple canonical_md artifacts")
             canonical_source = {
                 "role": role,
                 "path": path,
@@ -198,24 +197,28 @@ def build_agent_entry_manifest(
     if canonical_source["canonicality"] != "content_source":
         raise ValueError("canonical_md canonicality must be content_source")
 
-    read_first: List[Dict[str, Any]] = []
-    for priority_role in _READ_FIRST_PRIORITY:
-        for surface in available_surfaces:
-            if surface["role"] == priority_role:
-                read_first.append(surface)
-                break
+    surfaces_by_role = {
+        surface["role"]: surface
+        for surface in available_surfaces
+        if isinstance(surface.get("role"), str)
+    }
 
-    unavailable_surfaces: List[Dict[str, Any]] = []
-    for expected_role in _EXPECTED_SURFACES:
-        if expected_role not in available_roles:
-            unavailable_surfaces.append(
-                {
-                    "role": expected_role,
-                    "reason": "not_present_in_bundle_manifest",
-                    "required_for": [],
-                    "recommended_for": [],
-                }
-            )
+    read_first = [
+        surfaces_by_role[role]
+        for role in _READ_FIRST_PRIORITY
+        if role in surfaces_by_role
+    ]
+
+    unavailable_surfaces = [
+        {
+            "role": expected_role,
+            "reason": "not_present_in_bundle_manifest",
+            "required_for": [],
+            "recommended_for": [],
+        }
+        for expected_role in _EXPECTED_SURFACES
+        if expected_role not in available_roles
+    ]
 
     task_profiles_ref = {
         "kind": "lenskit.required_reading_protocol",

--- a/merger/lenskit/tests/test_agent_entry_manifest.py
+++ b/merger/lenskit/tests/test_agent_entry_manifest.py
@@ -71,26 +71,6 @@ def realistic_bundle_manifest_fixture() -> dict:
                 "risk_class": "navigation"
             },
             {
-                "role": "post_emit_health",
-                "path": "health.json",
-                "content_type": "application/json",
-                "bytes": 300,
-                "sha256": "cccc",
-                "authority": "diagnostic",
-                "canonicality": "derived",
-                "risk_class": "diagnostic"
-            },
-            {
-                "role": "output_health",
-                "path": "out.json",
-                "content_type": "application/json",
-                "bytes": 400,
-                "sha256": "dddd",
-                "authority": "diagnostic_signal",
-                "canonicality": "diagnostic",
-                "risk_class": "diagnostic"
-            },
-            {
                 "role": "claim_evidence_map_json",
                 "path": "claim_evidence.json",
                 "content_type": "application/json",
@@ -109,18 +89,13 @@ def realistic_bundle_manifest_fixture() -> dict:
                 "authority": "navigation_index",
                 "canonicality": "derived",
                 "risk_class": "navigation"
-            },
-            {
-                "role": "bundle_surface_validation",
-                "path": "surface_valid.json",
-                "content_type": "application/json",
-                "bytes": 700,
-                "sha256": "gggg",
-                "authority": "diagnostic_signal",
-                "canonicality": "diagnostic",
-                "risk_class": "diagnostic"
             }
-        ]
+        ],
+        "links": {
+            "post_emit_health_path": "health.json",
+            "bundle_surface_validation_path": "surface_valid.json",
+            "bundle_surface_validation_status": "pass"
+        }
     }
 
 
@@ -348,4 +323,118 @@ def test_agent_entry_manifest_skips_artifacts_without_role_or_path(schema):
     jsonschema.validate(instance=report, schema=schema)
     roles = {surface["role"] for surface in report["available_surfaces"]}
     assert "no_path" not in roles
+
+
+def test_agent_entry_manifest_includes_linked_post_emit_health_in_available_and_read_first(schema):
+    bundle = {
+        "run_id": "run-1",
+        "created_at": "2026-06-18T00:00:00Z",
+        "artifacts": [
+            {
+                "role": "canonical_md",
+                "path": "merge.md",
+                "sha256": "abc",
+                "authority": "canonical_content",
+                "canonicality": "content_source",
+            },
+            {
+                "role": "agent_reading_pack",
+                "path": "pack.md",
+                "sha256": "def",
+                "authority": "navigation_index",
+                "canonicality": "derived",
+            },
+        ],
+        "links": {
+            "post_emit_health_path": "merge.bundle_health.post.json",
+        },
+    }
+    report = build_agent_entry_manifest(bundle, created_at="2026-06-18T01:00:00Z")
+    jsonschema.validate(instance=report, schema=schema)
+    available = {surface["role"] for surface in report["available_surfaces"]}
+    unavailable = {surface["role"] for surface in report["unavailable_surfaces"]}
+    read_first = [surface["role"] for surface in report["read_first"]]
+    assert "post_emit_health" in available
+    assert "post_emit_health" not in unavailable
+    assert "post_emit_health" in read_first
+
+
+def test_agent_entry_manifest_includes_linked_bundle_surface_validation(schema):
+    bundle = {
+        "run_id": "run-1",
+        "created_at": "2026-06-18T00:00:00Z",
+        "artifacts": [
+            {
+                "role": "canonical_md",
+                "path": "merge.md",
+                "sha256": "abc",
+                "authority": "canonical_content",
+                "canonicality": "content_source",
+            }
+        ],
+        "links": {
+            "bundle_surface_validation_path": "merge.bundle_surface_validation.json",
+            "bundle_surface_validation_status": "pass",
+        },
+    }
+    report = build_agent_entry_manifest(bundle, created_at="2026-06-18T01:00:00Z")
+    jsonschema.validate(instance=report, schema=schema)
+    available = {surface["role"] for surface in report["available_surfaces"]}
+    unavailable = {surface["role"] for surface in report["unavailable_surfaces"]}
+    assert "bundle_surface_validation" in available
+    assert "bundle_surface_validation" not in unavailable
+
+
+def test_agent_entry_manifest_artifact_surface_wins_over_link_duplicate(schema):
+    bundle = {
+        "run_id": "run-1",
+        "created_at": "2026-06-18T00:00:00Z",
+        "artifacts": [
+            {
+                "role": "canonical_md",
+                "path": "merge.md",
+                "sha256": "abc",
+                "authority": "canonical_content",
+                "canonicality": "content_source",
+            },
+            {
+                "role": "post_emit_health",
+                "path": "artifact-post.json",
+                "sha256": "post-sha",
+                "authority": "diagnostic_signal",
+                "canonicality": "diagnostic",
+            },
+        ],
+        "links": {
+            "post_emit_health_path": "linked-post.json",
+        },
+    }
+    report = build_agent_entry_manifest(bundle, created_at="2026-06-18T01:00:00Z")
+    jsonschema.validate(instance=report, schema=schema)
+    post_surfaces = [
+        surface for surface in report["available_surfaces"]
+        if surface["role"] == "post_emit_health"
+    ]
+    assert len(post_surfaces) == 1
+    assert post_surfaces[0]["path"] == "artifact-post.json"
+    assert post_surfaces[0]["sha256"] == "post-sha"
+
+
+def test_agent_entry_manifest_infers_canonical_md_authority_and_canonicality_when_missing(schema):
+    bundle = {
+        "run_id": "run-1",
+        "created_at": "2026-06-18T00:00:00Z",
+        "artifacts": [
+            {
+                "role": "canonical_md",
+                "path": "merge.md",
+                "sha256": "abc",
+            }
+        ],
+    }
+    report = build_agent_entry_manifest(bundle, created_at="2026-06-18T01:00:00Z")
+    jsonschema.validate(instance=report, schema=schema)
+    assert report["canonical_source"]["authority"] == "canonical_content"
+    assert report["canonical_source"]["canonicality"] == "content_source"
+
 

--- a/merger/lenskit/tests/test_agent_entry_manifest.py
+++ b/merger/lenskit/tests/test_agent_entry_manifest.py
@@ -438,3 +438,81 @@ def test_agent_entry_manifest_infers_canonical_md_authority_and_canonicality_whe
     assert report["canonical_source"]["canonicality"] == "content_source"
 
 
+def test_agent_entry_manifest_schema_rejects_extra_does_not_establish_value(schema):
+    report = build_agent_entry_manifest(valid_bundle_fixture(), created_at="2026-06-18T00:00:00Z")
+    report["does_not_establish"].append("invented_boundary")
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=report, schema=schema)
+
+
+def test_agent_entry_manifest_schema_rejects_duplicate_does_not_establish_value(schema):
+    report = build_agent_entry_manifest(valid_bundle_fixture(), created_at="2026-06-18T00:00:00Z")
+    report["does_not_establish"] = [
+        "repo_understood",
+        "repo_understood",
+        "answer_safe_without_citations",
+        "claims_true",
+        "forensic_ready",
+    ]
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=report, schema=schema)
+
+
+def test_agent_entry_manifest_rejects_multiple_canonical_md_artifacts():
+    bundle = valid_bundle_fixture()
+    bundle["artifacts"].append(
+        {
+            "role": "canonical_md",
+            "path": "other.md",
+            "sha256": "other",
+            "authority": "canonical_content",
+            "canonicality": "content_source",
+        }
+    )
+    with pytest.raises(ValueError, match="multiple canonical_md artifacts"):
+        build_agent_entry_manifest(bundle, created_at="2026-06-18T00:00:00Z")
+
+
+def test_agent_entry_manifest_linked_sidecars_have_diagnostic_metadata(schema):
+    bundle = {
+        "run_id": "run-1",
+        "created_at": "2026-06-18T00:00:00Z",
+        "artifacts": [
+            {
+                "role": "canonical_md",
+                "path": "merge.md",
+                "sha256": "abc",
+                "authority": "canonical_content",
+                "canonicality": "content_source",
+            }
+        ],
+        "links": {
+            "post_emit_health_path": "merge.bundle_health.post.json",
+            "bundle_surface_validation_path": "merge.bundle_surface_validation.json",
+        },
+    }
+    report = build_agent_entry_manifest(bundle, created_at="2026-06-18T00:00:00Z")
+    jsonschema.validate(instance=report, schema=schema)
+    surfaces = {surface["role"]: surface for surface in report["available_surfaces"]}
+    assert surfaces["post_emit_health"]["authority"] == "diagnostic_signal"
+    assert surfaces["post_emit_health"]["canonicality"] == "diagnostic"
+    assert surfaces["bundle_surface_validation"]["authority"] == "diagnostic_signal"
+    assert surfaces["bundle_surface_validation"]["canonicality"] == "diagnostic"
+
+
+def test_agent_entry_manifest_ignores_non_string_link_paths(schema):
+    bundle = valid_bundle_fixture()
+    bundle["artifacts"] = [
+        artifact
+        for artifact in bundle["artifacts"]
+        if artifact["role"] != "post_emit_health"
+    ]
+    bundle["links"] = {
+        "post_emit_health_path": 123,
+        "bundle_surface_validation_path": [],
+    }
+    report = build_agent_entry_manifest(bundle, created_at="2026-06-18T00:00:00Z")
+    jsonschema.validate(instance=report, schema=schema)
+    unavailable = {surface["role"] for surface in report["unavailable_surfaces"]}
+    assert "post_emit_health" in unavailable
+    assert "bundle_surface_validation" in unavailable

--- a/merger/lenskit/tests/test_agent_entry_manifest.py
+++ b/merger/lenskit/tests/test_agent_entry_manifest.py
@@ -1,0 +1,213 @@
+import pytest
+import jsonschema
+import json
+from pathlib import Path
+
+from merger.lenskit.core.agent_entry_manifest import build_agent_entry_manifest
+
+SCHEMA_PATH = Path(__file__).parent.parent / "contracts" / "agent-entry-manifest.v1.schema.json"
+
+
+@pytest.fixture
+def schema():
+    with open(SCHEMA_PATH, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def valid_bundle_fixture() -> dict:
+    return {
+        "run_id": "run-1",
+        "created_at": "2026-06-18T00:00:00Z",
+        "artifacts": [
+            {
+                "role": "canonical_md",
+                "path": "lenskit_merge.md",
+                "sha256": "abc",
+                "authority": "canonical_content",
+                "canonicality": "content_source",
+            },
+            {
+                "role": "agent_reading_pack",
+                "path": "lenskit_merge.agent_reading_pack.md",
+                "sha256": "def",
+                "authority": "navigation_index",
+                "canonicality": "derived",
+            },
+            {
+                "role": "post_emit_health",
+                "path": "lenskit_merge.bundle_health.post.json",
+                "sha256": "ghi",
+                "authority": "diagnostic",
+                "canonicality": "derived",
+            },
+        ],
+    }
+
+
+def test_agent_entry_manifest_minimal_valid(schema):
+    report = build_agent_entry_manifest(
+        valid_bundle_fixture(),
+        created_at="2026-06-18T01:00:00Z",
+    )
+    jsonschema.validate(instance=report, schema=schema)
+    assert report["kind"] == "lenskit.agent_entry_manifest"
+    assert report["version"] == "1.0"
+    assert report["bundle_run_id"] == "run-1"
+    assert report["created_at"] == "2026-06-18T01:00:00Z"
+    assert report["authority"] == "navigation_index"
+    assert report["canonicality"] == "derived"
+    assert report["risk_class"] == "navigation"
+    assert report["canonical_source"]["role"] == "canonical_md"
+
+
+def test_agent_entry_manifest_missing_bundle_run_id_raises():
+    bundle = valid_bundle_fixture()
+    bundle.pop("run_id")
+    with pytest.raises(ValueError, match="bundle_run_id"):
+        build_agent_entry_manifest(bundle, created_at="2026-06-18T00:00:00Z")
+
+
+def test_agent_entry_manifest_missing_canonical_md_raises():
+    bundle = {"run_id": "run-1", "artifacts": []}
+    with pytest.raises(ValueError, match="canonical_md"):
+        build_agent_entry_manifest(bundle, created_at="2026-06-18T00:00:00Z")
+
+
+def test_agent_entry_manifest_rejects_noncanonical_canonical_md_authority():
+    bundle = valid_bundle_fixture()
+    bundle["artifacts"][0]["authority"] = "navigation_index"
+    with pytest.raises(ValueError, match="canonical_content"):
+        build_agent_entry_manifest(bundle, created_at="2026-06-18T00:00:00Z")
+
+
+def test_agent_entry_manifest_rejects_non_content_source_canonical_md():
+    bundle = valid_bundle_fixture()
+    bundle["artifacts"][0]["canonicality"] = "derived"
+    with pytest.raises(ValueError, match="content_source"):
+        build_agent_entry_manifest(bundle, created_at="2026-06-18T00:00:00Z")
+
+
+def test_agent_entry_manifest_missing_canonical_md_path_raises():
+    bundle = valid_bundle_fixture()
+    bundle["artifacts"][0].pop("path")
+    with pytest.raises(ValueError, match="canonical_md path"):
+        build_agent_entry_manifest(bundle, created_at="2026-06-18T00:00:00Z")
+
+
+def test_agent_entry_manifest_read_first_order_is_deterministic(schema):
+    bundle = {
+        "run_id": "run-1",
+        "artifacts": [
+            {
+                "role": "post_emit_health",
+                "path": "post.json",
+                "sha256": "1",
+                "authority": "diagnostic",
+                "canonicality": "derived",
+            },
+            {
+                "role": "canonical_md",
+                "path": "merge.md",
+                "sha256": "2",
+                "authority": "canonical_content",
+                "canonicality": "content_source",
+            },
+            {
+                "role": "agent_reading_pack",
+                "path": "pack.md",
+                "sha256": "3",
+                "authority": "navigation_index",
+                "canonicality": "derived",
+            },
+        ],
+    }
+    report = build_agent_entry_manifest(bundle, created_at="2026-06-18T00:00:00Z")
+    jsonschema.validate(instance=report, schema=schema)
+    assert [x["role"] for x in report["read_first"]] == [
+        "agent_reading_pack",
+        "post_emit_health",
+        "canonical_md",
+    ]
+
+
+def test_agent_entry_manifest_reports_unavailable_surfaces(schema):
+    bundle = {
+        "run_id": "run-1",
+        "artifacts": [
+            {
+                "role": "canonical_md",
+                "path": "merge.md",
+                "sha256": "abc",
+                "authority": "canonical_content",
+                "canonicality": "content_source",
+            }
+        ],
+    }
+    report = build_agent_entry_manifest(bundle, created_at="2026-06-18T00:00:00Z")
+    jsonschema.validate(instance=report, schema=schema)
+    unavailable = {x["role"] for x in report["unavailable_surfaces"]}
+    assert "agent_reading_pack" in unavailable
+    assert "post_emit_health" in unavailable
+
+
+def test_agent_entry_manifest_export_safety_report_may_be_unavailable(schema):
+    report = build_agent_entry_manifest(valid_bundle_fixture(), created_at="2026-06-18T00:00:00Z")
+    jsonschema.validate(instance=report, schema=schema)
+    unavailable = {x["role"] for x in report["unavailable_surfaces"]}
+    assert "export_safety_report" in unavailable
+
+
+def test_agent_entry_manifest_does_not_establish_boundary(schema):
+    report = build_agent_entry_manifest(valid_bundle_fixture(), created_at="2026-06-18T00:00:00Z")
+    jsonschema.validate(instance=report, schema=schema)
+    required = {
+        "repo_understood",
+        "answer_safe_without_citations",
+        "claims_true",
+        "forensic_ready",
+        "all_relevant_context_used",
+    }
+    assert required.issubset(set(report["does_not_establish"]))
+
+
+def test_agent_entry_manifest_schema_rejects_unknown_top_level_field(schema):
+    report = build_agent_entry_manifest(valid_bundle_fixture(), created_at="2026-06-18T00:00:00Z")
+    report["safe"] = True
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=report, schema=schema)
+
+
+def test_agent_entry_manifest_does_not_emit_truth_or_safety_flags(schema):
+    report = build_agent_entry_manifest(valid_bundle_fixture(), created_at="2026-06-18T00:00:00Z")
+    jsonschema.validate(instance=report, schema=schema)
+    forbidden = {
+        "safe",
+        "ready",
+        "verified",
+        "correct",
+        "complete",
+        "repo_understood",
+        "claims_true",
+        "forensic_ready",
+    }
+    assert forbidden.isdisjoint(report.keys())
+
+
+def test_agent_entry_manifest_uses_bundle_created_at_when_not_explicit(schema):
+    report = build_agent_entry_manifest(valid_bundle_fixture())
+    assert report["created_at"] == "2026-06-18T00:00:00Z"
+
+
+def test_agent_entry_manifest_created_at_unknown_when_absent(schema):
+    bundle = valid_bundle_fixture()
+    bundle.pop("created_at")
+    report = build_agent_entry_manifest(bundle)
+    jsonschema.validate(instance=report, schema=schema)
+    assert report["created_at"] == "unknown"
+
+
+def test_agent_entry_manifest_available_surfaces_include_manifest_artifacts(schema):
+    report = build_agent_entry_manifest(valid_bundle_fixture(), created_at="2026-06-18T00:00:00Z")
+    jsonschema.validate(instance=report, schema=schema)
+    roles = {x["role"] for x in report["available_surfaces"]}
+    assert {"canonical_md", "agent_reading_pack", "post_emit_health"}.issubset(roles)

--- a/merger/lenskit/tests/test_agent_entry_manifest.py
+++ b/merger/lenskit/tests/test_agent_entry_manifest.py
@@ -1,7 +1,8 @@
-import pytest
-import jsonschema
 import json
 from pathlib import Path
+
+import jsonschema
+import pytest
 
 from merger.lenskit.core.agent_entry_manifest import build_agent_entry_manifest
 
@@ -41,6 +42,85 @@ def valid_bundle_fixture() -> dict:
                 "canonicality": "derived",
             },
         ],
+    }
+
+
+def realistic_bundle_manifest_fixture() -> dict:
+    return {
+        "run_id": "run-xyz",
+        "created_at": "2026-06-18T02:00:00Z",
+        "artifacts": [
+            {
+                "role": "canonical_md",
+                "path": "merge.md",
+                "content_type": "text/markdown",
+                "bytes": 100,
+                "sha256": "aaaa",
+                "authority": "canonical_content",
+                "canonicality": "content_source",
+                "risk_class": "content"
+            },
+            {
+                "role": "agent_reading_pack",
+                "path": "pack.md",
+                "content_type": "text/markdown",
+                "bytes": 200,
+                "sha256": "bbbb",
+                "authority": "navigation_index",
+                "canonicality": "derived",
+                "risk_class": "navigation"
+            },
+            {
+                "role": "post_emit_health",
+                "path": "health.json",
+                "content_type": "application/json",
+                "bytes": 300,
+                "sha256": "cccc",
+                "authority": "diagnostic",
+                "canonicality": "derived",
+                "risk_class": "diagnostic"
+            },
+            {
+                "role": "output_health",
+                "path": "out.json",
+                "content_type": "application/json",
+                "bytes": 400,
+                "sha256": "dddd",
+                "authority": "diagnostic_signal",
+                "canonicality": "diagnostic",
+                "risk_class": "diagnostic"
+            },
+            {
+                "role": "claim_evidence_map_json",
+                "path": "claim_evidence.json",
+                "content_type": "application/json",
+                "bytes": 500,
+                "sha256": "eeee",
+                "authority": "navigation_index",
+                "canonicality": "derived",
+                "risk_class": "evidence_index"
+            },
+            {
+                "role": "citation_map_jsonl",
+                "path": "citation.jsonl",
+                "content_type": "application/x-ndjson",
+                "bytes": 600,
+                "sha256": "ffff",
+                "authority": "navigation_index",
+                "canonicality": "derived",
+                "risk_class": "navigation"
+            },
+            {
+                "role": "bundle_surface_validation",
+                "path": "surface_valid.json",
+                "content_type": "application/json",
+                "bytes": 700,
+                "sha256": "gggg",
+                "authority": "diagnostic_signal",
+                "canonicality": "diagnostic",
+                "risk_class": "diagnostic"
+            }
+        ]
     }
 
 
@@ -211,3 +291,61 @@ def test_agent_entry_manifest_available_surfaces_include_manifest_artifacts(sche
     jsonschema.validate(instance=report, schema=schema)
     roles = {x["role"] for x in report["available_surfaces"]}
     assert {"canonical_md", "agent_reading_pack", "post_emit_health"}.issubset(roles)
+
+
+def test_agent_entry_manifest_accepts_realistic_bundle_manifest_shape(schema):
+    report = build_agent_entry_manifest(
+        realistic_bundle_manifest_fixture(),
+        created_at="2026-06-18T02:00:00Z",
+    )
+    jsonschema.validate(instance=report, schema=schema)
+    assert report["bundle_run_id"]
+    assert report["canonical_source"]["role"] == "canonical_md"
+    assert report["canonical_source"]["authority"] == "canonical_content"
+    assert report["canonical_source"]["canonicality"] == "content_source"
+    available_roles = {surface["role"] for surface in report["available_surfaces"]}
+    assert "canonical_md" in available_roles
+    assert "agent_reading_pack" in available_roles
+    assert "post_emit_health" in available_roles
+    read_first_roles = [surface["role"] for surface in report["read_first"]]
+    assert read_first_roles[:1] == ["agent_reading_pack"]
+
+
+def test_agent_entry_manifest_non_list_artifacts_raises_missing_canonical_md():
+    bundle = {
+        "run_id": "run-1",
+        "artifacts": {
+            "role": "canonical_md",
+            "path": "merge.md",
+            "sha256": "abc",
+            "authority": "canonical_content",
+            "canonicality": "content_source",
+        },
+    }
+    with pytest.raises(ValueError, match="canonical_md"):
+        build_agent_entry_manifest(bundle, created_at="2026-06-18T00:00:00Z")
+
+
+def test_agent_entry_manifest_ignores_non_dict_artifacts(schema):
+    bundle = valid_bundle_fixture()
+    bundle["artifacts"].append("bad")
+    bundle["artifacts"].append(123)
+    report = build_agent_entry_manifest(bundle, created_at="2026-06-18T00:00:00Z")
+    jsonschema.validate(instance=report, schema=schema)
+    roles = {surface["role"] for surface in report["available_surfaces"]}
+    assert "canonical_md" in roles
+
+
+def test_agent_entry_manifest_skips_artifacts_without_role_or_path(schema):
+    bundle = valid_bundle_fixture()
+    bundle["artifacts"].extend(
+        [
+            {"path": "no-role.json", "sha256": "x"},
+            {"role": "no_path", "sha256": "y"},
+        ]
+    )
+    report = build_agent_entry_manifest(bundle, created_at="2026-06-18T00:00:00Z")
+    jsonschema.validate(instance=report, schema=schema)
+    roles = {surface["role"] for surface in report["available_surfaces"]}
+    assert "no_path" not in roles
+


### PR DESCRIPTION
## Summary
Adds Agent Entry Manifest v1 as a deterministic, machine-readable navigation entrypoint for Lenskit bundles.
The manifest identifies:
- canonical source
- read-first surfaces
- task profile reference
- available bundle surfaces
- unavailable expected surfaces
- diagnostic non-establishment boundaries
## Scope
New:
- `merger/lenskit/contracts/agent-entry-manifest.v1.schema.json`
- `merger/lenskit/core/agent_entry_manifest.py`
- `merger/lenskit/tests/test_agent_entry_manifest.py`
Not included:
- no bundle pipeline emission
- no Bundle Manifest mutation
- no CLI
- no Agent Reading Pack v2 changes
- no Required Reading changes
- no Consumption Trace changes
- no Export Safety changes
- no Lens Cards / Relation Cards
- no LLMs, embeddings, review judgments, or patch automation
## Semantic boundary
Agent Entry Manifest is navigation only.
It does not establish:
- repo_understood
- answer_safe_without_citations
- claims_true
- forensic_ready
- all_relevant_context_used
`canonical_md` remains the only content truth.
## Validation
- [x] `python -m pytest merger/lenskit/tests/test_agent_entry_manifest.py -q`
- [x] adjacent tests
- [x] contract tests
- [x] `ruff check merger/lenskit/core/agent_entry_manifest.py merger/lenskit/tests/test_agent_entry_manifest.py`
## Target proof
- Bundle artifact shape: artifacts array with dicts containing role, path, content_type, bytes, sha256
- Schema validation pattern: Draft7Validator, jsonschema.validate
- Timestamp convention: ISO-8601 UTC timestamp from created_at
- No pipeline mutation needed for v1: true
