### PR TITLE
fix(service): require auth for sensitive filesystem access

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,14 +71,15 @@ Pseudo-filesystems and volatile paths (`/proc`, `/sys`, `/dev`, `/run`, etc.) ar
 
 **Atlas Root Model:**
 Atlas employs a formalized root model internally, permitting execution against different types of targets without implicitly falling back or hiding behaviors. The `root_kind` in API requests must be one of:
-* `preset`: Used to refer to predefined, trusted directories like `hub`, `merges`, or `system` (user home).
+* `preset`: Used to refer to predefined, trusted directories like `hub`, `merges`, or `system` (the service user's home directory). The `system` preset is available only on loopback with bearer authentication.
 * `token`: Used with an opaque, server-signed token, primarily meant for file pickers and external integrations.
 * `abs_path`: Explicitly targets an absolute file system path (e.g., `/home/user/project`). This is an explicit internal mode. Traversal exploits (`..`) or relative paths are strictly rejected. Note that the WebUI catches invalid manual path inputs (like "home" instead of "/home") before creating an API request, preventing unnecessary Bad Requests.
 
 Example usage:
 
 ```bash
-# Explore arbitrary filesystem roots via CLI (when integrated) or API
+# Service API: broad system roots require loopback plus --token / RLENS_TOKEN.
+# The standalone Atlas CLI remains a local, explicit filesystem operation.
 rlens atlas scan /
 rlens atlas scan /home
 rlens atlas scan /etc

--- a/docs/adr/001-secure-fs-navigation.md
+++ b/docs/adr/001-secure-fs-navigation.md
@@ -12,14 +12,15 @@ However, standard implementation of absolute path browsing poses significant sec
 ## Decision
 We implement a "Secure Capability" architecture that balances functionality with strict governance and scanner compliance.
 
-### 1. Loopback-Scoped Root Access
-Browsing the system root (`/`) via API is enabled by default only when the service is bound to a loopback interface (`localhost` / `127.0.0.1`) and bearer authentication is configured (via the `token` parameter or `RLENS_TOKEN`). `RLENS_FS_TOKEN_SECRET` only signs filesystem navigation tokens; it does not activate bearer authentication and cannot authorize root browsing.
+### 1. Loopback- and Auth-Scoped Sensitive Access
+Browsing the service user's home directory (`system`) or the filesystem root (`/`) via API is enabled only when the service is bound to a loopback interface (`localhost` / `127.0.0.1`) **and** bearer authentication is configured (via the `token` parameter or `RLENS_TOKEN`). Loopback alone is not an authorization boundary because other local processes or users can connect to the service. `RLENS_FS_TOKEN_SECRET` only signs filesystem navigation tokens; it does not activate bearer authentication and cannot authorize sensitive filesystem browsing.
 
-If the service is bound to any non-loopback interface, root browsing is automatically refused.
+Without that combined condition, only the explicitly configured Hub and merges directory are allowlisted. Those operator-selected roots remain authoritative even if they are broad; they do not implicitly mint the separate `system` preset. Non-loopback bindings never receive the `system` or `/` capability, even when bearer authentication is present.
 
 This ensures:
-- Full operator capability in local deployments
-- No accidental exposure of system root over the network
+- Full operator capability in authenticated local deployments
+- No unauthenticated exposure of the service user's home directory to other local clients
+- No accidental exposure of sensitive filesystem roots over the network
 
 ### 2. Token-Based Navigation (The "Hard Cut")
 To satisfy security scanners and prevent path traversal, the API no longer accepts raw path strings for navigation.
@@ -36,10 +37,12 @@ We introduced a `TrustedPath` dataclass in the backend.
 This creates a visible type boundary between "untrusted user input" and "safe filesystem operations", aiding both code review and static analysis.
 
 ## Consequences
-*   **Positive**: CodeQL "path injection" warnings are resolved by design. Filesystem access is limited to authorized roots (optionally including system root on loopback + auth).
+*   **Positive**: CodeQL "path injection" warnings are resolved by design. Filesystem access is limited to authorized roots; the `system` home preset and `/` require loopback plus bearer authentication.
 *   **Negative**: "Quick and dirty" API calls using manual path strings are no longer possible; clients must obtain a valid token first (e.g., via `/api/fs/roots`).
 *   **Maintenance**: Filesystem navigation tokens require `RLENS_FS_TOKEN_SECRET` (or `RLENS_TOKEN` fallback) to be managed securely. This signing secret is not bearer authorization.
 
 ## References
-*   `merger/repoLens/service/fs_resolver.py`
-*   `merger/repoLens/service/security.py`
+*   `merger/lenskit/adapters/filesystem.py`
+*   `merger/lenskit/adapters/security.py`
+*   `merger/lenskit/service/app.py`
+*   `merger/lenskit/service/auth.py`

--- a/docs/proofs/rlens-sensitive-filesystem-access-v1.external-review.json
+++ b/docs/proofs/rlens-sensitive-filesystem-access-v1.external-review.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": 1,
+  "kind": "lenskit.external_security_review",
+  "authority": "independent_diff_review_evidence",
+  "repository": "heimgewebe/lenskit",
+  "pull_request": 949,
+  "reviewer": {
+    "tool": "codex-cli",
+    "version": "0.142.2",
+    "model": "gpt-5.5",
+    "reasoning_effort": "xhigh",
+    "mode": "isolated_packet_no_tools"
+  },
+  "reviewed_implementation": {
+    "head_sha": "9bf1358febd7d0e146a12080ab8c8c1afc854510",
+    "base_sha": "beeb2f14318577177b69d1699fe0aef8078c7fe7",
+    "diff_sha256": "63e83a4399ca97f5f5efdbdcaefe7b7516dc6f412cd02d1c20449f0b6cc76af8",
+    "diff_bytes": 23925,
+    "diff_hash_basis": "git diff --binary origin/main...9bf1358febd7d0e146a12080ab8c8c1afc854510 -- . ':(exclude)docs/proofs/rlens-sensitive-filesystem-access-v1.self-review.md'"
+  },
+  "supporting_context": [
+    {
+      "path": "merger/lenskit/adapters/security.py",
+      "sha256": "c9ee1de691130cd1cac0810f31464b2dbe44f82a3f76852b991ac92eab84a1d9",
+      "purpose": "Verify exception inheritance and two-stage canonical path validation."
+    }
+  ],
+  "packet_sha256": "1834da3e984621e8081ae0cc353f5839a11f20a02e9384573d36edd154e5901f",
+  "reviewed_at": "2026-07-10T11:30:04.837501+00:00",
+  "verdict": "PASS",
+  "summary": "No critical, high, or medium findings. The patch closes the main authorization bypass surfaces called out in the packet: `system` is now capability-gated separately from path allowlisting, stale sensitive grants are reset on reinitialization, and `abs_path` now goes through the central canonicalizing allowlist check instead of returning raw absolute paths.",
+  "findings": [
+    {
+      "severity": "low",
+      "file": "merger/lenskit/service/app.py",
+      "location": "init_service sensitive access block",
+      "problem": "Sensitive-mode startup can now fail if `Path.home().resolve()` or root allowlist registration raises.",
+      "rationale": "The previous home-root registration was best-effort and caught exceptions. The new loopback+token branch calls `sec.add_allowlist_root(Path.home().resolve())` and `sec.add_allowlist_root(root)` without handling resolution or registration failures. This is not an authorization bypass, but it is a compatibility/regression risk in unusual service-account or platform configurations.",
+      "recommendation": "Consider preserving best-effort behavior for the optional home preset while still granting `/` when appropriate, or fail with an explicit startup error that documents the configuration problem."
+    }
+  ],
+  "coverage": [
+    "Reviewed the supplied implementation diff only; no commands, file access, or modifications were performed.",
+    "Checked authorization gating for `system`, `/`, and `abs_path`.",
+    "Checked path canonicalization and symlink escape handling against the supplied `SecurityConfig.validate_path` context.",
+    "Checked reinitialization behavior for stale sensitive grants.",
+    "Checked allowlist versus capability semantics and related tests."
+  ],
+  "residual_risks": [
+    "The review relies on the supplied packet and supporting context; route-level exception handlers and full model validation were not independently inspected.",
+    "No runtime verification was performed, per instruction."
+  ],
+  "finding_triage": [
+    {
+      "severity": "low",
+      "disposition": "deferred_follow_up",
+      "reason": "Unusual Home-resolution startup failure is bounded and does not reopen the authorization boundary; tracked separately in Bureau."
+    }
+  ],
+  "does_not_establish": [
+    "runtime_deployment_correctness",
+    "full_test_sufficiency",
+    "absence_of_all_filesystem_side_channels",
+    "merge_authorization"
+  ]
+}

--- a/docs/proofs/rlens-sensitive-filesystem-access-v1.external-review.json
+++ b/docs/proofs/rlens-sensitive-filesystem-access-v1.external-review.json
@@ -12,11 +12,11 @@
     "mode": "isolated_packet_no_tools"
   },
   "reviewed_implementation": {
-    "head_sha": "9bf1358febd7d0e146a12080ab8c8c1afc854510",
+    "head_sha": "a2bcb176b0f12865562f74c2cc3a627a622df80e",
     "base_sha": "beeb2f14318577177b69d1699fe0aef8078c7fe7",
-    "diff_sha256": "63e83a4399ca97f5f5efdbdcaefe7b7516dc6f412cd02d1c20449f0b6cc76af8",
-    "diff_bytes": 23925,
-    "diff_hash_basis": "git diff --binary origin/main...9bf1358febd7d0e146a12080ab8c8c1afc854510 -- . ':(exclude)docs/proofs/rlens-sensitive-filesystem-access-v1.self-review.md'"
+    "diff_sha256": "c199feadc6d2dff693d659389bdfe7f7ea0353c7bccaecddcad3bb822071ba26",
+    "diff_bytes": 24015,
+    "diff_hash_basis": "git diff --binary origin/main...a2bcb176b0f12865562f74c2cc3a627a622df80e -- . ':(exclude)docs/proofs/rlens-sensitive-filesystem-access-v1.self-review.md' ':(exclude)docs/proofs/rlens-sensitive-filesystem-access-v1.external-review.json'"
   },
   "supporting_context": [
     {
@@ -25,41 +25,34 @@
       "purpose": "Verify exception inheritance and two-stage canonical path validation."
     }
   ],
-  "packet_sha256": "1834da3e984621e8081ae0cc353f5839a11f20a02e9384573d36edd154e5901f",
-  "reviewed_at": "2026-07-10T11:30:04.837501+00:00",
+  "packet_sha256": "979e63e020f8fc083a3ebeed5046b51eb76fdc49f28aeab8da91616666fe39f6",
+  "reviewed_at": "2026-07-10T11:37:13.605447+00:00",
   "verdict": "PASS",
-  "summary": "No critical, high, or medium findings. The patch closes the main authorization bypass surfaces called out in the packet: `system` is now capability-gated separately from path allowlisting, stale sensitive grants are reset on reinitialization, and `abs_path` now goes through the central canonicalizing allowlist check instead of returning raw absolute paths.",
-  "findings": [
-    {
-      "severity": "low",
-      "file": "merger/lenskit/service/app.py",
-      "location": "init_service sensitive access block",
-      "problem": "Sensitive-mode startup can now fail if `Path.home().resolve()` or root allowlist registration raises.",
-      "rationale": "The previous home-root registration was best-effort and caught exceptions. The new loopback+token branch calls `sec.add_allowlist_root(Path.home().resolve())` and `sec.add_allowlist_root(root)` without handling resolution or registration failures. This is not an authorization bypass, but it is a compatibility/regression risk in unusual service-account or platform configurations.",
-      "recommendation": "Consider preserving best-effort behavior for the optional home preset while still granting `/` when appropriate, or fail with an explicit startup error that documents the configuration problem."
-    }
-  ],
+  "summary": "No critical, high, or medium security findings in the supplied diff. The patch closes the main authorization gap by separating the `system` capability from mere path allowlisting, resets sensitive state on reinitialization, and routes `abs_path` through canonical allowlist validation so symlink escapes are denied.",
+  "findings": [],
   "coverage": [
-    "Reviewed the supplied implementation diff only; no commands, file access, or modifications were performed.",
-    "Checked authorization gating for `system`, `/`, and `abs_path`.",
-    "Checked path canonicalization and symlink escape handling against the supplied `SecurityConfig.validate_path` context.",
-    "Checked reinitialization behavior for stale sensitive grants.",
-    "Checked allowlist versus capability semantics and related tests."
+    "Reviewed sensitive filesystem authorization semantics for `system`, `/`, and `abs_path`.",
+    "Checked reinitialization behavior for stale root/home grants and the new `sensitive_fs_access` flag.",
+    "Checked path canonicalization flow against the supplied `SecurityConfig.validate_path` two-stage prefix and canonical checks.",
+    "Reviewed symlink escape coverage and compatibility implications from the updated tests and docs."
   ],
   "residual_risks": [
-    "The review relies on the supplied packet and supporting context; route-level exception handlers and full model validation were not independently inspected.",
-    "No runtime verification was performed, per instruction."
+    "The diff does not show endpoint dependency wiring, so this review assumes existing bearer enforcement is correctly applied to sensitive API routes when `sec.token` is configured.",
+    "Tests cover key symlink and reinitialization cases, but cross-platform edge cases such as case-insensitive filesystems or Windows drive behavior are not demonstrated in this packet."
   ],
-  "finding_triage": [
+  "historical_review_triage": [
     {
+      "source": "prior_review_iteration",
       "severity": "low",
       "disposition": "deferred_follow_up",
-      "reason": "Unusual Home-resolution startup failure is bounded and does not reopen the authorization boundary; tracked separately in Bureau."
+      "bureau_event_id": 33,
+      "reason": "Unusual Home-resolution startup failure remains a bounded compatibility question and does not reopen the authorization boundary."
     }
   ],
   "does_not_establish": [
     "runtime_deployment_correctness",
     "full_test_sufficiency",
+    "cross_platform_filesystem_correctness",
     "absence_of_all_filesystem_side_channels",
     "merge_authorization"
   ]

--- a/docs/proofs/rlens-sensitive-filesystem-access-v1.self-review.md
+++ b/docs/proofs/rlens-sensitive-filesystem-access-v1.self-review.md
@@ -1,15 +1,16 @@
 # rLens Sensitive Filesystem Access v1 Self-Review
 
-Reviewed implementation head SHA: `a1809b06f4ec37866645b6183a973697c26dfae1`
-Reviewed implementation diff SHA256: `cb80c4df5b88d2905d749a2811c9ddd72f9ec9aab8f5a55da00a1625a6a6c664`
-Reviewed implementation diff bytes: `21029`
-Diff hash basis: `git diff --binary origin/main...a1809b06f4ec37866645b6183a973697c26dfae1 -- .`
+PR: #949
+Reviewed implementation head SHA: `9bf1358febd7d0e146a12080ab8c8c1afc854510`
+Reviewed implementation diff SHA256: `63e83a4399ca97f5f5efdbdcaefe7b7516dc6f412cd02d1c20449f0b6cc76af8`
+Reviewed implementation diff bytes: `23925`
+Diff hash basis: `git diff --binary origin/main...9bf1358febd7d0e146a12080ab8c8c1afc854510 -- . ':(exclude)docs/proofs/rlens-sensitive-filesystem-access-v1.self-review.md'`
 Base: `origin/main` / `beeb2f14318577177b69d1699fe0aef8078c7fe7`
 Source finding: Bureau live-register event `27`.
 
 ## Evidence boundary
 
-This file records a critical review of the implementation diff above. It is committed separately and is not part of the reviewed implementation hash. A final merge gate must still verify the live PR head and diff, mergeability, current CI, comments and reviews.
+This file records a critical review of the implementation diff above. It is committed separately and is not part of the reviewed implementation hash. The independent external review is stored in `docs/proofs/rlens-sensitive-filesystem-access-v1.external-review.json`. A final merge gate must still verify the live PR head and diff, mergeability, current CI, comments and reviews.
 
 ## Reviewed files
 
@@ -27,7 +28,7 @@ Coverage: all implementation-diff files reviewed.
 
 ## Verdict
 
-**PASS for the reviewed implementation diff, conditional on independent review and live GitHub CI.**
+**PASS for the reviewed implementation diff, conditional on the final live PR diff and GitHub CI.**
 
 ## Findings and resolutions
 
@@ -35,7 +36,7 @@ Coverage: all implementation-diff files reviewed.
 
 - Loopback is a transport boundary, not authorization: other local processes or users can connect to a loopback service.
 - Hub and a configured merges directory remain ordinary, explicit operator roots.
-- The broad `system` preset and filesystem root are now granted only for loopback plus the bearer token actually enforced by `verify_token`.
+- The broad `system` preset and filesystem root are granted only for loopback plus the bearer token actually enforced by `verify_token`.
 - The broad capability has explicit state (`sensitive_fs_access`); an overlapping allowlist root cannot silently mint the `system` alias.
 - Reinitialization resets both the allowlist and the sensitive capability before rebuilding current configuration.
 
@@ -43,38 +44,48 @@ Coverage: all implementation-diff files reviewed.
 
 - Found and closed an additional bypass beyond the original live-register finding: Atlas `root_kind=abs_path` previously returned arbitrary absolute paths without calling the central allowlist validator.
 - Absolute Atlas paths now pass through `SecurityConfig.validate_path`; path denials propagate to the existing HTTP 403 handler.
+- The central validator retains its two-stage boundary: lexical containment before resolution, then canonical containment after symlink resolution.
 - `RLENS_FS_TOKEN_SECRET` remains only a navigation-token signing secret and cannot activate sensitive browsing.
 - Non-loopback bindings do not receive the broad capability even when bearer authentication is configured.
 - Explicit Hub or merges roots remain authoritative by design. An operator can still configure a broad Hub; this is an explicit configuration decision, not an implicit `system` capability.
 
 ### Regression risk
 
-- Unauthenticated loopback use can still inspect the configured Hub and merges roots, preserving the existing low-friction local workflow.
+- Unauthenticated loopback use can still inspect the configured Hub and merges roots, preserving the low-friction local workflow.
 - Authenticated loopback use retains Home and full-root operation.
 - The standalone Atlas CLI remains an explicit local filesystem operation; the new restriction applies to the service/API boundary.
-- The `system` omission is handled as an expected policy outcome rather than an unhandled security exception.
+- The `system` omission is ordinary conditional behavior, so it cannot make Hub/Merges root enumeration fail.
 
 ### Tests and validation
 
-- Focused policy suite: `14 passed`.
-- Focused Atlas/Auth suite: `21 passed`.
-- Broad service/API/Atlas regression suite: `163 passed, 1 skipped`.
+- Focused policy and real API boundary suite: `19 passed`.
+- Broad service/API/Atlas regression suite: `168 passed, 1 skipped`.
+- Explicit proofs cover a denied symlink escape, an allowed internal symlink, early `..` rejection, unauthenticated `/api/fs/roots`, and unauthenticated Atlas Home denial.
 - Ruff CI ratchet scope passed on every changed Python file.
 - Changed Python files passed `py_compile`.
 - `git diff --check` passed.
-- The existing `test_create_atlas_system_root` performs a real scan of the operator Home directory and is unsuitable as a bounded local check; it was not used as local evidence. GitHub `pytest-full` remains the authoritative full-suite gate.
+- The existing `test_create_atlas_system_root` performs a real scan of the operator Home directory and is unsuitable as a bounded local check; GitHub `pytest-full` remains the authoritative full-suite gate.
+
+### Independent review
+
+- Codex CLI `0.142.2`, model `gpt-5.5`, reasoning effort `xhigh`, reviewed an isolated immutable packet without tools or repository access.
+- Reviewed implementation head: `9bf1358febd7d0e146a12080ab8c8c1afc854510`.
+- Reviewed implementation diff SHA256: `63e83a4399ca97f5f5efdbdcaefe7b7516dc6f412cd02d1c20449f0b6cc76af8`.
+- Verdict: **PASS** with no critical, high or medium finding.
+- One low finding remains: authenticated startup can fail in unusual environments if the service user Home cannot be resolved or registered. This does not reopen the authorization boundary and is registered as a separate Bureau candidate.
+- Claude CLI was unavailable for review because the authenticated subscription session quota returned HTTP 429 before any review tokens were used; it is not counted as review evidence.
 
 ### Integration
 
-- Documentation now distinguishes explicit Hub/Merges roots, the broad `system` capability, service API rules and standalone CLI behavior.
-- Existing service mapping tests now explicitly enable and bypass auth only within their mapping-only fixture.
+- Documentation distinguishes explicit Hub/Merges roots, the broad `system` capability, service API rules and standalone CLI behavior.
+- Existing service mapping tests explicitly enable and bypass auth only within their mapping-only fixture.
 - No runtime restart, deployment, snapshot refresh or merge authorization is performed by this patch.
 
 ## Remaining observations
 
-- The local repo-wide Ruff invocation can scan `.git` metadata when a remote ref name ends in `.py`, because `ruff-ci.toml` replaces the default exclusions. This is unrelated to the product change and requires a separate parity task.
+- The local repo-wide Ruff invocation can scan `.git` metadata when a remote ref name ends in `.py`, because `ruff-ci.toml` replaces the default exclusions. This is unrelated to the product change and is tracked separately.
 - Credential-redacting access logging remains a separate Bureau candidate; this patch does not change the access-log decision from PR #948.
 
 ## Non-claims
 
-This review does not establish complete local-host isolation, correctness of arbitrary operator-selected Hub/Merges roots, absence of all filesystem side channels, full-suite success, runtime deployment correctness, review completeness, regression absence or merge readiness by itself.
+This self-review does not establish complete local-host isolation, correctness of arbitrary operator-selected Hub/Merges roots, absence of all filesystem side channels, full-suite success, runtime deployment correctness, review completeness, regression absence or merge readiness by itself.

--- a/docs/proofs/rlens-sensitive-filesystem-access-v1.self-review.md
+++ b/docs/proofs/rlens-sensitive-filesystem-access-v1.self-review.md
@@ -1,0 +1,80 @@
+# rLens Sensitive Filesystem Access v1 Self-Review
+
+Reviewed implementation head SHA: `a1809b06f4ec37866645b6183a973697c26dfae1`
+Reviewed implementation diff SHA256: `cb80c4df5b88d2905d749a2811c9ddd72f9ec9aab8f5a55da00a1625a6a6c664`
+Reviewed implementation diff bytes: `21029`
+Diff hash basis: `git diff --binary origin/main...a1809b06f4ec37866645b6183a973697c26dfae1 -- .`
+Base: `origin/main` / `beeb2f14318577177b69d1699fe0aef8078c7fe7`
+Source finding: Bureau live-register event `27`.
+
+## Evidence boundary
+
+This file records a critical review of the implementation diff above. It is committed separately and is not part of the reviewed implementation hash. A final merge gate must still verify the live PR head and diff, mergeability, current CI, comments and reviews.
+
+## Reviewed files
+
+- `README.md`
+- `docs/adr/001-secure-fs-navigation.md`
+- `docs/service-api.md`
+- `merger/lenskit/adapters/filesystem.py`
+- `merger/lenskit/adapters/security.py`
+- `merger/lenskit/cli/rlens.py`
+- `merger/lenskit/service/app.py`
+- `merger/lenskit/tests/test_atlas_system_flow.py`
+- `tests/test_security_root_policy.py`
+
+Coverage: all implementation-diff files reviewed.
+
+## Verdict
+
+**PASS for the reviewed implementation diff, conditional on independent review and live GitHub CI.**
+
+## Findings and resolutions
+
+### Correctness
+
+- Loopback is a transport boundary, not authorization: other local processes or users can connect to a loopback service.
+- Hub and a configured merges directory remain ordinary, explicit operator roots.
+- The broad `system` preset and filesystem root are now granted only for loopback plus the bearer token actually enforced by `verify_token`.
+- The broad capability has explicit state (`sensitive_fs_access`); an overlapping allowlist root cannot silently mint the `system` alias.
+- Reinitialization resets both the allowlist and the sensitive capability before rebuilding current configuration.
+
+### Security
+
+- Found and closed an additional bypass beyond the original live-register finding: Atlas `root_kind=abs_path` previously returned arbitrary absolute paths without calling the central allowlist validator.
+- Absolute Atlas paths now pass through `SecurityConfig.validate_path`; path denials propagate to the existing HTTP 403 handler.
+- `RLENS_FS_TOKEN_SECRET` remains only a navigation-token signing secret and cannot activate sensitive browsing.
+- Non-loopback bindings do not receive the broad capability even when bearer authentication is configured.
+- Explicit Hub or merges roots remain authoritative by design. An operator can still configure a broad Hub; this is an explicit configuration decision, not an implicit `system` capability.
+
+### Regression risk
+
+- Unauthenticated loopback use can still inspect the configured Hub and merges roots, preserving the existing low-friction local workflow.
+- Authenticated loopback use retains Home and full-root operation.
+- The standalone Atlas CLI remains an explicit local filesystem operation; the new restriction applies to the service/API boundary.
+- The `system` omission is handled as an expected policy outcome rather than an unhandled security exception.
+
+### Tests and validation
+
+- Focused policy suite: `14 passed`.
+- Focused Atlas/Auth suite: `21 passed`.
+- Broad service/API/Atlas regression suite: `163 passed, 1 skipped`.
+- Ruff CI ratchet scope passed on every changed Python file.
+- Changed Python files passed `py_compile`.
+- `git diff --check` passed.
+- The existing `test_create_atlas_system_root` performs a real scan of the operator Home directory and is unsuitable as a bounded local check; it was not used as local evidence. GitHub `pytest-full` remains the authoritative full-suite gate.
+
+### Integration
+
+- Documentation now distinguishes explicit Hub/Merges roots, the broad `system` capability, service API rules and standalone CLI behavior.
+- Existing service mapping tests now explicitly enable and bypass auth only within their mapping-only fixture.
+- No runtime restart, deployment, snapshot refresh or merge authorization is performed by this patch.
+
+## Remaining observations
+
+- The local repo-wide Ruff invocation can scan `.git` metadata when a remote ref name ends in `.py`, because `ruff-ci.toml` replaces the default exclusions. This is unrelated to the product change and requires a separate parity task.
+- Credential-redacting access logging remains a separate Bureau candidate; this patch does not change the access-log decision from PR #948.
+
+## Non-claims
+
+This review does not establish complete local-host isolation, correctness of arbitrary operator-selected Hub/Merges roots, absence of all filesystem side channels, full-suite success, runtime deployment correctness, review completeness, regression absence or merge readiness by itself.

--- a/docs/proofs/rlens-sensitive-filesystem-access-v1.self-review.md
+++ b/docs/proofs/rlens-sensitive-filesystem-access-v1.self-review.md
@@ -1,10 +1,10 @@
 # rLens Sensitive Filesystem Access v1 Self-Review
 
 PR: #949
-Reviewed implementation head SHA: `9bf1358febd7d0e146a12080ab8c8c1afc854510`
-Reviewed implementation diff SHA256: `63e83a4399ca97f5f5efdbdcaefe7b7516dc6f412cd02d1c20449f0b6cc76af8`
-Reviewed implementation diff bytes: `23925`
-Diff hash basis: `git diff --binary origin/main...9bf1358febd7d0e146a12080ab8c8c1afc854510 -- . ':(exclude)docs/proofs/rlens-sensitive-filesystem-access-v1.self-review.md'`
+Reviewed implementation head SHA: `a2bcb176b0f12865562f74c2cc3a627a622df80e`
+Reviewed implementation diff SHA256: `c199feadc6d2dff693d659389bdfe7f7ea0353c7bccaecddcad3bb822071ba26`
+Reviewed implementation diff bytes: `24015`
+Diff hash basis: `git diff --binary origin/main...a2bcb176b0f12865562f74c2cc3a627a622df80e -- . ':(exclude)docs/proofs/rlens-sensitive-filesystem-access-v1.self-review.md' ':(exclude)docs/proofs/rlens-sensitive-filesystem-access-v1.external-review.json'`
 Base: `origin/main` / `beeb2f14318577177b69d1699fe0aef8078c7fe7`
 Source finding: Bureau live-register event `27`.
 
@@ -69,10 +69,11 @@ Coverage: all implementation-diff files reviewed.
 ### Independent review
 
 - Codex CLI `0.142.2`, model `gpt-5.5`, reasoning effort `xhigh`, reviewed an isolated immutable packet without tools or repository access.
-- Reviewed implementation head: `9bf1358febd7d0e146a12080ab8c8c1afc854510`.
-- Reviewed implementation diff SHA256: `63e83a4399ca97f5f5efdbdcaefe7b7516dc6f412cd02d1c20449f0b6cc76af8`.
-- Verdict: **PASS** with no critical, high or medium finding.
-- One low finding remains: authenticated startup can fail in unusual environments if the service user Home cannot be resolved or registered. This does not reopen the authorization boundary and is registered as a separate Bureau candidate.
+- Reviewed implementation head: `a2bcb176b0f12865562f74c2cc3a627a622df80e`.
+- Reviewed implementation diff SHA256: `c199feadc6d2dff693d659389bdfe7f7ea0353c7bccaecddcad3bb822071ba26`.
+- Final verdict: **PASS** with no critical, high, medium or low finding.
+- A low compatibility observation from an earlier review iteration about unusual Home-resolution failures remains conservatively tracked as Bureau event `33`; it was not repeated as a finding in the final review.
+- The current platform code-quality comment was resolved by documenting why failure of the optional `system` root must not hide explicit Hub/Merges roots.
 - Claude CLI was unavailable for review because the authenticated subscription session quota returned HTTP 429 before any review tokens were used; it is not counted as review evidence.
 
 ### Integration

--- a/docs/service-api.md
+++ b/docs/service-api.md
@@ -18,7 +18,7 @@ The server guarantees:
 ## File System
 
 ### `/api/fs/roots`
-Returns a list of allowed root entry points.
+Returns a list of allowed root entry points. `hub` and a configured `merges` root are ordinary service roots. The `system` root (the service user's home directory) is returned only when the service runs on loopback with bearer authentication enabled; merely configuring an overlapping Hub or merges root does not mint the `system` alias.
 
 **Contract:**
 Each entry in the `roots` list guarantees the following fields:

--- a/merger/lenskit/adapters/filesystem.py
+++ b/merger/lenskit/adapters/filesystem.py
@@ -29,17 +29,17 @@ def list_allowed_roots(hub: Optional[Path], merges_dir: Optional[Path]) -> List[
         roots.append({"id": "hub", "path": str(hub.resolve())})
     if merges_dir:
         roots.append({"id": "merges", "path": str(merges_dir.resolve())})
-    try:
-        if not sec.sensitive_fs_access:
-            raise AccessDeniedError("Sensitive filesystem access is not enabled")
-        # The "system" preset maps to the service user's home directory.
-        # It is present only when init_service granted sensitive filesystem
-        # access (loopback + bearer auth). Policy denial is an expected outcome.
-        sys_root = Path.home().resolve()
-        sec.validate_path(sys_root)
-        roots.append({"id": "system", "path": str(sys_root)})
-    except (SecurityViolationError, OSError, RuntimeError):
-        pass
+    if sec.sensitive_fs_access:
+        try:
+            # The "system" preset maps to the service user's home directory.
+            # It is present only when init_service granted sensitive filesystem
+            # access (loopback + bearer auth). Validation failures omit only
+            # this optional root; ordinary Hub/Merges roots remain available.
+            sys_root = Path.home().resolve()
+            sec.validate_path(sys_root)
+            roots.append({"id": "system", "path": str(sys_root)})
+        except (SecurityViolationError, OSError, RuntimeError):
+            pass
     return roots
 
 def _b64url(data: bytes) -> str:

--- a/merger/lenskit/adapters/filesystem.py
+++ b/merger/lenskit/adapters/filesystem.py
@@ -39,6 +39,7 @@ def list_allowed_roots(hub: Optional[Path], merges_dir: Optional[Path]) -> List[
             sec.validate_path(sys_root)
             roots.append({"id": "system", "path": str(sys_root)})
         except (SecurityViolationError, OSError, RuntimeError):
+            # `system` is optional; its failure must not hide explicit Hub/Merges roots.
             pass
     return roots
 

--- a/merger/lenskit/adapters/filesystem.py
+++ b/merger/lenskit/adapters/filesystem.py
@@ -12,7 +12,11 @@ from fastapi import HTTPException
 from dataclasses import dataclass
 import os
 
-from .security import get_security_config
+from .security import (
+    AccessDeniedError,
+    SecurityViolationError,
+    get_security_config,
+)
 
 @dataclass(frozen=True)
 class TrustedPath:
@@ -26,11 +30,15 @@ def list_allowed_roots(hub: Optional[Path], merges_dir: Optional[Path]) -> List[
     if merges_dir:
         roots.append({"id": "merges", "path": str(merges_dir.resolve())})
     try:
-        # System root maps to User Home (e.g. /home/alex)
+        if not sec.sensitive_fs_access:
+            raise AccessDeniedError("Sensitive filesystem access is not enabled")
+        # The "system" preset maps to the service user's home directory.
+        # It is present only when init_service granted sensitive filesystem
+        # access (loopback + bearer auth). Policy denial is an expected outcome.
         sys_root = Path.home().resolve()
         sec.validate_path(sys_root)
         roots.append({"id": "system", "path": str(sys_root)})
-    except HTTPException:
+    except (SecurityViolationError, OSError, RuntimeError):
         pass
     return roots
 
@@ -109,6 +117,8 @@ def resolve_fs_path(hub: Optional[Path], merges_dir: Optional[Path], root_id: Op
             raise HTTPException(status_code=400, detail="Unknown root id")
 
         sec = get_security_config()
+        if root_id == "system" and not sec.sensitive_fs_access:
+            raise AccessDeniedError("System root requires loopback plus bearer authentication")
         # validate base
         base_resolved = sec.validate_path(base.resolve())
 

--- a/merger/lenskit/adapters/security.py
+++ b/merger/lenskit/adapters/security.py
@@ -23,9 +23,14 @@ class SecurityConfig:
     # Absolute, normalized roots only. Anything else is rejected at registration.
     allowlist_roots: List[Path] = field(default_factory=list)
     token: str | None = None
+    sensitive_fs_access: bool = False
 
     def set_token(self, token: Optional[str]):
         self.token = token
+
+    def set_sensitive_fs_access(self, enabled: bool) -> None:
+        """Record whether broad system/home browsing was explicitly granted."""
+        self.sensitive_fs_access = bool(enabled)
 
     def add_allowlist_root(self, path: Path) -> None:
         """

--- a/merger/lenskit/cli/rlens.py
+++ b/merger/lenskit/cli/rlens.py
@@ -136,7 +136,13 @@ def main():
         sys.exit(1)
 
     if not _is_loopback_host(args.host):
-        print("[rlens] Notice: Root browsing will be refused by policy (non-loopback host).", file=sys.stderr)
+        print("[rlens] Notice: Home and root browsing will be refused by policy (non-loopback host).", file=sys.stderr)
+    elif not token:
+        print(
+            "[rlens] Notice: Home and root browsing are disabled without bearer authentication; "
+            "hub and merges remain available.",
+            file=sys.stderr,
+        )
 
     # 4. Initialize Service
     init_service(

--- a/merger/lenskit/service/app.py
+++ b/merger/lenskit/service/app.py
@@ -284,6 +284,7 @@ def init_service(hub_path: Path, token: Optional[str] = None, host: str = "127.0
     sec = get_security_config()
     sec.allowlist_roots.clear()
     sec.set_token(token)
+    sec.set_sensitive_fs_access(False)
 
     # Allowlist the Hub
     sec.add_allowlist_root(hub_path)
@@ -291,37 +292,24 @@ def init_service(hub_path: Path, token: Optional[str] = None, host: str = "127.0
     if merges_dir:
         sec.add_allowlist_root(merges_dir)
 
-    # Allow System Root (Home) for Atlas
-    # "System" root maps to user home (e.g. /home/alex), not /
-    try:
-        sec.add_allowlist_root(Path.home().resolve())
-    except Exception as e:
-        logger.debug("Could not allow system root: %s", e, exc_info=True)
-
-    # Root Access: enabled by default on loopback with auth.
-    # Gate strictly on the bearer token that verify_token actually enforces
-    # (sec.token), so the invariant "root allowlisted ⟹ auth active" always
-    # holds. Env secrets like RLENS_FS_TOKEN_SECRET sign FS download tokens but
-    # do NOT enable bearer auth, so they must not, on their own, widen the jail.
+    # Sensitive filesystem access is available only on loopback with the
+    # bearer token that verify_token actually enforces. Loopback alone is not
+    # an authorization boundary: other local processes or users can connect.
+    # RLENS_FS_TOKEN_SECRET signs navigation tokens but is not request auth.
     is_loopback = _is_loopback_host(host)
     has_token = bool(sec.token)
     root = Path("/").resolve()
 
     if is_loopback and has_token:
-        if root not in getattr(sec, "allowlist_roots", []):
-            logger.warning("Root allowlisted (loopback + auth).")
-            sec.add_allowlist_root(root)
+        sec.set_sensitive_fs_access(True)
+        sec.add_allowlist_root(Path.home().resolve())
+        sec.add_allowlist_root(root)
+        logger.warning("Sensitive filesystem browsing enabled (home + root; loopback + auth).")
     else:
-        # init_service can be called repeatedly in-process. Remove a root grant
-        # left by an earlier authenticated loopback initialization so the
-        # allowlist cannot outlive the authorization condition that created it.
-        roots = getattr(sec, "allowlist_roots", None)
-        if isinstance(roots, list):
-            roots[:] = [allowed for allowed in roots if allowed != root]
         logger.warning(
-            "Root browsing refused (loopback=%s, has_token=%s).",
+            "Sensitive filesystem browsing refused (home + root; loopback=%s, has_token=%s).",
             is_loopback,
-            has_token
+            has_token,
         )
 
     # Apply CORS based on host
@@ -1600,14 +1588,20 @@ def resolve_atlas_root(request: AtlasRequest, hub_dir: Path, merges_dir: Optiona
             if not p.is_absolute():
                 raise ValueError("Path must be absolute")
 
-            # Return the validated absolute path directly.
-            # We explicitly avoid p.resolve() here to maintain the exact user input structure,
-            # avoiding unnecessary symlink expansions that alter semantic intent.
-            return ResolvedAtlasRoot(scan_root=p, root_kind="abs_path", is_internal_abs_path=True)
         except ValueError as e:
             raise HTTPException(status_code=400, detail=f"Invalid absolute path: {e}")
-        except Exception:
+        except (TypeError, OSError):
             raise HTTPException(status_code=400, detail="Invalid absolute path for root_kind='abs_path'")
+
+        # Absolute-path mode is not an authorization bypass. Canonicalize and
+        # enforce the same allowlist used by presets and signed navigation
+        # tokens. AccessDeniedError intentionally propagates to the 403 handler.
+        validated = get_security_config().validate_path(p)
+        return ResolvedAtlasRoot(
+            scan_root=validated,
+            root_kind="abs_path",
+            is_internal_abs_path=True,
+        )
 
     else:
         raise HTTPException(status_code=400, detail=f"Invalid root_kind: {root_kind}")

--- a/merger/lenskit/tests/test_atlas_system_flow.py
+++ b/merger/lenskit/tests/test_atlas_system_flow.py
@@ -2,7 +2,7 @@ import pytest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 from fastapi.testclient import TestClient
-from merger.lenskit.service.app import app, init_service, state
+from merger.lenskit.service.app import app, init_service, state, verify_token
 
 client = TestClient(app)
 
@@ -14,7 +14,8 @@ def mock_state():
     mock_merges = Path("/tmp/mock_merges")
     mock_merges.mkdir(parents=True, exist_ok=True)
 
-    init_service(hub_path=mock_hub, merges_dir=mock_merges)
+    init_service(hub_path=mock_hub, merges_dir=mock_merges, token="test-token")
+    app.dependency_overrides[verify_token] = lambda: True
 
     # Mock Security Config
     with patch("merger.lenskit.service.app.get_security_config") as mock_get_sec:
@@ -25,6 +26,7 @@ def mock_state():
         yield state
 
     # Cleanup
+    app.dependency_overrides.pop(verify_token, None)
     import shutil
     shutil.rmtree(mock_hub, ignore_errors=True)
     shutil.rmtree(mock_merges, ignore_errors=True)

--- a/tests/test_security_root_policy.py
+++ b/tests/test_security_root_policy.py
@@ -52,10 +52,12 @@ setup_mocks()
 # Ensure repo root is in path
 sys.path.insert(0, os.getcwd())
 
-from merger.lenskit.service.app import init_service, resolve_atlas_root
+from merger.lenskit.service.app import app, init_service, resolve_atlas_root
 from merger.lenskit.service.models import AtlasRequest
 from merger.lenskit.adapters.security import get_security_config, AccessDeniedError
 from merger.lenskit.adapters.filesystem import list_allowed_roots, resolve_fs_path
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
 
 def test_security_config_allowlist_invariant(tmp_path):
     """
@@ -157,6 +159,86 @@ def test_atlas_abs_path_cannot_bypass_sensitive_root_policy(tmp_path):
 
     with pytest.raises(AccessDeniedError):
         resolve_atlas_root(request, hub, None)
+
+
+def test_atlas_abs_path_rejects_symlink_escape_from_hub(tmp_path):
+    hub = tmp_path / "hub"
+    outside = tmp_path / "outside"
+    hub.mkdir()
+    outside.mkdir()
+    escape = hub / "escape"
+    escape.symlink_to(outside, target_is_directory=True)
+    init_service(hub, host="127.0.0.1", token=None)
+
+    request = AtlasRequest(root_kind="abs_path", root_value=str(escape))
+
+    with pytest.raises(AccessDeniedError):
+        resolve_atlas_root(request, hub, None)
+
+
+def test_atlas_abs_path_allows_symlink_that_stays_inside_hub(tmp_path):
+    hub = tmp_path / "hub"
+    target = hub / "target"
+    target.mkdir(parents=True)
+    alias = hub / "alias"
+    alias.symlink_to(target, target_is_directory=True)
+    init_service(hub, host="127.0.0.1", token=None)
+
+    request = AtlasRequest(root_kind="abs_path", root_value=str(alias))
+    resolved = resolve_atlas_root(request, hub, None)
+
+    assert resolved.scan_root == target.resolve()
+
+
+def test_atlas_abs_path_rejects_parent_components_before_resolution(tmp_path):
+    hub = tmp_path / "hub"
+    outside = tmp_path / "outside"
+    hub.mkdir()
+    outside.mkdir()
+    init_service(hub, host="127.0.0.1", token=None)
+
+    request = AtlasRequest(
+        root_kind="abs_path",
+        root_value=str(hub / ".." / outside.name),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        resolve_atlas_root(request, hub, None)
+
+    assert exc_info.value.status_code == 400
+    assert "Path traversal not allowed" in exc_info.value.detail
+
+
+def test_fs_roots_api_omits_system_without_auth(tmp_path, monkeypatch):
+    hub = tmp_path / "hub"
+    hub.mkdir()
+    monkeypatch.setenv("RLENS_FS_TOKEN_SECRET", "synthetic-fs-signing-secret")
+    init_service(hub, host="127.0.0.1", token=None)
+
+    with TestClient(app) as client:
+        response = client.get("/api/fs/roots")
+
+    assert response.status_code == 200
+    roots = response.json()["roots"]
+    assert {entry["id"] for entry in roots} == {"hub"}
+    assert all(entry["token"] for entry in roots)
+
+
+def test_atlas_api_rejects_home_abs_path_without_auth(tmp_path):
+    hub = tmp_path / "hub"
+    hub.mkdir()
+    init_service(hub, host="127.0.0.1", token=None)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/atlas",
+            json={
+                "root_kind": "abs_path",
+                "root_value": str(Path.home().resolve()),
+            },
+        )
+
+    assert response.status_code == 403
 
 
 def test_atlas_abs_path_within_hub_remains_available_without_auth(tmp_path):

--- a/tests/test_security_root_policy.py
+++ b/tests/test_security_root_policy.py
@@ -52,8 +52,10 @@ setup_mocks()
 # Ensure repo root is in path
 sys.path.insert(0, os.getcwd())
 
-from merger.lenskit.service.app import init_service
-from merger.lenskit.adapters.security import get_security_config
+from merger.lenskit.service.app import init_service, resolve_atlas_root
+from merger.lenskit.service.models import AtlasRequest
+from merger.lenskit.adapters.security import get_security_config, AccessDeniedError
+from merger.lenskit.adapters.filesystem import list_allowed_roots, resolve_fs_path
 
 def test_security_config_allowlist_invariant(tmp_path):
     """
@@ -99,7 +101,10 @@ def test_init_service_loopback_with_token_allows_root(monkeypatch, tmp_path):
     init_service(hub, host="127.0.0.1", token="secret")
 
     root_path = Path("/").resolve()
+    home_path = Path.home().resolve()
     assert root_path in sec.allowlist_roots
+    assert home_path in sec.allowlist_roots
+    assert sec.sensitive_fs_access is True
 
 def test_init_service_loopback_without_token_refuses_root(monkeypatch, tmp_path):
     """
@@ -117,7 +122,54 @@ def test_init_service_loopback_without_token_refuses_root(monkeypatch, tmp_path)
     init_service(hub, host="127.0.0.1", token=None)
 
     root_path = Path("/").resolve()
+    home_path = Path.home().resolve()
     assert root_path not in sec.allowlist_roots
+    assert home_path not in sec.allowlist_roots
+    assert sec.sensitive_fs_access is False
+
+    roots = list_allowed_roots(hub, None)
+    assert {entry["id"] for entry in roots} == {"hub"}
+    with pytest.raises(AccessDeniedError):
+        resolve_fs_path(hub=hub, merges_dir=None, root_id="system", rel_path="")
+
+def test_system_alias_requires_capability_not_only_path_allowlist(tmp_path):
+    hub = tmp_path / "hub"
+    hub.mkdir()
+    init_service(hub, host="127.0.0.1", token=None)
+    sec = get_security_config()
+
+    # Simulate an explicitly configured root that happens to include Home.
+    # That must not silently mint the broader `system` capability.
+    sec.add_allowlist_root(Path.home().resolve())
+
+    roots = list_allowed_roots(hub, None)
+    assert "system" not in {entry["id"] for entry in roots}
+    with pytest.raises(AccessDeniedError):
+        resolve_fs_path(hub=hub, merges_dir=None, root_id="system", rel_path="")
+
+
+def test_atlas_abs_path_cannot_bypass_sensitive_root_policy(tmp_path):
+    hub = tmp_path / "hub"
+    hub.mkdir()
+    init_service(hub, host="127.0.0.1", token=None)
+
+    request = AtlasRequest(root_kind="abs_path", root_value=str(Path.home().resolve()))
+
+    with pytest.raises(AccessDeniedError):
+        resolve_atlas_root(request, hub, None)
+
+
+def test_atlas_abs_path_within_hub_remains_available_without_auth(tmp_path):
+    hub = tmp_path / "hub"
+    child = hub / "project"
+    child.mkdir(parents=True)
+    init_service(hub, host="127.0.0.1", token=None)
+
+    request = AtlasRequest(root_kind="abs_path", root_value=str(child))
+    resolved = resolve_atlas_root(request, hub, None)
+
+    assert resolved.scan_root == child.resolve()
+
 
 def test_init_service_non_loopback_with_token_refuses_root(monkeypatch, tmp_path):
     """
@@ -131,7 +183,9 @@ def test_init_service_non_loopback_with_token_refuses_root(monkeypatch, tmp_path
     init_service(hub, host="192.168.1.1", token="secret")
 
     root_path = Path("/").resolve()
+    home_path = Path.home().resolve()
     assert root_path not in sec.allowlist_roots
+    assert home_path not in sec.allowlist_roots
 
 def test_init_service_replaces_previous_allowlist_configuration(tmp_path):
     """Reinitialization must revoke roots belonging to the previous hub."""
@@ -162,8 +216,8 @@ def test_init_service_removes_stale_root_when_auth_is_disabled(tmp_path):
 
     init_service(hub, host="127.0.0.1", token=None)
     assert Path("/").resolve() not in sec.allowlist_roots
+    assert Path.home().resolve() not in sec.allowlist_roots
     assert hub.resolve() in sec.allowlist_roots
-    assert Path.home().resolve() in sec.allowlist_roots
 
 
 def test_init_service_removes_stale_root_when_binding_becomes_non_loopback(tmp_path):
@@ -200,7 +254,8 @@ def test_init_service_fs_token_secret_without_bearer_refuses_root(monkeypatch, t
 
     root_path = Path("/").resolve()
     assert root_path not in sec.allowlist_roots
-    # Auth is not active (no bearer token), so root must remain refused.
+    assert Path.home().resolve() not in sec.allowlist_roots
+    # Auth is not active (no bearer token), so sensitive roots remain refused.
     assert not sec.token
 
 def test_static_source_check_app_py():
@@ -226,14 +281,16 @@ def test_static_source_check_rlens_cli():
     assert "RLENS_OPERATOR_MODE" not in content
 
     # Notice for non-loopback should be present
-    assert "Root browsing will be refused by policy (non-loopback host)" in content
+    assert "Home and root browsing will be refused by policy (non-loopback host)" in content
+    assert "Home and root browsing are disabled without bearer authentication" in content
 
 def test_static_source_check_adr():
     adr_path = Path("docs/adr/001-secure-fs-navigation.md")
     content = adr_path.read_text(encoding="utf-8")
 
-    assert "Loopback-Scoped Root Access" in content
-    assert "enabled by default only when the service is bound to a loopback interface" in content
-    assert "optionally including system root on loopback + auth" in content
+    assert "Loopback- and Auth-Scoped Sensitive Access" in content
+    assert "home directory (`system`) or the filesystem root (`/`)" in content
+    assert "only the explicitly configured Hub and merges directory are allowlisted" in content
     assert "does not activate bearer authentication" in content
-    assert "cannot authorize root browsing" in content
+    assert "cannot authorize sensitive filesystem browsing" in content
+    assert "other local processes or users" in content


### PR DESCRIPTION
## Summary

Closes Bureau live-register finding 27 by making broad service filesystem access an explicit capability.

- `system` (the service user's Home) and `/` require loopback plus enforced bearer authentication
- Hub and configured merges roots remain available as explicit operator-selected roots
- Atlas `root_kind=abs_path` now passes through the central two-stage allowlist validator instead of bypassing it
- an overlapping allowlist root cannot silently mint the separate `system` alias
- service notices and filesystem documentation describe the actual boundary

## Security boundary

Loopback is not treated as authorization because other local processes or users can connect. `RLENS_FS_TOKEN_SECRET` signs navigation tokens only and does not enable the broad capability. Non-loopback bindings never receive `system` or `/`, even with a bearer token.

An operator may still explicitly configure a broad Hub or merges root. That is an intentional configuration decision and remains distinguishable from the implicit `system` capability.

## Verification

- focused policy and real API boundary tests: 19 passed
- broad service/API/Atlas regression: 168 passed, 1 skipped
- explicit proofs: denied symlink escape, allowed internal symlink, early `..` rejection, unauthenticated `/api/fs/roots`, unauthenticated Atlas Home denial
- changed-file Ruff CI scope: passed
- changed-file py_compile: passed
- git diff --check: passed

The existing `test_create_atlas_system_root` performs a real scan of the operator Home directory and was not used as a bounded local proof. GitHub `pytest-full` is required before merge.

## Review evidence

- reviewed implementation head: `a2bcb176b0f12865562f74c2cc3a627a622df80e`
- reviewed implementation diff SHA-256: `c199feadc6d2dff693d659389bdfe7f7ea0353c7bccaecddcad3bb822071ba26`
- reviewed implementation diff bytes: `24015`
- self-review: `docs/proofs/rlens-sensitive-filesystem-access-v1.self-review.md`
- independent review: `docs/proofs/rlens-sensitive-filesystem-access-v1.external-review.json`
- independent verdict: PASS, no findings

A low compatibility observation from an earlier review iteration about unusual Home-resolution failures remains conservatively tracked as Bureau event 33; the final review did not repeat it as a finding.

Claude CLI was unavailable because the authenticated subscription session quota returned HTTP 429 before any review tokens were used. The successful independent evidence comes from an isolated Codex CLI diff review.

## Follow-ups

- Bureau event 33: define best-effort versus explicit startup failure for an unresolvable Home preset
- Bureau event 35: restore local Ruff exclusion for `.git` metadata while preserving the CI ratchet
- platform code-quality comment resolved: the optional `system` suppression now contains an explicit rationale
- existing Bureau candidate: credential-redacting HTTP access logging

## Non-claims

This PR does not establish local-host isolation, validate arbitrary operator-selected Hub/Merges roots, deploy or restart the service, or replace the separate credential-redacting access-log follow-up.
