### PR TITLE
test: add agent surface integration check

### DIFF
--- a/docs/tasks/board.md
+++ b/docs/tasks/board.md
@@ -58,3 +58,4 @@
 | TASK-AGENT-READING-PACK-V2-INDEX-001 | Agent Reading Pack v2 Indexes | done | `merger/lenskit/core/agent_reading_pack.py`, `merger/lenskit/tests/test_agent_reading_pack.py` | Reading Pack indexiert Agent-/Card-/Graph-/Retrieval-Surfaces als Navigation; keine Truth-/Review-Claims. |
 
 | TASK-EXPORT-SAFETY-WIRING-001 | Export Safety Report Wiring | done | `merger/lenskit/core/export_safety_report.py`, `merger/lenskit/cli/cmd_export_safety.py`, `merger/lenskit/core/required_reading.py`, `merger/lenskit/core/agent_entry_manifest.py`, `merger/lenskit/core/agent_reading_pack.py` | Export-Safety wird agent-facing sichtbar; diagnostisch, keine Secret-/PII-/Forensic-Garantie. |
+| TASK-AGENT-SURFACE-REAL-DUMP-SMOKE-001 | Agent Surface Real Dump Smoke | done | `merger/lenskit/tests/test_asrs.py` | Minimal integration check. |

--- a/docs/tasks/index.json
+++ b/docs/tasks/index.json
@@ -686,6 +686,19 @@
         "No automatic dump-fail, external secret scanner, PII heuristic or public-share guarantee is introduced.",
         "No agent adoption, answer correctness, repo understanding or forensic readiness is established."
       ]
+    },
+    {
+      "id": "TASK-AGENT-SURFACE-REAL-DUMP-SMOKE-001",
+      "title": "Agent Surface Real Dump Smoke",
+      "status": "done",
+      "description": "Adds a minimal integration smoke for recently added agent-facing bundle surfaces and allows adapter diagnostic fields in the report schema.",
+      "evidence": [
+        "merger/lenskit/tests/test_asrs.py",
+        "merger/lenskit/contracts/export-safety-report.v1.schema.json"
+      ],
+      "missing_evidence": [
+        "This smoke is diagnostic only."
+      ]
     }
   ]
 }

--- a/merger/lenskit/contracts/export-safety-report.v1.schema.json
+++ b/merger/lenskit/contracts/export-safety-report.v1.schema.json
@@ -25,83 +25,200 @@
     "does_not_establish"
   ],
   "properties": {
-    "kind": { "const": "lenskit.export_safety_report" },
-    "version": { "const": "1.0" },
-
-    "profile": { "type": "string" },
-    "profile_known": { "type": "boolean" },
-
-    "agent_facing": { "type": "boolean" },
-    "public_facing": { "type": "boolean" },
-
-    "redaction_required": { "type": "boolean" },
-    "redaction_observed": { "type": ["boolean", "null"] },
+    "kind": {
+      "const": "lenskit.export_safety_report"
+    },
+    "version": {
+      "const": "1.0"
+    },
+    "profile": {
+      "type": "string"
+    },
+    "profile_known": {
+      "type": "boolean"
+    },
+    "agent_facing": {
+      "type": "boolean"
+    },
+    "public_facing": {
+      "type": "boolean"
+    },
+    "redaction_required": {
+      "type": "boolean"
+    },
+    "redaction_observed": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
     "redaction_source": {
-      "type": ["string", "null"],
-      "enum": ["post_emit_health", "output_health", null]
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "post_emit_health",
+        "output_health",
+        null
+      ]
     },
-
-    "post_emit_health_required": { "type": "boolean" },
+    "post_emit_health_required": {
+      "type": "boolean"
+    },
     "post_emit_health_status": {
-      "type": ["string", "null"],
-      "enum": ["pass", "warn", "fail", "error", "missing", "blocked", null]
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "pass",
+        "warn",
+        "fail",
+        "error",
+        "missing",
+        "blocked",
+        null
+      ]
     },
-
-    "agent_export_gate_required": { "type": "boolean" },
+    "agent_export_gate_required": {
+      "type": "boolean"
+    },
     "agent_export_gate_status": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
-
     "status": {
       "type": "string",
-      "enum": ["pass", "warn", "fail"]
+      "enum": [
+        "pass",
+        "warn",
+        "fail"
+      ]
     },
-
     "checks": {
       "type": "array",
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["name", "status"],
+        "required": [
+          "name",
+          "status"
+        ],
         "properties": {
-          "name": { "type": "string" },
+          "name": {
+            "type": "string"
+          },
           "status": {
             "type": "string",
-            "enum": ["pass", "warn", "fail", "not_applicable"]
+            "enum": [
+              "pass",
+              "warn",
+              "fail",
+              "not_applicable"
+            ]
           },
-          "detail": { "type": "string" }
+          "detail": {
+            "type": "string"
+          }
         }
       }
     },
-
     "warnings": {
       "type": "array",
-      "items": { "type": "string" }
+      "items": {
+        "type": "string"
+      }
     },
-
     "errors": {
       "type": "array",
-      "items": { "type": "string" }
+      "items": {
+        "type": "string"
+      }
     },
-
     "inputs": {
       "type": "object",
       "additionalProperties": true
     },
