### PR TITLE
feat(repobrief): add history lens navigation

### DIFF
--- a/docs/architecture/history-lens-v1.md
+++ b/docs/architecture/history-lens-v1.md
@@ -1,0 +1,33 @@
+# RepoBrief History Lens v1
+
+Status: optional derived navigation
+Initiative: `REPOBRIEF-FRONTDOOR-GROUNDING-V1`
+Task: `RBGV-V1-T009`
+
+History Lens is a derived navigation and diagnostic surface for explicit history records such as commit, file, and pull-request provenance hints.
+
+It is not canonical content truth. Canonical repository content remains the selected RepoBrief snapshot's canonical source. Current work still requires live GitHub, CI, PR and working-tree checks.
+
+## Profiles and export policy
+
+History metadata is governed by an explicit profile:
+
+- `disabled`: no history metadata included;
+- `summary`: file churn summary only;
+- `full`: provenance chains included.
+
+Author metadata is excluded by default and may only be included when explicitly requested by the caller/profile.
+
+## Forbidden verdicts
+
+History Lens must not emit or imply:
+
+- person blame;
+- ownership verdicts;
+- correctness verdicts;
+- completeness verdicts;
+- merge-readiness verdicts.
+
+## Non-claims
+
+A History Lens output does not establish canonical content truth, repository understanding, live GitHub state, CI state, PR state, correctness, completeness, ownership, person blame, merge readiness or security correctness.

--- a/docs/proofs/history-lens-v1-proof.md
+++ b/docs/proofs/history-lens-v1-proof.md
@@ -1,0 +1,25 @@
+# RepoBrief History Lens v1 Proof
+
+Status: review_ready
+Initiative: `REPOBRIEF-FRONTDOOR-GROUNDING-V1`
+Task: `RBGV-V1-T009`
+
+## Result
+
+This slice adds optional History Lens derived navigation:
+
+- `merger/lenskit/core/history_lens.py`
+- `merger/lenskit/tests/test_history_lens.py`
+- `docs/architecture/history-lens-v1.md`
+
+## Validation
+
+```bash
+git diff --check
+python -m pytest merger/lenskit/tests/test_history_lens.py -q
+python -m ruff check merger/lenskit/core/history_lens.py merger/lenskit/tests/test_history_lens.py
+```
+
+## Does not establish
+
+This proof does not establish canonical content truth, person blame, ownership, correctness, completeness, live GitHub/CI/PR state, merge readiness, security correctness or regression absence.

--- a/docs/proofs/history-lens-v1.self-review.md
+++ b/docs/proofs/history-lens-v1.self-review.md
@@ -1,0 +1,29 @@
+# Self-review — RepoBrief History Lens v1
+
+Review target: `RBGV-V1-T009` branch head before PR creation
+
+## Result
+
+No blocking issue found in this optional derived-navigation slice.
+
+## Critical checks
+
+| Check | Result |
+| --- | --- |
+| Declared as derived navigation/diagnosis, not canonical truth | Pass |
+| Export profile controls history metadata inclusion | Pass |
+| Author metadata excluded by default | Pass |
+| Person blame / ownership / correctness / completeness verdicts forbidden | Pass |
+| Live GitHub/CI/PR boundary preserved | Pass |
+
+## Validation
+
+```bash
+git diff --check
+python -m pytest merger/lenskit/tests/test_history_lens.py -q
+python -m ruff check merger/lenskit/core/history_lens.py merger/lenskit/tests/test_history_lens.py
+```
+
+## Non-claims
+
+This self-review does not establish canonical content truth, person blame, ownership, correctness, completeness, live GitHub/CI/PR state, merge readiness, security correctness, full test sufficiency or absence of regressions.

