### PR TITLE
feat(repobrief): add resolved evidence query surface

### DIFF
--- a/docs/proofs/repobrief-resolved-evidence-query-v1-proof.md
+++ b/docs/proofs/repobrief-resolved-evidence-query-v1-proof.md
@@ -1,0 +1,37 @@
+# RepoBrief resolved evidence query v1 proof
+
+Status: implemented by the RPU-V1-T001 slice.
+
+## Scope
+
+The slice makes `repobrief query` a read-only, resolved evidence surface over an existing Brief Bundle manifest. It also enriches `query_existing_index(..., resolve_evidence=True)` so each resolved hit carries directly usable evidence fields:
+
+- text excerpt and truncation flag,
+- source/artifact path,
+- source and artifact line ranges,
+- range ref and range verification status,
+- citation id and citation verification status,
+- snapshot availability and freshness state.
+
+The CLI defaults to resolved evidence and compact source projection. A raw bounded index result remains available through `--raw-index-result` for compatibility and debugging.
+
+## Boundary
+
+The query path reads only existing bundle artifacts. It does not create snapshots, refresh stale bundles, mutate Git, open PRs, apply patches, write brief artifacts, run tests, or inspect secrets.
+
+## Validation
+
+Targeted validation:
+
+```bash
+python3 -m pytest -q \
+  merger/lenskit/tests/test_repobrief_resolved_evidence_query.py \
+  merger/lenskit/tests/test_repobrief_source_citation_projection.py \
+  merger/lenskit/tests/test_repobrief_access_boundary.py
+```
+
+Expected result: all tests pass.
+
+## Non-claims
+
+This proof does not establish semantic completeness, runtime correctness, test sufficiency, review completeness, agent quality improvement, stale-bundle validity, or merge readiness.

--- a/merger/lenskit/cli/cmd_repobrief.py
+++ b/merger/lenskit/cli/cmd_repobrief.py
@@ -268,6 +268,29 @@ def register_repobrief_command_groups(repobrief_parser: argparse.ArgumentParser)
     resolve_parser.add_argument("--bundle-manifest", required=True, help="Path to a Brief Bundle manifest")
     resolve_parser.add_argument("--task-profile", required=True, help="Required-reading task profile")
 
