### PR TITLE
feat(repobrief): add answer grounding verifier core

### DIFF
--- a/docs/proofs/answer-grounding-verifier-core-v1-proof.md
+++ b/docs/proofs/answer-grounding-verifier-core-v1-proof.md
@@ -1,0 +1,49 @@
+# RepoBrief Answer Grounding Verifier Core v1 Proof
+
+Status: review_ready
+Initiative: `REPOBRIEF-FRONTDOOR-GROUNDING-V1`
+Task: `RBGV-V1-T002`
+
+## Result
+
+This slice adds a minimal deterministic read-only grounding verifier:
+
+- `merger/lenskit/core/answer_grounding.py`
+- `merger/lenskit/tests/test_answer_grounding_verifier.py`
+
+The verifier reads an Answer Grounding declaration plus explicitly supplied existing bundle
+artifacts and emits an `answer-grounding-verdict.v1` shaped result.
+
+## What is checked
+
+- declared citation IDs against a supplied `citation_map_jsonl` file;
+- canonical ranges from citation-map entries, when present;
+- declared `used_ranges` via the existing `resolve_range_ref` path;
+- content/hash drift reported as `fail` with `content_hash_mismatch`;
+- missing citations reported as `fail` with `citation_not_found`;
+- invalid citation-map JSONL reported as `degraded` when no fail condition is present;
+- required artifacts as fail when undeclared;
+- recommended artifacts as warn when undeclared;
+- mandatory non-claims.
+
+## Read-only boundary
+
+The verifier performs no Git, shell, refresh, snapshot creation, patch, PR, test or merge
+operation. It only reads explicitly supplied paths and delegates range extraction to the
+existing range resolver.
+
+## Validation
+
+```bash
+git diff --check
+python -m pytest merger/lenskit/tests/test_answer_grounding_verifier.py -q
+python -m pytest merger/lenskit/tests/test_answer_grounding_contracts.py -q
+python -m pytest merger/lenskit/tests/test_range_resolver.py merger/lenskit/tests/test_citation_map_schema.py -q
+python -m ruff check merger/lenskit/core/answer_grounding.py merger/lenskit/tests/test_answer_grounding_verifier.py
+```
+
+## Does not establish
+
+This proof does not establish semantic answer correctness, actual model reading, complete
+context use, runtime correctness, test sufficiency, review completeness, merge readiness,
+security correctness or regression absence.

--- a/docs/proofs/answer-grounding-verifier-core-v1.self-review.md
+++ b/docs/proofs/answer-grounding-verifier-core-v1.self-review.md
@@ -1,0 +1,57 @@
+# Self-review — RepoBrief Answer Grounding Verifier Core v1
+
+Review target: `RBGV-V1-T002` branch head before PR creation
+
+Files reviewed:
+
+- `merger/lenskit/core/answer_grounding.py`
+- `merger/lenskit/tests/test_answer_grounding_verifier.py`
+- `docs/proofs/answer-grounding-verifier-core-v1-proof.md`
+- `docs/proofs/answer-grounding-verifier-core-v1.self-review.md`
+
+## Result
+
+No blocking issue found in this minimal verifier-core slice.
+
+## Critical checks
+
+| Check | Result |
+| --- | --- |
+| Existing-artifact read-only boundary | Pass |
+| Known citation ID resolution | Pass |
+| Declared range resolution through existing resolver | Pass |
+| Hash/text drift fails | Pass |
+| Missing citation fails | Pass |
+| Degraded dependency path visible | Pass |
+| Required/recommended artifact distinction | Pass |
+| Mandatory non-claims checked | Pass |
+
+## Review notes
+
+The verifier intentionally accepts explicit file paths instead of discovering or creating
+snapshots. This keeps `RBGV-V1-T002` narrow and prevents accidental refresh or repo mutation.
+The implementation does not validate the declaration schema itself; the previous contract
+slice owns schema shape, while this slice focuses on deterministic grounding mechanics.
+
+## Limitations
+
+- No CLI command yet; that belongs to later frontdoor tasks.
+- No MCP exposure yet.
+- Strong-claim markers are not semantically evaluated.
+- Citation-map entries without range information only prove ID presence, not span content.
+
+## Validation
+
+```bash
+git diff --check
+python -m pytest merger/lenskit/tests/test_answer_grounding_verifier.py -q
+python -m pytest merger/lenskit/tests/test_answer_grounding_contracts.py -q
+python -m pytest merger/lenskit/tests/test_range_resolver.py merger/lenskit/tests/test_citation_map_schema.py -q
+python -m ruff check merger/lenskit/core/answer_grounding.py merger/lenskit/tests/test_answer_grounding_verifier.py
+```
+
+## Non-claims
+
+This self-review does not establish semantic answer correctness, actual reading, runtime
+correctness, full test sufficiency, review completeness, merge readiness, security
+correctness or absence of regressions.

