### PR TITLE
feat: add retrieval range diagnostics

### DIFF
--- a/merger/lenskit/cli/cmd_query.py
+++ b/merger/lenskit/cli/cmd_query.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 from ..retrieval.query_core import execute_query
+from ..retrieval.query_range_coverage import build_query_range_coverage_report
 from ..retrieval.session import build_agent_query_session
 from ..retrieval.output_projection import project_output
 from .stale_check import check_stale_index
@@ -83,6 +84,17 @@ def run_query(args: argparse.Namespace) -> int:
             context_window_lines=context_window_lines
         )
 
+        range_coverage_requested = (
+            getattr(args, "range_coverage_report", False)
+            or bool(getattr(args, "citation_map", None))
+        )
+        if range_coverage_requested:
+            citation_map = getattr(args, "citation_map", None)
+            result["range_coverage"] = build_query_range_coverage_report(
+                result,
+                citation_map_jsonl=Path(citation_map) if citation_map else None,
+            )
+
         if getattr(args, "trace", False) and "query_trace" in result:
             out_dir_str = getattr(args, "trace_out_dir", None)
             out_dir = Path(out_dir_str) if out_dir_str else Path.cwd()
@@ -137,5 +149,25 @@ def run_query(args: argparse.Namespace) -> int:
             print("-" * 60)
             print("Explain Diagnostics:")
             print(json.dumps(result["explain"], indent=2))
+        if "range_coverage" in result:
+            coverage = result["range_coverage"]
+            counts = coverage["counts"]
+            print("-" * 60)
+            print("Range Coverage:")
+            print(
+                "    total={total} explicit={explicit} canonical={canonical} "
+                "derived={derived} unresolved={unresolved} malformed={malformed}".format(
+                    total=coverage["total_hits"],
+                    explicit=counts["hits_with_explicit_range_ref"],
+                    canonical=counts["hits_with_explicit_canonical_md_range_ref"],
+                    derived=counts["hits_with_derived_range_ref"],
+                    unresolved=counts["unresolved_hits"],
+                    malformed=counts["malformed_hits"],
+                )
+            )
+            if coverage["citation_map"]["warnings"]:
+                print("    citation_map_warnings:")
+                for warning in coverage["citation_map"]["warnings"]:
+                    print(f"    - {warning}")
 
     return 0

--- a/merger/lenskit/cli/main.py
+++ b/merger/lenskit/cli/main.py
@@ -102,6 +102,8 @@ def main(args: Optional[List[str]] = None) -> int:
     query_parser.add_argument("--context-window-lines", type=int, default=0, help="Number of lines to expand in window mode")
     query_parser.add_argument("--trace", action="store_true", help="Generate query_trace.json and agent_query_session.json (defaults to current directory, override with --trace-out-dir)")
     query_parser.add_argument("--trace-out-dir", help="Output directory for trace and session artifacts")
+    query_parser.add_argument("--range-diagnostics", dest="range_coverage_report", action="store_true", help="Attach per-hit range diagnostics")
+    query_parser.add_argument("--citation-map", help="Optional citation_map_jsonl for citation id candidates")
 
     # Eval command
     eval_parser = subparsers.add_parser("eval", help="Evaluate retrieval quality against Gold Queries")

