### PR TITLE
feat(repobrief): add grounding delta invalidation

### DIFF
--- a/docs/proofs/answer-grounding-delta-invalidation-v1-proof.md
+++ b/docs/proofs/answer-grounding-delta-invalidation-v1-proof.md
@@ -1,0 +1,47 @@
+# RepoBrief Answer Grounding Delta Invalidation v1 Proof
+
+Status: review_ready
+Initiative: `REPOBRIEF-FRONTDOOR-GROUNDING-V1`
+Task: `RBGV-V1-T008`
+
+## Result
+
+This slice adds a read-only delta/freshness invalidation helper:
+
+- `merger/lenskit/core/answer_grounding_delta.py`
+- tests in `merger/lenskit/tests/test_answer_grounding_delta.py`
+
+The helper checks an old Answer Grounding declaration against a newer explicit bundle manifest and optional citation map.
+
+## Status model
+
+Old citations/ranges are classified as:
+
+- `valid`
+- `drifted`
+- `missing`
+- `not_comparable`
+
+## Read-only boundary
+
+The helper reads explicitly supplied existing files only. It does not create snapshots, refresh bundles, fetch Git state, apply patches, run shells, create PRs, or normalize freshness into success.
+
+## Freshness behavior
+
+The old declaration's `snapshot_ref.freshness_status` is carried through as `old_snapshot_freshness_status`. The newer snapshot's freshness status is read from the existing manifest status surface and remains visible as reported.
+
+## Validation
+
+```bash
+git diff --check
+python -m pytest merger/lenskit/tests/test_answer_grounding_delta.py -q
+python -m pytest merger/lenskit/tests/test_answer_grounding_verifier.py -q
+python -m pytest merger/lenskit/tests/test_range_resolver.py -q
+python -m ruff check merger/lenskit/core/answer_grounding_delta.py merger/lenskit/tests/test_answer_grounding_delta.py
+```
+
+## Does not establish
+
+This proof does not establish semantic answer correctness, future citation stability across all commits,
+new snapshot freshness, runtime correctness outside tested paths, full test sufficiency, review completeness,
+merge readiness, security correctness or regression absence.

--- a/docs/proofs/answer-grounding-delta-invalidation-v1.self-review.md
+++ b/docs/proofs/answer-grounding-delta-invalidation-v1.self-review.md
@@ -1,0 +1,54 @@
+# Self-review — RepoBrief Answer Grounding Delta Invalidation v1
+
+Review target: `RBGV-V1-T008` branch head before PR creation
+
+Files reviewed:
+
+- `merger/lenskit/core/answer_grounding_delta.py`
+- `merger/lenskit/tests/test_answer_grounding_delta.py`
+- `docs/proofs/answer-grounding-delta-invalidation-v1-proof.md`
+- `docs/proofs/answer-grounding-delta-invalidation-v1.self-review.md`
+
+## Result
+
+No blocking issue found in this delta-invalidation slice.
+
+## Critical checks
+
+| Check | Result |
+| --- | --- |
+| Old citations/ranges classified as `valid` | Pass |
+| Drift/hash mismatch classified as `drifted` | Pass |
+| Missing citation classified as `missing` | Pass |
+| Non-comparable citation/range classified as `not_comparable` | Pass |
+| Helper reports no snapshot creation / no Git fetch / no refresh | Pass |
+| Existing freshness statuses remain visible | Pass |
+
+## Review notes
+
+The helper intentionally compares explicitly supplied artifacts only. It does not discover newer snapshots, fetch Git, or attempt to make an old citation stable across arbitrary commits.
+
+The status model is conservative: if the helper cannot compare a citation or range, it reports `not_comparable` instead of smoothing the case into `valid` or `drifted`.
+
+## Limitations
+
+- No CLI wrapper yet.
+- No cross-commit citation relocation algorithm.
+- No semantic claim-support judgment.
+- Citation entries without range information can only be marked `not_comparable`.
+
+## Validation
+
+```bash
+git diff --check
+python -m pytest merger/lenskit/tests/test_answer_grounding_delta.py -q
+python -m pytest merger/lenskit/tests/test_answer_grounding_verifier.py -q
+python -m pytest merger/lenskit/tests/test_range_resolver.py -q
+python -m ruff check merger/lenskit/core/answer_grounding_delta.py merger/lenskit/tests/test_answer_grounding_delta.py
+```
+
+## Non-claims
+
+This self-review does not establish semantic answer correctness, future citation stability across all commits,
+new snapshot freshness, runtime correctness, full test sufficiency, review completeness, merge readiness,
+security correctness or absence of regressions.

