### PR TITLE
fix(agent): list consumption preflight in reading pack

### DIFF
--- a/merger/lenskit/core/agent_reading_pack.py
+++ b/merger/lenskit/core/agent_reading_pack.py
@@ -580,6 +580,7 @@ def render_agent_reading_pack(model: PackModel) -> str:
         "- CLI: `python3 -m merger.lenskit.cli.main agent-consumption required "
         "--task-profile <profile> ...`"
     )
+    lines.append("- CLI: `python3 -m merger.lenskit.cli.main agent-consumption preflight --task-profile <profile> ...`")
     lines.append(
         "- CLI: `python3 -m merger.lenskit.cli.main agent-consumption validate-trace ...`"
     )

--- a/merger/lenskit/tests/test_agent_reading_pack.py
+++ b/merger/lenskit/tests/test_agent_reading_pack.py
@@ -1049,3 +1049,13 @@ def test_agent_reading_pack_export_safety_section_names_report_fields(tmp_path):
     assert "`redaction_required`" in section
     assert "`redaction_observed`" in section
     assert "secret absence" in section
+
+
+def test_agent_consumption_contracts_section_mentions_preflight_cli(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    body = Path(produce_agent_reading_pack(str(manifest))["output_path"]).read_text()
+    section = _section(body, "AGENT_CONSUMPTION_CONTRACTS")
+
+    assert "agent-consumption preflight" in section
+    assert "--task-profile <profile>" in section
+    assert "actual_reading_proven" in section


### PR DESCRIPTION
## Summary
- list `agent-consumption preflight` in the Agent Reading Pack agent-consumption command surface
- add a regression test that the AGENT_CONSUMPTION_CONTRACTS section mentions the preflight CLI

## Validation
- `python3 -m py_compile merger/lenskit/core/agent_reading_pack.py merger/lenskit/tests/test_agent_reading_pack.py` → passed
- `ruff check merger/lenskit/core/agent_reading_pack.py merger/lenskit/tests/test_agent_reading_pack.py` → passed
- producer smoke: generated a pack and asserted it contains `agent-consumption preflight` → passed

## Boundaries
- navigation-only follow-up to #827
- no new contract, no bundle mutation, no truth/review claim