### PR TITLE
docs: audit query range refs

### DIFF
--- a/docs/proofs/query-range-ref-audit-proof.md
+++ b/docs/proofs/query-range-ref-audit-proof.md
@@ -1,0 +1,123 @@
+# Query Range-Ref Audit Proof
+
+Status: done  
+Task: `TASK-QUERY-RANGE-REF-AUDIT-001`  
+Scope: audit only; no query runtime, schema, ranking, service, or bundle mutation.
+
+## 1. Purpose
+
+This audit answers a narrow operational question from the Agent Operationalization roadmap:
+
+> Which retrieval query results already carry resolvable range references, and what is still missing before a stronger proof-carrying query surface is justified?
+
+The audit is deliberately conservative. A query hit with a range pointer is easier to cite; it is not automatically true, sufficient, complete, or semantically important.
+
+## 2. Current implemented surfaces
+
+### Query output
+
+`execute_query()` already emits optional per-hit range surfaces:
+
+- `range_ref`: parsed from stored chunk metadata field `content_range_ref`.
+- `derived_range_ref`: built at query time when explicit metadata is absent but source-file, byte range, line range, and content hash are available.
+
+The top-level query result also carries `claim_boundaries`. Its `evidence_basis` includes `result_ranges` only when at least one result has `range_ref` or `derived_range_ref`.
+
+### Query Result contract
+
+`query-result.v1.schema.json` already accepts both `range_ref` and `derived_range_ref` on result items. Both may be v1 or v2 range refs. The schema does not require every result item to have one.
+
+### Context bundle
+
+`build_context_bundle()` propagates explicit and derived range refs into context hits and exposes epistemic status:
+
+- explicit `range_ref` -> `provenance_type=explicit`, `resolver_status=resolved_explicit`
+- `derived_range_ref` -> `provenance_type=derived`, `resolver_status=resolved_derived`
+- no ref -> `provenance_type=derived`, `resolver_status=unresolved`
+
+This is the right shape for agent-facing uncertainty: the context bundle distinguishes a real explicit pointer from a fallback and from an unresolved hit.
+
+### Resolver
+
+`resolve_range_ref()` accepts explicit bundle-backed references and source-file fallback references, with path and hash checks. Existing tests cover v1/v2 range refs, malformed refs, path traversal rejection, source-file fallback, and backwards compatibility.
+
+## 3. What is already good enough
+
+- Stored explicit `content_range_ref` can roundtrip into query `range_ref` and then through `resolve_range_ref()`.
+- Dynamic fallback can produce `derived_range_ref` when source-file metadata is available.
+- Old indexes without range metadata degrade safely: query execution completes without inventing a false range ref.
+- Query output boundaries already avoid claiming repository completeness or semantic importance.
+- Context bundles preserve the epistemic difference between explicit, derived, and unresolved hits.
+
+## 4. Gaps found
+
+### Gap A — no all-hit range guarantee
+
+`query-result.v1` allows result items without `range_ref` and without `derived_range_ref`. This is intentional for backwards compatibility and degraded indexes, but it means consumers cannot assume every query result is citation-ready.
+
+Consequence: a future proof-carrying query mode must report per-hit range coverage, not just presence of any range in the result set.
+
+### Gap B — `result_ranges` means at least one hit, not all hits
+
+`claim_boundaries.evidence_basis` currently adds `result_ranges` if any returned hit has a range ref. That is useful, but weaker than a coverage metric. It does not mean every hit is range-backed.
+
+Consequence: consumers must inspect each hit or a future summary field; top-level `result_ranges` is not enough for answer safety.
+
+### Gap C — derived source refs are not canonical citations
+
+`derived_range_ref` can be resolvable and useful, but it is a fallback to source-file provenance. It is not the same authority class as an explicit `canonical_md` range.
+
+Consequence: agent-facing citation policy should prefer explicit `canonical_md` `range_ref` and treat `derived_range_ref` as fallback context, not as canonical evidence.
+
+### Gap D — citation-map bridge is indirect
+
+Citation-map compatibility exists through chunk identity and canonical ranges, but raw query hits do not currently expose `citation_id`. A consumer that wants stable citation IDs must bridge from hit `chunk_id` / range metadata to `citation_map_jsonl`.
+
+Consequence: a minimal adapter is justified before any stronger agent-answer surface: `query_result -> citation candidates` should be explicit and diagnostic.
+
+## 5. Decision
+
+Do not create a new proof-carrying query contract yet.
+
+Instead, the next implementation slice should be a minimal diagnostic adapter:
+
+`query-range-coverage report`
+
+It should compute, for a query result or query execution:
+
+- total hits
+- hits with explicit `range_ref`
+- hits with explicit `canonical_md` range refs
+- hits with `derived_range_ref`
+- unresolved hits
+- optional `citation_id` candidates when `citation_map_jsonl` is available
+- per-hit status: `canonical_explicit`, `explicit_noncanonical`, `derived_source`, `unresolved`, `malformed`
+
+This report remains diagnostic. It must not score answer correctness, claim truth, retrieval completeness, test sufficiency, or repository understanding.
+
+## 6. Validation run
+
+Local focused validation:
+
+```text
+pytest -q merger/lenskit/tests/test_query_schema_range_ref.py
+# 7 passed
+
+pytest -q merger/lenskit/tests/test_range_ref_backwards_compat.py merger/lenskit/tests/test_range_resolver.py
+# 20 passed
+```
+
+This proves the audited contract/resolver basis remains green. It does not prove that every real bundle or old index has full range coverage.
+
+## 7. Non-claims
+
+This audit does not establish:
+
+- answer correctness
+- claim truth
+- full repository coverage
+- retrieval completeness
+- semantic importance of ranked hits
+- live working-tree state
+- that every query result is citation-ready
+- that `derived_range_ref` is equivalent to a canonical citation