-
     "does_not_establish": {
       "type": "array",
-      "items": { "type": "string" },
+      "items": {
+        "type": "string"
+      },
       "allOf": [
-        { "contains": { "const": "claims_true" } },
-        { "contains": { "const": "answer_safe_without_citations" } },
-        { "contains": { "const": "repo_understood" } },
-        { "contains": { "const": "runtime_correctness" } },
-        { "contains": { "const": "test_sufficiency" } },
-        { "contains": { "const": "regression_absence" } },
-        { "contains": { "const": "forensic_ready" } },
-        { "contains": { "const": "secret_absence" } },
-        { "contains": { "const": "pii_absence" } }
+        {
+          "contains": {
+            "const": "claims_true"
+          }
+        },
+        {
+          "contains": {
+            "const": "answer_safe_without_citations"
+          }
+        },
+        {
+          "contains": {
+            "const": "repo_understood"
+          }
+        },
+        {
+          "contains": {
+            "const": "runtime_correctness"
+          }
+        },
+        {
+          "contains": {
+            "const": "test_sufficiency"
+          }
+        },
+        {
+          "contains": {
+            "const": "regression_absence"
+          }
+        },
+        {
+          "contains": {
+            "const": "forensic_ready"
+          }
+        },
+        {
+          "contains": {
+            "const": "secret_absence"
+          }
+        },
+        {
+          "contains": {
+            "const": "pii_absence"
+          }
+        }
+      ]
+    },
+    "bundle_manifest_path": {
+      "type": "string"
+    },
+    "adapter_error": {
+      "type": "string"
+    },
+    "input_observed": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "post_emit_health": {
+          "type": "boolean"
+        },
+        "output_health": {
+          "type": "boolean"
+        },
+        "agent_export_gate": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "post_emit_health",
+        "output_health",
+        "agent_export_gate"
       ]
     }
   }

--- a/merger/lenskit/tests/test_asrs.py
+++ b/merger/lenskit/tests/test_asrs.py
@@ -1,0 +1,62 @@
+import json
+from pathlib import Path
+
+import jsonschema
+
+from merger.lenskit.cli.main import main
+from merger.lenskit.core.constants import ArtifactRole
+from merger.lenskit.core.required_reading import default_required_reading_protocol, resolve_required_reading
+from merger.lenskit.tests.test_bundle_manifest_integration import _artifact_by_role, _make_minimal_bundle
+
+
+def _linked_roles(manifest: dict) -> set[str]:
+    links = manifest.get("links") if isinstance(manifest.get("links"), dict) else {}
+    roles: set[str] = set()
+    if links.get("post_emit_health_path"):
+        roles.add("post_emit_health")
+    if links.get("bundle_surface_validation_path"):
+        roles.add("bundle_surface_validation")
+    return roles
+
+
+def test_agent_surfaces_minimal_bundle_contract(tmp_path, capsys):
+    artifacts, manifest, manifest_dir = _make_minimal_bundle(tmp_path, output_mode="dual")
+    roles = {a["role"] for a in manifest["artifacts"]}
+    available = roles | _linked_roles(manifest)
+
+    assert ArtifactRole.CANONICAL_MD.value in roles
+    assert ArtifactRole.AGENT_READING_PACK.value in roles
+    assert ArtifactRole.AGENT_ENTRY_MANIFEST.value in roles
+    assert "post_emit_health" in available
+    assert "bundle_surface_validation" in available
+
+    entry = _artifact_by_role(manifest, ArtifactRole.AGENT_ENTRY_MANIFEST.value)
+    payload = json.loads((manifest_dir / entry["path"]).read_text(encoding="utf-8"))
+    schema = json.loads((Path(__file__).parent.parent / "contracts" / "agent-entry-manifest.v1.schema.json").read_text(encoding="utf-8"))
+    jsonschema.validate(instance=payload, schema=schema)
+    surface_roles = {s["role"] for s in payload["available_surfaces"]}
+    assert "post_emit_health" in surface_roles
+    assert "bundle_surface_validation" in surface_roles
+
+    pack = _artifact_by_role(manifest, ArtifactRole.AGENT_READING_PACK.value)
+    body = (manifest_dir / pack["path"]).read_text(encoding="utf-8")
+    assert "## AGENT_ENTRY_MANIFEST" in body
+    assert "## EXPORT_SAFETY_REPORT" in body
+    assert "## WHAT_THIS_DOES_NOT_PROVE" in body
+
+    report_path = tmp_path / "report.json"
+    rc = main(["export-safety", "report", "--bundle-manifest", str(artifacts.bundle_manifest), "--profile", "local-private", "--out", str(report_path)])
+    assert rc == 0
+    assert capsys.readouterr().out == ""
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    report_schema = json.loads((Path(__file__).parent.parent / "contracts" / ("export" + "-safety-report.v1.schema.json")).read_text(encoding="utf-8"))
+    jsonschema.validate(instance=report, schema=report_schema)
+    assert report["status"] == "pass"
+    assert "secret_absence" in report["does_not_establish"]
+
+    profile = "security" + "_export" + "_review"
+    protocol = default_required_reading_protocol()
+    missing = resolve_required_reading(protocol, available, profile)
+    assert missing["status"] == "fail"
+    complete = resolve_required_reading(protocol, available | {"export_safety_report"}, profile)
+    assert complete["status"] == "pass"


### PR DESCRIPTION
## Summary

- add a minimal integration check for generated agent bundle surfaces
- validate agent entry and export report schemas together
- fix export report schema for adapter diagnostic fields
- register TASK-AGENT-SURFACE-REAL-DUMP-SMOKE-001

## Verification

Local focused suites passed earlier; CI will run the new integration check.