### PR TITLE
feat(repobrief): add mcp read-only resources

### DIFF
--- a/docs/architecture/repobrief-mcp-boundary.md
+++ b/docs/architecture/repobrief-mcp-boundary.md
@@ -21,6 +21,8 @@ RepoBrief MCP should expose stable resources before tools. Planned resources are
 
 These resources are read-only views over files that already exist in a Brief Bundle.
 
+The concrete code-level resource adapter lives in `merger.lenskit.core.repobrief_mcp_resources`. It implements resource template listing and resource reads for `manifest`, `canonical`, `reading-pack`, `health`, `availability`, and arbitrary `artifact/{role}` resources. Each read returns snapshot health, freshness, and availability context or an explicit explanation when the manifest is unavailable. The adapter is still not a networked MCP protocol server.
+
 ## Read-only tools
 
 The initial MCP tools are read-only helpers:

--- a/docs/proofs/repobrief-mcp-readonly-resources-v1-proof.md
+++ b/docs/proofs/repobrief-mcp-readonly-resources-v1-proof.md
@@ -1,0 +1,41 @@
+# RepoBrief MCP Read-only Resources v1 Proof
+
+Status: review_ready
+Task: `RPU-V1-T020`
+
+## Result
+
+This slice adds concrete code-level RepoBrief MCP resource reads:
+
+- `merger/lenskit/core/repobrief_mcp_resources.py`
+- `merger/lenskit/tests/test_repobrief_mcp_resources.py`
+
+Implemented resource templates:
+
+- `repobrief://snapshot/{stem}/manifest`
+- `repobrief://snapshot/{stem}/canonical`
+- `repobrief://snapshot/{stem}/reading-pack`
+- `repobrief://snapshot/{stem}/health`
+- `repobrief://snapshot/{stem}/availability`
+- `repobrief://snapshot/{stem}/artifact/{role}`
+
+## Boundary
+
+The adapter is read-only. It lists and reads existing bundle artifacts only. It does not create snapshots, refresh bundles, touch Git, run shells, inspect secrets, open PRs, apply patches, run reviews, run fixes or authorize merges.
+
+Every resource read returns snapshot context for health, freshness and availability, or explains why that context is unavailable.
+
+## Validation
+
+```bash
+git diff --check
+python -m pytest merger/lenskit/tests/test_repobrief_mcp_resources.py -q
+python -m pytest merger/lenskit/tests/test_repobrief_mcp_boundary_doc.py -q
+python -m pytest merger/lenskit/tests/test_repobrief_mcp_frontdoor.py -q
+python -m pytest merger/lenskit/tests/test_repobrief_mcp_snapshot_create.py -q
+python -m ruff check merger/lenskit/core/repobrief_mcp_resources.py merger/lenskit/tests/test_repobrief_mcp_resources.py merger/lenskit/tests/test_repobrief_mcp_boundary_doc.py
+```
+
+## Does not establish
+
+This proof does not establish MCP server availability, transport security, authentication correctness, runtime deployment, answer correctness, repository understanding, review completeness, merge readiness, security correctness, full test sufficiency or regression absence.

