### PR TITLE
feat(repobrief): add read-only snapshot check

### DIFF
--- a/merger/lenskit/cli/cmd_repobrief.py
+++ b/merger/lenskit/cli/cmd_repobrief.py
@@ -245,6 +245,9 @@ def register_repobrief_commands(subparsers: argparse._SubParsersAction) -> None:
 
     status_parser = snapshot_subparsers.add_parser("status", help="Read status for an existing Brief Snapshot")
     status_parser.add_argument("--bundle-manifest", required=True, help="Path to a Brief Bundle manifest")
+    check_parser = snapshot_subparsers.add_parser("check", help="Read-only snapshot check summary")
+    check_parser.add_argument("--bundle-manifest", required=True, help="Path to a Brief Bundle manifest")
+    check_parser.add_argument("--task-profile", default="basic_repo_question", help="Required-reading task profile")
 
     artifact_parser = repobrief_subparsers.add_parser("artifact", help="Brief artifact read-only commands")
     artifact_subparsers = artifact_parser.add_subparsers(
@@ -269,6 +272,8 @@ def register_repobrief_commands(subparsers: argparse._SubParsersAction) -> None:
 def run_repobrief(args: argparse.Namespace) -> int:
     if args.repobrief_cmd == "snapshot" and args.snapshot_cmd == "create":
         return run_snapshot_create(args)
+    if args.repobrief_cmd == "snapshot" and args.snapshot_cmd == "check":
+        return run_snapshot_check(args)
     if args.repobrief_cmd == "snapshot" and args.snapshot_cmd == "status":
         return run_snapshot_status(args)
     if args.repobrief_cmd == "artifact" and args.artifact_cmd == "get":
@@ -279,6 +284,18 @@ def run_repobrief(args: argparse.Namespace) -> int:
         return run_required_reading_resolve(args)
     print("Unsupported RepoBrief command", file=sys.stderr)
     return 2
+
+
+def run_snapshot_check(args: argparse.Namespace) -> int:
+    from merger.lenskit.core.repobrief_access import snapshot_check
+
+    try:
+        result = snapshot_check(args.bundle_manifest, args.task_profile)
+    except ValueError as exc:
+        print("repobrief snapshot check: " + str(exc), file=sys.stderr)
+        return 2
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result.get("status") in {"pass", "warn"} else 1
 
 
 def run_snapshot_status(args: argparse.Namespace) -> int:

--- a/merger/lenskit/core/repobrief_access.py
+++ b/merger/lenskit/core/repobrief_access.py
@@ -198,3 +198,52 @@ def get_artifact(bundle_manifest: str | Path, role: str) -> dict[str, Any]:
         },
         "does_not_establish": list(_DOES_NOT_ESTABLISH),
     }
+
+
+def snapshot_check(
+    bundle_manifest: str | Path,
+    task_profile: str = "basic_repo_question",
+) -> dict[str, Any]:
+    status = snapshot_status(bundle_manifest)
+    artifacts = list_artifacts(bundle_manifest)
+    required = resolve_required_reading_for_bundle(bundle_manifest, task_profile)
+    required_status = str(required.get("status", "unknown"))
+    profile_eval = status.get("profile_evaluation")
+    profile_status = None
+    if isinstance(profile_eval, dict):
+        raw_profile_status = profile_eval.get("status")
+        if isinstance(raw_profile_status, str):
+            profile_status = raw_profile_status
+
+    statuses = [required_status]
+    if profile_status:
+        statuses.append(profile_status)
+    if "fail" in statuses or "not_applicable" in statuses:
+        check_status = "fail"
+    elif "warn" in statuses:
+        check_status = "warn"
+    elif all(item == "pass" for item in statuses):
+        check_status = "pass"
+    else:
+        check_status = "unknown"
+    return {
+        "kind": "repobrief.snapshot_check",
+        "version": "v1",
+        "status": check_status,
+        "bundle_manifest": status["bundle_manifest"],
+        "bundle_run_id": status["bundle_run_id"],
+        "profile": status["profile"],
+        "profile_evaluation_status": profile_status,
+        "task_profile": task_profile,
+        "artifact_count": artifacts["artifact_count"],
+        "roles": artifacts["roles"],
+        "snapshot_status": status,
+        "artifact_list": artifacts,
+        "required_reading": required,
+        "mutation_boundary": {
+            "writes": [],
+            "does_not_mutate": ["git", "pull_requests", "patches", "source_working_tree", "brief_bundle_artifacts"],
+            "read_paths_do_not_refresh": True,
+        },
+        "does_not_establish": list(_DOES_NOT_ESTABLISH),
+    }

