### PR TITLE
feat(repobrief): add external manifest reference surface

### DIFF
--- a/merger/lenskit/cli/cmd_repobrief.py
+++ b/merger/lenskit/cli/cmd_repobrief.py
@@ -272,6 +272,30 @@ def register_repobrief_commands(subparsers: argparse._SubParsersAction) -> None:
     resolve_parser.add_argument("--bundle-manifest", required=True, help="Path to a Brief Bundle manifest")
     resolve_parser.add_argument("--task-profile", required=True, help="Required-reading task profile")
 
+    external_parser = repobrief_subparsers.add_parser(
+        "external-manifest",
+        help="Write bounded external manifest references from existing bundle manifests",
+    )
+    external_subparsers = external_parser.add_subparsers(
+        dest="external_manifest_cmd",
+        required=True,
+        help="External manifest commands",
+    )
+    external_write_parser = external_subparsers.add_parser(
+        "write",
+        help="Write an external manifest reference without refreshing the source snapshot",
+    )
+    external_write_parser.add_argument("--bundle-manifest", required=True, help="Path to a Brief Bundle manifest")
+    external_write_parser.add_argument("--out", required=True, help="Output manifest path")
+    external_write_parser.add_argument("--repository", required=True, help="Registry repository segment, for example cabinet")
+    external_write_parser.add_argument("--ref", required=True, help="Registry ref segment, for example main")
+    external_write_parser.add_argument(
+        "--artifact-family",
+        choices=["repobrief", "lenskit"],
+        default="repobrief",
+        help="External artifact family to advertise",
+    )
+
     patch_eval_parser = repobrief_subparsers.add_parser(
         "patch-evaluation",
         help="Read-only consumption of external Patch Evaluation Sidecar artifacts",
@@ -308,10 +332,33 @@ def run_repobrief(args: argparse.Namespace) -> int:
         return run_artifact_list(args)
     if args.repobrief_cmd == "required-reading" and args.required_reading_cmd == "resolve":
         return run_required_reading_resolve(args)
+    if args.repobrief_cmd == "external-manifest" and args.external_manifest_cmd == "write":
+        return run_external_manifest_write(args)
     if args.repobrief_cmd == "patch-evaluation" and args.patch_evaluation_cmd == "validate":
         return run_patch_evaluation_validate(args)
     print("Unsupported RepoBrief command", file=sys.stderr)
     return 2
+
+
+def run_external_manifest_write(args: argparse.Namespace) -> int:
+    from merger.lenskit.core.external_manifest_reference import (
+        ExternalManifestReferenceError,
+        write_external_manifest_reference,
+    )
+
+    try:
+        result = write_external_manifest_reference(
+            args.bundle_manifest,
+            args.out,
+            repository=args.repository,
+            ref=args.ref,
+            artifact_family=args.artifact_family,
+        )
+    except ExternalManifestReferenceError as exc:
+        print("repobrief external-manifest write: " + str(exc), file=sys.stderr)
+        return 2
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
 
 
 def run_patch_evaluation_validate(args: argparse.Namespace) -> int:

--- a/merger/lenskit/core/external_manifest_reference.py
+++ b/merger/lenskit/core/external_manifest_reference.py
@@ -1,0 +1,159 @@
+"""External manifest reference surface for RepoBrief/Lenskit consumers."""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+SUPPORTED_FAMILIES = {"repobrief", "lenskit"}
+BUNDLE_KIND = "repolens.bundle.manifest"
+DOES_NOT_ESTABLISH = (
+    "dump_freshness_truth",
+    "claim_truth",
+    "runtime_correctness",
+    "semantic_correctness",
+    "task_approval",
+    "dump_generation_permission",
+    "repo_understood",
+    "merge_readiness",
+)
+
+
+class ExternalManifestReferenceError(ValueError):
+    """Raised when an external manifest reference cannot be built."""
+
+
+def _read_json_object(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ExternalManifestReferenceError(f"bundle manifest does not exist: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ExternalManifestReferenceError(f"bundle manifest is not valid JSON: {path}") from exc
+    if not isinstance(data, dict):
+        raise ExternalManifestReferenceError("bundle manifest must be a JSON object")
+    return data
+
+
+def _relative_path(target: Path, base_dir: Path) -> str:
+    return Path(os.path.relpath(target.resolve(), base_dir.resolve())).as_posix()
+
+
+def _registry_segment(value: str, label: str) -> str:
+    if not isinstance(value, str) or not value or value.strip() != value or "/" in value or "\\" in value:
+        raise ExternalManifestReferenceError(f"{label} must be a non-empty registry segment")
+    if value in {".", ".."}:
+        raise ExternalManifestReferenceError(f"{label} must not be a traversal segment")
+    return value
+
+
+def _artifact_rows(bundle_manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    artifacts = bundle_manifest.get("artifacts")
+    if not isinstance(artifacts, list):
+        raise ExternalManifestReferenceError("bundle manifest artifacts must be a list")
+    rows: list[dict[str, Any]] = []
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            continue
+        role = artifact.get("role")
+        path = artifact.get("path")
+        sha256 = artifact.get("sha256")
+        if not isinstance(role, str) or not isinstance(path, str):
+            continue
+        row: dict[str, Any] = {
+            "role": role,
+            "path": path,
+            "sha256": sha256 if isinstance(sha256, str) else None,
+        }
+        if isinstance(artifact.get("bytes"), int):
+            row["bytes"] = artifact["bytes"]
+        if isinstance(artifact.get("content_type"), str):
+            row["contentType"] = artifact["content_type"]
+        rows.append(row)
+    rows.sort(key=lambda item: (item["role"], item["path"]))
+    return rows
+
+
+def build_external_manifest_reference(
+    bundle_manifest_path: str | Path,
+    *,
+    repository: str,
+    ref: str,
+    artifact_family: str = "repobrief",
+    output_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Build a bounded external manifest reference from an existing bundle manifest."""
+    family = artifact_family.strip().lower() if isinstance(artifact_family, str) else ""
+    if family not in SUPPORTED_FAMILIES:
+        raise ExternalManifestReferenceError("artifact_family must be repobrief or lenskit")
+    repository = _registry_segment(repository, "repository")
+    ref = _registry_segment(ref, "ref")
+    manifest_path = Path(bundle_manifest_path).expanduser().resolve()
+    bundle = _read_json_object(manifest_path)
+    if bundle.get("kind") != BUNDLE_KIND:
+        raise ExternalManifestReferenceError("bundle manifest kind must be repolens.bundle.manifest")
+    created_at = bundle.get("created_at")
+    if not isinstance(created_at, str) or not created_at:
+        raise ExternalManifestReferenceError("bundle manifest created_at must be present")
+    output_base = Path(output_path).expanduser().resolve().parent if output_path is not None else manifest_path.parent
+    snapshot_provenance = bundle.get("snapshot_provenance")
+    return {
+        "kind": f"{family}_bundle_manifest",
+        "version": "1",
+        "artifactFamily": family,
+        "repository": repository,
+        "ref": ref,
+        "generatedAt": created_at,
+        "freshnessBasis": "bundle_manifest.created_at",
+        "bundleManifest": {
+            "kind": BUNDLE_KIND,
+            "path": _relative_path(manifest_path, output_base),
+            "runId": bundle.get("run_id"),
+            "createdAt": created_at,
+        },
+        "snapshotProvenance": snapshot_provenance if isinstance(snapshot_provenance, dict) else None,
+        "artifacts": _artifact_rows(bundle),
+        "doesNotEstablish": list(DOES_NOT_ESTABLISH),
+    }
+
+
+def write_external_manifest_reference(
+    bundle_manifest_path: str | Path,
+    output_path: str | Path,
+    *,
+    repository: str,
+    ref: str,
+    artifact_family: str = "repobrief",
+) -> dict[str, Any]:
+    """Write an external manifest reference atomically and return it."""
+    out = Path(output_path).expanduser().resolve()
+    data = build_external_manifest_reference(
+        bundle_manifest_path,
+        repository=repository,
+        ref=ref,
+        artifact_family=artifact_family,
+        output_path=out,
+    )
+    out.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            delete=False,
+            dir=str(out.parent),
+            prefix=f".{out.name}.",
+            suffix=".tmp",
+        ) as tmp_file:
+            json.dump(data, tmp_file, indent=2, sort_keys=True)
+            tmp_file.write("\n")
+            tmp_file.flush()
+            os.fsync(tmp_file.fileno())
+            tmp_path = Path(tmp_file.name)
+        os.replace(tmp_path, out)
+    finally:
+        if tmp_path is not None and tmp_path.exists():
+            tmp_path.unlink()
+    return data

--- a/merger/lenskit/tests/test_external_manifest_reference.py
+++ b/merger/lenskit/tests/test_external_manifest_reference.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from merger.lenskit.core.external_manifest_reference import (
+    ExternalManifestReferenceError,
+    build_external_manifest_reference,
+    write_external_manifest_reference,
+)
+
+
+def write_bundle(tmp_path: Path) -> Path:
+    bundle = {
+        "kind": "repolens.bundle.manifest",
+        "version": "1.0",
+        "run_id": "run-1",
+        "created_at": "2026-07-06T13:00:00Z",
+        "generator": {"name": "repobrief", "version": "dev", "config_sha256": "a" * 64},
+        "artifacts": [
+            {
+                "role": "canonical_md",
+                "path": "cabinet_merge.md",
+                "content_type": "text/markdown",
+                "bytes": 12,
+                "sha256": "b" * 64,
+            },
+            {
+                "role": "agent_reading_pack",
+                "path": "cabinet_merge.agent_reading_pack.md",
+                "content_type": "text/markdown",
+                "bytes": 5,
+                "sha256": "c" * 64,
+            },
+        ],
+        "links": {},
+        "capabilities": {},
+        "snapshot_provenance": {
+            "version": "v1",
+            "repositories": [
+                {
+                    "name": "cabinet",
+                    "repo_root": None,
+                    "repo_remote": "git@github.com:heimgewebe/cabinet.git",
+                    "git_commit": "d" * 40,
+                    "git_dirty": False,
+                    "git_branch": "main",
+                    "provenance_status": "present",
+                    "freshness_basis": "git_commit",
+                }
+            ],
+            "does_not_establish": ["freshness_against_remote"],
+        },
+    }
+    path = tmp_path / "bundle" / "cabinet_merge.bundle.manifest.json"
+    path.parent.mkdir()
+    path.write_text(json.dumps(bundle), encoding="utf-8")
+    return path
+
+
+def test_builds_cabinet_compatible_repobrief_manifest_reference(tmp_path: Path) -> None:
+    bundle_path = write_bundle(tmp_path)
+    out = tmp_path / "external" / "repobrief" / "cabinet" / "main" / "manifest.json"
+
+    result = build_external_manifest_reference(
+        bundle_path,
+        repository="cabinet",
+        ref="main",
+        artifact_family="repobrief",
+        output_path=out,
+    )
+
+    assert result["kind"] == "repobrief_bundle_manifest"
+    assert result["generatedAt"] == "2026-07-06T13:00:00Z"
+    assert result["freshnessBasis"] == "bundle_manifest.created_at"
+    assert result["repository"] == "cabinet"
+    assert result["ref"] == "main"
+    assert result["bundleManifest"]["path"] == "../../../../bundle/cabinet_merge.bundle.manifest.json"
+    assert result["snapshotProvenance"]["repositories"][0]["git_commit"] == "d" * 40
+    assert [row["role"] for row in result["artifacts"]] == ["agent_reading_pack", "canonical_md"]
+    assert "claim_truth" in result["doesNotEstablish"]
+    assert "dump_generation_permission" in result["doesNotEstablish"]
+
+
+def test_writes_manifest_reference_atomically(tmp_path: Path) -> None:
+    bundle_path = write_bundle(tmp_path)
+    out = tmp_path / "external" / "lenskit" / "cabinet" / "main" / "manifest.json"
+
+    result = write_external_manifest_reference(
+        bundle_path,
+        out,
+        repository="cabinet",
+        ref="main",
+        artifact_family="lenskit",
+    )
+
+    written = json.loads(out.read_text(encoding="utf-8"))
+    assert written == result
+    assert written["kind"] == "lenskit_bundle_manifest"
+
+
+@pytest.mark.parametrize(
+    ("repository", "ref"),
+    [("heimgewebe/cabinet", "main"), ("cabinet", "feature/x"), (" cabinet", "main")],
+)
+def test_rejects_registry_segments_with_slashes_or_whitespace(tmp_path: Path, repository: str, ref: str) -> None:
+    bundle_path = write_bundle(tmp_path)
+
+    with pytest.raises(ExternalManifestReferenceError):
+        build_external_manifest_reference(bundle_path, repository=repository, ref=ref)
+
+
+def test_rejects_non_bundle_manifest(tmp_path: Path) -> None:
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps({"kind": "other", "created_at": "2026-07-06T13:00:00Z"}), encoding="utf-8")
+
+    with pytest.raises(ExternalManifestReferenceError, match="repolens.bundle.manifest"):
+        build_external_manifest_reference(path, repository="cabinet", ref="main")


### PR DESCRIPTION
Adds an external manifest reference writer for existing RepoBrief bundle manifests. Validation: focused pytest and CLI smoke. Boundary: no snapshot refresh and no consumer registry mutation.