### PR TITLE
feat(repobrief): add explicit snapshot create command

### DIFF
--- a/merger/lenskit/cli/cmd_repobrief.py
+++ b/merger/lenskit/cli/cmd_repobrief.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+from merger.lenskit.core.merge import ExtrasConfig, parse_human_size, scan_repo, write_reports_v2
+
+SNAPSHOT_PROFILES = {
+    "local-private": {"level": "dev"},
+    "agent-portable": {"level": "max"},
+    "full-max": {"level": "max"},
+    "pr-review": {"level": "dev"},
+    "security-export-review": {"level": "max"},
+    "public-share": {"level": "summary"},
+    "ci-artifact": {"level": "dev"},
+}
+
+DOES_NOT_ESTABLISH = [
+    "truth",
+    "correctness",
+    "completeness",
+    "runtime_behavior",
+    "test_sufficiency",
+    "regression_absence",
+    "repo_understood",
+    "claims_true",
+    "forensic_ready",
+]
+
+
+def _json_write_atomic(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path: Optional[Path] = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            delete=False,
+            dir=str(path.parent),
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+        ) as tmp_file:
+            json.dump(data, tmp_file, indent=2, sort_keys=True)
+            tmp_file.write("\n")
+            tmp_file.flush()
+            os.fsync(tmp_file.fileno())
+            tmp_path = Path(tmp_file.name)
+        os.replace(tmp_path, path)
+    finally:
+        if tmp_path is not None and tmp_path.exists():
+            try:
+                tmp_path.unlink()
+            except OSError:
+                # Best-effort cleanup must not hide the primary write result.
+                pass
+
+
+def mark_bundle_manifest_profile(bundle_manifest: Path | None, profile: str) -> None:
+    if bundle_manifest is None:
+        return
+    data = json.loads(bundle_manifest.read_text(encoding="utf-8"))
+    capabilities = data.setdefault("capabilities", {})
+    if not isinstance(capabilities, dict):
+        capabilities = {}
+        data["capabilities"] = capabilities
+    capabilities["repobrief_profile"] = profile
+    capabilities["repobrief_snapshot_create"] = True
+    _json_write_atomic(bundle_manifest, data)
+
+
+def parse_extensions(values: Iterable[str] | None) -> list[str] | None:
+    if not values:
+        return None
+    result: list[str] = []
+    for value in values:
+        for item in str(value).split(","):
+            item = item.strip().lower()
+            if not item:
+                continue
+            if not item.startswith("."):
+                item = f".{item}"
+            result.append(item)
+    return sorted(set(result)) or None
+
+
+def register_repobrief_commands(subparsers: argparse._SubParsersAction) -> None:
+    repobrief_parser = subparsers.add_parser(
+        "repobrief",
+        help="RepoBrief explicit snapshot and read-access commands",
+    )
+    repobrief_subparsers = repobrief_parser.add_subparsers(
+        dest="repobrief_cmd",
+        required=True,
+        help="RepoBrief command groups",
+    )
+    snapshot_parser = repobrief_subparsers.add_parser("snapshot", help="Brief Snapshot commands")
+    snapshot_subparsers = snapshot_parser.add_subparsers(
+        dest="snapshot_cmd",
+        required=True,
+        help="Snapshot commands",
+    )
+    create_parser = snapshot_subparsers.add_parser("create", help="Explicitly create a Brief Snapshot")
+    create_parser.add_argument("--repo", required=True, help="Repository path to snapshot")
+    create_parser.add_argument("--out", required=True, help="Output directory for Brief Bundle artifacts")
+    create_parser.add_argument(
+        "--profile",
+        choices=sorted(SNAPSHOT_PROFILES),
+        default="agent-portable",
+        help="RepoBrief snapshot profile label to record in the manifest",
+    )
+    create_parser.add_argument(
+        "--mode",
+        choices=["gesamt", "pro-repo"],
+        default="gesamt",
+        help="Existing renderer mode passed through to the deterministic generator",
+    )
+    create_parser.add_argument("--max-bytes", default="0")
+    create_parser.add_argument("--split-size", default="25MB")
+    create_parser.add_argument("--path-filter")
+    create_parser.add_argument("--ext", action="append")
+    create_parser.add_argument("--output-mode", choices=["archive", "retrieval", "dual"], default="dual")
+    create_parser.add_argument("--redact-secrets", action="store_true")
+    create_parser.add_argument("--no-include-hidden", action="store_false", dest="include_hidden")
+    create_parser.set_defaults(include_hidden=True)
+
+
+def run_repobrief(args: argparse.Namespace) -> int:
+    if args.repobrief_cmd == "snapshot" and args.snapshot_cmd == "create":
+        return run_snapshot_create(args)
+    print("Unsupported RepoBrief command", file=sys.stderr)
+    return 2
+
+
+def run_snapshot_create(args: argparse.Namespace) -> int:
+    profile = args.profile
+    repo = Path(args.repo).expanduser().resolve()
+    out = Path(args.out).expanduser().resolve()
+
+    if not repo.exists() or not repo.is_dir():
+        print(f"repobrief snapshot create: repo is not a directory: {repo}", file=sys.stderr)
+        return 2
+    if out == repo or repo in out.parents:
+        print("bad output path", file=sys.stderr)
+        return 2
+
+    out.mkdir(parents=True, exist_ok=True)
+    max_bytes = parse_human_size(args.max_bytes)
+    split_size = parse_human_size(args.split_size)
+    ext_filter = parse_extensions(args.ext)
+    extras = ExtrasConfig(json_sidecar=True, augment_sidecar=True)
+
+    summary = scan_repo(
+        repo,
+        extensions=ext_filter,
+        path_contains=args.path_filter,
+        max_bytes=max_bytes,
+        include_paths=None,
+        calculate_md5=True,
+        include_hidden=args.include_hidden,
+    )
+    generator_info = {
+        "name": "repobrief",
+        "version": os.getenv("RLENS_VERSION", "dev"),
+        "platform": "cli",
+    }
+    artifacts = write_reports_v2(
+        out,
+        repo.parent,
+        [summary],
+        SNAPSHOT_PROFILES[profile]["level"],
+        args.mode,
+        max_bytes,
+        False,
+        False,
+        split_size,
+        debug=False,
+        path_filter=args.path_filter,
+        ext_filter=ext_filter,
+        extras=extras,
+        output_mode=args.output_mode,
+        redact_secrets=args.redact_secrets,
+        include_hidden=args.include_hidden,
+        generator_info=generator_info,
+    )
+    mark_bundle_manifest_profile(artifacts.bundle_manifest, profile)
+
+    result = {
+        "status": "ok",
+        "command": "repobrief snapshot create",
+        "profile": profile,
+        "repo": str(repo),
+        "out": str(out),
+        "bundle_manifest": str(artifacts.bundle_manifest) if artifacts.bundle_manifest else None,
+        "artifacts": [str(path) for path in artifacts.get_all_paths()],
+        "mutation_boundary": {
+            "writes": ["brief_bundle_artifacts"],
+            "does_not_mutate": ["git", "pull_requests", "patches", "source_working_tree"],
+            "read_paths_do_not_refresh": True,
+        },
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0

--- a/merger/lenskit/cli/main.py
+++ b/merger/lenskit/cli/main.py
@@ -74,6 +74,10 @@ def main(args: Optional[List[str]] = None) -> int:
     from .cmd_rlens_client import register_rlens_client_commands
     register_rlens_client_commands(subparsers)
 
+    # RepoBrief command
+    from .cmd_repobrief import register_repobrief_commands
+    register_repobrief_commands(subparsers)
+
     # Index command
     index_parser = subparsers.add_parser("index", help="Build or verify retrieval index")
     index_parser.add_argument("--dump", required=True, help="Path to dump_index.json")
@@ -292,6 +296,9 @@ def main(args: Optional[List[str]] = None) -> int:
     elif parsed_args.command == "rlens-client":
         from .cmd_rlens_client import run_rlens_client
         return run_rlens_client(parsed_args)
+    elif parsed_args.command == "repobrief":
+        from .cmd_repobrief import run_repobrief
+        return run_repobrief(parsed_args)
 
     return 0
 

--- a/merger/lenskit/tests/test_repobrief_snapshot_cli.py
+++ b/merger/lenskit/tests/test_repobrief_snapshot_cli.py
@@ -1,0 +1,119 @@
+import json
+from pathlib import Path
+
+from merger.lenskit.cli.main import main
+from merger.lenskit.cli import cmd_repobrief
+
+
+class FakeArtifacts:
+    def __init__(self, manifest: Path):
+        self.bundle_manifest = manifest
+        self.canonical_md = manifest.with_name("brief.md")
+        self.canonical_md.write_text("# brief\n", encoding="utf-8")
+
+    def get_all_paths(self):
+        return [self.bundle_manifest, self.canonical_md]
+
+
+def test_manifest_profile_marker_uses_capabilities_extension(tmp_path):
+    manifest = tmp_path / "bundle.manifest.json"
+    manifest.write_text(
+        json.dumps({"kind": "repolens.bundle.manifest", "capabilities": {}}),
+        encoding="utf-8",
+    )
+
+    cmd_repobrief.mark_bundle_manifest_profile(manifest, "agent-portable")
+
+    data = json.loads(manifest.read_text(encoding="utf-8"))
+    assert data["capabilities"]["repobrief_profile"] == "agent-portable"
+    assert data["capabilities"]["repobrief_snapshot_create"] is True
+
+
+def test_snapshot_create_dispatches_existing_generator(monkeypatch, tmp_path, capsys):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "README.md").write_text("hello\n", encoding="utf-8")
+    out = tmp_path / "briefs"
+    calls = {}
+
+    def fake_scan_repo(*args, **kwargs):
+        calls["scan"] = {"args": args, "kwargs": kwargs}
+        return {"name": "repo", "root": repo, "files": [], "total_files": 0, "total_bytes": 0, "ext_hist": {}}
+
+    def fake_write_reports_v2(*args, **kwargs):
+        calls["write"] = {"args": args, "kwargs": kwargs}
+        manifest = out / "repo_merge.bundle.manifest.json"
+        manifest.parent.mkdir(parents=True, exist_ok=True)
+        manifest.write_text(
+            json.dumps({"kind": "repolens.bundle.manifest", "capabilities": {}}),
+            encoding="utf-8",
+        )
+        return FakeArtifacts(manifest)
+
+    monkeypatch.setattr(cmd_repobrief, "scan_repo", fake_scan_repo)
+    monkeypatch.setattr(cmd_repobrief, "write_reports_v2", fake_write_reports_v2)
+
+    rc = main([
+        "repobrief",
+        "snapshot",
+        "create",
+        "--repo",
+        str(repo),
+        "--out",
+        str(out),
+        "--profile",
+        "agent-portable",
+    ])
+
+    assert rc == 0
+    assert calls["scan"]["args"][0] == repo.resolve()
+    assert calls["write"]["args"][0] == out.resolve()
+    assert calls["write"]["args"][3] == "max"
+    assert calls["write"]["args"][5] == 0
+    assert calls["write"]["args"][6] is False
+    assert calls["write"]["kwargs"]["generator_info"]["name"] == "repobrief"
+
+    manifest_data = json.loads((out / "repo_merge.bundle.manifest.json").read_text(encoding="utf-8"))
+    assert manifest_data["capabilities"]["repobrief_profile"] == "agent-portable"
+
+    emitted = json.loads(capsys.readouterr().out)
+    assert emitted["command"] == "repobrief snapshot create"
+    assert emitted["mutation_boundary"]["writes"] == ["brief_bundle_artifacts"]
+    assert emitted["mutation_boundary"]["read_paths_do_not_refresh"] is True
+    assert "forensic_ready" in emitted["does_not_establish"]
+
+
+def test_snapshot_create_rejects_missing_repo_without_creating_snapshot(tmp_path):
+    out = tmp_path / "briefs"
+
+    rc = main([
+        "repobrief",
+        "snapshot",
+        "create",
+        "--repo",
+        str(tmp_path / "missing"),
+        "--out",
+        str(out),
+    ])
+
+    assert rc == 2
+    assert not out.exists()
+
+
+def test_snapshot_create_rejects_output_inside_repo(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    out = repo / "briefs"
+
+    rc = main([
+        "repobrief",
+        "snapshot",
+        "create",
+        "--repo",
+        str(repo),
+        "--out",
+        str(out),
+    ])
+
+    assert rc == 2
+    assert not out.exists()


### PR DESCRIPTION
Adds an explicit RepoBrief snapshot create command as the first write path after the naming slice.

Scope:
- adds `lenskit repobrief snapshot create`
- scans a requested repo and writes Brief Bundle artifacts to an explicit output directory
- records the selected RepoBrief profile in the bundle manifest capabilities extension
- emits a JSON result with mutation boundary and does_not_establish semantics
- keeps the existing lenskit CLI and generator compatibility surface unchanged

Local checks:
- python -m pytest -q -k 'repobrief or deterministic_lenskit_core_doc' -> 12 passed, 3193 deselected
- python -m merger.lenskit.cli.main repobrief snapshot create --help -> OK
- tiny real snapshot create -> status ok, profile agent-portable, 19 artifacts

Known note:
- tiny real snapshot create currently emits an existing graph-index meta warning from the generator; command exits successfully and the warning is outside this new command's control surface.