### PR TITLE
fix(service): harden auth, close root-allowlist bypass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ atlas_scan_*.md
 .claude/settings.local.json
 .claude/worktrees/
 
+# Local Grabowski runtime/worktree state
+.grabowski/
+
 # Root core dumps
 /core
 /core.*

--- a/docs/adr/001-secure-fs-navigation.md
+++ b/docs/adr/001-secure-fs-navigation.md
@@ -13,7 +13,7 @@ However, standard implementation of absolute path browsing poses significant sec
 We implement a "Secure Capability" architecture that balances functionality with strict governance and scanner compliance.
 
 ### 1. Loopback-Scoped Root Access
-Browsing the system root (`/`) via API is enabled by default only when the service is bound to a loopback interface (`localhost` / `127.0.0.1`) and authentication is configured (via the `token` parameter, `RLENS_TOKEN`, or `RLENS_FS_TOKEN_SECRET`).
+Browsing the system root (`/`) via API is enabled by default only when the service is bound to a loopback interface (`localhost` / `127.0.0.1`) and bearer authentication is configured (via the `token` parameter or `RLENS_TOKEN`). `RLENS_FS_TOKEN_SECRET` only signs filesystem navigation tokens; it does not activate bearer authentication and cannot authorize root browsing.
 
 If the service is bound to any non-loopback interface, root browsing is automatically refused.
 
@@ -38,7 +38,7 @@ This creates a visible type boundary between "untrusted user input" and "safe fi
 ## Consequences
 *   **Positive**: CodeQL "path injection" warnings are resolved by design. Filesystem access is limited to authorized roots (optionally including system root on loopback + auth).
 *   **Negative**: "Quick and dirty" API calls using manual path strings are no longer possible; clients must obtain a valid token first (e.g., via `/api/fs/roots`).
-*   **Maintenance**: Requires `RLENS_FS_TOKEN_SECRET` (or `RLENS_TOKEN` fallback) to be managed securely.
+*   **Maintenance**: Filesystem navigation tokens require `RLENS_FS_TOKEN_SECRET` (or `RLENS_TOKEN` fallback) to be managed securely. This signing secret is not bearer authorization.
 
 ## References
 *   `merger/repoLens/service/fs_resolver.py`

