### PR TITLE
feat(repobrief): add ask context pack cli

### DIFF
--- a/docs/contracts/repobrief-ask-frontdoor-v1.md
+++ b/docs/contracts/repobrief-ask-frontdoor-v1.md
@@ -57,3 +57,9 @@ agents. It is not an answer and not a proof that any agent read or understood ev
 A valid request or context pack does not establish answer correctness, claim truth, actual
 reading, complete context use, repository understanding, runtime correctness, test
 sufficiency, merge readiness, security correctness, forensic readiness or regression absence.
+
+## CLI prototype
+
+`repobrief ask` is the minimal v1 producer for this context-pack shape. It reads an existing bundle manifest, queries the existing read-only index, resolves evidence ranges where available and emits either JSON or a human-readable context pack.
+
+The emitted `budget` block reports `max_context_tokens`, `max_answer_tokens`, approximate context characters used and whether truncation happened. This is a constraint record, not a quality proof.

--- a/docs/proofs/repobrief-ask-cli-v1-proof.md
+++ b/docs/proofs/repobrief-ask-cli-v1-proof.md
@@ -1,0 +1,52 @@
+# RepoBrief Ask CLI v1 Proof
+
+Status: review_ready
+Initiative: `REPOBRIEF-FRONTDOOR-GROUNDING-V1`
+Task: `RBGV-V1-T005`
+
+## Result
+
+This slice adds a minimal read-only Ask Frontdoor producer:
+
+- `merger/lenskit/core/repobrief_ask.py`
+- `repobrief ask` CLI dispatch in `merger/lenskit/cli/cmd_repobrief.py`
+- tests in `merger/lenskit/tests/test_repobrief_ask_cli.py`
+
+## Behavior
+
+`repobrief ask` reads an existing bundle manifest and emits either:
+
+- JSON context pack matching `repobrief-ask-context-pack.v1`; or
+- human-readable context-pack text.
+
+The context pack includes:
+
+- snapshot reference;
+- freshness and availability blocks;
+- Required Reading result for the selected task profile;
+- retrieval hits;
+- resolved ranges where available;
+- answer scaffold with citation obligations, caveats and non-claims;
+- budget report.
+
+## Read-only boundary
+
+The implementation delegates to existing read-only access/query paths and does not write snapshots,
+refresh artifacts, mutate Git, apply patches, create PRs, execute shell commands or authorize merges.
+
+## Validation
+
+```bash
+git diff --check
+python -m pytest merger/lenskit/tests/test_repobrief_ask_cli.py -q
+python -m pytest merger/lenskit/tests/test_repobrief_ask_frontdoor_contracts.py -q
+python -m pytest merger/lenskit/tests/test_repobrief_resolved_evidence_query.py -q
+python -m pytest merger/lenskit/tests/test_repobrief_access_boundary.py -q
+python -m ruff check merger/lenskit/core/repobrief_ask.py merger/lenskit/cli/cmd_repobrief.py merger/lenskit/tests/test_repobrief_ask_cli.py
+```
+
+## Does not establish
+
+This proof does not establish answer correctness, claim truth, actual reading, complete context use,
+retrieval quality, runtime correctness outside tested paths, full test sufficiency, review completeness,
+merge readiness, security correctness or regression absence.

