### PR TITLE
feat(repobrief): wire python symbol index consumers

### DIFF
--- a/docs/proofs/repobrief-symbol-index-consumer-v1-proof.md
+++ b/docs/proofs/repobrief-symbol-index-consumer-v1-proof.md
@@ -1,0 +1,97 @@
+# RepoBrief Symbol Index Consumer v1 proof
+
+Task: `RPU-V1-T007`
+
+Status: implementation proof for wiring the existing Python AST Symbol Index into RepoBrief consumer surfaces.
+
+## Implemented surfaces
+
+This slice exposes the existing Python AST symbol index as a bounded RepoBrief navigation surface:
+
+```text
+python_symbol_index_json
+```
+
+The symbol index is generated for single-repo bundles from Python source files via the standard-library AST parser. Target code is parsed as text; it is not imported or executed.
+
+## Bundle and manifest registration
+
+The bundle manifest now accepts and registers role `python_symbol_index_json` with:
+
+- contract: `python-symbol-index` / `v1`;
+- authority: `navigation_index`;
+- canonicality: `derived`;
+- risk class: `navigation`;
+- `regenerable: true`;
+- `staleness_sensitive: true`.
+
+Profile availability includes the role. Public-share excludes it, so export-safe profiles do not retain the Python symbol surface.
+
+## Agent Reading Pack
+
+The Agent Reading Pack now includes a `SYMBOL_INDEX` section when the artifact is present. The section names the read-only CLI command and repeats the non-claims.
+
+## Read-only consumer command
+
+The new consumer command is:
+
+```bash
+python -m merger.lenskit.cli.main repobrief symbol search \
+  --bundle-manifest <manifest> \
+  --q <symbol-or-module-text>
+```
+
+Optional filters:
+
+```bash
+--kind class|function|async_function
+--path <path-substring>
+--k <max-results>
+```
+
+The consumer reads only an existing `python_symbol_index_json` artifact. It does not build the symbol index, refresh a snapshot, import target modules, execute target code, mutate Git, create files or alter bundle artifacts.
+
+## Returned evidence shape
+
+Each hit carries:
+
+- symbol id;
+- kind;
+- name;
+- qualified name;
+- module;
+- source path;
+- start and end lines;
+- source-line range reference;
+- decorators if present.
+
+This gives agents a lightweight path into source locations for later canonical/citation checks.
+
+## Validation scope
+
+Tests cover:
+
+- manifest registration and schema validity;
+- generated symbol document schema validity;
+- Agent Reading Pack guidance;
+- read-only symbol search;
+- CLI symbol search;
+- missing artifact diagnostics without creation;
+- kind and path filters;
+- public-share profile exclusion;
+- static AST symbol extraction remains deterministic.
+
+## Non-claims
+
+The symbol index and its consumers do not establish:
+
+- call graph completeness;
+- dependency completeness;
+- import success;
+- runtime behavior;
+- test sufficiency;
+- review impact;
+- merge readiness;
+- source truth;
+- repo understanding;
+- answer correctness.

--- a/merger/lenskit/cli/cmd_repobrief.py
+++ b/merger/lenskit/cli/cmd_repobrief.py
@@ -295,6 +295,25 @@ def register_repobrief_command_groups(repobrief_parser: argparse.ArgumentParser)
         help="Do not add the compact source citation projection",
     )
 
+    symbol_parser = repobrief_subparsers.add_parser(
+        "symbol",
+        help="Read-only Python symbol-index consumer commands",
+    )
+    symbol_subparsers = symbol_parser.add_subparsers(
+        dest="symbol_cmd",
+        required=True,
+        help="Symbol commands",
+    )
+    symbol_search_parser = symbol_subparsers.add_parser(
+        "search",
+        help="Search an existing python_symbol_index_json artifact without importing target code",
+    )
+    symbol_search_parser.add_argument("--bundle-manifest", required=True, help="Path to a Brief Bundle manifest")
+    symbol_search_parser.add_argument("--q", default="", help="Search text over name, qualified name, module, path and kind")
+    symbol_search_parser.add_argument("--k", type=int, default=25, help="Maximum symbol hits")
+    symbol_search_parser.add_argument("--kind", choices=["class", "function", "async_function"], help="Filter by symbol kind")
+    symbol_search_parser.add_argument("--path", help="Filter by source path substring")
+
     external_parser = repobrief_subparsers.add_parser(
         "external-manifest",
         help="Write bounded external manifest references from existing bundle manifests",
@@ -423,6 +442,8 @@ def run_repobrief(args: argparse.Namespace) -> int:
         return run_required_reading_resolve(args)
     if args.repobrief_cmd == "query":
         return run_query_existing_index(args)
+    if args.repobrief_cmd == "symbol" and args.symbol_cmd == "search":
+        return run_symbol_search(args)
     if args.repobrief_cmd == "external-manifest" and args.external_manifest_cmd == "write":
         return run_external_manifest_write(args)
     if args.repobrief_cmd == "external-manifest" and args.external_manifest_cmd == "publish":
@@ -676,6 +697,24 @@ def run_query_existing_index(args: argparse.Namespace) -> int:
         )
     except ValueError as exc:
         print("repobrief query: " + str(exc), file=sys.stderr)
