### PR TITLE
feat: add retrieval promotion gate

### DIFF
--- a/docs/proofs/retrieval-v2-promotion-gate-proof.md
+++ b/docs/proofs/retrieval-v2-promotion-gate-proof.md
@@ -1,0 +1,50 @@
+# Retrieval v2 Promotion Gate Proof
+
+Status: done  
+Task: `TASK-RETRIEVAL-V2-PROMOTION-GATE-001`
+
+## Result
+
+This slice adds a diagnostic promotion gate for retrieval-v2 style surfaces. It compares existing measurement reports and does not execute retrieval, change ranking, promote defaults, emit bundles or claim review readiness.
+
+Implemented surfaces:
+
+- `merger/lenskit/retrieval/retrieval_promotion_gate.py`
+- `scripts/proofs/retrieval_promotion_gate.py`
+- `merger/lenskit/tests/test_retrieval_promotion_gate.py`
+
+## Gate checks
+
+The gate compares legacy FTS and opt-in review-intent reports, plus optional graph and range/citation health reports.
+
+It checks:
+
+- global `recall@10` non-regression
+- global `MRR` non-regression
+- expected-target recall non-regression
+- per-category recall/MRR non-regression
+- miss count non-regression
+- fallback count is zero
+- supplied graph report is not stale/mismatched
+- supplied range/citation report has no malformed-hit failure
+
+## Decision boundary
+
+Even when all diagnostic gates pass, `promote_default` remains `false`. Default promotion requires a later explicit decision.
+
+## Validation
+
+```text
+python3 -m pytest -q merger/lenskit/tests/test_retrieval_promotion_gate.py
+# 4 passed
+
+python3 -m py_compile merger/lenskit/retrieval/retrieval_promotion_gate.py scripts/proofs/retrieval_promotion_gate.py merger/lenskit/tests/test_retrieval_promotion_gate.py
+# passed
+
+python3 -m ruff check merger/lenskit/retrieval/retrieval_promotion_gate.py scripts/proofs/retrieval_promotion_gate.py merger/lenskit/tests/test_retrieval_promotion_gate.py
+# passed
+```
+
+## Non-claims
+
+This slice does not establish retrieval correctness, review completeness, answer correctness, runtime behavior or readiness for default promotion beyond the measured diagnostic gate.

--- a/docs/roadmap/lenskit-agent-operationalization-roadmap.md
+++ b/docs/roadmap/lenskit-agent-operationalization-roadmap.md
@@ -160,6 +160,8 @@ Nichtziele: keine sofortige Persistenz, kein Testvollstaendigkeitsclaim, kein Re
 
 ### TASK-RETRIEVAL-V2-PROMOTION-GATE-001 - Retrieval v2 Promotion Gate
 
+Status: umgesetzt. Diagnostisches Promotion-Gate vergleicht Legacy-FTS und Review-Intent-Baselines plus optionale Graph-/Range-Health-Berichte; Default-Promotion bleibt auch bei bestandenem Gate eine spaetere explizite Entscheidung.
+
 Ziel: Retrieval v2 wird nicht als Wunschfeature gebaut, sondern als messbare Promotion-Frage behandelt.
 
 Vergleichen: legacy FTS; Review-Intent opt-in; Review-Intent plus frischer Graph, falls vorhanden.

