### PR TITLE
feat(repobrief): add read-only snapshot status

### DIFF
--- a/merger/lenskit/cli/cmd_repobrief.py
+++ b/merger/lenskit/cli/cmd_repobrief.py
@@ -243,13 +243,29 @@ def register_repobrief_commands(subparsers: argparse._SubParsersAction) -> None:
     create_parser.add_argument("--no-include-hidden", action="store_false", dest="include_hidden")
     create_parser.set_defaults(include_hidden=True)
 
+    status_parser = snapshot_subparsers.add_parser("status", help="Read status for an existing Brief Snapshot")
+    status_parser.add_argument("--bundle-manifest", required=True, help="Path to a Brief Bundle manifest")
+
 
 def run_repobrief(args: argparse.Namespace) -> int:
     if args.repobrief_cmd == "snapshot" and args.snapshot_cmd == "create":
         return run_snapshot_create(args)
+    if args.repobrief_cmd == "snapshot" and args.snapshot_cmd == "status":
+        return run_snapshot_status(args)
     print("Unsupported RepoBrief command", file=sys.stderr)
     return 2
 
+
+def run_snapshot_status(args: argparse.Namespace) -> int:
+    from merger.lenskit.core.repobrief_access import snapshot_status
+
+    try:
+        result = snapshot_status(args.bundle_manifest)
+    except ValueError as exc:
+        print("repobrief snapshot status: " + str(exc), file=sys.stderr)
+        return 2
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
 
 def run_snapshot_create(args: argparse.Namespace) -> int:
     profile = args.profile

