### PR TITLE
test(governance): negative required-check proof (do not merge)

### DIFF
--- a/ruleset_negative_proof.py
+++ b/ruleset_negative_proof.py
@@ -1,0 +1,3 @@
+"""Disposable negative proof: this import intentionally violates F401."""
+
+import os


### PR DESCRIPTION
Disposable negative enforcement proof for the active `main-required-checks` ruleset.

Expected result:
- `ruff` fails on an intentional F401 violation.
- GitHub reports this PR as blocked by required status checks.
- This PR must never be merged and will be closed after evidence capture.

Source: Bureau live-register candidate event 57 and active thread-focus event 70.

This PR does not establish test sufficiency, security correctness, or merge readiness.