### PR TITLE
fix(repobrief): stop validating graph index as agent json

### DIFF
--- a/merger/lenskit/core/merge.py
+++ b/merger/lenskit/core/merge.py
@@ -6117,6 +6117,7 @@ def write_reports_v2(
         and not p.name.endswith(".retrieval_eval.json")
         and not p.name.endswith(".architecture_graph.json")
         and not p.name.endswith(".entrypoints.json")
+        and not p.name.endswith(".graph_index.json")
     ]
 
     dump_indices = [p for p in out_paths if p.name.endswith(".dump_index.json")]

--- a/merger/lenskit/tests/test_repobrief_snapshot_cli.py
+++ b/merger/lenskit/tests/test_repobrief_snapshot_cli.py
@@ -218,3 +218,24 @@ def test_public_share_removes_profile_excluded_sqlite(monkeypatch, tmp_path, cap
     assert emitted["removed_profile_excluded_artifacts"]
     assert emitted["profile_evaluation"]["profile_excluded_present"] == []
     assert manifest_data["capabilities"]["fts5_bm25"] is False
+
+
+def test_snapshot_create_graph_index_is_not_verified_as_primary_json(tmp_path, capsys):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "README.md").write_text("hello\n", encoding="utf-8")
+    out = tmp_path / "briefs"
+    rc = main([
+        "repobrief",
+        "snapshot",
+        "create",
+        "--repo",
+        str(repo),
+        "--out",
+        str(out),
+        "--profile",
+        "agent-portable",
+    ])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.err == ""


### PR DESCRIPTION
Stops the graph_index JSON sidecar from being validated as a primary agent JSON artifact during snapshot create.

Scope:
- excludes .graph_index.json from the primary agent-json verification list
- keeps graph_index in its dedicated graph artifact path
- adds a snapshot create regression test asserting stderr stays empty for the graph-index case

Local checks:
- python -m pytest -q merger/lenskit/tests/test_repobrief_snapshot_cli.py -k graph_index -> 1 passed, 6 deselected
- python -m pytest -q -k 'repobrief or graph_index' -> 48 passed, 3175 deselected
- tiny agent-portable smoke -> stderr_bytes=0, status ok, profile pass