### PR TITLE
feat(repobrief): add mcp read-only frontdoor

### DIFF
--- a/docs/architecture/repobrief-mcp-boundary.md
+++ b/docs/architecture/repobrief-mcp-boundary.md
@@ -31,8 +31,18 @@ The initial MCP tools are read-only helpers:
 - `required_reading_resolve`
 - `range_get`
 - `query_existing_index`
+- `ask_context`
+- `grounding_verify`
 
 Read-only tools must not write files, refresh bundles, create snapshots, mutate Git state, open pull requests, apply patches, run shells, execute reviews, execute fixes, merge changes, or read secrets. A stale, missing, degraded, or invalid snapshot must be reported as such instead of being silently regenerated.
+
+## Read-only frontdoor tools
+
+`ask_context` exposes the same request/context-pack semantics as `repobrief ask`: it builds a context pack from existing artifacts and must not create or refresh snapshots.
+
+`grounding_verify` exposes the same declaration/verdict semantics as the Answer Grounding verifier: it checks declared citations, ranges, task-profile evidence and caveats against existing inputs. It must not run reviews, apply fixes, mutate Git, read secrets, or authorize merges.
+
+Both tools are code-level MCP-shaped handlers only. Their presence does not establish MCP server availability, transport security, authentication, runtime correctness or answer correctness.
 
 ## Explicit write path
 
@@ -66,6 +76,7 @@ RepoBrief MCP must not expose or indirectly trigger these operations:
 - `auto_fix`
 - `auto_merge`
 - `secret_read`
+- `snapshot_create_side_effect`
 
 The forbidden list applies to resource reads, read-only tools, and future write-tool orchestration unless a later architecture document explicitly narrows a safe operation. By default, absence of permission is the design.
 

--- a/docs/proofs/repobrief-mcp-readonly-frontdoor-v1-proof.md
+++ b/docs/proofs/repobrief-mcp-readonly-frontdoor-v1-proof.md
@@ -1,0 +1,52 @@
+# RepoBrief MCP Read-only Frontdoor v1 Proof
+
+Status: review_ready
+Initiative: `REPOBRIEF-FRONTDOOR-GROUNDING-V1`
+Task: `RBGV-V1-T007`
+
+## Result
+
+This slice adds code-level MCP-shaped read-only frontdoor handlers:
+
+- `ask_context`
+- `grounding_verify`
+
+They live in `merger.lenskit.core.repobrief_mcp_tools` alongside the existing explicit `snapshot_create` write handler.
+
+## Semantics
+
+`ask_context` exposes the same context-pack semantics as `repobrief ask` / `repobrief.ask_context_pack.v1`.
+
+`grounding_verify` exposes the same declaration/verdict semantics as the Answer Grounding verifier / `repobrief.answer_grounding_verdict.v1`.
+
+## Read-only boundary
+
+The read-only frontdoor handlers report `writes: []` and forbid:
+
+- Git push/pull/fetch;
+- PR creation;
+- patch application;
+- shell execution;
+- auto-review/auto-fix/auto-merge;
+- secret reads;
+- `snapshot_create` side effects.
+
+They do not call `snapshot_create` and do not write bundle files during read-only smoke tests.
+
+## Validation
+
+```bash
+git diff --check
+python -m pytest merger/lenskit/tests/test_repobrief_mcp_frontdoor.py -q
+python -m pytest merger/lenskit/tests/test_repobrief_mcp_boundary_doc.py -q
+python -m pytest merger/lenskit/tests/test_repobrief_mcp_snapshot_create.py -q
+python -m pytest merger/lenskit/tests/test_repobrief_ask_cli.py -q
+python -m pytest merger/lenskit/tests/test_answer_grounding_verifier.py -q
+python -m ruff check merger/lenskit/core/repobrief_mcp_tools.py merger/lenskit/tests/test_repobrief_mcp_frontdoor.py merger/lenskit/tests/test_repobrief_mcp_boundary_doc.py
+```
+
+## Does not establish
+
+This proof does not establish MCP protocol-server availability, transport/authentication correctness,
+runtime deployment, answer correctness, actual reading, repository understanding, review completeness,
+merge readiness, security correctness, full test sufficiency or regression absence.

