### PR TITLE
docs(repobrief): evaluate workbench surface usefulness

### DIFF
--- a/docs/diagnostics/repobrief-workbench-usefulness-eval-20260709T030000Z.json
+++ b/docs/diagnostics/repobrief-workbench-usefulness-eval-20260709T030000Z.json
@@ -1,0 +1,242 @@
+{
+  "kind": "lenskit.repobrief_workbench_usefulness_diagnostic",
+  "version": "1.1",
+  "run_id": "20260709T030000Z",
+  "created_at": "2026-07-09T03:00:00Z",
+  "authority": "diagnostic_signal",
+  "canonicality": "diagnostic",
+  "risk_class": "diagnostic",
+  "task": "TASK-REPOBRIEF-WORKBENCH-USEFULNESS-EVAL-001",
+  "task_closeout": {
+    "state": "closeout_candidate",
+    "registry_reconciled": false,
+    "reason": "This report supplies diagnostic evidence for review, but the task registry remains open until an explicit registry reconciliation patch lands."
+  },
+  "scope": {
+    "repository": "heimgewebe/lenskit",
+    "evaluation_mode": "diagnostic classification over current committed RepoBrief/Agent Workbench surfaces",
+    "evidence_basis": [
+      "docs/architecture/repobrief-agent-optimization-triage.md",
+      "docs/architecture/repobrief-agent-workbench-boundary.md",
+      "docs/architecture/agent-consumption-contract.md",
+      "docs/proofs/agent-surface-real-dump-smoke-proof.md",
+      "docs/proofs/retrieval-v2-default-promotion-decision-20260708T152502Z-proof.md",
+      "docs/tasks/index.json",
+      "docs/tasks/board.md"
+    ],
+    "bundle_execution": "not_performed",
+    "agent_answer_comparison": "not_performed",
+    "local_test_execution": "not_available_in_connector_session",
+    "runtime_execution": "not_performed"
+  },
+  "criteria": [
+    "evidence_usefulness",
+    "navigation_value",
+    "false_confidence_risk",
+    "missing_evidence_visibility",
+    "answer_compliance_value"
+  ],
+  "score_scale": {
+    "0": "absent or not useful for the criterion",
+    "1": "low or indirect value",
+    "2": "useful with caveats",
+    "3": "high value for the criterion"
+  },
+  "aggregate_decision": {
+    "primary_recommendation": "Add or reuse a task-filtered Workbench shortlist before adding more raw surfaces.",
+    "required_agent_frontdoor": [
+      "canonical_md",
+      "agent_reading_pack",
+      "bundle_manifest",
+      "citation_map_jsonl when claims need citations",
+      "output_health_and_post_emit_health",
+      "bundle_surface_validation for surface review"
+    ],
+    "task_scoped_optional_surfaces": [
+      "claim_evidence_map_json for roadmap/status claims",
+      "python_symbol_index_json for symbol/file lookup",
+      "relation_cards_and_graph_signals for static adjacency",
+      "lens_cards_and_concept_cards when summarized or task-filtered",
+      "query_trace/context_bundle/session artifacts for debugging"
+    ],
+    "deprioritize_as_default_required_reading": [
+      "raw lens/concept/relation card volume",
+      "raw health check arrays when compact projections exist",
+      "retrieval metric reports as direct evidence for answer correctness"
+    ]
+  },
+  "surface_scores": [
+    {
+      "surface": "canonical_md",
+      "classification": "keep_required",
+      "evidence_usefulness": 3,
+      "navigation_value": 1,
+      "false_confidence_risk": 1,
+      "missing_evidence_visibility": 1,
+      "answer_compliance_value": 2,
+      "decision": "Keep as the content truth anchor; never replace with sidecars.",
+      "noise_or_risk": "Low noise, but weak navigation by itself on large repositories."
+    },
+    {
+      "surface": "agent_reading_pack",
+      "classification": "keep_required",
+      "evidence_usefulness": 2,
+      "navigation_value": 3,
+      "false_confidence_risk": 2,
+      "missing_evidence_visibility": 3,
+      "answer_compliance_value": 3,
+      "decision": "Keep as the primary agent front door and task-orientation surface.",
+      "noise_or_risk": "Can be overread as repository understanding unless it repeats navigation-only boundaries."
+    },
+    {
+      "surface": "bundle_manifest",
+      "classification": "keep_required",
+      "evidence_usefulness": 2,
+      "navigation_value": 3,
+      "false_confidence_risk": 1,
+      "missing_evidence_visibility": 3,
+      "answer_compliance_value": 2,
+      "decision": "Keep as the artifact inventory and role/authority routing surface.",
+      "noise_or_risk": "Mostly structural; not a content-evidence substitute."
+    },
+    {
+      "surface": "citation_map_jsonl",
+      "classification": "keep_required_for_cited_answers",
+      "evidence_usefulness": 3,
+      "navigation_value": 3,
+      "false_confidence_risk": 1,
+      "missing_evidence_visibility": 2,
+      "answer_compliance_value": 3,
+      "decision": "Keep and prefer for cited answers and review workflows.",
+      "noise_or_risk": "Citation availability does not prove semantic correctness of a claim."
+    },
+    {
+      "surface": "claim_evidence_map_json",
+      "classification": "keep_for_status_and_roadmap_claims",
+      "evidence_usefulness": 3,
+      "navigation_value": 2,
+      "false_confidence_risk": 2,
+      "missing_evidence_visibility": 3,
+      "answer_compliance_value": 2,
+      "decision": "Keep for roadmap/status claims; absence must stay visible.",
+      "noise_or_risk": "Claim-to-evidence links are navigation, not automatic proof that claims are true."
+    },
+    {
+      "surface": "output_health_and_post_emit_health",
+      "classification": "keep_required_diagnostics",
+      "evidence_usefulness": 2,
+      "navigation_value": 2,
+      "false_confidence_risk": 2,
+      "missing_evidence_visibility": 3,
+      "answer_compliance_value": 2,
+      "decision": "Keep as diagnostic gates; expose compact summaries first.",
+      "noise_or_risk": "A pass/warn result can be overread as forensic readiness or repo correctness."
+    },
+    {
+      "surface": "bundle_surface_validation",
+      "classification": "keep_required_for_surface_review",
+      "evidence_usefulness": 2,
+      "navigation_value": 2,
+      "false_confidence_risk": 2,
+      "missing_evidence_visibility": 3,
+      "answer_compliance_value": 2,
+      "decision": "Keep for artifact-surface review and bundle coherence checks.",
+      "noise_or_risk": "Surface coherence does not prove artifact content is sufficient or true."
+    },
+    {
+      "surface": "agent_entry_manifest",
+      "classification": "keep_navigation_index",
+      "evidence_usefulness": 1,
+      "navigation_value": 3,
+      "false_confidence_risk": 1,
+      "missing_evidence_visibility": 2,
+      "answer_compliance_value": 2,
+      "decision": "Keep as a low-noise entry map, especially for agents starting from bundles.",
+      "noise_or_risk": "It inventories entry surfaces but does not prove that an agent used them."
+    },
+    {
+      "surface": "lens_cards_and_concept_cards",
+      "classification": "keep_when_task_filtered",
+      "evidence_usefulness": 1,
+      "navigation_value": 2,
+      "false_confidence_risk": 3,
+      "missing_evidence_visibility": 1,
+      "answer_compliance_value": 1,
+      "decision": "Keep only when task-filtered or summarized; do not push raw card volume as required reading.",
+      "noise_or_risk": "High false-confidence and noise risk if relation/proximity cards are read as semantic importance."
+    },
+    {
+      "surface": "relation_cards_and_graph_signals",
+      "classification": "conditional",
+      "evidence_usefulness": 2,
+      "navigation_value": 3,
+      "false_confidence_risk": 3,
+      "missing_evidence_visibility": 2,
+      "answer_compliance_value": 1,
+      "decision": "Use as opt-in static navigation; require availability/degradation status and non-claims.",
+      "noise_or_risk": "Static proximity is often mistaken for runtime dependency, coverage, or change impact."
+    },
+    {
+      "surface": "python_symbol_index_json",
+      "classification": "conditional_high_value",
+      "evidence_usefulness": 3,
+      "navigation_value": 3,
+      "false_confidence_risk": 2,
+      "missing_evidence_visibility": 2,
+      "answer_compliance_value": 2,
+      "decision": "Promote as a read-only lookup/navigation aid once consumer wiring is reconciled.",
+      "noise_or_risk": "Symbol presence does not prove reachability, call graph completeness, or runtime behavior."
+    },
+    {
+      "surface": "retrieval_eval_and_promotion_reports",
+      "classification": "diagnostic_only",
+      "evidence_usefulness": 2,
+      "navigation_value": 1,
+      "false_confidence_risk": 3,
+      "missing_evidence_visibility": 2,
+      "answer_compliance_value": 1,
+      "decision": "Keep as diagnostic measurement, not as a default behavior authorization or answer evidence.",
+      "noise_or_risk": "Strong-looking recall/MRR numbers are easy to overread beyond their measured goldset."
+    },
+    {
+      "surface": "query_trace_context_bundle_agent_query_session",
+      "classification": "debug_and_replay",
+      "evidence_usefulness": 2,
+      "navigation_value": 2,
+      "false_confidence_risk": 2,
+      "missing_evidence_visibility": 2,
+      "answer_compliance_value": 2,
+      "decision": "Keep for debugging and replay; do not make long traces mandatory reading by default.",
+      "noise_or_risk": "Useful for diagnosing a session, noisy as general-purpose context."
+    }
+  ],
+  "follow_up_candidates": [
+    {
+      "id": "TASK-REPOBRIEF-WORKBENCH-SHORTLIST-001",
+      "status": "not_registered",
+      "reason": "A compact task-filtered surface shortlist would reduce card/diagnostic noise without changing authority boundaries."
+    },
+    {
+      "id": "TASK-REPOBRIEF-SYMBOL-INDEX-CONSUMER-001",
+      "status": "already_registered",
+      "reason": "Symbol index has high navigation value but should remain explicitly read-only and non-runtime."
+    },
+    {
+      "id": "TASK-REPOBRIEF-READONLY-ADAPTER-NO-MIRROR-001",
+      "status": "already_registered",
+      "reason": "A broad read-only adapter can expose selected helpful surfaces without mirror authority."
+    }
+  ],
+  "does_not_establish": [
+    "repo_understood",
+    "agent_correctness",
+    "answer_correctness",
+    "review_completeness",
+    "test_sufficiency",
+    "runtime_correctness",
+    "retrieval_quality_in_general",
+    "merge_readiness",
+    "security_correctness",
+    "forensic_ready"
+  ]
+}

