### PR TITLE
docs(repobrief): define read-only adapter boundary

### DIFF
--- a/docs/architecture/repobrief-readonly-adapter-no-mirror.md
+++ b/docs/architecture/repobrief-readonly-adapter-no-mirror.md
@@ -1,0 +1,150 @@
+# RepoBrief Read-only Adapter without Mirror Authority v1
+
+Status: design_ready  
+Task: `TASK-REPOBRIEF-READONLY-ADAPTER-NO-MIRROR-001`
+
+## Purpose
+
+This document defines a broader read-only adapter for RepoBrief consumers without granting repository mirror authority.
+
+The adapter is a narrow consumer facade over existing snapshots, bundle artifacts, indexes, ranges, availability reports and task-facing helper results. It is not a repository mirror, not a synchronization layer and not a mutable workbench.
+
+## Decision
+
+RepoBrief should expose one shared read-only adapter contract for CLI, MCP-shaped handlers, library consumers and future Agent Workbench helpers.
+
+The adapter may only read or derive bounded views from already existing RepoBrief evidence surfaces. It must not acquire authority to clone, fetch, pull, refresh, create PRs, apply patches, run shells, read secrets or silently create snapshots.
+
+## Allowed read surfaces
+
+The adapter may expose:
+
+| Surface | Allowed operation | Boundary |
+| --- | --- | --- |
+| Snapshot inventory | list known snapshots under an explicit bundle root | no filesystem crawl outside configured roots |
+| Bundle manifest | read manifest and artifact roles | manifest is inventory, not content truth |
+| Canonical brief source | read canonical Markdown ranges or full content when requested | canonical for snapshot only, not live repo |
+| Agent reading pack | read required-reading/navigation surface | navigation, not proof of context use |
+| Health and availability | read output/post-emit health, bundle surface validation and availability reports | diagnostic only |
+| Artifact by role | resolve an artifact path from manifest/known roles | no implicit generation |
+| Citation/range lookup | resolve existing citation/range maps | no semantic claim validation |
+| Existing indexes | query existing SQLite/chunk/retrieval indexes | stale/missing/degraded remains visible |
+| Workbench static artifacts | read existing graph, symbol, relation or card artifacts | static/navigation only |
+| Runtime query artifacts | read explicitly named query/session artifacts | debugging/replay only |
+
+## Forbidden operations
+
+The adapter must not:
+
+- clone repositories;
+- fetch, pull, push, checkout or mutate Git;
+- inspect live working trees as a fallback for missing snapshot data;
+- create snapshots as a side effect of reads;
+- silently refresh stale or missing bundles;
+- create branches or pull requests;
+- apply, write, repair or stage patches;
+- run shells, tests, linters, build tools or sandboxes;
+- read secrets or privileged environment state;
+- execute deployment actions;
+- generate review verdicts;
+- auto-merge or label changes as safe.
+
+## Minimal adapter interface
+
+A later implementation should keep the surface small and explicit:
+
+| Method | Input | Output | Notes |
+| --- | --- | --- | --- |
+| `snapshot_list` | bundle root, optional repo/profile filters | snapshot summaries | no refresh |
+| `snapshot_status` | snapshot id/stem | status, freshness, availability | unknown/stale is reported, not fixed |
+| `artifact_get` | snapshot id/stem, role | artifact descriptor and optional content | role lookup only |
+| `canonical_range_get` | snapshot id/stem, range or citation id | canonical text span plus provenance | snapshot-bound |
+| `required_reading_resolve` | task profile, available roles | required/recommended/missing surfaces | protocol/navigation only |
+| `query_existing_index` | snapshot id/stem, query, index selector | ranked hits plus index status | no index creation |
+| `workbench_artifact_get` | snapshot id/stem, workbench artifact role | graph/symbol/card descriptor/content | static evidence only |
+| `runtime_artifact_get` | explicit artifact id/path | query/session artifact descriptor/content | debugging only |
+
+Every method should return explicit status fields such as `ok`, `missing`, `stale`, `degraded`, `invalid`, `not_applicable` or `forbidden` instead of smoothing failure into empty success.
+
+## Authority metadata
+
+Every returned object should carry, or be nestable under, these fields:
+
+- `authority`: `canonical_snapshot`, `navigation`, `diagnostic`, `static_analysis`, `external_evidence`, or `debugging`;
+- `canonicality`: whether the result is canonical content, a sidecar, an index, a diagnostic or a cache;
+- `snapshot_identity`: bundle stem/path and manifest hash when available;
+- `freshness_status`: `fresh`, `stale`, `unknown`, `not_comparable`, or `not_applicable`;
+- `availability_status`: `available`, `missing`, `degraded`, `invalid`, `profile_excluded`, or `not_applicable`;
+- `does_not_establish`: negative semantics appropriate to the surface.
+
+## Failure model
+
+The adapter should fail closed for authority crossings:
+
+| Condition | Expected result |
+| --- | --- |
+| Missing snapshot | `missing`, no fallback to live repo |
+| Stale snapshot | `stale`, no refresh |
+| Invalid manifest | `invalid`, no artifact inference beyond safe diagnostics |
+| Missing artifact role | `missing`, no generation |
+| Missing index | `missing`, no index build |
+| Requested live Git/read side effect | `forbidden` |
+| Requested shell/test/patch operation | `forbidden` |
+| Ambiguous artifact | `degraded` or `invalid`, no guess |
+
+## Relationship to MCP
+
+RepoBrief MCP remains read-first. MCP resources and read-only tools may wrap this adapter, but the adapter must not inherit protocol, network, authentication, scheduler or write-tool authority.
+
+A future `snapshot_create` tool remains a separate explicit write exception for Brief Bundle generation only. It must not be callable through read-only adapter paths and must not authorize patch, shell, Git or PR behavior.
+
+## Relationship to Agent Workbench
+
+The Agent Workbench may consume this adapter for deterministic code-understanding surfaces such as symbols, ranges, graph availability, relation hints and query helpers.
+
+Workbench outputs remain evidence or navigation surfaces. They must not state that a patch is correct, that the repo is understood, that tests are sufficient or that a PR is safe to merge.
+
+## Non-goals
+
+This design does not implement:
+
+- an MCP protocol server;
+- snapshot creation;
+- repository synchronization;
+- git mirror management;
+- a patch runner;
+- a shell/test executor;
+- a secret broker;
+- auto-review or auto-fix behavior;
+- task registry mutation;
+- default retrieval promotion;
+- proof that the adapter improves agent correctness.
+
+## Acceptance for v1 design
+
+This design satisfies the first bounded step for `TASK-REPOBRIEF-READONLY-ADAPTER-NO-MIRROR-001` if review accepts that it defines:
+
+- allowed read surfaces;
+- forbidden mirror/mutation operations;
+- a minimal adapter interface;
+- required authority/freshness/availability metadata;
+- fail-closed behavior for missing/stale/invalid evidence;
+- relationship to MCP and Agent Workbench;
+- explicit non-goals and non-claims.
+
+A later implementation task should add code-level contracts and tests before any consumer depends on the adapter.
+
+## Does not establish
+
+This document does not establish:
+
+- adapter implementation;
+- MCP deployment;
+- runtime correctness;
+- test sufficiency;
+- review completeness;
+- retrieval quality;
+- repo understanding;
+- merge readiness;
+- security correctness;
+- absence of regressions.

