### PR TITLE
fix(repobrief): make MCP resource reads atomic

### DIFF
--- a/docs/proofs/repobrief-mcp-resource-read-hardening-v1-proof.md
+++ b/docs/proofs/repobrief-mcp-resource-read-hardening-v1-proof.md
@@ -20,9 +20,11 @@ The adapter now applies additional read-side guards before returning resource co
 
 - a file-valued `bundle_root` is accepted only when it is a bounded `*.bundle.manifest.json` with RepoLens bundle-manifest shape;
 - arbitrary non-manifest files and fake manifest-shaped files are not exposed as manifest resources;
-- artifact content is capped by `MAX_RESOURCE_BYTES` (`16 MiB`) before hashing or text read;
-- artifact `bytes` and `sha256` metadata are checked before content is returned;
+- artifact content is capped by `MAX_RESOURCE_BYTES` (`16 MiB`) by reading at most `MAX_RESOURCE_BYTES + 1` bytes;
+- artifact `bytes` and `sha256` metadata are required and checked against the same bounded byte buffer that may be returned;
+- missing or malformed integrity metadata returns `integrity_unavailable` without returning `content_text`;
 - byte or hash drift returns `integrity_mismatch` without returning `content_text`;
+- file-valued invalid bundle roots return `blocked` with an explicit reason instead of looking like a missing snapshot;
 - relative path escapes and symlink escapes remain blocked before content read;
 - `artifact/bundle_manifest` now returns a consistent `artifact_ref` shape.
 

--- a/docs/proofs/repobrief-mcp-resource-read-hardening-v1.self-review.md
+++ b/docs/proofs/repobrief-mcp-resource-read-hardening-v1.self-review.md
@@ -1,7 +1,7 @@
 # Self-review — RepoBrief MCP Resource Read Hardening v1
 
 Status: complete
-Head: local branch `fix/mcp-resource-read-hardening-v1`
+Head: local branch `fix/mcp-resource-atomic-read-v1`
 Scope:
 
 - `merger/lenskit/core/repobrief_mcp_resources.py`
@@ -24,14 +24,16 @@ No blocking issue found in this hardening slice.
 | Absolute path escapes are blocked before content read | Pass |
 | Relative path escapes are blocked before content read | Pass |
 | Symlink escapes are blocked before content read | Pass |
-| Oversized artifact content is blocked before hashing/content read | Pass |
-| Byte/SHA drift returns `integrity_mismatch` without `content_text` | Pass |
+| Oversized artifact content is blocked by bounded byte read before hashing/content decode | Pass |
+| Byte/SHA drift is checked against the same bounded byte buffer that may be returned | Pass |
+| Missing or malformed integrity metadata returns `integrity_unavailable` without `content_text` | Pass |
+| Invalid file-valued bundle roots return explicit `blocked` status | Pass |
 | `artifact/bundle_manifest` returns an `artifact_ref` shape | Pass |
 | Read-only/non-claim semantics remain explicit | Pass |
 
 ## Notes
 
-The `MAX_RESOURCE_BYTES` cap is intentionally set to `16 MiB`: high enough for the current Lenskit canonical bundle observed locally, but still bounded for MCP-shaped reads.
+The `MAX_RESOURCE_BYTES` cap remains `16 MiB`: high enough for the current Lenskit canonical bundle observed locally, but now enforced by a bounded byte read rather than a separate `stat()`/`read_text()` sequence.
 
 ## Does not establish
 

--- a/merger/lenskit/core/repobrief_mcp_resources.py
+++ b/merger/lenskit/core/repobrief_mcp_resources.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from pathlib import Path
 from typing import Any
 from urllib.parse import unquote, urlparse
@@ -15,6 +16,7 @@ RESOURCE_PREFIX = "repobrief://snapshot/"
 MANIFEST_SUFFIX = ".bundle.manifest.json"
 MAX_MANIFEST_BYTES = 4 * 1024 * 1024
 MAX_RESOURCE_BYTES = 16 * 1024 * 1024
