### PR TITLE
feat(repobrief): add delta context compiler

### DIFF
--- a/docs/proofs/repobrief-delta-context-compiler-v1-proof.md
+++ b/docs/proofs/repobrief-delta-context-compiler-v1-proof.md
@@ -1,0 +1,119 @@
+# RepoBrief Delta Context Compiler v1 proof
+
+Task: `RPU-V1-T005`
+
+Status: implementation proof for a deterministic, read-only PR/revision delta context compiler.
+
+## Implemented surface
+
+This slice adds:
+
+```text
+repobrief.delta_context_compiler
+```
+
+and the CLI command:
+
+```bash
+python -m merger.lenskit.cli.main repobrief delta-context compile \
+  --diff <unified.diff> \
+  [--bundle-manifest <manifest>] \
+  [--task <task>] \
+  [--context-budget <tokens>]
+```
+
+## Input model
+
+The compiler accepts a unified Git diff. A RepoBrief bundle manifest is optional.
+
+Without a bundle, the compiler still emits changed files, changed hunk ranges,
+surrounding line windows and simple likely-reference hints. This satisfies the
+"no full repo dump required for every review" condition at the delta layer.
+
+With a bundle, the compiler also attempts bounded read-only hints from:
+
+- `python_symbol_index_json`;
+- `relation_cards_jsonl`;
+- resolved evidence via the existing RepoBrief query/source-citation path;
+- bundle availability, freshness and graph availability status.
+
+Missing, stale, invalid or empty signals are reported as `gaps`; they are not
+silently regenerated and do not block representation of the diff itself.
+
+## Output contract
+
+The compiler emits:
+
+- `changed_files`: parsed file-level delta records;
+- per-hunk `old_range`, `new_range`, `changed_range` and `surrounding_range`;
+- `review_context`: token-budget-selected context entries;
+- `omitted_context`: candidates skipped because the rough budget was exhausted;
+- `signals`: bundle, symbol, relation and resolved-evidence signal status;
+- `gaps`: missing/degraded/stale/empty signal observations with `severity`;
+- `input_validity`, `signal_quality` and `context_completeness`: separated status dimensions;
+- `selection_trace`: deterministic ordering and omission reasons;
+- `review_boundary`: explicit context-only non-verdict;
+- `mutation_boundary`: explicit read-only boundary.
+
+
+## Bounded signal handling
+
+Optional bundle signals are allowed to be absent or empty. Empty symbol, relation
+and resolved-evidence hits are represented as informational gaps rather than
+automatic warnings. Warnings are reserved for degraded/invalid signals, bounded
+scan limits or budget truncation.
+
+Relation-card scanning is bounded by artifact size, row count and per-line byte
+length. The scan uses a file iterator instead of loading all JSONL rows into
+memory, and it prefilters lines by changed path before JSON parsing.
+
+Changed paths are deduplicated before symbol and resolved-evidence lookups to
+avoid repeated expensive queries for repeated diff sections.
+
+## Read-only boundary
+
+The compiler must not:
+
+- apply the diff;
+- inspect or mutate the working tree;
+- run Git commands;
+- create or update pull requests;
+- refresh or create RepoBrief bundles;
+- update latest-complete registries;
+- run tests or shell commands on target code;
+- approve, reject, score, or authorize a merge.
+
+## Validation scope
+
+Tests cover:
+
+- unified diff parsing for modified, added, renamed, deleted, binary and no-prefix files;
+- changed hunk ranges and surrounding context windows;
+- diff-only operation without a bundle;
+- optional bundle signals for symbols, relation cards and resolved evidence;
+- small-budget omission behavior;
+- empty invalid diff classification;
+- optional empty symbol/relation/resolved-evidence hits as informational rather than toxic warnings;
+- nested test path likely-reference hints that do not point back to the same test file;
+- deduplication of repeated changed paths before expensive signal queries;
+- lazy bounded relation-card scanning with invalid-row reporting;
+- CLI JSON output;
+- explicit review-boundary non-verdict fields.
+
+## Non-claims
+
+The delta context compiler does not establish:
+
+- review verdict;
+- approval or rejection;
+- merge readiness;
+- correctness;
+- test sufficiency;
+- regression absence;
+- runtime behavior;
+- security correctness;
+- risk score;
+- blast-radius completeness;
+- all relevant context used;
+- repo understanding;
+- claims truth.

--- a/merger/lenskit/cli/cmd_repobrief.py
+++ b/merger/lenskit/cli/cmd_repobrief.py
@@ -336,6 +336,28 @@ def register_repobrief_command_groups(repobrief_parser: argparse.ArgumentParser)
     context_compile.add_argument("--bytes-per-token", type=float, default=4.0, help="Byte divisor used for rough token estimate")
     context_compile.add_argument("--strict", action="store_true", help="Treat warn status as exit code 1")
 
