### PR TITLE
docs(lens): define deterministic lens model

### DIFF
--- a/docs/architecture/agent-consumption-contract.md
+++ b/docs/architecture/agent-consumption-contract.md
@@ -184,4 +184,4 @@ Deferred:
 
 The validator performs no I/O, holds no global state, and reuses the existing Required Reading resolution rather than re-deriving it.
 
-`available_roles` is supplied explicitly. When omitted, only required and recommended roles are treated as known, and any other declared role is conservatively warned. The trace does not infer roles from the Bundle Manifest; that is later CLI / Entry Manifest work, and the `ArtifactRole` enum is not extended here.
+`available_roles` is supplied explicitly. When omitted, only required and recommended roles are treated as known, and any other declared role is conservatively warned. The trace does not infer roles from the Bundle Manifest. Bundle-aware CLI integration or Agent Entry Manifest consumption remains deferred, and the `ArtifactRole` enum is not extended here.

--- a/docs/architecture/agent-consumption-contract.md
+++ b/docs/architecture/agent-consumption-contract.md
@@ -5,7 +5,11 @@
 Required Reading Protocol Core implemented.
 Answer Compliance Contract v1 implemented.
 Agent Consumption Trace v1 implemented.
-Agent Entry Manifest, Agent Reading Pack v2, Export Safety Report, Lens Cards, Relation Cards, and Retrieval v2 are not yet implemented.
+The Agent Entry Manifest core is implemented with a contract, producer and
+focused tests.
+A dedicated CLI command, automatic bundle emission, bundle-manifest
+registration and stable consumer integration are not yet implemented.
+Agent Reading Pack v2, Export Safety Report, Lens Cards, Relation Cards, and Retrieval v2 are not yet implemented.
 
 ---
 
@@ -163,6 +167,21 @@ The trace is a declaration-comparison artifact only. It does not prove actual re
 
 ### Scope
 
-This slice ships the contract, the pure core validator, and tests only. A CLI, strict mode, exit-code policy, Agent Entry Manifest, Output Health / Post-Emit Health integration, Bundle Manifest mutation, and Export Safety wiring are intentionally deferred. The validator performs no I/O, holds no global state, and reuses the existing Required Reading resolution rather than re-deriving it.
+Implemented:
+- Agent Consumption Trace Contract
+- Core validator
+- strict-mode validation
+- deterministic exit-code policy
+- CLI commands for Required Reading resolution and trace validation
+- focused contract, validator and CLI tests
+
+Deferred:
+- automatic bundle emission
+- mutation of the bundle manifest
+- Output Health or Post-Emit Health integration
+- export-safety wiring
+- mandatory adoption by external agent wrappers
+
+The validator performs no I/O, holds no global state, and reuses the existing Required Reading resolution rather than re-deriving it.
 
 `available_roles` is supplied explicitly. When omitted, only required and recommended roles are treated as known, and any other declared role is conservatively warned. The trace does not infer roles from the Bundle Manifest; that is later CLI / Entry Manifest work, and the `ArtifactRole` enum is not extended here.

