### PR TITLE
feat(repobrief): Resolved Evidence Query v1 (RBEV1-T002)

### DIFF
--- a/merger/lenskit/core/repobrief_access.py
+++ b/merger/lenskit/core/repobrief_access.py
@@ -423,13 +423,16 @@ def _resolve_hit_evidence(
     by_range: dict[tuple[Any, ...], dict[str, Any]],
     citation_map_available: bool,
 ) -> dict[str, Any]:
+    range_candidates: list[tuple[str, dict[str, Any]]] = []
     range_ref = hit.get("range_ref")
-    range_ref_source = None
     if isinstance(range_ref, dict):
-        range_ref_source = "range_ref"
-    elif isinstance(hit.get("derived_range_ref"), dict):
-        range_ref = hit["derived_range_ref"]
-        range_ref_source = "derived_range_ref"
+        range_candidates.append(("range_ref", range_ref))
+    derived_range_ref = hit.get("derived_range_ref")
+    if isinstance(derived_range_ref, dict):
+        range_candidates.append(("derived_range_ref", derived_range_ref))
+
+    selected_range_ref: dict[str, Any] | None = None
+    range_ref_source = range_candidates[0][0] if range_candidates else None
 
     record: dict[str, Any] = {
         "chunk_id": hit.get("chunk_id"),
@@ -444,14 +447,19 @@ def _resolve_hit_evidence(
         "citation": None,
     }
 
-    if range_ref_source is None:
+    if not range_candidates:
         record["range_error_code"] = "range_ref_missing"
     else:
-        range_result = range_get(manifest_path, range_ref)
-        if range_result.get("status") == "available":
-            record["range_status"] = "resolved"
-            record["range"] = range_result.get("range")
-        else:
+        for candidate_source, candidate_ref in range_candidates:
+            range_result = range_get(manifest_path, candidate_ref)
+            record["range_ref_source"] = candidate_source
+            selected_range_ref = candidate_ref
+            if range_result.get("status") == "available":
+                record["range_status"] = "resolved"
+                record["range"] = range_result.get("range")
+                record["range_error"] = None
+                record["range_error_code"] = None
+                break
             record["range_error"] = range_result.get("error")
             record["range_error_code"] = range_result.get("error_code")
 
@@ -460,7 +468,7 @@ def _resolve_hit_evidence(
         chunk_id = hit.get("chunk_id")
         if isinstance(chunk_id, str):
             row = by_chunk_id.get(chunk_id)
-        range_key = _citation_range_key(range_ref)
+        range_key = _citation_range_key(selected_range_ref)
         if row is None and range_key is not None:
             row = by_range.get(range_key)
         if row is not None:

--- a/merger/lenskit/core/repobrief_access.py
+++ b/merger/lenskit/core/repobrief_access.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import Any
 
@@ -20,7 +21,9 @@ _DOES_NOT_ESTABLISH = (
 CITATION_MAP_ROLE = "citation_map_jsonl"
 RESOLVED_EVIDENCE_KIND = "repobrief.resolved_evidence"
 RESOLVED_EVIDENCE_VERSION = "v1"
-_CITATION_RANGE_KEY_FIELDS = ("file_path", "start_byte", "end_byte", "content_sha256")
+_CITATION_ID_RE = re.compile(r"^cit_[a-f0-9]{16}$")
+_SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
+_CITATION_RANGE_KEY_FIELDS = ("file_path", "start_byte", "end_byte")
 
 
 def _read_json_object(path: Path) -> dict[str, Any]:
@@ -330,13 +333,69 @@ def _empty_citation_map_status(
     return result
 
 
+def _is_non_empty_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value)
+
+
+def _is_sha256(value: Any) -> bool:
+    return isinstance(value, str) and _SHA256_RE.fullmatch(value) is not None
+
+
+def _is_int_not_bool(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
 def _citation_range_key(value: Any) -> tuple[Any, ...] | None:
     if not isinstance(value, dict):
         return None
-    key = tuple(value.get(field) for field in _CITATION_RANGE_KEY_FIELDS)
-    if any(part is None for part in key):
+    file_path, start_byte, end_byte = (
+        value.get(field) for field in _CITATION_RANGE_KEY_FIELDS
+    )
+    content_sha256 = value.get("range_content_sha256") or value.get("content_sha256")
+    if not _is_non_empty_string(file_path):
         return None
-    return key
+    if not _is_int_not_bool(start_byte) or not _is_int_not_bool(end_byte):
+        return None
+    if start_byte < 0 or end_byte <= start_byte:
+        return None
+    if not _is_sha256(content_sha256):
+        return None
+    return (file_path, start_byte, end_byte, content_sha256)
+
+
+def _citation_row_is_valid(row: dict[str, Any]) -> bool:
+    citation_id = row.get("citation_id")
+    if not isinstance(citation_id, str) or _CITATION_ID_RE.fullmatch(citation_id) is None:
+        return False
+    if not _is_non_empty_string(row.get("repo_id")):
+        return False
+
+    snapshot = row.get("snapshot")
+    if not isinstance(snapshot, dict):
+        return False
+    if not _is_non_empty_string(snapshot.get("run_id")):
+        return False
+    if not _is_non_empty_string(snapshot.get("canonical_md_path")):
+        return False
+    if not _is_sha256(snapshot.get("canonical_md_sha256")):
+        return False
+
+    canonical_range = row.get("canonical_range")
+    if _citation_range_key(canonical_range) is None:
+        return False
+    if not isinstance(canonical_range, dict):
+        return False
+    start_line = canonical_range.get("start_line")
+    end_line = canonical_range.get("end_line")
+    if not _is_int_not_bool(start_line) or not _is_int_not_bool(end_line):
+        return False
+    if start_line < 1 or end_line < start_line:
+        return False
+
+    chunk_id = row.get("chunk_id")
+    if chunk_id is not None and not _is_non_empty_string(chunk_id):
+        return False
+    return True
 
 
 def _load_citation_lookup(
@@ -374,11 +433,7 @@ def _load_citation_lookup(
                 except json.JSONDecodeError:
                     invalid_row_count += 1
                     continue
-                if not isinstance(row, dict):
-                    invalid_row_count += 1
-                    continue
-                citation_id = row.get("citation_id")
-                if not isinstance(citation_id, str) or not citation_id:
+                if not isinstance(row, dict) or not _citation_row_is_valid(row):
                     invalid_row_count += 1
                     continue
                 row_count += 1

--- a/merger/lenskit/core/repobrief_access.py
+++ b/merger/lenskit/core/repobrief_access.py
@@ -306,11 +306,180 @@ def range_get(bundle_manifest: str | Path, range_ref: dict[str, Any]) -> dict[st
     }
 
 
+def _load_citation_map(manifest_path: Path) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    artifact_result = get_artifact(manifest_path, "citation_map_jsonl")
+    artifact = artifact_result.get("artifact") if isinstance(artifact_result, dict) else None
+    artifact_path_str = artifact.get("absolute_path") if isinstance(artifact, dict) else None
+    if not artifact_path_str:
+        return [], {
+            "status": "missing",
+            "error_code": "citation_map_jsonl_missing",
+            "artifact_path": None,
+            "row_count": 0,
+            "invalid_row_count": 0,
+        }
+    artifact_path = Path(str(artifact_path_str))
+    if not artifact_path.exists():
+        return [], {
+            "status": "missing",
+            "error_code": "citation_map_jsonl_file_missing",
+            "artifact_path": str(artifact_path),
+            "row_count": 0,
+            "invalid_row_count": 0,
+        }
+    try:
+        lines = artifact_path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError) as exc:
+        return [], {
+            "status": "invalid",
+            "error_code": "citation_map_jsonl_unreadable",
+            "error": str(exc),
+            "artifact_path": str(artifact_path),
+            "row_count": 0,
+            "invalid_row_count": 0,
+        }
+    rows: list[dict[str, Any]] = []
+    invalid_row_count = 0
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            invalid_row_count += 1
+            continue
+        if isinstance(row, dict) and isinstance(row.get("citation_id"), str) and row["citation_id"]:
+            rows.append(row)
+        else:
+            invalid_row_count += 1
+    return rows, {
+        "status": "available",
+        "error_code": None,
+        "artifact_path": str(artifact_path),
+        "row_count": len(rows),
+        "invalid_row_count": invalid_row_count,
+    }
+
+
+def _citation_lookup(
+    rows: list[dict[str, Any]],
+) -> tuple[dict[str, dict[str, Any]], dict[tuple[Any, ...], dict[str, Any]]]:
+    by_chunk_id: dict[str, dict[str, Any]] = {}
+    by_range: dict[tuple[Any, ...], dict[str, Any]] = {}
+    for row in rows:
+        chunk_id = row.get("chunk_id")
+        if isinstance(chunk_id, str) and chunk_id and chunk_id not in by_chunk_id:
+            by_chunk_id[chunk_id] = row
+        canonical_range = row.get("canonical_range")
+        if isinstance(canonical_range, dict):
+            key = (
+                canonical_range.get("file_path"),
+                canonical_range.get("start_byte"),
+                canonical_range.get("end_byte"),
+                canonical_range.get("content_sha256"),
+            )
+            if all(value is not None for value in key) and key not in by_range:
+                by_range[key] = row
+    return by_chunk_id, by_range
+
+
+def _citation_record(row: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "citation_id": row.get("citation_id"),
+        "repo_id": row.get("repo_id"),
+        "chunk_id": row.get("chunk_id"),
+        "snapshot": row.get("snapshot"),
+        "canonical_range": row.get("canonical_range"),
+        "produced_by": row.get("produced_by"),
+    }
+
+
+def _resolve_hit_evidence(
+    manifest_path: Path,
+    hit: dict[str, Any],
+    by_chunk_id: dict[str, dict[str, Any]],
+    by_range: dict[tuple[Any, ...], dict[str, Any]],
+    citation_map_available: bool,
+) -> dict[str, Any]:
+    range_ref = hit.get("range_ref")
+    range_ref_source = "range_ref" if isinstance(range_ref, dict) else None
+    if range_ref_source is None and isinstance(hit.get("derived_range_ref"), dict):
+        range_ref = hit["derived_range_ref"]
+        range_ref_source = "derived_range_ref"
+
+    record: dict[str, Any] = {
+        "chunk_id": hit.get("chunk_id"),
+        "path": hit.get("path"),
+        "range_ref_source": range_ref_source,
+        "range_status": "unresolved",
+        "range": None,
+        "range_error": None,
+        "range_error_code": None,
+        "citation_status": "unmatched" if citation_map_available else "unavailable",
+        "citation_id": None,
+        "citation": None,
+    }
+
+    if range_ref_source is None:
+        record["range_error_code"] = "range_ref_missing"
+    else:
+        range_result = range_get(manifest_path, range_ref)
+        if range_result.get("status") == "available":
+            record["range_status"] = "resolved"
+            record["range"] = range_result.get("range")
+        else:
+            record["range_error"] = range_result.get("error")
+            record["range_error_code"] = range_result.get("error_code")
+
+    if citation_map_available:
+        row = None
+        chunk_id = hit.get("chunk_id")
+        if isinstance(chunk_id, str):
+            row = by_chunk_id.get(chunk_id)
+        explicit_ref = hit.get("range_ref")
+        if row is None and isinstance(explicit_ref, dict) and explicit_ref.get("artifact_role") == "canonical_md":
+            key = (
+                explicit_ref.get("file_path"),
+                explicit_ref.get("start_byte"),
+                explicit_ref.get("end_byte"),
+                explicit_ref.get("content_sha256"),
+            )
+            row = by_range.get(key)
+        if row is not None:
+            record["citation_status"] = "resolved"
+            record["citation_id"] = row.get("citation_id")
+            record["citation"] = _citation_record(row)
+
+    return record
+
+
+def _resolve_query_evidence(manifest_path: Path, query_result: Any) -> dict[str, Any]:
+    rows, citation_map_status = _load_citation_map(manifest_path)
+    by_chunk_id, by_range = _citation_lookup(rows)
+    citation_map_available = citation_map_status["status"] == "available"
+    hits = query_result.get("results") if isinstance(query_result, dict) else None
+    resolved_hits = [
+        _resolve_hit_evidence(manifest_path, hit, by_chunk_id, by_range, citation_map_available)
+        for hit in (hits if isinstance(hits, list) else [])
+        if isinstance(hit, dict)
+    ]
+    return {
+        "kind": "repobrief.resolved_evidence",
+        "version": "v1",
+        "citation_map": citation_map_status,
+        "hit_count": len(resolved_hits),
+        "hits": resolved_hits,
+        "does_not_establish": list(_DOES_NOT_ESTABLISH),
+    }
+
+
 def query_existing_index(
     bundle_manifest: str | Path,
     query: str,
     k: int = 10,
     filters: dict[str, str | None] | None = None,
+    resolve_evidence: bool = False,
 ) -> dict[str, Any]:
     manifest_path = Path(bundle_manifest).expanduser().resolve()
     if not isinstance(query, str):
@@ -329,6 +498,15 @@ def query_existing_index(
             status="invalid",
             error=f"k must be an integer between 1 and {MAX_QUERY_EXISTING_INDEX_K}",
             error_code="k_out_of_bounds",
+            extra={"query": query, "k": k, "query_result": None, "index_artifact": None},
+        )
+    if not isinstance(resolve_evidence, bool):
+        return _invalid_read_result(
+            kind="repobrief.query_existing_index",
+            bundle_manifest=manifest_path,
+            status="invalid",
+            error="resolve_evidence must be a boolean",
+            error_code="resolve_evidence_invalid",
             extra={"query": query, "k": k, "query_result": None, "index_artifact": None},
         )
 
@@ -385,8 +563,12 @@ def query_existing_index(
         "query": query,
         "k": k,
         "filters": filters or {},
+        "resolve_evidence": resolve_evidence,
         "index_artifact": artifact,
         "query_result": query_result,
+        "resolved_evidence": (
+            _resolve_query_evidence(manifest_path, query_result) if resolve_evidence else None
+        ),
         "mutation_boundary": _read_only_mutation_boundary(),
         "does_not_establish": list(_DOES_NOT_ESTABLISH),
     }

--- a/merger/lenskit/core/repobrief_access.py
+++ b/merger/lenskit/core/repobrief_access.py
@@ -17,6 +17,11 @@ _DOES_NOT_ESTABLISH = (
     "freshness",
 )
 
+CITATION_MAP_ROLE = "citation_map_jsonl"
+RESOLVED_EVIDENCE_KIND = "repobrief.resolved_evidence"
+RESOLVED_EVIDENCE_VERSION = "v1"
+_CITATION_RANGE_KEY_FIELDS = ("file_path", "start_byte", "end_byte", "content_sha256")
+
 
 def _read_json_object(path: Path) -> dict[str, Any]:
     try:
@@ -306,82 +311,98 @@ def range_get(bundle_manifest: str | Path, range_ref: dict[str, Any]) -> dict[st
     }
 
 
-def _load_citation_map(manifest_path: Path) -> tuple[list[dict[str, Any]], dict[str, Any]]:
-    artifact_result = get_artifact(manifest_path, "citation_map_jsonl")
+def _empty_citation_map_status(
+    *,
+    status: str,
+    error_code: str | None,
+    artifact_path: str | None,
+    error: str | None = None,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "status": status,
+        "error_code": error_code,
+        "artifact_path": artifact_path,
+        "row_count": 0,
+        "invalid_row_count": 0,
+    }
+    if error is not None:
+        result["error"] = error
+    return result
+
+
+def _citation_range_key(value: Any) -> tuple[Any, ...] | None:
+    if not isinstance(value, dict):
+        return None
+    key = tuple(value.get(field) for field in _CITATION_RANGE_KEY_FIELDS)
+    if any(part is None for part in key):
+        return None
+    return key
+
+
+def _load_citation_lookup(
+    manifest_path: Path,
+) -> tuple[dict[str, dict[str, Any]], dict[tuple[Any, ...], dict[str, Any]], dict[str, Any]]:
+    artifact_result = get_artifact(manifest_path, CITATION_MAP_ROLE)
     artifact = artifact_result.get("artifact") if isinstance(artifact_result, dict) else None
     artifact_path_str = artifact.get("absolute_path") if isinstance(artifact, dict) else None
     if not artifact_path_str:
-        return [], {
-            "status": "missing",
-            "error_code": "citation_map_jsonl_missing",
-            "artifact_path": None,
-            "row_count": 0,
-            "invalid_row_count": 0,
-        }
+        return {}, {}, _empty_citation_map_status(
+            status="missing",
+            error_code="citation_map_jsonl_missing",
+            artifact_path=None,
+        )
     artifact_path = Path(str(artifact_path_str))
     if not artifact_path.exists():
-        return [], {
-            "status": "missing",
-            "error_code": "citation_map_jsonl_file_missing",
-            "artifact_path": str(artifact_path),
-            "row_count": 0,
-            "invalid_row_count": 0,
-        }
-    try:
-        lines = artifact_path.read_text(encoding="utf-8").splitlines()
-    except (OSError, UnicodeDecodeError) as exc:
-        return [], {
-            "status": "invalid",
-            "error_code": "citation_map_jsonl_unreadable",
-            "error": str(exc),
-            "artifact_path": str(artifact_path),
-            "row_count": 0,
-            "invalid_row_count": 0,
-        }
-    rows: list[dict[str, Any]] = []
+        return {}, {}, _empty_citation_map_status(
+            status="missing",
+            error_code="citation_map_jsonl_file_missing",
+            artifact_path=str(artifact_path),
+        )
+
+    by_chunk_id: dict[str, dict[str, Any]] = {}
+    by_range: dict[tuple[Any, ...], dict[str, Any]] = {}
+    row_count = 0
     invalid_row_count = 0
-    for line in lines:
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            row = json.loads(line)
-        except json.JSONDecodeError:
-            invalid_row_count += 1
-            continue
-        if isinstance(row, dict) and isinstance(row.get("citation_id"), str) and row["citation_id"]:
-            rows.append(row)
-        else:
-            invalid_row_count += 1
-    return rows, {
+    try:
+        with artifact_path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    invalid_row_count += 1
+                    continue
+                if not isinstance(row, dict):
+                    invalid_row_count += 1
+                    continue
+                citation_id = row.get("citation_id")
+                if not isinstance(citation_id, str) or not citation_id:
+                    invalid_row_count += 1
+                    continue
+                row_count += 1
+                chunk_id = row.get("chunk_id")
+                if isinstance(chunk_id, str) and chunk_id and chunk_id not in by_chunk_id:
+                    by_chunk_id[chunk_id] = row
+                range_key = _citation_range_key(row.get("canonical_range"))
+                if range_key is not None and range_key not in by_range:
+                    by_range[range_key] = row
+    except (OSError, UnicodeDecodeError) as exc:
+        return {}, {}, _empty_citation_map_status(
+            status="invalid",
+            error_code="citation_map_jsonl_unreadable",
+            artifact_path=str(artifact_path),
+            error=str(exc),
+        )
+
+    return by_chunk_id, by_range, {
         "status": "available",
         "error_code": None,
         "artifact_path": str(artifact_path),
-        "row_count": len(rows),
+        "row_count": row_count,
         "invalid_row_count": invalid_row_count,
     }
-
-
-def _citation_lookup(
-    rows: list[dict[str, Any]],
-) -> tuple[dict[str, dict[str, Any]], dict[tuple[Any, ...], dict[str, Any]]]:
-    by_chunk_id: dict[str, dict[str, Any]] = {}
-    by_range: dict[tuple[Any, ...], dict[str, Any]] = {}
-    for row in rows:
-        chunk_id = row.get("chunk_id")
-        if isinstance(chunk_id, str) and chunk_id and chunk_id not in by_chunk_id:
-            by_chunk_id[chunk_id] = row
-        canonical_range = row.get("canonical_range")
-        if isinstance(canonical_range, dict):
-            key = (
-                canonical_range.get("file_path"),
-                canonical_range.get("start_byte"),
-                canonical_range.get("end_byte"),
-                canonical_range.get("content_sha256"),
-            )
-            if all(value is not None for value in key) and key not in by_range:
-                by_range[key] = row
-    return by_chunk_id, by_range
 
 
 def _citation_record(row: dict[str, Any]) -> dict[str, Any]:
@@ -403,8 +424,10 @@ def _resolve_hit_evidence(
     citation_map_available: bool,
 ) -> dict[str, Any]:
     range_ref = hit.get("range_ref")
-    range_ref_source = "range_ref" if isinstance(range_ref, dict) else None
-    if range_ref_source is None and isinstance(hit.get("derived_range_ref"), dict):
+    range_ref_source = None
+    if isinstance(range_ref, dict):
+        range_ref_source = "range_ref"
+    elif isinstance(hit.get("derived_range_ref"), dict):
         range_ref = hit["derived_range_ref"]
         range_ref_source = "derived_range_ref"
 
@@ -437,15 +460,9 @@ def _resolve_hit_evidence(
         chunk_id = hit.get("chunk_id")
         if isinstance(chunk_id, str):
             row = by_chunk_id.get(chunk_id)
-        explicit_ref = hit.get("range_ref")
-        if row is None and isinstance(explicit_ref, dict) and explicit_ref.get("artifact_role") == "canonical_md":
-            key = (
-                explicit_ref.get("file_path"),
-                explicit_ref.get("start_byte"),
-                explicit_ref.get("end_byte"),
-                explicit_ref.get("content_sha256"),
-            )
-            row = by_range.get(key)
+        range_key = _citation_range_key(range_ref)
+        if row is None and range_key is not None:
+            row = by_range.get(range_key)
         if row is not None:
             record["citation_status"] = "resolved"
             record["citation_id"] = row.get("citation_id")
@@ -455,24 +472,39 @@ def _resolve_hit_evidence(
 
 
 def _resolve_query_evidence(manifest_path: Path, query_result: Any) -> dict[str, Any]:
-    rows, citation_map_status = _load_citation_map(manifest_path)
-    by_chunk_id, by_range = _citation_lookup(rows)
-    citation_map_available = citation_map_status["status"] == "available"
     hits = query_result.get("results") if isinstance(query_result, dict) else None
+    hit_list = [hit for hit in (hits if isinstance(hits, list) else []) if isinstance(hit, dict)]
+    if not hit_list:
+        return {
+            "kind": RESOLVED_EVIDENCE_KIND,
+            "version": RESOLVED_EVIDENCE_VERSION,
+            "citation_map": {
+                "status": "skipped",
+                "error_code": None,
+                "artifact_path": None,
+                "row_count": 0,
+                "invalid_row_count": 0,
+                "reason": "no_hits",
+            },
+            "hit_count": 0,
+            "hits": [],
+            "does_not_establish": list(_DOES_NOT_ESTABLISH),
+        }
+
+    by_chunk_id, by_range, citation_map_status = _load_citation_lookup(manifest_path)
+    citation_map_available = citation_map_status["status"] == "available"
     resolved_hits = [
         _resolve_hit_evidence(manifest_path, hit, by_chunk_id, by_range, citation_map_available)
-        for hit in (hits if isinstance(hits, list) else [])
-        if isinstance(hit, dict)
+        for hit in hit_list
     ]
     return {
-        "kind": "repobrief.resolved_evidence",
-        "version": "v1",
+        "kind": RESOLVED_EVIDENCE_KIND,
+        "version": RESOLVED_EVIDENCE_VERSION,
         "citation_map": citation_map_status,
         "hit_count": len(resolved_hits),
         "hits": resolved_hits,
         "does_not_establish": list(_DOES_NOT_ESTABLISH),
     }
-
 
 def query_existing_index(
     bundle_manifest: str | Path,

--- a/merger/lenskit/tests/test_repobrief_resolved_evidence_query.py
+++ b/merger/lenskit/tests/test_repobrief_resolved_evidence_query.py
@@ -279,3 +279,24 @@ def test_resolved_evidence_skips_citation_map_for_empty_hits(tmp_path):
     assert resolved["citation_map"]["status"] == "skipped"
     assert resolved["citation_map"]["reason"] == "no_hits"
     assert resolved["citation_map"]["invalid_row_count"] == 0
+
+
+def test_resolved_evidence_falls_back_to_derived_range_ref_when_range_ref_invalid(tmp_path):
+    bundle = _build_resolved_bundle(tmp_path)
+    base = repobrief_access.query_existing_index(bundle["manifest"], "hello", k=1)
+    hit = dict(base["query_result"]["results"][0])
+    valid_range_ref = hit.pop("range_ref")
+    hit.pop("chunk_id", None)
+    hit["range_ref"] = {"artifact_role": "source_file", "path": "outside.py"}
+    hit["derived_range_ref"] = valid_range_ref
+
+    resolved = repobrief_access._resolve_query_evidence(bundle["manifest"], {"results": [hit]})
+
+    assert resolved["hit_count"] == 1
+    resolved_hit = resolved["hits"][0]
+    assert resolved_hit["range_ref_source"] == "derived_range_ref"
+    assert resolved_hit["range_status"] == "resolved"
+    assert resolved_hit["range_error_code"] is None
+    assert resolved_hit["range"]["text"] == bundle["chunk_text"]
+    assert resolved_hit["citation_status"] == "resolved"
+    assert resolved_hit["citation_id"] == bundle["citation_id"]

--- a/merger/lenskit/tests/test_repobrief_resolved_evidence_query.py
+++ b/merger/lenskit/tests/test_repobrief_resolved_evidence_query.py
@@ -300,3 +300,72 @@ def test_resolved_evidence_falls_back_to_derived_range_ref_when_range_ref_invali
     assert resolved_hit["range"]["text"] == bundle["chunk_text"]
     assert resolved_hit["citation_status"] == "resolved"
     assert resolved_hit["citation_id"] == bundle["citation_id"]
+
+
+def test_query_existing_index_rejects_structurally_malformed_citation_row(tmp_path):
+    bundle = _build_resolved_bundle(tmp_path)
+    citation_map_path = tmp_path / "demo.citation_map.jsonl"
+    citation_map_path.write_text(
+        json.dumps({
+            "citation_id": "cit_0000000000000001",
+            "repo_id": "demo",
+            "chunk_id": "c1",
+        })
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = repobrief_access.query_existing_index(
+        bundle["manifest"], "hello", k=5, resolve_evidence=True
+    )
+
+    assert result["status"] == "available"
+    citation_map = result["resolved_evidence"]["citation_map"]
+    assert citation_map["status"] == "available"
+    assert citation_map["row_count"] == 0
+    assert citation_map["invalid_row_count"] == 1
+    hit = result["resolved_evidence"]["hits"][0]
+    assert hit["citation_status"] == "unmatched"
+    assert hit["citation_id"] is None
+    assert hit["citation"] is None
+
+
+def test_resolved_evidence_matches_v2_range_ref_without_chunk_id(tmp_path):
+    from merger.lenskit.core.range_resolver import build_explicit_range_ref_v2
+
+    bundle = _build_resolved_bundle(tmp_path)
+    citation_map_path = tmp_path / "demo.citation_map.jsonl"
+    row = json.loads(citation_map_path.read_text(encoding="utf-8"))
+    row.pop("chunk_id")
+    citation_map_path.write_text(json.dumps(row) + "\n", encoding="utf-8")
+
+    base = repobrief_access.query_existing_index(bundle["manifest"], "hello", k=1)
+    hit = dict(base["query_result"]["results"][0])
+    v1_ref = hit.pop("range_ref")
+    hit.pop("chunk_id", None)
+
+    canonical_bytes = bundle["canonical"].read_bytes()
+    v2_ref = build_explicit_range_ref_v2(
+        artifact_role="canonical_md",
+        artifact_path=bundle["canonical"].name,
+        artifact_byte_start=v1_ref["start_byte"],
+        artifact_byte_end=v1_ref["end_byte"],
+        artifact_line_start=v1_ref["start_line"],
+        artifact_line_end=v1_ref["end_line"],
+        source_file_path=bundle["canonical"].name,
+        source_line_start=v1_ref["start_line"],
+        source_line_end=v1_ref["end_line"],
+        content_sha256=_sha256_bytes(canonical_bytes),
+        range_content_sha256=v1_ref["content_sha256"],
+        repo_id="demo",
+    )
+    hit["range_ref"] = v2_ref
+
+    resolved = repobrief_access._resolve_query_evidence(bundle["manifest"], {"results": [hit]})
+
+    assert resolved["hit_count"] == 1
+    resolved_hit = resolved["hits"][0]
+    assert resolved_hit["range_status"] == "resolved"
+    assert resolved_hit["range_ref_source"] == "range_ref"
+    assert resolved_hit["citation_status"] == "resolved"
+    assert resolved_hit["citation_id"] == bundle["citation_id"]

--- a/merger/lenskit/tests/test_repobrief_resolved_evidence_query.py
+++ b/merger/lenskit/tests/test_repobrief_resolved_evidence_query.py
@@ -1,0 +1,223 @@
+import hashlib
+import json
+
+from merger.lenskit.core import repobrief_access
+from merger.lenskit.core.citation_id import make_citation_id
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _sha256(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _sqlite_sidecars(index_path):
+    return {
+        index_path.with_name(index_path.name + suffix)
+        for suffix in ("-wal", "-shm", "-journal")
+    }
+
+
+def _build_resolved_bundle(tmp_path, with_citation_map=True):
+    from merger.lenskit.retrieval import index_db
+
+    canonical = tmp_path / "brief.md"
+    canonical.write_text("# Brief\n\nhello resolved world\n", encoding="utf-8")
+    content = canonical.read_bytes()
+    start = content.index(b"hello")
+    end = len(content)
+    chunk_bytes = content[start:end]
+    chunk_sha = _sha256_bytes(chunk_bytes)
+    canonical_sha = _sha256_bytes(content)
+
+    range_ref = {
+        "artifact_role": "canonical_md",
+        "repo_id": "demo",
+        "file_path": canonical.name,
+        "start_byte": start,
+        "end_byte": end,
+        "start_line": 3,
+        "end_line": 3,
+        "content_sha256": chunk_sha,
+    }
+    chunk = {
+        "chunk_id": "c1",
+        "repo_id": "demo",
+        "path": canonical.name,
+        "content": chunk_bytes.decode("utf-8"),
+        "start_byte": start,
+        "end_byte": end,
+        "start_line": 3,
+        "end_line": 3,
+        "layer": "core",
+        "artifact_type": "doc",
+        "content_sha256": chunk_sha,
+        "content_range_ref": range_ref,
+    }
+    chunk_path = tmp_path / "chunks.jsonl"
+    chunk_path.write_text(json.dumps(chunk) + "\n", encoding="utf-8")
+    dump_path = tmp_path / "dump.json"
+    dump_path.write_text(json.dumps({"version": "1.0", "repos": {"demo": {}}}), encoding="utf-8")
+    index_path = tmp_path / "demo.index.sqlite"
+    index_db.build_index(dump_path, chunk_path, index_path)
+
+    citation_id = make_citation_id(canonical_sha, start, end, chunk_sha)
+    artifacts = [
+        {
+            "role": "canonical_md",
+            "path": canonical.name,
+            "content_type": "text/markdown",
+            "bytes": len(content),
+            "sha256": canonical_sha,
+        },
+        {"role": "sqlite_index", "path": index_path.name},
+    ]
+    if with_citation_map:
+        citation_map_path = tmp_path / "demo.citation_map.jsonl"
+        row = {
+            "citation_id": citation_id,
+            "repo_id": "demo",
+            "chunk_id": "c1",
+            "snapshot": {
+                "run_id": "run-1",
+                "canonical_md_path": canonical.name,
+                "canonical_md_sha256": canonical_sha,
+            },
+            "canonical_range": {
+                "file_path": canonical.name,
+                "start_byte": start,
+                "end_byte": end,
+                "start_line": 3,
+                "end_line": 3,
+                "content_sha256": chunk_sha,
+            },
+            "produced_by": "citation_map_producer/v1",
+        }
+        citation_map_path.write_text(json.dumps(row) + "\n", encoding="utf-8")
+        artifacts.append({"role": "citation_map_jsonl", "path": citation_map_path.name})
+
+    manifest = tmp_path / "demo.bundle.manifest.json"
+    manifest.write_text(
+        json.dumps({
+            "kind": "repolens.bundle.manifest",
+            "version": "1.0",
+            "run_id": "run-1",
+            "artifacts": artifacts,
+            "links": {},
+            "capabilities": {},
+        }),
+        encoding="utf-8",
+    )
+    return {
+        "manifest": manifest,
+        "index_path": index_path,
+        "canonical": canonical,
+        "chunk_text": chunk_bytes.decode("utf-8"),
+        "citation_id": citation_id,
+    }
+
+
+def test_query_existing_index_resolves_hit_evidence_and_citation(tmp_path):
+    bundle = _build_resolved_bundle(tmp_path)
+
+    result = repobrief_access.query_existing_index(
+        bundle["manifest"], "hello", k=5, resolve_evidence=True
+    )
+
+    assert result["status"] == "available"
+    assert result["resolve_evidence"] is True
+    resolved = result["resolved_evidence"]
+    assert resolved["kind"] == "repobrief.resolved_evidence"
+    assert resolved["version"] == "v1"
+    assert resolved["citation_map"]["status"] == "available"
+    assert resolved["citation_map"]["row_count"] == 1
+    assert resolved["hit_count"] == 1
+    hit = resolved["hits"][0]
+    assert hit["chunk_id"] == "c1"
+    assert hit["range_ref_source"] == "range_ref"
+    assert hit["range_status"] == "resolved"
+    assert hit["range"]["text"] == bundle["chunk_text"]
+    assert hit["range_error_code"] is None
+    assert hit["citation_status"] == "resolved"
+    assert hit["citation_id"] == bundle["citation_id"]
+    assert hit["citation"]["canonical_range"]["file_path"] == bundle["canonical"].name
+    assert resolved["does_not_establish"] == result["does_not_establish"]
+    assert result["mutation_boundary"]["writes"] == []
+
+
+def test_query_existing_index_degrades_when_citation_map_missing(tmp_path):
+    bundle = _build_resolved_bundle(tmp_path, with_citation_map=False)
+
+    result = repobrief_access.query_existing_index(
+        bundle["manifest"], "hello", k=5, resolve_evidence=True
+    )
+
+    assert result["status"] == "available"
+    resolved = result["resolved_evidence"]
+    assert resolved["citation_map"]["status"] == "missing"
+    assert resolved["citation_map"]["error_code"] == "citation_map_jsonl_missing"
+    hit = resolved["hits"][0]
+    assert hit["range_status"] == "resolved"
+    assert hit["range"]["text"] == bundle["chunk_text"]
+    assert hit["citation_status"] == "unavailable"
+    assert hit["citation_id"] is None
+    assert hit["citation"] is None
+
+
+def test_query_existing_index_resolution_is_read_only(tmp_path):
+    bundle = _build_resolved_bundle(tmp_path)
+    index_path = bundle["index_path"]
+
+    before_files = {path.name for path in tmp_path.iterdir()}
+    before_hashes = {path.name: _sha256(path) for path in tmp_path.iterdir() if path.is_file()}
+
+    result = repobrief_access.query_existing_index(
+        bundle["manifest"], "hello", k=5, resolve_evidence=True
+    )
+
+    after_files = {path.name for path in tmp_path.iterdir()}
+    after_hashes = {path.name: _sha256(path) for path in tmp_path.iterdir() if path.is_file()}
+
+    assert result["status"] == "available"
+    assert result["resolved_evidence"]["hits"][0]["range_status"] == "resolved"
+    assert before_files == after_files
+    assert before_hashes == after_hashes
+    assert not any(path.exists() for path in _sqlite_sidecars(index_path))
+    assert result["mutation_boundary"]["writes"] == []
+    assert result["mutation_boundary"]["read_paths_do_not_refresh"] is True
+
+
+def test_query_existing_index_resolution_defaults_off(tmp_path):
+    bundle = _build_resolved_bundle(tmp_path)
+
+    result = repobrief_access.query_existing_index(bundle["manifest"], "hello", k=5)
+
+    assert result["status"] == "available"
+    assert result["resolve_evidence"] is False
+    assert result["resolved_evidence"] is None
+
+
+def test_query_existing_index_rejects_non_boolean_resolve_evidence(tmp_path):
+    manifest = tmp_path / "demo.bundle.manifest.json"
+    manifest.write_text(
+        json.dumps({
+            "kind": "repolens.bundle.manifest",
+            "version": "1.0",
+            "run_id": "run-1",
+            "artifacts": [],
+            "links": {},
+            "capabilities": {},
+        }),
+        encoding="utf-8",
+    )
+
+    for bad_value in ("yes", 1, None):
+        result = repobrief_access.query_existing_index(
+            manifest, "hello", k=1, resolve_evidence=bad_value
+        )
+
+        assert result["status"] == "invalid"
+        assert result["error_code"] == "resolve_evidence_invalid"
+        assert result["query_result"] is None

--- a/merger/lenskit/tests/test_repobrief_resolved_evidence_query.py
+++ b/merger/lenskit/tests/test_repobrief_resolved_evidence_query.py
@@ -221,3 +221,61 @@ def test_query_existing_index_rejects_non_boolean_resolve_evidence(tmp_path):
         assert result["status"] == "invalid"
         assert result["error_code"] == "resolve_evidence_invalid"
         assert result["query_result"] is None
+
+
+def test_query_existing_index_reports_invalid_citation_map_rows(tmp_path):
+    bundle = _build_resolved_bundle(tmp_path)
+    citation_map_path = tmp_path / "demo.citation_map.jsonl"
+    with citation_map_path.open("a", encoding="utf-8") as handle:
+        handle.write("not json\n")
+        handle.write(json.dumps({"chunk_id": "missing-citation-id"}) + "\n")
+
+    result = repobrief_access.query_existing_index(
+        bundle["manifest"], "hello", k=5, resolve_evidence=True
+    )
+
+    assert result["status"] == "available"
+    citation_map = result["resolved_evidence"]["citation_map"]
+    assert citation_map["status"] == "available"
+    assert citation_map["row_count"] == 1
+    assert citation_map["invalid_row_count"] == 2
+    hit = result["resolved_evidence"]["hits"][0]
+    assert hit["citation_status"] == "resolved"
+    assert hit["citation_id"] == bundle["citation_id"]
+
+
+def test_resolved_evidence_uses_derived_range_ref_when_range_ref_missing(tmp_path):
+    bundle = _build_resolved_bundle(tmp_path)
+    base = repobrief_access.query_existing_index(bundle["manifest"], "hello", k=1)
+    hit = dict(base["query_result"]["results"][0])
+    range_ref = hit.pop("range_ref")
+    hit.pop("chunk_id", None)
+    hit["derived_range_ref"] = range_ref
+
+    resolved = repobrief_access._resolve_query_evidence(bundle["manifest"], {"results": [hit]})
+
+    assert resolved["hit_count"] == 1
+    resolved_hit = resolved["hits"][0]
+    assert resolved_hit["range_ref_source"] == "derived_range_ref"
+    assert resolved_hit["range_status"] == "resolved"
+    assert resolved_hit["range"]["text"] == bundle["chunk_text"]
+    assert resolved_hit["citation_status"] == "resolved"
+    assert resolved_hit["citation_id"] == bundle["citation_id"]
+
+
+def test_resolved_evidence_skips_citation_map_for_empty_hits(tmp_path):
+    bundle = _build_resolved_bundle(tmp_path)
+    citation_map_path = tmp_path / "demo.citation_map.jsonl"
+    citation_map_path.write_text("not json\n", encoding="utf-8")
+
+    result = repobrief_access.query_existing_index(
+        bundle["manifest"], "no-such-token", k=5, resolve_evidence=True
+    )
+
+    assert result["status"] == "available"
+    resolved = result["resolved_evidence"]
+    assert resolved["hit_count"] == 0
+    assert resolved["hits"] == []
+    assert resolved["citation_map"]["status"] == "skipped"
+    assert resolved["citation_map"]["reason"] == "no_hits"
+    assert resolved["citation_map"]["invalid_row_count"] == 0


### PR DESCRIPTION
## Summary
- Adds an opt-in `resolve_evidence: bool = False` parameter to `repobrief_access.query_existing_index`.
- When enabled, each query hit is resolved to text/range metadata via the existing read-only `range_get` (explicit `range_ref` preferred, `derived_range_ref` fallback — still rejected at the `source_file` boundary), and joined to citation identity from the bundle's `citation_map_jsonl` (matched by `chunk_id`, falling back to canonical range identity).
- Missing/unreadable citation maps degrade structurally: per-hit `citation_status: "unavailable"` and a top-level `citation_map` status record; the query result itself stays `available`.
- Non-boolean `resolve_evidence` is rejected with `error_code: resolve_evidence_invalid`, matching the strict `k` validation style.

## Read-only boundary
- No Git/source/bundle mutation from read APIs; no implicit snapshot refresh; no review verdicts.
- Response keeps the existing `mutation_boundary` and `does_not_establish` fields; the resolved-evidence block carries its own `does_not_establish`.

## Out of scope (intentionally not implemented)
MCP server, embeddings, semantAH, federation, PR delta.

## Tests
- `test_repobrief_resolved_evidence_query.py`: resolved hit evidence (text + citation id), missing-citation-map degradation, read-only invariants (no new files, no hash changes, no SQLite `-wal`/`-shm`/`-journal` sidecars), default-off behavior, non-boolean flag rejection.
- Verified: `python -m compileall`, `ruff check`, targeted pytest (170 passed across repobrief/citation/query suites), `git diff --check`.

## does_not_establish
This PR does not establish: truth, correctness, completeness, runtime_behavior, test_sufficiency, regression_absence, repo_understood, claims_true, forensic_ready, freshness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)