### PR TITLE
chore(security): ratchet CodeQL suppressions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,6 +22,9 @@ jobs:
           fetch-depth: 1
           persist-credentials: true
 
+      - name: Validate CodeQL suppression inventory
+        run: python3 scripts/ci/check_codeql_suppressions.py
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:

--- a/config/codeql-path-suppressions.v1.json
+++ b/config/codeql-path-suppressions.v1.json
@@ -1,0 +1,370 @@
+{
+  "boundaries": {
+    "embedding-policy-file": {
+      "authority": "CLI policy paths are explicit local-operator selections; service policy paths are root-bounded siblings of a validated index.",
+      "expected_occurrences": 3,
+      "files": [
+        "merger/lenskit/cli/policy_loader.py"
+      ],
+      "sites": [
+        {
+          "path": "merger/lenskit/cli/policy_loader.py",
+          "scope": "_resolve_policy_file",
+          "statement": "resolved = path.resolve(strict=True)"
+        },
+        {
+          "path": "merger/lenskit/cli/policy_loader.py",
+          "scope": "_resolve_policy_file",
+          "statement": "if not resolved.is_file():"
+        },
+        {
+          "path": "merger/lenskit/cli/policy_loader.py",
+          "scope": "load_and_validate_embedding_policy",
+          "statement": "with resolved_policy.open(\"r\", encoding=\"utf-8\") as handle:"
+        }
+      ],
+      "tests": [
+        "merger/lenskit/tests/test_policy_loader.py::test_load_and_validate_embedding_policy_success",
+        "merger/lenskit/tests/test_policy_loader.py::test_load_embedding_policy_rejects_directory",
+        "merger/lenskit/tests/test_policy_loader.py::test_load_embedding_policy_rejects_nul_path"
+      ],
+      "validation": [
+        "NUL, empty and non-JSON paths are rejected.",
+        "The target must resolve to an existing regular file and validate against the embedding-policy schema."
+      ]
+    },
+    "federation-api-contained-path": {
+      "authority": "Service federation bundle paths are confined beneath the already resolved federation directory.",
+      "expected_occurrences": 1,
+      "files": [
+        "merger/lenskit/retrieval/federation_query.py"
+      ],
+      "sites": [
+        {
+          "path": "merger/lenskit/retrieval/federation_query.py",
+          "scope": "_resolve_persisted_bundle_path",
+          "statement": "resolved = candidate.resolve(strict=True)"
+        }
+      ],
+      "tests": [
+        "merger/lenskit/tests/test_code_scanning_security.py::test_federation_api_mode_rejects_external_bundle_path"
+      ],
+      "validation": [
+        "Absolute targets must remain beneath the federation directory after canonicalization.",
+        "Relative targets pass through resolve_secure_path."
+      ]
+    },
+    "federation-bundle-index-discovery": {
+      "authority": "The path has already been resolved by the persisted-bundle or explicit local-operator resolver before deterministic index discovery.",
+      "expected_occurrences": 5,
+      "files": [
+        "merger/lenskit/retrieval/federation_query.py"
+      ],
+      "sites": [
+        {
+          "path": "merger/lenskit/retrieval/federation_query.py",
+          "scope": "_find_bundle_index",
+          "statement": "if bundle_path.is_file() and bundle_path.name.endswith(\".index.sqlite\"):"
+        },
+        {
+          "path": "merger/lenskit/retrieval/federation_query.py",
+          "scope": "_find_bundle_index",
+          "statement": "if not bundle_path.is_dir():"
+        },
+        {
+          "path": "merger/lenskit/retrieval/federation_query.py",
+          "scope": "_find_bundle_index",
+          "statement": "chunk_indices = list(bundle_path.glob(\"*.chunk_index.index.sqlite\"))"
+        },
+        {
+          "path": "merger/lenskit/retrieval/federation_query.py",
+          "scope": "_find_bundle_index",
+          "statement": "generic_indices = list(bundle_path.glob(\"*.index.sqlite\"))"
+        },
+        {
+          "path": "merger/lenskit/retrieval/federation_query.py",
+          "scope": "_find_bundle_index",
+          "statement": "generic_indices = list(bundle_path.glob(\"*.index.sqlite\"))"
+        }
+      ],
+      "tests": [
+        "merger/lenskit/tests/test_federation_query.py::test_execute_federated_query_find_bundle_index_direct_file",
+        "merger/lenskit/tests/test_federation_query.py::test_execute_federated_query_find_bundle_index_generic_fallback",
+        "merger/lenskit/tests/test_federation_query.py::test_execute_federated_query_find_bundle_index_ambiguous"
+      ],
+      "validation": [
+        "API mode rejects external bundle paths and confines relative paths beneath the federation directory.",
+        "Discovery accepts only existing directories or .index.sqlite files and rejects ambiguous matches."
+      ]
+    },
+    "federation-index-entry": {
+      "authority": "The API supplies a root-bounded federation index while CLI callers exercise explicit local-operator authority.",
+      "expected_occurrences": 1,
+      "files": [
+        "merger/lenskit/retrieval/federation_query.py"
+      ],
+      "sites": [
+        {
+          "path": "merger/lenskit/retrieval/federation_query.py",
+          "scope": "execute_federated_query",
+          "statement": "resolved_federation_index = federation_index_path.resolve(strict=True)"
+        }
+      ],
+      "tests": [
+        "merger/lenskit/tests/test_code_scanning_security.py::test_federation_api_rejects_index_symlink_escape",
+        "merger/lenskit/tests/test_api_federation.py::test_api_federation_query_valid",
+        "merger/lenskit/tests/test_api_federation.py::test_api_federation_query_file_not_found"
+      ],
+      "validation": [
+        "The target must exist before loading.",
+        "load_federation_index_data enforces the JSON-file and schema contracts."
+      ]
+    },
+    "federation-index-file": {
+      "authority": "Federation index paths are explicit CLI selections or already root-bounded service paths.",
+      "expected_occurrences": 7,
+      "files": [
+        "merger/lenskit/core/federation.py"
+      ],
+      "sites": [
+        {
+          "path": "merger/lenskit/core/federation.py",
+          "scope": "_resolve_new_federation_index",
+          "statement": "parent = index_path.parent.resolve(strict=True)"
+        },
+        {
+          "path": "merger/lenskit/core/federation.py",
+          "scope": "_resolve_existing_federation_index",
+          "statement": "resolved = index_path.resolve(strict=True)"
+        },
+        {
+          "path": "merger/lenskit/core/federation.py",
+          "scope": "_resolve_existing_federation_index",
+          "statement": "if not resolved.is_file():"
+        },
+        {
+          "path": "merger/lenskit/core/federation.py",
+          "scope": "init_federation",
+          "statement": "with out_path.open(\"x\", encoding=\"utf-8\") as handle:"
+        },
+        {
+          "path": "merger/lenskit/core/federation.py",
+          "scope": "load_federation_index_data",
+          "statement": "with resolved_index.open(\"r\", encoding=\"utf-8\") as handle:"
+        },
+        {
+          "path": "merger/lenskit/core/federation.py",
+          "scope": "add_bundle",
+          "statement": "with index_path.open(\"r\", encoding=\"utf-8\") as handle:"
+        },
+        {
+          "path": "merger/lenskit/core/federation.py",
+          "scope": "add_bundle",
+          "statement": "with index_path.open(\"w\", encoding=\"utf-8\") as handle:"
+        }
+      ],
+      "tests": [
+        "merger/lenskit/tests/test_code_scanning_security.py::test_init_federation_rejects_non_json_output",
+        "merger/lenskit/tests/test_code_scanning_security.py::test_init_federation_rejects_missing_parent",
+        "merger/lenskit/tests/test_code_scanning_security.py::test_init_federation_rejects_dangling_symlink_output",
+        "merger/lenskit/tests/test_federation_cli.py::test_federation_add_cli_dispatch"
+      ],
+      "validation": [
+        "Only .json files are accepted.",
+        "New files require an existing directory and exclusive creation; existing files must resolve to regular files.",
+        "All loaded and written content is schema validated."
+      ]
+    },
+    "federation-inline-operator-path": {
+      "authority": "Repeated CLI --bundle inputs are explicit local-operator filesystem selections, not remote service input.",
+      "expected_occurrences": 1,
+      "files": [
+        "merger/lenskit/retrieval/federation_query.py"
+      ],
+      "sites": [
+        {
+          "path": "merger/lenskit/retrieval/federation_query.py",
+          "scope": "_resolve_existing_local_path",
+          "statement": "resolved = candidate.resolve(strict=True)"
+        }
+      ],
+      "tests": [
+        "merger/lenskit/tests/test_federation_query.py::test_execute_federated_query_from_inline_bundles",
+        "merger/lenskit/tests/test_federation_cli.py::test_federation_query_cli_inline_bundles"
+      ],
+      "validation": [
+        "URI syntax and NUL bytes are rejected.",
+        "The resolved target must be an existing directory or .index.sqlite file."
+      ]
+    },
+    "federation-readonly-sqlite": {
+      "authority": "The SQLite path is the unique deterministic index selected from an already resolved bundle path.",
+      "expected_occurrences": 1,
+      "files": [
+        "merger/lenskit/retrieval/federation_query.py"
+      ],
+      "sites": [
+        {
+          "path": "merger/lenskit/retrieval/federation_query.py",
+          "scope": "_execute_federated_query_data",
+          "statement": "with sqlite3.connect(db_uri, uri=True) as conn:"
+        }
+      ],
+      "tests": [
+        "merger/lenskit/tests/test_federation_query.py::test_stale_bundle_is_marked_in_federation_trace"
+      ],
+      "validation": [
+        "The connection uses SQLite URI mode=ro and immutable=1.",
+        "Ambiguous index sets are rejected before opening."
+      ]
+    },
+    "graph-index-file": {
+      "authority": "The graph path is produced by resolve_secure_path from an established root and normalized relative artifact name.",
+      "expected_occurrences": 2,
+      "files": [
+        "merger/lenskit/architecture/graph_index.py"
+      ],
+      "sites": [
+        {
+          "path": "merger/lenskit/architecture/graph_index.py",
+          "scope": "load_graph_index",
+          "statement": "if not path.exists():"
+        },
+        {
+          "path": "merger/lenskit/architecture/graph_index.py",
+          "scope": "load_graph_index",
+          "statement": "with path.open(encoding=\"utf-8\") as handle:"
+        }
+      ],
+      "tests": [
+        "merger/lenskit/tests/test_graph_index.py::test_graph_loader_keeps_existing_status_contract",
+        "merger/lenskit/tests/test_graph_index.py::test_graph_loader_rejects_absolute_path"
+      ],
+      "validation": [
+        "Traversal and symlink escapes are rejected before filesystem access.",
+        "Loaded JSON is contract validated and optionally provenance checked."
+      ]
+    },
+    "prescan-source-root": {
+      "authority": "Service prescan passes a root-bounded repository path; CLI prescan uses an explicit local-operator repository root.",
+      "expected_occurrences": 2,
+      "files": [
+        "merger/lenskit/core/merge.py"
+      ],
+      "sites": [
+        {
+          "path": "merger/lenskit/core/merge.py",
+          "scope": "prescan_repo",
+          "statement": "repo_root = repo_root.resolve(strict=True)"
+        },
+        {
+          "path": "merger/lenskit/core/merge.py",
+          "scope": "prescan_repo._walk",
+          "statement": "with os.scandir(path) as it:"
+        }
+      ],
+      "tests": [
+        "merger/lenskit/tests/test_code_scanning_security.py::test_prescan_api_rejects_repo_symlink_escape",
+        "merger/lenskit/tests/test_code_scanning_security.py::test_prescan_skips_internal_directory_symlink"
+      ],
+      "validation": [
+        "The root must resolve to an existing directory.",
+        "Directory walking skips symlinks and remains relative to the canonical root."
+      ]
+    },
+    "query-readonly-index": {
+      "authority": "Read-only query callers pass an absolute canonical index selected from validated artifact or bundle metadata.",
+      "expected_occurrences": 1,
+      "files": [
+        "merger/lenskit/retrieval/query_core.py"
+      ],
+      "sites": [
+        {
+          "path": "merger/lenskit/retrieval/query_core.py",
+          "scope": "execute_query",
+          "statement": "conn = sqlite3.connect(db_uri, uri=True)"
+        }
+      ],
+      "tests": [
+        "merger/lenskit/tests/test_api_query.py::test_api_query_valid",
+        "merger/lenskit/tests/test_api_query.py::test_api_query_invalid_paths",
+        "merger/lenskit/tests/test_federation_query.py::test_execute_federated_query",
+        "merger/lenskit/tests/test_retrieval_query.py::test_query_read_only_uses_immutable_sqlite_uri"
+      ],
+      "validation": [
+        "Read-only mode requires the canonical chunk-index SQLite suffix and an absolute path.",
+        "The SQLite URI uses mode=ro and immutable=1."
+      ]
+    },
+    "root-bounded-relative-path": {
+      "authority": "The root is application/operator registered and the relative path has passed strict component validation.",
+      "expected_occurrences": 2,
+      "files": [
+        "merger/lenskit/core/path_security.py"
+      ],
+      "sites": [
+        {
+          "path": "merger/lenskit/core/path_security.py",
+          "scope": "resolve_secure_path",
+          "statement": "root_abs = Path(root).resolve(strict=True)"
+        },
+        {
+          "path": "merger/lenskit/core/path_security.py",
+          "scope": "resolve_secure_path",
+          "statement": "resolved = candidate.resolve(strict=False)"
+        }
+      ],
+      "tests": [
+        "merger/lenskit/tests/test_code_scanning_security.py::test_resolve_secure_path_accepts_normalized_descendant",
+        "merger/lenskit/tests/test_code_scanning_security.py::test_resolve_secure_path_rejects_untrusted_syntax",
+        "merger/lenskit/tests/test_code_scanning_security.py::test_resolve_secure_path_rejects_symlink_escape"
+      ],
+      "validation": [
+        "Absolute, padded, empty, dot, parent, alternate-separator, colon and NUL forms are rejected.",
+        "Canonical post-resolution containment rejects symlink escapes."
+      ]
+    },
+    "service-api-root-bounded-files": {
+      "authority": "Remote API filenames are reduced to normalized relative names and resolved beneath established Hub, merges, or artifact directories.",
+      "expected_occurrences": 4,
+      "files": [
+        "merger/lenskit/service/app.py"
+      ],
+      "sites": [
+        {
+          "path": "merger/lenskit/service/app.py",
+          "scope": "api_prescan",
+          "statement": "if not repo_root.exists() or not repo_root.is_dir():"
+        },
+        {
+          "path": "merger/lenskit/service/app.py",
+          "scope": "api_federation_query",
+          "statement": "if not fed_index_path.exists():"
+        },
+        {
+          "path": "merger/lenskit/service/app.py",
+          "scope": "api_query",
+          "statement": "if not index_path.exists():"
+        },
+        {
+          "path": "merger/lenskit/service/app.py",
+          "scope": "api_query",
+          "statement": "if not graph_index_path.exists():"
+        }
+      ],
+      "tests": [
+        "merger/lenskit/tests/test_code_scanning_security.py::test_prescan_api_rejects_repo_symlink_escape",
+        "merger/lenskit/tests/test_code_scanning_security.py::test_federation_api_rejects_index_symlink_escape",
+        "merger/lenskit/tests/test_api_query.py::test_api_query_invalid_paths",
+        "merger/lenskit/tests/test_api_query.py::test_api_query_graph_index_not_found"
+      ],
+      "validation": [
+        "resolve_secure_path rejects traversal, absolute paths, alternate separators, colons and symlink escapes.",
+        "Artifact and graph paths remain siblings beneath their validated roots."
+      ]
+    }
+  },
+  "marker": "lgtm[py/path-injection]",
+  "rule": "py/path-injection",
+  "schema_version": 1
+}