--- a/docs/architecture/answer-compliance.md
+++ b/docs/architecture/answer-compliance.md
@@ -93,7 +93,10 @@ Range declarations accept a minimal v1-like line range or a minimal v2-like arti
 }
 ```
 
-## Later Slices
+## Boundary to Agent Consumption Trace
 
-Agent Consumption Trace and Validator will compare Required Reading Protocol expectations against Answer Compliance declarations.
-This PR does not implement that comparison.
+The Agent Consumption Trace validator compares Required Reading Protocol
+expectations against Answer Compliance declarations.
+The comparison remains declaration-based. It does not prove actual reading,
+correct use of an artifact, answer correctness, completeness or repository
+understanding.

--- a/docs/architecture/lens-model.md
+++ b/docs/architecture/lens-model.md
@@ -1,17 +1,14 @@
----
-doc_type: architecture
-status: active
----
-
 # Deterministic Lens Model
 
 ## 1. Zweck und Scope
 
 Dieses Dokument normiert die Begriffe und Schichtengrenzen der Lenskit-Linsenarchitektur.
-Es ist Architekturdefinition, Begriffsschicht und Grundlage fuer spaetere Contracts.
+Es ist Architekturdefinition, Begriffsschicht und Grundlage für spätere Contracts.
 
-Eine Lens ist etymologisch eine Linse: eine kontrollierte Sicht auf denselben Gegenstand.
-Im Systemkontext ist sie kein neuer Gegenstand und keine neue Wahrheit.
+Das englische `lens` geht auf das lateinische `lens` zurück, das die
+Linsenfrucht bezeichnet; die optische Linse wurde nach ihrer Form benannt.
+Im Systemkontext bezeichnet eine Lens eine kontrollierte Sicht auf denselben
+Gegenstand, nicht einen neuen Gegenstand und keine neue Wahrheit.
 
 Normativer Kernsatz:
 
@@ -19,6 +16,14 @@ Normativer Kernsatz:
 
 Dieses Dokument ist nicht Runtime-Evidence, kein JSON-Schema, kein Implementierungsbeweis,
 kein Bundle-Artefakt, kein Review-Bericht und kein Statusbeweis.
+
+Das Two-Layer Artifact Pattern bestimmt, welche Lens-Flächen nur zeigen und
+welche Quellen Inhalt beweisen.
+Der Agent Consumption Contract bestimmt, welche Flächen für eine Aufgabe
+konsumiert oder deklariert werden; er macht daraus keine Lens-Primitive.
+Das Lens-Modell ordnet Navigation, ersetzt aber weder diese
+Consumption-Regeln noch die bestehenden Authority- und
+Canonicality-Grenzen.
 
 Beziehungen:
 - `docs/blueprints/lenskit-agent-front-door-hardening.md`
@@ -31,22 +36,29 @@ Beziehungen:
 
 ## 2. Invarianten
 
-- Linsen sind abgeleitete Navigation, keine Inhaltsautoritaet.
+- Linsen sind abgeleitete Navigation, keine Inhaltsautorität.
 - `canonical_md` bleibt innerhalb eines Dump-Bundles die einzige Inhaltswahrheit.
 - Eine Primary Lens bleibt single-label.
 - Additive Facets, States, Relations und Task Contexts ersetzen keine Primary Lens.
-- Reihenfolgen in Listen duerfen keine semantische Prioritaet ausdruecken.
-- Unbekannte Begriffe werden nicht still zu bekannten Linsen- oder Facet-Namen umgedeutet.
+- Reihenfolgen in Listen duerfen keine semantische Priorität ausdruecken.
+- Unbekannte Begriffe werden nicht still zu bekannten Primary Lenses, Facets, States oder Relationstypen umgedeutet.
 
 ## 3. Primary Lens
 
 Eine Primary Lens beantwortet:
 
-> Was ist dieser Pfad primaer?
+> Was ist dieser Pfad primär?
 
-Jeder auditierbare Repo-Pfad hat genau eine Primary Lens. Sie beschreibt ausschliesslich
-die primaere technische Rolle des Pfads. Die Primary Lens wird aktuell durch
-`infer_lens()` in `merger/lenskit/core/lenses.py` bestimmt.
+Für jeden vom Modell akzeptierten und an `infer_lens()` übergebenen Repo-Pfad
+liefert die aktuelle Klassifikationsfunktion genau eine Primary Lens.
+Diese Totalität der Klassifikationsfunktion beweist nicht, dass ein konkreter
+Audit alle Repo-Pfade erhalten oder verarbeitet hat.
+
+`infer_lens()` ist die aktuelle Implementierung der Primary-Lens-Zuordnung.
+Das Lens-Modell normiert die Semantik der Primary Lens, nicht die dauerhafte
+Unveränderlichkeit einer einzelnen Python-Funktion.
+Änderungen an IDs, Prioritäten oder Zuordnungsregeln benötigen jedoch einen
+eigenen, kompatibilitätsgeprüften Slice.
 
 Die sieben kanonischen IDs bleiben unveraendert:
 - `entrypoints`
@@ -57,13 +69,13 @@ Die sieben kanonischen IDs bleiben unveraendert:
 - `ui`
 - `guards`
 
-Der Primary Lens Audit erklaert die bestehende `infer_lens()`-Zuordnung ueber
-`matched_rule`. Er ersetzt sie nicht, fuegt keine neue Lens hinzu und bleibt ebenfalls
+Der Primary Lens Audit erklärt die bestehende `infer_lens()`-Zuordnung ueber
+`matched_rule`. Er ersetzt sie nicht, fügt keine neue Lens hinzu und bleibt ebenfalls
 single-label.
 
 Primary Lens beantwortet nicht:
-- Warum ist der Pfad fuer diesen PR wichtig?
-- Was bricht bei einer Aenderung?
+- Warum ist der Pfad für diesen PR wichtig?
+- Was bricht bei einer Änderung?
 - Sind Tests ausreichend?
 - Ist der Code sicher?
 - Ist ein Review vollstaendig?
@@ -72,16 +84,17 @@ Primary Lens beantwortet nicht:
 ## 4. Facet
 
 Ein Facet ist eine additive Sichtachse. Ein Ziel kann null, ein oder mehrere Facets
-tragen. Facets veraendern keine Primary Lens und bilden keine zweite konkurrierende
+tragen. Facets verändern keine Primary Lens und bilden keine zweite konkurrierende
 Primary-Lens-Ebene.
 
-Jede spaetere Facet-Zuordnung muss deterministisch ableitbar sein und mindestens
-folgende Ebenen trennen:
-- `target`
-- `name`
-- `source_rule`
-- `confidence_class`
-- `does_not_establish`
+Jede spätere Facet-Zuordnung muss mindestens folgende Konzepte ausdrücken:
+- eine adressierbare Zielidentität,
+- einen kontrollierten Facet-Bezeichner,
+- eine dokumentierte Ableitungsregel,
+- eine Herkunfts- oder Ableitungsart,
+- explizite Negativsemantik.
+Die konkreten JSON-Feldnamen, die Zieladressierung und die genaue Shape werden
+im Facet-Model-v1-Contract festgelegt.
 
 Das bestehende Feld `possible_facets` im Primary Lens Audit ist derzeit nur ein leerer
 Platzhalter. Der aktuelle Producer emittiert dort leere Listen. Dieses Feld beweist
@@ -98,13 +111,13 @@ Repo-naher Blueprint-Kandidatenstand:
 - `security`
 - `test_guard`
 
-Aeltere Minimalstart-Idee:
+Ältere Minimalstart-Idee:
 - `contract`
 - `artifact_surface`
 - `uncertainty`
 
-Diese Listen sind nicht reconciled und werden hier nicht still zusammengefuehrt. Die
-endgueltige Facet-Model-v1-Taxonomie ist noch offen.
+Diese Listen sind nicht reconciled und werden in diesem Dokument weder
+zusammengeführt noch als finale Facet-Model-v1-Taxonomie festgelegt.
 
 `uncertainty` kann Facet- oder State-Semantik ueberlappen. `claim_boundary` kann Facet,
 State oder Negativgrenze sein. Diese Entscheidung gehoert in den folgenden
@@ -113,41 +126,72 @@ Facet-Model-v1-Slice.
 `impact`, `test_relevance` und `runtime_causality` sind keine Primary Lenses und keine
 automatisch zugelassenen v1-Facets.
 
-## 5. Confidence Class
+Ein Facet-Name autorisiert keine weitergehende Aussage.
 
-`confidence_class` beschreibt die Herkunftsart der Zuordnung. Sie ist keine
-Wahrscheinlichkeit, kein Korrektheitswert und kein numerischer Score.
+Beispiele:
 
-`direct` bedeutet: Die Zuordnung ist direkt aus einer kontrollierten Eigenschaft
-ableitbar, zum Beispiel aus explizitem Pfad, Dateisuffix, Contract-Datei, deklarierter
-Artifact Role oder Manifestwert.
+- `security` würde nur eine kontrollierte Zuordnung zu einer
+  sicherheitsbezogenen Oberfläche ausdrücken, nicht das Vorliegen eines
+  Risikos und nicht die Sicherheit des Ziels.
+- `test_guard` würde nur eine navigative Zuordnung zu Test- oder
+  Guard-Flächen ausdrücken, nicht Testabdeckung, Wirksamkeit oder
+  Test-Suffizienz.
+- `claim_boundary` würde nur eine deklarierte Claim-Grenze sichtbar machen,
+  nicht Wahrheit oder Falschheit eines Claims.
 
-`derived` bedeutet: Die Zuordnung wird deterministisch aus vorhandenen strukturierten
-Signalen abgeleitet.
+## 5. Ableitungsart
 
-`heuristic` bedeutet: Die Zuordnung folgt einer dokumentierten deterministischen Regel,
-ohne semantischen Vollstaendigkeits- oder Wahrheitsbeweis.
+Die Ableitungsart beschreibt, wie eine Zuordnung erzeugt wurde.
+Sie ist unabhängig von den bestehenden Achsen `authority` und
+`canonicality`.
+Sie ist keine Wahrscheinlichkeit, kein Korrektheitswert und kein numerischer
+Confidence Score.
 
-## 6. Source Rule und Evidence Ref
+`direct`
 
-`source_rule` beschreibt, durch welche Regel eine Zuordnung entstand.
+Die Zuordnung wird unmittelbar aus einer expliziten und kontrollierten
+Eigenschaft abgelesen, beispielsweise aus einem Pfad, einem Dateisuffix,
+einem Contract-Typ, einem Manifestwert oder einer deklarierten Artifact Role.
 
-`evidence_ref` adressiert eine konkrete Belegstelle oder ein strukturiertes Artefakt.
+`derived`
 
-`confidence_class` beschreibt die Herkunftsart der Zuordnung.
+Die Zuordnung wird deterministisch aus mehreren strukturierten Signalen
+abgeleitet.
 
-Keine dieser Ebenen beweist fuer sich Wahrheit, Vollstaendigkeit, semantische Wichtigkeit,
-Runtime-Wirkung oder Review-Relevanz. Ob `evidence_ref` in Facet Model v1 Pflicht wird,
-bleibt offen.
+`heuristic`
+
+Die Zuordnung folgt einer dokumentierten deterministischen Regel, ohne
+semantischen Wahrheits-, Vollständigkeits- oder Wichtigkeitsbeweis.
+
+Der Wert `derived` auf der Achse der Ableitungsart ist nicht identisch mit
+`canonicality = derived`.
+- Die Ableitungsart beschreibt, wie eine einzelne Zuordnung entstand.
+- Canonicality beschreibt den Quellenstatus eines Artefakts.
+
+## 6. Ableitungsregel und Evidence-Adresse
+
+Eine Ableitungsregel beschreibt, durch welche kontrollierte Regel eine
+Zuordnung entstand.
+Eine Evidence-Adresse verweist auf eine konkrete Belegstelle oder ein
+strukturiertes Artefakt.
+Die Ableitungsart beschreibt dagegen, auf welche Weise aus den verfügbaren
+Signalen eine Zuordnung erzeugt wurde.
+
+Keine dieser Ebenen beweist für sich Wahrheit, Vollständigkeit, semantische
+Wichtigkeit, Runtime-Wirkung oder Review-Relevanz.
+Ob Evidence-Adressen im Facet Model v1 Pflicht werden, bleibt offen.
 
 ## 7. Relation
 
-Eine Relation ist eine Verbindung zwischen zwei adressierbaren Zielen. Sie benoetigt
-Quelle, Ziel, Typ und Herkunft. Sie kann `direct`, `derived` oder `heuristic` sein.
+Eine Relation ist eine Verbindung zwischen zwei adressierbaren Zielen.
+Eine Relation muss konzeptionell eine Quelle, ein Ziel, einen Relationstyp
+und die Herkunft ihrer Zuordnung ausdrücken.
+Die konkreten Feldnamen, Adressformen und Relationstypen bleiben dem späteren
+Contract vorbehalten. Sie kann `direct`, `derived` oder `heuristic` sein.
 
 Kernsatz:
 
-> Relation beschreibt eine sichtbare Verbindung; sie beweist weder Kausalitaet noch Auswirkung einer Aenderung.
+> Relation beschreibt eine sichtbare Verbindung; sie beweist weder Kausalität noch Auswirkung einer Änderung.
 
 Dieser PR legt keine Relationstyp-Taxonomie fest.
 
@@ -158,21 +202,27 @@ Dateirolle, keine Primary Lens und keine automatische Fehlerbewertung.
 
 Beispielkandidaten, nicht finaler Contract:
 - `missing_evidence`
-- `heuristic_assignment`
 - `unresolved_reference`
+- `ambiguous_target`
+
+Ob eine Zuordnung heuristisch entstand, gehört zur Ableitungsart und wird
+nicht zusätzlich als State dupliziert.
+States beschreiben davon unabhängige Evidenz-, Auflösungs- oder
+Adressierungszustände.
 
 Ein `missing_evidence`-State bedeutet nicht automatisch:
 - Aussage falsch
 - Implementierung defekt
-- Aenderung unsicher
+- Änderung unsicher
 - Test fehlgeschlagen
 
-Ob `uncertainty` als eigenes Facet oder durch konkrete States modelliert wird, ist fuer
-Facet Model v1 noch zu entscheiden.
+Ob `uncertainty` als Facet, als Oberbegriff für konkrete States oder gar nicht
+als eigener kontrollierter Bezeichner modelliert wird, bleibt eine
+Entscheidung des Facet-Model-v1-Slices.
 
 ## 9. Task Context
 
-Task Context erklaert, warum ein Ziel fuer eine konkrete Aufgabe navigativ relevant ist.
+Task Context erklärt, warum ein Ziel für eine konkrete Aufgabe navigativ relevant ist.
 
 Beispiele:
 - `pr_review`
@@ -181,29 +231,32 @@ Beispiele:
 - `security_review`
 - `roadmap_status_claim`
 
-Task Context ist keine dauerhafte Eigenschaft der Datei, veraendert keine Primary Lens,
+Task Context ist keine dauerhafte Eigenschaft der Datei, verändert keine Primary Lens,
 ist nicht dasselbe wie ein Required-Reading-Profil und beweist keinen Review-Befund oder
 Change Impact.
+Task Context ist ein expliziter Input einer aufgabenspezifischen
+Navigationssicht und kein versteckter globaler Zustand.
 
 Required Reading beantwortet:
 
-> Welche Artefakte muessen gelesen werden?
+> Welche Artefakte müssen gelesen werden?
 
 Task Context beantwortet:
 
-> Warum kann dieses Ziel fuer die konkrete Aufgabe relevant sein?
+> Warum kann dieses Ziel für die konkrete Aufgabe relevant sein?
 
 ## 10. Lens Card
 
-Eine Lens Card ist eine kleine abgeleitete Navigationseinheit. Sie kann spaeter Primary
-Lens, Facets, States, Relations und Evidence-Adressen zusammenfuehren. Sie bleibt
+Eine Lens Card ist eine kleine abgeleitete Navigationseinheit. Sie kann später Primary
+Lens, Facets, States, Relations und Evidence-Adressen zusammenführen. Sie bleibt
 regenerierbar und ersetzt keine kanonischen Inhalte.
 
-Authority:
-- `navigation_index`
+Authority: `navigation_index`
+Canonicality: `derived`
 
-Canonicality:
-- `derived`
+Die Authority- und Canonicality-Achsen werden durch das Lens-Modell nicht neu
+definiert. Maßgeblich bleiben die bestehenden Authority-Risk- und
+Two-Layer-Regeln.
 
 Verbotene unqualifizierte Card-Felder oder Claims:
 - `verdict`
@@ -218,10 +271,10 @@ Verbotene unqualifizierte Card-Felder oder Claims:
 
 ## 11. Relation Card und Guard Relation
 
-Eine Relation Card ist eine spaetere Spezialisierung: die kompakte Darstellung einer
-Relation mit Herkunft und Evidence-Grenze. Sie ist kein Kausalitaets- oder Impact-Beweis.
+Eine Relation Card ist eine spätere Spezialisierung: die kompakte Darstellung einer
+Relation mit Herkunft und Evidence-Grenze. Sie ist kein Kausalitäts-- oder Impact-Beweis.
 
-Eine Guard Relation ist eine spaetere Spezialisierung: eine Relation zwischen Ziel und
+Eine Guard Relation ist eine spätere Spezialisierung: eine Relation zwischen Ziel und
 Test-, Validator-, Guard- oder CI-Flaeche. Sie dient Navigation.
 
 Eine Guard Relation beweist nicht:
@@ -235,22 +288,22 @@ Diese Spezialisierungen werden hier nicht implementiert.
 
 ## 12. Abgrenzung zum Agent Consumption Trace
 
-Agent Consumption Trace ist ausserhalb der Lens-Primitiven einzuordnen. Er ist eine
-Consumer-/Compliance-Flaeche und kann spaeter Lens Cards konsumieren.
+Agent Consumption Trace ist außerhalb der Lens-Primitiven einzuordnen. Er ist eine
+Consumer-/Compliance-Flaeche und kann später Lens Cards konsumieren.
 
 Agent Consumption Trace ist kein Facet, keine Relation, kein State und keine Primary Lens.
-Er beweist kein tatsaechliches Lesen und kein Repo-Verstaendnis.
+Er beweist kein tatsächliches Lesen und kein Repo-Verstaendnis.
 
 ## 13. Schichtenmodell
 
-| Schicht | Kardinalitaet | Zweck | Beweist nicht |
+| Schicht | Kardinalität | Beschreibt höchstens | Geltungsgrenze |
 | --- | --- | --- | --- |
-| Primary Lens | genau 1 pro Pfad | primaere technische Rolle | Wichtigkeit, Impact |
-| Facet | 0..n | additive Sichtachsen | Wahrheit, Prioritaet |
-| Relation | 0..n | sichtbare Verbindung | Kausalitaet, Bruch |
-| State | 0..n | epistemischer/Aufloesungszustand | Fehler oder Unsicherheit der Implementierung |
-| Task Context | 0..n pro Aufgabe | aufgabenspezifische Navigation | Review-Befund |
-| Lens Card | abgeleitet | kompakte Navigationsprojektion | Inhaltsautoritaet |
+| Primary Lens | genau 1 je akzeptiertem Pfad | primäre technische Rolle | keine Wichtigkeit, keine Audit-Vollständigkeit, kein Impact |
+| Facet | 0..n | additive Sichtachse | keine Wahrheit, Priorität oder Risikobewertung |
+| Relation | 0..n | sichtbare Verbindung | keine Kausalität oder Bruchbehauptung |
+| State | 0..n | Evidenz-, Auflösungs- oder Adressierungszustand | kein automatisches Fehlerurteil |
+| Task Context | 0..n je Aufgabe | aufgabenspezifische Navigationsrelevanz | kein Review-Befund |
+| Lens Card | abgeleitet | kompakte Navigationsprojektion | keine Inhaltsautorität |
 
 ## 14. Authority und Canonicality
 
@@ -278,39 +331,52 @@ projizieren oder navigativ ordnen.
 
 ## 15. Negativsemantik
 
-Als gemeinsame Mindestgrenze zukuenftiger Lens-/Facet-/Relation-/Card-Artefakte gilt:
+Als gemeinsame Mindestgrenze zukünftiger Lens-/Facet-/Relation-/Card-Artefakte gilt:
 
-```json
-{
-  "does_not_establish": [
-    "truth",
-    "correctness",
-    "completeness",
-    "runtime_behavior",
-    "test_sufficiency",
-    "regression_absence",
-    "semantic_importance",
-    "review_priority",
-    "change_impact"
-  ]
-}
-```
+Die folgende Liste definiert eine gemeinsame semantische Baseline für spätere
+Lens-, Facet-, Relation- und Card-Artefakte.
+Konkrete Contracts müssen äquivalente oder stärkere Negativsemantik
+ausdrücken und dürfen artefaktspezifische Grenzen ergänzen.
+Das Lens-Modell normiert damit die Bedeutung der Grenzen, aber nicht
+zwingend einen identischen JSON-Feldnamen oder eine identische Shape für
+jeden Contract.
 
-Bestehende Contracts verwenden teils andere Feldnamen wie `does_not_mean`,
-`does_not_prove` oder `claim_boundaries`. Dieser PR migriert keine bestehenden
-Contracts. Semantische Grenzen sollen konsistent sein. Feldnamenvereinheitlichung ist
-ein separater Task.
+- `truth`
+- `correctness`
+- `completeness`
+- `runtime_behavior`
+- `test_sufficiency`
+- `regression_absence`
+- `semantic_importance`
+- `review_priority`
+- `change_impact`
+
+Artefaktspezifische Ergänzungen dürfen genannt werden, beispielsweise `causality`, `coverage_completeness` oder `guard_effectiveness`.
+
+Bestehende Contracts verwenden dafür je nach Artefakt unter anderem
+`does_not_establish`, `does_not_mean`, `does_not_prove` oder
+`claim_boundaries`.
+Dieser PR deprecatet, migriert oder vereinheitlicht diese bestehenden
+Contract-Shapes nicht.
 
 ## 16. Determinismus-Invarianten
 
-1. Gleicher Repo-Zustand und gleiche Regeln erzeugen dieselbe Zuordnung.
+1. Gleiche normalisierte Eingaben, gleicher Repo- oder Bundle-Inhalt, gleiche
+   Regel- und Toolversion, gleiche Konfiguration und – wo relevant – gleicher
+   Task Context erzeugen dieselbe fachliche Zuordnung und dieselbe stabil
+   sortierte Ausgabe.
 2. Ausgaben werden stabil sortiert.
 3. Deduplizierung ist deterministisch.
-4. Reihenfolge erzeugt keine semantische Prioritaet.
-5. Keine Netzwerkabfrage ist fuer die Klassifikation erforderlich.
+4. Reihenfolge erzeugt keine semantische Priorität.
+5. Keine Netzwerkabfrage ist für die Klassifikation erforderlich.
 6. Keine LLM-Auswertung ist erforderlich.
 7. Keine Embeddings sind erforderlich.
-8. Keine Systemzeit veraendert die Zuordnung.
+8. Zeitstempel dürfen Metadaten verändern, nicht jedoch die fachliche
+   Zuordnung. Task Context ist ein expliziter Input und kein versteckter
+   globaler Zustand. Repo-Pfade werden vor einer pfadbasierten Zuordnung
+   nach einer contractuell festgelegten, plattformunabhängigen Semantik
+   normalisiert. Die konkrete Normalisierungsregel bleibt dem jeweiligen
+   Contract vorbehalten.
 9. Heuristische Regeln werden explizit benannt.
 10. Unbekannte Begriffe werden nicht still umgedeutet.
 11. Neue Facets aendern keine Primary Lens.
@@ -323,17 +389,20 @@ Implementiert:
 - `infer_lens()`
 - Primary Lens Audit Contract
 - Primary Lens Audit Core Producer
-- fokussierte Primary-Lens-Audit-Tests
+- fokussierte Tests für das Primary Lens Audit.
 
 Nicht implementiert:
 - Facet Model
 - Lens Cards
 - Relation Cards
 - Guard Relation Cards
-- automatische Primary-Lens-Audit-Bundle-Emission
-- verpflichtendes CLI-Wiring fuer den Audit
+- automatische Bundle-Emission
+- CLI-Anschluss
 
-Es wird nicht behauptet, dass jeder Dump bereits ein Primary-Lens-Audit-Sidecar enthaelt.
+Der implementierte Core-Slice ist unabhängig von CLI- oder Bundle-Emission
+nutzbar.
+Diese Anschlüsse werden durch den aktuellen Status weder verlangt noch als
+notwendige technische Schuld behauptet.
 
 ## 18. Sequenzierung
 
@@ -347,33 +416,42 @@ Primary Lens Audit v1 -- Contract/Core/Tests umgesetzt
 -> Relation Cards
 -> Guard Relation Cards
 
-Das Lens-Modell ist Voraussetzung fuer das Facet Model, aber kein Implementierungsbeweis.
+Das Lens-Modell ist Voraussetzung für das Facet Model, aber kein Implementierungsbeweis.
 
 ## 19. Open Decisions for Facet Model v1
 
 Diese Punkte werden in diesem PR nicht entschieden, sofern kein bestehendes Repo-Dokument
 sie bereits eindeutig normiert:
 
-1. endgueltige Facet-v1-Taxonomie
-2. `uncertainty` als Facet oder State-Modell
-3. Rolle von `claim_boundary`
-4. genaue JSON-Struktur
-5. Bericht versus einzelne Zuordnungen
-6. Identitaet und Deduplizierung
-7. Sortierregeln
-8. erlaubte `source_rule`-Taxonomie
-9. Evidence-Refs Pflicht oder optional
-10. Target-ID-Modell
-11. Verhalten bei unbekannten Facet-Namen
-12. Bundle-/Manifest-Sichtbarkeit
-13. CLI
-14. automatische Emission
-15. Feldnamen fuer Negativsemantik
+**Taxonomie und Semantik**
+- endgültige Facet-v1-Taxonomie
+- `uncertainty` als Facet, State-Oberbegriff oder kein eigener Bezeichner
+- Rolle von `claim_boundary`
+- kontrollierte State-Bezeichner
+- kontrollierte Relationstypen
+
+**Contract und Datenmodell**
+- JSON-Struktur des Facet Model v1
+- konkrete Feldnamen
+- Target-ID-Modell
+- Bericht versus einzelne Zuordnungen
+- Identität und Deduplizierung
+- Sortierregeln
+- Taxonomie der Ableitungsregeln
+- Evidence-Adressen Pflicht oder optional
+- Verhalten bei unbekannten Facet-Namen
+- konkrete Shape der Negativsemantik
+
+**Operationalisierung**
+- CLI
+- automatische Emission
+- Bundle-/Manifest-Sichtbarkeit
+- mögliche Artifact Role
 
 ## 20. Non-goals
 
 - keine neuen Primary Lenses
-- keine Aenderung an `infer_lens()`
+- keine Änderung an `infer_lens()`
 - keine gemeinsame Rule Engine
 - kein Facet-Contract
 - kein Facet-Code

--- a/docs/architecture/lens-model.md
+++ b/docs/architecture/lens-model.md
@@ -1,0 +1,268 @@
+---
+doc_type: architecture
+status: active
+---
+
+# Deterministic Lens Model
+
+## 1. Dokumentrolle
+
+Dieses Dokument normiert Begriffe und Schichtengrenzen der deterministischen Linsenarchitektur.
+Es ist keine Runtime-Evidence.
+Es ist kein Contract.
+Es ist kein Beweis, dass alle Zuordnungsregeln vollständig oder optimal sind.
+
+## 2. Verbindlicher Kernsatz
+
+Eine Lenskit-Linse ist eine deterministische, abgeleitete Sicht auf Repo-Artefakte.
+Sie besitzt eine Herkunftsregel und eine explizite Geltungsgrenze.
+Sie dient der Navigation und erzeugt kein eigenes Wahrheits-, Review-, Sicherheits- oder Impact-Urteil.
+
+## 3. Primary Lens
+
+Jeder auditierbare Repo-Pfad erhält genau eine Primary Lens.
+Die Primary Lens beschreibt ausschließlich die primäre technische Rolle des Pfads.
+
+Die kanonischen IDs bleiben:
+- `entrypoints`
+- `core`
+- `interfaces`
+- `data_models`
+- `pipelines`
+- `ui`
+- `guards`
+
+Die Primary Lens wird aktuell über die bestehende deterministische Heuristik `infer_lens()` bestimmt.
+Der Primary Lens Audit erklärt diese Zuordnung über `matched_rule`.
+Audit und Erklärung dürfen die bestehende Zuordnung nicht überschreiben.
+
+Primary Lens beantwortet:
+> Was ist dieser Pfad primär?
+
+Primary Lens beantwortet ausdrücklich nicht:
+- Warum ist der Pfad für einen bestimmten PR relevant?
+- Ist der Pfad semantisch wichtig?
+- Welche Änderung wirkt auf welche Runtime?
+- Sind Tests ausreichend?
+- Ist ein Review vollständig?
+- Ist eine Änderung sicher?
+
+## 4. Facet
+
+Ein Facet ist eine additive Sichtachse.
+Ein Pfad darf null, ein oder mehrere Facets besitzen.
+Facets verändern die Primary Lens nicht.
+Facets dürfen keine zweite konkurrierende Primary-Lens-Ebene bilden.
+
+Jede Facet-Zuordnung braucht später mindestens:
+- `target_path`
+- `name`
+- `source_rule`
+- `confidence_class`
+- `does_not_establish`
+
+Facets müssen deterministisch aus repo-belegten Regeln ableitbar sein.
+Facets sind Navigation, keine Inhaltswahrheit.
+
+**Kandidaten für Facet Model v1** (noch nicht als implementierter oder endgültiger Contract normiert):
+- `contract`
+- `artifact_surface`
+- `diagnostic`
+- `retrieval`
+- `claim_boundary`
+- `security`
+- `test_guard`
+
+Begriffe wie `impact`, `test_relevance` und `runtime_causality` bleiben ausdrücklich keine Primary Lenses und keine unbelegten v1-Facets.
+
+## 5. Confidence Class
+
+Confidence Class beschreibt die Herkunftsqualität der Zuordnung.
+Sie ist keine Wahrscheinlichkeit und kein Korrektheitswert. Numerische Confidence Scores sind nicht vorgesehen.
+
+### `direct`
+Die Zuordnung folgt unmittelbar aus einer kontrollierten Eigenschaft, beispielsweise:
+- expliziter Pfad
+- Dateisuffix
+- bekannte Contract-Datei
+- deklarierte Artifact Role
+- direkt vorliegender Schema- oder Manifestwert
+
+### `derived`
+Die Zuordnung wird deterministisch aus vorhandenen strukturierten Artefakten oder mehreren direkten Signalen abgeleitet.
+
+### `heuristic`
+Die Zuordnung folgt einer dokumentierten, deterministischen Heuristik, ist aber kein Beweis für semantische Bedeutung oder Vollständigkeit.
+
+## 6. Relation
+
+Eine Relation verbindet zwei adressierbare Repo- oder Bundle-Artefakte.
+Eine Relation braucht Quelle, Ziel, Relationstyp und Herkunft.
+Direkte, abgeleitete und heuristische Relations müssen unterscheidbar bleiben.
+Eine Relation beweist keine Kausalität und keinen Change Impact.
+Pfadnähe, Importnähe oder gemeinsame Benennung allein dürfen nicht als Runtime-Wirkung ausgegeben werden.
+
+Relation beantwortet:
+> Welche deterministisch belegte oder ausdrücklich heuristische Verbindung ist sichtbar?
+
+Relation beantwortet nicht:
+> Was bricht, wenn sich die Quelle ändert?
+
+## 7. State
+
+Ein State beschreibt einen epistemischen oder Auflösungszustand einer Zuordnung, Relation oder Evidence-Adresse.
+
+Beispielkandidaten:
+- `missing_evidence`
+- `heuristic_assignment`
+- `unresolved_reference`
+
+States sind keine Dateirollen und keine Primary Lenses.
+
+Ein State wie `missing_evidence` bedeutet nicht automatisch:
+- Aussage falsch
+- Implementierung defekt
+- Test fehlgeschlagen
+- Änderung unsicher
+
+Die konkrete State-Taxonomie bleibt einem späteren Contract vorbehalten.
+
+## 8. Task Context
+
+Task Context erklärt, warum ein Artefakt für eine bestimmte Aufgabe navigativ relevant ist.
+
+Beispiele:
+- `pr_review`
+- `contract_change_review`
+- `artifact_surface_review`
+- `security_review`
+- `roadmap_status_claim`
+
+Abgrenzung:
+- Task Context ändert nicht die Primary Lens.
+- Task Context ist nicht dauerhaft mit dem Pfad identisch.
+- Task Context ist eine Consumer-/Aufgabensicht.
+- Relevanz für eine Aufgabe beweist keinen Change Impact oder Review-Befund.
+
+Bestehende Required-Reading-Profile werden nicht als Lens-Taxonomie umdefiniert.
+
+## 9. Lens Card
+
+Eine Lens Card ist eine kleine, abgeleitete Navigationseinheit.
+Sie kann später Primary Lens, Facets, Navigation-Refs, States und begrenzte Relations zusammenführen.
+
+Sie bleibt:
+- `authority = navigation_index`
+- `canonicality = derived`
+
+Sie ersetzt weder `canonical_md` noch die zugrunde liegenden Contracts oder Evidence-Ranges.
+Sie enthält keine automatischen Findings oder Fix-Vorschläge.
+
+Verbotene unqualifizierte Card-Semantik:
+`verdict`, `approved`, `safe`, `complete`, `covered`, `critical`, `impact`, `breaks`, `requires_fix`
+
+## 10. Relation Card und Guard Relation
+
+Diese sind spätere Spezialisierungen und werden in v1 nicht implementiert.
+
+### Relation Card
+Kleine Navigationseinheit für eine Relation mit Herkunft und Evidence-Grenze.
+
+### Guard Relation
+Spezialisierte Relation zwischen einem Ziel und einem Guard-, Test-, Validator- oder CI-Pfad.
+Guard Relation bedeutet nicht:
+- Testabdeckung vollständig
+- Guard wirksam
+- CI ausreichend
+- Regression ausgeschlossen
+
+## 11. Agent Consumption Trace korrekt einordnen
+
+Der Agent Consumption Trace ist keine Lens-Primitive.
+Korrekte Einordnung:
+- angrenzende Consumption-/Compliance-Fläche
+- erklärt deklarierte Nutzung von Artefakten
+- kann Lens Cards später konsumieren
+- ist selbst weder Primary Lens, Facet, Relation noch State
+- beweist kein tatsächliches Lesen oder Repo-Verständnis
+
+## 12. Schichtenmodell
+
+| Schicht      | Kardinalität pro Pfad | Zweck                           | Darf nicht behaupten |
+| ------------ | --------------------: | ------------------------------- | -------------------- |
+| Primary Lens |               genau 1 | primäre technische Rolle        | Wichtigkeit, Impact  |
+| Facet        |                  0..n | additive Sichtachsen            | Wahrheit, Priorität  |
+| Relation     |                  0..n | sichtbare Verbindung            | Kausalität, Bruch    |
+| State        |                  0..n | epistemischer/Auflösungszustand | Fehlerurteil         |
+| Task Context |       0..n je Aufgabe | aufgabenspezifische Navigation  | Review-Befund        |
+| Lens Card    |            abgeleitet | kompakte Navigation             | Inhaltsautorität     |
+
+## 13. Negativsemantik
+
+Als gemeinsame Mindestgrenze für zukünftige Lens-/Facet-/Relation-/Card-Artefakte gilt:
+
+```json
+{
+  "does_not_establish": [
+    "truth",
+    "correctness",
+    "completeness",
+    "runtime_behavior",
+    "test_sufficiency",
+    "regression_absence",
+    "semantic_importance",
+    "review_priority",
+    "change_impact"
+  ]
+}
+```
+
+Hinweis: Bestehende Contracts dürfen andere Feldnamen wie `does_not_mean`, `does_not_prove` oder `claim_boundaries` verwenden. Dieser PR migriert oder vereinheitlicht bestehende Contracts nicht. Die semantische Grenze soll konsistent sein; die Feldnamenmigration ist kein Ziel.
+
+## 14. Determinismus-Invarianten
+
+1. Gleicher Repo-Zustand und gleiche Regeln erzeugen dieselben Zuordnungen.
+2. Ausgaben werden stabil sortiert.
+3. Mehrfachzuordnungen werden deterministisch dedupliziert.
+4. Keine Netzwerkanfrage ist für die Klassifikation erforderlich.
+5. Keine LLM- oder Embedding-Auswertung ist erforderlich.
+6. Keine Systemzeit darf die Zuordnung verändern.
+7. Heuristische Regeln werden explizit benannt.
+8. Unbekannte Begriffe werden nicht still zu bekannten Facets umgedeutet.
+9. Neue Facets ändern keine bestehende Primary Lens.
+10. Abgeleitete Karten bleiben regenerierbar.
+
+## 15. Authority- und Truth-Grenze
+
+`canonical_md` bleibt die einzige Inhaltswahrheit eines Dump-Bundles.
+Primary Lens Audit, Facets, Relations, States und Lens Cards sind abgeleitete Navigation.
+Health- und Surface-Pässe beweisen weder Repo-Verständnis noch Claim-Wahrheit.
+
+## 16. Sequenzierung
+
+Der verbindliche Folgepfad:
+1. Primary Lens Audit v1 — Core/Contract/Tests umgesetzt
+2. Lens Model — dieser PR
+3. Facet Model v1 — nächster Implementierungsslice
+4. Lens Cards v1
+5. PR Delta Cards
+6. Relation Cards
+7. Guard Relation Cards
+
+Klarstellung:
+- Der Primary Lens Audit wird derzeit nicht automatisch als neues Bundle-Artefakt emittiert, sofern dies im aktuellen Code nicht implementiert ist. Dieser PR fügt keine solche Emission hinzu.
+- Facet Model v1 ist der nächste Code-Slice.
+
+## 17. Open decisions for Facet Model v1
+
+Folgende Entscheidungen bleiben bewusst vertagt und sind Teil des Facet Model v1 PRs:
+1. exakte minimale v1-Facet-Liste
+2. exakte JSON-Output-Form
+3. ob ein Gesamtbericht oder einzelne Zuordnungen erzeugt werden
+4. Sortier- und Deduplizierungsregeln im Contract
+5. erlaubte `source_rule`-Taxonomie
+6. ob Evidence-Refs in v1 Pflicht oder optional sind
+7. Bundle-/Manifest-Sichtbarkeit
+8. CLI und automatische Emission
+9. Verhalten bei unbekannten Facet-Namen
+10. Verhältnis zwischen `claim_boundary` und allgemeiner Unsicherheitssemantik

--- a/docs/architecture/lens-model.md
+++ b/docs/architecture/lens-model.md
@@ -12,7 +12,7 @@ Gegenstand, nicht einen neuen Gegenstand und keine neue Wahrheit.
 
 Normativer Kernsatz:
 
-> Eine Lenskit-Linse ist eine deterministische, abgeleitete Sicht auf Repo- oder Bundle-Artefakte. Sie besitzt eine dokumentierte Herkunftsregel und eine explizite Geltungsgrenze. Sie dient der Navigation und erzeugt kein eigenes Wahrheits-, Review-, Sicherheits- oder Impact-Urteil.
+> Eine Lenskit-Linse ist eine deterministische, abgeleitete Sicht auf Repo- oder Bundle-Artefakte. Sie besitzt eine dokumentierte Ableitungsregel und eine explizite Geltungsgrenze. Sie dient der Navigation und erzeugt kein eigenes Wahrheits-, Review-, Sicherheits- oder Impact-Urteil.
 
 Dieses Dokument ist nicht Runtime-Evidence, kein JSON-Schema, kein Implementierungsbeweis,
 kein Bundle-Artefakt, kein Review-Bericht und kein Statusbeweis.
@@ -100,9 +100,7 @@ Das bestehende Feld `possible_facets` im Primary Lens Audit ist derzeit nur ein 
 Platzhalter. Der aktuelle Producer emittiert dort leere Listen. Dieses Feld beweist
 nicht, dass Facet-Zuordnung oder ein Facet Model bereits implementiert ist.
 
-Es existieren konkurrierende Kandidatenlisten:
-
-Repo-naher Blueprint-Kandidatenstand:
+Der aktuelle Blueprint nennt als erste, nicht finale Kandidaten:
 - `contract`
 - `artifact_surface`
 - `diagnostic`
@@ -111,15 +109,11 @@ Repo-naher Blueprint-Kandidatenstand:
 - `security`
 - `test_guard`
 
-Ältere Minimalstart-Idee:
-- `contract`
-- `artifact_surface`
-- `uncertainty`
+Die endgültige Facet-Model-v1-Taxonomie bleibt offen.
 
-Diese Listen sind nicht reconciled und werden in diesem Dokument weder
-zusammengeführt noch als finale Facet-Model-v1-Taxonomie festgelegt.
-
-`uncertainty` kann Facet- oder State-Semantik überlappen. `claim_boundary` kann Facet,
+Insbesondere ist noch zu entscheiden, ob `uncertainty` als Facet, als
+Oberbegriff für konkrete States oder gar nicht als eigener kontrollierter
+Bezeichner modelliert wird. `claim_boundary` kann Facet,
 State oder Negativgrenze sein. Diese Entscheidung gehört in den folgenden
 Facet-Model-v1-Slice.
 

--- a/docs/architecture/lens-model.md
+++ b/docs/architecture/lens-model.md
@@ -40,7 +40,7 @@ Beziehungen:
 - `canonical_md` bleibt innerhalb eines Dump-Bundles die einzige Inhaltswahrheit.
 - Eine Primary Lens bleibt single-label.
 - Additive Facets, States, Relations und Task Contexts ersetzen keine Primary Lens.
-- Reihenfolgen in Listen duerfen keine semantische Priorität ausdruecken.
+- Reihenfolgen in Listen dürfen keine semantische Priorität ausdrücken.
 - Unbekannte Begriffe werden nicht still zu bekannten Primary Lenses, Facets, States oder Relationstypen umgedeutet.
 
 ## 3. Primary Lens
@@ -60,7 +60,7 @@ Unveränderlichkeit einer einzelnen Python-Funktion.
 Änderungen an IDs, Prioritäten oder Zuordnungsregeln benötigen jedoch einen
 eigenen, kompatibilitätsgeprüften Slice.
 
-Die sieben kanonischen IDs bleiben unveraendert:
+Die sieben kanonischen IDs bleiben unverändert:
 - `entrypoints`
 - `core`
 - `interfaces`
@@ -69,7 +69,7 @@ Die sieben kanonischen IDs bleiben unveraendert:
 - `ui`
 - `guards`
 
-Der Primary Lens Audit erklärt die bestehende `infer_lens()`-Zuordnung ueber
+Der Primary Lens Audit erklärt die bestehende `infer_lens()`-Zuordnung über
 `matched_rule`. Er ersetzt sie nicht, fügt keine neue Lens hinzu und bleibt ebenfalls
 single-label.
 
@@ -78,7 +78,7 @@ Primary Lens beantwortet nicht:
 - Was bricht bei einer Änderung?
 - Sind Tests ausreichend?
 - Ist der Code sicher?
-- Ist ein Review vollstaendig?
+- Ist ein Review vollständig?
 - Welche semantische Wichtigkeit hat der Pfad?
 
 ## 4. Facet
@@ -91,7 +91,7 @@ Jede spätere Facet-Zuordnung muss mindestens folgende Konzepte ausdrücken:
 - eine adressierbare Zielidentität,
 - einen kontrollierten Facet-Bezeichner,
 - eine dokumentierte Ableitungsregel,
-- eine Herkunfts- oder Ableitungsart,
+- eine Ableitungsart,
 - explizite Negativsemantik.
 Die konkreten JSON-Feldnamen, die Zieladressierung und die genaue Shape werden
 im Facet-Model-v1-Contract festgelegt.
@@ -119,8 +119,8 @@ Repo-naher Blueprint-Kandidatenstand:
 Diese Listen sind nicht reconciled und werden in diesem Dokument weder
 zusammengeführt noch als finale Facet-Model-v1-Taxonomie festgelegt.
 
-`uncertainty` kann Facet- oder State-Semantik ueberlappen. `claim_boundary` kann Facet,
-State oder Negativgrenze sein. Diese Entscheidung gehoert in den folgenden
+`uncertainty` kann Facet- oder State-Semantik überlappen. `claim_boundary` kann Facet,
+State oder Negativgrenze sein. Diese Entscheidung gehört in den folgenden
 Facet-Model-v1-Slice.
 
 `impact`, `test_relevance` und `runtime_causality` sind keine Primary Lenses und keine
@@ -147,21 +147,15 @@ Sie ist unabhängig von den bestehenden Achsen `authority` und
 Sie ist keine Wahrscheinlichkeit, kein Korrektheitswert und kein numerischer
 Confidence Score.
 
-`direct`
-
-Die Zuordnung wird unmittelbar aus einer expliziten und kontrollierten
-Eigenschaft abgelesen, beispielsweise aus einem Pfad, einem Dateisuffix,
-einem Contract-Typ, einem Manifestwert oder einer deklarierten Artifact Role.
-
-`derived`
-
-Die Zuordnung wird deterministisch aus mehreren strukturierten Signalen
-abgeleitet.
-
-`heuristic`
-
-Die Zuordnung folgt einer dokumentierten deterministischen Regel, ohne
-semantischen Wahrheits-, Vollständigkeits- oder Wichtigkeitsbeweis.
+- `direct`: Die Zuordnung wird unmittelbar aus einer expliziten und
+  kontrollierten Eigenschaft abgelesen, beispielsweise aus einem Pfad,
+  einem Dateisuffix, einem Contract-Typ, einem Manifestwert oder einer
+  deklarierten Artifact Role.
+- `derived`: Die Zuordnung wird deterministisch aus mehreren strukturierten
+  Signalen abgeleitet.
+- `heuristic`: Die Zuordnung folgt einer dokumentierten deterministischen
+  Regel ohne semantischen Wahrheits-, Vollständigkeits- oder
+  Wichtigkeitsbeweis.
 
 Der Wert `derived` auf der Achse der Ableitungsart ist nicht identisch mit
 `canonicality = derived`.
@@ -185,9 +179,9 @@ Ob Evidence-Adressen im Facet Model v1 Pflicht werden, bleibt offen.
 
 Eine Relation ist eine Verbindung zwischen zwei adressierbaren Zielen.
 Eine Relation muss konzeptionell eine Quelle, ein Ziel, einen Relationstyp
-und die Herkunft ihrer Zuordnung ausdrücken.
+und die Ableitungsart der Relation ausdrücken.
 Die konkreten Feldnamen, Adressformen und Relationstypen bleiben dem späteren
-Contract vorbehalten. Sie kann `direct`, `derived` oder `heuristic` sein.
+Contract vorbehalten. Die Ableitungsart kann `direct`, `derived` oder `heuristic` sein.
 
 Kernsatz:
 
@@ -197,7 +191,7 @@ Dieser PR legt keine Relationstyp-Taxonomie fest.
 
 ## 8. State
 
-Ein State beschreibt einen epistemischen oder Aufloesungszustand. Er ist keine technische
+Ein State beschreibt einen epistemischen oder Auflösungszustand. Er ist keine technische
 Dateirolle, keine Primary Lens und keine automatische Fehlerbewertung.
 
 Beispielkandidaten, nicht finaler Contract:
@@ -272,10 +266,10 @@ Verbotene unqualifizierte Card-Felder oder Claims:
 ## 11. Relation Card und Guard Relation
 
 Eine Relation Card ist eine spätere Spezialisierung: die kompakte Darstellung einer
-Relation mit Herkunft und Evidence-Grenze. Sie ist kein Kausalitäts-- oder Impact-Beweis.
+Relation mit Herkunft und Evidence-Grenze. Sie ist kein Kausalitäts- oder Impact-Beweis.
 
 Eine Guard Relation ist eine spätere Spezialisierung: eine Relation zwischen Ziel und
-Test-, Validator-, Guard- oder CI-Flaeche. Sie dient Navigation.
+Test-, Validator-, Guard- oder CI-Fläche. Sie dient Navigation.
 
 Eine Guard Relation beweist nicht:
 - `test_sufficiency`
@@ -289,10 +283,10 @@ Diese Spezialisierungen werden hier nicht implementiert.
 ## 12. Abgrenzung zum Agent Consumption Trace
 
 Agent Consumption Trace ist außerhalb der Lens-Primitiven einzuordnen. Er ist eine
-Consumer-/Compliance-Flaeche und kann später Lens Cards konsumieren.
+Consumer-/Compliance-Fläche und kann später Lens Cards konsumieren.
 
 Agent Consumption Trace ist kein Facet, keine Relation, kein State und keine Primary Lens.
-Er beweist kein tatsächliches Lesen und kein Repo-Verstaendnis.
+Er beweist kein tatsächliches Lesen und kein Repo-Verständnis.
 
 ## 13. Schichtenmodell
 
@@ -303,13 +297,13 @@ Er beweist kein tatsächliches Lesen und kein Repo-Verstaendnis.
 | Relation | 0..n | sichtbare Verbindung | keine Kausalität oder Bruchbehauptung |
 | State | 0..n | Evidenz-, Auflösungs- oder Adressierungszustand | kein automatisches Fehlerurteil |
 | Task Context | 0..n je Aufgabe | aufgabenspezifische Navigationsrelevanz | kein Review-Befund |
-| Lens Card | abgeleitet | kompakte Navigationsprojektion | keine Inhaltsautorität |
+| Lens Card | noch nicht festgelegt | kompakte Navigationsprojektion | keine Inhaltsautorität |
 
 ## 14. Authority und Canonicality
 
 `canonical_md` bleibt innerhalb eines Dump-Bundles die einzige Inhaltswahrheit.
 
-Folgende Flaechen bleiben abgeleitete Navigation oder Diagnose:
+Folgende Flächen bleiben abgeleitete Navigation oder Diagnose:
 - Primary Lens Audit
 - Facets
 - Relations
@@ -330,8 +324,6 @@ Das Lens-Modell erzeugt keine neue Evidence. Es kann Evidence nur adressieren,
 projizieren oder navigativ ordnen.
 
 ## 15. Negativsemantik
-
-Als gemeinsame Mindestgrenze zukünftiger Lens-/Facet-/Relation-/Card-Artefakte gilt:
 
 Die folgende Liste definiert eine gemeinsame semantische Baseline für spätere
 Lens-, Facet-, Relation- und Card-Artefakte.
@@ -361,26 +353,29 @@ Contract-Shapes nicht.
 
 ## 16. Determinismus-Invarianten
 
-1. Gleiche normalisierte Eingaben, gleicher Repo- oder Bundle-Inhalt, gleiche
-   Regel- und Toolversion, gleiche Konfiguration und – wo relevant – gleicher
-   Task Context erzeugen dieselbe fachliche Zuordnung und dieselbe stabil
-   sortierte Ausgabe.
-2. Ausgaben werden stabil sortiert.
+1. Gleiche normalisierte Eingaben, gleicher Repo- oder Bundle-Inhalt,
+   gleiche Regelversion, gleiche Toolversion, gleiche Konfiguration und –
+   wo relevant – gleicher Task Context erzeugen dieselbe fachliche
+   Zuordnung.
+2. Fachliche Ausgaben werden stabil sortiert. Die Reihenfolge erzeugt
+   keine semantische Priorität.
 3. Deduplizierung ist deterministisch.
-4. Reihenfolge erzeugt keine semantische Priorität.
-5. Keine Netzwerkabfrage ist für die Klassifikation erforderlich.
-6. Keine LLM-Auswertung ist erforderlich.
-7. Keine Embeddings sind erforderlich.
-8. Zeitstempel dürfen Metadaten verändern, nicht jedoch die fachliche
-   Zuordnung. Task Context ist ein expliziter Input und kein versteckter
-   globaler Zustand. Repo-Pfade werden vor einer pfadbasierten Zuordnung
-   nach einer contractuell festgelegten, plattformunabhängigen Semantik
-   normalisiert. Die konkrete Normalisierungsregel bleibt dem jeweiligen
-   Contract vorbehalten.
-9. Heuristische Regeln werden explizit benannt.
-10. Unbekannte Begriffe werden nicht still umgedeutet.
-11. Neue Facets aendern keine Primary Lens.
-12. Abgeleitete Karten bleiben regenerierbar.
+4. Task Context ist ein expliziter Input und kein versteckter globaler
+   Zustand.
+5. Zeitstempel dürfen Metadaten verändern, nicht jedoch fachliche
+   Zuordnungen.
+6. Repo-Pfade werden vor einer pfadbasierten Zuordnung nach einer
+   contractuell festgelegten, plattformunabhängigen Semantik normalisiert.
+   Die konkrete Normalisierungsregel bleibt dem jeweiligen Contract
+   vorbehalten.
+7. Netzwerkabfragen, LLM-Auswertungen und Embeddings sind keine
+   fachlichen Inputs der deterministischen Klassifikation und dürfen die
+   Zuordnung nicht beeinflussen.
+8. Heuristische Regeln werden explizit benannt.
+9. Unbekannte Begriffe werden nicht still zu bekannten Primary Lenses,
+   Facets, States oder Relationstypen umgedeutet.
+10. Neue Facets verändern keine Primary Lens.
+11. Abgeleitete Karten bleiben regenerierbar.
 
 ## 17. Aktueller Implementierungsstand
 
@@ -408,13 +403,15 @@ notwendige technische Schuld behauptet.
 
 Sequenz:
 
-Primary Lens Audit v1 -- Contract/Core/Tests umgesetzt
--> Lens Model -- dieser PR
--> Facet Model v1 -- naechster Code-Slice
--> Lens Cards v1
--> PR Delta Cards
--> Relation Cards
--> Guard Relation Cards
+```text
+Primary Lens Audit v1 — Contract/Core/Tests umgesetzt
+→ Lens Model — dieser PR
+→ Facet Model v1 — nächster Code-Slice
+→ Lens Cards v1
+→ PR Delta Cards
+→ Relation Cards
+→ Guard Relation Cards
+```
 
 Das Lens-Modell ist Voraussetzung für das Facet Model, aber kein Implementierungsbeweis.
 
@@ -431,6 +428,7 @@ sie bereits eindeutig normiert:
 - kontrollierte Relationstypen
 
 **Contract und Datenmodell**
+- Kardinalität und Identität von Lens Cards
 - JSON-Struktur des Facet Model v1
 - konkrete Feldnamen
 - Target-ID-Modell
@@ -463,4 +461,4 @@ sie bereits eindeutig normiert:
 - keine Embeddings
 - keine LLM-Integration
 - keine Review-Urteile
-- keine Impact-Sprache
+- keine unqualifizierten oder kausalen Change-Impact-Behauptungen

--- a/docs/architecture/lens-model.md
+++ b/docs/architecture/lens-model.md
@@ -151,8 +151,8 @@ Confidence Score.
   kontrollierten Eigenschaft abgelesen, beispielsweise aus einem Pfad,
   einem Dateisuffix, einem Contract-Typ, einem Manifestwert oder einer
   deklarierten Artifact Role.
-- `derived`: Die Zuordnung wird deterministisch aus mehreren strukturierten
-  Signalen abgeleitet.
+- `derived`: Die Zuordnung wird deterministisch aus vorhandenen
+  strukturierten Signalen abgeleitet.
 - `heuristic`: Die Zuordnung folgt einer dokumentierten deterministischen
   Regel ohne semantischen Wahrheits-, Vollständigkeits- oder
   Wichtigkeitsbeweis.
@@ -265,8 +265,9 @@ Verbotene unqualifizierte Card-Felder oder Claims:
 
 ## 11. Relation Card und Guard Relation
 
-Eine Relation Card ist eine spätere Spezialisierung: die kompakte Darstellung einer
-Relation mit Herkunft und Evidence-Grenze. Sie ist kein Kausalitäts- oder Impact-Beweis.
+Eine Relation Card ist eine spätere Spezialisierung: die kompakte Darstellung
+einer Relation einschließlich ihrer Ableitungs- und Evidence-Grenzen. Sie ist
+kein Kausalitäts- oder Impact-Beweis.
 
 Eine Guard Relation ist eine spätere Spezialisierung: eine Relation zwischen Ziel und
 Test-, Validator-, Guard- oder CI-Fläche. Sie dient Navigation.
@@ -343,7 +344,8 @@ jeden Contract.
 - `review_priority`
 - `change_impact`
 
-Artefaktspezifische Ergänzungen dürfen genannt werden, beispielsweise `causality`, `coverage_completeness` oder `guard_effectiveness`.
+Artefaktspezifische Grenzen dürfen diese Baseline ergänzen, beispielsweise
+`causality`, `coverage_completeness` oder `guard_effectiveness`.
 
 Bestehende Contracts verwenden dafür je nach Artefakt unter anderem
 `does_not_establish`, `does_not_mean`, `does_not_prove` oder
@@ -415,32 +417,41 @@ Primary Lens Audit v1 — Contract/Core/Tests umgesetzt
 
 Das Lens-Modell ist Voraussetzung für das Facet Model, aber kein Implementierungsbeweis.
 
-## 19. Open Decisions for Facet Model v1
+## 19. Open Decisions for Subsequent Slices
 
-Diese Punkte werden in diesem PR nicht entschieden, sofern kein bestehendes Repo-Dokument
-sie bereits eindeutig normiert:
+Die folgenden Fragen werden in diesem Dokument nicht entschieden. Sie sind
+dem jeweils genannten Folgeslice oder einer ausdrücklich übergreifenden
+Modellentscheidung zugeordnet.
+
+### Facet Model v1
 
 **Taxonomie und Semantik**
 - endgültige Facet-v1-Taxonomie
 - `uncertainty` als Facet, State-Oberbegriff oder kein eigener Bezeichner
 - Rolle von `claim_boundary`
-- kontrollierte State-Bezeichner
-- kontrollierte Relationstypen
 
 **Contract und Datenmodell**
-- Kardinalität und Identität von Lens Cards
 - JSON-Struktur des Facet Model v1
 - konkrete Feldnamen
 - Target-ID-Modell
 - Bericht versus einzelne Zuordnungen
-- Identität und Deduplizierung
+- Identität und Deduplizierung von Facet-Zuordnungen
 - Sortierregeln
 - Taxonomie der Ableitungsregeln
 - Evidence-Adressen Pflicht oder optional
 - Verhalten bei unbekannten Facet-Namen
 - konkrete Shape der Negativsemantik
 
-**Operationalisierung**
+### Lens Cards v1
+- Kardinalität und Identität von Lens Cards
+
+### Relation Cards und Guard Relation Cards
+- kontrollierte Relationstypen
+
+### Übergreifende Modellentscheidungen
+- kontrollierte State-Bezeichner
+
+### Operationalisierung
 - CLI
 - automatische Emission
 - Bundle-/Manifest-Sichtbarkeit

--- a/docs/architecture/lens-model.md
+++ b/docs/architecture/lens-model.md
@@ -5,25 +5,50 @@ status: active
 
 # Deterministic Lens Model
 
-## 1. Dokumentrolle
+## 1. Zweck und Scope
 
-Dieses Dokument normiert Begriffe und Schichtengrenzen der deterministischen Linsenarchitektur.
-Es ist keine Runtime-Evidence.
-Es ist kein Contract.
-Es ist kein Beweis, dass alle Zuordnungsregeln vollständig oder optimal sind.
+Dieses Dokument normiert die Begriffe und Schichtengrenzen der Lenskit-Linsenarchitektur.
+Es ist Architekturdefinition, Begriffsschicht und Grundlage fuer spaetere Contracts.
 
-## 2. Verbindlicher Kernsatz
+Eine Lens ist etymologisch eine Linse: eine kontrollierte Sicht auf denselben Gegenstand.
+Im Systemkontext ist sie kein neuer Gegenstand und keine neue Wahrheit.
 
-Eine Lenskit-Linse ist eine deterministische, abgeleitete Sicht auf Repo-Artefakte.
-Sie besitzt eine Herkunftsregel und eine explizite Geltungsgrenze.
-Sie dient der Navigation und erzeugt kein eigenes Wahrheits-, Review-, Sicherheits- oder Impact-Urteil.
+Normativer Kernsatz:
+
+> Eine Lenskit-Linse ist eine deterministische, abgeleitete Sicht auf Repo- oder Bundle-Artefakte. Sie besitzt eine dokumentierte Herkunftsregel und eine explizite Geltungsgrenze. Sie dient der Navigation und erzeugt kein eigenes Wahrheits-, Review-, Sicherheits- oder Impact-Urteil.
+
+Dieses Dokument ist nicht Runtime-Evidence, kein JSON-Schema, kein Implementierungsbeweis,
+kein Bundle-Artefakt, kein Review-Bericht und kein Statusbeweis.
+
+Beziehungen:
+- `docs/blueprints/lenskit-agent-front-door-hardening.md`
+- `docs/blueprints/lenskit-authority-risk-matrix.md`
+- `docs/blueprints/lenskit-anti-hallucination-output-architecture.md`
+- `docs/architecture/two-layer-artifact-pattern.md`
+- `docs/architecture/agent-consumption-contract.md`
+- `docs/architecture/answer-compliance.md`
+- `docs/architecture/artifact-inventory.md`
+
+## 2. Invarianten
+
+- Linsen sind abgeleitete Navigation, keine Inhaltsautoritaet.
+- `canonical_md` bleibt innerhalb eines Dump-Bundles die einzige Inhaltswahrheit.
+- Eine Primary Lens bleibt single-label.
+- Additive Facets, States, Relations und Task Contexts ersetzen keine Primary Lens.
+- Reihenfolgen in Listen duerfen keine semantische Prioritaet ausdruecken.
+- Unbekannte Begriffe werden nicht still zu bekannten Linsen- oder Facet-Namen umgedeutet.
 
 ## 3. Primary Lens
 
-Jeder auditierbare Repo-Pfad erhält genau eine Primary Lens.
-Die Primary Lens beschreibt ausschließlich die primäre technische Rolle des Pfads.
+Eine Primary Lens beantwortet:
 
-Die kanonischen IDs bleiben:
+> Was ist dieser Pfad primaer?
+
+Jeder auditierbare Repo-Pfad hat genau eine Primary Lens. Sie beschreibt ausschliesslich
+die primaere technische Rolle des Pfads. Die Primary Lens wird aktuell durch
+`infer_lens()` in `merger/lenskit/core/lenses.py` bestimmt.
+
+Die sieben kanonischen IDs bleiben unveraendert:
 - `entrypoints`
 - `core`
 - `interfaces`
@@ -32,39 +57,39 @@ Die kanonischen IDs bleiben:
 - `ui`
 - `guards`
 
-Die Primary Lens wird aktuell über die bestehende deterministische Heuristik `infer_lens()` bestimmt.
-Der Primary Lens Audit erklärt diese Zuordnung über `matched_rule`.
-Audit und Erklärung dürfen die bestehende Zuordnung nicht überschreiben.
+Der Primary Lens Audit erklaert die bestehende `infer_lens()`-Zuordnung ueber
+`matched_rule`. Er ersetzt sie nicht, fuegt keine neue Lens hinzu und bleibt ebenfalls
+single-label.
 
-Primary Lens beantwortet:
-> Was ist dieser Pfad primär?
-
-Primary Lens beantwortet ausdrücklich nicht:
-- Warum ist der Pfad für einen bestimmten PR relevant?
-- Ist der Pfad semantisch wichtig?
-- Welche Änderung wirkt auf welche Runtime?
+Primary Lens beantwortet nicht:
+- Warum ist der Pfad fuer diesen PR wichtig?
+- Was bricht bei einer Aenderung?
 - Sind Tests ausreichend?
-- Ist ein Review vollständig?
-- Ist eine Änderung sicher?
+- Ist der Code sicher?
+- Ist ein Review vollstaendig?
+- Welche semantische Wichtigkeit hat der Pfad?
 
 ## 4. Facet
 
-Ein Facet ist eine additive Sichtachse.
-Ein Pfad darf null, ein oder mehrere Facets besitzen.
-Facets verändern die Primary Lens nicht.
-Facets dürfen keine zweite konkurrierende Primary-Lens-Ebene bilden.
+Ein Facet ist eine additive Sichtachse. Ein Ziel kann null, ein oder mehrere Facets
+tragen. Facets veraendern keine Primary Lens und bilden keine zweite konkurrierende
+Primary-Lens-Ebene.
 
-Jede Facet-Zuordnung braucht später mindestens:
-- `target_path`
+Jede spaetere Facet-Zuordnung muss deterministisch ableitbar sein und mindestens
+folgende Ebenen trennen:
+- `target`
 - `name`
 - `source_rule`
 - `confidence_class`
 - `does_not_establish`
 
-Facets müssen deterministisch aus repo-belegten Regeln ableitbar sein.
-Facets sind Navigation, keine Inhaltswahrheit.
+Das bestehende Feld `possible_facets` im Primary Lens Audit ist derzeit nur ein leerer
+Platzhalter. Der aktuelle Producer emittiert dort leere Listen. Dieses Feld beweist
+nicht, dass Facet-Zuordnung oder ein Facet Model bereits implementiert ist.
 
-**Kandidaten für Facet Model v1** (noch nicht als implementierter oder endgültiger Contract normiert):
+Es existieren konkurrierende Kandidatenlisten:
+
+Repo-naher Blueprint-Kandidatenstand:
 - `contract`
 - `artifact_surface`
 - `diagnostic`
@@ -73,63 +98,81 @@ Facets sind Navigation, keine Inhaltswahrheit.
 - `security`
 - `test_guard`
 
-Begriffe wie `impact`, `test_relevance` und `runtime_causality` bleiben ausdrücklich keine Primary Lenses und keine unbelegten v1-Facets.
+Aeltere Minimalstart-Idee:
+- `contract`
+- `artifact_surface`
+- `uncertainty`
+
+Diese Listen sind nicht reconciled und werden hier nicht still zusammengefuehrt. Die
+endgueltige Facet-Model-v1-Taxonomie ist noch offen.
+
+`uncertainty` kann Facet- oder State-Semantik ueberlappen. `claim_boundary` kann Facet,
+State oder Negativgrenze sein. Diese Entscheidung gehoert in den folgenden
+Facet-Model-v1-Slice.
+
+`impact`, `test_relevance` und `runtime_causality` sind keine Primary Lenses und keine
+automatisch zugelassenen v1-Facets.
 
 ## 5. Confidence Class
 
-Confidence Class beschreibt die Herkunftsqualität der Zuordnung.
-Sie ist keine Wahrscheinlichkeit und kein Korrektheitswert. Numerische Confidence Scores sind nicht vorgesehen.
+`confidence_class` beschreibt die Herkunftsart der Zuordnung. Sie ist keine
+Wahrscheinlichkeit, kein Korrektheitswert und kein numerischer Score.
 
-### `direct`
-Die Zuordnung folgt unmittelbar aus einer kontrollierten Eigenschaft, beispielsweise:
-- expliziter Pfad
-- Dateisuffix
-- bekannte Contract-Datei
-- deklarierte Artifact Role
-- direkt vorliegender Schema- oder Manifestwert
+`direct` bedeutet: Die Zuordnung ist direkt aus einer kontrollierten Eigenschaft
+ableitbar, zum Beispiel aus explizitem Pfad, Dateisuffix, Contract-Datei, deklarierter
+Artifact Role oder Manifestwert.
 
-### `derived`
-Die Zuordnung wird deterministisch aus vorhandenen strukturierten Artefakten oder mehreren direkten Signalen abgeleitet.
+`derived` bedeutet: Die Zuordnung wird deterministisch aus vorhandenen strukturierten
+Signalen abgeleitet.
 
-### `heuristic`
-Die Zuordnung folgt einer dokumentierten, deterministischen Heuristik, ist aber kein Beweis für semantische Bedeutung oder Vollständigkeit.
+`heuristic` bedeutet: Die Zuordnung folgt einer dokumentierten deterministischen Regel,
+ohne semantischen Vollstaendigkeits- oder Wahrheitsbeweis.
 
-## 6. Relation
+## 6. Source Rule und Evidence Ref
 
-Eine Relation verbindet zwei adressierbare Repo- oder Bundle-Artefakte.
-Eine Relation braucht Quelle, Ziel, Relationstyp und Herkunft.
-Direkte, abgeleitete und heuristische Relations müssen unterscheidbar bleiben.
-Eine Relation beweist keine Kausalität und keinen Change Impact.
-Pfadnähe, Importnähe oder gemeinsame Benennung allein dürfen nicht als Runtime-Wirkung ausgegeben werden.
+`source_rule` beschreibt, durch welche Regel eine Zuordnung entstand.
 
-Relation beantwortet:
-> Welche deterministisch belegte oder ausdrücklich heuristische Verbindung ist sichtbar?
+`evidence_ref` adressiert eine konkrete Belegstelle oder ein strukturiertes Artefakt.
 
-Relation beantwortet nicht:
-> Was bricht, wenn sich die Quelle ändert?
+`confidence_class` beschreibt die Herkunftsart der Zuordnung.
 
-## 7. State
+Keine dieser Ebenen beweist fuer sich Wahrheit, Vollstaendigkeit, semantische Wichtigkeit,
+Runtime-Wirkung oder Review-Relevanz. Ob `evidence_ref` in Facet Model v1 Pflicht wird,
+bleibt offen.
 
-Ein State beschreibt einen epistemischen oder Auflösungszustand einer Zuordnung, Relation oder Evidence-Adresse.
+## 7. Relation
 
-Beispielkandidaten:
+Eine Relation ist eine Verbindung zwischen zwei adressierbaren Zielen. Sie benoetigt
+Quelle, Ziel, Typ und Herkunft. Sie kann `direct`, `derived` oder `heuristic` sein.
+
+Kernsatz:
+
+> Relation beschreibt eine sichtbare Verbindung; sie beweist weder Kausalitaet noch Auswirkung einer Aenderung.
+
+Dieser PR legt keine Relationstyp-Taxonomie fest.
+
+## 8. State
+
+Ein State beschreibt einen epistemischen oder Aufloesungszustand. Er ist keine technische
+Dateirolle, keine Primary Lens und keine automatische Fehlerbewertung.
+
+Beispielkandidaten, nicht finaler Contract:
 - `missing_evidence`
 - `heuristic_assignment`
 - `unresolved_reference`
 
-States sind keine Dateirollen und keine Primary Lenses.
-
-Ein State wie `missing_evidence` bedeutet nicht automatisch:
+Ein `missing_evidence`-State bedeutet nicht automatisch:
 - Aussage falsch
 - Implementierung defekt
+- Aenderung unsicher
 - Test fehlgeschlagen
-- Änderung unsicher
 
-Die konkrete State-Taxonomie bleibt einem späteren Contract vorbehalten.
+Ob `uncertainty` als eigenes Facet oder durch konkrete States modelliert wird, ist fuer
+Facet Model v1 noch zu entscheiden.
 
-## 8. Task Context
+## 9. Task Context
 
-Task Context erklärt, warum ein Artefakt für eine bestimmte Aufgabe navigativ relevant ist.
+Task Context erklaert, warum ein Ziel fuer eine konkrete Aufgabe navigativ relevant ist.
 
 Beispiele:
 - `pr_review`
@@ -138,68 +181,104 @@ Beispiele:
 - `security_review`
 - `roadmap_status_claim`
 
-Abgrenzung:
-- Task Context ändert nicht die Primary Lens.
-- Task Context ist nicht dauerhaft mit dem Pfad identisch.
-- Task Context ist eine Consumer-/Aufgabensicht.
-- Relevanz für eine Aufgabe beweist keinen Change Impact oder Review-Befund.
+Task Context ist keine dauerhafte Eigenschaft der Datei, veraendert keine Primary Lens,
+ist nicht dasselbe wie ein Required-Reading-Profil und beweist keinen Review-Befund oder
+Change Impact.
 
-Bestehende Required-Reading-Profile werden nicht als Lens-Taxonomie umdefiniert.
+Required Reading beantwortet:
 
-## 9. Lens Card
+> Welche Artefakte muessen gelesen werden?
 
-Eine Lens Card ist eine kleine, abgeleitete Navigationseinheit.
-Sie kann später Primary Lens, Facets, Navigation-Refs, States und begrenzte Relations zusammenführen.
+Task Context beantwortet:
 
-Sie bleibt:
-- `authority = navigation_index`
-- `canonicality = derived`
+> Warum kann dieses Ziel fuer die konkrete Aufgabe relevant sein?
 
-Sie ersetzt weder `canonical_md` noch die zugrunde liegenden Contracts oder Evidence-Ranges.
-Sie enthält keine automatischen Findings oder Fix-Vorschläge.
+## 10. Lens Card
 
-Verbotene unqualifizierte Card-Semantik:
-`verdict`, `approved`, `safe`, `complete`, `covered`, `critical`, `impact`, `breaks`, `requires_fix`
+Eine Lens Card ist eine kleine abgeleitete Navigationseinheit. Sie kann spaeter Primary
+Lens, Facets, States, Relations und Evidence-Adressen zusammenfuehren. Sie bleibt
+regenerierbar und ersetzt keine kanonischen Inhalte.
 
-## 10. Relation Card und Guard Relation
+Authority:
+- `navigation_index`
 
-Diese sind spätere Spezialisierungen und werden in v1 nicht implementiert.
+Canonicality:
+- `derived`
 
-### Relation Card
-Kleine Navigationseinheit für eine Relation mit Herkunft und Evidence-Grenze.
+Verbotene unqualifizierte Card-Felder oder Claims:
+- `verdict`
+- `approved`
+- `safe`
+- `complete`
+- `covered`
+- `critical`
+- `impact`
+- `breaks`
+- `requires_fix`
 
-### Guard Relation
-Spezialisierte Relation zwischen einem Ziel und einem Guard-, Test-, Validator- oder CI-Pfad.
-Guard Relation bedeutet nicht:
-- Testabdeckung vollständig
-- Guard wirksam
-- CI ausreichend
-- Regression ausgeschlossen
+## 11. Relation Card und Guard Relation
 
-## 11. Agent Consumption Trace korrekt einordnen
+Eine Relation Card ist eine spaetere Spezialisierung: die kompakte Darstellung einer
+Relation mit Herkunft und Evidence-Grenze. Sie ist kein Kausalitaets- oder Impact-Beweis.
 
-Der Agent Consumption Trace ist keine Lens-Primitive.
-Korrekte Einordnung:
-- angrenzende Consumption-/Compliance-Fläche
-- erklärt deklarierte Nutzung von Artefakten
-- kann Lens Cards später konsumieren
-- ist selbst weder Primary Lens, Facet, Relation noch State
-- beweist kein tatsächliches Lesen oder Repo-Verständnis
+Eine Guard Relation ist eine spaetere Spezialisierung: eine Relation zwischen Ziel und
+Test-, Validator-, Guard- oder CI-Flaeche. Sie dient Navigation.
 
-## 12. Schichtenmodell
+Eine Guard Relation beweist nicht:
+- `test_sufficiency`
+- `coverage_completeness`
+- `guard_effectiveness`
+- `runtime_correctness`
+- `regression_absence`
 
-| Schicht      | Kardinalität pro Pfad | Zweck                           | Darf nicht behaupten |
-| ------------ | --------------------: | ------------------------------- | -------------------- |
-| Primary Lens |               genau 1 | primäre technische Rolle        | Wichtigkeit, Impact  |
-| Facet        |                  0..n | additive Sichtachsen            | Wahrheit, Priorität  |
-| Relation     |                  0..n | sichtbare Verbindung            | Kausalität, Bruch    |
-| State        |                  0..n | epistemischer/Auflösungszustand | Fehlerurteil         |
-| Task Context |       0..n je Aufgabe | aufgabenspezifische Navigation  | Review-Befund        |
-| Lens Card    |            abgeleitet | kompakte Navigation             | Inhaltsautorität     |
+Diese Spezialisierungen werden hier nicht implementiert.
 
-## 13. Negativsemantik
+## 12. Abgrenzung zum Agent Consumption Trace
 
-Als gemeinsame Mindestgrenze für zukünftige Lens-/Facet-/Relation-/Card-Artefakte gilt:
+Agent Consumption Trace ist ausserhalb der Lens-Primitiven einzuordnen. Er ist eine
+Consumer-/Compliance-Flaeche und kann spaeter Lens Cards konsumieren.
+
+Agent Consumption Trace ist kein Facet, keine Relation, kein State und keine Primary Lens.
+Er beweist kein tatsaechliches Lesen und kein Repo-Verstaendnis.
+
+## 13. Schichtenmodell
+
+| Schicht | Kardinalitaet | Zweck | Beweist nicht |
+| --- | --- | --- | --- |
+| Primary Lens | genau 1 pro Pfad | primaere technische Rolle | Wichtigkeit, Impact |
+| Facet | 0..n | additive Sichtachsen | Wahrheit, Prioritaet |
+| Relation | 0..n | sichtbare Verbindung | Kausalitaet, Bruch |
+| State | 0..n | epistemischer/Aufloesungszustand | Fehler oder Unsicherheit der Implementierung |
+| Task Context | 0..n pro Aufgabe | aufgabenspezifische Navigation | Review-Befund |
+| Lens Card | abgeleitet | kompakte Navigationsprojektion | Inhaltsautoritaet |
+
+## 14. Authority und Canonicality
+
+`canonical_md` bleibt innerhalb eines Dump-Bundles die einzige Inhaltswahrheit.
+
+Folgende Flaechen bleiben abgeleitete Navigation oder Diagnose:
+- Primary Lens Audit
+- Facets
+- Relations
+- States
+- Lens Cards
+- Health Reports
+- Surface Validation
+
+Ein Health- oder Surface-Pass beweist nicht:
+- `repo_understood`
+- `claims_true`
+- `review_complete`
+- `test_sufficiency`
+- `runtime_correctness`
+- `forensic_ready`
+
+Das Lens-Modell erzeugt keine neue Evidence. Es kann Evidence nur adressieren,
+projizieren oder navigativ ordnen.
+
+## 15. Negativsemantik
+
+Als gemeinsame Mindestgrenze zukuenftiger Lens-/Facet-/Relation-/Card-Artefakte gilt:
 
 ```json
 {
@@ -217,52 +296,93 @@ Als gemeinsame Mindestgrenze für zukünftige Lens-/Facet-/Relation-/Card-Artefa
 }
 ```
 
-Hinweis: Bestehende Contracts dürfen andere Feldnamen wie `does_not_mean`, `does_not_prove` oder `claim_boundaries` verwenden. Dieser PR migriert oder vereinheitlicht bestehende Contracts nicht. Die semantische Grenze soll konsistent sein; die Feldnamenmigration ist kein Ziel.
+Bestehende Contracts verwenden teils andere Feldnamen wie `does_not_mean`,
+`does_not_prove` oder `claim_boundaries`. Dieser PR migriert keine bestehenden
+Contracts. Semantische Grenzen sollen konsistent sein. Feldnamenvereinheitlichung ist
+ein separater Task.
 
-## 14. Determinismus-Invarianten
+## 16. Determinismus-Invarianten
 
-1. Gleicher Repo-Zustand und gleiche Regeln erzeugen dieselben Zuordnungen.
+1. Gleicher Repo-Zustand und gleiche Regeln erzeugen dieselbe Zuordnung.
 2. Ausgaben werden stabil sortiert.
-3. Mehrfachzuordnungen werden deterministisch dedupliziert.
-4. Keine Netzwerkanfrage ist für die Klassifikation erforderlich.
-5. Keine LLM- oder Embedding-Auswertung ist erforderlich.
-6. Keine Systemzeit darf die Zuordnung verändern.
-7. Heuristische Regeln werden explizit benannt.
-8. Unbekannte Begriffe werden nicht still zu bekannten Facets umgedeutet.
-9. Neue Facets ändern keine bestehende Primary Lens.
-10. Abgeleitete Karten bleiben regenerierbar.
+3. Deduplizierung ist deterministisch.
+4. Reihenfolge erzeugt keine semantische Prioritaet.
+5. Keine Netzwerkabfrage ist fuer die Klassifikation erforderlich.
+6. Keine LLM-Auswertung ist erforderlich.
+7. Keine Embeddings sind erforderlich.
+8. Keine Systemzeit veraendert die Zuordnung.
+9. Heuristische Regeln werden explizit benannt.
+10. Unbekannte Begriffe werden nicht still umgedeutet.
+11. Neue Facets aendern keine Primary Lens.
+12. Abgeleitete Karten bleiben regenerierbar.
 
-## 15. Authority- und Truth-Grenze
+## 17. Aktueller Implementierungsstand
 
-`canonical_md` bleibt die einzige Inhaltswahrheit eines Dump-Bundles.
-Primary Lens Audit, Facets, Relations, States und Lens Cards sind abgeleitete Navigation.
-Health- und Surface-Pässe beweisen weder Repo-Verständnis noch Claim-Wahrheit.
+Implementiert:
+- sieben Primary Lenses
+- `infer_lens()`
+- Primary Lens Audit Contract
+- Primary Lens Audit Core Producer
+- fokussierte Primary-Lens-Audit-Tests
 
-## 16. Sequenzierung
+Nicht implementiert:
+- Facet Model
+- Lens Cards
+- Relation Cards
+- Guard Relation Cards
+- automatische Primary-Lens-Audit-Bundle-Emission
+- verpflichtendes CLI-Wiring fuer den Audit
 
-Der verbindliche Folgepfad:
-1. Primary Lens Audit v1 — Core/Contract/Tests umgesetzt
-2. Lens Model — dieser PR
-3. Facet Model v1 — nächster Implementierungsslice
-4. Lens Cards v1
-5. PR Delta Cards
-6. Relation Cards
-7. Guard Relation Cards
+Es wird nicht behauptet, dass jeder Dump bereits ein Primary-Lens-Audit-Sidecar enthaelt.
 
-Klarstellung:
-- Der Primary Lens Audit wird derzeit nicht automatisch als neues Bundle-Artefakt emittiert, sofern dies im aktuellen Code nicht implementiert ist. Dieser PR fügt keine solche Emission hinzu.
-- Facet Model v1 ist der nächste Code-Slice.
+## 18. Sequenzierung
 
-## 17. Open decisions for Facet Model v1
+Sequenz:
 
-Folgende Entscheidungen bleiben bewusst vertagt und sind Teil des Facet Model v1 PRs:
-1. exakte minimale v1-Facet-Liste
-2. exakte JSON-Output-Form
-3. ob ein Gesamtbericht oder einzelne Zuordnungen erzeugt werden
-4. Sortier- und Deduplizierungsregeln im Contract
-5. erlaubte `source_rule`-Taxonomie
-6. ob Evidence-Refs in v1 Pflicht oder optional sind
-7. Bundle-/Manifest-Sichtbarkeit
-8. CLI und automatische Emission
-9. Verhalten bei unbekannten Facet-Namen
-10. Verhältnis zwischen `claim_boundary` und allgemeiner Unsicherheitssemantik
+Primary Lens Audit v1 -- Contract/Core/Tests umgesetzt
+-> Lens Model -- dieser PR
+-> Facet Model v1 -- naechster Code-Slice
+-> Lens Cards v1
+-> PR Delta Cards
+-> Relation Cards
+-> Guard Relation Cards
+
+Das Lens-Modell ist Voraussetzung fuer das Facet Model, aber kein Implementierungsbeweis.
+
+## 19. Open Decisions for Facet Model v1
+
+Diese Punkte werden in diesem PR nicht entschieden, sofern kein bestehendes Repo-Dokument
+sie bereits eindeutig normiert:
+
+1. endgueltige Facet-v1-Taxonomie
+2. `uncertainty` als Facet oder State-Modell
+3. Rolle von `claim_boundary`
+4. genaue JSON-Struktur
+5. Bericht versus einzelne Zuordnungen
+6. Identitaet und Deduplizierung
+7. Sortierregeln
+8. erlaubte `source_rule`-Taxonomie
+9. Evidence-Refs Pflicht oder optional
+10. Target-ID-Modell
+11. Verhalten bei unbekannten Facet-Namen
+12. Bundle-/Manifest-Sichtbarkeit
+13. CLI
+14. automatische Emission
+15. Feldnamen fuer Negativsemantik
+
+## 20. Non-goals
+
+- keine neuen Primary Lenses
+- keine Aenderung an `infer_lens()`
+- keine gemeinsame Rule Engine
+- kein Facet-Contract
+- kein Facet-Code
+- keine Lens Cards
+- keine Relationsimplementierung
+- kein CLI
+- keine Bundle-Emission
+- kein Retrieval-Ranking
+- keine Embeddings
+- keine LLM-Integration
+- keine Review-Urteile
+- keine Impact-Sprache

--- a/docs/blueprints/lenskit-agent-front-door-hardening.md
+++ b/docs/blueprints/lenskit-agent-front-door-hardening.md
@@ -115,6 +115,7 @@ oder Patch-Automat zu werden.
 | Bundle Surface Validation | Surface-/Link-Konsistenzdiagnose | `pass` bedeutet weder `claims_true` noch `forensic_ready` |
 | Retrieval Eval / Miss Taxonomy | Retrieval-Diagnostik | beweist keine semantische Vollständigkeit |
 | Primary Lenses | `entrypoints`, `core`, `interfaces`, `data_models`, `pipelines`, `ui`, `guards` | Focus-Overlay; keine neuen IDs in diesem Plan |
+| Primary Lens Audit | deterministische Erklärung der bestehenden infer_lens-Heuristik | Contract/Core/Tests vorhanden; keine neue Primary Lens, keine semantische Wichtigkeit, keine automatische Review-Priorität |
 
 ### 3.2 Noch nicht als stabile Repo-Fläche vorhanden
 
@@ -123,7 +124,6 @@ oder Patch-Automat zu werden.
 - Agent Consumption Trace
 - Agent Entry Manifest
 - Review-Retrieval-Goldset
-- Primary Lens Audit
 - Facet Model
 - Lens Cards
 - PR Delta Cards
@@ -685,14 +685,18 @@ Repo-Verständnis noch Antwortsicherheit.
 **Ziel:** Die bestehende heuristische Zuordnung zu den sieben Primary Lenses sichtbar und
 prüfbar machen, ohne IDs oder Prioritäten zu ändern.
 
-**Planungskandidaten:**
+**Status:** Contract, Core Producer und fokussierte Tests sind implementiert.
 
-```text
-merger/lenskit/contracts/primary-lens-audit.v1.schema.json
-merger/lenskit/core/lens_audit.py
-merger/lenskit/tests/test_primary_lens_audit.py
-docs/architecture/lens-model.md
-```
+**Belege (Evidence):**
+- `merger/lenskit/contracts/primary-lens-audit.v1.schema.json`
+- `merger/lenskit/core/lens_audit.py`
+- `merger/lenskit/tests/test_primary_lens_audit.py`
+
+**Weiterhin offen oder bewusst nicht Teil des Slices:**
+- keine automatische Bundle-Emission
+- kein CLI-Wiring
+- keine Änderung an LENS_IDS
+- keine Änderung an infer_lens()
 
 **Output-Grenze:** Pfad, Primary Lens, matched rule und Negativsemantik; keine Aussage zu
 semantischer Wichtigkeit, Review-Priorität oder vollständigem Kontext.
@@ -709,6 +713,9 @@ zu verändern.
 
 **Ziel:** Additive Sichtachsen einführen, ohne das genau-eine-Primary-Lens-Modell zu
 ersetzen.
+
+**Regelwerk:** Der Facet-Contract muss die in `docs/architecture/lens-model.md`
+festgelegten Schichtengrenzen und Negativsemantiken einhalten.
 
 **Erste Kandidaten:** `contract`, `artifact_surface`, `diagnostic`, `retrieval`,
 `claim_boundary`, `security`, `test_guard`.

--- a/docs/blueprints/lenskit-agent-front-door-hardening.md
+++ b/docs/blueprints/lenskit-agent-front-door-hardening.md
@@ -115,7 +115,7 @@ oder Patch-Automat zu werden.
 | Bundle Surface Validation | Surface-/Link-Konsistenzdiagnose | `pass` bedeutet weder `claims_true` noch `forensic_ready` |
 | Retrieval Eval / Miss Taxonomy | Retrieval-Diagnostik | beweist keine semantische Vollständigkeit |
 | Primary Lenses | `entrypoints`, `core`, `interfaces`, `data_models`, `pipelines`, `ui`, `guards` | Focus-Overlay; keine neuen IDs in diesem Plan |
-| Primary Lens Audit | deterministische Erklärung der bestehenden infer_lens-Heuristik | Contract/Core/Tests vorhanden; keine neue Primary Lens, keine semantische Wichtigkeit, keine automatische Review-Priorität, keine automatische Bundle-Emission |
+| Primary Lens Audit | aufrufbare Contract-/Core-Fläche zur deterministischen Erklärung von `infer_lens()` | Contract/Core/Tests vorhanden; kein CLI, keine automatische Bundle-Emission, keine neue Primary Lens und keine Review-Priorität |
 
 ### 3.2 Noch nicht als stabile Repo-Fläche vorhanden
 
@@ -692,11 +692,14 @@ prüfbar machen, ohne IDs oder Prioritäten zu ändern.
 - `merger/lenskit/core/lens_audit.py`
 - `merger/lenskit/tests/test_primary_lens_audit.py`
 
-**Weiterhin offen oder bewusst nicht Teil des Slices:**
-- keine automatische Bundle-Emission
-- kein CLI-Wiring
-- keine Änderung an LENS_IDS
-- keine Änderung an infer_lens()
+**Bewusst nicht Teil des abgeschlossenen Slices:**
+- automatische Bundle-Emission
+- CLI-Anschluss
+Diese Anschlüsse werden durch den Status nicht als notwendige Folgearbeiten
+festgelegt.
+**Unveränderte Invarianten:**
+- `LENS_IDS` bleibt unverändert
+- `infer_lens()` und seine bestehende Prioritätslogik bleiben unverändert
 
 **Output-Grenze:** Pfad, Primary Lens, matched rule und Negativsemantik; keine Aussage zu
 semantischer Wichtigkeit, Review-Priorität oder vollständigem Kontext.
@@ -715,7 +718,8 @@ zu verändern.
 ersetzen.
 
 **Regelwerk:** Der Facet-Contract muss die in `docs/architecture/lens-model.md`
-festgelegten Schichtengrenzen, Confidence Classes und Negativsemantiken einhalten.
+festgelegten Schichtengrenzen, Ableitungsarten und Negativsemantiken
+einhalten.
 
 **Erste Kandidaten, nicht finale Taxonomie:** `contract`, `artifact_surface`,
 `diagnostic`, `retrieval`, `claim_boundary`, `security`, `test_guard`.

--- a/docs/blueprints/lenskit-agent-front-door-hardening.md
+++ b/docs/blueprints/lenskit-agent-front-door-hardening.md
@@ -104,6 +104,11 @@ oder Patch-Automat zu werden.
 
 ### 3.1 Bereits vorhanden
 
+In diesem Abschnitt bedeutet „vorhanden“, dass eine belegte Repo-Fläche aus
+Contract, Core/Validator/Producer, Dokumentation oder fokussierten Tests
+existiert. Dies impliziert nicht automatisch Bundle-Emission, Consumer-
+Integration oder Runtime-Nutzung.
+
 | Fläche | Aktuelle Rolle | Planungsrelevante Grenze |
 | --- | --- | --- |
 | `canonical_md` | kanonische Inhaltsquelle | bleibt einzige Inhaltswahrheit |
@@ -113,17 +118,18 @@ oder Patch-Automat zu werden.
 | Claim Evidence Map | Evidence-Index | keine Claim-Bewertung |
 | Post-Emit-Health | finale Integritäts-/Oberflächendiagnose | `pass` bedeutet weder `repo_understood` noch `answer_safe_without_citations` |
 | Bundle Surface Validation | Surface-/Link-Konsistenzdiagnose | `pass` bedeutet weder `claims_true` noch `forensic_ready` |
-| Retrieval Eval / Miss Taxonomy | Retrieval-Diagnostik | beweist keine semantische Vollständigkeit |
+| Review Retrieval Goldset / Eval / Miss Taxonomy | versioniertes Review-Messset mit reproduzierbaren Metriken, Baseline und Miss-Diagnostik | diagnostische Oberfläche; beweist weder Review-Vollständigkeit noch ausreichende Retrieval-Qualität |
 | Primary Lenses | `entrypoints`, `core`, `interfaces`, `data_models`, `pipelines`, `ui`, `guards` | Focus-Overlay; keine neuen IDs in diesem Plan |
 | Primary Lens Audit | aufrufbare Contract-/Core-Fläche zur deterministischen Erklärung von `infer_lens()` | Contract/Core/Tests vorhanden; kein CLI, keine automatische Bundle-Emission, keine neue Primary Lens und keine Review-Priorität |
+| Required Reading Protocol | deterministische Auflösung der Pflichtartefakte je Task-Profil | definiert Leseanforderungen; beweist weder tatsächliches Lesen noch Antwortkorrektheit oder Repo-Verständnis |
+| Answer Compliance Contract | maschinenlesbare Selbstdeklaration der für eine Antwort verwendeten Artefakte und Belege | beweist weder tatsächliches Lesen noch Antwortkorrektheit, Vollständigkeit oder Repo-Verständnis |
+| Agent Consumption Trace | deterministische Prüfung deklarierter Nutzung gegen Required-Reading-Erwartungen | beweist kein tatsächliches Lesen, keine Antwortkorrektheit und kein Repo-Verständnis |
+| Agent Entry Manifest Core | Contract, Producer und Tests für einen abgeleiteten Agent-Einstiegsindex | keine belegte automatische Bundle-Emission oder stabile Consumer-Integration; beweist kein Repo-Verständnis |
 
 ### 3.2 Noch nicht als stabile Repo-Fläche vorhanden
 
-- hartes Required Reading je Task-Profil
-- Answer Compliance Contract
-- Agent Consumption Trace
-- Agent Entry Manifest
-- Review-Retrieval-Goldset
+- harte Durchsetzung des Required Reading Protocol in Consumer- oder Export-Gates
+- automatische Bundle-Emission und Consumer-Integration des Agent Entry Manifest
 - Facet Model
 - Lens Cards
 - PR Delta Cards

--- a/docs/blueprints/lenskit-agent-front-door-hardening.md
+++ b/docs/blueprints/lenskit-agent-front-door-hardening.md
@@ -693,13 +693,17 @@ prüfbar machen, ohne IDs oder Prioritäten zu ändern.
 - `merger/lenskit/tests/test_primary_lens_audit.py`
 
 **Bewusst nicht Teil des abgeschlossenen Slices:**
+
 - automatische Bundle-Emission
 - CLI-Anschluss
+
 Diese Anschlüsse werden durch den Status nicht als notwendige Folgearbeiten
 festgelegt.
-**Unveränderte Invarianten:**
-- `LENS_IDS` bleibt unverändert
-- `infer_lens()` und seine bestehende Prioritätslogik bleiben unverändert
+
+**Im abgeschlossenen Slice unverändert:**
+
+- `LENS_IDS`
+- `infer_lens()` und seine bestehende Prioritätslogik
 
 **Output-Grenze:** Pfad, Primary Lens, matched rule und Negativsemantik; keine Aussage zu
 semantischer Wichtigkeit, Review-Priorität oder vollständigem Kontext.

--- a/docs/blueprints/lenskit-agent-front-door-hardening.md
+++ b/docs/blueprints/lenskit-agent-front-door-hardening.md
@@ -115,7 +115,7 @@ oder Patch-Automat zu werden.
 | Bundle Surface Validation | Surface-/Link-Konsistenzdiagnose | `pass` bedeutet weder `claims_true` noch `forensic_ready` |
 | Retrieval Eval / Miss Taxonomy | Retrieval-Diagnostik | beweist keine semantische Vollständigkeit |
 | Primary Lenses | `entrypoints`, `core`, `interfaces`, `data_models`, `pipelines`, `ui`, `guards` | Focus-Overlay; keine neuen IDs in diesem Plan |
-| Primary Lens Audit | deterministische Erklärung der bestehenden infer_lens-Heuristik | Contract/Core/Tests vorhanden; keine neue Primary Lens, keine semantische Wichtigkeit, keine automatische Review-Priorität |
+| Primary Lens Audit | deterministische Erklärung der bestehenden infer_lens-Heuristik | Contract/Core/Tests vorhanden; keine neue Primary Lens, keine semantische Wichtigkeit, keine automatische Review-Priorität, keine automatische Bundle-Emission |
 
 ### 3.2 Noch nicht als stabile Repo-Fläche vorhanden
 
@@ -715,10 +715,10 @@ zu verändern.
 ersetzen.
 
 **Regelwerk:** Der Facet-Contract muss die in `docs/architecture/lens-model.md`
-festgelegten Schichtengrenzen und Negativsemantiken einhalten.
+festgelegten Schichtengrenzen, Confidence Classes und Negativsemantiken einhalten.
 
-**Erste Kandidaten:** `contract`, `artifact_surface`, `diagnostic`, `retrieval`,
-`claim_boundary`, `security`, `test_guard`.
+**Erste Kandidaten, nicht finale Taxonomie:** `contract`, `artifact_surface`,
+`diagnostic`, `retrieval`, `claim_boundary`, `security`, `test_guard`.
 
 **Planungskandidaten:**
 

--- a/docs/blueprints/lenskit-agent-front-door-hardening.md
+++ b/docs/blueprints/lenskit-agent-front-door-hardening.md
@@ -585,7 +585,8 @@ CLI-Lesepfad sind implementiert.
 - `merger/lenskit/contracts/required-reading-protocol.v1.schema.json`
 - `merger/lenskit/core/required_reading.py`
 - `merger/lenskit/tests/test_required_reading_protocol.py`
-- tatsächlicher CLI-Pfad für `agent-consumption required`
+- `merger/lenskit/cli/cmd_agent_consumption.py`
+- `merger/lenskit/cli/main.py`
 **Weiterhin offen:**
 - harte Durchsetzung in Consumer- oder Export-Gates
 - automatische Bundle-Integration
@@ -631,7 +632,8 @@ Exit-Code-Policy, fokussierte Tests und CLI sind implementiert.
 - `merger/lenskit/contracts/agent-consumption-trace.v1.schema.json`
 - `merger/lenskit/core/agent_consumption_validate.py`
 - `merger/lenskit/tests/test_agent_consumption_trace.py`
-- tatsächlicher CLI-Pfad für `validate-trace`
+- `merger/lenskit/cli/cmd_agent_consumption.py`
+- `merger/lenskit/cli/main.py`
 - `merger/lenskit/tests/test_cli_agent_consumption.py`
 **Weiterhin offen:**
 - automatische Bundle-Emission
@@ -721,7 +723,11 @@ merger/lenskit/tests/test_lens_facets.py
 ```
 
 **Regeln:** mehrere Facets pro Datei; genau eine Primary Lens; Facets sind Navigation;