+        return 2
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result.get("status") == "available" else 1
+
+
+def run_symbol_search(args: argparse.Namespace) -> int:
+    from merger.lenskit.core.repobrief_access import search_symbol_index
+
+    try:
+        result = search_symbol_index(
+            args.bundle_manifest,
+            args.q,
+            k=args.k,
+            kind=args.kind,
+            path=args.path,
+        )
+    except ValueError as exc:
+        print("repobrief symbol search: " + str(exc), file=sys.stderr)
         return 2
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0 if result.get("status") == "available" else 1

--- a/merger/lenskit/contracts/bundle-manifest.v1.schema.json
+++ b/merger/lenskit/contracts/bundle-manifest.v1.schema.json
@@ -146,7 +146,8 @@
               "lens_cards_jsonl",
               "concept_cards_jsonl",
               "relation_cards_jsonl",
-              "pr_delta_cards_jsonl"
+              "pr_delta_cards_jsonl",
+              "python_symbol_index_json"
             ],
             "description": "Machine-readable enum role for this artifact."
           },
@@ -314,7 +315,8 @@
                     "concept_cards_jsonl",
                     "relation_cards_jsonl",
                     "pr_delta_cards_jsonl",
-                    "snapshot_plan_json"
+                    "snapshot_plan_json",
+                    "python_symbol_index_json"
                   ]
                 }
               },

--- a/merger/lenskit/core/agent_reading_pack.py
+++ b/merger/lenskit/core/agent_reading_pack.py
@@ -71,6 +71,7 @@ _LENS_CARD_ROLES = ("lens_cards_jsonl", "lens_card_jsonl", "lens_cards")
 _CONCEPT_CARD_ROLES = ("concept_cards_jsonl", "concept_card_jsonl", "concept_cards")
 _PR_DELTA_CARD_ROLES = ("pr_delta_cards_jsonl", "pr_delta_card_jsonl", "pr_delta_cards")
 _RELATION_CARD_ROLES = ("relation_cards_jsonl", "relation_card_jsonl", "relation_cards")
+_SYMBOL_INDEX_ROLES = ("python_symbol_index_json", "python_symbol_index")
 
 
 class AgentReadingPackError(Exception):
@@ -424,6 +425,7 @@ _ROLE_GUIDE = {
     "delta_json": "diagnostic change delta vs a prior run",
     "concept_cards_jsonl": "Concept Card navigation index over explicit task concepts, dependencies, failures and queries",
     "relation_cards_jsonl": "Relation Card navigation index over supported local import edges",
+    "python_symbol_index_json": "Python AST symbol navigation index; static parse only, not runtime truth",
 }
 
 
@@ -699,6 +701,28 @@ def render_agent_reading_pack(model: PackModel) -> str:
     lines.append(
         "- Relation Cards, when present, expose formal or heuristic links. They do "
         "not prove impact, causality, test sufficiency, runtime behavior or regression absence."
+    )
+    lines.append("")
+
+    # ── SYMBOL_INDEX ────────────────────────────────────────────────────
+    lines.append("## SYMBOL_INDEX")
+    symbol_index_artifacts = _artifacts_by_roles(model, _SYMBOL_INDEX_ROLES)
+    if symbol_index_artifacts:
+        for artifact in symbol_index_artifacts:
+            _append_artifact_bullet(lines, artifact)
+        lines.append(
+            "- CLI: `python3 -m merger.lenskit.cli.main repobrief symbol search "
+            "--bundle-manifest <manifest> --q <name>`"
+        )
+    else:
+        lines.append("- No bundle-registered Python Symbol Index artifact is present in this manifest.")
+    lines.append(
+        "- Symbol Index records are parsed from Python AST without importing or executing "
+        "target code. They are navigation hints only."
+    )
+    lines.append(
+        "- does_not_establish: call graph completeness, dependency completeness, import "
+        "success, runtime behavior, test sufficiency, review impact or merge readiness."
     )
     lines.append("")
 

--- a/merger/lenskit/core/constants.py
+++ b/merger/lenskit/core/constants.py
@@ -30,6 +30,7 @@ class ArtifactRole(str, Enum):
     CONCEPT_CARDS_JSONL = "concept_cards_jsonl"
     RELATION_CARDS_JSONL = "relation_cards_jsonl"
     PR_DELTA_CARDS_JSONL = "pr_delta_cards_jsonl"