--- a/docs/proofs/repobrief-mcp-readonly-frontdoor-v1.self-review.md
+++ b/docs/proofs/repobrief-mcp-readonly-frontdoor-v1.self-review.md
@@ -1,0 +1,60 @@
+# Self-review — RepoBrief MCP Read-only Frontdoor v1
+
+Review target: `RBGV-V1-T007` branch head before PR creation
+
+Files reviewed:
+
+- `merger/lenskit/core/repobrief_mcp_tools.py`
+- `merger/lenskit/tests/test_repobrief_mcp_frontdoor.py`
+- `merger/lenskit/tests/test_repobrief_mcp_boundary_doc.py`
+- `docs/architecture/repobrief-mcp-boundary.md`
+- `docs/proofs/repobrief-mcp-readonly-frontdoor-v1-proof.md`
+- `docs/proofs/repobrief-mcp-readonly-frontdoor-v1.self-review.md`
+
+## Result
+
+No blocking issue found in this read-only MCP frontdoor slice.
+
+## Critical checks
+
+| Check | Result |
+| --- | --- |
+| `ask_context` shares ask context-pack semantics | Pass |
+| `grounding_verify` shares answer-grounding verdict semantics | Pass |
+| Read-only boundary reports `writes: []` | Pass |
+| No implicit `snapshot_create` side effect | Pass |
+| Forbidden operations include Git, shell, patch, PR, auto-merge, secret read | Pass |
+| Smoke tests cover ask context and grounding verification shapes | Pass |
+| Existing explicit `snapshot_create` boundary remains tested | Pass |
+| Documentation preserves no MCP-server availability claim | Pass |
+
+## Review notes
+
+The handlers are code-level MCP-shaped functions, not a protocol server. They intentionally reuse the existing CLI/core semantics rather than introducing separate MCP-only shapes.
+
+The existing `snapshot_create` handler remains an explicit write exception. The new frontdoor handlers are read-only and their boundary explicitly forbids `snapshot_create_side_effect`.
+
+## Limitations
+
+- No transport/server implementation is added.
+- No authentication/authorization behavior is implemented.
+- No network binding is introduced.
+- These tools still depend on existing snapshot artifacts and do not make stale snapshots fresh.
+
+## Validation
+
+```bash
+git diff --check
+python -m pytest merger/lenskit/tests/test_repobrief_mcp_frontdoor.py -q
+python -m pytest merger/lenskit/tests/test_repobrief_mcp_boundary_doc.py -q
+python -m pytest merger/lenskit/tests/test_repobrief_mcp_snapshot_create.py -q
+python -m pytest merger/lenskit/tests/test_repobrief_ask_cli.py -q
+python -m pytest merger/lenskit/tests/test_answer_grounding_verifier.py -q
+python -m ruff check merger/lenskit/core/repobrief_mcp_tools.py merger/lenskit/tests/test_repobrief_mcp_frontdoor.py merger/lenskit/tests/test_repobrief_mcp_boundary_doc.py
+```
+
+## Non-claims
+
+This self-review does not establish MCP server availability, transport/authentication correctness,
+runtime deployment, answer correctness, actual reading, repository understanding, review completeness,
+merge readiness, security correctness, full test sufficiency or absence of regressions.

--- a/merger/lenskit/core/repobrief_mcp_tools.py
+++ b/merger/lenskit/core/repobrief_mcp_tools.py
@@ -247,3 +247,99 @@ def snapshot_create(
         "mutation_boundary": _mutation_boundary(),
         "does_not_establish": list(DOES_NOT_ESTABLISH),
     }
