### PR TITLE
feat(repobrief): add consumption preflight

### DIFF
--- a/merger/lenskit/cli/cmd_repobrief.py
+++ b/merger/lenskit/cli/cmd_repobrief.py
@@ -249,6 +249,10 @@ def register_repobrief_commands(subparsers: argparse._SubParsersAction) -> None:
     check_parser.add_argument("--bundle-manifest", required=True, help="Path to a Brief Bundle manifest")
     check_parser.add_argument("--task-profile", default="basic_repo_question", help="Required-reading task profile")
 
+    preflight_parser = repobrief_subparsers.add_parser("preflight", help="Run RepoBrief consumption preflight")
+    preflight_parser.add_argument("--bundle-manifest", required=True, help="Path to a Brief Bundle manifest")
+    preflight_parser.add_argument("--task-profile", default="basic_repo_question", help="Required-reading task profile")
+
     artifact_parser = repobrief_subparsers.add_parser("artifact", help="Brief artifact read-only commands")
     artifact_subparsers = artifact_parser.add_subparsers(
         dest="artifact_cmd",
@@ -276,6 +280,8 @@ def run_repobrief(args: argparse.Namespace) -> int:
         return run_snapshot_check(args)
     if args.repobrief_cmd == "snapshot" and args.snapshot_cmd == "status":
         return run_snapshot_status(args)
+    if args.repobrief_cmd == "preflight":
+        return run_preflight(args)
     if args.repobrief_cmd == "artifact" and args.artifact_cmd == "get":
         return run_artifact_get(args)
     if args.repobrief_cmd == "artifact" and args.artifact_cmd == "list":
@@ -352,6 +358,18 @@ def run_required_reading_resolve(args: argparse.Namespace) -> int:
         return 2
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0 if result.get("status") in {"pass", "warn"} else 1
+
+def run_preflight(args: argparse.Namespace) -> int:
+    from merger.lenskit.core.repobrief_preflight import run_consumption_preflight
+
+    try:
+        result = run_consumption_preflight(args.bundle_manifest, args.task_profile)
+    except ValueError as exc:
+        print("repobrief preflight: " + str(exc), file=sys.stderr)
+        return 2
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result.get("status") in {"pass", "warn"} else 1
+
 
 def run_snapshot_create(args: argparse.Namespace) -> int:
     profile = args.profile

--- a/merger/lenskit/core/repobrief_preflight.py
+++ b/merger/lenskit/core/repobrief_preflight.py
@@ -53,6 +53,10 @@ STATUS_WARN = "warn"
 STATUS_FAIL = "fail"
 STATUS_NA = "not_applicable"
 
+_POST_EMIT_HEALTH_KIND = "lenskit.post_emit_health"
+_POST_EMIT_HEALTH_VERSION = "1.0"
+_POST_EMIT_HEALTH_STATUSES = {STATUS_PASS, STATUS_WARN, STATUS_FAIL, "blocked"}
+
 SEVERITY_FAIL = "fail"
 SEVERITY_WARN = "warn"
 SEVERITY_INFO = "info"
@@ -295,6 +299,18 @@ def _post_emit_health_binding_error(
     manifest_path: Path,
     manifest_run_id: Any,
 ) -> str | None:
+    kind = post_doc.get("kind")
+    if kind != _POST_EMIT_HEALTH_KIND:
+        return f"post-emit health kind mismatch: expected {_POST_EMIT_HEALTH_KIND!r} got {kind!r}"
+
+    version = post_doc.get("version")
+    if version != _POST_EMIT_HEALTH_VERSION:
+        return f"post-emit health version mismatch: expected {_POST_EMIT_HEALTH_VERSION!r} got {version!r}"
+
+    status = post_doc.get("status")
+    if not isinstance(status, str) or status not in _POST_EMIT_HEALTH_STATUSES:
+        return f"post-emit health has invalid status: {status!r}"
+
     manifest_path_value = post_doc.get("bundle_manifest_path")
     if not isinstance(manifest_path_value, str) or not manifest_path_value.strip():
         return "post-emit health bundle_manifest_path is missing or empty"
@@ -305,7 +321,6 @@ def _post_emit_health_binding_error(
     if post_manifest_path != manifest_path:
         return "post-emit health bundle_manifest_path does not match the evaluated manifest"
 
-    status = post_doc.get("status")
     if status == STATUS_PASS:
         if not isinstance(manifest_run_id, str) or not manifest_run_id.strip():
             return "manifest run_id is missing or empty; cannot bind post-emit health"
@@ -431,6 +446,7 @@ def consumption_preflight(preflight_input: PreflightInput) -> PreflightResult:
     missing_required = list(required_reading["missing_required"])
     missing_recommended = list(required_reading["missing_recommended"])
     required_role_set = set(required_roles)
+    recommended_role_set = set(recommended_roles)
 
     def add_sidecar_read_failure(role: str, detail: str) -> None:
         if role in required_role_set:
@@ -472,7 +488,7 @@ def consumption_preflight(preflight_input: PreflightInput) -> PreflightResult:
 
     # Manifest-listed roles whose files are gone degrade the bundle even when
     # the task profile does not need them.
-    needed = set(required_roles) | set(recommended_roles)
+    needed = required_role_set | recommended_role_set
     for role in sorted(file_missing_roles - needed):
         add(
             "artifact_file_missing",
@@ -496,14 +512,15 @@ def consumption_preflight(preflight_input: PreflightInput) -> PreflightResult:
     # ── Per-role artifact statuses relative to the task profile ─────────────
     artifact_statuses: list[PreflightArtifactStatus] = []
     listed_roles = set(records_by_role) | set(linked_paths) | {"bundle_manifest"}
-    for role in sorted(set(required_roles) | set(recommended_roles) | listed_roles):
-        if role in set(required_roles):
+    for role in sorted(required_role_set | recommended_role_set | listed_roles):
+        if role in required_role_set:
             requirement = REQUIREMENT_REQUIRED
-        elif role in set(recommended_roles):
+        elif role in recommended_role_set:
             requirement = REQUIREMENT_RECOMMENDED
         else:
             requirement = REQUIREMENT_NA
-        record = records_by_role.get(role, [{}])[0]
+        role_records = records_by_role.get(role)
+        record = role_records[0] if role_records else {}
         if role == "bundle_manifest" and not record:
             record = {"path": manifest_path.name, "file_exists": True}
         linked = linked_paths.get(role)
@@ -717,13 +734,10 @@ def consumption_preflight(preflight_input: PreflightInput) -> PreflightResult:
         )
 
     output_health_verdict: str | None = None
-    output_health_records = records_by_role.get("output_health", [])
-    output_health_path = next(
-        (r.get("absolute_path") for r in output_health_records if r.get("file_exists") and r.get("absolute_path")),
-        None,
-    )
-    if output_health_path:
-        output_doc, output_error = _load_json_file(Path(output_health_path))
+    output_health_path = artifact_paths_by_role.get("output_health")
+    output_health_present = output_health_path is not None and output_health_path.is_file()
+    if output_health_present:
+        output_doc, output_error = _load_json_file(output_health_path)
         if output_doc is None:
             add(
                 "validation_unreadable",
@@ -747,7 +761,7 @@ def consumption_preflight(preflight_input: PreflightInput) -> PreflightResult:
                     f"output health verdict invalid: {verdict!r}",
                     artifact="output_health",
                 )
-    validation["output_health"] = {"present": bool(output_health_path), "verdict": output_health_verdict}
+    validation["output_health"] = {"present": output_health_present, "verdict": output_health_verdict}
     validation["snapshot_profile_evaluation"] = snapshot_profile_evaluation
 
     validation_findings = [f for f in findings if f.area == "validation"]

--- a/merger/lenskit/core/repobrief_preflight.py
+++ b/merger/lenskit/core/repobrief_preflight.py
@@ -345,9 +345,10 @@ def consumption_preflight(preflight_input: PreflightInput) -> PreflightResult:
                     except ValueError:
                         candidate = None
             if candidate is not None:
-                artifact_paths_by_role.setdefault(role, candidate)
                 if candidate.exists():
+                    artifact_paths_by_role[role] = candidate
                     break
+                artifact_paths_by_role.setdefault(role, candidate)
     for role, path in linked_paths.items():
         if path is not None:
             artifact_paths_by_role[role] = path

--- a/merger/lenskit/core/repobrief_preflight.py
+++ b/merger/lenskit/core/repobrief_preflight.py
@@ -199,6 +199,10 @@ def _read_json_object(path: Path, *, label: str) -> dict[str, Any]:
         raise ValueError(f"{label} does not exist: {path}") from exc
     except json.JSONDecodeError as exc:
         raise ValueError(f"{label} is not valid JSON: {path}") from exc
+    except UnicodeError as exc:
+        raise ValueError(f"{label} is not valid UTF-8 text: {path}") from exc
+    except OSError as exc:
+        raise ValueError(f"{label} cannot be read: {path}") from exc
     if not isinstance(data, dict):
         raise ValueError(f"{label} must be a JSON object")
     return data
@@ -581,9 +585,21 @@ def consumption_preflight(preflight_input: PreflightInput) -> PreflightResult:
                 artifact="post_emit_health",
             )
 
+    recorded_surface_status = links.get("bundle_surface_validation_status")
+    surface_path = linked_paths.get("bundle_surface_validation")
+    if surface_path is not None:
+        surface_doc, surface_error = _load_json_file(surface_path)
+        if surface_doc is None:
+            add("validation_unreadable", SEVERITY_WARN, "validation", f"bundle surface validation sidecar cannot be read: {surface_error}", artifact="bundle_surface_validation")
+        elif isinstance(surface_doc.get("status"), str):
+            links = dict(links)
+            links["bundle_surface_validation_status"] = surface_doc["status"]
+        else:
+            add("validation_unreadable", SEVERITY_WARN, "validation", "bundle surface validation sidecar carries no string status", artifact="bundle_surface_validation")
     surface_status = links.get("bundle_surface_validation_status")
     validation["bundle_surface_validation"] = {
-        "recorded_status": surface_status if isinstance(surface_status, str) else None,
+        "status": surface_status if isinstance(surface_status, str) else None,
+        "recorded_status": recorded_surface_status if isinstance(recorded_surface_status, str) else None,
         "path": str(linked_paths["bundle_surface_validation"]) if linked_paths.get("bundle_surface_validation") else None,
     }
     if surface_status == STATUS_WARN:
@@ -790,28 +806,33 @@ def consumption_preflight(preflight_input: PreflightInput) -> PreflightResult:
             )
             known_ids = set()
             unparseable_lines = 0
-            try:
-                with Path(map_record["absolute_path"]).open("r", encoding="utf-8") as handle:
-                    for line in handle:
-                        line = line.strip()
-                        if not line:
-                            continue
-                        try:
-                            entry = json.loads(line)
-                        except json.JSONDecodeError:
-                            unparseable_lines += 1
-                            continue
-                        if isinstance(entry, dict) and isinstance(entry.get("citation_id"), str):
-                            known_ids.add(entry["citation_id"])
-            except OSError as exc:
+            map_path = map_record.get("absolute_path") if isinstance(map_record, Mapping) else None
+            if not isinstance(map_path, str) or not map_path:
                 known_ids = None