--- a/docs/proofs/repobrief-ask-cli-v1.self-review.md
+++ b/docs/proofs/repobrief-ask-cli-v1.self-review.md
@@ -1,0 +1,58 @@
+# Self-review — RepoBrief Ask CLI v1
+
+Review target: `RBGV-V1-T005` branch head before PR creation
+
+Files reviewed:
+
+- `merger/lenskit/core/repobrief_ask.py`
+- `merger/lenskit/cli/cmd_repobrief.py`
+- `merger/lenskit/contracts/repobrief-ask-context-pack.v1.schema.json`
+- `merger/lenskit/tests/test_repobrief_ask_cli.py`
+- `docs/contracts/repobrief-ask-frontdoor-v1.md`
+- `docs/proofs/repobrief-ask-cli-v1-proof.md`
+- `docs/proofs/repobrief-ask-cli-v1.self-review.md`
+
+## Result
+
+No blocking issue found in this minimal CLI slice.
+
+## Critical checks
+
+| Check | Result |
+| --- | --- |
+| JSON context-pack output | Pass |
+| Human-readable context-pack output | Pass |
+| Uses existing read-only access/query surfaces | Pass |
+| Does not write snapshots or refresh artifacts | Pass |
+| Token budget affects excerpt truncation and is reported as constraint | Pass |
+| Basic profile smoke | Pass |
+| Stricter `pr_review` profile smoke | Pass |
+| Missing required evidence returns failure | Pass |
+
+## Review notes
+
+The CLI is intentionally narrow. It does not try to answer the user's question. It produces an
+answer-ready context pack and scaffold. Retrieval quality remains a later evaluation topic (`RBGV-V1-T006`).
+
+## Limitations
+
+- The selector is minimal and uses existing index results; no gold-query optimization yet.
+- If no `sqlite_index` exists, query evidence is surfaced as unavailable rather than causing a refresh.
+- The human output is for operator readability, not a stable machine contract.
+
+## Validation
+
+```bash
+git diff --check
+python -m pytest merger/lenskit/tests/test_repobrief_ask_cli.py -q
+python -m pytest merger/lenskit/tests/test_repobrief_ask_frontdoor_contracts.py -q
+python -m pytest merger/lenskit/tests/test_repobrief_resolved_evidence_query.py -q
+python -m pytest merger/lenskit/tests/test_repobrief_access_boundary.py -q
+python -m ruff check merger/lenskit/core/repobrief_ask.py merger/lenskit/cli/cmd_repobrief.py merger/lenskit/tests/test_repobrief_ask_cli.py
+```
+
+## Non-claims
+
+This self-review does not establish answer correctness, claim truth, actual reading, complete context use,
+retrieval quality, runtime correctness, full test sufficiency, review completeness, merge readiness,
+security correctness or absence of regressions.

--- a/merger/lenskit/cli/cmd_repobrief.py
+++ b/merger/lenskit/cli/cmd_repobrief.py
@@ -295,6 +295,19 @@ def register_repobrief_command_groups(repobrief_parser: argparse.ArgumentParser)
         help="Do not add the compact source citation projection",
     )
 
+    ask_parser = repobrief_subparsers.add_parser(
+        "ask",
+        help="Build a read-only RepoBrief ask context pack from an existing snapshot",
+    )
+    ask_parser.add_argument("--bundle-manifest", required=True, help="Path to a Brief Bundle manifest")
+    ask_parser.add_argument("--q", required=True, help="Question or task query")
+    ask_parser.add_argument("--task-profile", default="basic_repo_question", help="Required-reading task profile")
+    ask_parser.add_argument("--context-budget", type=int, default=8000, help="Maximum context token budget")
+    ask_parser.add_argument("--answer-budget", type=int, default=1200, help="Maximum downstream answer token budget")
+    ask_parser.add_argument("--k", type=int, default=5, help="Maximum retrieval hits")
+    ask_parser.add_argument("--emit", choices=["json", "text"], default="json", help="Output format")
+    ask_parser.add_argument("--strict", action="store_true", help="Treat warn status as exit code 1")
+
     symbol_parser = repobrief_subparsers.add_parser(
         "symbol",
         help="Read-only Python symbol-index consumer commands",
@@ -504,6 +517,8 @@ def run_repobrief(args: argparse.Namespace) -> int:
         return run_required_reading_resolve(args)
     if args.repobrief_cmd == "query":
         return run_query_existing_index(args)
+    if args.repobrief_cmd == "ask":
+        return run_ask(args)
     if args.repobrief_cmd == "symbol" and args.symbol_cmd == "search":
         return run_symbol_search(args)
     if args.repobrief_cmd == "context" and args.context_cmd == "compile":
@@ -768,6 +783,36 @@ def run_query_existing_index(args: argparse.Namespace) -> int:
         return 2
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0 if result.get("status") == "available" else 1
+
+
+def run_ask(args: argparse.Namespace) -> int:
+    from merger.lenskit.core.repobrief_ask import (
+        build_ask_context_pack,
+        render_ask_context_pack_text,
+    )
+
+    try:
+        result = build_ask_context_pack(
+            args.bundle_manifest,
+            query=args.q,
+            task_profile=args.task_profile,
+            max_context_tokens=args.context_budget,
+            max_answer_tokens=args.answer_budget,
+            k=args.k,
+        )
+    except ValueError as exc:
+        print("repobrief ask: " + str(exc), file=sys.stderr)
+        return 2
+    if args.emit == "text":
+        print(render_ask_context_pack_text(result), end="")
+    else:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    status = result.get("required_reading", {}).get("status")
+    if status == "fail":
+        return 1
+    if status == "warn" and args.strict:
+        return 1
+    return 0
 
 
 def run_symbol_search(args: argparse.Namespace) -> int:

--- a/merger/lenskit/contracts/repobrief-ask-context-pack.v1.schema.json
+++ b/merger/lenskit/contracts/repobrief-ask-context-pack.v1.schema.json
@@ -558,6 +558,39 @@
         }
       ],
       "description": "Boundaries this context pack does not establish."
