### PR TITLE
feat(repobrief): add read-only artifact list CLI

### DIFF
--- a/merger/lenskit/cli/cmd_repobrief.py
+++ b/merger/lenskit/cli/cmd_repobrief.py
@@ -256,6 +256,9 @@ def register_repobrief_commands(subparsers: argparse._SubParsersAction) -> None:
     get_parser.add_argument("--bundle-manifest", required=True, help="Path to a Brief Bundle manifest")
     get_parser.add_argument("--role", required=True, help="Artifact role to resolve")
     get_parser.add_argument("--path-only", action="store_true", help="Print only the resolved artifact path")
+    list_parser = artifact_subparsers.add_parser("list", help="List artifact metadata")
+    list_parser.add_argument("--bundle-manifest", required=True, help="Path to a Brief Bundle manifest")
+    list_parser.add_argument("--roles-only", action="store_true", help="Print only artifact roles")
 
 
 def run_repobrief(args: argparse.Namespace) -> int:
@@ -265,6 +268,8 @@ def run_repobrief(args: argparse.Namespace) -> int:
         return run_snapshot_status(args)
     if args.repobrief_cmd == "artifact" and args.artifact_cmd == "get":
         return run_artifact_get(args)
+    if args.repobrief_cmd == "artifact" and args.artifact_cmd == "list":
+        return run_artifact_list(args)
     print("Unsupported RepoBrief command", file=sys.stderr)
     return 2
 
@@ -297,6 +302,21 @@ def run_artifact_get(args: argparse.Namespace) -> int:
         return 0
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0 if result.get("status") == "available" else 1
+
+def run_artifact_list(args: argparse.Namespace) -> int:
+    from merger.lenskit.core.repobrief_access import list_artifacts
+
+    try:
+        result = list_artifacts(args.bundle_manifest)
+    except ValueError as exc:
+        print("repobrief artifact list: " + str(exc), file=sys.stderr)
+        return 2
+    if args.roles_only:
+        for role in result.get("roles", []):
+            print(role)
+        return 0
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
 
 def run_snapshot_create(args: argparse.Namespace) -> int:
     profile = args.profile

--- a/merger/lenskit/core/repobrief_access.py
+++ b/merger/lenskit/core/repobrief_access.py
@@ -94,6 +94,23 @@ def snapshot_status(bundle_manifest: str | Path) -> dict[str, Any]:
     }
 
 
+def list_artifacts(bundle_manifest: str | Path) -> dict[str, Any]:
+    status = snapshot_status(bundle_manifest)
+    return {
+        "kind": "repobrief.artifact_list",
+        "version": "v1",
+        "status": status["status"],
+        "bundle_manifest": status["bundle_manifest"],
+        "bundle_run_id": status["bundle_run_id"],
+        "profile": status["profile"],
+        "artifact_count": status["artifact_count"],
+        "roles": status["roles"],
+        "artifacts": status["artifacts"],
+        "mutation_boundary": status["mutation_boundary"],
+        "does_not_establish": status["does_not_establish"],
+    }
+
+
 def get_artifact(bundle_manifest: str | Path, role: str) -> dict[str, Any]:
     manifest_path = Path(bundle_manifest).expanduser().resolve()
     manifest = _read_json_object(manifest_path)

--- a/merger/lenskit/tests/test_repobrief_snapshot_cli.py
+++ b/merger/lenskit/tests/test_repobrief_snapshot_cli.py
@@ -407,3 +407,36 @@ def test_repobrief_artifact_get_cli_reports_available_missing_and_path_only(tmp_
     rc = main(["repobrief", "artifact", "get", "--bundle-manifest", str(manifest), "--role", "canonical_md", "--path-only"])
     assert rc == 0
     assert capsys.readouterr().out.strip() == str(artifact.resolve())
+
+
+def test_repobrief_artifact_list_cli_reports_artifacts_and_roles_only(tmp_path, capsys):
+    first = tmp_path / "demo.md"
+    second = tmp_path / "plan.json"
+    first.write_text("# demo\n", encoding="utf-8")
+    second.write_text("{}\n", encoding="utf-8")
+    manifest = tmp_path / "demo.bundle.manifest.json"
+    manifest.write_text(json.dumps({
+        "kind": "repolens.bundle.manifest",
+        "version": "1.0",
+        "run_id": "run-1",
+        "created_at": "2026-07-03T00:00:00Z",
+        "generator": {"name": "test", "version": "1", "config_sha256": "a" * 64},
+        "artifacts": [
+            {"role": "snapshot_plan_json", "path": second.name, "content_type": "application/json", "bytes": second.stat().st_size, "sha256": "c" * 64},
+            {"role": "canonical_md", "path": first.name, "content_type": "text/markdown", "bytes": first.stat().st_size, "sha256": "b" * 64},
+        ],
+        "links": {},
+        "capabilities": {},
+    }), encoding="utf-8")
+
+    rc = main(["repobrief", "artifact", "list", "--bundle-manifest", str(manifest)])
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert out["kind"] == "repobrief.artifact_list"
+    assert out["roles"] == ["canonical_md", "snapshot_plan_json"]
+    assert out["artifact_count"] == 2
+    assert out["mutation_boundary"]["writes"] == []
+
+    rc = main(["repobrief", "artifact", "list", "--bundle-manifest", str(manifest), "--roles-only"])
+    assert rc == 0
+    assert capsys.readouterr().out.splitlines() == ["canonical_md", "snapshot_plan_json"]


### PR DESCRIPTION
Adds a read-only RepoBrief artifact listing command.

Scope:
- adds core repobrief_access.list_artifacts
- adds repobrief artifact list --bundle-manifest <path>
- supports --roles-only for newline-separated role names
- keeps behavior read-only: no contents, no refresh, no git, no mutation

Local checks:
- python3 -m py_compile cmd_repobrief.py repobrief_access.py test_repobrief_snapshot_cli.py -> pass
- python3 -m pytest -q merger/lenskit/tests/test_repobrief_snapshot_cli.py -> 14 passed
- smoke: snapshot create followed by artifact list --roles-only -> rc 0, roles written