### PR TITLE
feat(cards): emit lens cards in bundles

### DIFF
--- a/docs/tasks/board.md
+++ b/docs/tasks/board.md
@@ -59,3 +59,4 @@
 
 | TASK-EXPORT-SAFETY-WIRING-001 | Export Safety Report Wiring | done | `merger/lenskit/core/export_safety_report.py`, `merger/lenskit/cli/cmd_export_safety.py`, `merger/lenskit/core/required_reading.py`, `merger/lenskit/core/agent_entry_manifest.py`, `merger/lenskit/core/agent_reading_pack.py` | Export-Safety wird agent-facing sichtbar; diagnostisch, keine Secret-/PII-/Forensic-Garantie. |
 | TASK-AGENT-SURFACE-REAL-DUMP-SMOKE-001 | Agent Surface Real Dump Smoke | done | `merger/lenskit/tests/test_asrs.py` | Minimal integration check. |
+| TASK-CARD-BUNDLE-EMISSION-001 | Lens Card Bundle Emission | done | `merger/lenskit/core/merge.py`, `merger/lenskit/contracts/bundle-manifest.v1.schema.json`, `merger/lenskit/tests/test_bundle_manifest_integration.py` | Emittiert `lens_cards_jsonl` als navigierendes Bundle-Artefakt; keine Truth-/Review-/Impact-Claims. |

--- a/docs/tasks/index.json
+++ b/docs/tasks/index.json
@@ -699,6 +699,25 @@
       "missing_evidence": [
         "This smoke is diagnostic only."
       ]
+    },
+    {
+      "id": "TASK-CARD-BUNDLE-EMISSION-001",
+      "title": "Lens Card Bundle Emission",
+      "status": "done",
+      "description": "Emits Lens Cards v1 as a bundle-registered lens_cards_jsonl navigation artifact. This wires the existing Lens Card producer into the standard bundle manifest and Agent Reading Pack index without adding review, impact or truth claims. PR Delta Card and Relation Card bundle emission remain follow-up slices.",
+      "evidence": [
+        "merger/lenskit/core/constants.py",
+        "merger/lenskit/core/merge.py",
+        "merger/lenskit/core/agent_reading_pack.py",
+        "merger/lenskit/contracts/bundle-manifest.v1.schema.json",
+        "merger/lenskit/tests/test_bundle_manifest_integration.py",
+        "merger/lenskit/tests/test_agent_reading_pack.py",
+        "merger/lenskit/tests/test_cli_agent_pack.py"
+      ],
+      "missing_evidence": [
+        "PR Delta Cards and Relation Cards are not emitted by this slice.",
+        "Lens Cards remain navigation_index/derived and do not prove change impact, truth, review completeness or runtime behavior."
+      ]
     }
   ]
 }

--- a/merger/lenskit/contracts/bundle-manifest.v1.schema.json
+++ b/merger/lenskit/contracts/bundle-manifest.v1.schema.json
@@ -141,7 +141,8 @@
               "claim_evidence_map_json",
               "agent_reading_pack",
               "agent_entry_manifest",
-              "export_safety_report"
+              "export_safety_report",
+              "lens_cards_jsonl"
             ],
             "description": "Machine-readable enum role for this artifact."
           },
@@ -304,7 +305,8 @@
                     "entrypoints_json",
                     "graph_index_json",
                     "architecture_summary",
-                    "agent_entry_manifest"
+                    "agent_entry_manifest",
+                    "lens_cards_jsonl"
                   ]
                 }
               },