+    },
+    "budget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "max_context_tokens",
+        "max_answer_tokens",
+        "approx_context_chars_used",
+        "truncated",
+        "does_not_establish_quality"
+      ],
+      "properties": {
+        "max_context_tokens": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "max_answer_tokens": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "approx_context_chars_used": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "truncated": {
+          "type": "boolean"
+        },
+        "does_not_establish_quality": {
+          "type": "boolean",
+          "const": true
+        }
+      },
+      "description": "Token budget report. This is a constraint record, not a quality proof."
     }
   }
 }

--- a/merger/lenskit/core/repobrief_ask.py
+++ b/merger/lenskit/core/repobrief_ask.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any
+
+from merger.lenskit.core.repobrief_access import (
+    query_existing_index,
+    resolve_required_reading_for_bundle,
+    snapshot_status,
+)
+
+KIND = "repobrief.ask_context_pack"
+VERSION = "1.0"
+FORBIDDEN_OPERATIONS = [
+    "implicit_refresh",
+    "git_mutation",
+    "snapshot_creation_on_read",
+    "patch_application",
+    "pull_request_mutation",
+    "shell_execution",
+    "merge_authorization",
+]
+DOES_NOT_ESTABLISH = [
+    "actual_reading_proven",
+    "answer_correct",
+    "repo_understood",
+    "all_relevant_context_used",
+    "claims_true",
+    "test_sufficiency",
+    "regression_absence",
+    "runtime_behavior",
+    "forensic_ready",
+    "merge_readiness",
+    "security_correctness",
+]
+_FRESHNESS_STATUSES = {"fresh", "stale", "unknown", "not_comparable", "not_applicable"}
+_AVAILABILITY_STATUSES = {"available", "partial", "missing", "unknown"}
+_RANGE_STATUSES = {"resolved", "missing", "drifted", "invalid", "degraded", "not_applicable"}
+
+
+def _sha256_file(path: Path) -> str | None:
+    try:
+        h = hashlib.sha256()
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                h.update(chunk)
+        return h.hexdigest()
+    except OSError:
+        return None
+
+
+def _as_status(value: Any, allowed: set[str], default: str) -> str:
+    if isinstance(value, str) and value in allowed:
+        return value
+    return default
+
+
+def _freshness_block(snapshot: dict[str, Any]) -> dict[str, Any]:
+    raw = snapshot.get("freshness")
+    if isinstance(raw, dict):
+        status = _as_status(raw.get("status"), _FRESHNESS_STATUSES, "unknown")
+        caveats = []
+        if status in {"stale", "unknown", "not_comparable"}:
+            caveats.append({
+                "kind": "unknown_freshness" if status == "unknown" else "stale_snapshot",
+                "detail": f"Snapshot freshness status is {status}.",
+            })
+        return {"status": status, "caveats": caveats}
+    return {
+        "status": "unknown",
+        "caveats": [{"kind": "unknown_freshness", "detail": "Snapshot freshness metadata was unavailable."}],
+    }
+
+
+def _availability_block(snapshot: dict[str, Any]) -> dict[str, Any]:
+    model = snapshot.get("availability_model")
+    if isinstance(model, dict):
+        status = _as_status(model.get("status"), _AVAILABILITY_STATUSES, "unknown")
+        caveats = []
+        if status in {"partial", "missing", "unknown"}:
+            caveats.append({
+                "kind": "missing_artifact" if status in {"partial", "missing"} else "degraded_validation",
+                "detail": f"Snapshot availability status is {status}.",
+            })
+        return {"status": status, "caveats": caveats}
+    return {
+        "status": "unknown",
+        "caveats": [{"kind": "degraded_validation", "detail": "Snapshot availability metadata was unavailable."}],
+    }
+
+
+def _snapshot_ref(snapshot: dict[str, Any], manifest_path: Path, freshness: dict[str, Any]) -> dict[str, Any]:
+    manifest_sha = _sha256_file(manifest_path)
+    result: dict[str, Any] = {
+        "stem": manifest_path.name.replace(".bundle.manifest.json", ""),
+        "manifest_path": str(manifest_path),
+        "freshness_policy": "allow_stale_with_caveat",
+        "freshness_status": freshness["status"],
+    }
+    if manifest_sha:
+        result["manifest_sha256"] = manifest_sha
+    run_id = snapshot.get("bundle_run_id")
+    if isinstance(run_id, str) and run_id:
+        result["git_commit"] = snapshot.get("git_commit") if isinstance(snapshot.get("git_commit"), str) else None
+    return result
+
+
+def _retrieval_hits(query_result: dict[str, Any]) -> list[dict[str, Any]]:
+    raw = query_result.get("query_result") if isinstance(query_result, dict) else None
+    hits = raw.get("results") if isinstance(raw, dict) else []
+    result = []
+    for idx, hit in enumerate(hits if isinstance(hits, list) else []):
+        if not isinstance(hit, dict):
+            continue
+        result.append({
+            "artifact_role": str(hit.get("artifact_role") or hit.get("artifact_type") or "sqlite_index"),
+            "ref": str(hit.get("chunk_id") or hit.get("id") or f"hit-{idx + 1}"),
+            "score": float(hit.get("score") or hit.get("bm25_score") or 0.0),
+            "purpose": "retrieval candidate for ask context",
+        })
+    return result
+
+
+def _resolved_ranges(query_result: dict[str, Any], max_context_tokens: int) -> tuple[list[dict[str, Any]], int, bool]:
+    resolved = query_result.get("resolved_evidence") if isinstance(query_result, dict) else None
+    hits = resolved.get("hits") if isinstance(resolved, dict) else []
+    budget_chars = max_context_tokens * 4
+    used_chars = 0
+    truncated = False
+    result = []
+    for idx, hit in enumerate(hits if isinstance(hits, list) else []):
+        if not isinstance(hit, dict):
+            continue
+        range_value = hit.get("range") if isinstance(hit.get("range"), dict) else {}
+        text = range_value.get("text") if isinstance(range_value, dict) else None
+        excerpt = text if isinstance(text, str) else hit.get("text_excerpt")
+        if isinstance(excerpt, str):
+            remaining = max(0, budget_chars - used_chars)
+            if len(excerpt) > remaining:
+                excerpt = excerpt[:remaining]
+                truncated = True
+            used_chars += len(excerpt)
+        status = _as_status(hit.get("range_status"), _RANGE_STATUSES, "degraded")
+        range_ref = hit.get("range_ref") if isinstance(hit.get("range_ref"), dict) else {"ref": str(hit.get("chunk_id") or f"range-{idx + 1}")}
+        item: dict[str, Any] = {
+            "artifact_role": str(hit.get("artifact_role") or "canonical_md"),
+            "status": status,
+            "range_ref": range_ref,
+        }
+        if isinstance(excerpt, str):
+            item["text_excerpt"] = excerpt
+        content_sha = None
+        if isinstance(range_value, dict):
+            content_sha = range_value.get("content_sha256") or range_value.get("sha256")
+        if isinstance(content_sha, str) and len(content_sha) == 64:
+            item["content_sha256"] = content_sha
+        result.append(item)
+    return result, used_chars, truncated
+
+
+def _required_reading_block(resolution: dict[str, Any]) -> dict[str, Any]:
+    rr = resolution.get("required_reading") if isinstance(resolution, dict) else {}
+    if not isinstance(rr, dict):
+        rr = {}
+    return {
+        "task_profile": str(resolution.get("task_profile") or rr.get("task_profile") or "basic_repo_question"),
+        "required": list(rr.get("required") or []),
+        "recommended": list(rr.get("recommended") or []),
+        "missing_required": list(rr.get("missing_required") or []),
+        "missing_recommended": list(rr.get("missing_recommended") or []),
+        "status": str(rr.get("status") or resolution.get("status") or "not_applicable"),
+    }
+
+
+def build_ask_context_pack(
+    bundle_manifest: str | Path,
+    *,
+    query: str,
+    task_profile: str = "basic_repo_question",
+    max_context_tokens: int = 8000,
+    max_answer_tokens: int = 1200,
+    k: int = 5,
+) -> dict[str, Any]:
+    """Build a read-only RepoBrief ask context pack from existing artifacts.
+
+    The function does not create or refresh snapshots. It delegates retrieval to the
+    existing read-only index query and reports token budget as a constraint, not as a
+    quality or correctness proof.
+    """
+    manifest_path = Path(bundle_manifest).expanduser().resolve()
+    snapshot = snapshot_status(manifest_path)
+    freshness = _freshness_block(snapshot)
+    availability = _availability_block(snapshot)
+    required_reading = _required_reading_block(resolve_required_reading_for_bundle(manifest_path, task_profile))
+    query_result = query_existing_index(
+        manifest_path,
+        query,
+        k=k,
+        filters={},
+        resolve_evidence=True,
+        project_sources=True,
+    )
+    retrieval_hits = _retrieval_hits(query_result)
+    resolved_ranges, used_chars, truncated = _resolved_ranges(query_result, max_context_tokens)
+    caveats = list(freshness.get("caveats") or []) + list(availability.get("caveats") or [])
+    if query_result.get("status") != "available":
+        caveats.append({"kind": "missing_artifact", "detail": str(query_result.get("error") or "Query evidence unavailable.")})
+    if truncated:
+        caveats.append({"kind": "other", "detail": "Context excerpts were truncated to respect max_context_tokens."})
+    citation_obligations = [
+        "Cite every strong repository claim with resolved RepoBrief evidence where available.",
+        "Surface freshness, availability and non-claim caveats in the answer.",
+    ]
+    return {
+        "kind": KIND,
+        "version": VERSION,
+        "request_id": hashlib.sha256(f"{manifest_path}\0{task_profile}\0{query}".encode("utf-8")).hexdigest()[:16],
+        "snapshot_ref": _snapshot_ref(snapshot, manifest_path, freshness),
+        "freshness": freshness,
+        "availability": availability,
+        "required_reading": required_reading,
+        "retrieval_hits": retrieval_hits,
+        "resolved_ranges": resolved_ranges,
+        "answer_scaffold": {
+            "citation_obligations": citation_obligations,
+            "caveats_to_surface": caveats,
+            "non_claims_to_surface": list(DOES_NOT_ESTABLISH),
+        },
+        "budget": {
+            "max_context_tokens": max_context_tokens,
+            "max_answer_tokens": max_answer_tokens,
+            "approx_context_chars_used": used_chars,
+            "truncated": truncated,
+            "does_not_establish_quality": True,
+        },
+        "forbidden_operations": list(FORBIDDEN_OPERATIONS),
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }
+
+
+def render_ask_context_pack_text(pack: dict[str, Any]) -> str:
+    lines = [
+        "RepoBrief Ask Context Pack",
+        f"status: required_reading={pack.get('required_reading', {}).get('status')} freshness={pack.get('freshness', {}).get('status')} availability={pack.get('availability', {}).get('status')}",
+        f"snapshot: {pack.get('snapshot_ref', {}).get('manifest_path')}",
+        "",
+        "Citation obligations:",
+    ]
+    for item in pack.get("answer_scaffold", {}).get("citation_obligations", []):
+        lines.append(f"- {item}")
+    lines.append("")
+    lines.append("Resolved ranges:")
+    for item in pack.get("resolved_ranges", []):
+        excerpt = item.get("text_excerpt")
+        ref = item.get("range_ref")
+        lines.append(f"- {item.get('artifact_role')} {item.get('status')} {ref}")
+        if excerpt:
+            lines.append(f"  excerpt: {excerpt[:240].replace(chr(10), ' ')}")
+    lines.append("")
+    lines.append("Non-claims:")
+    for item in pack.get("does_not_establish", []):
+        lines.append(f"- {item}")
+    return "\n".join(lines) + "\n"

