### PR TITLE
feat(repobrief): emit export safety report for snapshot profiles

### DIFF
--- a/merger/lenskit/cli/cmd_repobrief.py
+++ b/merger/lenskit/cli/cmd_repobrief.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import sys
@@ -73,6 +74,59 @@ def mark_bundle_manifest_profile(bundle_manifest: Path | None, profile: str) -> 
     _json_write_atomic(bundle_manifest, data)
     return evaluation
 
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _add_manifest_artifact(bundle_manifest: Path, artifact_path: Path, role: str, content_type: str) -> None:
+    data = json.loads(bundle_manifest.read_text(encoding="utf-8"))
+    artifacts = data.setdefault("artifacts", [])
+    if not isinstance(artifacts, list):
+        artifacts = []
+        data["artifacts"] = artifacts
+    artifacts[:] = [a for a in artifacts if not (isinstance(a, dict) and a.get("role") == role)]
+    artifacts.append({
+        "path": artifact_path.name,
+        "role": role,
+        "content_type": content_type,
+        "bytes": artifact_path.stat().st_size,
+        "sha256": _sha256_file(artifact_path),
+    })
+    artifacts.sort(key=lambda a: (str(a.get("role", "")), str(a.get("path", ""))))
+    _json_write_atomic(bundle_manifest, data)
+
+
+def _export_safety_requirement(profile: str) -> str:
+    return str(profile_policy(profile)["artifact_rules"].get("export_safety_report", "optional"))
+
+
+def should_emit_export_safety_report(profile: str) -> bool:
+    return _export_safety_requirement(profile) in {"required", "recommended"}
+
+
+def emit_export_safety_report(bundle_manifest: Path | None, profile: str) -> Path | None:
+    if bundle_manifest is None or not should_emit_export_safety_report(profile):
+        return None
+    from merger.lenskit.core.export_safety_report import build_export_safety_report_from_bundle_manifest
+
+    report = build_export_safety_report_from_bundle_manifest(
+        bundle_manifest,
+        profile=profile,
+        agent_facing=True if profile in {"agent-portable", "full-max", "pr-review", "ci-artifact"} else None,
+        public_facing=True if profile == "public-share" else None,
+    )
+    out = bundle_manifest.with_name(
+        bundle_manifest.name.replace(".bundle.manifest.json", ".export_safety_report.json")
+    )
+    _json_write_atomic(out, report)
+    _add_manifest_artifact(bundle_manifest, out, "export_safety_report", "application/json")
+    return out
 
 def parse_extensions(values: Iterable[str] | None) -> list[str] | None:
     if not values:
@@ -188,7 +242,11 @@ def run_snapshot_create(args: argparse.Namespace) -> int:
         include_hidden=args.include_hidden,
         generator_info=generator_info,
     )
+    export_safety_path = emit_export_safety_report(artifacts.bundle_manifest, profile)
     profile_evaluation = mark_bundle_manifest_profile(artifacts.bundle_manifest, profile)
+    artifact_paths = artifacts.get_all_paths()
+    if export_safety_path is not None and export_safety_path not in artifact_paths:
+        artifact_paths.append(export_safety_path)
 
     result = {
         "status": "ok",
@@ -198,7 +256,8 @@ def run_snapshot_create(args: argparse.Namespace) -> int:
         "out": str(out),
         "bundle_manifest": str(artifacts.bundle_manifest) if artifacts.bundle_manifest else None,
         "profile_evaluation": profile_evaluation,
-        "artifacts": [str(path) for path in artifacts.get_all_paths()],
+        "export_safety_report": str(export_safety_path) if export_safety_path else None,
+        "artifacts": [str(path) for path in artifact_paths],
         "mutation_boundary": {
             "writes": ["brief_bundle_artifacts"],
             "does_not_mutate": ["git", "pull_requests", "patches", "source_working_tree"],

--- a/merger/lenskit/tests/test_repobrief_snapshot_cli.py
+++ b/merger/lenskit/tests/test_repobrief_snapshot_cli.py
@@ -75,11 +75,15 @@ def test_snapshot_create_dispatches_existing_generator(monkeypatch, tmp_path, ca
 
     manifest_data = json.loads((out / "repo_merge.bundle.manifest.json").read_text(encoding="utf-8"))
     assert manifest_data["capabilities"]["repobrief_profile"] == "agent-portable"
+    assert any(a["role"] == "export_safety_report" for a in manifest_data["artifacts"])
+    assert (out / "repo_merge.export_safety_report.json").exists()
 
     emitted = json.loads(capsys.readouterr().out)
     assert emitted["command"] == "repobrief snapshot create"
     assert emitted["mutation_boundary"]["writes"] == ["brief_bundle_artifacts"]
     assert emitted["mutation_boundary"]["read_paths_do_not_refresh"] is True
+    assert emitted["export_safety_report"].endswith(".export_safety_report.json")
+    assert "export_safety_report" not in emitted["profile_evaluation"]["missing_required"]
     assert "forensic_ready" in emitted["does_not_establish"]
 
 
@@ -117,3 +121,42 @@ def test_snapshot_create_rejects_output_inside_repo(tmp_path):
 
     assert rc == 2
     assert not out.exists()
+
+
+def test_local_private_does_not_emit_optional_export_safety(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "README.md").write_text("hello\n", encoding="utf-8")
+    out = tmp_path / "briefs"
+
+    def fake_scan_repo(*args, **kwargs):
+        return {"name": "repo", "root": repo, "files": [], "total_files": 0, "total_bytes": 0, "ext_hist": {}}
+
+    def fake_write_reports_v2(*args, **kwargs):
+        manifest = out / "repo_merge.bundle.manifest.json"
+        manifest.parent.mkdir(parents=True, exist_ok=True)
+        manifest.write_text(
+            json.dumps({"kind": "repolens.bundle.manifest", "artifacts": [], "capabilities": {}}),
+            encoding="utf-8",
+        )
+        return FakeArtifacts(manifest)
+
+    monkeypatch.setattr(cmd_repobrief, "scan_repo", fake_scan_repo)
+    monkeypatch.setattr(cmd_repobrief, "write_reports_v2", fake_write_reports_v2)
+
+    rc = main([
+        "repobrief",
+        "snapshot",
+        "create",
+        "--repo",
+        str(repo),
+        "--out",
+        str(out),
+        "--profile",
+        "local-private",
+    ])
+
+    assert rc == 0
+    assert not (out / "repo_merge.export_safety_report.json").exists()
+    manifest_data = json.loads((out / "repo_merge.bundle.manifest.json").read_text(encoding="utf-8"))
+    assert all(a.get("role") != "export_safety_report" for a in manifest_data.get("artifacts", []))


### PR DESCRIPTION
Emits export_safety_report during repobrief snapshot create for profiles that require or recommend it.

Scope:
- builds export_safety_report from the finalized bundle manifest for required/recommended profiles
- registers the report in bundle manifest artifacts before profile evaluation
- keeps local-private light by not emitting optional export safety by default
- returns export_safety_report path in the snapshot create JSON result
- adds regression coverage for agent-portable and local-private behavior

Local checks:
- python -m pytest -q merger/lenskit/tests/test_repobrief_snapshot_cli.py merger/lenskit/tests/test_repobrief_profiles.py -> 10 passed
- python -m pytest -q -k 'repobrief or export' -> 118 passed, 3103 deselected
- agent-portable smoke -> status ok, profile pass, missing_required [], export report exists
- local-private smoke -> status ok, profile pass, export_safety_report None

Known note:
- tiny snapshot generation still emits the pre-existing graph_index metadata warning; this PR does not alter graph-index generation.