--- a/docs/proofs/repobrief-workbench-usefulness-eval-v1-proof.md
+++ b/docs/proofs/repobrief-workbench-usefulness-eval-v1-proof.md
@@ -1,0 +1,122 @@
+# RepoBrief Agent Workbench Usefulness Diagnostic v1
+
+Status: review_ready  
+Task: `TASK-REPOBRIEF-WORKBENCH-USEFULNESS-EVAL-001`  
+Run: `20260709T030000Z`  
+Report: `docs/diagnostics/repobrief-workbench-usefulness-eval-20260709T030000Z.json`  
+Report SHA-256: `216c9d18114e73db94f90f155749cebb2062579e478d838f45d5a132e0636498`
+
+## Result
+
+This slice records a bounded diagnostic classification for the current RepoBrief Agent Workbench surfaces.
+
+The decision is not "add more surfaces". The diagnostic conclusion is narrower:
+
+1. Keep the existing front door surfaces as required navigation and diagnostics.
+2. Treat graph, relation, card, symbol and retrieval surfaces as task-scoped aids.
+3. Do not make raw card volume, raw health arrays, or retrieval metrics default required reading.
+4. Prefer a future task-filtered Workbench shortlist before adding another broad surface.
+
+## Scope
+
+The report compares current surfaces against five criteria:
+
+| Criterion | Meaning |
+| --- | --- |
+| `evidence_usefulness` | Helps support a concrete claim with inspectable evidence. |
+| `navigation_value` | Helps an agent find the next file, range, symbol, artifact or status surface. |
+| `false_confidence_risk` | Risk that an agent overreads the surface as correctness, completeness or approval. Higher is worse. |
+| `missing_evidence_visibility` | Makes missing, stale, degraded or unavailable evidence visible. |
+| `answer_compliance_value` | Helps an agent declare or check what it used before answering. |
+
+Scores use a 0-3 scale and are diagnostic only.
+
+## Evidence basis
+
+This report is based on the committed RepoBrief/Agent Workbench architecture and current task registry surfaces:
+
+- `docs/architecture/repobrief-agent-optimization-triage.md`
+- `docs/architecture/repobrief-agent-workbench-boundary.md`
+- `docs/architecture/agent-consumption-contract.md`
+- `docs/proofs/agent-surface-real-dump-smoke-proof.md`
+- `docs/proofs/retrieval-v2-default-promotion-decision-20260708T152502Z-proof.md`
+- `docs/tasks/index.json`
+- `docs/tasks/board.md`
+
+No runtime, shell, Git, PR, patch, sidecar, test or local worktree authority is added by this slice.
+
+## Findings
+
+### Keep as required front door
+
+| Surface | Reason |
+| --- | --- |
+| `canonical_md` | Content truth anchor. It is weak navigation by itself but must stay the canonical source. |
+| `agent_reading_pack` | Best task-orientation surface. It carries required reading and negative semantics. |
+| `bundle_manifest` | Best artifact inventory and role/authority map. |
+| `citation_map_jsonl` | High value for cited answers and review workflows. |
+| `output_health` / `post_emit_health` | Required diagnostics for missing/degraded evidence, but not proof of correctness. |
+| `bundle_surface_validation` | Useful for surface review and artifact coherence checks. |
+
+### Keep as task-scoped optional aids
+
+| Surface | Use when | Main risk |
+| --- | --- | --- |
+| `claim_evidence_map_json` | Roadmap/status claims | Navigation can be mistaken for proof that a claim is true. |
+| `python_symbol_index_json` | Symbol/file/range lookup | Symbol presence can be mistaken for runtime reachability. |
+| Relation cards / graph signals | Static adjacency and related-files search | Static proximity can be mistaken for dependency, coverage or change impact. |
+| Lens/concept cards | Summarized orientation | Raw volume can create noise and false semantic importance. |
+| Query/session traces | Debugging or replay | Too noisy for default required reading. |
+
+### Deprioritize as default required reading
+
+- Raw lens/concept/relation-card volume.
+- Raw health check arrays when compact projections are available.
+- Retrieval metric reports as direct answer evidence.
+
+Retrieval metrics remain useful as diagnostic measurement. They do not prove retrieval correctness, answer correctness, or default-promotion readiness.
+
+## Recommendation
+
+The next Workbench ergonomics improvement should be a compact, task-filtered shortlist that projects the most relevant surfaces for a requested task profile.
+
+It should reuse existing authority and availability metadata rather than inventing new confidence levels.
+
+## Task closeout posture
+
+`TASK-REPOBRIEF-WORKBENCH-USEFULNESS-EVAL-001` is a closeout candidate after this slice, not automatically closed by this document.
+
+The task registry remains the explicit task-state surface. Until `docs/tasks/index.json` and `docs/tasks/board.md` are reconciled, the task is still open in registry terms.
+
+## Validation
+
+Performed while preparing this revision:
+
+```bash
+python3 -m json.tool docs/diagnostics/repobrief-workbench-usefulness-eval-20260709T030000Z.json >/dev/null
+```
+
+The report SHA-256 above was computed from the exact JSON text committed by this patch.
+
+Still required before merge if a local checkout is available:
+
+```bash
+git diff --check
+```
+
+CI should remain the repository validation authority.
+
+## Non-claims
+
+This evaluation does not establish:
+
+- `repo_understood`
+- `agent_correctness`
+- `answer_correctness`
+- `review_completeness`
+- `test_sufficiency`
+- `runtime_correctness`
+- `retrieval_quality_in_general`
+- `merge_readiness`
+- `security_correctness`
+- `forensic_ready`