--- a/merger/lenskit/tests/test_repobrief_ask_cli.py
+++ b/merger/lenskit/tests/test_repobrief_ask_cli.py
@@ -1,0 +1,197 @@
+import hashlib
+import json
+from pathlib import Path
+
+import jsonschema
+
+from merger.lenskit.cli.main import main
+from merger.lenskit.core.repobrief_ask import build_ask_context_pack
+from merger.lenskit.tests.test_repobrief_resolved_evidence_query import _build_resolved_bundle
+
+CONTEXT_SCHEMA = Path(__file__).parent.parent / "contracts" / "repobrief-ask-context-pack.v1.schema.json"
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _add_artifact(bundle: dict, role: str, filename: str, content: str = "ok\n") -> None:
+    manifest = bundle["manifest"]
+    artifact_path = manifest.parent / filename
+    artifact_path.write_text(content, encoding="utf-8")
+    data = json.loads(manifest.read_text(encoding="utf-8"))
+    artifacts = data.setdefault("artifacts", [])
+    artifacts.append({
+        "role": role,
+        "path": filename,
+        "content_type": "application/json" if filename.endswith(".json") else "text/markdown",
+        "bytes": artifact_path.stat().st_size,
+        "sha256": _sha256(artifact_path),
+    })
+    manifest.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _complete_basic_bundle(tmp_path: Path) -> dict:
+    bundle = _build_resolved_bundle(tmp_path)
+    _add_artifact(bundle, "agent_reading_pack", "demo.agent_reading_pack.md", "# Agent pack\n")
+    _add_artifact(bundle, "snapshot_plan_json", "demo.snapshot_plan.json", "{}\n")
+    return bundle
+
+
+def _complete_pr_review_bundle(tmp_path: Path) -> dict:
+    bundle = _complete_basic_bundle(tmp_path)
+    _add_artifact(bundle, "post_emit_health", "demo.bundle_health.post.json", "{}\n")
+    _add_artifact(bundle, "bundle_surface_validation", "demo.bundle_surface_validation.json", "{}\n")
+    _add_artifact(bundle, "claim_evidence_map_json", "demo.claim_evidence_map.json", "{}\n")
+    return bundle
+
+
+def _validate_context_pack(pack: dict) -> None:
+    schema = json.loads(CONTEXT_SCHEMA.read_text(encoding="utf-8"))
+    jsonschema.validate(instance=pack, schema=schema)
+
+
+def test_build_ask_context_pack_json_for_basic_profile(tmp_path):
+    bundle = _complete_basic_bundle(tmp_path)
+
+    pack = build_ask_context_pack(
+        bundle["manifest"],
+        query="hello",
+        task_profile="basic_repo_question",
+        max_context_tokens=8000,
+        max_answer_tokens=1200,
+        k=5,
+    )
+
+    _validate_context_pack(pack)
+    assert pack["kind"] == "repobrief.ask_context_pack"
+    assert pack["required_reading"]["status"] == "pass"
+    assert pack["retrieval_hits"]
+    assert pack["resolved_ranges"][0]["status"] == "resolved"
+    assert "hello resolved world" in pack["resolved_ranges"][0]["text_excerpt"]
+    assert pack["budget"]["max_context_tokens"] == 8000
+    assert pack["budget"]["does_not_establish_quality"] is True
+    assert pack["forbidden_operations"] == [
+        "implicit_refresh",
+        "git_mutation",
+        "snapshot_creation_on_read",
+        "patch_application",
+        "pull_request_mutation",
+        "shell_execution",
+        "merge_authorization",
+    ]
+
+
+def test_repobrief_ask_cli_emits_json_context_pack(tmp_path, capsys):
+    bundle = _complete_basic_bundle(tmp_path)
+
+    rc = main([
+        "repobrief",
+        "ask",
+        "--bundle-manifest",
+        str(bundle["manifest"]),
+        "--q",
+        "hello",
+        "--task-profile",
+        "basic_repo_question",
+        "--context-budget",
+        "8000",
+        "--answer-budget",
+        "1200",
+        "--emit",
+        "json",
+    ])
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    pack = json.loads(captured.out)
+    _validate_context_pack(pack)
+    assert pack["required_reading"]["status"] == "pass"
+    assert pack["retrieval_hits"]
+    assert pack["does_not_establish"]
+
+
+def test_repobrief_ask_cli_emits_human_context_pack(tmp_path, capsys):
+    bundle = _complete_basic_bundle(tmp_path)
+
+    rc = main([
+        "repobrief",
+        "ask",
+        "--bundle-manifest",
+        str(bundle["manifest"]),
+        "--q",
+        "hello",
+        "--emit",
+        "text",
+    ])
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "RepoBrief Ask Context Pack" in captured.out
+    assert "Citation obligations" in captured.out
+    assert "Non-claims" in captured.out
+
+
+def test_repobrief_ask_cli_stricter_profile_smoke(tmp_path, capsys):
+    bundle = _complete_pr_review_bundle(tmp_path)
+
+    rc = main([
+        "repobrief",
+        "ask",
+        "--bundle-manifest",
+        str(bundle["manifest"]),
+        "--q",
+        "hello",
+        "--task-profile",
+        "pr_review",
+        "--emit",
+        "json",
+    ])
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    pack = json.loads(captured.out)
+    _validate_context_pack(pack)
+    assert pack["required_reading"]["task_profile"] == "pr_review"
+    assert pack["required_reading"]["status"] == "pass"
+
+
+def test_repobrief_ask_budget_truncates_without_quality_claim(tmp_path):
+    bundle = _complete_basic_bundle(tmp_path)
+
+    pack = build_ask_context_pack(
+        bundle["manifest"],
+        query="hello",
+        task_profile="basic_repo_question",
+        max_context_tokens=1,
+        max_answer_tokens=1200,
+        k=5,
+    )
+
+    _validate_context_pack(pack)
+    assert pack["budget"]["truncated"] is True
+    assert pack["budget"]["does_not_establish_quality"] is True
+    assert any("truncated" in caveat["detail"] for caveat in pack["answer_scaffold"]["caveats_to_surface"])
+
+
+def test_repobrief_ask_missing_required_profile_returns_failure(tmp_path, capsys):
+    bundle = _build_resolved_bundle(tmp_path)
+
+    rc = main([
+        "repobrief",
+        "ask",
+        "--bundle-manifest",
+        str(bundle["manifest"]),
+        "--q",
+        "hello",
+        "--task-profile",
+        "pr_review",
+        "--emit",
+        "json",
+    ])
+
+    captured = capsys.readouterr()
+    assert rc == 1
+    pack = json.loads(captured.out)
+    assert pack["required_reading"]["status"] == "fail"
+    assert "post_emit_health" in pack["required_reading"]["missing_required"]


### PR DESCRIPTION
## Summary

- implements `repobrief ask` for `RBGV-V1-T005`
- emits JSON context packs and human-readable context-pack text
- builds from an existing bundle manifest and existing read-only query/access surfaces
- reports token budget as a constraint, including truncation, without making quality claims
- covers `basic_repo_question`, stricter `pr_review`, missing-required evidence, and budget truncation smoke paths

## Validation

- `git diff --check`
- `python -m pytest merger/lenskit/tests/test_repobrief_ask_cli.py -q`
- `python -m pytest merger/lenskit/tests/test_repobrief_ask_frontdoor_contracts.py -q`
- `python -m pytest merger/lenskit/tests/test_repobrief_resolved_evidence_query.py -q`
- `python -m pytest merger/lenskit/tests/test_repobrief_access_boundary.py -q`
- `python -m ruff check merger/lenskit/core/repobrief_ask.py merger/lenskit/cli/cmd_repobrief.py merger/lenskit/tests/test_repobrief_ask_cli.py`

## Boundary

The command reads existing artifacts only. It does not refresh snapshots, mutate Git, write bundle artifacts, apply patches, create PRs, execute shell commands, authorize merges, or answer the user's question. It produces a context pack and answer scaffold.
