### PR TITLE
feat(repobrief): harden federated bundle search

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -114,6 +114,12 @@ Weitere Subkommandos: `eval`, `architecture`, `atlas`, `federation`,
 `context-quality`, `governance`, `parity`, `artifact`, `rlens-client`, `verify`,
 `pr-explain`. Jeweils `--help` für Details.
 
+Federierte Query ohne persistierten Index:
+
+```bash
+lenskit federation query --bundle repo_a=/path/to/bundle-a --bundle repo_b=/path/to/bundle-b -q "symbol" --trace
+```
+
 ## 6. Fehlerbehebung (Kurz)
 
 - **„range_ref failed schema" / Hash mismatch:** Der `range_ref` passt nicht

--- a/docs/proofs/federated-fleet-bundle-search-rpu-v1-t016-proof.md
+++ b/docs/proofs/federated-fleet-bundle-search-rpu-v1-t016-proof.md
@@ -1,0 +1,120 @@
+# RPU-V1-T016 — Federated fleet bundle search proof
+
+Status: implemented
+Date: 2026-07-08
+
+## Scope
+
+This proof covers `RPU-V1-T016`: federated RepoBrief bundle search over multiple
+repository bundles with explicit per-bundle freshness and authority boundaries.
+
+The change keeps federation in the existing read-only retrieval layer. It does
+not create snapshots, refresh bundles, mutate Git, run shells, open PRs, apply
+patches or assert runtime truth.
+
+## Implemented surfaces
+
+### Registry-backed query
+
+Existing persisted federation index queries remain supported:
+
+```text
+lenskit federation query --index federation_index.json -q "query text" --trace
+```
+
+The persisted `federation_index.json` is still schema-validated before bundle
+access.
+
+### Inline multi-bundle query
+
+Federated search can now run directly over repeated bundle roots without writing
+a `federation_index.json`:
+
+```text
+lenskit federation query \
+  --bundle repo_a=/path/to/repo-a-bundle \
+  --bundle repo_b=/path/to/repo-b-bundle \
+  --federation-id local-fleet \
+  -q "query text" \
+  --trace
+```
+
+Each `--bundle` uses `REPO_ID=PATH`. The inline input is converted to a transient,
+schema-validated federation object in memory only.
+
+## Result provenance
+
+Returned hits now carry both the legacy bundle tag and a structured origin object:
+
+```json
+{
+  "federation_bundle": "repo_a",
+  "federation_bundle_status": "ok",
+  "federation_freshness_status": "unverified",
+  "federation_origin": {
+    "repo_id": "repo_a",
+    "bundle_path": "/path/to/repo-a-bundle",
+    "availability_status": "ok",
+    "freshness_status": "unverified",
+    "expected_fingerprint": null,
+    "observed_fingerprint": null
+  }
+}
+```
+
+When a bundle is stale according to `last_fingerprint` versus the local SQLite
+index metadata, hits from that bundle remain queryable but are explicitly marked:
+
+```json
+{
+  "federation_bundle_status": "stale",
+  "federation_freshness_status": "stale",
+  "federation_origin": {
+    "availability_status": "stale",
+    "freshness_status": "stale"
+  }
+}
+```
+
+This prevents stale bundle results from being silently promoted as ordinary
+fresh/current evidence.
+
+## Acceptance mapping
+
+- `rpu-v1-t016-multi-bundle`: satisfied by
+  `execute_federated_query_from_bundles` and CLI repeated `--bundle` support;
+  persisted `--index` queries remain supported.
+- `rpu-v1-t016-freshness`: satisfied by per-hit
+  `federation_bundle_status`, `federation_freshness_status` and
+  `federation_origin` fields, including stale-hit tests.
+- `rpu-v1-t016-no-global-truth`: preserved by read-only federation inputs,
+  schema validation, explicit non-claims and unchanged heuristic boundaries for
+  `cross_repo_links` and `federation_conflicts`.
+
+## Validation
+
+Targeted tests:
+
+```text
+python3 -m pytest -q \
+  merger/lenskit/tests/test_federation_*.py \
+  merger/lenskit/tests/test_api_federation.py
+# 93 passed
+```
+
+Additional validation before merge should include the normal focused lint and
+contract checks for the changed modules.
+
+## Non-claims
+
+This proof does not establish:
+
+- ecosystem completeness;
+- semantic identity between repositories;
+- dependency relationships between repositories;
+- runtime correctness;
+- test sufficiency;
+- review completeness;
+- merge readiness;
+- production query quality;
+- global ranking correctness beyond the existing deterministic minimal ranking.

