### PR TITLE
test(graph): cover provenance compiler failures

### DIFF
--- a/merger/lenskit/tests/graph_compiler_fixtures.py
+++ b/merger/lenskit/tests/graph_compiler_fixtures.py
@@ -1,0 +1,70 @@
+def graph_document(run_id="run", canonical_sha="0" * 64):
+    return {
+        "kind": "lenskit.architecture.graph",
+        "version": "1.0",
+        "run_id": run_id,
+        "canonical_dump_index_sha256": canonical_sha,
+        "granularity": "file",
+        "nodes": [
+            {
+                "node_id": "file:main.py",
+                "kind": "file",
+                "path": "main.py",
+                "repo": "repo",
+                "language": "python",
+                "layer": "unknown",
+                "is_test": False,
+            },
+            {
+                "node_id": "file:util.py",
+                "kind": "file",
+                "path": "util.py",
+                "repo": "repo",
+                "language": "python",
+                "layer": "unknown",
+                "is_test": False,
+            },
+            {
+                "node_id": "file:unreach.py",
+                "kind": "file",
+                "path": "unreach.py",
+                "repo": "repo",
+                "language": "python",
+                "layer": "unknown",
+                "is_test": False,
+            },
+        ],
+        "edges": [
+            {
+                "src": "file:main.py",
+                "dst": "file:util.py",
+                "edge_type": "import",
+                "evidence_level": "S1",
+                "evidence": {"source_path": "main.py", "start_line": 1},
+            }
+        ],
+        "coverage": {
+            "files_seen": 3,
+            "files_parsed": 3,
+            "edge_counts_by_type": {"import": 1},
+            "unknown_layer_share": 1.0,
+        },
+    }
+
+
+def entrypoints_document(run_id="run", canonical_sha="0" * 64):
+    return {
+        "kind": "lenskit.entrypoints",
+        "version": "1.0",
+        "run_id": run_id,
+        "canonical_dump_index_sha256": canonical_sha,
+        "entrypoints": [
+            {
+                "id": "main.py:module_main",
+                "type": "module_main",
+                "path": "main.py",
+                "evidence_level": "S0",
+                "evidence": {"rule": "fixture"},
+            }
+        ],
+    }

--- a/merger/lenskit/tests/test_graph_compiler_provenance.py
+++ b/merger/lenskit/tests/test_graph_compiler_provenance.py
@@ -1,0 +1,102 @@
+import argparse
+import json
+
+import pytest
+
+from merger.lenskit.architecture import graph_source_validation
+from merger.lenskit.architecture.graph_index import GraphIndexCompilationError, compile_graph_index
+from merger.lenskit.cli import cmd_architecture
+from merger.lenskit.tests.graph_compiler_fixtures import entrypoints_document, graph_document
+
+
+def write_sources(tmp_path, graph=None, entrypoints=None):
+    graph_path = tmp_path / "graph.json"
+    entrypoints_path = tmp_path / "entrypoints.json"
+    graph_path.write_text(json.dumps(graph or graph_document()), encoding="utf-8")
+    entrypoints_path.write_text(json.dumps(entrypoints or entrypoints_document()), encoding="utf-8")
+    return graph_path, entrypoints_path
+
+
+def test_invalid_graph_schema(tmp_path):
+    graph = graph_document()
+    graph.pop("coverage")
+    with pytest.raises(GraphIndexCompilationError) as caught:
+        compile_graph_index(*write_sources(tmp_path, graph=graph))
+    assert (caught.value.code, caught.value.source) == ("invalid_schema", "architecture_graph")
+
+
+def test_invalid_entrypoints_schema(tmp_path):
+    entrypoints = entrypoints_document()
+    entrypoints["entrypoints"][0].pop("evidence_level")
+    with pytest.raises(GraphIndexCompilationError) as caught:
+        compile_graph_index(*write_sources(tmp_path, entrypoints=entrypoints))
+    assert (caught.value.code, caught.value.source) == ("invalid_schema", "entrypoints")
+
+
+def test_compiler_requires_jsonschema(tmp_path, monkeypatch):
+    paths = write_sources(tmp_path)
+    monkeypatch.setattr(graph_source_validation, "jsonschema", None)
+    with pytest.raises(GraphIndexCompilationError) as caught:
+        compile_graph_index(*paths)
+    assert caught.value.code == "validation_unavailable"
+
+
+@pytest.mark.parametrize("target", ["graph", "entrypoints"])
+def test_run_id_must_be_nonempty(tmp_path, target):
+    graph = graph_document()
+    entrypoints = entrypoints_document()
+    (graph if target == "graph" else entrypoints)["run_id"] = ""
+    with pytest.raises(GraphIndexCompilationError) as caught:
+        compile_graph_index(*write_sources(tmp_path, graph, entrypoints))
+    assert caught.value.code == "invalid_provenance"
+
+
+def test_source_provenance_must_match(tmp_path):
+    with pytest.raises(GraphIndexCompilationError) as caught:
+        compile_graph_index(*write_sources(tmp_path, entrypoints=entrypoints_document(run_id="other")))
+    assert caught.value.code == "provenance_mismatch"
+
+    with pytest.raises(GraphIndexCompilationError) as caught:
+        compile_graph_index(*write_sources(tmp_path, entrypoints=entrypoints_document(canonical_sha="1" * 64)))
+    assert caught.value.code == "provenance_mismatch"
+
+
+def test_expected_bundle_provenance_must_match(tmp_path):
+    paths = write_sources(tmp_path)
+    with pytest.raises(GraphIndexCompilationError) as caught:
+        compile_graph_index(*paths, expected_run_id="other")
+    assert caught.value.code == "bundle_provenance_mismatch"
+
+    with pytest.raises(GraphIndexCompilationError) as caught:
+        compile_graph_index(*paths, expected_canonical_sha256="1" * 64)
+    assert caught.value.code == "bundle_provenance_mismatch"
+
+
+def test_error_has_stable_machine_shape():
+    error = GraphIndexCompilationError("provenance_mismatch", "mismatch", source="provenance", errors=["a", "b"])
+    assert error.as_dict() == {
+        "code": "provenance_mismatch",
+        "message": "mismatch",
+        "source": "provenance",
+        "errors": ["a", "b"],
+    }
+
+
+def test_cli_reports_structured_failure(tmp_path, capsys):
+    graph = graph_document()
+    graph.pop("coverage")
+    graph_path, entrypoints_path = write_sources(tmp_path, graph=graph)
+    args = argparse.Namespace(
+        entrypoints=False,
+        import_graph=False,
+        graph_index=True,
+        graph_in=str(graph_path),
+        entrypoints_in=str(entrypoints_path),
+        repo=str(tmp_path),
+    )
+    assert cmd_architecture.run_architecture_cmd(args) == 2
+    captured = capsys.readouterr()
+    payload = json.loads(captured.err)
+    assert payload["code"] == "invalid_schema"
+    assert payload["source"] == "architecture_graph"
+    assert "Traceback" not in captured.err


### PR DESCRIPTION
Ports provenance compiler failure tests from the stale graph-provenance-coherence audit onto current main. Local focused pytest and git diff check passed.