--- a/merger/lenskit/tests/test_repobrief_snapshot_cli.py
+++ b/merger/lenskit/tests/test_repobrief_snapshot_cli.py
@@ -478,3 +478,80 @@ def test_repobrief_required_reading_resolve_cli_uses_bundle_roles(tmp_path, caps
     assert out["required_reading"]["status"] == "pass"
     assert out["required_reading"]["missing_recommended"] == []
     assert out["mutation_boundary"]["writes"] == []
+
+
+def test_repobrief_snapshot_check_cli_summarizes_read_only_surfaces(tmp_path, capsys):
+    manifest = tmp_path / "demo.bundle.manifest.json"
+    manifest.write_text(json.dumps({
+        "kind": "repolens.bundle.manifest",
+        "version": "1.0",
+        "run_id": "run-1",
+        "created_at": "2026-07-03T00:00:00Z",
+        "generator": {"name": "test", "version": "1", "config_sha256": "a" * 64},
+        "artifacts": [
+            {"role": "agent_reading_pack", "path": "pack.md"},
+            {"role": "canonical_md", "path": "demo.md"},
+            {"role": "citation_map_jsonl", "path": "citation.jsonl"},
+            {"role": "snapshot_plan_json", "path": "plan.json"},
+        ],
+        "links": {},
+        "capabilities": {"repobrief_profile": "agent-portable"},
+    }), encoding="utf-8")
+
+    rc = main([
+        "repobrief",
+        "snapshot",
+        "check",
+        "--bundle-manifest",
+        str(manifest),
+        "--task-profile",
+        "basic_repo_question",
+    ])
+
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert out["kind"] == "repobrief.snapshot_check"
+    assert out["status"] == "pass"
+    assert out["task_profile"] == "basic_repo_question"
+    assert out["snapshot_status"]["kind"] == "repobrief.snapshot_status"
+    assert out["artifact_list"]["kind"] == "repobrief.artifact_list"
+    assert out["required_reading"]["kind"] == "repobrief.required_reading_resolution"
+    assert out["mutation_boundary"]["writes"] == []
+
+
+def test_repobrief_snapshot_check_propagates_failed_profile_evaluation(tmp_path, capsys):
+    manifest = tmp_path / "demo.bundle.manifest.json"
+    manifest.write_text(json.dumps({
+        "kind": "repolens.bundle.manifest",
+        "version": "1.0",
+        "run_id": "run-1",
+        "created_at": "2026-07-03T00:00:00Z",
+        "generator": {"name": "test", "version": "1", "config_sha256": "a" * 64},
+        "artifacts": [
+            {"role": "agent_reading_pack", "path": "pack.md"},
+            {"role": "canonical_md", "path": "demo.md"},
+            {"role": "citation_map_jsonl", "path": "citation.jsonl"},
+            {"role": "snapshot_plan_json", "path": "plan.json"},
+        ],
+        "links": {},
+        "capabilities": {
+            "repobrief_profile": "agent-portable",
+            "repobrief_profile_evaluation": {"status": "fail", "missing_required": ["export_safety_report"]},
+        },
+    }), encoding="utf-8")
+
+    rc = main([
+        "repobrief",
+        "snapshot",
+        "check",
+        "--bundle-manifest",
+        str(manifest),
+        "--task-profile",
+        "basic_repo_question",
+    ])
+
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 1
+    assert out["status"] == "fail"
+    assert out["profile_evaluation_status"] == "fail"
+    assert out["required_reading"]["status"] == "pass"


### PR DESCRIPTION
Adds a read-only RepoBrief snapshot check summary over an existing bundle manifest.

Scope:
- adds repobrief_access.snapshot_check
- adds CLI: repobrief snapshot check --bundle-manifest <path> --task-profile <profile>
- combines snapshot status, artifact list, and required-reading resolve
- no contents, no refresh, no git, no mutation

Local checks:
- cmd_repobrief.py and repobrief_access.py py_compile pass
- python3 -m pytest -q merger/lenskit/tests/test_repobrief_snapshot_cli.py -> 16 passed
- smoke: snapshot create followed by snapshot check -> rc 0, check JSON written