-                add(
-                    "used_citations_unverifiable",
-                    SEVERITY_FAIL,
-                    "used_citations",
-                    f"citation map cannot be read: {exc}",
-                    artifact="citation_map_jsonl",
-                )
+                add("used_citations_unverifiable", SEVERITY_FAIL, "used_citations", "citation map is marked available but no readable absolute path was resolved", artifact="citation_map_jsonl")
+            else:
+                try:
+                    with Path(map_path).open("r", encoding="utf-8") as handle:
+                        for line in handle:
+                            line = line.strip()
+                            if not line:
+                                continue
+                            try:
+                                entry = json.loads(line)
+                            except json.JSONDecodeError:
+                                unparseable_lines += 1
+                                continue
+                            if isinstance(entry, dict) and isinstance(entry.get("citation_id"), str):
+                                known_ids.add(entry["citation_id"])
+                except OSError as exc:
+                    known_ids = None
+                    add(
+                        "used_citations_unverifiable",
+                        SEVERITY_FAIL,
+                        "used_citations",
+                        f"citation map cannot be read: {exc}",
+                        artifact="citation_map_jsonl",
+                    )
             if unparseable_lines and known_ids is not None:
                 add(
                     "citation_map_lines_unparseable",
@@ -874,29 +895,27 @@ def consumption_preflight(preflight_input: PreflightInput) -> PreflightResult:
             if bounds is None:
                 unresolved(f"range_ref for '{role}' carries no integer line bounds", artifact=role)
                 continue
-            start_line, end_line, artifact_anchored = bounds
+            start_line, end_line, _artifact_anchored = bounds
             if start_line < 1 or end_line < start_line:
                 unresolved(f"range_ref for '{role}' has invalid line bounds {start_line}..{end_line}", artifact=role)
                 continue
-            resolution = "role_available_only"
-            if artifact_anchored:
-                if role not in line_counts:
-                    record = next(
-                        (r for r in records_by_role.get(role, []) if r.get("file_exists") and r.get("absolute_path")),
-                        None,
-                    )
-                    line_counts[role] = _count_lines(Path(record["absolute_path"])) if record else None
-                total_lines = line_counts[role]
-                if total_lines is None:
-                    unresolved(f"artifact '{role}' file cannot be read to verify line bounds", artifact=role)
-                    continue
-                if end_line > total_lines:
-                    unresolved(
-                        f"range {start_line}..{end_line} exceeds artifact '{role}' length of {total_lines} line(s)",
-                        artifact=role,
-                    )
-                    continue
-                resolution = "artifact_lines_verified"
+            if role not in line_counts:
+                record = next(
+                    (r for r in records_by_role.get(role, []) if r.get("file_exists") and r.get("absolute_path")),
+                    None,
+                )
+                line_counts[role] = _count_lines(Path(record["absolute_path"])) if record else None
+            total_lines = line_counts[role]
+            if total_lines is None:
+                unresolved(f"artifact '{role}' file cannot be read to verify line bounds", artifact=role)
+                continue
+            if end_line > total_lines:
+                unresolved(
+                    f"range {start_line}..{end_line} exceeds artifact '{role}' length of {total_lines} line(s)",
+                    artifact=role,
+                )
+                continue
+            resolution = "artifact_lines_verified"
             used_ranges_block["resolved"].append(
                 {"index": index, "artifact": role, "start_line": start_line, "end_line": end_line, "resolution": resolution}
             )

--- a/merger/lenskit/core/repobrief_preflight.py
+++ b/merger/lenskit/core/repobrief_preflight.py
@@ -1,0 +1,1009 @@
+"""RepoBrief Agent Consumption Preflight (v1).
+
+Deterministic, read-only readiness check an agent runs *before* consuming a
+Brief Bundle for a task profile.  It answers one question: does the bundle
+provide enough declared, file-backed evidence for this task profile, and is
+any of that evidence degraded, stale, or unverifiable?
+
+Layer separation (strict):
+
+* Required Reading Protocol (``required_reading``) stays the sole expectation
+  policy — the preflight resolves it, it does not define parallel role tables.
+* Snapshot profile policy (``repobrief_profiles``) stays the sole
+  generation-side policy — the preflight re-evaluates the recorded label, it
+  does not redefine it.
+* Health diagnostics (post-emit health, bundle surface validation,
+  output health) are diagnostic signals.  The preflight surfaces their status;
+  it never converts a degraded or skipped validation into success.
+* Availability and freshness are metadata about the bundle, not statements
+  about the repository or the answer.
+
+The preflight performs no writes, no refresh, no Git access, no snapshot
+creation.  It makes no truth claim: it does not establish that tests are
+sufficient, runtime behavior is correct, a review is complete, a PR is
+mergeable, or that forensic readiness exists.
+"""
+from __future__ import annotations
+
+import datetime
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from merger.lenskit.core.clock import now_utc
+from merger.lenskit.core.path_security import resolve_secure_path
+from merger.lenskit.core.post_emit_health import derive_post_health_path
+from merger.lenskit.core.repobrief_access import snapshot_status
+from merger.lenskit.core.repobrief_profiles import (
+    evaluate_profile,
+    present_roles_from_manifest,
+    profile_names,
+)
+from merger.lenskit.core.required_reading import (
+    default_required_reading_protocol,
+    resolve_required_reading,
+)
+
+KIND = "repobrief.consumption_preflight"
+VERSION = "v1"
+
+STATUS_PASS = "pass"
+STATUS_WARN = "warn"
+STATUS_FAIL = "fail"
+STATUS_NA = "not_applicable"
+
+SEVERITY_FAIL = "fail"
+SEVERITY_WARN = "warn"
+SEVERITY_INFO = "info"
+
+REQUIREMENT_REQUIRED = "required"
+REQUIREMENT_RECOMMENDED = "recommended"
+REQUIREMENT_NA = "not_applicable"
+
+AVAILABILITY_AVAILABLE = "available"
+AVAILABILITY_MISSING = "missing"
+AVAILABILITY_FILE_MISSING = "file_missing"
+
+_LINKED_SIDECAR_ROLES = {
+    "post_emit_health_path": "post_emit_health",
+    "bundle_surface_validation_path": "bundle_surface_validation",
+    "export_safety_report_path": "export_safety_report",
+}
+
+_AUTHORITY_LAYERS = (
+    "canonical_content",
+    "navigation_index",
+    "retrieval_index",
+    "diagnostic_signal",
+    "runtime_cache",
+    "runtime_observation",
+)
+
+DOES_NOT_ESTABLISH = (
+    "truth",
+    "correctness",
+    "completeness",
+    "runtime_behavior",
+    "test_sufficiency",
+    "regression_absence",
+    "repo_understood",
+    "claims_true",
+    "forensic_ready",
+    "freshness",
+    "review_complete",
+    "pr_mergeable",
+)
+
+MUTATION_BOUNDARY = {
+    "writes": [],
+    "does_not_mutate": [
+        "git",
+        "pull_requests",
+        "patches",
+        "source_working_tree",
+        "brief_bundle_artifacts",
+    ],
+    "read_paths_do_not_refresh": True,
+}
+
+
+@dataclass(frozen=True)
+class PreflightFinding:
+    """One machine-readable defect or notice discovered by the preflight."""
+
+    code: str
+    severity: str
+    area: str
+    detail: str
+    artifact: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "code": self.code,
+            "severity": self.severity,
+            "area": self.area,
+            "detail": self.detail,
+        }
+        if self.artifact is not None:
+            data["artifact"] = self.artifact
+        return data
+
+
+@dataclass(frozen=True)
+class PreflightArtifactStatus:
+    """Availability of one artifact role relative to the task profile."""
+
+    role: str
+    requirement: str
+    availability: str
+    file_exists: bool
+    path: str | None = None
+    authority: str | None = None
+    canonicality: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "role": self.role,
+            "requirement": self.requirement,
+            "availability": self.availability,
+            "file_exists": self.file_exists,
+            "path": self.path,
+            "authority": self.authority,
+            "canonicality": self.canonicality,
+        }
+
+
+@dataclass(frozen=True)
+class PreflightInput:
+    """Inputs for one consumption preflight run.
+
+    ``used_citations`` and ``used_ranges`` are optional declarations of the
+    evidence references the agent intends to rely on; when present they are
+    resolved against the bundle.  ``declaration`` is an optional consumption
+    self-report; when provided it must carry non-empty ``does_not_establish``
+    boundaries.  ``max_age_seconds`` enables the staleness check; ``as_of``
+    pins the reference time for reproducible staleness evaluation (defaults to
+    the injectable lenskit clock).
+    """
+
+    bundle_manifest: str | Path
+    task_profile: str = "basic_repo_question"
+    used_citations: tuple[Any, ...] = ()
+    used_ranges: tuple[Any, ...] = ()
+    declaration: Mapping[str, Any] | None = None
+    max_age_seconds: float | None = None
+    as_of: datetime.datetime | None = None
+
+
+@dataclass(frozen=True)
+class PreflightResult:
+    """Typed preflight verdict plus the full v1 payload dict."""
+
+    status: str
+    task_profile: str
+    bundle_manifest: str
+    findings: tuple[PreflightFinding, ...]
+    artifacts: tuple[PreflightArtifactStatus, ...]
+    checks: tuple[Mapping[str, Any], ...]
+    data: Mapping[str, Any] = field(repr=False)
+
+    def to_dict(self) -> dict[str, Any]:
+        return json.loads(json.dumps(self.data))
+
+
+def _read_json_object(path: Path, *, label: str) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(f"{label} does not exist: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{label} is not valid JSON: {path}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"{label} must be a JSON object")
+    return data
+
+
+def _load_json_file(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    if not path.exists() or not path.is_file():
+        return None, "file not found"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeError) as exc:
+        return None, str(exc)
+    if not isinstance(data, dict):
+        return None, "JSON root must be an object"
+    return data, None
+
+
+def _check(name: str, status: str, detail: str) -> dict[str, str]:
+    return {"name": name, "status": status, "detail": detail}
+
+
+def _parse_created_at(value: Any) -> datetime.datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    raw = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=datetime.timezone.utc)
+    return parsed.astimezone(datetime.timezone.utc)
+
+
+def _normalize_citation_ids(values: Sequence[Any]) -> tuple[list[str], list[str]]:
+    """Return (sorted unique citation ids, invalid entries as reprs)."""
+    ids: set[str] = set()
+    invalid: list[str] = []
+    for value in values:
+        if isinstance(value, str) and value.strip():
+            ids.add(value.strip())
+        elif isinstance(value, Mapping) and isinstance(value.get("citation_id"), str) and value["citation_id"].strip():
+            ids.add(value["citation_id"].strip())
+        else:
+            invalid.append(repr(value))
+    return sorted(ids), invalid
+
+
+def _line_bounds(range_ref: Mapping[str, Any]) -> tuple[int, int, bool] | None:
+    """Extract (start_line, end_line, artifact_anchored) from a range ref."""
+    if isinstance(range_ref.get("artifact_line_start"), int) and isinstance(range_ref.get("artifact_line_end"), int):
+        return range_ref["artifact_line_start"], range_ref["artifact_line_end"], True
+    if isinstance(range_ref.get("start_line"), int) and isinstance(range_ref.get("end_line"), int):
+        return range_ref["start_line"], range_ref["end_line"], False
+    return None
+
+
+def _count_lines(path: Path) -> int | None:
+    try:
+        with path.open("rb") as handle:
+            count = 0
+            saw_bytes = False
+            for chunk in iter(lambda: handle.read(65536), b""):
+                saw_bytes = True
+                count += chunk.count(b"\n")
+                last_chunk = chunk
+            if saw_bytes and not last_chunk.endswith(b"\n"):
+                count += 1
+            return count
+    except OSError:
+        return None
+
+
+def _resolve_link_path(manifest_dir: Path, raw: Any) -> tuple[Path | None, str | None]:
+    if not isinstance(raw, str) or not raw:
+        return None, None
+    try:
+        return resolve_secure_path(manifest_dir, raw), None
+    except ValueError as exc:
+        return None, str(exc)
+
+
+def consumption_preflight(preflight_input: PreflightInput) -> PreflightResult:
+    """Run the RepoBrief agent consumption preflight for one bundle manifest.
+
+    Raises ``ValueError`` when the bundle manifest itself is unreadable; every
+    other condition is reported as a structured finding, never an exception.
+    """
+    manifest_path = Path(preflight_input.bundle_manifest).expanduser().resolve()
+    manifest = _read_json_object(manifest_path, label="bundle manifest")
+    manifest_dir = manifest_path.parent
+    status_report = snapshot_status(manifest_path)
+    records = [a for a in status_report["artifacts"] if isinstance(a, dict)]
+
+    findings: list[PreflightFinding] = []
+    checks: list[dict[str, str]] = []
+
+    def add(code: str, severity: str, area: str, detail: str, artifact: str | None = None) -> None:
+        findings.append(PreflightFinding(code=code, severity=severity, area=area, detail=detail, artifact=artifact))
+
+    # ── Effective availability: manifest role + file on disk ────────────────
+    records_by_role: dict[str, list[dict[str, Any]]] = {}
+    for record in records:
+        role = record.get("role")
+        if isinstance(role, str) and role:
+            records_by_role.setdefault(role, []).append(record)
+
+    linked_paths: dict[str, Path | None] = {}
+    links = manifest.get("links") if isinstance(manifest.get("links"), dict) else {}
+    for link_key, role in _LINKED_SIDECAR_ROLES.items():
+        resolved, error = _resolve_link_path(manifest_dir, links.get(link_key))
+        if error is not None:
+            add(
+                "sidecar_path_rejected",
+                SEVERITY_WARN,
+                "availability",
+                f"link {link_key} rejected: {error}",
+                artifact=role,
+            )
+        if resolved is not None and role not in linked_paths:
+            linked_paths[role] = resolved
+    if "post_emit_health" not in linked_paths:
+        derived = derive_post_health_path(manifest_path)
+        if derived.exists():
+            linked_paths["post_emit_health"] = derived
+
+    available_roles: set[str] = {"bundle_manifest"}
+    file_missing_roles: set[str] = set()
+    for role, role_records in records_by_role.items():
+        if any(record.get("file_exists") for record in role_records):
+            available_roles.add(role)
+        else:
+            file_missing_roles.add(role)
+    for role, path in linked_paths.items():
+        if role in available_roles:
+            continue
+        if path is not None and path.exists():
+            available_roles.add(role)
+        elif role in _LINKED_SIDECAR_ROLES.values() and any(
+            links.get(key) for key, mapped in _LINKED_SIDECAR_ROLES.items() if mapped == role
+        ):
+            file_missing_roles.add(role)
+    file_missing_roles -= available_roles
+
+    # ── Task profile expectation (Required Reading Protocol, reused) ────────
+    protocol = default_required_reading_protocol()
+    required_reading = resolve_required_reading(protocol, available_roles, preflight_input.task_profile)
+    task_profile_known = required_reading["status"] != STATUS_NA
+
+    if task_profile_known:
+        checks.append(_check("task_profile", STATUS_PASS, f"task profile '{preflight_input.task_profile}' resolved"))
+    else:
+        checks.append(
+            _check("task_profile", STATUS_NA, f"task profile '{preflight_input.task_profile}' is not in the Required Reading Protocol")
+        )
+        add(
+            "task_profile_unknown",
+            SEVERITY_INFO,
+            "task_profile",
+            f"task profile '{preflight_input.task_profile}' is not in the Required Reading Protocol; "
+            f"known profiles: {', '.join(sorted(protocol['task_profiles']))}",
+        )
+
+    required_roles = list(required_reading["required"])
+    recommended_roles = list(required_reading["recommended"])
+    missing_required = list(required_reading["missing_required"])
+    missing_recommended = list(required_reading["missing_recommended"])
+
+    for role in missing_required:
+        if role in file_missing_roles:
+            detail = f"required artifact '{role}' is listed in the manifest but its file is missing"
+        else:
+            detail = f"required artifact '{role}' is not present in the bundle"
+        add("missing_required_artifact", SEVERITY_FAIL, "required_artifacts", detail, artifact=role)
+    for role in missing_recommended:
+        if role in file_missing_roles:
+            detail = f"recommended artifact '{role}' is listed in the manifest but its file is missing"
+        else:
+            detail = f"recommended artifact '{role}' is not present in the bundle"
+        add("missing_recommended_artifact", SEVERITY_WARN, "recommended_artifacts", detail, artifact=role)
+
+    if not task_profile_known:
+        checks.append(_check("required_artifacts", STATUS_NA, "no expectation without a known task profile"))
+        checks.append(_check("recommended_artifacts", STATUS_NA, "no expectation without a known task profile"))
+    else:
+        checks.append(
+            _check(
+                "required_artifacts",
+                STATUS_FAIL if missing_required else STATUS_PASS,
+                f"missing required: {', '.join(missing_required) if missing_required else 'none'}",
+            )
+        )
+        checks.append(
+            _check(
+                "recommended_artifacts",
+                STATUS_WARN if missing_recommended else STATUS_PASS,
+                f"missing recommended: {', '.join(missing_recommended) if missing_recommended else 'none'}",
+            )
+        )
+
+    # Manifest-listed roles whose files are gone degrade the bundle even when
+    # the task profile does not need them.
+    needed = set(required_roles) | set(recommended_roles)
+    for role in sorted(file_missing_roles - needed):
+        add(
+            "artifact_file_missing",
+            SEVERITY_WARN,
+            "availability",
+            f"artifact '{role}' is listed in the manifest but its file is missing",
+            artifact=role,
+        )
+    if file_missing_roles:
+        artifact_files_status = STATUS_FAIL if file_missing_roles & set(required_roles) else STATUS_WARN
+    else:
+        artifact_files_status = STATUS_PASS
+    checks.append(
+        _check(
+            "artifact_files",
+            artifact_files_status,
+            f"manifest-listed roles without files: {', '.join(sorted(file_missing_roles)) if file_missing_roles else 'none'}",
+        )
+    )
+
+    # ── Per-role artifact statuses relative to the task profile ─────────────
+    artifact_statuses: list[PreflightArtifactStatus] = []
+    listed_roles = set(records_by_role) | set(linked_paths) | {"bundle_manifest"}
+    for role in sorted(set(required_roles) | set(recommended_roles) | listed_roles):
+        if role in set(required_roles):
+            requirement = REQUIREMENT_REQUIRED
+        elif role in set(recommended_roles):
+            requirement = REQUIREMENT_RECOMMENDED
+        else:
+            requirement = REQUIREMENT_NA
+        record = records_by_role.get(role, [{}])[0]
+        if role == "bundle_manifest" and not record:
+            record = {"path": manifest_path.name, "file_exists": True}
+        linked = linked_paths.get(role)
+        if role in available_roles:
+            availability = AVAILABILITY_AVAILABLE
+        elif role in file_missing_roles:
+            availability = AVAILABILITY_FILE_MISSING
+        else:
+            availability = AVAILABILITY_MISSING
+        path_value = record.get("path")
+        if path_value is None and linked is not None:
+            path_value = str(linked)
+        artifact_statuses.append(
+            PreflightArtifactStatus(
+                role=role,
+                requirement=requirement,
+                availability=availability,
+                file_exists=availability == AVAILABILITY_AVAILABLE,
+                path=path_value if isinstance(path_value, str) else None,
+                authority=record.get("authority") if isinstance(record.get("authority"), str) else None,
+                canonicality=record.get("canonicality") if isinstance(record.get("canonicality"), str) else None,
+            )
+        )
+
+    evidence_layers: dict[str, list[str]] = {layer: [] for layer in _AUTHORITY_LAYERS}
+    evidence_layers["unspecified"] = []
+    for status in artifact_statuses:
+        if status.availability != AVAILABILITY_AVAILABLE:
+            continue
+        layer = status.authority if status.authority in _AUTHORITY_LAYERS else "unspecified"
+        evidence_layers[layer].append(status.role)
+
+    # ── Snapshot profile policy (generation-side, re-evaluated) ─────────────
+    capabilities = manifest.get("capabilities") if isinstance(manifest.get("capabilities"), dict) else {}
+    snapshot_profile = capabilities.get("repobrief_profile")
+    snapshot_profile_evaluation: dict[str, Any] | None = None
+    if not isinstance(snapshot_profile, str) or not snapshot_profile:
+        snapshot_profile = None
+        checks.append(_check("snapshot_profile_policy", STATUS_NA, "manifest carries no repobrief_profile label"))
+    elif snapshot_profile not in profile_names():
+        checks.append(_check("snapshot_profile_policy", STATUS_WARN, f"unknown snapshot profile label '{snapshot_profile}'"))
+        add(
+            "snapshot_profile_unknown",
+            SEVERITY_WARN,
+            "validation",
+            f"manifest labels an unknown RepoBrief snapshot profile '{snapshot_profile}'",
+        )
+    else:
+        snapshot_profile_evaluation = evaluate_profile(snapshot_profile, present_roles_from_manifest(manifest))
+        profile_status = snapshot_profile_evaluation["status"]
+        checks.append(
+            _check(
+                "snapshot_profile_policy",
+                profile_status if profile_status in {STATUS_PASS, STATUS_WARN, STATUS_FAIL} else STATUS_WARN,
+                f"snapshot profile '{snapshot_profile}' evaluated {profile_status}",
+            )
+        )
+        for role in snapshot_profile_evaluation["missing_required"]:
+            add(
+                "snapshot_profile_missing_required",
+                SEVERITY_FAIL,
+                "validation",
+                f"snapshot profile '{snapshot_profile}' requires artifact '{role}' but the manifest does not provide it",
+                artifact=role,
+            )
+        for role in snapshot_profile_evaluation["profile_excluded_present"]:
+            add(
+                "snapshot_profile_excluded_present",
+                SEVERITY_FAIL,
+                "validation",
+                f"snapshot profile '{snapshot_profile}' excludes artifact '{role}' but the manifest still lists it",
+                artifact=role,
+            )
+        for role in snapshot_profile_evaluation["missing_recommended"]:
+            add(
+                "snapshot_profile_missing_recommended",
+                SEVERITY_WARN,
+                "validation",
+                f"snapshot profile '{snapshot_profile}' recommends artifact '{role}' but the manifest does not provide it",
+                artifact=role,
+            )
+
+    # ── Degraded validation states (diagnostic layer, never hidden) ─────────
+    validation: dict[str, Any] = {}
+
+    post_path = linked_paths.get("post_emit_health")
+    post_doc: dict[str, Any] | None = None
+    post_error: str | None = None
+    if post_path is not None:
+        post_doc, post_error = _load_json_file(post_path)
+    skipped_checks: list[str] = []
+    if post_path is None:
+        validation["post_emit_health"] = {"present": False, "status": None, "skipped_checks": [], "path": None}
+        add(
+            "validation_unavailable",
+            SEVERITY_WARN,
+            "validation",
+            "no post-emit health sidecar is linked or discoverable; bundle validation state is unknown",
+            artifact="post_emit_health",
+        )
+    elif post_doc is None:
+        validation["post_emit_health"] = {"present": False, "status": None, "skipped_checks": [], "path": str(post_path)}
+        add(
+            "validation_unreadable",
+            SEVERITY_WARN,
+            "validation",
+            f"post-emit health sidecar cannot be read: {post_error}",
+            artifact="post_emit_health",
+        )
+    else:
+        post_status = post_doc.get("status")
+        for item in post_doc.get("checks") or []:
+            if isinstance(item, dict) and item.get("status") == "skipped" and isinstance(item.get("name"), str):
+                skipped_checks.append(item["name"])
+        skipped_checks.sort()
+        validation["post_emit_health"] = {
+            "present": True,
+            "status": post_status if isinstance(post_status, str) else None,
+            "skipped_checks": skipped_checks,
+            "path": str(post_path),
+        }
+        if post_status == STATUS_WARN:
+            add("validation_degraded", SEVERITY_WARN, "validation", "post-emit health reports status=warn", artifact="post_emit_health")
+        elif post_status in {STATUS_FAIL, "blocked"}:
+            add(
+                "validation_failed",
+                SEVERITY_FAIL,
+                "validation",
+                f"post-emit health reports status={post_status}",
+                artifact="post_emit_health",
+            )
+        elif post_status != STATUS_PASS:
+            add(
+                "validation_unreadable",
+                SEVERITY_WARN,
+                "validation",
+                f"post-emit health reports invalid status {post_status!r}",
+                artifact="post_emit_health",
+            )
+        if skipped_checks:
+            add(
+                "validation_checks_skipped",
+                SEVERITY_WARN,
+                "validation",
+                "post-emit health skipped checks: " + ", ".join(skipped_checks),
+                artifact="post_emit_health",
+            )
+
+    surface_status = links.get("bundle_surface_validation_status")
+    validation["bundle_surface_validation"] = {
+        "recorded_status": surface_status if isinstance(surface_status, str) else None,
+        "path": str(linked_paths["bundle_surface_validation"]) if linked_paths.get("bundle_surface_validation") else None,
+    }
+    if surface_status == STATUS_WARN:
+        add(
+            "validation_degraded",
+            SEVERITY_WARN,
+            "validation",
+            "bundle surface validation recorded status=warn",
+            artifact="bundle_surface_validation",
+        )
+    elif surface_status in {STATUS_FAIL, "blocked"}:
+        add(
+            "validation_failed",
+            SEVERITY_FAIL,
+            "validation",
+            f"bundle surface validation recorded status={surface_status}",
+            artifact="bundle_surface_validation",
+        )
+
+    output_health_verdict: str | None = None
+    output_health_records = records_by_role.get("output_health", [])
+    output_health_path = next(
+        (r.get("absolute_path") for r in output_health_records if r.get("file_exists") and r.get("absolute_path")),
+        None,
+    )
+    if output_health_path:
+        output_doc, output_error = _load_json_file(Path(output_health_path))
+        if output_doc is None:
+            add(
+                "validation_unreadable",
+                SEVERITY_WARN,
+                "validation",
+                f"output health artifact cannot be read: {output_error}",
+                artifact="output_health",
+            )
+        else:
+            verdict = output_doc.get("verdict")
+            output_health_verdict = verdict if isinstance(verdict, str) else None
+            if verdict == STATUS_WARN:
+                add("validation_degraded", SEVERITY_WARN, "validation", "output health verdict=warn", artifact="output_health")
+            elif verdict == STATUS_FAIL:
+                add("validation_failed", SEVERITY_FAIL, "validation", "output health verdict=fail", artifact="output_health")
+            elif verdict != STATUS_PASS:
+                add(
+                    "validation_unreadable",
+                    SEVERITY_WARN,
+                    "validation",
+                    f"output health verdict invalid: {verdict!r}",
+                    artifact="output_health",
+                )
+    validation["output_health"] = {"present": bool(output_health_path), "verdict": output_health_verdict}
+    validation["snapshot_profile_evaluation"] = snapshot_profile_evaluation
+
+    validation_findings = [f for f in findings if f.area == "validation" and f.code.startswith("validation")]
+    if any(f.severity == SEVERITY_FAIL for f in validation_findings):
+        validation_status = STATUS_FAIL
+    elif validation_findings:
+        validation_status = STATUS_WARN
+    else:
+        validation_status = STATUS_PASS
+    checks.append(
+        _check(
+            "validation_state",
+            validation_status,
+            "degraded validation findings: " + (", ".join(sorted({f.code for f in validation_findings})) if validation_findings else "none"),
+        )
+    )
+
+    # ── Freshness / provenance visibility ───────────────────────────────────
+    created_at_raw = manifest.get("created_at")
+    created_at = _parse_created_at(created_at_raw)
+    generator = manifest.get("generator") if isinstance(manifest.get("generator"), dict) else {}
+    runtime = generator.get("runtime") if isinstance(generator.get("runtime"), dict) else None
+    git_commit = runtime.get("git_commit") if isinstance(runtime, dict) else None
+
+    freshness: dict[str, Any] = {
+        "created_at": created_at_raw if isinstance(created_at_raw, str) else None,
+        "status": "recorded",
+        "age_seconds": None,
+        "max_age_seconds": preflight_input.max_age_seconds,
+        "as_of": None,
+        "generator_runtime_recorded": runtime is not None,
+        "generator_git_commit": git_commit if isinstance(git_commit, str) else None,
+    }
+    if created_at is None:
+        freshness["status"] = "unknown"
+        add(
+            "freshness_unknown",
+            SEVERITY_WARN,
+            "freshness",
+            "bundle manifest carries no parseable created_at; snapshot freshness is unknown",
+        )
+    elif preflight_input.max_age_seconds is not None:
+        as_of = preflight_input.as_of or now_utc()
+        if as_of.tzinfo is None:
+            as_of = as_of.replace(tzinfo=datetime.timezone.utc)
+        age = (as_of - created_at).total_seconds()
+        freshness["as_of"] = as_of.strftime("%Y-%m-%dT%H:%M:%SZ")
+        if age < 0:
+            freshness["status"] = "unknown"
+            add(
+                "freshness_unknown",
+                SEVERITY_WARN,
+                "freshness",
+                "bundle created_at is in the future relative to the as-of time; snapshot freshness is unknown",
+            )
+        else:
+            freshness["age_seconds"] = int(age)
+            if age > preflight_input.max_age_seconds:
+                freshness["status"] = "stale"
+                add(
+                    "snapshot_stale",
+                    SEVERITY_WARN,
+                    "freshness",
+                    f"snapshot age {int(age)}s exceeds max age {int(preflight_input.max_age_seconds)}s",
+                )
+            else:
+                freshness["status"] = "fresh"
+    if runtime is None:
+        freshness["status"] = "unknown"
+        add(
+            "generator_provenance_missing",
+            SEVERITY_WARN,
+            "freshness",
+            "bundle manifest records no generator runtime provenance; snapshot freshness is unknown",
+        )
+    elif not isinstance(git_commit, str) or not git_commit:
+        freshness["status"] = "unknown"
+        add(
+            "generator_git_commit_missing",
+            SEVERITY_WARN,
+            "freshness",
+            "bundle manifest records generator runtime provenance without a git_commit; snapshot freshness is unknown",
+        )
+    freshness_status = STATUS_WARN if freshness["status"] in {"unknown", "stale"} else STATUS_PASS
+    checks.append(_check("freshness", freshness_status, f"freshness {freshness['status']}"))
+
+    # ── Consumption declaration (negative semantics are mandatory) ──────────
+    declaration = preflight_input.declaration
+    used_citations_input = list(preflight_input.used_citations)
+    used_ranges_input = list(preflight_input.used_ranges)
+    if declaration is not None:
+        if isinstance(declaration.get("used_citations"), list):
+            used_citations_input.extend(declaration["used_citations"])
+        if isinstance(declaration.get("used_ranges"), list):
+            used_ranges_input.extend(declaration["used_ranges"])
+        boundaries = declaration.get("does_not_establish")
+        boundaries_ok = isinstance(boundaries, list) and len(boundaries) > 0 and all(
+            isinstance(item, str) and item for item in boundaries
+        )
+        if not boundaries_ok:
+            add(
+                "declaration_missing_negative_semantics",
+                SEVERITY_FAIL,
+                "declaration",
+                "consumption declaration must carry a non-empty does_not_establish list",
+            )
+        checks.append(
+            _check(
+                "does_not_establish",
+                STATUS_PASS if boundaries_ok else STATUS_FAIL,
+                "declaration carries negative semantics" if boundaries_ok else "declaration lacks does_not_establish boundaries",
+            )
+        )
+    else:
+        checks.append(_check("does_not_establish", STATUS_NA, "no consumption declaration provided"))
+    declaration_block = {
+        "provided": declaration is not None,
+        "does_not_establish_present": bool(declaration is not None and declaration.get("does_not_establish")),
+    }
+
+    # ── Used citations: resolve against the citation map ────────────────────
+    citation_ids, invalid_citations = _normalize_citation_ids(used_citations_input)
+    used_citations_block: dict[str, Any] = {
+        "declared": citation_ids,
+        "resolved": [],
+        "unresolved": [],
+        "invalid": invalid_citations,
+        "citation_map_available": "citation_map_jsonl" in available_roles,
+    }
+    if not citation_ids and not invalid_citations:
+        checks.append(_check("used_citations", STATUS_NA, "no used citations declared"))
+    else:
+        for entry in invalid_citations:
+            add(
+                "used_citation_invalid",
+                SEVERITY_FAIL,
+                "used_citations",
+                f"used citation entry is not a citation id or citation declaration: {entry}",
+            )
+        known_ids: set[str] | None = None
+        if "citation_map_jsonl" not in available_roles:
+            add(
+                "used_citations_unverifiable",
+                SEVERITY_FAIL,
+                "used_citations",
+                "used citations were declared but no citation_map_jsonl artifact is available to resolve them",
+                artifact="citation_map_jsonl",
+            )
+        else:
+            map_record = next(
+                (r for r in records_by_role.get("citation_map_jsonl", []) if r.get("file_exists") and r.get("absolute_path")),
+                None,
+            )
+            known_ids = set()
+            unparseable_lines = 0
+            try:
+                with Path(map_record["absolute_path"]).open("r", encoding="utf-8") as handle:
+                    for line in handle:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        try:
+                            entry = json.loads(line)
+                        except json.JSONDecodeError:
+                            unparseable_lines += 1
+                            continue
+                        if isinstance(entry, dict) and isinstance(entry.get("citation_id"), str):
+                            known_ids.add(entry["citation_id"])
+            except OSError as exc:
+                known_ids = None
+                add(
+                    "used_citations_unverifiable",
+                    SEVERITY_FAIL,
+                    "used_citations",
+                    f"citation map cannot be read: {exc}",
+                    artifact="citation_map_jsonl",
+                )
+            if unparseable_lines and known_ids is not None:
+                add(
+                    "citation_map_lines_unparseable",
+                    SEVERITY_WARN,
+                    "used_citations",
+                    f"citation map contains {unparseable_lines} unparseable line(s)",
+                    artifact="citation_map_jsonl",
+                )
+        if known_ids is not None:
+            for citation_id in citation_ids:
+                if citation_id in known_ids:
+                    used_citations_block["resolved"].append(citation_id)
+                else:
+                    used_citations_block["unresolved"].append(citation_id)
+                    add(
+                        "used_citation_unresolved",
+                        SEVERITY_FAIL,
+                        "used_citations",
+                        f"used citation '{citation_id}' does not resolve in the citation map",
+                    )
+        citation_fail = any(f.area == "used_citations" and f.severity == SEVERITY_FAIL for f in findings)
+        citation_warn = any(f.area == "used_citations" and f.severity == SEVERITY_WARN for f in findings)
+        checks.append(
+            _check(
+                "used_citations",
+                STATUS_FAIL if citation_fail else STATUS_WARN if citation_warn else STATUS_PASS,
+                f"declared={len(citation_ids)} resolved={len(used_citations_block['resolved'])} "
+                f"unresolved={len(used_citations_block['unresolved'])}",
+            )
+        )
+
+    # ── Used ranges: bind to available artifacts and line bounds ────────────
+    used_ranges_block: dict[str, Any] = {"declared": len(used_ranges_input), "resolved": [], "unresolved": []}
+    if not used_ranges_input:
+        checks.append(_check("used_ranges", STATUS_NA, "no used ranges declared"))
+    else:
+        line_counts: dict[str, int | None] = {}
+        for index, raw in enumerate(used_ranges_input):
+            label = f"used_ranges[{index}]"
+
+            def unresolved(detail: str, artifact: str | None = None) -> None:
+                used_ranges_block["unresolved"].append({"index": index, "detail": detail})
+                add("used_range_unresolved", SEVERITY_FAIL, "used_ranges", f"{label}: {detail}", artifact=artifact)
+
+            if not isinstance(raw, Mapping):
+                unresolved("range declaration must be an object with artifact and range_ref")
+                continue
+            role = raw.get("artifact")
+            range_ref = raw.get("range_ref")
+            if not isinstance(role, str) or not role:
+                unresolved("range declaration lacks an artifact role")
+                continue
+            if not isinstance(range_ref, Mapping):
+                unresolved(f"range declaration for '{role}' lacks a range_ref object", artifact=role)
+                continue
+            if role not in available_roles:
+                unresolved(f"artifact '{role}' is not available in the bundle", artifact=role)
+                continue
+            bounds = _line_bounds(range_ref)
+            if bounds is None:
+                unresolved(f"range_ref for '{role}' carries no integer line bounds", artifact=role)
+                continue
+            start_line, end_line, artifact_anchored = bounds
+            if start_line < 1 or end_line < start_line:
+                unresolved(f"range_ref for '{role}' has invalid line bounds {start_line}..{end_line}", artifact=role)
+                continue
+            resolution = "role_available_only"
+            if artifact_anchored:
+                if role not in line_counts:
+                    record = next(
+                        (r for r in records_by_role.get(role, []) if r.get("file_exists") and r.get("absolute_path")),
+                        None,
+                    )
+                    line_counts[role] = _count_lines(Path(record["absolute_path"])) if record else None
+                total_lines = line_counts[role]
+                if total_lines is None:
+                    unresolved(f"artifact '{role}' file cannot be read to verify line bounds", artifact=role)
+                    continue
+                if end_line > total_lines:
+                    unresolved(
+                        f"range {start_line}..{end_line} exceeds artifact '{role}' length of {total_lines} line(s)",
+                        artifact=role,
+                    )
+                    continue
+                resolution = "artifact_lines_verified"
+            used_ranges_block["resolved"].append(
+                {"index": index, "artifact": role, "start_line": start_line, "end_line": end_line, "resolution": resolution}
+            )
+        checks.append(
+            _check(
+                "used_ranges",
+                STATUS_FAIL if used_ranges_block["unresolved"] else STATUS_PASS,
+                f"declared={len(used_ranges_input)} resolved={len(used_ranges_block['resolved'])} "
+                f"unresolved={len(used_ranges_block['unresolved'])}",
+            )
+        )
+
+    # ── Aggregate: fail > not_applicable (unknown profile) > warn > pass ────
+    severity_order = {SEVERITY_FAIL: 0, SEVERITY_WARN: 1, SEVERITY_INFO: 2}
+    ordered_findings = tuple(
+        sorted(findings, key=lambda f: (severity_order[f.severity], f.code, f.artifact or "", f.detail))
+    )
+    if any(f.severity == SEVERITY_FAIL for f in ordered_findings):
+        overall = STATUS_FAIL
+    elif not task_profile_known:
+        overall = STATUS_NA
+    elif any(f.severity == SEVERITY_WARN for f in ordered_findings):
+        overall = STATUS_WARN
+    else:
+        overall = STATUS_PASS
+
+    check_order = {name: i for i, name in enumerate(
+        (
+            "task_profile",
+            "required_artifacts",
+            "recommended_artifacts",
+            "artifact_files",
+            "snapshot_profile_policy",
+            "validation_state",
+            "freshness",
+            "used_citations",
+            "used_ranges",
+            "does_not_establish",
+        )
+    )}
+    ordered_checks = tuple(sorted(checks, key=lambda c: check_order.get(c["name"], len(check_order))))
+
+    data: dict[str, Any] = {
+        "kind": KIND,
+        "version": VERSION,
+        "status": overall,
+        "bundle_manifest": str(manifest_path),
+        "bundle_run_id": status_report.get("bundle_run_id"),
+        "snapshot_profile": snapshot_profile,
+        "task_profile": preflight_input.task_profile,
+        "task_profile_known": task_profile_known,
+        "citation_required": required_reading["citation_required"],
+        "required_artifacts": required_roles,
+        "recommended_artifacts": recommended_roles,
+        "available_artifacts": sorted(available_roles),
+        "missing_required_artifacts": missing_required,
+        "missing_recommended_artifacts": missing_recommended,
+        "artifact_statuses": [s.to_dict() for s in artifact_statuses],
+        "evidence_layers": {layer: sorted(roles) for layer, roles in evidence_layers.items()},
+        "validation": validation,
+        "freshness": freshness,
+        "used_citations": used_citations_block,
+        "used_ranges": used_ranges_block,
+        "declaration": declaration_block,
+        "required_reading": required_reading,
+        "checks": list(ordered_checks),
+        "findings": [f.to_dict() for f in ordered_findings],
+        "finding_counts": {
+            SEVERITY_FAIL: sum(1 for f in ordered_findings if f.severity == SEVERITY_FAIL),
+            SEVERITY_WARN: sum(1 for f in ordered_findings if f.severity == SEVERITY_WARN),
+            SEVERITY_INFO: sum(1 for f in ordered_findings if f.severity == SEVERITY_INFO),
+        },
+        "mutation_boundary": json.loads(json.dumps(MUTATION_BOUNDARY)),
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }
+
+    return PreflightResult(
+        status=overall,
+        task_profile=preflight_input.task_profile,
+        bundle_manifest=str(manifest_path),
+        findings=ordered_findings,
+        artifacts=tuple(artifact_statuses),
+        checks=ordered_checks,
+        data=data,
+    )
+
+
+def run_consumption_preflight(
+    bundle_manifest: str | Path,
+    task_profile: str = "basic_repo_question",
+    *,
+    used_citations: Sequence[Any] = (),
+    used_ranges: Sequence[Any] = (),
+    declaration: Mapping[str, Any] | None = None,
+    max_age_seconds: float | None = None,
+    as_of: datetime.datetime | None = None,
+) -> dict[str, Any]:
+    """Dict-level convenience wrapper around :func:`consumption_preflight`."""
+    result = consumption_preflight(
+        PreflightInput(
+            bundle_manifest=bundle_manifest,
+            task_profile=task_profile,
+            used_citations=tuple(used_citations),
+            used_ranges=tuple(used_ranges),
+            declaration=declaration,
+            max_age_seconds=max_age_seconds,
+            as_of=as_of,
+        )
+    )
+    return result.to_dict()