+
+READ_ONLY_KIND = "repobrief.mcp.read_only_frontdoor"
+READ_ONLY_VERSION = "v1"
+READ_ONLY_FORBIDDEN_OPERATIONS = (
+    "git_push",
+    "git_pull",
+    "git_fetch",
+    "create_pr",
+    "apply_patch",
+    "run_shell",
+    "auto_review",
+    "auto_fix",
+    "auto_merge",
+    "secret_read",
+    "snapshot_create_side_effect",
+)
+
+
+def _read_only_boundary() -> dict[str, Any]:
+    return {
+        "writes": [],
+        "does_not_mutate": [
+            "git",
+            "pull_requests",
+            "patches",
+            "source_working_tree",
+            "brief_bundle_artifacts",
+            "secrets",
+        ],
+        "read_paths_do_not_refresh": True,
+        "explicit_write_tool": False,
+        "not_reachable_from_snapshot_create": True,
+        "forbidden_operations": list(READ_ONLY_FORBIDDEN_OPERATIONS),
+    }
+
+
+def ask_context(
+    *,
+    bundle_manifest: str | Path,
+    query: str,
+    task_profile: str = "basic_repo_question",
+    max_context_tokens: int = 8000,
+    max_answer_tokens: int = 1200,
+    k: int = 5,
+) -> dict[str, Any]:
+    """MCP-shaped read-only frontdoor for RepoBrief ask context packs."""
+    from merger.lenskit.core.repobrief_ask import build_ask_context_pack
+
+    context_pack = build_ask_context_pack(
+        bundle_manifest,
+        query=query,
+        task_profile=task_profile,
+        max_context_tokens=max_context_tokens,
+        max_answer_tokens=max_answer_tokens,
+        k=k,
+    )
+    return {
+        "kind": READ_ONLY_KIND,
+        "version": READ_ONLY_VERSION,
+        "tool": "ask_context",
+        "status": "ok",
+        "context_pack": context_pack,
+        "request_semantics": "repobrief.ask_request.v1",
+        "context_pack_semantics": "repobrief.ask_context_pack.v1",
+        "mutation_boundary": _read_only_boundary(),
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }
+
+
+def grounding_verify(
+    *,
+    declaration: dict[str, Any],
+    bundle_manifest: str | Path,
+    citation_map: str | Path | None = None,
+    task_profile: str | None = None,
+) -> dict[str, Any]:
+    """MCP-shaped read-only frontdoor for Answer Grounding verification."""
+    from merger.lenskit.core.answer_grounding import verify_answer_grounding_for_task_profile
+
+    verdict = verify_answer_grounding_for_task_profile(
+        declaration,
+        bundle_manifest=bundle_manifest,
+        citation_map=citation_map,
+        task_profile=task_profile,
+    )
+    return {
+        "kind": READ_ONLY_KIND,
+        "version": READ_ONLY_VERSION,
+        "tool": "grounding_verify",
+        "status": verdict.get("status", "degraded"),
+        "verdict": verdict,
+        "declaration_semantics": "repobrief.answer_grounding_declaration.v1",
+        "verdict_semantics": "repobrief.answer_grounding_verdict.v1",
+        "mutation_boundary": _read_only_boundary(),
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }

--- a/merger/lenskit/tests/test_repobrief_mcp_boundary_doc.py
+++ b/merger/lenskit/tests/test_repobrief_mcp_boundary_doc.py
@@ -21,6 +21,8 @@ READ_ONLY_TOOLS = (
     "required_reading_resolve",
     "range_get",
     "query_existing_index",
+    "ask_context",
+    "grounding_verify",
 )
 
 FORBIDDEN_OPERATIONS = (
@@ -34,6 +36,7 @@ FORBIDDEN_OPERATIONS = (
     "auto_fix",
     "auto_merge",
     "secret_read",
+    "snapshot_create_side_effect",
 )
 
 NEGATIVE_SEMANTICS = (

--- a/merger/lenskit/tests/test_repobrief_mcp_frontdoor.py
+++ b/merger/lenskit/tests/test_repobrief_mcp_frontdoor.py
@@ -1,0 +1,87 @@
+from pathlib import Path
+
+from merger.lenskit.core import repobrief_mcp_tools
+from merger.lenskit.tests.test_answer_grounding_verifier import _bundle, _declaration
+from merger.lenskit.tests.test_repobrief_ask_cli import _complete_basic_bundle
+
+
+def test_mcp_ask_context_exposes_same_context_pack_semantics(tmp_path):
+    bundle = _complete_basic_bundle(tmp_path)
+
+    result = repobrief_mcp_tools.ask_context(
+        bundle_manifest=bundle["manifest"],
+        query="hello",
+        task_profile="basic_repo_question",
+        max_context_tokens=8000,
+        max_answer_tokens=1200,
+        k=5,
+    )
+
+    assert result["kind"] == "repobrief.mcp.read_only_frontdoor"
+    assert result["tool"] == "ask_context"
+    assert result["status"] == "ok"
+    assert result["request_semantics"] == "repobrief.ask_request.v1"
+    assert result["context_pack_semantics"] == "repobrief.ask_context_pack.v1"
+    assert result["context_pack"]["kind"] == "repobrief.ask_context_pack"
+    assert result["context_pack"]["required_reading"]["status"] == "pass"
+    assert result["context_pack"]["resolved_ranges"][0]["status"] == "resolved"
+    assert result["mutation_boundary"]["writes"] == []
+    assert result["mutation_boundary"]["read_paths_do_not_refresh"] is True
+    assert "snapshot_create_side_effect" in result["mutation_boundary"]["forbidden_operations"]
+    assert "secret_read" in result["mutation_boundary"]["forbidden_operations"]
+
+
+def test_mcp_grounding_verify_exposes_same_verdict_semantics(tmp_path):
+    manifest, citation_map, range_ref = _bundle(tmp_path)
+    declaration = _declaration(range_ref)
+    declaration["declared_artifacts"] = [
+        "agent_reading_pack",
+        "canonical_md",
+        "citation_map_jsonl",
+        "snapshot_plan_json",
+    ]
+
+    result = repobrief_mcp_tools.grounding_verify(
+        declaration=declaration,
+        bundle_manifest=manifest,
+        citation_map=citation_map,
+        task_profile="basic_repo_question",
+    )
+
+    assert result["kind"] == "repobrief.mcp.read_only_frontdoor"
+    assert result["tool"] == "grounding_verify"
+    assert result["status"] == "pass"
+    assert result["declaration_semantics"] == "repobrief.answer_grounding_declaration.v1"
+    assert result["verdict_semantics"] == "repobrief.answer_grounding_verdict.v1"
+    assert result["verdict"]["kind"] == "repobrief.answer_grounding_verdict"
+    assert result["verdict"]["status"] == "pass"
+    assert result["mutation_boundary"]["writes"] == []
+    assert "git_push" in result["mutation_boundary"]["forbidden_operations"]
+    assert "auto_merge" in result["mutation_boundary"]["forbidden_operations"]
+
+
+def test_mcp_read_only_frontdoor_does_not_call_snapshot_create(monkeypatch, tmp_path):
+    bundle = _complete_basic_bundle(tmp_path)
+
+    def forbidden_snapshot_create(**_kwargs):
+        raise AssertionError("read-only MCP frontdoor must not call snapshot_create")
+
+    monkeypatch.setattr(repobrief_mcp_tools, "snapshot_create", forbidden_snapshot_create)
+
+    result = repobrief_mcp_tools.ask_context(
+        bundle_manifest=bundle["manifest"],
+        query="hello",
+    )
+
+    assert result["status"] == "ok"
+    assert result["mutation_boundary"]["writes"] == []
+
+
+def test_mcp_read_only_frontdoor_does_not_write_bundle_files(tmp_path):
+    bundle = _complete_basic_bundle(tmp_path)
+    before = {path.name for path in Path(tmp_path).iterdir()}
+
+    repobrief_mcp_tools.ask_context(bundle_manifest=bundle["manifest"], query="hello")
+
+    after = {path.name for path in Path(tmp_path).iterdir()}
+    assert after == before


### PR DESCRIPTION
## Summary

- implements code-level MCP-shaped read-only frontdoor handlers for `RBGV-V1-T007`
- adds `ask_context` using the same `repobrief ask` context-pack semantics
- adds `grounding_verify` using the same Answer Grounding declaration/verdict semantics
- documents the read-only MCP frontdoor boundary and forbidden operations
- adds smoke tests for ask context, grounding verification, no snapshot-create side effects, and no bundle writes

## Validation

- `git diff --check`
- `python -m pytest merger/lenskit/tests/test_repobrief_mcp_frontdoor.py -q`
- `python -m pytest merger/lenskit/tests/test_repobrief_mcp_boundary_doc.py -q`
- `python -m pytest merger/lenskit/tests/test_repobrief_mcp_snapshot_create.py -q`
- `python -m pytest merger/lenskit/tests/test_repobrief_ask_cli.py -q`
- `python -m pytest merger/lenskit/tests/test_answer_grounding_verifier.py -q`
- `python -m ruff check merger/lenskit/core/repobrief_mcp_tools.py merger/lenskit/tests/test_repobrief_mcp_frontdoor.py merger/lenskit/tests/test_repobrief_mcp_boundary_doc.py`

## Boundary

This is not an MCP protocol server. The new handlers are read-only and do not trigger snapshot creation, Git, shell, patch, PR, review, merge, or secret-read authority. The existing `snapshot_create` handler remains an explicit write exception for Brief Bundle artifacts only.
