### PR TITLE
fix: pin patched pytest

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
-pytest==8.3.4
-pytest-asyncio==0.23.8
+pytest==9.0.3
+pytest-asyncio==1.4.0
 ruff==0.15.13
 fastapi>=0.119,<1
 pydantic>=2,<3


### PR DESCRIPTION
## Summary
- Bump pytest from 8.3.4 to 9.0.3, the minimal patched version for CVE-2025-71176 / GHSA-6w46-j5rx-g56g.
- Bump pytest-asyncio from 0.23.8 to 1.4.0 because 0.23.8 requires pytest <9 and blocks the patched pytest pin.
- Leave requirements-browser.txt unchanged because it includes requirements-dev.txt.

## Verification
- Throwaway venv installed merger/lenskit/requirements.txt + requirements-dev.txt with pytest 9.0.3 and pytest-asyncio 1.4.0.
- /tmp/lenskit-pytest903-venv/bin/python -m pip check
- /tmp/lenskit-pytest903-venv/bin/python -m pytest -q merger/lenskit/tests/test_validation_check_view.py merger/lenskit/tests/test_validation_check_shapes.py scripts/docmeta/tests/test_check_planning_registration.py
- /tmp/lenskit-pytest903-venv/bin/python -m pytest -q merger/lenskit/tests/test_doc_freshness.py merger/lenskit/tests/test_graph_quality_goldset.py merger/lenskit/tests/test_architecture_source_roots_schema.py merger/lenskit/tests/test_bundle_manifest_integration.py
- python3 scripts/docmeta/check_planning_registration.py --strict
- git diff --check

## Notes
- A direct pytest-only bump was tested and failed dependency resolution because pytest-asyncio 0.23.8 requires pytest <9.
- A broad full-suite local run with only requirements-dev.txt was not valid because jsonschema is supplied by merger/lenskit/requirements.txt in CI-like setup.