--- a/merger/lenskit/cli/cmd_federation.py
+++ b/merger/lenskit/cli/cmd_federation.py
@@ -29,12 +29,38 @@ def register_federation_commands(subparsers) -> None:
 
     # query
     query_parser = federation_subparsers.add_parser("query", help="Execute a minimal federated query fan-out across local bundles")
-    query_parser.add_argument("--index", required=True, help="Path to federation index")
+    query_parser.add_argument("--index", help="Path to federation index")
+    query_parser.add_argument(
+        "--bundle",
+        action="append",
+        default=[],
+        metavar="REPO_ID=PATH",
+        help="Inline bundle root or index file. May be repeated instead of --index.",
+    )
+    query_parser.add_argument(
+        "--federation-id",
+        default="inline-bundle-set",
+        help="Federation ID used for inline --bundle queries.",
+    )
     query_parser.add_argument("-q", "--query", required=True, help="Query string")
     query_parser.add_argument("-k", type=int, default=10, help="Number of final results to return (top-k across all bundles)")
     query_parser.add_argument("--repo", type=str, help="Filter by repository ID (currently the only supported filter)")
     query_parser.add_argument("--trace", action="store_true", help="Include diagnostic trace and generate federation_trace.json (and federation_conflicts.json if applicable) in CWD")
 
+
+
+def _parse_inline_bundle_specs(bundle_args: list[str]) -> list[dict[str, str]]:
+    specs: list[dict[str, str]] = []
+    for raw in bundle_args:
+        if "=" not in raw:
+            raise ValueError("--bundle must use REPO_ID=PATH")
+        repo_id, bundle_path = raw.split("=", 1)
+        repo_id = repo_id.strip()
+        bundle_path = bundle_path.strip()
+        if not repo_id or not bundle_path:
+            raise ValueError("--bundle requires non-empty REPO_ID and PATH")
+        specs.append({"repo_id": repo_id, "bundle_path": bundle_path})
+    return specs
 
 def handle_federation_command(args: argparse.Namespace) -> int:
     """Dispatches federation commands to their respective handlers."""
@@ -89,19 +115,35 @@ def handle_federation_command(args: argparse.Namespace) -> int:
 
     elif args.federation_command == "query":
         from merger.lenskit.retrieval.federation_query import execute_federated_query
-        index_path = Path(args.index)
+        from merger.lenskit.retrieval.federation_query import execute_federated_query_from_bundles
+        index_path = Path(args.index) if args.index else None
+        inline_bundles = getattr(args, "bundle", []) or []
         filters = None
         if args.repo:
             filters = {"repo": args.repo}
 
         try:
-            res = execute_federated_query(
-                index_path,
-                query_text=args.query,
-                k=args.k,
-                filters=filters,
-                trace=args.trace
-            )
+            if bool(index_path) == bool(inline_bundles):
+                raise ValueError("provide exactly one query source: --index or one or more --bundle REPO_ID=PATH")
+
+            if index_path:
+                res = execute_federated_query(
+                    index_path,
+                    query_text=args.query,
+                    k=args.k,
+                    filters=filters,
+                    trace=args.trace
+                )
+            else:
+                res = execute_federated_query_from_bundles(
+                    _parse_inline_bundle_specs(inline_bundles),
+                    query_text=args.query,
+                    k=args.k,
+                    filters=filters,
+                    trace=args.trace,
+                    federation_id=args.federation_id,
+                    base_path=Path.cwd(),
+                )
             print(json.dumps(res, indent=2))
 
             # Write trace if requested
