### PR TITLE
feat(repobrief): Source Citation Projection v1 (RBEV1-T003)

### DIFF
--- a/merger/lenskit/core/repobrief_access.py
+++ b/merger/lenskit/core/repobrief_access.py
@@ -613,30 +613,65 @@ def _source_range_projection(range_value: Any) -> dict[str, Any] | None:
     if not isinstance(provenance, dict):
         provenance = {}
     start_line, end_line = _line_pair(range_value.get("lines"))
+    artifact_path = _first_not_none(
+        range_value.get("artifact_path"),
+        range_value.get("file_path"),
+        range_value.get("path"),
+        provenance.get("artifact_path"),
+        provenance.get("file_path"),
+    )
+    artifact_start_byte = _first_not_none(
+        range_value.get("artifact_byte_start"),
+        range_value.get("start_byte"),
+        provenance.get("artifact_byte_start"),
+        provenance.get("start_byte"),
+    )
+    artifact_end_byte = _first_not_none(
+        range_value.get("artifact_byte_end"),
+        range_value.get("end_byte"),
+        provenance.get("artifact_byte_end"),
+        provenance.get("end_byte"),
+    )
+    artifact_start_line = _first_not_none(
+        range_value.get("artifact_line_start"),
+        range_value.get("start_line"),
+        start_line,
+    )
+    artifact_end_line = _first_not_none(
+        range_value.get("artifact_line_end"),
+        range_value.get("end_line"),
+        end_line,
+    )
+    source_file_path = _first_not_none(
+        range_value.get("source_file_path"),
+        provenance.get("source_file_path"),
+    )
+    source_start_line = _first_not_none(
+        range_value.get("source_line_start"),
+        provenance.get("source_line_start"),
+    )
+    source_end_line = _first_not_none(
+        range_value.get("source_line_end"),
+        provenance.get("source_line_end"),
+    )
+    has_source_axis = source_file_path is not None
     return {
         "artifact_role": _first_not_none(range_value.get("artifact_role"), provenance.get("artifact_role")),
-        "file_path": _first_not_none(
-            range_value.get("file_path"),
-            range_value.get("path"),
-            range_value.get("artifact_path"),
-            provenance.get("file_path"),
-            provenance.get("artifact_path"),
-        ),
-        "start_byte": _first_not_none(
-            range_value.get("start_byte"),
-            range_value.get("artifact_byte_start"),
-            provenance.get("start_byte"),
-            provenance.get("artifact_byte_start"),
-        ),
-        "end_byte": _first_not_none(
-            range_value.get("end_byte"),
-            range_value.get("artifact_byte_end"),
-            provenance.get("end_byte"),
-            provenance.get("artifact_byte_end"),
-        ),
-        "start_line": _first_not_none(range_value.get("start_line"), range_value.get("artifact_line_start"), start_line),
-        "end_line": _first_not_none(range_value.get("end_line"), range_value.get("artifact_line_end"), end_line),
+        "file_path": source_file_path if has_source_axis else artifact_path,
+        "start_byte": artifact_start_byte,
+        "end_byte": artifact_end_byte,
+        "start_line": source_start_line if has_source_axis else artifact_start_line,
+        "end_line": source_end_line if has_source_axis else artifact_end_line,
         "content_sha256": _first_not_none(range_value.get("range_content_sha256"), range_value.get("content_sha256"), range_value.get("sha256")),
+        "artifact_path": artifact_path,
+        "artifact_start_byte": artifact_start_byte,
+        "artifact_end_byte": artifact_end_byte,
+        "artifact_start_line": artifact_start_line,
+        "artifact_end_line": artifact_end_line,
+        "source_file_path": source_file_path,
+        "source_start_line": source_start_line,
+        "source_end_line": source_end_line,
+        "coordinate_basis": "source_lines_artifact_bytes" if has_source_axis else "artifact_bytes",
     }
 
 
@@ -664,6 +699,7 @@ def _project_source_citations(resolved_evidence: Any) -> dict[str, Any]:
     hit_list = [hit for hit in (hits if isinstance(hits, list) else []) if isinstance(hit, dict)]
     items: list[dict[str, Any]] = []
     citation_count = 0
+    unresolved_count = 0
     range_unresolved_count = 0
     citation_unresolved_count = 0
     for ordinal, hit in enumerate(hit_list):
@@ -689,14 +725,17 @@ def _project_source_citations(resolved_evidence: Any) -> dict[str, Any]:
         citation_id = hit.get("citation_id")
         if range_status != "resolved":
             range_unresolved_count += 1
-        if (
+        citation_resolved = (
             citation_status == "resolved"
             and isinstance(citation_id, str)
             and _CITATION_ID_RE.fullmatch(citation_id) is not None
-        ):
+        )
+        if citation_resolved:
             citation_count += 1
-        if citation_status != "resolved":
+        else:
             citation_unresolved_count += 1
