### PR TITLE
feat: add token budget report

### DIFF
--- a/docs/proofs/token-budget-report-v1-proof.md
+++ b/docs/proofs/token-budget-report-v1-proof.md
@@ -1,0 +1,39 @@
+# Token Budget Report v1 Proof
+
+Status: done  
+Task: `TASK-TOKEN-BUDGET-REPORT-001`
+
+## Result
+
+This slice adds a diagnostic Token Budget Report for bundle manifests.
+
+Implemented surfaces:
+
+- `merger/lenskit/core/token_budget_report.py`
+- `merger/lenskit/cli/cmd_token_budget.py`
+- `lenskit token-budget report --bundle-manifest <path>`
+- `merger/lenskit/tests/test_token_budget_report.py`
+
+## Behavior
+
+The report reads `artifacts[].bytes` from a bundle manifest and estimates rough token cost with a configurable byte divisor. The default estimate is deliberately simple: `ceil(bytes / 4.0)`.
+
+It reports total artifact bytes, estimated tokens, budget remaining or overflow, per-role totals, largest artifacts, warnings when the estimate exceeds the configured context budget, and fail status for malformed artifact byte metadata.
+
+## Boundaries
+
+The report is diagnostic only. It does not use a model tokenizer, does not assert exact token counts, does not prove model-context fit, does not choose which artifacts to include, and does not establish repository understanding or answer correctness.
+
+No bundle emission, manifest role, LLM integration, truncation policy or export decision is introduced in this slice.
+
+## Validation
+
+```text
+python3 -m pytest -q merger/lenskit/tests/test_token_budget_report.py
+# 5 passed
+
+python3 -m py_compile merger/lenskit/core/token_budget_report.py merger/lenskit/cli/cmd_token_budget.py merger/lenskit/cli/main.py merger/lenskit/tests/test_token_budget_report.py
+# passed
+```
+
+A focused Ruff command was attempted locally but blocked by the operational filter. CI remains the authoritative style gate for the PR.

--- a/docs/roadmap/lenskit-agent-operationalization-roadmap.md
+++ b/docs/roadmap/lenskit-agent-operationalization-roadmap.md
@@ -172,7 +172,7 @@ Default-Promotion nur wenn: besser als Baseline; keine zentrale Kategorie schlec
 
 ## P4 - Backlog
 
-Bewusst spaeter: Symbol Index v1, Token Budget Report, Compat Export Projection, Read-only Adapter ohne Mirror.
+Status: Token Budget Report v1 ist umgesetzt. Bewusst spaeter bleiben: Symbol Index v1, Compat Export Projection, Read-only Adapter ohne Mirror.
 
 Diese Backlog-Punkte duerfen keine neuen Wahrheits-, Review-, Patch- oder Runtime-Claims einfuehren.
 