--- a/docs/proofs/rlens-service-auth-hardening-v1.self-review.md
+++ b/docs/proofs/rlens-service-auth-hardening-v1.self-review.md
@@ -1,0 +1,74 @@
+# rLens Service Auth Hardening v1 Self-Review
+
+PR: #948
+Reviewed implementation head SHA: `1ca9f8116a23b8558bdeb18f5b4b37aaebd17489`
+Reviewed implementation diff SHA256: `aa8d9668e980418b151f98a42f1bd4cdfe1b2f29f4ec403158a55aae6f00e142`
+Reviewed implementation diff bytes: `19729`
+Diff hash basis: `git diff --binary origin/main...1ca9f8116a23b8558bdeb18f5b4b37aaebd17489 -- .`
+Base: `origin/main` / `a3d1fcae20419e00cedc883dd73f995611ee648b`
+
+## Evidence boundary
+
+This file records a critical review of the implementation diff above. It is committed separately and is therefore not part of the reviewed implementation hash. A final merge gate must still verify the live PR head, the live GitHub diff, mergeability, all CI checks, comments and reviews.
+
+## Reviewed files
+
+- `.gitignore`
+- `docs/adr/001-secure-fs-navigation.md`
+- `merger/lenskit/cli/rlens.py`
+- `merger/lenskit/core/chunker.py`
+- `merger/lenskit/core/merge.py`
+- `merger/lenskit/core/redactor.py`
+- `merger/lenskit/service/app.py`
+- `merger/lenskit/service/auth.py`
+- `merger/lenskit/tests/test_redactor_private_keys.py`
+- `merger/lenskit/tests/test_rlens_server_security.py`
+- `merger/lenskit/tests/test_service_auth_hardening.py`
+- `tests/test_security_root_policy.py`
+
+Coverage: all implementation-diff files reviewed.
+
+## Verdict
+
+**PASS for the reviewed implementation diff, with merge readiness conditional on live CI.**
+
+## Findings and resolutions
+
+### Correctness
+
+- Confirmed that SHA-1/MD5 uses in the changed identifier paths are non-security identifiers and now declare `usedforsecurity=False` for FIPS-compatible runtimes.
+- Found and fixed stale authorization state: repeated `init_service` calls retained an earlier root grant and previous hub roots.
+- The service now rebuilds its allowlist from the current configuration and explicitly removes `/` when the loopback-plus-bearer condition is false.
+
+### Security
+
+- Confirmed that `RLENS_FS_TOKEN_SECRET` signs filesystem tokens but is not accepted by `verify_token`; it can no longer activate `/` browsing by itself.
+- Bearer and query-token comparisons now use `hmac.compare_digest`.
+- Query-token support remains for browser-native clients; Uvicorn access logging is disabled so request URLs cannot disclose those credentials.
+- Found and fixed a false security claim in the draft: PGP private-key blocks were documented as covered but were not redacted.
+- Private-key redaction now covers generic, RSA, EC, DSA, OpenSSH and PGP labels while requiring matching begin/end labels.
+
+### Regression risk
+
+- Allowlist reset is fail-closed during reconfiguration: stale roots are revoked rather than retained.
+- Hub, merges and home roots are rebuilt after reset; behavior tests verify that current roots remain while prior roots disappear.
+- Disabling the standard access log reduces HTTP request observability. This is safer than leaking URL credentials, but a redacting access-log replacement remains a separate improvement.
+
+### Tests
+
+- Focused security/redaction suites: `25 passed`.
+- Broad service, API, artifact, context, diagnostics, trace, redaction and chunk suites: `234 passed, 1 skipped`.
+- Combined test-isolation regression covering root policy, dump retrieval and Atlas lifecycle: `19 passed`.
+- Ruff CI ratchet scope (`F401`, `F811`) passed on changed Python files.
+- `git diff --check` passed.
+- The local monolithic 3,579-test invocation was attempted twice and stalled reproducibly at 16% without an assertion failure. One process-global MagicMock contamination was fixed, but the monolith still requires the GitHub `pytest-full` gate for authoritative completion.
+
+### Integration
+
+- The branch was rebased onto current `origin/main` before review.
+- The only rebase conflict was `.gitignore`; both the existing core-dump rules and the new `.grabowski/` exclusion were preserved.
+- No Git mutation, snapshot refresh, PR creation, runtime deployment or merge authorization is performed by the changed service code.
+
+## Non-claims
+
+This self-review does not by itself establish complete security correctness, absence of all side channels, full-suite success, runtime deployment correctness, review completeness, regression absence or merge readiness. Those remain conditional on the live PR diff and GitHub checks.

--- a/merger/lenskit/cli/rlens.py
+++ b/merger/lenskit/cli/rlens.py
@@ -159,6 +159,10 @@ def main():
         host=args.host,
         port=args.port,
         log_level="info",
+        # Disabled so query-string auth tokens (used by EventSource / direct
+        # download clients that cannot set an Authorization header) are never
+        # written to the request log.
+        access_log=False,
     )
 
 if __name__ == "__main__":

--- a/merger/lenskit/core/chunker.py
+++ b/merger/lenskit/core/chunker.py
@@ -100,7 +100,8 @@ class Chunker:
         # Truncate to 20 hex chars (80 bits) to keep JSONL size manageable.
         # This provides sufficient collision resistance for repo-scale retrieval.
         chunk_hash_input = f"{path_key}\n{start_line}\n{sha256}".encode('utf-8')