-jedes Facet nennt `source_rule`, Confidence-Klasse und Negativsemantik.
+jedes Facet nennt `source_rule`, eine Ableitungsart und Negativsemantik.
+- jede Facet-Zuordnung drückt eine Ableitungsart aus: `direct`, `derived` oder `heuristic`.
+Die Ableitungsart beschreibt die Entstehungsweise der Zuordnung und keinen
+Confidence Score. Der konkrete JSON-Feldname bleibt dem
+Facet-Model-v1-Contract vorbehalten.
 
 **Akzeptanz:** Facets sind deterministisch aus repo-belegten Regeln ableitbar und werden
 nicht als semantische Wahrheit oder Review-Priorität behandelt.
@@ -987,8 +993,12 @@ Exact shape: see the canonical contract at
 
 ### 15.3 Required Reading Resolver
 
-Exact shape: see the canonical contract at
-`merger/lenskit/contracts/required-reading-protocol.v1.schema.json`.
+Für das Resolver-Ergebnis existiert derzeit kein eigener JSON-Contract.
+Die deterministische Output-Shape wird durch
+`merger/lenskit/core/required_reading.py::resolve_required_reading`
+erzeugt und durch
+`merger/lenskit/tests/test_required_reading_protocol.py`
+abgesichert.
 
 ### 15.4 Answer Compliance
 

