### PR TITLE
ci: harden contracts mirror pin coherence

### DIFF
--- a/.github/workflows/contracts-validate.yml
+++ b/.github/workflows/contracts-validate.yml
@@ -44,59 +44,96 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
-      - name: Verify 'uses:' pins for heimgewebe/contracts
+      - name: Verify 'uses:' pins for heimgewebe/contracts-mirror
         env:
-          REQUIRED_REPO: "heimgewebe/contracts/.github/workflows/contracts-ajv-reusable.yml"
-          REQUIRED_REF: "contracts-v1"
+          REQUIRED_REPO: "heimgewebe/contracts-mirror/.github/workflows/contracts-ajv-reusable.yml"
+          REQUIRED_REF: "6fd5c239d6fa1fb6b280fc4742b2007a8cd9f5c0"
         run: |
           set -euo pipefail
           shopt -s extglob
 
-          files=()
-          while IFS= read -r -d '' f; do files+=("$f"); done < \
-            <(git ls-files -z -- '.github/workflows/*.yml' '.github/workflows/*.yaml' || true)
+          WF_FILE=".github/workflows/contracts-validate.yml"
+          [[ -f "$WF_FILE" ]] || { echo "::error::Workflow file not found"; exit 1; }
 
-          [[ ${#files[@]} -gt 0 ]] || { echo "::notice::No workflow files"; exit 0; }
-
-          extract_pair() {
-            local line="$1"
-            line="${line%%#*}"
-            line="${line##+([[:space:]])}"
-            line="${line%%+([[:space:]])}"
-            if [[ "$line" =~ ^(-[[:space:]]*)?uses:[[:space:]]*'([^']+)' ]]; then
-              echo "${BASHREMATCH[2]}"; return 0
-            fi
-            if [[ "$line" =~ ^(-[[:space:]]*)?uses:[[:space:]]*\"([^\"]+)\" ]]; then
-              echo "${BASHREMATCH[2]}"; return 0
-            fi
-            if [[ "$line" =~ ^(-[[:space:]]*)?uses:[[:space:]]*([^[:space:]#]+) ]]; then
-              echo "${BASHREMATCH[2]}"; return 0
-            fi
-            return 1
-          }
-
-          check_pair() {
-            local wf="$1" repo="$2" ref="$3"
-            [[ "$repo" == "$REQUIRED_REPO" ]] || return 0
-            if [[ "$ref" =~ (\$\{|\$\(|\$[A-Za-z_]) ]]; then
-              echo "::error file=$wf::Dynamic ref not allowed: $ref"; return 1
-            fi
-            if [[ "$ref" != "$REQUIRED_REF" ]]; then
-              echo "::error file=$wf::Pin mismatch: expected '$REQUIRED_REF', got '$ref'"; return 1
-            fi
-            return 0
-          }
-
+          uses_count=0
+          contracts_ref_count=0
           mismatches=0
-          for wf in "${files[@]}"; do
-            while IFS= read -r line || [[ -n "$line" ]]; do
-              if pair="$(extract_pair "$line")"; then
-                [[ "$pair" == *"@"* ]] || continue
-                repo="${pair%@*}"; ref="${pair#*@}"
-                if ! check_pair "$wf" "$repo" "$ref"; then mismatches=1; fi
+
+          while IFS= read -r line || [[ -n "$line" ]]; do
+            clean_line="${line%%#*}"
+            trimmed="${clean_line#"${clean_line%%[![:space:]]*}"}"
+
+            if [[ "$trimmed" == uses:* ]]; then
+              val="${trimmed#uses:}"
+              val="${val#"${val%%[![:space:]]*}"}"
+              val="${val%\"}"
+              val="${val#\"}"
+              val="${val%\'}"
+              val="${val#\'}"
+
+              if [[ "$val" == *"heimgewebe/contracts"* ]]; then
+                uses_count=$((uses_count + 1))
+
+                if [[ "$val" != *"@"* ]]; then
+                  echo "::error file=$WF_FILE::uses reference missing @ symbol"
+                  mismatches=1
+                  continue
+                fi
+
+                repo="${val%@*}"
+                ref="${val#*@}"
+
+                if [[ "$repo" != "$REQUIRED_REPO" ]]; then
+                  echo "::error file=$WF_FILE::Expected repository $REQUIRED_REPO but got $repo"
+                  mismatches=1
+                fi
+
+                if [[ ! "$ref" =~ ^[0-9a-f]{40}$ ]]; then
+                  echo "::error file=$WF_FILE::uses ref must be a 40-character lowercase hex SHA, got $ref"
+                  mismatches=1
+                fi
+
+                if [[ "$ref" != "$REQUIRED_REF" ]]; then
+                  echo "::error file=$WF_FILE::uses ref mismatch. Expected $REQUIRED_REF, got $ref"
+                  mismatches=1
+                fi
               fi
-            done < "$wf"
-          done
+            fi
+
+            if [[ "$trimmed" == contracts_ref:* ]]; then
+              contracts_ref_count=$((contracts_ref_count + 1))
+              val="${trimmed#contracts_ref:}"
+              val="${val#"${val%%[![:space:]]*}"}"
+              val="${val%\"}"
+              val="${val#\"}"
+              val="${val%\'}"
+              val="${val#\'}"
+
+              if [[ ! "$val" =~ ^[0-9a-f]{40}$ ]]; then
+                echo "::error file=$WF_FILE::contracts_ref must be a 40-character lowercase hex SHA, got $val"
+                mismatches=1
+              fi
+
+              if [[ "$val" != "$REQUIRED_REF" ]]; then
+                echo "::error file=$WF_FILE::contracts_ref mismatch. Expected $REQUIRED_REF, got $val"
+                mismatches=1
+              fi
+            fi
+          done < "$WF_FILE"
+
+          if [[ $uses_count -ne 1 ]]; then
+            echo "::error file=$WF_FILE::Expected exactly 1 uses caller for mirror, found $uses_count"
+            mismatches=1
+          fi
+
+          if [[ $contracts_ref_count -ne 1 ]]; then
+            echo "::error file=$WF_FILE::Expected exactly 1 contracts_ref input, found $contracts_ref_count"
+            mismatches=1
+          fi
+
+          if [[ $mismatches -ne 0 ]]; then
+            exit 1
+          fi
 
           [[ $mismatches -eq 0 ]] || exit 1
           echo "::notice::✅ All version pins validated"
@@ -184,7 +221,8 @@ jobs:
   validate:
     name: "Validate fixtures via reusable workflow"
     needs: [version-sync-check, guard]
-    uses: heimgewebe/contracts/.github/workflows/contracts-ajv-reusable.yml@contracts-v1
+    uses: heimgewebe/contracts-mirror/.github/workflows/contracts-ajv-reusable.yml@6fd5c239d6fa1fb6b280fc4742b2007a8cd9f5c0
     secrets: inherit
     with:
       fixtures_glob: ${{ vars.FIXTURES_GLOB || 'fixtures/**/*.jsonl' }}
+      contracts_ref: 6fd5c239d6fa1fb6b280fc4742b2007a8cd9f5c0

--- a/.github/workflows/contracts-validate.yml
+++ b/.github/workflows/contracts-validate.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Verify 'uses:' pins for heimgewebe/contracts-mirror
         env:
           REQUIRED_REPO: "heimgewebe/contracts-mirror/.github/workflows/contracts-ajv-reusable.yml"
-          REQUIRED_REF: "6fd5c239d6fa1fb6b280fc4742b2007a8cd9f5c0"
+          REQUIRED_REF: "0e5430c72b7948124e2b892da9473bdf8f8a120e"
         run: |
           set -euo pipefail
           shopt -s extglob
@@ -221,8 +221,8 @@ jobs:
   validate:
     name: "Validate fixtures via reusable workflow"
     needs: [version-sync-check, guard]
-    uses: heimgewebe/contracts-mirror/.github/workflows/contracts-ajv-reusable.yml@6fd5c239d6fa1fb6b280fc4742b2007a8cd9f5c0
+    uses: heimgewebe/contracts-mirror/.github/workflows/contracts-ajv-reusable.yml@0e5430c72b7948124e2b892da9473bdf8f8a120e
     secrets: inherit
     with:
       fixtures_glob: ${{ vars.FIXTURES_GLOB || 'fixtures/**/*.jsonl' }}
-      contracts_ref: 6fd5c239d6fa1fb6b280fc4742b2007a8cd9f5c0
+      contracts_ref: 0e5430c72b7948124e2b892da9473bdf8f8a120e


### PR DESCRIPTION
## Summary

Repairs and hardens the `contracts-validate` reusable-workflow caller without touching Lens Cards v1.

## Changes

- switches the reusable-workflow repository from `heimgewebe/contracts` to `heimgewebe/contracts-mirror`;
- pins the reusable-workflow caller to immutable commit `6fd5c239d6fa1fb6b280fc4742b2007a8cd9f5c0`;
- passes the same immutable SHA through `contracts_ref`, preventing fallback to the unresolved `contracts-v1` tag;
- makes the static guard require exactly one expected reusable-workflow caller;
- makes the guard require exactly one static `contracts_ref`;
- enforces equality between the `uses:` SHA, `contracts_ref`, and `REQUIRED_REF`;
- rejects missing, duplicated, dynamic, shortened, or divergent references.

## Scope

Exactly one repository file changes:

- `.github/workflows/contracts-validate.yml`

No Lens Card code, contracts, proofs, task records, bundle logic, validation semantics, or contracts-mirror content is changed.

## Validation target

This PR is successful only when:

1. GitHub creates the workflow jobs instead of failing before job creation;
2. the static repository/ref/coherence guard passes;
3. the reusable workflow resolves at the pinned mirror commit;
4. its internal contracts checkout uses the identical SHA supplied through `contracts_ref`;
5. the actual contract validation executes;
6. all required jobs finish successfully.

## Source identity

- Mirror reusable workflow:
  `6fd5c239d6fa1fb6b280fc4742b2007a8cd9f5c0`
- Mirror contracts checkout:
  `6fd5c239d6fa1fb6b280fc4742b2007a8cd9f5c0`

## Boundaries

This PR repairs repository and reference resolution and statically enforces the two-pin identity invariant.

It does not:

- weaken contract validation;
- introduce a moving or unpinned fallback;
- modify protected contracts;
- modify Lens Cards v1;
- claim that a green static guard alone proves runtime validation.

The PR remains Draft until the reusable workflow creates jobs and the complete contract-validation path is green.
