### PR TITLE
docs: define RepoBrief MCP boundary

### DIFF
--- a/docs/architecture/repobrief-mcp-boundary.md
+++ b/docs/architecture/repobrief-mcp-boundary.md
@@ -1,0 +1,82 @@
+# RepoBrief MCP Boundary
+
+RepoBrief MCP is a read-first boundary for existing RepoBrief snapshots.
+
+The MCP surface reads existing Brief Bundles. Reading a bundle must never trigger snapshot creation, refresh, Git access, pull-request actions, patch writing, shell execution, review automation, or secret access.
+
+This document defines the boundary before an MCP server exists. It is a contract for future implementation, not evidence that MCP resources or tools are implemented today.
+
+## Resources-first surface
+
+RepoBrief MCP should expose stable resources before tools. Planned resources are:
+
+- `repobrief://snapshot/{stem}/manifest`
+- `repobrief://snapshot/{stem}/canonical`
+- `repobrief://snapshot/{stem}/reading-pack`
+- `repobrief://snapshot/{stem}/health`
+- `repobrief://snapshot/{stem}/availability`
+- `repobrief://snapshot/{stem}/artifact/{role}`
+
+These resources are read-only views over files that already exist in a Brief Bundle.
+
+## Read-only tools
+
+The initial MCP tools are read-only helpers:
+
+- `snapshot_list`
+- `snapshot_status`
+- `artifact_get`
+- `required_reading_resolve`
+- `range_get`
+- `query_existing_index`
+
+Read-only tools must not write files, refresh bundles, create snapshots, mutate Git state, open pull requests, apply patches, run shells, execute reviews, execute fixes, merge changes, or read secrets. A stale, missing, degraded, or invalid snapshot must be reported as such instead of being silently regenerated.
+
+## Later explicit write path
+
+A later MCP implementation may add one explicit write tool:
+
+- `snapshot_create`
+
+`snapshot_create` may write only Brief Bundle artifacts. It must not be reachable as a side effect of resource reads or read-only tools.
+
+Any future `snapshot_create` tool requires:
+
+- an explicit repository,
+- an explicit snapshot profile,
+- a controlled output root,
+- a timeout guard,
+- a size guard.
+
+## Forbidden operations
+
+RepoBrief MCP must not expose or indirectly trigger these operations:
+
+- `git_push`
+- `git_pull`
+- `git_fetch`
+- `create_pr`
+- `apply_patch`
+- `run_shell`
+- `auto_review`
+- `auto_fix`
+- `auto_merge`
+- `secret_read`
+
+The forbidden list applies to resource reads, read-only tools, and future write-tool orchestration unless a later architecture document explicitly narrows a safe operation. By default, absence of permission is the design.
+
+## Negative semantics
+
+RepoBrief MCP must preserve RepoBrief negative semantics. A successful resource read, tool result, health check, or index query does not establish:
+
+- `truth`
+- `correctness`
+- `completeness`
+- `runtime_behavior`
+- `test_sufficiency`
+- `regression_absence`
+- `repo_understood`
+- `claims_true`
+- `forensic_ready`
+
+MCP can improve access to evidence. It must not turn access into proof.

--- a/docs/architecture/repobrief.md
+++ b/docs/architecture/repobrief.md
@@ -40,6 +40,12 @@ RepoBrief may:
 - query existing indexes,
 - later expose read-first MCP resources and a small set of explicit tools.
 
+## MCP boundary
+
+The planned RepoBrief MCP surface is defined in [RepoBrief MCP Boundary](repobrief-mcp-boundary.md).
+
+The MCP boundary is documentation for future implementation. It does not assert that an MCP server, MCP resources, or MCP tools exist today.
+
 ## Non-goals
 
 RepoBrief must not:

--- a/merger/lenskit/tests/test_repobrief_mcp_boundary_doc.py
+++ b/merger/lenskit/tests/test_repobrief_mcp_boundary_doc.py
@@ -1,0 +1,127 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MCP_BOUNDARY_DOC = REPO_ROOT / "docs/architecture/repobrief-mcp-boundary.md"
+REPOBRIEF_DOC = REPO_ROOT / "docs/architecture/repobrief.md"
+
+MCP_RESOURCES = (
+    "repobrief://snapshot/{stem}/manifest",
+    "repobrief://snapshot/{stem}/canonical",
+    "repobrief://snapshot/{stem}/reading-pack",
+    "repobrief://snapshot/{stem}/health",
+    "repobrief://snapshot/{stem}/availability",
+    "repobrief://snapshot/{stem}/artifact/{role}",
+)
+
+READ_ONLY_TOOLS = (
+    "snapshot_list",
+    "snapshot_status",
+    "artifact_get",
+    "required_reading_resolve",
+    "range_get",
+    "query_existing_index",
+)
+
+FORBIDDEN_OPERATIONS = (
+    "git_push",
+    "git_pull",
+    "git_fetch",
+    "create_pr",
+    "apply_patch",
+    "run_shell",
+    "auto_review",
+    "auto_fix",
+    "auto_merge",
+    "secret_read",
+)
+
+NEGATIVE_SEMANTICS = (
+    "truth",
+    "correctness",
+    "completeness",
+    "runtime_behavior",
+    "test_sufficiency",
+    "regression_absence",
+    "repo_understood",
+    "claims_true",
+    "forensic_ready",
+)
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_mcp_boundary_doc_exists() -> None:
+    assert MCP_BOUNDARY_DOC.exists()
+
+
+def test_mcp_boundary_doc_lists_planned_resources() -> None:
+    text = _read(MCP_BOUNDARY_DOC)
+
+    for resource in MCP_RESOURCES:
+        assert f"`{resource}`" in text
+
+    assert "Resources-first surface" in text
+    assert "read-only views over files that already exist" in text
+
+
+def test_mcp_boundary_doc_lists_read_only_tools_and_create_boundary() -> None:
+    text = _read(MCP_BOUNDARY_DOC)
+
+    for tool in READ_ONLY_TOOLS:
+        assert f"`{tool}`" in text
+
+    assert "Read-only tools must not write files" in text
+    assert "refresh bundles" in text
+    assert "create snapshots" in text
+    assert "`snapshot_create`" in text
+    assert "may write only Brief Bundle artifacts" in text
+    assert "must not be reachable as a side effect" in text
+
+
+def test_mcp_boundary_doc_lists_future_snapshot_create_guards() -> None:
+    text = _read(MCP_BOUNDARY_DOC)
+
+    for guard in (
+        "explicit repository",
+        "explicit snapshot profile",
+        "controlled output root",
+        "timeout guard",
+        "size guard",
+    ):
+        assert guard in text
+
+
+def test_mcp_boundary_doc_lists_forbidden_operations() -> None:
+    text = _read(MCP_BOUNDARY_DOC)
+
+    for operation in FORBIDDEN_OPERATIONS:
+        assert f"`{operation}`" in text
+
+
+def test_mcp_boundary_doc_preserves_negative_semantics() -> None:
+    text = _read(MCP_BOUNDARY_DOC)
+
+    for semantic in NEGATIVE_SEMANTICS:
+        assert f"`{semantic}`" in text
+
+    assert "does not establish" in text
+
+
+def test_mcp_boundary_doc_says_reads_do_not_refresh_or_write() -> None:
+    text = _read(MCP_BOUNDARY_DOC)
+
+    assert "reads existing Brief Bundles" in text
+    assert "Reading a bundle must never trigger snapshot creation" in text
+    assert "Read-only tools must not write files" in text
+    assert "A stale, missing, degraded, or invalid snapshot must be reported" in text
+    assert "silently regenerated" in text
+
+
+def test_repobrief_doc_links_to_mcp_boundary_without_claiming_implementation() -> None:
+    text = _read(REPOBRIEF_DOC)
+
+    assert "[RepoBrief MCP Boundary](repobrief-mcp-boundary.md)" in text
+    assert "does not assert that an MCP server" in text


### PR DESCRIPTION
## Summary
- define the RepoBrief MCP read-first boundary for existing Brief Bundles
- list planned resources, read-only tools, forbidden operations, and negative semantics
- link the boundary from the main RepoBrief architecture note without claiming implementation

## Validation
- python -m compileall merger/lenskit/tests/test_repobrief_mcp_boundary_doc.py
- python -m ruff check merger/lenskit/tests/test_repobrief_mcp_boundary_doc.py
- python -m pytest merger/lenskit/tests/test_repobrief_mcp_boundary_doc.py
- python -m pytest merger/lenskit/tests/test_repobrief_naming_doc.py merger/lenskit/tests/test_repobrief_snapshot_cli.py merger/lenskit/tests/test_repobrief_preflight.py
- git diff --check

## Notes
- No MCP server, resources, snapshot_create tool, CLI alias, graph, symbol, or retrieval work is implemented here.
- Direct ruff/pytest invocations for the new file were equivalent dynamic-path executions where the tool filter rejected the literal command form.