--- a/docs/blueprints/lenskit-agent-front-door-hardening.md
+++ b/docs/blueprints/lenskit-agent-front-door-hardening.md
@@ -136,16 +136,20 @@ Integration oder Runtime-Nutzung.
 - Relation Cards
 - Guard Relation Cards
 
-### 3.3 Retrieval-Baseline: bewusst offene Evidence-Lücke
-
-Die extern vorgeschlagenen Zahlen `recall@10 = 13.33`, `MRR = 0.0889` und zwei Hits bei
-15 Queries sind im Repository nicht als committetes Eval belegt; der bestehende
-Capability-Audit markiert diesen Befund als unklar. Dieser Blueprint verwendet die Zahlen
-daher **nicht** als Architekturbeweis oder Promotion-Baseline.
-
-Konsequenz: Slice 3 muss ein versioniertes Review-Goldset und eine reproduzierbare
-Baseline im Repo schaffen, bevor Retrieval-v2-Arbeit priorisiert, bewertet oder promoted
-werden darf.
+### 3.3 Review-Retrieval-Baseline
+Das versionierte Review-Goldset, der Metrikadapter, die reproduzierbaren
+Metriken und die Miss-Diagnostik sind implementiert.
+Belege:
+- `docs/retrieval/review_queries.v1.json`
+- `merger/lenskit/retrieval/review_eval.py`
+- `merger/lenskit/tests/test_review_retrieval_goldset.py`
+- `merger/lenskit/tests/test_review_retrieval_metrics.py`
+- `docs/diagnostics/review-retrieval-baseline.md`
+Konkrete Metrikwerte werden gegen einen gewählten Index reproduziert und
+nicht als zeitlose Leistungszahlen dieses Blueprints festgeschrieben.
+Die Baseline ist eine diagnostische Messfläche. Sie beweist weder
+ausreichende Retrieval-Qualität noch Review-Vollständigkeit oder
+semantische Abdeckung.
 
 ## 4. Problem
 
