### PR TITLE
feat: reconcile graph source roots consumers

### DIFF
--- a/docs/architecture/graph-source-roots.md
+++ b/docs/architecture/graph-source-roots.md
@@ -6,7 +6,7 @@ This is the contract boundary required before the Python import graph may resolv
 
 The schema is `merger/lenskit/contracts/architecture.source_roots.v1.schema.json`. A minimal example is `merger/lenskit/contracts/examples/source_roots_minimal.json`.
 
-This slice defines and tests the declaration only. The graph producer, bundle producer, CLI, ranking, and graph-quality baseline do not consume it yet.
+The declaration is now consumed by the graph producer, the architecture CLI (`--source-roots` / `--source-roots-file`), and the bundle graph-source producer when a single-repo summary supplies `source_roots`. Ranking and default retrieval behavior do not consume it.
 
 ## Shape
 
@@ -34,6 +34,6 @@ Schema validity alone therefore proves neither directory existence nor safe prod
 
 The declaration says only that a caller explicitly supplied additional roots. It does not establish effective runtime `sys.path`, installed-package state, editable-install behavior, build-backend interpretation, runtime import order, or runtime causality.
 
-## Planned consumer tests
+## Consumer tests
 
-A later producer slice must prove that explicit roots resolve the two G4b source-root cases, competing roots remain ambiguous, and absence of a declaration preserves current graph behavior.
+Consumer tests prove that explicit roots resolve source-root import cases, competing roots remain ambiguous, absence of a declaration preserves current graph behavior, the architecture CLI passes roots into import-graph generation, and bundle-bound graph source production consumes `repo_summaries[].source_roots` for single-repo outputs. Invalid declarations fail closed; no directory-name guessing is introduced.

--- a/docs/roadmap/lenskit-agent-operationalization-roadmap.md
+++ b/docs/roadmap/lenskit-agent-operationalization-roadmap.md
@@ -139,6 +139,8 @@ Nichtziele: kein grosser neuer Query-Contract ohne Gap-Beweis, kein Graph-/Symbo
 ## P2 - Graph und Relations kontrolliert weiterfuehren
 
 ### TASK-GRAPH-SOURCE-ROOTS-RECONCILE-001 - Graph Source Roots Consumer Reconciliation
+Status: umgesetzt. Graph Producer, CLI und Single-Repo-Bundlepfad konsumieren explizite Source Roots; Default-Ranking bleibt unveraendert.
+
 
 Ziel: Nach G4c-2 wird verifiziert, dass der Source-Roots-Consumer sauber in Graph Producer, CLI, Bundle, Degradation und Tests verdrahtet ist.
 

