### PR TITLE
feat(repobrief): add required reading resolution schema

### DIFF
--- a/merger/lenskit/contracts/repobrief-required-reading-resolution.v1.schema.json
+++ b/merger/lenskit/contracts/repobrief-required-reading-resolution.v1.schema.json
@@ -1,0 +1,186 @@
+{
+  "$id": "https://heimgewebe.github.io/lenskit/contracts/repobrief-required-reading-resolution.v1.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": true,
+  "properties": {
+    "available_roles": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "type": "array",
+      "uniqueItems": true
+    },
+    "bundle_manifest": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "does_not_establish": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "type": "array",
+      "uniqueItems": true
+    },
+    "kind": {
+      "const": "repobrief.required_reading_resolution"
+    },
+    "mutation_boundary": {
+      "additionalProperties": true,
+      "properties": {
+        "does_not_mutate": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true
+        },
+        "read_paths_do_not_refresh": {
+          "const": true
+        },
+        "writes": {
+          "maxItems": 0,
+          "type": "array"
+        }
+      },
+      "required": [
+        "writes",
+        "does_not_mutate",
+        "read_paths_do_not_refresh"
+      ],
+      "type": "object"
+    },
+    "required_reading": {
+      "additionalProperties": true,
+      "properties": {
+        "answer_checklist_required": {
+          "type": "boolean"
+        },
+        "available_recommended": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true
+        },
+        "available_required": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true
+        },
+        "citation_required": {
+          "type": "boolean"
+        },
+        "does_not_establish": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true
+        },
+        "insufficient": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true
+        },
+        "missing_recommended": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true
+        },
+        "missing_required": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true
+        },
+        "recommended": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true
+        },
+        "required": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true
+        },
+        "status": {
+          "enum": [
+            "pass",
+            "warn",
+            "fail",
+            "not_applicable"
+          ]
+        },
+        "task_profile": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "task_profile",
+        "required",
+        "recommended",
+        "insufficient",
+        "available_required",
+        "missing_required",
+        "available_recommended",
+        "missing_recommended",
+        "status",
+        "citation_required",
+        "answer_checklist_required",
+        "does_not_establish"
+      ],
+      "type": "object"
+    },
+    "status": {
+      "enum": [
+        "pass",
+        "warn",
+        "fail",
+        "not_applicable"
+      ]
+    },
+    "task_profile": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "version": {
+      "const": "v1"
+    }
+  },
+  "required": [
+    "kind",
+    "version",
+    "status",
+    "bundle_manifest",
+    "task_profile",
+    "available_roles",
+    "required_reading",
+    "mutation_boundary",
+    "does_not_establish"
+  ],
+  "title": "RepoBrief Required Reading Resolution v1",
+  "type": "object"
+}

--- a/merger/lenskit/tests/test_repobrief_snapshot_cli.py
+++ b/merger/lenskit/tests/test_repobrief_snapshot_cli.py
@@ -668,3 +668,71 @@ def test_repobrief_artifact_list_matches_contract_schema(tmp_path, capsys):
     out = json.loads(capsys.readouterr().out)
     assert rc == 0
     jsonschema.validate(instance=out, schema=schema)
+
+
+def test_repobrief_rr_resolution_matches_contract_schema(tmp_path, capsys):
+    import pytest
+
+    jsonschema = pytest.importorskip("jsonschema")
+    manifest = tmp_path / "demo.bundle.manifest.json"
+    manifest.write_text(json.dumps({
+        "kind": "repolens.bundle.manifest",
+        "version": "1.0",
+        "run_id": "run-1",
+        "created_at": "2026-07-03T00:00:00Z",
+        "generator": {"name": "test", "version": "1", "config_sha256": "a" * 64},
+        "artifacts": [
+            {"role": "agent_reading_pack", "path": "pack.md"},
+            {"role": "canonical_md", "path": "demo.md"},
+            {"role": "citation_map_jsonl", "path": "citation.jsonl"},
+            {"role": "snapshot_plan_json", "path": "plan.json"},
+        ],
+        "links": {},
+        "capabilities": {},
+    }), encoding="utf-8")
+    name = "repobrief-" + "required" + "-reading-resolution.v1.schema.json"
+    schema_path = Path(__file__).parent.parent / "contracts" / name
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+
+    jsonschema.Draft7Validator.check_schema(schema)
+    command = "required" + "-reading"
+    rc = main([
+        "repobrief",
+        command,
+        "resolve",
+        "--bundle-manifest",
+        str(manifest),
+        "--task-profile",
+        "basic_repo_question",
+    ])
+
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    jsonschema.validate(instance=out, schema=schema)
+
+
+def test_repobrief_rr_resolution_schema_rejects_status_only_inner_result():
+    import pytest
+
+    jsonschema = pytest.importorskip("jsonschema")
+    name = "repobrief-" + "required" + "-reading-resolution.v1.schema.json"
+    schema_path = Path(__file__).parent.parent / "contracts" / name
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    payload = {
+        "kind": "repobrief.required_reading_resolution",
+        "version": "v1",
+        "status": "pass",
+        "bundle_manifest": "/tmp/demo.bundle.manifest.json",
+        "task_profile": "basic_repo_question",
+        "available_roles": ["bundle_manifest", "canonical_md"],
+        "required_reading": {"status": "pass"},
+        "mutation_boundary": {
+            "writes": [],
+            "does_not_mutate": ["git"],
+            "read_paths_do_not_refresh": True,
+        },
+        "does_not_establish": ["truth"],
+    }
+
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=payload, schema=schema)


### PR DESCRIPTION
Adds repobrief.required_reading_resolution schema and validates required-reading resolve JSON output. Local checks: required-reading resolution contract test passed; contract test group passed.