### PR TITLE
feat(repobrief): add artifact list schema

### DIFF
--- a/merger/lenskit/contracts/repobrief-artifact-list.v1.schema.json
+++ b/merger/lenskit/contracts/repobrief-artifact-list.v1.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://heimgewebe.github.io/lenskit/contracts/repobrief-artifact-list.v1.schema.json",
+  "title": "RepoBrief Artifact List v1",
+  "type": "object",
+  "required": [
+    "kind",
+    "version",
+    "status",
+    "bundle_manifest",
+    "artifact_count",
+    "roles",
+    "artifacts",
+    "mutation_boundary",
+    "does_not_establish"
+  ],
+  "properties": {
+    "kind": {"const": "repobrief.artifact_list"},
+    "version": {"const": "v1"},
+    "status": {"const": "ok"},
+    "bundle_manifest": {"type": "string", "minLength": 1},
+    "bundle_run_id": {"type": ["string", "null"]},
+    "profile": {"type": ["string", "null"]},
+    "artifact_count": {"type": "integer", "minimum": 0},
+    "roles": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1},
+      "uniqueItems": true
+    },
+    "artifacts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["role", "path", "absolute_path", "file_exists"],
+        "properties": {
+          "role": {"type": ["string", "null"]},
+          "path": {"type": ["string", "null"]},
+          "absolute_path": {"type": ["string", "null"]},
+          "file_exists": {"type": "boolean"},
+          "content_type": {"type": ["string", "null"]},
+          "bytes": {"type": ["integer", "null"], "minimum": 0},
+          "sha256": {"type": ["string", "null"]},
+          "authority": {"type": ["string", "null"]},
+          "canonicality": {"type": ["string", "null"]},
+          "risk_class": {"type": ["string", "null"]},
+          "contract": {"type": ["object", "null"]},
+          "interpretation": {"type": ["object", "null"]}
+        },
+        "additionalProperties": true
+      }
+    },
+    "mutation_boundary": {
+      "type": "object",
+      "required": ["writes", "does_not_mutate", "read_paths_do_not_refresh"],
+      "properties": {
+        "writes": {"type": "array", "maxItems": 0},
+        "does_not_mutate": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true
+        },
+        "read_paths_do_not_refresh": {"const": true}
+      },
+      "additionalProperties": true
+    },
+    "does_not_establish": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1},
+      "uniqueItems": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/merger/lenskit/tests/test_repobrief_snapshot_cli.py
+++ b/merger/lenskit/tests/test_repobrief_snapshot_cli.py
@@ -635,3 +635,36 @@ def test_repobrief_artifact_ref_matches_contract_schema(tmp_path, capsys):
     assert rc == 1
     jsonschema.validate(instance=missing, schema=schema)
 
+
+
+def test_repobrief_artifact_list_matches_contract_schema(tmp_path, capsys):
+    import pytest
+
+    jsonschema = pytest.importorskip("jsonschema")
+    first = tmp_path / "demo.md"
+    second = tmp_path / "plan.json"
+    first.write_text("# demo\n", encoding="utf-8")
+    second.write_text("{}\n", encoding="utf-8")
+    manifest = tmp_path / "demo.bundle.manifest.json"
+    manifest.write_text(json.dumps({
+        "kind": "repolens.bundle.manifest",
+        "version": "1.0",
+        "run_id": "run-1",
+        "created_at": "2026-07-03T00:00:00Z",
+        "generator": {"name": "test", "version": "1", "config_sha256": "a" * 64},
+        "artifacts": [
+            {"role": "snapshot_plan_json", "path": second.name, "content_type": "application/json", "bytes": second.stat().st_size, "sha256": "c" * 64},
+            {"role": "canonical_md", "path": first.name, "content_type": "text/markdown", "bytes": first.stat().st_size, "sha256": "b" * 64},
+        ],
+        "links": {},
+        "capabilities": {"repobrief_profile": "agent-portable"},
+    }), encoding="utf-8")
+    schema_path = Path(__file__).parent.parent / "contracts" / "repobrief-artifact-list.v1.schema.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+
+    jsonschema.Draft7Validator.check_schema(schema)
+    rc = main(["repobrief", "artifact", "list", "--bundle-manifest", str(manifest)])
+
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    jsonschema.validate(instance=out, schema=schema)


### PR DESCRIPTION
Adds repobrief.artifact_list schema and validates artifact list JSON output. Local checks: artifact-list contract test passed; repobrief snapshot CLI tests passed.