--- a/merger/lenskit/core/repobrief_preflight.py
+++ b/merger/lenskit/core/repobrief_preflight.py
@@ -329,6 +329,29 @@ def consumption_preflight(preflight_input: PreflightInput) -> PreflightResult:
         if derived.exists():
             linked_paths["post_emit_health"] = derived
 
+    # Central role -> file map used by validation and range checks.
+    artifact_paths_by_role: dict[str, Path] = {"bundle_manifest": manifest_path}
+    for role, role_records in records_by_role.items():
+        for record in role_records:
+            candidate: Path | None = None
+            absolute_path = record.get("absolute_path")
+            if isinstance(absolute_path, str) and absolute_path:
+                candidate = Path(absolute_path)
+            else:
+                relative_path = record.get("path")
+                if isinstance(relative_path, str) and relative_path:
+                    try:
+                        candidate = resolve_secure_path(manifest_dir, relative_path)
+                    except ValueError:
+                        candidate = None
+            if candidate is not None:
+                artifact_paths_by_role.setdefault(role, candidate)
+                if candidate.exists():
+                    break
+    for role, path in linked_paths.items():
+        if path is not None:
+            artifact_paths_by_role[role] = path
+
     available_roles: set[str] = {"bundle_manifest"}
     file_missing_roles: set[str] = set()
     for role, role_records in records_by_role.items():