--- a/docs/proofs/codeql-suppression-ratchet-v1-proof.md
+++ b/docs/proofs/codeql-suppression-ratchet-v1-proof.md
@@ -1,0 +1,86 @@
+# Lenskit CodeQL suppression ratchet v1 proof
+
+## Trigger
+
+PRs #952 and #953 closed the observed Lenskit code-scanning findings. The
+resulting `main` tree intentionally retained 30 inline
+`lgtm[py/path-injection]` comments at filesystem sinks whose project-specific
+validation barriers are not modeled by CodeQL.
+
+A clean SARIF result alone would not reveal a future bare suppression, a moved
+suppression attached to a different sink, or an inventory entry that cited no
+real regression test. This slice adds a fail-closed review surface for those
+comments.
+
+## Ratchet design
+
+`config/codeql-path-suppressions.v1.json` groups the 30 sites into 12 authority
+and validation boundaries. Every boundary records:
+
+- expected occurrence count;
+- exact file set;
+- exact source statements and enclosing Python scopes, independent of line
+  numbers;
+- authority rationale;
+- validation rationale;
+- concrete pytest node IDs.
+
+`scripts/ci/check_codeql_suppressions.py`:
+
+- tokenizes every tracked Python source file, `.pyi`/`.pyw` file, and Python-shebang
+  script plus equivalent non-excluded local source, considering only actual comment tokens;
+- broadly detects spacing, case, and multi-rule variants that could be
+  interpreted as path-injection suppressions, then rejects every noncanonical
+  marker form, bare suppression, and unknown boundary ID;
+- rejects count, file, scope, or exact-statement drift;
+- rejects comment-only suppressions that are not inline with a sink;
+- rejects missing rationale, invalid inventory structure, and missing test
+  files or test functions;
+- fails closed when a source containing a suppression cannot be tokenized.
+
+The CodeQL workflow runs the ratchet before CodeQL initialization. The existing
+raw-SARIF clean gate remains mandatory after analysis.
+
+## Runtime scope
+
+The eight existing Python runtime modules changed only by suppression-comment
+annotation. AST comparison against base
+`f0a652bd9ad9a1e155ffb69e7c27fdbb826aca1b` was identical for all eight files.
+The new executable behavior is confined to the standard-library-only CI
+checker and its tests. Most added lines are declarative inventory and negative
+tests rather than runtime product logic.
+
+## Local validation
+
+- suppression inventory: 30 sites across 12 boundaries, pass;
+- ratchet unit and negative tests: 20 passed;
+- 29 unique inventoried pytest node IDs: 42 parametrized cases passed;
+- focused and adjacent security/API suite: 157 passed;
+- default Ruff on new Python files: passed;
+- repository `ruff-ci.toml` ratchet: passed;
+- JSON parsing, workflow YAML parsing, Python byte compilation, and
+  `git diff --check`: passed;
+- planning-registration ratchet: zero findings and zero control errors;
+- runtime-module AST comparison: eight of eight unchanged;
+- direct runtime proofs confirm internal Prescan directory symlinks are skipped
+  and read-only SQLite access uses `mode=ro&immutable=1`.
+
+## Required live proof
+
+Local validation cannot establish the behavior of GitHub's current CodeQL
+runner. The pull request must show:
+
+1. `Validate CodeQL suppression inventory` succeeds before analysis;
+2. ordinary CodeQL analysis succeeds;
+3. `Require clean raw CodeQL SARIF` reports no results;
+4. the remaining repository checks are green.
+
+After merge, the `main` CodeQL analysis must remain at zero current results.
+
+## Non-claims
+
+This proof does not establish that every suppression is forever necessary, that
+the referenced tests are sufficient, that upstream validation cannot regress,
+that all filesystem races are eliminated, that CodeQL detects every
+vulnerability, or that green CI alone proves runtime correctness or merge
+readiness.