+    query_parser = repobrief_subparsers.add_parser(
+        "query",
+        help="Run a read-only resolved evidence query against an existing Brief Bundle",
+    )
+    query_parser.add_argument("--bundle-manifest", required=True, help="Path to a Brief Bundle manifest")
+    query_parser.add_argument("--q", default="", help="Search query text")
+    query_parser.add_argument("--k", type=int, default=10, help="Maximum resolved hits")
+    query_parser.add_argument("--repo", help="Filter by repo_id")
+    query_parser.add_argument("--path", help="Filter by path substring")
+    query_parser.add_argument("--ext", help="Filter by file extension")
+    query_parser.add_argument("--layer", help="Filter by layer")
+    query_parser.add_argument("--artifact-type", help="Filter by artifact_type")
+    query_parser.add_argument(
+        "--raw-index-result",
+        action="store_true",
+        help="Disable resolved evidence and return only the bounded raw index result",
+    )
+    query_parser.add_argument(
+        "--no-project-sources",
+        action="store_true",
+        help="Do not add the compact source citation projection",
+    )
+
     external_parser = repobrief_subparsers.add_parser(
         "external-manifest",
         help="Write bounded external manifest references from existing bundle manifests",
@@ -372,6 +395,8 @@ def run_repobrief(args: argparse.Namespace) -> int:
         return run_artifact_list(args)
     if args.repobrief_cmd == "required-reading" and args.required_reading_cmd == "resolve":
         return run_required_reading_resolve(args)
+    if args.repobrief_cmd == "query":
+        return run_query_existing_index(args)
     if args.repobrief_cmd == "external-manifest" and args.external_manifest_cmd == "write":
         return run_external_manifest_write(args)
     if args.repobrief_cmd == "external-manifest" and args.external_manifest_cmd == "publish":
@@ -574,6 +599,32 @@ def run_required_reading_resolve(args: argparse.Namespace) -> int:
         return 2
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0 if result.get("status") in {"pass", "warn"} else 1
+
+def run_query_existing_index(args: argparse.Namespace) -> int:
+    from merger.lenskit.core.repobrief_access import query_existing_index
+
+    filters = {
+        "repo": args.repo,
+        "path": args.path,
+        "ext": args.ext,
+        "layer": args.layer,
+        "artifact_type": getattr(args, "artifact_type", None),
+    }
+    try:
+        result = query_existing_index(
+            args.bundle_manifest,
+            args.q,
+            k=args.k,
+            filters=filters,
+            resolve_evidence=not args.raw_index_result,
+            project_sources=not args.raw_index_result and not args.no_project_sources,
+        )
+    except ValueError as exc:
+        print("repobrief query: " + str(exc), file=sys.stderr)
+        return 2
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result.get("status") == "available" else 1
+
 
 def run_preflight(args: argparse.Namespace) -> int:
     from merger.lenskit.core.repobrief_preflight import run_consumption_preflight

--- a/merger/lenskit/core/repobrief_access.py
+++ b/merger/lenskit/core/repobrief_access.py
@@ -479,12 +479,133 @@ def _citation_record(row: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _artifact_availability(availability_model: dict[str, Any] | None, role: str) -> dict[str, Any]:
+    if not isinstance(availability_model, dict):
+        return {
+            "role": role,
+            "availability": "unknown",
+            "requirement": None,
+            "reason": "availability_model_unavailable",
+        }
+    artifacts = availability_model.get("artifacts")
+    if isinstance(artifacts, list):
+        for artifact in artifacts:
+            if isinstance(artifact, dict) and artifact.get("role") == role:
+                return {
+                    "role": role,
+                    "availability": artifact.get("availability"),
+                    "requirement": artifact.get("requirement"),
+                    "reason": artifact.get("reason"),
+                }
+    return {
+        "role": role,
+        "availability": "missing",
+        "requirement": None,
+        "reason": "role_not_reported_in_availability_model",
+    }
+
+
+def _line_range(start_line: Any, end_line: Any) -> dict[str, Any] | None:
+    if not _is_int_not_bool(start_line) or not _is_int_not_bool(end_line):
+        return None
+    if start_line < 1 or end_line < start_line:
+        return None
+    return {
+        "start_line": start_line,
+        "end_line": end_line,
+        "display": f"{start_line}-{end_line}",
+    }
+
+
+def _enrich_resolved_hit_for_direct_use(
+    hit: dict[str, Any],
+    *,
+    availability_model: dict[str, Any] | None,
+) -> None:
+    range_value = hit.get("range")
+    text = range_value.get("text") if isinstance(range_value, dict) else None
+    raw_citation = hit.get("citation")
+    citation = raw_citation if isinstance(raw_citation, dict) else None
+    citation_range = _source_range_projection(
+        citation.get("canonical_range") if citation else None
+    )
+    range_ref_projection = (
+        _source_range_projection(hit.get("range_ref"))
+        if hit.get("range_status") == "resolved"
+        else None
+    )
+    range_projection = _source_range_projection(range_value)
+    candidates = [range_ref_projection, citation_range, range_projection]
+    source_range = next(
+        (candidate for candidate in candidates if _has_range_identity(candidate)),
+        None,
+    )
+    if source_range is None:
+        source_range = next(
+            (candidate for candidate in candidates if isinstance(candidate, dict)),
+            None,
+        )
+
+    source_path = None
+    source_line_range = None
+    artifact_path = None
+    artifact_line_range = None
+    artifact_role = None
+    if isinstance(source_range, dict):
+        source_path = _first_not_none(
+            source_range.get("source_file_path"),
+            source_range.get("file_path"),
+            hit.get("path"),
+        )
+        source_line_range = _line_range(
+            _first_not_none(source_range.get("source_start_line"), source_range.get("start_line")),
+            _first_not_none(source_range.get("source_end_line"), source_range.get("end_line")),
+        )
+        artifact_path = _first_not_none(source_range.get("artifact_path"), source_range.get("file_path"))
+        artifact_line_range = _line_range(
+            _first_not_none(source_range.get("artifact_start_line"), source_range.get("start_line")),
+            _first_not_none(source_range.get("artifact_end_line"), source_range.get("end_line")),
+        )
+        artifact_role = source_range.get("artifact_role")
+    if source_path is None:
+        source_path = hit.get("path")
+
+    hit["text_excerpt"] = text[:TEXT_EXCERPT_MAX_CHARS] if isinstance(text, str) else None
+    hit["text_truncated"] = isinstance(text, str) and len(text) > TEXT_EXCERPT_MAX_CHARS
+    hit["source_path"] = source_path
+    hit["line_range"] = source_line_range or artifact_line_range
+    hit["source_line_range"] = source_line_range
+    hit["artifact_path"] = artifact_path
+    hit["artifact_role"] = artifact_role
+    hit["artifact_line_range"] = artifact_line_range
+    hit["range_ref_verified"] = hit.get("range_status") == "resolved"
+    hit["citation_verified"] = hit.get("citation_status") == "resolved" and isinstance(
+        hit.get("citation_id"),
+        str,
+    )
+    hit["availability"] = {
+        "snapshot_status": availability_model.get("status")
+        if isinstance(availability_model, dict)
+        else "unknown",
+        "artifact": _artifact_availability(
+            availability_model,
+            str(artifact_role or "canonical_md"),
+        ),
+        "index_artifact": _artifact_availability(availability_model, "sqlite_index"),
+    }
+    hit["freshness"] = (
+        availability_model.get("freshness") if isinstance(availability_model, dict) else None
+    )
+
+
 def _resolve_hit_evidence(
     manifest_path: Path,
     hit: dict[str, Any],
     by_chunk_id: dict[str, dict[str, Any]],
     by_range: dict[tuple[Any, ...], dict[str, Any]],
     citation_map_available: bool,
+    *,
+    availability_model: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     range_candidates: list[tuple[str, dict[str, Any]]] = []
     range_ref = hit.get("range_ref")
@@ -541,16 +662,34 @@ def _resolve_hit_evidence(
             record["citation_id"] = row.get("citation_id")
             record["citation"] = _citation_record(row)
 
+    _enrich_resolved_hit_for_direct_use(record, availability_model=availability_model)
     return record
 
 
-def _resolve_query_evidence(manifest_path: Path, query_result: Any) -> dict[str, Any]:
+def _availability_model_for_manifest(manifest_path: Path) -> dict[str, Any]:
+    from merger.lenskit.core.repobrief_availability import snapshot_availability_model
+
+    manifest = _read_json_object(manifest_path)
+    return snapshot_availability_model(manifest_path, manifest)
+
+
+def _resolve_query_evidence(
+    manifest_path: Path,
+    query_result: Any,
+    *,
+    availability_model: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     hits = query_result.get("results") if isinstance(query_result, dict) else None
     hit_list = [hit for hit in (hits if isinstance(hits, list) else []) if isinstance(hit, dict)]
+    if availability_model is None:
+        availability_model = _availability_model_for_manifest(manifest_path)
+    freshness = availability_model.get("freshness") if isinstance(availability_model, dict) else None
     if not hit_list:
         return {
             "kind": RESOLVED_EVIDENCE_KIND,
             "version": RESOLVED_EVIDENCE_VERSION,
+            "availability": availability_model,
+            "freshness": freshness,
             "citation_map": {
                 "status": "skipped",
                 "error_code": None,
@@ -567,12 +706,21 @@ def _resolve_query_evidence(manifest_path: Path, query_result: Any) -> dict[str,
     by_chunk_id, by_range, citation_map_status = _load_citation_lookup(manifest_path)
     citation_map_available = citation_map_status["status"] == "available"
     resolved_hits = [
-        _resolve_hit_evidence(manifest_path, hit, by_chunk_id, by_range, citation_map_available)
+        _resolve_hit_evidence(
+            manifest_path,
+            hit,
+            by_chunk_id,
+            by_range,
+            citation_map_available,
+            availability_model=availability_model,
+        )
         for hit in hit_list
     ]
     return {
         "kind": RESOLVED_EVIDENCE_KIND,
         "version": RESOLVED_EVIDENCE_VERSION,
+        "availability": availability_model,
+        "freshness": freshness,
         "citation_map": citation_map_status,
         "hit_count": len(resolved_hits),
         "hits": resolved_hits,
@@ -868,8 +1016,14 @@ def query_existing_index(
             extra={"query": query, "k": k, "query_result": None, "index_artifact": artifact},
         )
 
+    availability_model = _availability_model_for_manifest(manifest_path)
+    freshness = availability_model.get("freshness") if isinstance(availability_model, dict) else None
     resolved_evidence = (
-        _resolve_query_evidence(manifest_path, query_result)
+        _resolve_query_evidence(
+            manifest_path,
+            query_result,
+            availability_model=availability_model,
+        )
         if (resolve_evidence or project_sources)
         else None
     )
@@ -888,6 +1042,8 @@ def query_existing_index(
         "resolve_evidence": resolve_evidence,
         "project_sources": project_sources,
         "index_artifact": artifact,
+        "availability": availability_model,
+        "freshness": freshness,
         "query_result": query_result,
         "evidence_resolution_used": resolve_evidence or project_sources,
         "resolved_evidence": resolved_evidence if resolve_evidence else None,

--- a/merger/lenskit/tests/test_repobrief_resolved_evidence_query.py
+++ b/merger/lenskit/tests/test_repobrief_resolved_evidence_query.py
@@ -370,3 +370,96 @@ def test_resolved_evidence_matches_v2_range_ref_without_chunk_id(tmp_path):
     assert resolved_hit["range_ref_source"] == "range_ref"
     assert resolved_hit["citation_status"] == "resolved"
     assert resolved_hit["citation_id"] == bundle["citation_id"]
+
+
+def test_resolved_evidence_hits_are_directly_usable(tmp_path):
+    bundle = _build_resolved_bundle(tmp_path)
+
+    result = repobrief_access.query_existing_index(
+        bundle["manifest"], "hello", k=1, resolve_evidence=True
+    )
+
+    assert result["availability"]["kind"] == "repobrief.snapshot_availability"
+    assert result["freshness"]["status"] == "unknown"
+    resolved = result["resolved_evidence"]
+    assert resolved["availability"] == result["availability"]
+    assert resolved["freshness"] == result["freshness"]
+    hit = resolved["hits"][0]
+    assert hit["text_excerpt"] == bundle["chunk_text"]
+    assert hit["text_truncated"] is False
+    assert hit["source_path"] == bundle["canonical"].name
+    assert hit["line_range"] == {"start_line": 3, "end_line": 3, "display": "3-3"}
+    assert hit["source_line_range"] == {"start_line": 3, "end_line": 3, "display": "3-3"}
+    assert hit["artifact_role"] == "canonical_md"
+    assert hit["artifact_path"] == bundle["canonical"].name
+    assert hit["range_ref_verified"] is True
+    assert hit["citation_verified"] is True
+    assert hit["availability"]["snapshot_status"] == result["availability"]["status"]
+    assert hit["availability"]["artifact"]["role"] == "canonical_md"
+    assert hit["availability"]["artifact"]["availability"] == "available"
+    assert hit["availability"]["index_artifact"]["role"] == "sqlite_index"
+    assert hit["availability"]["index_artifact"]["availability"] == "available"
+    assert hit["freshness"] == result["freshness"]
+
+
+def test_repobrief_query_cli_defaults_to_resolved_evidence(tmp_path, capsys):
+    from merger.lenskit.cli.main import main
+
+    bundle = _build_resolved_bundle(tmp_path)
+
+    rc = main([
+        "repobrief",
+        "query",
+        "--bundle-manifest",
+        str(bundle["manifest"]),
+        "--q",
+        "hello",
+        "--k",
+        "1",
+    ])
+
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["kind"] == "repobrief.query_existing_index"
+    assert data["status"] == "available"
+    assert data["resolve_evidence"] is True
+    assert data["project_sources"] is True
+    assert data["evidence_resolution_used"] is True
+    assert data["freshness"]["status"] == "unknown"
+    assert data["availability"]["kind"] == "repobrief.snapshot_availability"
+    hit = data["resolved_evidence"]["hits"][0]
+    assert hit["text_excerpt"] == bundle["chunk_text"]
+    assert hit["source_path"] == bundle["canonical"].name
+    assert hit["line_range"]["display"] == "3-3"
+    assert hit["citation_id"] == bundle["citation_id"]
+    assert data["source_citation_projection"]["items"][0]["citation_id"] == bundle["citation_id"]
+    assert data["mutation_boundary"]["writes"] == []
+    assert data["mutation_boundary"]["read_paths_do_not_refresh"] is True
+
+
+def test_repobrief_query_cli_can_emit_raw_bounded_index_result(tmp_path, capsys):
+    from merger.lenskit.cli.main import main
+
+    bundle = _build_resolved_bundle(tmp_path)
+
+    rc = main([
+        "repobrief",
+        "query",
+        "--bundle-manifest",
+        str(bundle["manifest"]),
+        "--q",
+        "hello",
+        "--k",
+        "1",
+        "--raw-index-result",
+    ])
+
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["resolve_evidence"] is False
+    assert data["project_sources"] is False
+    assert data["evidence_resolution_used"] is False
+    assert data["resolved_evidence"] is None
+    assert data["source_citation_projection"] is None
+    assert data["query_result"]["count"] == 1
+    assert data["freshness"]["status"] == "unknown"


### PR DESCRIPTION
Implements Bureau task RPU-V1-T001 — Resolved evidence query with content.

Scope:
- adds a read-only `repobrief query` CLI surface over existing Brief Bundle manifests
- defaults the CLI to resolved evidence and compact source citation projection
- enriches `query_existing_index(..., resolve_evidence=True)` hits with directly usable fields: text excerpt, source/artifact path, line ranges, range/citation verification, availability and freshness
- keeps `--raw-index-result` for compatibility/debugging
- documents the proof/boundary in `docs/proofs/repobrief-resolved-evidence-query-v1-proof.md`

Validation:
- `python3 -m pytest -q merger/lenskit/tests/test_repobrief_*.py merger/lenskit/tests/test_cli_query_profiles.py merger/lenskit/tests/test_api_query.py` -> 150 passed
- `python3 -m ruff check merger/lenskit/core/repobrief_access.py merger/lenskit/cli/cmd_repobrief.py merger/lenskit/tests/test_repobrief_resolved_evidence_query.py` -> pass
- `python3 -m scripts.docmeta.check_planning_registration` -> pass
- `git diff --check` -> pass

Boundaries / non-claims:
- read-only over existing bundle artifacts
- no snapshot creation, no hidden refresh, no Git mutation, no PR or patch action
- does not establish semantic completeness, runtime correctness, test sufficiency, review completeness, agent quality improvement, stale-bundle validity, or merge readiness
