### PR TITLE
feat(agent): surface consumption contract in agent pack

### DIFF
--- a/merger/lenskit/core/agent_export_gate.py
+++ b/merger/lenskit/core/agent_export_gate.py
@@ -205,6 +205,12 @@ def _read_text_artifact(
     return text, None
 
 
+def _has_markdown_heading(text: str, heading: str) -> bool:
+    """Return True when ``text`` contains a level-2 Markdown heading line matching ``heading``."""
+    target = f"## {heading}"
+    return any(line.strip() == target for line in text.splitlines())
+
+
 def _doc_forbidden_inferences(doc: Dict[str, Any]) -> set[str]:
     """Return the optional C2.3 ``forbidden_inferences`` strings of a diagnostic doc."""
     values = doc.get("forbidden_inferences")
@@ -487,17 +493,16 @@ def evaluate_agent_export_gate(
     # never changes status or errors. This adds no truth layer and no
     # strict-gate semantics; it only makes the agent-consumption strand visible.
     if agent_facing:
-        roles = _artifact_roles(manifest)
-        if "agent_entry_manifest" not in roles:
+        if _find_artifact_path(manifest, "agent_entry_manifest") is None:
             warnings.append("missing_agent_entry_manifest")
-        if "required_reading_protocol" not in roles:
+        if _find_artifact_path(manifest, "required_reading_protocol") is None:
             warnings.append("missing_required_reading_protocol")
         pack_text, _pack_read_error = _read_text_artifact(
             manifest, manifest_dir, "agent_reading_pack"
         )
         if pack_text is None:
             warnings.append("cannot_check_answer_compliance_checklist")
-        elif "ANSWER_COMPLIANCE_CHECKLIST" not in pack_text:
+        elif not _has_markdown_heading(pack_text, "ANSWER_COMPLIANCE_CHECKLIST"):
             warnings.append("missing_answer_compliance_checklist")
 
     return {

--- a/merger/lenskit/core/agent_export_gate.py
+++ b/merger/lenskit/core/agent_export_gate.py
@@ -147,6 +147,64 @@ def _find_output_health_verdict(manifest: Dict[str, Any], manifest_dir: Path) ->
     return None
 
 
+def _artifact_roles(manifest: Dict[str, Any]) -> set[str]:
+    """Return the set of declared artifact ``role`` strings in the manifest."""
+    roles: set[str] = set()
+    artifacts = manifest.get("artifacts")
+    if isinstance(artifacts, list):
+        for art in artifacts:
+            if isinstance(art, dict):
+                role = art.get("role")
+                if isinstance(role, str):
+                    roles.add(role)
+    return roles
+
+
+def _find_artifact_path(manifest: Dict[str, Any], role: str) -> Optional[str]:
+    """Return the relative path of the first artifact carrying ``role``.
+
+    Returns ``None`` when no artifact declares the role, or when the first
+    matching artifact has no usable non-empty string path.
+    """
+    artifacts = manifest.get("artifacts")
+    if not isinstance(artifacts, list):
+        return None
+    for art in artifacts:
+        if not isinstance(art, dict) or art.get("role") != role:
+            continue
+        path = art.get("path")
+        if isinstance(path, str) and path:
+            return path
+        return None
+    return None
+
+
+def _read_text_artifact(
+    manifest: Dict[str, Any],
+    manifest_dir: Path,
+    role: str,
+) -> Tuple[Optional[str], Optional[str]]:
+    """Securely read a bundle text artifact's contents by role.
+
+    Returns ``(text, None)`` on success or ``(None, reason)`` otherwise, where
+    reason is a short machine-readable tag (``missing_artifact:<role>`` or
+    ``read_failed:<role>``). Path resolution stays confined to the bundle
+    directory and no IO/decoding exception escapes: an unreadable surface is a
+    warning condition, never a hard error.
+    """
+    rel_path = _find_artifact_path(manifest, role)
+    if rel_path is None:
+        return None, f"missing_artifact:{role}"
+    try:
+        resolved = resolve_secure_path(manifest_dir, rel_path)
+        if not resolved.exists() or not resolved.is_file():
+            return None, f"read_failed:{role}"
+        text = resolved.read_text(encoding="utf-8")
+    except (ValueError, OSError, UnicodeDecodeError):
+        return None, f"read_failed:{role}"
+    return text, None
+
+
 def _doc_forbidden_inferences(doc: Dict[str, Any]) -> set[str]:
     """Return the optional C2.3 ``forbidden_inferences`` strings of a diagnostic doc."""
     values = doc.get("forbidden_inferences")
@@ -423,6 +481,24 @@ def evaluate_agent_export_gate(
                 "agent-facing export blocked by forbidden inference(s): "
                 + ", ".join(blocking_inferences)
             )
+
+    # Agent-consumption surface advisory. Non-blocking navigation hints only: a
+    # missing or unreadable consumption surface is surfaced as a warning and
+    # never changes status or errors. This adds no truth layer and no
+    # strict-gate semantics; it only makes the agent-consumption strand visible.
+    if agent_facing:
+        roles = _artifact_roles(manifest)
+        if "agent_entry_manifest" not in roles:
+            warnings.append("missing_agent_entry_manifest")
+        if "required_reading_protocol" not in roles:
+            warnings.append("missing_required_reading_protocol")
+        pack_text, _pack_read_error = _read_text_artifact(
+            manifest, manifest_dir, "agent_reading_pack"
+        )
+        if pack_text is None:
+            warnings.append("cannot_check_answer_compliance_checklist")
+        elif "ANSWER_COMPLIANCE_CHECKLIST" not in pack_text:
+            warnings.append("missing_answer_compliance_checklist")
 
     return {
         "kind": KIND,

--- a/merger/lenskit/core/agent_export_gate.py
+++ b/merger/lenskit/core/agent_export_gate.py
@@ -147,19 +147,6 @@ def _find_output_health_verdict(manifest: Dict[str, Any], manifest_dir: Path) ->
     return None
 
 
-def _artifact_roles(manifest: Dict[str, Any]) -> set[str]:
-    """Return the set of declared artifact ``role`` strings in the manifest."""
-    roles: set[str] = set()
-    artifacts = manifest.get("artifacts")
-    if isinstance(artifacts, list):
-        for art in artifacts:
-            if isinstance(art, dict):
-                role = art.get("role")
-                if isinstance(role, str):
-                    roles.add(role)
-    return roles
-
-
 def _find_artifact_path(manifest: Dict[str, Any], role: str) -> Optional[str]:
     """Return the relative path of the first artifact carrying ``role``.
 

--- a/merger/lenskit/core/agent_reading_pack.py
+++ b/merger/lenskit/core/agent_reading_pack.py
@@ -505,6 +505,48 @@ def render_agent_reading_pack(model: PackModel) -> str:
     )
     lines.append("")
 
+    # ── AGENT_CONSUMPTION_CONTRACT ───────────────────────────────────────
+    lines.append("## AGENT_CONSUMPTION_CONTRACT")
+    lines.append(
+        "Agent-consumption surfaces are navigation and accountability aids. "
+        "They do not replace `canonical_md`."
+    )
+    lines.append("Use them when present:")
+    lines.append(
+        "- `agent_entry_manifest` / `lenskit.agent_entry_manifest`: "
+        "machine-readable bundle entrypoint."
+    )
+    lines.append(
+        "- `required_reading_protocol` / `lenskit.required_reading_protocol`: "
+        "task-profile-specific required reading."
+    )
+    lines.append(
+        "- `agent_consumption_trace` / `lenskit.agent_consumption_trace`: "
+        "machine-readable declaration of consumed artifacts, ranges, and citations."
+    )
+    lines.append(
+        "- `answer_compliance` / `ANSWER_COMPLIANCE_CHECKLIST`: answer-side "
+        "obligations and non-claims; declaration only, not proof of actual reading."
+    )
+    lines.append(
+        "- `export_safety_report` / `lenskit.export_safety_report`: "
+        "export diagnostic only."
+    )
+    lines.append(
+        "This does not establish `repo_understood`, `answer_safe_without_citations`, "
+        "`claims_true`, `all_relevant_context_used`, `secret_absence`, `pii_absence`, "
+        "or `forensic_ready`."
+    )
+    lines.append("`canonical_md` remains the only content truth.")
+    lines.append(
+        "Sidecars remain navigation, diagnostics, index, evidence, or cache."
+    )
+    lines.append(
+        "Health passes do not prove repo understanding, answer safety, test "
+        "sufficiency, runtime correctness, regression absence, or forensic readiness."
+    )
+    lines.append("")
+
     # ── ANSWER_COMPLIANCE_CHECKLIST ──────────────────────────────────────
     lines.append("## ANSWER_COMPLIANCE_CHECKLIST")
     lines.append("```text")

--- a/merger/lenskit/tests/test_agent_export_gate.py
+++ b/merger/lenskit/tests/test_agent_export_gate.py
@@ -1014,3 +1014,83 @@ def test_agent_export_gate_warns_when_answer_compliance_checklist_cannot_be_chec
     assert "missing_answer_compliance_checklist" not in report["warnings"]
     assert report["status"] == "pass"
     assert report["errors"] == []
+
+
+def test_agent_export_gate_requires_answer_compliance_heading_not_plain_text(tmp_path):
+    manifest = _write_manifest(tmp_path, redaction=True)
+    _write_post_health(tmp_path, "pass")
+    # Pack contains the token as plain text, not as a ## heading — must still warn.
+    _append_artifact(
+        manifest,
+        tmp_path,
+        role="agent_reading_pack",
+        filename="demo.agent_reading_pack.md",
+        content=b"# Agent Reading Pack\n\nANSWER_COMPLIANCE_CHECKLIST\n",
+    )
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    assert "missing_answer_compliance_checklist" in report["warnings"]
+    assert "cannot_check_answer_compliance_checklist" not in report["warnings"]
+    assert report["status"] == "pass"
+    assert report["errors"] == []
+
+
+def test_agent_export_gate_warns_when_agent_entry_manifest_artifact_has_no_path(tmp_path):
+    manifest = _write_manifest(tmp_path, redaction=True)
+    _write_post_health(tmp_path, "pass")
+    # Role is declared but path is empty: _find_artifact_path must return None.
+    doc = json.loads(manifest.read_text(encoding="utf-8"))
+    doc["artifacts"].append({
+        "role": "agent_entry_manifest",
+        "path": "",
+        "content_type": "application/json",
+        "bytes": 0,
+        "sha256": _sha256(b""),
+        "authority": "navigation_index",
+        "canonicality": "derived",
+        "interpretation": {"mode": "role_only"},
+    })
+    manifest.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    assert "missing_agent_entry_manifest" in report["warnings"]
+    assert report["status"] == "pass"
+    assert report["errors"] == []
+
+
+def test_agent_export_gate_warns_when_required_reading_protocol_artifact_has_no_path(tmp_path):
+    manifest = _write_manifest(tmp_path, redaction=True)
+    _write_post_health(tmp_path, "pass")
+    # Role is declared but path is empty: _find_artifact_path must return None.
+    doc = json.loads(manifest.read_text(encoding="utf-8"))
+    doc["artifacts"].append({
+        "role": "required_reading_protocol",
+        "path": "",
+        "content_type": "application/json",
+        "bytes": 0,
+        "sha256": _sha256(b""),
+        "authority": "navigation_index",
+        "canonicality": "derived",
+        "interpretation": {"mode": "role_only"},
+    })
+    manifest.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    assert "missing_required_reading_protocol" in report["warnings"]
+    assert report["status"] == "pass"
+    assert report["errors"] == []

--- a/merger/lenskit/tests/test_agent_export_gate.py
+++ b/merger/lenskit/tests/test_agent_export_gate.py
@@ -839,3 +839,178 @@ def test_c2_5_blocked_report_validates_against_schema(tmp_path):
     assert report["status"] == "fail"
     schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
     jsonschema.validate(instance=report, schema=schema)
+
+
+# ---------------------------------------------------------------------------
+# Agent-consumption surface advisory (non-blocking warnings)
+# ---------------------------------------------------------------------------
+
+def _append_artifact(
+    manifest_path: Path,
+    tmp_path: Path,
+    *,
+    role: str,
+    filename: str,
+    content: bytes,
+    authority: str = "navigation_index",
+    canonicality: str = "derived",
+    content_type: str = "text/markdown",
+) -> None:
+    """Write a file and append a manifest artifact entry referencing it."""
+    (tmp_path / filename).write_bytes(content)
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["artifacts"].append(
+        {
+            "role": role,
+            "path": filename,
+            "content_type": content_type,
+            "bytes": len(content),
+            "sha256": _sha256(content),
+            "authority": authority,
+            "canonicality": canonicality,
+            "interpretation": {"mode": "role_only"},
+        }
+    )
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+
+def test_agent_export_gate_warns_when_agent_entry_manifest_missing(tmp_path):
+    manifest = _write_manifest(tmp_path, redaction=True)
+    _write_post_health(tmp_path, "pass")
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    assert "missing_agent_entry_manifest" in report["warnings"]
+    assert report["status"] == "pass"
+    assert report["errors"] == []
+
+
+def test_agent_export_gate_warns_when_required_reading_protocol_missing(tmp_path):
+    manifest = _write_manifest(tmp_path, redaction=True)
+    _write_post_health(tmp_path, "pass")
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    assert "missing_required_reading_protocol" in report["warnings"]
+    assert report["status"] == "pass"
+    assert report["errors"] == []
+
+
+def test_agent_export_gate_warns_when_answer_compliance_checklist_missing(tmp_path):
+    manifest = _write_manifest(tmp_path, redaction=True)
+    _write_post_health(tmp_path, "pass")
+    _append_artifact(
+        manifest,
+        tmp_path,
+        role="agent_reading_pack",
+        filename="demo.agent_reading_pack.md",
+        content=b"# Agent Reading Pack\n\nNo checklist section here.\n",
+    )
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    assert "missing_answer_compliance_checklist" in report["warnings"]
+    assert "cannot_check_answer_compliance_checklist" not in report["warnings"]
+    assert report["status"] == "pass"
+    assert report["errors"] == []
+
+
+def test_agent_export_gate_consumption_warnings_do_not_block_agent_export(tmp_path):
+    manifest = _write_manifest(tmp_path, redaction=True)
+    _write_post_health(tmp_path, "pass")
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    assert report["status"] == "pass"
+    assert report["errors"] == []
+    assert "missing_agent_entry_manifest" in report["warnings"]
+    assert "missing_required_reading_protocol" in report["warnings"]
+    assert "cannot_check_answer_compliance_checklist" in report["warnings"]
+
+
+def test_agent_export_gate_does_not_warn_when_consumption_surfaces_present(tmp_path):
+    manifest = _write_manifest(tmp_path, redaction=True)
+    _write_post_health(tmp_path, "pass")
+    _append_artifact(
+        manifest,
+        tmp_path,
+        role="agent_entry_manifest",
+        filename="demo.agent_entry_manifest.json",
+        content=b"{}",
+        content_type="application/json",
+    )
+    _append_artifact(
+        manifest,
+        tmp_path,
+        role="required_reading_protocol",
+        filename="demo.required_reading_protocol.json",
+        content=b"{}",
+        content_type="application/json",
+    )
+    _append_artifact(
+        manifest,
+        tmp_path,
+        role="agent_reading_pack",
+        filename="demo.agent_reading_pack.md",
+        content=b"# Agent Reading Pack\n\n## ANSWER_COMPLIANCE_CHECKLIST\n",
+    )
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    assert "missing_agent_entry_manifest" not in report["warnings"]
+    assert "missing_required_reading_protocol" not in report["warnings"]
+    assert "missing_answer_compliance_checklist" not in report["warnings"]
+    assert "cannot_check_answer_compliance_checklist" not in report["warnings"]
+    assert report["status"] == "pass"
+
+
+def test_agent_export_gate_warns_when_answer_compliance_checklist_cannot_be_checked(tmp_path):
+    manifest = _write_manifest(tmp_path, redaction=True)
+    _write_post_health(tmp_path, "pass")
+    # Declare an agent_reading_pack artifact whose file is absent: the gate must
+    # surface a cannot-check warning rather than guessing or blocking.
+    doc = json.loads(manifest.read_text(encoding="utf-8"))
+    doc["artifacts"].append(
+        {
+            "role": "agent_reading_pack",
+            "path": "missing.agent_reading_pack.md",
+            "content_type": "text/markdown",
+            "bytes": 0,
+            "sha256": _sha256(b""),
+            "authority": "navigation_index",
+            "canonicality": "derived",
+            "interpretation": {"mode": "role_only"},
+        }
+    )
+    manifest.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+
+    report = evaluate_agent_export_gate(
+        manifest_path=str(manifest),
+        profile="agent_minimal",
+        require_redaction=True,
+    )
+
+    assert "cannot_check_answer_compliance_checklist" in report["warnings"]
+    assert "missing_answer_compliance_checklist" not in report["warnings"]
+    assert report["status"] == "pass"
+    assert report["errors"] == []

--- a/merger/lenskit/tests/test_agent_reading_pack.py
+++ b/merger/lenskit/tests/test_agent_reading_pack.py
@@ -391,6 +391,67 @@ def test_pack_answer_compliance_checklist_is_declarative(tmp_path):
     assert "declaration aid, not proof" in body
 
 
+def test_agent_reading_pack_surfaces_agent_consumption_contract(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    body = Path(produce_agent_reading_pack(str(manifest))["output_path"]).read_text()
+
+    assert "## AGENT_CONSUMPTION_CONTRACT" in body
+    section = _section(body, "AGENT_CONSUMPTION_CONTRACT")
+    # Backtick-insensitive: surfaces are rendered as inline code spans.
+    flat = section.replace("`", "")
+    for needle in (
+        "agent_entry_manifest",
+        "lenskit.agent_entry_manifest",
+        "required_reading_protocol",
+        "lenskit.required_reading_protocol",
+        "agent_consumption_trace",
+        "lenskit.agent_consumption_trace",
+        "ANSWER_COMPLIANCE_CHECKLIST",
+        "export_safety_report",
+        "lenskit.export_safety_report",
+        "canonical_md remains the only content truth",
+    ):
+        assert needle in flat, f"missing {needle!r} in AGENT_CONSUMPTION_CONTRACT"
+
+
+def test_agent_reading_pack_consumption_contract_preserves_non_claims(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    body = Path(produce_agent_reading_pack(str(manifest))["output_path"]).read_text()
+    section = _section(body, "AGENT_CONSUMPTION_CONTRACT")
+
+    assert "does not establish" in section
+    for token in (
+        "repo_understood",
+        "answer_safe_without_citations",
+        "claims_true",
+        "all_relevant_context_used",
+        "secret_absence",
+        "pii_absence",
+        "forensic_ready",
+    ):
+        assert token in section, f"non-claim {token!r} missing from consumption contract"
+
+
+def test_agent_reading_pack_consumption_contract_does_not_add_positive_truth_claims(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    body = Path(produce_agent_reading_pack(str(manifest))["output_path"]).read_text()
+    section = _section(body, "AGENT_CONSUMPTION_CONTRACT")
+
+    # Only positive machine-readable assertions are forbidden; negated prose is fine.
+    for forbidden in (
+        "repo_understood: true",
+        "claims_true: true",
+        "forensic_ready: true",
+        "secret_absence: true",
+        "pii_absence: true",
+        "answer_safe_without_citations: true",
+        "verified: true",
+        "safe: true",
+        "complete: true",
+    ):
+        assert forbidden not in section, f"unexpected positive claim {forbidden!r}"
+
+
 def test_pack_lists_present_artifact_roles(tmp_path):
     manifest = _make_bundle(tmp_path)
     body = Path(produce_agent_reading_pack(str(manifest))["output_path"]).read_text()


### PR DESCRIPTION
## Summary
Surfaces the Agent Consumption Contract in the Agent Reading Pack and adds advisory Export Gate warnings for missing agent-consumption surfaces.

## Scope
Changed:
- `merger/lenskit/core/agent_reading_pack.py`
- `merger/lenskit/tests/test_agent_reading_pack.py`
- `merger/lenskit/core/agent_export_gate.py`
- `merger/lenskit/tests/test_agent_export_gate.py`

Not included:
- no new sidecar
- no new schema
- no Bundle Manifest mutation
- no bundle emission
- no CLI
- no Strict Gate
- no CI failure path
- no Lens Cards / Relation Cards
- no Primary Lens work

## Semantics
Agent Reading Pack now adds an `AGENT_CONSUMPTION_CONTRACT` section (rendered after `SIDECAR_USAGE_RULES`, before `ANSWER_COMPLIANCE_CHECKLIST`) that references the existing agent-consumption strand using its real kinds:
- `agent_entry_manifest` / `lenskit.agent_entry_manifest`
- `required_reading_protocol` / `lenskit.required_reading_protocol`
- `agent_consumption_trace` / `lenskit.agent_consumption_trace`
- `answer_compliance` / `ANSWER_COMPLIANCE_CHECKLIST`
- `export_safety_report` / `lenskit.export_safety_report`

Export Gate warnings are advisory only. For agent-facing profiles the gate emits non-blocking warnings (`missing_agent_entry_manifest`, `missing_required_reading_protocol`, `missing_answer_compliance_checklist`, `cannot_check_answer_compliance_checklist`). They never populate `errors` and never change `status`.

`canonical_md` remains the only content truth. Consumption surfaces do not prove repo understanding, answer safety, claim truth, all-relevant-context use, secret absence, PII absence, or forensic readiness.

Note: current bundles do not yet emit `agent_entry_manifest` or `required_reading_protocol` as artifacts, so agent-facing exports will warn `missing_agent_entry_manifest` / `missing_required_reading_protocol` until those surfaces are emitted. This is the intended advisory state, not a failure.

## Validation
- [x] `python -m pytest merger/lenskit/tests/test_agent_reading_pack.py merger/lenskit/tests/test_agent_export_gate.py -q` → 104 passed
- [x] adjacent agent-consumption tests (entry manifest, required reading, consumption trace, cli consumption, export safety) → 139 passed
- [x] regression tests (agent session/bundle manifest schema, post_emit_health, bundle surface validate, cli agent pack, bundle manifest integration, reading pack usage rules) — green except one pre-existing failure unrelated to this change (`test_output_health_broken_range_ref_is_fail_in_repo_near_flow`, fails identically on the base commit)
- [x] `ruff check` on changed files → clean

## Target proof
- Agent Pack had consumption contract before: no
- Export Gate had missing-surface warnings before: no
- Warning shape: `report["warnings"]` is `list[str]`; advisory IDs added under `if agent_facing:` only
- No Strict Gate: warnings never touch `status`/`errors`; no new CLI flag or `require_*` parameter; export-gate schema unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EzvsVuk87iLiMtvLcjW7zn

---
_Generated by [Claude Code](https://claude.ai/code/session_01EzvsVuk87iLiMtvLcjW7zn)_