### PR TITLE
feat(repobrief): add review coverage report

### DIFF
--- a/docs/proofs/repobrief-review-coverage-v1-proof.md
+++ b/docs/proofs/repobrief-review-coverage-v1-proof.md
@@ -1,0 +1,101 @@
+# RepoBrief Review Coverage v1 proof
+
+Task: `RPU-V1-T006`
+
+Status: implementation proof for a proof-of-reading coverage report over RepoBrief delta-context output and review artifacts.
+
+## Implemented surface
+
+This slice adds:
+
+```text
+repobrief.review_coverage
+```
+
+and the CLI command:
+
+```bash
+python -m merger.lenskit.cli.main repobrief review-coverage compile \
+  --delta-context <delta-context.json> \
+  --review <review.md-or-json> \
+  [--min-range-coverage 0.6] \
+  [--policy-name advisory]
+```
+
+## Input model
+
+The report reads:
+
+1. a `repobrief.delta_context_compiler` JSON object, normally produced by `repobrief delta-context compile`;
+2. a review artifact, either text/Markdown or JSON.
+
+Delta-context `changed_files[*].hunks[*].changed_range` entries become task-relevant line ranges. Changed files without hunks, for example binary files, become file-level relevant ranges.
+
+Review citations are extracted from:
+
+- text forms such as `path#L10-L13`, `path:L10-L13`, `path:10-13`, and `path lines 10-13`, including root-level files such as `README.md#L1-L3`;
+- JSON objects containing `path`/`file_path`/`source_path` plus `start_line`/`end_line`, `line_range`, `range`, or nested `source_range`;
+- file mentions for file-level relevant ranges only.
+
+A file-only citation or mention does not cover a concrete line range.
+
+## Output contract
+
+The report emits:
+
+- `coverage`: totals and ratios for cited vs relevant ranges and cited line intersections;
+- `relevant_ranges`: all changed/task-relevant ranges considered;
+- `cited_ranges`: relevant ranges with matching citations;
+- `uncovered_ranges`: relevant ranges without matching citations;
+- `citations`: extracted line citations and file mentions;
+- `thresholds`: advisory configurable thresholds;
+- `bureau_evidence`: explicit evidence-only boundary for later Bureau consumption;
+- `mutation_boundary`: explicit read-only boundary.
+
+## Threshold semantics
+
+Thresholds are configurable and advisory by default. A below-threshold report may return `status: warn`, but this is not a merge gate by itself. Gating requires an external Bureau/CI policy that explicitly chooses to consume this report.
+
+## Read-only boundary
+
+The report must not:
+
+- mutate Git;
+- mutate pull requests;
+- mutate patches;
+- inspect or mutate the source working tree;
+- refresh or create RepoBrief bundle artifacts;
+- update Bureau registry state;
+- approve, reject, score or authorize a merge.
+
+## Validation scope
+
+Tests cover:
+
+- text citation extraction and uncovered range reporting;
+- threshold-met and below-threshold behavior;
+- JSON `source_range` / `line_range` citation extraction;
+- no-citation warning behavior;
+- invalid delta-context handling;
+- invalid threshold rejection;
+- file-only citation not covering concrete line ranges;
+- root-level file citations;
+- parent `path` plus nested `source_range` JSON citations;
+- partial line-intersection accounting so one cited line does not count an entire large hunk;
+- CLI JSON output and advisory warning exit behavior.
+
+## Non-claims
+
+The review coverage report does not establish:
+
+- review correctness;
+- review completeness;
+- test sufficiency;
+- security correctness;
+- runtime behavior;
+- regression absence;
+- merge readiness;
+- approval or rejection;
+- risk score;
+- all relevant context used;
+- claims truth.

--- a/merger/lenskit/cli/cmd_repobrief.py
+++ b/merger/lenskit/cli/cmd_repobrief.py
@@ -358,6 +358,24 @@ def register_repobrief_command_groups(repobrief_parser: argparse.ArgumentParser)
     delta_context_compile.add_argument("--bytes-per-token", type=float, default=4.0, help="Byte divisor used for rough token estimate")
     delta_context_compile.add_argument("--strict", action="store_true", help="Treat warn status as exit code 1")
 