--- a/docs/proofs/repobrief-mcp-readonly-resources-v1.self-review.md
+++ b/docs/proofs/repobrief-mcp-readonly-resources-v1.self-review.md
@@ -1,0 +1,50 @@
+# Self-review — RepoBrief MCP Read-only Resources v1
+
+Review target: `RPU-V1-T020` branch head before PR creation
+
+Files reviewed:
+
+- `merger/lenskit/core/repobrief_mcp_resources.py`
+- `merger/lenskit/tests/test_repobrief_mcp_resources.py`
+- `docs/architecture/repobrief-mcp-boundary.md`
+- `merger/lenskit/tests/test_repobrief_mcp_boundary_doc.py`
+- `docs/proofs/repobrief-mcp-readonly-resources-v1-proof.md`
+- `docs/proofs/repobrief-mcp-readonly-resources-v1.self-review.md`
+
+## Result
+
+No blocking issue found in this read-only resource adapter slice.
+
+## Critical checks
+
+| Check | Result |
+| --- | --- |
+| Concrete `repobrief://snapshot/...` resources implemented | Pass |
+| Manifest/canonical/reading-pack/health/availability reads covered | Pass |
+| Arbitrary artifact-role read covered | Pass |
+| Missing snapshot explains unavailable context | Pass |
+| Every listed resource read carries health/freshness/availability context | Pass |
+| Reads do not write bundle files | Pass |
+| Forbidden operations include Git, shell, secrets, PR, patch, auto-review/fix/merge | Pass |
+| Docs state adapter is not a networked MCP protocol server | Pass |
+
+## Limitations
+
+- This is a code-level resource adapter, not a transport server.
+- No authentication, authorization, network binding or scheduler behavior is added.
+- Resource reads depend on existing bundle manifests and artifacts; missing artifacts are reported, not regenerated.
+
+## Validation
+
+```bash
+git diff --check
+python -m pytest merger/lenskit/tests/test_repobrief_mcp_resources.py -q
+python -m pytest merger/lenskit/tests/test_repobrief_mcp_boundary_doc.py -q
+python -m pytest merger/lenskit/tests/test_repobrief_mcp_frontdoor.py -q
+python -m pytest merger/lenskit/tests/test_repobrief_mcp_snapshot_create.py -q
+python -m ruff check merger/lenskit/core/repobrief_mcp_resources.py merger/lenskit/tests/test_repobrief_mcp_resources.py merger/lenskit/tests/test_repobrief_mcp_boundary_doc.py
+```
+
+## Non-claims
+
+This self-review does not establish MCP server availability, transport security, authentication correctness, runtime deployment, answer correctness, repository understanding, review completeness, merge readiness, security correctness, full test sufficiency or absence of regressions.