--- a/docs/proofs/codeql-suppression-ratchet-v1.external-review.json
+++ b/docs/proofs/codeql-suppression-ratchet-v1.external-review.json
@@ -1,0 +1,79 @@
+{
+  "authority_boundary": {
+    "does_not_prove": [
+      "github_codeql_runtime_success",
+      "raw_sarif_gate_runtime_success",
+      "test_sufficiency",
+      "runtime_correctness",
+      "absence_of_other_vulnerabilities",
+      "merge_readiness",
+      "deployment_state"
+    ],
+    "proves": [
+      "independent_review_was_performed_on_the_bound_packet",
+      "the_initial_material_finding_was_corrected_before_the_final_review",
+      "the_final_reviewer_reported_no_critical_high_or_medium_finding"
+    ]
+  },
+  "result": {
+    "coverage": [
+      "Suppression scanner tokenizer and regex logic",
+      "Inventory boundary and scope validation",
+      "Directory escape and path resolution constraints",
+      "Tracked file coverage (`git ls-files`) validation",
+      "Test reference AST parsing"
+    ],
+    "findings": [],
+    "residual_risks": [
+      "The ratchet proves tests exist in the AST but cannot evaluate their runtime thoroughness or correctness.",
+      "Upstream validation logic could conceptually regress without triggering the ratchet if the exact suppression site and scope remain unchanged.",
+      "CodeQL's Python extractor could hypothetically process edge-case files that the ratchet ignores (e.g., specific tracked extensionless symlinks pointing to external valid python code), though standard auto-build behavior makes this practically non-exploitable."
+    ],
+    "summary": "The CodeQL suppression ratchet is robust, fail-closed, and highly bypass-resistant. It correctly enforces the exact suppression inventory, validates boundaries, and ensures test references exist without altering runtime logic.",
+    "verdict": "PASS"
+  },
+  "review_history": [
+    {
+      "findings": [
+        {
+          "disposition": "addressed by broad variant detection plus canonical-form enforcement",
+          "severity": "HIGH",
+          "title": "Strict marker parsing could miss suppression syntax variants"
+        },
+        {
+          "disposition": "addressed by .pyi/.pyw and extensionless Python-shebang coverage",
+          "severity": "LOW",
+          "title": "Python source discovery covered only .py files"
+        }
+      ],
+      "implementation_head": "bf0644965cc1aa25c07fb62cac80b47043b00166",
+      "round": 1,
+      "verdict": "FAIL"
+    },
+    {
+      "findings": [],
+      "implementation_head": "b85cc35445d72f6b90f896f509488a4e69f734a6",
+      "packet_sha256": "12a5b090cbba63b99d7420e3194a9b74cc9a8ecb9226fa4bf9520e18ce20643e",
+      "round": 2,
+      "verdict": "PASS"
+    }
+  ],
+  "review_mode": "immutable_diff_only_no_tools",
+  "reviewed_base": "f0a652bd9ad9a1e155ffb69e7c27fdbb826aca1b",
+  "reviewed_implementation_head": "b85cc35445d72f6b90f896f509488a4e69f734a6",
+  "reviewed_packet": {
+    "bytes": 100555,
+    "context_lines": 20,
+    "excluded_files": [
+      "docs/proofs/codeql-suppression-ratchet-v1.self-review.md",
+      "docs/proofs/codeql-suppression-ratchet-v1.external-review.json"
+    ],
+    "sha256": "12a5b090cbba63b99d7420e3194a9b74cc9a8ecb9226fa4bf9520e18ce20643e"
+  },
+  "reviewer": "gemini-cli-direct",
+  "schema": "lenskit.external_security_review.v1",
+  "tool_notes": [
+    "The Antigravity wrapper failed before review with a Node virtual-memory reservation error.",
+    "Both recorded review rounds used the direct Gemini CLI in sandboxed print mode without tools."
+  ]
+}

--- a/docs/proofs/codeql-suppression-ratchet-v1.self-review.md
+++ b/docs/proofs/codeql-suppression-ratchet-v1.self-review.md
@@ -1,0 +1,121 @@
+# CodeQL suppression ratchet v1 — self-review
+
+## Binding
+
+- base: `f0a652bd9ad9a1e155ffb69e7c27fdbb826aca1b`
+- reviewed implementation head: `b85cc35445d72f6b90f896f509488a4e69f734a6`
+- immutable review packet SHA-256:
+  `12a5b090cbba63b99d7420e3194a9b74cc9a8ecb9226fa4bf9520e18ce20643e`
+- packet bytes: `100555`
+- packet context: 20 unchanged lines
+
+The packet contains the complete implementation diff and predates this
+self-review and the external-review evidence files.
+
+## Reviewed files
+
+- `.github/workflows/codeql.yml`
+- `config/codeql-path-suppressions.v1.json`
+- `docs/proofs/codeql-suppression-ratchet-v1-proof.md`
+- `docs/testing/codeql-suppression-ratchet.md`
+- eight existing runtime modules carrying the 30 suppression comments
+- three existing runtime-security test modules
+- `merger/lenskit/tests/test_codeql_suppression_ratchet.py`
+- `scripts/ci/check_codeql_suppressions.py`
+
+## Review axes
+
+### Correctness
+
+The checker inventories 30 current `py/path-injection` suppressions across 12
+explicit trust boundaries. It compares observed comments against exact file,
+Python scope, and source-statement tuples while intentionally ignoring line
+numbers. This permits harmless line movement but rejects semantic site drift.
+
+The eight changed product modules were AST-compared with the base and remained
+identical. Product behavior changes are limited to added tests; the runtime
+modules changed only in suppression-comment placement and boundary labels.
+
+### Bypass resistance
+
+The implementation rejects:
+
+- bare or unknown boundary annotations;
+- alternate `codeql[...]` markers;
+- spacing, case, and multi-rule marker variants;
+- marker-like strings that are not Python comments;
+- suppressions moved to another file, function/class scope, or statement;
+- occurrence-count and file-set drift;
+- source paths or test references escaping the repository;
+- missing test files and missing pytest function/class nodes;
+- tracked Python sources hidden beneath excluded cache/environment directories;
+- unparseable suppression-bearing Python source.
+
+The scanner covers tracked `.py`, `.pyi`, `.pyw`, and extensionless
+Python-shebang sources, plus equivalent non-excluded local files. It does not
+follow extensionless symlinks merely to inspect their shebang.
+
+### Regression risk
+
+The ratchet is isolated to CI and uses only the Python standard library. The
+CodeQL workflow runs it before CodeQL initialization. Existing CodeQL analysis
+and the raw-SARIF zero-result gate remain separate requirements afterward.
+
+Directory walking prunes cache and environment directories before descending.
+Git coverage then fails if a tracked Python source would have been hidden by
+those exclusions.
+
+### Tests
+
+Local evidence on the reviewed implementation head:
+
+- 20 ratchet unit and negative tests passed;
+- 29 inventory-linked pytest node IDs produced 42 passing cases;
+- 157 focused and adjacent security/API cases passed;
+- direct tests prove internal Prescan directory symlinks are skipped;
+- direct tests prove SQLite read-only paths use `mode=ro&immutable=1`;
+- default Ruff passed on changed Python files;
+- repository `ruff-ci.toml` passed;
+- JSON, YAML, byte compilation, diff check, and planning-registration ratchet
+  passed;
+- eight of eight changed product modules were AST-identical to base.
+
+### Security and integration
+
+The ratchet does not make a suppression safe. It makes the decision explicit
+and reviewable. Runtime validation, CodeQL execution, raw SARIF inspection, test
+execution, and merge gates remain independent controls.
+
+The workflow still uses CodeQL action v3 and the repository ruleset does not
+currently require named status checks. Those are separate governance and
+maintenance concerns, not concealed claims of this patch.
+
+## Review history
+
+1. An initial independent review of implementation head
+   `bf0644965cc1aa25c07fb62cac80b47043b00166` returned FAIL. It identified a
+   high-severity parser differential for suppression syntax variants and a
+   low-severity Python-file discovery gap.
+2. The scanner was broadened to detect spacing, case, multi-rule, and alternate
+   marker forms while still requiring one canonical inventory form. `.pyi`,
+   `.pyw`, and extensionless Python-shebang sources were added. Additional
+   negative tests were added.
+3. A new independent review of the corrected head and newly hashed packet
+   returned PASS with no findings.
+
+## Residual risks
+
+- Test-node existence does not prove test sufficiency or that a test cannot be
+  weakened later.
+- Upstream validation could regress while a suppression remains at the same
+  site; ordinary tests and CodeQL remain necessary.
+- CodeQL can have false negatives unrelated to explicit suppressions.
+- Edge-case extractor behavior for extensionless symlinks is not established by
+  this ratchet.
+- A green ratchet does not establish runtime correctness, absence of other
+  vulnerabilities, merge readiness, or deployment state.
+
+## Verdict
+
+**PASS** — no known critical, high, or medium finding remains on the bound
+implementation packet.