+    review_coverage_parser = repobrief_subparsers.add_parser(
+        "review-coverage",
+        help="Measure proof-of-reading citation coverage for delta reviews",
+    )
+    review_coverage_subparsers = review_coverage_parser.add_subparsers(
+        dest="review_coverage_cmd",
+        required=True,
+        help="Review-coverage commands",
+    )
+    review_coverage_compile = review_coverage_subparsers.add_parser(
+        "compile",
+        help="Compare a delta-context report with citations in a review artifact",
+    )
+    review_coverage_compile.add_argument("--delta-context", required=True, help="Path to a repobrief delta-context JSON report")
+    review_coverage_compile.add_argument("--review", required=True, help="Path to review text or JSON")
+    review_coverage_compile.add_argument("--min-range-coverage", type=float, default=0.6, help="Advisory minimum covered relevant range ratio")
+    review_coverage_compile.add_argument("--policy-name", default="advisory", help="Label for the advisory threshold policy")
+
     external_parser = repobrief_subparsers.add_parser(
         "external-manifest",
         help="Write bounded external manifest references from existing bundle manifests",
@@ -492,6 +510,8 @@ def run_repobrief(args: argparse.Namespace) -> int:
         return run_context_compile(args)
     if args.repobrief_cmd == "delta-context" and args.delta_context_cmd == "compile":
         return run_delta_context_compile(args)
+    if args.repobrief_cmd == "review-coverage" and args.review_coverage_cmd == "compile":
+        return run_review_coverage_compile(args)
     if args.repobrief_cmd == "external-manifest" and args.external_manifest_cmd == "write":
         return run_external_manifest_write(args)
     if args.repobrief_cmd == "external-manifest" and args.external_manifest_cmd == "publish":
@@ -766,6 +786,19 @@ def run_symbol_search(args: argparse.Namespace) -> int:
         return 2
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0 if result.get("status") == "available" else 1
+
+
+def run_review_coverage_compile(args: argparse.Namespace) -> int:
+    from merger.lenskit.core.repobrief_review_coverage import compile_review_coverage
+
+    result = compile_review_coverage(
+        delta_context_path=args.delta_context,
+        review_path=args.review,
+        min_range_coverage=args.min_range_coverage,
+        policy_name=args.policy_name,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 1 if result.get("status") == "invalid" else 0
 
 
 def run_delta_context_compile(args: argparse.Namespace) -> int:

--- a/merger/lenskit/core/repobrief_review_coverage.py
+++ b/merger/lenskit/core/repobrief_review_coverage.py
@@ -1,0 +1,509 @@
+"""Proof-of-reading coverage for RepoBrief delta reviews.
+
+This module compares task/PR-relevant ranges from a delta-context report with
+ranges cited in a review artifact. It measures citation coverage only. It does
+not evaluate review correctness, quality, approval, risk or merge readiness.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+KIND = "repobrief.review_coverage"
+VERSION = "v1"
+MAX_REVIEW_BYTES = 2_000_000
+MAX_DELTA_CONTEXT_BYTES = 5_000_000
+DEFAULT_MIN_RANGE_COVERAGE = 0.6
+
+DOES_NOT_ESTABLISH = (
+    "review_correctness",
+    "review_completeness",
+    "test_sufficiency",
+    "security_correctness",
+    "runtime_behavior",
+    "regression_absence",
+    "merge_readiness",
+    "approval",
+    "rejection",
+    "risk_score",
+    "all_relevant_context_used",
+    "claims_true",
+)
+
+_LINE_CITATION_RE = re.compile(
+    r"(?P<path>(?:(?:[A-Za-z0-9_.-]+/)+)?[A-Za-z0-9_.-]+)"
+    r"(?:#L|:L|:|\s+lines?\s+)"
+    r"(?P<start>\d+)"
+    r"(?:\s*-\s*(?:L)?(?P<end>\d+))?"
+)
+
+
+def _read_only_boundary() -> dict[str, Any]:
+    return {
+        "writes": [],
+        "does_not_mutate": [
+            "git",
+            "pull_requests",
+            "patches",
+            "source_working_tree",
+            "brief_bundle_artifacts",
+            "bureau_registry",
+        ],
+        "read_paths_do_not_refresh": True,
+    }
+
+
+def _invalid_result(*, error: str, error_code: str) -> dict[str, Any]:
+    return {
+        "kind": KIND,
+        "version": VERSION,
+        "status": "invalid",
+        "error": error,
+        "error_code": error_code,
+        "coverage": {},
+        "uncovered_ranges": [],
+        "cited_ranges": [],
+        "citations": [],
+        "thresholds": {},
+        "bureau_evidence": _bureau_evidence_boundary(),
+        "mutation_boundary": _read_only_boundary(),
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }
+
+
+def _bureau_evidence_boundary() -> dict[str, Any]:
+    return {
+        "role": "evidence_signal",
+        "consumer": "bureau",
+        "advisory_by_default": True,
+        "requires_external_policy_to_gate": True,
+        "does_not_authorize_merge": True,
+        "does_not_close_tasks_by_itself": True,
+    }
+
+
+def _safe_path(raw: Any) -> str | None:
+    if not isinstance(raw, str):
+        return None
+    path = raw.strip()
+    if not path or path == "/dev/null":
+        return None
+    if path.startswith("a/") or path.startswith("b/"):
+        path = path[2:]
+    if path.startswith("/") or "\\" in path or "//" in path or path.endswith("/"):
+        return None
+    parts = path.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        return None
+    return path
+
+
+def _as_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+    return None
+
+
+def _normalize_range(
+    *,
+    path: Any,
+    start_line: Any = None,
+    end_line: Any = None,
+    range_id: str,
+    source: str,
+    basis: str | None = None,
+    range_kind: str = "line_range",
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    safe_path = _safe_path(path)
+    if safe_path is None:
+        return None
+    start = _as_int(start_line)
+    end = _as_int(end_line)
+    if start is None and end is None:
+        return {
+            "id": range_id,
+            "source": source,
+            "path": safe_path,
+            "range_kind": "file",
+            "start_line": None,
+            "end_line": None,
+            "basis": basis,
+            "metadata": metadata or {},
+        }
+    if start is None:
+        start = end
+    if end is None:
+        end = start
+    if start is None or end is None or start < 0 or end < 0:
+        return None
+    if end < start:
+        start, end = end, start
+    return {
+        "id": range_id,
+        "source": source,
+        "path": safe_path,
+        "range_kind": range_kind,
+        "start_line": start,
+        "end_line": end,
+        "basis": basis,
+        "metadata": metadata or {},
+    }
+
+
+def _range_overlap(a: Mapping[str, Any], b: Mapping[str, Any]) -> bool:
+    if a.get("path") != b.get("path"):
+        return False
+    if a.get("range_kind") == "file":
+        return True
+    if b.get("range_kind") == "file":
+        return False
+    a_start = _as_int(a.get("start_line"))
+    a_end = _as_int(a.get("end_line"))
+    b_start = _as_int(b.get("start_line"))
+    b_end = _as_int(b.get("end_line"))
+    if None in {a_start, a_end, b_start, b_end}:
+        return False
+    return not (a_end < b_start or b_end < a_start)
+
+
+def _range_line_count(item: Mapping[str, Any]) -> int:
+    if item.get("range_kind") == "file":
+        return 0
+    start = _as_int(item.get("start_line"))
+    end = _as_int(item.get("end_line"))
+    if start is None or end is None or end < start:
+        return 0
+    return end - start + 1
+
+
+def _load_json_file(path: str | Path, *, max_bytes: int) -> tuple[dict[str, Any] | None, str | None]:
+    p = Path(path).expanduser().resolve()
+    if not p.is_file():
+        return None, f"file not found: {p}"
+    size = p.stat().st_size
+    if size > max_bytes:
+        return None, f"file exceeds max bytes: {size} > {max_bytes}"
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, ValueError) as exc:
+        return None, str(exc)
+    if not isinstance(data, dict):
+        return None, "json root must be an object"
+    return data, None
+
+
+def _load_review_payload(path: str | Path) -> tuple[str, Any, str | None]:
+    p = Path(path).expanduser().resolve()
+    if not p.is_file():
+        return "", None, f"file not found: {p}"
+    size = p.stat().st_size
+    if size > MAX_REVIEW_BYTES:
+        return "", None, f"review file exceeds max bytes: {size} > {MAX_REVIEW_BYTES}"
+    try:
+        text = p.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        return "", None, str(exc)
+    parsed: Any = None
+    try:
+        parsed = json.loads(text)
+    except ValueError:
+        parsed = None
+    return text, parsed, None
+
+
+def _target_ranges_from_delta_context(delta_context: Mapping[str, Any]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    ranges: list[dict[str, Any]] = []
+    gaps: list[dict[str, Any]] = []
+    files = delta_context.get("changed_files")
+    if not isinstance(files, list):
+        return [], [{"source": "delta_context", "status": "invalid", "severity": "error", "reason": "changed_files missing or not a list"}]
+    for file_index, file_item in enumerate(files):
+        if not isinstance(file_item, dict):
+            gaps.append({"source": "delta_context", "status": "invalid_file", "severity": "warn", "index": file_index})
+            continue
+        path = file_item.get("path")
+        hunks = file_item.get("hunks")
+        if isinstance(hunks, list) and hunks:
+            for hunk_index, hunk in enumerate(hunks):
+                if not isinstance(hunk, dict):
+                    continue
+                changed = hunk.get("changed_range") if isinstance(hunk.get("changed_range"), dict) else {}
+                item = _normalize_range(
+                    path=path,
+                    start_line=changed.get("start_line"),
+                    end_line=changed.get("end_line"),
+                    basis=changed.get("basis") if isinstance(changed.get("basis"), str) else None,
+                    range_id=f"delta:{file_index}:{hunk_index}",
+                    source="delta_context.changed_range",
+                    metadata={
+                        "change_status": file_item.get("change_status"),
+                        "hunk_header": hunk.get("header"),
+                        "binary": file_item.get("binary"),
+                    },
+                )
+                if item is not None:
+                    ranges.append(item)
+        else:
+            item = _normalize_range(
+                path=path,
+                range_id=f"delta:{file_index}:file",
+                source="delta_context.file",
+                range_kind="file",
+                metadata={
+                    "change_status": file_item.get("change_status"),
+                    "binary": file_item.get("binary"),
+                    "reason": "file-level delta without line hunks",
+                },
+            )
+            if item is not None:
+                ranges.append(item)
+    if not ranges:
+        gaps.append({"source": "delta_context", "status": "empty", "severity": "error", "reason": "no reviewable ranges found"})
+    return ranges, gaps
+
+
+def _range_from_dict(obj: Mapping[str, Any], *, source: str, range_id: str) -> dict[str, Any] | None:
+    path = obj.get("path") or obj.get("file_path") or obj.get("source_path") or obj.get("changed_path")
+    start = obj.get("start_line")
+    end = obj.get("end_line")
+    line_range = obj.get("line_range") or obj.get("range") or obj.get("source_range")
+    if (start is None or end is None) and isinstance(line_range, dict):
+        start = line_range.get("start_line") or line_range.get("start")
+        end = line_range.get("end_line") or line_range.get("end")
+    if (start is None or end is None) and isinstance(line_range, list) and len(line_range) >= 2:
+        start = line_range[0]
+        end = line_range[1]
+    if (start is None or end is None) and isinstance(line_range, str):
+        match = re.search(r"L?(\d+)\s*-\s*L?(\d+)", line_range)
+        if match:
+            start = match.group(1)
+            end = match.group(2)
+    return _normalize_range(path=path, start_line=start, end_line=end, range_id=range_id, source=source)
+
+
+def _walk_json_citations(value: Any, *, citations: list[dict[str, Any]], seen: set[tuple[Any, ...]], prefix: str) -> None:
+    if isinstance(value, Mapping):
+        source_range = value.get("source_range") if isinstance(value.get("source_range"), Mapping) else None
+        if source_range is not None:
+            _walk_json_citations(source_range, citations=citations, seen=seen, prefix=f"{prefix}.source_range")
+        item = _range_from_dict(value, source="review_json", range_id=f"review-json:{len(citations)}")
+        if item is not None:
+            key = (item.get("path"), item.get("start_line"), item.get("end_line"), item.get("range_kind"))
+            if key not in seen:
+                seen.add(key)
+                citations.append(item)
+        for child in value.values():
+            _walk_json_citations(child, citations=citations, seen=seen, prefix=prefix)
+    elif isinstance(value, list):
+        for child in value:
+            _walk_json_citations(child, citations=citations, seen=seen, prefix=prefix)
+
+
+def _text_line_citations(text: str) -> list[dict[str, Any]]:
+    citations: list[dict[str, Any]] = []
+    seen: set[tuple[Any, ...]] = set()
+    for match in _LINE_CITATION_RE.finditer(text):
+        item = _normalize_range(
+            path=match.group("path"),
+            start_line=match.group("start"),
+            end_line=match.group("end") or match.group("start"),
+            range_id=f"review-text:{len(citations)}",
+            source="review_text",
+        )
+        if item is None:
+            continue
+        key = (item.get("path"), item.get("start_line"), item.get("end_line"))
+        if key in seen:
+            continue
+        seen.add(key)
+        citations.append(item)
+    return citations
+
+
+def _file_mentions(text: str, target_paths: Iterable[str]) -> list[dict[str, Any]]:
+    mentions: list[dict[str, Any]] = []
+    for path in sorted(set(target_paths)):
+        if path and path in text:
+            item = _normalize_range(path=path, range_id=f"review-file:{len(mentions)}", source="review_text_file_mention")
+            if item is not None:
+                mentions.append(item)
+    return mentions
+
+
+def extract_review_citations(review_text: str, review_json: Any, *, target_paths: Iterable[str] = ()) -> dict[str, Any]:
+    citations = _text_line_citations(review_text)
+    seen = {(item.get("path"), item.get("start_line"), item.get("end_line"), item.get("range_kind")) for item in citations}
+    if review_json is not None:
+        _walk_json_citations(review_json, citations=citations, seen=seen, prefix="review")
+    mentions = _file_mentions(review_text, target_paths)
+    return {
+        "line_citations": citations,
+        "file_mentions": mentions,
+        "citation_count": len(citations),
+        "file_mention_count": len(mentions),
+    }
+
+
+def _cited_line_intersection_count(target: Mapping[str, Any], citations: list[dict[str, Any]]) -> int:
+    if target.get("range_kind") == "file":
+        return 0
+    target_start = _as_int(target.get("start_line"))
+    target_end = _as_int(target.get("end_line"))
+    if target_start is None or target_end is None:
+        return 0
+    intervals: list[tuple[int, int]] = []
+    for citation in citations:
+        if citation.get("path") != target.get("path") or citation.get("range_kind") == "file":
+            continue
+        citation_start = _as_int(citation.get("start_line"))
+        citation_end = _as_int(citation.get("end_line"))
+        if citation_start is None or citation_end is None:
+            continue
+        start = max(target_start, citation_start)
+        end = min(target_end, citation_end)
+        if end >= start:
+            intervals.append((start, end))
+    if not intervals:
+        return 0
+    intervals.sort()
+    merged: list[tuple[int, int]] = []
+    for start, end in intervals:
+        if not merged or start > merged[-1][1] + 1:
+            merged.append((start, end))
+        else:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+    return sum(end - start + 1 for start, end in merged)
+
+
+def _coverage_for_ranges(target_ranges: list[dict[str, Any]], citations: list[dict[str, Any]], file_mentions: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]], dict[str, Any]]:
+    covered: list[dict[str, Any]] = []
+    uncovered: list[dict[str, Any]] = []
+    cited_lines = 0
+    total_lines = 0
+    for target in target_ranges:
+        matches = [citation for citation in citations if _range_overlap(target, citation)]
+        mention_matches = [mention for mention in file_mentions if mention.get("path") == target.get("path")]
+        line_count = _range_line_count(target)
+        cited_line_count = _cited_line_intersection_count(target, matches)
+        total_lines += line_count
+        if matches or (target.get("range_kind") == "file" and mention_matches):
+            item = {
+                **target,
+                "coverage_status": "covered",
+                "matching_citations": matches,
+                "matching_file_mentions": mention_matches,
+                "cited_line_count": cited_line_count,
+            }
+            covered.append(item)
+            cited_lines += cited_line_count
+        else:
+            uncovered.append({
+                **target,
+                "coverage_status": "uncovered",
+                "matching_citations": [],
+                "matching_file_mentions": mention_matches,
+                "cited_line_count": 0,
+            })
+    total = len(target_ranges)
+    cited = len(covered)
+    return covered, uncovered, {
+        "total_relevant_ranges": total,
+        "cited_relevant_ranges": cited,
+        "uncovered_relevant_ranges": len(uncovered),
+        "range_coverage_ratio": (cited / total) if total else 0.0,
+        "total_relevant_lines": total_lines,
+        "cited_relevant_lines": cited_lines,
+        "line_coverage_ratio": (cited_lines / total_lines) if total_lines else None,
+    }
+
+
+def compile_review_coverage(
+    *,
+    delta_context_path: str | Path | None = None,
+    delta_context: Mapping[str, Any] | None = None,
+    review_path: str | Path | None = None,
+    review_text: str | None = None,
+    review_json: Any = None,
+    min_range_coverage: float = DEFAULT_MIN_RANGE_COVERAGE,
+    policy_name: str = "advisory",
+) -> dict[str, Any]:
+    if not isinstance(min_range_coverage, (int, float)) or isinstance(min_range_coverage, bool) or not 0 <= float(min_range_coverage) <= 1:
+        return _invalid_result(error="min_range_coverage must be between 0 and 1", error_code="threshold_invalid")
+    if delta_context is None:
+        if delta_context_path is None:
+            return _invalid_result(error="delta_context_path or delta_context is required", error_code="delta_context_missing")
+        delta_context_obj, error = _load_json_file(delta_context_path, max_bytes=MAX_DELTA_CONTEXT_BYTES)
+        if error:
+            return _invalid_result(error=error, error_code="delta_context_invalid")
+        delta_context = delta_context_obj
+    if not isinstance(delta_context, Mapping):
+        return _invalid_result(error="delta_context must be an object", error_code="delta_context_invalid")
+
+    if review_text is None:
+        if review_path is None:
+            return _invalid_result(error="review_path or review_text is required", error_code="review_missing")
+        review_text, parsed_review_json, error = _load_review_payload(review_path)
+        if error:
+            return _invalid_result(error=error, error_code="review_invalid")
+        if review_json is None:
+            review_json = parsed_review_json
+    else:
+        if review_json is None:
+            try:
+                review_json = json.loads(review_text)
+            except ValueError:
+                review_json = None
+
+    target_ranges, range_gaps = _target_ranges_from_delta_context(delta_context)
+    target_paths = [item["path"] for item in target_ranges if isinstance(item.get("path"), str)]
+    citation_payload = extract_review_citations(review_text or "", review_json, target_paths=target_paths)
+    covered, uncovered, metrics = _coverage_for_ranges(
+        target_ranges,
+        citation_payload["line_citations"],
+        citation_payload["file_mentions"],
+    )
+    threshold_met = metrics["range_coverage_ratio"] >= float(min_range_coverage)
+    gaps = list(range_gaps)
+    if not citation_payload["line_citations"] and not citation_payload["file_mentions"]:
+        gaps.append({"source": "review", "status": "no_citations", "severity": "warn", "reason": "review contains no parseable citations or file mentions"})
+    if uncovered:
+        gaps.append({"source": "coverage", "status": "uncovered_ranges", "severity": "info", "reason": "some relevant ranges were not cited", "count": len(uncovered)})
+    if not threshold_met:
+        gaps.append({"source": "threshold", "status": "below_threshold", "severity": "warn", "reason": "range coverage is below advisory threshold"})
+
+    has_warning = any(gap.get("severity") in {"warn", "error"} for gap in gaps)
+    status = "invalid" if range_gaps and any(g.get("severity") == "error" for g in range_gaps) else ("warn" if has_warning or not threshold_met else "pass")
+    return {
+        "kind": KIND,
+        "version": VERSION,
+        "status": status,
+        "policy_name": policy_name,
+        "delta_context": {
+            "kind": delta_context.get("kind"),
+            "version": delta_context.get("version"),
+            "status": delta_context.get("status"),
+            "diff": delta_context.get("diff"),
+        },
+        "coverage": metrics,
+        "thresholds": {
+            "min_range_coverage": float(min_range_coverage),
+            "range_threshold_met": threshold_met,
+            "advisory": True,
+            "external_policy_required_to_gate": True,
+        },
+        "relevant_ranges": target_ranges,
+        "cited_ranges": covered,
+        "uncovered_ranges": uncovered,
+        "citations": citation_payload,
+        "gaps": gaps,
+        "bureau_evidence": _bureau_evidence_boundary(),
+        "mutation_boundary": _read_only_boundary(),
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }

--- a/merger/lenskit/tests/test_repobrief_review_coverage.py
+++ b/merger/lenskit/tests/test_repobrief_review_coverage.py
@@ -1,0 +1,258 @@
+import json
+from merger.lenskit.cli.main import main
+from merger.lenskit.core import repobrief_review_coverage as cov
+
+
+def _delta_context() -> dict:
+    return {
+        "kind": "repobrief.delta_context_compiler",
+        "version": "v1",
+        "status": "pass",
+        "diff": {"file_count": 3},
+        "changed_files": [
+            {
+                "path": "merger/lenskit/core/example.py",
+                "change_status": "modified",
+                "binary": False,
+                "hunks": [
+                    {
+                        "header": "@@ -10,3 +10,4 @@",
+                        "changed_range": {"start_line": 10, "end_line": 13, "line_count": 4, "basis": "new"},
+                    }
+                ],
+            },
+            {
+                "path": "merger/lenskit/core/other.py",
+                "change_status": "modified",
+                "binary": False,
+                "hunks": [
+                    {
+                        "header": "@@ -20,2 +20,3 @@",
+                        "changed_range": {"start_line": 20, "end_line": 22, "line_count": 3, "basis": "new"},
+                    }
+                ],
+            },
+            {
+                "path": "assets/logo.png",
+                "change_status": "modified",
+                "binary": True,
+                "hunks": [],
+            },
+        ],
+    }
+
+
+def test_review_coverage_measures_cited_and_uncovered_ranges_from_text():
+    review = "I checked merger/lenskit/core/example.py#L10-L13 and noted assets/logo.png."
+
+    result = cov.compile_review_coverage(
+        delta_context=_delta_context(),
+        review_text=review,
+        min_range_coverage=0.75,
+    )
+
+    assert result["kind"] == "repobrief.review_coverage"
+    assert result["status"] == "warn"
+    assert result["coverage"]["total_relevant_ranges"] == 3
+    assert result["coverage"]["cited_relevant_ranges"] == 2
+    assert result["coverage"]["uncovered_relevant_ranges"] == 1
+    assert result["coverage"]["range_coverage_ratio"] == 2 / 3
+    assert result["thresholds"]["range_threshold_met"] is False
+    assert result["thresholds"]["advisory"] is True
+    assert result["bureau_evidence"]["requires_external_policy_to_gate"] is True
+    assert result["mutation_boundary"]["writes"] == []
+    assert "merge_readiness" in result["does_not_establish"]
+    assert result["uncovered_ranges"][0]["path"] == "merger/lenskit/core/other.py"
+
+
+def test_review_coverage_passes_when_threshold_is_met():
+    review = "See merger/lenskit/core/example.py:10-13 and merger/lenskit/core/other.py:L20-L22. assets/logo.png"
+
+    result = cov.compile_review_coverage(
+        delta_context=_delta_context(),
+        review_text=review,
+        min_range_coverage=1.0,
+    )
+
+    assert result["status"] == "pass"
+    assert result["coverage"]["range_coverage_ratio"] == 1.0
+    assert result["uncovered_ranges"] == []
+
+
+def test_review_coverage_extracts_json_source_ranges():
+    review_json = {
+        "reviews": [
+            {"finding": "ok", "source_range": {"file_path": "merger/lenskit/core/example.py", "start_line": 10, "end_line": 13}},
+            {"path": "merger/lenskit/core/other.py", "line_range": [20, 22]},
+        ]
+    }
+
+    result = cov.compile_review_coverage(
+        delta_context=_delta_context(),
+        review_text=json.dumps(review_json),
+        review_json=review_json,
+        min_range_coverage=0.6,
+    )
+
+    assert result["status"] == "pass"
+    assert result["coverage"]["cited_relevant_ranges"] == 2
+    assert result["coverage"]["uncovered_relevant_ranges"] == 1
+    assert result["citations"]["citation_count"] == 2
+
+
+def test_file_only_json_citation_does_not_cover_line_range():
+    result = cov.compile_review_coverage(
+        delta_context=_delta_context(),
+        review_text=json.dumps({"path": "merger/lenskit/core/example.py"}),
+        review_json={"path": "merger/lenskit/core/example.py"},
+        min_range_coverage=0.1,
+    )
+
+    assert result["status"] == "warn"
+    assert result["coverage"]["cited_relevant_ranges"] == 0
+    assert {item["path"] for item in result["uncovered_ranges"]} == {
+        "merger/lenskit/core/example.py",
+        "merger/lenskit/core/other.py",
+        "assets/logo.png",
+    }
+
+
+def test_review_coverage_no_citations_is_warn_not_proof():
+    result = cov.compile_review_coverage(
+        delta_context=_delta_context(),
+        review_text="Looks good to me.",
+        min_range_coverage=0.1,
+    )
+
+    assert result["status"] == "warn"
+    assert result["coverage"]["cited_relevant_ranges"] == 0
+    assert any(gap["source"] == "review" and gap["status"] == "no_citations" for gap in result["gaps"])
+    assert result["bureau_evidence"]["does_not_authorize_merge"] is True
+
+
+def test_review_coverage_no_citations_warns_even_with_zero_threshold():
+    result = cov.compile_review_coverage(
+        delta_context=_delta_context(),
+        review_text="Looks good to me.",
+        min_range_coverage=0.0,
+    )
+
+    assert result["status"] == "warn"
+    assert result["thresholds"]["range_threshold_met"] is True
+    assert any(gap["source"] == "review" and gap["severity"] == "warn" for gap in result["gaps"])
+
+
+def test_review_coverage_invalid_delta_context_is_invalid():
+    result = cov.compile_review_coverage(
+        delta_context={"kind": "repobrief.delta_context_compiler"},
+        review_text="merger/lenskit/core/example.py#L10-L13",
+    )
+
+    assert result["status"] == "invalid"
+    assert result["coverage"]["total_relevant_ranges"] == 0
+    assert any(gap["source"] == "delta_context" and gap["severity"] == "error" for gap in result["gaps"])
+
+
+def test_review_coverage_rejects_invalid_threshold():
+    result = cov.compile_review_coverage(
+        delta_context=_delta_context(),
+        review_text="x",
+        min_range_coverage=1.5,
+    )
+
+    assert result["status"] == "invalid"
+    assert result["error_code"] == "threshold_invalid"
+
+
+def test_review_coverage_parses_root_level_file_citation():
+    delta = {
+        "changed_files": [
+            {
+                "path": "README.md",
+                "change_status": "modified",
+                "binary": False,
+                "hunks": [{"changed_range": {"start_line": 1, "end_line": 3, "basis": "new"}}],
+            }
+        ]
+    }
+
+    result = cov.compile_review_coverage(
+        delta_context=delta,
+        review_text="Reviewed README.md#L1-L3.",
+        min_range_coverage=1.0,
+    )
+
+    assert result["status"] == "pass"
+    assert result["coverage"]["range_coverage_ratio"] == 1.0
+    assert result["citations"]["line_citations"][0]["path"] == "README.md"
+
+
+def test_review_coverage_parses_parent_path_with_nested_source_range():
+    review_json = {
+        "path": "merger/lenskit/core/example.py",
+        "source_range": {"start_line": 10, "end_line": 13},
+    }
+
+    result = cov.compile_review_coverage(
+        delta_context=_delta_context(),
+        review_text=json.dumps(review_json),
+        review_json=review_json,
+        min_range_coverage=0.3,
+    )
+
+    assert result["status"] == "pass"
+    assert result["coverage"]["cited_relevant_ranges"] == 1
+    assert result["citations"]["line_citations"][0]["start_line"] == 10
+
+
+def test_review_coverage_counts_only_cited_line_intersections():
+    delta = {
+        "changed_files": [
+            {
+                "path": "src/big.py",
+                "change_status": "modified",
+                "binary": False,
+                "hunks": [{"changed_range": {"start_line": 1, "end_line": 100, "basis": "new"}}],
+            }
+        ]
+    }
+
+    result = cov.compile_review_coverage(
+        delta_context=delta,
+        review_text="Reviewed src/big.py#L1.",
+        min_range_coverage=1.0,
+    )
+
+    assert result["status"] == "pass"
+    assert result["coverage"]["cited_relevant_ranges"] == 1
+    assert result["coverage"]["cited_relevant_lines"] == 1
+    assert result["coverage"]["total_relevant_lines"] == 100
+    assert result["coverage"]["line_coverage_ratio"] == 0.01
+
+
+def test_review_coverage_cli_outputs_json_and_advisory_warn_exit_zero(tmp_path, capsys):
+    delta = tmp_path / "delta.json"
+    delta.write_text(json.dumps(_delta_context()), encoding="utf-8")
+    review = tmp_path / "review.md"
+    review.write_text("Only merger/lenskit/core/example.py#L10-L13 was inspected.", encoding="utf-8")
+
+    rc = main([
+        "repobrief",
+        "review-coverage",
+        "compile",
+        "--delta-context",
+        str(delta),
+        "--review",
+        str(review),
+        "--min-range-coverage",
+        "0.8",
+        "--policy-name",
+        "demo-advisory",
+    ])
+
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert out["kind"] == "repobrief.review_coverage"
+    assert out["status"] == "warn"
+    assert out["policy_name"] == "demo-advisory"
+    assert out["thresholds"]["external_policy_required_to_gate"] is True


### PR DESCRIPTION
Implements Bureau task RPU-V1-T006 — Proof-of-reading review coverage.

Scope:
- adds read-only core surface repobrief.review_coverage
- adds CLI: repobrief review-coverage compile
- consumes a repobrief.delta_context_compiler JSON report and a review text/JSON artifact
- computes cited vs relevant changed ranges and lists uncovered ranges
- supports text citations like path#L10-L13/path:L10-L13/path:10-13/path lines 10-13, including root-level files like README.md#L1-L3
- supports JSON source_range/line_range/path citation shapes, including parent path plus nested source_range
- treats file mentions as covering file-level ranges only, not concrete line ranges
- counts cited line intersections rather than whole hunks for line coverage
- exposes configurable advisory thresholds and a Bureau evidence boundary
- adds proof doc: docs/proofs/repobrief-review-coverage-v1-proof.md

Self/Codex review fixes included:
- root-level file citations are parsed
- parent path + nested source_range JSON citations are parsed as line citations
- partial line citations no longer inflate cited_relevant_lines to the full hunk size
- file-only citation does not cover concrete line ranges
- no-citation reports warn even with zero threshold

Validation:
- python3 -m pytest -q merger/lenskit/tests/test_repobrief_review_coverage.py merger/lenskit/tests/test_repobrief_delta_context.py merger/lenskit/tests/test_repobrief_context_compiler.py merger/lenskit/tests/test_repobrief_resolved_evidence_query.py merger/lenskit/tests/test_repobrief_source_citation_projection.py merger/lenskit/tests/test_repobrief_access_boundary.py merger/lenskit/tests/test_external_manifest_reference.py merger/lenskit/tests/test_repobrief_preflight.py -> 111 passed
- python3 -m ruff check --config ruff-ci.toml merger/lenskit/core/repobrief_review_coverage.py merger/lenskit/cli/cmd_repobrief.py merger/lenskit/tests/test_repobrief_review_coverage.py -> pass
- python3 -m scripts.docmeta.check_planning_registration --baseline docs/tasks/planning-registration-baseline.json --ratchet --format human -> no new drift
- python3 -m merger.lenskit.cli.main doc-freshness inspect -> PASS
- git diff --check -> pass
- manual CLI smoke: delta-context compile followed by review-coverage compile -> status pass, writes=[], Bureau gate requires external policy

Boundary / non-claims:
- Does not establish review correctness, review completeness, test sufficiency, security correctness, runtime behavior, regression absence, merge readiness, approval, rejection, risk score, all relevant context used or claims true.
- Does not mutate Git, PRs, patches, source working tree, bundle artifacts or Bureau registry.

Diff SHA256: `7703485fb7fe859955a9ca893aecf919d3e6b80aadb6d80225a85bbe29547f09`
Head: `3e5620e7dada025d4a0d681f386f019ea6472513`