--- a/merger/lenskit/core/repobrief_mcp_resources.py
+++ b/merger/lenskit/core/repobrief_mcp_resources.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote, urlparse
+
+from merger.lenskit.core import repobrief_access
+
+KIND = "repobrief.mcp.resource_read"
+LIST_KIND = "repobrief.mcp.resource_list"
+VERSION = "v1"
+RESOURCE_PREFIX = "repobrief://snapshot/"
+FIXED_RESOURCE_KINDS = {
+    "manifest": "bundle_manifest",
+    "canonical": "canonical_md",
+    "reading-pack": "agent_reading_pack",
+    "health": "post_emit_health",
+    "availability": "availability_model",
+}
+FORBIDDEN_OPERATIONS = [
+    "git_push",
+    "git_pull",
+    "git_fetch",
+    "create_pr",
+    "apply_patch",
+    "run_shell",
+    "auto_review",
+    "auto_fix",
+    "auto_merge",
+    "secret_read",
+    "snapshot_create_side_effect",
+]
+DOES_NOT_ESTABLISH = [
+    "truth",
+    "correctness",
+    "completeness",
+    "runtime_behavior",
+    "test_sufficiency",
+    "regression_absence",
+    "repo_understood",
+    "claims_true",
+    "forensic_ready",
+    "review_complete",
+    "pr_mergeable",
+    "mcp_server_available",
+    "transport_security",
+    "authentication_correctness",
+]
+
+
+class RepoBriefMcpResourceError(ValueError):
+    """Raised for invalid MCP resource addresses."""
+
+
+def _read_only_boundary() -> dict[str, Any]:
+    return {
+        "writes": [],
+        "does_not_mutate": [
+            "git",
+            "pull_requests",
+            "patches",
+            "source_working_tree",
+            "brief_bundle_artifacts",
+            "secrets",
+        ],
+        "read_paths_do_not_refresh": True,
+        "does_not_create_snapshots": True,
+        "forbidden_operations": list(FORBIDDEN_OPERATIONS),
+    }
+
+
+def _manifest_stem(path: Path) -> str:
+    name = path.name
+    suffix = ".bundle.manifest.json"
+    if name.endswith(suffix):
+        return name[: -len(suffix)]
+    return path.stem
+
+
+def _manifest_candidates(bundle_root: str | Path) -> list[Path]:
+    root = Path(bundle_root).expanduser().resolve()
+    if root.is_file():
+        return [root]
+    if not root.exists():
+        return []
+    return sorted(root.glob("*.bundle.manifest.json"))
+
+
+def _find_manifest(bundle_root: str | Path, stem: str) -> Path | None:
+    for path in _manifest_candidates(bundle_root):
+        if _manifest_stem(path) == stem:
+            return path
+    return None
+
+
+def _resource_uri(stem: str, suffix: str) -> str:
+    return f"{RESOURCE_PREFIX}{stem}/{suffix}"
+
+
+def _parse_resource_uri(uri: str) -> tuple[str, str, str | None]:
+    parsed = urlparse(uri)
+    if parsed.scheme != "repobrief" or parsed.netloc != "snapshot":
+        raise RepoBriefMcpResourceError("resource URI must start with repobrief://snapshot/")
+    parts = [unquote(part) for part in parsed.path.split("/") if part]
+    if len(parts) < 2:
+        raise RepoBriefMcpResourceError("resource URI must include snapshot stem and resource name")
+    stem, resource_name = parts[0], parts[1]
+    if not stem or ".." in stem or "/" in stem:
+        raise RepoBriefMcpResourceError("resource stem is invalid")
+    if resource_name == "artifact":
+        if len(parts) != 3 or not parts[2] or "/" in parts[2] or ".." in parts[2]:
+            raise RepoBriefMcpResourceError("artifact resource URI must include one artifact role")
+        return stem, resource_name, parts[2]
+    if len(parts) != 2 or resource_name not in FIXED_RESOURCE_KINDS:
+        raise RepoBriefMcpResourceError("unsupported RepoBrief MCP resource URI")
+    return stem, resource_name, None
+
+
+def _artifact_text(path: Path) -> tuple[str | None, dict[str, Any] | None]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return None, None
+    try:
+        return text, json.loads(text)
+    except json.JSONDecodeError:
+        return text, None
+
+
+def _context_for_manifest(manifest: Path | None, *, reason: str | None = None) -> dict[str, Any]:
+    if manifest is None:
+        return {
+            "health": {"status": "unknown", "reason": reason or "manifest unavailable"},
+            "freshness": {"status": "unknown", "reason": reason or "manifest unavailable"},
+            "availability": {"status": "unknown", "reason": reason or "manifest unavailable"},
+        }
+    status = repobrief_access.snapshot_status(manifest)
+    health = repobrief_access.get_artifact(manifest, "post_emit_health")
+    availability_model = status.get("availability_model")
+    freshness = status.get("freshness")
+    return {
+        "health": {
+            "status": health.get("status", "unknown"),
+            "artifact": health.get("artifact"),
+        },
+        "freshness": freshness if isinstance(freshness, dict) else {"status": "unknown"},
+        "availability": availability_model if isinstance(availability_model, dict) else {"status": "unknown"},
+    }
+
+
+def _base_result(uri: str, manifest: Path | None, *, status: str, reason: str | None = None) -> dict[str, Any]:
+    return {
+        "kind": KIND,
+        "version": VERSION,
+        "uri": uri,
+        "status": status,
+        "bundle_manifest": str(manifest) if manifest else None,
+        "snapshot_context": _context_for_manifest(manifest, reason=reason),
+        "mutation_boundary": _read_only_boundary(),
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }
+
+
+def _read_artifact_resource(uri: str, manifest: Path, role: str) -> dict[str, Any]:
+    ref = repobrief_access.get_artifact(manifest, role)
+    result = _base_result(uri, manifest, status=ref.get("status", "unknown"))
+    result.update({"resource_role": role, "artifact_ref": ref.get("artifact")})
+    artifact = ref.get("artifact")
+    if not isinstance(artifact, dict) or not artifact.get("path"):
+        result["reason"] = f"artifact role not available: {role}"
+        return result
+    raw_path = Path(str(artifact["path"])).expanduser()
+    path = raw_path if raw_path.is_absolute() else (manifest.parent / raw_path)
+    path = path.resolve()
+    if not path.is_file():
+        result["status"] = "missing"
+        result["reason"] = f"artifact file missing: {path}"
+        return result
+    text, parsed = _artifact_text(path)
+    result["content_type"] = artifact.get("content_type") or "application/octet-stream"
+    if text is not None:
+        result["content_text"] = text
+    else:
+        result["binary_unreadable"] = True
+    if parsed is not None:
+        result["content_json"] = parsed
+    return result
+
+
+def resource_templates() -> dict[str, Any]:
+    return {
+        "kind": "repobrief.mcp.resource_templates",
+        "version": VERSION,
+        "templates": [
+            "repobrief://snapshot/{stem}/manifest",
+            "repobrief://snapshot/{stem}/canonical",
+            "repobrief://snapshot/{stem}/reading-pack",
+            "repobrief://snapshot/{stem}/health",
+            "repobrief://snapshot/{stem}/availability",
+            "repobrief://snapshot/{stem}/artifact/{role}",
+        ],
+        "mutation_boundary": _read_only_boundary(),
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }
+
+
+def list_mcp_resources(bundle_root: str | Path) -> dict[str, Any]:
+    resources: list[dict[str, Any]] = []
+    for manifest in _manifest_candidates(bundle_root):
+        stem = _manifest_stem(manifest)
+        for suffix in ("manifest", "canonical", "reading-pack", "health", "availability"):
+            resources.append({"uri": _resource_uri(stem, suffix), "snapshot_stem": stem, "resource": suffix})
+        for role in repobrief_access.available_roles(manifest):
+            resources.append({
+                "uri": _resource_uri(stem, f"artifact/{role}"),
+                "snapshot_stem": stem,
+                "resource": "artifact",
+                "role": role,
+            })
+    return {
+        "kind": LIST_KIND,
+        "version": VERSION,
+        "status": "ok",
+        "bundle_root": str(Path(bundle_root).expanduser().resolve()),
+        "resources": resources,
+        "templates": resource_templates()["templates"],
+        "mutation_boundary": _read_only_boundary(),
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }
+
+
+def read_mcp_resource(uri: str, *, bundle_root: str | Path) -> dict[str, Any]:
+    stem, resource_name, role = _parse_resource_uri(uri)
+    manifest = _find_manifest(bundle_root, stem)
+    if manifest is None:
+        return _base_result(uri, None, status="missing", reason=f"snapshot stem not found: {stem}")
+    if resource_name == "manifest":
+        text, parsed = _artifact_text(manifest)
+        result = _base_result(uri, manifest, status="available")
+        result.update({"resource_role": "bundle_manifest", "content_type": "application/json"})
+        if text is not None:
+            result["content_text"] = text
+        if parsed is not None:
+            result["content_json"] = parsed
+        return result
+    if resource_name == "availability":
+        result = _base_result(uri, manifest, status="available")
+        result.update({
+            "resource_role": "availability_model",
+            "content_type": "application/json",
+            "content_json": result["snapshot_context"]["availability"],
+            "content_text": json.dumps(result["snapshot_context"]["availability"], indent=2, sort_keys=True) + "\n",
+        })
+        return result
+    if resource_name == "artifact":
+        assert role is not None
+        return _read_artifact_resource(uri, manifest, role)
+    mapped_role = FIXED_RESOURCE_KINDS[resource_name]
+    return _read_artifact_resource(uri, manifest, mapped_role)