@@ -370,6 +393,13 @@ def consumption_preflight(preflight_input: PreflightInput) -> PreflightResult:
     recommended_roles = list(required_reading["recommended"])
     missing_required = list(required_reading["missing_required"])
     missing_recommended = list(required_reading["missing_recommended"])
+    required_role_set = set(required_roles)
+
+    def add_sidecar_read_failure(role: str, detail: str) -> None:
+        if role in required_role_set:
+            add("validation_required_sidecar_unreadable", SEVERITY_FAIL, "validation", detail, artifact=role)
+        else:
+            add("validation_unreadable", SEVERITY_WARN, "validation", detail, artifact=role)
 
     for role in missing_required:
         if role in file_missing_roles:
@@ -415,7 +445,7 @@ def consumption_preflight(preflight_input: PreflightInput) -> PreflightResult:
             artifact=role,
         )
     if file_missing_roles:
-        artifact_files_status = STATUS_FAIL if file_missing_roles & set(required_roles) else STATUS_WARN
+        artifact_files_status = STATUS_FAIL if file_missing_roles & required_role_set else STATUS_WARN
     else:
         artifact_files_status = STATUS_PASS
     checks.append(
@@ -447,6 +477,10 @@ def consumption_preflight(preflight_input: PreflightInput) -> PreflightResult:
         else:
             availability = AVAILABILITY_MISSING
         path_value = record.get("path")
+        if path_value is None:
+            mapped_path = artifact_paths_by_role.get(role)
+            if mapped_path is not None:
+                path_value = str(mapped_path)
         if path_value is None and linked is not None:
             path_value = str(linked)
         artifact_statuses.append(
@@ -539,12 +573,9 @@ def consumption_preflight(preflight_input: PreflightInput) -> PreflightResult:
         )
     elif post_doc is None:
         validation["post_emit_health"] = {"present": False, "status": None, "skipped_checks": [], "path": str(post_path)}
-        add(
-            "validation_unreadable",
-            SEVERITY_WARN,
-            "validation",
+        add_sidecar_read_failure(
+            "post_emit_health",
             f"post-emit health sidecar cannot be read: {post_error}",
-            artifact="post_emit_health",
         )
     else:
         post_status = post_doc.get("status")
@@ -587,27 +618,48 @@ def consumption_preflight(preflight_input: PreflightInput) -> PreflightResult:
 
     recorded_surface_status = links.get("bundle_surface_validation_status")
     surface_path = linked_paths.get("bundle_surface_validation")
+    surface_sidecar_status: str | None = None
     if surface_path is not None:
         surface_doc, surface_error = _load_json_file(surface_path)
         if surface_doc is None:
-            add("validation_unreadable", SEVERITY_WARN, "validation", f"bundle surface validation sidecar cannot be read: {surface_error}", artifact="bundle_surface_validation")
+            add_sidecar_read_failure(
+                "bundle_surface_validation",
+                f"bundle surface validation sidecar cannot be read: {surface_error}",
+            )
         elif isinstance(surface_doc.get("status"), str):
-            links = dict(links)
-            links["bundle_surface_validation_status"] = surface_doc["status"]
+            surface_sidecar_status = surface_doc["status"]
         else:
-            add("validation_unreadable", SEVERITY_WARN, "validation", "bundle surface validation sidecar carries no string status", artifact="bundle_surface_validation")
-    surface_status = links.get("bundle_surface_validation_status")
+            add_sidecar_read_failure(
+                "bundle_surface_validation",
+                "bundle surface validation sidecar carries no string status",
+            )
+    surface_status = surface_sidecar_status
+    if surface_status is None and isinstance(recorded_surface_status, str):
+        surface_status = recorded_surface_status
     validation["bundle_surface_validation"] = {
         "status": surface_status if isinstance(surface_status, str) else None,
         "recorded_status": recorded_surface_status if isinstance(recorded_surface_status, str) else None,
+        "sidecar_status": surface_sidecar_status,
         "path": str(linked_paths["bundle_surface_validation"]) if linked_paths.get("bundle_surface_validation") else None,
     }
+    if (
+        isinstance(recorded_surface_status, str)
+        and surface_sidecar_status is not None
+        and recorded_surface_status != surface_sidecar_status
+    ):
+        add(
+            "validation_surface_status_mismatch",
+            SEVERITY_WARN,
+            "validation",
+            f"bundle surface validation recorded status={recorded_surface_status} but sidecar status={surface_sidecar_status}",
+            artifact="bundle_surface_validation",
+        )
     if surface_status == STATUS_WARN:
         add(
             "validation_degraded",
             SEVERITY_WARN,
             "validation",
-            "bundle surface validation recorded status=warn",
+            "bundle surface validation status=warn",
             artifact="bundle_surface_validation",
         )
     elif surface_status in {STATUS_FAIL, "blocked"}:
@@ -615,7 +667,7 @@ def consumption_preflight(preflight_input: PreflightInput) -> PreflightResult:
             "validation_failed",
             SEVERITY_FAIL,
             "validation",
-            f"bundle surface validation recorded status={surface_status}",
+            f"bundle surface validation status={surface_status}",
             artifact="bundle_surface_validation",
         )
 
@@ -900,11 +952,8 @@ def consumption_preflight(preflight_input: PreflightInput) -> PreflightResult:
                 unresolved(f"range_ref for '{role}' has invalid line bounds {start_line}..{end_line}", artifact=role)
                 continue
             if role not in line_counts:
-                record = next(
-                    (r for r in records_by_role.get(role, []) if r.get("file_exists") and r.get("absolute_path")),
-                    None,
-                )
-                line_counts[role] = _count_lines(Path(record["absolute_path"])) if record else None
+                path = artifact_paths_by_role.get(role)
+                line_counts[role] = _count_lines(path) if path is not None else None
             total_lines = line_counts[role]
             if total_lines is None:
                 unresolved(f"artifact '{role}' file cannot be read to verify line bounds", artifact=role)

--- a/merger/lenskit/core/repobrief_preflight.py
+++ b/merger/lenskit/core/repobrief_preflight.py
@@ -139,6 +139,7 @@ class PreflightArtifactStatus:
     availability: str
     file_exists: bool
     path: str | None = None
+    resolved_path: str | None = None
     authority: str | None = None
     canonicality: str | None = None
 
@@ -149,6 +150,7 @@ class PreflightArtifactStatus:
             "availability": self.availability,
             "file_exists": self.file_exists,
             "path": self.path,
+            "resolved_path": self.resolved_path,
             "authority": self.authority,
             "canonicality": self.canonicality,
         }