@@ -449,21 +453,20 @@ Tests erkannt.
 
 ### Slice 3 — Retrieval Review Goldset v1
 
-**Ziel:** Review-relevante Auffindbarkeit messen, bevor Retrieval verändert wird.
-
-**Geplante Deliverables, vor Umsetzung gegen bestehende Retrieval-Konventionen zu
-prüfen:**
-
-```text
-docs/retrieval/review_queries.v1.json
-merger/lenskit/contracts/review-retrieval-goldset.v1.schema.json
-merger/lenskit/tests/test_review_retrieval_goldset.py
-docs/diagnostics/review-retrieval-baseline.md
-```
-
-Der Schema-Pfad ist ein Planungskandidat, keine Vorentscheidung: Falls das vorhandene
-Query-Format `docs/retrieval/queries.v1.json` ohne neue Contract-Familie erweitert werden
-kann, ist Wiederverwendung vorzuziehen.
+**Status:** Structural Goldset sowie Metric Baseline und Miss Diagnostics
+sind implementiert.
+**Belege:**
+- `docs/retrieval/review_queries.v1.json`
+- `merger/lenskit/retrieval/review_eval.py`
+- `merger/lenskit/tests/test_review_retrieval_goldset.py`
+- `merger/lenskit/tests/test_review_retrieval_metrics.py`
+- `docs/diagnostics/review-retrieval-baseline.md`
+**Bewusst nicht Teil des abgeschlossenen Slices:**
+- kein neuer Goldset-Contract
+- kein neuer CLI-Befehl
+- kein Bundle-Sidecar
+- keine Ranking- oder Runtime-Änderung
+- keine Promotion der gemessenen Retrieval-Qualität
 
 **Mindestumfang:** mindestens 20 Queries aus den Kategorien:
 
