### PR TITLE
fix(repobrief): classify validation-unavailable graph evidence as degraded

### DIFF
--- a/docs/proofs/graph-degradation-semantics-v1-proof.md
+++ b/docs/proofs/graph-degradation-semantics-v1-proof.md
@@ -2,7 +2,7 @@
 
 Task: `TASK-GRAPH-DEGRADATION-SEMANTICS-HARDENING-001` / Bureau `RPU-V1-T010`.
 
-Status: shared diagnostic vocabulary and consumer wiring for stale, missing, invalid, degraded or unavailable graph evidence.
+Status: shared diagnostic vocabulary and consumer wiring for stale, missing, invalid, validation-unavailable, degraded or unavailable graph evidence.
 
 ## Implemented surface
 
@@ -52,6 +52,7 @@ missing_provenance
 stale
 profile_excluded
 invalid
+validation_unavailable
 degraded
 ```
 
@@ -100,7 +101,7 @@ Tests cover:
 - stale graph use is flagged inconsistent;
 - availability degradation vocabulary for stale, missing, available and profile-excluded states;
 - gap projection preserving negative semantics;
-- graph availability model output for available, stale, missing and profile-excluded bundles;
+- graph availability model output for available, stale, missing, validation-unavailable and profile-excluded bundles;
 - query explain output for stale graph diagnostics;
 - query claim-boundary language.
 

--- a/merger/lenskit/core/graph_degradation.py
+++ b/merger/lenskit/core/graph_degradation.py
@@ -9,6 +9,7 @@ GRAPH_AVAILABILITY_STATUS_VALUES = (
     "profile_excluded",
     "blocked_by_missing_source",
     "blocked_by_missing_provenance",
+    "validation_unavailable",
     "invalid",
 )
 
@@ -56,6 +57,7 @@ _AVAILABILITY_STATUS_MAP: dict[str, tuple[str, str]] = {
     "profile_excluded": ("profile_excluded", "info"),
     "blocked_by_missing_source": ("missing_source", "warn"),
     "blocked_by_missing_provenance": ("missing_provenance", "warn"),
+    "validation_unavailable": ("degraded", "warn"),
     "invalid": ("invalid", "error"),
 }
 

--- a/merger/lenskit/core/repobrief_availability.py
+++ b/merger/lenskit/core/repobrief_availability.py
@@ -198,6 +198,8 @@ def graph_availability_model(manifest_path: str | Path, manifest: Mapping[str, A
         _complete_graph_availability(base, status="stale", reason="graph index canonical dump hash does not match this snapshot", load_status=graph_status)
     elif graph_status in {"not_found", "unreadable"}:
         _complete_graph_availability(base, status="blocked_by_missing_source", reason=f"graph index load status is {graph_status}", load_status=graph_status)
+    elif graph_status == "validation_unavailable":
+        _complete_graph_availability(base, status="validation_unavailable", reason="graph index validation is unavailable in this runtime", load_status=graph_status)
     else:
         _complete_graph_availability(base, status="invalid", reason=f"graph index load status is {graph_status}", load_status=graph_status)
     return base

--- a/merger/lenskit/tests/test_graph_degradation_semantics.py
+++ b/merger/lenskit/tests/test_graph_degradation_semantics.py
@@ -34,12 +34,16 @@ def test_graph_load_degradation_flags_inconsistent_use():
 def test_graph_availability_degradation_vocabulary():
     stale = graph_availability_degradation("stale", load_status="stale_or_mismatched")
     missing = graph_availability_degradation("not_generated")
+    validation_unavailable = graph_availability_degradation("validation_unavailable", load_status="validation_unavailable")
     available = graph_availability_degradation("available", load_status="ok")
     assert stale["degradation"] == "stale"
     assert stale["severity"] == "warn"
     assert stale["retrieval_eligible"] is False
     assert missing["degradation"] == "missing"
     assert missing["severity"] == "info"
+    assert validation_unavailable["degradation"] == "degraded"
+    assert validation_unavailable["severity"] == "warn"
+    assert validation_unavailable["retrieval_eligible"] is False
     assert available["degradation"] == "none"
     assert available["retrieval_eligible"] is True
 

--- a/merger/lenskit/tests/test_repobrief_profiles.py
+++ b/merger/lenskit/tests/test_repobrief_profiles.py
@@ -236,6 +236,43 @@ def test_graph_availability_reports_available_and_stale(tmp_path):
     assert stale_graph["degradation"]["graph_must_not_influence_retrieval"] is True
 
 
+def test_graph_availability_reports_validation_unavailable_as_degraded(tmp_path, monkeypatch):
+    import json
+    from merger.lenskit.core import repobrief_availability as availability
+
+    graph_path = tmp_path / "x.architecture_graph.json"
+    graph_path.write_text('{"kind":"placeholder"}', encoding="utf-8")
+    graph_index = tmp_path / "x.graph_index.json"
+    graph_index.write_text('{"kind":"placeholder"}', encoding="utf-8")
+    expected_sha = "a" * 64
+    data = {
+        "created_at": "2026-07-06T10:00:00Z",
+        "artifacts": [
+            {"role": "architecture_graph_json", "path": graph_path.name},
+            {"role": "graph_index_json", "path": graph_index.name},
+        ],
+        "links": {"canonical_dump_index_sha256": expected_sha},
+        "capabilities": {"repobrief_profile": "agent-portable"},
+    }
+    path = tmp_path / "bundle.manifest.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+    monkeypatch.setattr(
+        availability,
+        "load_graph_index",
+        lambda *_args, **_kwargs: {"status": "validation_unavailable", "graph": None},
+    )
+
+    graph = availability.snapshot_availability_model(path, data)["graph_availability"]
+
+    assert graph["status"] == "validation_unavailable"
+    assert graph["graph_index"]["load_status"] == "validation_unavailable"
+    assert graph["retrieval_eligible"] is False
+    assert graph["degradation"]["degradation"] == "degraded"
+    assert graph["degradation"]["severity"] == "warn"
+    assert graph["degradation"]["graph_must_not_influence_retrieval"] is True
+
+
 def test_graph_availability_profile_excluded_for_public_share(tmp_path):
     import json
     from merger.lenskit.core.repobrief_availability import snapshot_availability_model


### PR DESCRIPTION
Follow-up to PR #924 for RPU-V1-T010.

Fixes Codex feedback: `validation_unavailable` should be degraded/warn rather than invalid/error.

Scope:
- adds `validation_unavailable` to graph availability vocabulary
- maps it to `degradation=degraded`, `severity=warn`
- `repobrief.graph_availability` now reports status `validation_unavailable` when the graph loader returns that state
- adds tests for availability and degradation semantics
- updates proof wording

Validation:
- `python3 -m pytest -q merger/lenskit/tests/test_graph_degradation_semantics.py merger/lenskit/tests/test_repobrief_profiles.py merger/lenskit/tests/test_retrieval_query.py merger/lenskit/tests/test_graph_eval.py` -> 59 passed
- `python3 -m ruff check --config ruff-ci.toml merger/lenskit/core/graph_degradation.py merger/lenskit/core/repobrief_availability.py merger/lenskit/tests/test_graph_degradation_semantics.py merger/lenskit/tests/test_repobrief_profiles.py` -> pass
- planning-registration ratchet -> no new drift
- doc-freshness -> PASS
- git diff --check -> pass

Boundary:
- No graph producer, ranking change, or default promotion is added.
- Does not establish runtime reachability, causality, change impact, graph completeness, or merge readiness.

Head: `34499c5bf3708f52a7b8810b96d3090bcd73085d`
Diff SHA256: `e7e48bb523bf07c2daa2418730ea171b25a5de6937673c1054506b5348a9b28d`