--- a/merger/lenskit/architecture/bundle_sources.py
+++ b/merger/lenskit/architecture/bundle_sources.py
@@ -135,6 +135,7 @@ def ensure_bundle_graph_sources(
     run_id: str,
     canonical_dump_index_sha256: str,
     generated_at: str,
+    source_roots: Sequence[str] | None = None,
 ) -> BundleGraphSources:
     """Create a coherent source pair from the bundle retrieval surface.
 
@@ -179,6 +180,11 @@ def ensure_bundle_graph_sources(
     try:
         repo_root = Path(summary["root"])
         repo_name = str(summary["name"])
+        explicit_source_roots = tuple(
+            source_roots
+            if source_roots is not None
+            else summary.get("source_roots", ())
+        )
         selected_paths = _eligible_python_paths(chunk_index_path, repo_name)
         with tempfile.TemporaryDirectory(prefix="lenskit-graph-sources-") as tmp:
             selected_root = Path(tmp)
@@ -191,6 +197,7 @@ def ensure_bundle_graph_sources(
                 selected_root,
                 run_id,
                 canonical_dump_index_sha256,
+                source_roots=explicit_source_roots,
             )
             entrypoints = generate_entrypoints_document(
                 selected_root,

--- a/merger/lenskit/cli/cmd_architecture.py
+++ b/merger/lenskit/cli/cmd_architecture.py
@@ -8,6 +8,33 @@ from ..architecture.entrypoints import generate_entrypoints_document
 from ..architecture.import_graph import generate_import_graph_document
 
 
+def _load_source_roots(args: argparse.Namespace) -> tuple[str, ...]:
+    roots: list[str] = []
+    raw_roots = getattr(args, "source_roots", None)
+    if raw_roots:
+        roots.extend(root.strip() for root in raw_roots.split(",") if root.strip())
+
+    source_roots_file = getattr(args, "source_roots_file", None)
+    if source_roots_file:
+        path = Path(source_roots_file).expanduser().resolve()
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            raise ValueError(f"failed to read --source-roots-file: {exc}") from exc
+        if not isinstance(payload, dict):
+            raise ValueError("--source-roots-file must contain a JSON object")
+        if payload.get("kind") != "lenskit.architecture.source_roots":
+            raise ValueError("--source-roots-file has invalid kind")
+        if payload.get("version") != "1.0":
+            raise ValueError("--source-roots-file has invalid version")
+        file_roots = payload.get("roots")
+        if not isinstance(file_roots, list) or not all(isinstance(root, str) for root in file_roots):
+            raise ValueError("--source-roots-file roots must be a string array")
+        roots.extend(file_roots)
+
+    return tuple(roots)
+
+
 def run_architecture_cmd(args: argparse.Namespace) -> int:
     """Execute the architecture CLI command."""
 
@@ -29,7 +56,17 @@ def run_architecture_cmd(args: argparse.Namespace) -> int:
             return 1
         run_id = f"cmd_run_{uuid.uuid4().hex[:8]}"
         canonical_sha256 = "0" * 64
-        doc = generate_import_graph_document(repo_root, run_id, canonical_sha256)
+        try:
+            source_roots = _load_source_roots(args)
+            doc = generate_import_graph_document(
+                repo_root,
+                run_id,
+                canonical_sha256,
+                source_roots=source_roots,
+            )
+        except ValueError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 2
         print(json.dumps(doc, indent=2))
         return 0
 

--- a/merger/lenskit/cli/main.py
+++ b/merger/lenskit/cli/main.py
@@ -155,6 +155,8 @@ def main(args: Optional[List[str]] = None) -> int:
     architecture_group.add_argument("--graph-index", action="store_true", help="Compile graph index from entrypoints and import graph")
     architecture_parser.add_argument("--graph-in", help="Path to architecture.graph.json")
     architecture_parser.add_argument("--entrypoints-in", help="Path to entrypoints.json")
+    architecture_parser.add_argument("--source-roots", help="Comma-separated explicit Python source roots for --import-graph")
+    architecture_parser.add_argument("--source-roots-file", help="Path to architecture.source_roots.v1 JSON for --import-graph")
 
     # Atlas command
     from .cmd_atlas import register_atlas_commands

--- a/merger/lenskit/tests/test_gsr_reconcile.py
+++ b/merger/lenskit/tests/test_gsr_reconcile.py
@@ -1,0 +1,62 @@
+import json
+
+from merger.lenskit.architecture.bundle_sources import ensure_bundle_graph_sources
+from merger.lenskit.cli.main import main
+
+
+SHA = "a" * 64
+
+
+def test_architecture_cli_import_graph_uses_configured_roots(tmp_path, capsys):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "app.py").write_text("import lib\n", encoding="utf-8")
+    (src / "lib.py").write_text("VALUE = 1\n", encoding="utf-8")
+
+    rc = main(["architecture", "--repo", str(tmp_path), "--import-graph", "--" + "source-roots", "src"])
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    edges = {(edge["src"], edge["dst"]) for edge in payload["edges"]}
+    assert ("file:src/app.py", "file:src/lib.py") in edges
+    assert ("file:src/app.py", "module:lib") not in edges
+
+
+def test_architecture_cli_roots_file_shape_is_fail_closed(tmp_path, capsys):
+    roots_file = tmp_path / "roots.json"
+    roots_file.write_text(json.dumps({"kind": "wrong", "version": "1.0", "roots": ["src"]}), encoding="utf-8")
+
+    rc = main(["architecture", "--repo", str(tmp_path), "--import-graph", "--" + "source-roots-file", str(roots_file)])
+
+    assert rc == 2
+    assert "invalid kind" in capsys.readouterr().err
+
+
+def test_bundle_graph_sources_use_summary_roots(tmp_path):
+    repo_root = tmp_path / "repo1"
+    src = repo_root / "src"
+    src.mkdir(parents=True)
+    (src / "app.py").write_text("import lib\n", encoding="utf-8")
+    (src / "lib.py").write_text("VALUE = 1\n", encoding="utf-8")
+
+    chunk_index = tmp_path / "repo1.chunk_index.jsonl"
+    records = [
+        {"repo": "repo1", "path": "src/app.py", "source_status": "full", "truncated": False, "source_range": {"status": "declared"}},
+        {"repo": "repo1", "path": "src/lib.py", "source_status": "full", "truncated": False, "source_range": {"status": "declared"}},
+    ]
+    chunk_index.write_text("".join(json.dumps(record) + "\n" for record in records), encoding="utf-8")
+
+    result = ensure_bundle_graph_sources(
+        base_path=tmp_path / "bundle",
+        chunk_index_path=chunk_index,
+        repo_summaries=[{"root": repo_root, "name": "repo1", "source_roots": ["src"]}],
+        run_id="run-1",
+        canonical_dump_index_sha256=SHA,
+        generated_at="2026-07-01T00:00:00Z",
+    )
+
+    assert result.status == "produced"
+    graph = json.loads(result.graph_path.read_text(encoding="utf-8"))
+    edges = {(edge["src"], edge["dst"]) for edge in graph["edges"]}
+    assert ("file:src/app.py", "file:src/lib.py") in edges
+    assert ("file:src/app.py", "module:lib") not in edges


### PR DESCRIPTION
Adds source-root consumption to architecture import-graph CLI and bundle-bound graph source production. Validation: test_gsr_reconcile 3 passed; architecture import graph 18 passed; graph bundle sources 6 passed. Boundaries: no ranking default, no graph completeness or runtime causality claim.