@@ -576,23 +579,17 @@ der Slice gestoppt und neu geplant.
 
 ### Slice 6 — Required Reading Protocol v1 als JSON
 
-**Voraussetzung:** Slices 1 bis 5 sind stabil, und mindestens ein Maschinenconsumer
-benötigt die Regeln außerhalb des Markdown-Packs.
-
-**Planungskandidaten:**
-
-```text
-merger/lenskit/contracts/required-reading-protocol.v1.schema.json
-merger/lenskit/core/required_reading.py
-merger/lenskit/tests/test_required_reading_protocol.py
-```
-
-Optional, nur bei belegtem Operator-/Wrapper-Bedarf:
-
-```text
-merger/lenskit/cli/cmd_required_reading.py
-merger/lenskit/tests/test_cli_required_reading.py
-```
+**Status:** Required Reading Protocol, Resolver, fokussierte Tests und der
+CLI-Lesepfad sind implementiert.
+**Belege:**
+- `merger/lenskit/contracts/required-reading-protocol.v1.schema.json`
+- `merger/lenskit/core/required_reading.py`
+- `merger/lenskit/tests/test_required_reading_protocol.py`
+- tatsächlicher CLI-Pfad für `agent-consumption required`
+**Weiterhin offen:**
+- harte Durchsetzung in Consumer- oder Export-Gates
+- automatische Bundle-Integration
+- tatsächliche Adoption durch externe Agent-Wrapper
 
 **Contract-Inhalt:** versionierte Task-Profile mit `required`, `recommended`, `optional`
 und Negativsemantik. Ein Resolver darf Manifest-Verfügbarkeit gegen ein Task-Profil
