### PR TITLE
feat(repobrief): add latest complete registry

### DIFF
--- a/docs/proofs/repobrief-latest-complete-registry-v1-proof.md
+++ b/docs/proofs/repobrief-latest-complete-registry-v1-proof.md
@@ -1,0 +1,99 @@
+# RepoBrief latest-complete registry v1 proof
+
+Task: `RPU-V1-T003`
+
+Status: implementation proof for the latest-complete RepoBrief bundle registry and read-only freshness status path.
+
+## Implemented surface
+
+This slice adds a small machine-readable registry with kind:
+
+```text
+repobrief.latest_complete_registry
+```
+
+The registry records:
+
+- bundle stem;
+- bundle manifest path;
+- bundle manifest SHA-256;
+- bundle run id;
+- bundle generation timestamp;
+- recorded source commit from `snapshot_provenance`;
+- health summary from available health sidecars;
+- freshness status vocabulary and explicit unknown state.
+
+## Read-only status path
+
+The read-only status command is:
+
+```bash
+python -m merger.lenskit.cli.main repobrief latest-complete status --registry <registry.json> [--repo <repo>]
+```
+
+Without `--repo`, source freshness is `unknown` with reason `live_repo_not_provided`.
+
+With `--repo`, the status path compares the registry's recorded source commit with the explicit local repo `HEAD`:
+
+- matching commit: `fresh`;
+- different commit: `stale` with reason `head_drift`;
+- unavailable repo or missing commit: `unknown`.
+
+A stale result is not a failure by itself. It is a visible observation that consumers can use before relying on a bundle.
+
+## Explicit write paths
+
+The registry is written only by explicit write operations:
+
+```bash
+python -m merger.lenskit.cli.main repobrief latest-complete write --bundle-manifest <manifest> --out <registry.json>
+```
+
+or during explicit snapshot creation when the caller passes:
+
+```bash
+--latest-complete-registry <registry.json>
+```
+
+Read paths do not update the registry.
+
+## Boundary
+
+The read-only status path does not:
+
+- create snapshots;
+- refresh bundles;
+- mutate Git;
+- alter the source working tree;
+- write registry files;
+- write bundle artifacts;
+- create pull requests;
+- run tests or reviews.
+
+## Validation scope
+
+Tests cover:
+
+- registry field emission;
+- JSON-schema validation for emitted registries;
+- health signal projection;
+- fresh/stale/unknown freshness states;
+- stale not being a failure by itself;
+- read status not writing files or mutating the registry;
+- CLI write and CLI status commands;
+- optional explicit registry write during `snapshot create`.
+
+## Non-claims
+
+This proof does not establish:
+
+- content truth;
+- bundle completeness;
+- runtime correctness;
+- test sufficiency beyond the checked scope;
+- review completeness;
+- merge readiness;
+- repo understanding;
+- claim truth;
+- freshness against a remote branch;
+- agent quality improvement.

--- a/merger/lenskit/cli/cmd_repobrief.py
+++ b/merger/lenskit/cli/cmd_repobrief.py
@@ -237,6 +237,10 @@ def register_repobrief_command_groups(repobrief_parser: argparse.ArgumentParser)
     create_parser.add_argument("--output-mode", choices=["archive", "retrieval", "dual"])
     create_parser.add_argument("--redact-secrets", action="store_true")
     create_parser.add_argument("--no-include-hidden", action="store_false", dest="include_hidden")
+    create_parser.add_argument(
+        "--latest-complete-registry",
+        help="Explicitly write/update a RepoBrief latest-complete registry JSON for this created snapshot",
+    )
     create_parser.set_defaults(include_hidden=True)
 
     status_parser = snapshot_subparsers.add_parser("status", help="Read status for an existing Brief Snapshot")
@@ -352,6 +356,28 @@ def register_repobrief_command_groups(repobrief_parser: argparse.ArgumentParser)
     external_refresh_parser.add_argument("--no-include-hidden", action="store_false", dest="include_hidden")
     external_refresh_parser.set_defaults(include_hidden=True)
 
