### PR TITLE
feat(repobrief): integrate grounding task profiles

### DIFF
--- a/docs/proofs/answer-grounding-task-profile-integration-v1-proof.md
+++ b/docs/proofs/answer-grounding-task-profile-integration-v1-proof.md
@@ -1,0 +1,41 @@
+# RepoBrief Answer Grounding Task-Profile Integration v1 Proof
+
+Status: review_ready
+Initiative: `REPOBRIEF-FRONTDOOR-GROUNDING-V1`
+Task: `RBGV-V1-T003`
+
+## Result
+
+This slice connects the Answer Grounding verifier to the existing Required Reading task-profile matrix.
+
+Added/changed:
+
+- `verify_answer_grounding_for_task_profile(...)`
+- required/recommended evidence roles derived from `default_required_reading_protocol()`
+- declaration `availability_caveats` carried into verdicts
+- tests for required fail, recommended warn, caveat propagation, and unknown profile behavior
+
+## Behavior
+
+- The task profile determines required and recommended evidence roles.
+- Missing required evidence yields failing required-reading checks.
+- Missing recommended evidence yields warning required-reading checks.
+- Freshness caveats are mirrored from declaration to verdict.
+- Availability caveats are mirrored from declaration to verdict.
+- Verdicts keep mandatory non-claims, including that grounding does not prove actual reading or repository understanding.
+
+## Validation
+
+```bash
+git diff --check
+python -m pytest merger/lenskit/tests/test_answer_grounding_verifier.py -q
+python -m pytest merger/lenskit/tests/test_answer_grounding_contracts.py -q
+python -m pytest merger/lenskit/tests/test_required_reading_protocol.py -q
+python -m ruff check merger/lenskit/core/answer_grounding.py merger/lenskit/tests/test_answer_grounding_verifier.py
+```
+
+## Does not establish
+
+This proof does not establish actual reading, semantic answer correctness, complete context use,
+runtime correctness outside the tested paths, test sufficiency, review completeness, merge readiness,
+security correctness or regression absence.

--- a/docs/proofs/answer-grounding-task-profile-integration-v1.self-review.md
+++ b/docs/proofs/answer-grounding-task-profile-integration-v1.self-review.md
@@ -1,0 +1,57 @@
+# Self-review — RepoBrief Answer Grounding Task-Profile Integration v1
+
+Review target: `RBGV-V1-T003` branch head before PR creation
+
+Files reviewed:
+
+- `merger/lenskit/core/answer_grounding.py`
+- `merger/lenskit/contracts/answer-grounding-declaration.v1.schema.json`
+- `merger/lenskit/tests/test_answer_grounding_verifier.py`
+- `docs/proofs/answer-grounding-task-profile-integration-v1-proof.md`
+- `docs/proofs/answer-grounding-task-profile-integration-v1.self-review.md`
+
+## Result
+
+No blocking issue found in this integration slice.
+
+## Critical checks
+
+| Check | Result |
+| --- | --- |
+| Task profiles determine required/recommended evidence | Pass |
+| Missing required evidence fails | Pass |
+| Missing recommended evidence warns | Pass |
+| Freshness caveats carried into verdict | Pass |
+| Availability caveats carried into verdict | Pass |
+| Non-claims still visible | Pass |
+| Unknown profile does not become a false pass | Pass |
+| No Git/shell/refresh/patch/PR/merge authority added | Pass |
+
+## Review notes
+
+The integration uses declared evidence roles rather than the bundle's physical artifact list. That is deliberate: this verifier checks the answer declaration, not whether the bundle generator emitted every possible artifact. The physical artifact existence and range resolution remain checked through the existing explicit artifact inputs.
+
+The unknown-profile path appends a `not_applicable` diagnostic and avoids turning an unknown profile into a meaningful grounding pass.
+
+## Limitations
+
+- No CLI command yet.
+- No MCP/frontdoor exposure yet.
+- Strong-claim markers are still not semantically evaluated.
+- A declaration can still lie about whether the model actually read evidence; the verdict keeps that as a non-claim.
+
+## Validation
+
+```bash
+git diff --check
+python -m pytest merger/lenskit/tests/test_answer_grounding_verifier.py -q
+python -m pytest merger/lenskit/tests/test_answer_grounding_contracts.py -q
+python -m pytest merger/lenskit/tests/test_required_reading_protocol.py -q
+python -m ruff check merger/lenskit/core/answer_grounding.py merger/lenskit/tests/test_answer_grounding_verifier.py
+```
+
+## Non-claims
+
+This self-review does not establish actual reading, semantic answer correctness, complete context use,
+runtime correctness, full test sufficiency, review completeness, merge readiness, security correctness
+or absence of regressions.