@@ -608,81 +605,62 @@ Profile werden konservativ behandelt.
 
 ### Slice 7 — Answer Compliance Contract v1
 
-**Ziel:** Eine Antwort kann verwendete Artefakte, Zitate, epistemische Lücken und bewusst
-nicht gelesene Empfehlungen deklarieren.
-
-**Planungskandidaten:**
-
-```text
-merger/lenskit/contracts/answer-compliance.v1.schema.json
-docs/architecture/answer-compliance.md
-merger/lenskit/tests/test_answer_compliance_schema.py
-```
-
-**Mindestfelder:** Task-Profil, deklarierte Artefakte, deklarierte Zitate, epistemische
-Lücken, nicht gelesene Empfehlungen und `does_not_establish`.
-
-**Grenze:** Der Contract normiert eine Selbstauskunft. Er beweist weder tatsächliche
-Nutzung noch Antwortkorrektheit, vollständigen Kontext oder Repo-Verständnis.
-
-**Akzeptanz:** Der Contract kann unabhängig von einem konkreten LLM-Provider validiert
-werden und enthält keine Wahrheits- oder Review-Verdicts.
+**Status:** Answer Compliance Contract, Architekturgrenzen und fokussierte
+Tests sind implementiert.
+**Belege:**
+- `merger/lenskit/contracts/answer-compliance.v1.schema.json`
+- `docs/architecture/answer-compliance.md`
+- `merger/lenskit/tests/test_answer_compliance_schema.py`
+**Geltungsgrenze:**
+Answer Compliance ist eine deklarative Selbstauskunft über verwendete
+Artefakte, Citations, Ranges und epistemische Lücken.
+Sie beweist weder tatsächliches Lesen noch korrekte Nutzung, Vollständigkeit,
+Antwortkorrektheit oder Repo-Verständnis.
+**Bewusst nicht Teil:**
+- eigener Answer-Compliance-Producer
+- automatische Bundle-Emission
+- eigenständige Wahrheitsbewertung
 
 **Komplexität:** mittel.
 
 ### Slice 8 — Agent Consumption Trace v1
 