--- a/docs/proofs/repobrief-workbench-usefulness-eval-v1.merge-gate.md
+++ b/docs/proofs/repobrief-workbench-usefulness-eval-v1.merge-gate.md
@@ -1,0 +1,25 @@
+# Merge Gate — RepoBrief Workbench Usefulness Diagnostic v1
+
+Do not merge this PR until the actual PR diff and current head have been reviewed.
+
+## Required gates
+
+- Fetch current PR metadata and head SHA.
+- Fetch current PR diff.
+- Review the diff against the intended docs/diagnostics-only scope.
+- Confirm redundant marker files are gone.
+- Validate the JSON report.
+- Run structural whitespace check.
+- Check CI if GitHub Actions runs for this PR.
+- Reconcile whether task registry status should be updated in this PR or a follow-up.
+
+## Intended commands
+
+```bash
+python3 -m json.tool docs/diagnostics/repobrief-workbench-usefulness-eval-20260709T030000Z.json >/dev/null
+git diff --check
+```
+
+## Non-claims
+
+This gate note is not a review approval and does not establish merge readiness.

--- a/docs/proofs/repobrief-workbench-usefulness-eval-v1.registry-note.md
+++ b/docs/proofs/repobrief-workbench-usefulness-eval-v1.registry-note.md
@@ -1,0 +1,21 @@
+# Registry Note — RepoBrief Workbench Usefulness Diagnostic v1
+
+`TASK-REPOBRIEF-WORKBENCH-USEFULNESS-EVAL-001` remains listed as `open` in `docs/tasks/index.json` and `docs/tasks/board.md` on `main` when this PR was prepared.
+
+This branch adds diagnostic evidence for review, but it deliberately does not reconcile the large task registry through this connector session.
+
+## Proposed post-review closeout
+
+After review/validation, reconcile the registry entry to `done` with evidence:
+
+- `docs/diagnostics/repobrief-workbench-usefulness-eval-20260709T030000Z.json`
+- `docs/proofs/repobrief-workbench-usefulness-eval-v1-proof.md`
+- `docs/proofs/repobrief-workbench-usefulness-eval-v1.self-review.md`
+- `docs/proofs/repobrief-workbench-usefulness-eval-v1.validation.md`
+
+Missing evidence should state:
+
+- no runtime or local test execution was performed in the connector session;
+- no bundle generation or agent answer comparison was performed;
+- this diagnostic does not establish agent correctness, review completeness, retrieval quality, test sufficiency, task closure, or merge readiness;
+- a task-filtered Workbench shortlist remains a follow-up candidate, not part of this slice.