--- a/merger/lenskit/core/answer_grounding.py
+++ b/merger/lenskit/core/answer_grounding.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from merger.lenskit.core.range_resolver import resolve_range_ref
+
+KIND = "repobrief.answer_grounding_verdict"
+VERSION = "1.0"
+NON_CLAIMS = [
+    "actual_reading_proven",
+    "answer_correct",
+    "repo_understood",
+    "all_relevant_context_used",
+    "claims_true",
+    "test_sufficiency",
+    "regression_absence",
+    "runtime_behavior",
+    "forensic_ready",
+    "merge_readiness",
+    "security_correctness",
+]
+
+
+def _sha256_json(data: Mapping[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(data, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def _snapshot_ref(declaration: Mapping[str, Any], manifest_path: Path) -> dict[str, Any]:
+    raw = declaration.get("snapshot_ref")
+    if isinstance(raw, Mapping):
+        result = dict(raw)
+    else:
+        result = {"stem": manifest_path.stem, "manifest_path": str(manifest_path)}
+    result.setdefault("stem", manifest_path.stem)
+    result.setdefault("manifest_path", str(manifest_path))
+    return result
+
+
+def _declaration_ref(declaration: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "answer_id": str(declaration.get("answer_id") or "unknown-answer"),
+        "question_hash": str(declaration.get("question_hash") or "0" * 64),
+        "answer_hash": str(declaration.get("answer_hash") or "0" * 64),
+        "declaration_sha256": _sha256_json(declaration),
+    }
+
+
+def _diagnostic(code: str, severity: str, detail: str, ref: str | None = None) -> dict[str, Any]:
+    item = {"code": code, "severity": severity, "detail": detail}
+    if ref:
+        item["ref"] = ref
+    return item
+
+
+def _evidence_check(
+    ref: str,
+    status: str,
+    severity: str,
+    detail: str,
+    *,
+    artifact_role: str | None = None,
+    authority: str = "canonical_snapshot",
+) -> dict[str, Any]:
+    item = {
+        "ref": ref,
+        "status": status,
+        "severity": severity,
+        "authority": authority,
+        "detail": detail,
+    }
+    if artifact_role:
+        item["artifact_role"] = artifact_role
+    return item
+
+
+def _required_reading_check(
+    artifact_role: str,
+    status: str,
+    severity: str,
+    detail: str,
+) -> dict[str, Any]:
+    return {
+        "artifact_role": artifact_role,
+        "status": status,
+        "severity": severity,
+        "detail": detail,
+    }
+
+
+def _load_citation_map(path: Path | None) -> tuple[dict[str, dict[str, Any]], list[dict[str, Any]]]:
+    if path is None:
+        return {}, []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        return {}, [_diagnostic("missing_required_artifact", "fail", f"Citation map does not exist: {path}")]
+    except OSError as exc:
+        return {}, [_diagnostic("degraded_dependency", "warn", f"Citation map could not be read: {exc}")]
+
+    entries: dict[str, dict[str, Any]] = {}
+    diagnostics: list[dict[str, Any]] = []
+    for lineno, line in enumerate(lines, start=1):
+        if not line.strip():
+            continue
+        try:
+            data = json.loads(line)
+        except json.JSONDecodeError as exc:
+            diagnostics.append(
+                _diagnostic(
+                    "degraded_dependency",
+                    "warn",
+                    f"Citation map JSONL line {lineno} is invalid JSON: {exc.msg}",
+                )
+            )
+            continue
+        if not isinstance(data, dict):
+            diagnostics.append(
+                _diagnostic("degraded_dependency", "warn", f"Citation map line {lineno} is not an object")
+            )
+            continue
+        citation_id = data.get("citation_id")
+        if isinstance(citation_id, str) and citation_id:
+            entries[citation_id] = data
+    return entries, diagnostics
+
+
+def _range_ref_from_citation(entry: Mapping[str, Any]) -> dict[str, Any] | None:
+    existing = entry.get("range_ref")
+    if isinstance(existing, dict):
+        return dict(existing)
+    canonical_range = entry.get("canonical_range")
+    if not isinstance(canonical_range, Mapping):
+        return None
+    return {
+        "artifact_role": "canonical_md",
+        "repo_id": entry.get("repo_id") or "unknown-repo",
+        "file_path": canonical_range.get("file_path"),
+        "start_byte": canonical_range.get("start_byte"),
+        "end_byte": canonical_range.get("end_byte"),
+        "start_line": canonical_range.get("start_line"),
+        "end_line": canonical_range.get("end_line"),
+        "content_sha256": canonical_range.get("content_sha256"),
+    }
+
+
+def _resolve_range(manifest_path: Path, range_ref: Mapping[str, Any]) -> tuple[bool, str, str]:
+    try:
+        result = resolve_range_ref(manifest_path, dict(range_ref))
+    except Exception as exc:  # range_resolver exposes several precise exceptions
+        detail = str(exc)
+        if "hash mismatch" in detail.lower():
+            return False, "drifted", detail
+        return False, "invalid", detail
+    return True, "resolved", f"Range resolved ({result.get('bytes', 'unknown')} bytes)."
+
+
+def verify_answer_grounding(
+    declaration: Mapping[str, Any],
+    *,
+    bundle_manifest: str | Path,
+    citation_map: str | Path | None = None,
+    required_artifacts: Sequence[str] = (),
+    recommended_artifacts: Sequence[str] = (),
+) -> dict[str, Any]:
+    """Verify declared answer grounding against existing RepoBrief artifacts.
+
+    This is deliberately read-only: it only reads explicitly supplied files and delegates
+    range extraction to the existing range resolver. It performs no Git, shell, refresh,
+    snapshot creation, patch, PR, test or merge operation.
+    """
+    manifest_path = Path(bundle_manifest).expanduser().resolve()
+    citation_map_path = Path(citation_map).expanduser().resolve() if citation_map is not None else None
+
+    citation_checks: list[dict[str, Any]] = []
+    range_checks: list[dict[str, Any]] = []
+    required_checks: list[dict[str, Any]] = []
+    diagnostics: list[dict[str, Any]] = []
+    freshness_caveats = list(declaration.get("freshness_caveats") or [])
+    availability_caveats: list[dict[str, Any]] = []
+
+    if not manifest_path.exists():
+        diagnostics.append(
+            _diagnostic("missing_required_artifact", "fail", f"Bundle manifest does not exist: {manifest_path}")
+        )
+
+    citation_entries, citation_map_diagnostics = _load_citation_map(citation_map_path)
+    diagnostics.extend(citation_map_diagnostics)
+
+    used_citations = declaration.get("used_citations") or []
+    if not isinstance(used_citations, list):
+        used_citations = []
+        diagnostics.append(_diagnostic("degraded_dependency", "warn", "used_citations is not an array"))
+
+    for item in used_citations:
+        citation_id = item.get("citation_id") if isinstance(item, Mapping) else None
+        citation_ref = str(citation_id or "<missing-citation-id>")
+        if not citation_id or citation_id not in citation_entries:
+            citation_checks.append(
+                _evidence_check(
+                    citation_ref,
+                    "missing",
+                    "fail",
+                    "Declared citation ID was not found in the supplied citation map.",
+                    artifact_role="citation_map_jsonl",
+                )
+            )
+            diagnostics.append(
+                _diagnostic("citation_not_found", "fail", "Declared citation ID was not found.", citation_ref)
+            )
+            continue
+        entry = citation_entries[citation_id]
+        citation_checks.append(
+            _evidence_check(
+                citation_ref,
+                "resolved",
+                "info",
+                "Declared citation ID exists in the supplied citation map.",
+                artifact_role="citation_map_jsonl",
+            )
+        )
+        citation_range_ref = _range_ref_from_citation(entry)
+        if citation_range_ref:
+            ok, status, detail = _resolve_range(manifest_path, citation_range_ref)
+            severity = "info" if ok else "fail"
+            citation_checks.append(
+                _evidence_check(
+                    f"{citation_ref}:canonical_range",
+                    status,
+                    severity,
+                    detail,
+                    artifact_role="canonical_md",
+                )
+            )
+            if not ok:
+                diagnostics.append(
+                    _diagnostic(
+                        "content_hash_mismatch" if status == "drifted" else "range_not_resolved",
+                        "fail",
+                        detail,
+                        citation_ref,
+                    )
+                )
+
+    used_ranges = declaration.get("used_ranges") or []
+    if not isinstance(used_ranges, list):
+        used_ranges = []
+        diagnostics.append(_diagnostic("degraded_dependency", "warn", "used_ranges is not an array"))
+
+    for idx, item in enumerate(used_ranges, start=1):
+        if not isinstance(item, Mapping) or not isinstance(item.get("range_ref"), Mapping):
+            ref = f"declared-range-{idx}"
+            range_checks.append(_evidence_check(ref, "invalid", "fail", "Declared range is missing range_ref."))
+            diagnostics.append(_diagnostic("range_not_resolved", "fail", "Declared range is missing range_ref.", ref))
+            continue
+        ref = item.get("claim_ref") or f"declared-range-{idx}"
+        ok, status, detail = _resolve_range(manifest_path, item["range_ref"])
+        severity = "info" if ok else "fail"
+        range_checks.append(
+            _evidence_check(
+                str(ref),
+                status,
+                severity,
+                detail,
+                artifact_role=str(item.get("artifact_role") or item["range_ref"].get("artifact_role") or "canonical_md"),
+            )
+        )
+        if not ok:
+            diagnostics.append(
+                _diagnostic(
+                    "content_hash_mismatch" if status == "drifted" else "range_not_resolved",
+                    "fail",
+                    detail,
+                    str(ref),
+                )
+            )
+
+    declared_roles = set(declaration.get("declared_artifacts") or [])
+    # Grounding declarations may not carry declared_artifacts yet; infer roles from evidence.
+    declared_roles.update(
+        str(r.get("artifact_role"))
+        for r in used_ranges
+        if isinstance(r, Mapping) and r.get("artifact_role")
+    )
+    if used_citations:
+        declared_roles.add("citation_map_jsonl")
+
+    for role in required_artifacts:
+        if role in declared_roles:
+            required_checks.append(_required_reading_check(role, "declared", "info", "Required artifact was declared."))
+        else:
+            required_checks.append(_required_reading_check(role, "missing_required", "fail", "Required artifact was not declared."))
+            diagnostics.append(_diagnostic("missing_required_artifact", "fail", f"Required artifact was not declared: {role}", role))
+    for role in recommended_artifacts:
+        if role in declared_roles:
+            required_checks.append(_required_reading_check(role, "declared", "info", "Recommended artifact was declared."))
+        else:
+            required_checks.append(_required_reading_check(role, "missing_recommended", "warn", "Recommended artifact was not declared."))
+            diagnostics.append(_diagnostic("missing_recommended_artifact", "warn", f"Recommended artifact was not declared: {role}", role))
+
+    declared_non_claims = set(declaration.get("does_not_establish") or [])
+    missing_non_claims = [claim for claim in NON_CLAIMS if claim not in declared_non_claims]
+    for claim in missing_non_claims:
+        diagnostics.append(_diagnostic("missing_non_claim", "fail", f"Declaration is missing non-claim: {claim}", claim))
+
+    if any(d.get("severity") == "fail" for d in diagnostics):
+        status = "fail"
+    elif any(d.get("code") == "degraded_dependency" for d in diagnostics):
+        status = "degraded"
+    elif any(d.get("severity") == "warn" for d in diagnostics):
+        status = "warn"
+    elif not used_citations and not used_ranges and not required_artifacts:
+        status = "not_applicable"
+        diagnostics.append(_diagnostic("not_applicable", "info", "No citations, ranges or required artifacts were declared for verification."))
+    else:
+        status = "pass"
+
+    return {
+        "kind": KIND,
+        "version": VERSION,
+        "status": status,
+        "checked_declaration": _declaration_ref(declaration),
+        "snapshot_ref": _snapshot_ref(declaration, manifest_path),
+        "citation_checks": citation_checks,
+        "range_checks": range_checks,
+        "required_reading_checks": required_checks,
+        "diagnostics": diagnostics,
+        "freshness_caveats": freshness_caveats,
+        "availability_caveats": availability_caveats,
+        "does_not_establish": list(NON_CLAIMS),
+    }

--- a/merger/lenskit/tests/test_answer_grounding_verifier.py
+++ b/merger/lenskit/tests/test_answer_grounding_verifier.py
@@ -1,0 +1,206 @@
+import hashlib
+import json
+from pathlib import Path
+
+import jsonschema
+
+from merger.lenskit.core.answer_grounding import NON_CLAIMS, verify_answer_grounding
+
+SHA = "a" * 64
+
+
+def _bundle(tmp_path: Path, content: bytes = b"Line 1\nLine 2\nLine 3\n"):
+    canonical = tmp_path / "demo_merge.md"
+    canonical.write_bytes(content)
+    manifest = tmp_path / "demo.bundle.manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "kind": "repolens.bundle.manifest",
+                "run_id": "demo-run",
+                "artifacts": [{"role": "canonical_md", "path": canonical.name}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    start, end = 7, 14
+    range_hash = hashlib.sha256(content[start:end]).hexdigest()
+    full_hash = hashlib.sha256(content).hexdigest()
+    citation_map = tmp_path / "demo.citation_map.jsonl"
+    citation_map.write_text(
+        json.dumps(
+            {
+                "citation_id": "cit_0000000000000001",
+                "repo_id": "demo",
+                "snapshot": {
+                    "run_id": "demo-run",
+                    "canonical_md_path": canonical.name,
+                    "canonical_md_sha256": full_hash,
+                },
+                "canonical_range": {
+                    "file_path": canonical.name,
+                    "start_byte": start,
+                    "end_byte": end,
+                    "start_line": 2,
+                    "end_line": 2,
+                    "content_sha256": range_hash,
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    range_ref = {
+        "artifact_role": "canonical_md",
+        "repo_id": "demo",
+        "file_path": canonical.name,
+        "start_byte": start,
+        "end_byte": end,
+        "start_line": 2,
+        "end_line": 2,
+        "content_sha256": range_hash,
+    }
+    return manifest, citation_map, range_ref
+
+
+def _declaration(range_ref=None, citation_id="cit_0000000000000001", non_claims=None):
+    return {
+        "kind": "repobrief.answer_grounding_declaration",
+        "version": "1.0",
+        "answer_id": "answer-1",
+        "snapshot_ref": {
+            "stem": "demo",
+            "manifest_path": "demo.bundle.manifest.json",
+            "manifest_sha256": SHA,
+            "freshness_status": "fresh",
+        },
+        "task_profile": "basic_repo_question",
+        "question_hash": SHA,
+        "answer_hash": "b" * 64,
+        "used_citations": [{"citation_id": citation_id, "purpose": "ground claim"}],
+        "used_ranges": [
+            {
+                "artifact_role": "canonical_md",
+                "range_ref": range_ref,
+                "purpose": "check span",
+            }
+        ] if range_ref else [],
+        "declared_non_claims": non_claims or NON_CLAIMS,
+        "freshness_caveats": [],
+        "does_not_establish": non_claims or NON_CLAIMS,
+    }
+
+
+def _validate_verdict(verdict):
+    schema = json.loads(
+        (Path(__file__).parent.parent / "contracts" / "answer-grounding-verdict.v1.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    jsonschema.validate(instance=verdict, schema=schema)
+
+
+def test_verify_answer_grounding_pass_resolves_citation_and_range(tmp_path):
+    manifest, citation_map, range_ref = _bundle(tmp_path)
+
+    verdict = verify_answer_grounding(
+        _declaration(range_ref),
+        bundle_manifest=manifest,
+        citation_map=citation_map,
+        required_artifacts=["citation_map_jsonl", "canonical_md"],
+    )
+
+    _validate_verdict(verdict)
+    assert verdict["status"] == "pass"
+    assert {check["status"] for check in verdict["citation_checks"]} == {"resolved"}
+    assert verdict["range_checks"][0]["status"] == "resolved"
+    assert verdict["does_not_establish"] == NON_CLAIMS
+
+
+def test_verify_answer_grounding_fails_missing_citation(tmp_path):
+    manifest, citation_map, range_ref = _bundle(tmp_path)
+
+    verdict = verify_answer_grounding(
+        _declaration(range_ref, citation_id="cit_ffffffffffffffff"),
+        bundle_manifest=manifest,
+        citation_map=citation_map,
+    )
+
+    _validate_verdict(verdict)
+    assert verdict["status"] == "fail"
+    assert any(d["code"] == "citation_not_found" for d in verdict["diagnostics"])
+
+
+def test_verify_answer_grounding_fails_hash_drift(tmp_path):
+    manifest, citation_map, range_ref = _bundle(tmp_path)
+    range_ref = dict(range_ref)
+    range_ref["content_sha256"] = "e" * 64
+
+    verdict = verify_answer_grounding(
+        _declaration(range_ref),
+        bundle_manifest=manifest,
+        citation_map=citation_map,
+    )
+
+    _validate_verdict(verdict)
+    assert verdict["status"] == "fail"
+    assert verdict["range_checks"][0]["status"] == "drifted"
+    assert any(d["code"] == "content_hash_mismatch" for d in verdict["diagnostics"])
+
+
+def test_verify_answer_grounding_degraded_for_invalid_citation_map_jsonl(tmp_path):
+    manifest, citation_map, range_ref = _bundle(tmp_path)
+    citation_map.write_text("{not-json}\n", encoding="utf-8")
+
+    declaration = _declaration(range_ref)
+    declaration["used_citations"] = []
+    verdict = verify_answer_grounding(
+        declaration,
+        bundle_manifest=manifest,
+        citation_map=citation_map,
+    )
+
+    _validate_verdict(verdict)
+    assert verdict["status"] == "degraded"
+    assert any(d["code"] == "degraded_dependency" for d in verdict["diagnostics"])
+
+
+def test_verify_answer_grounding_fails_missing_required_non_claim(tmp_path):
+    manifest, citation_map, range_ref = _bundle(tmp_path)
+
+    verdict = verify_answer_grounding(
+        _declaration(range_ref, non_claims=NON_CLAIMS[:-1]),
+        bundle_manifest=manifest,
+        citation_map=citation_map,
+    )
+
+    _validate_verdict(verdict)
+    assert verdict["status"] == "fail"
+    assert any(d["code"] == "missing_non_claim" for d in verdict["diagnostics"])
+
+
+def test_verify_answer_grounding_warns_missing_recommended_artifact(tmp_path):
+    manifest, citation_map, range_ref = _bundle(tmp_path)
+
+    verdict = verify_answer_grounding(
+        _declaration(range_ref),
+        bundle_manifest=manifest,
+        citation_map=citation_map,
+        recommended_artifacts=["bundle_surface_validation"],
+    )
+
+    _validate_verdict(verdict)
+    assert verdict["status"] == "warn"
+    assert any(d["code"] == "missing_recommended_artifact" for d in verdict["diagnostics"])
+
+
+def test_verify_answer_grounding_not_applicable_without_evidence(tmp_path):
+    manifest, citation_map, _range_ref = _bundle(tmp_path)
+    declaration = _declaration(range_ref=None)
+    declaration["used_citations"] = []
+
+    verdict = verify_answer_grounding(declaration, bundle_manifest=manifest, citation_map=citation_map)
+
+    _validate_verdict(verdict)
+    assert verdict["status"] == "not_applicable"
+    assert any(d["code"] == "not_applicable" for d in verdict["diagnostics"])


### PR DESCRIPTION
## Summary

- implements a minimal read-only answer grounding verifier core for `RBGV-V1-T002`
- verifies declared citation IDs against an explicit citation map JSONL file
- resolves declared ranges and citation canonical ranges through the existing range resolver
- reports missing citations, range/hash drift, degraded citation-map loading, required/recommended artifact checks, and mandatory non-claims

## Validation

- `git diff --check`
- `python -m pytest merger/lenskit/tests/test_answer_grounding_verifier.py -q`
- `python -m pytest merger/lenskit/tests/test_answer_grounding_contracts.py -q`
- `python -m pytest merger/lenskit/tests/test_range_resolver.py merger/lenskit/tests/test_citation_map_schema.py -q`
- `python -m ruff check merger/lenskit/core/answer_grounding.py merger/lenskit/tests/test_answer_grounding_verifier.py`

## Boundary

The verifier only reads explicitly supplied existing artifacts. It performs no Git, shell, refresh, snapshot creation, patch, PR, test, merge, or review action. A pass verdict is a technical grounding-contract result, not semantic answer correctness.
