### PR TITLE
feat(repobrief): add snapshot check schema

### DIFF
--- a/merger/lenskit/contracts/repobrief-snapshot-check.v1.schema.json
+++ b/merger/lenskit/contracts/repobrief-snapshot-check.v1.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://heimgewebe.github.io/lenskit/contracts/repobrief-snapshot-check.v1.schema.json",
+  "title": "RepoBrief Snapshot Check v1",
+  "type": "object",
+  "required": [
+    "kind",
+    "version",
+    "status",
+    "bundle_manifest",
+    "bundle_run_id",
+    "profile",
+    "profile_evaluation_status",
+    "task_profile",
+    "artifact_count",
+    "roles",
+    "snapshot_status",
+    "artifact_list",
+    "required_reading",
+    "mutation_boundary",
+    "does_not_establish"
+  ],
+  "properties": {
+    "kind": {"const": "repobrief.snapshot_check"},
+    "version": {"const": "v1"},
+    "status": {"enum": ["pass", "warn", "fail", "unknown"]},
+    "bundle_manifest": {"type": "string", "minLength": 1},
+    "bundle_run_id": {"type": ["string", "null"]},
+    "profile": {"type": ["string", "null"]},
+    "profile_evaluation_status": {"type": ["string", "null"]},
+    "task_profile": {"type": "string", "minLength": 1},
+    "artifact_count": {"type": "integer", "minimum": 0},
+    "roles": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1},
+      "uniqueItems": true
+    },
+    "snapshot_status": {
+      "type": "object",
+      "required": ["kind", "version", "status"],
+      "properties": {
+        "kind": {"const": "repobrief.snapshot_status"},
+        "version": {"const": "v1"},
+        "status": {"const": "ok"}
+      },
+      "additionalProperties": true
+    },
+    "artifact_list": {
+      "type": "object",
+      "required": ["kind", "version", "status"],
+      "properties": {
+        "kind": {"const": "repobrief.artifact_list"},
+        "version": {"const": "v1"},
+        "status": {"const": "ok"}
+      },
+      "additionalProperties": true
+    },
+    "required_reading": {
+      "type": "object",
+      "required": ["kind", "version", "status"],
+      "properties": {
+        "kind": {"const": "repobrief.required_reading_resolution"},
+        "version": {"const": "v1"},
+        "status": {"enum": ["pass", "warn", "fail", "not_applicable"]}
+      },
+      "additionalProperties": true
+    },
+    "mutation_boundary": {
+      "type": "object",
+      "required": ["writes", "does_not_mutate", "read_paths_do_not_refresh"],
+      "properties": {
+        "writes": {"type": "array", "maxItems": 0},
+        "does_not_mutate": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true
+        },
+        "read_paths_do_not_refresh": {"const": true}
+      },
+      "additionalProperties": true
+    },
+    "does_not_establish": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1},
+      "uniqueItems": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/merger/lenskit/tests/test_repobrief_snapshot_cli.py
+++ b/merger/lenskit/tests/test_repobrief_snapshot_cli.py
@@ -736,3 +736,69 @@ def test_repobrief_rr_resolution_schema_rejects_status_only_inner_result():
 
     with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(instance=payload, schema=schema)
+
+
+def test_repobrief_snapshot_check_matches_contract_schema(tmp_path, capsys):
+    import pytest
+
+    jsonschema = pytest.importorskip("jsonschema")
+    manifest = tmp_path / "demo.bundle.manifest.json"
+    manifest.write_text(json.dumps({
+        "kind": "repolens.bundle.manifest",
+        "version": "1.0",
+        "run_id": "run-1",
+        "created_at": "2026-07-03T00:00:00Z",
+        "generator": {"name": "test", "version": "1", "config_sha256": "a" * 64},
+        "artifacts": [
+            {"role": "agent_reading_pack", "path": "pack.md"},
+            {"role": "canonical_md", "path": "demo.md"},
+            {"role": "citation_map_jsonl", "path": "citation.jsonl"},
+            {"role": "snapshot_plan_json", "path": "plan.json"},
+        ],
+        "links": {},
+        "capabilities": {"repobrief_profile": "agent-portable"},
+    }), encoding="utf-8")
+    schema_path = Path(__file__).parent.parent / "contracts" / "repobrief-snapshot-check.v1.schema.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+
+    jsonschema.Draft7Validator.check_schema(schema)
+    rc = main([
+        "repobrief",
+        "snapshot",
+        "check",
+        "--bundle-manifest",
+        str(manifest),
+        "--task-profile",
+        "basic_repo_question",
+    ])
+
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    jsonschema.validate(instance=out, schema=schema)
+
+
+def test_repobrief_snapshot_check_schema_requires_profile_evaluation_status():
+    import pytest
+
+    jsonschema = pytest.importorskip("jsonschema")
+    schema_path = Path(__file__).parent.parent / "contracts" / "repobrief-snapshot-check.v1.schema.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    payload = {
+        "kind": "repobrief.snapshot_check",
+        "version": "v1",
+        "status": "pass",
+        "bundle_manifest": "/tmp/demo.bundle.manifest.json",
+        "bundle_run_id": "run-1",
+        "profile": "agent-portable",
+        "task_profile": "basic_repo_question",
+        "artifact_count": 0,
+        "roles": [],
+        "snapshot_status": {"kind": "repobrief.snapshot_status", "version": "v1", "status": "ok"},
+        "artifact_list": {"kind": "repobrief.artifact_list", "version": "v1", "status": "ok"},
+        "required_reading": {"kind": "repobrief.required_reading_resolution", "version": "v1", "status": "pass"},
+        "mutation_boundary": {"writes": [], "does_not_mutate": ["git"], "read_paths_do_not_refresh": True},
+        "does_not_establish": ["truth"],
+    }
+
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=payload, schema=schema)


### PR DESCRIPTION
Adds repobrief.snapshot_check schema and validates snapshot check JSON output. Local checks: snapshot-check contract tests passed; contract test group passed.