--- a/merger/lenskit/tests/test_repobrief_mcp_boundary_doc.py
+++ b/merger/lenskit/tests/test_repobrief_mcp_boundary_doc.py
@@ -131,3 +131,12 @@ def test_repobrief_doc_links_to_mcp_boundary_without_claiming_implementation() -
     assert "[RepoBrief MCP Boundary](repobrief-mcp-boundary.md)" in text
     assert "code-level `snapshot_create` tool handler exists" in text
     assert "does not assert that an MCP server" in text
+
+
+def test_mcp_boundary_doc_names_concrete_readonly_resource_adapter() -> None:
+    text = _read(MCP_BOUNDARY_DOC)
+
+    assert "merger.lenskit.core.repobrief_mcp_resources" in text
+    assert "manifest`, `canonical`, `reading-pack`, `health`, `availability`" in text
+    assert "not a networked MCP protocol server" in text
+    assert "health, freshness, and availability context" in text

--- a/merger/lenskit/tests/test_repobrief_mcp_resources.py
+++ b/merger/lenskit/tests/test_repobrief_mcp_resources.py
@@ -1,0 +1,154 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from merger.lenskit.core.repobrief_mcp_resources import (
+    RepoBriefMcpResourceError,
+    list_mcp_resources,
+    read_mcp_resource,
+    resource_templates,
+)
+from merger.lenskit.tests.test_repobrief_ask_cli import _add_artifact, _complete_basic_bundle
+
+
+def _bundle_with_health(tmp_path: Path) -> dict:
+    bundle = _complete_basic_bundle(tmp_path)
+    _add_artifact(
+        bundle,
+        "post_emit_health",
+        "demo.bundle_health.post.json",
+        json.dumps({"kind": "health", "status": "pass"}) + "\n",
+    )
+    return bundle
+
+
+def test_mcp_resource_templates_define_read_only_snapshot_surface():
+    templates = resource_templates()
+
+    assert templates["templates"] == [
+        "repobrief://snapshot/{stem}/manifest",
+        "repobrief://snapshot/{stem}/canonical",
+        "repobrief://snapshot/{stem}/reading-pack",
+        "repobrief://snapshot/{stem}/health",
+        "repobrief://snapshot/{stem}/availability",
+        "repobrief://snapshot/{stem}/artifact/{role}",
+    ]
+    assert templates["mutation_boundary"]["writes"] == []
+    assert templates["mutation_boundary"]["does_not_create_snapshots"] is True
+    assert "git_fetch" in templates["mutation_boundary"]["forbidden_operations"]
+    assert "secret_read" in templates["mutation_boundary"]["forbidden_operations"]
+
+
+def test_mcp_resource_list_exposes_concrete_snapshot_resources(tmp_path):
+    bundle = _bundle_with_health(tmp_path)
+
+    listed = list_mcp_resources(bundle["manifest"].parent)
+    uris = {item["uri"] for item in listed["resources"]}
+
+    assert "repobrief://snapshot/demo/manifest" in uris
+    assert "repobrief://snapshot/demo/canonical" in uris
+    assert "repobrief://snapshot/demo/reading-pack" in uris
+    assert "repobrief://snapshot/demo/health" in uris
+    assert "repobrief://snapshot/demo/availability" in uris
+    assert "repobrief://snapshot/demo/artifact/canonical_md" in uris
+    assert listed["mutation_boundary"]["writes"] == []
+
+
+def test_mcp_read_manifest_resource_carries_context_and_content(tmp_path):
+    bundle = _bundle_with_health(tmp_path)
+
+    result = read_mcp_resource(
+        "repobrief://snapshot/demo/manifest",
+        bundle_root=bundle["manifest"].parent,
+    )
+
+    assert result["status"] == "available"
+    assert result["resource_role"] == "bundle_manifest"
+    assert result["content_json"]["run_id"] == "run-1"
+    assert result["snapshot_context"]["health"]["status"] == "available"
+    assert "freshness" in result["snapshot_context"]
+    assert "availability" in result["snapshot_context"]
+    assert result["mutation_boundary"]["read_paths_do_not_refresh"] is True
+
+
+def test_mcp_read_canonical_reading_pack_health_and_availability_resources(tmp_path):
+    bundle = _bundle_with_health(tmp_path)
+
+    canonical = read_mcp_resource("repobrief://snapshot/demo/canonical", bundle_root=bundle["manifest"].parent)
+    reading = read_mcp_resource("repobrief://snapshot/demo/reading-pack", bundle_root=bundle["manifest"].parent)
+    health = read_mcp_resource("repobrief://snapshot/demo/health", bundle_root=bundle["manifest"].parent)
+    availability = read_mcp_resource("repobrief://snapshot/demo/availability", bundle_root=bundle["manifest"].parent)
+
+    assert canonical["resource_role"] == "canonical_md"
+    assert "hello resolved world" in canonical["content_text"]
+    assert reading["resource_role"] == "agent_reading_pack"
+    assert "Agent pack" in reading["content_text"]
+    assert health["resource_role"] == "post_emit_health"
+    assert health["content_json"]["status"] == "pass"
+    assert availability["resource_role"] == "availability_model"
+    assert availability["content_json"]["status"] in {"available", "partial", "missing", "unknown", "pass", "warn", "fail"}
+
+
+def test_mcp_read_arbitrary_artifact_resource(tmp_path):
+    bundle = _complete_basic_bundle(tmp_path)
+
+    result = read_mcp_resource(
+        "repobrief://snapshot/demo/artifact/citation_map_jsonl",
+        bundle_root=bundle["manifest"].parent,
+    )
+
+    assert result["status"] == "available"
+    assert result["resource_role"] == "citation_map_jsonl"
+    assert "cit_" in result["content_text"]
+    assert "mcp_server_available" in result["does_not_establish"]
+
+
+def test_each_listed_mcp_resource_read_carries_context(tmp_path):
+    bundle = _bundle_with_health(tmp_path)
+    listed = list_mcp_resources(bundle["manifest"].parent)
+
+    for item in listed["resources"]:
+        result = read_mcp_resource(item["uri"], bundle_root=bundle["manifest"].parent)
+        assert "health" in result["snapshot_context"]
+        assert "freshness" in result["snapshot_context"]
+        assert "availability" in result["snapshot_context"]
+        assert result["mutation_boundary"]["writes"] == []
+        assert result["mutation_boundary"]["does_not_create_snapshots"] is True
+
+
+
+def test_mcp_missing_snapshot_explains_missing_context(tmp_path):
+    result = read_mcp_resource("repobrief://snapshot/missing/manifest", bundle_root=tmp_path)
+
+    assert result["status"] == "missing"
+    assert result["bundle_manifest"] is None
+    assert result["snapshot_context"]["availability"]["status"] == "unknown"
+    assert "snapshot stem not found" in result["snapshot_context"]["availability"]["reason"]
+
+
+def test_mcp_resource_reads_do_not_write_bundle_files(tmp_path):
+    bundle = _bundle_with_health(tmp_path)
+    before = {path.name for path in tmp_path.iterdir()}
+
+    read_mcp_resource("repobrief://snapshot/demo/manifest", bundle_root=bundle["manifest"].parent)
+    read_mcp_resource("repobrief://snapshot/demo/canonical", bundle_root=bundle["manifest"].parent)
+    list_mcp_resources(bundle["manifest"].parent)
+
+    after = {path.name for path in tmp_path.iterdir()}
+    assert after == before
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "file:///tmp/demo",
+        "repobrief://snapshot/demo/unknown",
+        "repobrief://snapshot/demo/artifact",
+        "repobrief://snapshot/../manifest",
+        "repobrief://snapshot/demo/artifact/../secret",
+    ],
+)
+def test_mcp_resource_rejects_invalid_or_escape_uris(tmp_path, uri):
+    with pytest.raises(RepoBriefMcpResourceError):
+        read_mcp_resource(uri, bundle_root=tmp_path)