--- a/docs/proofs/repobrief-readonly-adapter-no-mirror-v1-proof.md
+++ b/docs/proofs/repobrief-readonly-adapter-no-mirror-v1-proof.md
@@ -47,13 +47,14 @@ The adapter must not:
 
 This is a docs-only architecture slice.
 
-Expected validation before merge:
+Validation for this docs-only slice:
 
 ```bash
 git diff --check
+python -m pytest merger/lenskit/tests/test_repobrief_access_boundary.py -q
 ```
 
-No local checkout was available in this connector session.
+Local checkout validation was available in the review continuation and is recorded in the PR closeout.
 
 ## Task closeout posture
 

--- a/docs/proofs/repobrief-readonly-adapter-no-mirror-v1-proof.md
+++ b/docs/proofs/repobrief-readonly-adapter-no-mirror-v1-proof.md
@@ -1,0 +1,77 @@
+# RepoBrief Read-only Adapter without Mirror Authority v1 Proof
+
+Status: review_ready  
+Task: `TASK-REPOBRIEF-READONLY-ADAPTER-NO-MIRROR-001`  
+Design: `docs/architecture/repobrief-readonly-adapter-no-mirror.md`
+
+## Result
+
+This slice adds the bounded design for a broad RepoBrief read-only adapter without repository mirror authority.
+
+It defines which existing RepoBrief surfaces may be exposed to consumers and which operations remain forbidden.
+
+## Evidence basis
+
+The design is aligned with existing RepoBrief boundary documents:
+
+- `docs/architecture/repobrief-agent-workbench-boundary.md`
+- `docs/architecture/repobrief-mcp-boundary.md`
+- `docs/architecture/repobrief.md`
+- `docs/roadmap/lenskit-agent-operationalization-roadmap.md`
+
+## What this slice adds
+
+- allowed read surfaces;
+- forbidden mirror/mutation operations;
+- minimal future adapter method list;
+- authority, canonicality, freshness and availability metadata requirements;
+- fail-closed missing/stale/invalid evidence behavior;
+- separation from MCP protocol authority;
+- separation from Patch Evaluation Sidecar mutation authority;
+- explicit non-goals and non-claims.
+
+## Critical boundaries
+
+The adapter must not:
+
+- clone, fetch, pull, push or checkout Git;
+- inspect live worktrees as a fallback;
+- silently create or refresh snapshots;
+- create PRs, branches or patches;
+- run shells, tests, linters, builds or sandboxes;
+- read secrets;
+- produce review verdicts;
+- claim repo understanding, correctness, test sufficiency or merge readiness.
+
+## Validation
+
+This is a docs-only architecture slice.
+
+Expected validation before merge:
+
+```bash
+git diff --check
+```
+
+No local checkout was available in this connector session.
+
+## Task closeout posture
+
+This design is a review-ready closeout candidate for the design portion of `TASK-REPOBRIEF-READONLY-ADAPTER-NO-MIRROR-001`.
+
+It does not close an implementation task. A later implementation slice should add code-level contracts, tests and consumer wiring.
+
+## Non-claims
+
+This proof does not establish:
+
+- adapter implementation;
+- MCP deployment;
+- runtime correctness;
+- test sufficiency;
+- review completeness;
+- retrieval quality;
+- repo understanding;
+- merge readiness;
+- security correctness;
+- absence of regressions.

