### PR TITLE
feat(repobrief): add token budget context compiler

### DIFF
--- a/docs/proofs/repobrief-context-compiler-v1-proof.md
+++ b/docs/proofs/repobrief-context-compiler-v1-proof.md
@@ -1,0 +1,105 @@
+# RepoBrief Context Compiler v1 proof
+
+Task: `RPU-V1-T004`
+
+Status: implementation proof for a deterministic token-budget context compiler over existing RepoBrief bundle artifacts.
+
+## Implemented surface
+
+This slice adds:
+
+```text
+repobrief.context_compiler
+```
+
+and the CLI command:
+
+```bash
+python -m merger.lenskit.cli.main repobrief context compile \
+  --bundle-manifest <manifest> \
+  --task <task> \
+  --task-profile <required-reading-profile> \
+  --context-budget <tokens>
+```
+
+Optional controls:
+
+```bash
+--query <retrieval-or-symbol-query>
+--signal-k <max-signal-hits>
+--bytes-per-token <rough-byte-divisor>
+--strict
+```
+
+## Selection model
+
+The compiler reads an existing bundle manifest and then builds bounded candidates from:
+
+1. resolved evidence query results with source ranges and citation projection;
+2. Python Symbol Index hits when `python_symbol_index_json` is present;
+3. Required Reading roles for the selected task profile;
+4. recommended reading roles when available.
+
+Candidates are ordered deterministically by priority, estimated token count and id:
+
+```text
+resolved evidence -> symbol index -> required reading -> recommended reading
+```
+
+Token estimates use a byte-based approximation. No exact tokenizer or model-specific fit claim is made.
+
+## Output contract
+
+The compiler emits:
+
+- `selected_context`: ordered context entries that fit into the token budget;
+- `omitted_context`: entries skipped because their estimated tokens would exceed the remaining budget;
+- `gaps`: missing or degraded signals such as missing retrieval, symbol, graph, freshness or required-reading surfaces;
+- `signals`: bounded status for resolved evidence, symbol index, required reading and availability;
+- `fallback_context`: canonical/front-door required reading roles available as fallback;
+- `selection_trace`: priority bands and omission reasons;
+- `mutation_boundary`: explicit read-only boundary.
+
+Selected context entries carry source path/range data and citation/range references where available. This supports answer-compliance workflows, but it does not prove answer correctness.
+
+## Read-only boundary
+
+The compiler must not:
+
+- refresh snapshots;
+- create or mutate bundle artifacts;
+- mutate Git;
+- create pull requests;
+- import or execute target repository code;
+- update latest-complete registries.
+
+## Validation scope
+
+Tests cover:
+
+- ordered resolved-evidence selection with source range/citation payload;
+- symbol-index candidates;
+- relation-card candidates from `relation_cards_jsonl`;
+- fallback to canonical/agent required reading when retrieval, relation and symbol signals are missing;
+- visible omitted candidates under small budgets;
+- invalid budget and estimator input handling;
+- CLI JSON output.
+
+Manual smoke covered compiling context from a freshly generated tiny RepoBrief snapshot.
+
+## Non-claims
+
+The context compiler does not establish:
+
+- exact token count;
+- model context fit;
+- best possible context;
+- all relevant context used;
+- answer correctness;
+- repo understanding;
+- claims truth;
+- runtime behavior;
+- test sufficiency;
+- review completeness;
+- merge readiness;
+- agent quality improvement.

--- a/merger/lenskit/cli/cmd_repobrief.py
+++ b/merger/lenskit/cli/cmd_repobrief.py
@@ -314,6 +314,28 @@ def register_repobrief_command_groups(repobrief_parser: argparse.ArgumentParser)
     symbol_search_parser.add_argument("--kind", choices=["class", "function", "async_function"], help="Filter by symbol kind")
     symbol_search_parser.add_argument("--path", help="Filter by source path substring")
 