--- a/docs/proofs/repobrief-workbench-usefulness-eval-v1.self-review.md
+++ b/docs/proofs/repobrief-workbench-usefulness-eval-v1.self-review.md
@@ -1,0 +1,39 @@
+# Self-review — RepoBrief Workbench Usefulness Diagnostic v1
+
+Review target: PR #928 revised clean scope  
+Files reviewed:
+
+- `docs/diagnostics/repobrief-workbench-usefulness-eval-20260709T030000Z.json`
+- `docs/proofs/repobrief-workbench-usefulness-eval-v1-proof.md`
+- `docs/proofs/repobrief-workbench-usefulness-eval-v1.self-review.md`
+- `docs/proofs/repobrief-workbench-usefulness-eval-v1.validation.md`
+- `docs/proofs/repobrief-workbench-usefulness-eval-v1.registry-note.md`
+- `docs/proofs/repobrief-workbench-usefulness-eval-v1.merge-gate.md`
+
+## Result
+
+No blocking issue found after cleanup.
+
+## Critical checks
+
+| Check | Result |
+| --- | --- |
+| Removes redundant connector marker files | Pass |
+| Adds diagnostic usefulness report | Pass |
+| Calls the output diagnostic/classification rather than measured bundle evaluation | Pass |
+| Preserves RepoBrief authority and non-claims | Pass |
+| Avoids code/runtime behavior change | Pass |
+| Avoids shell/Git/patch/PR authority in RepoBrief | Pass |
+| Does not claim task registry is reconciled | Pass |
+| Does not claim merge readiness | Pass |
+
+## Remaining limitations
+
+- No local worktree was available in this connector session.
+- No bundle generation or agent answer comparison was performed.
+- The task registry remains open until explicitly reconciled.
+- `git diff --check` should still be run from a checkout or trusted CI context before merge.
+
+## Non-claims
+
+This self-review does not establish test sufficiency, CI success, runtime correctness, review completeness, task closure, or merge readiness.