--- a/docs/proofs/repobrief-readonly-adapter-no-mirror-v1.self-review.md
+++ b/docs/proofs/repobrief-readonly-adapter-no-mirror-v1.self-review.md
@@ -1,0 +1,40 @@
+# Self-review — RepoBrief Read-only Adapter without Mirror Authority v1
+
+Review target: `docs/repobrief-readonly-adapter-no-mirror-v1`
+
+Files reviewed:
+
+- `docs/architecture/repobrief-readonly-adapter-no-mirror.md`
+- `docs/proofs/repobrief-readonly-adapter-no-mirror-v1-proof.md`
+- `docs/proofs/repobrief-readonly-adapter-no-mirror-v1.self-review.md`
+
+## Result
+
+No blocking issue found in the prepared docs-only design slice.
+
+## Critical checks
+
+| Check | Result |
+| --- | --- |
+| Defines broad read-only adapter boundary | Pass |
+| Preserves no-mirror rule | Pass |
+| Forbids clone/fetch/pull/Git mutation | Pass |
+| Forbids shell/test/patch/PR/secret authority | Pass |
+| Requires missing/stale/invalid evidence to stay visible | Pass |
+| Separates MCP protocol/write-tool authority | Pass |
+| Separates Patch Evaluation Sidecar mutation authority | Pass |
+| Avoids implementation or runtime claims | Pass |
+
+## Review notes
+
+This PR intentionally does not implement adapter code. That is correct for a first boundary slice because the task has no safe implementation surface until the allowed reads, forbidden operations and metadata model are explicit.
+
+## Remaining limitations
+
+- No local worktree was available in this connector session.
+- `git diff --check` should be run from a checkout or trusted CI context.
+- Task registry reconciliation is not included in this PR.
+
+## Non-claims
+
+This self-review does not establish implementation correctness, runtime behavior, test sufficiency, review completeness, task closure, security correctness or merge readiness.

--- a/docs/proofs/repobrief-readonly-adapter-no-mirror-v1.self-review.md
+++ b/docs/proofs/repobrief-readonly-adapter-no-mirror-v1.self-review.md
@@ -1,6 +1,6 @@
 # Self-review — RepoBrief Read-only Adapter without Mirror Authority v1
 
-Review target: `docs/repobrief-readonly-adapter-no-mirror-v1`
+Review target: PR #929 head after rebase onto `origin/main`
 
 Files reviewed:
 
@@ -31,10 +31,18 @@ This PR intentionally does not implement adapter code. That is correct for a fir
 
 ## Remaining limitations
 
-- No local worktree was available in this connector session.
-- `git diff --check` should be run from a checkout or trusted CI context.
+- Local validation is now available and was run after rebase.
 - Task registry reconciliation is not included in this PR.
 
 ## Non-claims
 
-This self-review does not establish implementation correctness, runtime behavior, test sufficiency, review completeness, task closure, security correctness or merge readiness.
+This self-review does not establish implementation correctness, runtime behavior, full test sufficiency, review completeness, task closure, security correctness or merge readiness.
+
+## Review continuation validation
+
+```bash
+git diff --check
+python -m pytest merger/lenskit/tests/test_repobrief_access_boundary.py -q
+```
+
+The review continuation also rebased the branch onto current `origin/main` before validation.


### PR DESCRIPTION
## Summary

- Adds the design for `TASK-REPOBRIEF-READONLY-ADAPTER-NO-MIRROR-001`.
- Defines a broad read-only adapter facade over existing RepoBrief snapshots, artifacts, ranges, indexes, health/availability and Workbench static surfaces.
- Explicitly forbids repository mirror authority: no clone/fetch/pull/Git mutation, no live-worktree fallback, no implicit refresh, no PR/patch/shell/test/secret authority.
- Records required authority/freshness/availability metadata and fail-closed behavior for missing/stale/invalid evidence.

## Validation

Not run locally; connector session has no local checkout.

Expected before merge:

```bash
git diff --check
```

## Non-claims

This is a docs-only design slice. It does not implement the adapter, deploy MCP, prove runtime correctness, prove test sufficiency, prove review completeness, or establish merge readiness.