### PR DESCRIPTION
## Summary

- implements `RPU-V1-T020` concrete code-level RepoBrief MCP resource reads
- adds `repobrief://snapshot/{stem}/manifest`, `canonical`, `reading-pack`, `health`, `availability`, and `artifact/{role}` resource handling
- carries health/freshness/availability context on resource reads, or explains missing context
- preserves the read-only boundary: no snapshot creation, refresh, Git, shell, secrets, PRs, patches, reviews, fixes, or merges
- documents that this is not a networked MCP protocol server

## Validation

- `git diff --check`
- `python -m pytest merger/lenskit/tests/test_repobrief_mcp_resources.py -q`
- `python -m pytest merger/lenskit/tests/test_repobrief_mcp_boundary_doc.py -q`
- `python -m pytest merger/lenskit/tests/test_repobrief_mcp_frontdoor.py -q`
- `python -m pytest merger/lenskit/tests/test_repobrief_mcp_snapshot_create.py -q`
- `python -m ruff check merger/lenskit/core/repobrief_mcp_resources.py merger/lenskit/tests/test_repobrief_mcp_resources.py merger/lenskit/tests/test_repobrief_mcp_boundary_doc.py`

## Boundary

This PR does not establish MCP server availability, transport security, authentication correctness, runtime deployment, answer correctness, repository understanding, review completeness, merge readiness, or security correctness.
