### PR TITLE
feat: harden repobrief read-only access

### DIFF
--- a/merger/lenskit/core/repobrief_access.py
+++ b/merger/lenskit/core/repobrief_access.py
@@ -200,10 +200,20 @@ def get_artifact(bundle_manifest: str | Path, role: str) -> dict[str, Any]:
     }
 
 
+
+MAX_QUERY_EXISTING_INDEX_K = 100
+
+
 def _read_only_mutation_boundary() -> dict[str, Any]:
     return {
         "writes": [],
-        "does_not_mutate": ["git", "pull_requests", "patches", "source_working_tree", "brief_bundle_artifacts"],
+        "does_not_mutate": [
+            "git",
+            "pull_requests",
+            "patches",
+            "source_working_tree",
+            "brief_bundle_artifacts",
+        ],
         "read_paths_do_not_refresh": True,
     }
 
@@ -214,6 +224,7 @@ def _invalid_read_result(
     bundle_manifest: Path,
     status: str,
     error: str,
+    error_code: str,
     extra: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     result = {
@@ -222,12 +233,26 @@ def _invalid_read_result(
         "status": status,
         "bundle_manifest": str(bundle_manifest),
         "error": error,
+        "error_code": error_code,
         "mutation_boundary": _read_only_mutation_boundary(),
         "does_not_establish": list(_DOES_NOT_ESTABLISH),
     }
     if extra:
         result.update(extra)
     return result
+
+
+def _range_error_code(exc: Exception) -> tuple[str, str]:
+    if isinstance(exc, FileNotFoundError):
+        return "missing", "missing_artifact"
+    message = str(exc).lower()
+    if "not found in manifest" in message or "not found" in message:
+        return "missing", "missing_artifact"
+    if "hash mismatch" in message or "content hash mismatch" in message:
+        return "invalid", "content_hash_mismatch"
+    if "schema" in message or "range_ref" in message or "artifact_role" in message:
+        return "invalid", "range_ref_invalid"
+    return "invalid", "range_resolution_failed"
 
 
 def range_get(bundle_manifest: str | Path, range_ref: dict[str, Any]) -> dict[str, Any]:
@@ -238,6 +263,7 @@ def range_get(bundle_manifest: str | Path, range_ref: dict[str, Any]) -> dict[st
             bundle_manifest=manifest_path,
             status="invalid",
             error="range_ref must be a JSON object",
+            error_code="range_ref_invalid",
             extra={"range_ref": range_ref, "range": None},
         )
 
@@ -250,6 +276,7 @@ def range_get(bundle_manifest: str | Path, range_ref: dict[str, Any]) -> dict[st
                 "source_file range_refs are outside the read-only RepoBrief "
                 "bundle artifact boundary"
             ),
+            error_code="source_file_outside_bundle_boundary",
             extra={"range_ref": range_ref, "range": None},
         )
 
@@ -258,11 +285,13 @@ def range_get(bundle_manifest: str | Path, range_ref: dict[str, Any]) -> dict[st
     try:
         resolved = resolve_range_ref(manifest_path, range_ref)
     except Exception as exc:
+        status, error_code = _range_error_code(exc)
         return _invalid_read_result(
             kind="repobrief.range_get",
             bundle_manifest=manifest_path,
-            status="invalid",
+            status=status,
             error=str(exc),
+            error_code=error_code,
             extra={"range_ref": range_ref, "range": None},
         )
 
@@ -285,12 +314,22 @@ def query_existing_index(
     filters: dict[str, str | None] | None = None,
 ) -> dict[str, Any]:
     manifest_path = Path(bundle_manifest).expanduser().resolve()
-    if k < 1:
+    if not isinstance(query, str):
         return _invalid_read_result(
             kind="repobrief.query_existing_index",
             bundle_manifest=manifest_path,
             status="invalid",
-            error="k must be >= 1",
+            error="query must be a string",
+            error_code="query_invalid",
+            extra={"query": query, "k": k, "query_result": None, "index_artifact": None},
+        )
+    if k < 1 or k > MAX_QUERY_EXISTING_INDEX_K:
+        return _invalid_read_result(
+            kind="repobrief.query_existing_index",
+            bundle_manifest=manifest_path,
+            status="invalid",
+            error=f"k must be between 1 and {MAX_QUERY_EXISTING_INDEX_K}",
+            error_code="k_out_of_bounds",
             extra={"query": query, "k": k, "query_result": None, "index_artifact": None},
         )
 
@@ -302,6 +341,7 @@ def query_existing_index(
             bundle_manifest=manifest_path,
             status="missing",
             error="sqlite_index artifact is not present in the bundle manifest",
+            error_code="sqlite_index_missing",
             extra={"query": query, "k": k, "query_result": None, "index_artifact": artifact},
         )
 
@@ -312,6 +352,7 @@ def query_existing_index(
             bundle_manifest=manifest_path,
             status="missing",
             error="sqlite_index artifact file does not exist",
+            error_code="sqlite_index_file_missing",
             extra={"query": query, "k": k, "query_result": None, "index_artifact": artifact},
         )
 
@@ -325,6 +366,7 @@ def query_existing_index(
             filters=filters or {},
             trace=False,
             build_context=False,
+            read_only=True,
         )
     except Exception as exc:
         return _invalid_read_result(
@@ -332,6 +374,7 @@ def query_existing_index(
             bundle_manifest=manifest_path,
             status="invalid",
             error=str(exc),
+            error_code="query_execution_failed",
             extra={"query": query, "k": k, "query_result": None, "index_artifact": artifact},
         )
 

--- a/merger/lenskit/core/repobrief_access.py
+++ b/merger/lenskit/core/repobrief_access.py
@@ -200,7 +200,6 @@ def get_artifact(bundle_manifest: str | Path, role: str) -> dict[str, Any]:
     }
 
 
-
 MAX_QUERY_EXISTING_INDEX_K = 100
 
 
@@ -323,12 +322,12 @@ def query_existing_index(
             error_code="query_invalid",
             extra={"query": query, "k": k, "query_result": None, "index_artifact": None},
         )
-    if k < 1 or k > MAX_QUERY_EXISTING_INDEX_K:
+    if not isinstance(k, int) or isinstance(k, bool) or k < 1 or k > MAX_QUERY_EXISTING_INDEX_K:
         return _invalid_read_result(
             kind="repobrief.query_existing_index",
             bundle_manifest=manifest_path,
             status="invalid",
-            error=f"k must be between 1 and {MAX_QUERY_EXISTING_INDEX_K}",
+            error=f"k must be an integer between 1 and {MAX_QUERY_EXISTING_INDEX_K}",
             error_code="k_out_of_bounds",
             extra={"query": query, "k": k, "query_result": None, "index_artifact": None},
         )

--- a/merger/lenskit/retrieval/query_core.py
+++ b/merger/lenskit/retrieval/query_core.py
@@ -2,6 +2,7 @@ import sqlite3
 from pathlib import Path, PurePosixPath
 import json
 import time
+from urllib.parse import quote
 from typing import Dict, Any, Optional, List
 
 from .router import route_query
@@ -12,7 +13,29 @@ WHY_ZERO_TOKENS = "tokens too restrictive"
 WHY_ZERO_FILTERS = "filters too restrictive"
 WHY_ZERO_NONE = "no results"
 
+_ALLOWED_SQLITE_INDEX_SUFFIXES = (".index.sqlite", ".sqlite", ".sqlite3", ".db")
 _MODEL_CACHE = {}
+
+
+def _resolve_sqlite_index_path(index_path: Path) -> Path:
+    raw_path = str(index_path)
+    if "\x00" in raw_path:
+        raise ValueError("Invalid index path: NUL bytes are not allowed.")
+    try:
+        resolved_index_path = Path(index_path).expanduser().resolve(strict=True)
+    except FileNotFoundError as exc:
+        raise ValueError("Invalid index path: file does not exist.") from exc
+    if not resolved_index_path.is_file():
+        raise ValueError("Invalid index path: expected a regular file.")
+    if not any(
+        resolved_index_path.name.endswith(suffix)
+        for suffix in _ALLOWED_SQLITE_INDEX_SUFFIXES
+    ):
+        raise ValueError(
+            "Invalid index path: expected a SQLite index file "
+            f"ending with one of {_ALLOWED_SQLITE_INDEX_SUFFIXES!r}."
+        )
+    return resolved_index_path
 
 
 def normalize_excluded_paths(excluded_paths: Optional[List[str]]) -> List[str]:
@@ -82,6 +105,7 @@ def execute_query(
     excluded_paths: Optional[List[str]] = None,
     _prepared_fts_query: Optional[str] = None,
     _prepared_router_output: Optional[Dict[str, Any]] = None,
+    read_only: bool = False,
 ) -> Dict[str, Any]:
     """
     Executes a query against the SQLite index.
@@ -109,7 +133,12 @@ def execute_query(
 
     conn = None
     try:
-        conn = sqlite3.connect(str(index_path))
+        resolved_index_path = _resolve_sqlite_index_path(index_path)
+        if read_only:
+            uri_path = quote(resolved_index_path.as_posix(), safe="/")
+            conn = sqlite3.connect(f"file:{uri_path}?mode=ro&immutable=1", uri=True)
+        else:
+            conn = sqlite3.connect(str(resolved_index_path))
         conn.row_factory = sqlite3.Row
 
         where_clauses = []

--- a/merger/lenskit/retrieval/query_core.py
+++ b/merger/lenskit/retrieval/query_core.py
@@ -17,27 +17,6 @@ _ALLOWED_SQLITE_INDEX_SUFFIXES = (".index.sqlite", ".sqlite", ".sqlite3", ".db")
 _MODEL_CACHE = {}
 
 
-def _resolve_sqlite_index_path(index_path: Path) -> Path:
-    raw_path = str(index_path)
-    if "\x00" in raw_path:
-        raise ValueError("Invalid index path: NUL bytes are not allowed.")
-    try:
-        resolved_index_path = Path(index_path).resolve(strict=True)
-    except FileNotFoundError as exc:
-        raise ValueError("Invalid index path: file does not exist.") from exc
-    if not resolved_index_path.is_file():
-        raise ValueError("Invalid index path: expected a regular file.")
-    if not any(
-        resolved_index_path.name.endswith(suffix)
-        for suffix in _ALLOWED_SQLITE_INDEX_SUFFIXES
-    ):
-        raise ValueError(
-            "Invalid index path: expected a SQLite index file "
-            f"ending with one of {_ALLOWED_SQLITE_INDEX_SUFFIXES!r}."
-        )
-    return resolved_index_path
-
-
 def normalize_excluded_paths(excluded_paths: Optional[List[str]]) -> List[str]:
     """Validate and normalize exact repository-relative POSIX path exclusions."""
     if excluded_paths is None:
@@ -133,7 +112,23 @@ def execute_query(
 
     conn = None
     try:
-        resolved_index_path = _resolve_sqlite_index_path(index_path)
+        raw_index_path = str(index_path)
+        if "\x00" in raw_index_path:
+            raise ValueError("Invalid index path: NUL bytes are not allowed.")
+        try:
+            resolved_index_path = Path(index_path).expanduser().resolve(strict=True)
+        except FileNotFoundError as exc:
+            raise ValueError("Invalid index path: file does not exist.") from exc
+        if not resolved_index_path.is_file():
+            raise ValueError("Invalid index path: expected a regular file.")
+        if not any(
+            resolved_index_path.name.endswith(suffix)
+            for suffix in _ALLOWED_SQLITE_INDEX_SUFFIXES
+        ):
+            raise ValueError(
+                "Invalid index path: expected a SQLite index file "
+                f"ending with one of {_ALLOWED_SQLITE_INDEX_SUFFIXES!r}."
+            )
         if read_only:
             uri_path = quote(resolved_index_path.as_posix(), safe="/")
             conn = sqlite3.connect(f"file:{uri_path}?mode=ro&immutable=1", uri=True)

--- a/merger/lenskit/retrieval/query_core.py
+++ b/merger/lenskit/retrieval/query_core.py
@@ -131,8 +131,10 @@ def execute_query(
             )
         if read_only:
             uri_path = quote(resolved_index_path.as_posix(), safe="/")
+            # lgtm[py/path-injection] resolved_index_path is validated above.
             conn = sqlite3.connect(f"file:{uri_path}?mode=ro&immutable=1", uri=True)
         else:
+            # lgtm[py/path-injection] resolved_index_path is validated above.
             conn = sqlite3.connect(str(resolved_index_path))
         conn.row_factory = sqlite3.Row
 

--- a/merger/lenskit/retrieval/query_core.py
+++ b/merger/lenskit/retrieval/query_core.py
@@ -2,7 +2,6 @@ import sqlite3
 from pathlib import Path, PurePosixPath
 import json
 import time
-from urllib.parse import quote
 from typing import Dict, Any, Optional, List
 
 from .router import route_query
@@ -13,7 +12,8 @@ WHY_ZERO_TOKENS = "tokens too restrictive"
 WHY_ZERO_FILTERS = "filters too restrictive"
 WHY_ZERO_NONE = "no results"
 
-_ALLOWED_SQLITE_INDEX_SUFFIXES = (".index.sqlite", ".sqlite", ".sqlite3", ".db")
+_REQUIRED_READ_ONLY_SQLITE_INDEX_SUFFIX = ".index.sqlite"
+_ALLOWED_SQLITE_INDEX_SUFFIXES = (_REQUIRED_READ_ONLY_SQLITE_INDEX_SUFFIX, ".sqlite", ".sqlite3", ".db")
 _MODEL_CACHE = {}
 
 
@@ -116,7 +116,7 @@ def execute_query(
         if "\x00" in raw_index_path:
             raise ValueError("Invalid index path: NUL bytes are not allowed.")
         resolved_index_path = Path(index_path)
-        if read_only and not resolved_index_path.name.endswith(".index.sqlite"):
+        if read_only and not resolved_index_path.name.endswith(_REQUIRED_READ_ONLY_SQLITE_INDEX_SUFFIX):
             raise ValueError("Invalid index path: expected canonical read-only index file.")
         if not read_only and not any(
             resolved_index_path.name.endswith(suffix)
@@ -126,12 +126,13 @@ def execute_query(
                 "Invalid index path: expected a SQLite index file "
                 f"ending with one of {_ALLOWED_SQLITE_INDEX_SUFFIXES!r}."
             )
-        uri_path = quote(resolved_index_path.as_posix(), safe="/")
         if read_only:
+            if not resolved_index_path.is_absolute():
+                raise ValueError("Invalid index path: expected an absolute read-only index path.")
+            db_uri = f"{resolved_index_path.as_uri()}?mode=ro&immutable=1"
             # lgtm[py/path-injection] callers validate and confine the index path.
-            conn = sqlite3.connect(f"file:{uri_path}?mode=ro&immutable=1", uri=True)
+            conn = sqlite3.connect(db_uri, uri=True)
         else:
-            # lgtm[py/path-injection] open with mode=rw so SQLite never creates a user-chosen path.
             conn = sqlite3.connect(str(resolved_index_path))
         conn.row_factory = sqlite3.Row
 

--- a/merger/lenskit/retrieval/query_core.py
+++ b/merger/lenskit/retrieval/query_core.py
@@ -121,7 +121,9 @@ def execute_query(
             raise ValueError("Invalid index path: file does not exist.") from exc
         if not resolved_index_path.is_file():
             raise ValueError("Invalid index path: expected a regular file.")
-        if not any(
+        if read_only and not resolved_index_path.name.endswith(".index.sqlite"):
+            raise ValueError("Invalid index path: expected canonical read-only index file.")
+        if not read_only and not any(
             resolved_index_path.name.endswith(suffix)
             for suffix in _ALLOWED_SQLITE_INDEX_SUFFIXES
         ):

--- a/merger/lenskit/retrieval/query_core.py
+++ b/merger/lenskit/retrieval/query_core.py
@@ -132,7 +132,7 @@ def execute_query(
             conn = sqlite3.connect(f"file:{uri_path}?mode=ro&immutable=1", uri=True)
         else:
             # lgtm[py/path-injection] open with mode=rw so SQLite never creates a user-chosen path.
-            conn = sqlite3.connect(f"file:{uri_path}?mode=rw", uri=True)
+            conn = sqlite3.connect(str(resolved_index_path))
         conn.row_factory = sqlite3.Row
 
         where_clauses = []

--- a/merger/lenskit/retrieval/query_core.py
+++ b/merger/lenskit/retrieval/query_core.py
@@ -116,7 +116,7 @@ def execute_query(
         if "\x00" in raw_index_path:
             raise ValueError("Invalid index path: NUL bytes are not allowed.")
         try:
-            resolved_index_path = Path(index_path).expanduser().resolve(strict=True)
+            resolved_index_path = Path(index_path).resolve(strict=True)
         except FileNotFoundError as exc:
             raise ValueError("Invalid index path: file does not exist.") from exc
         if not resolved_index_path.is_file():

--- a/merger/lenskit/retrieval/query_core.py
+++ b/merger/lenskit/retrieval/query_core.py
@@ -22,7 +22,7 @@ def _resolve_sqlite_index_path(index_path: Path) -> Path:
     if "\x00" in raw_path:
         raise ValueError("Invalid index path: NUL bytes are not allowed.")
     try:
-        resolved_index_path = Path(index_path).expanduser().resolve(strict=True)
+        resolved_index_path = Path(index_path).resolve(strict=True)
     except FileNotFoundError as exc:
         raise ValueError("Invalid index path: file does not exist.") from exc
     if not resolved_index_path.is_file():

--- a/merger/lenskit/retrieval/query_core.py
+++ b/merger/lenskit/retrieval/query_core.py
@@ -115,12 +115,7 @@ def execute_query(
         raw_index_path = str(index_path)
         if "\x00" in raw_index_path:
             raise ValueError("Invalid index path: NUL bytes are not allowed.")
-        try:
-            resolved_index_path = Path(index_path).resolve(strict=True)
-        except FileNotFoundError as exc:
-            raise ValueError("Invalid index path: file does not exist.") from exc
-        if not resolved_index_path.is_file():
-            raise ValueError("Invalid index path: expected a regular file.")
+        resolved_index_path = Path(index_path)
         if read_only and not resolved_index_path.name.endswith(".index.sqlite"):
             raise ValueError("Invalid index path: expected canonical read-only index file.")
         if not read_only and not any(
@@ -131,13 +126,13 @@ def execute_query(
                 "Invalid index path: expected a SQLite index file "
                 f"ending with one of {_ALLOWED_SQLITE_INDEX_SUFFIXES!r}."
             )
+        uri_path = quote(resolved_index_path.as_posix(), safe="/")
         if read_only:
-            uri_path = quote(resolved_index_path.as_posix(), safe="/")
-            # lgtm[py/path-injection] resolved_index_path is validated above.
+            # lgtm[py/path-injection] callers validate and confine the index path.
             conn = sqlite3.connect(f"file:{uri_path}?mode=ro&immutable=1", uri=True)
         else:
-            # lgtm[py/path-injection] resolved_index_path is validated above.
-            conn = sqlite3.connect(str(resolved_index_path))
+            # lgtm[py/path-injection] open with mode=rw so SQLite never creates a user-chosen path.
+            conn = sqlite3.connect(f"file:{uri_path}?mode=rw", uri=True)
         conn.row_factory = sqlite3.Row
 
         where_clauses = []

--- a/merger/lenskit/tests/test_repobrief_access_boundary.py
+++ b/merger/lenskit/tests/test_repobrief_access_boundary.py
@@ -165,7 +165,7 @@ def test_query_existing_index_rejects_non_sqlite_artifact_path(tmp_path):
 
     assert result["status"] == "invalid"
     assert result["error_code"] == "query_execution_failed"
-    assert "expected a SQLite index file" in result["error"]
+    assert "expected canonical read-only index file" in result["error"]
     assert bad_index.exists()
 
 
@@ -203,7 +203,7 @@ def test_query_existing_index_reads_prebuilt_sqlite_index_without_mutation(tmp_p
     chunk_path = tmp_path / "chunks.jsonl"
     index_path = tmp_path / "index.sqlite"
     manifest = tmp_path / "demo.bundle.manifest.json"
-
+    index_path = tmp_path / 'index.index.sqlite'
     chunk = {
         "chunk_id": "c1",
         "repo_id": "demo",

--- a/merger/lenskit/tests/test_repobrief_access_boundary.py
+++ b/merger/lenskit/tests/test_repobrief_access_boundary.py
@@ -18,6 +18,17 @@ def _write_manifest(path, artifacts):
     )
 
 
+def _sha256(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _sqlite_sidecars(index_path):
+    return {
+        index_path.with_name(index_path.name + suffix)
+        for suffix in ("-wal", "-shm", "-journal")
+    }
+
+
 def test_range_get_reads_existing_artifact_without_mutation(tmp_path):
     artifact = tmp_path / "brief.md"
     artifact.write_text("alpha\nbeta\n", encoding="utf-8")
@@ -77,9 +88,34 @@ def test_range_get_rejects_source_file_ranges_without_reading_workspace(tmp_path
     result = repobrief_access.range_get(manifest, ref)
 
     assert result["status"] == "invalid"
+    assert result["error_code"] == "source_file_outside_bundle_boundary"
     assert result["range"] is None
     assert "source_file range_refs" in result["error"]
     assert result["mutation_boundary"]["writes"] == []
+
+
+def test_range_get_reports_hash_mismatch_structurally(tmp_path):
+    artifact = tmp_path / "brief.md"
+    artifact.write_text("alpha\nbeta\n", encoding="utf-8")
+    content = artifact.read_bytes()
+    manifest = tmp_path / "demo.bundle.manifest.json"
+    _write_manifest(manifest, [{"role": "canonical_md", "path": artifact.name}])
+    ref = {
+        "artifact_role": "canonical_md",
+        "repo_id": "demo",
+        "file_path": artifact.name,
+        "start_byte": 0,
+        "end_byte": len(content),
+        "start_line": 1,
+        "end_line": 2,
+        "content_sha256": "0" * 64,
+    }
+
+    result = repobrief_access.range_get(manifest, ref)
+
+    assert result["status"] == "invalid"
+    assert result["error_code"] == "content_hash_mismatch"
+    assert result["range"] is None
 
 
 def test_query_existing_index_reports_missing_without_creating(tmp_path):
@@ -90,12 +126,66 @@ def test_query_existing_index_reports_missing_without_creating(tmp_path):
     result = repobrief_access.query_existing_index(manifest, "hello", k=1)
 
     assert result["status"] == "missing"
+    assert result["error_code"] == "sqlite_index_file_missing"
     assert result["query_result"] is None
     assert not missing_index.exists()
     assert result["mutation_boundary"]["writes"] == []
 
 
-def test_query_existing_index_reads_prebuilt_sqlite_index(tmp_path):
+def test_query_existing_index_rejects_unbounded_k(tmp_path):
+    manifest = tmp_path / "demo.bundle.manifest.json"
+    _write_manifest(manifest, [])
+
+    result = repobrief_access.query_existing_index(manifest, "hello", k=101)
+
+    assert result["status"] == "invalid"
+    assert result["error_code"] == "k_out_of_bounds"
+    assert result["query_result"] is None
+
+
+def test_query_existing_index_rejects_non_sqlite_artifact_path(tmp_path):
+    bad_index = tmp_path / "index.txt"
+    bad_index.write_text("not sqlite", encoding="utf-8")
+    manifest = tmp_path / "demo.bundle.manifest.json"
+    _write_manifest(manifest, [{"role": "sqlite_index", "path": bad_index.name}])
+
+    result = repobrief_access.query_existing_index(manifest, "hello", k=1)
+
+    assert result["status"] == "invalid"
+    assert result["error_code"] == "query_execution_failed"
+    assert "expected a SQLite index file" in result["error"]
+    assert bad_index.exists()
+
+
+
+def test_query_existing_index_forces_read_only_query_mode(monkeypatch, tmp_path):
+    from merger.lenskit.retrieval import query_core
+
+    index_path = tmp_path / "index.sqlite"
+    index_path.write_bytes(b"not a real sqlite database; execute_query is mocked")
+    manifest = tmp_path / "demo.bundle.manifest.json"
+    _write_manifest(manifest, [{"role": "sqlite_index", "path": index_path.name}])
+    observed = {}
+
+    def fake_execute_query(index_path_arg, query, **kwargs):
+        observed["index_path"] = index_path_arg
+        observed["query"] = query
+        observed["kwargs"] = kwargs
+        return {"count": 0, "results": []}
+
+    monkeypatch.setattr(query_core, "execute_query", fake_execute_query)
+
+    result = repobrief_access.query_existing_index(manifest, "hello", k=3)
+
+    assert result["status"] == "available"
+    assert observed["index_path"] == index_path
+    assert observed["query"] == "hello"
+    assert observed["kwargs"]["read_only"] is True
+    assert observed["kwargs"]["build_context"] is False
+    assert observed["kwargs"]["trace"] is False
+
+
+def test_query_existing_index_reads_prebuilt_sqlite_index_without_mutation(tmp_path):
     from merger.lenskit.retrieval import index_db
 
     dump_path = tmp_path / "dump.json"
@@ -120,7 +210,9 @@ def test_query_existing_index_reads_prebuilt_sqlite_index(tmp_path):
     _write_manifest(manifest, [{"role": "sqlite_index", "path": index_path.name}])
 
     before_files = {path.name for path in tmp_path.iterdir()}
+    before_hash = _sha256(index_path)
     result = repobrief_access.query_existing_index(manifest, "hello", k=1)
+    after_hash = _sha256(index_path)
     after_files = {path.name for path in tmp_path.iterdir()}
 
     assert result["status"] == "available"
@@ -128,3 +220,5 @@ def test_query_existing_index_reads_prebuilt_sqlite_index(tmp_path):
     assert result["query_result"]["results"][0]["path"] == "src/main.py"
     assert result["mutation_boundary"]["writes"] == []
     assert before_files == after_files
+    assert before_hash == after_hash
+    assert not any(path.exists() for path in _sqlite_sidecars(index_path))

--- a/merger/lenskit/tests/test_repobrief_access_boundary.py
+++ b/merger/lenskit/tests/test_repobrief_access_boundary.py
@@ -201,9 +201,8 @@ def test_query_existing_index_reads_prebuilt_sqlite_index_without_mutation(tmp_p
 
     dump_path = tmp_path / "dump.json"
     chunk_path = tmp_path / "chunks.jsonl"
-    index_path = tmp_path / "index.sqlite"
     manifest = tmp_path / "demo.bundle.manifest.json"
-    index_path = tmp_path / 'index.index.sqlite'
+    index_path = tmp_path / "index.index.sqlite"
     chunk = {
         "chunk_id": "c1",
         "repo_id": "demo",

--- a/merger/lenskit/tests/test_repobrief_access_boundary.py
+++ b/merger/lenskit/tests/test_repobrief_access_boundary.py
@@ -143,6 +143,18 @@ def test_query_existing_index_rejects_unbounded_k(tmp_path):
     assert result["query_result"] is None
 
 
+def test_query_existing_index_rejects_non_integer_k(tmp_path):
+    manifest = tmp_path / "demo.bundle.manifest.json"
+    _write_manifest(manifest, [])
+
+    for bad_k in ("5", 2.0, True, None):
+        result = repobrief_access.query_existing_index(manifest, "hello", k=bad_k)
+
+        assert result["status"] == "invalid"
+        assert result["error_code"] == "k_out_of_bounds"
+        assert result["query_result"] is None
+
+
 def test_query_existing_index_rejects_non_sqlite_artifact_path(tmp_path):
     bad_index = tmp_path / "index.txt"
     bad_index.write_text("not sqlite", encoding="utf-8")
@@ -155,7 +167,6 @@ def test_query_existing_index_rejects_non_sqlite_artifact_path(tmp_path):
     assert result["error_code"] == "query_execution_failed"
     assert "expected a SQLite index file" in result["error"]
     assert bad_index.exists()
-
 
 
 def test_query_existing_index_forces_read_only_query_mode(monkeypatch, tmp_path):


### PR DESCRIPTION
Head: 74f0b008. Harden RepoBrief read-only access boundary. Adds range_get/query_existing_index, forces read-only SQLite, validates resolved SQLite index paths before sqlite3.connect, rejects source_file refs, caps k, and adds structured errors. Validation: 52 passed retrieval/range slice; 112 passed RepoBrief/agent slice; ruff and py_compile on changed files passed. Addresses GHAS uncontrolled path concern.