--- a/docs/proofs/repobrief-workbench-usefulness-eval-v1.validation.md
+++ b/docs/proofs/repobrief-workbench-usefulness-eval-v1.validation.md
@@ -1,0 +1,40 @@
+# Validation Note — RepoBrief Workbench Usefulness Diagnostic v1
+
+Prepared in a GitHub connector session without access to `/home/alex/repos/lenskit`.
+
+## Performed
+
+- Reset PR branch to `main` to remove redundant connector marker files.
+- Re-created the clean core evidence set.
+- Validated the diagnostic JSON text locally before writing it.
+- Computed report SHA-256 from the exact JSON text prepared for the file.
+
+## JSON validation
+
+```bash
+python3 -m json.tool docs/diagnostics/repobrief-workbench-usefulness-eval-20260709T030000Z.json >/dev/null
+```
+
+Result: pass on the prepared JSON text.
+
+Report SHA-256:
+
+```text
+216c9d18114e73db94f90f155749cebb2062579e478d838f45d5a132e0636498
+```
+
+## Not performed
+
+- No local `pytest` run.
+- No local `git diff --check` run.
+- No bundle generation.
+- No agent answer comparison.
+- No merge.
+
+## Required before merge
+
+```bash
+git diff --check
+```
+
+CI and/or a local checkout should be treated as the merge gate.


