### PR TITLE
feat: add review intent cli

### DIFF
--- a/docs/roadmap/lenskit-agent-operationalization-roadmap.md
+++ b/docs/roadmap/lenskit-agent-operationalization-roadmap.md
@@ -118,9 +118,11 @@ Nichtziel: Kein echter Lesebeweis. Ein Agent kann eine Trace falsch ausfuellen; 
 
 ### TASK-REVIEW-INTENT-CLI-001 - Review-Intent Router CLI
 
+Status: umgesetzt. `lenskit query --review-intent` ist opt-in verfuegbar; Default-Query bleibt unveraendert.
+
 Ziel: Der vorhandene Review-Intent Router wird als opt-in CLI-Oberflaeche nutzbar, ohne Default-Promotion.
 
-Aufgaben: CLI-Flag oder separater Command fuer Review-Intent Query; Ausgabe von Intent, Lane-Plan, Exclusions, Treffern, Fallbacks und Miss-Klassen; Default-Query bleibt unveraendert.
+Umgesetzt: CLI-Flag fuer Review-Intent Query; bei `--explain` Ausgabe von Intent-Plan, Lane-Summaries, Fusion und Treffern; inkompatible Graph-/Semantic-/Trace-/Context-Optionen werden fail-closed abgelehnt, statt still ignoriert zu werden.
 
 Promotion-Gate: keine zentrale Query-Klasse regressiert; expected-target recall besser oder gleich; Fehler-/Fallback-Zaehlung ehrlich; stale Graph Index beeinflusst Ranking nicht.
 

--- a/merger/lenskit/cli/cmd_query.py
+++ b/merger/lenskit/cli/cmd_query.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 from ..retrieval.query_core import execute_query
+from ..retrieval.review_query import execute_review_query
 from ..retrieval.query_range_coverage import build_query_range_coverage_report
 from ..retrieval.session import build_agent_query_session
 from ..retrieval.output_projection import project_output
@@ -67,22 +68,48 @@ def run_query(args: argparse.Namespace) -> int:
             or context_window_lines > 0
         )
 
