### PR TITLE
fix(service): define Home preset startup degradation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Pseudo-filesystems and volatile paths (`/proc`, `/sys`, `/dev`, `/run`, etc.) ar
 
 **Atlas Root Model:**
 Atlas employs a formalized root model internally, permitting execution against different types of targets without implicitly falling back or hiding behaviors. The `root_kind` in API requests must be one of:
-* `preset`: Used to refer to predefined, trusted directories like `hub`, `merges`, or `system` (the service user's home directory). The `system` preset is available only on loopback with bearer authentication.
+* `preset`: Used to refer to predefined, trusted directories like `hub`, `merges`, or `system` (the service user's home directory). The `system` preset requires loopback, configured Bearer authentication, and a Home path resolved successfully during startup. If Home is unavailable, the service starts in authenticated root-only mode, omits `system` from `/api/fs/roots`, and keeps explicit filesystem-root access available.
 * `token`: Used with an opaque, server-signed token, primarily meant for file pickers and external integrations.
 * `abs_path`: Explicitly targets an absolute file system path (e.g., `/home/user/project`). This is an explicit internal mode. Traversal exploits (`..`) or relative paths are strictly rejected. Note that the WebUI catches invalid manual path inputs (like "home" instead of "/home") before creating an API request, preventing unnecessary Bad Requests.
 

--- a/docs/adr/001-secure-fs-navigation.md
+++ b/docs/adr/001-secure-fs-navigation.md
@@ -17,6 +17,8 @@ Browsing the service user's home directory (`system`) or the filesystem root (`/
 
 Without that combined condition, only the explicitly configured Hub and merges directory are allowlisted. Those operator-selected roots remain authoritative even if they are broad; they do not implicitly mint the separate `system` preset. Non-loopback bindings never receive the `system` or `/` capability, even when bearer authentication is present.
 
+Within authenticated loopback mode, filesystem root (`/`) is the core broad capability and the `system` Home preset is optional convenience state. The service resolves Home once during startup and stores that canonical path. If Home resolution or allowlist registration fails, startup continues in a logged **root-only** mode: `/` remains authorized, `system` is omitted from root discovery, and stale direct `system` requests return `503`. If the core filesystem-root grant itself cannot be initialized, startup fails closed with an explicit error. Later requests never recompute Home, avoiding runtime drift from the startup authorization decision.
+
 This ensures:
 - Full operator capability in authenticated local deployments
 - No unauthenticated exposure of the service user's home directory to other local clients
@@ -37,7 +39,8 @@ We introduced a `TrustedPath` dataclass in the backend.
 This creates a visible type boundary between "untrusted user input" and "safe filesystem operations", aiding both code review and static analysis.
 
 ## Consequences
-*   **Positive**: CodeQL "path injection" warnings are resolved by design. Filesystem access is limited to authorized roots; the `system` home preset and `/` require loopback plus bearer authentication.
+*   **Positive**: CodeQL "path injection" warnings are resolved by design. Filesystem access is limited to authorized roots; broad `/` access requires loopback plus configured Bearer authentication, and `system` additionally requires a successfully resolved startup Home.
+*   **Resilience**: An unusual or unavailable service-account Home degrades only the `system` convenience preset; authenticated root browsing and ordinary Hub/Merges operation remain available. Core root-grant failure remains fail-closed.
 *   **Negative**: "Quick and dirty" API calls using manual path strings are no longer possible; clients must obtain a valid token first (e.g., via `/api/fs/roots`).
 *   **Maintenance**: Filesystem navigation tokens require `RLENS_FS_TOKEN_SECRET` (or `RLENS_TOKEN` fallback) to be managed securely. This signing secret is not bearer authorization.
 

--- a/docs/proofs/rlens-home-preset-startup-policy-v1-proof.md
+++ b/docs/proofs/rlens-home-preset-startup-policy-v1-proof.md
@@ -34,6 +34,7 @@ The successful startup Home path is stored as `SecurityConfig.home_preset_root`.
 - `home_preset_root` may be activated only after the same canonical path is present in `allowlist_roots`.
 - A previously cached Home preset is cleared whenever sensitive access is disabled or the service is reinitialized without authorization.
 - Home failure cannot leave a stale alias active.
+- A later I/O or runtime failure while validating the optional cached Home omits only `system`; explicit Hub/Merges roots remain discoverable.
 - Root-only degradation does not widen authorization: it occurs only after loopback-plus-auth was already established and root itself was successfully allowlisted.
 - Signed filesystem navigation secrets remain distinct from Bearer request authentication.
 
@@ -45,7 +46,7 @@ Focused policy validation:
 python3 -m pytest -q tests/test_security_root_policy.py
 ```
 
-Result: `24 passed`.
+Result: `25 passed`.
 
 Adjacent service and Atlas validation:
 
@@ -60,7 +61,7 @@ python3 -m pytest -q \
   merger/lenskit/tests/test_service_startup_reconciliation.py
 ```
 
-Result: `51 passed`, including the final HTTP `503` behavior and root-only Webmaschine export assertion.
+Result: `52 passed`, including HTTP `503`, root-only Webmaschine export, failed-reinitialization revocation and cached-Home I/O fallback assertions.
 
 Additional checks:
 

--- a/docs/proofs/rlens-home-preset-startup-policy-v1-proof.md
+++ b/docs/proofs/rlens-home-preset-startup-policy-v1-proof.md
@@ -1,0 +1,79 @@
+# rLens Home Preset Startup Policy v1 Proof
+
+## Scope
+
+Source: Bureau live-register event `33`.
+
+This slice makes the authenticated Home preset startup behavior explicit. It does not change the loopback-plus-auth authorization prerequisite introduced by PR #949.
+
+## Decision
+
+The authenticated filesystem root (`/`) is the core broad capability. The `system` alias for the service user's Home directory is optional convenience state.
+
+At service initialization:
+
+1. Hub and an explicit merges directory are registered normally.
+2. In loopback-plus-auth mode, filesystem-root registration is mandatory.
+3. Home is resolved once and registered as the optional `system` preset.
+4. If Home resolution or registration fails, startup continues in logged root-only mode.
+5. If filesystem-root initialization fails, startup raises an explicit error and sensitive access remains disabled.
+
+The successful startup Home path is stored as `SecurityConfig.home_preset_root`. Runtime root discovery, direct `system` resolution and Webmaschine export use this stored path rather than recomputing `Path.home()`.
+
+## Observable behavior
+
+| Condition | Broad root | `system` discovery | Direct `system` request | Startup |
+| --- | --- | --- | --- | --- |
+| loopback + auth + Home available | enabled | present | succeeds | succeeds |
+| loopback + auth + Home unavailable | enabled | omitted | `503 Service Unavailable` | succeeds with warning |
+| loopback + auth + root grant failure | disabled | omitted | unavailable | fails closed with explicit `RuntimeError` |
+| no auth or non-loopback | disabled | omitted | authorization denied | succeeds with Hub/Merges only |
+
+## Security boundaries
+
+- `home_preset_root` may be activated only after the same canonical path is present in `allowlist_roots`.
+- A previously cached Home preset is cleared whenever sensitive access is disabled or the service is reinitialized without authorization.
+- Home failure cannot leave a stale alias active.
+- Root-only degradation does not widen authorization: it occurs only after loopback-plus-auth was already established and root itself was successfully allowlisted.
+- Signed filesystem navigation secrets remain distinct from Bearer request authentication.
+
+## Validation
+
+Focused policy validation:
+
+```bash
+python3 -m pytest -q tests/test_security_root_policy.py
+```
+
+Result: `24 passed`.
+
+Adjacent service and Atlas validation:
+
+```bash
+python3 -m pytest -q \
+  tests/test_security_root_policy.py \
+  merger/lenskit/tests/test_service_hardening.py \
+  merger/lenskit/tests/test_service_artifact_security.py \
+  merger/lenskit/tests/test_atlas_system_flow.py \
+  merger/lenskit/tests/test_atlas_system.py::test_fs_roots_includes_system \
+  merger/lenskit/tests/test_atlas_system.py::test_export_webmaschine_includes_roots \
+  merger/lenskit/tests/test_service_startup_reconciliation.py
+```
+
+Result: `51 passed`, including the final HTTP `503` behavior and root-only Webmaschine export assertion.
+
+Additional checks:
+
+```bash
+ruff check merger/lenskit/adapters/security.py \
+  merger/lenskit/adapters/filesystem.py \
+  merger/lenskit/service/app.py
+ruff check --config ruff-ci.toml tests/test_security_root_policy.py
+git diff --check
+```
+
+All passed.
+
+## Non-claims
+
+This proof does not establish cross-platform equivalence for every filesystem, full-suite sufficiency, runtime correctness outside the tested paths, absence of further filesystem-policy defects, deployment status, or merge readiness. GitHub CI and final PR review remain separate gates.

--- a/docs/proofs/rlens-home-preset-startup-policy-v1.external-review.json
+++ b/docs/proofs/rlens-home-preset-startup-policy-v1.external-review.json
@@ -10,30 +10,49 @@
     "model": "default model; exact identifier not surfaced by print mode",
     "mode": "isolated_diff_packet_no_tools"
   },
-  "reviewed_implementation": {
-    "head_sha": "1f7e79c99a04c04a13a6f9868a5b18742da42a3e",
+  "reviewed_code": {
+    "head_sha": "217e192e9ee6fe4a0c100fa9957864bd3723ccd5",
     "base_sha": "292b9a7d22630e31dc2203be294f20700f39a629",
-    "diff_sha256": "0db2df960fb955326cb66183b56ec20e8171dec59336efeef090c11e63f2ab19",
-    "diff_bytes": 24746
+    "packet_sha256": "da4213a8c0d78e5bf10af2a301e01a8c2d1a033b4885bbb610ccee7791c36e99",
+    "packet_bytes": 51646,
+    "unified_context_lines": 40,
+    "excluded_evidence_files": [
+      "docs/proofs/rlens-home-preset-startup-policy-v1.self-review.md",
+      "docs/proofs/rlens-home-preset-startup-policy-v1.external-review.json"
+    ]
   },
   "verdict": "PASS",
-  "summary": "The implementation successfully separates the broad authenticated root-level capability from the optional `system` preset. Startup resolution of Home prevents runtime drift and gracefully falls back to explicit root-only operation if the user's home directory is unresolvable or unregistered. State is properly synchronized, exceptions are handled explicitly, tests assert all edge cases correctly, and Webmaschine export behavior stays aligned with runtime availability.",
+  "summary": "The diff implements the authenticated Home preset startup policy correctly. State resets, exception handling, capability degradation, and documentation all look solid and correctly preserve invariants without widening authorization domains. Test coverage accurately reflects the edge cases.",
   "findings": [],
   "coverage": [
-    "merger/lenskit/adapters/filesystem.py",
-    "merger/lenskit/adapters/security.py",
-    "merger/lenskit/service/app.py",
-    "tests/test_security_root_policy.py",
-    "docs/adr/001-secure-fs-navigation.md",
-    "docs/proofs/rlens-home-preset-startup-policy-v1-proof.md",
-    "docs/service-api.md"
+    "authorization invariants",
+    "partial initialization",
+    "stale global state across failed reinitialization",
+    "root-only degradation",
+    "cached Home path correctness",
+    "HTTP status semantics",
+    "exception handling including cached-Home I/O failure",
+    "optional error suppression",
+    "Webmaschine export",
+    "tests",
+    "documentation consistency"
   ],
   "residual_risks": [],
-  "excluded_attempts": [
+  "prior_attempts": [
     {
       "tool": "codex-cli",
-      "reason": "usage_limit_before_review_output",
+      "outcome": "usage_limit_before_review_output",
       "counted_as_evidence": false
+    },
+    {
+      "tool": "agy-antigravity-cli",
+      "outcome": "medium_cached_home_io_finding_addressed",
+      "counted_as_final_evidence": false
+    },
+    {
+      "tool": "agy-antigravity-cli",
+      "outcome": "false_positive_stale_state_due_to_insufficient_diff_context",
+      "counted_as_final_evidence": false
     }
   ],
   "does_not_establish": [

--- a/docs/proofs/rlens-home-preset-startup-policy-v1.external-review.json
+++ b/docs/proofs/rlens-home-preset-startup-policy-v1.external-review.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": 1,
+  "kind": "lenskit.external_review",
+  "repository": "heimgewebe/lenskit",
+  "pull_request": null,
+  "reviewer": {
+    "tool": "agy-antigravity-cli",
+    "version": "1.1.1",
+    "provider": "Gemini subscription",
+    "model": "default model; exact identifier not surfaced by print mode",
+    "mode": "isolated_diff_packet_no_tools"
+  },
+  "reviewed_implementation": {
+    "head_sha": "1f7e79c99a04c04a13a6f9868a5b18742da42a3e",
+    "base_sha": "292b9a7d22630e31dc2203be294f20700f39a629",
+    "diff_sha256": "0db2df960fb955326cb66183b56ec20e8171dec59336efeef090c11e63f2ab19",
+    "diff_bytes": 24746
+  },
+  "verdict": "PASS",
+  "summary": "The implementation successfully separates the broad authenticated root-level capability from the optional `system` preset. Startup resolution of Home prevents runtime drift and gracefully falls back to explicit root-only operation if the user's home directory is unresolvable or unregistered. State is properly synchronized, exceptions are handled explicitly, tests assert all edge cases correctly, and Webmaschine export behavior stays aligned with runtime availability.",
+  "findings": [],
+  "coverage": [
+    "merger/lenskit/adapters/filesystem.py",
+    "merger/lenskit/adapters/security.py",
+    "merger/lenskit/service/app.py",
+    "tests/test_security_root_policy.py",
+    "docs/adr/001-secure-fs-navigation.md",
+    "docs/proofs/rlens-home-preset-startup-policy-v1-proof.md",
+    "docs/service-api.md"
+  ],
+  "residual_risks": [],
+  "excluded_attempts": [
+    {
+      "tool": "codex-cli",
+      "reason": "usage_limit_before_review_output",
+      "counted_as_evidence": false
+    }
+  ],
+  "does_not_establish": [
+    "full_test_sufficiency",
+    "deployment_state",
+    "runtime_correctness_on_all_platforms",
+    "merge_authorization"
+  ]
+}

--- a/docs/proofs/rlens-home-preset-startup-policy-v1.external-review.json
+++ b/docs/proofs/rlens-home-preset-startup-policy-v1.external-review.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "kind": "lenskit.external_review",
   "repository": "heimgewebe/lenskit",
-  "pull_request": null,
+  "pull_request": 951,
   "reviewer": {
     "tool": "agy-antigravity-cli",
     "version": "1.1.1",

--- a/docs/proofs/rlens-home-preset-startup-policy-v1.self-review.md
+++ b/docs/proofs/rlens-home-preset-startup-policy-v1.self-review.md
@@ -1,0 +1,71 @@
+# rLens Home Preset Startup Policy v1 Self-Review
+
+PR: pending
+Reviewed implementation head: `1f7e79c99a04c04a13a6f9868a5b18742da42a3e`
+Base: `292b9a7d22630e31dc2203be294f20700f39a629`
+Reviewed implementation diff SHA-256: `0db2df960fb955326cb66183b56ec20e8171dec59336efeef090c11e63f2ab19`
+Reviewed implementation diff bytes: `24746`
+Source: Bureau live-register event `33`.
+
+## Verdict
+
+**PASS**, conditional on an unchanged live PR diff and green GitHub CI.
+
+## Reviewed files
+
+- `README.md`
+- `docs/adr/001-secure-fs-navigation.md`
+- `docs/proofs/rlens-home-preset-startup-policy-v1-proof.md`
+- `docs/service-api.md`
+- `merger/lenskit/adapters/filesystem.py`
+- `merger/lenskit/adapters/security.py`
+- `merger/lenskit/service/app.py`
+- `tests/test_security_root_policy.py`
+
+Coverage: every implementation-diff file reviewed.
+
+## Correctness
+
+- The service resolves Home once during authenticated loopback startup and stores the canonical path in `home_preset_root`.
+- Root discovery, direct `system` resolution and Webmaschine export consume the same stored value; they do not recompute `Path.home()`.
+- A missing Home preset is observable: discovery omits it, stale direct requests return `503`, and startup logs root-only degradation.
+- Successful normal startup retains the prior Home-plus-root behavior.
+
+## Security
+
+- Root-only mode is not an authorization expansion. The filesystem root was already granted only after the existing loopback-plus-Bearer gate; omitting the Home alias removes convenience state from that already broader capability.
+- `home_preset_root` cannot be activated until the same canonical path is in the central allowlist.
+- Home resolution or registration failure clears the candidate before capability activation, preventing a stale or unregistered alias.
+- Core root-registration failure raises explicitly while sensitive access stays disabled.
+- A failed reinitialization revokes the previous hub, Home and root grants before leaving only the new explicit Hub root.
+- `RLENS_FS_TOKEN_SECRET` remains unrelated to Bearer request authorization.
+
+## Regression and integration risk
+
+- Hub/Merges behavior and unauthenticated/non-loopback policy are unchanged.
+- `system` remains a compatibility alias when Home is available.
+- The new `503` distinguishes a configured but temporarily unavailable preset from an unknown root (`400`) and unauthorized sensitive access (`403`).
+- Webmaschine export omits unavailable Home instead of inventing or recomputing it.
+- Atlas explicit absolute-root operation remains available in authenticated root-only mode.
+
+## Validation
+
+- Focused and adjacent policy/service/Atlas suite: `51 passed`.
+- Production-file Ruff default rules: passed.
+- Existing repo-wide Ruff ratchet on the legacy root-policy test: passed.
+- Python byte-compilation: passed.
+- Planning registration ratchet: zero findings and zero control errors.
+- `git diff --check`: passed.
+
+The existing `test_create_atlas_system_root` performs a real scan of the operator Home directory and is intentionally not used as a bounded local proof. GitHub `pytest-full` remains the authoritative full-suite gate.
+
+## Independent review
+
+Gemini through Antigravity CLI reviewed only the immutable diff packet, without repository or tool access. Verdict: **PASS**, no findings.
+
+A separate Codex attempt ended at the quota boundary before producing any review and is not counted as evidence.
+
+## Residual limits
+
+- Local tests exercise POSIX root semantics; GitHub CI supplies the broader suite.
+- The review does not establish deployment state, every platform-specific Home lookup behavior, absence of unrelated defects, or merge authorization by itself.

--- a/docs/proofs/rlens-home-preset-startup-policy-v1.self-review.md
+++ b/docs/proofs/rlens-home-preset-startup-policy-v1.self-review.md
@@ -1,6 +1,6 @@
 # rLens Home Preset Startup Policy v1 Self-Review
 
-PR: pending
+PR: #951
 Reviewed implementation head: `1f7e79c99a04c04a13a6f9868a5b18742da42a3e`
 Base: `292b9a7d22630e31dc2203be294f20700f39a629`
 Reviewed implementation diff SHA-256: `0db2df960fb955326cb66183b56ec20e8171dec59336efeef090c11e63f2ab19`

--- a/docs/proofs/rlens-home-preset-startup-policy-v1.self-review.md
+++ b/docs/proofs/rlens-home-preset-startup-policy-v1.self-review.md
@@ -1,15 +1,16 @@
 # rLens Home Preset Startup Policy v1 Self-Review
 
 PR: #951
-Reviewed implementation head: `1f7e79c99a04c04a13a6f9868a5b18742da42a3e`
+Reviewed code head: `217e192e9ee6fe4a0c100fa9957864bd3723ccd5`
 Base: `292b9a7d22630e31dc2203be294f20700f39a629`
-Reviewed implementation diff SHA-256: `0db2df960fb955326cb66183b56ec20e8171dec59336efeef090c11e63f2ab19`
-Reviewed implementation diff bytes: `24746`
+Reviewed code packet: unified diff with 40 context lines, excluding review-evidence files
+Reviewed packet SHA-256: `da4213a8c0d78e5bf10af2a301e01a8c2d1a033b4885bbb610ccee7791c36e99`
+Reviewed packet bytes: `51646`
 Source: Bureau live-register event `33`.
 
 ## Verdict
 
-**PASS**, conditional on an unchanged live PR diff and green GitHub CI.
+**PASS**, conditional on an unchanged live PR code diff and green GitHub CI.
 
 ## Reviewed files
 
@@ -22,7 +23,7 @@ Source: Bureau live-register event `33`.
 - `merger/lenskit/service/app.py`
 - `tests/test_security_root_policy.py`
 
-Coverage: every implementation-diff file reviewed.
+Coverage: every code/proof file in the reviewed packet.
 
 ## Correctness
 
@@ -37,20 +38,29 @@ Coverage: every implementation-diff file reviewed.
 - `home_preset_root` cannot be activated until the same canonical path is in the central allowlist.
 - Home resolution or registration failure clears the candidate before capability activation, preventing a stale or unregistered alias.
 - Core root-registration failure raises explicitly while sensitive access stays disabled.
-- A failed reinitialization revokes the previous hub, Home and root grants before leaving only the new explicit Hub root.
+- `init_service` clears roots and calls `set_sensitive_fs_access(False)` before any new root registration. A failed reinitialization therefore revokes the previous hub, Home and root grants before leaving only the new explicit Hub root.
 - `RLENS_FS_TOKEN_SECRET` remains unrelated to Bearer request authorization.
 
 ## Regression and integration risk
 
 - Hub/Merges behavior and unauthenticated/non-loopback policy are unchanged.
 - `system` remains a compatibility alias when Home is available.
-- The new `503` distinguishes a configured but temporarily unavailable preset from an unknown root (`400`) and unauthorized sensitive access (`403`).
+- The new `503` distinguishes a configured but unavailable preset from an unknown root (`400`) and unauthorized sensitive access (`403`).
 - Webmaschine export omits unavailable Home instead of inventing or recomputing it.
 - Atlas explicit absolute-root operation remains available in authenticated root-only mode.
+- I/O or runtime failure while validating the optional cached Home preserves explicit Hub/Merges roots.
+
+## Findings and triage
+
+1. GitHub Code Quality reported an empty optional exception handler. Addressed by an explanatory comment and explicit return of existing roots.
+2. Independent review found that cached-Home I/O errors could escape after exception narrowing. Addressed by restoring `(SecurityViolationError, OSError, RuntimeError)` and adding a regression test.
+3. A later standard-context review claimed stale sensitive state after failed reinitialization. This was a false positive caused by the three-line diff context omitting the existing reset immediately above the hunk. The actual code and dedicated failed-reinitialization test prove revocation. The review was repeated with 40 context lines and returned PASS.
+4. A Codex attempt stopped at its usage limit before producing output and is not counted as evidence.
 
 ## Validation
 
-- Focused and adjacent policy/service/Atlas suite: `51 passed`.
+- Focused and adjacent policy/service/Atlas suite: `52 passed`.
+- Focused root-policy suite: `25 passed`.
 - Production-file Ruff default rules: passed.
 - Existing repo-wide Ruff ratchet on the legacy root-policy test: passed.
 - Python byte-compilation: passed.
@@ -61,9 +71,7 @@ The existing `test_create_atlas_system_root` performs a real scan of the operato
 
 ## Independent review
 
-Gemini through Antigravity CLI reviewed only the immutable diff packet, without repository or tool access. Verdict: **PASS**, no findings.
-
-A separate Codex attempt ended at the quota boundary before producing any review and is not counted as evidence.
+Gemini through Antigravity CLI reviewed the immutable 40-context-line packet without repository or tool access. Verdict: **PASS**, no findings.
 
 ## Residual limits
 

--- a/docs/service-api.md
+++ b/docs/service-api.md
@@ -18,7 +18,9 @@ The server guarantees:
 ## File System
 
 ### `/api/fs/roots`
-Returns a list of allowed root entry points. `hub` and a configured `merges` root are ordinary service roots. The `system` root (the service user's home directory) is returned only when the service runs on loopback with bearer authentication enabled; merely configuring an overlapping Hub or merges root does not mint the `system` alias.
+Returns a list of allowed root entry points. `hub` and a configured `merges` root are ordinary service roots. The `system` root (the service user's home directory) is returned only when the service runs on loopback with configured Bearer authentication **and** Home was resolved and registered successfully during startup; merely configuring an overlapping Hub or merges root does not mint the `system` alias.
+
+Home is an optional convenience preset, while authenticated filesystem-root access is the core broad capability. If Home resolution or registration fails, startup continues in explicit root-only mode: `system` is omitted from this response, the startup log records the degradation, and a stale direct request using `root=system` returns `503 Service Unavailable`. Failure to initialize the authenticated filesystem root itself remains fatal and fails startup closed.
 
 **Contract:**
 Each entry in the `roots` list guarantees the following fields:

--- a/merger/lenskit/adapters/filesystem.py
+++ b/merger/lenskit/adapters/filesystem.py
@@ -35,7 +35,7 @@ def list_allowed_roots(hub: Optional[Path], merges_dir: Optional[Path]) -> List[
             # optional preset must not hide explicit Hub/Merges roots.
             sys_root = sec.validate_path(sec.home_preset_root)
             roots.append({"id": "system", "path": str(sys_root)})
-        except SecurityViolationError:
+        except (SecurityViolationError, OSError, RuntimeError):
             # The Home preset is optional; preserve explicit Hub/Merges roots.
             return roots
     return roots

--- a/merger/lenskit/adapters/filesystem.py
+++ b/merger/lenskit/adapters/filesystem.py
@@ -29,17 +29,13 @@ def list_allowed_roots(hub: Optional[Path], merges_dir: Optional[Path]) -> List[
         roots.append({"id": "hub", "path": str(hub.resolve())})
     if merges_dir:
         roots.append({"id": "merges", "path": str(merges_dir.resolve())})
-    if sec.sensitive_fs_access:
+    if sec.sensitive_fs_access and sec.home_preset_root is not None:
         try:
-            # The "system" preset maps to the service user's home directory.
-            # It is present only when init_service granted sensitive filesystem
-            # access (loopback + bearer auth). Validation failures omit only
-            # this optional root; ordinary Hub/Merges roots remain available.
-            sys_root = Path.home().resolve()
-            sec.validate_path(sys_root)
+            # Use the Home path resolved once during service startup. A missing
+            # optional preset must not hide explicit Hub/Merges roots.
+            sys_root = sec.validate_path(sec.home_preset_root)
             roots.append({"id": "system", "path": str(sys_root)})
-        except (SecurityViolationError, OSError, RuntimeError):
-            # `system` is optional; its failure must not hide explicit Hub/Merges roots.
+        except SecurityViolationError:
             pass
     return roots
 
@@ -108,18 +104,25 @@ def resolve_fs_path(hub: Optional[Path], merges_dir: Optional[Path], root_id: Op
         return TrustedPath(resolve_fs_token(token))
 
     if root_id is not None:
-        root_map: Dict[str, Optional[Path]] = {
-            "hub": hub,
-            "merges": merges_dir,
-            "system": Path.home().resolve(),
-        }
-        base = root_map.get(root_id)
-        if base is None:
-            raise HTTPException(status_code=400, detail="Unknown root id")
-
         sec = get_security_config()
-        if root_id == "system" and not sec.sensitive_fs_access:
-            raise AccessDeniedError("System root requires loopback plus bearer authentication")
+        if root_id == "system":
+            if not sec.sensitive_fs_access:
+                raise AccessDeniedError("System root requires loopback plus Bearer <REDACTED>")
+            base = sec.home_preset_root
+            if base is None:
+                raise HTTPException(
+                    status_code=503,
+                    detail="Home preset is unavailable in this service configuration",
+                )
+        else:
+            root_map: Dict[str, Optional[Path]] = {
+                "hub": hub,
+                "merges": merges_dir,
+            }
+            if root_id not in root_map or root_map[root_id] is None:
+                raise HTTPException(status_code=400, detail="Unknown root id")
+            base = root_map[root_id]
+
         # validate base
         base_resolved = sec.validate_path(base.resolve())
 

--- a/merger/lenskit/adapters/filesystem.py
+++ b/merger/lenskit/adapters/filesystem.py
@@ -36,7 +36,8 @@ def list_allowed_roots(hub: Optional[Path], merges_dir: Optional[Path]) -> List[
             sys_root = sec.validate_path(sec.home_preset_root)
             roots.append({"id": "system", "path": str(sys_root)})
         except SecurityViolationError:
-            pass
+            # The Home preset is optional; preserve explicit Hub/Merges roots.
+            return roots
     return roots
 
 def _b64url(data: bytes) -> str:

--- a/merger/lenskit/adapters/security.py
+++ b/merger/lenskit/adapters/security.py
@@ -24,13 +24,29 @@ class SecurityConfig:
     allowlist_roots: List[Path] = field(default_factory=list)
     token: str | None = None
     sensitive_fs_access: bool = False
+    home_preset_root: Optional[Path] = None
 
     def set_token(self, token: Optional[str]):
         self.token = token
 
-    def set_sensitive_fs_access(self, enabled: bool) -> None:
-        """Record whether broad system/home browsing was explicitly granted."""
-        self.sensitive_fs_access = bool(enabled)
+    def set_sensitive_fs_access(
+        self,
+        enabled: bool,
+        *,
+        home_preset_root: Optional[Path] = None,
+    ) -> None:
+        """Record broad access and the optional, startup-resolved Home preset."""
+        enabled = bool(enabled)
+        if not enabled:
+            self.sensitive_fs_access = False
+            self.home_preset_root = None
+            return
+
+        if home_preset_root is not None and home_preset_root not in self.allowlist_roots:
+            raise ValueError("Home preset root must be allowlisted before activation")
+
+        self.sensitive_fs_access = True
+        self.home_preset_root = home_preset_root
 
     def add_allowlist_root(self, path: Path) -> None:
         """

--- a/merger/lenskit/service/app.py
+++ b/merger/lenskit/service/app.py
@@ -298,13 +298,36 @@ def init_service(hub_path: Path, token: Optional[str] = None, host: str = "127.0
     # RLENS_FS_TOKEN_SECRET signs navigation tokens but is not request auth.
     is_loopback = _is_loopback_host(host)
     has_token = bool(sec.token)
-    root = Path("/").resolve()
 
     if is_loopback and has_token:
-        sec.set_sensitive_fs_access(True)
-        sec.add_allowlist_root(Path.home().resolve())
-        sec.add_allowlist_root(root)
-        logger.warning("Sensitive filesystem browsing enabled (home + root; loopback + auth).")
+        try:
+            root = Path("/").resolve()
+            sec.add_allowlist_root(root)
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise RuntimeError(
+                "Authenticated filesystem-root access could not be initialized"
+            ) from exc
+
+        home_root: Optional[Path] = None
+        try:
+            home_root = Path.home().resolve()
+            sec.add_allowlist_root(home_root)
+        except (OSError, RuntimeError, ValueError) as exc:
+            home_root = None
+            logger.warning(
+                "Home preset unavailable; authenticated filesystem-root browsing remains enabled (%s).",
+                type(exc).__name__,
+            )
+
+        sec.set_sensitive_fs_access(True, home_preset_root=home_root)
+        if home_root is None:
+            logger.warning(
+                "Sensitive filesystem browsing enabled (root only; loopback + auth)."
+            )
+        else:
+            logger.warning(
+                "Sensitive filesystem browsing enabled (home + root; loopback + auth)."
+            )
     else:
         logger.warning(
             "Sensitive filesystem browsing refused (home + root; loopback=%s, has_token=%s).",
@@ -2179,13 +2202,14 @@ def export_webmaschine():
         # 3. Machine Definition (machine.json)
         machine_roots = []
         try:
-            # Check if system is allowed/resolved (maps to Home)
-            sys_root = Path.home().resolve()
+            # Export only the Home preset resolved and stored during startup.
             sec = get_security_config()
-            sec.validate_path(sys_root)
-            machine_roots.append(str(sys_root))
-        except Exception as e:
-            logger.debug("System root not available for export: %s", e, exc_info=True)
+            sys_root = sec.home_preset_root
+            if sys_root is not None:
+                sec.validate_path(sys_root)
+                machine_roots.append(str(sys_root))
+        except (InvalidPathError, AccessDeniedError, OSError, RuntimeError) as exc:
+            logger.debug("System root not available for export: %s", exc, exc_info=True)
 
         machine_def = {
             "hub": str(hub.resolve()),

--- a/tests/test_security_root_policy.py
+++ b/tests/test_security_root_policy.py
@@ -190,6 +190,36 @@ def test_init_service_home_resolution_failure_degrades_to_root_only(
     assert machine["roots"] == []
 
 
+def test_list_allowed_roots_preserves_explicit_roots_on_home_io_failure(
+    monkeypatch, tmp_path
+):
+    """An optional cached Home failure must not hide Hub or Merges roots."""
+    hub = tmp_path / "hub"
+    merges = tmp_path / "merges"
+    fake_home = tmp_path / "service-home"
+    hub.mkdir()
+    merges.mkdir()
+    fake_home.mkdir()
+
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+    init_service(hub, host="127.0.0.1", token="secret")
+    sec = get_security_config()
+    original_validate = sec.validate_path
+
+    def fail_cached_home(path):
+        if path == sec.home_preset_root:
+            raise OSError("synthetic cached Home I/O failure")
+        return original_validate(path)
+
+    monkeypatch.setattr(sec, "validate_path", fail_cached_home)
+
+    roots = list_allowed_roots(hub, merges)
+    assert roots == [
+        {"id": "hub", "path": str(hub.resolve())},
+        {"id": "merges", "path": str(merges.resolve())},
+    ]
+
+
 def test_init_service_home_registration_failure_degrades_to_root_only(
     monkeypatch, tmp_path
 ):

--- a/tests/test_security_root_policy.py
+++ b/tests/test_security_root_policy.py
@@ -1,3 +1,5 @@
+import json
+import logging
 import os
 import sys
 import pytest
@@ -91,6 +93,22 @@ def _reset_allowlist(sec):
     # fallback: replace with empty list
     sec.allowlist_roots = []
 
+def test_sensitive_home_preset_must_already_be_allowlisted(tmp_path):
+    from merger.lenskit.adapters.security import SecurityConfig
+
+    sec = SecurityConfig()
+    untrusted_home = (tmp_path / "untrusted-home").resolve()
+
+    with pytest.raises(
+        ValueError,
+        match="Home preset root must be allowlisted before activation",
+    ):
+        sec.set_sensitive_fs_access(True, home_preset_root=untrusted_home)
+
+    assert sec.sensitive_fs_access is False
+    assert sec.home_preset_root is None
+
+
 def test_init_service_loopback_with_token_allows_root(monkeypatch, tmp_path):
     """
     Behavioral: Loopback + Token -> Root IS allowlisted.
@@ -107,6 +125,170 @@ def test_init_service_loopback_with_token_allows_root(monkeypatch, tmp_path):
     assert root_path in sec.allowlist_roots
     assert home_path in sec.allowlist_roots
     assert sec.sensitive_fs_access is True
+
+def test_init_service_home_resolution_failure_degrades_to_root_only(
+    monkeypatch, tmp_path, caplog
+):
+    """An unavailable Home preset must not abort authenticated root access."""
+    hub = tmp_path / "hub"
+    hub.mkdir()
+    sec = get_security_config()
+    _reset_allowlist(sec)
+
+    def fail_home():
+        raise RuntimeError("synthetic home lookup failure")
+
+    monkeypatch.setattr(Path, "home", fail_home)
+    with caplog.at_level(logging.WARNING):
+        init_service(hub, host="127.0.0.1", token="secret")
+
+    assert Path("/").resolve() in sec.allowlist_roots
+    assert sec.sensitive_fs_access is True
+    assert sec.home_preset_root is None
+    assert {entry["id"] for entry in list_allowed_roots(hub, None)} == {"hub"}
+    assert "Home preset unavailable" in caplog.text
+    assert "root only" in caplog.text
+
+    with pytest.raises(HTTPException) as exc_info:
+        resolve_fs_path(hub=hub, merges_dir=None, root_id="system", rel_path="")
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == (
+        "Home preset is unavailable in this service configuration"
+    )
+
+    with pytest.raises(HTTPException) as atlas_exc:
+        resolve_atlas_root(
+            AtlasRequest(root_kind="preset", root_value="system"),
+            hub,
+            None,
+        )
+    assert atlas_exc.value.status_code == 503
+
+    root_request = AtlasRequest(root_kind="abs_path", root_value=str(Path("/")))
+    assert resolve_atlas_root(root_request, hub, None).scan_root == Path("/").resolve()
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/api/fs/list",
+            params={"root": "system", "rel": ""},
+            headers={"Authorization": "Bearer secret"},
+        )
+    assert response.status_code == 503
+    assert response.json() == {
+        "detail": "Home preset is unavailable in this service configuration"
+    }
+
+    with TestClient(app) as client:
+        export_response = client.post(
+            "/api/export/webmaschine",
+            headers={"Authorization": "Bearer secret"},
+        )
+    assert export_response.status_code == 200
+    machine_path = Path(export_response.json()["path"]) / "machine.json"
+    machine = json.loads(machine_path.read_text(encoding="utf-8"))
+    assert machine["roots"] == []
+
+
+def test_init_service_home_registration_failure_degrades_to_root_only(
+    monkeypatch, tmp_path
+):
+    """A rejected Home registration must not leave a stale preset path active."""
+    hub = tmp_path / "hub"
+    fake_home = tmp_path / "service-home"
+    hub.mkdir()
+    fake_home.mkdir()
+    sec = get_security_config()
+    _reset_allowlist(sec)
+    original_add_root = sec.add_allowlist_root
+
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+    def reject_home(path):
+        if path == fake_home.resolve():
+            raise ValueError("synthetic Home registration failure")
+        original_add_root(path)
+
+    monkeypatch.setattr(sec, "add_allowlist_root", reject_home)
+    init_service(hub, host="127.0.0.1", token="secret")
+
+    assert Path("/").resolve() in sec.allowlist_roots
+    assert fake_home.resolve() not in sec.allowlist_roots
+    assert sec.sensitive_fs_access is True
+    assert sec.home_preset_root is None
+    assert {entry["id"] for entry in list_allowed_roots(hub, None)} == {"hub"}
+
+
+def test_init_service_root_registration_failure_is_explicit_and_fail_closed(
+    monkeypatch, tmp_path
+):
+    """A failed reinit must revoke every earlier sensitive grant."""
+    previous_hub = tmp_path / "previous-hub"
+    hub = tmp_path / "hub"
+    previous_hub.mkdir()
+    hub.mkdir()
+    sec = get_security_config()
+    _reset_allowlist(sec)
+    root = Path("/").resolve()
+    home = Path.home().resolve()
+
+    init_service(previous_hub, host="127.0.0.1", token="secret")
+    assert sec.sensitive_fs_access is True
+    assert sec.home_preset_root == home
+
+    original_add_root = sec.add_allowlist_root
+
+    def reject_root(path):
+        if path == root:
+            raise ValueError("synthetic root registration failure")
+        original_add_root(path)
+
+    monkeypatch.setattr(sec, "add_allowlist_root", reject_root)
+
+    with pytest.raises(
+        RuntimeError,
+        match="Authenticated filesystem-root access could not be initialized",
+    ):
+        init_service(hub, host="127.0.0.1", token="secret")
+
+    assert sec.sensitive_fs_access is False
+    assert sec.home_preset_root is None
+    assert root not in sec.allowlist_roots
+    assert home not in sec.allowlist_roots
+    assert previous_hub.resolve() not in sec.allowlist_roots
+    assert sec.allowlist_roots == [hub.resolve()]
+
+
+def test_home_preset_uses_startup_resolved_path_without_recomputing(
+    monkeypatch, tmp_path
+):
+    """Later Home lookup failures must not invalidate a successful startup grant."""
+    hub = tmp_path / "hub"
+    fake_home = tmp_path / "service-home"
+    hub.mkdir()
+    fake_home.mkdir()
+
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+    init_service(hub, host="127.0.0.1", token="secret")
+    sec = get_security_config()
+    assert sec.home_preset_root == fake_home.resolve()
+
+    def fail_home():
+        raise RuntimeError("Home must not be recomputed after startup")
+
+    monkeypatch.setattr(Path, "home", fail_home)
+
+    roots = list_allowed_roots(hub, None)
+    system = next(entry for entry in roots if entry["id"] == "system")
+    assert system["path"] == str(fake_home.resolve())
+    trusted = resolve_fs_path(
+        hub=hub,
+        merges_dir=None,
+        root_id="system",
+        rel_path="",
+    )
+    assert trusted.path == fake_home.resolve()
+
 
 def test_init_service_loopback_without_token_refuses_root(monkeypatch, tmp_path):
     """
@@ -299,6 +481,7 @@ def test_init_service_removes_stale_root_when_auth_is_disabled(tmp_path):
     init_service(hub, host="127.0.0.1", token=None)
     assert Path("/").resolve() not in sec.allowlist_roots
     assert Path.home().resolve() not in sec.allowlist_roots
+    assert sec.home_preset_root is None
     assert hub.resolve() in sec.allowlist_roots
 
 


### PR DESCRIPTION
## Summary

Closes Bureau live-register event 33 by making authenticated Home-preset startup behavior explicit.

- treats filesystem root (`/`) as the core broad capability
- treats `system` (the service user's Home) as an optional convenience preset
- resolves and stores Home once during startup
- degrades to logged root-only mode when Home resolution or registration fails
- omits unavailable Home from root discovery and Webmaschine export
- returns `503 Service Unavailable` for stale direct `system` requests
- fails startup closed if the core root grant cannot be initialized
- revokes prior sensitive grants before a failed reinitialization can leave stale state
- preserves Hub/Merges discovery if later cached-Home validation raises I/O/runtime errors

## Security boundary

The authorization prerequisite is unchanged: broad filesystem access still requires loopback binding plus configured Bearer authentication. Root-only degradation does not widen access; it removes the Home alias from an already-authorized root capability.

## Verification

- focused root-policy suite: 25 passed
- focused and adjacent service/Atlas suite: 52 passed
- Python byte-compilation: passed
- production-file Ruff default rules: passed
- repo-wide Ruff ratchet for the legacy policy test: passed
- planning registration ratchet: zero findings/control errors
- `git diff --check`: passed

The unbounded real-Home Atlas scan is intentionally left to GitHub `pytest-full`.

## Review evidence

- reviewed code head: `217e192e9ee6fe4a0c100fa9957864bd3723ccd5`
- reviewed packet: unified diff with 40 context lines, excluding review-evidence files
- reviewed packet SHA-256: `da4213a8c0d78e5bf10af2a301e01a8c2d1a033b4885bbb610ccee7791c36e99`
- reviewed packet bytes: `51646`
- self-review: `docs/proofs/rlens-home-preset-startup-policy-v1.self-review.md`
- independent Gemini/Antigravity review: `docs/proofs/rlens-home-preset-startup-policy-v1.external-review.json`
- final independent verdict: PASS, no findings

Review history is recorded truthfully: one valid cached-Home I/O finding was fixed and tested; one stale-state claim was a short-context false positive and disappeared when the existing reset lines were included. A Codex attempt stopped at its usage limit before producing output and is excluded from evidence.

## Non-claims

This PR does not change remote-access policy, add a new filesystem capability, prove every platform-specific Home lookup behavior, establish deployment state, or establish merge readiness without live CI.
