### PR TITLE
feat(repobrief): plan output mode by profile

### DIFF
--- a/merger/lenskit/cli/cmd_repobrief.py
+++ b/merger/lenskit/cli/cmd_repobrief.py
@@ -13,8 +13,10 @@ from merger.lenskit.core.merge import ExtrasConfig, parse_human_size, scan_repo,
 from merger.lenskit.core.repobrief_profiles import (
     evaluate_profile,
     present_roles_from_manifest,
+    profile_default_output_mode,
     profile_level,
     profile_names,
+    profile_output_mode_conflicts,
     profile_policy,
     profile_excluded_roles,
 )
@@ -179,7 +181,7 @@ def register_repobrief_commands(subparsers: argparse._SubParsersAction) -> None:
     create_parser.add_argument("--split-size", default="25MB")
     create_parser.add_argument("--path-filter")
     create_parser.add_argument("--ext", action="append")
-    create_parser.add_argument("--output-mode", choices=["archive", "retrieval", "dual"], default="dual")
+    create_parser.add_argument("--output-mode", choices=["archive", "retrieval", "dual"])
     create_parser.add_argument("--redact-secrets", action="store_true")
     create_parser.add_argument("--no-include-hidden", action="store_false", dest="include_hidden")
     create_parser.set_defaults(include_hidden=True)
@@ -202,6 +204,16 @@ def run_snapshot_create(args: argparse.Namespace) -> int:
         return 2
     if out == repo or repo in out.parents:
         print("bad output path", file=sys.stderr)
+        return 2
+
+    output_mode = args.output_mode or profile_default_output_mode(profile)
+    conflicts = profile_output_mode_conflicts(profile, output_mode)
+    if conflicts:
+        print(
+            f"repobrief snapshot create: profile {profile} excludes artifacts produced by output mode {output_mode}: "
+            + ", ".join(conflicts),
+            file=sys.stderr,
+        )
         return 2
 
     out.mkdir(parents=True, exist_ok=True)
@@ -238,7 +250,7 @@ def run_snapshot_create(args: argparse.Namespace) -> int:
         path_filter=args.path_filter,
         ext_filter=ext_filter,
         extras=extras,
-        output_mode=args.output_mode,
+        output_mode=output_mode,
         redact_secrets=args.redact_secrets,
         include_hidden=args.include_hidden,
         generator_info=generator_info,
@@ -256,6 +268,7 @@ def run_snapshot_create(args: argparse.Namespace) -> int:
         "status": "ok",
         "command": "repobrief snapshot create",
         "profile": profile,
+        "output_mode": output_mode,
         "repo": str(repo),
         "out": str(out),
         "bundle_manifest": str(artifacts.bundle_manifest) if artifacts.bundle_manifest else None,

--- a/merger/lenskit/core/repobrief_profiles.py
+++ b/merger/lenskit/core/repobrief_profiles.py
@@ -94,8 +94,11 @@ PROFILE_ARTIFACT_RULES = {
     },
     "public-share": {
         **BASE_RULES,
+        "citation_map_jsonl": REQ_OPTIONAL,
+        "chunk_index_jsonl": REQ_OPTIONAL,
         "sqlite_index": REQ_EXCLUDED,
         "export_safety_report": REQ_REQUIRED,
+        "retrieval_eval_json": REQ_NA,
     },
     "ci-artifact": {
         **BASE_RULES,
@@ -208,3 +211,27 @@ def present_roles_from_manifest(bundle_manifest: Mapping[str, Any]) -> set[str]:
 def profile_excluded_roles(profile: str) -> tuple[str, ...]:
     rules = _rules(profile)
     return tuple(role for role in ARTIFACT_ORDER if rules[role] == REQ_EXCLUDED)
+
+
+PROFILE_DEFAULT_OUTPUT_MODES = {
+    "public-share": "archive",
+}
+
+OUTPUT_MODE_ARTIFACT_ROLES = {
+    "archive": frozenset(),
+    "retrieval": frozenset({"sqlite_index"}),
+    "dual": frozenset({"sqlite_index"}),
+}
+
+
+def profile_default_output_mode(profile: str) -> str:
+    _rules(profile)
+    return PROFILE_DEFAULT_OUTPUT_MODES.get(profile, "dual")
+
+
+def profile_output_mode_conflicts(profile: str, output_mode: str) -> tuple[str, ...]:
+    if output_mode not in OUTPUT_MODE_ARTIFACT_ROLES:
+        raise ValueError(f"unknown RepoBrief output mode: {output_mode}")
+    excluded = set(profile_excluded_roles(profile))
+    produced = set(OUTPUT_MODE_ARTIFACT_ROLES[output_mode])
+    return tuple(sorted(excluded & produced))

--- a/merger/lenskit/tests/test_repobrief_snapshot_cli.py
+++ b/merger/lenskit/tests/test_repobrief_snapshot_cli.py
@@ -239,3 +239,67 @@ def test_snapshot_create_graph_index_is_not_verified_as_primary_json(tmp_path, c
     captured = capsys.readouterr()
     assert rc == 0
     assert captured.err == ""
+
+
+def test_public_share_uses_archive_output_mode_by_default(monkeypatch, tmp_path, capsys):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "README.md").write_text("hello\n", encoding="utf-8")
+    out = tmp_path / "briefs"
+    calls = {}
+
+    def fake_scan_repo(*args, **kwargs):
+        return {"name": "repo", "root": repo, "files": [], "total_files": 0, "total_bytes": 0, "ext_hist": {}}
+
+    def fake_write_reports_v2(*args, **kwargs):
+        calls["output_mode"] = kwargs["output_mode"]
+        manifest = out / "repo_merge.bundle.manifest.json"
+        manifest.parent.mkdir(parents=True, exist_ok=True)
+        manifest.write_text(
+            json.dumps({"kind": "repolens.bundle.manifest", "artifacts": [], "links": {}, "capabilities": {}}),
+            encoding="utf-8",
+        )
+        return FakeArtifacts(manifest)
+
+    monkeypatch.setattr(cmd_repobrief, "scan_repo", fake_scan_repo)
+    monkeypatch.setattr(cmd_repobrief, "write_reports_v2", fake_write_reports_v2)
+
+    rc = main([
+        "repobrief",
+        "snapshot",
+        "create",
+        "--repo",
+        str(repo),
+        "--out",
+        str(out),
+        "--profile",
+        "public-share",
+    ])
+
+    emitted = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert calls["output_mode"] == "archive"
+    assert emitted["output_mode"] == "archive"
+
+
+def test_public_share_rejects_explicit_dual_output_mode(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    out = tmp_path / "briefs"
+
+    rc = main([
+        "repobrief",
+        "snapshot",
+        "create",
+        "--repo",
+        str(repo),
+        "--out",
+        str(out),
+        "--profile",
+        "public-share",
+        "--output-mode",
+        "dual",
+    ])
+
+    assert rc == 2
+    assert not out.exists()


### PR DESCRIPTION
Adds profile-aware output-mode planning for RepoBrief snapshot create. Public-share defaults to archive and rejects output modes that would produce profile-excluded artifacts.