### PR TITLE
feat(repobrief): surface snapshot plan for agents

### DIFF
--- a/merger/lenskit/core/agent_entry_manifest.py
+++ b/merger/lenskit/core/agent_entry_manifest.py
@@ -38,6 +38,7 @@ _EXPECTED_SURFACES = (
     "bundle_surface_validation",
     "output_health",
     "export_safety_report",
+    "snapshot_plan_json",
 )
 
 

--- a/merger/lenskit/core/agent_reading_pack.py
+++ b/merger/lenskit/core/agent_reading_pack.py
@@ -66,6 +66,7 @@ _CLAIM_EVIDENCE_MAP = ArtifactRole.CLAIM_EVIDENCE_MAP_JSON.value
 _SELF_ROLE = ArtifactRole.AGENT_READING_PACK.value
 _AGENT_ENTRY_MANIFEST = ArtifactRole.AGENT_ENTRY_MANIFEST.value
 _EXPORT_SAFETY_REPORT = "export_safety_report"
+_SNAPSHOT_PLAN_JSON = "snapshot_plan_json"
 _LENS_CARD_ROLES = ("lens_cards_jsonl", "lens_card_jsonl", "lens_cards")
 _CONCEPT_CARD_ROLES = ("concept_cards_jsonl", "concept_card_jsonl", "concept_cards")
 _PR_DELTA_CARD_ROLES = ("pr_delta_cards_jsonl", "pr_delta_card_jsonl", "pr_delta_cards")
@@ -614,6 +615,20 @@ def render_agent_reading_pack(model: PackModel) -> str:
     )
     lines.append("")
 
+    # ── SNAPSHOT_PLAN_REPORT ─────────────────────────────────────────────
+    lines.append("## SNAPSHOT_PLAN_REPORT")
+    snapshot_plan = _artifact_by_role(model, _SNAPSHOT_PLAN_JSON)
+    if snapshot_plan is not None:
+        _append_artifact_bullet(lines, snapshot_plan)
+    else:
+        lines.append("- No bundle-registered `snapshot_plan_json` artifact is present in this manifest.")
+    lines.append(
+        "- Snapshot Plan reports describe how RepoBrief selected the snapshot profile "
+        "and output mode. They do not prove repo understanding, correctness, "
+        "completeness, safety, test sufficiency or forensic readiness."
+    )
+    lines.append("")
+
     # ── LENS_CARD_INDEX ─────────────────────────────────────────────────
     lines.append("## LENS_CARD_INDEX")
     lens_card_artifacts = _artifacts_by_roles(model, _LENS_CARD_ROLES)
@@ -782,6 +797,11 @@ def render_agent_reading_pack(model: PackModel) -> str:
     lines.append(
         "- `export_safety_report` / `lenskit.export_safety_report`: "
         "export diagnostic only."
+    )
+    lines.append(
+        "- `snapshot_plan_json` / `repobrief.snapshot_plan`: snapshot planning "
+        "diagnostic only; it records profile/output-mode decisions and does not "
+        "prove correctness, completeness or safety."
     )
     lines.append(
         "This does not establish `repo_understood`, `answer_safe_without_citations`, "

--- a/merger/lenskit/tests/test_agent_entry_manifest.py
+++ b/merger/lenskit/tests/test_agent_entry_manifest.py
@@ -586,3 +586,34 @@ def test_agent_entry_manifest_includes_linked_export_safety_report(schema):
     assert surfaces["export_safety_report"]["authority"] == "diagnostic_signal"
     unavailable = {surface["role"] for surface in report["unavailable_surfaces"]}
     assert "export_safety_report" not in unavailable
+
+
+def test_agent_entry_manifest_surfaces_snapshot_plan(schema):
+    bundle = valid_bundle_fixture()
+    bundle["artifacts"].append(
+        {
+            "role": "snapshot_plan_json",
+            "path": "merge.snapshot_plan.json",
+            "sha256": "plan-sha",
+            "authority": "diagnostic_signal",
+            "canonicality": "diagnostic",
+            "risk_class": "diagnostic",
+        }
+    )
+
+    report = build_agent_entry_manifest(bundle, created_at="2026-06-18T00:00:00Z")
+
+    jsonschema.validate(instance=report, schema=schema)
+    surfaces = {surface["role"]: surface for surface in report["available_surfaces"]}
+    assert surfaces["snapshot_plan_json"]["path"] == "merge.snapshot_plan.json"
+    assert surfaces["snapshot_plan_json"]["authority"] == "diagnostic_signal"
+    unavailable = {surface["role"] for surface in report["unavailable_surfaces"]}
+    assert "snapshot_plan_json" not in unavailable
+
+
+def test_agent_entry_manifest_old_bundle_marks_snapshot_plan_unavailable(schema):
+    report = build_agent_entry_manifest(valid_bundle_fixture(), created_at="2026-06-18T00:00:00Z")
+
+    jsonschema.validate(instance=report, schema=schema)
+    unavailable = {surface["role"] for surface in report["unavailable_surfaces"]}
+    assert "snapshot_plan_json" in unavailable

--- a/merger/lenskit/tests/test_agent_reading_pack.py
+++ b/merger/lenskit/tests/test_agent_reading_pack.py
@@ -1087,3 +1087,40 @@ def test_agent_consumption_contracts_section_mentions_preflight_cli(tmp_path):
     assert "agent-consumption preflight" in section
     assert "--task-profile <profile>" in section
     assert "actual_reading_proven" in section
+
+
+def test_reading_pack_surfaces_snapshot_plan_report(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    plan_doc = {
+        "kind": "repobrief.snapshot_plan",
+        "version": "v1",
+        "profile": "public-share",
+        "output_plan": {"selected_output_mode": "archive"},
+        "does_not_establish": ["truth"],
+    }
+    plan_bytes = json.dumps(plan_doc, indent=2).encode("utf-8")
+    plan_path = tmp_path / "demo.snapshot_plan.json"
+    plan_path.write_bytes(plan_bytes)
+    data = json.loads(manifest.read_text(encoding="utf-8"))
+    data["artifacts"].append(
+        {
+            "role": "snapshot_plan_json",
+            "path": plan_path.name,
+            "content_type": "application/json",
+            "bytes": len(plan_bytes),
+            "sha256": _sha256(plan_bytes),
+            "authority": "diagnostic_signal",
+            "canonicality": "diagnostic",
+            "risk_class": "diagnostic",
+        }
+    )
+    manifest.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+    report = produce_agent_reading_pack(str(manifest))
+    body = Path(report["output_path"]).read_text(encoding="utf-8")
+
+    section = _section(body, "SNAPSHOT_PLAN_REPORT")
+    assert "snapshot_plan_json" in section
+    assert "demo.snapshot_plan.json" in section
+    assert "do not prove repo understanding" in section
+    assert "`snapshot_plan_json` / `repobrief.snapshot_plan`" in body


### PR DESCRIPTION
Makes the new snapshot_plan_json artifact visible to agent consumption surfaces.

Scope:
- Agent Entry Manifest treats snapshot_plan_json as an expected surface
- old bundles mark snapshot_plan_json unavailable instead of failing
- Agent Reading Pack includes a SNAPSHOT_PLAN_REPORT section
- Agent Reading Pack lists repobrief.snapshot_plan in agent-consumption guidance

Local checks:
- python -m pytest -q merger/lenskit/tests/test_agent_entry_manifest.py merger/lenskit/tests/test_agent_reading_pack.py -> 91 passed
- public-share smoke -> status ok, eval pass, entry_has_plan true, pack_section true, stderr 0