@@ -913,6 +915,64 @@
                 },
                 "risk_class": {
                   "const": "diagnostic"
+                },
+                "regenerable": {
+                  "const": true
+                },
+                "staleness_sensitive": {
+                  "const": true
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "role": {
+                  "const": "lens_cards_jsonl"
+                }
+              },
+              "required": [
+                "role"
+              ]
+            },
+            "then": {
+              "required": [
+                "content_type",
+                "contract",
+                "authority",
+                "canonicality",
+                "risk_class",
+                "regenerable",
+                "staleness_sensitive"
+              ],
+              "properties": {
+                "content_type": {
+                  "const": "application/x-ndjson"
+                },
+                "contract": {
+                  "type": "object",
+                  "required": [
+                    "id",
+                    "version"
+                  ],
+                  "properties": {
+                    "id": {
+                      "const": "lens-card"
+                    },
+                    "version": {
+                      "const": "v1"
+                    }
+                  }
+                },
+                "authority": {
+                  "const": "navigation_index"
+                },
+                "canonicality": {
+                  "const": "derived"
+                },
+                "risk_class": {
+                  "const": "navigation"
                 },
                 "regenerable": {
                   "const": true

--- a/merger/lenskit/core/agent_reading_pack.py
+++ b/merger/lenskit/core/agent_reading_pack.py
@@ -726,9 +726,8 @@ def render_agent_reading_pack(model: PackModel) -> str:
         "change impact."
     )
     lines.append(
-        "This Reading Pack does not claim that any Lens Card artifact is present in "
-        "the bundle; automatic bundle, manifest or consumer integration is outside "
-        "the current Lens Card v1 slice."
+        "When `lens_cards_jsonl` is present in the bundle manifest, treat it as "
+        "a path-navigation artifact only; it still does not replace canonical reads."
     )
     lines.append("")
 

--- a/merger/lenskit/core/constants.py
+++ b/merger/lenskit/core/constants.py
@@ -25,6 +25,7 @@ class ArtifactRole(str, Enum):
     AGENT_READING_PACK = "agent_reading_pack"
     AGENT_ENTRY_MANIFEST = "agent_entry_manifest"
     EXPORT_SAFETY_REPORT = "export_safety_report"
+    LENS_CARDS_JSONL = "lens_cards_jsonl"
 
 
 CLAIM_EVIDENCE_MAP_ABSENCE_REASON_LINK_KEY = "claim_evidence_map_absence_reason"

--- a/merger/lenskit/core/merge.py
+++ b/merger/lenskit/core/merge.py
@@ -231,6 +231,7 @@ ARTIFACT_CONTRACT_REGISTRY = {
     ArtifactRole.CLAIM_EVIDENCE_MAP_JSON: {"id": "claim-evidence-map", "version": "v1"},
     ArtifactRole.AGENT_ENTRY_MANIFEST: {"id": "agent-entry-manifest", "version": "v1"},
     ArtifactRole.EXPORT_SAFETY_REPORT: {"id": "export-safety-report", "version": "v1"},
+    ArtifactRole.LENS_CARDS_JSONL: {"id": "lens-card", "version": "v1"},
 }
 
 ARTIFACT_AUTHORITY_REGISTRY = {
@@ -341,6 +342,13 @@ ARTIFACT_AUTHORITY_REGISTRY = {
         "authority": "diagnostic_signal",
         "canonicality": "diagnostic",
         "risk_class": "diagnostic",
+        "regenerable": True,
+        "staleness_sensitive": True,
+    },
+    ArtifactRole.LENS_CARDS_JSONL: {
+        "authority": "navigation_index",
+        "canonicality": "derived",
+        "risk_class": "navigation",
         "regenerable": True,
         "staleness_sensitive": True,
     },
@@ -606,6 +614,7 @@ class MergeArtifacts:
     claim_evidence_map: Optional[Path] = None
     agent_reading_pack: Optional[Path] = None
     agent_entry_manifest: Optional[Path] = None
+    lens_cards: Optional[Path] = None
     other: List[Path] = None
 
     def __post_init__(self):
@@ -643,6 +652,8 @@ class MergeArtifacts:
             paths.append(self.agent_reading_pack)
         if self.agent_entry_manifest and self.agent_entry_manifest not in paths:
             paths.append(self.agent_entry_manifest)
+        if self.lens_cards and self.lens_cards not in paths:
+            paths.append(self.lens_cards)
         if self.bundle_manifest:
             paths.append(self.bundle_manifest)
 
@@ -6216,6 +6227,39 @@ def write_reports_v2(
     if derived_manifests:
         _add_artifact(derived_manifests[-1], ArtifactRole.DERIVED_MANIFEST_JSON, "application/json")
 
+
+    def _write_lens_cards_jsonl(base_manifest_path: Path) -> Optional[Path]:
+        """Emit Lens Cards v1 as deterministic JSONL navigation."""
+        from .lens_cards import produce_lens_cards
+
+        paths: List[str] = []
+        for summary in repo_summaries:
+            for fi in summary.get("files", []):
+                if getattr(fi, "is_text", False):
+                    paths.append(fi.rel_path.as_posix())
+        if not paths:
+            return None
+        cards = produce_lens_cards(paths)
+        if not cards:
+            return None
+        out_path = base_manifest_path.with_name(
+            base_manifest_path.name.replace(".bundle.manifest.json", ".lens_cards.jsonl")
+        )
+        text = "".join(json.dumps(card, sort_keys=True) + "\n" for card in cards)
+        _write_text_atomic(out_path, text)
+        return out_path
+
+    lens_cards_path = _write_lens_cards_jsonl(bundle_manifest_path)
+    if lens_cards_path is not None:
+        out_paths.append(lens_cards_path)
+        if lens_cards_path not in other_paths:
+            other_paths.append(lens_cards_path)
+        _add_artifact(
+            lens_cards_path,
+            ArtifactRole.LENS_CARDS_JSONL,
+            "application/x-ndjson",
+        )
+
     # Write output health report BEFORE the bundle manifest is finalized.
     # In this implementation, health checks are anchored to already-materialized primary artifacts
     # (especially dump_index), not to the final bundle manifest entry itself.
@@ -6571,6 +6615,7 @@ def write_reports_v2(
             claim_evidence_map=claim_evidence_map_path,
             agent_reading_pack=agent_reading_pack_path,
             agent_entry_manifest=agent_entry_manifest_path,
+            lens_cards=lens_cards_path,
             other=other_paths
         )
     else:
@@ -6589,5 +6634,6 @@ def write_reports_v2(
             claim_evidence_map=claim_evidence_map_path,
             agent_reading_pack=agent_reading_pack_path,
             agent_entry_manifest=agent_entry_manifest_path,
+            lens_cards=lens_cards_path,
             other=other_paths
         )

--- a/merger/lenskit/tests/test_agent_reading_pack.py
+++ b/merger/lenskit/tests/test_agent_reading_pack.py
@@ -345,8 +345,8 @@ def test_agent_reading_pack_lens_card_guidance_is_static_and_bounded(tmp_path):
     assert "repo understanding" in section
     assert "review completeness" in section
     assert "change impact" in section
-    assert "does not claim that any Lens Card artifact is present" in section
-    assert "automatic bundle, manifest or consumer integration is outside" in section
+    assert "path-navigation artifact only" in section
+    assert "does not replace canonical reads" in section
 
 
 def test_agent_pack_retrieval_quality_review_mentions_miss_taxonomy(tmp_path):

--- a/merger/lenskit/tests/test_bundle_manifest_integration.py
+++ b/merger/lenskit/tests/test_bundle_manifest_integration.py
@@ -788,17 +788,47 @@ def test_agent_reading_pack_emitted_schema_valid_and_hashed(tmp_path):
     ):
         assert marker in body, f"emitted agent_reading_pack missing v1.1 marker: {marker}"
     assert "NAVIGATION, NOT TRUTH" in body
-    # The exact serialization boundary below proves a specific string is absent,
-    # it does not formally prove artifact non-emission.
-    assert '"kind": "lenskit.lens_card"' not in body
-    assert "does not claim that any Lens Card artifact is present" in body
-    assert "automatic bundle, manifest or consumer integration is outside" in body
+    assert "## LENS_CARD_INDEX" in body
+    assert "lens_cards_jsonl" in body
+    assert "path-navigation artifact only" in body
     assert data["run_id"] in body
     # The pack must never list its own role as bundle content.
     assert "| agent_reading_pack |" not in body
     # It should reference the bundle's truth anchor and health verdict.
     assert "## OUTPUT_HEALTH_SUMMARY" in body
     assert "## TOP_CHUNK_SPANS" in body
+
+
+
+def test_lens_cards_jsonl_bundle_artifact_is_emitted(tmp_path):
+    artifacts, data, manifest_dir = _make_minimal_bundle(tmp_path)
+
+    entry = _artifact_by_role(data, ArtifactRole.LENS_CARDS_JSONL.value)
+    assert entry is not None
+    assert entry["content_type"] == "application/x-ndjson"
+    assert entry["contract"] == {"id": "lens-card", "version": "v1"}
+    assert entry["interpretation"] == {"mode": "contract"}
+    assert entry["authority"] == "navigation_index"
+    assert entry["canonicality"] == "derived"
+    assert entry["risk_class"] == "navigation"
+    assert entry["regenerable"] is True
+    assert entry["staleness_sensitive"] is True
+
+    assert artifacts.lens_cards is not None
+    lens_cards_path = manifest_dir / entry["path"]
+    assert lens_cards_path == artifacts.lens_cards
+    assert lens_cards_path.exists()
+    assert entry["bytes"] == lens_cards_path.stat().st_size
+    assert entry["sha256"] == _sha256_file(lens_cards_path)
+
+    cards = [json.loads(line) for line in lens_cards_path.read_text(encoding="utf-8").splitlines()]
+    assert len(cards) == 1
+    card = cards[0]
+    assert card["kind"] == "lenskit.lens_card"
+    assert card["authority"] == "navigation_index"
+    assert card["canonicality"] == "derived"
+    assert card["path"] == "file1.txt"
+    assert "change_impact" in card["does_not_establish"]
 
 
 def test_bundle_manifest_canonical_dump_index_sha_matches_dump_index_artifact(tmp_path):

--- a/merger/lenskit/tests/test_cli_agent_pack.py
+++ b/merger/lenskit/tests/test_cli_agent_pack.py
@@ -83,8 +83,8 @@ def test_cli_agent_pack_json_ok(tmp_path, capsys):
     # The exact serialization boundary below proves a specific string is absent,
     # it does not formally prove artifact non-emission.
     assert '"kind": "lenskit.lens_card"' not in body
-    assert "does not claim that any Lens Card artifact is present" in body
-    assert "automatic bundle, manifest or consumer integration is outside" in body
+    assert "path-navigation artifact only" in body
+    assert "does not replace canonical reads" in body
 
 
 def test_cli_agent_pack_human_ok(tmp_path, capsys):


### PR DESCRIPTION
## Summary

- emit Lens Cards v1 as `lens_cards_jsonl` during standard bundle creation
- register `lens_cards_jsonl` in ArtifactRole, bundle manifest schema, contract registry and authority registry
- expose the emitted artifact through Agent Reading Pack `LENS_CARD_INDEX`
- add bundle integration tests for artifact metadata, file hash and JSONL card payload
- register TASK-CARD-BUNDLE-EMISSION-001

## Scope

This slice intentionally emits Lens Cards only. PR Delta Cards and Relation Cards remain follow-up slices because they need separate source surfaces.

## Verification

- pytest test_bundle_manifest_integration.py: 44 passed
- pytest test_bundle_manifest_schema.py test_role_completeness.py: 46 passed
- pytest test_agent_reading_pack.py test_cli_agent_pack.py: 58 passed
- pytest test_lens_cards.py: 81 passed
- pytest test_lens_card_validate.py: 13 passed
- planning-registration strict: passed
- ruff F401,F811 focused: passed
- git diff --check: passed

## Does not establish

- change impact
- review completeness
- runtime behavior
- truth
- regression absence