--- a/merger/lenskit/core/answer_grounding_delta.py
+++ b/merger/lenskit/core/answer_grounding_delta.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from merger.lenskit.core.answer_grounding import NON_CLAIMS
+from merger.lenskit.core.range_resolver import resolve_range_ref
+from merger.lenskit.core.repobrief_access import snapshot_status
+
+KIND = "repobrief.answer_grounding_delta_verdict"
+VERSION = "1.0"
+STATUSES = ("valid", "drifted", "missing", "not_comparable")
+
+
+def _read_citation_map(path: str | Path | None) -> tuple[dict[str, dict[str, Any]], list[dict[str, Any]]]:
+    if path is None:
+        return {}, [{"code": "citation_map_missing", "severity": "warn", "detail": "No new citation map supplied."}]
+    p = Path(path).expanduser().resolve()
+    try:
+        lines = p.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        return {}, [{"code": "citation_map_missing", "severity": "warn", "detail": f"Citation map missing: {p}"}]
+    entries: dict[str, dict[str, Any]] = {}
+    diagnostics: list[dict[str, Any]] = []
+    for lineno, line in enumerate(lines, start=1):
+        if not line.strip():
+            continue
+        try:
+            data = json.loads(line)
+        except json.JSONDecodeError:
+            diagnostics.append({"code": "citation_map_invalid", "severity": "warn", "detail": f"Invalid JSONL line {lineno}."})
+            continue
+        if isinstance(data, dict) and isinstance(data.get("citation_id"), str):
+            entries[data["citation_id"]] = data
+    return entries, diagnostics
+
+
+def _range_ref_from_citation(entry: Mapping[str, Any]) -> dict[str, Any] | None:
+    range_ref = entry.get("range_ref")
+    if isinstance(range_ref, dict):
+        return dict(range_ref)
+    canonical_range = entry.get("canonical_range")
+    if isinstance(canonical_range, Mapping):
+        return {
+            "artifact_role": "canonical_md",
+            "repo_id": entry.get("repo_id") or "unknown-repo",
+            "file_path": canonical_range.get("file_path"),
+            "start_byte": canonical_range.get("start_byte"),
+            "end_byte": canonical_range.get("end_byte"),
+            "start_line": canonical_range.get("start_line"),
+            "end_line": canonical_range.get("end_line"),
+            "content_sha256": canonical_range.get("content_sha256"),
+        }
+    return None
+
+
+def _check_range(manifest: Path, range_ref: dict[str, Any]) -> tuple[str, str]:
+    try:
+        resolve_range_ref(manifest, range_ref)
+    except Exception as exc:
+        detail = str(exc)
+        if "hash mismatch" in detail.lower():
+            return "drifted", detail
+        return "not_comparable", detail
+    return "valid", "Citation range resolved against the newer snapshot."
+
+
+def _freshness_from_snapshot_ref(snapshot_ref: Mapping[str, Any] | None) -> str:
+    if not isinstance(snapshot_ref, Mapping):
+        return "unknown"
+    value = snapshot_ref.get("freshness_status")
+    return str(value) if isinstance(value, str) and value else "unknown"
+
+
+def check_answer_grounding_delta(
+    old_declaration: Mapping[str, Any],
+    *,
+    new_bundle_manifest: str | Path,
+    new_citation_map: str | Path | None = None,
+) -> dict[str, Any]:
+    """Check old declared citations/ranges against a newer snapshot.
+
+    Read-only: this function reads explicitly supplied existing files only. It does not
+    create snapshots, fetch Git state, refresh bundles, or normalize freshness statuses.
+    """
+    manifest_path = Path(new_bundle_manifest).expanduser().resolve()
+    entries, diagnostics = _read_citation_map(new_citation_map)
+    citation_checks: list[dict[str, Any]] = []
+    range_checks: list[dict[str, Any]] = []
+
+    for item in old_declaration.get("used_citations") or []:
+        if not isinstance(item, Mapping):
+            continue
+        citation_id = item.get("citation_id")
+        if not isinstance(citation_id, str) or not citation_id:
+            continue
+        entry = entries.get(citation_id)
+        if entry is None:
+            citation_checks.append({
+                "citation_id": citation_id,
+                "status": "missing",
+                "detail": "Citation ID was not present in the newer citation map.",
+            })
+            continue
+        range_ref = _range_ref_from_citation(entry)
+        if range_ref is None:
+            citation_checks.append({
+                "citation_id": citation_id,
+                "status": "not_comparable",
+                "detail": "New citation entry has no comparable range reference.",
+            })
+            continue
+        status, detail = _check_range(manifest_path, range_ref)
+        citation_checks.append({"citation_id": citation_id, "status": status, "detail": detail})
+
+    for idx, item in enumerate(old_declaration.get("used_ranges") or [], start=1):
+        if not isinstance(item, Mapping) or not isinstance(item.get("range_ref"), dict):
+            range_checks.append({
+                "range_id": f"declared-range-{idx}",
+                "status": "not_comparable",
+                "detail": "Old declaration range is missing range_ref.",
+            })
+            continue
+        status, detail = _check_range(manifest_path, dict(item["range_ref"]))
+        range_checks.append({
+            "range_id": str(item.get("claim_ref") or f"declared-range-{idx}"),
+            "status": status,
+            "detail": detail,
+        })
+
+    all_statuses = [item["status"] for item in citation_checks + range_checks]
+    if "drifted" in all_statuses:
+        status = "drifted"
+    elif "missing" in all_statuses:
+        status = "missing"
+    elif "not_comparable" in all_statuses or not all_statuses:
+        status = "not_comparable"
+    else:
+        status = "valid"
+
+    new_status = snapshot_status(manifest_path)
+    new_freshness = new_status.get("freshness") if isinstance(new_status, dict) else None
+    return {
+        "kind": KIND,
+        "version": VERSION,
+        "status": status,
+        "valid_statuses": list(STATUSES),
+        "old_snapshot_freshness_status": _freshness_from_snapshot_ref(old_declaration.get("snapshot_ref")),
+        "new_snapshot_freshness_status": (
+            new_freshness.get("status") if isinstance(new_freshness, dict) else "unknown"
+        ),
+        "citation_checks": citation_checks,
+        "range_checks": range_checks,
+        "diagnostics": diagnostics,
+        "mutation_boundary": {
+            "writes": [],
+            "reads_existing_files_only": True,
+            "does_not_create_snapshots": True,
+            "does_not_fetch_git": True,
+            "does_not_refresh_bundles": True,
+        },
+        "does_not_establish": list(NON_CLAIMS) + [
+            "semantic_answer_correctness",
+            "new_snapshot_is_fresh",
+            "citation_stability_across_all_commits",
+        ],
+    }