--- a/merger/lenskit/core/history_lens.py
+++ b/merger/lenskit/core/history_lens.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any, Iterable, Mapping
+
+KIND = "repobrief.history_lens"
+VERSION = "1.0"
+PROFILES = ("disabled", "summary", "full")
+DOES_NOT_ESTABLISH = [
+    "canonical_content_truth",
+    "person_blame",
+    "ownership_verdict",
+    "correctness",
+    "completeness",
+    "live_github_state",
+    "ci_state",
+    "pull_request_state",
+    "merge_readiness",
+    "security_correctness",
+]
+FORBIDDEN_VERDICTS = [
+    "person_blame",
+    "ownership",
+    "correctness",
+    "completeness",
+    "merge_readiness",
+]
+
+
+def _record_path(record: Mapping[str, Any]) -> str | None:
+    path = record.get("path") or record.get("file_path")
+    return str(path) if isinstance(path, str) and path else None
+
+
+def _commit_id(record: Mapping[str, Any]) -> str | None:
+    commit = record.get("commit") or record.get("commit_sha") or record.get("sha")
+    return str(commit) if isinstance(commit, str) and commit else None
+
+
+def _public_record(record: Mapping[str, Any], *, include_author_metadata: bool) -> dict[str, Any]:
+    item: dict[str, Any] = {}
+    for key in ("commit", "commit_sha", "sha", "pr", "pull_request", "path", "file_path", "summary"):
+        value = record.get(key)
+        if isinstance(value, (str, int, float, bool)):
+            item[key] = value
+    if include_author_metadata:
+        for key in ("author", "author_email", "committer"):
+            value = record.get(key)
+            if isinstance(value, str):
+                item[key] = value
+    return item
+
+
+def build_history_lens(
+    records: Iterable[Mapping[str, Any]],
+    *,
+    profile: str = "summary",
+    include_author_metadata: bool = False,
+) -> dict[str, Any]:
+    """Build a derived history navigation surface from explicit history records.
+
+    This function does not call Git or GitHub. It only summarizes records supplied by
+    the caller and marks the result as derived navigation/diagnosis, not canonical truth.
+    """
+    if profile not in PROFILES:
+        raise ValueError(f"unsupported history lens profile: {profile}")
+    if profile == "disabled":
+        return {
+            "kind": KIND,
+            "version": VERSION,
+            "status": "not_applicable",
+            "profile": profile,
+            "derived_navigation": True,
+            "canonical_content_truth": False,
+            "export_policy": {
+                "profile": profile,
+                "history_metadata_included": False,
+                "author_metadata_included": False,
+                "allowed_profiles": list(PROFILES),
+            },
+            "file_churn": [],
+            "provenance_chains": [],
+            "forbidden_verdicts": list(FORBIDDEN_VERDICTS),
+            "live_state_boundary": "Use live GitHub/CI/PR checks for current work; History Lens does not replace them.",
+            "does_not_establish": list(DOES_NOT_ESTABLISH),
+        }
+
+    churn: dict[str, set[str]] = defaultdict(set)
+    provenance: list[dict[str, Any]] = []
+    for record in records:
+        path = _record_path(record)
+        commit = _commit_id(record)
+        if path and commit:
+            churn[path].add(commit)
+        if profile == "full":
+            public = _public_record(record, include_author_metadata=include_author_metadata)
+            if public:
+                provenance.append(public)
+
+    file_churn = [
+        {"path": path, "commit_count": len(commits), "navigation_only": True}
+        for path, commits in sorted(churn.items())
+    ]
+    return {
+        "kind": KIND,
+        "version": VERSION,
+        "status": "ok",
+        "profile": profile,
+        "derived_navigation": True,
+        "canonical_content_truth": False,
+        "export_policy": {
+            "profile": profile,
+            "history_metadata_included": True,
+            "author_metadata_included": bool(include_author_metadata),
+            "allowed_profiles": list(PROFILES),
+        },
+        "file_churn": file_churn,
+        "provenance_chains": provenance,
+        "forbidden_verdicts": list(FORBIDDEN_VERDICTS),
+        "live_state_boundary": "Use live GitHub/CI/PR checks for current work; History Lens does not replace them.",
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }

--- a/merger/lenskit/tests/test_history_lens.py
+++ b/merger/lenskit/tests/test_history_lens.py
@@ -1,0 +1,61 @@
+import pytest
+
+from merger.lenskit.core.history_lens import build_history_lens
+
+
+RECORDS = [
+    {"commit": "a" * 40, "path": "src/a.py", "pr": 1, "author": "Ada", "summary": "touch a"},
+    {"commit": "b" * 40, "path": "src/a.py", "pr": 2, "author": "Bob", "summary": "touch a again"},
+    {"commit": "c" * 40, "path": "src/b.py", "pr": 3, "author": "Cyd", "summary": "touch b"},
+]
+
+
+def test_history_lens_is_derived_navigation_not_canonical_truth():
+    lens = build_history_lens(RECORDS, profile="summary")
+
+    assert lens["kind"] == "repobrief.history_lens"
+    assert lens["derived_navigation"] is True
+    assert lens["canonical_content_truth"] is False
+    assert "canonical_content_truth" in lens["does_not_establish"]
+    assert lens["file_churn"] == [
+        {"path": "src/a.py", "commit_count": 2, "navigation_only": True},
+        {"path": "src/b.py", "commit_count": 1, "navigation_only": True},
+    ]
+
+
+def test_history_lens_export_profile_controls_metadata_inclusion():
+    disabled = build_history_lens(RECORDS, profile="disabled")
+    full_without_authors = build_history_lens(RECORDS, profile="full")
+    full_with_authors = build_history_lens(RECORDS, profile="full", include_author_metadata=True)
+
+    assert disabled["status"] == "not_applicable"
+    assert disabled["export_policy"]["history_metadata_included"] is False
+    assert full_without_authors["export_policy"]["history_metadata_included"] is True
+    assert full_without_authors["export_policy"]["author_metadata_included"] is False
+    assert "author" not in full_without_authors["provenance_chains"][0]
+    assert full_with_authors["export_policy"]["author_metadata_included"] is True
+    assert full_with_authors["provenance_chains"][0]["author"] == "Ada"
+
+
+def test_history_lens_forbids_blame_ownership_correctness_and_completeness_verdicts():
+    lens = build_history_lens(RECORDS, profile="summary")
+
+    assert "person_blame" in lens["forbidden_verdicts"]
+    assert "ownership" in lens["forbidden_verdicts"]
+    assert "correctness" in lens["forbidden_verdicts"]
+    assert "completeness" in lens["forbidden_verdicts"]
+    assert "ownership_verdict" in lens["does_not_establish"]
+
+
+def test_history_lens_preserves_live_state_boundary():
+    lens = build_history_lens(RECORDS, profile="summary")
+
+    assert "live GitHub/CI/PR checks" in lens["live_state_boundary"]
+    assert "live_github_state" in lens["does_not_establish"]
+    assert "ci_state" in lens["does_not_establish"]
+    assert "pull_request_state" in lens["does_not_establish"]
+
+
+def test_history_lens_rejects_unknown_profile():
+    with pytest.raises(ValueError, match="unsupported history lens profile"):
+        build_history_lens(RECORDS, profile="unsafe")


### PR DESCRIPTION
## Summary

- implements optional `RBGV-V1-T009` History Lens derived navigation
- summarizes explicit history records into file churn and optional provenance chains
- adds export-profile control for disabled/summary/full history metadata
- excludes author metadata by default
- forbids person blame, ownership, correctness, completeness, and merge-readiness verdicts
- preserves the live GitHub/CI/PR boundary

## Validation

- `git diff --check`
- `python -m pytest merger/lenskit/tests/test_history_lens.py -q`
- `python -m ruff check merger/lenskit/core/history_lens.py merger/lenskit/tests/test_history_lens.py`

## Boundary

History Lens is derived navigation/diagnosis, not canonical content truth. It does not replace live GitHub, CI, PR, or working-tree checks and does not establish person blame, ownership, correctness, completeness, merge readiness, or security correctness.
