### PR TITLE
feat(repobrief): add live source citation addresses

### DIFF
--- a/docs/proofs/repobrief-live-source-citation-address-v1-proof.md
+++ b/docs/proofs/repobrief-live-source-citation-address-v1-proof.md
@@ -1,0 +1,43 @@
+# RepoBrief live source citation address v1 proof
+
+Status: implemented by the RPU-V1-T002 slice.
+
+## Scope
+
+The slice adds an optional live repository source address next to canonical Brief Bundle citations.
+
+A citation map row may now include:
+
+- `source_range`: normalized source-file path and line/byte range from the chunk index;
+- `live_repo_address`: repository convenience address with repo id, remote, git commit, dirty state, source path, line range, optional Git SHA-1 blob id and explicit status.
+
+`repobrief query` and `query_existing_index(..., resolve_evidence=True)` project those fields into resolved evidence results while retaining the canonical citation id and canonical Brief Source range.
+
+## Authority model
+
+`canonical_range` remains the authoritative citation locator. `live_repo_address` is a convenience address for normal repository reading. It is never promoted to canonical content authority.
+
+When provenance is missing, unavailable, dirty, or lacks a blob hash, the live address is marked `unknown`, `unavailable`, or `degraded` instead of inventing freshness.
+
+## Boundary
+
+The query path remains read-only over existing bundle artifacts. The snapshot generation path records file-content Git blob ids in chunk metadata for later citation-map projection, but does not mutate Git, run Git writes, create PRs, apply patches, or refresh stale bundles.
+
+## Validation
+
+Targeted validation:
+
+```bash
+python3 -m pytest -q \
+  merger/lenskit/tests/test_citation_map_schema.py \
+  merger/lenskit/tests/test_citation_map_producer.py \
+  merger/lenskit/tests/test_repobrief_resolved_evidence_query.py \
+  merger/lenskit/tests/test_repobrief_source_citation_projection.py \
+  merger/lenskit/tests/test_chunk_index_dual_ranges.py
+```
+
+Expected result: all tests pass.
+
+## Non-claims
+
+This proof does not establish semantic completeness, runtime correctness, test sufficiency, review completeness, stale-bundle validity, freshness against remote, or merge readiness.

--- a/merger/lenskit/contracts/citation-map.v1.schema.json
+++ b/merger/lenskit/contracts/citation-map.v1.schema.json
@@ -137,7 +137,11 @@
       "if": {
         "properties": {
           "status": {
-            "enum": ["declared", "exact", "derived"]
+            "enum": [
+              "declared",
+              "exact",
+              "derived"
+            ]
           }
         }
       },
@@ -157,6 +161,103 @@
     "produced_by": {
       "type": "string",
       "description": "Optional producer hint, e.g. citation_map_producer name/version. Diagnostic only."
+    },
+    "live_repo_address": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "authority",
+        "canonical_authority_preserved",
+        "repo_id",
+        "path",
+        "does_not_establish"
+      ],
+      "description": "Optional convenience address into the source repository at snapshot time. It is derived navigation only; canonical_range remains the authoritative citation locator.",
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "available",
+            "degraded",
+            "unavailable",
+            "unknown"
+          ]
+        },
+        "reason": {
+          "type": "string"
+        },
+        "authority": {
+          "type": "string",
+          "enum": [
+            "source_address_convenience"
+          ]
+        },
+        "canonical_authority_preserved": {
+          "type": "boolean"
+        },
+        "repo_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "repo_remote": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "git_commit": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^[a-f0-9]{40,64}$"
+        },
+        "git_dirty": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "provenance_status": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "start_line": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "end_line": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "blob_sha1": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{40}$"
+        },
+        "blob_hash_algorithm": {
+          "type": "string",
+          "enum": [
+            "git-sha1"
+          ]
+        },
+        "blob_hash_basis": {
+          "type": "string"
+        },
+        "does_not_establish": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        }
+      }
     }
   }
 }