+_SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
 FIXED_RESOURCE_KINDS = {
     "manifest": "bundle_manifest",
     "canonical": "canonical_md",
@@ -81,21 +83,66 @@ def _manifest_stem(path: Path) -> str:
     return path.stem
 
 
-def _is_bundle_manifest_file(path: Path) -> bool:
-    if not path.is_file() or not path.name.endswith(MANIFEST_SUFFIX):
-        return False
+def _bytes_issue(status: str, reason: str, **extra: Any) -> dict[str, Any]:
+    issue: dict[str, Any] = {"status": status, "reason": reason}
+    issue.update(extra)
+    return issue
+
+
+def _read_bounded_bytes(path: Path, *, max_bytes: int, too_large_reason: str) -> tuple[bytes | None, dict[str, Any] | None]:
     try:
-        if path.stat().st_size > MAX_MANIFEST_BYTES:
-            return False
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
-        return False
-    return (
-        isinstance(data, dict)
-        and data.get("kind") == "repolens.bundle.manifest"
-        and isinstance(data.get("run_id"), str)
-        and isinstance(data.get("artifacts"), list)
+        with path.open("rb") as handle:
+            data = handle.read(max_bytes + 1)
+    except OSError as exc:
+        return None, _bytes_issue("missing", f"artifact file unavailable: {exc}")
+    if len(data) > max_bytes:
+        return None, _bytes_issue(
+            "blocked",
+            too_large_reason,
+            bytes_lower_bound=len(data),
+            max_bytes=max_bytes,
+        )
+    return data, None
+
+
+def _decode_json_bytes(data: bytes) -> tuple[str | None, Any | None, dict[str, Any] | None]:
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError:
+        return None, None, _bytes_issue("blocked", "artifact is not valid UTF-8 text")
+    try:
+        return text, json.loads(text), None
+    except json.JSONDecodeError:
+        return text, None, None
+
+
+def _bundle_manifest_validation_issue(path: Path) -> dict[str, Any] | None:
+    if not path.is_file() or not path.name.endswith(MANIFEST_SUFFIX):
+        return _bytes_issue("blocked", "bundle root is not a RepoLens bundle manifest file")
+    data, issue = _read_bounded_bytes(
+        path,
+        max_bytes=MAX_MANIFEST_BYTES,
+        too_large_reason="bundle manifest exceeds MCP manifest size limit",
     )
+    if issue is not None:
+        return issue
+    assert data is not None
+    _text, parsed, parse_issue = _decode_json_bytes(data)
+    if parse_issue is not None:
+        return parse_issue
+    if not isinstance(parsed, dict):
+        return _bytes_issue("blocked", "bundle manifest must be a JSON object")
+    if (
+        parsed.get("kind") != "repolens.bundle.manifest"
+        or not isinstance(parsed.get("run_id"), str)
+        or not isinstance(parsed.get("artifacts"), list)
+    ):
+        return _bytes_issue("blocked", "bundle root is not a valid RepoLens bundle manifest")
+    return None
+
+
+def _is_bundle_manifest_file(path: Path) -> bool:
+    return _bundle_manifest_validation_issue(path) is None
 
 
 def _manifest_candidates(bundle_root: str | Path) -> list[Path]:
@@ -112,6 +159,15 @@ def _find_manifest(bundle_root: str | Path, stem: str) -> Path | None:
         if _manifest_stem(path) == stem:
             return path
     return None
+
+
+def _bundle_root_file_issue(bundle_root: str | Path, stem: str) -> dict[str, Any] | None:
+    root = Path(bundle_root).expanduser().resolve()
+    if not root.exists() or not root.is_file():
+        return None
+    if _manifest_stem(root) != stem:
+        return None
+    return _bundle_manifest_validation_issue(root)
 
 
 def _resource_uri(stem: str, suffix: str) -> str:
@@ -137,80 +193,61 @@ def _parse_resource_uri(uri: str) -> tuple[str, str, str | None]:
     return stem, resource_name, None
 
 
-def _artifact_size_issue(path: Path) -> dict[str, Any] | None:
-    try:
-        size = path.stat().st_size
-    except OSError as exc:
-        return {"status": "missing", "reason": f"artifact file unavailable: {exc}"}
-    if size > MAX_RESOURCE_BYTES:
-        return {
-            "status": "blocked",
-            "reason": "artifact exceeds MCP resource size limit",
-            "bytes": size,
-            "max_bytes": MAX_RESOURCE_BYTES,
-        }
-    return None
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
 
 
-def _artifact_text(path: Path) -> tuple[str | None, dict[str, Any] | None, dict[str, Any] | None]:
-    size_issue = _artifact_size_issue(path)
-    if size_issue is not None:
-        return None, None, size_issue
-    try:
-        text = path.read_text(encoding="utf-8")
-    except UnicodeDecodeError:
-        return None, None, None
-    try:
-        return text, json.loads(text), None
-    except json.JSONDecodeError:
-        return text, None, None
-
-
-def _sha256(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
-def _artifact_integrity_issue(path: Path, artifact: dict[str, Any]) -> dict[str, Any] | None:
+def _artifact_integrity_issue(data: bytes, artifact: dict[str, Any]) -> dict[str, Any] | None:
     expected_bytes = artifact.get("bytes")
-    if isinstance(expected_bytes, int):
-        actual_bytes = path.stat().st_size
-        if actual_bytes != expected_bytes:
-            return {
-                "status": "integrity_mismatch",
-                "reason": "artifact byte size does not match manifest",
-                "expected_bytes": expected_bytes,
-                "actual_bytes": actual_bytes,
-            }
+    if not isinstance(expected_bytes, int):
+        return _bytes_issue("integrity_unavailable", "artifact byte size is missing or invalid in manifest")
+    actual_bytes = len(data)
+    if actual_bytes != expected_bytes:
+        return _bytes_issue(
+            "integrity_mismatch",
+            "artifact byte size does not match manifest",
+            expected_bytes=expected_bytes,
+            actual_bytes=actual_bytes,
+        )
     expected_sha256 = artifact.get("sha256")
-    if isinstance(expected_sha256, str) and expected_sha256:
-        actual_sha256 = _sha256(path)
-        if actual_sha256 != expected_sha256:
-            return {
-                "status": "integrity_mismatch",
-                "reason": "artifact sha256 does not match manifest",
-                "expected_sha256": expected_sha256,
-                "actual_sha256": actual_sha256,
-            }
+    if not isinstance(expected_sha256, str) or not _SHA256_RE.fullmatch(expected_sha256):
+        return _bytes_issue("integrity_unavailable", "artifact sha256 is missing or invalid in manifest")
+    actual_sha256 = _sha256_bytes(data)
+    if actual_sha256 != expected_sha256:
+        return _bytes_issue(
+            "integrity_mismatch",
+            "artifact sha256 does not match manifest",
+            expected_sha256=expected_sha256,
+            actual_sha256=actual_sha256,
+        )
     return None
 
 
-def _apply_artifact_content(result: dict[str, Any], path: Path) -> dict[str, Any]:
-    text, parsed, issue = _artifact_text(path)
+def _apply_artifact_bytes(result: dict[str, Any], data: bytes) -> dict[str, Any]:
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError:
+        result["binary_unreadable"] = True
+        return result
+    result["content_text"] = text
+    try:
+        result["content_json"] = json.loads(text)
+    except json.JSONDecodeError:
+        pass
+    return result
+
+
+def _read_manifest_content(result: dict[str, Any], manifest: Path) -> dict[str, Any]:
+    data, issue = _read_bounded_bytes(
+        manifest,
+        max_bytes=MAX_MANIFEST_BYTES,
+        too_large_reason="bundle manifest exceeds MCP manifest size limit",
+    )
     if issue is not None:
         result.update(issue)
         return result
-    if text is not None:
-        result["content_text"] = text
-    else:
-        result["binary_unreadable"] = True
-    if parsed is not None:
-        result["content_json"] = parsed
-    return result
-
+    assert data is not None
+    return _apply_artifact_bytes(result, data)
 
 def _context_for_manifest(manifest: Path | None, *, reason: str | None = None) -> dict[str, Any]:
     if manifest is None:
@@ -272,7 +309,7 @@ def _read_artifact_resource(uri: str, manifest: Path, role: str) -> dict[str, An
                 "bytes": manifest.stat().st_size if manifest.is_file() else None,
             },
         })
-        return _apply_artifact_content(result, manifest)
+        return _read_manifest_content(result, manifest)
 
     ref = repobrief_access.get_artifact(manifest, role)
     result = _base_result(uri, manifest, status=ref.get("status", "unknown"))
@@ -290,16 +327,21 @@ def _read_artifact_resource(uri: str, manifest: Path, role: str) -> dict[str, An
         result["status"] = "missing"
         result["reason"] = f"artifact file missing: {path}"
         return result
-    size_issue = _artifact_size_issue(path)
-    if size_issue is not None:
-        result.update(size_issue)
+    data, read_issue = _read_bounded_bytes(
+        path,
+        max_bytes=MAX_RESOURCE_BYTES,
+        too_large_reason="artifact exceeds MCP resource size limit",
+    )
+    if read_issue is not None:
+        result.update(read_issue)
         return result
-    integrity_issue = _artifact_integrity_issue(path, artifact)
+    assert data is not None
+    integrity_issue = _artifact_integrity_issue(data, artifact)
     if integrity_issue is not None:
         result.update(integrity_issue)
         return result
     result["content_type"] = artifact.get("content_type") or "application/octet-stream"
-    return _apply_artifact_content(result, path)
+    return _apply_artifact_bytes(result, data)
 
 
 def resource_templates() -> dict[str, Any]:
@@ -348,6 +390,11 @@ def read_mcp_resource(uri: str, *, bundle_root: str | Path) -> dict[str, Any]:
     stem, resource_name, role = _parse_resource_uri(uri)
     manifest = _find_manifest(bundle_root, stem)
     if manifest is None:
+        bundle_root_issue = _bundle_root_file_issue(bundle_root, stem)
+        if bundle_root_issue is not None:
+            result = _base_result(uri, None, status=bundle_root_issue["status"], reason=bundle_root_issue["reason"])
+            result.update(bundle_root_issue)
+            return result
         return _base_result(uri, None, status="missing", reason=f"snapshot stem not found: {stem}")
     if resource_name == "manifest":
         return _read_artifact_resource(uri, manifest, "bundle_manifest")

--- a/merger/lenskit/tests/test_repobrief_mcp_resources.py
+++ b/merger/lenskit/tests/test_repobrief_mcp_resources.py
@@ -93,15 +93,16 @@ def test_mcp_read_canonical_reading_pack_health_and_availability_resources(tmp_p
 
 def test_mcp_read_arbitrary_artifact_resource(tmp_path):
     bundle = _complete_basic_bundle(tmp_path)
+    _add_artifact(bundle, "extra_json", "extra.json", "{\"ok\": true}\n")
 
     result = read_mcp_resource(
-        "repobrief://snapshot/demo/artifact/citation_map_jsonl",
+        "repobrief://snapshot/demo/artifact/extra_json",
         bundle_root=bundle["manifest"].parent,
     )
 
     assert result["status"] == "available"
-    assert result["resource_role"] == "citation_map_jsonl"
-    assert "cit_" in result["content_text"]
+    assert result["resource_role"] == "extra_json"
+    assert result["content_json"] == {"ok": True}
     assert "mcp_server_available" in result["does_not_establish"]
 
 
@@ -130,7 +131,8 @@ def test_mcp_file_bundle_root_accepts_only_real_bundle_manifest(tmp_path):
     secret.write_text("plain secret\n", encoding="utf-8")
     missing = read_mcp_resource("repobrief://snapshot/demo/manifest", bundle_root=secret)
 
-    assert missing["status"] == "missing"
+    assert missing["status"] == "blocked"
+    assert missing["reason"] == "bundle root is not a RepoLens bundle manifest file"
     assert "content_text" not in missing
 
 
@@ -140,7 +142,8 @@ def test_mcp_file_bundle_root_rejects_fake_manifest_shape(tmp_path):
 
     result = read_mcp_resource("repobrief://snapshot/fake/manifest", bundle_root=fake)
 
-    assert result["status"] == "missing"
+    assert result["status"] == "blocked"
+    assert result["reason"] == "bundle root is not a valid RepoLens bundle manifest"
     assert "content_text" not in result
 
 
@@ -238,6 +241,52 @@ def test_mcp_artifact_resource_blocks_integrity_mismatch(tmp_path):
         "artifact byte size does not match manifest",
         "artifact sha256 does not match manifest",
     }
+
+
+def test_mcp_artifact_resource_blocks_missing_integrity_metadata(tmp_path):
+    bundle = _complete_basic_bundle(tmp_path)
+    data = json.loads(bundle["manifest"].read_text(encoding="utf-8"))
+    data["artifacts"].append({
+        "role": "no_integrity",
+        "path": "no_integrity.txt",
+        "content_type": "text/plain",
+    })
+    (bundle["manifest"].parent / "no_integrity.txt").write_text("not trusted\n", encoding="utf-8")
+    bundle["manifest"].write_text(json.dumps(data), encoding="utf-8")
+
+    result = read_mcp_resource(
+        "repobrief://snapshot/demo/artifact/no_integrity",
+        bundle_root=bundle["manifest"].parent,
+    )
+
+    assert result["status"] == "integrity_unavailable"
+    assert result["reason"] == "artifact byte size is missing or invalid in manifest"
+    assert "content_text" not in result
+
+
+def test_mcp_artifact_resource_blocks_invalid_sha_metadata(tmp_path):
+    bundle = _complete_basic_bundle(tmp_path)
+    data = json.loads(bundle["manifest"].read_text(encoding="utf-8"))
+    content = "not trusted\n"
+    artifact = bundle["manifest"].parent / "bad_sha.txt"
+    artifact.write_text(content, encoding="utf-8")
+    data["artifacts"].append({
+        "role": "bad_sha",
+        "path": artifact.name,
+        "content_type": "text/plain",
+        "bytes": artifact.stat().st_size,
+        "sha256": "not-a-sha",
+    })
+    bundle["manifest"].write_text(json.dumps(data), encoding="utf-8")
+
+    result = read_mcp_resource(
+        "repobrief://snapshot/demo/artifact/bad_sha",
+        bundle_root=bundle["manifest"].parent,
+    )
+
+    assert result["status"] == "integrity_unavailable"
+    assert result["reason"] == "artifact sha256 is missing or invalid in manifest"
+    assert "content_text" not in result
 
 
 def test_mcp_artifact_resource_blocks_oversized_content(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- make MCP-shaped resource reads use one bounded byte buffer for size enforcement, hash verification, JSON decode, and returned content
- require valid `bytes` and `sha256` metadata before artifact content is returned
- return `integrity_unavailable` for missing/malformed integrity metadata without returning `content_text`
- return explicit `blocked` for invalid file-valued bundle roots instead of reporting a missing snapshot
- update MCP resource hardening proof/self-review

## Diff for external review

- Diff SHA256: `cc7c34db7fc143b3133f6fcc34caa28120b6b6adb3926ea9be91ead8af9bba3f`
- Diff bytes: `18933`
- Local diff path: `/tmp/lenskit-pr-mcp-resource-atomic-read.diff`

## Validation

- `python3 -m pytest -q merger/lenskit/tests/test_repobrief_mcp_resources.py merger/lenskit/tests/test_repobrief_mcp_boundary_doc.py merger/lenskit/tests/test_repobrief_mcp_frontdoor.py merger/lenskit/tests/test_repobrief_mcp_snapshot_create.py` → `42 passed`
- `ruff check merger/lenskit/core/repobrief_mcp_resources.py merger/lenskit/tests/test_repobrief_mcp_resources.py merger/lenskit/tests/test_repobrief_mcp_boundary_doc.py` → pass
- `git diff --check` → pass
- `python3 -m json.tool docs/tasks/index.json >/dev/null` → pass
- `python3 -m scripts.docmeta.check_planning_registration --baseline docs/tasks/planning-registration-baseline.json --ratchet --format json` → no new drift

## Collision note

Open PR #944 also modifies `docs/tasks/index.json` and `docs/tasks/board.md`; this PR intentionally avoids those files to reduce collision surface.

## Non-claims

This remains a code-level resource adapter. It does not establish MCP protocol server availability, transport/authentication correctness, runtime deployment, artifact truth, repository understanding, complete security correctness, full test sufficiency, regression absence, review completeness, or merge readiness.