--- a/docs/testing/codeql-suppression-ratchet.md
+++ b/docs/testing/codeql-suppression-ratchet.md
@@ -1,0 +1,58 @@
+# CodeQL path-injection suppression ratchet
+
+Lenskit uses a small number of inline `lgtm[py/path-injection]` comments where a
+filesystem sink is protected by a project-specific validation boundary that
+CodeQL does not infer. A suppression is not a security boundary and must never
+replace validation.
+
+## Source of record
+
+`config/codeql-path-suppressions.v1.json` inventories every accepted
+suppression. Each boundary records:
+
+- the authority under which the path may be used;
+- the validation that runs before the filesystem sink;
+- the exact source statement and enclosing Python scope;
+- the expected occurrence count and files;
+- concrete regression-test node IDs.
+
+`scripts/ci/check_codeql_suppressions.py` validates this inventory before the
+CodeQL action starts. It tokenizes every tracked Python source file, including `.pyi`/`.pyw` and extensionless
+Python-shebang scripts, plus equivalent local files outside excluded cache and
+environment directories. Only real
+comment tokens count, not marker-like text inside strings.
+
+## Changing a suppression
+
+1. Establish or review the runtime validation boundary first.
+2. Keep the suppression inline with the exact filesystem sink.
+3. Reuse a boundary ID only when authority and validation are genuinely the
+   same. Otherwise create a new boundary entry.
+4. Update the exact site, occurrence count, file set, rationale, and concrete
+   regression-test references in the inventory.
+5. Run:
+
+   ```bash
+   python3 scripts/ci/check_codeql_suppressions.py
+   pytest -q merger/lenskit/tests/test_codeql_suppression_ratchet.py
+   ```
+
+6. Review the complete diff. An inventory update is evidence of an explicit
+   decision, not proof that the suppression is justified.
+7. Require both ordinary CodeQL success and the raw-SARIF clean gate.
+
+The ratchet verifies that referenced pytest nodes exist. The normal test-suite
+workflow remains responsible for executing them.
+
+A source statement may move to another line without inventory churn. Changing
+the statement or enclosing scope, moving it to another file, adding or deleting
+an occurrence, or using an alternative, unknown, or bare suppression fails the
+ratchet.
+
+## Boundaries of the ratchet
+
+The ratchet establishes only that suppressions are explicit, stable, and tied
+to named tests and documented trust boundaries. It does not establish that the
+referenced tests are sufficient, that upstream validation cannot regress, that
+CodeQL has no blind spots, or that a green analysis proves runtime safety or
+merge readiness.

