### PR TITLE
fix(graph): infer bundle provenance from sibling dump index

### DIFF
--- a/merger/lenskit/architecture/graph_index.py
+++ b/merger/lenskit/architecture/graph_index.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import logging
 from pathlib import Path
@@ -74,6 +75,57 @@ def load_graph_index(
     return {"status": "ok", "graph": data}
 
 
+def _sibling_dump_index(
+    graph_path: Path,
+    entrypoints_path: Path,
+) -> Path | None:
+    graph_suffix = ".architecture_graph.json"
+    entrypoints_suffix = ".entrypoints.json"
+    if not graph_path.name.endswith(graph_suffix):
+        return None
+    if not entrypoints_path.name.endswith(entrypoints_suffix):
+        return None
+
+    graph_stem = graph_path.name[: -len(graph_suffix)]
+    entrypoints_stem = entrypoints_path.name[: -len(entrypoints_suffix)]
+    if graph_path.parent != entrypoints_path.parent or graph_stem != entrypoints_stem:
+        return None
+
+    candidate = graph_path.parent / f"{graph_stem}.dump_index.json"
+    return candidate if candidate.is_file() else None
+
+
+def _infer_bundle_provenance(
+    graph_path: Path,
+    entrypoints_path: Path,
+) -> tuple[str | None, str | None]:
+    dump_index_path = _sibling_dump_index(graph_path, entrypoints_path)
+    if dump_index_path is None:
+        return None, None
+
+    try:
+        with dump_index_path.open(encoding="utf-8") as handle:
+            dump_index = json.load(handle)
+        run_id = dump_index["run_id"]
+    except (OSError, json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise GraphIndexCompilationError(
+            "bundle_provenance_unavailable",
+            f"sibling dump index is unusable: {dump_index_path}",
+            source="expected_provenance",
+            errors=[str(exc)],
+        ) from exc
+
+    if not isinstance(run_id, str) or not run_id:
+        raise GraphIndexCompilationError(
+            "invalid_expected_provenance",
+            "sibling dump index run_id must be a non-empty string",
+            source="expected_provenance",
+        )
+
+    digest = hashlib.sha256(dump_index_path.read_bytes()).hexdigest()
+    return run_id, digest
+
+
 def compile_graph_index(
     graph_path: Path,
     entrypoints_path: Path,
@@ -93,6 +145,11 @@ def compile_graph_index(
         "entrypoints.v1.schema.json",
         "entrypoints",
     )
+    if expected_run_id is None and expected_canonical_sha256 is None:
+        expected_run_id, expected_canonical_sha256 = _infer_bundle_provenance(
+            graph_path,
+            entrypoints_path,
+        )
     run_id, canonical_sha = require_coherence(
         graph,
         entrypoints,

--- a/merger/lenskit/tests/test_graph_index.py
+++ b/merger/lenskit/tests/test_graph_index.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 
 import pytest
@@ -96,6 +97,16 @@ def _write(tmp_path, graph=None, entrypoints=None):
     return graph_path, entrypoints_path
 
 
+def _write_bundle_sources(tmp_path, stem="bundle", graph=None, entrypoints=None):
+    graph_path = tmp_path / f"{stem}.architecture_graph.json"
+    entrypoints_path = tmp_path / f"{stem}.entrypoints.json"
+    graph_path.write_text(json.dumps(graph or _graph()), encoding="utf-8")
+    entrypoints_path.write_text(
+        json.dumps(entrypoints or _entrypoints()), encoding="utf-8"
+    )
+    return graph_path, entrypoints_path
+
+
 def test_compile_graph_index_requires_coherent_validated_sources(tmp_path):
     graph_path, entrypoints_path = _write(tmp_path)
 
@@ -116,6 +127,71 @@ def test_compile_graph_index_requires_coherent_validated_sources(tmp_path):
         "nodes_reachable": 2,
         "unreachable_nodes": 0,
     }
+
+
+def test_compile_infers_expected_bundle_provenance_from_sibling_dump_index(tmp_path):
+    dump_path = tmp_path / "bundle.dump_index.json"
+    dump_path.write_text(
+        json.dumps({"contract": "dump-index", "run_id": "run-1"}),
+        encoding="utf-8",
+    )
+    dump_sha = hashlib.sha256(dump_path.read_bytes()).hexdigest()
+    graph_path, entrypoints_path = _write_bundle_sources(
+        tmp_path,
+        graph=_graph(sha=dump_sha),
+        entrypoints=_entrypoints(sha=dump_sha),
+    )
+
+    result = compile_graph_index(graph_path, entrypoints_path)
+
+    assert result["run_id"] == "run-1"
+    assert result["canonical_dump_index_sha256"] == dump_sha
+
+
+def test_compile_rejects_sibling_dump_index_hash_mismatch(tmp_path):
+    dump_path = tmp_path / "bundle.dump_index.json"
+    dump_path.write_text(
+        json.dumps({"contract": "dump-index", "run_id": "run-1"}),
+        encoding="utf-8",
+    )
+    graph_path, entrypoints_path = _write_bundle_sources(tmp_path)
+
+    with pytest.raises(GraphIndexCompilationError) as caught:
+        compile_graph_index(graph_path, entrypoints_path)
+
+    assert caught.value.code == "bundle_provenance_mismatch"
+    assert caught.value.source == "expected_provenance"
+
+
+def test_compile_rejects_unusable_sibling_dump_index(tmp_path):
+    dump_path = tmp_path / "bundle.dump_index.json"
+    dump_path.write_text(json.dumps({"contract": "dump-index"}), encoding="utf-8")
+    graph_path, entrypoints_path = _write_bundle_sources(tmp_path)
+
+    with pytest.raises(GraphIndexCompilationError) as caught:
+        compile_graph_index(graph_path, entrypoints_path)
+
+    assert caught.value.code == "bundle_provenance_unavailable"
+    assert caught.value.source == "expected_provenance"
+
+
+def test_compile_keeps_explicit_expected_provenance_override(tmp_path):
+    dump_path = tmp_path / "bundle.dump_index.json"
+    dump_path.write_text(
+        json.dumps({"contract": "dump-index", "run_id": "other-run"}),
+        encoding="utf-8",
+    )
+    graph_path, entrypoints_path = _write_bundle_sources(tmp_path)
+
+    result = compile_graph_index(
+        graph_path,
+        entrypoints_path,
+        expected_run_id="run-1",
+        expected_canonical_sha256=SHA_A,
+    )
+
+    assert result["run_id"] == "run-1"
+    assert result["canonical_dump_index_sha256"] == SHA_A
 
 
 @pytest.mark.parametrize("source", ["graph", "entrypoints"])


### PR DESCRIPTION
## Summary
- infer expected graph-index bundle provenance from a sibling `<stem>.dump_index.json` when explicit expected provenance is absent
- fail closed when the sibling dump index is unusable or when graph/entrypoint sources do not match its run/hash
- preserve explicit expected provenance as the authoritative override and add focused regression tests

## Context
This is the small retained graph-provenance slice. It does not port the old `graph-provenance-coherence` worktree.

## Tests
- `python3 -m py_compile merger/lenskit/architecture/graph_index.py merger/lenskit/tests/test_graph_index.py`
- graph index unit scope: `19 passed`
- graph E2E: `1 passed`
- graph-model relevant scope: `79 passed`
- `python3 -m ruff check merger/lenskit/architecture/graph_index.py merger/lenskit/tests/test_graph_index.py`
- `git diff --check`

## Not proven
- Full repository test suite: direct full pytest invocation was terminated by the tool response without a result.
- CI and external review still need to run before merge.