--- a/merger/lenskit/core/repobrief_access.py
+++ b/merger/lenskit/core/repobrief_access.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+_DOES_NOT_ESTABLISH = (
+    "truth",
+    "correctness",
+    "completeness",
+    "runtime_behavior",
+    "test_sufficiency",
+    "regression_absence",
+    "repo_understood",
+    "claims_true",
+    "forensic_ready",
+    "freshness",
+)
+
+
+def _read_json_object(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(f"bundle manifest does not exist: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"bundle manifest is not valid JSON: {path}") from exc
+    if not isinstance(data, dict):
+        raise ValueError("bundle manifest must be a JSON object")
+    return data
+
+
+def _artifact_list(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    artifacts = manifest.get("artifacts", [])
+    if not isinstance(artifacts, list):
+        raise ValueError("bundle manifest artifacts must be an array")
+    return [a for a in artifacts if isinstance(a, dict)]
+
+
+def _safe_artifact_path(root: Path, raw_path: Any) -> Path | None:
+    if not isinstance(raw_path, str) or not raw_path:
+        return None
+    candidate = (root / raw_path).resolve()
+    try:
+        candidate.relative_to(root.resolve())
+    except ValueError:
+        return None
+    return candidate
+
+
+def _artifact_record(bundle_manifest: Path, artifact: dict[str, Any]) -> dict[str, Any]:
+    root = bundle_manifest.parent
+    artifact_path = _safe_artifact_path(root, artifact.get("path"))
+    file_exists = bool(artifact_path and artifact_path.exists())
+    return {
+        "role": artifact.get("role"),
+        "path": artifact.get("path"),
+        "absolute_path": str(artifact_path) if artifact_path else None,
+        "file_exists": file_exists,
+        "content_type": artifact.get("content_type"),
+        "bytes": artifact.get("bytes"),
+        "sha256": artifact.get("sha256"),
+        "authority": artifact.get("authority"),
+        "canonicality": artifact.get("canonicality"),
+        "risk_class": artifact.get("risk_class"),
+        "contract": artifact.get("contract"),
+        "interpretation": artifact.get("interpretation"),
+    }
+
+
+def snapshot_status(bundle_manifest: str | Path) -> dict[str, Any]:
+    manifest_path = Path(bundle_manifest).expanduser().resolve()
+    manifest = _read_json_object(manifest_path)
+    artifacts = [_artifact_record(manifest_path, a) for a in _artifact_list(manifest)]
+    roles = sorted(str(a["role"]) for a in artifacts if isinstance(a.get("role"), str))
+    capabilities = manifest.get("capabilities") if isinstance(manifest.get("capabilities"), dict) else {}
+    return {
+        "kind": "repobrief.snapshot_status",
+        "version": "v1",
+        "status": "ok",
+        "bundle_manifest": str(manifest_path),
+        "bundle_run_id": manifest.get("run_id"),
+        "profile": capabilities.get("repobrief_profile"),
+        "profile_evaluation": capabilities.get("repobrief_profile_evaluation"),
+        "artifact_count": len(artifacts),
+        "roles": roles,
+        "artifacts": artifacts,
+        "mutation_boundary": {
+            "writes": [],
+            "does_not_mutate": ["git", "pull_requests", "patches", "source_working_tree", "brief_bundle_artifacts"],
+            "read_paths_do_not_refresh": True,
+        },
+        "does_not_establish": list(_DOES_NOT_ESTABLISH),
+    }
+
+
+def get_artifact(bundle_manifest: str | Path, role: str) -> dict[str, Any]:
+    manifest_path = Path(bundle_manifest).expanduser().resolve()
+    manifest = _read_json_object(manifest_path)
+    matches = [a for a in _artifact_list(manifest) if a.get("role") == role]
+    if not matches:
+        return {
+            "kind": "repobrief.artifact_ref",
+            "version": "v1",
+            "status": "missing",
+            "bundle_manifest": str(manifest_path),
+            "role": role,
+            "artifact": None,
+            "mutation_boundary": {
+                "writes": [],
+                "does_not_mutate": ["git", "pull_requests", "patches", "source_working_tree", "brief_bundle_artifacts"],
+                "read_paths_do_not_refresh": True,
+            },
+            "does_not_establish": list(_DOES_NOT_ESTABLISH),
+        }
+    return {
+        "kind": "repobrief.artifact_ref",
+        "version": "v1",
+        "status": "available",
+        "bundle_manifest": str(manifest_path),
+        "role": role,
+        "artifact": _artifact_record(manifest_path, matches[0]),
+        "mutation_boundary": {
+            "writes": [],
+            "does_not_mutate": ["git", "pull_requests", "patches", "source_working_tree", "brief_bundle_artifacts"],
+            "read_paths_do_not_refresh": True,
+        },
+        "does_not_establish": list(_DOES_NOT_ESTABLISH),
+    }

--- a/merger/lenskit/tests/test_repobrief_snapshot_cli.py
+++ b/merger/lenskit/tests/test_repobrief_snapshot_cli.py
@@ -330,3 +330,49 @@ def test_snapshot_create_emits_snapshot_plan_report(tmp_path, capsys):
     assert report["kind"] == "repobrief.snapshot_plan"
     assert report["output_plan"] == emitted["output_plan"]
     assert any(a.get("role") == "snapshot_plan_json" for a in manifest_data["artifacts"])
+# access test marker
+
+
+def test_repobrief_snapshot_status_reads_existing_manifest(tmp_path, capsys):
+    artifact = tmp_path / "demo.md"
+    artifact.write_text("# demo\n", encoding="utf-8")
+    manifest = tmp_path / "demo.bundle.manifest.json"
+    manifest.write_text(json.dumps({
+        "kind": "repolens.bundle.manifest",
+        "version": "1.0",
+        "run_id": "run-1",
+        "created_at": "2026-07-03T00:00:00Z",
+        "generator": {"name": "test", "version": "1", "config_sha256": "a" * 64},
+        "artifacts": [{"role": "canonical_md", "path": artifact.name, "content_type": "text/markdown", "bytes": artifact.stat().st_size, "sha256": "b" * 64, "authority": "canonical_content", "canonicality": "content_source"}],
+        "links": {},
+        "capabilities": {"repobrief_profile": "agent-portable", "repobrief_profile_evaluation": {"status": "pass"}},
+    }), encoding="utf-8")
+
+    rc = main(["repobrief", "snapshot", "status", "--bundle-manifest", str(manifest)])
+
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert out["kind"] == "repobrief.snapshot_status"
+    assert out["profile"] == "agent-portable"
+    assert out["roles"] == ["canonical_md"]
+    assert out["mutation_boundary"]["writes"] == []
+
+
+def test_repobrief_core_get_artifact_reports_available_and_missing(tmp_path):
+    from merger.lenskit.core.repobrief_access import get_artifact
+
+    artifact = tmp_path / "demo.md"
+    artifact.write_text("# demo\n", encoding="utf-8")
+    manifest = tmp_path / "demo.bundle.manifest.json"
+    manifest.write_text(json.dumps({
+        "artifacts": [{"role": "canonical_md", "path": artifact.name}],
+        "capabilities": {},
+    }), encoding="utf-8")
+
+    found = get_artifact(manifest, "canonical_md")
+    missing = get_artifact(manifest, "missing_role")
+
+    assert found["status"] == "available"
+    assert found["artifact"]["file_exists"] is True
+    assert missing["status"] == "missing"
+    assert missing["artifact"] is None


### PR DESCRIPTION
Adds a minimal read-only RepoBrief access layer.

Scope:
- adds core repobrief_access snapshot_status and get_artifact helpers
- adds CLI command: repobrief snapshot status --bundle-manifest <path>
- keeps access read-only: no refresh, no git, no mutation
- intentionally does not expose artifact get in CLI yet; core helper is present for the next slice

Local checks:
- python3 -m pytest -q merger/lenskit/tests/test_repobrief_snapshot_cli.py -> 12 passed
- smoke: repobrief snapshot create followed by repobrief snapshot status -> rc 0, status JSON written