-        result = execute_query(
-            index_path=index_path,
-            query_text=args.q,
-            k=args.k,
-            filters=applied_filters,
-            embedding_policy=policy_instance,
-            explain=getattr(args, "explain", False),
-            overmatch_guard=getattr(args, "overmatch_guard", False),
-            graph_index_path=Path(args.graph_index) if getattr(args, "graph_index", None) else None,
-            graph_weights=graph_weights_dict,
-            test_penalty=getattr(args, "test_penalty", 0.75),
-            trace=getattr(args, "trace", False),
-            build_context=build_context,
-            context_mode=context_mode,
-            context_window_lines=context_window_lines
-        )
+        use_review_intent = bool(getattr(args, "review_intent", False))
+        if use_review_intent:
+            blocked_options = []
+            if policy_instance is not None:
+                blocked_options.append("--embedding-policy")
+            if getattr(args, "graph_index", None):
+                blocked_options.append("--graph-index")
+            if getattr(args, "trace", False):
+                blocked_options.append("--trace")
+            if build_context:
+                blocked_options.append("context bundle/output profile options")
+            if blocked_options:
+                joined = ", ".join(blocked_options)
+                print(
+                    "Error: --review-intent does not combine with " + joined,
+                    file=sys.stderr,
+                )
+                return 1
+            result = execute_review_query(
+                index_path=index_path,
+                query_text=args.q,
+                k=args.k,
+                filters=applied_filters,
+                explain=getattr(args, "explain", False),
+            )
+        else:
+            result = execute_query(
+                index_path=index_path,
+                query_text=args.q,
+                k=args.k,
+                filters=applied_filters,
+                embedding_policy=policy_instance,
+                explain=getattr(args, "explain", False),
+                overmatch_guard=getattr(args, "overmatch_guard", False),
+                graph_index_path=Path(args.graph_index) if getattr(args, "graph_index", None) else None,
+                graph_weights=graph_weights_dict,
+                test_penalty=getattr(args, "test_penalty", 0.75),
+                trace=getattr(args, "trace", False),
+                build_context=build_context,
+                context_mode=context_mode,
+                context_window_lines=context_window_lines
+            )
 
         range_coverage_requested = (
             getattr(args, "range_coverage_report", False)

--- a/merger/lenskit/cli/main.py
+++ b/merger/lenskit/cli/main.py
@@ -93,6 +93,7 @@ def main(args: Optional[List[str]] = None) -> int:
     query_parser.add_argument("--embedding-policy", help="Path to embedding-policy.v1 JSON policy instance (requests semantic pipeline; currently candidate overfetch only)")
     query_parser.add_argument("--explain", action="store_true", help="Include diagnostic explain block in query results")
     query_parser.add_argument("--overmatch-guard", action="store_true", help="Disable synonym OR-expansion in router")
+    query_parser.add_argument("--review-intent", action="store_true", help="Use opt-in deterministic Review-Intent Router; default query behavior remains unchanged")
     query_parser.add_argument("--graph-index", help="Path to graph_index.json to enable graph-aware reranking")
     query_parser.add_argument("--graph-weights", help='JSON string of graph weights (e.g. \'{"w_bm25": 0.65}\')')
     query_parser.add_argument("--test-penalty", type=float, default=0.75, help="Score penalty multiplier for test files")

--- a/merger/lenskit/tests/test_review_query.py
+++ b/merger/lenskit/tests/test_review_query.py
@@ -252,3 +252,84 @@ def test_review_query_rejects_invalid_k(review_fixture):
 
     with pytest.raises(ValueError, match="k must be at least 1"):
         execute_review_query(index_path, query, k=0)
+
+
+def test_cli_query_review_intent_opt_in_uses_review_router(review_fixture, capsys):
+    from argparse import Namespace
+    from merger.lenskit.cli import cmd_query
+
+    _, _, index_path, query = review_fixture
+    args = Namespace(
+        index=str(index_path),
+        q=query,
+        k=4,
+        repo=None,
+        path=None,
+        ext=None,
+        layer=None,
+        artifact_type=None,
+        emit="json",
+        stale_policy="ignore",
+        embedding_policy=None,
+        explain=True,
+        graph_index=None,
+        graph_weights=None,
+        test_penalty=0.75,
+        output_profile=None,
+        context_window_lines=0,
+        context_mode="exact",
+        build_context_bundle=False,
+        overmatch_guard=False,
+        review_intent=True,
+        trace=False,
+        range_coverage_report=False,
+        citation_map=None,
+    )
+
+    rc = cmd_query.run_query(args)
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+
+    assert data["query_mode"] == "review_intent"
+    assert data["engine"] == "fts5+review_intent_v1"
+    assert data["count"] == 4
+    assert "review_intent_router" in data["explain"]
+    assert data["explain"]["fusion"]["method"] == "round_robin_unique_path"
+    assert "This opt-in result does not establish readiness for default promotion." in data["claim_boundaries"]["does_not_prove"]
+
+
+def test_cli_query_review_intent_rejects_context_options(review_fixture, capsys):
+    from argparse import Namespace
+    from merger.lenskit.cli import cmd_query
+
+    _, _, index_path, query = review_fixture
+    args = Namespace(
+        index=str(index_path),
+        q=query,
+        k=4,
+        repo=None,
+        path=None,
+        ext=None,
+        layer=None,
+        artifact_type=None,
+        emit="json",
+        stale_policy="ignore",
+        embedding_policy=None,
+        explain=True,
+        graph_index=None,
+        graph_weights=None,
+        test_penalty=0.75,
+        output_profile="review_context",
+        context_window_lines=0,
+        context_mode="exact",
+        build_context_bundle=False,
+        overmatch_guard=False,
+        review_intent=True,
+        trace=False,
+        range_coverage_report=False,
+        citation_map=None,
+    )
+
+    rc = cmd_query.run_query(args)
+    assert rc == 1
+    assert "--review-intent does not combine" in capsys.readouterr().err


### PR DESCRIPTION
Adds opt-in lenskit query --review-intent. Validation: review_query tests 9 passed; ruff passed; py_compile passed. Default query unchanged; no default promotion.