### PR TITLE
feat(repobrief): add read-only artifact get CLI

### DIFF
--- a/merger/lenskit/cli/cmd_repobrief.py
+++ b/merger/lenskit/cli/cmd_repobrief.py
@@ -246,12 +246,25 @@ def register_repobrief_commands(subparsers: argparse._SubParsersAction) -> None:
     status_parser = snapshot_subparsers.add_parser("status", help="Read status for an existing Brief Snapshot")
     status_parser.add_argument("--bundle-manifest", required=True, help="Path to a Brief Bundle manifest")
 
+    artifact_parser = repobrief_subparsers.add_parser("artifact", help="Brief artifact read-only commands")
+    artifact_subparsers = artifact_parser.add_subparsers(
+        dest="artifact_cmd",
+        required=True,
+        help="Artifact commands",
+    )
+    get_parser = artifact_subparsers.add_parser("get", help="Read artifact metadata by role")
+    get_parser.add_argument("--bundle-manifest", required=True, help="Path to a Brief Bundle manifest")
+    get_parser.add_argument("--role", required=True, help="Artifact role to resolve")
+    get_parser.add_argument("--path-only", action="store_true", help="Print only the resolved artifact path")
+
 
 def run_repobrief(args: argparse.Namespace) -> int:
     if args.repobrief_cmd == "snapshot" and args.snapshot_cmd == "create":
         return run_snapshot_create(args)
     if args.repobrief_cmd == "snapshot" and args.snapshot_cmd == "status":
         return run_snapshot_status(args)
+    if args.repobrief_cmd == "artifact" and args.artifact_cmd == "get":
+        return run_artifact_get(args)
     print("Unsupported RepoBrief command", file=sys.stderr)
     return 2
 
@@ -266,6 +279,24 @@ def run_snapshot_status(args: argparse.Namespace) -> int:
         return 2
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0
+
+
+def run_artifact_get(args: argparse.Namespace) -> int:
+    from merger.lenskit.core.repobrief_access import get_artifact
+
+    try:
+        result = get_artifact(args.bundle_manifest, args.role)
+    except ValueError as exc:
+        print("repobrief artifact get: " + str(exc), file=sys.stderr)
+        return 2
+    if args.path_only:
+        artifact = result.get("artifact") if isinstance(result, dict) else None
+        if not isinstance(artifact, dict) or not artifact.get("absolute_path"):
+            return 1
+        print(artifact["absolute_path"])
+        return 0
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result.get("status") == "available" else 1
 
 def run_snapshot_create(args: argparse.Namespace) -> int:
     profile = args.profile

--- a/merger/lenskit/tests/test_repobrief_snapshot_cli.py
+++ b/merger/lenskit/tests/test_repobrief_snapshot_cli.py
@@ -376,3 +376,34 @@ def test_repobrief_core_get_artifact_reports_available_and_missing(tmp_path):
     assert found["artifact"]["file_exists"] is True
     assert missing["status"] == "missing"
     assert missing["artifact"] is None
+
+
+def test_repobrief_artifact_get_cli_reports_available_missing_and_path_only(tmp_path, capsys):
+    artifact = tmp_path / "demo.md"
+    artifact.write_text("# demo\n", encoding="utf-8")
+    manifest = tmp_path / "demo.bundle.manifest.json"
+    manifest.write_text(json.dumps({
+        "kind": "repolens.bundle.manifest",
+        "version": "1.0",
+        "run_id": "run-1",
+        "created_at": "2026-07-03T00:00:00Z",
+        "generator": {"name": "test", "version": "1", "config_sha256": "a" * 64},
+        "artifacts": [{"role": "canonical_md", "path": artifact.name, "content_type": "text/markdown", "bytes": artifact.stat().st_size, "sha256": "b" * 64, "authority": "canonical_content", "canonicality": "content_source"}],
+        "links": {},
+        "capabilities": {},
+    }), encoding="utf-8")
+
+    rc = main(["repobrief", "artifact", "get", "--bundle-manifest", str(manifest), "--role", "canonical_md"])
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert out["status"] == "available"
+    assert out["artifact"]["role"] == "canonical_md"
+
+    rc = main(["repobrief", "artifact", "get", "--bundle-manifest", str(manifest), "--role", "missing_role"])
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 1
+    assert out["status"] == "missing"
+
+    rc = main(["repobrief", "artifact", "get", "--bundle-manifest", str(manifest), "--role", "canonical_md", "--path-only"])
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == str(artifact.resolve())


### PR DESCRIPTION
Adds a read-only RepoBrief artifact metadata command.

Scope:
- adds repobrief artifact get --bundle-manifest <path> --role <role>
- supports --path-only for resolved artifact paths
- returns structured missing response with exit 1 for missing roles
- does not emit artifact contents
- does not refresh, mutate, call git, or write bundle artifacts

Local checks:
- python3 -m pytest -q merger/lenskit/tests/test_repobrief_snapshot_cli.py -> 13 passed
- targeted artifact get test -> passed