--- a/merger/lenskit/retrieval/retrieval_promotion_gate.py
+++ b/merger/lenskit/retrieval/retrieval_promotion_gate.py
@@ -1,0 +1,189 @@
+"""Diagnostic promotion gate for retrieval-v2 style surfaces.
+
+This module compares existing measurement reports. It does not execute retrieval,
+change ranking, or promote any runtime path.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+DOES_NOT_ESTABLISH = [
+    "retrieval_correctness",
+    "review_completeness",
+    "answer_correctness",
+    "default_promotion_readiness_beyond_this_goldset",
+    "runtime_behavior",
+]
+
+
+def _metric(report: dict[str, Any], key: str, default: float = 0.0) -> float:
+    value = (report.get("metrics") or {}).get(key, default)
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    return default
+
+
+def _expected_target_recall(report: dict[str, Any]) -> float:
+    metrics = report.get("metrics") or {}
+    hits = metrics.get("expected_target_hits", 0)
+    total = metrics.get("expected_target_total", 0)
+    if not isinstance(hits, (int, float)) or isinstance(hits, bool):
+        hits = 0
+    if not isinstance(total, (int, float)) or isinstance(total, bool) or total <= 0:
+        return 0.0
+    return round(float(hits) / float(total), 6)
+
+
+def _category_stats(report: dict[str, Any], category: str, recall_key: str) -> tuple[float, float]:
+    stats = (report.get("categories") or {}).get(category) or {}
+    recall = stats.get(recall_key, 0.0)
+    mrr = stats.get("MRR", 0.0)
+    if not isinstance(recall, (int, float)) or isinstance(recall, bool):
+        recall = 0.0
+    if not isinstance(mrr, (int, float)) or isinstance(mrr, bool):
+        mrr = 0.0
+    return float(recall), float(mrr)
+
+
+def _miss_count(report: dict[str, Any]) -> int:
+    diagnostics = report.get("miss_diagnostics") or []
+    return len(diagnostics) if isinstance(diagnostics, list) else 0
+
+
+def _fallback_count(report: dict[str, Any]) -> int:
+    conditions = report.get("measurement_conditions") or {}
+    review = conditions.get("review_intent") or {}
+    for key in ("fallback_count", "legacy_fallback_count", "fallbacks"):
+        value = review.get(key)
+        if isinstance(value, int) and not isinstance(value, bool):
+            return value
+    return 0
+
+
+def _graph_is_fresh(graph_report: dict[str, Any] | None) -> bool:
+    if graph_report is None:
+        return True
+    status = graph_report.get("graph_status") or graph_report.get("status")
+    if status in {"stale", "stale_or_mismatched", "mismatched"}:
+        return False
+    if graph_report.get("stale") is True:
+        return False
+    return True
+
+
+def _range_health_ok(range_report: dict[str, Any] | None) -> bool:
+    if range_report is None:
+        return True
+    status = range_report.get("status") or range_report.get("range_citation_health")
+    if status in {"fail", "error", "unhealthy"}:
+        return False
+    malformed = ((range_report.get("counts") or {}).get("malformed_hits"))
+    if isinstance(malformed, int) and malformed > 0:
+        return False
+    return True
+
+
+def build_promotion_gate_report(
+    legacy_report: dict[str, Any],
+    review_report: dict[str, Any],
+    *,
+    graph_report: dict[str, Any] | None = None,
+    range_report: dict[str, Any] | None = None,
+    recall_key: str = "recall@10",
+) -> dict[str, Any]:
+    """Compare diagnostic baselines and return a conservative gate decision."""
+    gates: list[dict[str, Any]] = []
+
+    legacy_recall = _metric(legacy_report, recall_key)
+    review_recall = _metric(review_report, recall_key)
+    gates.append({
+        "name": "global_recall_non_regression",
+        "passed": review_recall >= legacy_recall,
+        "legacy": legacy_recall,
+        "candidate": review_recall,
+    })
+
+    legacy_mrr = _metric(legacy_report, "MRR")
+    review_mrr = _metric(review_report, "MRR")
+    gates.append({
+        "name": "global_mrr_non_regression",
+        "passed": review_mrr >= legacy_mrr,
+        "legacy": legacy_mrr,
+        "candidate": review_mrr,
+    })
+
+    legacy_target = _expected_target_recall(legacy_report)
+    review_target = _expected_target_recall(review_report)
+    gates.append({
+        "name": "expected_target_recall_non_regression",
+        "passed": review_target >= legacy_target,
+        "legacy": legacy_target,
+        "candidate": review_target,
+    })
+
+    category_reports = []
+    categories = sorted(set((legacy_report.get("categories") or {})) | set((review_report.get("categories") or {})))
+    category_passed = True
+    for category in categories:
+        legacy_cat_recall, legacy_cat_mrr = _category_stats(legacy_report, category, recall_key)
+        review_cat_recall, review_cat_mrr = _category_stats(review_report, category, recall_key)
+        passed = review_cat_recall >= legacy_cat_recall and review_cat_mrr >= legacy_cat_mrr
+        category_passed = category_passed and passed
+        category_reports.append({
+            "category": category,
+            "passed": passed,
+            "legacy": {recall_key: legacy_cat_recall, "MRR": legacy_cat_mrr},
+            "candidate": {recall_key: review_cat_recall, "MRR": review_cat_mrr},
+        })
+    gates.append({
+        "name": "per_category_non_regression",
+        "passed": category_passed,
+        "categories": category_reports,
+    })
+
+    gates.append({
+        "name": "miss_count_non_regression",
+        "passed": _miss_count(review_report) <= _miss_count(legacy_report),
+        "legacy": _miss_count(legacy_report),
+        "candidate": _miss_count(review_report),
+    })
+    gates.append({
+        "name": "fallback_count_zero",
+        "passed": _fallback_count(review_report) == 0,
+        "candidate": _fallback_count(review_report),
+    })
+    gates.append({
+        "name": "fresh_graph_if_supplied",
+        "passed": _graph_is_fresh(graph_report),
+        "graph_supplied": graph_report is not None,
+    })
+    gates.append({
+        "name": "range_citation_health_ok_if_supplied",
+        "passed": _range_health_ok(range_report),
+        "range_report_supplied": range_report is not None,
+    })
+
+    passed = all(gate["passed"] for gate in gates)
+    return {
+        "kind": "lenskit.retrieval_promotion_gate",
+        "version": "1.0",
+        "status": "passed" if passed else "blocked",
+        "promote_default": False,
+        "gates": gates,
+        "decision": {
+            "default_promotion_allowed": False,
+            "reason": "diagnostic gate only; promotion requires explicit later decision even when gates pass" if passed else "one or more diagnostic gates failed",
+        },
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return data

--- a/merger/lenskit/tests/test_retrieval_promotion_gate.py
+++ b/merger/lenskit/tests/test_retrieval_promotion_gate.py
@@ -1,0 +1,91 @@
+import json
+import subprocess
+
+from merger.lenskit.retrieval.retrieval_promotion_gate import build_promotion_gate_report
+
+
+def _report(*, recall=0.5, mrr=0.5, target_hits=5, target_total=10, miss_count=2, fallback_count=0, category_recall=0.5, category_mrr=0.5):
+    return {
+        "metrics": {
+            "recall@10": recall,
+            "MRR": mrr,
+            "expected_target_hits": target_hits,
+            "expected_target_total": target_total,
+        },
+        "categories": {
+            "contracts": {"recall@10": category_recall, "MRR": category_mrr},
+        },
+        "miss_diagnostics": [{} for _ in range(miss_count)],
+        "measurement_conditions": {
+            "review_intent": {"fallback_count": fallback_count}
+        } if fallback_count else {},
+    }
+
+
+def _gate_names(report):
+    return {gate["name"]: gate for gate in report["gates"]}
+
+
+def test_promotion_gate_passes_non_regression_but_does_not_allow_default_promotion():
+    legacy = _report()
+    review = _report(recall=0.7, mrr=0.6, target_hits=7, miss_count=1, category_recall=0.7, category_mrr=0.6)
+
+    report = build_promotion_gate_report(legacy, review, graph_report={"status": "fresh"}, range_report={"counts": {"malformed_hits": 0}})
+
+    assert report["status"] == "passed"
+    assert report["promote_default"] is False
+    assert report["decision"]["default_promotion_allowed"] is False
+    assert "review_completeness" in report["does_not_establish"]
+
+
+def test_promotion_gate_blocks_category_regression():
+    legacy = _report(category_recall=0.8, category_mrr=0.8)
+    review = _report(recall=0.9, mrr=0.9, target_hits=8, category_recall=0.7, category_mrr=0.9)
+
+    report = build_promotion_gate_report(legacy, review)
+    gates = _gate_names(report)
+
+    assert report["status"] == "blocked"
+    assert gates["per_category_non_regression"]["passed"] is False
+
+
+def test_promotion_gate_blocks_fallback_stale_graph_and_range_failures():
+    legacy = _report()
+    review = _report(recall=0.8, mrr=0.8, target_hits=8, miss_count=1, fallback_count=1, category_recall=0.8, category_mrr=0.8)
+
+    report = build_promotion_gate_report(
+        legacy,
+        review,
+        graph_report={"status": "stale_or_mismatched"},
+        range_report={"counts": {"malformed_hits": 1}},
+    )
+    gates = _gate_names(report)
+
+    assert report["status"] == "blocked"
+    assert gates["fallback_count_zero"]["passed"] is False
+    assert gates["fresh_graph_if_supplied"]["passed"] is False
+    assert gates["range_citation_health_ok_if_supplied"]["passed"] is False
+
+
+def test_promotion_gate_script_writes_json(tmp_path):
+    legacy = tmp_path / "legacy.json"
+    review = tmp_path / "review.json"
+    out = tmp_path / "gate.json"
+    legacy.write_text(json.dumps(_report()), encoding="utf-8")
+    review.write_text(json.dumps(_report(recall=0.6, mrr=0.6, target_hits=6, miss_count=1, category_recall=0.6, category_mrr=0.6)), encoding="utf-8")
+
+    subprocess.check_call([
+        "python3",
+        "scripts/proofs/retrieval_promotion_gate.py",
+        "--legacy",
+        str(legacy),
+        "--review",
+        str(review),
+        "--out",
+        str(out),
+    ])
+
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["kind"] == "lenskit.retrieval_promotion_gate"
+    assert payload["status"] == "passed"
+    assert payload["promote_default"] is False

--- a/scripts/proofs/retrieval_promotion_gate.py
+++ b/scripts/proofs/retrieval_promotion_gate.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Build a diagnostic Retrieval Promotion Gate report from existing measurements."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from merger.lenskit.retrieval.retrieval_promotion_gate import (  # noqa: E402
+    build_promotion_gate_report,
+    load_json,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="diagnostic retrieval promotion gate")
+    parser.add_argument("--legacy", required=True, help="Legacy FTS baseline JSON")
+    parser.add_argument("--review", required=True, help="Review-intent baseline JSON")
+    parser.add_argument("--graph", help="Optional graph freshness/status JSON")
+    parser.add_argument("--range", dest="range_report", help="Optional range/citation health JSON")
+    parser.add_argument("--recall-key", default="recall@10")
+    parser.add_argument("--out")
+    args = parser.parse_args()
+
+    report = build_promotion_gate_report(
+        load_json(Path(args.legacy)),
+        load_json(Path(args.review)),
+        graph_report=load_json(Path(args.graph)) if args.graph else None,
+        range_report=load_json(Path(args.range_report)) if args.range_report else None,
+        recall_key=args.recall_key,
+    )
+    text = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.out:
+        Path(args.out).write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds a diagnostic retrieval promotion gate that compares legacy and review-intent measurement reports without changing ranking or allowing default promotion. Validation: promotion gate tests passed; py_compile passed; ruff passed.