+    context_parser = repobrief_subparsers.add_parser(
+        "context",
+        help="Compile bounded RepoBrief context plans for a task and token budget",
+    )
+    context_subparsers = context_parser.add_subparsers(
+        dest="context_cmd",
+        required=True,
+        help="Context commands",
+    )
+    context_compile = context_subparsers.add_parser(
+        "compile",
+        help="Select ordered context from existing bundle artifacts without refreshing them",
+    )
+    context_compile.add_argument("--bundle-manifest", required=True, help="Path to a Brief Bundle manifest")
+    context_compile.add_argument("--task", required=True, help="Natural-language task description")
+    context_compile.add_argument("--task-profile", default="basic_repo_question", help="Required-reading task profile")
+    context_compile.add_argument("--query", help="Optional retrieval/symbol query; defaults to --task")
+    context_compile.add_argument("--context-budget", type=int, default=8000, help="Token budget for selected context")
+    context_compile.add_argument("--signal-k", type=int, default=10, help="Maximum retrieval/symbol signal hits")
+    context_compile.add_argument("--bytes-per-token", type=float, default=4.0, help="Byte divisor used for rough token estimate")
+    context_compile.add_argument("--strict", action="store_true", help="Treat warn status as exit code 1")
+
     external_parser = repobrief_subparsers.add_parser(
         "external-manifest",
         help="Write bounded external manifest references from existing bundle manifests",
@@ -444,6 +466,8 @@ def run_repobrief(args: argparse.Namespace) -> int:
         return run_query_existing_index(args)
     if args.repobrief_cmd == "symbol" and args.symbol_cmd == "search":
         return run_symbol_search(args)
+    if args.repobrief_cmd == "context" and args.context_cmd == "compile":
+        return run_context_compile(args)
     if args.repobrief_cmd == "external-manifest" and args.external_manifest_cmd == "write":
         return run_external_manifest_write(args)
     if args.repobrief_cmd == "external-manifest" and args.external_manifest_cmd == "publish":
@@ -718,6 +742,29 @@ def run_symbol_search(args: argparse.Namespace) -> int:
         return 2
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0 if result.get("status") == "available" else 1
+
+
+def run_context_compile(args: argparse.Namespace) -> int:
+    from merger.lenskit.core.repobrief_context_compiler import compile_context_plan
+
+    result = compile_context_plan(
+        args.bundle_manifest,
+        task=args.task,
+        task_profile=args.task_profile,
+        context_budget_tokens=args.context_budget,
+        query=args.query,
+        signal_k=args.signal_k,
+        bytes_per_token=args.bytes_per_token,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    status = result.get("status")
+    if status == "pass":
+        return 0
+    if status == "warn":
+        return 1 if args.strict else 0
+    if status in {"fail", "invalid"}:
+        return 1
+    return 2
 
 
 def run_preflight(args: argparse.Namespace) -> int:

--- a/merger/lenskit/core/repobrief_context_compiler.py
+++ b/merger/lenskit/core/repobrief_context_compiler.py
@@ -1,0 +1,632 @@
+"""Deterministic RepoBrief token-budget context compiler.
+
+The compiler reads existing bundle artifacts only. It does not create snapshots,
+refresh indexes, import target code, or write bundle artifacts. It ranks bounded
+context candidates from resolved evidence, symbol navigation and required
+reading, then selects as many as fit into a caller-supplied token budget.
+"""
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any, Mapping
+
+from merger.lenskit.core.repobrief_access import (
+    query_existing_index,
+    resolve_required_reading_for_bundle,
+    search_symbol_index,
+    snapshot_status,
+)
+
+KIND = "repobrief.context_compiler"
+VERSION = "v1"
+MAX_CONTEXT_BUDGET_TOKENS = 1_000_000
+MAX_SIGNAL_HITS = 50
+DEFAULT_BYTES_PER_TOKEN = 4.0
+
+DOES_NOT_ESTABLISH = (
+    "exact_token_count",
+    "model_context_fit",
+    "best_possible_context",
+    "all_relevant_context_used",
+    "answer_correctness",
+    "repo_understood",
+    "claims_true",
+    "runtime_behavior",
+    "test_sufficiency",
+    "review_completeness",
+    "merge_readiness",
+    "agent_quality_improvement",
+)
+
+
+def _read_only_mutation_boundary() -> dict[str, Any]:
+    return {
+        "writes": [],
+        "does_not_mutate": [
+            "git",
+            "pull_requests",
+            "patches",
+            "source_working_tree",
+            "brief_bundle_artifacts",
+            "latest_complete_registry",
+        ],
+        "read_paths_do_not_refresh": True,
+    }
+
+
+def _invalid_result(
+    manifest_path: Path,
+    *,
+    error: str,
+    error_code: str,
+    task: str,
+    task_profile: str,
+    context_budget_tokens: Any,
+) -> dict[str, Any]:
+    return {
+        "kind": KIND,
+        "version": VERSION,
+        "status": "invalid",
+        "bundle_manifest": str(manifest_path),
+        "task": task,
+        "task_profile": task_profile,
+        "context_budget_tokens": context_budget_tokens,
+        "error": error,
+        "error_code": error_code,
+        "selected_context": [],
+        "omitted_context": [],
+        "gaps": [],
+        "mutation_boundary": _read_only_mutation_boundary(),
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }
+
+
+def _estimate_tokens_from_bytes(byte_count: Any, bytes_per_token: float) -> int:
+    if isinstance(byte_count, bool) or not isinstance(byte_count, int) or byte_count <= 0:
+        return 1
+    return max(1, int(math.ceil(byte_count / bytes_per_token)))
+
+
+def _estimate_tokens_from_text(text: Any, bytes_per_token: float) -> int:
+    if not isinstance(text, str) or not text:
+        return 1
+    return max(1, int(math.ceil(len(text.encode("utf-8")) / bytes_per_token)))
+
+
+def _compact_match_text(value: str) -> str:
+    return "".join(ch for ch in value.casefold() if ch.isalnum())
+
+
+def _artifact_by_role(status: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    result: dict[str, dict[str, Any]] = {}
+    artifacts = status.get("artifacts")
+    if not isinstance(artifacts, list):
+        return result
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            continue
+        role = artifact.get("role")
+        if isinstance(role, str) and role not in result:
+            result[role] = artifact
+    return result
+
+
+def _candidate(
+    *,
+    candidate_id: str,
+    source: str,
+    priority: int,
+    estimated_tokens: int,
+    selection_reason: str,
+    payload: dict[str, Any],
+    citations: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": candidate_id,
+        "source": source,
+        "priority": priority,
+        "estimated_tokens": estimated_tokens,
+        "selection_reason": selection_reason,
+        "citations": citations or [],
+        **payload,
+    }
+
+
+def _retrieval_candidates(
+    manifest_path: Path,
+    *,
+    query: str,
+    signal_k: int,
+    bytes_per_token: float,
+) -> tuple[list[dict[str, Any]], dict[str, Any], list[dict[str, Any]]]:
+    if not query.strip():
+        return [], {"status": "skipped", "reason": "query_empty"}, []
+    result = query_existing_index(
+        manifest_path,
+        query,
+        k=signal_k,
+        resolve_evidence=True,
+        project_sources=True,
+    )
+    gaps: list[dict[str, Any]] = []
+    if result.get("status") != "available":
+        gaps.append({
+            "source": "resolved_evidence",
+            "status": result.get("status"),
+            "error_code": result.get("error_code"),
+            "reason": result.get("error") or "resolved evidence query unavailable",
+        })
+        return [], {"status": result.get("status"), "error_code": result.get("error_code")}, gaps
+
+    projection = result.get("source_citation_projection")
+    items = projection.get("items") if isinstance(projection, dict) else []
+    candidates: list[dict[str, Any]] = []
+    for ordinal, item in enumerate(items if isinstance(items, list) else []):
+        if not isinstance(item, dict):
+            continue
+        text = item.get("text_excerpt")
+        citation_id = item.get("citation_id") if isinstance(item.get("citation_id"), str) else None
+        source_range = item.get("source_range") if isinstance(item.get("source_range"), dict) else None
+        citation_range = item.get("citation_range") if isinstance(item.get("citation_range"), dict) else None
+        citations = []
+        if citation_id or source_range or citation_range:
+            citations.append({
+                "citation_id": citation_id,
+                "source_range": source_range,
+                "citation_range": citation_range,
+                "range_status": item.get("range_status"),
+                "citation_status": item.get("citation_status"),
+                "live_repo_address": item.get("live_repo_address"),
+            })
+        token_estimate = _estimate_tokens_from_text(text, bytes_per_token)
+        candidates.append(
+            _candidate(
+                candidate_id=f"resolved-evidence:{ordinal}",
+                source="resolved_evidence",
+                priority=10 + ordinal,
+                estimated_tokens=token_estimate,
+                selection_reason="query_match_with_resolved_range",
+                citations=citations,
+                payload={
+                    "title": item.get("path") or item.get("chunk_id") or f"resolved evidence {ordinal}",
+                    "artifact_role": "canonical_md",
+                    "path": item.get("path"),
+                    "chunk_id": item.get("chunk_id"),
+                    "text_excerpt": text,
+                    "text_truncated": item.get("text_truncated"),
+                    "source_range": source_range,
+                    "canonical_authority": item.get("canonical_authority"),
+                },
+            )
+        )
+    if not candidates:
+        gaps.append({"source": "resolved_evidence", "status": "empty", "reason": "query returned no resolved source candidates"})
+    signal = {
+        "status": "available",
+        "hit_count": len(candidates),
+        "query_status": result.get("status"),
+        "citation_projection_status": projection.get("status") if isinstance(projection, dict) else None,
+    }
+    return candidates, signal, gaps
+
+
+def _symbol_candidates(
+    manifest_path: Path,
+    *,
+    query: str,
+    signal_k: int,
+    bytes_per_token: float,
+) -> tuple[list[dict[str, Any]], dict[str, Any], list[dict[str, Any]]]:
+    if not query.strip():
+        return [], {"status": "skipped", "reason": "query_empty"}, []
+    result = search_symbol_index(manifest_path, query, k=signal_k)
+    if result.get("status") == "available" and result.get("hit_count") == 0:
+        compact_query = _compact_match_text(query)
+        if compact_query and compact_query != query.strip().casefold():
+            compact_result = search_symbol_index(manifest_path, compact_query, k=signal_k)
+            if compact_result.get("status") == "available" and compact_result.get("hit_count", 0) > 0:
+                result = compact_result
+    gaps: list[dict[str, Any]] = []
+    if result.get("status") != "available":
+        gaps.append({
+            "source": "python_symbol_index_json",
+            "status": result.get("status"),
+            "error_code": result.get("error_code"),
+            "reason": result.get("error") or "symbol index unavailable",
+        })
+        return [], {"status": result.get("status"), "error_code": result.get("error_code")}, gaps
+    candidates: list[dict[str, Any]] = []
+    for ordinal, hit in enumerate(result.get("hits") if isinstance(result.get("hits"), list) else []):
+        if not isinstance(hit, dict):
+            continue
+        label = " ".join(
+            str(hit.get(part, ""))
+            for part in ("kind", "qualified_name", "path", "range_ref")
+        )
+        source_range = hit.get("source_range") if isinstance(hit.get("source_range"), dict) else None
+        range_ref = hit.get("range_ref") if isinstance(hit.get("range_ref"), str) else None
+        citations = [{"range_ref": range_ref, "source_range": source_range}] if range_ref or source_range else []
+        candidates.append(
+            _candidate(
+                candidate_id=f"symbol:{ordinal}",
+                source="python_symbol_index_json",
+                priority=20 + ordinal,
+                estimated_tokens=_estimate_tokens_from_text(label, bytes_per_token),
+                selection_reason="symbol_name_or_path_match",
+                citations=citations,
+                payload={
+                    "title": hit.get("qualified_name") or hit.get("name"),
+                    "symbol": hit,
+                    "path": hit.get("path"),
+                    "source_range": source_range,
+                },
+            )
+        )
+    if not candidates:
+        gaps.append({"source": "python_symbol_index_json", "status": "empty", "reason": "symbol search returned no candidates"})
+    return candidates, {"status": "available", "hit_count": len(candidates)}, gaps
+
+
+
+def _relation_path_value(value: Any) -> str | None:
+    if isinstance(value, dict) and isinstance(value.get("path"), str):
+        return value["path"]
+    if isinstance(value, str):
+        return value
+    return None
+
+
+def _relation_candidates(
+    status: Mapping[str, Any],
+    *,
+    query: str,
+    signal_k: int,
+    bytes_per_token: float,
+) -> tuple[list[dict[str, Any]], dict[str, Any], list[dict[str, Any]]]:
+    artifacts = _artifact_by_role(status)
+    artifact = artifacts.get("relation_cards_jsonl")
+    if not isinstance(artifact, dict) or not artifact.get("absolute_path"):
+        return [], {"status": "missing", "error_code": "relation_cards_jsonl_missing"}, [{
+            "source": "relation_cards_jsonl",
+            "status": "missing",
+            "error_code": "relation_cards_jsonl_missing",
+            "reason": "relation_cards_jsonl artifact is not present in the bundle manifest",
+        }]
+    path = Path(str(artifact["absolute_path"]))
+    if not path.is_file():
+        return [], {"status": "missing", "error_code": "relation_cards_jsonl_file_missing"}, [{
+            "source": "relation_cards_jsonl",
+            "status": "missing",
+            "error_code": "relation_cards_jsonl_file_missing",
+            "reason": "relation_cards_jsonl artifact file does not exist",
+        }]
+    q = query.strip().casefold()
+    candidates: list[dict[str, Any]] = []
+    errors: list[dict[str, Any]] = []
+    try:
+        rows = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeError) as exc:
+        return [], {"status": "invalid", "error_code": "relation_cards_jsonl_unreadable"}, [{
+            "source": "relation_cards_jsonl",
+            "status": "invalid",
+            "error_code": "relation_cards_jsonl_unreadable",
+            "reason": str(exc),
+        }]
+    for row_number, line in enumerate(rows, start=1):
+        if not line.strip():
+            continue
+        try:
+            card = json.loads(line)
+        except ValueError as exc:
+            errors.append({"row": row_number, "error": str(exc)})
+            continue
+        if not isinstance(card, dict):
+            errors.append({"row": row_number, "error": "row_not_object"})
+            continue
+        source_path = _relation_path_value(card.get("source"))
+        target_path = _relation_path_value(card.get("target"))
+        evidence = card.get("evidence") if isinstance(card.get("evidence"), dict) else {}
+        haystack = " ".join(
+            str(value)
+            for value in (
+                card.get("relation"),
+                source_path,
+                target_path,
+                evidence.get("source_path"),
+                evidence.get("start_line"),
+                evidence.get("end_line"),
+            )
+        ).casefold()
+        if q and q not in haystack:
+            compact_query = _compact_match_text(q)
+            compact_haystack = _compact_match_text(haystack)
+            if not compact_query or compact_query not in compact_haystack:
+                continue
+        label = f"{source_path or '?'} -> {target_path or '?'} {card.get('relation') or ''}"
+        candidates.append(
+            _candidate(
+                candidate_id=f"relation:{row_number}",
+                source="relation_cards_jsonl",
+                priority=25 + row_number,
+                estimated_tokens=_estimate_tokens_from_text(label, bytes_per_token),
+                selection_reason="relation_card_match",
+                citations=[{
+                    "artifact_role": "relation_cards_jsonl",
+                    "source_path": source_path,
+                    "target_path": target_path,
+                    "evidence": evidence,
+                    "evidence_level": card.get("evidence_level"),
+                }],
+                payload={
+                    "title": label,
+                    "artifact_role": "relation_cards_jsonl",
+                    "path": source_path,
+                    "relation": card.get("relation"),
+                    "source_path": source_path,
+                    "target_path": target_path,
+                    "evidence": evidence,
+                },
+            )
+        )
+        if len(candidates) >= signal_k:
+            break
+    gaps: list[dict[str, Any]] = []
+    if errors:
+        gaps.append({"source": "relation_cards_jsonl", "status": "invalid_rows", "row_errors": errors[:10]})
+    if not candidates:
+        gaps.append({"source": "relation_cards_jsonl", "status": "empty", "reason": "relation card search returned no candidates"})
+    signal_status = "warn" if errors else "available"
+    return candidates, {"status": signal_status, "hit_count": len(candidates), "invalid_row_count": len(errors)}, gaps
+
+def _required_reading_candidates(
+    status: Mapping[str, Any],
+    required_reading: Mapping[str, Any],
+    *,
+    bytes_per_token: float,
+) -> list[dict[str, Any]]:
+    artifacts = _artifact_by_role(status)
+    candidates: list[dict[str, Any]] = []
+    for group, base_priority, reason in (
+        ("available_required", 30, "required_reading_role"),
+        ("available_recommended", 60, "recommended_reading_role"),
+    ):
+        roles = required_reading.get(group)
+        if not isinstance(roles, list):
+            continue
+        for ordinal, role in enumerate(str(role) for role in roles):
+            artifact = artifacts.get(role)
+            if role == "bundle_manifest":
+                artifact = {
+                    "role": "bundle_manifest",
+                    "path": Path(str(status.get("bundle_manifest", "bundle_manifest"))).name,
+                    "absolute_path": status.get("bundle_manifest"),
+                    "bytes": None,
+                    "authority": "navigation_index",
+                    "canonicality": "derived",
+                }
+            if not isinstance(artifact, dict):
+                continue
+            candidates.append(
+                _candidate(
+                    candidate_id=f"artifact:{role}",
+                    source="required_reading",
+                    priority=base_priority + ordinal,
+                    estimated_tokens=_estimate_tokens_from_bytes(artifact.get("bytes"), bytes_per_token),
+                    selection_reason=reason,
+                    citations=[{
+                        "artifact_role": role,
+                        "path": artifact.get("path"),
+                        "authority": artifact.get("authority"),
+                        "canonicality": artifact.get("canonicality"),
+                    }],
+                    payload={
+                        "title": role,
+                        "artifact_role": role,
+                        "path": artifact.get("path"),
+                        "absolute_path": artifact.get("absolute_path"),
+                        "authority": artifact.get("authority"),
+                        "canonicality": artifact.get("canonicality"),
+                    },
+                )
+            )
+    return candidates
+
+
+def _dedupe_candidates(candidates: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    seen: set[tuple[Any, Any, Any]] = set()
+    result: list[dict[str, Any]] = []
+    for candidate in sorted(candidates, key=lambda c: (c["priority"], c["estimated_tokens"], c["id"])):
+        key = (candidate.get("source"), candidate.get("path"), candidate.get("title"))
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(candidate)
+    return result
+
+
+def _select_candidates(candidates: list[dict[str, Any]], budget: int) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    selected: list[dict[str, Any]] = []
+    omitted: list[dict[str, Any]] = []
+    used = 0
+    for candidate in candidates:
+        estimate = candidate["estimated_tokens"]
+        if used + estimate <= budget:
+            selected_item = {**candidate, "selection_status": "selected", "budget_before_tokens": used, "budget_after_tokens": used + estimate}
+            selected.append(selected_item)
+            used += estimate
+        else:
+            omitted.append({
+                **candidate,
+                "selection_status": "omitted",
+                "omission_reason": "estimated_tokens_exceed_remaining_budget",
+                "budget_remaining_tokens": max(budget - used, 0),
+            })
+    return selected, omitted
+
+
+def compile_context_plan(
+    bundle_manifest: str | Path,
+    *,
+    task: str,
+    task_profile: str = "basic_repo_question",
+    context_budget_tokens: int = 8_000,
+    query: str | None = None,
+    signal_k: int = 10,
+    bytes_per_token: float = DEFAULT_BYTES_PER_TOKEN,
+) -> dict[str, Any]:
+    manifest_path = Path(bundle_manifest).expanduser().resolve()
+    if not isinstance(task, str) or not task.strip():
+        return _invalid_result(manifest_path, error="task must be a non-empty string", error_code="task_invalid", task=str(task), task_profile=task_profile, context_budget_tokens=context_budget_tokens)
+    if not isinstance(task_profile, str) or not task_profile.strip():
+        return _invalid_result(manifest_path, error="task_profile must be a non-empty string", error_code="task_profile_invalid", task=task, task_profile=str(task_profile), context_budget_tokens=context_budget_tokens)
+    if not isinstance(context_budget_tokens, int) or isinstance(context_budget_tokens, bool) or context_budget_tokens < 1 or context_budget_tokens > MAX_CONTEXT_BUDGET_TOKENS:
+        return _invalid_result(manifest_path, error=f"context_budget_tokens must be an integer between 1 and {MAX_CONTEXT_BUDGET_TOKENS}", error_code="context_budget_out_of_bounds", task=task, task_profile=task_profile, context_budget_tokens=context_budget_tokens)
+    if not isinstance(signal_k, int) or isinstance(signal_k, bool) or signal_k < 1 or signal_k > MAX_SIGNAL_HITS:
+        return _invalid_result(manifest_path, error=f"signal_k must be an integer between 1 and {MAX_SIGNAL_HITS}", error_code="signal_k_out_of_bounds", task=task, task_profile=task_profile, context_budget_tokens=context_budget_tokens)
+    if not isinstance(bytes_per_token, (int, float)) or isinstance(bytes_per_token, bool) or bytes_per_token <= 0:
+        return _invalid_result(manifest_path, error="bytes_per_token must be a number greater than 0", error_code="bytes_per_token_invalid", task=task, task_profile=task_profile, context_budget_tokens=context_budget_tokens)
+    bytes_per_token = float(bytes_per_token)
+
+    effective_query = query if isinstance(query, str) and query.strip() else task
+    try:
+        status = snapshot_status(manifest_path)
+        required_resolution = resolve_required_reading_for_bundle(manifest_path, task_profile)
+    except ValueError as exc:
+        return _invalid_result(manifest_path, error=str(exc), error_code="bundle_manifest_invalid", task=task, task_profile=task_profile, context_budget_tokens=context_budget_tokens)
+
+    required = required_resolution.get("required_reading") if isinstance(required_resolution.get("required_reading"), dict) else {}
+    gaps: list[dict[str, Any]] = []
+    if required.get("status") in {"fail", "not_applicable"}:
+        gaps.append({
+            "source": "required_reading",
+            "status": required.get("status"),
+            "missing_required": required.get("missing_required"),
+            "reason": "required reading is not fully available",
+        })
+    elif required.get("missing_recommended"):
+        gaps.append({
+            "source": "required_reading",
+            "status": "warn",
+            "missing_recommended": required.get("missing_recommended"),
+            "reason": "recommended reading is not fully available",
+        })
+
+    availability = status.get("availability_model") if isinstance(status.get("availability_model"), dict) else {}
+    freshness = availability.get("freshness") if isinstance(availability, dict) else None
+    graph_availability = availability.get("graph_availability") if isinstance(availability, dict) else None
+    if isinstance(freshness, dict) and freshness.get("status") not in {"fresh", "not_comparable"}:
+        gaps.append({"source": "freshness", "status": freshness.get("status"), "reason": freshness.get("reason")})
+    if isinstance(graph_availability, dict) and graph_availability.get("status") != "available":
+        gaps.append({"source": "graph_availability", "status": graph_availability.get("status"), "reason": graph_availability.get("reason")})
+
+    retrieval_candidates, retrieval_signal, retrieval_gaps = _retrieval_candidates(
+        manifest_path,
+        query=effective_query,
+        signal_k=signal_k,
+        bytes_per_token=bytes_per_token,
+    )
+    symbol_candidates, symbol_signal, symbol_gaps = _symbol_candidates(
+        manifest_path,
+        query=effective_query,
+        signal_k=signal_k,
+        bytes_per_token=bytes_per_token,
+    )
+    relation_candidates, relation_signal, relation_gaps = _relation_candidates(
+        status,
+        query=effective_query,
+        signal_k=signal_k,
+        bytes_per_token=bytes_per_token,
+    )
+    gaps.extend(retrieval_gaps)
+    gaps.extend(symbol_gaps)
+    gaps.extend(relation_gaps)
+
+    required_candidates = _required_reading_candidates(
+        status,
+        required,
+        bytes_per_token=bytes_per_token,
+    )
+    all_candidates = _dedupe_candidates(retrieval_candidates + symbol_candidates + relation_candidates + required_candidates)
+    selected, omitted = _select_candidates(all_candidates, context_budget_tokens)
+
+    used_tokens = sum(item["estimated_tokens"] for item in selected)
+    candidate_counts: dict[str, int] = {}
+    selected_counts: dict[str, int] = {}
+    for candidate in all_candidates:
+        source = str(candidate.get("source"))
+        candidate_counts[source] = candidate_counts.get(source, 0) + 1
+    for candidate in selected:
+        source = str(candidate.get("source"))
+        selected_counts[source] = selected_counts.get(source, 0) + 1
+
+    fallback_roles = [
+        item for item in selected + omitted
+        if item.get("source") == "required_reading" and item.get("artifact_role") in {"canonical_md", "agent_reading_pack", "bundle_manifest"}
+    ]
+    status_value = "pass"
+    if not selected or required.get("status") in {"fail", "not_applicable"}:
+        status_value = "fail"
+    elif gaps or omitted:
+        status_value = "warn"
+
+    return {
+        "kind": KIND,
+        "version": VERSION,
+        "status": status_value,
+        "bundle_manifest": str(manifest_path),
+        "bundle_run_id": status.get("bundle_run_id"),
+        "task": task,
+        "task_profile": task_profile,
+        "query": effective_query,
+        "budget": {
+            "context_budget_tokens": context_budget_tokens,
+            "estimated_used_tokens": used_tokens,
+            "estimated_remaining_tokens": max(context_budget_tokens - used_tokens, 0),
+            "bytes_per_token": bytes_per_token,
+            "exact_tokenizer": False,
+        },
+        "signals": {
+            "resolved_evidence": retrieval_signal,
+            "python_symbol_index_json": symbol_signal,
+            "relation_cards_jsonl": relation_signal,
+            "required_reading": {
+                "status": required.get("status"),
+                "required": required.get("required"),
+                "recommended": required.get("recommended"),
+                "missing_required": required.get("missing_required"),
+                "missing_recommended": required.get("missing_recommended"),
+            },
+            "availability": {
+                "status": availability.get("status") if isinstance(availability, dict) else None,
+                "freshness": freshness,
+                "graph_availability": graph_availability,
+            },
+        },
+        "candidate_count": len(all_candidates),
+        "selected_count": len(selected),
+        "omitted_count": len(omitted),
+        "candidate_counts_by_source": candidate_counts,
+        "selected_counts_by_source": selected_counts,
+        "selected_context": selected,
+        "omitted_context": omitted,
+        "fallback_context": {
+            "available": bool(fallback_roles),
+            "roles": fallback_roles,
+            "reason": "required reading canonical/front-door roles remain available as fallback when retrieval, graph or symbol signals are missing",
+        },
+        "gaps": gaps,
+        "selection_trace": {
+            "ordering": "priority_then_estimated_tokens_then_id",
+            "priority_bands": [
+                {"source": "resolved_evidence", "priority": "10-19"},
+                {"source": "python_symbol_index_json", "priority": "20-29"},
+                {"source": "relation_cards_jsonl", "priority": "25+"},
+                {"source": "required_reading", "priority": "30+ required, 60+ recommended"},
+            ],
+            "omission_reasons": sorted({item.get("omission_reason") for item in omitted if item.get("omission_reason")}),
+        },
+        "mutation_boundary": _read_only_mutation_boundary(),
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }

--- a/merger/lenskit/tests/test_repobrief_context_compiler.py
+++ b/merger/lenskit/tests/test_repobrief_context_compiler.py
@@ -1,0 +1,320 @@
+import hashlib
+import json
+from pathlib import Path
+
+from merger.lenskit.cli.main import main
+from merger.lenskit.core.citation_id import make_citation_id
+from merger.lenskit.core.repobrief_context_compiler import compile_context_plan
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _artifact(role: str, path: Path, **extra):
+    return {
+        "role": role,
+        "path": path.name,
+        "content_type": extra.pop("content_type", "application/json"),
+        "bytes": path.stat().st_size,
+        "sha256": _sha256(path),
+        **extra,
+    }
+
+
+def _write_complete_bundle(tmp_path: Path) -> Path:
+    from merger.lenskit.retrieval import index_db
+
+    canonical = tmp_path / "brief.md"
+    canonical.write_text("# Brief\n\nhello context compiler world\n", encoding="utf-8")
+    content = canonical.read_bytes()
+    start = content.index(b"hello")
+    end = len(content)
+    chunk_bytes = content[start:end]
+    chunk_sha = _sha256_bytes(chunk_bytes)
+    canonical_sha = _sha256_bytes(content)
+    range_ref = {
+        "artifact_role": "canonical_md",
+        "repo_id": "demo",
+        "file_path": canonical.name,
+        "start_byte": start,
+        "end_byte": end,
+        "start_line": 3,
+        "end_line": 3,
+        "content_sha256": chunk_sha,
+    }
+    chunk = {
+        "chunk_id": "c1",
+        "repo_id": "demo",
+        "path": canonical.name,
+        "content": chunk_bytes.decode("utf-8"),
+        "start_byte": start,
+        "end_byte": end,
+        "start_line": 3,
+        "end_line": 3,
+        "layer": "core",
+        "artifact_type": "doc",
+        "content_sha256": chunk_sha,
+        "content_range_ref": range_ref,
+    }
+    chunk_path = tmp_path / "chunks.jsonl"
+    chunk_path.write_text(json.dumps(chunk) + "\n", encoding="utf-8")
+    dump_path = tmp_path / "dump.json"
+    dump_path.write_text(json.dumps({"version": "1.0", "repos": {"demo": {}}}), encoding="utf-8")
+    index_path = tmp_path / "demo.index.sqlite"
+    index_db.build_index(dump_path, chunk_path, index_path)
+
+    citation_id = make_citation_id(canonical_sha, start, end, chunk_sha)
+    citation_map = tmp_path / "demo.citation_map.jsonl"
+    citation_map.write_text(
+        json.dumps(
+            {
+                "citation_id": citation_id,
+                "repo_id": "demo",
+                "chunk_id": "c1",
+                "snapshot": {
+                    "run_id": "run-1",
+                    "canonical_md_path": canonical.name,
+                    "canonical_md_sha256": canonical_sha,
+                },
+                "canonical_range": {
+                    "file_path": canonical.name,
+                    "start_byte": start,
+                    "end_byte": end,
+                    "start_line": 3,
+                    "end_line": 3,
+                    "content_sha256": chunk_sha,
+                },
+                "range_ref": range_ref,
+                "produced_by": "citation_map_producer/v1",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    agent_pack = tmp_path / "demo.agent.md"
+    agent_pack.write_text("# Agent Pack\n\nRead canonical_md for truth.\n", encoding="utf-8")
+    symbol_index = tmp_path / "demo.python_symbol_index.json"
+    symbol_index.write_text(
+        json.dumps(
+            {
+                "kind": "lenskit.python_symbol_index",
+                "version": "1.0",
+                "run_id": "run-1",
+                "canonical_dump_index_sha256": "a" * 64,
+                "language": "python",
+                "symbol_kinds": ["class", "function", "async_function"],
+                "symbols": [
+                    {
+                        "id": "py:pkg/context.py:class:ContextCompiler",
+                        "kind": "class",
+                        "name": "ContextCompiler",
+                        "qualified_name": "ContextCompiler",
+                        "module": "pkg.context",
+                        "path": "pkg/context.py",
+                        "start_line": 10,
+                        "end_line": 30,
+                        "range_ref": "file:pkg/context.py#L10-L30",
+                    }
+                ],
+                "skipped_files_count": 0,
+                "skipped_errors": [],
+                "does_not_establish": [
+                    "call_graph_completeness",
+                    "dependency_completeness",
+                    "runtime_behavior",
+                    "import_success",
+                    "test_sufficiency",
+                    "review_impact",
+                    "merge_readiness",
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    relation_cards = tmp_path / "demo.relation_cards.jsonl"
+    relation_cards.write_text(
+        json.dumps(
+            {
+                "kind": "lenskit.relation_card",
+                "version": "1.0",
+                "id": "rel-1",
+                "relation": "imports",
+                "source": {"kind": "repo_path", "path": "pkg/context_compiler.py"},
+                "target": {"kind": "repo_path", "path": "pkg/token_budget.py"},
+                "evidence": {"source_path": "pkg/context_compiler.py", "start_line": 1, "end_line": 1},
+                "evidence_level": "S1",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    manifest = tmp_path / "demo.bundle.manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "kind": "repolens.bundle.manifest",
+                "version": "1.0",
+                "run_id": "run-1",
+                "created_at": "2026-07-08T10:00:00Z",
+                "artifacts": [
+                    _artifact("canonical_md", canonical, content_type="text/markdown"),
+                    _artifact("agent_reading_pack", agent_pack, content_type="text/markdown"),
+                    _artifact("chunk_index_jsonl", chunk_path, content_type="application/x-ndjson"),
+                    _artifact("sqlite_index", index_path, content_type="application/vnd.sqlite3"),
+                    _artifact("citation_map_jsonl", citation_map, content_type="application/x-ndjson"),
+                    _artifact("python_symbol_index_json", symbol_index),
+                    _artifact("relation_cards_jsonl", relation_cards, content_type="application/x-ndjson"),
+                ],
+                "links": {},
+                "capabilities": {"repobrief_profile": "agent-portable"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def _write_fallback_bundle(tmp_path: Path) -> Path:
+    canonical = tmp_path / "brief.md"
+    canonical.write_text("# Brief\n\nOnly canonical fallback is available.\n", encoding="utf-8")
+    agent_pack = tmp_path / "demo.agent.md"
+    agent_pack.write_text("# Agent Pack\n", encoding="utf-8")
+    manifest = tmp_path / "demo.bundle.manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "kind": "repolens.bundle.manifest",
+                "version": "1.0",
+                "run_id": "run-fallback",
+                "artifacts": [
+                    _artifact("canonical_md", canonical, content_type="text/markdown"),
+                    _artifact("agent_reading_pack", agent_pack, content_type="text/markdown"),
+                ],
+                "links": {},
+                "capabilities": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def test_compile_context_plan_selects_ordered_evidence_with_citations(tmp_path):
+    manifest = _write_complete_bundle(tmp_path)
+
+    plan = compile_context_plan(
+        manifest,
+        task="Explain the context compiler",
+        task_profile="basic_repo_question",
+        query="context compiler",
+        context_budget_tokens=120,
+        bytes_per_token=4.0,
+    )
+
+    assert plan["kind"] == "repobrief.context_compiler"
+    assert plan["status"] in {"pass", "warn"}
+    assert plan["selected_context"][0]["source"] == "resolved_evidence"
+    first_citation = plan["selected_context"][0]["citations"][0]
+    assert first_citation["source_range"]["file_path"] == "brief.md"
+    assert plan["selected_context"][0]["source_range"]["file_path"] == "brief.md"
+    assert any(item["source"] == "python_symbol_index_json" for item in plan["selected_context"])
+    assert any(item["source"] == "relation_cards_jsonl" for item in plan["selected_context"])
+    assert plan["signals"]["relation_cards_jsonl"]["status"] == "available"
+    assert plan["fallback_context"]["available"] is True
+    assert plan["mutation_boundary"]["writes"] == []
+    assert "exact_token_count" in plan["does_not_establish"]
+
+
+def test_compile_context_plan_falls_back_to_required_reading_when_signals_missing(tmp_path):
+    manifest = _write_fallback_bundle(tmp_path)
+
+    plan = compile_context_plan(
+        manifest,
+        task="Fallback only",
+        task_profile="basic_repo_question",
+        context_budget_tokens=100,
+    )
+
+    assert plan["status"] == "warn"
+    selected_roles = {item.get("artifact_role") for item in plan["selected_context"]}
+    assert {"canonical_md", "agent_reading_pack"}.issubset(selected_roles)
+    assert plan["signals"]["resolved_evidence"]["status"] == "missing"
+    assert plan["signals"]["python_symbol_index_json"]["status"] == "missing"
+    assert any(gap["source"] == "resolved_evidence" for gap in plan["gaps"])
+    assert plan["fallback_context"]["available"] is True
+
+
+def test_compile_context_plan_records_omitted_candidates_when_budget_is_small(tmp_path):
+    manifest = _write_complete_bundle(tmp_path)
+
+    plan = compile_context_plan(
+        manifest,
+        task="Explain the context compiler",
+        task_profile="basic_repo_question",
+        query="context compiler",
+        context_budget_tokens=12,
+        bytes_per_token=4.0,
+    )
+
+    assert plan["status"] == "warn"
+    assert plan["selected_count"] >= 1
+    assert plan["omitted_count"] >= 1
+    assert "estimated_tokens_exceed_remaining_budget" in plan["selection_trace"]["omission_reasons"]
+    assert all("budget_remaining_tokens" in item for item in plan["omitted_context"])
+
+
+def test_compile_context_plan_rejects_invalid_budget(tmp_path):
+    manifest = _write_fallback_bundle(tmp_path)
+
+    plan = compile_context_plan(
+        manifest,
+        task="invalid",
+        context_budget_tokens=0,
+    )
+
+    assert plan["status"] == "invalid"
+    assert plan["error_code"] == "context_budget_out_of_bounds"
+    assert plan["mutation_boundary"]["writes"] == []
+
+
+def test_compile_context_plan_rejects_invalid_bytes_per_token(tmp_path):
+    manifest = _write_fallback_bundle(tmp_path)
+
+    plan = compile_context_plan(
+        manifest,
+        task="invalid",
+        bytes_per_token="four",
+    )
+
+    assert plan["status"] == "invalid"
+    assert plan["error_code"] == "bytes_per_token_invalid"
+
+
+def test_context_compile_cli_outputs_plan(tmp_path, capsys):
+    manifest = _write_complete_bundle(tmp_path)
+
+    rc = main([
+        "repobrief",
+        "context",
+        "compile",
+        "--bundle-manifest",
+        str(manifest),
+        "--task",
+        "Explain the context compiler",
+        "--query",
+        "context compiler",
+        "--context-budget",
+        "120",
+    ])
+
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert out["kind"] == "repobrief.context_compiler"
+    assert out["selected_count"] >= 1
+    assert out["budget"]["context_budget_tokens"] == 120


### PR DESCRIPTION
Implements Bureau task RPU-V1-T004 — Token-budget context compiler.

Scope:
- adds read-only core surface repobrief.context_compiler
- adds CLI: repobrief context compile
- accepts task, task profile, query, signal-k, context budget and byte/token estimator
- selects ordered context from existing bundle artifacts using resolved evidence, python_symbol_index_json, relation_cards_jsonl and required-reading roles
- emits selected_context, omitted_context, gaps, signals, fallback_context and selection_trace
- carries source ranges, citation/range refs and relation evidence where available
- adds proof doc: docs/proofs/repobrief-context-compiler-v1-proof.md

Validation:
- python3 -m pytest -q merger/lenskit/tests/test_repobrief_context_compiler.py merger/lenskit/tests/test_token_budget_report.py merger/lenskit/tests/test_repobrief_symbol_index_consumer.py merger/lenskit/tests/test_relation_cards.py merger/lenskit/tests/test_relation_card_validate.py merger/lenskit/tests/test_repobrief_resolved_evidence_query.py merger/lenskit/tests/test_repobrief_source_citation_projection.py merger/lenskit/tests/test_repobrief_access_boundary.py merger/lenskit/tests/test_repobrief_snapshot_cli.py merger/lenskit/tests/test_repobrief_latest_complete.py merger/lenskit/tests/test_repobrief_profiles.py merger/lenskit/tests/test_external_manifest_reference.py merger/lenskit/tests/test_repobrief_preflight.py -> 222 passed
- python3 -m ruff check --config ruff-ci.toml merger/lenskit/core/repobrief_context_compiler.py merger/lenskit/cli/cmd_repobrief.py merger/lenskit/tests/test_repobrief_context_compiler.py -> pass
- python3 -m scripts.docmeta.check_planning_registration --baseline docs/tasks/planning-registration-baseline.json --ratchet --format human -> no new drift
- python3 -m merger.lenskit.cli.main doc-freshness inspect -> PASS
- git diff --check origin/main...HEAD -> pass
- manual CLI smoke: generated a tiny RepoBrief snapshot, ran repobrief context compile, selected resolved evidence and symbol context, reported relation_cards_jsonl as a missing signal gap, fallback_context.available=true and writes=[]

Boundary / non-claims:
- The compiler is read-only over existing bundle artifacts.
- It does not refresh snapshots, mutate Git, create pull requests, import or execute target code, mutate bundle artifacts, or update latest-complete registries.
- Token estimates are byte-based approximations, not exact tokenizer counts.
- This does not establish model context fit, best possible context, all relevant context used, answer correctness, repo understanding, claims truth, runtime behavior, test sufficiency, review completeness, merge readiness or agent quality improvement.

Diff SHA256: `62e45886cf53edf8d8c810b9a72fdd83a7e1eba205aca4461a3abf8504323984`