+    latest_parser = repobrief_subparsers.add_parser(
+        "latest-complete",
+        help="Read or explicitly write the latest-complete RepoBrief registry",
+    )
+    latest_subparsers = latest_parser.add_subparsers(
+        dest="latest_complete_cmd",
+        required=True,
+        help="Latest-complete registry commands",
+    )
+    latest_write = latest_subparsers.add_parser(
+        "write",
+        help="Explicitly write a latest-complete registry from an existing bundle manifest",
+    )
+    latest_write.add_argument("--bundle-manifest", required=True, help="Path to a Brief Bundle manifest")
+    latest_write.add_argument("--out", required=True, help="Output path for the latest-complete registry JSON")
+    latest_status = latest_subparsers.add_parser(
+        "status",
+        help="Read-only freshness status for an existing latest-complete registry",
+    )
+    latest_status.add_argument("--registry", required=True, help="Path to latest-complete registry JSON")
+    latest_status.add_argument("--repo", help="Optional local repo path for explicit HEAD drift comparison")
+
     patch_eval_parser = repobrief_subparsers.add_parser(
         "patch-evaluation",
         help="Read-only consumption of external Patch Evaluation Sidecar artifacts",
@@ -403,6 +429,10 @@ def run_repobrief(args: argparse.Namespace) -> int:
         return run_external_manifest_publish(args)
     if args.repobrief_cmd == "external-manifest" and args.external_manifest_cmd == "refresh":
         return run_external_manifest_refresh(args)
+    if args.repobrief_cmd == "latest-complete" and args.latest_complete_cmd == "write":
+        return run_latest_complete_write(args)
+    if args.repobrief_cmd == "latest-complete" and args.latest_complete_cmd == "status":
+        return run_latest_complete_status(args)
     if args.repobrief_cmd == "patch-evaluation" and args.patch_evaluation_cmd == "validate":
         return run_patch_evaluation_validate(args)
     print("Unsupported RepoBrief command", file=sys.stderr)
@@ -483,6 +513,7 @@ def run_external_manifest_refresh(args: argparse.Namespace) -> int:
         max_bytes=args.max_bytes, split_size=args.split_size, path_filter=args.path_filter,
         ext=args.ext, output_mode=args.output_mode, redact_secrets=args.redact_secrets,
         include_hidden=args.include_hidden,
+        latest_complete_registry=None,
     )
     snapshot_stdout = io.StringIO()
     with contextlib.redirect_stdout(snapshot_stdout):
@@ -511,6 +542,30 @@ def run_external_manifest_refresh(args: argparse.Namespace) -> int:
         "does_not_establish": list(DOES_NOT_ESTABLISH),
     }, indent=2, sort_keys=True))
     return 0
+
+
+def run_latest_complete_write(args: argparse.Namespace) -> int:
+    from merger.lenskit.core.repobrief_latest_complete import write_latest_complete_registry
+
+    try:
+        result = write_latest_complete_registry(args.bundle_manifest, args.out)
+    except ValueError as exc:
+        print("repobrief latest-complete write: " + str(exc), file=sys.stderr)
+        return 2
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+def run_latest_complete_status(args: argparse.Namespace) -> int:
+    from merger.lenskit.core.repobrief_latest_complete import latest_complete_status
+
+    try:
+        result = latest_complete_status(args.registry, repo=args.repo)
+    except ValueError as exc:
+        print("repobrief latest-complete status: " + str(exc), file=sys.stderr)
+        return 2
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result.get("status") in {"ok", "warn"} else 1
 
 
 def run_patch_evaluation_validate(args: argparse.Namespace) -> int:
@@ -702,6 +757,15 @@ def build_snapshot_create_result(args: argparse.Namespace) -> dict[str, Any]:
     export_safety_path = emit_export_safety_report(artifacts.bundle_manifest, profile)
     refreshed_paths = refresh_entry(artifacts.bundle_manifest)
     profile_evaluation = mark_bundle_manifest_profile(artifacts.bundle_manifest, profile, output_plan)
+    latest_registry_result = None
+    latest_registry_arg = getattr(args, "latest_complete_registry", None)
+    if latest_registry_arg and artifacts.bundle_manifest is not None:
+        from merger.lenskit.core.repobrief_latest_complete import write_latest_complete_registry
+
+        latest_registry_result = write_latest_complete_registry(
+            artifacts.bundle_manifest,
+            latest_registry_arg,
+        )
     artifact_paths = [path for path in artifacts.get_all_paths() if path not in dropped_profile_paths]
     if snapshot_plan_path is not None and snapshot_plan_path not in artifact_paths:
         artifact_paths.append(snapshot_plan_path)
@@ -720,6 +784,7 @@ def build_snapshot_create_result(args: argparse.Namespace) -> dict[str, Any]:
         "profile_evaluation": profile_evaluation,
         "snapshot_plan_report": str(snapshot_plan_path) if snapshot_plan_path else None,
         "export_safety_report": str(export_safety_path) if export_safety_path else None,
+        "latest_complete_registry": latest_registry_result,
         "refreshed_agent_entrypoints": [str(path) for path in refreshed_paths],
         "removed_profile_excluded_artifacts": [str(path) for path in dropped_profile_paths],
         "artifacts": [str(path) for path in artifact_paths],

