### PR TITLE
fix(repobrief): clarify MCP resource error contracts

### DIFF
--- a/docs/proofs/repobrief-mcp-resource-read-hardening-v1-proof.md
+++ b/docs/proofs/repobrief-mcp-resource-read-hardening-v1-proof.md
@@ -21,12 +21,14 @@ The adapter now applies additional read-side guards before returning resource co
 - a file-valued `bundle_root` is accepted only when it is a bounded `*.bundle.manifest.json` with RepoLens bundle-manifest shape;
 - arbitrary non-manifest files and fake manifest-shaped files are not exposed as manifest resources;
 - artifact content is capped by `MAX_RESOURCE_BYTES` (`16 MiB`) by reading at most `MAX_RESOURCE_BYTES + 1` bytes;
-- artifact `bytes` and `sha256` metadata are required and checked against the same bounded byte buffer that may be returned;
-- missing or malformed integrity metadata returns `integrity_unavailable` without returning `content_text`;
+- artifact `bytes` and `sha256` metadata are required for artifact content and checked against the same bounded byte buffer that may be returned;
+- missing or malformed artifact integrity metadata returns `integrity_unavailable` without returning `content_text`;
 - byte or hash drift returns `integrity_mismatch` without returning `content_text`;
+- uppercase SHA-256 hex in manifests is accepted after normalization;
 - file-valued invalid bundle roots return `blocked` with an explicit reason instead of looking like a missing snapshot;
+- invalid JSON bundle manifests return `blocked` with `bundle manifest is not valid JSON`;
 - relative path escapes and symlink escapes remain blocked before content read;
-- `artifact/bundle_manifest` now returns a consistent `artifact_ref` shape.
+- `artifact/bundle_manifest` now returns a consistent `artifact_ref` shape and is size/shape checked; manifest self-integrity is not established by the manifest itself.
 
 ## Validation
 

--- a/docs/proofs/repobrief-mcp-resource-read-hardening-v1.self-review.md
+++ b/docs/proofs/repobrief-mcp-resource-read-hardening-v1.self-review.md
@@ -1,7 +1,7 @@
 # Self-review — RepoBrief MCP Resource Read Hardening v1
 
 Status: complete
-Head: local branch `fix/mcp-resource-atomic-read-v1`
+Head: local branch `fix/mcp-resource-error-contract-v1`
 Scope:
 
 - `merger/lenskit/core/repobrief_mcp_resources.py`
@@ -26,14 +26,17 @@ No blocking issue found in this hardening slice.
 | Symlink escapes are blocked before content read | Pass |
 | Oversized artifact content is blocked by bounded byte read before hashing/content decode | Pass |
 | Byte/SHA drift is checked against the same bounded byte buffer that may be returned | Pass |
-| Missing or malformed integrity metadata returns `integrity_unavailable` without `content_text` | Pass |
+| Missing or malformed artifact integrity metadata returns `integrity_unavailable` without `content_text` | Pass |
+| Uppercase SHA-256 hex metadata is accepted after normalization | Pass |
+| Invalid JSON manifests produce a precise blocked reason | Pass |
+| File-valued bundle-root stem mismatch reports a precise blocked reason | Pass |
 | Invalid file-valued bundle roots return explicit `blocked` status | Pass |
 | `artifact/bundle_manifest` returns an `artifact_ref` shape | Pass |
 | Read-only/non-claim semantics remain explicit | Pass |
 
 ## Notes
 
-The `MAX_RESOURCE_BYTES` cap remains `16 MiB`: high enough for the current Lenskit canonical bundle observed locally, but now enforced by a bounded byte read rather than a separate `stat()`/`read_text()` sequence.
+The `MAX_RESOURCE_BYTES` cap remains `16 MiB`: high enough for the current Lenskit canonical bundle observed locally, but now enforced by a bounded byte read rather than a separate `stat()`/`read_text()` sequence. Manifest reads are size/shape checked; artifact content is additionally checked against manifest `bytes`/`sha256` metadata.
 
 ## Does not establish
 

--- a/merger/lenskit/core/repobrief_mcp_resources.py
+++ b/merger/lenskit/core/repobrief_mcp_resources.py
@@ -16,7 +16,7 @@ RESOURCE_PREFIX = "repobrief://snapshot/"
 MANIFEST_SUFFIX = ".bundle.manifest.json"
 MAX_MANIFEST_BYTES = 4 * 1024 * 1024
 MAX_RESOURCE_BYTES = 16 * 1024 * 1024