+        if range_status != "resolved" or not citation_resolved:
+            unresolved_count += 1
         items.append({
             "ordinal": ordinal,
             "chunk_id": hit.get("chunk_id"),
@@ -716,7 +755,7 @@ def _project_source_citations(resolved_evidence: Any) -> dict[str, Any]:
         "status": "available",
         "hit_count": len(items),
         "citation_count": citation_count,
-        "unresolved_count": range_unresolved_count,
+        "unresolved_count": unresolved_count,
         "range_unresolved_count": range_unresolved_count,
         "citation_unresolved_count": citation_unresolved_count,
         "text_excerpt_max_chars": TEXT_EXCERPT_MAX_CHARS,

--- a/merger/lenskit/core/repobrief_access.py
+++ b/merger/lenskit/core/repobrief_access.py
@@ -654,14 +654,14 @@ def _source_range_projection(range_value: Any) -> dict[str, Any] | None:
         range_value.get("source_line_end"),
         provenance.get("source_line_end"),
     )
-    has_source_axis = source_file_path is not None
+    has_source_axis = _is_non_empty_string(source_file_path)
     return {
         "artifact_role": _first_not_none(range_value.get("artifact_role"), provenance.get("artifact_role")),
-        "file_path": source_file_path if has_source_axis else artifact_path,
+        "file_path": artifact_path,
         "start_byte": artifact_start_byte,
         "end_byte": artifact_end_byte,
-        "start_line": source_start_line if has_source_axis else artifact_start_line,
-        "end_line": source_end_line if has_source_axis else artifact_end_line,
+        "start_line": artifact_start_line,
+        "end_line": artifact_end_line,
         "content_sha256": _first_not_none(range_value.get("range_content_sha256"), range_value.get("content_sha256"), range_value.get("sha256")),
         "artifact_path": artifact_path,
         "artifact_start_byte": artifact_start_byte,
@@ -671,7 +671,7 @@ def _source_range_projection(range_value: Any) -> dict[str, Any] | None:
         "source_file_path": source_file_path,
         "source_start_line": source_start_line,
         "source_end_line": source_end_line,
-        "coordinate_basis": "source_lines_artifact_bytes" if has_source_axis else "artifact_bytes",
+        "coordinate_basis": "artifact_bytes_with_source_lines" if has_source_axis else "artifact_bytes",
     }
 
 
@@ -705,7 +705,8 @@ def _project_source_citations(resolved_evidence: Any) -> dict[str, Any]:
     for ordinal, hit in enumerate(hit_list):
         range_value = hit.get("range")
         text = range_value.get("text") if isinstance(range_value, dict) else None
-        citation = hit.get("citation") if isinstance(hit.get("citation"), dict) else None
+        raw_citation = hit.get("citation")
+        citation = raw_citation if isinstance(raw_citation, dict) else None
         citation_range = _source_range_projection(
             citation.get("canonical_range") if citation else None
         )
@@ -718,8 +719,13 @@ def _project_source_citations(resolved_evidence: Any) -> dict[str, Any]:
         candidates = [range_ref_projection, citation_range, range_projection]
         source_range = next(
             (candidate for candidate in candidates if _has_range_identity(candidate)),
-            next((candidate for candidate in candidates if isinstance(candidate, dict)), None),
+            None,
         )
+        if source_range is None:
+            source_range = next(
+                (candidate for candidate in candidates if isinstance(candidate, dict)),
+                None,
+            )
         range_status = hit.get("range_status")
         citation_status = hit.get("citation_status")
         citation_id = hit.get("citation_id")
@@ -746,6 +752,7 @@ def _project_source_citations(resolved_evidence: Any) -> dict[str, Any]:
             "text_excerpt": text[:TEXT_EXCERPT_MAX_CHARS] if isinstance(text, str) else None,
             "text_truncated": isinstance(text, str) and len(text) > TEXT_EXCERPT_MAX_CHARS,
             "citation_status": citation_status,
+            "citation_resolved": citation_resolved,
             "citation_id": citation_id,
             "citation_range": citation_range,
         })