--- a/merger/lenskit/tests/test_answer_grounding_delta.py
+++ b/merger/lenskit/tests/test_answer_grounding_delta.py
@@ -1,0 +1,93 @@
+import json
+from pathlib import Path
+
+from merger.lenskit.core.answer_grounding_delta import check_answer_grounding_delta
+from merger.lenskit.tests.test_answer_grounding_verifier import _bundle, _declaration
+
+
+def _empty_citation_map(path: Path) -> Path:
+    path.write_text("", encoding="utf-8")
+    return path
+
+
+def _citation_without_range(path: Path) -> Path:
+    path.write_text(json.dumps({"citation_id": "cit_0000000000000001", "repo_id": "demo"}) + "\n", encoding="utf-8")
+    return path
+
+
+def test_answer_grounding_delta_valid_unchanged(tmp_path):
+    manifest, citation_map, range_ref = _bundle(tmp_path)
+    declaration = _declaration(range_ref)
+
+    verdict = check_answer_grounding_delta(
+        declaration,
+        new_bundle_manifest=manifest,
+        new_citation_map=citation_map,
+    )
+
+    assert verdict["status"] == "valid"
+    assert verdict["citation_checks"][0]["status"] == "valid"
+    assert verdict["range_checks"][0]["status"] == "valid"
+    assert verdict["mutation_boundary"]["does_not_create_snapshots"] is True
+    assert verdict["mutation_boundary"]["does_not_fetch_git"] is True
+
+
+def test_answer_grounding_delta_drifted_hash_mismatch(tmp_path):
+    manifest, citation_map, range_ref = _bundle(tmp_path)
+    declaration = _declaration(range_ref)
+    (tmp_path / "demo_merge.md").write_text("Line 1\nchanged\nLine 3\n", encoding="utf-8")
+
+    verdict = check_answer_grounding_delta(
+        declaration,
+        new_bundle_manifest=manifest,
+        new_citation_map=citation_map,
+    )
+
+    assert verdict["status"] == "drifted"
+    assert any(item["status"] == "drifted" for item in verdict["citation_checks"] + verdict["range_checks"])
+
+
+def test_answer_grounding_delta_missing_citation(tmp_path):
+    manifest, _citation_map, range_ref = _bundle(tmp_path)
+    declaration = _declaration(range_ref)
+    empty = _empty_citation_map(tmp_path / "empty.citation_map.jsonl")
+
+    verdict = check_answer_grounding_delta(
+        declaration,
+        new_bundle_manifest=manifest,
+        new_citation_map=empty,
+    )
+
+    assert verdict["status"] == "missing"
+    assert verdict["citation_checks"][0]["status"] == "missing"
+
+
+def test_answer_grounding_delta_not_comparable_when_range_absent(tmp_path):
+    manifest, _citation_map, range_ref = _bundle(tmp_path)
+    declaration = _declaration(range_ref)
+    declaration["used_ranges"] = []
+    no_range = _citation_without_range(tmp_path / "no-range.citation_map.jsonl")
+
+    verdict = check_answer_grounding_delta(
+        declaration,
+        new_bundle_manifest=manifest,
+        new_citation_map=no_range,
+    )
+
+    assert verdict["status"] == "not_comparable"
+    assert verdict["citation_checks"][0]["status"] == "not_comparable"
+
+
+def test_answer_grounding_delta_preserves_existing_freshness_status(tmp_path):
+    manifest, citation_map, range_ref = _bundle(tmp_path)
+    declaration = _declaration(range_ref)
+    declaration["snapshot_ref"]["freshness_status"] = "stale"
+
+    verdict = check_answer_grounding_delta(
+        declaration,
+        new_bundle_manifest=manifest,
+        new_citation_map=citation_map,
+    )
+
+    assert verdict["old_snapshot_freshness_status"] == "stale"
+    assert verdict["new_snapshot_freshness_status"] == "unknown"


### PR DESCRIPTION
## Summary

- implements `RBGV-V1-T008` answer-grounding delta/freshness invalidation helper
- classifies old citations/ranges against a newer explicit snapshot as `valid`, `drifted`, `missing`, or `not_comparable`
- preserves old and new freshness status surfaces without normalizing them into success
- keeps the helper read-only: no snapshot creation, no refresh, no Git fetch, no patch/PR/shell authority

## Validation

- `git diff --check`
- `python -m pytest merger/lenskit/tests/test_answer_grounding_delta.py -q`
- `python -m pytest merger/lenskit/tests/test_answer_grounding_verifier.py -q`
- `python -m pytest merger/lenskit/tests/test_range_resolver.py -q`
- `python -m ruff check merger/lenskit/core/answer_grounding_delta.py merger/lenskit/tests/test_answer_grounding_delta.py`

## Boundary

This helper does not establish semantic answer correctness, citation stability across all commits, new snapshot freshness, review completeness, merge readiness, runtime correctness, or security correctness.