-_SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
+_SHA256_RE = re.compile(r"^[A-Fa-f0-9]{64}$")
 FIXED_RESOURCE_KINDS = {
     "manifest": "bundle_manifest",
     "canonical": "canonical_md",
@@ -89,12 +89,18 @@ def _bytes_issue(status: str, reason: str, **extra: Any) -> dict[str, Any]:
     return issue
 
 
-def _read_bounded_bytes(path: Path, *, max_bytes: int, too_large_reason: str) -> tuple[bytes | None, dict[str, Any] | None]:
+def _read_bounded_bytes(
+    path: Path,
+    *,
+    max_bytes: int,
+    too_large_reason: str,
+    unavailable_reason: str = "artifact file unavailable",
+) -> tuple[bytes | None, dict[str, Any] | None]:
     try:
         with path.open("rb") as handle:
             data = handle.read(max_bytes + 1)
     except OSError as exc:
-        return None, _bytes_issue("missing", f"artifact file unavailable: {exc}")
+        return None, _bytes_issue("missing", f"{unavailable_reason}: {exc}")
     if len(data) > max_bytes:
         return None, _bytes_issue(
             "blocked",
@@ -105,14 +111,21 @@ def _read_bounded_bytes(path: Path, *, max_bytes: int, too_large_reason: str) ->
     return data, None
 
 
-def _decode_json_bytes(data: bytes) -> tuple[str | None, Any | None, dict[str, Any] | None]:
+def _decode_json_bytes(
+    data: bytes,
+    *,
+    invalid_utf8_reason: str = "artifact is not valid UTF-8 text",
+    invalid_json_reason: str | None = None,
+) -> tuple[str | None, Any | None, dict[str, Any] | None]:
     try:
         text = data.decode("utf-8")
     except UnicodeDecodeError:
-        return None, None, _bytes_issue("blocked", "artifact is not valid UTF-8 text")
+        return None, None, _bytes_issue("blocked", invalid_utf8_reason)
     try:
         return text, json.loads(text), None
     except json.JSONDecodeError:
+        if invalid_json_reason is not None:
+            return text, None, _bytes_issue("blocked", invalid_json_reason)
         return text, None, None
 
 
@@ -123,11 +136,16 @@ def _bundle_manifest_validation_issue(path: Path) -> dict[str, Any] | None:
         path,
         max_bytes=MAX_MANIFEST_BYTES,
         too_large_reason="bundle manifest exceeds MCP manifest size limit",
+        unavailable_reason="bundle manifest unavailable",
     )
     if issue is not None:
         return issue
     assert data is not None
-    _text, parsed, parse_issue = _decode_json_bytes(data)
+    _text, parsed, parse_issue = _decode_json_bytes(
+        data,
+        invalid_utf8_reason="bundle manifest is not valid UTF-8 text",
+        invalid_json_reason="bundle manifest is not valid JSON",
+    )
     if parse_issue is not None:
         return parse_issue
     if not isinstance(parsed, dict):
@@ -165,8 +183,16 @@ def _bundle_root_file_issue(bundle_root: str | Path, stem: str) -> dict[str, Any
     root = Path(bundle_root).expanduser().resolve()
     if not root.exists() or not root.is_file():
         return None
-    if _manifest_stem(root) != stem:
-        return None
+    if not root.name.endswith(MANIFEST_SUFFIX):
+        return _bundle_manifest_validation_issue(root)
+    root_stem = _manifest_stem(root)
+    if root_stem != stem:
+        return _bytes_issue(
+            "blocked",
+            "bundle root file stem does not match requested snapshot stem",
+            bundle_root_stem=root_stem,
+            requested_stem=stem,
+        )
     return _bundle_manifest_validation_issue(root)
 
 
@@ -212,8 +238,9 @@ def _artifact_integrity_issue(data: bytes, artifact: dict[str, Any]) -> dict[str
     expected_sha256 = artifact.get("sha256")
     if not isinstance(expected_sha256, str) or not _SHA256_RE.fullmatch(expected_sha256):
         return _bytes_issue("integrity_unavailable", "artifact sha256 is missing or invalid in manifest")
+    expected_sha256_normalized = expected_sha256.lower()
     actual_sha256 = _sha256_bytes(data)
-    if actual_sha256 != expected_sha256:
+    if actual_sha256 != expected_sha256_normalized:
         return _bytes_issue(
             "integrity_mismatch",
             "artifact sha256 does not match manifest",
@@ -242,12 +269,14 @@ def _read_manifest_content(result: dict[str, Any], manifest: Path) -> dict[str, 
         manifest,
         max_bytes=MAX_MANIFEST_BYTES,
         too_large_reason="bundle manifest exceeds MCP manifest size limit",
+        unavailable_reason="bundle manifest unavailable",
     )
     if issue is not None:
         result.update(issue)
         return result
     assert data is not None
     return _apply_artifact_bytes(result, data)
+
 
 def _context_for_manifest(manifest: Path | None, *, reason: str | None = None) -> dict[str, Any]:
     if manifest is None:

--- a/merger/lenskit/tests/test_repobrief_mcp_resources.py
+++ b/merger/lenskit/tests/test_repobrief_mcp_resources.py
@@ -147,6 +147,28 @@ def test_mcp_file_bundle_root_rejects_fake_manifest_shape(tmp_path):
     assert "content_text" not in result
 
 
+def test_mcp_file_bundle_root_rejects_invalid_json_manifest(tmp_path):
+    bad = tmp_path / "bad.bundle.manifest.json"
+    bad.write_text("{not-json\n", encoding="utf-8")
+
+    result = read_mcp_resource("repobrief://snapshot/bad/manifest", bundle_root=bad)
+
+    assert result["status"] == "blocked"
+    assert result["reason"] == "bundle manifest is not valid JSON"
+    assert "content_text" not in result
+
+
+def test_mcp_file_bundle_root_reports_stem_mismatch(tmp_path):
+    bundle = _complete_basic_bundle(tmp_path)
+
+    result = read_mcp_resource("repobrief://snapshot/other/manifest", bundle_root=bundle["manifest"])
+
+    assert result["status"] == "blocked"
+    assert result["reason"] == "bundle root file stem does not match requested snapshot stem"
+    assert result["bundle_root_stem"] == "demo"
+    assert result["requested_stem"] == "other"
+
+
 def test_mcp_artifact_resource_blocks_paths_outside_bundle_root(tmp_path):
     bundle = _complete_basic_bundle(tmp_path)
     outside = tmp_path.parent / "secret.txt"
@@ -286,6 +308,40 @@ def test_mcp_artifact_resource_blocks_invalid_sha_metadata(tmp_path):
 
     assert result["status"] == "integrity_unavailable"
     assert result["reason"] == "artifact sha256 is missing or invalid in manifest"
+    assert "content_text" not in result
+
+
+def test_mcp_artifact_resource_accepts_uppercase_sha_metadata(tmp_path):
+    bundle = _complete_basic_bundle(tmp_path)
+    _add_artifact(bundle, "upper_sha", "upper_sha.txt", "trusted\n")
+    data = json.loads(bundle["manifest"].read_text(encoding="utf-8"))
+    for artifact in data["artifacts"]:
+        if artifact["role"] == "upper_sha":
+            artifact["sha256"] = artifact["sha256"].upper()
+            break
+    else:
+        raise AssertionError("upper_sha artifact missing")
+    bundle["manifest"].write_text(json.dumps(data), encoding="utf-8")
+
+    result = read_mcp_resource(
+        "repobrief://snapshot/demo/artifact/upper_sha",
+        bundle_root=bundle["manifest"].parent,
+    )
+
+    assert result["status"] == "available"
+    assert result["content_text"] == "trusted\n"
+
+
+def test_mcp_existing_minimal_artifact_without_integrity_is_blocked(tmp_path):
+    bundle = _complete_basic_bundle(tmp_path)
+
+    result = read_mcp_resource(
+        "repobrief://snapshot/demo/artifact/citation_map_jsonl",
+        bundle_root=bundle["manifest"].parent,
+    )
+
+    assert result["status"] == "integrity_unavailable"
+    assert result["reason"] == "artifact byte size is missing or invalid in manifest"
     assert "content_text" not in result
 
 


### PR DESCRIPTION
## Summary

- clarify MCP resource error contracts after atomic read hardening
- split artifact vs bundle-manifest unavailable wording
- report invalid JSON bundle manifests as `bundle manifest is not valid JSON`
- report file-valued bundle-root stem mismatches explicitly
- accept uppercase SHA-256 hex after normalization
- add tests for invalid JSON manifests, stem mismatch, uppercase SHA, and minimal artifacts without integrity metadata
- clarify proof wording: manifest is size/shape checked; artifact content is checked against manifest integrity metadata

## Diff for external review

- Diff SHA256: `a4645f83f1345a7a0ee6f0e532cc47033287d0224b089de5a3110ecf060eab06`
- Diff bytes: `12422`
- Local diff path: `/tmp/lenskit-pr-mcp-resource-error-contract.diff`

## Validation

- `python3 -m pytest -q merger/lenskit/tests/test_repobrief_mcp_resources.py merger/lenskit/tests/test_repobrief_mcp_boundary_doc.py merger/lenskit/tests/test_repobrief_mcp_frontdoor.py merger/lenskit/tests/test_repobrief_mcp_snapshot_create.py` → `46 passed`
- `ruff check merger/lenskit/core/repobrief_mcp_resources.py merger/lenskit/tests/test_repobrief_mcp_resources.py merger/lenskit/tests/test_repobrief_mcp_boundary_doc.py` → pass
- `git diff --check` → pass
- `python3 -m json.tool docs/tasks/index.json >/dev/null` → pass
- `python3 -m scripts.docmeta.check_planning_registration --baseline docs/tasks/planning-registration-baseline.json --ratchet --format json` → no new drift

## Collision note

Open PR #944 still touches task registry files; this PR intentionally avoids `docs/tasks/index.json` and `docs/tasks/board.md`.

## Non-claims

This remains a code-level resource adapter. It does not establish MCP protocol server availability, transport/authentication correctness, runtime deployment, artifact truth, repository understanding, complete security correctness, full test sufficiency, regression absence, review completeness, or merge readiness.