### PR TITLE
feat(repobrief): add ask gold query evaluation

### DIFF
--- a/docs/proofs/repobrief-ask-gold-query-eval-v1-proof.md
+++ b/docs/proofs/repobrief-ask-gold-query-eval-v1-proof.md
@@ -1,0 +1,48 @@
+# RepoBrief Ask Gold Query Evaluation v1 Proof
+
+Status: review_ready
+Initiative: `REPOBRIEF-FRONTDOOR-GROUNDING-V1`
+Task: `RBGV-V1-T006`
+
+## Result
+
+This slice adds a minimal Ask Frontdoor gold-query evaluator:
+
+- `merger/lenskit/core/repobrief_ask_eval.py`
+- `repobrief ask-eval` CLI dispatch
+- `docs/retrieval/repobrief_ask_goldset.v1.example.json`
+- tests in `merger/lenskit/tests/test_repobrief_ask_eval.py`
+
+## What is measured
+
+- expected path recall;
+- citation coverage;
+- Required Reading coverage;
+- MRR@k;
+- budget truncation rate;
+- miss taxonomy counts.
+
+## Promotion gate
+
+The evaluation emits a promotion gate that requires:
+
+- no central-query metric regression against a supplied baseline;
+- documented measurement advantage over that baseline.
+
+If no baseline is supplied, otherwise passing results remain `warn` for promotion purposes.
+
+## Validation
+
+```bash
+git diff --check
+python -m pytest merger/lenskit/tests/test_repobrief_ask_eval.py -q
+python -m pytest merger/lenskit/tests/test_repobrief_ask_cli.py -q
+python -m pytest merger/lenskit/tests/test_repobrief_resolved_evidence_query.py -q
+python -m ruff check merger/lenskit/core/repobrief_ask_eval.py merger/lenskit/core/repobrief_ask.py merger/lenskit/cli/cmd_repobrief.py merger/lenskit/tests/test_repobrief_ask_eval.py
+```
+
+## Does not establish
+
+This proof does not establish answer correctness, repository understanding, review completeness,
+retrieval quality sufficiency, default-promotion safety, runtime correctness outside the tested paths,
+full test sufficiency, merge readiness, security correctness or regression absence.

--- a/docs/proofs/repobrief-ask-gold-query-eval-v1.self-review.md
+++ b/docs/proofs/repobrief-ask-gold-query-eval-v1.self-review.md
@@ -1,0 +1,58 @@
+# Self-review — RepoBrief Ask Gold Query Evaluation v1
+
+Review target: `RBGV-V1-T006` branch head before PR creation
+
+Files reviewed:
+
+- `merger/lenskit/core/repobrief_ask_eval.py`
+- `merger/lenskit/core/repobrief_ask.py`
+- `merger/lenskit/cli/cmd_repobrief.py`
+- `merger/lenskit/tests/test_repobrief_ask_eval.py`
+- `docs/retrieval/repobrief_ask_goldset.v1.example.json`
+- `docs/proofs/repobrief-ask-gold-query-eval-v1-proof.md`
+- `docs/proofs/repobrief-ask-gold-query-eval-v1.self-review.md`
+
+## Result
+
+No blocking issue found in this evaluation slice.
+
+## Critical checks
+
+| Check | Result |
+| --- | --- |
+| Gold queries specify expected paths/citations | Pass |
+| Evaluation reports citation coverage | Pass |
+| Evaluation reports Required Reading coverage | Pass |
+| Evaluation reports recall/MRR | Pass |
+| Evaluation reports miss taxonomy | Pass |
+| Promotion gate requires baseline/no regression/advantage | Pass |
+| Non-claims include no retrieval sufficiency/default-promotion safety | Pass |
+| CLI emits evaluation report | Pass |
+
+## Review notes
+
+The evaluator is deliberately small and deterministic. It uses `repobrief ask` context packs as the evaluated artifact. It does not run an LLM and does not judge final answer quality.
+
+The promotion gate is conservative: without baseline metrics, otherwise passing results remain a warning for promotion. With baseline metrics, eligibility requires no regression and positive aggregate measurement advantage.
+
+## Limitations
+
+- The goldset shape is documented by example and tests, not yet a separate schema.
+- Expected range matching is currently path/citation focused; more precise range matching can come later.
+- Metrics are only as strong as the provided goldset and baseline.
+
+## Validation
+
+```bash
+git diff --check
+python -m pytest merger/lenskit/tests/test_repobrief_ask_eval.py -q
+python -m pytest merger/lenskit/tests/test_repobrief_ask_cli.py -q
+python -m pytest merger/lenskit/tests/test_repobrief_resolved_evidence_query.py -q
+python -m ruff check merger/lenskit/core/repobrief_ask_eval.py merger/lenskit/core/repobrief_ask.py merger/lenskit/cli/cmd_repobrief.py merger/lenskit/tests/test_repobrief_ask_eval.py
+```
+
+## Non-claims
+
+This self-review does not establish answer correctness, repository understanding, review completeness,
+retrieval quality sufficiency, default-promotion safety, runtime correctness, full test sufficiency,
+merge readiness, security correctness or absence of regressions.