--- a/merger/lenskit/retrieval/query_range_coverage.py
+++ b/merger/lenskit/retrieval/query_range_coverage.py
@@ -1,0 +1,288 @@
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+
+_RANGE_REF_REQUIRED_KEYS = (
+    "artifact_role",
+    "repo_id",
+    "file_path",
+    "start_byte",
+    "end_byte",
+    "start_line",
+    "end_line",
+    "content_sha256",
+)
+
+_DOES_NOT_ESTABLISH = [
+    "truth",
+    "answer_correctness",
+    "retrieval_completeness",
+    "repository_understanding",
+    "runtime_behavior",
+    "test_sufficiency",
+    "regression_absence",
+    "that every query result is citation-ready",
+]
+
+
+def _is_int_not_bool(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _range_ref_error(ref: Any) -> Optional[str]:
+    if not isinstance(ref, dict):
+        return "range ref is not an object"
+
+    missing = [key for key in _RANGE_REF_REQUIRED_KEYS if key not in ref]
+    if missing:
+        return "range ref missing required keys: " + ", ".join(missing)
+
+    for key in ("artifact_role", "repo_id", "file_path", "content_sha256"):
+        if not isinstance(ref.get(key), str) or not ref.get(key):
+            return f"range ref field {key!r} must be a non-empty string"
+
+    for key in ("start_byte", "end_byte", "start_line", "end_line"):
+        if not _is_int_not_bool(ref.get(key)):
+            return f"range ref field {key!r} must be an integer"
+
+    if ref["start_byte"] < 0:
+        return "range ref start_byte must be >= 0"
+    if ref["end_byte"] <= ref["start_byte"]:
+        return "range ref end_byte must be > start_byte"
+    if ref["start_line"] < 1:
+        return "range ref start_line must be >= 1"
+    if ref["end_line"] < ref["start_line"]:
+        return "range ref end_line must be >= start_line"
+
+    return None
+
+
+def _canonical_range_key(ref: Dict[str, Any]) -> Tuple[str, int, int, str]:
+    return (
+        str(ref.get("file_path", "")),
+        int(ref.get("start_byte", -1)),
+        int(ref.get("end_byte", -1)),
+        str(ref.get("content_sha256", "")),
+    )
+
+
+def _classify_hit(hit: Dict[str, Any]) -> Tuple[str, Optional[str], Optional[str]]:
+    explicit_ref = hit.get("range_ref")
+    if explicit_ref is not None:
+        error = _range_ref_error(explicit_ref)
+        if error:
+            return "malformed", "range_ref", error
+        if explicit_ref.get("artifact_role") == "canonical_md":
+            return "canonical_explicit", "range_ref", None
+        return "explicit_noncanonical", "range_ref", None
+
+    derived_ref = hit.get("derived_range_ref")
+    if derived_ref is not None:
+        error = _range_ref_error(derived_ref)
+        if error:
+            return "malformed", "derived_range_ref", error
+        if derived_ref.get("artifact_role") != "source_file":
+            return (
+                "malformed",
+                "derived_range_ref",
+                "derived range ref must use artifact_role='source_file'",
+            )
+        return "derived_source", "derived_range_ref", None
+
+    return "unresolved", None, None
+
+
+def _load_citation_rows(
+    citation_map_jsonl: Path,
+) -> Tuple[Dict[str, List[Dict[str, Any]]], Dict[Tuple[str, int, int, str], List[Dict[str, Any]]], List[str]]:
+    by_chunk: Dict[str, List[Dict[str, Any]]] = {}
+    by_range: Dict[Tuple[str, int, int, str], List[Dict[str, Any]]] = {}
+    warnings: List[str] = []
+
+    if not citation_map_jsonl.exists():
+        warnings.append(f"citation_map_jsonl not found: {citation_map_jsonl}")
+        return by_chunk, by_range, warnings
+
+    for lineno, raw_line in enumerate(
+        citation_map_jsonl.read_text(encoding="utf-8").splitlines(), start=1
+    ):
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError as exc:
+            warnings.append(f"line {lineno}: invalid JSON: {exc.msg}")
+            continue
+
+        citation_id = row.get("citation_id")
+        if not isinstance(citation_id, str) or not citation_id:
+            warnings.append(f"line {lineno}: missing citation_id")
+            continue
+
+        chunk_id = row.get("chunk_id")
+        if isinstance(chunk_id, str) and chunk_id:
+            by_chunk.setdefault(chunk_id, []).append(row)
+
+        canonical_range = row.get("canonical_range")
+        if isinstance(canonical_range, dict):
+            key = _canonical_range_key(canonical_range)
+            if key[1] >= 0 and key[2] > key[1] and key[3]:
+                by_range.setdefault(key, []).append(row)
+            else:
+                warnings.append(f"line {lineno}: malformed canonical_range")
+
+    return by_chunk, by_range, warnings
+
+
+def _merge_candidate(
+    candidates: Dict[str, Dict[str, Any]], row: Dict[str, Any], reason: str
+) -> None:
+    citation_id = row.get("citation_id")
+    if not isinstance(citation_id, str) or not citation_id:
+        return
+
+    current = candidates.setdefault(
+        citation_id,
+        {
+            "citation_id": citation_id,
+            "match_reasons": [],
+        },
+    )
+    if reason not in current["match_reasons"]:
+        current["match_reasons"].append(reason)
+
+
+def _citation_candidates_for_hit(
+    hit: Dict[str, Any],
+    by_chunk: Dict[str, List[Dict[str, Any]]],
+    by_range: Dict[Tuple[str, int, int, str], List[Dict[str, Any]]],
+) -> List[Dict[str, Any]]:
+    candidates: Dict[str, Dict[str, Any]] = {}
+
+    chunk_id = hit.get("chunk_id")
+    if isinstance(chunk_id, str):
+        for row in by_chunk.get(chunk_id, []):
+            _merge_candidate(candidates, row, "chunk_id")
+
+    explicit_ref = hit.get("range_ref")
+    if (
+        isinstance(explicit_ref, dict)
+        and explicit_ref.get("artifact_role") == "canonical_md"
+        and _range_ref_error(explicit_ref) is None
+    ):
+        for row in by_range.get(_canonical_range_key(explicit_ref), []):
+            _merge_candidate(candidates, row, "canonical_range")
+
+    return sorted(candidates.values(), key=lambda item: item["citation_id"])
+
+
+def build_query_range_coverage_report(
+    query_result: Dict[str, Any],
+    *,
+    citation_map_jsonl: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Build a diagnostic coverage report for per-hit query range evidence.
+
+    The report is deliberately narrower than an answer-quality or retrieval-quality
+    verdict. It only classifies the range-reference surface already present on query
+    hits and optionally proposes citation-id candidates from a citation map.
+    """
+    hits = query_result.get("results", [])
+    if not isinstance(hits, list):
+        hits = []
+
+    by_chunk: Dict[str, List[Dict[str, Any]]] = {}
+    by_range: Dict[Tuple[str, int, int, str], List[Dict[str, Any]]] = {}
+    warnings: List[str] = []
+    citation_map_status = "not_provided"
+
+    if citation_map_jsonl is not None:
+        by_chunk, by_range, warnings = _load_citation_rows(citation_map_jsonl)
+        citation_map_status = "loaded" if not warnings else "loaded_with_warnings"
+        if warnings and not by_chunk and not by_range:
+            citation_map_status = "unusable"
+
+    counts = {
+        "hits_with_explicit_range_ref": 0,
+        "hits_with_explicit_canonical_md_range_ref": 0,
+        "hits_with_derived_range_ref": 0,
+        "unresolved_hits": 0,
+        "malformed_hits": 0,
+        "citation_id_candidate_hits": 0,
+    }
+    status_counts: Dict[str, int] = {}
+    per_hit: List[Dict[str, Any]] = []
+
+    for idx, raw_hit in enumerate(hits):
+        hit = raw_hit if isinstance(raw_hit, dict) else {}
+        status, ref_kind, error = _classify_hit(hit)
+        status_counts[status] = status_counts.get(status, 0) + 1
+
+        if status in {"canonical_explicit", "explicit_noncanonical"}:
+            counts["hits_with_explicit_range_ref"] += 1
+        if status == "canonical_explicit":
+            counts["hits_with_explicit_canonical_md_range_ref"] += 1
+        if status == "derived_source":
+            counts["hits_with_derived_range_ref"] += 1
+        if status == "unresolved":
+            counts["unresolved_hits"] += 1
+        if status == "malformed":
+            counts["malformed_hits"] += 1
+
+        candidates = _citation_candidates_for_hit(hit, by_chunk, by_range)
+        if candidates:
+            counts["citation_id_candidate_hits"] += 1
+
+        item = {
+            "hit_index": idx,
+            "chunk_id": hit.get("chunk_id"),
+            "path": hit.get("path"),
+            "range": hit.get("range"),
+            "status": status,
+            "range_ref_kind": ref_kind,
+        }
+        if error:
+            item["error"] = error
+        if candidates:
+            item["citation_id_candidates"] = candidates
+        per_hit.append(item)
+
+    total_hits = len(hits)
+
+    def ratio(value: int) -> float:
+        return round(value / total_hits, 6) if total_hits else 0.0
+
+    report = {
+        "kind": "lenskit.query_range_coverage_report",
+        "version": "1.0",
+        "total_hits": total_hits,
+        "counts": counts,
+        "status_counts": status_counts,
+        "coverage": {
+            "explicit_range_ref_ratio": ratio(counts["hits_with_explicit_range_ref"]),
+            "explicit_canonical_md_ratio": ratio(
+                counts["hits_with_explicit_canonical_md_range_ref"]
+            ),
+            "derived_range_ref_ratio": ratio(counts["hits_with_derived_range_ref"]),
+            "unresolved_ratio": ratio(counts["unresolved_hits"]),
+            "malformed_ratio": ratio(counts["malformed_hits"]),
+            "citation_id_candidate_ratio": ratio(
+                counts["citation_id_candidate_hits"]
+            ),
+        },
+        "per_hit": per_hit,
+        "citation_map": {
+            "status": citation_map_status,
+            "path": str(citation_map_jsonl) if citation_map_jsonl is not None else None,
+            "warnings": warnings,
+        },
+        "diagnostic_semantics": {
+            "authority": "query_result_surface",
+            "canonical_preference": "explicit canonical_md range_ref",
+            "derived_range_ref_policy": "fallback context, not canonical citation",
+            "does_not_establish": list(_DOES_NOT_ESTABLISH),
+        },
+    }
+    return report

--- a/merger/lenskit/tests/test_query_range_coverage.py
+++ b/merger/lenskit/tests/test_query_range_coverage.py
@@ -1,0 +1,96 @@
+import json
+
+from merger.lenskit.retrieval.query_range_coverage import build_query_range_coverage_report
+
+
+def _ref(role='canonical_md', *, file_path='merge.md', start_byte=0, end_byte=10):
+    return {
+        'artifact_role': role,
+        'repo_id': 'lenskit',
+        'file_path': file_path,
+        'start_byte': start_byte,
+        'end_byte': end_byte,
+        'start_line': 1,
+        'end_line': 2,
+        'content_sha256': 'a' * 64,
+    }
+
+
+def test_query_range_coverage_counts_per_hit_statuses():
+    result = {
+        'results': [
+            {'chunk_id': 'canonical', 'path': 'merge.md', 'range': '1-2', 'range_ref': _ref('canonical_md')},
+            {'chunk_id': 'noncanonical', 'path': 'src/example.py', 'range': '1-2', 'range_ref': _ref('source_file', file_path='src/example.py')},
+            {'chunk_id': 'derived', 'path': 'src/derived.py', 'range': '1-2', 'derived_range_ref': _ref('source_file', file_path='src/derived.py')},
+            {'chunk_id': 'unresolved', 'path': 'src/unresolved.py', 'range': '1-2'},
+            {'chunk_id': 'malformed', 'path': 'src/broken.py', 'range': '1-2', 'range_ref': {'artifact_role': 'canonical_md'}},
+        ]
+    }
+
+    report = build_query_range_coverage_report(result)
+
+    assert report['total_hits'] == 5
+    assert report['counts'] == {
+        'hits_with_explicit_range_ref': 2,
+        'hits_with_explicit_canonical_md_range_ref': 1,
+        'hits_with_derived_range_ref': 1,
+        'unresolved_hits': 1,
+        'malformed_hits': 1,
+        'citation_id_candidate_hits': 0,
+    }
+    assert report['status_counts'] == {
+        'canonical_explicit': 1,
+        'explicit_noncanonical': 1,
+        'derived_source': 1,
+        'unresolved': 1,
+        'malformed': 1,
+    }
+    assert [hit['status'] for hit in report['per_hit']] == [
+        'canonical_explicit',
+        'explicit_noncanonical',
+        'derived_source',
+        'unresolved',
+        'malformed',
+    ]
+    assert 'truth' in report['diagnostic_semantics']['does_not_establish']
+    assert report['diagnostic_semantics']['canonical_preference'] == 'explicit canonical_md range_ref'
+
+
+def test_query_range_coverage_adds_citation_id_candidates(tmp_path):
+    canonical_ref = _ref('canonical_md')
+    citation_map = tmp_path / 'citation_map.jsonl'
+    citation_map.write_text(
+        json.dumps({
+            'citation_id': 'cite-123',
+            'repo_id': 'lenskit',
+            'chunk_id': 'chunk-a',
+            'canonical_range': {
+                'file_path': canonical_ref['file_path'],
+                'start_byte': canonical_ref['start_byte'],
+                'end_byte': canonical_ref['end_byte'],
+                'start_line': canonical_ref['start_line'],
+                'end_line': canonical_ref['end_line'],
+                'content_sha256': canonical_ref['content_sha256'],
+            },
+        }) + '\n',
+        encoding='utf-8',
+    )
+    result = {'results': [{'chunk_id': 'chunk-a', 'path': 'merge.md', 'range': '1-2', 'range_ref': canonical_ref}]}
+
+    report = build_query_range_coverage_report(result, citation_map_jsonl=citation_map)
+
+    assert report['counts']['citation_id_candidate_hits'] == 1
+    assert report['per_hit'][0]['citation_id_candidates'] == [
+        {'citation_id': 'cite-123', 'match_reasons': ['chunk_id', 'canonical_range']}
+    ]
+    assert report['citation_map']['status'] == 'loaded'
+
+
+def test_query_range_coverage_missing_citation_map_is_diagnostic(tmp_path):
+    missing = tmp_path / 'missing.citation_map.jsonl'
+    report = build_query_range_coverage_report({'results': []}, citation_map_jsonl=missing)
+
+    assert report['citation_map']['status'] == 'unusable'
+    assert 'not found' in report['citation_map']['warnings'][0]
+    assert report['total_hits'] == 0
+    assert report['coverage']['explicit_range_ref_ratio'] == 0.0


### PR DESCRIPTION
## Summary
- add a diagnostic per-hit range coverage report for query results
- classify hits as canonical explicit, explicit noncanonical, derived source, unresolved, or malformed
- expose diagnostics through query --range-diagnostics and optional --citation-map candidate lookup

## Validation
- python3 -m pytest -q merger/lenskit/tests/test_query_range_coverage.py (3 passed before import cleanup)
- manual invocation of the 3 new test functions after import cleanup
- python3 -m pytest -q merger/lenskit/tests/test_query_schema_range_ref.py (7 passed)
- python3 -m py_compile merger/lenskit/retrieval/query_range_coverage.py merger/lenskit/tests/test_query_range_coverage.py merger/lenskit/cli/cmd_query.py merger/lenskit/cli/main.py
- git diff --check

## Non-claims
- diagnostic only
- does not prove answer correctness, retrieval completeness, runtime behavior, repository understanding, or that every hit is citation-ready