@@ -209,8 +211,10 @@ def _read_json_object(path: Path, *, label: str) -> dict[str, Any]:
 
 
 def _load_json_file(path: Path) -> tuple[dict[str, Any] | None, str | None]:
-    if not path.exists() or not path.is_file():
+    if not path.exists():
         return None, "file not found"
+    if not path.is_file():
+        return None, "not a regular file"
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError, UnicodeError) as exc:
@@ -326,7 +330,7 @@ def consumption_preflight(preflight_input: PreflightInput) -> PreflightResult:
             linked_paths[role] = resolved
     if "post_emit_health" not in linked_paths:
         derived = derive_post_health_path(manifest_path)
-        if derived.exists():
+        if derived.is_file():
             linked_paths["post_emit_health"] = derived
 
     # Central role -> file map used by validation and range checks.
@@ -345,7 +349,7 @@ def consumption_preflight(preflight_input: PreflightInput) -> PreflightResult:
                     except ValueError:
                         candidate = None
             if candidate is not None:
-                if candidate.exists():
+                if candidate.is_file():
                     artifact_paths_by_role[role] = candidate
                     break
                 artifact_paths_by_role.setdefault(role, candidate)
@@ -356,14 +360,17 @@ def consumption_preflight(preflight_input: PreflightInput) -> PreflightResult:
     available_roles: set[str] = {"bundle_manifest"}
     file_missing_roles: set[str] = set()
     for role, role_records in records_by_role.items():
-        if any(record.get("file_exists") for record in role_records):
+        artifact_path = artifact_paths_by_role.get(role)
+        if any(record.get("file_exists") for record in role_records) and (
+            artifact_path is None or artifact_path.is_file()
+        ):
             available_roles.add(role)
         else:
             file_missing_roles.add(role)
     for role, path in linked_paths.items():
         if role in available_roles:
             continue
