### PR TITLE
fix(agent-consumption): expose bundle manifest self-role

### DIFF
--- a/merger/lenskit/cli/cmd_agent_consumption.py
+++ b/merger/lenskit/cli/cmd_agent_consumption.py
@@ -117,6 +117,13 @@ def _load_roles_from_bundle_manifest(path: Path | None) -> set[str]:
         raise AgentConsumptionCliError(
             f"Invalid bundle manifest {path}: expected artifacts array."
         )
+
+    # The bundle manifest is the source used to derive the available roles.
+    # Treat it as available for required-reading profiles that explicitly ask
+    # for the manifest surface without pretending it is listed inside its own
+    # artifacts array.
+    roles.add("bundle_manifest")
+
     for artifact in artifacts:
         if isinstance(artifact, dict) and isinstance(artifact.get("role"), str):
             roles.add(artifact["role"])

--- a/merger/lenskit/tests/test_cli_agent_consumption.py
+++ b/merger/lenskit/tests/test_cli_agent_consumption.py
@@ -420,11 +420,38 @@ def test_cli_preflight_stdout_from_bundle_manifest(tmp_path, capsys):
     assert out["required_reading"]["status"] == "pass"
     assert "post_emit_health" in out["available_roles"]
     assert "bundle_surface_validation" in out["available_roles"]
+    assert "bundle_manifest" in out["available_roles"]
     assert out["agent_consumption_trace"] is None
     assert set(out["answer_compliance_template"]["declared_artifacts"]) == set(
         out["required_reading"]["required"] + out["required_reading"]["recommended"]
     )
     assert "repo_understood" in out["does_not_establish"]
+
+
+def test_cli_preflight_bundle_manifest_self_role_satisfies_surface_review(tmp_path, capsys):
+    manifest = tmp_path / "bundle.manifest.json"
+    manifest.write_text(json.dumps({
+        "artifacts": [
+            {"role": "canonical_md"},
+            {"role": "output_health"},
+        ],
+        "links": {
+            "post_emit_health_path": "demo.post_emit_health.json",
+            "bundle_surface_validation_path": "demo.bundle_surface_validation.json",
+        },
+    }), encoding="utf-8")
+
+    rc = main([
+        "agent-consumption", "preflight",
+        "--task-profile", "artifact_surface_review",
+        "--bundle-manifest", str(manifest),
+    ])
+
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["status"] == "pass"
+    assert out["required_reading"]["missing_required"] == []
+    assert "bundle_manifest" in out["required_reading"]["available_required"]
 
 
 def test_cli_preflight_validates_answer_compliance(tmp_path, capsys):


### PR DESCRIPTION
## Summary
- Treat the supplied bundle manifest as the `bundle_manifest` self-role for `agent-consumption preflight --bundle-manifest`.
- Add regression coverage for `artifact_surface_review`.
- Verify the current fresh Lenskit bundle now passes artifact-surface preflight.

## Tests
- `python3 -m pytest -q merger/lenskit/tests/test_cli_agent_consumption.py` -> 22 passed
- `agent-consumption preflight --task-profile artifact_surface_review --bundle-manifest ~/repos/merges/lenskit-max-260701-1454_merge.bundle.manifest.json` -> pass, `missing_required=[]`

## Boundaries
- Required-reading/preflight surface fix only.
- Does not make health passes into review completeness or claim truth.

Operator-Lab-Run: vibe-lab: experiments/2026-07-01_operator-lab-loop/artifacts/run-002-rlens-agent-ecosystem/run-card.yml