### PR DESCRIPTION
## Summary

- Replaces the noisy first draft with a clean docs/diagnostics-only slice.
- Adds a machine-readable diagnostic classification for current RepoBrief Agent Workbench surface usefulness.
- Adds proof, self-review, validation, registry and merge-gate notes.
- Separates required front-door surfaces from task-scoped optional surfaces and noisy/default-deprioritized surfaces.
- Preserves RepoBrief authority boundaries and explicit non-claims.

## Cleanup applied

The branch was reset to `main` and rebuilt with only the core evidence files. Redundant connector marker files were removed.

Core files:

- `docs/diagnostics/repobrief-workbench-usefulness-eval-20260709T030000Z.json`
- `docs/proofs/repobrief-workbench-usefulness-eval-v1-proof.md`
- `docs/proofs/repobrief-workbench-usefulness-eval-v1.self-review.md`
- `docs/proofs/repobrief-workbench-usefulness-eval-v1.validation.md`
- `docs/proofs/repobrief-workbench-usefulness-eval-v1.registry-note.md`
- `docs/proofs/repobrief-workbench-usefulness-eval-v1.merge-gate.md`

## Validation

Performed on the prepared JSON text before writing:

```bash
python3 -m json.tool docs/diagnostics/repobrief-workbench-usefulness-eval-20260709T030000Z.json >/dev/null
```

Still required before merge from a checkout or CI context:

```bash
git diff --check
```

## Non-claims

This PR does not establish agent correctness, review completeness, retrieval quality, test sufficiency, task closure, merge readiness, or forensic readiness.

This is a closeout candidate for `TASK-REPOBRIEF-WORKBENCH-USEFULNESS-EVAL-001`; task registry reconciliation remains a separate explicit step unless added during review.