-        if path is not None and path.exists():
+        if path is not None and path.is_file():
             available_roles.add(role)
         elif role in _LINKED_SIDECAR_ROLES.values() and any(
             links.get(key) for key, mapped in _LINKED_SIDECAR_ROLES.items() if mapped == role
@@ -477,11 +484,9 @@ def consumption_preflight(preflight_input: PreflightInput) -> PreflightResult:
             availability = AVAILABILITY_FILE_MISSING
         else:
             availability = AVAILABILITY_MISSING
+        mapped_path = artifact_paths_by_role.get(role)
+        resolved_path_value = str(mapped_path) if mapped_path is not None else None
         path_value = record.get("path")
-        if path_value is None:
-            mapped_path = artifact_paths_by_role.get(role)
-            if mapped_path is not None:
-                path_value = str(mapped_path)
         if path_value is None and linked is not None:
             path_value = str(linked)
         artifact_statuses.append(
@@ -491,6 +496,7 @@ def consumption_preflight(preflight_input: PreflightInput) -> PreflightResult:
                 availability=availability,
                 file_exists=availability == AVAILABILITY_AVAILABLE,
                 path=path_value if isinstance(path_value, str) else None,
+                resolved_path=resolved_path_value,
                 authority=record.get("authority") if isinstance(record.get("authority"), str) else None,
                 canonicality=record.get("canonicality") if isinstance(record.get("canonicality"), str) else None,
             )
@@ -706,7 +712,7 @@ def consumption_preflight(preflight_input: PreflightInput) -> PreflightResult:
     validation["output_health"] = {"present": bool(output_health_path), "verdict": output_health_verdict}
     validation["snapshot_profile_evaluation"] = snapshot_profile_evaluation
 
-    validation_findings = [f for f in findings if f.area == "validation" and f.code.startswith("validation")]
+    validation_findings = [f for f in findings if f.area == "validation"]
     if any(f.severity == SEVERITY_FAIL for f in validation_findings):
         validation_status = STATUS_FAIL
     elif validation_findings:
@@ -800,21 +806,24 @@ def consumption_preflight(preflight_input: PreflightInput) -> PreflightResult:
         if isinstance(declaration.get("used_ranges"), list):
             used_ranges_input.extend(declaration["used_ranges"])
         boundaries = declaration.get("does_not_establish")
-        boundaries_ok = isinstance(boundaries, list) and len(boundaries) > 0 and all(
-            isinstance(item, str) and item for item in boundaries
-        )
+        required_boundaries = set(DOES_NOT_ESTABLISH)
+        if isinstance(boundaries, list):
+            provided_boundaries = {item for item in boundaries if isinstance(item, str) and item}
+        else:
+            provided_boundaries = set()
+        boundaries_ok = required_boundaries <= provided_boundaries
         if not boundaries_ok:
             add(
                 "declaration_missing_negative_semantics",
                 SEVERITY_FAIL,
                 "declaration",
-                "consumption declaration must carry a non-empty does_not_establish list",
+                "consumption declaration must include all required does_not_establish boundaries",
             )
         checks.append(
             _check(
                 "does_not_establish",
                 STATUS_PASS if boundaries_ok else STATUS_FAIL,
-                "declaration carries negative semantics" if boundaries_ok else "declaration lacks does_not_establish boundaries",
+                "declaration carries negative semantics" if boundaries_ok else "declaration lacks required does_not_establish boundaries",
             )
         )
     else:
@@ -853,19 +862,21 @@ def consumption_preflight(preflight_input: PreflightInput) -> PreflightResult:
                 artifact="citation_map_jsonl",
             )
         else:
-            map_record = next(
-                (r for r in records_by_role.get("citation_map_jsonl", []) if r.get("file_exists") and r.get("absolute_path")),
-                None,
-            )
             known_ids = set()
             unparseable_lines = 0
-            map_path = map_record.get("absolute_path") if isinstance(map_record, Mapping) else None
-            if not isinstance(map_path, str) or not map_path:
+            map_path = artifact_paths_by_role.get("citation_map_jsonl")
+            if map_path is None or not map_path.is_file():
                 known_ids = None
-                add("used_citations_unverifiable", SEVERITY_FAIL, "used_citations", "citation map is marked available but no readable absolute path was resolved", artifact="citation_map_jsonl")
+                add(
+                    "used_citations_unverifiable",
+                    SEVERITY_FAIL,
+                    "used_citations",
+                    "citation map is marked available but no readable file path was resolved",
+                    artifact="citation_map_jsonl",
+                )
             else:
                 try:
-                    with Path(map_path).open("r", encoding="utf-8") as handle:
+                    with map_path.open("r", encoding="utf-8") as handle:
                         for line in handle:
                             line = line.strip()
                             if not line:

--- a/merger/lenskit/core/repobrief_preflight.py
+++ b/merger/lenskit/core/repobrief_preflight.py
@@ -289,6 +289,34 @@ def _resolve_link_path(manifest_dir: Path, raw: Any) -> tuple[Path | None, str |
         return None, str(exc)
 
 
+def _post_emit_health_binding_error(
+    post_doc: Mapping[str, Any],
+    *,
+    manifest_path: Path,
+    manifest_run_id: Any,
+) -> str | None:
+    manifest_path_value = post_doc.get("bundle_manifest_path")
+    if not isinstance(manifest_path_value, str) or not manifest_path_value.strip():
+        return "post-emit health bundle_manifest_path is missing or empty"
+    try:
+        post_manifest_path = Path(manifest_path_value).expanduser().resolve()
+    except OSError as exc:
+        return f"post-emit health bundle_manifest_path cannot be resolved: {exc}"
+    if post_manifest_path != manifest_path:
+        return "post-emit health bundle_manifest_path does not match the evaluated manifest"
+
+    status = post_doc.get("status")
+    if status == STATUS_PASS:
+        if not isinstance(manifest_run_id, str) or not manifest_run_id.strip():
+            return "manifest run_id is missing or empty; cannot bind post-emit health"
+        post_bundle_run_id = post_doc.get("bundle_run_id")
+        if not isinstance(post_bundle_run_id, str) or not post_bundle_run_id.strip():
+            return "post-emit health bundle_run_id is missing or empty"
+        if post_bundle_run_id != manifest_run_id:
+            return "post-emit health bundle_run_id does not match manifest run_id"
+    return None
+
+
 def consumption_preflight(preflight_input: PreflightInput) -> PreflightResult:
     """Run the RepoBrief agent consumption preflight for one bundle manifest.
 
@@ -298,6 +326,7 @@ def consumption_preflight(preflight_input: PreflightInput) -> PreflightResult:
     manifest_path = Path(preflight_input.bundle_manifest).expanduser().resolve()
     manifest = _read_json_object(manifest_path, label="bundle manifest")
     manifest_dir = manifest_path.parent
+    manifest_run_id = manifest.get("run_id")
     status_report = snapshot_status(manifest_path)
     records = [a for a in status_report["artifacts"] if isinstance(a, dict)]
 
@@ -590,12 +619,21 @@ def consumption_preflight(preflight_input: PreflightInput) -> PreflightResult:
             if isinstance(item, dict) and item.get("status") == "skipped" and isinstance(item.get("name"), str):
                 skipped_checks.append(item["name"])
         skipped_checks.sort()
+        post_binding_error = _post_emit_health_binding_error(
+            post_doc,
+            manifest_path=manifest_path,
+            manifest_run_id=manifest_run_id,
+        )
         validation["post_emit_health"] = {
             "present": True,
             "status": post_status if isinstance(post_status, str) else None,
             "skipped_checks": skipped_checks,
             "path": str(post_path),
+            "binding_status": "fail" if post_binding_error else "pass",
+            "binding_error": post_binding_error,
         }
+        if post_binding_error is not None:
+            add_sidecar_read_failure("post_emit_health", post_binding_error)
         if post_status == STATUS_WARN:
             add("validation_degraded", SEVERITY_WARN, "validation", "post-emit health reports status=warn", artifact="post_emit_health")
         elif post_status in {STATUS_FAIL, "blocked"}:

--- a/merger/lenskit/tests/test_repobrief_preflight.py
+++ b/merger/lenskit/tests/test_repobrief_preflight.py
@@ -37,14 +37,13 @@ def _bundle(tmp_path: Path, roles, *, generator=True, post=True, capabilities=No
             encoding='utf-8',
         )
     elif isinstance(post, dict):
-        if post.get('status') == 'pass':
-            post = {
-                'kind': 'lenskit.post_emit_health',
-                'version': '1.0',
-                'bundle_manifest_path': str(manifest.resolve()),
-                'bundle_run_id': data['run_id'],
-                **post,
-            }
+        post = {
+            'kind': 'lenskit.post_emit_health',
+            'version': '1.0',
+            'bundle_manifest_path': str(manifest.resolve()),
+            'bundle_run_id': data['run_id'],
+            **post,
+        }
         (tmp_path / 'sample.bundle_health.post.json').write_text(json.dumps(post), encoding='utf-8')
     return manifest
 
@@ -436,6 +435,45 @@ def _write_bound_post_health(manifest: Path, *, status='pass', bundle_run_id='ru
         encoding='utf-8',
     )
 
+
+
+def test_post_emit_health_must_have_expected_kind(tmp_path):
+    manifest = _bundle(tmp_path, FULL_BASIC, post={'kind': 'not.post.emit.health', 'status': 'pass'})
+
+    result = run_consumption_preflight(manifest, 'pr_review')
+
+    assert result['status'] == 'fail'
+    assert result['validation']['post_emit_health']['binding_status'] == 'fail'
+    assert any(
+        f['artifact'] == 'post_emit_health' and 'kind mismatch' in f['detail']
+        for f in result['findings']
+    )
+
+
+def test_post_emit_health_must_have_expected_version(tmp_path):
+    manifest = _bundle(tmp_path, FULL_BASIC, post={'version': '2.0', 'status': 'pass'})
+
+    result = run_consumption_preflight(manifest, 'pr_review')
+
+    assert result['status'] == 'fail'
+    assert result['validation']['post_emit_health']['binding_status'] == 'fail'
+    assert any(
+        f['artifact'] == 'post_emit_health' and 'version mismatch' in f['detail']
+        for f in result['findings']
+    )
+
+
+def test_post_emit_health_rejects_invalid_status(tmp_path):
+    manifest = _bundle(tmp_path, FULL_BASIC, post={'status': 'degraded'})
+
+    result = run_consumption_preflight(manifest, 'pr_review')
+
+    assert result['status'] == 'fail'
+    assert result['validation']['post_emit_health']['binding_status'] == 'fail'
+    assert any(
+        f['artifact'] == 'post_emit_health' and 'invalid status' in f['detail']
+        for f in result['findings']
+    )
 
 def test_post_emit_health_must_bind_to_manifest_path(tmp_path):
     manifest = _bundle(tmp_path, FULL_BASIC)

--- a/merger/lenskit/tests/test_repobrief_preflight.py
+++ b/merger/lenskit/tests/test_repobrief_preflight.py
@@ -1,0 +1,149 @@
+import json
+from pathlib import Path
+
+from merger.lenskit.core.repobrief_preflight import run_consumption_preflight
+
+
+def _artifact(root: Path, role: str, text: str = 'x\n') -> dict:
+    path = root / f'{role}.txt'
+    path.write_text(text, encoding='utf-8')
+    return {'role': role, 'path': path.name, 'content_type': 'text/plain', 'bytes': path.stat().st_size, 'sha256': '0' * 64}
+
+
+def _bundle(tmp_path: Path, roles, *, generator=True, post=True, capabilities=None):
+    artifacts = [_artifact(tmp_path, role) for role in roles]
+    data = {'kind': 'repobrief.bundle_manifest', 'created_at': '2026-07-04T06:00:00Z', 'artifacts': artifacts}
+    if generator:
+        data['generator'] = {'runtime': {'git_commit': 'a' * 40}}
+    if capabilities:
+        data['capabilities'] = capabilities
+    manifest = tmp_path / 'sample.bundle.manifest.json'
+    manifest.write_text(json.dumps(data), encoding='utf-8')
+    if post is True:
+        (tmp_path / 'sample.bundle_health.post.json').write_text(json.dumps({'status': 'pass', 'checks': []}), encoding='utf-8')
+    elif isinstance(post, dict):
+        (tmp_path / 'sample.bundle_health.post.json').write_text(json.dumps(post), encoding='utf-8')
+    return manifest
+
+
+FULL_BASIC = ['agent_reading_pack', 'canonical_md', 'citation_map_jsonl', 'snapshot_plan_json']
+
+
+def test_full_basic_bundle_passes(tmp_path):
+    result = run_consumption_preflight(_bundle(tmp_path, FULL_BASIC), 'basic_repo_question')
+    assert result['status'] == 'pass'
+    assert result['missing_required_artifacts'] == []
+
+
+def test_missing_required_fails(tmp_path):
+    result = run_consumption_preflight(_bundle(tmp_path, ['agent_reading_pack', 'citation_map_jsonl', 'snapshot_plan_json']), 'basic_repo_question')
+    assert result['status'] == 'fail'
+    assert 'canonical_md' in result['missing_required_artifacts']
+
+
+def test_missing_recommended_warns(tmp_path):
+    result = run_consumption_preflight(_bundle(tmp_path, ['agent_reading_pack', 'canonical_md']), 'basic_repo_question')
+    assert result['status'] == 'warn'
+    assert 'citation_map_jsonl' in result['missing_recommended_artifacts']
+
+
+def test_skipped_validation_is_visible(tmp_path):
+    manifest = _bundle(tmp_path, FULL_BASIC, post={'status': 'pass', 'checks': [{'name': 'range_refs', 'status': 'skipped'}]})
+    result = run_consumption_preflight(manifest, 'basic_repo_question')
+    assert result['status'] == 'warn'
+    assert any(f['code'] == 'validation_checks_skipped' for f in result['findings'])
+
+
+def test_missing_provenance_is_visible(tmp_path):
+    result = run_consumption_preflight(_bundle(tmp_path, FULL_BASIC, generator=False), 'basic_repo_question')
+    assert result['status'] == 'warn'
+    assert result['freshness']['status'] == 'unknown'
+    assert any(f['code'] == 'generator_provenance_missing' and f['severity'] == 'warn' for f in result['findings'])
+
+
+def test_missing_git_commit_marks_freshness_unknown(tmp_path):
+    manifest = _bundle(tmp_path, FULL_BASIC)
+    data = json.loads(manifest.read_text(encoding='utf-8'))
+    data['generator'] = {'runtime': {}}
+    manifest.write_text(json.dumps(data), encoding='utf-8')
+    result = run_consumption_preflight(manifest, 'basic_repo_question')
+    assert result['status'] == 'warn'
+    assert result['freshness']['status'] == 'unknown'
+    assert any(f['code'] == 'generator_git_commit_missing' for f in result['findings'])
+
+
+def test_missing_negative_semantics_fails(tmp_path):
+    result = run_consumption_preflight(_bundle(tmp_path, FULL_BASIC), 'basic_repo_question', declaration={'does_not_establish': []})
+    assert result['status'] == 'fail'
+    assert any(f['code'] == 'declaration_missing_negative_semantics' for f in result['findings'])
+
+
+def test_unknown_task_profile_is_not_applicable(tmp_path):
+    result = run_consumption_preflight(_bundle(tmp_path, FULL_BASIC), 'no_such_profile')
+    assert result['status'] == 'not_applicable'
+
+
+def test_pr_delta_not_required_for_basic_profile(tmp_path):
+    result = run_consumption_preflight(_bundle(tmp_path, FULL_BASIC + ['pr_delta_cards_jsonl']), 'basic_repo_question')
+    assert result['status'] == 'pass'
+    assert 'pr_delta_cards_jsonl' not in result['missing_required_artifacts']
+
+
+def test_security_profile_without_export_safety_fails(tmp_path):
+    manifest = _bundle(tmp_path, ['agent_reading_pack', 'canonical_md', 'post_emit_health'], capabilities={'repobrief_profile': 'security-export-review'})
+    result = run_consumption_preflight(manifest, 'security_export_review')
+    assert result['status'] == 'fail'
+    assert 'export_safety_report' in result['missing_required_artifacts']
+
+
+def test_unresolved_citation_fails(tmp_path):
+    manifest = _bundle(tmp_path, FULL_BASIC)
+    (tmp_path / 'citation_map_jsonl.txt').write_text('{"citation_id":"known"}\n', encoding='utf-8')
+    result = run_consumption_preflight(manifest, 'basic_repo_question', used_citations=['missing'])
+    assert result['status'] == 'fail'
+    assert any(f['code'] == 'used_citation_unresolved' for f in result['findings'])
+
+
+def test_unresolved_range_fails(tmp_path):
+    result = run_consumption_preflight(
+        _bundle(tmp_path, FULL_BASIC),
+        'basic_repo_question',
+        used_ranges=[{'artifact': 'canonical_md', 'range_ref': {'artifact_line_start': 1, 'artifact_line_end': 3}}],
+    )
+    assert result['status'] == 'fail'
+    assert any(f['code'] == 'used_range_unresolved' for f in result['findings'])
+
+
+def test_preflight_cli_missing_manifest_returns_usage_error(tmp_path, capsys):
+    from merger.lenskit.cli.main import main
+
+    rc = main([
+        'repobrief',
+        'preflight',
+        '--bundle-manifest',
+        str(tmp_path / 'missing.bundle.manifest.json'),
+    ])
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert 'repobrief preflight: bundle manifest does not exist' in captured.err
+    assert 'Traceback' not in captured.err
+
+
+def test_preflight_cli_invalid_manifest_json_returns_usage_error(tmp_path, capsys):
+    from merger.lenskit.cli.main import main
+
+    manifest = tmp_path / 'bad.bundle.manifest.json'
+    manifest.write_text('{bad json', encoding='utf-8')
+
+    rc = main([
+        'repobrief',
+        'preflight',
+        '--bundle-manifest',
+        str(manifest),
+    ])
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert 'repobrief preflight: bundle manifest is not valid JSON' in captured.err
+    assert 'Traceback' not in captured.err

--- a/merger/lenskit/tests/test_repobrief_preflight.py
+++ b/merger/lenskit/tests/test_repobrief_preflight.py
@@ -319,3 +319,82 @@ def test_used_range_prefers_existing_duplicate_role_path(tmp_path):
     assert result['status'] == 'pass'
     assert result['used_ranges']['resolved'][0]['artifact'] == 'canonical_md'
 
+
+def test_snapshot_profile_fail_counts_in_validation_state(tmp_path):
+    manifest = _bundle(
+        tmp_path,
+        FULL_BASIC,
+        capabilities={'repobrief_profile': 'security-export-review'},
+    )
+
+    result = run_consumption_preflight(manifest, 'basic_repo_question')
+
+    validation_check = next(c for c in result['checks'] if c['name'] == 'validation_state')
+    assert validation_check['status'] == 'fail'
+    assert any(f['code'] == 'snapshot_profile_missing_required' for f in result['findings'])
+
+
+def test_declaration_must_include_required_negative_semantics(tmp_path):
+    result = run_consumption_preflight(
+        _bundle(tmp_path, FULL_BASIC),
+        'basic_repo_question',
+        declaration={'does_not_establish': ['irgendwas']},
+    )
+
+    assert result['status'] == 'fail'
+    assert any(f['code'] == 'declaration_missing_negative_semantics' for f in result['findings'])
+
+
+def test_artifact_status_exposes_resolved_duplicate_role_path(tmp_path):
+    existing = tmp_path / 'canonical_existing.txt'
+    existing.write_text('ok\n', encoding='utf-8')
+
+    manifest = _bundle(tmp_path, ['agent_reading_pack', 'citation_map_jsonl', 'snapshot_plan_json'])
+    data = json.loads(manifest.read_text(encoding='utf-8'))
+    data['artifacts'].append({
+        'role': 'canonical_md',
+        'path': 'canonical_missing.txt',
+        'content_type': 'text/plain',
+        'bytes': 1,
+        'sha256': '0' * 64,
+    })
+    data['artifacts'].append({
+        'role': 'canonical_md',
+        'path': existing.name,
+        'content_type': 'text/plain',
+        'bytes': existing.stat().st_size,
+        'sha256': '1' * 64,
+    })
+    manifest.write_text(json.dumps(data), encoding='utf-8')
+
+    result = run_consumption_preflight(
+        manifest,
+        'basic_repo_question',
+        used_ranges=[{'artifact': 'canonical_md', 'range_ref': {'start_line': 1, 'end_line': 1}}],
+    )
+
+    status = next(s for s in result['artifact_statuses'] if s['role'] == 'canonical_md')
+    assert result['status'] == 'pass'
+    assert status['path'] == 'canonical_missing.txt'
+    assert status['resolved_path'].endswith('canonical_existing.txt')
+
+
+def test_linked_directory_sidecar_is_not_available(tmp_path):
+    manifest = _bundle(tmp_path, FULL_BASIC)
+    surface = tmp_path / 'surface.json'
+    surface.mkdir()
+    data = json.loads(manifest.read_text(encoding='utf-8'))
+    data['links'] = {'bundle_surface_validation_path': surface.name}
+    manifest.write_text(json.dumps(data), encoding='utf-8')
+
+    result = run_consumption_preflight(manifest, 'basic_repo_question')
+
+    status = next(s for s in result['artifact_statuses'] if s['role'] == 'bundle_surface_validation')
+    assert result['status'] == 'warn'
+    assert status['availability'] == 'file_missing'
+    assert status['file_exists'] is False
+    assert any(
+        f['artifact'] == 'bundle_surface_validation' and 'not a regular file' in f['detail']
+        for f in result['findings']
+    )
+

--- a/merger/lenskit/tests/test_repobrief_preflight.py
+++ b/merger/lenskit/tests/test_repobrief_preflight.py
@@ -12,7 +12,12 @@ def _artifact(root: Path, role: str, text: str = 'x\n') -> dict:
 
 def _bundle(tmp_path: Path, roles, *, generator=True, post=True, capabilities=None):
     artifacts = [_artifact(tmp_path, role) for role in roles]
-    data = {'kind': 'repobrief.bundle_manifest', 'created_at': '2026-07-04T06:00:00Z', 'artifacts': artifacts}
+    data = {
+        'kind': 'repobrief.bundle_manifest',
+        'run_id': 'run-1',
+        'created_at': '2026-07-04T06:00:00Z',
+        'artifacts': artifacts,
+    }
     if generator:
         data['generator'] = {'runtime': {'git_commit': 'a' * 40}}
     if capabilities:
@@ -20,8 +25,26 @@ def _bundle(tmp_path: Path, roles, *, generator=True, post=True, capabilities=No
     manifest = tmp_path / 'sample.bundle.manifest.json'
     manifest.write_text(json.dumps(data), encoding='utf-8')
     if post is True:
-        (tmp_path / 'sample.bundle_health.post.json').write_text(json.dumps({'status': 'pass', 'checks': []}), encoding='utf-8')
+        (tmp_path / 'sample.bundle_health.post.json').write_text(
+            json.dumps({
+                'kind': 'lenskit.post_emit_health',
+                'version': '1.0',
+                'bundle_manifest_path': str(manifest.resolve()),
+                'bundle_run_id': 'run-1',
+                'status': 'pass',
+                'checks': [],
+            }),
+            encoding='utf-8',
+        )
     elif isinstance(post, dict):
+        if post.get('status') == 'pass':
+            post = {
+                'kind': 'lenskit.post_emit_health',
+                'version': '1.0',
+                'bundle_manifest_path': str(manifest.resolve()),
+                'bundle_run_id': data['run_id'],
+                **post,
+            }
         (tmp_path / 'sample.bundle_health.post.json').write_text(json.dumps(post), encoding='utf-8')
     return manifest
 
@@ -395,6 +418,76 @@ def test_linked_directory_sidecar_is_not_available(tmp_path):
     assert status['file_exists'] is False
     assert any(
         f['artifact'] == 'bundle_surface_validation' and 'not a regular file' in f['detail']
+        for f in result['findings']
+    )
+
+
+def _write_bound_post_health(manifest: Path, *, status='pass', bundle_run_id='run-1', manifest_path=None):
+    target_manifest = manifest if manifest_path is None else manifest_path
+    (manifest.parent / 'sample.bundle_health.post.json').write_text(
+        json.dumps({
+            'kind': 'lenskit.post_emit_health',
+            'version': '1.0',
+            'bundle_manifest_path': str(target_manifest.resolve()),
+            'bundle_run_id': bundle_run_id,
+            'status': status,
+            'checks': [],
+        }),
+        encoding='utf-8',
+    )
+
+
+def test_post_emit_health_must_bind_to_manifest_path(tmp_path):
+    manifest = _bundle(tmp_path, FULL_BASIC)
+    data = json.loads(manifest.read_text(encoding='utf-8'))
+    data['run_id'] = 'run-1'
+    manifest.write_text(json.dumps(data), encoding='utf-8')
+    other_manifest = tmp_path / 'other.bundle.manifest.json'
+    other_manifest.write_text(json.dumps({'kind': 'repobrief.bundle_manifest', 'run_id': 'other'}), encoding='utf-8')
+    _write_bound_post_health(manifest, manifest_path=other_manifest)
+
+    result = run_consumption_preflight(manifest, 'pr_review')
+
+    assert result['status'] == 'fail'
+    assert result['validation']['post_emit_health']['binding_status'] == 'fail'
+    assert any(
+        f['code'] == 'validation_required_sidecar_unreadable'
+        and f['artifact'] == 'post_emit_health'
+        and 'bundle_manifest_path does not match' in f['detail']
+        for f in result['findings']
+    )
+
+
+def test_post_emit_health_pass_must_bind_to_manifest_run_id(tmp_path):
+    manifest = _bundle(tmp_path, FULL_BASIC)
+    data = json.loads(manifest.read_text(encoding='utf-8'))
+    data['run_id'] = 'run-1'
+    manifest.write_text(json.dumps(data), encoding='utf-8')
+    _write_bound_post_health(manifest, bundle_run_id='other-run')
+
+    result = run_consumption_preflight(manifest, 'pr_review')
+
+    assert result['status'] == 'fail'
+    assert result['validation']['post_emit_health']['binding_status'] == 'fail'
+    assert any(
+        f['artifact'] == 'post_emit_health'
+        and 'bundle_run_id does not match' in f['detail']
+        for f in result['findings']
+    )
+
+
+def test_post_emit_health_valid_binding_passes(tmp_path):
+    manifest = _bundle(tmp_path, FULL_BASIC)
+    data = json.loads(manifest.read_text(encoding='utf-8'))
+    data['run_id'] = 'run-1'
+    manifest.write_text(json.dumps(data), encoding='utf-8')
+    _write_bound_post_health(manifest, bundle_run_id='run-1')
+
+    result = run_consumption_preflight(manifest, 'pr_review')
+
+    assert result['validation']['post_emit_health']['binding_status'] == 'pass'
+    assert not any(
+        f['artifact'] == 'post_emit_health' and 'does not match' in f['detail']
         for f in result['findings']
     )
 

--- a/merger/lenskit/tests/test_repobrief_preflight.py
+++ b/merger/lenskit/tests/test_repobrief_preflight.py
@@ -208,3 +208,82 @@ def test_preflight_cli_valid_manifest_prints_preflight_json(tmp_path, capsys):
     assert emitted['kind'] == 'repobrief.consumption_preflight'
     assert emitted['status'] == 'pass'
     assert emitted['mutation_boundary']['writes'] == []
+
+
+def test_required_linked_surface_sidecar_unreadable_fails(tmp_path):
+    manifest = _bundle(tmp_path, FULL_BASIC)
+    surface = tmp_path / 'surface.json'
+    surface.mkdir()
+    data = json.loads(manifest.read_text(encoding='utf-8'))
+    data['links'] = {'bundle_surface_validation_path': surface.name}
+    manifest.write_text(json.dumps(data), encoding='utf-8')
+
+    result = run_consumption_preflight(manifest, 'artifact_surface_review')
+
+    assert result['status'] == 'fail'
+    assert any(
+        f['code'] == 'validation_required_sidecar_unreadable'
+        and f['artifact'] == 'bundle_surface_validation'
+        and f['severity'] == 'fail'
+        for f in result['findings']
+    )
+
+
+def test_bundle_surface_recorded_status_mismatch_warns(tmp_path):
+    manifest = _bundle(tmp_path, FULL_BASIC)
+    surface = tmp_path / 'surface.json'
+    surface.write_text(json.dumps({'status': 'pass'}), encoding='utf-8')
+    data = json.loads(manifest.read_text(encoding='utf-8'))
+    data['links'] = {
+        'bundle_surface_validation_path': surface.name,
+        'bundle_surface_validation_status': 'warn',
+    }
+    manifest.write_text(json.dumps(data), encoding='utf-8')
+
+    result = run_consumption_preflight(manifest, 'basic_repo_question')
+
+    assert result['status'] == 'warn'
+    assert result['validation']['bundle_surface_validation']['recorded_status'] == 'warn'
+    assert result['validation']['bundle_surface_validation']['sidecar_status'] == 'pass'
+    assert any(f['code'] == 'validation_surface_status_mismatch' for f in result['findings'])
+
+
+def test_used_range_resolves_bundle_manifest_lines(tmp_path):
+    result = run_consumption_preflight(
+        _bundle(tmp_path, FULL_BASIC),
+        'basic_repo_question',
+        used_ranges=[{'artifact': 'bundle_manifest', 'range_ref': {'start_line': 1, 'end_line': 1}}],
+    )
+
+    assert result['status'] == 'pass'
+    assert result['used_ranges']['resolved'][0]['artifact'] == 'bundle_manifest'
+
+
+def test_used_range_resolves_linked_post_emit_health_lines(tmp_path):
+    result = run_consumption_preflight(
+        _bundle(tmp_path, FULL_BASIC),
+        'basic_repo_question',
+        used_ranges=[{'artifact': 'post_emit_health', 'range_ref': {'start_line': 1, 'end_line': 1}}],
+    )
+
+    assert result['status'] == 'pass'
+    assert result['used_ranges']['resolved'][0]['artifact'] == 'post_emit_health'
+
+
+def test_used_range_resolves_bundle_surface_validation_lines(tmp_path):
+    manifest = _bundle(tmp_path, FULL_BASIC)
+    surface = tmp_path / 'surface.json'
+    surface.write_text(json.dumps({'status': 'pass'}), encoding='utf-8')
+    data = json.loads(manifest.read_text(encoding='utf-8'))
+    data['links'] = {'bundle_surface_validation_path': surface.name}
+    manifest.write_text(json.dumps(data), encoding='utf-8')
+
+    result = run_consumption_preflight(
+        manifest,
+        'basic_repo_question',
+        used_ranges=[{'artifact': 'bundle_surface_validation', 'range_ref': {'start_line': 1, 'end_line': 1}}],
+    )
+
+    assert result['status'] == 'pass'
+    assert result['used_ranges']['resolved'][0]['artifact'] == 'bundle_surface_validation'
+

--- a/merger/lenskit/tests/test_repobrief_preflight.py
+++ b/merger/lenskit/tests/test_repobrief_preflight.py
@@ -287,3 +287,35 @@ def test_used_range_resolves_bundle_surface_validation_lines(tmp_path):
     assert result['status'] == 'pass'
     assert result['used_ranges']['resolved'][0]['artifact'] == 'bundle_surface_validation'
 
+
+def test_used_range_prefers_existing_duplicate_role_path(tmp_path):
+    existing = tmp_path / 'canonical_existing.txt'
+    existing.write_text('ok\n', encoding='utf-8')
+
+    manifest = _bundle(tmp_path, ['agent_reading_pack', 'citation_map_jsonl', 'snapshot_plan_json'])
+    data = json.loads(manifest.read_text(encoding='utf-8'))
+    data['artifacts'].append({
+        'role': 'canonical_md',
+        'path': 'canonical_missing.txt',
+        'content_type': 'text/plain',
+        'bytes': 1,
+        'sha256': '0' * 64,
+    })
+    data['artifacts'].append({
+        'role': 'canonical_md',
+        'path': existing.name,
+        'content_type': 'text/plain',
+        'bytes': existing.stat().st_size,
+        'sha256': '1' * 64,
+    })
+    manifest.write_text(json.dumps(data), encoding='utf-8')
+
+    result = run_consumption_preflight(
+        manifest,
+        'basic_repo_question',
+        used_ranges=[{'artifact': 'canonical_md', 'range_ref': {'start_line': 1, 'end_line': 1}}],
+    )
+
+    assert result['status'] == 'pass'
+    assert result['used_ranges']['resolved'][0]['artifact'] == 'canonical_md'
+

--- a/merger/lenskit/tests/test_repobrief_preflight.py
+++ b/merger/lenskit/tests/test_repobrief_preflight.py
@@ -147,3 +147,64 @@ def test_preflight_cli_invalid_manifest_json_returns_usage_error(tmp_path, capsy
     assert rc == 2
     assert 'repobrief preflight: bundle manifest is not valid JSON' in captured.err
     assert 'Traceback' not in captured.err
+
+
+def test_start_end_line_range_exceeding_artifact_length_fails(tmp_path):
+    result = run_consumption_preflight(
+        _bundle(tmp_path, FULL_BASIC),
+        'basic_repo_question',
+        used_ranges=[{'artifact': 'canonical_md', 'range_ref': {'start_line': 1, 'end_line': 3}}],
+    )
+    assert result['status'] == 'fail'
+    assert any(f['code'] == 'used_range_unresolved' for f in result['findings'])
+
+
+def test_start_end_line_range_within_artifact_length_passes(tmp_path):
+    result = run_consumption_preflight(
+        _bundle(tmp_path, FULL_BASIC, post=True),
+        'basic_repo_question',
+        used_ranges=[{'artifact': 'canonical_md', 'range_ref': {'start_line': 1, 'end_line': 1}}],
+    )
+    assert result['status'] == 'pass'
+    assert result['used_ranges']['resolved'][0]['resolution'] == 'artifact_lines_verified'
+
+
+def test_bundle_surface_sidecar_fail_fails_even_without_recorded_manifest_status(tmp_path):
+    manifest = _bundle(tmp_path, FULL_BASIC)
+    surface = tmp_path / 'surface.json'
+    surface.write_text(json.dumps({'status': 'fail'}), encoding='utf-8')
+    data = json.loads(manifest.read_text(encoding='utf-8'))
+    data['links'] = {'bundle_surface_validation_path': surface.name}
+    manifest.write_text(json.dumps(data), encoding='utf-8')
+
+    result = run_consumption_preflight(manifest, 'basic_repo_question')
+
+    assert result['status'] == 'fail'
+    assert any(f['artifact'] == 'bundle_surface_validation' and f['severity'] == 'fail' for f in result['findings'])
+
+
+def test_bundle_surface_sidecar_warn_warns(tmp_path):
+    manifest = _bundle(tmp_path, FULL_BASIC)
+    surface = tmp_path / 'surface.json'
+    surface.write_text(json.dumps({'status': 'warn'}), encoding='utf-8')
+    data = json.loads(manifest.read_text(encoding='utf-8'))
+    data['links'] = {'bundle_surface_validation_path': surface.name}
+    manifest.write_text(json.dumps(data), encoding='utf-8')
+
+    result = run_consumption_preflight(manifest, 'basic_repo_question')
+
+    assert result['status'] == 'warn'
+    assert any(f['artifact'] == 'bundle_surface_validation' and f['severity'] == 'warn' for f in result['findings'])
+
+
+def test_preflight_cli_valid_manifest_prints_preflight_json(tmp_path, capsys):
+    from merger.lenskit.cli.main import main
+
+    rc = main(['repobrief', 'preflight', '--bundle-manifest', str(_bundle(tmp_path, FULL_BASIC))])
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    emitted = json.loads(captured.out)
+    assert emitted['kind'] == 'repobrief.consumption_preflight'
+    assert emitted['status'] == 'pass'
+    assert emitted['mutation_boundary']['writes'] == []


### PR DESCRIPTION
## Summary

Adds a read-only RepoBrief agent consumption preflight for existing Brief Bundles.

The preflight reports whether a consuming agent has enough declared bundle evidence for a task profile and surfaces missing required/recommended artifacts, degraded validation, freshness/provenance gaps, declared citation/range resolution, and negative semantics boundaries.

## Scope

- New core module: `merger/lenskit/core/repobrief_preflight.py`
- Minimal CLI entry: `repobrief preflight --bundle-manifest ... [--task-profile ...]`
- Focused tests: `merger/lenskit/tests/test_repobrief_preflight.py`

## Important boundaries

This does **not** establish:

- answer correctness
- repo understanding
- runtime correctness
- test sufficiency
- regression absence
- forensic readiness
- PR mergeability

The preflight performs no writes, no refresh, no Git access, no snapshot creation, no PR/Patch action.

## Validation performed

- `python3 -m compileall -q merger/lenskit/core/repobrief_preflight.py merger/lenskit/cli/cmd_repobrief.py merger/lenskit/tests/test_repobrief_preflight.py`
- `python3 -m ruff check merger/lenskit/core/repobrief_preflight.py merger/lenskit/cli/cmd_repobrief.py merger/lenskit/tests/test_repobrief_preflight.py`
- `python3 -m pytest merger/lenskit/tests/test_repobrief_preflight.py merger/lenskit/tests/test_repobrief_snapshot_cli.py -q` → 38 passed
- `python3 -m pytest merger/lenskit/tests/test_repobrief_preflight.py merger/lenskit/tests/test_repobrief_snapshot_cli.py merger/lenskit/tests/test_repobrief_profiles.py merger/lenskit/tests/test_repobrief_naming_doc.py -q` → 49 passed

## Manual CLI regression checks

- missing manifest returns rc=2 without Traceback
- invalid manifest JSON returns rc=2 without Traceback

## Known gaps / review focus

- Full `merger/lenskit/tests` run was started but stopped after hanging around 17% without stderr; not counted as green.
- Core is large (~1000 LOC) and should be reviewed for decomposition before merge if maintainability is considered a blocker.
- CLI is intentionally minimal and does not yet expose every core input (`used_citations`, `used_ranges`, `declaration`, `max_age_seconds`).

## Self-review verdict

Draft PR only. No merge until CI and review complete.