### PR TITLE
feat(repobrief): add publish command

### DIFF
--- a/docs/proofs/external-publish-v1-proof.md
+++ b/docs/proofs/external-publish-v1-proof.md
@@ -1,0 +1,36 @@
+# RepoBrief External Publish v1 — Proof
+
+Date: 2026-07-06
+
+## Decision
+
+External manifest publication belongs to RepoBrief/Lenskit, not Cabinet. Cabinet observes external manifest references; it must not create dumps or publish producer-owned manifests.
+
+## Boundary
+
+The new publish command takes an existing Brief Bundle manifest and a caller-chosen publication root. It writes bounded manifest references under this deterministic layout:
+
+```text
+<publication-root>/external/repobrief/<repository>/<ref>/manifest.json
+<publication-root>/external/lenskit/<repository>/<ref>/manifest.json
+```
+
+The publication root is explicit. RepoBrief does not decide whether that root is a Git checkout, object store sync directory, web root, or local artifact directory.
+
+## Difference from write
+
+`write` writes one manifest to one explicit output path.
+
+`publish` writes one or more manifest families to the stable external layout below a publication root.
+
+## Non-goals
+
+The command does not create or refresh a source snapshot, mutate Cabinet, import into Bureau, dispatch agents, or claim semantic truth, merge readiness, runtime correctness, or repo understanding.
+
+## Target proof
+
+```text
+python3 -m pytest merger/lenskit/tests/test_external_manifest_reference.py -q
+```
+
+Expected: publication path helper, core publisher, and CLI publish path pass.

--- a/merger/lenskit/cli/cmd_repobrief.py
+++ b/merger/lenskit/cli/cmd_repobrief.py
@@ -292,6 +292,22 @@ def register_repobrief_command_groups(repobrief_parser: argparse.ArgumentParser)
         help="External artifact family to advertise",
     )
 
+    external_publish_parser = external_subparsers.add_parser(
+        "publish",
+        help="Publish external manifest references under a stable publication root",
+    )
+    external_publish_parser.add_argument("--bundle-manifest", required=True, help="Path to a Brief Bundle manifest")
+    external_publish_parser.add_argument("--publication-root", required=True, help="Root directory for published external manifests")
+    external_publish_parser.add_argument("--repository", required=True, help="Registry repository segment, for example cabinet")
+    external_publish_parser.add_argument("--ref", required=True, help="Registry ref segment, for example main")
+    external_publish_parser.add_argument(
+        "--artifact-family",
+        choices=["repobrief", "lenskit"],
+        action="append",
+        dest="artifact_families",
+        help="Artifact family to publish; repeatable; defaults to both",
+    )
+
     patch_eval_parser = repobrief_subparsers.add_parser(
         "patch-evaluation",
         help="Read-only consumption of external Patch Evaluation Sidecar artifacts",
@@ -337,6 +353,8 @@ def run_repobrief(args: argparse.Namespace) -> int:
         return run_required_reading_resolve(args)
     if args.repobrief_cmd == "external-manifest" and args.external_manifest_cmd == "write":
         return run_external_manifest_write(args)
+    if args.repobrief_cmd == "external-manifest" and args.external_manifest_cmd == "publish":
+        return run_external_manifest_publish(args)
     if args.repobrief_cmd == "patch-evaluation" and args.patch_evaluation_cmd == "validate":
         return run_patch_evaluation_validate(args)
     print("Unsupported RepoBrief command", file=sys.stderr)
@@ -359,6 +377,27 @@ def run_external_manifest_write(args: argparse.Namespace) -> int:
         )
     except ExternalManifestReferenceError as exc:
         print("repobrief external-manifest write: " + str(exc), file=sys.stderr)
+        return 2
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+def run_external_manifest_publish(args: argparse.Namespace) -> int:
+    from merger.lenskit.core.external_manifest_reference import (
+        ExternalManifestReferenceError,
+        publish_external_manifest_references,
+    )
+
+    try:
+        result = publish_external_manifest_references(
+            args.bundle_manifest,
+            args.publication_root,
+            repository=args.repository,
+            ref=args.ref,
+            artifact_families=args.artifact_families,
+        )
+    except ExternalManifestReferenceError as exc:
+        print("repobrief external-manifest publish: " + str(exc), file=sys.stderr)
         return 2
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0

--- a/merger/lenskit/core/external_manifest_reference.py
+++ b/merger/lenskit/core/external_manifest_reference.py
@@ -5,7 +5,7 @@ import json
 import os
 import tempfile
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable
 
 SUPPORTED_FAMILIES = {"repobrief", "lenskit"}
 BUNDLE_KIND = "repolens.bundle.manifest"
@@ -115,6 +115,68 @@ def build_external_manifest_reference(
         },
         "snapshotProvenance": snapshot_provenance if isinstance(snapshot_provenance, dict) else None,
         "artifacts": _artifact_rows(bundle),