--- a/merger/lenskit/contracts/repobrief-latest-complete-registry.v1.schema.json
+++ b/merger/lenskit/contracts/repobrief-latest-complete-registry.v1.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://heimgewebe.github.io/lenskit/contracts/repobrief-latest-complete-registry.v1.schema.json",
+  "title": "RepoBrief Latest Complete Registry v1",
+  "type": "object",
+  "required": [
+    "kind",
+    "version",
+    "updated_at",
+    "bundle",
+    "source",
+    "health",
+    "freshness",
+    "mutation_boundary",
+    "does_not_establish"
+  ],
+  "properties": {
+    "kind": {"const": "repobrief.latest_complete_registry"},
+    "version": {"const": "v1"},
+    "updated_at": {"type": "string", "minLength": 1},
+    "bundle": {
+      "type": "object",
+      "required": ["stem", "manifest_path", "manifest_sha256", "run_id", "generated_at"],
+      "properties": {
+        "stem": {"type": "string", "minLength": 1},
+        "manifest_path": {"type": "string", "minLength": 1},
+        "manifest_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "run_id": {"type": ["string", "null"]},
+        "generated_at": {"type": ["string", "null"]}
+      },
+      "additionalProperties": true
+    },
+    "source": {
+      "type": "object",
+      "required": ["commit", "commit_status", "repositories"],
+      "properties": {
+        "commit": {"type": ["string", "null"]},
+        "commit_status": {"type": "string", "minLength": 1},
+        "repositories": {"type": "array", "items": {"type": "object"}}
+      },
+      "additionalProperties": true
+    },
+    "health": {
+      "type": "object",
+      "required": ["status", "signals", "health_values"],
+      "properties": {
+        "status": {"enum": ["pass", "warn", "fail", "unknown"]},
+        "signals": {"type": "object"},
+        "health_values": {
+          "type": "array",
+          "items": {"enum": ["pass", "warn", "fail", "unknown"]},
+          "uniqueItems": true
+        }
+      },
+      "additionalProperties": true
+    },
+    "freshness": {
+      "type": "object",
+      "required": ["status", "reason", "snapshot_commit", "live_head", "head_drift", "basis"],
+      "properties": {
+        "status": {"enum": ["fresh", "stale", "unknown", "not_comparable"]},
+        "reason": {"type": "string", "minLength": 1},
+        "checked_at": {"type": ["string", "null"]},
+        "snapshot_commit": {"type": ["string", "null"]},
+        "live_head": {"type": ["string", "null"]},
+        "head_drift": {"type": ["boolean", "null"]},
+        "basis": {"type": "string", "minLength": 1},
+        "freshness_values": {
+          "type": "array",
+          "items": {"enum": ["fresh", "stale", "unknown", "not_comparable"]},
+          "uniqueItems": true
+        }
+      },
+      "additionalProperties": true
+    },
+    "mutation_boundary": {
+      "type": "object",
+      "required": ["writes", "does_not_mutate", "read_paths_do_not_refresh", "hidden_refresh_allowed"],
+      "properties": {
+        "writes": {"type": "array", "items": {"type": "string"}},
+        "does_not_mutate": {"type": "array", "items": {"type": "string"}},
+        "read_paths_do_not_refresh": {"const": true},
+        "hidden_refresh_allowed": {"const": false}
+      },
+      "additionalProperties": true
+    },
+    "does_not_establish": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1},
+      "uniqueItems": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/merger/lenskit/core/repobrief_latest_complete.py
+++ b/merger/lenskit/core/repobrief_latest_complete.py
@@ -1,0 +1,445 @@
+"""Latest-complete RepoBrief bundle registry.
+
+The registry is a small, machine-readable pointer to the latest known complete
+bundle for a repository/ref lane. It is not an automatic refresh mechanism.
+Read paths may compare recorded snapshot provenance to an explicitly supplied
+local repo HEAD, but they must never create snapshots, mutate Git, or update the
+registry as a side effect.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import hashlib
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any, Mapping
+
+KIND = "repobrief.latest_complete_registry"
+VERSION = "v1"
+STATUS_KIND = "repobrief.latest_complete_status"
+WRITE_KIND = "repobrief.latest_complete_registry_write"
+
+FRESHNESS_VALUES = ("fresh", "stale", "unknown", "not_comparable")
+HEALTH_VALUES = ("pass", "warn", "fail", "unknown")
+
+DOES_NOT_ESTABLISH = (
+    "truth",
+    "correctness",
+    "completeness",
+    "runtime_behavior",
+    "test_sufficiency",
+    "regression_absence",
+    "repo_understood",
+    "claims_true",
+    "forensic_ready",
+    "freshness_against_remote",
+    "merge_readiness",
+    "agent_quality_improvement",
+)
+
+
+def _now_iso() -> str:
+    return _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _read_json_object(path: Path, *, label: str) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(f"{label} does not exist: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{label} is not valid JSON: {path}") from exc
+    except UnicodeError as exc:
+        raise ValueError(f"{label} is not valid UTF-8: {path}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"{label} must be a JSON object")
+    return data
+
+
+def _manifest_stem(path: Path) -> str:
+    suffix = ".bundle.manifest.json"
+    if path.name.endswith(suffix):
+        return path.name[: -len(suffix)]
+    return path.stem
+
+
+def _relative_or_absolute(target: Path, base_dir: Path | None) -> str:
+    target = target.resolve()
+    if base_dir is None:
+        return str(target)
+    try:
+        return Path(os.path.relpath(target, base_dir.resolve())).as_posix()
+    except ValueError:
+        return str(target)
+
+
+def _safe_bundle_path(registry_path: Path, raw_path: Any) -> Path | None:
+    if not isinstance(raw_path, str) or not raw_path:
+        return None
+    candidate = (registry_path.parent / raw_path).resolve()
+    if candidate.is_file():
+        return candidate
+    absolute = Path(raw_path).expanduser().resolve()
+    if absolute.is_file():
+        return absolute
+    return candidate
+
+
+def _source_repositories(manifest: Mapping[str, Any]) -> list[dict[str, Any]]:
+    provenance = manifest.get("snapshot_provenance")
+    repositories = provenance.get("repositories") if isinstance(provenance, dict) else None
+    if not isinstance(repositories, list):
+        return []
+    result: list[dict[str, Any]] = []
+    for repo in repositories:
+        if not isinstance(repo, dict):
+            continue
+        result.append(
+            {
+                "name": repo.get("name") if isinstance(repo.get("name"), str) else None,
+                "repo_remote": repo.get("repo_remote") if isinstance(repo.get("repo_remote"), str) else None,
+                "repo_root_recorded": isinstance(repo.get("repo_root"), str) and bool(repo.get("repo_root")),
+                "git_commit": repo.get("git_commit") if isinstance(repo.get("git_commit"), str) else None,
+                "git_dirty": repo.get("git_dirty") if isinstance(repo.get("git_dirty"), bool) else None,
+                "git_branch": repo.get("git_branch") if isinstance(repo.get("git_branch"), str) else None,
+                "provenance_status": repo.get("provenance_status") if isinstance(repo.get("provenance_status"), str) else "unknown",
+                "freshness_basis": repo.get("freshness_basis") if isinstance(repo.get("freshness_basis"), str) else "unknown",
+            }
+        )
+    return result
+
+
+def _primary_source_commit(repositories: list[dict[str, Any]]) -> tuple[str | None, str]:
+    present = [
+        repo for repo in repositories
+        if repo.get("provenance_status") == "present" and isinstance(repo.get("git_commit"), str) and repo.get("git_commit")
+    ]
+    if not present:
+        return None, "snapshot_commit_missing"
+    if len(present) > 1:
+        commits = {repo["git_commit"] for repo in present}
+        if len(commits) == 1:
+            return present[0]["git_commit"], "single_commit_multi_repo"
+        return None, "multiple_source_commits_not_comparable"
+    return present[0]["git_commit"], "single_repo_commit"
+
+
+def _artifact_by_role(manifest: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    artifacts = manifest.get("artifacts")
+    result: dict[str, dict[str, Any]] = {}
+    if not isinstance(artifacts, list):
+        return result
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            continue
+        role = artifact.get("role")
+        if isinstance(role, str) and role not in result:
+            result[role] = artifact
+    return result
+
+
+def _linked_path_for_role(manifest: Mapping[str, Any], role: str) -> str | None:
+    role_to_link = {
+        "post_emit_health": "post_emit_health_path",
+        "bundle_surface_validation": "bundle_surface_validation_path",
+        "output_health": "output_health_path",
+    }
+    links = manifest.get("links")
+    key = role_to_link.get(role)
+    if isinstance(links, dict) and key and isinstance(links.get(key), str):
+        return links[key]
+    return None
+
+
+def _status_from_doc(role: str, doc: Mapping[str, Any]) -> str | None:
+    if role == "output_health":
+        value = doc.get("verdict") or doc.get("status")
+    else:
+        value = doc.get("status") or doc.get("verdict")
+    if isinstance(value, str) and value in {"pass", "warn", "fail"}:
+        return value
+    if isinstance(value, str) and value in {"blocked", "invalid"}:
+        return "fail"
+    return None
+
+
+def _health_signals(manifest_path: Path, manifest: Mapping[str, Any]) -> dict[str, Any]:
+    artifacts = _artifact_by_role(manifest)
+    signals: dict[str, Any] = {}
+    for role in ("output_health", "post_emit_health", "bundle_surface_validation"):
+        artifact = artifacts.get(role)
+        raw_path = artifact.get("path") if isinstance(artifact, dict) else None
+        if raw_path is None:
+            raw_path = _linked_path_for_role(manifest, role)
+        if not isinstance(raw_path, str) or not raw_path:
+            signals[role] = {"status": "unknown", "path": None, "reason": "not_listed"}
+            continue
+        candidate = (manifest_path.parent / raw_path).resolve()
+        try:
+            candidate.relative_to(manifest_path.parent.resolve())
+        except ValueError:
+            signals[role] = {"status": "fail", "path": raw_path, "reason": "path_escapes_bundle_root"}
+            continue
+        if not candidate.is_file():
+            signals[role] = {"status": "unknown", "path": raw_path, "reason": "file_missing"}
+            continue
+        try:
+            doc = json.loads(candidate.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            signals[role] = {"status": "fail", "path": raw_path, "reason": "unreadable", "error": str(exc)}
+            continue
+        if not isinstance(doc, dict):
+            signals[role] = {"status": "fail", "path": raw_path, "reason": "not_object"}
+            continue
+        status = _status_from_doc(role, doc)
+        signals[role] = {
+            "status": status or "unknown",
+            "path": raw_path,
+            "reason": None if status else "status_missing_or_unrecognized",
+            "kind": doc.get("kind") if isinstance(doc.get("kind"), str) else None,
+        }
+    return signals
+
+
+def _aggregate_health(signals: Mapping[str, Any]) -> str:
+    statuses = [
+        signal.get("status")
+        for signal in signals.values()
+        if isinstance(signal, Mapping) and isinstance(signal.get("status"), str)
+    ]
+    if any(status == "fail" for status in statuses):
+        return "fail"
+    if any(status == "warn" for status in statuses):
+        return "warn"
+    if any(status == "pass" for status in statuses):
+        return "pass"
+    return "unknown"
+
+
+def _unknown_freshness(reason: str, *, checked_at: str | None = None) -> dict[str, Any]:
+    return {
+        "status": "unknown",
+        "reason": reason,
+        "checked_at": checked_at,
+        "snapshot_commit": None,
+        "live_head": None,
+        "head_drift": None,
+        "basis": "git_commit",
+    }
+
+
+def _git(repo: Path, *args: str) -> tuple[str | None, str | None]:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo), *args],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
+        return None, str(exc)
+    if result.returncode != 0:
+        return None, (result.stderr or result.stdout or "git command failed").strip()
+    return result.stdout.strip(), None
+
+
+def evaluate_registry_freshness(
+    registry: Mapping[str, Any],
+    *,
+    repo: str | Path | None = None,
+    checked_at: str | None = None,
+) -> dict[str, Any]:
+    checked_at = checked_at or _now_iso()
+    snapshot_commit = registry.get("source", {}).get("commit") if isinstance(registry.get("source"), Mapping) else None
+    if not isinstance(snapshot_commit, str) or not snapshot_commit:
+        return _unknown_freshness("snapshot_commit_missing", checked_at=checked_at)
+    if repo is None:
+        result = _unknown_freshness("live_repo_not_provided", checked_at=checked_at)
+        result["snapshot_commit"] = snapshot_commit
+        return result
+    repo_path = Path(repo).expanduser().resolve()
+    if not repo_path.is_dir():
+        result = _unknown_freshness("live_repo_not_directory", checked_at=checked_at)
+        result["snapshot_commit"] = snapshot_commit
+        return result
+    live_head, err = _git(repo_path, "rev-parse", "HEAD")
+    if err is not None or not live_head:
+        result = _unknown_freshness("live_head_unavailable", checked_at=checked_at)
+        result["snapshot_commit"] = snapshot_commit
+        result["error"] = err
+        return result
+    status, status_err = _git(repo_path, "status", "--porcelain")
+    dirty = None if status_err is not None else bool(status)
+    head_drift = live_head != snapshot_commit
+    return {
+        "status": "stale" if head_drift else "fresh",
+        "reason": "head_drift" if head_drift else "head_matches_snapshot_commit",
+        "checked_at": checked_at,
+        "snapshot_commit": snapshot_commit,
+        "live_head": live_head,
+        "head_drift": head_drift,
+        "live_git_dirty": dirty,
+        "basis": "git_commit",
+    }
+
+
+def build_latest_complete_registry(
+    bundle_manifest: str | Path,
+    *,
+    registry_path: str | Path | None = None,
+    checked_at: str | None = None,
+) -> dict[str, Any]:
+    manifest_path = Path(bundle_manifest).expanduser().resolve()
+    manifest = _read_json_object(manifest_path, label="bundle manifest")
+    registry_target = Path(registry_path).expanduser().resolve() if registry_path is not None else None
+    base_dir = registry_target.parent if registry_target is not None else None
+    repositories = _source_repositories(manifest)
+    source_commit, source_reason = _primary_source_commit(repositories)
+    signals = _health_signals(manifest_path, manifest)
+    registry: dict[str, Any] = {
+        "kind": KIND,
+        "version": VERSION,
+        "updated_at": checked_at or _now_iso(),
+        "bundle": {
+            "stem": _manifest_stem(manifest_path),
+            "manifest_path": _relative_or_absolute(manifest_path, base_dir),
+            "manifest_sha256": _sha256_file(manifest_path),
+            "run_id": manifest.get("run_id") if isinstance(manifest.get("run_id"), str) else None,
+            "generated_at": manifest.get("created_at") if isinstance(manifest.get("created_at"), str) else None,
+        },
+        "source": {
+            "commit": source_commit,
+            "commit_status": source_reason,
+            "repositories": repositories,
+        },
+        "health": {
+            "status": _aggregate_health(signals),
+            "signals": signals,
+            "health_values": list(HEALTH_VALUES),
+        },
+        "freshness": {
+            "status": "unknown",
+            "reason": "live_repo_not_checked",
+            "checked_at": None,
+            "snapshot_commit": source_commit,
+            "live_head": None,
+            "head_drift": None,
+            "basis": "git_commit" if source_commit else "unknown",
+            "freshness_values": list(FRESHNESS_VALUES),
+        },
+        "mutation_boundary": {
+            "writes": ["latest_complete_registry"] if registry_target is not None else [],
+            "does_not_mutate": ["git", "pull_requests", "patches", "source_working_tree", "brief_bundle_artifacts"],
+            "read_paths_do_not_refresh": True,
+            "hidden_refresh_allowed": False,
+        },
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }
+    return registry
+
+
+def write_latest_complete_registry(
+    bundle_manifest: str | Path,
+    output_path: str | Path,
+    *,
+    checked_at: str | None = None,
+) -> dict[str, Any]:
+    out = Path(output_path).expanduser().resolve()
+    registry = build_latest_complete_registry(
+        bundle_manifest,
+        registry_path=out,
+        checked_at=checked_at,
+    )
+    out.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            delete=False,
+            dir=str(out.parent),
+            prefix=f".{out.name}.",
+            suffix=".tmp",
+        ) as handle:
+            json.dump(registry, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+            tmp_path = Path(handle.name)
+        os.replace(tmp_path, out)
+    finally:
+        if tmp_path is not None and tmp_path.exists():
+            tmp_path.unlink()
+    return {
+        "kind": WRITE_KIND,
+        "version": VERSION,
+        "status": "ok",
+        "registry_path": str(out),
+        "registry": registry,
+        "mutation_boundary": {
+            "writes": ["latest_complete_registry"],
+            "does_not_mutate": ["git", "pull_requests", "patches", "source_working_tree", "brief_bundle_artifacts"],
+            "read_paths_do_not_refresh": True,
+            "hidden_refresh_allowed": False,
+        },
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }
+
+
+def latest_complete_status(
+    registry_path: str | Path,
+    *,
+    repo: str | Path | None = None,
+    checked_at: str | None = None,
+) -> dict[str, Any]:
+    path = Path(registry_path).expanduser().resolve()
+    registry = _read_json_object(path, label="latest-complete registry")
+    if registry.get("kind") != KIND:
+        raise ValueError(f"latest-complete registry kind must be {KIND}")
+    bundle_info = registry.get("bundle") if isinstance(registry.get("bundle"), dict) else {}
+    bundle_path = _safe_bundle_path(path, bundle_info.get("manifest_path") if isinstance(bundle_info, dict) else None)
+    manifest_hash_status = "unknown"
+    observed_manifest_sha256 = None
+    if bundle_path is not None and bundle_path.is_file():
+        observed_manifest_sha256 = _sha256_file(bundle_path)
+        expected = bundle_info.get("manifest_sha256") if isinstance(bundle_info, dict) else None
+        manifest_hash_status = "match" if expected == observed_manifest_sha256 else "mismatch"
+    elif bundle_path is not None:
+        manifest_hash_status = "missing"
+    freshness = evaluate_registry_freshness(registry, repo=repo, checked_at=checked_at)
+    status = "ok"
+    if manifest_hash_status in {"mismatch", "missing"}:
+        status = "warn"
+    return {
+        "kind": STATUS_KIND,
+        "version": VERSION,
+        "status": status,
+        "registry_path": str(path),
+        "registry": registry,
+        "bundle_manifest": str(bundle_path) if bundle_path is not None else None,
+        "manifest_hash": {
+            "status": manifest_hash_status,
+            "expected_sha256": bundle_info.get("manifest_sha256") if isinstance(bundle_info, dict) else None,
+            "observed_sha256": observed_manifest_sha256,
+        },
+        "freshness": freshness,
+        "mutation_boundary": {
+            "writes": [],
+            "does_not_mutate": ["git", "pull_requests", "patches", "source_working_tree", "brief_bundle_artifacts", "latest_complete_registry"],
+            "read_paths_do_not_refresh": True,
+            "hidden_refresh_allowed": False,
+        },
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }

--- a/merger/lenskit/tests/test_repobrief_latest_complete.py
+++ b/merger/lenskit/tests/test_repobrief_latest_complete.py
@@ -1,0 +1,304 @@
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+
+import jsonschema
+
+from merger.lenskit.cli.main import main
+from merger.lenskit.cli import cmd_repobrief
+from merger.lenskit.core.repobrief_latest_complete import (
+    build_latest_complete_registry,
+    latest_complete_status,
+    write_latest_complete_registry,
+)
+
+
+def _sha(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _git_repo(tmp_path: Path) -> tuple[Path, str]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "Test User")
+    (repo / "README.md").write_text("first\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "first")
+    return repo, _git(repo, "rev-parse", "HEAD")
+
+
+def _manifest(tmp_path: Path, *, commit: str | None = None, health_status: str = "pass") -> Path:
+    canonical = tmp_path / "demo.md"
+    canonical.write_text("# demo\n", encoding="utf-8")
+    output_health = tmp_path / "demo.output_health.json"
+    output_health.write_text(
+        json.dumps({"kind": "lenskit.output_health", "verdict": health_status}),
+        encoding="utf-8",
+    )
+    manifest = tmp_path / "demo.bundle.manifest.json"
+    data = {
+        "kind": "repolens.bundle.manifest",
+        "version": "1.0",
+        "run_id": "run-1",
+        "created_at": "2026-07-08T10:00:00Z",
+        "artifacts": [
+            {
+                "role": "canonical_md",
+                "path": canonical.name,
+                "content_type": "text/markdown",
+                "bytes": canonical.stat().st_size,
+                "sha256": _sha(canonical),
+            },
+            {
+                "role": "output_health",
+                "path": output_health.name,
+                "content_type": "application/json",
+                "bytes": output_health.stat().st_size,
+                "sha256": _sha(output_health),
+            },
+        ],
+        "links": {},
+        "capabilities": {"repobrief_profile": "agent-portable"},
+        "snapshot_provenance": {
+            "version": "v1",
+            "repositories": [
+                {
+                    "name": "repo",
+                    "repo_root": str(tmp_path / "repo"),
+                    "repo_remote": None,
+                    "git_commit": commit,
+                    "git_dirty": False,
+                    "git_branch": "main",
+                    "provenance_status": "present" if commit else "producer_did_not_collect",
+                    "freshness_basis": "git_commit" if commit else "unknown",
+                }
+            ],
+            "does_not_establish": ["freshness_against_remote"],
+        },
+    }
+    manifest.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    return manifest
+
+
+def test_build_latest_complete_registry_records_manifest_source_and_health(tmp_path):
+    manifest = _manifest(tmp_path, commit="a" * 40)
+    registry_path = tmp_path / "latest.json"
+
+    registry = build_latest_complete_registry(
+        manifest,
+        registry_path=registry_path,
+        checked_at="2026-07-08T11:00:00Z",
+    )
+
+    assert registry["kind"] == "repobrief.latest_complete_registry"
+    assert registry["bundle"]["stem"] == "demo"
+    assert registry["bundle"]["manifest_path"] == "demo.bundle.manifest.json"
+    assert registry["bundle"]["manifest_sha256"] == _sha(manifest)
+    assert registry["bundle"]["generated_at"] == "2026-07-08T10:00:00Z"
+    assert registry["source"]["commit"] == "a" * 40
+    assert registry["source"]["commit_status"] == "single_repo_commit"
+    assert registry["health"]["status"] == "pass"
+    assert registry["health"]["signals"]["output_health"]["status"] == "pass"
+    assert registry["freshness"]["status"] == "unknown"
+    assert registry["freshness"]["reason"] == "live_repo_not_checked"
+    assert registry["mutation_boundary"]["writes"] == ["latest_complete_registry"]
+    assert registry["mutation_boundary"]["hidden_refresh_allowed"] is False
+
+
+def test_latest_complete_registry_schema_accepts_emitted_registry(tmp_path):
+    manifest = _manifest(tmp_path, commit="b" * 40)
+    registry_path = tmp_path / "latest.json"
+    result = write_latest_complete_registry(manifest, registry_path)
+    schema = json.loads(
+        Path("merger/lenskit/contracts/repobrief-latest-complete-registry.v1.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert result["status"] == "ok"
+    jsonschema.validate(instance=json.loads(registry_path.read_text(encoding="utf-8")), schema=schema)
+
+
+def test_latest_complete_status_detects_head_drift_without_writing(tmp_path):
+    repo, first_commit = _git_repo(tmp_path)
+    manifest = _manifest(tmp_path, commit=first_commit)
+    registry_path = tmp_path / "latest.json"
+    write_latest_complete_registry(manifest, registry_path)
+
+    before_files = {path.name for path in tmp_path.iterdir()}
+    before_registry_hash = _sha(registry_path)
+    before_manifest_hash = _sha(manifest)
+    fresh = latest_complete_status(
+        registry_path,
+        repo=repo,
+        checked_at="2026-07-08T11:00:00Z",
+    )
+
+    assert fresh["freshness"]["status"] == "fresh"
+    assert fresh["freshness"]["head_drift"] is False
+    assert fresh["manifest_hash"]["status"] == "match"
+    assert fresh["mutation_boundary"]["writes"] == []
+    assert fresh["mutation_boundary"]["hidden_refresh_allowed"] is False
+    assert {path.name for path in tmp_path.iterdir()} == before_files
+    assert _sha(registry_path) == before_registry_hash
+    assert _sha(manifest) == before_manifest_hash
+
+    (repo / "README.md").write_text("second\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "second")
+
+    stale = latest_complete_status(
+        registry_path,
+        repo=repo,
+        checked_at="2026-07-08T11:05:00Z",
+    )
+
+    assert stale["status"] == "ok"
+    assert stale["freshness"]["status"] == "stale"
+    assert stale["freshness"]["reason"] == "head_drift"
+    assert stale["freshness"]["snapshot_commit"] == first_commit
+    assert stale["freshness"]["live_head"] != first_commit
+    assert stale["freshness"]["head_drift"] is True
+    assert _sha(registry_path) == before_registry_hash
+
+
+def test_latest_complete_status_without_repo_is_unknown_not_failure(tmp_path):
+    manifest = _manifest(tmp_path, commit="c" * 40)
+    registry_path = tmp_path / "latest.json"
+    write_latest_complete_registry(manifest, registry_path)
+
+    status = latest_complete_status(registry_path)
+
+    assert status["status"] == "ok"
+    assert status["freshness"]["status"] == "unknown"
+    assert status["freshness"]["reason"] == "live_repo_not_provided"
+    assert status["mutation_boundary"]["writes"] == []
+
+
+def test_latest_complete_cli_write_and_status(tmp_path, capsys):
+    repo, commit = _git_repo(tmp_path)
+    manifest = _manifest(tmp_path, commit=commit)
+    registry_path = tmp_path / "latest.json"
+
+    rc = main([
+        "repobrief",
+        "latest-complete",
+        "write",
+        "--bundle-manifest",
+        str(manifest),
+        "--out",
+        str(registry_path),
+    ])
+
+    write_out = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert registry_path.exists()
+    assert write_out["kind"] == "repobrief.latest_complete_registry_write"
+    assert write_out["mutation_boundary"]["writes"] == ["latest_complete_registry"]
+
+    rc = main([
+        "repobrief",
+        "latest-complete",
+        "status",
+        "--registry",
+        str(registry_path),
+        "--repo",
+        str(repo),
+    ])
+
+    status_out = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert status_out["kind"] == "repobrief.latest_complete_status"
+    assert status_out["freshness"]["status"] == "fresh"
+    assert status_out["mutation_boundary"]["writes"] == []
+
+
+class _FakeArtifacts:
+    def __init__(self, manifest: Path):
+        self.bundle_manifest = manifest
+        self.canonical_md = manifest.with_name("brief.md")
+        self.canonical_md.write_text("# brief\n", encoding="utf-8")
+
+    def get_all_paths(self):
+        return [self.bundle_manifest, self.canonical_md]
+
+
+def test_snapshot_create_can_explicitly_write_latest_complete_registry(monkeypatch, tmp_path, capsys):
+    repo, commit = _git_repo(tmp_path)
+    out = tmp_path / "briefs"
+    registry_path = tmp_path / "latest" / "registry.json"
+
+    def fake_scan_repo(*args, **kwargs):
+        return {"name": "repo", "root": repo, "files": [], "total_files": 0, "total_bytes": 0, "ext_hist": {}}
+
+    def fake_write_reports_v2(*args, **kwargs):
+        manifest = out / "repo_merge.bundle.manifest.json"
+        manifest.parent.mkdir(parents=True, exist_ok=True)
+        manifest.write_text(
+            json.dumps(
+                {
+                    "kind": "repolens.bundle.manifest",
+                    "version": "1.0",
+                    "run_id": "run-1",
+                    "created_at": "2026-07-08T10:00:00Z",
+                    "artifacts": [],
+                    "links": {},
+                    "capabilities": {},
+                    "snapshot_provenance": {
+                        "version": "v1",
+                        "repositories": [
+                            {
+                                "name": "repo",
+                                "repo_root": str(repo),
+                                "repo_remote": None,
+                                "git_commit": commit,
+                                "git_dirty": False,
+                                "git_branch": "main",
+                                "provenance_status": "present",
+                                "freshness_basis": "git_commit",
+                            }
+                        ],
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        return _FakeArtifacts(manifest)
+
+    monkeypatch.setattr(cmd_repobrief, "scan_repo", fake_scan_repo)
+    monkeypatch.setattr(cmd_repobrief, "write_reports_v2", fake_write_reports_v2)
+
+    rc = main([
+        "repobrief",
+        "snapshot",
+        "create",
+        "--repo",
+        str(repo),
+        "--out",
+        str(out),
+        "--profile",
+        "agent-portable",
+        "--latest-complete-registry",
+        str(registry_path),
+    ])
+
+    emitted = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert registry_path.exists()
+    assert emitted["latest_complete_registry"]["status"] == "ok"
+    registry = json.loads(registry_path.read_text(encoding="utf-8"))
+    assert registry["source"]["commit"] == commit
+    assert registry["mutation_boundary"]["writes"] == ["latest_complete_registry"]


### PR DESCRIPTION
Implements Bureau task RPU-V1-T003 — Latest-complete freshness registry.

Scope:
- adds repobrief.latest_complete_registry JSON surface
- records bundle stem, manifest path/hash, run id, generated_at, source commit and health signals
- adds read-only freshness status against an explicitly supplied local repo HEAD
- reports head drift as stale without treating stale as failure by itself
- keeps reads non-mutating: no snapshot creation, no hidden refresh, no Git mutation and no registry writes
- adds explicit CLI commands: repobrief latest-complete write/status
- allows explicit registry writing during repobrief snapshot create via --latest-complete-registry
- adds proof doc: docs/proofs/repobrief-latest-complete-registry-v1-proof.md

Validation:
- python3 -m pytest -q merger/lenskit/tests/test_repobrief_latest_complete.py merger/lenskit/tests/test_repobrief_snapshot_cli.py merger/lenskit/tests/test_repobrief_access_boundary.py merger/lenskit/tests/test_repobrief_profiles.py merger/lenskit/tests/test_repobrief_preflight.py merger/lenskit/tests/test_repobrief_mcp_snapshot_create.py merger/lenskit/tests/test_repobrief_resolved_evidence_query.py merger/lenskit/tests/test_repobrief_source_citation_projection.py merger/lenskit/tests/test_external_manifest_reference.py merger/lenskit/tests/test_bundle_manifest_integration.py merger/lenskit/tests/test_snapshot_provenance.py -> 185 passed
- python3 -m ruff check --config ruff-ci.toml [changed py/test files] -> pass
- python3 -m json.tool merger/lenskit/contracts/repobrief-latest-complete-registry.v1.schema.json -> pass
- python3 -m scripts.docmeta.check_planning_registration --baseline docs/tasks/planning-registration-baseline.json --ratchet --format human -> no new drift
- python3 -m merger.lenskit.cli.main doc-freshness inspect -> PASS
- git diff --check origin/main...HEAD -> pass

Boundary / non-claims:
- no content truth, bundle completeness, runtime correctness, test sufficiency, review completeness, merge readiness, repo understanding, claim truth, remote-branch freshness or agent quality improvement is established
- read-only status does not refresh, re-dump, write registry files or mutate Git

Diff SHA256: `39f8c1a3d4694d2d84012ffbb6c677ebbd5fa9107f23aeda37a542b9041c9e80`