--- a/merger/lenskit/cli/cmd_token_budget.py
+++ b/merger/lenskit/cli/cmd_token_budget.py
@@ -1,0 +1,68 @@
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+class TokenBudgetCliError(Exception):
+    """User-facing CLI input/output error."""
+
+
+def register_token_budget_commands(subparsers) -> None:
+    parser = subparsers.add_parser("token-budget", help="Token budget diagnostics")
+    sub = parser.add_subparsers(dest="token_budget_cmd", required=True)
+
+    report = sub.add_parser("report", help="Estimate bundle artifact token budget from manifest bytes")
+    report.add_argument("--bundle-manifest", required=True, help="Path to bundle-manifest.v1 JSON")
+    report.add_argument("--context-budget", type=int, default=128000, help="Context budget in tokens used for share/overflow diagnostics")
+    report.add_argument("--bytes-per-token", type=float, default=4.0, help="Byte divisor used for rough token estimate")
+    report.add_argument("--strict", action="store_true", help="Treat warn status as exit code 1")
+    report.add_argument("--out", "--output", dest="out", help="Output path; stdout when omitted")
+
+
+def _write_json_or_stdout(payload: dict, out: Path | None) -> None:
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if out is None:
+        sys.stdout.write(text)
+        return
+    try:
+        out.write_text(text, encoding="utf-8")
+    except OSError as exc:
+        raise TokenBudgetCliError(f"Could not write to {out}: {exc}") from exc
+
+
+def _exit_for_status(status: str, *, strict: bool = False) -> int:
+    if status == "pass":
+        return 0
+    if status == "warn":
+        return 1 if strict else 0
+    if status == "fail":
+        return 1
+    return 2
+
+
+def run_token_budget_report(args: argparse.Namespace) -> int:
+    from merger.lenskit.core.token_budget_report import (
+        build_token_budget_report_from_bundle_manifest,
+    )
+
+    try:
+        report = build_token_budget_report_from_bundle_manifest(
+            Path(args.bundle_manifest),
+            context_budget_tokens=args.context_budget,
+            bytes_per_token=args.bytes_per_token,
+        )
+        _write_json_or_stdout(report, Path(args.out) if args.out else None)
+        return _exit_for_status(str(report.get("status", "unknown")), strict=args.strict)
+    except TokenBudgetCliError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+    except Exception as exc:
+        print(f"Error: unexpected failure: {exc}", file=sys.stderr)
+        return 2
+
+
+def run_token_budget(args: argparse.Namespace) -> int:
+    if args.token_budget_cmd == "report":
+        return run_token_budget_report(args)
+    return 2

--- a/merger/lenskit/cli/main.py
+++ b/merger/lenskit/cli/main.py
@@ -66,6 +66,10 @@ def main(args: Optional[List[str]] = None) -> int:
     from .cmd_agent_consumption import register_agent_consumption_commands
     register_agent_consumption_commands(subparsers)
 
+    # Token budget command
+    from .cmd_token_budget import register_token_budget_commands
+    register_token_budget_commands(subparsers)
+
     # rLens client command
     from .cmd_rlens_client import register_rlens_client_commands
     register_rlens_client_commands(subparsers)
@@ -279,6 +283,9 @@ def main(args: Optional[List[str]] = None) -> int:
     elif parsed_args.command == "agent-consumption":
         from .cmd_agent_consumption import run_agent_consumption
         return run_agent_consumption(parsed_args)
+    elif parsed_args.command == "token-budget":
+        from .cmd_token_budget import run_token_budget
+        return run_token_budget(parsed_args)
     elif parsed_args.command == "artifact":
         from . import cmd_artifact
         return cmd_artifact.run_artifact_lookup(parsed_args)

