### PR TITLE
feat(repobrief): add explicit MCP snapshot create tool

### DIFF
--- a/docs/architecture/repobrief-mcp-boundary.md
+++ b/docs/architecture/repobrief-mcp-boundary.md
@@ -4,7 +4,7 @@ RepoBrief MCP is a read-first boundary for existing RepoBrief snapshots.
 
 The MCP surface reads existing Brief Bundles. Reading a bundle must never trigger snapshot creation, refresh, Git access, pull-request actions, patch writing, shell execution, review automation, or secret access.
 
-This document defines the boundary before an MCP server exists. It is a contract for future implementation, not evidence that MCP resources or tools are implemented today.
+This document defines the boundary before an MCP protocol server exists. Code-level MCP-shaped handlers may exist before protocol binding; their presence is not evidence that an MCP server or MCP resources are deployed.
 
 RepoBrief MCP may later expose integrated Agent Workbench resources when they are deterministic read-only code-understanding surfaces. Mutable Patch Evaluation Sidecar authority for patch application, worktrees, shell/test execution, and patch-evaluation artifacts is defined separately in [RepoBrief Agent Workbench Boundary](repobrief-agent-workbench-boundary.md). That authority must not be smuggled into RepoBrief resources or read-only tools.
 
@@ -34,21 +34,23 @@ The initial MCP tools are read-only helpers:
 
 Read-only tools must not write files, refresh bundles, create snapshots, mutate Git state, open pull requests, apply patches, run shells, execute reviews, execute fixes, merge changes, or read secrets. A stale, missing, degraded, or invalid snapshot must be reported as such instead of being silently regenerated.
 
-## Later explicit write path
+## Explicit write path
 
-A later MCP implementation may add one explicit write tool:
+RepoBrief exposes one code-level MCP-shaped write handler for a future protocol adapter:
 
 - `snapshot_create`
 
-`snapshot_create` may write only Brief Bundle artifacts. It must not be reachable as a side effect of resource reads or read-only tools.
+The handler lives in `merger.lenskit.core.repobrief_mcp_tools`. It may write only Brief Bundle artifacts. It must not be reachable as a side effect of resource reads or read-only tools.
 
-Any future `snapshot_create` tool requires:
+`snapshot_create` requires:
 
 - an explicit repository,
 - an explicit snapshot profile,
 - a controlled output root,
 - a timeout guard,
 - a size guard.
+
+The current implementation is a deterministic tool handler, not an MCP protocol server. It does not expose transport, authentication, network binding, resource routing, or scheduler behaviour by itself.
 
 ## Forbidden operations
 

--- a/docs/architecture/repobrief.md
+++ b/docs/architecture/repobrief.md
@@ -44,7 +44,7 @@ RepoBrief may:
 
 The planned RepoBrief MCP surface is defined in [RepoBrief MCP Boundary](repobrief-mcp-boundary.md).
 
-The MCP boundary is documentation for future implementation. It does not assert that an MCP server, MCP resources, or MCP tools exist today.
+The MCP boundary is documentation for protocol exposure. A code-level `snapshot_create` tool handler exists for explicit snapshot generation, but this does not assert that an MCP server, MCP resources, network transport, or scheduler integration exists today.
 
 ## Agent Workbench boundary
 

--- a/docs/proofs/repobrief-mcp-snapshot-create-tool-v1-proof.md
+++ b/docs/proofs/repobrief-mcp-snapshot-create-tool-v1-proof.md
@@ -1,0 +1,58 @@
+# RepoBrief MCP snapshot_create tool v1 proof
+
+Task: `RBV1-T011`  
+Status: implementation proof for the code-level handler, not an MCP server proof.
+
+## What changed
+
+RepoBrief now has an explicit MCP-shaped `snapshot_create` handler at:
+
+```text
+merger.lenskit.core.repobrief_mcp_tools.snapshot_create
+```
+
+The existing CLI generator path remains available as:
+
+```text
+repobrief snapshot create
+```
+
+The CLI implementation now exposes `build_snapshot_create_result(...)` so the MCP-shaped handler can reuse the same deterministic generator without scraping printed JSON.
+
+## Guards
+
+The handler requires:
+
+- explicit repository path;
+- explicit snapshot profile;
+- explicit controlled output root;
+- optional relative output subdirectory that cannot escape the output root;
+- timeout guard;
+- maximum total repository content-size guard;
+- per-file size guard forwarded to the existing snapshot generator.
+
+The handler rejects an output directory that is the repository or is inside the repository.
+
+## Boundary
+
+The handler may write only Brief Bundle artifacts. It does not mutate:
+
+- Git state;
+- pull requests;
+- patches;
+- the source working tree.
+
+Read-only RepoBrief helpers remain read-only and do not call the MCP-shaped write handler as fallback.
+
+## Non-claims
+
+This proof does not establish:
+
+- MCP protocol server availability;
+- transport/security correctness;
+- runtime correctness;
+- test sufficiency;
+- review completeness;
+- repository truth;
+- PR mergeability;
+- forensic readiness.