--- a/merger/lenskit/core/repobrief_access.py
+++ b/merger/lenskit/core/repobrief_access.py
@@ -512,9 +512,9 @@ def _resolve_hit_evidence(
         for candidate_source, candidate_ref in range_candidates:
             range_result = range_get(manifest_path, candidate_ref)
             record["range_ref_source"] = candidate_source
-            selected_range_ref = candidate_ref
-            record["range_ref"] = selected_range_ref
             if range_result.get("status") == "available":
+                selected_range_ref = candidate_ref
+                record["range_ref"] = selected_range_ref
                 record["range_status"] = "resolved"
                 record["range"] = range_result.get("range")
                 record["range_error"] = None
@@ -574,11 +574,33 @@ def _resolve_query_evidence(manifest_path: Path, query_result: Any) -> dict[str,
         "does_not_establish": list(_DOES_NOT_ESTABLISH),
     }
 
-def _first_not_none(*values):
+
+def _first_not_none(*values: Any) -> Any:
     for value in values:
         if value is not None:
             return value
     return None
+
+
+def _line_pair(value: Any) -> tuple[int | None, int | None]:
+    if not isinstance(value, list) or len(value) != 2:
+        return None, None
+    start, end = value
+    if isinstance(start, bool) or isinstance(end, bool):
+        return None, None
+    if not isinstance(start, int) or not isinstance(end, int):
+        return None, None
+    return start, end
+
+
+def _has_range_identity(value: Any) -> bool:
+    return (
+        isinstance(value, dict)
+        and value.get("file_path") is not None
+        and value.get("start_byte") is not None
+        and value.get("end_byte") is not None
+    )
+
 
 def _source_range_projection(range_value: Any) -> dict[str, Any] | None:
     if not isinstance(range_value, dict):
@@ -586,10 +608,7 @@ def _source_range_projection(range_value: Any) -> dict[str, Any] | None:
     provenance = range_value.get("provenance")
     if not isinstance(provenance, dict):
         provenance = {}
-    lines = range_value.get("lines")
-    start_line = end_line = None
-    if isinstance(lines, list) and len(lines) == 2:
-        start_line, end_line = lines
+    start_line, end_line = _line_pair(range_value.get("lines"))
     return {
         "artifact_role": _first_not_none(range_value.get("artifact_role"), provenance.get("artifact_role")),
         "file_path": _first_not_none(range_value.get("file_path"), range_value.get("path"), range_value.get("artifact_path")),
@@ -600,29 +619,67 @@ def _source_range_projection(range_value: Any) -> dict[str, Any] | None:
         "content_sha256": _first_not_none(range_value.get("range_content_sha256"), range_value.get("content_sha256"), range_value.get("sha256")),
     }
 
+
+def _empty_source_citation_projection(status: str = "unavailable") -> dict[str, Any]:
+    return {
+        "kind": SOURCE_CITATION_PROJECTION_KIND,
+        "version": SOURCE_CITATION_PROJECTION_VERSION,
+        "status": status,
+        "hit_count": 0,
+        "citation_count": 0,
+        "unresolved_count": 0,
+        "range_unresolved_count": 0,
+        "citation_unresolved_count": 0,
+        "text_excerpt_max_chars": TEXT_EXCERPT_MAX_CHARS,
+        "items": [],
+        "does_not_establish": list(_DOES_NOT_ESTABLISH),
+    }
+
+
 def _project_source_citations(resolved_evidence: Any) -> dict[str, Any]:
-    hits = resolved_evidence.get("hits") if isinstance(resolved_evidence, dict) else None
+    if not isinstance(resolved_evidence, dict):
+        return _empty_source_citation_projection()
+
+    hits = resolved_evidence.get("hits")
     hit_list = [hit for hit in (hits if isinstance(hits, list) else []) if isinstance(hit, dict)]
     items: list[dict[str, Any]] = []
+    citation_count = 0
+    range_unresolved_count = 0
+    citation_unresolved_count = 0
     for ordinal, hit in enumerate(hit_list):
         range_value = hit.get("range")
         text = range_value.get("text") if isinstance(range_value, dict) else None
         citation = hit.get("citation") if isinstance(hit.get("citation"), dict) else None
-        citation_range = _source_range_projection(citation.get("canonical_range") if citation else None)
-        source_range = _source_range_projection(hit.get("range_ref")) or citation_range or _source_range_projection(range_value)
-        if isinstance(source_range, dict) and source_range.get("file_path") is None:
-            source_range = citation_range if isinstance(citation_range, dict) else source_range
+        citation_range = _source_range_projection(
+            citation.get("canonical_range") if citation else None
+        )
+        range_ref_projection = _source_range_projection(hit.get("range_ref"))
+        range_projection = _source_range_projection(range_value)
+        candidates = [range_ref_projection, citation_range, range_projection]
+        source_range = next(
+            (candidate for candidate in candidates if _has_range_identity(candidate)),
+            next((candidate for candidate in candidates if isinstance(candidate, dict)), None),
+        )
+        range_status = hit.get("range_status")
+        citation_status = hit.get("citation_status")
+        citation_id = hit.get("citation_id")
+        if range_status != "resolved":
+            range_unresolved_count += 1
+        if citation_status == "resolved" and citation_id:
+            citation_count += 1
+        if citation_status != "resolved":
+            citation_unresolved_count += 1
         items.append({
             "ordinal": ordinal,
             "chunk_id": hit.get("chunk_id"),
             "path": hit.get("path"),
-            "range_status": hit.get("range_status"),
+            "range_status": range_status,
             "range_ref_source": hit.get("range_ref_source"),
             "source_range": source_range,
             "text_excerpt": text[:TEXT_EXCERPT_MAX_CHARS] if isinstance(text, str) else None,
             "text_truncated": isinstance(text, str) and len(text) > TEXT_EXCERPT_MAX_CHARS,
-            "citation_status": hit.get("citation_status"),
-            "citation_id": hit.get("citation_id"),
+            "citation_status": citation_status,
+            "citation_id": citation_id,
             "citation_range": citation_range,
         })
     return {
@@ -630,8 +687,11 @@ def _project_source_citations(resolved_evidence: Any) -> dict[str, Any]:
         "version": SOURCE_CITATION_PROJECTION_VERSION,
         "status": "available",
         "hit_count": len(items),
-        "citation_count": sum(1 for item in items if item.get("citation_status") == "resolved"),
-        "unresolved_count": sum(1 for item in items if item.get("range_status") != "resolved"),
+        "citation_count": citation_count,
+        "unresolved_count": range_unresolved_count,
+        "range_unresolved_count": range_unresolved_count,
+        "citation_unresolved_count": citation_unresolved_count,
+        "text_excerpt_max_chars": TEXT_EXCERPT_MAX_CHARS,
         "items": items,
         "does_not_establish": list(_DOES_NOT_ESTABLISH),
     }

--- a/merger/lenskit/core/repobrief_access.py
+++ b/merger/lenskit/core/repobrief_access.py
@@ -594,12 +594,16 @@ def _line_pair(value: Any) -> tuple[int | None, int | None]:
 
 
 def _has_range_identity(value: Any) -> bool:
-    return (
-        isinstance(value, dict)
-        and value.get("file_path") is not None
-        and value.get("start_byte") is not None
-        and value.get("end_byte") is not None
-    )
+    if not isinstance(value, dict):
+        return False
+    file_path = value.get("file_path")
+    start_byte = value.get("start_byte")
+    end_byte = value.get("end_byte")
+    if not _is_non_empty_string(file_path):
+        return False
+    if not _is_int_not_bool(start_byte) or not _is_int_not_bool(end_byte):
+        return False
+    return start_byte >= 0 and end_byte > start_byte
 
 
 def _source_range_projection(range_value: Any) -> dict[str, Any] | None:
@@ -611,9 +615,25 @@ def _source_range_projection(range_value: Any) -> dict[str, Any] | None:
     start_line, end_line = _line_pair(range_value.get("lines"))
     return {
         "artifact_role": _first_not_none(range_value.get("artifact_role"), provenance.get("artifact_role")),
-        "file_path": _first_not_none(range_value.get("file_path"), range_value.get("path"), range_value.get("artifact_path")),
-        "start_byte": _first_not_none(range_value.get("start_byte"), range_value.get("artifact_byte_start")),
-        "end_byte": _first_not_none(range_value.get("end_byte"), range_value.get("artifact_byte_end")),
+        "file_path": _first_not_none(
+            range_value.get("file_path"),
+            range_value.get("path"),
+            range_value.get("artifact_path"),
+            provenance.get("file_path"),
+            provenance.get("artifact_path"),
+        ),
+        "start_byte": _first_not_none(
+            range_value.get("start_byte"),
+            range_value.get("artifact_byte_start"),
+            provenance.get("start_byte"),
+            provenance.get("artifact_byte_start"),
+        ),
+        "end_byte": _first_not_none(
+            range_value.get("end_byte"),
+            range_value.get("artifact_byte_end"),
+            provenance.get("end_byte"),
+            provenance.get("artifact_byte_end"),
+        ),
         "start_line": _first_not_none(range_value.get("start_line"), range_value.get("artifact_line_start"), start_line),
         "end_line": _first_not_none(range_value.get("end_line"), range_value.get("artifact_line_end"), end_line),
         "content_sha256": _first_not_none(range_value.get("range_content_sha256"), range_value.get("content_sha256"), range_value.get("sha256")),
@@ -653,7 +673,11 @@ def _project_source_citations(resolved_evidence: Any) -> dict[str, Any]:
         citation_range = _source_range_projection(
             citation.get("canonical_range") if citation else None
         )
-        range_ref_projection = _source_range_projection(hit.get("range_ref"))
+        range_ref_projection = (
+            _source_range_projection(hit.get("range_ref"))
+            if hit.get("range_status") == "resolved"
+            else None
+        )
         range_projection = _source_range_projection(range_value)
         candidates = [range_ref_projection, citation_range, range_projection]
         source_range = next(
@@ -665,7 +689,11 @@ def _project_source_citations(resolved_evidence: Any) -> dict[str, Any]:
         citation_id = hit.get("citation_id")
         if range_status != "resolved":
             range_unresolved_count += 1
-        if citation_status == "resolved" and citation_id:
+        if (
+            citation_status == "resolved"
+            and isinstance(citation_id, str)
+            and _CITATION_ID_RE.fullmatch(citation_id) is not None
+        ):
             citation_count += 1
         if citation_status != "resolved":
             citation_unresolved_count += 1

--- a/merger/lenskit/core/repobrief_access.py
+++ b/merger/lenskit/core/repobrief_access.py
@@ -23,6 +23,7 @@ RESOLVED_EVIDENCE_KIND = "repobrief.resolved_evidence"
 RESOLVED_EVIDENCE_VERSION = "v1"
 SOURCE_CITATION_PROJECTION_KIND = "repobrief.source_citation_projection"
 SOURCE_CITATION_PROJECTION_VERSION = "v1"
+TEXT_EXCERPT_MAX_CHARS = 1200
 _CITATION_ID_RE = re.compile(r"^cit_[a-f0-9]{16}$")
 _SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
 _CITATION_RANGE_KEY_FIELDS = ("file_path", "start_byte", "end_byte")
@@ -495,6 +496,7 @@ def _resolve_hit_evidence(
         "chunk_id": hit.get("chunk_id"),
         "path": hit.get("path"),
         "range_ref_source": range_ref_source,
+        "range_ref": None,
         "range_status": "unresolved",
         "range": None,
         "range_error": None,
@@ -511,6 +513,7 @@ def _resolve_hit_evidence(
             range_result = range_get(manifest_path, candidate_ref)
             record["range_ref_source"] = candidate_source
             selected_range_ref = candidate_ref
+            record["range_ref"] = selected_range_ref
             if range_result.get("status") == "available":
                 record["range_status"] = "resolved"
                 record["range"] = range_result.get("range")
@@ -571,19 +574,31 @@ def _resolve_query_evidence(manifest_path: Path, query_result: Any) -> dict[str,
         "does_not_establish": list(_DOES_NOT_ESTABLISH),
     }
 
+def _first_not_none(*values):
+    for value in values:
+        if value is not None:
+            return value
+    return None
+
 def _source_range_projection(range_value: Any) -> dict[str, Any] | None:
     if not isinstance(range_value, dict):
         return None
+    provenance = range_value.get("provenance")
+    if not isinstance(provenance, dict):
+        provenance = {}
+    lines = range_value.get("lines")
+    start_line = end_line = None
+    if isinstance(lines, list) and len(lines) == 2:
+        start_line, end_line = lines
     return {
-        "artifact_role": range_value.get("artifact_role"),
-        "file_path": range_value.get("file_path") or range_value.get("path") or range_value.get("artifact_path"),
-        "start_byte": range_value.get("start_byte") or range_value.get("artifact_byte_start"),
-        "end_byte": range_value.get("end_byte") or range_value.get("artifact_byte_end"),
-        "start_line": range_value.get("start_line") or range_value.get("artifact_line_start"),
-        "end_line": range_value.get("end_line") or range_value.get("artifact_line_end"),
-        "content_sha256": range_value.get("range_content_sha256") or range_value.get("content_sha256"),
+        "artifact_role": _first_not_none(range_value.get("artifact_role"), provenance.get("artifact_role")),
+        "file_path": _first_not_none(range_value.get("file_path"), range_value.get("path"), range_value.get("artifact_path")),
+        "start_byte": _first_not_none(range_value.get("start_byte"), range_value.get("artifact_byte_start")),
+        "end_byte": _first_not_none(range_value.get("end_byte"), range_value.get("artifact_byte_end")),
+        "start_line": _first_not_none(range_value.get("start_line"), range_value.get("artifact_line_start"), start_line),
+        "end_line": _first_not_none(range_value.get("end_line"), range_value.get("artifact_line_end"), end_line),
+        "content_sha256": _first_not_none(range_value.get("range_content_sha256"), range_value.get("content_sha256"), range_value.get("sha256")),
     }
-
 
 def _project_source_citations(resolved_evidence: Any) -> dict[str, Any]:
     hits = resolved_evidence.get("hits") if isinstance(resolved_evidence, dict) else None
@@ -593,8 +608,8 @@ def _project_source_citations(resolved_evidence: Any) -> dict[str, Any]:
         range_value = hit.get("range")
         text = range_value.get("text") if isinstance(range_value, dict) else None
         citation = hit.get("citation") if isinstance(hit.get("citation"), dict) else None
-        citation_range = citation.get("canonical_range") if citation else None
-        source_range = _source_range_projection(range_value)
+        citation_range = _source_range_projection(citation.get("canonical_range") if citation else None)
+        source_range = _source_range_projection(hit.get("range_ref")) or citation_range or _source_range_projection(range_value)
         if isinstance(source_range, dict) and source_range.get("file_path") is None:
             source_range = citation_range if isinstance(citation_range, dict) else source_range
         items.append({
@@ -604,7 +619,8 @@ def _project_source_citations(resolved_evidence: Any) -> dict[str, Any]:
             "range_status": hit.get("range_status"),
             "range_ref_source": hit.get("range_ref_source"),
             "source_range": source_range,
-            "text": text if isinstance(text, str) else None,
+            "text_excerpt": text[:TEXT_EXCERPT_MAX_CHARS] if isinstance(text, str) else None,
+            "text_truncated": isinstance(text, str) and len(text) > TEXT_EXCERPT_MAX_CHARS,
             "citation_status": hit.get("citation_status"),
             "citation_id": hit.get("citation_id"),
             "citation_range": citation_range,
@@ -734,7 +750,8 @@ def query_existing_index(
         "project_sources": project_sources,
         "index_artifact": artifact,
         "query_result": query_result,
-        "resolved_evidence": resolved_evidence,
+        "evidence_resolution_used": resolve_evidence or project_sources,
+        "resolved_evidence": resolved_evidence if resolve_evidence else None,
         "source_citation_projection": source_citation_projection,
         "mutation_boundary": _read_only_mutation_boundary(),
         "does_not_establish": list(_DOES_NOT_ESTABLISH),

--- a/merger/lenskit/core/repobrief_access.py
+++ b/merger/lenskit/core/repobrief_access.py
@@ -21,6 +21,8 @@ _DOES_NOT_ESTABLISH = (
 CITATION_MAP_ROLE = "citation_map_jsonl"
 RESOLVED_EVIDENCE_KIND = "repobrief.resolved_evidence"
 RESOLVED_EVIDENCE_VERSION = "v1"
+SOURCE_CITATION_PROJECTION_KIND = "repobrief.source_citation_projection"
+SOURCE_CITATION_PROJECTION_VERSION = "v1"
 _CITATION_ID_RE = re.compile(r"^cit_[a-f0-9]{16}$")
 _SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
 _CITATION_RANGE_KEY_FIELDS = ("file_path", "start_byte", "end_byte")
@@ -569,12 +571,63 @@ def _resolve_query_evidence(manifest_path: Path, query_result: Any) -> dict[str,
         "does_not_establish": list(_DOES_NOT_ESTABLISH),
     }
 
+def _source_range_projection(range_value: Any) -> dict[str, Any] | None:
+    if not isinstance(range_value, dict):
+        return None
+    return {
+        "artifact_role": range_value.get("artifact_role"),
+        "file_path": range_value.get("file_path") or range_value.get("path") or range_value.get("artifact_path"),
+        "start_byte": range_value.get("start_byte") or range_value.get("artifact_byte_start"),
+        "end_byte": range_value.get("end_byte") or range_value.get("artifact_byte_end"),
+        "start_line": range_value.get("start_line") or range_value.get("artifact_line_start"),
+        "end_line": range_value.get("end_line") or range_value.get("artifact_line_end"),
+        "content_sha256": range_value.get("range_content_sha256") or range_value.get("content_sha256"),
+    }
+
+
+def _project_source_citations(resolved_evidence: Any) -> dict[str, Any]:
+    hits = resolved_evidence.get("hits") if isinstance(resolved_evidence, dict) else None
+    hit_list = [hit for hit in (hits if isinstance(hits, list) else []) if isinstance(hit, dict)]
+    items: list[dict[str, Any]] = []
+    for ordinal, hit in enumerate(hit_list):
+        range_value = hit.get("range")
+        text = range_value.get("text") if isinstance(range_value, dict) else None
+        citation = hit.get("citation") if isinstance(hit.get("citation"), dict) else None
+        citation_range = citation.get("canonical_range") if citation else None
+        source_range = _source_range_projection(range_value)
+        if isinstance(source_range, dict) and source_range.get("file_path") is None:
+            source_range = citation_range if isinstance(citation_range, dict) else source_range
+        items.append({
+            "ordinal": ordinal,
+            "chunk_id": hit.get("chunk_id"),
+            "path": hit.get("path"),
+            "range_status": hit.get("range_status"),
+            "range_ref_source": hit.get("range_ref_source"),
+            "source_range": source_range,
+            "text": text if isinstance(text, str) else None,
+            "citation_status": hit.get("citation_status"),
+            "citation_id": hit.get("citation_id"),
+            "citation_range": citation_range,
+        })
+    return {
+        "kind": SOURCE_CITATION_PROJECTION_KIND,
+        "version": SOURCE_CITATION_PROJECTION_VERSION,
+        "status": "available",
+        "hit_count": len(items),
+        "citation_count": sum(1 for item in items if item.get("citation_status") == "resolved"),
+        "unresolved_count": sum(1 for item in items if item.get("range_status") != "resolved"),
+        "items": items,
+        "does_not_establish": list(_DOES_NOT_ESTABLISH),
+    }
+
+
 def query_existing_index(
     bundle_manifest: str | Path,
     query: str,
     k: int = 10,
     filters: dict[str, str | None] | None = None,
     resolve_evidence: bool = False,
+    project_sources: bool = False,
 ) -> dict[str, Any]:
     manifest_path = Path(bundle_manifest).expanduser().resolve()
     if not isinstance(query, str):
@@ -602,6 +655,16 @@ def query_existing_index(
             status="invalid",
             error="resolve_evidence must be a boolean",
             error_code="resolve_evidence_invalid",
+            extra={"query": query, "k": k, "query_result": None, "index_artifact": None},
+        )
+
+    if not isinstance(project_sources, bool):
+        return _invalid_read_result(
+            kind="repobrief.query_existing_index",
+            bundle_manifest=manifest_path,
+            status="invalid",
+            error="project_sources must be a boolean",
+            error_code="project_sources_invalid",
             extra={"query": query, "k": k, "query_result": None, "index_artifact": None},
         )
 
@@ -650,6 +713,15 @@ def query_existing_index(
             extra={"query": query, "k": k, "query_result": None, "index_artifact": artifact},
         )
 
+    resolved_evidence = (
+        _resolve_query_evidence(manifest_path, query_result)
+        if (resolve_evidence or project_sources)
+        else None
+    )
+    source_citation_projection = (
+        _project_source_citations(resolved_evidence) if project_sources else None
+    )
+
     return {
         "kind": "repobrief.query_existing_index",
         "version": "v1",
@@ -659,11 +731,11 @@ def query_existing_index(
         "k": k,
         "filters": filters or {},
         "resolve_evidence": resolve_evidence,
+        "project_sources": project_sources,
         "index_artifact": artifact,
         "query_result": query_result,
-        "resolved_evidence": (
-            _resolve_query_evidence(manifest_path, query_result) if resolve_evidence else None
-        ),
+        "resolved_evidence": resolved_evidence,
+        "source_citation_projection": source_citation_projection,
         "mutation_boundary": _read_only_mutation_boundary(),
         "does_not_establish": list(_DOES_NOT_ESTABLISH),
     }

--- a/merger/lenskit/tests/test_repobrief_resolved_evidence_query.py
+++ b/merger/lenskit/tests/test_repobrief_resolved_evidence_query.py
@@ -296,6 +296,7 @@ def test_resolved_evidence_falls_back_to_derived_range_ref_when_range_ref_invali
     resolved_hit = resolved["hits"][0]
     assert resolved_hit["range_ref_source"] == "derived_range_ref"
     assert resolved_hit["range_status"] == "resolved"
+    assert resolved_hit["range_ref"] == valid_range_ref
     assert resolved_hit["range_error_code"] is None
     assert resolved_hit["range"]["text"] == bundle["chunk_text"]
     assert resolved_hit["citation_status"] == "resolved"

--- a/merger/lenskit/tests/test_repobrief_source_citation_projection.py
+++ b/merger/lenskit/tests/test_repobrief_source_citation_projection.py
@@ -261,25 +261,46 @@ def test_source_citation_projection_ignores_range_ref_when_range_status_unresolv
     item = projection["items"][0]
     assert item["source_range"]["file_path"] == "resolved-output.md"
     assert projection["range_unresolved_count"] == 1
-def test_source_range_projection_uses_v2_source_and_artifact_axes():
-    source_range = repobrief_access._source_range_projection({
-        "range_ref_version": "2",
-        "artifact_role": "canonical_md",
-        "artifact_path": "merged.md",
-        "artifact_byte_start": 10,
-        "artifact_byte_end": 20,
-        "artifact_line_start": 3,
-        "artifact_line_end": 4,
-        "source_file_path": "src/main.py",
-        "source_line_start": 100,
-        "source_line_end": 104,
-        "content_sha256": "a" * 64,
-        "range_content_sha256": "b" * 64,
+
+
+def test_source_citation_projection_projects_v2_source_and_artifact_axes():
+    projection = repobrief_access._project_source_citations({
+        "hits": [{
+            "chunk_id": "c-v2",
+            "path": "merged.md",
+            "range_status": "resolved",
+            "range_ref_source": "range_ref",
+            "range_ref": {
+                "range_ref_version": "2",
+                "artifact_role": "canonical_md",
+                "repo_id": "demo",
+                "artifact_path": "merged.md",
+                "artifact_byte_start": 10,
+                "artifact_byte_end": 20,
+                "artifact_line_start": 3,
+                "artifact_line_end": 4,
+                "source_file_path": "src/main.py",
+                "source_line_start": 100,
+                "source_line_end": 104,
+                "content_sha256": "a" * 64,
+                "range_content_sha256": "b" * 64,
+                "file_path": "merged.md",
+                "start_byte": 10,
+                "end_byte": 20,
+                "start_line": 3,
+                "end_line": 4,
+            },
+            "range": {"text": "hello"},
+            "citation_status": "unavailable",
+            "citation_id": None,
+            "citation": None,
+        }]
     })
 
-    assert source_range["file_path"] == "src/main.py"
-    assert source_range["start_line"] == 100
-    assert source_range["end_line"] == 104
+    source_range = projection["items"][0]["source_range"]
+    assert source_range["file_path"] == "merged.md"
+    assert source_range["start_line"] == 3
+    assert source_range["end_line"] == 4
     assert source_range["start_byte"] == 10
     assert source_range["end_byte"] == 20
     assert source_range["artifact_path"] == "merged.md"
@@ -290,4 +311,4 @@ def test_source_range_projection_uses_v2_source_and_artifact_axes():
     assert source_range["source_file_path"] == "src/main.py"
     assert source_range["source_start_line"] == 100
     assert source_range["source_end_line"] == 104
-    assert source_range["coordinate_basis"] == "source_lines_artifact_bytes"
+    assert source_range["coordinate_basis"] == "artifact_bytes_with_source_lines"

--- a/merger/lenskit/tests/test_repobrief_source_citation_projection.py
+++ b/merger/lenskit/tests/test_repobrief_source_citation_projection.py
@@ -67,6 +67,10 @@ def test_query_existing_index_projection_degrades_without_citation_map(tmp_path)
     assert item["source_range"]["file_path"] == bundle["canonical"].name
     assert item["source_range"]["start_byte"] is not None
     assert item["source_range"]["end_byte"] is not None
+    projection = result["source_citation_projection"]
+    assert projection["unresolved_count"] == 1
+    assert projection["range_unresolved_count"] == 0
+    assert projection["citation_unresolved_count"] == 1
 
 
 def test_query_existing_index_projection_defaults_off(tmp_path):
@@ -163,8 +167,9 @@ def test_source_citation_projection_counts_only_resolved_citations_with_id():
     })
 
     assert projection["citation_count"] == 0
+    assert projection["unresolved_count"] == 1
     assert projection["range_unresolved_count"] == 0
-    assert projection["citation_unresolved_count"] == 0
+    assert projection["citation_unresolved_count"] == 1
 
 
 def test_source_citation_projection_rejects_non_dict_resolved_evidence():
@@ -256,3 +261,33 @@ def test_source_citation_projection_ignores_range_ref_when_range_status_unresolv
     item = projection["items"][0]
     assert item["source_range"]["file_path"] == "resolved-output.md"
     assert projection["range_unresolved_count"] == 1
+def test_source_range_projection_uses_v2_source_and_artifact_axes():
+    source_range = repobrief_access._source_range_projection({
+        "range_ref_version": "2",
+        "artifact_role": "canonical_md",
+        "artifact_path": "merged.md",
+        "artifact_byte_start": 10,
+        "artifact_byte_end": 20,
+        "artifact_line_start": 3,
+        "artifact_line_end": 4,
+        "source_file_path": "src/main.py",
+        "source_line_start": 100,
+        "source_line_end": 104,
+        "content_sha256": "a" * 64,
+        "range_content_sha256": "b" * 64,
+    })
+
+    assert source_range["file_path"] == "src/main.py"
+    assert source_range["start_line"] == 100
+    assert source_range["end_line"] == 104
+    assert source_range["start_byte"] == 10
+    assert source_range["end_byte"] == 20
+    assert source_range["artifact_path"] == "merged.md"
+    assert source_range["artifact_start_byte"] == 10
+    assert source_range["artifact_end_byte"] == 20
+    assert source_range["artifact_start_line"] == 3
+    assert source_range["artifact_end_line"] == 4
+    assert source_range["source_file_path"] == "src/main.py"
+    assert source_range["source_start_line"] == 100
+    assert source_range["source_end_line"] == 104
+    assert source_range["coordinate_basis"] == "source_lines_artifact_bytes"

--- a/merger/lenskit/tests/test_repobrief_source_citation_projection.py
+++ b/merger/lenskit/tests/test_repobrief_source_citation_projection.py
@@ -9,16 +9,21 @@ def test_query_existing_index_projects_source_citations(tmp_path):
     )
     assert result["status"] == "available"
     assert result["project_sources"] is True
+    assert result["resolve_evidence"] is False
+    assert result["resolved_evidence"] is None
+    assert result["evidence_resolution_used"] is True
     projection = result["source_citation_projection"]
     assert projection["kind"] == "repobrief.source_citation_projection"
     assert projection["hit_count"] == 1
     assert projection["citation_count"] == 1
     assert projection["unresolved_count"] == 0
     item = projection["items"][0]
-    assert item["text"] == bundle["chunk_text"]
+    assert item["text_excerpt"] == bundle["chunk_text"]
+    assert item["text_truncated"] is False
     assert item["citation_status"] == "resolved"
     assert item["citation_id"] == bundle["citation_id"]
     assert item["source_range"]["file_path"] == bundle["canonical"].name
+    assert item["citation_range"]["file_path"] == bundle["canonical"].name
 
 
 def test_query_existing_index_projection_degrades_without_citation_map(tmp_path):
@@ -31,6 +36,47 @@ def test_query_existing_index_projection_degrades_without_citation_map(tmp_path)
     assert item["citation_status"] == "unavailable"
     assert item["citation_id"] is None
     assert item["citation_range"] is None
+    assert item["source_range"]["file_path"] == bundle["canonical"].name
+    assert item["source_range"]["start_byte"] is not None
+    assert item["source_range"]["end_byte"] is not None
+
+
+def test_query_existing_index_projection_defaults_off(tmp_path):
+    bundle = _build_resolved_bundle(tmp_path)
+    result = repobrief_access.query_existing_index(bundle["manifest"], "hello", k=5)
+    assert result["status"] == "available"
+    assert result["project_sources"] is False
+    assert result["source_citation_projection"] is None
+    assert result["resolved_evidence"] is None
+
+
+def test_source_citation_projection_preserves_zero_start_byte():
+    source_range = {
+        "artifact_role": "canonical_md",
+        "file_path": "brief.md",
+        "start_byte": 0,
+        "end_byte": 5,
+        "start_line": 1,
+        "end_line": 1,
+        "content_sha256": "a" * 64,
+    }
+    projection = repobrief_access._project_source_citations({
+        "hits": [{
+            "chunk_id": "c0",
+            "path": "brief.md",
+            "range_status": "resolved",
+            "range_ref_source": "range_ref",
+            "range_ref": source_range,
+            "range": {"text": "hello", "sha256": "a" * 64},
+            "citation_status": "unavailable",
+            "citation_id": None,
+            "citation": None,
+        }]
+    })
+    item = projection["items"][0]
+    assert item["source_range"]["start_byte"] == 0
+    assert item["source_range"]["end_byte"] == 5
+    assert item["text_excerpt"] == "hello"
 
 
 def test_query_existing_index_rejects_non_boolean_project_sources(tmp_path):

--- a/merger/lenskit/tests/test_repobrief_source_citation_projection.py
+++ b/merger/lenskit/tests/test_repobrief_source_citation_projection.py
@@ -1,0 +1,43 @@
+from merger.lenskit.core import repobrief_access
+from merger.lenskit.tests.test_repobrief_resolved_evidence_query import _build_resolved_bundle
+
+
+def test_query_existing_index_projects_source_citations(tmp_path):
+    bundle = _build_resolved_bundle(tmp_path)
+    result = repobrief_access.query_existing_index(
+        bundle["manifest"], "hello", k=5, project_sources=True
+    )
+    assert result["status"] == "available"
+    assert result["project_sources"] is True
+    projection = result["source_citation_projection"]
+    assert projection["kind"] == "repobrief.source_citation_projection"
+    assert projection["hit_count"] == 1
+    assert projection["citation_count"] == 1
+    assert projection["unresolved_count"] == 0
+    item = projection["items"][0]
+    assert item["text"] == bundle["chunk_text"]
+    assert item["citation_status"] == "resolved"
+    assert item["citation_id"] == bundle["citation_id"]
+    assert item["source_range"]["file_path"] == bundle["canonical"].name
+
+
+def test_query_existing_index_projection_degrades_without_citation_map(tmp_path):
+    bundle = _build_resolved_bundle(tmp_path, with_citation_map=False)
+    result = repobrief_access.query_existing_index(
+        bundle["manifest"], "hello", k=5, project_sources=True
+    )
+    item = result["source_citation_projection"]["items"][0]
+    assert item["range_status"] == "resolved"
+    assert item["citation_status"] == "unavailable"
+    assert item["citation_id"] is None
+    assert item["citation_range"] is None
+
+
+def test_query_existing_index_rejects_non_boolean_project_sources(tmp_path):
+    manifest = tmp_path / "demo.bundle.manifest.json"
+    manifest.write_text('{"artifacts": []}', encoding="utf-8")
+    result = repobrief_access.query_existing_index(
+        manifest, "hello", k=1, project_sources="yes"
+    )
+    assert result["status"] == "invalid"
+    assert result["error_code"] == "project_sources_invalid"

--- a/merger/lenskit/tests/test_repobrief_source_citation_projection.py
+++ b/merger/lenskit/tests/test_repobrief_source_citation_projection.py
@@ -123,7 +123,7 @@ def test_source_citation_projection_prefers_complete_citation_range_over_partial
                 "sha256": "b" * 64,
             },
             "citation_status": "resolved",
-            "citation_id": "cit_present",
+            "citation_id": "cit_0000000000000001",
             "citation": {
                 "canonical_range": {
                     "file_path": "citation.md",
@@ -200,3 +200,59 @@ def test_query_existing_index_rejects_non_boolean_project_sources(tmp_path):
     )
     assert result["status"] == "invalid"
     assert result["error_code"] == "project_sources_invalid"
+
+
+def test_source_citation_projection_ignores_structurally_invalid_range_identity():
+    projection = repobrief_access._project_source_citations({
+        "hits": [{
+            "chunk_id": "c1",
+            "path": "brief.md",
+            "range_status": "resolved",
+            "range_ref_source": "range_ref",
+            "range_ref": {
+                "file_path": "bad.md",
+                "start_byte": True,
+                "end_byte": 5,
+            },
+            "range": {
+                "text": "hello",
+                "file_path": "good.md",
+                "start_byte": 0,
+                "end_byte": 5,
+            },
+            "citation_status": "unavailable",
+            "citation_id": None,
+            "citation": None,
+        }]
+    })
+
+    assert projection["items"][0]["source_range"]["file_path"] == "good.md"
+
+
+def test_source_citation_projection_ignores_range_ref_when_range_status_unresolved():
+    projection = repobrief_access._project_source_citations({
+        "hits": [{
+            "chunk_id": "c1",
+            "path": "brief.md",
+            "range_status": "unresolved",
+            "range_ref_source": "range_ref",
+            "range_ref": {
+                "file_path": "stale.md",
+                "start_byte": 0,
+                "end_byte": 5,
+            },
+            "range": {
+                "text": "hello",
+                "file_path": "resolved-output.md",
+                "start_byte": 0,
+                "end_byte": 5,
+            },
+            "citation_status": "unavailable",
+            "citation_id": None,
+            "citation": None,
+        }]
+    })
+
+    item = projection["items"][0]
+    assert item["source_range"]["file_path"] == "resolved-output.md"
+    assert projection["range_unresolved_count"] == 1

--- a/merger/lenskit/tests/test_repobrief_source_citation_projection.py
+++ b/merger/lenskit/tests/test_repobrief_source_citation_projection.py
@@ -1,5 +1,9 @@
 from merger.lenskit.core import repobrief_access
-from merger.lenskit.tests.test_repobrief_resolved_evidence_query import _build_resolved_bundle
+from merger.lenskit.tests.test_repobrief_resolved_evidence_query import (
+    _build_resolved_bundle,
+    _sha256,
+    _sqlite_sidecars,
+)
 
 
 def test_query_existing_index_projects_source_citations(tmp_path):
@@ -17,6 +21,9 @@ def test_query_existing_index_projects_source_citations(tmp_path):
     assert projection["hit_count"] == 1
     assert projection["citation_count"] == 1
     assert projection["unresolved_count"] == 0
+    assert projection["range_unresolved_count"] == 0
+    assert projection["citation_unresolved_count"] == 0
+    assert projection["text_excerpt_max_chars"] == repobrief_access.TEXT_EXCERPT_MAX_CHARS
     item = projection["items"][0]
     assert item["text_excerpt"] == bundle["chunk_text"]
     assert item["text_truncated"] is False
@@ -24,6 +31,27 @@ def test_query_existing_index_projects_source_citations(tmp_path):
     assert item["citation_id"] == bundle["citation_id"]
     assert item["source_range"]["file_path"] == bundle["canonical"].name
     assert item["citation_range"]["file_path"] == bundle["canonical"].name
+
+
+def test_query_existing_index_projection_is_read_only(tmp_path):
+    bundle = _build_resolved_bundle(tmp_path)
+    index_path = bundle["index_path"]
+
+    before_files = {path.name for path in tmp_path.iterdir()}
+    before_hashes = {path.name: _sha256(path) for path in tmp_path.iterdir() if path.is_file()}
+
+    result = repobrief_access.query_existing_index(
+        bundle["manifest"], "hello", k=5, project_sources=True
+    )
+
+    after_files = {path.name for path in tmp_path.iterdir()}
+    after_hashes = {path.name: _sha256(path) for path in tmp_path.iterdir() if path.is_file()}
+
+    assert result["status"] == "available"
+    assert before_files == after_files
+    assert before_hashes == after_hashes
+    assert not any(path.exists() for path in _sqlite_sidecars(index_path))
+    assert result["mutation_boundary"]["writes"] == []
 
 
 def test_query_existing_index_projection_degrades_without_citation_map(tmp_path):
@@ -77,6 +105,91 @@ def test_source_citation_projection_preserves_zero_start_byte():
     assert item["source_range"]["start_byte"] == 0
     assert item["source_range"]["end_byte"] == 5
     assert item["text_excerpt"] == "hello"
+
+
+def test_source_citation_projection_prefers_complete_citation_range_over_partial_range_ref():
+    projection = repobrief_access._project_source_citations({
+        "hits": [{
+            "chunk_id": "c1",
+            "path": "brief.md",
+            "range_status": "resolved",
+            "range_ref_source": "range_ref",
+            "range_ref": {"file_path": "partial.md"},
+            "range": {
+                "text": "hello",
+                "file_path": "range.md",
+                "start_byte": 1,
+                "end_byte": 6,
+                "sha256": "b" * 64,
+            },
+            "citation_status": "resolved",
+            "citation_id": "cit_present",
+            "citation": {
+                "canonical_range": {
+                    "file_path": "citation.md",
+                    "start_byte": 4,
+                    "end_byte": 9,
+                    "start_line": 2,
+                    "end_line": 2,
+                    "content_sha256": "a" * 64,
+                }
+            },
+        }]
+    })
+
+    item = projection["items"][0]
+    assert item["source_range"]["file_path"] == "citation.md"
+    assert item["source_range"]["start_byte"] == 4
+    assert item["source_range"]["end_byte"] == 9
+
+
+def test_source_citation_projection_counts_only_resolved_citations_with_id():
+    projection = repobrief_access._project_source_citations({
+        "hits": [{
+            "chunk_id": "c1",
+            "path": "brief.md",
+            "range_status": "resolved",
+            "range_ref_source": "range_ref",
+            "range_ref": {
+                "file_path": "brief.md",
+                "start_byte": 0,
+                "end_byte": 5,
+            },
+            "range": {"text": "hello"},
+            "citation_status": "resolved",
+            "citation_id": None,
+            "citation": None,
+        }]
+    })
+
+    assert projection["citation_count"] == 0
+    assert projection["range_unresolved_count"] == 0
+    assert projection["citation_unresolved_count"] == 0
+
+
+def test_source_citation_projection_rejects_non_dict_resolved_evidence():
+    projection = repobrief_access._project_source_citations(["not", "a", "dict"])
+
+    assert projection["status"] == "unavailable"
+    assert projection["hit_count"] == 0
+    assert projection["citation_count"] == 0
+    assert projection["unresolved_count"] == 0
+    assert projection["range_unresolved_count"] == 0
+    assert projection["citation_unresolved_count"] == 0
+    assert projection["text_excerpt_max_chars"] == repobrief_access.TEXT_EXCERPT_MAX_CHARS
+    assert projection["items"] == []
+
+
+def test_source_range_projection_ignores_bool_line_pair():
+    source_range = repobrief_access._source_range_projection({
+        "file_path": "brief.md",
+        "start_byte": 0,
+        "end_byte": 5,
+        "lines": [True, 2],
+    })
+
+    assert source_range["start_line"] is None
+    assert source_range["end_line"] is None
 
 
 def test_query_existing_index_rejects_non_boolean_project_sources(tmp_path):


### PR DESCRIPTION
RBEV1-T003. Adds optional project_sources=True to query_existing_index and returns repobrief.source_citation_projection v1. Scope: read-only access layer only; no MCP, context compiler, federation, semantAH, embeddings, PR delta, runtime probing, or merge. Local validation: compileall, ruff, targeted pytest, git diff --check. Non-claims: does not establish truth, completeness, runtime behavior, test sufficiency, regression absence, repo understanding, claim truth, forensic readiness, or freshness.