-**Voraussetzung:** Ein realer Wrapper oder Workflow erzeugt Answer Compliance und
-benötigt einen Vergleich mit Required Reading.
-
-**Planungskandidaten:**
-
-```text
-merger/lenskit/contracts/agent-consumption-trace.v1.schema.json
-merger/lenskit/core/agent_consumption_validate.py
-merger/lenskit/tests/test_agent_consumption_trace.py
-```
-
-Optionaler CLI-Pfad nur bei konkretem Consumer:
-
-```text
-merger/lenskit/cli/cmd_agent_consumption.py
-merger/lenskit/tests/test_cli_agent_consumption.py
-```
-
-**Validator-Grenzen:** fehlendes Required → `fail`; fehlendes Recommended → `warn`;
-unbekannte Rolle → konservative Warnung; fehlende Negativsemantik oder Truth-Claim →
-`fail`.
-
-**Pflichtgrenze:** Der Trace erklärt deklarierte Nutzung, beweist aber kein tatsächliches
-Lesen.
-
-**Akzeptanz:** Required-Reading-Abweichungen sind maschinenlesbar, ohne
-`actual_reading_proven`, `answer_correct` oder `repo_understood` zu behaupten.
+**Status:** Agent Consumption Trace Contract, Validator, Strict-Mode,
+Exit-Code-Policy, fokussierte Tests und CLI sind implementiert.
+**Belege:**
+- `merger/lenskit/contracts/agent-consumption-trace.v1.schema.json`
+- `merger/lenskit/core/agent_consumption_validate.py`
+- `merger/lenskit/tests/test_agent_consumption_trace.py`
+- tatsächlicher CLI-Pfad für `validate-trace`
+- `merger/lenskit/tests/test_cli_agent_consumption.py`
+**Weiterhin offen:**
+- automatische Bundle-Emission
+- Einbindung in Output Health oder Post-Emit Health
+- Export-Safety-Wiring
+- verbindliche Adoption durch externe Agent-Wrapper
+**Geltungsgrenze:**
+Der Trace vergleicht deklarierte Nutzung mit Required-Reading-Erwartungen.
+Er beweist kein tatsächliches Lesen, keine Antwortkorrektheit und kein
+Repo-Verständnis.
 
 **Komplexität:** mittel bis hoch.
 
 ### Slice 9 — Agent Entry Manifest v1
 
-**Voraussetzung:** Required Reading, Answer Compliance oder Consumption Trace existieren,
-oder die agent-facing Sidecar-Fläche ist nachweislich zu groß für einen stabilen Einstieg.
-
-**Planungskandidaten:**
-
-```text
-merger/lenskit/contracts/agent-entry-manifest.v1.schema.json
-merger/lenskit/core/agent_entry_manifest.py
-merger/lenskit/tests/test_agent_entry_manifest.py
-```
-
-**Inhalt:** kanonische Quelle, `read_first`, Verweis auf Task-Protokoll, verfügbare
-Flächen und Negativsemantik.
-
-**Nicht-Ziel:** kein zweites Bundle Manifest, keine neue Truth-Registry, keine Einführung
-nur zur Bequemlichkeit.
-
-**Akzeptanz:** ultrakleiner, deterministischer Index; die Existenz beweist weder
-Repo-Verständnis noch Antwortsicherheit.
+**Status:** Agent Entry Manifest Contract, Core-Producer und fokussierte
+Tests sind implementiert.
+**Belege:**
+- `merger/lenskit/contracts/agent-entry-manifest.v1.schema.json`
+- `merger/lenskit/core/agent_entry_manifest.py`
+- `merger/lenskit/tests/test_agent_entry_manifest.py`
+**Weiterhin offen:**
+- eigener CLI-Befehl
+- automatische Bundle-Emission
+- Bundle-Manifest-Rolle
+- stabile Consumer-Integration
+**Geltungsgrenze:**
+Der Core erzeugt einen abgeleiteten Agent-Einstiegsindex. Das beweist weder
+automatische Bereitstellung noch tatsächlichen Konsum oder Repo-Verständnis.
 
 **Komplexität:** mittel.
 
@@ -963,54 +941,34 @@ Authority-Promotion oder Antwortkorrektheitsbehauptung enthalten.
 
 ## 13. Open Questions
 
-1. Reicht Markdown-Front-Door-Härtung oder ist ein JSON-Contract nötig?
-2. Welcher reale Consumer rechtfertigt Agent Consumption Trace?
-3. Wie wird Sidecar-Nutzung gemessen, ohne tatsächliches Lesen vorzutäuschen?
-4. Welche Retrieval-Goldset-Kategorien sind für PR Review zuerst erforderlich?
-5. Lässt sich das bestehende Query-Format für das Goldset wiederverwenden?
-6. Wann ist die Sidecar-Fläche groß genug für ein Agent Entry Manifest?
-7. Wann dürfen Lens Cards eingeführt werden, ohne Primary-Lens- und Authority-Grenzen zu
-   verwischen?
-8. Welche Negativsemantik bleibt Markdown, welche wird später Contract-Pflicht?
-9. Wie werden capability-degradierte Hosts in Required Reading abgebildet?
-10. Welche konkrete Nichtregressionsschwelle promoted Retrieval v2?
+### Resolved
 
-## 14. Next Implementation Slice
+- Required Reading benötigt eine maschinenlesbare Contract-Fläche: ja
+- Answer Compliance benötigt JSON: ja
+- vorhandenes Review-Query-Format wird wiederverwendet: ja
+- neuer Goldset-Contract: nein
+- Review-Goldset-Kategorien: festgelegt
+- Agent Consumption Trace besitzt einen Validator und CLI: ja
+- Agent Entry Manifest Core: implementiert
+- Review-Goldset und Baseline: implementiert
 
-**TASK-AGENT-FRONTDOOR-001 — Agent Reading Pack v1.1: Required Reading and Compliance
-Front Door**
+### Still open
 
-### Erlaubter Scope
+- harte Required-Reading-Durchsetzung
+- Adoption durch externe Consumer-/Agent-Wrapper
+- automatische Entry-Manifest-Emission
+- Bundle-/Manifest-Integration des Entry Manifest
+- Consumption-Trace-Integration in Health-/Export-Gates
+- konkrete Promotion-Schwelle für Retrieval v2
+- Facet Model v1
 
-```text
-merger/lenskit/core/agent_reading_pack.py
-merger/lenskit/tests/test_agent_reading_pack.py
-merger/lenskit/tests/test_cli_agent_pack.py
-docs/proofs/agent-reading-pack-producer-proof.md
-```
+## 14. Next Unimplemented Architecture Slice
 
-Optional:
-
-```text
-merger/lenskit/tests/test_agent_reading_pack_usage_rules.py
-```
-
-### Nicht ändern
-
-```text
-merger/lenskit/core/post_emit_health.py
-merger/lenskit/core/bundle_surface_validate.py
-merger/lenskit/core/agent_export_gate.py
-merger/lenskit/core/merge.py
-merger/lenskit/contracts/*.schema.json
-```
-
-### Erfolgskriterium
-
-Ein lesender Agent sieht nach dem Pack explizit, dass für PR Review, Status-Claims,
-Surface Review und Retrieval-Qualitätsbewertung zusätzliche rollenadäquate Flächen nötig
-sind. Gleichzeitig bleibt klar, dass weder Pack noch Sidecars Wahrheit, Vollständigkeit,
-Review-Suffizienz oder Antwortkorrektheit beweisen.
+Der nächste noch nicht implementierte Architektur-Slice ist das
+Facet Model v1.
+Voraussetzung ist, dass das Deterministic Lens Model als normative
+Begriffs- und Schichtengrundlage akzeptiert ist.
+Dieser Blueprint erzeugt dafür keine neue Task-ID.
 
 ## 15. Nicht-normative Contract- und Output-Skizzen
 
@@ -1020,129 +978,32 @@ werden.
 
 ### 15.1 Review-Goldset-Query
 
-```json
-{
-  "id": "find-agent-reading-pack-producer",
-  "query": "agent reading pack producer",
-  "task_profile": "pr_review",
-  "expected_paths": [
-    "merger/lenskit/core/agent_reading_pack.py",
-    "merger/lenskit/tests/test_agent_reading_pack.py"
-  ],
-  "required_in_top_k": 10,
-  "does_not_establish": [
-    "semantic_completeness",
-    "review_sufficiency"
-  ]
-}
-```
+Exact shape: see `docs/retrieval/review_queries.v1.json`.
 
 ### 15.2 Required Reading Protocol
 
-```json
-{
-  "kind": "lenskit.required_reading_protocol",
-  "version": "1.0",
-  "task_profiles": {
-    "pr_review": {
-      "required": [
-        "agent_reading_pack",
-        "canonical_md",
-        "citation_map_jsonl",
-        "post_emit_health"
-      ],
-      "recommended": [
-        "claim_evidence_map_json",
-        "bundle_surface_validation"
-      ],
-      "optional": [
-        "retrieval_eval_json",
-        "sqlite_index"
-      ],
-      "does_not_establish": [
-        "answer_correct",
-        "repo_understood",
-        "review_complete",
-        "test_sufficiency"
-      ]
-    }
-  }
-}
-```
+Exact shape: see the canonical contract at
+`merger/lenskit/contracts/required-reading-protocol.v1.schema.json`.
 
 ### 15.3 Required Reading Resolver
 
-```json
-{
-  "task_profile": "pr_review",
-  "available_required": [],
-  "missing_required": [],
-  "available_recommended": [],
-  "missing_recommended": [],
-  "status": "pass|warn|fail|not_applicable",
-  "does_not_establish": []
-}
-```
+Exact shape: see the canonical contract at
+`merger/lenskit/contracts/required-reading-protocol.v1.schema.json`.
 
 ### 15.4 Answer Compliance
 
-```json
-{
-  "kind": "lenskit.answer_compliance",
-  "version": "1.0",
-  "task_profile": "pr_review",
-  "declared_used_artifacts": [],
-  "declared_citations": [],
-  "declared_epistemic_gaps": [],
-  "declared_unread_recommended": [],
-  "does_not_establish": [
-    "answer_correct",
-    "repo_understood",
-    "all_relevant_context_used"
-  ]
-}
-```
+Exact shape: see the canonical contract at
+`merger/lenskit/contracts/answer-compliance.v1.schema.json`.
 
 ### 15.5 Agent Consumption Trace
 
-```json
-{
-  "kind": "lenskit.agent_consumption_trace",
-  "version": "1.0",
-  "task_profile": "pr_review",
-  "used_artifacts": [
-    {"role": "agent_reading_pack", "usage": "read"},
-    {"role": "canonical_md", "usage": "cited"}
-  ],
-  "used_citation_ids": [],
-  "unread_required_artifacts": [],
-  "unread_recommended_artifacts": [],
-  "epistemic_gaps": [],
-  "does_not_establish": [
-    "actual_reading_proven",
-    "answer_correct",
-    "repo_understood"
-  ]
-}
-```
+Exact shape: see the canonical contract at
+`merger/lenskit/contracts/agent-consumption-trace.v1.schema.json`.
 
 ### 15.6 Agent Entry Manifest
 
-```json
-{
-  "kind": "lenskit.agent_entry_manifest",
-  "version": "1.0",
-  "canonical_source": "canonical_md",
-  "read_first": ["agent_reading_pack"],
-  "task_protocol": "required_reading_protocol",
-  "available_surfaces": [],
-  "does_not_establish": [
-    "repo_understood",
-    "answer_safe_without_citations",
-    "claims_true"
-  ]
-}
-```
+Exact shape: see the canonical contract at
+`merger/lenskit/contracts/agent-entry-manifest.v1.schema.json`.
 
 ### 15.7 Primary Lens Audit
 


### PR DESCRIPTION
## Purpose

Define the deterministic Lenskit lens model and reconcile the front-door
blueprint with already implemented agent and retrieval surfaces.

## Changes

- define Primary Lens, Facet, Relation, State, Task Context and card boundaries
- preserve the existing seven Primary Lens IDs and single-label invariant
- separate navigation projections from content authority and review claims
- reconcile implemented and deferred Agent Consumption / Entry surfaces
- reconcile the existing Review Retrieval baseline and diagnostics
- align Facet derivation semantics with direct / derived / heuristic

## Explicit non-goals

- no change to LENS_IDS or infer_lens()
- no Facet Model v1 contract or producer
- no bundle emission or consumer integration
- no runtime, CLI, retrieval or workflow changes
- no claim of review completeness, repository understanding or forensic readiness

## Open follow-up

Facet Model v1 must decide the final taxonomy, target identity, JSON shape,
negative semantics, evidence requirements and uncertainty treatment.

## Validation

- `test_lenses.py` and `test_primary_lens_audit.py`: 53 passed
- `test_link_integrity.py`: 5 passed
- Agent surface tests: 142 passed
- Review retrieval tests: 46 passed
- Planning Registration: Ratchet check passed (0 findings)
- `git diff --check`: clean
