### PR TITLE
fix(graph): harden sibling dump-index provenance hashing

### DIFF
--- a/merger/lenskit/architecture/graph_index.py
+++ b/merger/lenskit/architecture/graph_index.py
@@ -104,10 +104,16 @@ def _infer_bundle_provenance(
         return None, None
 
     try:
-        with dump_index_path.open(encoding="utf-8") as handle:
-            dump_index = json.load(handle)
+        raw_dump_index = dump_index_path.read_bytes()
+        dump_index = json.loads(raw_dump_index.decode("utf-8"))
         run_id = dump_index["run_id"]
-    except (OSError, json.JSONDecodeError, KeyError, TypeError) as exc:
+    except (
+        OSError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        KeyError,
+        TypeError,
+    ) as exc:
         raise GraphIndexCompilationError(
             "bundle_provenance_unavailable",
             f"sibling dump index is unusable: {dump_index_path}",
@@ -122,7 +128,7 @@ def _infer_bundle_provenance(
             source="expected_provenance",
         )
 
-    digest = hashlib.sha256(dump_index_path.read_bytes()).hexdigest()
+    digest = hashlib.sha256(raw_dump_index).hexdigest()
     return run_id, digest
 
 

--- a/merger/lenskit/tests/test_graph_index.py
+++ b/merger/lenskit/tests/test_graph_index.py
@@ -163,6 +163,26 @@ def test_compile_rejects_sibling_dump_index_hash_mismatch(tmp_path):
     assert caught.value.source == "expected_provenance"
 
 
+def test_compile_rejects_sibling_dump_index_run_id_mismatch(tmp_path):
+    dump_path = tmp_path / "bundle.dump_index.json"
+    dump_path.write_text(
+        json.dumps({"contract": "dump-index", "run_id": "expected-run"}),
+        encoding="utf-8",
+    )
+    dump_sha = hashlib.sha256(dump_path.read_bytes()).hexdigest()
+    graph_path, entrypoints_path = _write_bundle_sources(
+        tmp_path,
+        graph=_graph(run_id="source-run", sha=dump_sha),
+        entrypoints=_entrypoints(run_id="source-run", sha=dump_sha),
+    )
+
+    with pytest.raises(GraphIndexCompilationError) as caught:
+        compile_graph_index(graph_path, entrypoints_path)
+
+    assert caught.value.code == "bundle_provenance_mismatch"
+    assert caught.value.source == "expected_provenance"
+
+
 def test_compile_rejects_unusable_sibling_dump_index(tmp_path):
     dump_path = tmp_path / "bundle.dump_index.json"
     dump_path.write_text(json.dumps({"contract": "dump-index"}), encoding="utf-8")


### PR DESCRIPTION
## Summary

Follow-up to #857. This hardens sibling dump-index provenance inference: the dump index is read once as bytes, JSON is decoded from that same byte buffer, and the same byte buffer is hashed.

## Why

#857 added fallback provenance inference from a sibling dump_index file. This follow-up keeps the interpreted provenance input and the proven hash input byte-identical.

## Changes

- Read sibling dump index once as bytes.
- Decode UTF-8 and JSON from that byte buffer.
- Hash that same byte buffer.
- Treat non-UTF-8 dump indexes as provenance unavailable.
- Add regression coverage for sibling dump-index run_id mismatch.

## Tests

Branch-prep checks reported:

- py_compile for graph_index.py and test_graph_index.py
- pytest merger/lenskit/tests/test_graph_index.py -q: 20 passed
- ruff check for graph_index.py and test_graph_index.py

GitHub checks observed on head 3a74f3389dae609ca47f3dd80a73a08df0bda6af:

- ai-context guard: success
- lint: success
- Graph Model: success
- task-index: success
- CodeQL: success

## Review status

- Codex review requested.
- Codex reported no major issues for head 3a74f3389d.
- No separate Claude review was available through this execution path; given the two-file +30/-4 scope, this is recorded as a conscious waiver, not a silent omission.