### PR TITLE
feat(repobrief): add snapshot status schema

### DIFF
--- a/merger/lenskit/contracts/repobrief-snapshot-status.v1.schema.json
+++ b/merger/lenskit/contracts/repobrief-snapshot-status.v1.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://heimgewebe.github.io/lenskit/contracts/repobrief-snapshot-status.v1.schema.json",
+  "title": "RepoBrief Snapshot Status v1",
+  "type": "object",
+  "required": [
+    "kind",
+    "version",
+    "status",
+    "bundle_manifest",
+    "artifact_count",
+    "roles",
+    "artifacts",
+    "mutation_boundary",
+    "does_not_establish"
+  ],
+  "properties": {
+    "kind": {"const": "repobrief.snapshot_status"},
+    "version": {"const": "v1"},
+    "status": {"const": "ok"},
+    "bundle_manifest": {"type": "string", "minLength": 1},
+    "bundle_run_id": {"type": ["string", "null"]},
+    "profile": {"type": ["string", "null"]},
+    "profile_evaluation": {"type": ["object", "null"]},
+    "artifact_count": {"type": "integer", "minimum": 0},
+    "roles": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1},
+      "uniqueItems": true
+    },
+    "artifacts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["role", "path", "absolute_path", "file_exists"],
+        "properties": {
+          "role": {"type": ["string", "null"]},
+          "path": {"type": ["string", "null"]},
+          "absolute_path": {"type": ["string", "null"]},
+          "file_exists": {"type": "boolean"},
+          "content_type": {"type": ["string", "null"]},
+          "bytes": {"type": ["integer", "null"], "minimum": 0},
+          "sha256": {"type": ["string", "null"]},
+          "authority": {"type": ["string", "null"]},
+          "canonicality": {"type": ["string", "null"]},
+          "risk_class": {"type": ["string", "null"]},
+          "contract": {"type": ["object", "null"]},
+          "interpretation": {"type": ["object", "null"]}
+        },
+        "additionalProperties": true
+      }
+    },
+    "mutation_boundary": {
+      "type": "object",
+      "required": ["writes", "does_not_mutate", "read_paths_do_not_refresh"],
+      "properties": {
+        "writes": {
+          "type": "array",
+          "maxItems": 0
+        },
+        "does_not_mutate": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true
+        },
+        "read_paths_do_not_refresh": {"const": true}
+      },
+      "additionalProperties": true
+    },
+    "does_not_establish": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1},
+      "uniqueItems": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/merger/lenskit/tests/test_repobrief_snapshot_cli.py
+++ b/merger/lenskit/tests/test_repobrief_snapshot_cli.py
@@ -555,3 +555,42 @@ def test_repobrief_snapshot_check_propagates_failed_profile_evaluation(tmp_path,
     assert out["status"] == "fail"
     assert out["profile_evaluation_status"] == "fail"
     assert out["required_reading"]["status"] == "pass"
+
+
+def test_repobrief_snapshot_status_matches_contract_schema(tmp_path, capsys):
+    import pytest
+
+    jsonschema = pytest.importorskip("jsonschema")
+    artifact = tmp_path / "demo.md"
+    artifact.write_text("# demo\n", encoding="utf-8")
+    manifest = tmp_path / "demo.bundle.manifest.json"
+    manifest.write_text(json.dumps({
+        "kind": "repolens.bundle.manifest",
+        "version": "1.0",
+        "run_id": "run-1",
+        "created_at": "2026-07-03T00:00:00Z",
+        "generator": {"name": "test", "version": "1", "config_sha256": "a" * 64},
+        "artifacts": [{
+            "role": "canonical_md",
+            "path": artifact.name,
+            "content_type": "text/markdown",
+            "bytes": artifact.stat().st_size,
+            "sha256": "b" * 64,
+            "authority": "canonical_content",
+            "canonicality": "content_source",
+        }],
+        "links": {},
+        "capabilities": {
+            "repobrief_profile": "agent-portable",
+            "repobrief_profile_evaluation": {"status": "pass"},
+        },
+    }), encoding="utf-8")
+    schema_path = Path(__file__).parent.parent / "contracts" / "repobrief-snapshot-status.v1.schema.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+
+    jsonschema.Draft7Validator.check_schema(schema)
+    rc = main(["repobrief", "snapshot", "status", "--bundle-manifest", str(manifest)])
+
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    jsonschema.validate(instance=out, schema=schema)


### PR DESCRIPTION
Adds a JSON Schema contract for repobrief.snapshot_status and validates CLI output against it. Local checks: schema JSON ok; targeted contract test passed; repobrief snapshot CLI tests passed.