--- a/docs/retrieval/repobrief_ask_goldset.v1.example.json
+++ b/docs/retrieval/repobrief_ask_goldset.v1.example.json
@@ -1,0 +1,19 @@
+{
+  "kind": "repobrief.ask_goldset",
+  "version": "1.0",
+  "queries": [
+    {
+      "id": "ask-demo-1",
+      "query": "Where is the demonstrated resolved world text?",
+      "task_profile": "basic_repo_question",
+      "expected_paths": ["brief.md"],
+      "expected_citation_ids": []
+    }
+  ],
+  "does_not_establish": [
+    "answer_correctness",
+    "repo_understood",
+    "retrieval_quality_sufficient",
+    "default_promotion_safe"
+  ]
+}

--- a/merger/lenskit/cli/cmd_repobrief.py
+++ b/merger/lenskit/cli/cmd_repobrief.py
@@ -308,6 +308,17 @@ def register_repobrief_command_groups(repobrief_parser: argparse.ArgumentParser)
     ask_parser.add_argument("--emit", choices=["json", "text"], default="json", help="Output format")
     ask_parser.add_argument("--strict", action="store_true", help="Treat warn status as exit code 1")
 
+    ask_eval_parser = repobrief_subparsers.add_parser(
+        "ask-eval",
+        help="Evaluate repobrief ask context packs against a gold-query set",
+    )
+    ask_eval_parser.add_argument("--bundle-manifest", required=True, help="Path to a Brief Bundle manifest")
+    ask_eval_parser.add_argument("--goldset", required=True, help="Path to repobrief ask goldset JSON")
+    ask_eval_parser.add_argument("--baseline", help="Optional previous eval JSON or metrics JSON for promotion gating")
+    ask_eval_parser.add_argument("--k", type=int, default=5, help="Maximum retrieval hits per query")
+    ask_eval_parser.add_argument("--context-budget", type=int, default=8000, help="Maximum context token budget")
+    ask_eval_parser.add_argument("--strict", action="store_true", help="Treat warn status as exit code 1")
+
     symbol_parser = repobrief_subparsers.add_parser(
         "symbol",
         help="Read-only Python symbol-index consumer commands",
@@ -519,6 +530,8 @@ def run_repobrief(args: argparse.Namespace) -> int:
         return run_query_existing_index(args)
     if args.repobrief_cmd == "ask":
         return run_ask(args)
+    if args.repobrief_cmd == "ask-eval":
+        return run_ask_eval(args)
     if args.repobrief_cmd == "symbol" and args.symbol_cmd == "search":
         return run_symbol_search(args)
     if args.repobrief_cmd == "context" and args.context_cmd == "compile":
@@ -808,6 +821,29 @@ def run_ask(args: argparse.Namespace) -> int:
     else:
         print(json.dumps(result, indent=2, sort_keys=True))
     status = result.get("required_reading", {}).get("status")
+    if status == "fail":
+        return 1
+    if status == "warn" and args.strict:
+        return 1
+    return 0
+
+
+def run_ask_eval(args: argparse.Namespace) -> int:
+    from merger.lenskit.core.repobrief_ask_eval import evaluate_ask_goldset
+
+    try:
+        result = evaluate_ask_goldset(
+            args.bundle_manifest,
+            args.goldset,
+            k=args.k,
+            max_context_tokens=args.context_budget,
+            baseline_path=args.baseline,
+        )
+    except ValueError as exc:
+        print("repobrief ask-eval: " + str(exc), file=sys.stderr)
+        return 2
+    print(json.dumps(result, indent=2, sort_keys=True))
+    status = result.get("status")
     if status == "fail":
         return 1
     if status == "warn" and args.strict:

--- a/merger/lenskit/core/repobrief_ask.py
+++ b/merger/lenskit/core/repobrief_ask.py
@@ -109,16 +109,28 @@ def _snapshot_ref(snapshot: dict[str, Any], manifest_path: Path, freshness: dict
 def _retrieval_hits(query_result: dict[str, Any]) -> list[dict[str, Any]]:
     raw = query_result.get("query_result") if isinstance(query_result, dict) else None
     hits = raw.get("results") if isinstance(raw, dict) else []
+    projection = query_result.get("source_citation_projection") if isinstance(query_result, dict) else None
+    projected_items = projection.get("items") if isinstance(projection, dict) else []
+    citations_by_ref = {
+        str(item.get("chunk_id")): item.get("citation_id")
+        for item in (projected_items if isinstance(projected_items, list) else [])
+        if isinstance(item, dict) and item.get("chunk_id") is not None
+    }
     result = []
     for idx, hit in enumerate(hits if isinstance(hits, list) else []):
         if not isinstance(hit, dict):
             continue
-        result.append({
+        ref = str(hit.get("chunk_id") or hit.get("id") or f"hit-{idx + 1}")
+        item = {
             "artifact_role": str(hit.get("artifact_role") or hit.get("artifact_type") or "sqlite_index"),
-            "ref": str(hit.get("chunk_id") or hit.get("id") or f"hit-{idx + 1}"),
+            "ref": ref,
             "score": float(hit.get("score") or hit.get("bm25_score") or 0.0),
             "purpose": "retrieval candidate for ask context",
-        })
+        }
+        citation_id = citations_by_ref.get(ref)
+        if isinstance(citation_id, str) and citation_id.startswith("cit_"):
+            item["citation_id"] = citation_id
+        result.append(item)
     return result
 
 

--- a/merger/lenskit/core/repobrief_ask_eval.py
+++ b/merger/lenskit/core/repobrief_ask_eval.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from merger.lenskit.core.repobrief_ask import DOES_NOT_ESTABLISH, build_ask_context_pack
+
+KIND = "repobrief.ask_eval"
+VERSION = "1.0"
+MISS_CODES = (
+    "missing_expected_path",
+    "missing_expected_citation",
+    "required_reading_fail",
+    "no_resolved_ranges",
+    "budget_truncated",
+)
+
+
+def _read_json(path: str | Path) -> dict[str, Any]:
+    p = Path(path).expanduser().resolve()
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(f"goldset does not exist: {p}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"goldset is not valid JSON: {p}") from exc
+    if not isinstance(data, dict):
+        raise ValueError("goldset must be a JSON object")
+    return data
+
+
+def _range_paths(pack: dict[str, Any]) -> list[str]:
+    paths: list[str] = []
+    for item in pack.get("resolved_ranges", []):
+        if not isinstance(item, dict):
+            continue
+        ref = item.get("range_ref")
+        if isinstance(ref, dict):
+            path = ref.get("file_path") or ref.get("artifact_path") or ref.get("path")
+            if isinstance(path, str) and path:
+                paths.append(path)
+    return paths
+
+
+def _citation_ids(pack: dict[str, Any]) -> list[str]:
+    result: list[str] = []
+    for hit in pack.get("retrieval_hits", []):
+        if isinstance(hit, dict) and isinstance(hit.get("citation_id"), str):
+            result.append(hit["citation_id"])
+    return result
+
+
+def _recall(expected: list[str], found: list[str]) -> tuple[float, list[str]]:
+    if not expected:
+        return 1.0, []
+    found_set = set(found)
+    missing = [item for item in expected if item not in found_set]
+    return (len(expected) - len(missing)) / len(expected), missing
+
+
+def _mrr(expected: list[str], ranked: list[str]) -> float:
+    if not expected:
+        return 1.0
+    expected_set = set(expected)
+    for idx, item in enumerate(ranked, start=1):
+        if item in expected_set:
+            return 1.0 / idx
+    return 0.0
+
+
+def _evaluate_one(bundle_manifest: Path, entry: dict[str, Any], *, k: int, max_context_tokens: int) -> dict[str, Any]:
+    query = str(entry.get("query") or entry.get("q") or "")
+    task_profile = str(entry.get("task_profile") or "basic_repo_question")
+    max_answer_tokens = int(entry.get("max_answer_tokens") or 1200)
+    pack = build_ask_context_pack(
+        bundle_manifest,
+        query=query,
+        task_profile=task_profile,
+        max_context_tokens=max_context_tokens,
+        max_answer_tokens=max_answer_tokens,
+        k=k,
+    )
+    expected_paths = [str(x) for x in entry.get("expected_paths") or []]
+    expected_citations = [str(x) for x in entry.get("expected_citation_ids") or []]
+    found_paths = _range_paths(pack)
+    found_citations = _citation_ids(pack)
+    path_recall, missing_paths = _recall(expected_paths, found_paths)
+    citation_coverage, missing_citations = _recall(expected_citations, found_citations)
+    rr_status = pack.get("required_reading", {}).get("status")
+    required_reading_coverage = 0.0 if rr_status == "fail" else 1.0
+    miss_taxonomy: dict[str, int] = {code: 0 for code in MISS_CODES}
+    miss_taxonomy["missing_expected_path"] = len(missing_paths)
+    miss_taxonomy["missing_expected_citation"] = len(missing_citations)
+    miss_taxonomy["required_reading_fail"] = 1 if rr_status == "fail" else 0
+    miss_taxonomy["no_resolved_ranges"] = 1 if not pack.get("resolved_ranges") else 0
+    miss_taxonomy["budget_truncated"] = 1 if pack.get("budget", {}).get("truncated") is True else 0
+    status = "pass" if sum(miss_taxonomy.values()) == 0 else "fail"
+    return {
+        "id": str(entry.get("id") or query),
+        "status": status,
+        "query": query,
+        "task_profile": task_profile,
+        "expected_paths": expected_paths,
+        "found_paths": found_paths,
+        "missing_paths": missing_paths,
+        "expected_citation_ids": expected_citations,
+        "found_citation_ids": found_citations,
+        "missing_citation_ids": missing_citations,
+        "metrics": {
+            "expected_path_recall": path_recall,
+            "citation_coverage": citation_coverage,
+            "required_reading_coverage": required_reading_coverage,
+            "mrr_at_k": _mrr(expected_paths, found_paths),
+        },
+        "miss_taxonomy": miss_taxonomy,
+        "context_pack": pack,
+    }
+
+
+def _mean(values: list[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def _promotion_gate(metrics: dict[str, Any], baseline: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(baseline, dict):
+        return {
+            "eligible": False,
+            "status": "warn",
+            "reason": "baseline_metrics_missing",
+            "requires_no_central_query_regression": True,
+            "requires_documented_measurement_advantage": True,
+        }
+    baseline_metrics = baseline.get("metrics") if isinstance(baseline.get("metrics"), dict) else baseline
+    regression_keys = ["expected_path_recall", "citation_coverage", "required_reading_coverage", "mrr_at_k"]
+    regressions = [
+        key for key in regression_keys
+        if float(metrics.get(key, 0.0)) < float(baseline_metrics.get(key, 0.0))
+    ]
+    advantage = sum(float(metrics.get(key, 0.0)) - float(baseline_metrics.get(key, 0.0)) for key in regression_keys)
+    return {
+        "eligible": not regressions and advantage > 0,
+        "status": "pass" if not regressions and advantage > 0 else "fail",
+        "regressions": regressions,
+        "measurement_advantage": advantage,
+        "requires_no_central_query_regression": True,
+        "requires_documented_measurement_advantage": True,
+    }
+
+
+def evaluate_ask_goldset(
+    bundle_manifest: str | Path,
+    goldset_path: str | Path,
+    *,
+    k: int = 5,
+    max_context_tokens: int = 8000,
+    baseline_path: str | Path | None = None,
+) -> dict[str, Any]:
+    manifest_path = Path(bundle_manifest).expanduser().resolve()
+    goldset = _read_json(goldset_path)
+    queries = goldset.get("queries")
+    if not isinstance(queries, list) or not all(isinstance(item, dict) for item in queries):
+        raise ValueError("goldset queries must be an array of objects")
+    results = [_evaluate_one(manifest_path, item, k=k, max_context_tokens=max_context_tokens) for item in queries]
+    metrics = {
+        "query_count": len(results),
+        "expected_path_recall": _mean([r["metrics"]["expected_path_recall"] for r in results]),
+        "citation_coverage": _mean([r["metrics"]["citation_coverage"] for r in results]),
+        "required_reading_coverage": _mean([r["metrics"]["required_reading_coverage"] for r in results]),
+        "mrr_at_k": _mean([r["metrics"]["mrr_at_k"] for r in results]),
+        "budget_truncation_rate": _mean([1.0 if r["context_pack"].get("budget", {}).get("truncated") else 0.0 for r in results]),
+    }
+    miss_taxonomy = {code: sum(r["miss_taxonomy"].get(code, 0) for r in results) for code in MISS_CODES}
+    baseline = _read_json(baseline_path) if baseline_path else None
+    promotion_gate = _promotion_gate(metrics, baseline)
+    status = "pass" if all(r["status"] == "pass" for r in results) else "fail"
+    if status == "pass" and promotion_gate["status"] == "warn":
+        status = "warn"
+    return {
+        "kind": KIND,
+        "version": VERSION,
+        "status": status,
+        "bundle_manifest": str(manifest_path),
+        "goldset": str(Path(goldset_path).expanduser().resolve()),
+        "metrics": metrics,
+        "miss_taxonomy": miss_taxonomy,
+        "promotion_gate": promotion_gate,
+        "results": results,
+        "does_not_establish": list(DOES_NOT_ESTABLISH) + ["retrieval_quality_sufficient", "default_promotion_safe"],
+    }

--- a/merger/lenskit/tests/test_repobrief_ask_eval.py
+++ b/merger/lenskit/tests/test_repobrief_ask_eval.py
@@ -1,0 +1,127 @@
+import json
+from pathlib import Path
+
+from merger.lenskit.cli.main import main
+from merger.lenskit.core.repobrief_ask import build_ask_context_pack
+from merger.lenskit.core.repobrief_ask_eval import evaluate_ask_goldset
+from merger.lenskit.tests.test_repobrief_ask_cli import _complete_basic_bundle
+
+
+def _write_goldset(path: Path, *, expected_paths=None, expected_citation_ids=None) -> Path:
+    path.write_text(
+        json.dumps({
+            "kind": "repobrief.ask_goldset",
+            "version": "1.0",
+            "queries": [
+                {
+                    "id": "q1",
+                    "query": "hello",
+                    "task_profile": "basic_repo_question",
+                    "expected_paths": expected_paths if expected_paths is not None else ["brief.md"],
+                    "expected_citation_ids": expected_citation_ids if expected_citation_ids is not None else [],
+                }
+            ],
+            "does_not_establish": [
+                "answer_correctness",
+                "repo_understood",
+                "retrieval_quality_sufficient",
+                "default_promotion_safe",
+            ],
+        }),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_ask_context_pack_carries_citation_id_for_eval(tmp_path):
+    bundle = _complete_basic_bundle(tmp_path)
+
+    pack = build_ask_context_pack(bundle["manifest"], query="hello")
+
+    assert pack["retrieval_hits"][0]["citation_id"].startswith("cit_")
+
+
+def test_evaluate_ask_goldset_reports_core_metrics_and_miss_taxonomy(tmp_path):
+    bundle = _complete_basic_bundle(tmp_path)
+    goldset = _write_goldset(tmp_path / "ask_goldset.json")
+
+    report = evaluate_ask_goldset(bundle["manifest"], goldset)
+
+    assert report["kind"] == "repobrief.ask_eval"
+    assert report["status"] == "warn"  # pass results, but no baseline for promotion decision
+    assert report["metrics"]["query_count"] == 1
+    assert report["metrics"]["expected_path_recall"] == 1.0
+    assert report["metrics"]["required_reading_coverage"] == 1.0
+    assert report["metrics"]["mrr_at_k"] == 1.0
+    assert report["miss_taxonomy"]["missing_expected_path"] == 0
+    assert report["promotion_gate"]["status"] == "warn"
+    assert report["promotion_gate"]["requires_no_central_query_regression"] is True
+    assert report["promotion_gate"]["requires_documented_measurement_advantage"] is True
+    assert "retrieval_quality_sufficient" in report["does_not_establish"]
+
+
+def test_evaluate_ask_goldset_reports_citation_coverage(tmp_path):
+    bundle = _complete_basic_bundle(tmp_path)
+    citation_id = build_ask_context_pack(bundle["manifest"], query="hello")["retrieval_hits"][0]["citation_id"]
+    goldset = _write_goldset(tmp_path / "ask_goldset.json", expected_citation_ids=[citation_id])
+
+    report = evaluate_ask_goldset(bundle["manifest"], goldset)
+
+    assert report["metrics"]["citation_coverage"] == 1.0
+    assert report["miss_taxonomy"]["missing_expected_citation"] == 0
+
+
+def test_evaluate_ask_goldset_fails_missing_expected_path(tmp_path):
+    bundle = _complete_basic_bundle(tmp_path)
+    goldset = _write_goldset(tmp_path / "ask_goldset.json", expected_paths=["missing.md"])
+
+    report = evaluate_ask_goldset(bundle["manifest"], goldset)
+
+    assert report["status"] == "fail"
+    assert report["metrics"]["expected_path_recall"] == 0.0
+    assert report["miss_taxonomy"]["missing_expected_path"] == 1
+    assert report["results"][0]["missing_paths"] == ["missing.md"]
+
+
+def test_evaluate_ask_goldset_promotion_gate_with_baseline_advantage(tmp_path):
+    bundle = _complete_basic_bundle(tmp_path)
+    goldset = _write_goldset(tmp_path / "ask_goldset.json")
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(
+        json.dumps({
+            "metrics": {
+                "expected_path_recall": 0.5,
+                "citation_coverage": 0.0,
+                "required_reading_coverage": 1.0,
+                "mrr_at_k": 0.5,
+            }
+        }),
+        encoding="utf-8",
+    )
+
+    report = evaluate_ask_goldset(bundle["manifest"], goldset, baseline_path=baseline)
+
+    assert report["status"] == "pass"
+    assert report["promotion_gate"]["status"] == "pass"
+    assert report["promotion_gate"]["eligible"] is True
+    assert report["promotion_gate"]["measurement_advantage"] > 0
+
+
+def test_repobrief_ask_eval_cli_emits_report(tmp_path, capsys):
+    bundle = _complete_basic_bundle(tmp_path)
+    goldset = _write_goldset(tmp_path / "ask_goldset.json")
+
+    rc = main([
+        "repobrief",
+        "ask-eval",
+        "--bundle-manifest",
+        str(bundle["manifest"]),
+        "--goldset",
+        str(goldset),
+    ])
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    report = json.loads(captured.out)
+    assert report["kind"] == "repobrief.ask_eval"
+    assert report["metrics"]["expected_path_recall"] == 1.0


### PR DESCRIPTION
## Summary

- implements `repobrief ask-eval` for `RBGV-V1-T006`
- evaluates `repobrief ask` context packs against a gold-query JSON set
- reports expected path recall, citation coverage, Required Reading coverage, MRR@k, budget truncation rate, and miss taxonomy
- adds a conservative promotion gate: no central-query regression and documented measurement advantage against a supplied baseline
- keeps non-claims explicit: no answer correctness, no repository understanding, no retrieval sufficiency, no default-promotion safety

## Validation

- `git diff --check`
- `python -m pytest merger/lenskit/tests/test_repobrief_ask_eval.py -q`
- `python -m pytest merger/lenskit/tests/test_repobrief_ask_cli.py -q`
- `python -m pytest merger/lenskit/tests/test_repobrief_resolved_evidence_query.py -q`
- `python -m ruff check merger/lenskit/core/repobrief_ask_eval.py merger/lenskit/core/repobrief_ask.py merger/lenskit/cli/cmd_repobrief.py merger/lenskit/tests/test_repobrief_ask_eval.py`

## Boundary

This evaluator measures context-pack evidence retrieval, not final answer quality. It does not prove answer correctness, repository understanding, review completeness, retrieval quality sufficiency, default-promotion safety, runtime correctness, or security correctness.