--- a/merger/lenskit/contracts/answer-grounding-declaration.v1.schema.json
+++ b/merger/lenskit/contracts/answer-grounding-declaration.v1.schema.json
@@ -86,6 +86,13 @@
     },
     "does_not_establish": {
       "$ref": "#/definitions/does_not_establish_array"
+    },
+    "availability_caveats": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/caveat"
+      },
+      "description": "Availability caveats carried by the answer declaration and later mirrored into the grounding verdict."
     }
   },
   "definitions": {

--- a/merger/lenskit/core/answer_grounding.py
+++ b/merger/lenskit/core/answer_grounding.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 from merger.lenskit.core.range_resolver import resolve_range_ref
+from merger.lenskit.core.required_reading import default_required_reading_protocol, resolve_required_reading
 
 KIND = "repobrief.answer_grounding_verdict"
 VERSION = "1.0"
@@ -159,6 +160,73 @@ def _resolve_range(manifest_path: Path, range_ref: Mapping[str, Any]) -> tuple[b
     return True, "resolved", f"Range resolved ({result.get('bytes', 'unknown')} bytes)."
 
 
+
+def _declared_evidence_roles(
+    declaration: Mapping[str, Any],
+    *,
+    used_citations: Sequence[Any] | None = None,
+    used_ranges: Sequence[Any] | None = None,
+) -> set[str]:
+    declared_roles = {str(role) for role in declaration.get("declared_artifacts") or []}
+    ranges = used_ranges if used_ranges is not None else declaration.get("used_ranges") or []
+    declared_roles.update(
+        str(item.get("artifact_role"))
+        for item in ranges
+        if isinstance(item, Mapping) and item.get("artifact_role")
+    )
+    citations = used_citations if used_citations is not None else declaration.get("used_citations") or []
+    if citations:
+        declared_roles.add("citation_map_jsonl")
+    return declared_roles
+
+
+def _profile_artifacts(task_profile: str, declared_roles: set[str]) -> tuple[list[str], list[str], dict[str, Any]]:
+    protocol = default_required_reading_protocol()
+    resolution = resolve_required_reading(protocol, declared_roles, task_profile)
+    return (
+        list(resolution.get("required") or []),
+        list(resolution.get("recommended") or []),
+        resolution,
+    )
+
+
+def verify_answer_grounding_for_task_profile(
+    declaration: Mapping[str, Any],
+    *,
+    bundle_manifest: str | Path,
+    citation_map: str | Path | None = None,
+    task_profile: str | None = None,
+) -> dict[str, Any]:
+    """Verify answer grounding using the Required Reading task-profile matrix.
+
+    The profile controls required and recommended evidence roles. Missing required
+    roles become failing required-reading checks; missing recommended roles become
+    warnings. This still does not prove that the model actually read or understood
+    the declared evidence.
+    """
+    profile = task_profile or str(declaration.get("task_profile") or "basic_repo_question")
+    declared_roles = _declared_evidence_roles(declaration)
+    required, recommended, profile_resolution = _profile_artifacts(profile, declared_roles)
+    verdict = verify_answer_grounding(
+        declaration,
+        bundle_manifest=bundle_manifest,
+        citation_map=citation_map,
+        required_artifacts=required,
+        recommended_artifacts=recommended,
+    )
+    if profile_resolution.get("status") == "not_applicable":
+        verdict["diagnostics"].append(
+            _diagnostic(
+                "not_applicable",
+                "info",
+                f"Unknown required-reading task profile: {profile}",
+                profile,
+            )
+        )
+        if verdict["status"] == "pass":
+            verdict["status"] = "not_applicable"
+    return verdict
+
 def verify_answer_grounding(
     declaration: Mapping[str, Any],
     *,
@@ -181,7 +249,7 @@ def verify_answer_grounding(
     required_checks: list[dict[str, Any]] = []
     diagnostics: list[dict[str, Any]] = []
     freshness_caveats = list(declaration.get("freshness_caveats") or [])
-    availability_caveats: list[dict[str, Any]] = []
+    availability_caveats = list(declaration.get("availability_caveats") or [])
 
     if not manifest_path.exists():
         diagnostics.append(
@@ -279,15 +347,7 @@ def verify_answer_grounding(
                 )
             )
 
-    declared_roles = set(declaration.get("declared_artifacts") or [])
-    # Grounding declarations may not carry declared_artifacts yet; infer roles from evidence.
-    declared_roles.update(
-        str(r.get("artifact_role"))
-        for r in used_ranges
-        if isinstance(r, Mapping) and r.get("artifact_role")
-    )
-    if used_citations:
-        declared_roles.add("citation_map_jsonl")
+    declared_roles = _declared_evidence_roles(declaration, used_citations=used_citations, used_ranges=used_ranges)
 
     for role in required_artifacts:
         if role in declared_roles:

--- a/merger/lenskit/tests/test_answer_grounding_verifier.py
+++ b/merger/lenskit/tests/test_answer_grounding_verifier.py
@@ -4,7 +4,11 @@ from pathlib import Path
 
 import jsonschema
 
-from merger.lenskit.core.answer_grounding import NON_CLAIMS, verify_answer_grounding
+from merger.lenskit.core.answer_grounding import (
+    NON_CLAIMS,
+    verify_answer_grounding,
+    verify_answer_grounding_for_task_profile,
+)
 
 SHA = "a" * 64
 
@@ -200,6 +204,93 @@ def test_verify_answer_grounding_not_applicable_without_evidence(tmp_path):
     declaration["used_citations"] = []
 
     verdict = verify_answer_grounding(declaration, bundle_manifest=manifest, citation_map=citation_map)
+
+    _validate_verdict(verdict)
+    assert verdict["status"] == "not_applicable"
+    assert any(d["code"] == "not_applicable" for d in verdict["diagnostics"])
+
+
+def test_task_profile_missing_required_evidence_fails(tmp_path):
+    manifest, citation_map, range_ref = _bundle(tmp_path)
+    declaration = _declaration(range_ref)
+    declaration["task_profile"] = "pr_review"
+    declaration["declared_artifacts"] = ["agent_reading_pack", "canonical_md", "citation_map_jsonl"]
+
+    verdict = verify_answer_grounding_for_task_profile(
+        declaration,
+        bundle_manifest=manifest,
+        citation_map=citation_map,
+    )
+
+    _validate_verdict(verdict)
+    assert verdict["status"] == "fail"
+    assert any(
+        check["artifact_role"] == "post_emit_health" and check["status"] == "missing_required"
+        for check in verdict["required_reading_checks"]
+    )
+
+
+def test_task_profile_missing_recommended_evidence_warns(tmp_path):
+    manifest, citation_map, range_ref = _bundle(tmp_path)
+    declaration = _declaration(range_ref)
+    declaration["task_profile"] = "basic_repo_question"
+    declaration["declared_artifacts"] = ["agent_reading_pack", "canonical_md", "citation_map_jsonl"]
+
+    verdict = verify_answer_grounding_for_task_profile(
+        declaration,
+        bundle_manifest=manifest,
+        citation_map=citation_map,
+    )
+
+    _validate_verdict(verdict)
+    assert verdict["status"] == "warn"
+    assert any(
+        check["artifact_role"] == "snapshot_plan_json" and check["status"] == "missing_recommended"
+        for check in verdict["required_reading_checks"]
+    )
+
+
+def test_task_profile_carries_freshness_availability_and_non_claims(tmp_path):
+    manifest, citation_map, range_ref = _bundle(tmp_path)
+    declaration = _declaration(range_ref)
+    declaration["task_profile"] = "basic_repo_question"
+    declaration["declared_artifacts"] = [
+        "agent_reading_pack",
+        "canonical_md",
+        "citation_map_jsonl",
+        "snapshot_plan_json",
+    ]
+    declaration["freshness_caveats"] = [
+        {"kind": "unknown_freshness", "detail": "Snapshot freshness was not compared."}
+    ]
+    declaration["availability_caveats"] = [
+        {"kind": "missing_artifact", "detail": "Optional browser screenshot was unavailable."}
+    ]
+
+    verdict = verify_answer_grounding_for_task_profile(
+        declaration,
+        bundle_manifest=manifest,
+        citation_map=citation_map,
+    )
+
+    _validate_verdict(verdict)
+    assert verdict["status"] == "pass"
+    assert verdict["freshness_caveats"] == declaration["freshness_caveats"]
+    assert verdict["availability_caveats"] == declaration["availability_caveats"]
+    assert "actual_reading_proven" in verdict["does_not_establish"]
+    assert "repo_understood" in verdict["does_not_establish"]
+
+
+def test_unknown_task_profile_is_not_applicable(tmp_path):
+    manifest, citation_map, range_ref = _bundle(tmp_path)
+    declaration = _declaration(range_ref)
+    declaration["task_profile"] = "not-a-profile"
+
+    verdict = verify_answer_grounding_for_task_profile(
+        declaration,
+        bundle_manifest=manifest,
+        citation_map=citation_map,
+    )
 
     _validate_verdict(verdict)
     assert verdict["status"] == "not_applicable"


### PR DESCRIPTION
## Summary

- adds `verify_answer_grounding_for_task_profile(...)` for `RBGV-V1-T003`
- derives required/recommended evidence roles from the Required Reading task-profile matrix
- makes missing required evidence fail and missing recommended evidence warn
- carries freshness and availability caveats into the grounding verdict
- keeps non-claims explicit, including no proof of actual reading or repo understanding

## Validation

- `git diff --check`
- `python -m pytest merger/lenskit/tests/test_answer_grounding_verifier.py -q`
- `python -m pytest merger/lenskit/tests/test_answer_grounding_contracts.py -q`
- `python -m pytest merger/lenskit/tests/test_required_reading_protocol.py -q`
- `python -m ruff check merger/lenskit/core/answer_grounding.py merger/lenskit/tests/test_answer_grounding_verifier.py`

## Boundary

This integrates declaration checks with task profiles. It does not prove actual reading, semantic answer correctness, complete context use, merge readiness, or security correctness.