--- a/merger/lenskit/core/token_budget_report.py
+++ b/merger/lenskit/core/token_budget_report.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+
+_DOES_NOT_ESTABLISH = [
+    "exact_token_count",
+    "model_context_fit",
+    "answer_correctness",
+    "repo_understood",
+    "claims_true",
+    "review_completeness",
+    "runtime_behavior",
+    "forensic_ready",
+]
+
+
+def _require_mapping(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be a JSON object")
+    return value
+
+
+def _estimate_tokens(byte_count: int, bytes_per_token: float) -> int:
+    if byte_count <= 0:
+        return 0
+    return int(math.ceil(byte_count / bytes_per_token))
+
+
+def build_token_budget_report(
+    bundle_manifest: dict[str, Any],
+    *,
+    source_path: str | None = None,
+    context_budget_tokens: int = 128_000,
+    bytes_per_token: float = 4.0,
+) -> dict[str, Any]:
+    """Build a diagnostic token-budget estimate from a bundle manifest.
+
+    The estimate is byte-based. It intentionally avoids tokenizer/model claims.
+    """
+    if context_budget_tokens < 1:
+        raise ValueError("context_budget_tokens must be at least 1")
+    if bytes_per_token <= 0:
+        raise ValueError("bytes_per_token must be greater than 0")
+
+    manifest = _require_mapping(bundle_manifest, "bundle_manifest")
+    artifacts = manifest.get("artifacts")
+    if not isinstance(artifacts, list):
+        raise ValueError("bundle_manifest.artifacts must be a list")
+
+    errors: list[str] = []
+    warnings: list[str] = []
+    artifact_reports: list[dict[str, Any]] = []
+    by_role: dict[str, dict[str, int]] = {}
+
+    for index, artifact in enumerate(artifacts):
+        if not isinstance(artifact, dict):
+            errors.append(f"artifact_{index}_not_object")
+            continue
+        role = artifact.get("role")
+        path = artifact.get("path")
+        byte_count = artifact.get("bytes")
+        if not isinstance(role, str) or not role:
+            errors.append(f"artifact_{index}_missing_role")
+            role = "unknown"
+        if not isinstance(path, str) or not path:
+            errors.append(f"artifact_{index}_missing_path")
+            path = ""
+        if not isinstance(byte_count, int) or isinstance(byte_count, bool) or byte_count < 0:
+            errors.append(f"artifact_{index}_invalid_bytes")
+            byte_count = 0
+
+        estimated_tokens = _estimate_tokens(byte_count, bytes_per_token)
+        share = round(estimated_tokens / context_budget_tokens, 6)
+        role_bucket = by_role.setdefault(role, {"artifact_count": 0, "bytes": 0, "estimated_tokens": 0})
+        role_bucket["artifact_count"] += 1
+        role_bucket["bytes"] += byte_count
+        role_bucket["estimated_tokens"] += estimated_tokens
+        artifact_reports.append({
+            "role": role,
+            "path": path,
+            "bytes": byte_count,
+            "estimated_tokens": estimated_tokens,
+            "context_budget_share": share,
+        })
+
+    total_bytes = sum(item["bytes"] for item in artifact_reports)
+    total_tokens = sum(item["estimated_tokens"] for item in artifact_reports)
+    over_budget = total_tokens > context_budget_tokens
+    if over_budget:
+        warnings.append("estimated_tokens_exceed_context_budget")
+
+    sorted_artifacts = sorted(
+        artifact_reports,
+        key=lambda item: (-item["estimated_tokens"], item["role"], item["path"]),
+    )
+    largest = sorted_artifacts[:10]
+    role_rows = [
+        {"role": role, **values}
+        for role, values in sorted(by_role.items(), key=lambda item: (-item[1]["estimated_tokens"], item[0]))
+    ]
+
+    status = "fail" if errors else ("warn" if warnings else "pass")
+    return {
+        "kind": "lenskit.token_budget_report",
+        "version": "1.0",
+        "source_manifest": source_path,
+        "run_id": manifest.get("run_id"),
+        "estimator": {
+            "method": "bytes_divided_by_constant",
+            "bytes_per_token": bytes_per_token,
+            "exact_tokenizer": False,
+        },
+        "context_budget_tokens": context_budget_tokens,
+        "status": status,
+        "totals": {
+            "artifact_count": len(artifact_reports),
+            "bytes": total_bytes,
+            "estimated_tokens": total_tokens,
+            "budget_remaining_tokens": max(context_budget_tokens - total_tokens, 0),
+            "budget_overflow_tokens": max(total_tokens - context_budget_tokens, 0),
+            "estimated_budget_share": round(total_tokens / context_budget_tokens, 6),
+        },
+        "by_role": role_rows,
+        "largest_artifacts": largest,
+        "warnings": warnings,
+        "errors": errors,
+        "does_not_establish": list(_DOES_NOT_ESTABLISH),
+    }
+
+
+def build_token_budget_report_from_bundle_manifest(
+    bundle_manifest_path: Path,
+    *,
+    context_budget_tokens: int = 128_000,
+    bytes_per_token: float = 4.0,
+) -> dict[str, Any]:
+    path = Path(bundle_manifest_path)
+    manifest = json.loads(path.read_text(encoding="utf-8"))
+    return build_token_budget_report(
+        manifest,
+        source_path=str(path),
+        context_budget_tokens=context_budget_tokens,
+        bytes_per_token=bytes_per_token,
+    )

--- a/merger/lenskit/tests/test_token_budget_report.py
+++ b/merger/lenskit/tests/test_token_budget_report.py
@@ -1,0 +1,85 @@
+import json
+
+from merger.lenskit.cli.main import main
+from merger.lenskit.core.token_budget_report import build_token_budget_report
+
+
+def _manifest():
+    return {
+        "kind": "repolens.bundle.manifest",
+        "version": "1.0",
+        "run_id": "run-1",
+        "artifacts": [
+            {"role": "canonical_md", "path": "bundle.md", "bytes": 400, "sha256": "a" * 64, "content_type": "text/markdown"},
+            {"role": "agent_reading_pack", "path": "bundle.agent.md", "bytes": 40, "sha256": "b" * 64, "content_type": "text/markdown"},
+            {"role": "chunk_index_jsonl", "path": "bundle.chunk.jsonl", "bytes": 160, "sha256": "c" * 64, "content_type": "application/jsonl"},
+        ],
+    }
+
+
+def test_token_budget_report_estimates_from_manifest_bytes():
+    report = build_token_budget_report(_manifest(), context_budget_tokens=200, bytes_per_token=4.0)
+
+    assert report["kind"] == "lenskit.token_budget_report"
+    assert report["status"] == "pass"
+    assert report["totals"]["bytes"] == 600
+    assert report["totals"]["estimated_tokens"] == 150
+    assert report["totals"]["budget_remaining_tokens"] == 50
+    assert report["largest_artifacts"][0]["role"] == "canonical_md"
+    assert "exact_token_count" in report["does_not_establish"]
+
+
+def test_token_budget_report_warns_when_estimate_exceeds_context_budget():
+    report = build_token_budget_report(_manifest(), context_budget_tokens=100, bytes_per_token=4.0)
+
+    assert report["status"] == "warn"
+    assert report["totals"]["budget_overflow_tokens"] == 50
+    assert "estimated_tokens_exceed_context_budget" in report["warnings"]
+
+
+def test_token_budget_report_fails_invalid_artifact_bytes():
+    manifest = _manifest()
+    manifest["artifacts"].append({"role": "output_health", "path": "bad.json", "bytes": -1})
+
+    report = build_token_budget_report(manifest, context_budget_tokens=200, bytes_per_token=4.0)
+
+    assert report["status"] == "fail"
+    assert "artifact_3_invalid_bytes" in report["errors"]
+
+
+def test_token_budget_cli_report_outputs_json(tmp_path, capsys):
+    manifest = tmp_path / "bundle.manifest.json"
+    manifest.write_text(json.dumps(_manifest()), encoding="utf-8")
+
+    rc = main([
+        "token-budget",
+        "report",
+        "--bundle-manifest",
+        str(manifest),
+        "--context-budget",
+        "200",
+    ])
+
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["status"] == "pass"
+    assert data["source_manifest"] == str(manifest)
+
+
+def test_token_budget_cli_strict_warn_returns_one(tmp_path, capsys):
+    manifest = tmp_path / "bundle.manifest.json"
+    manifest.write_text(json.dumps(_manifest()), encoding="utf-8")
+
+    rc = main([
+        "token-budget",
+        "report",
+        "--bundle-manifest",
+        str(manifest),
+        "--context-budget",
+        "100",
+        "--strict",
+    ])
+
+    assert rc == 1
+    data = json.loads(capsys.readouterr().out)
+    assert data["status"] == "warn"


### PR DESCRIPTION
Adds a diagnostic token budget report for bundle manifests. It estimates token cost from manifest artifact byte sizes only. No tokenizer, no context-fit guarantee, no bundle emission, no truncation policy. Validation: pytest test_token_budget_report.py passed; py_compile passed.