+        "doesNotEstablish": list(DOES_NOT_ESTABLISH),
+    }
+
+
+def publication_manifest_path(
+    publication_root: str | Path,
+    *,
+    repository: str,
+    ref: str,
+    artifact_family: str,
+) -> Path:
+    """Return the stable external manifest publication path for a registry segment."""
+    family = artifact_family.strip().lower() if isinstance(artifact_family, str) else ""
+    if family not in SUPPORTED_FAMILIES:
+        raise ExternalManifestReferenceError("artifact_family must be repobrief or lenskit")
+    repository = _registry_segment(repository, "repository")
+    ref = _registry_segment(ref, "ref")
+    return Path(publication_root).expanduser().resolve() / "external" / family / repository / ref / "manifest.json"
+
+
+def publish_external_manifest_references(
+    bundle_manifest_path: str | Path,
+    publication_root: str | Path,
+    *,
+    repository: str,
+    ref: str,
+    artifact_families: Iterable[str] | None = None,
+) -> dict[str, Any]:
+    """Publish one or more external manifest references under a stable root."""
+    families = list(dict.fromkeys(artifact_families)) if artifact_families is not None else sorted(SUPPORTED_FAMILIES)
+    if not families:
+        raise ExternalManifestReferenceError("at least one artifact family is required")
+    published = []
+    for family in families:
+        out = publication_manifest_path(
+            publication_root,
+            repository=repository,
+            ref=ref,
+            artifact_family=family,
+        )
+        manifest = write_external_manifest_reference(
+            bundle_manifest_path,
+            out,
+            repository=repository,
+            ref=ref,
+            artifact_family=family,
+        )
+        published.append({
+            "artifactFamily": manifest["artifactFamily"],
+            "kind": manifest["kind"],
+            "path": str(out),
+            "generatedAt": manifest["generatedAt"],
+            "relativePublicationPath": Path(os.path.relpath(out, Path(publication_root).expanduser().resolve())).as_posix(),
+        })
+    return {
+        "kind": "repobrief.external_manifest_publication",
+        "version": "1",
+        "repository": _registry_segment(repository, "repository"),
+        "ref": _registry_segment(ref, "ref"),
+        "publicationRoot": str(Path(publication_root).expanduser().resolve()),
+        "bundleManifest": str(Path(bundle_manifest_path).expanduser().resolve()),
+        "published": published,
         "doesNotEstablish": list(DOES_NOT_ESTABLISH),
     }
 

--- a/merger/lenskit/tests/test_external_manifest_reference.py
+++ b/merger/lenskit/tests/test_external_manifest_reference.py
@@ -8,6 +8,8 @@ import pytest
 from merger.lenskit.core.external_manifest_reference import (
     ExternalManifestReferenceError,
     build_external_manifest_reference,
+    publication_manifest_path,
+    publish_external_manifest_references,
     write_external_manifest_reference,
 )
 
@@ -118,3 +120,54 @@ def test_rejects_non_bundle_manifest(tmp_path: Path) -> None:
 
     with pytest.raises(ExternalManifestReferenceError, match="repolens.bundle.manifest"):
         build_external_manifest_reference(path, repository="cabinet", ref="main")
+
+def test_publication_manifest_path_uses_stable_external_layout(tmp_path: Path) -> None:
+    path = publication_manifest_path(
+        tmp_path / "published",
+        repository="cabinet",
+        ref="main",
+        artifact_family="repobrief",
+    )
+
+    assert path == tmp_path / "published" / "external" / "repobrief" / "cabinet" / "main" / "manifest.json"
+
+
+def test_publish_external_manifest_references_can_publish_one_family(tmp_path: Path) -> None:
+    bundle_path = write_bundle(tmp_path)
+    root = tmp_path / "published"
+
+    result = publish_external_manifest_references(
+        bundle_path,
+        root,
+        repository="cabinet",
+        ref="main",
+        artifact_families=["repobrief"],
+    )
+
+    assert [row["artifactFamily"] for row in result["published"]] == ["repobrief"]
+    assert (root / "external" / "repobrief" / "cabinet" / "main" / "manifest.json").is_file()
+    assert not (root / "external" / "lenskit" / "cabinet" / "main" / "manifest.json").exists()
+
+
+def test_repobrief_cli_publishes_external_manifest_references(tmp_path: Path) -> None:
+    from merger.lenskit.cli.repobrief import main as repobrief_main
+
+    bundle_path = write_bundle(tmp_path)
+    root = tmp_path / "published"
+
+    rc = repobrief_main([
+        "external-manifest",
+        "publish",
+        "--bundle-manifest",
+        str(bundle_path),
+        "--publication-root",
+        str(root),
+        "--repository",
+        "cabinet",
+        "--ref",
+        "main",
+    ])
+
+    assert rc == 0
+    assert (root / "external" / "repobrief" / "cabinet" / "main" / "manifest.json").is_file()
+    assert (root / "external" / "lenskit" / "cabinet" / "main" / "manifest.json").is_file()


### PR DESCRIPTION
Adds stable publication root support. Validation: 81 focused tests passed.