@@ -117,9 +159,14 @@ def handle_federation_command(args: argparse.Namespace) -> int:
                     "bundles": []
                 }
 
-                # Fetch original bundles from index to get full info
-                with index_path.open("r", encoding="utf-8") as f:
-                    fed_data = json.load(f)
+                # Fetch original bundles from the persisted index or from inline specs.
+                if index_path:
+                    with index_path.open("r", encoding="utf-8") as f:
+                        fed_data = json.load(f)
+                else:
+                    fed_data = {
+                        "bundles": _parse_inline_bundle_specs(inline_bundles),
+                    }
 
                 status_map = res["federation_trace"].get("bundle_status", {})
                 error_map = res["federation_trace"].get("bundle_errors", {})

--- a/merger/lenskit/core/federation.py
+++ b/merger/lenskit/core/federation.py
@@ -1,4 +1,8 @@
+import datetime
 import json
+from pathlib import Path
+from typing import Any, Optional
+
 try:
     import jsonschema
     from jsonschema.exceptions import ValidationError as JsonSchemaValidationError
@@ -6,13 +10,11 @@ except ImportError:
     jsonschema = None
     JsonSchemaValidationError = None
 
+
 def _require_jsonschema() -> None:
     if jsonschema is None:
         raise RuntimeError("jsonschema is required for federation schema validation but is not installed.")
 
-import datetime
-from pathlib import Path
-from typing import Optional
 
 FEDERATION_KIND = "repolens.federation.index"
 FEDERATION_VERSION = "1.0"
@@ -65,22 +67,19 @@ def init_federation(federation_id: str, out_path: Path) -> dict:
 
     return fed_data
 
-def validate_federation(index_path: Path) -> bool:
+def validate_federation_data(fed_data: dict[str, Any]) -> bool:
     """
-    Validates a federation index against its schema and additional logical constraints.
-    Returns True if valid, raises an exception otherwise.
-    """
-    if not index_path.exists():
-        raise FileNotFoundError(f"Federation index not found at: {index_path.resolve().as_posix()}")
+    Validates a federation index object against its schema and logical constraints.
 
+    This is shared by persisted federation_index.json files and transient, read-only
+    bundle lists built by callers such as the CLI. It validates only structure and
+    identifiers; it does not inspect bundle contents, run refreshes, touch Git or
+    establish runtime correctness.
+    """
     schema = load_federation_schema()
     if not schema:
         raise RuntimeError("Federation schema missing at expected path (contracts/federation-index.v1.schema.json)")
 
-    with index_path.open("r", encoding="utf-8") as f:
-        fed_data = json.load(f)
-
-    # 1. Schema Validation
     _require_jsonschema()
 
     try:
@@ -88,7 +87,6 @@ def validate_federation(index_path: Path) -> bool:
     except JsonSchemaValidationError as e:
         raise ValueError(f"Schema validation failed: {e.message} at path {list(e.path)}")
 
-    # 2. Logical Constraints
     bundles = fed_data.get("bundles", [])
     repo_ids = set()
     for b in bundles:
@@ -100,11 +98,31 @@ def validate_federation(index_path: Path) -> bool:
         if not bundle_path:
             raise ValueError("Invalid bundle: missing 'bundle_path'.")
 
-        # check uniqueness
         if repo_id in repo_ids:
             raise ValueError(f"Duplicate 'repo_id' found: {repo_id}")
         repo_ids.add(repo_id)
 
+    return True
+
+
+def load_federation_index_data(index_path: Path) -> dict[str, Any]:
+    """Load and validate a persisted federation index JSON file."""
+    if not index_path.exists():
+        raise FileNotFoundError(f"Federation index not found at: {index_path.resolve().as_posix()}")
+
+    with index_path.open("r", encoding="utf-8") as f:
+        fed_data = json.load(f)
+
+    validate_federation_data(fed_data)
+    return fed_data
+
+
+def validate_federation(index_path: Path) -> bool:
+    """
+    Validates a federation index against its schema and additional logical constraints.
+    Returns True if valid, raises an exception otherwise.
+    """
+    load_federation_index_data(index_path)
     return True
 
 def inspect_federation(index_path: Path) -> dict:

--- a/merger/lenskit/retrieval/federation_query.py
+++ b/merger/lenskit/retrieval/federation_query.py
@@ -1,10 +1,12 @@
-import json
+import datetime
 import time
 from pathlib import Path
-from typing import Dict, Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 from .query_core import execute_query
-from ..core.federation import validate_federation
+from ..core.federation import FEDERATION_KIND, FEDERATION_VERSION
+from ..core.federation import load_federation_index_data
+from ..core.federation import validate_federation_data
 
 def _build_cross_repo_links(results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """
@@ -87,8 +89,65 @@ def _find_bundle_index(bundle_path: Path) -> Optional[Path]:
 
     return None
 
-def execute_federated_query(
-    federation_index_path: Path,
+def _resolve_existing_local_path(raw_path: str, base_path: Path) -> Path:
+    """Resolve a caller-supplied local path without creating or refreshing anything."""
+    if "://" in raw_path:
+        raise ValueError("inline --bundle paths must be local filesystem paths")
+    candidate = Path(raw_path)
+    if not candidate.is_absolute():
+        candidate = base_path / candidate
+    resolved = candidate.resolve(strict=True)
+    if not resolved.is_dir() and not (resolved.is_file() and resolved.name.endswith(".index.sqlite")):
+        raise ValueError("inline --bundle path must be an existing bundle directory or .index.sqlite file")
+    return resolved
+
+
+
+def _build_transient_federation_index(
+    bundle_specs: List[Dict[str, str]],
+    federation_id: str = "inline-bundle-set",
+    base_path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Builds a schema-valid, read-only federation index object from bundle specs."""
+    resolved_base = (base_path or Path.cwd()).resolve(strict=True)
+    now = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0).isoformat()
+    bundles: List[Dict[str, str]] = []
+    for spec in bundle_specs:
+        item = {
+            "repo_id": spec["repo_id"],
+            "bundle_path": _resolve_existing_local_path(spec["bundle_path"], resolved_base).as_posix(),
+        }
+        if spec.get("last_fingerprint"):
+            item["last_fingerprint"] = spec["last_fingerprint"]
+        bundles.append(item)
+    bundles.sort(key=lambda x: x["repo_id"])
+    fed_data = {
+        "kind": FEDERATION_KIND,
+        "version": FEDERATION_VERSION,
+        "federation_id": federation_id,
+        "created_at": now,
+        "updated_at": now,
+        "bundles": bundles,
+    }
+    validate_federation_data(fed_data)
+    return fed_data
+
+
+def _freshness_status(expected_fingerprint: Optional[str], observed_fingerprint: Optional[str], bundle_status: str) -> str:
+    if bundle_status == "stale":
+        return "stale"
+    if not expected_fingerprint:
+        return "unverified"
+    if observed_fingerprint is None:
+        return "unverified"
+    if observed_fingerprint == expected_fingerprint:
+        return "current"
+    return "stale"
+
+
+def _execute_federated_query_data(
+    fed_data: Dict[str, Any],
+    federation_base_path: Path,
     query_text: str,
     k: int = 10,
     filters: Optional[Dict[str, Optional[str]]] = None,
@@ -97,19 +156,8 @@ def execute_federated_query(
     trace: bool = False,
     build_context: bool = False
 ) -> Dict[str, Any]:
-    """
-    Executes a minimal federated query aggregation across local bundles referenced by a federation index.
-    This is not a full federated ranking system, but a fan-out mechanism that collects results and sorts them globally.
-    """
-    if not federation_index_path.exists():
-        raise FileNotFoundError(f"Federation index not found at: {federation_index_path.resolve().as_posix()}")
-
-    # Diagnose-Gate: Validate structural integrity before accessing keys to avoid KeyErrors mid-flight.
-    # This is a deliberate safety check for the minimal fan-out, not intended as a highly optimized performance model.
-    validate_federation(federation_index_path)
-
-    with federation_index_path.open("r", encoding="utf-8") as f:
-        fed_data = json.load(f)
+    """Executes federated query aggregation over a validated federation object."""
+    validate_federation_data(fed_data)
 
     bundles = fed_data.get("bundles", [])
 
@@ -147,7 +195,7 @@ def execute_federated_query(
 
             bundle_path = Path(bundle_path_str)
             if not bundle_path.is_absolute():
-                bundle_path = federation_index_path.parent / bundle_path
+                bundle_path = federation_base_path / bundle_path
 
             db_path = _find_bundle_index(bundle_path)
             if not db_path:
@@ -198,8 +246,20 @@ def execute_federated_query(
                     if not hit.get("range_ref") and not hit.get("derived_range_ref"):
                         continue
 
-                    # Tag results with bundle origin (Provenance)
+                    # Tag results with bundle origin, availability and freshness provenance.
+                    status = bundle_status.get(repo_id, "ok")
+                    freshness = _freshness_status(expected_fingerprint, db_fingerprint, status)
                     hit["federation_bundle"] = repo_id
+                    hit["federation_bundle_status"] = status
+                    hit["federation_freshness_status"] = freshness
+                    hit["federation_origin"] = {
+                        "repo_id": repo_id,
+                        "bundle_path": bundle_path_str,
+                        "availability_status": status,
+                        "freshness_status": freshness,
+                        "expected_fingerprint": expected_fingerprint,
+                        "observed_fingerprint": db_fingerprint,
+                    }
                     all_results.append(hit)
 
             if repo_id not in bundle_status:
@@ -314,3 +374,71 @@ def execute_federated_query(
         }
 
     return out
+
+def execute_federated_query(
+    federation_index_path: Path,
+    query_text: str,
+    k: int = 10,
+    filters: Optional[Dict[str, Optional[str]]] = None,
+    embedding_policy: Optional[Dict[str, Any]] = None,
+    explain: bool = False,
+    trace: bool = False,
+    build_context: bool = False,
+) -> Dict[str, Any]:
+    """
+    Executes a minimal federated query aggregation across local bundles referenced by a federation index.
+
+    The federation index is a read-only registry input. This function does not create snapshots,
+    refresh bundles, mutate Git, run shells or assert global repository truth.
+    """
+    fed_data = load_federation_index_data(federation_index_path)
+
+    return _execute_federated_query_data(
+        fed_data=fed_data,
+        federation_base_path=federation_index_path.parent,
+        query_text=query_text,
+        k=k,
+        filters=filters,
+        embedding_policy=embedding_policy,
+        explain=explain,
+        trace=trace,
+        build_context=build_context,
+    )
+
+
+def execute_federated_query_from_bundles(
+    bundle_specs: List[Dict[str, str]],
+    query_text: str,
+    k: int = 10,
+    filters: Optional[Dict[str, Optional[str]]] = None,
+    embedding_policy: Optional[Dict[str, Any]] = None,
+    explain: bool = False,
+    trace: bool = False,
+    build_context: bool = False,
+    federation_id: str = "inline-bundle-set",
+    base_path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """
+    Executes the same read-only federation query over an explicit list of bundle roots.
+
+    `bundle_specs` items require `repo_id` and `bundle_path`, and may include
+    `last_fingerprint`. Relative bundle paths resolve against `base_path` (or CWD).
+    No federation_index.json is written.
+    """
+    resolved_base = (base_path or Path.cwd()).resolve(strict=True)
+    fed_data = _build_transient_federation_index(
+        bundle_specs,
+        federation_id=federation_id,
+        base_path=resolved_base,
+    )
+    return _execute_federated_query_data(
+        fed_data=fed_data,
+        federation_base_path=resolved_base,
+        query_text=query_text,
+        k=k,
+        filters=filters,
+        embedding_policy=embedding_policy,
+        explain=explain,
+        trace=trace,
+        build_context=build_context,
+    )

--- a/merger/lenskit/tests/test_federation_cli.py
+++ b/merger/lenskit/tests/test_federation_cli.py
@@ -511,6 +511,51 @@ def _make_two_bundle_fed(tmp_path, fed_id="crl-fed"):
     return out_path
 
 
+def test_federation_query_cli_inline_bundles(tmp_path: Path, monkeypatch, capsys):
+    """CLI query can use repeated --bundle inputs without writing federation_index.json."""
+    monkeypatch.chdir(tmp_path)
+    fed_path = _make_two_bundle_fed(tmp_path, fed_id="unused-index")
+    fed_path.unlink()
+
+    from merger.lenskit.cli import main
+
+    ret = main.main([
+        "federation",
+        "query",
+        "--bundle",
+        f"repo1={tmp_path / 'b1'}",
+        "--bundle",
+        f"repo2={tmp_path / 'b2'}",
+        "--federation-id",
+        "inline-cli",
+        "-q",
+        "hello",
+        "--trace",
+    ])
+    assert ret == 0
+
+    parsed = json.loads(capsys.readouterr().out)
+    assert parsed["federation_id"] == "inline-cli"
+    assert parsed["count"] == 2
+    for hit in parsed["results"]:
+        assert hit["federation_origin"]["repo_id"] in {"repo1", "repo2"}
+        assert hit["federation_origin"]["availability_status"] == "ok"
+        assert hit["federation_origin"]["freshness_status"] == "unverified"
+
+    trace_file = tmp_path / "federation_trace.json"
+    assert trace_file.exists()
+    trace_data = json.loads(trace_file.read_text(encoding="utf-8"))
+    assert {b["repo_id"] for b in trace_data["bundles"]} == {"repo1", "repo2"}
+
+
+def test_federation_query_cli_requires_one_query_source(tmp_path: Path, capsys):
+    from merger.lenskit.cli import main
+
+    ret = main.main(["federation", "query", "-q", "hello"])
+    assert ret == 1
+    assert "provide exactly one query source" in capsys.readouterr().err
+
+
 def test_federation_query_trace_writes_cross_repo_links_json(tmp_path: Path, monkeypatch):
     """CLI --trace with multi-bundle results writes cross_repo_links.json."""
     monkeypatch.chdir(tmp_path)

--- a/merger/lenskit/tests/test_federation_query.py
+++ b/merger/lenskit/tests/test_federation_query.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from merger.lenskit.core.federation import init_federation, add_bundle
 from merger.lenskit.retrieval.federation_query import execute_federated_query
+from merger.lenskit.retrieval.federation_query import execute_federated_query_from_bundles
 from merger.lenskit.retrieval import index_db
 
 @pytest.fixture
@@ -67,6 +68,39 @@ def test_execute_federated_query(federated_setup):
     # Minimal provenance preservation via federation_bundle tagging
     repos = {h["federation_bundle"] for h in res["results"]}
     assert repos == {"repo1", "repo2"}
+
+    for hit in res["results"]:
+        assert hit["federation_bundle_status"] == "ok"
+        assert hit["federation_freshness_status"] == "unverified"
+        assert hit["federation_origin"]["repo_id"] == hit["federation_bundle"]
+        assert hit["federation_origin"]["availability_status"] == "ok"
+        assert hit["federation_origin"]["freshness_status"] == "unverified"
+
+
+def test_execute_federated_query_from_inline_bundles(federated_setup):
+    res = execute_federated_query_from_bundles(
+        [
+            {"repo_id": "repo1", "bundle_path": "repo1"},
+            {"repo_id": "repo2", "bundle_path": "repo2"},
+        ],
+        query_text="hello",
+        k=10,
+        trace=True,
+        federation_id="inline-test",
+        base_path=federated_setup.parent,
+    )
+
+    assert res["federation_id"] == "inline-test"
+    assert res["count"] == 2
+    repos = {h["federation_origin"]["repo_id"] for h in res["results"]}
+    assert repos == {"repo1", "repo2"}
+    for hit in res["results"]:
+        assert hit["derived_range_ref"]
+        assert hit["federation_bundle"] in {"repo1", "repo2"}
+        assert hit["federation_bundle_status"] == "ok"
+        assert hit["federation_freshness_status"] == "unverified"
+    assert res["federation_trace"]["bundle_status"] == {"repo1": "ok", "repo2": "ok"}
+
 
 def test_execute_federated_query_with_repo_filter(federated_setup):
     res = execute_federated_query(
@@ -415,6 +449,16 @@ def test_stale_bundle_is_marked_in_federation_trace(federated_setup):
     assert trace["bundle_status"]["repo2"] == "ok"
     assert trace["queried_bundles_effective"] == 2
 
+    stale_hits = [hit for hit in res["results"] if hit["federation_bundle"] == "repo1"]
+    assert stale_hits, "stale bundle still returns hits, but they must be explicitly marked"
+    for hit in stale_hits:
+        assert hit["federation_bundle_status"] == "stale"
+        assert hit["federation_freshness_status"] == "stale"
+        assert hit["federation_origin"]["availability_status"] == "stale"
+        assert hit["federation_origin"]["freshness_status"] == "stale"
+        assert hit["federation_origin"]["expected_fingerprint"] == "stale_hash"
+        assert hit["federation_origin"]["observed_fingerprint"] == "actual_hash"
+
 def test_execute_federated_query_rejects_falsy_provenance(federated_setup, monkeypatch):
     from merger.lenskit.retrieval import federation_query
 
@@ -659,7 +703,7 @@ def test_build_cross_repo_links_directly():
     ]
     links3 = _build_cross_repo_links(hits_three_repos)
     assert len(links3) == 3
-    pairs = {(l["source_repo"], l["target_repo"]) for l in links3}
+    pairs = {(link["source_repo"], link["target_repo"]) for link in links3}
     assert ("repo1", "repo2") in pairs
     assert ("repo1", "repo3") in pairs
     assert ("repo2", "repo3") in pairs


### PR DESCRIPTION
## Summary

Implements `RPU-V1-T016`: federated fleet bundle search hardening.

Changes:

- adds `execute_federated_query_from_bundles` for repeated in-memory bundle roots without writing `federation_index.json`;
- keeps existing `--index` federation query behavior;
- adds CLI `lenskit federation query --bundle REPO_ID=PATH` support;
- adds per-hit `federation_bundle_status`, `federation_freshness_status` and structured `federation_origin`;
- ensures stale bundle hits are still returned only with explicit stale marking;
- documents the proof and non-claims in `docs/proofs/federated-fleet-bundle-search-rpu-v1-t016-proof.md`.

## Self-review

- Scope is limited to existing read-only federation/query surfaces.
- No snapshot creation, refresh, Git mutation, shell execution, PR creation or patch application is introduced.
- Existing persisted `--index` query remains supported and validated.
- Inline `--bundle` is mutually exclusive with `--index` and is converted to a transient schema-validated federation object in memory only.
- Stale bundles are not silently promoted: returned stale hits carry stale status/freshness fields directly, even when `trace=false`.
- Existing heuristic boundaries remain unchanged: `cross_repo_links` still means co-occurrence only; `federation_conflicts` remains unresolved/heuristic.
- This does not establish ecosystem completeness, semantic identity, dependency relationships, runtime correctness, test sufficiency, review completeness, merge readiness, production query quality or full global ranking correctness.

## Validation

```text
python3 -m py_compile \
  merger/lenskit/core/federation.py \
  merger/lenskit/retrieval/federation_query.py \
  merger/lenskit/cli/cmd_federation.py \
  merger/lenskit/tests/test_federation_query.py \
  merger/lenskit/tests/test_federation_cli.py

python3 -m ruff check \
  merger/lenskit/core/federation.py \
  merger/lenskit/retrieval/federation_query.py \
  merger/lenskit/cli/cmd_federation.py \
  merger/lenskit/tests/test_federation_query.py \
  merger/lenskit/tests/test_federation_cli.py

python3 -m pytest -q \
  merger/lenskit/tests/test_federation_*.py \
  merger/lenskit/tests/test_api_federation.py
# 93 passed

python3 -m scripts.docmeta.check_planning_registration --ratchet --baseline docs/tasks/planning-registration-baseline.json --format json
# no findings

git diff --check
```