--- a/merger/lenskit/core/citation_map.py
+++ b/merger/lenskit/core/citation_map.py
@@ -280,6 +280,143 @@ def resolve_repo_id(
     return candidates[0][1], candidates[0][0]
 
 
+def normalize_source_range(chunk: Dict[str, Any], lineno: int) -> Optional[Dict[str, Any]]:
+    """Return a schema-clean source_range from a chunk, when present and usable."""
+    raw = chunk.get("source_range")
+    if not isinstance(raw, dict):
+        return None
+    raw_status = raw.get("status")
+    if raw_status not in {"declared", "exact", "derived", "unavailable"}:
+        return None
+    raw_path = raw.get("file_path") or chunk.get("path")
+    if not isinstance(raw_path, str) or not raw_path:
+        return None
+    try:
+        file_path = _normalize_relative_path(raw_path, f"source_range.file_path line {lineno}")
+    except ValueError:
+        return None
+
+    source_range: Dict[str, Any] = {"file_path": file_path, "status": raw_status}
+    for field in ("start_byte", "end_byte", "start_line", "end_line"):
+        value = raw.get(field)
+        if isinstance(value, bool) or not isinstance(value, int):
+            if raw_status in {"declared", "exact", "derived"}:
+                return None
+            continue
+        source_range[field] = value
+    content_sha256 = raw.get("content_sha256")
+    if isinstance(content_sha256, str) and _SHA256_RE.fullmatch(content_sha256):
+        source_range["content_sha256"] = content_sha256
+    return source_range
+
+
+def _snapshot_repo(snapshot_provenance: Any, repo_id: str) -> Optional[Dict[str, Any]]:
+    repositories = (
+        snapshot_provenance.get("repositories")
+        if isinstance(snapshot_provenance, dict)
+        else None
+    )
+    if not isinstance(repositories, list):
+        return None
+    for repo in repositories:
+        if isinstance(repo, dict) and repo.get("name") == repo_id:
+            return repo
+    return None
+
+
+def _valid_git_blob_sha1(value: Any) -> Optional[str]:
+    if isinstance(value, str) and re.fullmatch(r"[a-f0-9]{40}", value):
+        return value
+    return None
+
+
+def build_live_repo_address(
+    chunk: Dict[str, Any],
+    repo_id: str,
+    source_range: Optional[Dict[str, Any]],
+    snapshot_provenance: Any,
+) -> Optional[Dict[str, Any]]:
+    """Build a convenience source address without replacing canonical authority."""
+    path_value = (
+        source_range.get("file_path")
+        if isinstance(source_range, dict)
+        else chunk.get("path")
+    )
+    if not isinstance(path_value, str) or not path_value:
+        return None
+    try:
+        path_value = _normalize_relative_path(path_value, "live_repo_address.path")
+    except ValueError:
+        return None
+
+    repo = _snapshot_repo(snapshot_provenance, repo_id)
+    status = "unknown"
+    reason = "snapshot_provenance_missing"
+    repo_remote = None
+    git_commit = None
+    git_dirty = None
+    provenance_status = None
+    if repo is not None:
+        provenance_status = repo.get("provenance_status")
+        repo_remote = repo.get("repo_remote") if isinstance(repo.get("repo_remote"), str) else None
+        git_commit = repo.get("git_commit") if isinstance(repo.get("git_commit"), str) else None
+        git_dirty = repo.get("git_dirty") if isinstance(repo.get("git_dirty"), bool) else None
+        if provenance_status != "present":
+            status = "unavailable"
+            reason = f"snapshot_provenance_status_{provenance_status or 'unknown'}"
+        elif not git_commit:
+            status = "unknown"
+            reason = "git_commit_missing"
+        elif git_dirty is True:
+            status = "degraded"
+            reason = "snapshot_worktree_dirty"
+        else:
+            status = "available"
+            reason = "snapshot_git_provenance_present"
+
+    if isinstance(source_range, dict) and source_range.get("status") == "unavailable":
+        status = "unavailable"
+        reason = "source_range_unavailable"
+
+    raw_source_range = chunk.get("source_range") if isinstance(chunk.get("source_range"), dict) else {}
+    blob_sha1 = _valid_git_blob_sha1(raw_source_range.get("git_blob_sha1"))
+    if blob_sha1 is None and status == "available":
+        status = "degraded"
+        reason = "source_blob_sha_unavailable"
+
+    address: Dict[str, Any] = {
+        "status": status,
+        "reason": reason,
+        "authority": "source_address_convenience",
+        "canonical_authority_preserved": True,
+        "repo_id": repo_id,
+        "repo_remote": repo_remote,
+        "git_commit": git_commit,
+        "git_dirty": git_dirty,
+        "provenance_status": provenance_status,
+        "path": path_value,
+        "does_not_establish": [
+            "canonical_content",
+            "freshness_against_remote",
+            "runtime_correctness",
+            "merge_readiness",
+        ],
+    }
+    if isinstance(source_range, dict):
+        for out_key, in_key in (("start_line", "start_line"), ("end_line", "end_line")):
+            value = source_range.get(in_key)
+            if isinstance(value, int) and not isinstance(value, bool):
+                address[out_key] = value
+    if blob_sha1 is not None:
+        address["blob_sha1"] = blob_sha1
+        address["blob_hash_algorithm"] = "git-sha1"
+        address["blob_hash_basis"] = raw_source_range.get(
+            "git_blob_sha1_basis",
+            "source_worktree_file_content",
+        )
+    return address
+
+
 # ---------------------------------------------------------------------------
 # Byte-range verification
 # ---------------------------------------------------------------------------
@@ -356,6 +493,7 @@ def iter_chunk_results(
     canonical_md_rel: str,
     canonical_md_sha256: str,
     run_id: str,
+    snapshot_provenance: Any = None,
 ) -> Iterator[_ChunkResult]:
     """
     Yield one _ChunkResult per non-empty line of the chunk index.
@@ -497,6 +635,19 @@ def iter_chunk_results(
                 },
                 "produced_by": PRODUCED_BY,
             }
+
+            source_range = normalize_source_range(chunk, lineno)
+            if source_range is not None:
+                row["source_range"] = source_range
+
+            live_repo_address = build_live_repo_address(
+                chunk,
+                repo_id,
+                source_range,
+                snapshot_provenance,
+            )
+            if live_repo_address is not None:
+                row["live_repo_address"] = live_repo_address
 
             chunk_id = chunk.get("chunk_id")
             if chunk_id is not None:
@@ -783,6 +934,7 @@ def produce_citation_map(  # lenskit:requires-authority=canonical_content
         )
 
     bundle_run_id = manifest.get("run_id")
+    snapshot_provenance = manifest.get("snapshot_provenance")
 
     # H3: run_id must be a non-empty string — an empty snapshot.run_id is invalid.
     if not isinstance(bundle_run_id, str) or not bundle_run_id:
@@ -930,6 +1082,7 @@ def produce_citation_map(  # lenskit:requires-authority=canonical_content
         canonical_md_rel,
         actual_canonical_sha,
         bundle_run_id or "",
+        snapshot_provenance=snapshot_provenance,
     ):
         chunk_count += 1
 

--- a/merger/lenskit/core/merge.py
+++ b/merger/lenskit/core/merge.py
@@ -2029,6 +2029,16 @@ def _compute_file_sha256(path: Path) -> str:
         return "ERROR"
 
 
+def _compute_git_blob_sha1(path: Path) -> str | None:
+    """Return the Git SHA-1 blob id for the current file bytes, if readable."""
+    try:
+        data = path.read_bytes()
+    except OSError:
+        return None
+    header = f"blob {len(data)}\0".encode("utf-8")
+    return hashlib.sha1(header + data, usedforsecurity=False).hexdigest()
+
+
 def compute_md5(path: Path, limit_bytes: Optional[int] = None) -> str:
     # MD5 is used for file integrity checking, not cryptographic security
     try:
@@ -5499,6 +5509,12 @@ def write_reports_v2(
                 content, _redacted_items = redactor.redact(content)
                 was_redacted = bool(_redacted_items)
 
+            source_git_blob_sha1 = (
+                _compute_git_blob_sha1(fi.abs_path)
+                if not was_redacted and not truncated
+                else None
+            )
+
             # Get Semantic Metadata
             sem_meta = get_semantic_metadata(fi.rel_path.as_posix(), content)
 
@@ -5606,6 +5622,9 @@ def write_reports_v2(
                         "content_sha256": d["sha256"],
                         "status": "declared",
                     }
+                    if source_git_blob_sha1:
+                        d["source_range"]["git_blob_sha1"] = source_git_blob_sha1
+                        d["source_range"]["git_blob_sha1_basis"] = "source_worktree_file_content"
 
                 d["search_keys"] = {
                     "repo_id": fi.root_label,

--- a/merger/lenskit/core/repobrief_access.py
+++ b/merger/lenskit/core/repobrief_access.py
@@ -475,6 +475,8 @@ def _citation_record(row: dict[str, Any]) -> dict[str, Any]:
         "chunk_id": row.get("chunk_id"),
         "snapshot": row.get("snapshot"),
         "canonical_range": row.get("canonical_range"),
+        "source_range": row.get("source_range") if isinstance(row.get("source_range"), dict) else None,
+        "live_repo_address": row.get("live_repo_address") if isinstance(row.get("live_repo_address"), dict) else None,
         "produced_by": row.get("produced_by"),
     }
 
@@ -526,8 +528,16 @@ def _enrich_resolved_hit_for_direct_use(
     text = range_value.get("text") if isinstance(range_value, dict) else None
     raw_citation = hit.get("citation")
     citation = raw_citation if isinstance(raw_citation, dict) else None
-    citation_range = _source_range_projection(
+    canonical_range = _source_range_projection(
         citation.get("canonical_range") if citation else None
+    )
+    citation_source_range = _source_range_projection(
+        citation.get("source_range") if citation else None
+    )
+    live_repo_address = (
+        citation.get("live_repo_address")
+        if citation and isinstance(citation.get("live_repo_address"), dict)
+        else None
     )
     range_ref_projection = (
         _source_range_projection(hit.get("range_ref"))
@@ -535,7 +545,7 @@ def _enrich_resolved_hit_for_direct_use(
         else None
     )
     range_projection = _source_range_projection(range_value)
-    candidates = [range_ref_projection, citation_range, range_projection]
+    candidates = [citation_source_range, range_ref_projection, canonical_range, range_projection]
     source_range = next(
         (candidate for candidate in candidates if _has_range_identity(candidate)),
         None,
@@ -551,13 +561,20 @@ def _enrich_resolved_hit_for_direct_use(
     artifact_path = None
     artifact_line_range = None
     artifact_role = None
+    if isinstance(live_repo_address, dict):
+        source_path = live_repo_address.get("path")
+        source_line_range = _line_range(
+            live_repo_address.get("start_line"),
+            live_repo_address.get("end_line"),
+        )
     if isinstance(source_range, dict):
         source_path = _first_not_none(
+            source_path,
             source_range.get("source_file_path"),
             source_range.get("file_path"),
             hit.get("path"),
         )
-        source_line_range = _line_range(
+        source_line_range = source_line_range or _line_range(
             _first_not_none(source_range.get("source_start_line"), source_range.get("start_line")),
             _first_not_none(source_range.get("source_end_line"), source_range.get("end_line")),
         )
@@ -578,6 +595,18 @@ def _enrich_resolved_hit_for_direct_use(
     hit["artifact_path"] = artifact_path
     hit["artifact_role"] = artifact_role
     hit["artifact_line_range"] = artifact_line_range
+    hit["canonical_authority"] = {
+        "authority": "canonical_brief_source",
+        "artifact_role": "canonical_md",
+        "range": canonical_range,
+        "citation_id": hit.get("citation_id"),
+    }
+    hit["live_repo_address"] = live_repo_address
+    hit["live_repo_address_status"] = (
+        live_repo_address.get("status")
+        if isinstance(live_repo_address, dict)
+        else "unavailable"
+    )
     hit["range_ref_verified"] = hit.get("range_status") == "resolved"
     hit["citation_verified"] = hit.get("citation_status") == "resolved" and isinstance(
         hit.get("citation_id"),
@@ -863,13 +892,21 @@ def _project_source_citations(resolved_evidence: Any) -> dict[str, Any]:
         citation_range = _source_range_projection(
             citation.get("canonical_range") if citation else None
         )
+        citation_source_range = _source_range_projection(
+            citation.get("source_range") if citation else None
+        )
+        live_repo_address = (
+            citation.get("live_repo_address")
+            if citation and isinstance(citation.get("live_repo_address"), dict)
+            else None
+        )
         range_ref_projection = (
             _source_range_projection(hit.get("range_ref"))
             if hit.get("range_status") == "resolved"
             else None
         )
         range_projection = _source_range_projection(range_value)
-        candidates = [range_ref_projection, citation_range, range_projection]
+        candidates = [citation_source_range, range_ref_projection, citation_range, range_projection]
         source_range = next(
             (candidate for candidate in candidates if _has_range_identity(candidate)),
             None,
@@ -908,6 +945,19 @@ def _project_source_citations(resolved_evidence: Any) -> dict[str, Any]:
             "citation_resolved": citation_resolved,
             "citation_id": citation_id,
             "citation_range": citation_range,
+            "citation_source_range": citation_source_range,
+            "live_repo_address": live_repo_address,
+            "live_repo_address_status": (
+                live_repo_address.get("status")
+                if isinstance(live_repo_address, dict)
+                else "unavailable"
+            ),
+            "canonical_authority": {
+                "authority": "canonical_brief_source",
+                "artifact_role": "canonical_md",
+                "range": citation_range,
+                "citation_id": citation_id,
+            },
         })
     return {
         "kind": SOURCE_CITATION_PROJECTION_KIND,

--- a/merger/lenskit/tests/test_chunk_index_dual_ranges.py
+++ b/merger/lenskit/tests/test_chunk_index_dual_ranges.py
@@ -296,3 +296,15 @@ def test_citation_map_jsonl_emitted(dual_range_artifacts):
         f"citation_map_jsonl must be emitted exactly once; found: {citation_files}"
     )
     assert citation_files[0].exists()
+
+
+def test_source_range_declared_carries_git_blob_sha1_for_live_repo_addressing(dual_range_artifacts):
+    _, chunks, _ = dual_range_artifacts
+    assert chunks
+    for chunk in chunks:
+        sr = chunk["source_range"]
+        if sr["status"] != "declared":
+            continue
+        assert len(sr["git_blob_sha1"]) == 40
+        assert sr["git_blob_sha1_basis"] == "source_worktree_file_content"
+        int(sr["git_blob_sha1"], 16)

--- a/merger/lenskit/tests/test_citation_map_producer.py
+++ b/merger/lenskit/tests/test_citation_map_producer.py
@@ -1272,3 +1272,103 @@ class TestExplicitOutputProtectionBeforeArtifactResolution:
         assert canonical_md.exists(), (
             "Explicit --output must not be deleted before artifact protection is complete"
         )
+
+
+def _git_blob_sha1(data: bytes) -> str:
+    return hashlib.sha1(b"blob " + str(len(data)).encode("ascii") + b"\0" + data, usedforsecurity=False).hexdigest()
+
+
+class TestLiveRepoAddress:
+    def test_producer_emits_live_repo_address_when_provenance_present(self, tmp_path):
+        content = b"alpha\nbeta\n"
+        source_bytes = b"print('hello')\n"
+        chunk = _canonical_range_chunk(content, 0, 5, "test_merge.md", repo_id="testrepo", chunk_id="c-live")
+        chunk["path"] = "src/app.py"
+        chunk["source_range"] = {
+            "file_path": "src/app.py",
+            "repo_id": "testrepo",
+            "start_byte": 0,
+            "end_byte": len(source_bytes),
+            "start_line": 10,
+            "end_line": 10,
+            "content_sha256": _sha256(source_bytes),
+            "status": "declared",
+            "git_blob_sha1": _git_blob_sha1(source_bytes),
+            "git_blob_sha1_basis": "source_worktree_file_content",
+        }
+        manifest_path = _make_bundle(tmp_path, content, [chunk])
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest["snapshot_provenance"] = {
+            "version": "v1",
+            "repositories": [{
+                "name": "testrepo",
+                "repo_root": str(tmp_path / "testrepo"),
+                "repo_remote": "git@github.com:heimgewebe/lenskit.git",
+                "git_commit": "a" * 40,
+                "git_dirty": False,
+                "git_branch": "main",
+                "provenance_status": "present",
+                "freshness_basis": "git_commit",
+            }],
+            "does_not_establish": ["freshness_against_remote"],
+        }
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+        report = produce_citation_map(str(manifest_path))
+
+        assert report["status"] == "ok", report["errors"]
+        row = report["sample_rows"][0]
+        assert row["source_range"]["file_path"] == "src/app.py"
+        assert row["source_range"]["start_line"] == 10
+        address = row["live_repo_address"]
+        assert address["status"] == "available"
+        assert address["authority"] == "source_address_convenience"
+        assert address["canonical_authority_preserved"] is True
+        assert address["repo_remote"] == "git@github.com:heimgewebe/lenskit.git"
+        assert address["git_commit"] == "a" * 40
+        assert address["git_dirty"] is False
+        assert address["path"] == "src/app.py"
+        assert address["start_line"] == 10
+        assert address["end_line"] == 10
+        assert address["blob_sha1"] == _git_blob_sha1(source_bytes)
+        assert address["blob_hash_algorithm"] == "git-sha1"
+
+    def test_dirty_snapshot_degrades_live_repo_address(self, tmp_path):
+        content = b"alpha\nbeta\n"
+        chunk = _canonical_range_chunk(content, 0, 5, "test_merge.md", repo_id="testrepo", chunk_id="c-dirty")
+        chunk["path"] = "src/app.py"
+        chunk["source_range"] = {
+            "file_path": "src/app.py",
+            "repo_id": "testrepo",
+            "start_byte": 0,
+            "end_byte": 5,
+            "start_line": 1,
+            "end_line": 1,
+            "content_sha256": "b" * 64,
+            "status": "declared",
+            "git_blob_sha1": "c" * 40,
+        }
+        manifest_path = _make_bundle(tmp_path, content, [chunk])
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest["snapshot_provenance"] = {
+            "version": "v1",
+            "repositories": [{
+                "name": "testrepo",
+                "repo_remote": None,
+                "git_commit": "a" * 40,
+                "git_dirty": True,
+                "git_branch": "topic",
+                "provenance_status": "present",
+                "freshness_basis": "git_commit",
+            }],
+            "does_not_establish": ["freshness_against_remote"],
+        }
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+        report = produce_citation_map(str(manifest_path))
+
+        assert report["status"] == "ok", report["errors"]
+        address = report["sample_rows"][0]["live_repo_address"]
+        assert address["status"] == "degraded"
+        assert address["reason"] == "snapshot_worktree_dirty"
+        assert address["git_dirty"] is True

--- a/merger/lenskit/tests/test_citation_map_schema.py
+++ b/merger/lenskit/tests/test_citation_map_schema.py
@@ -273,3 +273,44 @@ def test_example_jsonl_lines_all_validate(schema):
     for line in lines:
         entry = json.loads(line)
         jsonschema.validate(instance=entry, schema=schema)
+
+
+# ---------------------------------------------------------------------------
+# live_repo_address — convenience only, canonical_range remains authority
+# ---------------------------------------------------------------------------
+
+def test_live_repo_address_is_valid(schema):
+    entry = _minimal_entry()
+    entry["live_repo_address"] = {
+        "status": "available",
+        "reason": "snapshot_git_provenance_present",
+        "authority": "source_address_convenience",
+        "canonical_authority_preserved": True,
+        "repo_id": "lenskit",
+        "repo_remote": "git@github.com:heimgewebe/lenskit.git",
+        "git_commit": "a" * 40,
+        "git_dirty": False,
+        "provenance_status": "present",
+        "path": "src/app.py",
+        "start_line": 10,
+        "end_line": 12,
+        "blob_sha1": "b" * 40,
+        "blob_hash_algorithm": "git-sha1",
+        "blob_hash_basis": "source_worktree_file_content",
+        "does_not_establish": ["canonical_content", "freshness_against_remote"],
+    }
+    jsonschema.validate(instance=entry, schema=schema)
+
+
+def test_live_repo_address_rejects_canonical_authority_claim(schema):
+    entry = _minimal_entry()
+    entry["live_repo_address"] = {
+        "status": "available",
+        "authority": "canonical_content",
+        "canonical_authority_preserved": True,
+        "repo_id": "lenskit",
+        "path": "src/app.py",
+        "does_not_establish": ["canonical_content"],
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=entry, schema=schema)

--- a/merger/lenskit/tests/test_repobrief_source_citation_projection.py
+++ b/merger/lenskit/tests/test_repobrief_source_citation_projection.py
@@ -1,3 +1,4 @@
+import json
 from merger.lenskit.core import repobrief_access
 from merger.lenskit.tests.test_repobrief_resolved_evidence_query import (
     _build_resolved_bundle,
@@ -312,3 +313,56 @@ def test_source_citation_projection_projects_v2_source_and_artifact_axes():
     assert source_range["source_start_line"] == 100
     assert source_range["source_end_line"] == 104
     assert source_range["coordinate_basis"] == "artifact_bytes_with_source_lines"
+
+
+def test_query_projection_exposes_live_repo_address_and_preserves_canonical_authority(tmp_path):
+    bundle = _build_resolved_bundle(tmp_path)
+    citation_map_path = tmp_path / "demo.citation_map.jsonl"
+    row = json.loads(citation_map_path.read_text(encoding="utf-8"))
+    row["source_range"] = {
+        "file_path": "src/app.py",
+        "start_byte": 0,
+        "end_byte": 12,
+        "start_line": 7,
+        "end_line": 8,
+        "content_sha256": "d" * 64,
+        "status": "declared",
+    }
+    row["live_repo_address"] = {
+        "status": "available",
+        "reason": "snapshot_git_provenance_present",
+        "authority": "source_address_convenience",
+        "canonical_authority_preserved": True,
+        "repo_id": "demo",
+        "repo_remote": "git@example.test/demo.git",
+        "git_commit": "e" * 40,
+        "git_dirty": False,
+        "provenance_status": "present",
+        "path": "src/app.py",
+        "start_line": 7,
+        "end_line": 8,
+        "blob_sha1": "f" * 40,
+        "blob_hash_algorithm": "git-sha1",
+        "blob_hash_basis": "source_worktree_file_content",
+        "does_not_establish": ["canonical_content", "freshness_against_remote"],
+    }
+    citation_map_path.write_text(json.dumps(row) + "\n", encoding="utf-8")
+
+    result = repobrief_access.query_existing_index(
+        bundle["manifest"], "hello", k=1, resolve_evidence=True, project_sources=True
+    )
+
+    hit = result["resolved_evidence"]["hits"][0]
+    assert hit["source_path"] == "src/app.py"
+    assert hit["line_range"] == {"start_line": 7, "end_line": 8, "display": "7-8"}
+    assert hit["live_repo_address_status"] == "available"
+    assert hit["live_repo_address"]["git_commit"] == "e" * 40
+    assert hit["live_repo_address"]["blob_sha1"] == "f" * 40
+    assert hit["canonical_authority"]["authority"] == "canonical_brief_source"
+    assert hit["canonical_authority"]["range"]["file_path"] == bundle["canonical"].name
+
+    item = result["source_citation_projection"]["items"][0]
+    assert item["source_range"]["file_path"] == "src/app.py"
+    assert item["live_repo_address_status"] == "available"
+    assert item["canonical_authority"]["authority"] == "canonical_brief_source"
+    assert item["citation_range"]["file_path"] == bundle["canonical"].name


### PR DESCRIPTION
Implements Bureau task RPU-V1-T002 — Live-repo source citation addressing.

Scope:
- adds optional `live_repo_address` to citation map rows as a convenience source address beside the canonical bundle range
- records source-file Git SHA-1 blob ids in chunk `source_range` metadata when source content is available and not redacted
- projects live repo path, lines, commit, dirty state and blob hash through resolved RepoBrief query output
- keeps canonical `citation_id` and `canonical_range` as the generated snapshot authority
- marks missing/dirty/unavailable provenance as `unknown`, `unavailable`, or `degraded` instead of inventing freshness
- updates citation-map schema, tests, and proof documentation

Validation:
- `python3 -m pytest -q merger/lenskit/tests/test_citation_map_schema.py merger/lenskit/tests/test_citation_map_producer.py merger/lenskit/tests/test_repobrief_resolved_evidence_query.py merger/lenskit/tests/test_repobrief_source_citation_projection.py merger/lenskit/tests/test_chunk_index_dual_ranges.py` -> 146 passed
- `python3 -m pytest -q merger/lenskit/tests/test_citation_*.py merger/lenskit/tests/test_repobrief_*.py merger/lenskit/tests/test_range_*.py merger/lenskit/tests/test_query_schema_range_ref.py merger/lenskit/tests/test_query_range_coverage.py` -> 319 passed
- `python3 -m ruff check --config ruff-ci.toml ...targeted files...` -> pass
- `python3 -m json.tool merger/lenskit/contracts/citation-map.v1.schema.json` -> pass
- `python3 -m scripts.docmeta.check_planning_registration` -> pass
- `git diff --check` -> pass

Boundaries / non-claims:
- `live_repo_address` is convenience navigation, not canonical content authority
- no hidden snapshot refresh, no Git mutation, no PR or patch action
- does not establish semantic completeness, runtime correctness, test sufficiency, review completeness, stale-bundle validity, freshness against remote, or merge readiness
