### PR TITLE
feat(repobrief): recommend snapshot plan in agent preflight

### DIFF
--- a/merger/lenskit/core/required_reading.py
+++ b/merger/lenskit/core/required_reading.py
@@ -7,6 +7,8 @@ navigation layer; canonical_md remains the sole content truth.
 from __future__ import annotations
 
 
+_SNAPSHOT_PLAN_RECOMMENDED = ("snapshot_plan_json",)
+
 _DOES_NOT_ESTABLISH = (
     "all_relevant_context_used",
     "answer_safe_without_citations",
@@ -18,7 +20,7 @@ _DOES_NOT_ESTABLISH = (
 _PROFILES: dict[str, dict] = {
     "basic_repo_question": {
         "required": ("agent_reading_pack", "canonical_md"),
-        "recommended": ("citation_map_jsonl",),
+        "recommended": ("citation_map_jsonl",) + _SNAPSHOT_PLAN_RECOMMENDED,
         "insufficient": ("sidecar-only claims without canonical verification",),
         "citation_required": False,
         "answer_checklist_required": True,
@@ -31,7 +33,7 @@ _PROFILES: dict[str, dict] = {
             "citation_map_jsonl",
             "post_emit_health",
         ),
-        "recommended": ("bundle_surface_validation", "claim_evidence_map_json"),
+        "recommended": ("bundle_surface_validation", "claim_evidence_map_json") + _SNAPSHOT_PLAN_RECOMMENDED,
         "insufficient": (
             "only reading canonical_md linearly",
             "treating health pass as review completeness",
@@ -42,7 +44,7 @@ _PROFILES: dict[str, dict] = {
     },
     "roadmap_status_claim": {
         "required": ("agent_reading_pack", "canonical_md", "claim_evidence_map_json"),
-        "recommended": ("citation_map_jsonl",),
+        "recommended": ("citation_map_jsonl",) + _SNAPSHOT_PLAN_RECOMMENDED,
         "insufficient": (
             "roadmap status without Claim Evidence Map",
             "roadmap status without canonical check",
@@ -58,7 +60,7 @@ _PROFILES: dict[str, dict] = {
             "canonical_md",
             "post_emit_health",
         ),
-        "recommended": ("output_health",),
+        "recommended": ("output_health",) + _SNAPSHOT_PLAN_RECOMMENDED,
         "insufficient": (
             "output_health alone",
             "treating health pass as claim truth",
@@ -74,7 +76,7 @@ _PROFILES: dict[str, dict] = {
             "retrieval_eval_json",
             "sqlite_index",
         ),
-        "recommended": ("docs/retrieval/*",),
+        "recommended": ("docs/retrieval/*",) + _SNAPSHOT_PLAN_RECOMMENDED,
         "insufficient": ("impressionistic retrieval claims without metrics",),
         "citation_required": True,
         "answer_checklist_required": True,

--- a/merger/lenskit/tests/test_cli_agent_consumption.py
+++ b/merger/lenskit/tests/test_cli_agent_consumption.py
@@ -19,7 +19,7 @@ def test_cli_required_stdout(capsys):
     rc = main([
         "agent-consumption", "required",
         "--task-profile", "basic_repo_question",
-        "--available-roles", "agent_reading_pack,canonical_md,citation_map_jsonl"
+        "--available-roles", "agent_reading_pack,canonical_md,citation_map_jsonl,snapshot_plan_json"
     ])
     assert rc == 0
     out = json.loads(capsys.readouterr().out)
@@ -34,7 +34,7 @@ def test_cli_required_out_file(tmp_path, capsys):
     rc = main([
         "agent-consumption", "required",
         "--task-profile", "basic_repo_question",
-        "--available-roles", "agent_reading_pack,canonical_md,citation_map_jsonl",
+        "--available-roles", "agent_reading_pack,canonical_md,citation_map_jsonl,snapshot_plan_json",
         "--output", str(out_file)
     ])
     assert rc == 0
@@ -95,7 +95,7 @@ def test_cli_validate_trace_pass(tmp_path, capsys):
         "agent-consumption", "validate-trace",
         "--required-reading", str(rr_file),
         "--answer-compliance", str(ac_file),
-        "--available-roles", "agent_reading_pack,canonical_md,citation_map_jsonl,post_emit_health,bundle_surface_validation,claim_evidence_map_json"
+        "--available-roles", "agent_reading_pack,canonical_md,citation_map_jsonl,snapshot_plan_json,post_emit_health,bundle_surface_validation,claim_evidence_map_json"
     ])
     out = json.loads(capsys.readouterr().out)
     assert rc == 0
@@ -242,6 +242,7 @@ def test_cli_roles_file_list(tmp_path, capsys):
         "agent_reading_pack",
         "canonical_md",
         "citation_map_jsonl",
+        "snapshot_plan_json",
     ]
     roles_file.write_text(json.dumps(roles_data), encoding="utf-8")
     rc = main([
@@ -263,6 +264,7 @@ def test_cli_roles_file_object(tmp_path, capsys):
             "agent_reading_pack",
             "canonical_md",
             "citation_map_jsonl",
+            "snapshot_plan_json",
         ]
     }
     roles_file.write_text(json.dumps(roles_data), encoding="utf-8")
@@ -284,7 +286,7 @@ def test_cli_roles_union(tmp_path, capsys):
     rc = main([
         "agent-consumption", "required",
         "--task-profile", "basic_repo_question",
-        "--available-roles", "canonical_md,citation_map_jsonl",
+        "--available-roles", "canonical_md,citation_map_jsonl,snapshot_plan_json",
         "--available-roles-file", str(roles_file)
     ])
     assert rc == 0
@@ -400,6 +402,7 @@ def test_cli_preflight_stdout_from_bundle_manifest(tmp_path, capsys):
             {"role": "canonical_md"},
             {"role": "citation_map_jsonl"},
             {"role": "claim_evidence_map_json"},
+            {"role": "snapshot_plan_json"},
         ],
         "links": {
             "post_emit_health_path": "demo.post_emit_health.json",
@@ -434,6 +437,7 @@ def test_cli_preflight_bundle_manifest_self_role_satisfies_surface_review(tmp_pa
         "artifacts": [
             {"role": "canonical_md"},
             {"role": "output_health"},
+            {"role": "snapshot_plan_json"},
         ],
         "links": {
             "post_emit_health_path": "demo.post_emit_health.json",
@@ -458,14 +462,14 @@ def test_cli_preflight_validates_answer_compliance(tmp_path, capsys):
     ac_file = tmp_path / "answer-compliance.json"
     ac_file.write_text(json.dumps({
         "task_profile": "basic_repo_question",
-        "declared_artifacts": ["agent_reading_pack", "canonical_md", "citation_map_jsonl"],
+        "declared_artifacts": ["agent_reading_pack", "canonical_md", "citation_map_jsonl", "snapshot_plan_json"],
         "does_not_establish": DOES_NOT_ESTABLISH,
     }), encoding="utf-8")
 
     rc = main([
         "agent-consumption", "preflight",
         "--task-profile", "basic_repo_question",
-        "--available-roles", "agent_reading_pack,canonical_md,citation_map_jsonl",
+        "--available-roles", "agent_reading_pack,canonical_md,citation_map_jsonl,snapshot_plan_json",
         "--answer-compliance", str(ac_file),
     ])
 
@@ -474,7 +478,7 @@ def test_cli_preflight_validates_answer_compliance(tmp_path, capsys):
     assert out["status"] == "pass"
     assert out["agent_consumption_trace"]["status"] == "pass"
     assert out["agent_consumption_trace"]["declared_artifacts"] == [
-        "agent_reading_pack", "canonical_md", "citation_map_jsonl"
+        "agent_reading_pack", "canonical_md", "citation_map_jsonl", "snapshot_plan_json"
     ]
 
 
@@ -489,7 +493,7 @@ def test_cli_preflight_warn_strict_exits_1(tmp_path, capsys):
     assert rc == 1
     out = json.loads(capsys.readouterr().out)
     assert out["status"] == "warn"
-    assert out["required_reading"]["missing_recommended"] == ["citation_map_jsonl"]
+    assert out["required_reading"]["missing_recommended"] == ["citation_map_jsonl", "snapshot_plan_json"]
 
 
 def test_cli_preflight_invalid_manifest_shape(tmp_path, capsys):

--- a/merger/lenskit/tests/test_required_reading_protocol.py
+++ b/merger/lenskit/tests/test_required_reading_protocol.py
@@ -75,7 +75,7 @@ def test_basic_repo_question_all_present_is_pass():
     protocol = default_required_reading_protocol()
     result = resolve_required_reading(
         protocol,
-        available_roles={"agent_reading_pack", "canonical_md", "citation_map_jsonl"},
+        available_roles={"agent_reading_pack", "canonical_md", "citation_map_jsonl", "snapshot_plan_json"},
         task_profile="basic_repo_question",
     )
     assert result["status"] == "pass"
@@ -95,6 +95,7 @@ def test_basic_repo_question_missing_recommended_is_warn():
     assert result["status"] == "warn"
     assert result["missing_required"] == []
     assert "citation_map_jsonl" in result["missing_recommended"]
+    assert "snapshot_plan_json" in result["missing_recommended"]
 
 
 # ── 6. pr_review: required role missing → fail ──────────────────────────────
@@ -189,7 +190,7 @@ def test_resolver_preserves_profile_metadata():
     protocol = default_required_reading_protocol()
     result = resolve_required_reading(
         protocol,
-        available_roles={"agent_reading_pack", "canonical_md", "citation_map_jsonl"},
+        available_roles={"agent_reading_pack", "canonical_md", "citation_map_jsonl", "snapshot_plan_json"},
         task_profile="basic_repo_question",
     )
     profile = protocol["task_profiles"]["basic_repo_question"]


### PR DESCRIPTION
Adds snapshot_plan_json as a recommended diagnostic surface in required-reading and agent-consumption preflight.

Scope:
- Required Reading Protocol recommends snapshot_plan_json for task profiles
- missing snapshot_plan_json warns but does not fail
- CLI preflight pass fixtures include snapshot_plan_json
- strict warning test expects snapshot_plan_json as missing recommended when absent

Local checks:
- python -m pytest -q merger/lenskit/tests/test_required_reading_protocol.py -> 20 passed
- python -m pytest -q merger/lenskit/tests/test_required_reading_protocol.py merger/lenskit/tests/test_cli_agent_consumption.py -> 42 passed
- preflight smoke with snapshot_plan_json available -> pass pass []