+    delta_context_parser = repobrief_subparsers.add_parser(
+        "delta-context",
+        help="Compile bounded PR/revision delta context without emitting a review verdict",
+    )
+    delta_context_subparsers = delta_context_parser.add_subparsers(
+        dest="delta_context_cmd",
+        required=True,
+        help="Delta-context commands",
+    )
+    delta_context_compile = delta_context_subparsers.add_parser(
+        "compile",
+        help="Read a unified diff and optional bundle signals into review context",
+    )
+    delta_context_compile.add_argument("--diff", required=True, help="Path to a unified git diff")
+    delta_context_compile.add_argument("--bundle-manifest", help="Optional existing Brief Bundle manifest")
+    delta_context_compile.add_argument("--task", default="Review pull request delta", help="Natural-language review task")
+    delta_context_compile.add_argument("--context-budget", type=int, default=8000, help="Token budget for selected context")
+    delta_context_compile.add_argument("--signal-k", type=int, default=10, help="Maximum symbol/relation/citation hints")
+    delta_context_compile.add_argument("--context-window-lines", type=int, default=20, help="Lines around each changed hunk to report")
+    delta_context_compile.add_argument("--bytes-per-token", type=float, default=4.0, help="Byte divisor used for rough token estimate")
+    delta_context_compile.add_argument("--strict", action="store_true", help="Treat warn status as exit code 1")
+
     external_parser = repobrief_subparsers.add_parser(
         "external-manifest",
         help="Write bounded external manifest references from existing bundle manifests",
@@ -468,6 +490,8 @@ def run_repobrief(args: argparse.Namespace) -> int:
         return run_symbol_search(args)
     if args.repobrief_cmd == "context" and args.context_cmd == "compile":
         return run_context_compile(args)
+    if args.repobrief_cmd == "delta-context" and args.delta_context_cmd == "compile":
+        return run_delta_context_compile(args)
     if args.repobrief_cmd == "external-manifest" and args.external_manifest_cmd == "write":
         return run_external_manifest_write(args)
     if args.repobrief_cmd == "external-manifest" and args.external_manifest_cmd == "publish":
@@ -742,6 +766,29 @@ def run_symbol_search(args: argparse.Namespace) -> int:
         return 2
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0 if result.get("status") == "available" else 1
+
+
+def run_delta_context_compile(args: argparse.Namespace) -> int:
+    from merger.lenskit.core.repobrief_delta_context import compile_delta_context
+
+    result = compile_delta_context(
+        diff_path=args.diff,
+        bundle_manifest=args.bundle_manifest,
+        task=args.task,
+        context_budget_tokens=args.context_budget,
+        signal_k=args.signal_k,
+        context_window_lines=args.context_window_lines,
+        bytes_per_token=args.bytes_per_token,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    status = result.get("status")
+    if status == "pass":
+        return 0
+    if status == "warn":
+        return 1 if args.strict else 0
+    if status in {"fail", "invalid"}:
+        return 1
+    return 2
 
 
 def run_context_compile(args: argparse.Namespace) -> int:

--- a/merger/lenskit/core/repobrief_delta_context.py
+++ b/merger/lenskit/core/repobrief_delta_context.py
@@ -1,0 +1,733 @@
+"""Delta-Lens PR context compiler for RepoBrief.
+
+This module reads a unified diff and optional existing RepoBrief bundle artifacts
+and returns bounded review context. It deliberately emits no review verdict,
+risk score, approval, rejection or merge readiness claim.
+"""
+from __future__ import annotations
+
+import json
+import math
+import re
+from pathlib import Path
+from typing import Any, Mapping
+
+from merger.lenskit.core.lens_cards import produce_lens_card
+from merger.lenskit.core.repobrief_access import query_existing_index, search_symbol_index, snapshot_status
+
+KIND = "repobrief.delta_context_compiler"
+VERSION = "v1"
+MAX_DIFF_BYTES = 5_000_000
+MAX_FILES = 200
+MAX_HUNKS_PER_FILE = 100
+MAX_SIGNAL_HITS = 50
+MAX_RELATION_CARDS_BYTES = 25_000_000
+MAX_RELATION_CARD_LINE_BYTES = 250_000
+MAX_RELATION_CARD_SCAN_ROWS = 200_000
+DEFAULT_CONTEXT_BUDGET_TOKENS = 8_000
+DEFAULT_BYTES_PER_TOKEN = 4.0
+
+DOES_NOT_ESTABLISH = (
+    "review_verdict",
+    "approval",
+    "rejection",
+    "merge_readiness",
+    "correctness",
+    "test_sufficiency",
+    "regression_absence",
+    "runtime_behavior",
+    "security_correctness",
+    "risk_score",
+    "blast_radius_completeness",
+    "all_relevant_context_used",
+    "repo_understood",
+    "claims_true",
+)
+
+_HUNK_RE = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
+_DIFF_GIT_RE = re.compile(r"^diff --git (.+?) (.+)$")
+
+
+def _read_only_boundary() -> dict[str, Any]:
+    return {
+        "writes": [],
+        "does_not_mutate": [
+            "git",
+            "pull_requests",
+            "patches",
+            "source_working_tree",
+            "brief_bundle_artifacts",
+            "latest_complete_registry",
+        ],
+        "read_paths_do_not_refresh": True,
+    }
+
+
+def _invalid_result(*, error: str, error_code: str, diff_path: str | Path | None, task: str | None) -> dict[str, Any]:
+    return {
+        "kind": KIND,
+        "version": VERSION,
+        "status": "invalid",
+        "diff_path": str(diff_path) if diff_path is not None else None,
+        "task": task,
+        "error": error,
+        "error_code": error_code,
+        "changed_files": [],
+        "review_context": [],
+        "signals": {},
+        "gaps": [],
+        "mutation_boundary": _read_only_boundary(),
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }
+
+
+def _rough_size_bytes(value: Any, *, depth: int = 0) -> int:
+    if depth > 8:
+        return len(str(type(value)).encode("utf-8"))
+    if value is None or isinstance(value, bool):
+        return 4
+    if isinstance(value, (int, float)):
+        return len(str(value).encode("utf-8"))
+    if isinstance(value, str):
+        return len(value.encode("utf-8"))
+    if isinstance(value, Mapping):
+        total = 2
+        for key, item in value.items():
+            total += _rough_size_bytes(str(key), depth=depth + 1)
+            total += _rough_size_bytes(item, depth=depth + 1)
+            total += 2
+        return total
+    if isinstance(value, list | tuple):
+        return sum(_rough_size_bytes(item, depth=depth + 1) + 1 for item in value) + 2
+    return len(str(value).encode("utf-8"))
+
+
+def _estimate_tokens(value: Any, bytes_per_token: float) -> int:
+    return max(1, int(math.ceil(_rough_size_bytes(value) / bytes_per_token)))
+
+
+def _compact(value: str) -> str:
+    return "".join(ch for ch in value.casefold() if ch.isalnum())
+
+
+def _gap(source: str, status: str, reason: str, *, severity: str = "info", **extra: Any) -> dict[str, Any]:
+    return {
+        "source": source,
+        "status": status,
+        "severity": severity,
+        "reason": reason,
+        **extra,
+    }
+
+
+def _has_warn_or_error(gaps: list[dict[str, Any]]) -> bool:
+    return any(gap.get("severity") in {"warn", "error"} for gap in gaps)
+
+
+def _dedupe_ordered(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(values))
+
+
+def _safe_path(raw: str | None) -> str | None:
+    if raw is None:
+        return None
+    path = raw.strip()
+    if not path or path == "/dev/null":
+        return None
+    if path.startswith("a/") or path.startswith("b/"):
+        path = path[2:]
+    if path.startswith("/") or "\\" in path or "//" in path or path.endswith("/"):
+        return None
+    parts = path.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        return None
+    return path
+
+
+def _line_range(start: int, count: int, *, fallback_old: bool = False) -> dict[str, Any]:
+    if count <= 0:
+        return {"start_line": start, "end_line": start, "line_count": 0, "empty": True, "basis": "old" if fallback_old else "new"}
+    return {"start_line": start, "end_line": start + count - 1, "line_count": count, "empty": False, "basis": "old" if fallback_old else "new"}
+
+
+def _surrounding_range(range_info: Mapping[str, Any], *, window: int) -> dict[str, Any]:
+    start = int(range_info.get("start_line") or 1)
+    end = int(range_info.get("end_line") or start)
+    return {
+        "start_line": max(1, start - window),
+        "end_line": max(start, end + window),
+        "window_lines": window,
+        "basis": range_info.get("basis"),
+    }
+
+
+def parse_unified_diff(diff_text: str, *, context_window_lines: int = 20, max_files: int = MAX_FILES) -> dict[str, Any]:
+    """Parse a bounded subset of unified git diff metadata.
+
+    The parser extracts file status and hunk ranges only. It does not apply the
+    patch, inspect the repository, or infer semantic impact.
+    """
+    if not isinstance(diff_text, str):
+        raise TypeError("diff_text must be a string")
+    files: list[dict[str, Any]] = []
+    current: dict[str, Any] | None = None
+    old_path: str | None = None
+    new_path: str | None = None
+    old_mode_deleted = False
+    new_mode_added = False
+    rename_from: str | None = None
+    rename_to: str | None = None
+    binary_change = False
+    truncated = False
+
+    def finalize() -> None:
+        nonlocal current, old_path, new_path, old_mode_deleted, new_mode_added, rename_from, rename_to, binary_change
+        if current is None:
+            return
+        path = new_path or old_path or current.get("path")
+        if rename_to:
+            path = rename_to
+        status = "modified"
+        if old_mode_deleted or (old_path and not new_path):
+            status = "deleted"
+        if new_mode_added or (new_path and not old_path):
+            status = "added"
+        if rename_from or rename_to:
+            status = "renamed"
+        current["path"] = path
+        current["old_path"] = rename_from or old_path
+        current["new_path"] = rename_to or new_path
+        current["change_status"] = status
+        current["hunk_count"] = len(current["hunks"])
+        current["binary"] = binary_change
+        files.append(current)
+        current = None
+        old_path = None
+        new_path = None
+        old_mode_deleted = False
+        new_mode_added = False
+        rename_from = None
+        rename_to = None
+        binary_change = False
+
+    for line in diff_text.splitlines():
+        m = _DIFF_GIT_RE.match(line)
+        if m:
+            finalize()
+            a_path = _safe_path(m.group(1))
+            b_path = _safe_path(m.group(2))
+            current = {"path": b_path or a_path, "old_path": a_path, "new_path": b_path, "hunks": []}
+            old_path = a_path
+            new_path = b_path
+            continue
+        if current is None:
+            continue
+        if line.startswith("Binary files ") or line.startswith("GIT binary patch"):
+            binary_change = True
+            continue
+        if line.startswith("deleted file mode"):
+            old_mode_deleted = True
+            continue
+        if line.startswith("new file mode"):
+            new_mode_added = True
+            continue
+        if line.startswith("rename from "):
+            rename_from = _safe_path(line[len("rename from "):])
+            continue
+        if line.startswith("rename to "):
+            rename_to = _safe_path(line[len("rename to "):])
+            continue
+        if line.startswith("--- "):
+            old_path = _safe_path(line[4:])
+            continue
+        if line.startswith("+++ "):
+            new_path = _safe_path(line[4:])
+            continue
+        hm = _HUNK_RE.match(line)
+        if hm:
+            if len(current["hunks"]) >= MAX_HUNKS_PER_FILE:
+                truncated = True
+                continue
+            old_start = int(hm.group(1))
+            old_count = int(hm.group(2) or "1")
+            new_start = int(hm.group(3))
+            new_count = int(hm.group(4) or "1")
+            old_range = _line_range(old_start, old_count, fallback_old=True)
+            new_range = _line_range(new_start, new_count)
+            effective = old_range if new_count == 0 else new_range
+            current["hunks"].append({
+                "old_range": old_range,
+                "new_range": new_range,
+                "changed_range": effective,
+                "surrounding_range": _surrounding_range(effective, window=context_window_lines),
+                "header": line,
+            })
+    finalize()
+
+    safe_files = []
+    for item in files:
+        path = item.get("path")
+        if isinstance(path, str) and _safe_path(path):
+            safe_files.append(item)
+    if len(safe_files) > max_files:
+        truncated = True
+        safe_files = safe_files[:max_files]
+    counts: dict[str, int] = {}
+    for item in safe_files:
+        status = str(item.get("change_status"))
+        counts[status] = counts.get(status, 0) + 1
+    return {
+        "file_count": len(safe_files),
+        "change_status_counts": counts,
+        "files": safe_files,
+        "truncated": truncated,
+        "context_window_lines": context_window_lines,
+    }
+
+
+def _load_diff(diff_path: str | Path) -> tuple[str, dict[str, Any]]:
+    path = Path(diff_path).expanduser().resolve()
+    if not path.is_file():
+        raise ValueError(f"diff file not found: {path}")
+    size = path.stat().st_size
+    if size > MAX_DIFF_BYTES:
+        raise ValueError(f"diff file exceeds max bytes: {size} > {MAX_DIFF_BYTES}")
+    return path.read_text(encoding="utf-8"), {"path": str(path), "bytes": size}
+
+
+def _path_query(path: str) -> str:
+    p = Path(path)
+    stem = p.stem.replace("_", " ").replace("-", " ")
+    parts = [path, p.name, stem]
+    return " ".join(part for part in parts if part)
+
+
+def _implementation_hints_for_test_path(path: str) -> list[str]:
+    p = Path(path)
+    stem = p.stem.removeprefix("test_")
+    suffix = p.suffix or ".py"
+    hints: list[str] = []
+    parts = list(p.parts)
+    if "tests" in parts:
+        idx = parts.index("tests")
+        package_root = "/".join(parts[:idx])
+        tail_parts = parts[idx + 1 : -1]
+        if package_root:
+            hints.append("/".join([package_root, *tail_parts, f"{stem}{suffix}"]))
+            hints.append("/".join([package_root, "core", f"{stem}{suffix}"]))
+        hints.append("/".join([*tail_parts, f"{stem}{suffix}"]))
+    hints.append(f"{stem}{suffix}")
+    return [hint for hint in _dedupe_ordered(hints) if hint and hint != path]
+
+
+def _likely_refs(path: str, status: str) -> list[dict[str, Any]]:
+    p = Path(path)
+    name = p.name
+    stem = p.stem
+    refs: list[dict[str, Any]] = []
+    if "/tests/" in f"/{path}" or name.startswith("test_"):
+        for hint in _implementation_hints_for_test_path(path):
+            refs.append({"kind": "implementation_candidate", "path_hint": hint, "reason": "changed_file_is_test"})
+    elif p.suffix == ".py":
+        refs.append({"kind": "test_candidate", "path_hint": f"tests/test_{stem}.py", "reason": "python_module_name_heuristic"})
+        refs.append({"kind": "test_candidate", "path_hint": f"merger/lenskit/tests/test_{stem}.py", "reason": "lenskit_test_layout_heuristic"})
+    if path.endswith(".schema.json") or "/contracts/" in path:
+        refs.append({"kind": "contract_validation_candidate", "path_hint": path, "reason": "contract_schema_path"})
+    if path.startswith("docs/"):
+        refs.append({"kind": "doc_context", "path_hint": path, "reason": "documentation_path"})
+    if status == "deleted":
+        refs.append({"kind": "deletion_followup", "path_hint": path, "reason": "deleted_file_needs_reference_check"})
+    return refs
+
+
+def _bundle_signals(bundle_manifest: str | Path | None) -> tuple[dict[str, Any], list[dict[str, Any]], dict[str, Any] | None]:
+    if bundle_manifest is None:
+        return {"status": "not_requested"}, [_gap("bundle_manifest", "not_requested", "no bundle manifest supplied", severity="info")], None
+    try:
+        status = snapshot_status(bundle_manifest)
+    except ValueError as exc:
+        return {"status": "invalid", "error": str(exc)}, [_gap("bundle_manifest", "invalid", str(exc), severity="error")], None
+    availability = status.get("availability_model") if isinstance(status.get("availability_model"), dict) else {}
+    freshness = availability.get("freshness") if isinstance(availability, dict) and isinstance(availability.get("freshness"), dict) else None
+    graph = availability.get("graph_availability") if isinstance(availability, dict) and isinstance(availability.get("graph_availability"), dict) else None
+    signal = {
+        "status": status.get("status"),
+        "bundle_run_id": status.get("bundle_run_id"),
+        "availability_status": availability.get("status") if isinstance(availability, dict) else None,
+        "freshness": freshness,
+        "graph_availability": graph,
+    }
+    gaps: list[dict[str, Any]] = []
+    if signal["status"] not in {"ok", "available", "pass"}:
+        gaps.append(_gap("bundle_manifest", str(signal["status"]), "bundle manifest status is not fully available", severity="warn"))
+    if signal["availability_status"] not in {None, "pass", "available", "ok"}:
+        gaps.append(_gap(
+            "freshness",
+            str(signal["availability_status"]),
+            "bundle availability/freshness is degraded for delta review context",
+            severity="warn",
+            freshness_status=freshness.get("status") if isinstance(freshness, dict) else None,
+            freshness_reason=freshness.get("reason") if isinstance(freshness, dict) else None,
+        ))
+    graph_status = graph.get("status") if isinstance(graph, dict) else None
+    if graph_status not in {None, "available", "profile_excluded"}:
+        gaps.append(_gap(
+            "graph_availability",
+            str(graph_status),
+            graph.get("reason") if isinstance(graph, dict) else "graph availability is unknown",
+            severity="warn",
+        ))
+    return signal, gaps, status
+
+
+def _artifact_by_role(status: Mapping[str, Any] | None) -> dict[str, dict[str, Any]]:
+    result: dict[str, dict[str, Any]] = {}
+    if not isinstance(status, Mapping):
+        return result
+    artifacts = status.get("artifacts")
+    if not isinstance(artifacts, list):
+        return result
+    for artifact in artifacts:
+        if isinstance(artifact, dict) and isinstance(artifact.get("role"), str):
+            result.setdefault(artifact["role"], artifact)
+    return result
+
+
+def _relation_hints(status: Mapping[str, Any] | None, changed_paths: set[str], *, max_hits: int) -> tuple[list[dict[str, Any]], dict[str, Any], list[dict[str, Any]]]:
+    if status is None:
+        return [], {"status": "not_requested", "hit_count": 0}, []
+    artifacts = _artifact_by_role(status)
+    artifact = artifacts.get("relation_cards_jsonl")
+    if not artifact or not artifact.get("absolute_path"):
+        return [], {"status": "missing", "hit_count": 0}, [_gap("relation_cards_jsonl", "missing", "relation card artifact unavailable", severity="info")]
+    path = Path(str(artifact["absolute_path"]))
+    if not path.is_file():
+        return [], {"status": "missing", "hit_count": 0}, [_gap("relation_cards_jsonl", "missing", "relation card file unavailable", severity="info")]
+    size = path.stat().st_size
+    if size > MAX_RELATION_CARDS_BYTES:
+        return [], {"status": "limited", "hit_count": 0, "bytes": size}, [_gap(
+            "relation_cards_jsonl",
+            "limited",
+            "relation card artifact exceeds bounded scan size",
+            severity="warn",
+            bytes=size,
+            max_bytes=MAX_RELATION_CARDS_BYTES,
+        )]
+    hints: list[dict[str, Any]] = []
+    errors = 0
+    skipped_by_prefilter = 0
+    scanned_rows = 0
+    changed_needles = tuple(changed_paths)
+    with path.open("r", encoding="utf-8") as handle:
+        for row_number, line in enumerate(handle, start=1):
+            scanned_rows = row_number
+            if row_number > MAX_RELATION_CARD_SCAN_ROWS:
+                break
+            if not line.strip():
+                continue
+            if len(line.encode("utf-8")) > MAX_RELATION_CARD_LINE_BYTES:
+                errors += 1
+                continue
+            if changed_needles and not any(needle in line for needle in changed_needles):
+                skipped_by_prefilter += 1
+                continue
+            try:
+                card = json.loads(line)
+            except ValueError:
+                errors += 1
+                continue
+            if not isinstance(card, dict):
+                errors += 1
+                continue
+            source = card.get("source") if isinstance(card.get("source"), dict) else {}
+            target = card.get("target") if isinstance(card.get("target"), dict) else {}
+            source_path = source.get("path") if isinstance(source.get("path"), str) else None
+            target_path = target.get("path") if isinstance(target.get("path"), str) else None
+            if source_path not in changed_paths and target_path not in changed_paths:
+                continue
+            hints.append({
+                "source": "relation_cards_jsonl",
+                "row": row_number,
+                "relation": card.get("relation"),
+                "source_path": source_path,
+                "target_path": target_path,
+                "evidence": card.get("evidence"),
+                "evidence_level": card.get("evidence_level"),
+                "does_not_establish": card.get("does_not_establish"),
+            })
+            if len(hints) >= max_hits:
+                break
+    gaps: list[dict[str, Any]] = []
+    if errors:
+        gaps.append(_gap("relation_cards_jsonl", "invalid_rows", "some relation-card rows were invalid or too large", severity="warn", invalid_row_count=errors))
+    if scanned_rows > MAX_RELATION_CARD_SCAN_ROWS:
+        gaps.append(_gap("relation_cards_jsonl", "scan_limited", "relation-card scan row limit reached", severity="warn", max_rows=MAX_RELATION_CARD_SCAN_ROWS))
+    if not hints:
+        gaps.append(_gap("relation_cards_jsonl", "empty", "no relation cards matched changed paths", severity="info"))
+    return hints, {
+        "status": "warn" if errors or scanned_rows > MAX_RELATION_CARD_SCAN_ROWS else ("available" if hints else "empty"),
+        "hit_count": len(hints),
+        "invalid_row_count": errors,
+        "scanned_rows": min(scanned_rows, MAX_RELATION_CARD_SCAN_ROWS),
+        "skipped_by_prefilter": skipped_by_prefilter,
+    }, gaps
+
+
+def _symbol_hints(bundle_manifest: str | Path | None, changed_paths: list[str], *, max_hits: int) -> tuple[list[dict[str, Any]], dict[str, Any], list[dict[str, Any]]]:
+    if bundle_manifest is None:
+        return [], {"status": "not_requested", "hit_count": 0}, []
+    hints: list[dict[str, Any]] = []
+    gaps: list[dict[str, Any]] = []
+    seen: set[tuple[str | None, str | None]] = set()
+    for path in changed_paths:
+        if len(hints) >= max_hits:
+            break
+        p = Path(path)
+        queries = []
+        for query in (_path_query(path), p.name, p.stem, _compact(p.stem)):
+            if query and query not in queries:
+                queries.append(query)
+        result: dict[str, Any] | None = None
+        hits: list[Any] = []
+        for query in queries:
+            result = search_symbol_index(bundle_manifest, query, k=min(10, max_hits))
+            if result.get("status") != "available":
+                continue
+            hits = result.get("hits") if isinstance(result.get("hits"), list) else []
+            if hits:
+                break
+        if result is None or result.get("status") != "available":
+            gaps.append(_gap(
+                "python_symbol_index_json",
+                str(None if result is None else result.get("status")),
+                "symbol index query unavailable for changed path",
+                severity="warn" if result is not None and result.get("status") == "invalid" else "info",
+                path=path,
+                error_code=None if result is None else result.get("error_code"),
+            ))
+            continue
+        for hit in hits:
+            if not isinstance(hit, dict):
+                continue
+            key = (hit.get("path"), hit.get("qualified_name"))
+            if key in seen:
+                continue
+            seen.add(key)
+            hints.append({"source": "python_symbol_index_json", "changed_path": path, "symbol": hit})
+            if len(hints) >= max_hits:
+                break
+    if not hints and not gaps:
+        gaps.append(_gap("python_symbol_index_json", "empty", "no symbol hits for changed paths", severity="info"))
+    status = "available" if hints else ("warn" if _has_warn_or_error(gaps) else "empty")
+    return hints, {"status": status, "hit_count": len(hints)}, gaps
+
+
+def _citation_hints(bundle_manifest: str | Path | None, changed_paths: list[str], *, max_hits: int) -> tuple[list[dict[str, Any]], dict[str, Any], list[dict[str, Any]]]:
+    if bundle_manifest is None:
+        return [], {"status": "not_requested", "hit_count": 0}, []
+    hints: list[dict[str, Any]] = []
+    gaps: list[dict[str, Any]] = []
+    for path in changed_paths:
+        if len(hints) >= max_hits:
+            break
+        result = query_existing_index(bundle_manifest, _path_query(path), k=min(5, max_hits), resolve_evidence=True, project_sources=True)
+        if result.get("status") != "available":
+            gaps.append(_gap(
+                "resolved_evidence",
+                str(result.get("status")),
+                "resolved evidence query unavailable for changed path",
+                severity="warn" if result.get("status") == "invalid" else "info",
+                path=path,
+                error_code=result.get("error_code"),
+            ))
+            continue
+        projection = result.get("source_citation_projection") if isinstance(result.get("source_citation_projection"), dict) else {}
+        for item in projection.get("items", []) if isinstance(projection.get("items"), list) else []:
+            if not isinstance(item, dict):
+                continue
+            hints.append({
+                "source": "resolved_evidence",
+                "changed_path": path,
+                "path": item.get("path"),
+                "chunk_id": item.get("chunk_id"),
+                "source_range": item.get("source_range"),
+                "citation_id": item.get("citation_id"),
+                "citation_status": item.get("citation_status"),
+                "text_excerpt": item.get("text_excerpt"),
+                "text_truncated": item.get("text_truncated"),
+            })
+            if len(hints) >= max_hits:
+                break
+    if not hints and not gaps:
+        gaps.append(_gap("resolved_evidence", "empty", "no resolved evidence hits for changed paths", severity="info"))
+    status = "available" if hints else ("warn" if _has_warn_or_error(gaps) else "empty")
+    return hints, {"status": status, "hit_count": len(hints)}, gaps
+
+
+def _select_context(candidates: list[dict[str, Any]], *, budget: int, bytes_per_token: float) -> tuple[list[dict[str, Any]], list[dict[str, Any]], int]:
+    selected: list[dict[str, Any]] = []
+    omitted: list[dict[str, Any]] = []
+    used = 0
+    for candidate in sorted(candidates, key=lambda c: (c.get("priority", 999), c.get("id", ""))):
+        estimate = _estimate_tokens(candidate, bytes_per_token)
+        item = {**candidate, "estimated_tokens": estimate}
+        if used + estimate <= budget:
+            item["selection_status"] = "selected"
+            item["budget_before_tokens"] = used
+            used += estimate
+            item["budget_after_tokens"] = used
+            selected.append(item)
+        else:
+            item["selection_status"] = "omitted"
+            item["omission_reason"] = "estimated_tokens_exceed_remaining_budget"
+            item["budget_remaining_tokens"] = max(budget - used, 0)
+            omitted.append(item)
+    return selected, omitted, used
+
+
+def compile_delta_context(
+    *,
+    diff_path: str | Path | None = None,
+    diff_text: str | None = None,
+    bundle_manifest: str | Path | None = None,
+    task: str = "Review pull request delta",
+    context_budget_tokens: int = DEFAULT_CONTEXT_BUDGET_TOKENS,
+    signal_k: int = 10,
+    context_window_lines: int = 20,
+    bytes_per_token: float = DEFAULT_BYTES_PER_TOKEN,
+) -> dict[str, Any]:
+    if not isinstance(context_budget_tokens, int) or isinstance(context_budget_tokens, bool) or context_budget_tokens < 1:
+        return _invalid_result(error="context_budget_tokens must be a positive integer", error_code="context_budget_invalid", diff_path=diff_path, task=task)
+    if not isinstance(signal_k, int) or isinstance(signal_k, bool) or signal_k < 1 or signal_k > MAX_SIGNAL_HITS:
+        return _invalid_result(error=f"signal_k must be between 1 and {MAX_SIGNAL_HITS}", error_code="signal_k_invalid", diff_path=diff_path, task=task)
+    if not isinstance(context_window_lines, int) or isinstance(context_window_lines, bool) or context_window_lines < 0 or context_window_lines > 200:
+        return _invalid_result(error="context_window_lines must be an integer between 0 and 200", error_code="context_window_invalid", diff_path=diff_path, task=task)
+    if not isinstance(bytes_per_token, (int, float)) or isinstance(bytes_per_token, bool) or bytes_per_token <= 0:
+        return _invalid_result(error="bytes_per_token must be a number greater than 0", error_code="bytes_per_token_invalid", diff_path=diff_path, task=task)
+    bytes_per_token = float(bytes_per_token)
+
+    diff_meta: dict[str, Any]
+    try:
+        if diff_text is None:
+            if diff_path is None:
+                return _invalid_result(error="either diff_path or diff_text is required", error_code="diff_missing", diff_path=diff_path, task=task)
+            diff_text, diff_meta = _load_diff(diff_path)
+        else:
+            diff_meta = {"path": str(diff_path) if diff_path else None, "bytes": len(diff_text.encode("utf-8"))}
+            if diff_meta["bytes"] > MAX_DIFF_BYTES:
+                return _invalid_result(error="diff_text exceeds max bytes", error_code="diff_too_large", diff_path=diff_path, task=task)
+        parsed = parse_unified_diff(diff_text, context_window_lines=context_window_lines)
+    except (OSError, UnicodeError, ValueError, TypeError) as exc:
+        return _invalid_result(error=str(exc), error_code="diff_invalid", diff_path=diff_path, task=task)
+
+    gaps: list[dict[str, Any]] = []
+    if parsed["file_count"] == 0:
+        gaps.append(_gap("diff", "empty", "no changed files parsed from diff", severity="error"))
+
+    bundle_signal, bundle_gaps, bundle_status = _bundle_signals(bundle_manifest)
+    gaps.extend(bundle_gaps)
+    changed_paths = _dedupe_ordered([str(item["path"]) for item in parsed["files"] if isinstance(item.get("path"), str)])
+    changed_path_set = set(changed_paths)
+
+    symbol_hints, symbol_signal, symbol_gaps = _symbol_hints(bundle_manifest, changed_paths, max_hits=signal_k)
+    relation_hints, relation_signal, relation_gaps = _relation_hints(bundle_status, changed_path_set, max_hits=signal_k)
+    citation_hints, citation_signal, citation_gaps = _citation_hints(bundle_manifest, changed_paths, max_hits=signal_k)
+    gaps.extend(symbol_gaps)
+    gaps.extend(relation_gaps)
+    gaps.extend(citation_gaps)
+
+    file_context: list[dict[str, Any]] = []
+    for ordinal, item in enumerate(parsed["files"]):
+        path = str(item["path"])
+        status = str(item.get("change_status"))
+        try:
+            lens_card = produce_lens_card(path)
+        except (TypeError, ValueError) as exc:
+            lens_card = {"status": "unavailable", "reason": str(exc)}
+        file_context.append({
+            "id": f"changed-file:{ordinal}",
+            "priority": 10 + ordinal,
+            "source": "diff",
+            "path": path,
+            "old_path": item.get("old_path"),
+            "new_path": item.get("new_path"),
+            "change_status": status,
+            "hunks": item.get("hunks", []),
+            "hunk_count": item.get("hunk_count", 0),
+            "lens_card": lens_card,
+            "likely_refs": _likely_refs(path, status),
+        })
+
+    candidates: list[dict[str, Any]] = []
+    candidates.extend(file_context)
+    for ordinal, hint in enumerate(citation_hints):
+        candidates.append({"id": f"citation-hint:{ordinal}", "priority": 100 + ordinal, **hint})
+    for ordinal, hint in enumerate(symbol_hints):
+        candidates.append({"id": f"symbol-hint:{ordinal}", "priority": 200 + ordinal, **hint})
+    for ordinal, hint in enumerate(relation_hints):
+        candidates.append({"id": f"relation-hint:{ordinal}", "priority": 250 + ordinal, **hint})
+
+    selected, omitted, used = _select_context(candidates, budget=context_budget_tokens, bytes_per_token=bytes_per_token)
+
+    input_validity = "invalid" if parsed["file_count"] == 0 else "valid"
+    signal_quality = "degraded" if _has_warn_or_error(gaps) else "complete_or_not_requested"
+    context_completeness = "budget_truncated" if omitted else "within_budget"
+    status = "pass"
+    if input_validity == "invalid":
+        status = "invalid"
+    elif signal_quality == "degraded" or context_completeness == "budget_truncated":
+        status = "warn"
+
+    return {
+        "kind": KIND,
+        "version": VERSION,
+        "status": status,
+        "task": task,
+        "diff": {
+            **diff_meta,
+            "file_count": parsed["file_count"],
+            "change_status_counts": parsed["change_status_counts"],
+            "truncated": parsed["truncated"],
+            "context_window_lines": parsed["context_window_lines"],
+        },
+        "bundle_manifest": str(Path(bundle_manifest).expanduser().resolve()) if bundle_manifest is not None else None,
+        "budget": {
+            "context_budget_tokens": context_budget_tokens,
+            "estimated_used_tokens": used,
+            "estimated_remaining_tokens": max(context_budget_tokens - used, 0),
+            "bytes_per_token": bytes_per_token,
+            "exact_tokenizer": False,
+        },
+        "input_validity": input_validity,
+        "signal_quality": signal_quality,
+        "context_completeness": context_completeness,
+        "changed_files": parsed["files"],
+        "review_context": selected,
+        "omitted_context": omitted,
+        "signals": {
+            "bundle": bundle_signal,
+            "python_symbol_index_json": symbol_signal,
+            "relation_cards_jsonl": relation_signal,
+            "resolved_evidence": citation_signal,
+        },
+        "gaps": gaps,
+        "selection_trace": {
+            "ordering": "diff_changed_ranges_then_citation_then_symbol_then_relation_hints",
+            "priority_bands": [
+                {"source": "diff", "priority": "10+"},
+                {"source": "resolved_evidence", "priority": "100+"},
+                {"source": "python_symbol_index_json", "priority": "200+"},
+                {"source": "relation_cards_jsonl", "priority": "250+"},
+            ],
+            "omission_reasons": sorted({item.get("omission_reason") for item in omitted if item.get("omission_reason")}),
+        },
+        "review_boundary": {
+            "context_only": True,
+            "verdict": None,
+            "approval": False,
+            "rejection": False,
+            "merge_authorization": False,
+        },
+        "mutation_boundary": _read_only_boundary(),
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }

--- a/merger/lenskit/tests/test_repobrief_delta_context.py
+++ b/merger/lenskit/tests/test_repobrief_delta_context.py
@@ -1,0 +1,436 @@
+import hashlib
+import json
+from pathlib import Path
+
+from merger.lenskit.cli.main import main
+import merger.lenskit.core.repobrief_delta_context as dc
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _artifact(role: str, path: Path, **extra):
+    return {
+        "role": role,
+        "path": path.name,
+        "content_type": extra.pop("content_type", "application/json"),
+        "bytes": path.stat().st_size,
+        "sha256": _sha256(path),
+        **extra,
+    }
+
+
+def _sample_diff() -> str:
+    return """diff --git a/merger/lenskit/core/example.py b/merger/lenskit/core/example.py
+index 1111111..2222222 100644
+--- a/merger/lenskit/core/example.py
++++ b/merger/lenskit/core/example.py
+@@ -10,3 +10,4 @@ def existing():
+ old = 1
++new = 2
+ keep = 3
+diff --git a/docs/old.md b/docs/new.md
+similarity index 90%
+rename from docs/old.md
+rename to docs/new.md
+--- a/docs/old.md
++++ b/docs/new.md
+@@ -1,2 +1,2 @@
+-old title
++new title
+diff --git a/merger/lenskit/core/added.py b/merger/lenskit/core/added.py
+new file mode 100644
+--- /dev/null
++++ b/merger/lenskit/core/added.py
+@@ -0,0 +1,2 @@
++fresh
++code
+diff --git a/merger/lenskit/core/removed.py b/merger/lenskit/core/removed.py
+deleted file mode 100644
+--- a/merger/lenskit/core/removed.py
++++ /dev/null
+@@ -1,2 +0,0 @@
+-dead
+-code
+"""
+
+
+def _write_bundle(tmp_path: Path) -> Path:
+    from merger.lenskit.retrieval import index_db
+
+    canonical = tmp_path / "brief.md"
+    canonical.write_text(
+        "# Brief\n\nmerger/lenskit/core/example.py defines ExampleCompiler.\n",
+        encoding="utf-8",
+    )
+    content = canonical.read_bytes()
+    start = content.index(b"merger/lenskit/core/example.py")
+    end = len(content)
+    chunk_bytes = content[start:end]
+    chunk = {
+        "chunk_id": "c1",
+        "repo_id": "demo",
+        "path": "merger/lenskit/core/example.py",
+        "content": chunk_bytes.decode("utf-8"),
+        "start_byte": start,
+        "end_byte": end,
+        "start_line": 3,
+        "end_line": 3,
+        "layer": "core",
+        "artifact_type": "code",
+        "content_sha256": _sha256_bytes(chunk_bytes),
+        "content_range_ref": {
+            "artifact_role": "canonical_md",
+            "repo_id": "demo",
+            "file_path": canonical.name,
+            "start_byte": start,
+            "end_byte": end,
+            "start_line": 3,
+            "end_line": 3,
+            "content_sha256": _sha256_bytes(chunk_bytes),
+        },
+    }
+    chunk_path = tmp_path / "chunks.jsonl"
+    chunk_path.write_text(json.dumps(chunk) + "\n", encoding="utf-8")
+    dump_path = tmp_path / "dump.json"
+    dump_path.write_text(json.dumps({"version": "1.0", "repos": {"demo": {}}}), encoding="utf-8")
+    index_path = tmp_path / "demo.index.sqlite"
+    index_db.build_index(dump_path, chunk_path, index_path)
+
+    agent_pack = tmp_path / "agent.md"
+    agent_pack.write_text("# Agent Pack\n", encoding="utf-8")
+    symbol_index = tmp_path / "symbols.json"
+    symbol_index.write_text(
+        json.dumps(
+            {
+                "kind": "lenskit.python_symbol_index",
+                "version": "1.0",
+                "run_id": "run-1",
+                "canonical_dump_index_sha256": "a" * 64,
+                "language": "python",
+                "symbol_kinds": ["class", "function", "async_function"],
+                "symbols": [
+                    {
+                        "id": "py:merger/lenskit/core/example.py:class:ExampleCompiler",
+                        "kind": "class",
+                        "name": "ExampleCompiler",
+                        "qualified_name": "ExampleCompiler",
+                        "module": "merger.lenskit.core.example",
+                        "path": "merger/lenskit/core/example.py",
+                        "start_line": 10,
+                        "end_line": 20,
+                        "range_ref": "file:merger/lenskit/core/example.py#L10-L20",
+                    }
+                ],
+                "skipped_files_count": 0,
+                "skipped_errors": [],
+                "does_not_establish": [
+                    "call_graph_completeness",
+                    "dependency_completeness",
+                    "runtime_behavior",
+                    "import_success",
+                    "test_sufficiency",
+                    "review_impact",
+                    "merge_readiness",
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    relation_cards = tmp_path / "relations.jsonl"
+    relation_cards.write_text(
+        json.dumps(
+            {
+                "kind": "lenskit.relation_card",
+                "version": "1.0",
+                "relation": "imports",
+                "source": {"kind": "repo_path", "path": "merger/lenskit/core/example.py"},
+                "target": {"kind": "repo_path", "path": "merger/lenskit/tests/test_example.py"},
+                "evidence": {"source_path": "merger/lenskit/core/example.py", "start_line": 1, "end_line": 1},
+                "evidence_level": "S1",
+                "does_not_establish": ["runtime_dependency", "causality"],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    manifest = tmp_path / "bundle.manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "kind": "repolens.bundle.manifest",
+                "version": "1.0",
+                "run_id": "run-1",
+                "created_at": "2026-07-08T10:00:00Z",
+                "artifacts": [
+                    _artifact("canonical_md", canonical, content_type="text/markdown"),
+                    _artifact("agent_reading_pack", agent_pack, content_type="text/markdown"),
+                    _artifact("chunk_index_jsonl", chunk_path, content_type="application/x-ndjson"),
+                    _artifact("sqlite_index", index_path, content_type="application/vnd.sqlite3"),
+                    _artifact("python_symbol_index_json", symbol_index),
+                    _artifact("relation_cards_jsonl", relation_cards, content_type="application/x-ndjson"),
+                ],
+                "links": {},
+                "capabilities": {"repobrief_profile": "agent-portable"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def test_parse_unified_diff_extracts_changed_ranges_and_surrounding_context():
+    parsed = dc.parse_unified_diff(_sample_diff(), context_window_lines=5)
+
+    assert parsed["file_count"] == 4
+    assert parsed["change_status_counts"] == {"modified": 1, "renamed": 1, "added": 1, "deleted": 1}
+    first = parsed["files"][0]
+    assert first["path"] == "merger/lenskit/core/example.py"
+    assert first["hunks"][0]["new_range"] == {"start_line": 10, "end_line": 13, "line_count": 4, "empty": False, "basis": "new"}
+    assert first["hunks"][0]["surrounding_range"]["start_line"] == 5
+    added = parsed["files"][2]
+    assert added["change_status"] == "added"
+    assert added["hunks"][0]["changed_range"]["basis"] == "new"
+    deleted = parsed["files"][3]
+    assert deleted["change_status"] == "deleted"
+    assert deleted["hunks"][0]["changed_range"]["basis"] == "old"
+
+
+def test_compile_delta_context_without_bundle_is_context_only_and_passes_with_info_gap(tmp_path):
+    diff = tmp_path / "change.diff"
+    diff.write_text(_sample_diff(), encoding="utf-8")
+
+    result = dc.compile_delta_context(diff_path=diff, context_budget_tokens=5000)
+
+    assert result["kind"] == "repobrief.delta_context_compiler"
+    assert result["status"] == "pass"
+    assert result["input_validity"] == "valid"
+    assert result["signal_quality"] == "complete_or_not_requested"
+    assert result["context_completeness"] == "within_budget"
+    assert result["diff"]["file_count"] == 4
+    assert result["signals"]["bundle"]["status"] == "not_requested"
+    assert any(gap["source"] == "bundle_manifest" and gap["severity"] == "info" for gap in result["gaps"])
+    assert result["review_boundary"] == {
+        "context_only": True,
+        "verdict": None,
+        "approval": False,
+        "rejection": False,
+        "merge_authorization": False,
+    }
+    assert result["mutation_boundary"]["writes"] == []
+    assert "merge_readiness" in result["does_not_establish"]
+    assert any(item["source"] == "diff" for item in result["review_context"])
+
+
+def test_compile_delta_context_uses_optional_bundle_signals(tmp_path):
+    diff = tmp_path / "change.diff"
+    diff.write_text(_sample_diff(), encoding="utf-8")
+    manifest = _write_bundle(tmp_path)
+
+    result = dc.compile_delta_context(
+        diff_path=diff,
+        bundle_manifest=manifest,
+        context_budget_tokens=5000,
+        signal_k=5,
+    )
+
+    assert result["status"] in {"pass", "warn"}
+    assert result["signals"]["bundle"]["status"] == "ok"
+    assert result["signals"]["python_symbol_index_json"]["hit_count"] >= 1
+    assert result["signals"]["relation_cards_jsonl"]["hit_count"] == 1
+    assert result["signals"]["resolved_evidence"]["hit_count"] >= 1
+    assert any(gap["source"] == "freshness" for gap in result["gaps"])
+    assert any(gap["source"] == "graph_availability" for gap in result["gaps"])
+    sources = {item["source"] for item in result["review_context"]}
+    assert {"diff", "python_symbol_index_json", "relation_cards_jsonl", "resolved_evidence"}.issubset(sources)
+    assert result["review_boundary"]["verdict"] is None
+
+
+def test_compile_delta_context_small_budget_omits_context(tmp_path):
+    diff = tmp_path / "change.diff"
+    diff.write_text(_sample_diff(), encoding="utf-8")
+
+    result = dc.compile_delta_context(diff_path=diff, context_budget_tokens=20)
+
+    assert result["status"] == "warn"
+    assert result["omitted_context"]
+    assert "estimated_tokens_exceed_remaining_budget" in result["selection_trace"]["omission_reasons"]
+
+
+def test_compile_delta_context_invalid_empty_diff_fails(tmp_path):
+    diff = tmp_path / "empty.diff"
+    diff.write_text("not a unified diff\n", encoding="utf-8")
+
+    result = dc.compile_delta_context(diff_path=diff)
+
+    assert result["status"] == "invalid"
+    assert result["input_validity"] == "invalid"
+    assert result["changed_files"] == []
+    assert any(gap["source"] == "diff" and gap["severity"] == "error" for gap in result["gaps"])
+
+
+def test_delta_context_cli_outputs_json(tmp_path, capsys):
+    diff = tmp_path / "change.diff"
+    diff.write_text(_sample_diff(), encoding="utf-8")
+
+    rc = main([
+        "repobrief",
+        "delta-context",
+        "compile",
+        "--diff",
+        str(diff),
+        "--context-budget",
+        "500",
+    ])
+
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert out["kind"] == "repobrief.delta_context_compiler"
+    assert out["review_boundary"]["approval"] is False
+
+
+
+def test_compile_delta_context_empty_optional_signal_hits_do_not_warn(tmp_path):
+    diff = tmp_path / "doc.diff"
+    diff.write_text(
+        """diff --git a/docs/guide.md b/docs/guide.md
+--- a/docs/guide.md
++++ b/docs/guide.md
+@@ -1,1 +1,2 @@
+ title
++more
+""",
+        encoding="utf-8",
+    )
+    manifest = _write_bundle(tmp_path)
+
+    result = dc.compile_delta_context(
+        diff_path=diff,
+        bundle_manifest=manifest,
+        context_budget_tokens=500,
+    )
+
+    assert result["input_validity"] == "valid"
+    # The synthetic bundle has degraded availability, so the overall result may warn,
+    # but empty symbol/relation/evidence searches are informational only.
+    empty_optional = [
+        gap for gap in result["gaps"]
+        if gap["source"] in {"python_symbol_index_json", "relation_cards_jsonl", "resolved_evidence"}
+        and gap["status"] == "empty"
+    ]
+    assert empty_optional
+    assert all(gap["severity"] == "info" for gap in empty_optional)
+    assert result["signals"]["python_symbol_index_json"]["status"] in {"empty", "available"}
+
+
+def test_likely_refs_for_nested_test_path_points_outside_test_file(tmp_path):
+    diff = tmp_path / "test.diff"
+    diff.write_text(
+        """diff --git a/merger/lenskit/tests/test_example.py b/merger/lenskit/tests/test_example.py
+--- a/merger/lenskit/tests/test_example.py
++++ b/merger/lenskit/tests/test_example.py
+@@ -1,1 +1,2 @@
+ def test_example(): pass
++def test_more(): pass
+""",
+        encoding="utf-8",
+    )
+
+    result = dc.compile_delta_context(diff_path=diff)
+    file_item = result["review_context"][0]
+    hints = {item["path_hint"] for item in file_item["likely_refs"] if item["kind"] == "implementation_candidate"}
+
+    assert "merger/lenskit/tests/test_example.py" not in hints
+    assert "merger/lenskit/core/example.py" in hints
+    assert "example.py" in hints
+
+
+def test_parse_unified_diff_supports_no_prefix_and_binary_file():
+    parsed = dc.parse_unified_diff(
+        """diff --git src/a.py src/a.py
+--- src/a.py
++++ src/a.py
+@@ -1 +1 @@
+-old
++new
+diff --git assets/logo.png assets/logo.png
+Binary files assets/logo.png and assets/logo.png differ
+""",
+        context_window_lines=0,
+    )
+
+    assert parsed["file_count"] == 2
+    assert parsed["files"][0]["path"] == "src/a.py"
+    assert parsed["files"][0]["hunk_count"] == 1
+    assert parsed["files"][1]["path"] == "assets/logo.png"
+    assert parsed["files"][1]["hunk_count"] == 0
+    assert parsed["files"][1]["binary"] is True
+
+
+
+def test_changed_path_signal_queries_are_deduplicated(monkeypatch, tmp_path):
+    diff = tmp_path / "dup.diff"
+    diff.write_text(
+        """diff --git a/src/a.py b/src/a.py
+--- a/src/a.py
++++ b/src/a.py
+@@ -1 +1 @@
+-old
++new
+diff --git a/src/a.py b/src/a.py
+--- a/src/a.py
++++ b/src/a.py
+@@ -3 +3 @@
+-old2
++new2
+""",
+        encoding="utf-8",
+    )
+    manifest = _write_bundle(tmp_path)
+    calls = []
+
+    def fake_symbol_search(bundle_manifest, query, *, k=25, kind=None, path=None):
+        calls.append(query)
+        return {"status": "available", "hit_count": 0, "hits": []}
+
+    monkeypatch.setattr(dc, "search_symbol_index", fake_symbol_search)
+    result = dc.compile_delta_context(diff_path=diff, bundle_manifest=manifest, context_budget_tokens=5000)
+
+    assert result["diff"]["file_count"] == 2
+    assert calls.count("src/a.py a.py a") <= 1
+    assert len({tuple(call for call in calls)}) == 1
+
+def test_relation_card_scan_is_lazy_and_reports_invalid_rows(tmp_path):
+    diff = tmp_path / "change.diff"
+    diff.write_text(_sample_diff(), encoding="utf-8")
+    manifest = _write_bundle(tmp_path)
+    manifest_data = json.loads(manifest.read_text(encoding="utf-8"))
+    relation_artifact = next(item for item in manifest_data["artifacts"] if item["role"] == "relation_cards_jsonl")
+    relation_path = tmp_path / relation_artifact["path"]
+    relation_path.write_text(
+        '{not json but mentions merger/lenskit/core/example.py}\n'
+        + json.dumps(
+            {
+                "kind": "lenskit.relation_card",
+                "source": {"kind": "repo_path", "path": "merger/lenskit/core/example.py"},
+                "target": {"kind": "repo_path", "path": "merger/lenskit/tests/test_example.py"},
+                "relation": "imports",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    relation_artifact["bytes"] = relation_path.stat().st_size
+    relation_artifact["sha256"] = _sha256(relation_path)
+    manifest.write_text(json.dumps(manifest_data), encoding="utf-8")
+
+    result = dc.compile_delta_context(diff_path=diff, bundle_manifest=manifest, context_budget_tokens=5000)
+
+    assert result["signals"]["relation_cards_jsonl"]["status"] == "warn"
+    assert result["signals"]["relation_cards_jsonl"]["invalid_row_count"] == 1
+    assert any(gap["source"] == "relation_cards_jsonl" and gap["severity"] == "warn" for gap in result["gaps"])


### PR DESCRIPTION
Implements Bureau task RPU-V1-T005 — Delta-Lens PR context compiler.

Scope:
- adds read-only core surface repobrief.delta_context_compiler
- adds CLI: repobrief delta-context compile
- parses unified git diffs into changed files, hunk ranges and surrounding ranges
- works without a full RepoBrief bundle and reports bundle absence as an informational gap
- optionally enriches review context with python_symbol_index_json, relation_cards_jsonl and resolved evidence from an existing bundle
- emits review_context, omitted_context, gaps, signals, selection_trace and explicit non-verdict review_boundary
- emits separated dimensions: input_validity, signal_quality and context_completeness
- adds proof doc: docs/proofs/repobrief-delta-context-compiler-v1-proof.md

Self/external review fixes included:
- optional empty symbol/relation/resolved-evidence hits are informational and do not toxically warn by themselves
- empty/non-diff input is classified as status=invalid with input_validity=invalid
- bundle freshness/availability and graph degradations are explicit gaps with severity
- changed_paths are deduplicated before expensive symbol/resolved-evidence lookups
- relation_cards_jsonl is scanned lazily with artifact-size, line-size and row-count limits
- relation rows are prefiltered by changed path before JSON parsing
- nested test paths no longer point back to the same test file as implementation_candidate
- parser test coverage now includes modified, added, renamed, deleted, binary and no-prefix diffs
- token estimation no longer json.dumps-es every candidate; it uses a simple recursive rough-size estimator
- PR bot review fixed: test module now uses a single module-import style

Validation:
- python3 -m pytest -q merger/lenskit/tests/test_repobrief_delta_context.py merger/lenskit/tests/test_repobrief_context_compiler.py merger/lenskit/tests/test_token_budget_report.py merger/lenskit/tests/test_repobrief_symbol_index_consumer.py merger/lenskit/tests/test_relation_cards.py merger/lenskit/tests/test_relation_card_validate.py merger/lenskit/tests/test_pr_delta_cards.py merger/lenskit/tests/test_pr_delta_card_validate.py merger/lenskit/tests/test_pr_schau_delta_schema.py merger/lenskit/tests/test_repobrief_resolved_evidence_query.py merger/lenskit/tests/test_repobrief_source_citation_projection.py merger/lenskit/tests/test_repobrief_access_boundary.py merger/lenskit/tests/test_repobrief_snapshot_cli.py merger/lenskit/tests/test_repobrief_latest_complete.py merger/lenskit/tests/test_repobrief_profiles.py merger/lenskit/tests/test_external_manifest_reference.py merger/lenskit/tests/test_repobrief_preflight.py -> 298 passed
- python3 -m ruff check --config ruff-ci.toml merger/lenskit/core/repobrief_delta_context.py merger/lenskit/cli/cmd_repobrief.py merger/lenskit/tests/test_repobrief_delta_context.py -> pass
- python3 -m scripts.docmeta.check_planning_registration --baseline docs/tasks/planning-registration-baseline.json --ratchet --format human -> no new drift
- python3 -m merger.lenskit.cli.main doc-freshness inspect -> PASS
- git diff --check -> pass
- CLI help smoke for repobrief delta-context compile -> pass

Boundary / non-claims:
- Does not establish review verdict, approval, rejection, merge readiness, correctness, test sufficiency, regression absence, runtime behavior, security correctness, risk score, blast-radius completeness, all relevant context used, repo understanding or claims truth.
- Does not apply patches, inspect/mutate working trees, run Git, create/update PRs, refresh/create RepoBrief bundles, update latest-complete registries, or run tests/shell commands on target code.

External review gate:
- Do not merge until the updated diff has been reviewed/accepted.
- Head: `3eb3ff169cf966cda17ab5f225aaf654b582105b`
- Diff SHA256: `27a04f5c05b007cc4347d8251037883d7784fc5a07f748c253f6e24ab6ee2fa6`