+    PYTHON_SYMBOL_INDEX_JSON = "python_symbol_index_json"
 
 
 CLAIM_EVIDENCE_MAP_ABSENCE_REASON_LINK_KEY = "claim_evidence_map_absence_reason"

--- a/merger/lenskit/core/merge.py
+++ b/merger/lenskit/core/merge.py
@@ -236,6 +236,7 @@ ARTIFACT_CONTRACT_REGISTRY = {
     ArtifactRole.CONCEPT_CARDS_JSONL: {"id": "concept-card", "version": "v1"},
     ArtifactRole.RELATION_CARDS_JSONL: {"id": "relation-card", "version": "v1"},
     ArtifactRole.PR_DELTA_CARDS_JSONL: {"id": "pr-delta-card", "version": "v1"},
+    ArtifactRole.PYTHON_SYMBOL_INDEX_JSON: {"id": "python-symbol-index", "version": "v1"},
 }
 
 ARTIFACT_AUTHORITY_REGISTRY = {
@@ -388,6 +389,13 @@ ARTIFACT_AUTHORITY_REGISTRY = {
         "authority": "diagnostic_signal",
         "canonicality": "diagnostic",
         "risk_class": "diagnostic",
+        "regenerable": True,
+        "staleness_sensitive": True,
+    },
+    ArtifactRole.PYTHON_SYMBOL_INDEX_JSON: {
+        "authority": "navigation_index",
+        "canonicality": "derived",
+        "risk_class": "navigation",
         "regenerable": True,
         "staleness_sensitive": True,
     },
@@ -658,6 +666,7 @@ class MergeArtifacts:
     relation_cards: Optional[Path] = None
     delta_json: Optional[Path] = None
     pr_delta_cards: Optional[Path] = None
+    python_symbol_index: Optional[Path] = None
     other: List[Path] = None
 
     def __post_init__(self):
@@ -705,6 +714,8 @@ class MergeArtifacts:
             paths.append(self.delta_json)
         if self.pr_delta_cards and self.pr_delta_cards not in paths:
             paths.append(self.pr_delta_cards)
+        if self.python_symbol_index and self.python_symbol_index not in paths:
+            paths.append(self.python_symbol_index)
         if self.bundle_manifest:
             paths.append(self.bundle_manifest)
 
@@ -6298,6 +6309,41 @@ def write_reports_v2(
     if derived_manifests:
         _add_artifact(derived_manifests[-1], ArtifactRole.DERIVED_MANIFEST_JSON, "application/json")
 
+    def _write_python_symbol_index_json(base_manifest_path: Path) -> Optional[Path]:
+        """Emit Python Symbol Index v1 for single-repo bundles as navigation only."""
+        if len(repo_summaries) != 1 or not final_dump_index or not final_dump_index.exists():
+            return None
+        repo_root = repo_summaries[0].get("root")
+        if repo_root is None:
+            return None
+        from merger.lenskit.architecture.symbol_index import generate_symbol_index_document
+
+        canonical_sha = _compute_file_sha256(final_dump_index)
+        if not canonical_sha:
+            return None
+        document = generate_symbol_index_document(Path(repo_root), run_id, canonical_sha)
+        out_path = base_manifest_path.with_name(
+            base_manifest_path.name.replace(
+                ".bundle.manifest.json", ".python_symbol_index.json"
+            )
+        )
+        _write_text_atomic(
+            out_path,
+            json.dumps(document, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
+        )
+        return out_path
+
+    python_symbol_index_path = _write_python_symbol_index_json(bundle_manifest_path)
+    if python_symbol_index_path is not None:
+        out_paths.append(python_symbol_index_path)
+        if python_symbol_index_path not in other_paths:
+            other_paths.append(python_symbol_index_path)
+        _add_artifact(
+            python_symbol_index_path,
+            ArtifactRole.PYTHON_SYMBOL_INDEX_JSON,
+            "application/json",
+        )
+
 
     def _write_lens_cards_jsonl(base_manifest_path: Path) -> Optional[Path]:
         """Emit Lens Cards v1 as deterministic JSONL navigation."""
@@ -6824,6 +6870,7 @@ def write_reports_v2(
             relation_cards=relation_cards_path,
             delta_json=delta_json_path,
             pr_delta_cards=pr_delta_cards_path,
+            python_symbol_index=python_symbol_index_path,
             other=other_paths
         )
     else:
@@ -6847,5 +6894,6 @@ def write_reports_v2(
             relation_cards=relation_cards_path,
             delta_json=delta_json_path,
             pr_delta_cards=pr_delta_cards_path,
+            python_symbol_index=python_symbol_index_path,
             other=other_paths
         )

--- a/merger/lenskit/core/repobrief_access.py
+++ b/merger/lenskit/core/repobrief_access.py
@@ -1153,6 +1153,173 @@ def query_existing_index(
     }
 
 
+SYMBOL_INDEX_ROLE = "python_symbol_index_json"
+SYMBOL_SEARCH_KIND = "repobrief.symbol_search"
+MAX_SYMBOL_SEARCH_K = 200
+
+
+def _symbol_source_range(symbol: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "path": symbol.get("path"),
+        "start_line": symbol.get("start_line"),
+        "end_line": symbol.get("end_line"),
+        "range_ref": symbol.get("range_ref"),
+        "coordinate_basis": "source_lines",
+    }
+
+
+def _symbol_record(symbol: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": symbol.get("id"),
+        "kind": symbol.get("kind"),
+        "name": symbol.get("name"),
+        "qualified_name": symbol.get("qualified_name"),
+        "module": symbol.get("module"),
+        "path": symbol.get("path"),
+        "start_line": symbol.get("start_line"),
+        "end_line": symbol.get("end_line"),
+        "range_ref": symbol.get("range_ref"),
+        "source_range": _symbol_source_range(symbol),
+        "decorators": symbol.get("decorators") if isinstance(symbol.get("decorators"), list) else [],
+    }
+
+
+def _load_symbol_index(manifest_path: Path) -> tuple[dict[str, Any] | None, dict[str, Any] | None, dict[str, Any] | None]:
+    artifact_result = get_artifact(manifest_path, SYMBOL_INDEX_ROLE)
+    artifact = artifact_result.get("artifact") if isinstance(artifact_result, dict) else None
+    if not isinstance(artifact, dict) or not artifact.get("absolute_path"):
+        return None, artifact, {
+            "status": "missing",
+            "error_code": "python_symbol_index_json_missing",
+            "error": "python_symbol_index_json artifact is not present in the bundle manifest",
+        }
+    index_path = Path(str(artifact["absolute_path"]))
+    if not index_path.exists():
+        return None, artifact, {
+            "status": "missing",
+            "error_code": "python_symbol_index_json_file_missing",
+            "error": "python_symbol_index_json artifact file does not exist",
+        }
+    try:
+        data = json.loads(index_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return None, artifact, {
+            "status": "invalid",
+            "error_code": "python_symbol_index_json_unreadable",
+            "error": str(exc),
+        }
+    if not isinstance(data, dict) or data.get("kind") != "lenskit.python_symbol_index":
+        return None, artifact, {
+            "status": "invalid",
+            "error_code": "python_symbol_index_json_invalid_kind",
+            "error": "python_symbol_index_json must be a lenskit.python_symbol_index object",
+        }
+    symbols = data.get("symbols")
+    if not isinstance(symbols, list):
+        return None, artifact, {
+            "status": "invalid",
+            "error_code": "python_symbol_index_symbols_invalid",
+            "error": "python_symbol_index_json symbols must be an array",
+        }
+    return data, artifact, None
+
+
+def search_symbol_index(
+    bundle_manifest: str | Path,
+    query: str = "",
+    *,
+    k: int = 25,
+    kind: str | None = None,
+    path: str | None = None,
+) -> dict[str, Any]:
+    manifest_path = Path(bundle_manifest).expanduser().resolve()
+    if not isinstance(query, str):
+        return _invalid_read_result(
+            kind=SYMBOL_SEARCH_KIND,
+            bundle_manifest=manifest_path,
+            status="invalid",
+            error="query must be a string",
+            error_code="query_invalid",
+            extra={"query": query, "k": k, "symbol_index": None, "hits": []},
+        )
+    if not isinstance(k, int) or isinstance(k, bool) or k < 1 or k > MAX_SYMBOL_SEARCH_K:
+        return _invalid_read_result(
+            kind=SYMBOL_SEARCH_KIND,
+            bundle_manifest=manifest_path,
+            status="invalid",
+            error=f"k must be an integer between 1 and {MAX_SYMBOL_SEARCH_K}",
+            error_code="k_out_of_bounds",
+            extra={"query": query, "k": k, "symbol_index": None, "hits": []},
+        )
+    data, artifact, error = _load_symbol_index(manifest_path)
+    if error is not None:
+        return _invalid_read_result(
+            kind=SYMBOL_SEARCH_KIND,
+            bundle_manifest=manifest_path,
+            status=error["status"],
+            error=error["error"],
+            error_code=error["error_code"],
+            extra={"query": query, "k": k, "symbol_index": artifact, "hits": []},
+        )
+    assert data is not None
+    symbols = [item for item in data.get("symbols", []) if isinstance(item, dict)]
+    q = query.strip().casefold()
+    kind_filter = kind.strip() if isinstance(kind, str) and kind.strip() else None
+    path_filter = path.strip().casefold() if isinstance(path, str) and path.strip() else None
+    matched: list[dict[str, Any]] = []
+    omitted_by_filter = 0
+    for symbol in symbols:
+        haystack = " ".join(
+            str(symbol.get(field, ""))
+            for field in ("name", "qualified_name", "module", "path", "kind")
+        ).casefold()
+        if q and q not in haystack:
+            omitted_by_filter += 1
+            continue
+        if kind_filter and symbol.get("kind") != kind_filter:
+            omitted_by_filter += 1
+            continue
+        if path_filter and path_filter not in str(symbol.get("path", "")).casefold():
+            omitted_by_filter += 1
+            continue
+        matched.append(_symbol_record(symbol))
+        if len(matched) > k:
+            break
+    hits = matched[:k]
+    availability = _availability_model_for_manifest(manifest_path)
+    return {
+        "kind": SYMBOL_SEARCH_KIND,
+        "version": "v1",
+        "status": "available",
+        "bundle_manifest": str(manifest_path),
+        "query": query,
+        "k": k,
+        "filters": {"kind": kind, "path": path},
+        "symbol_index": artifact,
+        "symbol_index_metadata": {
+            "language": data.get("language"),
+            "symbol_kinds": data.get("symbol_kinds"),
+            "skipped_files_count": data.get("skipped_files_count"),
+            "skipped_errors": data.get("skipped_errors"),
+            "canonical_dump_index_sha256": data.get("canonical_dump_index_sha256"),
+        },
+        "availability": availability,
+        "freshness": availability.get("freshness") if isinstance(availability, dict) else None,
+        "hit_count": len(hits),
+        "omitted_by_filter_count": omitted_by_filter,
+        "truncated": len(matched) > k,
+        "hits": hits,
+        "mutation_boundary": _read_only_mutation_boundary(),
+        "does_not_establish": list(_DOES_NOT_ESTABLISH) + [
+            "call_graph_completeness",
+            "dependency_completeness",
+            "import_success",
+            "review_impact",
+            "merge_readiness",
+        ],
+    }
+
+
 def snapshot_check(
     bundle_manifest: str | Path,
     task_profile: str = "basic_repo_question",

--- a/merger/lenskit/core/repobrief_profiles.py
+++ b/merger/lenskit/core/repobrief_profiles.py
@@ -43,6 +43,7 @@ ARTIFACT_ORDER = (
     "pr_delta_cards_jsonl",
     "relation_cards_jsonl",
     "retrieval_eval_json",
+    "python_symbol_index_json",
 )
 
 BASE_RULES = {
@@ -60,6 +61,7 @@ BASE_RULES = {
     "pr_delta_cards_jsonl": REQ_NA,
     "relation_cards_jsonl": REQ_OPTIONAL,
     "retrieval_eval_json": REQ_OPTIONAL,
+    "python_symbol_index_json": REQ_OPTIONAL,
 }
 
 PROFILE_ARTIFACT_RULES = {
@@ -74,6 +76,7 @@ PROFILE_ARTIFACT_RULES = {
         "sqlite_index": REQ_RECOMMENDED,
         "export_safety_report": REQ_REQUIRED,
         "retrieval_eval_json": REQ_RECOMMENDED,
+        "python_symbol_index_json": REQ_RECOMMENDED,
     },
     "full-max": {
         **BASE_RULES,
@@ -82,6 +85,7 @@ PROFILE_ARTIFACT_RULES = {
         "pr_delta_cards_jsonl": REQ_OPTIONAL,
         "relation_cards_jsonl": REQ_RECOMMENDED,
         "retrieval_eval_json": REQ_RECOMMENDED,
+        "python_symbol_index_json": REQ_RECOMMENDED,
     },
     "pr-review": {
         **BASE_RULES,
@@ -101,12 +105,14 @@ PROFILE_ARTIFACT_RULES = {
         "sqlite_index": REQ_EXCLUDED,
         "export_safety_report": REQ_REQUIRED,
         "retrieval_eval_json": REQ_NA,
+        "python_symbol_index_json": REQ_EXCLUDED,
     },
     "ci-artifact": {
         **BASE_RULES,
         "citation_map_jsonl": REQ_RECOMMENDED,
         "export_safety_report": REQ_RECOMMENDED,
         "retrieval_eval_json": REQ_RECOMMENDED,
+        "python_symbol_index_json": REQ_RECOMMENDED,
     },
 }
 

--- a/merger/lenskit/tests/test_agent_reading_pack.py
+++ b/merger/lenskit/tests/test_agent_reading_pack.py
@@ -1169,3 +1169,55 @@ def test_reading_pack_surfaces_snapshot_plan_report(tmp_path):
     assert "demo.snapshot_plan.json" in section
     assert "do not prove repo understanding" in section
     assert "`snapshot_plan_json` / `repobrief.snapshot_plan`" in body
+
+
+
+def test_pack_renders_symbol_index_guidance(tmp_path):
+    manifest = _make_bundle(tmp_path)
+    symbol_index = tmp_path / "demo.python_symbol_index.json"
+    symbol_index.write_text(
+        json.dumps(
+            {
+                "kind": "lenskit.python_symbol_index",
+                "version": "1.0",
+                "run_id": "demo-run",
+                "canonical_dump_index_sha256": "a" * 64,
+                "language": "python",
+                "symbol_kinds": ["class", "function", "async_function"],
+                "symbols": [],
+                "skipped_files_count": 0,
+                "skipped_errors": [],
+                "does_not_establish": [
+                    "call_graph_completeness",
+                    "dependency_completeness",
+                    "runtime_behavior",
+                    "import_success",
+                    "test_sufficiency",
+                    "review_impact",
+                    "merge_readiness",
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    data = json.loads(manifest.read_text(encoding="utf-8"))
+    data["artifacts"].append(
+        {
+            "role": "python_symbol_index_json",
+            "path": symbol_index.name,
+            "content_type": "application/json",
+            "bytes": symbol_index.stat().st_size,
+            "sha256": _sha256(symbol_index.read_bytes()),
+            "authority": "navigation_index",
+            "canonicality": "derived",
+        }
+    )
+    manifest.write_text(json.dumps(data), encoding="utf-8")
+
+    report = produce_agent_reading_pack(str(manifest))
+    body = Path(report["output_path"]).read_text(encoding="utf-8")
+
+    assert "## SYMBOL_INDEX" in body
+    assert "python_symbol_index_json" in body
+    assert "repobrief symbol search" in body
+    assert "does_not_establish: call graph completeness" in body

--- a/merger/lenskit/tests/test_bundle_manifest_integration.py
+++ b/merger/lenskit/tests/test_bundle_manifest_integration.py
@@ -1997,3 +1997,45 @@ def test_agent_entry_manifest_file_exists_and_schema_valid(tmp_path):
     assert payload["authority"] == "navigation_index"
     assert payload["canonicality"] == "derived"
     assert "repo_understood" in payload["does_not_establish"]
+
+
+
+def test_bundle_manifest_registers_python_symbol_index_json(tmp_path):
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    (src_dir / "tool.py").write_text("def build_context():\n    return None\n", encoding="utf-8")
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    hub_dir = tmp_path / "hub"
+    hub_dir.mkdir()
+
+    artifacts = write_reports_v2(
+        merges_dir=out_dir,
+        hub=hub_dir,
+        repo_summaries=[scan_repo(src_dir)],
+        detail="test",
+        mode="gesamt",
+        max_bytes=1000,
+        plan_only=False,
+        code_only=False,
+        extras=MockExtras(),
+        output_mode="dual",
+        generator_info=make_generator_info(),
+    )
+    manifest = json.loads(artifacts.bundle_manifest.read_text(encoding="utf-8"))
+    schema = json.loads(_BUNDLE_MANIFEST_SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.validate(instance=manifest, schema=schema)
+    entry = _artifact_by_role(manifest, ArtifactRole.PYTHON_SYMBOL_INDEX_JSON.value)
+
+    assert entry is not None
+    assert entry["contract"] == {"id": "python-symbol-index", "version": "v1"}
+    assert entry["interpretation"]["mode"] == "contract"
+    assert entry["authority"] == "navigation_index"
+    assert entry["canonicality"] == "derived"
+    assert entry["risk_class"] == "navigation"
+    symbol_path = artifacts.bundle_manifest.parent / entry["path"]
+    symbol_doc = json.loads(symbol_path.read_text(encoding="utf-8"))
+    symbol_schema = json.loads((_CONTRACTS_DIR / "python-symbol-index.v1.schema.json").read_text(encoding="utf-8"))
+    jsonschema.validate(instance=symbol_doc, schema=symbol_schema)
+    assert symbol_doc["symbols"][0]["qualified_name"] == "build_context"
+    assert artifacts.python_symbol_index == symbol_path

--- a/merger/lenskit/tests/test_repobrief_profiles.py
+++ b/merger/lenskit/tests/test_repobrief_profiles.py
@@ -104,7 +104,7 @@ def test_profile_output_mode_plan_is_machine_readable():
     assert public_default["selected_output_mode"] == "archive"
     assert public_default["defaulted"] is True
     assert public_default["conflicts"] == []
-    assert public_default["excluded_roles"] == ["sqlite_index"]
+    assert public_default["excluded_roles"] == ["sqlite_index", "python_symbol_index_json"]
 
     public_dual = profile_output_mode_plan("public-share", "dual")
     assert public_dual["selected_output_mode"] == "dual"

--- a/merger/lenskit/tests/test_repobrief_symbol_index_consumer.py
+++ b/merger/lenskit/tests/test_repobrief_symbol_index_consumer.py
@@ -1,0 +1,209 @@
+import hashlib
+import json
+from pathlib import Path
+
+from merger.lenskit.cli.main import main
+from merger.lenskit.core.repobrief_access import search_symbol_index
+
+
+def _sha(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _write_symbol_bundle(tmp_path: Path) -> Path:
+    symbol_index = tmp_path / "demo.python_symbol_index.json"
+    symbol_index.write_text(
+        json.dumps(
+            {
+                "kind": "lenskit.python_symbol_index",
+                "version": "1.0",
+                "run_id": "run-1",
+                "canonical_dump_index_sha256": "a" * 64,
+                "language": "python",
+                "symbol_kinds": ["class", "function", "async_function"],
+                "symbols": [
+                    {
+                        "id": "py:pkg:mod.py:function:build_context",
+                        "kind": "function",
+                        "name": "build_context",
+                        "qualified_name": "build_context",
+                        "module": "pkg.mod",
+                        "path": "pkg/mod.py",
+                        "start_line": 3,
+                        "end_line": 5,
+                        "range_ref": "file:pkg/mod.py#L3-L5",
+                    },
+                    {
+                        "id": "py:pkg:mod.py:class:ContextPlan",
+                        "kind": "class",
+                        "name": "ContextPlan",
+                        "qualified_name": "ContextPlan",
+                        "module": "pkg.mod",
+                        "path": "pkg/mod.py",
+                        "start_line": 8,
+                        "end_line": 12,
+                        "range_ref": "file:pkg/mod.py#L8-L12",
+                    },
+                ],
+                "skipped_files_count": 0,
+                "skipped_errors": [],
+                "does_not_establish": [
+                    "call_graph_completeness",
+                    "dependency_completeness",
+                    "runtime_behavior",
+                    "import_success",
+                    "test_sufficiency",
+                    "review_impact",
+                    "merge_readiness",
+                ],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    manifest = tmp_path / "demo.bundle.manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "kind": "repolens.bundle.manifest",
+                "version": "1.0",
+                "run_id": "run-1",
+                "created_at": "2026-07-08T10:00:00Z",
+                "generator": {"name": "test", "version": "1", "config_sha256": "b" * 64},
+                "artifacts": [
+                    {
+                        "role": "python_symbol_index_json",
+                        "path": symbol_index.name,
+                        "content_type": "application/json",
+                        "bytes": symbol_index.stat().st_size,
+                        "sha256": _sha(symbol_index),
+                        "contract": {"id": "python-symbol-index", "version": "v1"},
+                        "interpretation": {"mode": "contract"},
+                        "authority": "navigation_index",
+                        "canonicality": "derived",
+                        "risk_class": "navigation",
+                        "regenerable": True,
+                        "staleness_sensitive": True,
+                    }
+                ],
+                "links": {},
+                "capabilities": {"repobrief_profile": "agent-portable"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def test_symbol_search_reads_existing_artifact_without_workspace_execution(tmp_path):
+    manifest = _write_symbol_bundle(tmp_path)
+    before_files = {path.name for path in tmp_path.iterdir()}
+    before_manifest_hash = _sha(manifest)
+
+    result = search_symbol_index(manifest, "context", k=5)
+
+    assert result["kind"] == "repobrief.symbol_search"
+    assert result["status"] == "available"
+    assert result["hit_count"] == 2
+    assert [hit["qualified_name"] for hit in result["hits"]] == ["build_context", "ContextPlan"]
+    assert result["hits"][0]["source_range"] == {
+        "path": "pkg/mod.py",
+        "start_line": 3,
+        "end_line": 5,
+        "range_ref": "file:pkg/mod.py#L3-L5",
+        "coordinate_basis": "source_lines",
+    }
+    assert result["mutation_boundary"]["writes"] == []
+    assert result["mutation_boundary"]["read_paths_do_not_refresh"] is True
+    assert "runtime_behavior" in result["does_not_establish"]
+    assert "call_graph_completeness" in result["does_not_establish"]
+    assert {path.name for path in tmp_path.iterdir()} == before_files
+    assert _sha(manifest) == before_manifest_hash
+
+
+def test_symbol_search_filters_by_kind_and_path(tmp_path):
+    manifest = _write_symbol_bundle(tmp_path)
+
+    result = search_symbol_index(manifest, "context", k=5, kind="class", path="pkg/mod")
+
+    assert result["status"] == "available"
+    assert result["hit_count"] == 1
+    assert result["hits"][0]["qualified_name"] == "ContextPlan"
+    assert result["hits"][0]["kind"] == "class"
+
+
+def test_symbol_search_reports_missing_artifact_without_creating_it(tmp_path):
+    manifest = tmp_path / "demo.bundle.manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "kind": "repolens.bundle.manifest",
+                "version": "1.0",
+                "run_id": "run-1",
+                "artifacts": [],
+                "links": {},
+                "capabilities": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = search_symbol_index(manifest, "context")
+
+    assert result["status"] == "missing"
+    assert result["error_code"] == "python_symbol_index_json_missing"
+    assert result["hits"] == []
+    assert result["mutation_boundary"]["writes"] == []
+    assert not (tmp_path / "demo.python_symbol_index.json").exists()
+
+
+def test_symbol_search_cli_returns_symbol_hits(tmp_path, capsys):
+    manifest = _write_symbol_bundle(tmp_path)
+
+    rc = main([
+        "repobrief",
+        "symbol",
+        "search",
+        "--bundle-manifest",
+        str(manifest),
+        "--q",
+        "ContextPlan",
+        "--kind",
+        "class",
+    ])
+
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert out["status"] == "available"
+    assert out["hit_count"] == 1
+    assert out["hits"][0]["source_range"]["range_ref"] == "file:pkg/mod.py#L8-L12"
+
+
+def test_public_share_snapshot_excludes_python_symbol_index(tmp_path, capsys):
+    repo = tmp_path / "repo"
+    (repo / "pkg").mkdir(parents=True)
+    (repo / "pkg" / "mod.py").write_text("def hidden_symbol():\n    return None\n", encoding="utf-8")
+    out = tmp_path / "out"
+
+    rc = main([
+        "repobrief",
+        "snapshot",
+        "create",
+        "--repo",
+        str(repo),
+        "--out",
+        str(out),
+        "--profile",
+        "public-share",
+    ])
+
+    emitted = json.loads(capsys.readouterr().out)
+    manifest = json.loads(Path(emitted["bundle_manifest"]).read_text(encoding="utf-8"))
+    roles = {artifact["role"] for artifact in manifest["artifacts"]}
+    assert rc == 0
+    assert "python_symbol_index_json" not in roles
+    assert any(
+        path.endswith(".python_symbol_index.json")
+        for path in emitted["removed_profile_excluded_artifacts"]
+    )
+    assert not list(out.glob("*.python_symbol_index.json"))


### PR DESCRIPTION
Implements Bureau task RPU-V1-T007 — Symbol index consumer wiring.

Scope:
- registers python_symbol_index_json as a RepoBrief bundle artifact role
- emits a Python AST symbol index for single-repo bundles without importing or executing target code
- wires the role into bundle-manifest schema, profile availability and public-share exclusion
- adds Agent Reading Pack SYMBOL_INDEX guidance
- adds read-only consumer CLI: repobrief symbol search
- returns symbol hits with source path, line range and range_ref
- adds proof doc: docs/proofs/repobrief-symbol-index-consumer-v1-proof.md

Validation:
- python3 -m pytest -q merger/lenskit/tests/test_repobrief_symbol_index_consumer.py merger/lenskit/tests/test_python_symbol_index.py merger/lenskit/tests/test_bundle_manifest_integration.py merger/lenskit/tests/test_agent_reading_pack.py merger/lenskit/tests/test_repobrief_profiles.py merger/lenskit/tests/test_repobrief_snapshot_cli.py merger/lenskit/tests/test_repobrief_access_boundary.py merger/lenskit/tests/test_repobrief_preflight.py merger/lenskit/tests/test_repobrief_resolved_evidence_query.py merger/lenskit/tests/test_external_manifest_reference.py merger/lenskit/tests/test_repobrief_latest_complete.py -> 231 passed
- python3 -m ruff check --config ruff-ci.toml [changed py/test files] -> pass
- python3 -m json.tool merger/lenskit/contracts/bundle-manifest.v1.schema.json -> pass
- python3 -m json.tool merger/lenskit/contracts/python-symbol-index.v1.schema.json -> pass
- python3 -m scripts.docmeta.check_planning_registration --baseline docs/tasks/planning-registration-baseline.json --ratchet --format human -> no new drift
- python3 -m merger.lenskit.cli.main doc-freshness inspect -> PASS
- git diff --check origin/main...HEAD -> pass
- manual CLI smoke: snapshot create on tiny Python repo produced python_symbol_index_json; repobrief symbol search found ContextPlan and reported writes=[]
- manual public-share smoke: snapshot create removed python_symbol_index_json from manifest and artifact output

Boundary / non-claims:
- Symbol records are navigation hints only.
- Target code is parsed by AST; not imported or executed.
- This does not establish call graph completeness, dependency completeness, import success, runtime behavior, test sufficiency, review impact, merge readiness, source truth, repo understanding or answer correctness.

Diff SHA256: `ecac37d775cfc3e08e8dffa0b85147559bedafd4dfb17c9402d29422950e878e`
