### PR TITLE
fix(repobrief): harden external manifest publication

### DIFF
--- a/docs/proofs/external-publish-v1-proof.md
+++ b/docs/proofs/external-publish-v1-proof.md
@@ -27,6 +27,19 @@ The publication root is explicit. RepoBrief does not decide whether that root is
 
 The command does not create or refresh a source snapshot, mutate Cabinet, import into Bureau, dispatch agents, or claim semantic truth, merge readiness, runtime correctness, or repo understanding.
 
+
+## 2026-07-09 hardening follow-up
+
+External manifest publication is now portable-root strict for the stable `publish` path: the referenced bundle manifest must live inside the explicit publication root. This prevents producer output such as `../../../../../merges/...` from being published into a Git checkout where consumers cannot resolve the bundle.
+
+The external reference also includes linked post-emit sidecars from the bundle manifest `links` surface, specifically `post_emit_health_path` and bundle-surface validation links, without mutating the bundle manifest. These sidecars are intentionally not normal bundle artifacts because they would otherwise create self-hash circularity; the external publication surface may still advertise them as observed companion artifacts with bytes and sha256.
+
+Additional regression coverage:
+
+- `test_publish_rejects_bundle_manifest_outside_publication_root`
+- `test_build_includes_linked_post_emit_health_sidecar`
+- `test_linked_sidecar_must_remain_inside_bundle_directory`
+
 ## Target proof
 
 ```text

--- a/merger/lenskit/core/external_manifest_reference.py
+++ b/merger/lenskit/core/external_manifest_reference.py
@@ -1,6 +1,7 @@
 """External manifest reference surface for RepoBrief/Lenskit consumers."""
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import tempfile
@@ -49,6 +50,14 @@ def _registry_segment(value: str, label: str) -> str:
     return value
 
 
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
 def _artifact_rows(bundle_manifest: dict[str, Any]) -> list[dict[str, Any]]:
     artifacts = bundle_manifest.get("artifacts")
     if not isinstance(artifacts, list):
@@ -72,8 +81,67 @@ def _artifact_rows(bundle_manifest: dict[str, Any]) -> list[dict[str, Any]]:
         if isinstance(artifact.get("content_type"), str):
             row["contentType"] = artifact["content_type"]
         rows.append(row)
-    rows.sort(key=lambda item: (item["role"], item["path"]))
     return rows
+
+
+def _linked_sidecar_rows(bundle_manifest_path: Path, bundle_manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    links = bundle_manifest.get("links")
+    if not isinstance(links, dict):
+        return []
+    linked_roles = {
+        "post_emit_health_path": "post_emit_health",
+        "bundle_surface_validation_path": "bundle_surface_validation",
+        "surface_validation_path": "bundle_surface_validation",
+    }
+    rows: list[dict[str, Any]] = []
+    bundle_dir = bundle_manifest_path.parent.resolve()
+    seen_paths: set[str] = set()
+    for link_key, role in linked_roles.items():
+        raw_path = links.get(link_key)
+        if not isinstance(raw_path, str) or not raw_path:
+            continue
+        linked_path = (bundle_dir / raw_path).resolve()
+        try:
+            linked_path.relative_to(bundle_dir)
+        except ValueError as exc:
+            raise ExternalManifestReferenceError(
+                f"bundle manifest link {link_key} must stay inside the bundle directory"
+            ) from exc
+        if not linked_path.is_file():
+            raise ExternalManifestReferenceError(
+                f"bundle manifest link {link_key} does not exist: {raw_path}"
+            )
+        path_value = Path(raw_path).as_posix()
+        if path_value in seen_paths:
+            continue
+        seen_paths.add(path_value)
+        rows.append({
+            "role": role,
+            "path": path_value,
+            "sha256": _sha256_file(linked_path),
+            "bytes": linked_path.stat().st_size,
+            "contentType": "application/json",
+        })
+    return rows
+
+
+def _combined_artifact_rows(bundle_manifest_path: Path, bundle_manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    rows_by_key: dict[tuple[str, str], dict[str, Any]] = {}
+    for row in _artifact_rows(bundle_manifest) + _linked_sidecar_rows(bundle_manifest_path, bundle_manifest):
+        rows_by_key[(row["role"], row["path"])] = row
+    return sorted(rows_by_key.values(), key=lambda item: (item["role"], item["path"]))
+
+
+def _require_inside_publication_root(bundle_manifest_path: Path, publication_root: Path | None) -> None:
+    if publication_root is None:
+        return
+    root = publication_root.expanduser().resolve()
+    try:
+        bundle_manifest_path.relative_to(root)
+    except ValueError as exc:
+        raise ExternalManifestReferenceError(
+            "bundle manifest must be inside publication_root for portable external publication"
+        ) from exc
 
 
 def build_external_manifest_reference(
@@ -83,6 +151,7 @@ def build_external_manifest_reference(
     ref: str,
     artifact_family: str = "repobrief",
     output_path: str | Path | None = None,
+    publication_root: str | Path | None = None,
 ) -> dict[str, Any]:
     """Build a bounded external manifest reference from an existing bundle manifest."""
     family = artifact_family.strip().lower() if isinstance(artifact_family, str) else ""
@@ -91,6 +160,10 @@ def build_external_manifest_reference(
     repository = _registry_segment(repository, "repository")
     ref = _registry_segment(ref, "ref")
     manifest_path = Path(bundle_manifest_path).expanduser().resolve()
+    _require_inside_publication_root(
+        manifest_path,
+        Path(publication_root) if publication_root is not None else None,
+    )
     bundle = _read_json_object(manifest_path)
     if bundle.get("kind") != BUNDLE_KIND:
         raise ExternalManifestReferenceError("bundle manifest kind must be repolens.bundle.manifest")
@@ -114,7 +187,7 @@ def build_external_manifest_reference(
             "createdAt": created_at,
         },
         "snapshotProvenance": snapshot_provenance if isinstance(snapshot_provenance, dict) else None,
-        "artifacts": _artifact_rows(bundle),
+        "artifacts": _combined_artifact_rows(manifest_path, bundle),
         "doesNotEstablish": list(DOES_NOT_ESTABLISH),
     }
 
@@ -161,6 +234,7 @@ def publish_external_manifest_references(
             repository=repository,
             ref=ref,
             artifact_family=family,
+            publication_root=publication_root,
         )
         published.append({
             "artifactFamily": manifest["artifactFamily"],
@@ -188,6 +262,7 @@ def write_external_manifest_reference(
     repository: str,
     ref: str,
     artifact_family: str = "repobrief",
+    publication_root: str | Path | None = None,
 ) -> dict[str, Any]:
     """Write an external manifest reference atomically and return it."""
     out = Path(output_path).expanduser().resolve()
@@ -197,6 +272,7 @@ def write_external_manifest_reference(
         ref=ref,
         artifact_family=artifact_family,
         output_path=out,
+        publication_root=publication_root,
     )
     out.parent.mkdir(parents=True, exist_ok=True)
     tmp_path: Path | None = None

--- a/merger/lenskit/tests/test_external_manifest_reference.py
+++ b/merger/lenskit/tests/test_external_manifest_reference.py
@@ -57,7 +57,7 @@ def write_bundle(tmp_path: Path) -> Path:
         },
     }
     path = tmp_path / "bundle" / "cabinet_merge.bundle.manifest.json"
-    path.parent.mkdir()
+    path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(bundle), encoding="utf-8")
     return path
 
@@ -133,8 +133,8 @@ def test_publication_manifest_path_uses_stable_external_layout(tmp_path: Path) -
 
 
 def test_publish_external_manifest_references_can_publish_one_family(tmp_path: Path) -> None:
-    bundle_path = write_bundle(tmp_path)
     root = tmp_path / "published"
+    bundle_path = write_bundle(root)
 
     result = publish_external_manifest_references(
         bundle_path,
@@ -152,8 +152,8 @@ def test_publish_external_manifest_references_can_publish_one_family(tmp_path: P
 def test_repobrief_cli_publishes_external_manifest_references(tmp_path: Path) -> None:
     from merger.lenskit.cli.repobrief import main as repobrief_main
 
-    bundle_path = write_bundle(tmp_path)
     root = tmp_path / "published"
+    bundle_path = write_bundle(root)
 
     rc = repobrief_main([
         "external-manifest",
@@ -171,3 +171,50 @@ def test_repobrief_cli_publishes_external_manifest_references(tmp_path: Path) ->
     assert rc == 0
     assert (root / "external" / "repobrief" / "cabinet" / "main" / "manifest.json").is_file()
     assert (root / "external" / "lenskit" / "cabinet" / "main" / "manifest.json").is_file()
+
+
+def test_build_includes_linked_post_emit_health_sidecar(tmp_path: Path) -> None:
+    bundle_path = write_bundle(tmp_path)
+    sidecar = bundle_path.with_name("cabinet_merge.bundle_health.post.json")
+    sidecar.write_text('{"kind":"lenskit.post_emit_health","status":"pass"}\n', encoding="utf-8")
+    bundle = json.loads(bundle_path.read_text(encoding="utf-8"))
+    bundle["links"]["post_emit_health_path"] = sidecar.name
+    bundle_path.write_text(json.dumps(bundle), encoding="utf-8")
+
+    result = build_external_manifest_reference(
+        bundle_path,
+        repository="cabinet",
+        ref="main",
+        artifact_family="repobrief",
+    )
+
+    row = next(artifact for artifact in result["artifacts"] if artifact["role"] == "post_emit_health")
+    assert row["path"] == "cabinet_merge.bundle_health.post.json"
+    assert row["contentType"] == "application/json"
+    assert row["bytes"] == sidecar.stat().st_size
+    assert len(row["sha256"]) == 64
+
+
+def test_publish_rejects_bundle_manifest_outside_publication_root(tmp_path: Path) -> None:
+    bundle_path = write_bundle(tmp_path / "bundle-source")
+    root = tmp_path / "published"
+
+    with pytest.raises(ExternalManifestReferenceError, match="inside publication_root"):
+        publish_external_manifest_references(
+            bundle_path,
+            root,
+            repository="cabinet",
+            ref="main",
+        )
+
+
+def test_linked_sidecar_must_remain_inside_bundle_directory(tmp_path: Path) -> None:
+    bundle_path = write_bundle(tmp_path)
+    outside = tmp_path / "outside.bundle_health.post.json"
+    outside.write_text("{}\n", encoding="utf-8")
+    bundle = json.loads(bundle_path.read_text(encoding="utf-8"))
+    bundle["links"]["post_emit_health_path"] = "../outside.bundle_health.post.json"
+    bundle_path.write_text(json.dumps(bundle), encoding="utf-8")
+
+    with pytest.raises(ExternalManifestReferenceError, match="inside the bundle directory"):
+        build_external_manifest_reference(bundle_path, repository="cabinet", ref="main")


### PR DESCRIPTION
## Summary

Hardens the RepoBrief/Lenskit external manifest producer path after the Cabinet consumer-side follow-up in heimgewebe/cabinet#102.

This patch prevents two producer-side drift modes:

- stable `external-manifest publish` now fails closed when the referenced bundle manifest is outside the explicit publication root, avoiding non-portable `../../../../../merges/...` references in published manifests;
- external manifest references now include linked post-emit / bundle-surface sidecars from the bundle manifest `links` surface with `bytes` and `sha256`, without mutating the original bundle manifest.

## Details

- Keeps explicit `external-manifest write` flexible for explicit one-off output paths.
- Makes stable `publish` portable-root strict.
- Adds linked companion artifact rows for:
  - `post_emit_health_path` -> `post_emit_health`
  - `bundle_surface_validation_path` / `surface_validation_path` -> `bundle_surface_validation`
- Rejects linked sidecars that escape the bundle directory.
- Rejects linked sidecars that are referenced but missing.

## Checks

```text
python3 -m pytest merger/lenskit/tests/test_external_manifest_reference.py -q
python3 -m pytest \
  merger/lenskit/tests/test_external_manifest_reference.py \
  merger/lenskit/tests/test_repobrief_latest_complete.py \
  merger/lenskit/tests/test_cli_agent_consumption.py \
  merger/lenskit/tests/test_bundle_manifest_integration.py \
  -q
```

Results:

```text
12 passed
91 passed
```

## Boundaries

This does not make Cabinet a dump producer. It does not copy bundles into publication roots, does not mutate source repositories, and does not establish semantic truth, repo understanding, runtime correctness, test sufficiency, or merge readiness.
