### PR TITLE
feat(repobrief): resolve required reading from bundle

### DIFF
--- a/merger/lenskit/cli/cmd_repobrief.py
+++ b/merger/lenskit/cli/cmd_repobrief.py
@@ -259,6 +259,11 @@ def register_repobrief_commands(subparsers: argparse._SubParsersAction) -> None:
     list_parser = artifact_subparsers.add_parser("list", help="List artifact metadata")
     list_parser.add_argument("--bundle-manifest", required=True, help="Path to a Brief Bundle manifest")
     list_parser.add_argument("--roles-only", action="store_true", help="Print only artifact roles")
+    reading_parser = repobrief_subparsers.add_parser("required-reading", help="Brief required-reading commands")
+    reading_subparsers = reading_parser.add_subparsers(dest="required_reading_cmd", required=True, help="Required-reading commands")
+    resolve_parser = reading_subparsers.add_parser("resolve", help="Resolve required reading from a bundle manifest")
+    resolve_parser.add_argument("--bundle-manifest", required=True, help="Path to a Brief Bundle manifest")
+    resolve_parser.add_argument("--task-profile", required=True, help="Required-reading task profile")
 
 
 def run_repobrief(args: argparse.Namespace) -> int:
@@ -270,6 +275,8 @@ def run_repobrief(args: argparse.Namespace) -> int:
         return run_artifact_get(args)
     if args.repobrief_cmd == "artifact" and args.artifact_cmd == "list":
         return run_artifact_list(args)
+    if args.repobrief_cmd == "required-reading" and args.required_reading_cmd == "resolve":
+        return run_required_reading_resolve(args)
     print("Unsupported RepoBrief command", file=sys.stderr)
     return 2
 
@@ -317,6 +324,17 @@ def run_artifact_list(args: argparse.Namespace) -> int:
         return 0
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0
+
+def run_required_reading_resolve(args: argparse.Namespace) -> int:
+    from merger.lenskit.core.repobrief_access import resolve_required_reading_for_bundle
+
+    try:
+        result = resolve_required_reading_for_bundle(args.bundle_manifest, args.task_profile)
+    except ValueError as exc:
+        print("repobrief required-reading resolve: " + str(exc), file=sys.stderr)
+        return 2
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result.get("status") in {"pass", "warn"} else 1
 
 def run_snapshot_create(args: argparse.Namespace) -> int:
     profile = args.profile

--- a/merger/lenskit/core/repobrief_access.py
+++ b/merger/lenskit/core/repobrief_access.py
@@ -68,6 +68,60 @@ def _artifact_record(bundle_manifest: Path, artifact: dict[str, Any]) -> dict[st
     }
 
 
+def available_roles(bundle_manifest: str | Path) -> list[str]:
+    manifest_path = Path(bundle_manifest).expanduser().resolve()
+    manifest = _read_json_object(manifest_path)
+    roles: set[str] = {"bundle_manifest"}
+    for artifact in _artifact_list(manifest):
+        role = artifact.get("role")
+        if isinstance(role, str) and role:
+            roles.add(role)
+    links = manifest.get("links")
+    if isinstance(links, dict):
+        linked_roles = {
+            "post_emit_health_path": "post_emit_health",
+            "bundle_surface_validation_path": "bundle_surface_validation",
+            "export_safety_report_path": "export_safety_report",
+        }
+        for key, role in linked_roles.items():
+            if links.get(key):
+                roles.add(role)
+    return sorted(roles)
+
+
+def resolve_required_reading_for_bundle(
+    bundle_manifest: str | Path,
+    task_profile: str,
+) -> dict[str, Any]:
+    from merger.lenskit.core.required_reading import (
+        default_required_reading_protocol,
+        resolve_required_reading,
+    )
+
+    manifest_path = Path(bundle_manifest).expanduser().resolve()
+    roles = available_roles(manifest_path)
+    required = resolve_required_reading(
+        default_required_reading_protocol(),
+        set(roles),
+        task_profile,
+    )
+    return {
+        "kind": "repobrief.required_reading_resolution",
+        "version": "v1",
+        "status": required.get("status"),
+        "bundle_manifest": str(manifest_path),
+        "task_profile": task_profile,
+        "available_roles": roles,
+        "required_reading": required,
+        "mutation_boundary": {
+            "writes": [],
+            "does_not_mutate": ["git", "pull_requests", "patches", "source_working_tree", "brief_bundle_artifacts"],
+            "read_paths_do_not_refresh": True,
+        },
+        "does_not_establish": list(_DOES_NOT_ESTABLISH),
+    }
+
+
 def snapshot_status(bundle_manifest: str | Path) -> dict[str, Any]:
     manifest_path = Path(bundle_manifest).expanduser().resolve()
     manifest = _read_json_object(manifest_path)

--- a/merger/lenskit/tests/test_repobrief_snapshot_cli.py
+++ b/merger/lenskit/tests/test_repobrief_snapshot_cli.py
@@ -440,3 +440,41 @@ def test_repobrief_artifact_list_cli_reports_artifacts_and_roles_only(tmp_path, 
     rc = main(["repobrief", "artifact", "list", "--bundle-manifest", str(manifest), "--roles-only"])
     assert rc == 0
     assert capsys.readouterr().out.splitlines() == ["canonical_md", "snapshot_plan_json"]
+
+
+def test_repobrief_required_reading_resolve_cli_uses_bundle_roles(tmp_path, capsys):
+    manifest = tmp_path / "demo.bundle.manifest.json"
+    manifest.write_text(json.dumps({
+        "kind": "repolens.bundle.manifest",
+        "version": "1.0",
+        "run_id": "run-1",
+        "created_at": "2026-07-03T00:00:00Z",
+        "generator": {"name": "test", "version": "1", "config_sha256": "a" * 64},
+        "artifacts": [
+            {"role": "agent_reading_pack", "path": "pack.md"},
+            {"role": "canonical_md", "path": "demo.md"},
+            {"role": "citation_map_jsonl", "path": "citation.jsonl"},
+            {"role": "snapshot_plan_json", "path": "plan.json"},
+        ],
+        "links": {},
+        "capabilities": {},
+    }), encoding="utf-8")
+
+    rc = main([
+        "repobrief",
+        "required-reading",
+        "resolve",
+        "--bundle-manifest",
+        str(manifest),
+        "--task-profile",
+        "basic_repo_question",
+    ])
+
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert out["kind"] == "repobrief.required_reading_resolution"
+    assert out["status"] == "pass"
+    assert "bundle_manifest" in out["available_roles"]
+    assert out["required_reading"]["status"] == "pass"
+    assert out["required_reading"]["missing_recommended"] == []
+    assert out["mutation_boundary"]["writes"] == []


### PR DESCRIPTION
Adds read-only required-reading resolution over an existing RepoBrief bundle manifest. Local checks: py_compile pass; targeted RepoBrief/required-reading tests 35 passed.