### PR TITLE
feat(repobrief): add read-only access boundary helpers

### DIFF
--- a/merger/lenskit/core/repobrief_access.py
+++ b/merger/lenskit/core/repobrief_access.py
@@ -200,6 +200,144 @@ def get_artifact(bundle_manifest: str | Path, role: str) -> dict[str, Any]:
     }
 
 
+def _read_only_mutation_boundary() -> dict[str, Any]:
+    return {
+        "writes": [],
+        "does_not_mutate": ["git", "pull_requests", "patches", "source_working_tree", "brief_bundle_artifacts"],
+        "read_paths_do_not_refresh": True,
+    }
+
+
+def _invalid_read_result(
+    *,
+    kind: str,
+    bundle_manifest: Path,
+    status: str,
+    error: str,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    result = {
+        "kind": kind,
+        "version": "v1",
+        "status": status,
+        "bundle_manifest": str(bundle_manifest),
+        "error": error,
+        "mutation_boundary": _read_only_mutation_boundary(),
+        "does_not_establish": list(_DOES_NOT_ESTABLISH),
+    }
+    if extra:
+        result.update(extra)
+    return result
+
+
+def range_get(bundle_manifest: str | Path, range_ref: dict[str, Any]) -> dict[str, Any]:
+    manifest_path = Path(bundle_manifest).expanduser().resolve()
+    if not isinstance(range_ref, dict):
+        return _invalid_read_result(
+            kind="repobrief.range_get",
+            bundle_manifest=manifest_path,
+            status="invalid",
+            error="range_ref must be a JSON object",
+            extra={"range_ref": range_ref, "range": None},
+        )
+
+    from merger.lenskit.core.range_resolver import resolve_range_ref
+
+    try:
+        resolved = resolve_range_ref(manifest_path, range_ref)
+    except Exception as exc:
+        return _invalid_read_result(
+            kind="repobrief.range_get",
+            bundle_manifest=manifest_path,
+            status="invalid",
+            error=str(exc),
+            extra={"range_ref": range_ref, "range": None},
+        )
+
+    return {
+        "kind": "repobrief.range_get",
+        "version": "v1",
+        "status": "available",
+        "bundle_manifest": str(manifest_path),
+        "range_ref": range_ref,
+        "range": resolved,
+        "mutation_boundary": _read_only_mutation_boundary(),
+        "does_not_establish": list(_DOES_NOT_ESTABLISH),
+    }
+
+
+def query_existing_index(
+    bundle_manifest: str | Path,
+    query: str,
+    k: int = 10,
+    filters: dict[str, str | None] | None = None,
+) -> dict[str, Any]:
+    manifest_path = Path(bundle_manifest).expanduser().resolve()
+    if k < 1:
+        return _invalid_read_result(
+            kind="repobrief.query_existing_index",
+            bundle_manifest=manifest_path,
+            status="invalid",
+            error="k must be >= 1",
+            extra={"query": query, "k": k, "query_result": None, "index_artifact": None},
+        )
+
+    artifact_result = get_artifact(manifest_path, "sqlite_index")
+    artifact = artifact_result.get("artifact") if isinstance(artifact_result, dict) else None
+    if not isinstance(artifact, dict) or not artifact.get("absolute_path"):
+        return _invalid_read_result(
+            kind="repobrief.query_existing_index",
+            bundle_manifest=manifest_path,
+            status="missing",
+            error="sqlite_index artifact is not present in the bundle manifest",
+            extra={"query": query, "k": k, "query_result": None, "index_artifact": artifact},
+        )
+
+    index_path = Path(str(artifact["absolute_path"]))
+    if not index_path.exists():
+        return _invalid_read_result(
+            kind="repobrief.query_existing_index",
+            bundle_manifest=manifest_path,
+            status="missing",
+            error="sqlite_index artifact file does not exist",
+            extra={"query": query, "k": k, "query_result": None, "index_artifact": artifact},
+        )
+
+    from merger.lenskit.retrieval.query_core import execute_query
+
+    try:
+        query_result = execute_query(
+            index_path,
+            query,
+            k=k,
+            filters=filters or {},
+            trace=False,
+            build_context=False,
+        )
+    except Exception as exc:
+        return _invalid_read_result(
+            kind="repobrief.query_existing_index",
+            bundle_manifest=manifest_path,
+            status="invalid",
+            error=str(exc),
+            extra={"query": query, "k": k, "query_result": None, "index_artifact": artifact},
+        )
+
+    return {
+        "kind": "repobrief.query_existing_index",
+        "version": "v1",
+        "status": "available",
+        "bundle_manifest": str(manifest_path),
+        "query": query,
+        "k": k,
+        "filters": filters or {},
+        "index_artifact": artifact,
+        "query_result": query_result,
+        "mutation_boundary": _read_only_mutation_boundary(),
+        "does_not_establish": list(_DOES_NOT_ESTABLISH),
+    }
+
+
 def snapshot_check(
     bundle_manifest: str | Path,
     task_profile: str = "basic_repo_question",

--- a/merger/lenskit/core/repobrief_access.py
+++ b/merger/lenskit/core/repobrief_access.py
@@ -241,6 +241,18 @@ def range_get(bundle_manifest: str | Path, range_ref: dict[str, Any]) -> dict[st
             extra={"range_ref": range_ref, "range": None},
         )
 
+    if range_ref.get("artifact_role") == "source_file":
+        return _invalid_read_result(
+            kind="repobrief.range_get",
+            bundle_manifest=manifest_path,
+            status="invalid",
+            error=(
+                "source_file range_refs are outside the read-only RepoBrief "
+                "bundle artifact boundary"
+            ),
+            extra={"range_ref": range_ref, "range": None},
+        )
+
     from merger.lenskit.core.range_resolver import resolve_range_ref
 
     try:

--- a/merger/lenskit/tests/test_repobrief_access_boundary.py
+++ b/merger/lenskit/tests/test_repobrief_access_boundary.py
@@ -51,6 +51,37 @@ def test_range_get_reads_existing_artifact_without_mutation(tmp_path):
     assert result["mutation_boundary"]["read_paths_do_not_refresh"] is True
 
 
+def test_range_get_rejects_source_file_ranges_without_reading_workspace(tmp_path):
+    hub = tmp_path / "hub"
+    run_dir = hub / "merges" / "run-1"
+    source_dir = hub / "demo" / "src"
+    run_dir.mkdir(parents=True)
+    source_dir.mkdir(parents=True)
+
+    source_file = source_dir / "secret.py"
+    source_file.write_text("secret = True\n", encoding="utf-8")
+    content = source_file.read_bytes()
+    manifest = run_dir / "demo.bundle.manifest.json"
+    _write_manifest(manifest, [])
+    ref = {
+        "artifact_role": "source_file",
+        "repo_id": "demo",
+        "file_path": "src/secret.py",
+        "start_byte": 0,
+        "end_byte": len(content),
+        "start_line": 1,
+        "end_line": 1,
+        "content_sha256": hashlib.sha256(content).hexdigest(),
+    }
+
+    result = repobrief_access.range_get(manifest, ref)
+
+    assert result["status"] == "invalid"
+    assert result["range"] is None
+    assert "source_file range_refs" in result["error"]
+    assert result["mutation_boundary"]["writes"] == []
+
+
 def test_query_existing_index_reports_missing_without_creating(tmp_path):
     manifest = tmp_path / "demo.bundle.manifest.json"
     missing_index = tmp_path / "missing.sqlite"

--- a/merger/lenskit/tests/test_repobrief_access_boundary.py
+++ b/merger/lenskit/tests/test_repobrief_access_boundary.py
@@ -1,0 +1,99 @@
+import hashlib
+import json
+
+from merger.lenskit.core import repobrief_access
+
+
+def _write_manifest(path, artifacts):
+    path.write_text(
+        json.dumps({
+            "kind": "repolens.bundle.manifest",
+            "version": "1.0",
+            "run_id": "run-1",
+            "artifacts": artifacts,
+            "links": {},
+            "capabilities": {},
+        }),
+        encoding="utf-8",
+    )
+
+
+def test_range_get_reads_existing_artifact_without_mutation(tmp_path):
+    artifact = tmp_path / "brief.md"
+    artifact.write_text("alpha\nbeta\n", encoding="utf-8")
+    content = artifact.read_bytes()
+    start = content.index(b"beta")
+    end = len(content)
+    manifest = tmp_path / "demo.bundle.manifest.json"
+    _write_manifest(manifest, [{
+        "role": "canonical_md",
+        "path": artifact.name,
+        "content_type": "text/markdown",
+        "bytes": len(content),
+        "sha256": hashlib.sha256(content).hexdigest(),
+    }])
+    ref = {
+        "artifact_role": "canonical_md",
+        "repo_id": "demo",
+        "file_path": artifact.name,
+        "start_byte": start,
+        "end_byte": end,
+        "start_line": 2,
+        "end_line": 2,
+        "content_sha256": hashlib.sha256(content[start:end]).hexdigest(),
+    }
+
+    result = repobrief_access.range_get(manifest, ref)
+
+    assert result["status"] == "available"
+    assert result["range"]["text"] == "beta\n"
+    assert result["mutation_boundary"]["writes"] == []
+    assert result["mutation_boundary"]["read_paths_do_not_refresh"] is True
+
+
+def test_query_existing_index_reports_missing_without_creating(tmp_path):
+    manifest = tmp_path / "demo.bundle.manifest.json"
+    missing_index = tmp_path / "missing.sqlite"
+    _write_manifest(manifest, [{"role": "sqlite_index", "path": missing_index.name}])
+
+    result = repobrief_access.query_existing_index(manifest, "hello", k=1)
+
+    assert result["status"] == "missing"
+    assert result["query_result"] is None
+    assert not missing_index.exists()
+    assert result["mutation_boundary"]["writes"] == []
+
+
+def test_query_existing_index_reads_prebuilt_sqlite_index(tmp_path):
+    from merger.lenskit.retrieval import index_db
+
+    dump_path = tmp_path / "dump.json"
+    chunk_path = tmp_path / "chunks.jsonl"
+    index_path = tmp_path / "index.sqlite"
+    manifest = tmp_path / "demo.bundle.manifest.json"
+
+    chunk = {
+        "chunk_id": "c1",
+        "repo_id": "demo",
+        "path": "src/main.py",
+        "content": "def main(): print('hello world')",
+        "start_line": 1,
+        "end_line": 1,
+        "layer": "core",
+        "artifact_type": "code",
+        "content_sha256": "h1",
+    }
+    chunk_path.write_text(json.dumps(chunk) + "\n", encoding="utf-8")
+    dump_path.write_text(json.dumps({"version": "1.0", "repos": {"demo": {}}}), encoding="utf-8")
+    index_db.build_index(dump_path, chunk_path, index_path)
+    _write_manifest(manifest, [{"role": "sqlite_index", "path": index_path.name}])
+
+    before_files = {path.name for path in tmp_path.iterdir()}
+    result = repobrief_access.query_existing_index(manifest, "hello", k=1)
+    after_files = {path.name for path in tmp_path.iterdir()}
+
+    assert result["status"] == "available"
+    assert result["query_result"]["count"] == 1
+    assert result["query_result"]["results"][0]["path"] == "src/main.py"
+    assert result["mutation_boundary"]["writes"] == []
+    assert before_files == after_files


### PR DESCRIPTION
Summary:
- add range_get and query_existing_index read-only RepoBrief access helpers
- report missing and invalid read states without creating artifacts
- add boundary tests for range reads and existing SQLite index reads

Validation:
- compileall targeted files: pass
- ruff targeted files: pass
- pytest new access boundary test: 3 passed
- pytest RepoBrief slice: 81 passed
- git diff --check: pass