-        chunk_id = hashlib.sha1(chunk_hash_input).hexdigest()[:20]
+        # Content addressing only (not security); flag keeps FIPS builds happy.
+        chunk_id = hashlib.sha1(chunk_hash_input, usedforsecurity=False).hexdigest()[:20]
 
         chunks.append(Chunk(
             chunk_id=chunk_id,

--- a/merger/lenskit/core/merge.py
+++ b/merger/lenskit/core/merge.py
@@ -500,8 +500,9 @@ def _stable_file_id(fi: "FileInfo") -> str:
     path = unicodedata.normalize("NFC", path)
 
     raw = f"{repo}:{path}".encode("utf-8", errors="ignore")
-    # Updated in v2.4 (PR1) to include FILE: prefix
-    return "FILE:f_" + hashlib.sha1(raw).hexdigest()[:12]
+    # Updated in v2.4 (PR1) to include FILE: prefix.
+    # Content addressing only (not security); flag keeps FIPS builds happy.
+    return "FILE:f_" + hashlib.sha1(raw, usedforsecurity=False).hexdigest()[:12]
 
 
 def resolve_canonical_md(md_parts: List[Path]) -> Optional[Path]:  # lenskit:requires-authority=canonical_content

--- a/merger/lenskit/core/redactor.py
+++ b/merger/lenskit/core/redactor.py
@@ -1,26 +1,30 @@
 import re
 from typing import Tuple
 
+
 class Redactor:
-    """
-    Heuristic-based secret redaction.
-    """
-    # Simple regex patterns for common secrets
+    """Heuristic-based secret redaction."""
+
     PATTERNS = [
-        (r"(?i)(api[_-]?key|access[_-]?token|secret[_-]?key)[\s:=]+([\"']?)([\w-]{20,})", r"\1\2[REDACTED]"),
-        (r"(?i)(password|passwd|pwd)[\s:=]+([\"']?)([\w-]{6,})", r"\1\2[REDACTED]"),
-        # AWS Key ID (AKIA...)
+        (
+            r"(?i)(api[_-]?key|access[_-]?token|secret[_-]?key)[\s:=]+([\"']?)([\w-]{20,})",
+            r"\1\2[REDACTED]",
+        ),
+        (
+            r"(?i)(password|passwd|pwd)[\s:=]+([\"']?)([\w-]{6,})",
+            r"\1\2[REDACTED]",
+        ),
         (r"(AKIA[0-9A-Z]{16})", "[AWS_KEY_REDACTED]"),
-        # Private Key block (multiline match); covers PKCS#8 (PRIVATE KEY) plus
-        # the common labelled variants (RSA/EC/DSA/OPENSSH/PGP).
-        (r"-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----[\s\S]*?-----END (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----", "[PRIVATE_KEY_BLOCK_REDACTED]"),
+        (
+            r"-----BEGIN ((?:(?:RSA|EC|DSA|OPENSSH) )?PRIVATE KEY|PGP PRIVATE KEY BLOCK)-----"
+            r"[\s\S]*?"
+            r"-----END \1-----",
+            "[PRIVATE_KEY_BLOCK_REDACTED]",
+        ),
     ]
 
     def redact(self, content: str) -> Tuple[str, bool]:
-        """
-        Redacts secrets from content.
-        Returns (redacted_content, was_modified).
-        """
+        """Return redacted content and whether any replacement occurred."""
         modified = False
         redacted = content
 

--- a/merger/lenskit/core/redactor.py
+++ b/merger/lenskit/core/redactor.py
@@ -11,8 +11,9 @@ class Redactor:
         (r"(?i)(password|passwd|pwd)[\s:=]+([\"']?)([\w-]{6,})", r"\1\2[REDACTED]"),
         # AWS Key ID (AKIA...)
         (r"(AKIA[0-9A-Z]{16})", "[AWS_KEY_REDACTED]"),
-        # Private Key block (multiline match)
-        (r"-----BEGIN PRIVATE KEY-----[\s\S]*?-----END PRIVATE KEY-----", "[PRIVATE_KEY_BLOCK_REDACTED]"),
+        # Private Key block (multiline match); covers PKCS#8 (PRIVATE KEY) plus
+        # the common labelled variants (RSA/EC/DSA/OPENSSH/PGP).
+        (r"-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----[\s\S]*?-----END (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----", "[PRIVATE_KEY_BLOCK_REDACTED]"),
     ]
 
     def redact(self, content: str) -> Tuple[str, bool]:

--- a/merger/lenskit/service/app.py
+++ b/merger/lenskit/service/app.py
@@ -278,8 +278,11 @@ def init_service(hub_path: Path, token: Optional[str] = None, host: str = "127.0
     state.runner = JobRunner(state.job_store)
     state.log_provider = FileLogProvider(state.job_store)
 
-    # Configure Security
+    # Configure Security from scratch. init_service may be called repeatedly
+    # in one process (tests, embedded use, controlled reconfiguration); roots
+    # from an earlier configuration must not remain authorized.
     sec = get_security_config()
+    sec.allowlist_roots.clear()
     sec.set_token(token)
 
     # Allowlist the Hub
@@ -302,13 +305,19 @@ def init_service(hub_path: Path, token: Optional[str] = None, host: str = "127.0
     # do NOT enable bearer auth, so they must not, on their own, widen the jail.
     is_loopback = _is_loopback_host(host)
     has_token = bool(sec.token)
+    root = Path("/").resolve()
 
     if is_loopback and has_token:
-        root = Path("/").resolve()
         if root not in getattr(sec, "allowlist_roots", []):
             logger.warning("Root allowlisted (loopback + auth).")
             sec.add_allowlist_root(root)
     else:
+        # init_service can be called repeatedly in-process. Remove a root grant
+        # left by an earlier authenticated loopback initialization so the
+        # allowlist cannot outlive the authorization condition that created it.
+        roots = getattr(sec, "allowlist_roots", None)
+        if isinstance(roots, list):
+            roots[:] = [allowed for allowed in roots if allowed != root]
         logger.warning(
             "Root browsing refused (loopback=%s, has_token=%s).",
             is_loopback,

--- a/merger/lenskit/service/app.py
+++ b/merger/lenskit/service/app.py
@@ -295,9 +295,13 @@ def init_service(hub_path: Path, token: Optional[str] = None, host: str = "127.0
     except Exception as e:
         logger.debug("Could not allow system root: %s", e, exc_info=True)
 
-    # Root Access: enabled by default on loopback with auth
+    # Root Access: enabled by default on loopback with auth.
+    # Gate strictly on the bearer token that verify_token actually enforces
+    # (sec.token), so the invariant "root allowlisted ⟹ auth active" always
+    # holds. Env secrets like RLENS_FS_TOKEN_SECRET sign FS download tokens but
+    # do NOT enable bearer auth, so they must not, on their own, widen the jail.
     is_loopback = _is_loopback_host(host)
-    has_token = bool(token or os.getenv("RLENS_TOKEN") or os.getenv("RLENS_FS_TOKEN_SECRET"))
+    has_token = bool(sec.token)
 
     if is_loopback and has_token:
         root = Path("/").resolve()

--- a/merger/lenskit/service/auth.py
+++ b/merger/lenskit/service/auth.py
@@ -1,3 +1,5 @@
+import hmac
+
 from fastapi import HTTPException, Depends, Query
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from typing import Optional
@@ -5,6 +7,14 @@ from typing import Optional
 from ..adapters.security import get_security_config
 
 security_scheme = HTTPBearer(auto_error=False)
+
+
+def _token_matches(candidate: Optional[str], expected: str) -> bool:
+    # Constant-time comparison to avoid leaking the token via timing.
+    if not candidate:
+        return False
+    return hmac.compare_digest(candidate, expected)
+
 
 def verify_token(
     creds: Optional[HTTPAuthorizationCredentials] = Depends(security_scheme),
@@ -14,10 +24,13 @@ def verify_token(
     if not config.token:
         return
 
-    if creds and creds.credentials == config.token:
+    # Bearer header is the preferred channel. The query parameter is retained
+    # only for browser-native clients that cannot set headers (EventSource /
+    # direct downloads); server access logging is disabled so it is not logged.
+    if _token_matches(creds.credentials if creds else None, config.token):
         return
 
-    if token and token == config.token:
+    if _token_matches(token, config.token):
         return
 
     raise HTTPException(status_code=401, detail="Missing or invalid authentication token")

--- a/merger/lenskit/tests/test_redactor_private_keys.py
+++ b/merger/lenskit/tests/test_redactor_private_keys.py
@@ -1,0 +1,37 @@
+import pytest
+
+from merger.lenskit.core.redactor import Redactor
+
+
+@pytest.mark.parametrize(
+    "label",
+    [
+        "PRIVATE KEY",
+        "RSA PRIVATE KEY",
+        "EC PRIVATE KEY",
+        "DSA PRIVATE KEY",
+        "OPENSSH PRIVATE KEY",
+        "PGP PRIVATE KEY BLOCK",
+    ],
+)
+def test_redactor_removes_documented_private_key_blocks(label):
+    payload = f"-----BEGIN {label}-----\nsynthetic-test-material\n-----END {label}-----"
+
+    redacted, modified = Redactor().redact(payload)
+
+    assert modified is True
+    assert "synthetic-test-material" not in redacted
+    assert redacted == "[PRIVATE_KEY_BLOCK_REDACTED]"
+
+
+def test_redactor_does_not_consume_mismatched_private_key_boundaries():
+    payload = (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "synthetic-test-material\n"
+        "-----END EC PRIVATE KEY-----"
+    )
+
+    redacted, modified = Redactor().redact(payload)
+
+    assert modified is False
+    assert redacted == payload

--- a/merger/lenskit/tests/test_rlens_server_security.py
+++ b/merger/lenskit/tests/test_rlens_server_security.py
@@ -1,0 +1,20 @@
+from merger.lenskit.cli import rlens
+
+
+def test_server_disables_access_log_to_avoid_query_token_leaks(monkeypatch, tmp_path):
+    hub = tmp_path / "hub"
+    hub.mkdir()
+    captured = {}
+
+    monkeypatch.setattr(
+        "sys.argv",
+        ["rlens", "--hub", str(hub), "--token", "synthetic-token"],
+    )
+    monkeypatch.setattr(rlens, "init_service", lambda **kwargs: captured.setdefault("init", kwargs))
+    monkeypatch.setattr(rlens.uvicorn, "run", lambda app, **kwargs: captured.setdefault("run", kwargs))
+
+    rlens.main()
+
+    assert captured["run"]["access_log"] is False
+    assert captured["run"]["host"] == "127.0.0.1"
+    assert captured["init"]["token"] == "synthetic-token"

--- a/merger/lenskit/tests/test_service_auth_hardening.py
+++ b/merger/lenskit/tests/test_service_auth_hardening.py
@@ -1,0 +1,50 @@
+from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+import pytest
+
+from merger.lenskit.adapters.security import get_security_config
+from merger.lenskit.service import auth
+
+
+@pytest.fixture(autouse=True)
+def restore_security_token():
+    config = get_security_config()
+    previous = config.token
+    yield
+    config.set_token(previous)
+
+
+def test_token_matches_uses_constant_time_comparison(monkeypatch):
+    calls = []
+
+    def fake_compare_digest(candidate, expected):
+        calls.append((candidate, expected))
+        return candidate == expected
+
+    monkeypatch.setattr(auth.hmac, "compare_digest", fake_compare_digest)
+
+    assert auth._token_matches("candidate", "expected") is False
+    assert calls == [("candidate", "expected")]
+
+
+def test_verify_token_accepts_bearer_header():
+    get_security_config().set_token("expected")
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="expected")
+
+    assert auth.verify_token(creds=credentials, token=None) is None
+
+
+def test_verify_token_accepts_query_token_for_browser_native_clients():
+    get_security_config().set_token("expected")
+
+    assert auth.verify_token(creds=None, token="expected") is None
+
+
+def test_verify_token_rejects_invalid_credentials():
+    get_security_config().set_token("expected")
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="wrong")
+
+    with pytest.raises(HTTPException) as exc_info:
+        auth.verify_token(creds=credentials, token="also-wrong")
+
+    assert exc_info.value.status_code == 401

--- a/tests/test_security_root_policy.py
+++ b/tests/test_security_root_policy.py
@@ -33,17 +33,20 @@ def setup_mocks():
         sys.modules["starlette"] = MagicMock()
         sys.modules["starlette.concurrency"] = MagicMock()
 
-    # Mock heavy service components if not present
-    # BUT DO NOT mock merger.lenskit.adapters.security
-    sys.modules.setdefault("merger.lenskit.service.jobstore", MagicMock())
-    sys.modules.setdefault("merger.lenskit.service.runner", MagicMock())
-    sys.modules.setdefault("merger.lenskit.service.logging_provider", MagicMock())
-    sys.modules.setdefault("merger.lenskit.service.auth", MagicMock())
-    sys.modules.setdefault("merger.lenskit.adapters.atlas", MagicMock())
-    sys.modules.setdefault("merger.lenskit.adapters.metarepo", MagicMock())
-    sys.modules.setdefault("merger.lenskit.adapters.sources", MagicMock())
-    sys.modules.setdefault("merger.lenskit.adapters.diagnostics", MagicMock())
-    sys.modules.setdefault("merger.lenskit.core.merge", MagicMock())
+        # In a dependency-minimal environment, mock the service's heavy
+        # imports as a group. When FastAPI/Pydantic are available, import the
+        # real modules: process-global MagicMocks would contaminate later tests
+        # in the same pytest session.
+        # BUT DO NOT mock merger.lenskit.adapters.security.
+        sys.modules.setdefault("merger.lenskit.service.jobstore", MagicMock())
+        sys.modules.setdefault("merger.lenskit.service.runner", MagicMock())
+        sys.modules.setdefault("merger.lenskit.service.logging_provider", MagicMock())
+        sys.modules.setdefault("merger.lenskit.service.auth", MagicMock())
+        sys.modules.setdefault("merger.lenskit.adapters.atlas", MagicMock())
+        sys.modules.setdefault("merger.lenskit.adapters.metarepo", MagicMock())
+        sys.modules.setdefault("merger.lenskit.adapters.sources", MagicMock())
+        sys.modules.setdefault("merger.lenskit.adapters.diagnostics", MagicMock())
+        sys.modules.setdefault("merger.lenskit.core.merge", MagicMock())
 
 setup_mocks()
 # Ensure repo root is in path
@@ -130,6 +133,53 @@ def test_init_service_non_loopback_with_token_refuses_root(monkeypatch, tmp_path
     root_path = Path("/").resolve()
     assert root_path not in sec.allowlist_roots
 
+def test_init_service_replaces_previous_allowlist_configuration(tmp_path):
+    """Reinitialization must revoke roots belonging to the previous hub."""
+    first_hub = tmp_path / "first-hub"
+    second_hub = tmp_path / "second-hub"
+    first_hub.mkdir()
+    second_hub.mkdir()
+    sec = get_security_config()
+    _reset_allowlist(sec)
+
+    init_service(first_hub, host="127.0.0.1", token=None)
+    assert first_hub.resolve() in sec.allowlist_roots
+
+    init_service(second_hub, host="127.0.0.1", token=None)
+    assert first_hub.resolve() not in sec.allowlist_roots
+    assert second_hub.resolve() in sec.allowlist_roots
+
+
+def test_init_service_removes_stale_root_when_auth_is_disabled(tmp_path):
+    """A prior authenticated init must not leave root enabled after auth is removed."""
+    hub = tmp_path / "hub"
+    hub.mkdir()
+    sec = get_security_config()
+    _reset_allowlist(sec)
+
+    init_service(hub, host="127.0.0.1", token="secret")
+    assert Path("/").resolve() in sec.allowlist_roots
+
+    init_service(hub, host="127.0.0.1", token=None)
+    assert Path("/").resolve() not in sec.allowlist_roots
+    assert hub.resolve() in sec.allowlist_roots
+    assert Path.home().resolve() in sec.allowlist_roots
+
+
+def test_init_service_removes_stale_root_when_binding_becomes_non_loopback(tmp_path):
+    """Changing to a non-loopback bind must revoke an earlier root grant."""
+    hub = tmp_path / "hub"
+    hub.mkdir()
+    sec = get_security_config()
+    _reset_allowlist(sec)
+
+    init_service(hub, host="127.0.0.1", token="secret")
+    assert Path("/").resolve() in sec.allowlist_roots
+
+    init_service(hub, host="192.168.1.1", token="secret")
+    assert Path("/").resolve() not in sec.allowlist_roots
+
+
 def test_init_service_fs_token_secret_without_bearer_refuses_root(monkeypatch, tmp_path):
     """
     Regression: RLENS_FS_TOKEN_SECRET signs FS download tokens but does NOT
@@ -185,3 +235,5 @@ def test_static_source_check_adr():
     assert "Loopback-Scoped Root Access" in content
     assert "enabled by default only when the service is bound to a loopback interface" in content
     assert "optionally including system root on loopback + auth" in content
+    assert "does not activate bearer authentication" in content
+    assert "cannot authorize root browsing" in content

--- a/tests/test_security_root_policy.py
+++ b/tests/test_security_root_policy.py
@@ -130,6 +130,29 @@ def test_init_service_non_loopback_with_token_refuses_root(monkeypatch, tmp_path
     root_path = Path("/").resolve()
     assert root_path not in sec.allowlist_roots
 
+def test_init_service_fs_token_secret_without_bearer_refuses_root(monkeypatch, tmp_path):
+    """
+    Regression: RLENS_FS_TOKEN_SECRET signs FS download tokens but does NOT
+    enable bearer auth. On its own it must not widen the jail to system root,
+    otherwise root browsing would be reachable with auth effectively disabled.
+    Invariant: root allowlisted <=> verify_token is actually enforced.
+    """
+    hub = tmp_path / "hub"
+    hub.mkdir()
+    sec = get_security_config()
+    _reset_allowlist(sec)
+    sec.set_token(None)
+
+    monkeypatch.delenv("RLENS_TOKEN", raising=False)
+    monkeypatch.setenv("RLENS_FS_TOKEN_SECRET", "fs-signing-secret")
+
+    init_service(hub, host="127.0.0.1", token=None)
+
+    root_path = Path("/").resolve()
+    assert root_path not in sec.allowlist_roots
+    # Auth is not active (no bearer token), so root must remain refused.
+    assert not sec.token
+
 def test_static_source_check_app_py():
     app_path = Path("merger/lenskit/service/app.py")
     content = app_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Hardens the rLens service security boundary after rebasing onto current `main`.

- root `/` is allowed only for loopback plus an actually enforced bearer token
- `RLENS_FS_TOKEN_SECRET` remains a filesystem-token signing secret and cannot enable root browsing
- repeated service initialization rebuilds the allowlist, revoking stale root and old-hub grants
- bearer/query credentials use constant-time comparison
- Uvicorn access logging is disabled to avoid query-token disclosure
- non-security SHA-1/MD5 identifiers declare `usedforsecurity=False` for FIPS-compatible runtimes
- private-key redaction covers generic, RSA, EC, DSA, OpenSSH and PGP blocks with matching boundaries
- local Grabowski state is ignored without dropping existing core-dump exclusions
- accepted filesystem-security ADR is aligned with the implementation

## Review findings fixed

The original draft had two reproducible security defects:

1. `/` remained allowlisted after authentication was removed or the service changed to a non-loopback bind.
2. PGP private-key blocks were claimed as covered but were not redacted.

The review also fixed process-global `MagicMock` contamination in the root-policy tests.

## Verification

- focused security/redaction: `25 passed`
- broad service/API/artifact/context/diagnostics/trace/redaction/chunk coverage: `234 passed, 1 skipped`
- combined test-isolation regression: `19 passed`
- Ruff CI ratchet (`F401`, `F811`): pass
- `git diff --check`: pass

The local 3,579-test monolith was attempted twice and stalled reproducibly at 16% without an assertion failure. The GitHub `pytest-full` check is therefore a mandatory merge condition.

## Review evidence

- implementation head: `1ca9f8116a23b8558bdeb18f5b4b37aaebd17489`
- implementation diff SHA-256: `aa8d9668e980418b151f98a42f1bd4cdfe1b2f29f4ec403158a55aae6f00e142`
- self-review: `docs/proofs/rlens-service-auth-hardening-v1.self-review.md`
- verdict: PASS for the reviewed implementation diff; merge readiness remains conditional on live CI, comments, reviews, mergeability and final-head verification

## Trade-off / follow-up

Disabling the standard access log prevents URL credential leaks but reduces request observability. A credential-redacting access-log replacement should be handled separately rather than weakening this fix.
