### PR TITLE
fix(graph): skip optional graph artifacts without schema validation

### DIFF
--- a/merger/lenskit/core/merge.py
+++ b/merger/lenskit/core/merge.py
@@ -5023,6 +5023,7 @@ def build_derived_artifacts(dump_index_path, chunk_path, base_name_func, run_id,
     architecture_graph_path = None
     entrypoints_path = None
     graph_index_path = None
+    source_result = None
     try:
         from ..architecture.bundle_sources import (
             BundleGraphSourceError,
@@ -5052,9 +5053,6 @@ def build_derived_artifacts(dump_index_path, chunk_path, base_name_func, run_id,
                 file=sys.stderr,
             )
 
-        for source_path in (architecture_graph_path, entrypoints_path):
-            if source_path.exists() and source_path not in derived_paths:
-                derived_paths.append(source_path)
 
         if architecture_graph_path.exists() or entrypoints_path.exists():
             graph_index_data = compile_graph_index(
@@ -5068,6 +5066,9 @@ def build_derived_artifacts(dump_index_path, chunk_path, base_name_func, run_id,
                 json.dumps(graph_index_data, indent=2, sort_keys=True),
                 encoding="utf-8",
             )
+            for source_path in (architecture_graph_path, entrypoints_path):
+                if source_path.exists() and source_path not in derived_paths:
+                    derived_paths.append(source_path)
             derived_paths.append(graph_index_path)
     except ImportError as e:
         if debug:
@@ -5075,7 +5076,28 @@ def build_derived_artifacts(dump_index_path, chunk_path, base_name_func, run_id,
                 f"Skipping graph artifacts: architecture modules not available ({e})",
                 file=sys.stderr,
             )
-    except (BundleGraphSourceError, GraphIndexCompilationError):
+    except GraphIndexCompilationError as e:
+        if getattr(e, "code", None) == "validation_unavailable":
+            if debug:
+                print(
+                    "Skipping graph artifacts: graph index validation unavailable "
+                    f"({e})",
+                    file=sys.stderr,
+                )
+            if source_result is not None and source_result.produced:
+                for source_path in (architecture_graph_path, entrypoints_path):
+                    if source_path is None:
+                        continue
+                    try:
+                        source_path.unlink(missing_ok=True)
+                    except OSError:
+                        pass
+            architecture_graph_path = None
+            entrypoints_path = None
+            graph_index_path = None
+        else:
+            raise
+    except BundleGraphSourceError:
         raise
     except Exception as e:
         if debug:

--- a/merger/lenskit/tests/test_graph_artifact_degrade.py
+++ b/merger/lenskit/tests/test_graph_artifact_degrade.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+
+from merger.lenskit.architecture import graph_source_validation
+from merger.lenskit.core.merge import build_derived_artifacts
+
+
+def test_graph_side_artifacts_skip_when_schema_dependency_absent(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    source = repo / "src" / "main.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("def main():\n    return 1\n", encoding="utf-8")
+
+    dump = tmp_path / "bundle.dump_index.json"
+    dump.write_text(json.dumps({"contract": "dump-index", "artifacts": {}}), encoding="utf-8")
+
+    chunks = tmp_path / "bundle.chunk_index.jsonl"
+    chunks.write_text(json.dumps({
+        "chunk_id": "c1",
+        "repo": "sample",
+        "path": "src/main.py",
+        "source_status": "full",
+        "truncated": False,
+        "source_range": {"status": "declared"},
+    }) + "\n", encoding="utf-8")
+
+    monkeypatch.setattr(graph_source_validation, "json" + "schema", None)
+
+    def base_name(part_suffix=""):
+        return tmp_path / f"bundle{part_suffix or ''}"
+
+    paths = build_derived_artifacts(
+        dump, chunks, base_name, "run", tmp_path, {"name": "test"}, ["sample"], True,
+        repo_summaries=[{"name": "sample", "root": str(repo)}],
+    )
+
+    names = {Path(path).name for path in paths}
+    assert "bundle.graph_index.json" not in names
+    assert "bundle.architecture_graph.json" not in names
+    assert "bundle.entrypoints.json" not in names

--- a/merger/lenskit/tests/test_graph_current_state_audit.py
+++ b/merger/lenskit/tests/test_graph_current_state_audit.py
@@ -88,7 +88,9 @@ def test_g2_compiler_validates_and_binds_both_sources() -> None:
     assert "dump_sha256 = _compute_file_sha256(dump_index_path)" in merge_source
     assert "expected_run_id=run_id" in merge_source
     assert "expected_canonical_sha256=dump_sha256" in merge_source
-    assert "except (BundleGraphSourceError, GraphIndexCompilationError):" in merge_source
+    assert 'except GraphIndexCompilationError as e:' in merge_source
+    assert '"validation_unavailable"' in merge_source
+    assert 'except BundleGraphSourceError:' in merge_source
     assert "Draft7Validator" in validation
     assert '"validation_unavailable"' in validation
     assert '"provenance_mismatch"' in validation

--- a/merger/lenskit/tests/test_jsonschema_degradation.py
+++ b/merger/lenskit/tests/test_jsonschema_degradation.py
@@ -108,17 +108,18 @@ from pathlib import Path
 import logging
 logging.basicConfig(level=logging.WARNING)
 
-result = gi.load_graph_index(Path("{graph_path}"))
-if result["status"] == "ok" and "graph" in result:
+result = gi.load_graph_index(Path("{tmp_path}"), "graph.json")
+if result["status"] == "validation_unavailable" and result["graph"] is None:
     print("Success")
 else:
+    print(f"Wrong result: {result}")
     sys.exit(1)
 """
     repo_root = get_repo_root()
     result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, env=get_test_env(), cwd=repo_root)
     assert result.returncode == 0
     assert "Success" in result.stdout
-    assert "Schema validation skipped" in result.stderr
+    assert "Graph index validation unavailable" in result.stderr
 
 def test_federation_degradation(tmp_path):
     code = f"""

--- a/merger/lenskit/tests/test_jsonschema_degradation.py
+++ b/merger/lenskit/tests/test_jsonschema_degradation.py
@@ -112,7 +112,7 @@ result = gi.load_graph_index(Path("{tmp_path}"), "graph.json")
 if result["status"] == "validation_unavailable" and result["graph"] is None:
     print("Success")
 else:
-    print(f"Wrong result: {result}")
+    print(f"Wrong result: {{result}}")
     sys.exit(1)
 """
     repo_root = get_repo_root()


### PR DESCRIPTION
## Summary
- keeps the main merge/dump path running when graph index validation is unavailable
- skips graph_index and auto-produced graph source artifacts instead of publishing unvalidated derived graph artifacts
- keeps other graph source and compilation errors fail-closed

## Validation
- python3 -m pytest -q merger/lenskit/tests/test_graph_artifact_degrade.py merger/lenskit/tests/test_graph_index.py merger/lenskit/tests/test_graph_e2e.py merger/lenskit/tests/test_jsonschema_degradation.py
- Result: 23 passed in 0.36s