--- a/docs/roadmap/lenskit-agent-operationalization-roadmap.md
+++ b/docs/roadmap/lenskit-agent-operationalization-roadmap.md
@@ -126,9 +126,11 @@ Promotion-Gate: keine zentrale Query-Klasse regressiert; expected-target recall 
 
 ### TASK-QUERY-RANGE-REF-AUDIT-001 - Query Range-Ref Audit
 
+Status: umgesetzt. Beleg: `docs/proofs/query-range-ref-audit-proof.md`.
+
 Ziel: Vor einem neuen Proof-Carrying-Query-Contract pruefen, welche Query-Treffer bereits aufloesbare Range-Refs tragen.
 
-Aufgaben: Query-Result-Schema und Runtime-Ausgabe gegen Range-Ref-Faehigkeit auditieren; Roundtrip gegen `canonical_md` pruefen; Citation-Map-Kompatibilitaet pruefen; nur bei belegter Luecke minimalen Adapter planen.
+Umgesetzt: Query-Result-Schema und Runtime-Ausgabe gegen Range-Ref-Faehigkeit auditiert; vorhandene Roundtrip-/Resolver-Tests gruen; Citation-Map-Kompatibilitaet als indirekte Chunk-/Range-Bruecke bewertet; naechster minimaler Adapter `query-range-coverage report` geplant.
 
 Nichtziele: kein grosser neuer Query-Contract ohne Gap-Beweis, kein Graph-/Symbol-Boost in diesem Slice.
 

--- a/merger/lenskit/tests/test_query_range_ref_audit_doc.py
+++ b/merger/lenskit/tests/test_query_range_ref_audit_doc.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+
+DOC = Path(__file__).parents[3] / "docs" / "proofs" / "query-range-ref-audit-proof.md"
+
+
+def test_query_range_ref_audit_records_current_surfaces_and_gaps():
+    text = DOC.read_text(encoding="utf-8")
+    for token in (
+        "range_ref",
+        "derived_range_ref",
+        "content_range_ref",
+        "query-result.v1.schema.json",
+        "claim_boundaries",
+        "result_ranges",
+        "citation_map_jsonl",
+        "all-hit range guarantee",
+        "query-range-coverage report",
+        "does not establish",
+    ):
+        assert token in text
+
+
+def test_query_range_ref_audit_keeps_diagnostic_boundary():
+    text = DOC.read_text(encoding="utf-8")
+    for forbidden in (
+        "answer correctness: true",
+        "claim truth: true",
+        "retrieval completeness: true",
+        "repo_understood: true",
+        "every query result is citation-ready: true",
+    ):
+        assert forbidden not in text


### PR DESCRIPTION
## Summary
- add Query Range-Ref Audit proof
- mark roadmap slice as implemented
- add doc regression test for audit content and diagnostic boundary

## Validation
- python3 -m pytest -q merger/lenskit/tests/test_query_range_ref_audit_doc.py
- python3 -m pytest -q merger/lenskit/tests/test_query_schema_range_ref.py
- python3 -m pytest -q merger/lenskit/tests/test_range_ref_backwards_compat.py
- python3 -m pytest -q merger/lenskit/tests/test_range_resolver.py

## Non-claims
- no runtime/query behavior change
- no proof-carrying query contract yet
- no claim that every query result is citation-ready