--- a/merger/lenskit/cli/cmd_repobrief.py
+++ b/merger/lenskit/cli/cmd_repobrief.py
@@ -638,28 +638,24 @@ def run_preflight(args: argparse.Namespace) -> int:
     return 0 if result.get("status") in {"pass", "warn"} else 1
 
 
-def run_snapshot_create(args: argparse.Namespace) -> int:
+def build_snapshot_create_result(args: argparse.Namespace) -> dict[str, Any]:
     profile = args.profile
     repo = Path(args.repo).expanduser().resolve()
     out = Path(args.out).expanduser().resolve()
 
     if not repo.exists() or not repo.is_dir():
-        print(f"repobrief snapshot create: repo is not a directory: {repo}", file=sys.stderr)
-        return 2
+        raise ValueError(f"repo is not a directory: {repo}")
     if out == repo or repo in out.parents:
-        print("bad output path", file=sys.stderr)
-        return 2
+        raise ValueError("bad output path")
 
     output_plan = profile_output_mode_plan(profile, args.output_mode)
     output_mode = output_plan["selected_output_mode"]
     conflicts = tuple(output_plan["conflicts"])
     if conflicts:
-        print(
-            f"repobrief snapshot create: profile {profile} excludes artifacts produced by output mode {output_mode}: "
-            + ", ".join(conflicts),
-            file=sys.stderr,
+        raise ValueError(
+            f"profile {profile} excludes artifacts produced by output mode {output_mode}: "
+            + ", ".join(conflicts)
         )
-        return 2
 
     out.mkdir(parents=True, exist_ok=True)
     max_bytes = parse_human_size(args.max_bytes)
@@ -679,7 +675,7 @@ def run_snapshot_create(args: argparse.Namespace) -> int:
     generator_info = {
         "name": "repobrief",
         "version": os.getenv("RLENS_VERSION", "dev"),
-        "platform": "cli",
+        "platform": getattr(args, "platform", "cli"),
         "repobrief_output_plan": output_plan,
     }
     artifacts = write_reports_v2(
@@ -712,7 +708,7 @@ def run_snapshot_create(args: argparse.Namespace) -> int:
     if export_safety_path is not None and export_safety_path not in artifact_paths:
         artifact_paths.append(export_safety_path)
 
-    result = {
+    return {
         "status": "ok",
         "command": "repobrief snapshot create",
         "profile": profile,
@@ -734,6 +730,14 @@ def run_snapshot_create(args: argparse.Namespace) -> int:
         },
         "does_not_establish": list(DOES_NOT_ESTABLISH),
     }
+
+
+def run_snapshot_create(args: argparse.Namespace) -> int:
+    try:
+        result = build_snapshot_create_result(args)
+    except ValueError as exc:
+        print(f"repobrief snapshot create: {exc}", file=sys.stderr)
+        return 2
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0
 

--- a/merger/lenskit/core/repobrief_mcp_tools.py
+++ b/merger/lenskit/core/repobrief_mcp_tools.py
@@ -1,0 +1,249 @@
+"""Explicit RepoBrief MCP-shaped tools.
+
+This module is not a protocol server. It provides deterministic tool handlers
+that a future MCP adapter can expose. Read-only RepoBrief access helpers must
+not call these handlers as a fallback or side effect.
+"""
+from __future__ import annotations
+
+import argparse
+import signal
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator
+
+from merger.lenskit.cli.cmd_repobrief import build_snapshot_create_result
+from merger.lenskit.core.merge import parse_human_size
+from merger.lenskit.core.repobrief_profiles import profile_names
+
+KIND = "repobrief.mcp.snapshot_create"
+VERSION = "v1"
+DEFAULT_TIMEOUT_SECONDS = 300
+MAX_TIMEOUT_SECONDS = 1800
+DEFAULT_MAX_FILE_BYTES = "25MB"
+DEFAULT_MAX_TOTAL_BYTES = "512MB"
+DEFAULT_SPLIT_SIZE = "25MB"
+MCP_PLATFORM = "mcp-explicit-tool"
+
+DOES_NOT_ESTABLISH = (
+    "truth",
+    "correctness",
+    "completeness",
+    "runtime_behavior",
+    "test_sufficiency",
+    "regression_absence",
+    "repo_understood",
+    "claims_true",
+    "forensic_ready",
+    "review_complete",
+    "pr_mergeable",
+    "mcp_server_available",
+)
+
+FORBIDDEN_OPERATIONS = (
+    "git_push",
+    "git_pull",
+    "git_fetch",
+    "create_pr",
+    "apply_patch",
+    "run_shell",
+    "auto_review",
+    "auto_fix",
+    "auto_merge",
+    "secret_read",
+)
+
+
+class RepoBriefMcpToolError(ValueError):
+    """Raised when an explicit MCP tool request violates RepoBrief bounds."""
+
+
+class RepoBriefMcpToolTimeout(TimeoutError):
+    """Raised when an explicit MCP tool exceeds its timeout guard."""
+
+
+@contextmanager
+def _timeout_guard(seconds: int) -> Iterator[None]:
+    if seconds <= 0:
+        raise RepoBriefMcpToolError("timeout_seconds must be positive")
+    if threading.current_thread() is not threading.main_thread():
+        raise RepoBriefMcpToolError(
+            "timeout guard requires main thread or an external process-level timeout wrapper"
+        )
+    previous_handler = signal.getsignal(signal.SIGALRM)
+    previous_timer = signal.setitimer(signal.ITIMER_REAL, 0)
+
+    def _handler(_signum: int, _frame: object) -> None:
+        raise RepoBriefMcpToolTimeout(f"snapshot_create exceeded {seconds}s timeout")
+
+    signal.signal(signal.SIGALRM, _handler)
+    signal.setitimer(signal.ITIMER_REAL, float(seconds))
+    try:
+        yield
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, previous_handler)
+        if previous_timer[0] > 0:
+            signal.setitimer(signal.ITIMER_REAL, previous_timer[0], previous_timer[1])
+
+
+def _guarded_path(raw: str | Path, *, label: str) -> Path:
+    path = Path(raw).expanduser().resolve()
+    if not str(path):
+        raise RepoBriefMcpToolError(f"{label} is required")
+    return path
+
+
+def _path_is_within(child: Path, parent: Path) -> bool:
+    try:
+        child.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _resolve_output_dir(output_root: str | Path, output_subdir: str | None) -> tuple[Path, Path]:
+    root = _guarded_path(output_root, label="output_root")
+    if output_subdir is None or output_subdir == "":
+        return root, root
+    raw = Path(output_subdir)
+    if raw.is_absolute() or ".." in raw.parts:
+        raise RepoBriefMcpToolError("output_subdir must be relative and must not contain '..'")
+    out = (root / raw).resolve()
+    if not _path_is_within(out, root):
+        raise RepoBriefMcpToolError("output_subdir must remain inside output_root")
+    return root, out
+
+
+def _file_visible(path: Path, repo: Path, include_hidden: bool) -> bool:
+    try:
+        rel = path.relative_to(repo)
+    except ValueError:
+        return False
+    if ".git" in rel.parts:
+        return False
+    if include_hidden:
+        return True
+    return not any(part.startswith(".") for part in rel.parts)
+
+
+def _estimate_repo_bytes(repo: Path, *, include_hidden: bool) -> int:
+    total = 0
+    for path in repo.rglob("*"):
+        if not path.is_file() or not _file_visible(path, repo, include_hidden):
+            continue
+        total += path.stat().st_size
+    return total
+
+
+def _mutation_boundary() -> dict[str, Any]:
+    return {
+        "writes": ["brief_bundle_artifacts"],
+        "does_not_mutate": ["git", "pull_requests", "patches", "source_working_tree"],
+        "read_paths_do_not_refresh": True,
+        "explicit_write_tool": True,
+        "not_reachable_from_read_tools": True,
+        "forbidden_operations": list(FORBIDDEN_OPERATIONS),
+    }
+
+
+def _tool_args(
+    *,
+    repo: Path,
+    out: Path,
+    profile: str,
+    output_mode: str | None,
+    max_file_bytes: str,
+    split_size: str,
+    include_hidden: bool,
+    path_filter: str | None,
+    ext: list[str] | None,
+    redact_secrets: bool,
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        repo=str(repo),
+        out=str(out),
+        profile=profile,
+        output_mode=output_mode,
+        mode="gesamt",
+        max_bytes=max_file_bytes,
+        split_size=split_size,
+        path_filter=path_filter,
+        ext=ext,
+        include_hidden=include_hidden,
+        redact_secrets=redact_secrets,
+        platform=MCP_PLATFORM,
+    )
+
+
+def snapshot_create(
+    *,
+    repo: str | Path,
+    output_root: str | Path,
+    profile: str,
+    output_subdir: str | None = None,
+    output_mode: str | None = None,
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+    max_file_bytes: str = DEFAULT_MAX_FILE_BYTES,
+    max_total_bytes: str = DEFAULT_MAX_TOTAL_BYTES,
+    split_size: str = DEFAULT_SPLIT_SIZE,
+    include_hidden: bool = False,
+    path_filter: str | None = None,
+    ext: list[str] | None = None,
+    redact_secrets: bool = True,
+) -> dict[str, Any]:
+    """Run the explicit RepoBrief snapshot_create tool under MCP guards."""
+    repo_path = _guarded_path(repo, label="repo")
+    if not repo_path.is_dir():
+        raise RepoBriefMcpToolError(f"repo is not a directory: {repo_path}")
+    output_root_path, out_path = _resolve_output_dir(output_root, output_subdir)
+    if out_path == repo_path or _path_is_within(out_path, repo_path):
+        raise RepoBriefMcpToolError("output directory must not be the repository or inside it")
+    if profile not in profile_names():
+        raise RepoBriefMcpToolError(f"unsupported profile: {profile}")
+    if timeout_seconds > MAX_TIMEOUT_SECONDS:
+        raise RepoBriefMcpToolError(
+            f"timeout_seconds exceeds maximum {MAX_TIMEOUT_SECONDS}: {timeout_seconds}"
+        )
+    max_total = parse_human_size(max_total_bytes)
+    estimated_total = _estimate_repo_bytes(repo_path, include_hidden=include_hidden)
+    if max_total and estimated_total > max_total:
+        raise RepoBriefMcpToolError(
+            f"repo content estimate {estimated_total} exceeds max_total_bytes {max_total}"
+        )
+    args = _tool_args(
+        repo=repo_path,
+        out=out_path,
+        profile=profile,
+        output_mode=output_mode,
+        max_file_bytes=max_file_bytes,
+        split_size=split_size,
+        include_hidden=include_hidden,
+        path_filter=path_filter,
+        ext=ext,
+        redact_secrets=redact_secrets,
+    )
+    with _timeout_guard(timeout_seconds):
+        created = build_snapshot_create_result(args)
+    return {
+        "kind": KIND,
+        "version": VERSION,
+        "status": "ok",
+        "tool": "snapshot_create",
+        "repo": str(repo_path),
+        "output_root": str(output_root_path),
+        "out": str(out_path),
+        "profile": profile,
+        "timeout_seconds": timeout_seconds,
+        "size_guards": {
+            "max_file_bytes": max_file_bytes,
+            "max_total_bytes": max_total_bytes,
+            "estimated_repo_bytes": estimated_total,
+            "include_hidden": include_hidden,
+        },
+        "created_snapshot": created,
+        "bundle_manifest": created.get("bundle_manifest"),
+        "mutation_boundary": _mutation_boundary(),
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }

--- a/merger/lenskit/tests/test_repobrief_mcp_boundary_doc.py
+++ b/merger/lenskit/tests/test_repobrief_mcp_boundary_doc.py
@@ -79,9 +79,11 @@ def test_mcp_boundary_doc_lists_read_only_tools_and_create_boundary() -> None:
     assert "`snapshot_create`" in text
     assert "may write only Brief Bundle artifacts" in text
     assert "must not be reachable as a side effect" in text
+    assert "merger.lenskit.core.repobrief_mcp_tools" in text
+    assert "not an MCP protocol server" in text
 
 
-def test_mcp_boundary_doc_lists_future_snapshot_create_guards() -> None:
+def test_mcp_boundary_doc_lists_snapshot_create_guards() -> None:
     text = _read(MCP_BOUNDARY_DOC)
 
     for guard in (
@@ -124,4 +126,5 @@ def test_repobrief_doc_links_to_mcp_boundary_without_claiming_implementation() -
     text = _read(REPOBRIEF_DOC)
 
     assert "[RepoBrief MCP Boundary](repobrief-mcp-boundary.md)" in text
+    assert "code-level `snapshot_create` tool handler exists" in text
     assert "does not assert that an MCP server" in text

--- a/merger/lenskit/tests/test_repobrief_mcp_snapshot_create.py
+++ b/merger/lenskit/tests/test_repobrief_mcp_snapshot_create.py
@@ -1,0 +1,152 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from merger.lenskit.core import repobrief_mcp_tools
+from merger.lenskit.core import repobrief_access
+
+
+class FakeArtifacts:
+    def __init__(self, manifest: Path):
+        self.bundle_manifest = manifest
+        self.canonical_md = manifest.with_name("brief.md")
+        self.canonical_md.write_text("# brief\n", encoding="utf-8")
+
+    def get_all_paths(self):
+        return [self.bundle_manifest, self.canonical_md]
+
+
+def test_mcp_snapshot_create_dispatches_existing_generator_with_guards(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "README.md").write_text("hello\n", encoding="utf-8")
+    output_root = tmp_path / "brief-root"
+    calls = {}
+
+    def fake_scan_repo(*args, **kwargs):
+        calls["scan"] = {"args": args, "kwargs": kwargs}
+        return {"name": "repo", "root": repo, "files": [], "total_files": 0, "total_bytes": 0, "ext_hist": {}}
+
+    def fake_write_reports_v2(*args, **kwargs):
+        calls["write"] = {"args": args, "kwargs": kwargs}
+        out = args[0]
+        manifest = out / "repo_merge.bundle.manifest.json"
+        manifest.parent.mkdir(parents=True, exist_ok=True)
+        manifest.write_text(
+            json.dumps({"kind": "repolens.bundle.manifest", "capabilities": {}, "artifacts": []}),
+            encoding="utf-8",
+        )
+        return FakeArtifacts(manifest)
+
+    from merger.lenskit.cli import cmd_repobrief
+
+    monkeypatch.setattr(cmd_repobrief, "scan_repo", fake_scan_repo)
+    monkeypatch.setattr(cmd_repobrief, "write_reports_v2", fake_write_reports_v2)
+
+    result = repobrief_mcp_tools.snapshot_create(
+        repo=repo,
+        output_root=output_root,
+        output_subdir="run-1",
+        profile="agent-portable",
+        timeout_seconds=30,
+        max_total_bytes="1MB",
+    )
+
+    assert result["kind"] == "repobrief.mcp.snapshot_create"
+    assert result["status"] == "ok"
+    assert result["mutation_boundary"]["explicit_write_tool"] is True
+    assert result["mutation_boundary"]["not_reachable_from_read_tools"] is True
+    assert result["mutation_boundary"]["writes"] == ["brief_bundle_artifacts"]
+    assert "git_push" in result["mutation_boundary"]["forbidden_operations"]
+    assert result["created_snapshot"]["command"] == "repobrief snapshot create"
+    assert result["created_snapshot"]["mutation_boundary"]["read_paths_do_not_refresh"] is True
+    assert calls["scan"]["args"][0] == repo.resolve()
+    assert calls["scan"]["kwargs"]["include_hidden"] is False
+    assert calls["write"]["kwargs"]["generator_info"]["platform"] == "mcp-explicit-tool"
+    assert calls["write"]["args"][0] == (output_root / "run-1").resolve()
+    assert "mcp_server_available" in result["does_not_establish"]
+
+
+def test_mcp_snapshot_create_rejects_output_inside_repo(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    with pytest.raises(repobrief_mcp_tools.RepoBriefMcpToolError, match="inside"):
+        repobrief_mcp_tools.snapshot_create(
+            repo=repo,
+            output_root=repo / "briefs",
+            profile="agent-portable",
+        )
+
+
+def test_mcp_snapshot_create_rejects_relative_escape_subdir(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    output_root = tmp_path / "briefs"
+
+    with pytest.raises(repobrief_mcp_tools.RepoBriefMcpToolError, match="relative"):
+        repobrief_mcp_tools.snapshot_create(
+            repo=repo,
+            output_root=output_root,
+            output_subdir="../escape",
+            profile="agent-portable",
+        )
+
+
+def test_mcp_snapshot_create_rejects_oversized_repo_before_writes(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "big.txt").write_bytes(b"x" * 64)
+    output_root = tmp_path / "briefs"
+
+    with pytest.raises(repobrief_mcp_tools.RepoBriefMcpToolError, match="exceeds"):
+        repobrief_mcp_tools.snapshot_create(
+            repo=repo,
+            output_root=output_root,
+            profile="agent-portable",
+            max_total_bytes="32",
+        )
+    assert not output_root.exists()
+
+
+def test_mcp_snapshot_create_rejects_timeout_above_guard(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    output_root = tmp_path / "briefs"
+
+    with pytest.raises(repobrief_mcp_tools.RepoBriefMcpToolError, match="timeout_seconds"):
+        repobrief_mcp_tools.snapshot_create(
+            repo=repo,
+            output_root=output_root,
+            profile="agent-portable",
+            timeout_seconds=repobrief_mcp_tools.MAX_TIMEOUT_SECONDS + 1,
+        )
+
+
+def test_read_only_access_does_not_trigger_mcp_snapshot_create(monkeypatch, tmp_path):
+    artifact = tmp_path / "demo.md"
+    artifact.write_text("# demo\n", encoding="utf-8")
+    manifest = tmp_path / "demo.bundle.manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "kind": "repolens.bundle.manifest",
+                "artifacts": [{"role": "canonical_md", "path": artifact.name}],
+                "capabilities": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def forbidden_call(**_kwargs):
+        raise AssertionError("read-only access must not call snapshot_create")
+
+    monkeypatch.setattr(repobrief_mcp_tools, "snapshot_create", forbidden_call)
+
+    status = repobrief_access.snapshot_status(manifest)
+    found = repobrief_access.get_artifact(manifest, "canonical_md")
+
+    assert status["mutation_boundary"]["writes"] == []
+    assert status["mutation_boundary"]["read_paths_do_not_refresh"] is True
+    assert found["status"] == "available"


### PR DESCRIPTION
Implements Bureau task RBV1-T011 — Add explicit MCP snapshot_create tool.

Scope:
- adds `merger.lenskit.core.repobrief_mcp_tools.snapshot_create` as an explicit MCP-shaped write handler
- reuses the existing deterministic `repobrief snapshot create` generator through a new `build_snapshot_create_result(...)` function
- adds guards for explicit repo, explicit profile, controlled output root/subdir, timeout, total-size, per-file size, and output-not-inside-repo
- keeps read-only RepoBrief access helpers read-only; tests assert they do not trigger `snapshot_create`
- updates MCP boundary docs to distinguish code-level handler from MCP protocol/server availability
- adds proof doc for RBV1-T011

Validation:
- `python3 -m pytest -q merger/lenskit/tests/test_repobrief_mcp_snapshot_create.py merger/lenskit/tests/test_repobrief_snapshot_cli.py merger/lenskit/tests/test_repobrief_mcp_boundary_doc.py merger/lenskit/tests/test_repobrief_access_boundary.py merger/lenskit/tests/test_repobrief_resolved_evidence_query.py merger/lenskit/tests/test_repobrief_source_citation_projection.py merger/lenskit/tests/test_repobrief_preflight.py merger/lenskit/tests/test_repobrief_profiles.py` -> 125 passed
- `python3 -m ruff check --config ruff-ci.toml merger/lenskit/core/repobrief_mcp_tools.py merger/lenskit/cli/cmd_repobrief.py merger/lenskit/tests/test_repobrief_mcp_snapshot_create.py merger/lenskit/tests/test_repobrief_mcp_boundary_doc.py` -> pass
- `git diff --check` -> pass

Boundary / non-claims:
- no MCP protocol server is implemented
- no resource transport, authentication, network binding, scheduler, PR, shell, patch, review, merge, or Git mutation authority is added
- successful snapshot creation does not establish truth, correctness, completeness, runtime behavior, test sufficiency, regression absence, repo understanding, claim truth, forensic readiness, review completeness, or PR mergeability

Diff SHA256: `1e84acb5c0d059ef19660e4b46a0f17bbbac9bb59ef57aac35a0eaefb5f69593`