--- a/merger/lenskit/architecture/graph_index.py
+++ b/merger/lenskit/architecture/graph_index.py
@@ -38,10 +38,10 @@ def load_graph_index(
         logger.warning("Graph index path rejected: %s", exc)
         return {"status": "invalid_path", "graph": None}
 
-    if not path.exists():  # lgtm[py/path-injection]
+    if not path.exists():  # lgtm[py/path-injection] codeql-boundary:graph-index-file
         return {"status": "not_found", "graph": None}
     try:
-        with path.open(encoding="utf-8") as handle:  # lgtm[py/path-injection]
+        with path.open(encoding="utf-8") as handle:  # lgtm[py/path-injection] codeql-boundary:graph-index-file
             data = json.load(handle)
     except json.JSONDecodeError:
         return {"status": "invalid_json", "graph": None}

--- a/merger/lenskit/cli/policy_loader.py
+++ b/merger/lenskit/cli/policy_loader.py
@@ -19,10 +19,10 @@ def _resolve_policy_file(path: Path) -> Path:
     if path.suffix.lower() != ".json":
         raise EmbeddingPolicyError("Embedding policy must be a JSON file")
     try:
-        resolved = path.resolve(strict=True)  # lgtm[py/path-injection]
+        resolved = path.resolve(strict=True)  # lgtm[py/path-injection] codeql-boundary:embedding-policy-file
     except (OSError, RuntimeError) as exc:
         raise EmbeddingPolicyError(f"Embedding policy file not found: {path}") from exc
-    if not resolved.is_file():  # lgtm[py/path-injection]
+    if not resolved.is_file():  # lgtm[py/path-injection] codeql-boundary:embedding-policy-file
         raise EmbeddingPolicyError("Embedding policy path is not a regular file")
     return resolved
 
@@ -32,7 +32,7 @@ def load_and_validate_embedding_policy(path: Path) -> Dict[str, Any]:
     resolved_policy = _resolve_policy_file(path)
 
     try:
-        with resolved_policy.open("r", encoding="utf-8") as handle:  # lgtm[py/path-injection]
+        with resolved_policy.open("r", encoding="utf-8") as handle:  # lgtm[py/path-injection] codeql-boundary:embedding-policy-file
             policy_instance = json.load(handle)
     except json.JSONDecodeError as exc:
         raise EmbeddingPolicyError(

--- a/merger/lenskit/core/federation.py
+++ b/merger/lenskit/core/federation.py
@@ -27,7 +27,7 @@ def _resolve_new_federation_index(index_path: Path) -> Path:
     if index_path.suffix.lower() != ".json":
         raise ValueError("Federation index must be a JSON file")
     try:
-        parent = index_path.parent.resolve(strict=True)  # lgtm[py/path-injection]
+        parent = index_path.parent.resolve(strict=True)  # lgtm[py/path-injection] codeql-boundary:federation-index-file
     except (OSError, RuntimeError) as exc:
         raise FileNotFoundError("Federation index parent directory not found") from exc
     if not parent.is_dir():
@@ -42,10 +42,10 @@ def _resolve_existing_federation_index(index_path: Path) -> Path:
     if index_path.suffix.lower() != ".json":
         raise ValueError("Federation index must be a JSON file")
     try:
-        resolved = index_path.resolve(strict=True)  # lgtm[py/path-injection]
+        resolved = index_path.resolve(strict=True)  # lgtm[py/path-injection] codeql-boundary:federation-index-file
     except (OSError, RuntimeError) as exc:
         raise FileNotFoundError(f"Federation index not found at: {index_path}") from exc
-    if not resolved.is_file():  # lgtm[py/path-injection]
+    if not resolved.is_file():  # lgtm[py/path-injection] codeql-boundary:federation-index-file
         raise ValueError("Federation index path is not a regular file")
     return resolved
 
@@ -94,7 +94,7 @@ def init_federation(federation_id: str, out_path: Path) -> dict:
     try:
         # Exclusive creation prevents overwrite and rejects existing symlinks,
         # including dangling links, at the filesystem operation itself.
-        with out_path.open("x", encoding="utf-8") as handle:  # lgtm[py/path-injection]
+        with out_path.open("x", encoding="utf-8") as handle:  # lgtm[py/path-injection] codeql-boundary:federation-index-file
             json.dump(fed_data, handle, indent=2, sort_keys=True)
     except FileExistsError as exc:
         raise FileExistsError(
@@ -144,7 +144,7 @@ def validate_federation_data(fed_data: dict[str, Any]) -> bool:
 def load_federation_index_data(index_path: Path) -> dict[str, Any]:
     """Load and validate a persisted federation index JSON file."""
     resolved_index = _resolve_existing_federation_index(index_path)
-    with resolved_index.open("r", encoding="utf-8") as handle:  # lgtm[py/path-injection]
+    with resolved_index.open("r", encoding="utf-8") as handle:  # lgtm[py/path-injection] codeql-boundary:federation-index-file
         fed_data = json.load(handle)
 
     validate_federation_data(fed_data)
@@ -189,7 +189,7 @@ def add_bundle(index_path: Path, repo_id: str, bundle_path: str) -> dict:
     if not schema:
         raise RuntimeError("Federation schema missing at expected path (contracts/federation-index.v1.schema.json)")
 
-    with index_path.open("r", encoding="utf-8") as handle:  # lgtm[py/path-injection]
+    with index_path.open("r", encoding="utf-8") as handle:  # lgtm[py/path-injection] codeql-boundary:federation-index-file
         fed_data = json.load(handle)
 
     # Pre-validate existing data to prevent poor failure modes (e.g. KeyError on missing repo_id)
@@ -231,7 +231,7 @@ def add_bundle(index_path: Path, repo_id: str, bundle_path: str) -> dict:
     except JsonSchemaValidationError as e:
         raise ValueError(f"Failed to generate valid federation index schema after modification: {e}")
 
-    with index_path.open("w", encoding="utf-8") as handle:  # lgtm[py/path-injection]
+    with index_path.open("w", encoding="utf-8") as handle:  # lgtm[py/path-injection] codeql-boundary:federation-index-file
         json.dump(fed_data, handle, indent=2, sort_keys=True)
 
     return fed_data

--- a/merger/lenskit/core/merge.py
+++ b/merger/lenskit/core/merge.py
@@ -2230,7 +2230,7 @@ def prescan_repo(repo_root: Path, max_depth: int = 10, ignore_globs: Optional[Li
     Lightweight scan for structure visualization (Prescan).
     Returns a nested dict representing the tree.
     """
-    repo_root = repo_root.resolve(strict=True)  # lgtm[py/path-injection]
+    repo_root = repo_root.resolve(strict=True)  # lgtm[py/path-injection] codeql-boundary:prescan-source-root
     if not repo_root.is_dir():
         raise ValueError("Prescan root must be an existing directory")
     root_label = repo_root.name
@@ -2281,7 +2281,7 @@ def prescan_repo(repo_root: Path, max_depth: int = 10, ignore_globs: Optional[Li
 
         try:
             # Sort for deterministic output
-            with os.scandir(path) as it:  # lgtm[py/path-injection]
+            with os.scandir(path) as it:  # lgtm[py/path-injection] codeql-boundary:prescan-source-root
                 entries = sorted(it, key=lambda e: e.name)
         except OSError:
             return node

--- a/merger/lenskit/core/path_security.py
+++ b/merger/lenskit/core/path_security.py
@@ -36,11 +36,11 @@ def resolve_secure_path(root: Path, relpath: str) -> Path:
         # `root` is chosen by the application/operator, and `relpath` has passed the
         # strict component allowlist above. The comments document the custom barrier
         # for CodeQL, which cannot infer the component-level validation.
-        root_abs = Path(root).resolve(strict=True)  # lgtm[py/path-injection]
+        root_abs = Path(root).resolve(strict=True)  # lgtm[py/path-injection] codeql-boundary:root-bounded-relative-path
         if not root_abs.is_dir():
             raise ValueError("Root must be an existing directory")
         candidate = root_abs.joinpath(*parts)
-        resolved = candidate.resolve(strict=False)  # lgtm[py/path-injection]
+        resolved = candidate.resolve(strict=False)  # lgtm[py/path-injection] codeql-boundary:root-bounded-relative-path
         resolved.relative_to(root_abs)
         return resolved
     except (ValueError, RuntimeError, OSError) as exc:

--- a/merger/lenskit/retrieval/federation_query.py
+++ b/merger/lenskit/retrieval/federation_query.py
@@ -68,17 +68,17 @@ def _find_bundle_index(bundle_path: Path) -> Optional[Path]:
     4. If ambiguous (multiple matches at the same level), return None safely.
     """
     # The caller resolves and confines this path before discovery.
-    if bundle_path.is_file() and bundle_path.name.endswith(".index.sqlite"):  # lgtm[py/path-injection]
+    if bundle_path.is_file() and bundle_path.name.endswith(".index.sqlite"):  # lgtm[py/path-injection] codeql-boundary:federation-bundle-index-discovery
         return bundle_path
 
-    if not bundle_path.is_dir():  # lgtm[py/path-injection]
+    if not bundle_path.is_dir():  # lgtm[py/path-injection] codeql-boundary:federation-bundle-index-discovery
         return None
 
     # Search for canonical chunk index
-    chunk_indices = list(bundle_path.glob("*.chunk_index.index.sqlite"))  # lgtm[py/path-injection]
+    chunk_indices = list(bundle_path.glob("*.chunk_index.index.sqlite"))  # lgtm[py/path-injection] codeql-boundary:federation-bundle-index-discovery
     if len(chunk_indices) == 1:
         # Also ensure there isn't another generic index lying around competing for canonical truth
-        generic_indices = list(bundle_path.glob("*.index.sqlite"))  # lgtm[py/path-injection]
+        generic_indices = list(bundle_path.glob("*.index.sqlite"))  # lgtm[py/path-injection] codeql-boundary:federation-bundle-index-discovery
         # We expect exactly 1 generic index too (the same one we just found). If there are more, it's ambiguous.
         if len(generic_indices) > 1:
             return None
@@ -87,7 +87,7 @@ def _find_bundle_index(bundle_path: Path) -> Optional[Path]:
         return None
 
     # Search for generic index as fallback
-    generic_indices = list(bundle_path.glob("*.index.sqlite"))  # lgtm[py/path-injection]
+    generic_indices = list(bundle_path.glob("*.index.sqlite"))  # lgtm[py/path-injection] codeql-boundary:federation-bundle-index-discovery
     if len(generic_indices) == 1:
         return generic_indices[0]
     elif len(generic_indices) > 1:
@@ -102,7 +102,7 @@ def _resolve_existing_local_path(raw_path: str, base_path: Path) -> Path:
     candidate = Path(raw_path)
     if not candidate.is_absolute():
         candidate = base_path / candidate
-    resolved = candidate.resolve(strict=True)  # lgtm[py/path-injection]
+    resolved = candidate.resolve(strict=True)  # lgtm[py/path-injection] codeql-boundary:federation-inline-operator-path
     if not resolved.is_dir() and not (
         resolved.is_file() and resolved.name.endswith(".index.sqlite")
     ):
@@ -127,7 +127,7 @@ def _resolve_persisted_bundle_path(
     candidate = Path(raw_path)
     if candidate.is_absolute():
         base_resolved = base_path.resolve(strict=True)
-        resolved = candidate.resolve(strict=True)  # lgtm[py/path-injection]
+        resolved = candidate.resolve(strict=True)  # lgtm[py/path-injection] codeql-boundary:federation-api-contained-path
         try:
             resolved.relative_to(base_resolved)
         except ValueError as exc:
@@ -251,7 +251,7 @@ def _execute_federated_query_data(
             if expected_fingerprint:
                 try:
                     db_uri = f"{db_path.resolve().as_uri()}?mode=ro&immutable=1"
-                    with sqlite3.connect(db_uri, uri=True) as conn:  # lgtm[py/path-injection]
+                    with sqlite3.connect(db_uri, uri=True) as conn:  # lgtm[py/path-injection] codeql-boundary:federation-readonly-sqlite
                         cursor = conn.execute("SELECT value FROM index_meta WHERE key='canonical_dump_index_sha256'")
                         row = cursor.fetchone()
                         if row:
@@ -442,7 +442,7 @@ def execute_federated_query(
     The federation index is a read-only registry input. This function does not create snapshots,
     refresh bundles, mutate Git, run shells or assert global repository truth.
     """
-    resolved_federation_index = federation_index_path.resolve(strict=True)  # lgtm[py/path-injection]
+    resolved_federation_index = federation_index_path.resolve(strict=True)  # lgtm[py/path-injection] codeql-boundary:federation-index-entry
     fed_data = load_federation_index_data(resolved_federation_index)
 
     return _execute_federated_query_data(

--- a/merger/lenskit/retrieval/query_core.py
+++ b/merger/lenskit/retrieval/query_core.py
@@ -133,8 +133,8 @@ def execute_query(
             if not resolved_index_path.is_absolute():
                 raise ValueError("Invalid index path: expected an absolute read-only index path.")
             db_uri = f"{resolved_index_path.as_uri()}?mode=ro&immutable=1"
-            # lgtm[py/path-injection] callers validate and confine the index path.
-            conn = sqlite3.connect(db_uri, uri=True)
+            # Callers validate and confine the index path before read-only execution.
+            conn = sqlite3.connect(db_uri, uri=True)  # lgtm[py/path-injection] codeql-boundary:query-readonly-index
         else:
             conn = sqlite3.connect(str(resolved_index_path))
         conn.row_factory = sqlite3.Row

--- a/merger/lenskit/service/app.py
+++ b/merger/lenskit/service/app.py
@@ -681,7 +681,7 @@ def api_prescan(request: PrescanRequest):
     # Resolve repo
     repo_name = validate_repo_name(request.repo)
     repo_root = _resolve_request_path(state.hub, repo_name, label="repository")
-    if not repo_root.exists() or not repo_root.is_dir():  # lgtm[py/path-injection]
+    if not repo_root.exists() or not repo_root.is_dir():  # lgtm[py/path-injection] codeql-boundary:service-api-root-bounded-files
         raise HTTPException(status_code=404, detail=f"Repo {repo_name} not found")
 
     try:
@@ -762,7 +762,7 @@ def api_federation_query(request: FederationQueryRequest):
         label="federation index",
     )
 
-    if not fed_index_path.exists():  # lgtm[py/path-injection]
+    if not fed_index_path.exists():  # lgtm[py/path-injection] codeql-boundary:service-api-root-bounded-files
         raise HTTPException(status_code=404, detail="Federation index not found")
 
 
@@ -921,7 +921,7 @@ def api_query(request: QueryRequest):
     merges_dir = merges_dir.resolve()
 
     index_path = _resolve_request_path(merges_dir, filename, label="index artifact")
-    if not index_path.exists():  # lgtm[py/path-injection]
+    if not index_path.exists():  # lgtm[py/path-injection] codeql-boundary:service-api-root-bounded-files
          raise HTTPException(status_code=404, detail="Index file missing on disk")
 
     is_stale = check_stale_index(index_path, stale_policy=request.stale_policy)
@@ -961,7 +961,7 @@ def api_query(request: QueryRequest):
             request.graph_index,
             label="graph index",
         )
-        if not graph_index_path.exists():  # lgtm[py/path-injection]
+        if not graph_index_path.exists():  # lgtm[py/path-injection] codeql-boundary:service-api-root-bounded-files
             raise HTTPException(status_code=404, detail="Explicitly provided graph index file does not exist")
 
     if request.context_mode == "window" and request.context_window_lines <= 0:

--- a/merger/lenskit/tests/test_code_scanning_security.py
+++ b/merger/lenskit/tests/test_code_scanning_security.py
@@ -5,6 +5,7 @@ import pytest
 import yaml
 
 from merger.lenskit.core.federation import add_bundle, init_federation
+from merger.lenskit.core.merge import prescan_repo
 from merger.lenskit.core.path_security import resolve_secure_path
 from merger.lenskit.retrieval.federation_query import execute_federated_query
 
@@ -39,6 +40,30 @@ def test_resolve_secure_path_rejects_symlink_escape(tmp_path):
 
     with pytest.raises(ValueError, match="Path resolution failed"):
         resolve_secure_path(root, "escape/secret.json")
+
+
+def test_prescan_skips_internal_directory_symlink(tmp_path):
+    repo = tmp_path / "repo"
+    outside = tmp_path / "outside"
+    repo.mkdir()
+    outside.mkdir()
+    (repo / "visible.txt").write_text("visible", encoding="utf-8")
+    (outside / "secret.txt").write_text("secret", encoding="utf-8")
+    (repo / "linked-outside").symlink_to(outside, target_is_directory=True)
+
+    result = prescan_repo(repo, max_depth=3)
+    paths: set[str] = set()
+
+    def collect(node):
+        for child in node.get("children", []):
+            paths.add(child["path"])
+            collect(child)
+
+    collect(result["tree"])
+
+    assert paths == {"visible.txt"}
+    assert result["file_count"] == 1
+    assert "secret.txt" not in json.dumps(result)
 
 
 def test_prescan_api_rejects_repo_symlink_escape(service_client, tmp_path):

--- a/merger/lenskit/tests/test_codeql_suppression_ratchet.py
+++ b/merger/lenskit/tests/test_codeql_suppression_ratchet.py
@@ -1,0 +1,370 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.ci.check_codeql_suppressions import (
+    _assert_tracked_python_coverage,
+    _scan,
+    validate,
+)
+
+
+def _marker() -> str:
+    # Keep the suppression token out of this repository test source itself; the
+    # scanner must observe only the temporary fixture written by each test.
+    return "lgtm" + "[py/path-injection]"
+
+
+def _write_inventory(
+    root: Path,
+    *,
+    boundary: str = "fixture-boundary",
+    expected_occurrences: int = 1,
+    files: list[str] | None = None,
+    tests: list[str] | None = None,
+    scope: str = "<module>",
+) -> Path:
+    files = files or ["merger/example.py"]
+    tests = tests or ["tests/test_example.py::test_fixture"]
+    inventory = {
+        "schema_version": 1,
+        "rule": "py/path-injection",
+        "marker": _marker(),
+        "boundaries": {
+            boundary: {
+                "expected_occurrences": expected_occurrences,
+                "files": files,
+                "sites": [
+                    {
+                        "path": "merger/example.py",
+                        "scope": scope,
+                        "statement": 'open("fixture")',
+                    }
+                ],
+                "authority": "Explicit fixture authority.",
+                "validation": ["Fixture validation is bounded."],
+                "tests": tests,
+            }
+        },
+    }
+    path = root / "config" / "codeql-path-suppressions.v1.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(inventory), encoding="utf-8")
+    return path
+
+
+def _write_source(
+    root: Path,
+    marker_suffix: str,
+    *,
+    statement: str = 'open("fixture")',
+    copies: int = 1,
+    scope: str | None = None,
+) -> None:
+    path = root / "merger" / "example.py"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    statements = "".join(
+        f"{statement}  # {_marker()} {marker_suffix}\n"
+        for _ in range(copies)
+    )
+    if scope is not None:
+        statements = f"def {scope}():\n" + "".join(
+            f"    {line}\n" for line in statements.splitlines()
+        )
+    path.write_text(statements, encoding="utf-8")
+    test_path = root / "tests" / "test_example.py"
+    test_path.parent.mkdir(parents=True, exist_ok=True)
+    test_path.write_text("def test_fixture():\n    assert True\n", encoding="utf-8")
+
+
+def test_repository_codeql_suppressions_match_inventory():
+    root = Path(__file__).resolve().parents[3]
+    inventory = root / "config" / "codeql-path-suppressions.v1.json"
+
+    assert validate(root, inventory) == []
+
+
+def test_ratchet_rejects_unregistered_suppression(tmp_path):
+    inventory = _write_inventory(tmp_path)
+    _write_source(tmp_path, "")
+
+    findings = validate(tmp_path, inventory)
+
+    assert any("unregistered suppression" in finding for finding in findings)
+    assert any("expected 1 occurrence(s), found 0" in finding for finding in findings)
+
+
+def test_ratchet_rejects_unknown_boundary(tmp_path):
+    inventory = _write_inventory(tmp_path)
+    _write_source(tmp_path, "codeql-boundary:unknown-boundary")
+
+    findings = validate(tmp_path, inventory)
+
+    assert any("unknown boundary unknown-boundary" in finding for finding in findings)
+    assert any("expected 1 occurrence(s), found 0" in finding for finding in findings)
+
+
+def test_ratchet_rejects_occurrence_drift(tmp_path):
+    inventory = _write_inventory(tmp_path)
+    _write_source(
+        tmp_path,
+        "codeql-boundary:fixture-boundary",
+        copies=2,
+    )
+
+    findings = validate(tmp_path, inventory)
+
+    assert any(
+        "boundary fixture-boundary expected 1 occurrence(s), found 2" in finding
+        for finding in findings
+    )
+
+
+def test_ratchet_rejects_site_drift_with_unchanged_count(tmp_path):
+    inventory = _write_inventory(tmp_path)
+    _write_source(
+        tmp_path,
+        "codeql-boundary:fixture-boundary",
+        statement='open("different")',
+    )
+
+    findings = validate(tmp_path, inventory)
+
+    assert len(findings) == 1
+    assert "boundary fixture-boundary sites mismatch" in findings[0]
+    assert 'open("fixture")' in findings[0]
+    assert 'open("different")' in findings[0]
+
+
+def test_ratchet_rejects_missing_regression_test(tmp_path):
+    inventory = _write_inventory(tmp_path, tests=["tests/test_missing.py::test_missing"])
+    _write_source(tmp_path, "codeql-boundary:fixture-boundary")
+
+    findings = validate(tmp_path, inventory)
+
+    assert findings == [
+        "boundary fixture-boundary references missing test: "
+        "tests/test_missing.py::test_missing"
+    ]
+
+
+def test_ratchet_rejects_missing_regression_test_node(tmp_path):
+    inventory = _write_inventory(
+        tmp_path,
+        tests=["tests/test_example.py::test_missing"],
+    )
+    _write_source(tmp_path, "codeql-boundary:fixture-boundary")
+
+    findings = validate(tmp_path, inventory)
+
+    assert findings == [
+        "boundary fixture-boundary references missing test: "
+        "tests/test_example.py::test_missing"
+    ]
+
+
+def test_scanner_ignores_marker_inside_python_string(tmp_path):
+    path = tmp_path / "merger" / "example.py"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        f'marker = "{_marker()} codeql-boundary:not-a-comment"\n',
+        encoding="utf-8",
+    )
+
+    assert _scan(tmp_path) == []
+
+
+def test_scanner_covers_top_level_python_files(tmp_path):
+    path = tmp_path / "top_level.py"
+    path.write_text(
+        f'open("fixture")  # {_marker()} codeql-boundary:fixture-boundary\n',
+        encoding="utf-8",
+    )
+
+    assert _scan(tmp_path) == [
+        (
+            "top_level.py",
+            1,
+            _marker(),
+            "fixture-boundary",
+            "<module>",
+            'open("fixture")',
+        )
+    ]
+
+
+def test_ratchet_rejects_test_reference_outside_repository(tmp_path):
+    inventory = _write_inventory(
+        tmp_path,
+        tests=["../test_outside.py::test_outside"],
+    )
+    _write_source(tmp_path, "codeql-boundary:fixture-boundary")
+
+    findings = validate(tmp_path, inventory)
+
+    assert findings == [
+        "boundary fixture-boundary references missing test: "
+        "../test_outside.py::test_outside"
+    ]
+
+
+def test_ratchet_rejects_scope_drift_with_unchanged_statement(tmp_path):
+    inventory = _write_inventory(tmp_path, scope="expected_scope")
+    _write_source(
+        tmp_path,
+        "codeql-boundary:fixture-boundary",
+        scope="different_scope",
+    )
+
+    findings = validate(tmp_path, inventory)
+
+    assert len(findings) == 1
+    assert "boundary fixture-boundary sites mismatch" in findings[0]
+    assert "expected_scope" in findings[0]
+    assert "different_scope" in findings[0]
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        "codeql[py/path-injection]",
+        "lgtm [py/path-injection]",
+        "LGTM[PY/PATH-INJECTION]",
+        "lgtm[py/other, py/path-injection]",
+    ],
+)
+def test_ratchet_rejects_alternative_codeql_marker(tmp_path, marker):
+    inventory = _write_inventory(tmp_path)
+    path = tmp_path / "merger" / "example.py"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f'open("fixture")  # {marker} codeql-boundary:fixture-boundary\n',
+        encoding="utf-8",
+    )
+    test_path = tmp_path / "tests" / "test_example.py"
+    test_path.parent.mkdir(parents=True, exist_ok=True)
+    test_path.write_text("def test_fixture():\n    assert True\n", encoding="utf-8")
+
+    findings = validate(tmp_path, inventory)
+
+    assert any(
+        f"unsupported suppression marker {marker}" in finding
+        for finding in findings
+    )
+    assert any("expected 1 occurrence(s), found 0" in finding for finding in findings)
+
+
+def test_tracked_python_coverage_rejects_excluded_file(tmp_path, monkeypatch):
+    scanned = tmp_path / "main.py"
+    scanned.write_text("pass\n", encoding="utf-8")
+    (tmp_path / ".git").mkdir()
+
+    class Result:
+        stdout = b"main.py\0.venv/hidden.py\0"
+
+    monkeypatch.setattr(
+        "scripts.ci.check_codeql_suppressions.subprocess.run",
+        lambda *args, **kwargs: Result(),
+    )
+
+    try:
+        _assert_tracked_python_coverage(tmp_path, [scanned])
+    except ValueError as exc:
+        assert str(exc) == (
+            "Tracked Python files are excluded from suppression scanning: "
+            ".venv/hidden.py"
+        )
+    else:
+        raise AssertionError("expected tracked Python coverage failure")
+
+
+def test_scanner_records_nested_class_method_scope(tmp_path):
+    path = tmp_path / "nested.py"
+    path.write_text(
+        "class Example:\n"
+        "    def run(self):\n"
+        f'        open("fixture")  # {_marker()} '
+        "codeql-boundary:fixture-boundary\n",
+        encoding="utf-8",
+    )
+
+    assert _scan(tmp_path) == [
+        (
+            "nested.py",
+            3,
+            _marker(),
+            "fixture-boundary",
+            "Example.run",
+            'open("fixture")',
+        )
+    ]
+
+
+def test_scanner_covers_pyi_pyw_and_python_shebang(tmp_path):
+    pyi = tmp_path / "types.pyi"
+    pyi.write_text(
+        f'open("pyi")  # {_marker()} codeql-boundary:fixture-boundary\n',
+        encoding="utf-8",
+    )
+    pyw = tmp_path / "window.pyw"
+    pyw.write_text(
+        f'open("pyw")  # {_marker()} codeql-boundary:fixture-boundary\n',
+        encoding="utf-8",
+    )
+    script = tmp_path / "tool"
+    script.write_text(
+        "#!/usr/bin/env python3\n"
+        f'open("script")  # {_marker()} codeql-boundary:fixture-boundary\n',
+        encoding="utf-8",
+    )
+
+    assert _scan(tmp_path) == [
+        (
+            "tool",
+            2,
+            _marker(),
+            "fixture-boundary",
+            "<module>",
+            'open("script")',
+        ),
+        (
+            "types.pyi",
+            1,
+            _marker(),
+            "fixture-boundary",
+            "<module>",
+            'open("pyi")',
+        ),
+        (
+            "window.pyw",
+            1,
+            _marker(),
+            "fixture-boundary",
+            "<module>",
+            'open("pyw")',
+        ),
+    ]
+
+
+def test_scanner_ignores_non_target_suppression_comment(tmp_path):
+    path = tmp_path / "example.py"
+    path.write_text(
+        'open("fixture")  # lgtm[py/other-rule]\n',
+        encoding="utf-8",
+    )
+
+    assert _scan(tmp_path) == []
+
+
+def test_scanner_does_not_follow_extensionless_symlink_for_shebang(tmp_path):
+    outside = tmp_path / "outside.py-source"
+    outside.write_text(
+        "#!/usr/bin/env python3\n"
+        f'open("outside")  # {_marker()} codeql-boundary:fixture-boundary\n',
+        encoding="utf-8",
+    )
+    link = tmp_path / "tool"
+    link.symlink_to(outside)
+
+    assert _scan(tmp_path) == []

--- a/merger/lenskit/tests/test_federation_query.py
+++ b/merger/lenskit/tests/test_federation_query.py
@@ -415,7 +415,7 @@ def test_conflicts_are_reported_not_merged(federated_setup):
         assert "conflict_refs" in h
         assert c["conflict_id"] in h["conflict_refs"]
 
-def test_stale_bundle_is_marked_in_federation_trace(federated_setup):
+def test_stale_bundle_is_marked_in_federation_trace(federated_setup, monkeypatch):
     import sqlite3
 
     # Set fingerprint in federation.json that mismatches the actual index
@@ -436,6 +436,15 @@ def test_stale_bundle_is_marked_in_federation_trace(federated_setup):
     conn.commit()
     conn.close()
 
+    real_connect = sqlite3.connect
+    calls = []
+
+    def recording_connect(database, *args, **kwargs):
+        calls.append((database, kwargs.get("uri")))
+        return real_connect(database, *args, **kwargs)
+
+    monkeypatch.setattr(sqlite3, "connect", recording_connect)
+
     res = execute_federated_query(
         federation_index_path=federated_setup,
         query_text="hello",
@@ -448,6 +457,8 @@ def test_stale_bundle_is_marked_in_federation_trace(federated_setup):
     assert trace["bundle_status"]["repo1"] == "stale"
     assert trace["bundle_status"]["repo2"] == "ok"
     assert trace["queried_bundles_effective"] == 2
+    repo1_uri = f"{repo1_db.resolve().as_uri()}?mode=ro&immutable=1"
+    assert calls.count((repo1_uri, True)) == 2
 
     stale_hits = [hit for hit in res["results"] if hit["federation_bundle"] == "repo1"]
     assert stale_hits, "stale bundle still returns hits, but they must be explicitly marked"

--- a/merger/lenskit/tests/test_retrieval_query.py
+++ b/merger/lenskit/tests/test_retrieval_query.py
@@ -27,6 +27,32 @@ def mini_index(tmp_path):
 
     return db_path
 
+def test_query_read_only_uses_immutable_sqlite_uri(mini_index, monkeypatch):
+    canonical_index = mini_index.with_name("chunk.index.sqlite")
+    mini_index.replace(canonical_index)
+    canonical_index = canonical_index.resolve()
+    real_connect = sqlite3.connect
+    calls = []
+
+    def recording_connect(database, *args, **kwargs):
+        calls.append((database, kwargs.get("uri")))
+        return real_connect(database, *args, **kwargs)
+
+    monkeypatch.setattr(query_core.sqlite3, "connect", recording_connect)
+
+    result = query_core.execute_query(
+        canonical_index,
+        query_text="",
+        k=1,
+        read_only=True,
+    )
+
+    assert result["count"] == 1
+    assert calls == [
+        (f"{canonical_index.as_uri()}?mode=ro&immutable=1", True),
+    ]
+
+
 def test_query_metadata_filter(mini_index):
     # Filter by layer
     res = query_core.execute_query(mini_index, query_text="", k=10, filters={"layer": "core"})

--- a/scripts/ci/check_codeql_suppressions.py
+++ b/scripts/ci/check_codeql_suppressions.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+"""Validate that every CodeQL path-injection suppression is reviewed and inventoried."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import io
+import json
+import os
+import re
+import subprocess
+import tokenize
+from collections import Counter, defaultdict
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+_MARKER_TEXT = "lgtm[py/path-injection]"
+_SUPPRESSION_BLOCK_RE = re.compile(
+    r"(?P<marker>(?:lgtm|codeql)\s*\[(?P<rules>[^\]]*)\])",
+    re.IGNORECASE,
+)
+_TARGET_TEXT_RE = re.compile(
+    r"(?:lgtm|codeql)\s*\[[^\]]*py\s*/\s*path-injection[^\]]*\]",
+    re.IGNORECASE,
+)
+_BOUNDARY_RE = re.compile(r"\bcodeql-boundary:([a-z0-9][a-z0-9-]*)\b")
+_EXCLUDED_DIRECTORY_NAMES = {
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".tox",
+    ".venv",
+    "__pycache__",
+    "node_modules",
+    "venv",
+}
+
+
+def _load_inventory(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"Invalid suppression inventory: {path}") from exc
+    if data.get("schema_version") != 1:
+        raise ValueError("Suppression inventory schema_version must be 1")
+    if data.get("rule") != "py/path-injection":
+        raise ValueError("Suppression inventory rule must be py/path-injection")
+    if data.get("marker") != _MARKER_TEXT:
+        raise ValueError(f"Suppression inventory marker must be {_MARKER_TEXT}")
+    boundaries = data.get("boundaries")
+    if not isinstance(boundaries, dict) or not boundaries:
+        raise ValueError("Suppression inventory boundaries must be a non-empty object")
+    return data
+
+
+def _is_python_source(path: Path) -> bool:
+    if path.is_symlink():
+        return path.suffix.lower() in {".py", ".pyi", ".pyw"}
+    if path.suffix.lower() in {".py", ".pyi", ".pyw"}:
+        return True
+    if path.suffix:
+        return False
+    try:
+        with path.open("rb") as handle:
+            first_line = handle.readline(512).lower()
+    except OSError:
+        return False
+    return first_line.startswith(b"#!") and b"python" in first_line
+
+
+def _python_sources(root: Path) -> list[Path]:
+    root_resolved = root.resolve()
+    sources: list[Path] = []
+    for directory, child_dirs, filenames in os.walk(
+        root,
+        topdown=True,
+        followlinks=False,
+    ):
+        child_dirs[:] = sorted(
+            name for name in child_dirs if name not in _EXCLUDED_DIRECTORY_NAMES
+        )
+        for filename in sorted(filenames):
+            path = Path(directory) / filename
+            if not _is_python_source(path):
+                continue
+            relative = path.relative_to(root)
+            try:
+                path.resolve(strict=True).relative_to(root_resolved)
+            except (OSError, RuntimeError, ValueError) as exc:
+                raise ValueError(
+                    f"Python source escapes repository root: {relative.as_posix()}"
+                ) from exc
+            sources.append(path)
+    return sources
+
+
+def _assert_tracked_python_coverage(root: Path, sources: list[Path]) -> None:
+    git_marker = root / ".git"
+    if not git_marker.exists():
+        return
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(root), "ls-files", "-z"],
+            check=True,
+            capture_output=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise ValueError("Cannot enumerate tracked Python files") from exc
+
+    tracked = set()
+    for item in result.stdout.split(b"\0"):
+        if not item:
+            continue
+        relative = item.decode("utf-8")
+        candidate = root / relative
+        if _is_python_source(candidate):
+            tracked.add(relative)
+    scanned = {path.relative_to(root).as_posix() for path in sources}
+    missed = sorted(tracked - scanned)
+    if missed:
+        raise ValueError(
+            "Tracked Python files are excluded from suppression scanning: "
+            + ", ".join(missed)
+        )
+
+
+def _scope_ranges(module: ast.Module) -> list[tuple[int, int, str]]:
+    ranges: list[tuple[int, int, str]] = []
+
+    def visit(body: list[ast.stmt], prefix: str = "") -> None:
+        for node in body:
+            if not isinstance(
+                node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+            ):
+                continue
+            name = f"{prefix}.{node.name}" if prefix else node.name
+            end_line = getattr(node, "end_lineno", node.lineno)
+            ranges.append((node.lineno, end_line, name))
+            visit(node.body, name)
+
+    visit(module.body)
+    return ranges
+
+
+def _scope_for_line(ranges: list[tuple[int, int, str]], line: int) -> str:
+    candidates = [
+        (end - start, name)
+        for start, end, name in ranges
+        if start <= line <= end
+    ]
+    if not candidates:
+        return "<module>"
+    return min(candidates, key=lambda item: item[0])[1]
+
+def _target_suppressions(comment: str) -> list[tuple[str, str | None]]:
+    matches = list(_SUPPRESSION_BLOCK_RE.finditer(comment))
+    found: list[tuple[str, str | None]] = []
+    for index, match in enumerate(matches):
+        normalized_rules = re.sub(r"\s+", "", match.group("rules")).casefold()
+        if "py/path-injection" not in normalized_rules:
+            continue
+        segment_end = matches[index + 1].start() if index + 1 < len(matches) else len(comment)
+        tail = comment[match.end():segment_end]
+        boundary_match = _BOUNDARY_RE.search(tail)
+        boundary = boundary_match.group(1) if boundary_match else None
+        found.append((match.group("marker"), boundary))
+    return found
+
+
+def _scan(root: Path) -> list[tuple[str, int, str, str | None, str, str]]:
+    found: list[tuple[str, int, str, str | None, str, str]] = []
+    sources = _python_sources(root)
+    _assert_tracked_python_coverage(root, sources)
+    for path in sources:
+        relative = path.relative_to(root).as_posix()
+        try:
+            source = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as exc:
+            raise ValueError(f"Cannot read Python source: {relative}") from exc
+        lines = source.splitlines()
+        try:
+            tokens = list(tokenize.generate_tokens(io.StringIO(source).readline))
+        except (IndentationError, tokenize.TokenError) as exc:
+            if _TARGET_TEXT_RE.search(source):
+                raise ValueError(
+                    f"Cannot tokenize Python source containing suppression: {relative}"
+                ) from exc
+            continue
+        suppression_tokens = [
+            token
+            for token in tokens
+            if token.type == tokenize.COMMENT and _target_suppressions(token.string)
+        ]
+        if not suppression_tokens:
+            continue
+        try:
+            module = ast.parse(source, filename=relative)
+        except SyntaxError as exc:
+            raise ValueError(
+                f"Cannot parse Python source containing suppression: {relative}"
+            ) from exc
+        ranges = _scope_ranges(module)
+        for token in suppression_tokens:
+            line_number, column = token.start
+            statement = lines[line_number - 1][:column].strip()
+            scope = _scope_for_line(ranges, line_number)
+            for marker, boundary in _target_suppressions(token.string):
+                found.append(
+                    (relative, line_number, marker, boundary, scope, statement)
+                )
+    return found
+
+
+def _resolve_inventory_path(root: Path, raw_path: str) -> Path | None:
+    if not isinstance(raw_path, str) or not raw_path or "\x00" in raw_path:
+        return None
+    if "\\" in raw_path or raw_path != raw_path.strip():
+        return None
+    pure = PurePosixPath(raw_path)
+    if pure.is_absolute() or any(part in {"", ".", ".."} for part in pure.parts):
+        return None
+    if pure.as_posix() != raw_path:
+        return None
+    candidate = root.joinpath(*pure.parts)
+    try:
+        candidate.resolve(strict=False).relative_to(root.resolve())
+    except (OSError, RuntimeError, ValueError):
+        return None
+    return candidate
+
+
+def _test_reference_exists(root: Path, test_ref: str) -> bool:
+    parts = test_ref.split("::")
+    if len(parts) < 2 or not parts[-1].startswith("test_"):
+        return False
+    path = _resolve_inventory_path(root, parts[0])
+    if path is None or not path.name.startswith("test_") or not path.is_file():
+        return False
+    try:
+        module = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (OSError, SyntaxError, UnicodeError):
+        return False
+
+    body = module.body
+    for name in parts[1:]:
+        match = next(
+            (
+                node
+                for node in body
+                if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef))
+                and node.name == name
+            ),
+            None,
+        )
+        if match is None:
+            return False
+        body = match.body if isinstance(match, ast.ClassDef) else []
+    return True
+
+
+def validate(root: Path, inventory_path: Path) -> list[str]:
+    inventory = _load_inventory(inventory_path)
+    boundaries: dict[str, Any] = inventory["boundaries"]
+    findings: list[str] = []
+
+    observed = _scan(root)
+    counts: Counter[str] = Counter()
+    files_by_boundary: dict[str, set[str]] = defaultdict(set)
+    sites_by_boundary: dict[str, Counter[tuple[str, str, str]]] = defaultdict(Counter)
+
+    for path, line, marker, boundary, scope, statement in observed:
+        if marker != _MARKER_TEXT:
+            findings.append(
+                f"unsupported suppression marker {marker} at {path}:{line}; "
+                f"expected {_MARKER_TEXT}"
+            )
+            continue
+        if boundary is None:
+            findings.append(f"unregistered suppression at {path}:{line}")
+            continue
+        if boundary not in boundaries:
+            findings.append(f"unknown boundary {boundary} at {path}:{line}")
+            continue
+        if not statement:
+            findings.append(
+                f"suppression {boundary} at {path}:{line} must be inline with its sink"
+            )
+        counts[boundary] += 1
+        files_by_boundary[boundary].add(path)
+        sites_by_boundary[boundary][(path, scope, statement)] += 1
+
+    for boundary, record in sorted(boundaries.items()):
+        if not re.fullmatch(r"[a-z0-9][a-z0-9-]*", boundary):
+            findings.append(f"invalid boundary identifier: {boundary}")
+            continue
+        if not isinstance(record, dict):
+            findings.append(f"boundary {boundary} must be an object")
+            continue
+
+        expected = record.get("expected_occurrences")
+        if not isinstance(expected, int) or expected <= 0:
+            findings.append(f"boundary {boundary} has invalid expected_occurrences")
+        elif counts[boundary] != expected:
+            findings.append(
+                f"boundary {boundary} expected {expected} occurrence(s), "
+                f"found {counts[boundary]}"
+            )
+
+        expected_files = record.get("files")
+        if not isinstance(expected_files, list) or not expected_files or not all(
+            isinstance(item, str)
+            and _resolve_inventory_path(root, item) is not None
+            for item in expected_files
+        ):
+            findings.append(f"boundary {boundary} has invalid files")
+        elif len(set(expected_files)) != len(expected_files):
+            findings.append(f"boundary {boundary} contains duplicate files")
+        elif set(expected_files) != files_by_boundary[boundary]:
+            findings.append(
+                f"boundary {boundary} files mismatch: expected {sorted(expected_files)}, "
+                f"found {sorted(files_by_boundary[boundary])}"
+            )
+
+        expected_sites = record.get("sites")
+        if not isinstance(expected_sites, list) or not expected_sites:
+            findings.append(f"boundary {boundary} has no site inventory")
+        else:
+            parsed_sites: Counter[tuple[str, str, str]] = Counter()
+            for site in expected_sites:
+                if not isinstance(site, dict):
+                    findings.append(f"boundary {boundary} has invalid site entry")
+                    continue
+                site_path = site.get("path")
+                scope = site.get("scope")
+                statement = site.get("statement")
+                if (
+                    not isinstance(site_path, str)
+                    or _resolve_inventory_path(root, site_path) is None
+                    or not isinstance(scope, str)
+                    or not scope.strip()
+                    or not isinstance(statement, str)
+                    or not statement.strip()
+                ):
+                    findings.append(f"boundary {boundary} has invalid site entry")
+                    continue
+                parsed_sites[(site_path, scope, statement)] += 1
+            if isinstance(expected, int) and sum(parsed_sites.values()) != expected:
+                findings.append(
+                    f"boundary {boundary} site inventory has "
+                    f"{sum(parsed_sites.values())} occurrence(s), expected {expected}"
+                )
+            if parsed_sites != sites_by_boundary[boundary]:
+                expected_rendered = sorted(
+                    f"{path}::{scope}: {statement}"
+                    for (path, scope, statement), count in parsed_sites.items()
+                    for _ in range(count)
+                )
+                observed_rendered = sorted(
+                    f"{path}::{scope}: {statement}"
+                    for (path, scope, statement), count in sites_by_boundary[boundary].items()
+                    for _ in range(count)
+                )
+                findings.append(
+                    f"boundary {boundary} sites mismatch: "
+                    f"expected {expected_rendered}, found {observed_rendered}"
+                )
+
+        authority = record.get("authority")
+        if not isinstance(authority, str) or not authority.strip():
+            findings.append(f"boundary {boundary} has no authority rationale")
+
+        validation = record.get("validation")
+        if not isinstance(validation, list) or not validation or not all(
+            isinstance(item, str) and item.strip() for item in validation
+        ):
+            findings.append(f"boundary {boundary} has no validation rationale")
+
+        tests = record.get("tests")
+        if not isinstance(tests, list) or not tests or not all(
+            isinstance(item, str) and item.strip() for item in tests
+        ):
+            findings.append(f"boundary {boundary} has no regression tests")
+        else:
+            for test_ref in tests:
+                if not _test_reference_exists(root, test_ref):
+                    findings.append(
+                        f"boundary {boundary} references missing test: {test_ref}"
+                    )
+
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument(
+        "--inventory",
+        type=Path,
+        default=Path("config/codeql-path-suppressions.v1.json"),
+    )
+    args = parser.parse_args()
+
+    root = args.root.resolve()
+    inventory = args.inventory
+    if not inventory.is_absolute():
+        inventory = root / inventory
+
+    try:
+        findings = validate(root, inventory)
+    except ValueError as exc:
+        print(f"CodeQL suppression ratchet error: {exc}")
+        return 2
+
+    if findings:
+        print(f"CodeQL suppression ratchet found {len(findings)} problem(s):")
+        for finding in findings:
+            print(f"- {finding}")
+        return 1
+
+    observed = _scan(root)
+    print(
+        "CodeQL suppression ratchet passed: "
+        f"{len(observed)} suppression(s), all inventoried."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- inventory all 30 intentional `py/path-injection` suppressions under 12 named trust boundaries
- fail CI on bare, alternate, unknown, moved, or untested suppression sites
- scan tracked `.py`, `.pyi`, `.pyw`, and Python-shebang sources without following extensionless symlinks
- run the suppression ratchet before CodeQL initialization while preserving the raw-SARIF zero-result gate
- add direct Prescan symlink and immutable read-only SQLite proofs

## Local validation

- 20 ratchet unit and negative tests passed
- 29 inventory-linked pytest node IDs produced 42 passing cases
- 157 focused and adjacent security/API tests passed
- default Ruff on changed Python files passed
- repository `ruff-ci.toml` passed
- planning-registration ratchet: 0 findings, 0 control errors
- eight changed product modules are AST-identical to base

## Review

- self-review: PASS, bound to implementation head `b85cc35445d72f6b90f896f509488a4e69f734a6`
- first independent review: FAIL; parser and source-discovery findings addressed
- final independent review: PASS with no findings
- final review packet SHA-256: `12a5b090cbba63b99d7420e3194a9b74cc9a8ecb9226fa4bf9520e18ce20643e`

## Non-claims

This ratchet does not make suppressions safe, prove test sufficiency, replace CodeQL or raw SARIF inspection, establish runtime correctness, or establish merge readiness.
