### PR TITLE
chore(governance): require main CI and CodeQL gates

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   analyze:
-    name: Analyze (python)
+    name: Lenskit CodeQL policy (python)
     runs-on: ubuntu-latest
 
     steps:

--- a/config/github-main-required-checks.v1.json
+++ b/config/github-main-required-checks.v1.json
@@ -52,5 +52,6 @@
     ],
     "target": "branch"
   },
-  "schema_version": 1
+  "schema_version": 1,
+  "source_type": "Repository"
 }

--- a/config/github-main-required-checks.v1.json
+++ b/config/github-main-required-checks.v1.json
@@ -1,0 +1,56 @@
+{
+  "does_not_establish": [
+    "github_runtime_enforcement",
+    "check_correctness",
+    "test_sufficiency",
+    "absence_of_security_findings",
+    "merge_readiness"
+  ],
+  "repository": "heimgewebe/lenskit",
+  "ruleset": {
+    "bypass_actors": [],
+    "conditions": {
+      "ref_name": {
+        "exclude": [],
+        "include": [
+          "refs/heads/main"
+        ]
+      }
+    },
+    "enforcement": "active",
+    "name": "main-required-checks",
+    "rules": [
+      {
+        "parameters": {
+          "do_not_enforce_on_create": false,
+          "required_status_checks": [
+            {
+              "context": "Lenskit CodeQL policy (python)",
+              "integration_id": 15368
+            },
+            {
+              "context": "CodeQL",
+              "integration_id": 57789
+            },
+            {
+              "context": "pytest-full",
+              "integration_id": 15368
+            },
+            {
+              "context": "ruff",
+              "integration_id": 15368
+            },
+            {
+              "context": "webui-js-tests",
+              "integration_id": 15368
+            }
+          ],
+          "strict_required_status_checks_policy": true
+        },
+        "type": "required_status_checks"
+      }
+    ],
+    "target": "branch"
+  },
+  "schema_version": 1
+}

--- a/docs/proofs/lenskit-main-required-checks-v1-proof.md
+++ b/docs/proofs/lenskit-main-required-checks-v1-proof.md
@@ -21,7 +21,7 @@ The new ruleset has GitHub ruleset id `18784275`, has no bypass actors, and requ
 
 The custom workflow job has the unique context `Lenskit CodeQL policy (python)` so GitHub's separate default `Analyze (python)` check cannot ambiguously satisfy this policy.
 
-The machine-readable desired state is `config/github-main-required-checks.v1.json`. The read-only, network-free validator is `scripts/ci/check_github_main_ruleset.py`.
+The machine-readable desired state is `config/github-main-required-checks.v1.json`. The read-only, network-free validator is `scripts/ci/check_github_main_ruleset.py`. It fails unless the observed API response identifies `source=heimgewebe/lenskit` and `source_type=Repository`; a same-shaped ruleset from another repository is therefore rejected.
 
 Operator check:
 

--- a/docs/proofs/lenskit-main-required-checks-v1-proof.md
+++ b/docs/proofs/lenskit-main-required-checks-v1-proof.md
@@ -1,0 +1,85 @@
+# Lenskit main required checks v1 proof
+
+Status: implemented and structurally verified on 2026-07-10. Positive implementation-PR evidence is recorded before merge.
+
+## Scope
+
+A separate repository ruleset named `main-required-checks` protects only `refs/heads/main`.
+It does not replace the existing `zweigschutz` ruleset, which continues to protect deletion and non-fast-forward updates.
+
+The new ruleset has GitHub ruleset id `18784275`, has no bypass actors, and requires these checks from their observed GitHub Apps:
+
+| Required context | Integration id | Evidence guarded |
+|---|---:|---|
+| `Lenskit CodeQL policy (python)` | `15368` | The repository CodeQL workflow, including suppression-inventory validation and the post-analysis raw-SARIF clean gate |
+| `CodeQL` | `57789` | GitHub Advanced Security's pull-request CodeQL result |
+| `pytest-full` | `15368` | The full Python test suite excluding explicitly non-blocking markers |
+| `ruff` | `15368` | The pinned repository-wide Ruff ratchet |
+| `webui-js-tests` | `15368` | The Web UI JavaScript test suite |
+
+`strict_required_status_checks_policy` is enabled. A pull request whose branch is behind `main` must therefore be brought up to date and revalidated before merge. This trades extra CI reruns for evidence against the current base.
+
+The custom workflow job has the unique context `Lenskit CodeQL policy (python)` so GitHub's separate default `Analyze (python)` check cannot ambiguously satisfy this policy.
+
+The machine-readable desired state is `config/github-main-required-checks.v1.json`. The read-only, network-free validator is `scripts/ci/check_github_main_ruleset.py`.
+
+Operator check:
+
+```bash
+gh api repos/heimgewebe/lenskit/rulesets/18784275 \
+  | python3 scripts/ci/check_github_main_ruleset.py
+```
+
+A successful validator result establishes only structural agreement between the observed API response and the checked-in policy. It does not establish that GitHub will enforce the rule at merge time.
+
+## Staged activation proof
+
+The ruleset was first created with `enforcement=disabled`.
+The validator failed with exactly one finding:
+
+```text
+enforcement mismatch: expected 'active', found 'disabled'
+```
+
+After the payload was checked, the same ruleset was updated to `enforcement=active`, read back from the GitHub API, and validated with `status=pass` and no findings.
+
+## Negative enforcement proof
+
+Disposable pull request [#955](https://github.com/heimgewebe/lenskit/pull/955) used head commit `9a777407c43a002a7a528cf98bdf69ef2ec322d7` and intentionally introduced one Ruff `F401` violation.
+
+Observed on 2026-07-10:
+
+- GitHub computed the branch as `mergeable=MERGEABLE`; there was no content conflict.
+- Required check `ruff` completed with `FAILURE`.
+- GitHub reported `mergeStateStatus=BLOCKED`.
+- The pull request was closed without merge.
+- The disposable remote branch and worktree were removed.
+
+This demonstrates that a content-mergeable pull request is blocked when a configured required check fails. It does not prove that every possible bypass, permission path, GitHub outage, or future rule edit is covered.
+
+## Positive implementation proof
+
+To be completed on the implementation pull request after the checked-in policy, validator, tests, and this proof have passed all five required checks on the current `main` base.
+
+## Rollback
+
+If an incorrect context or GitHub incident deadlocks merges:
+
+1. set ruleset `18784275` to `enforcement=disabled`;
+2. diagnose the mismatched context or integration id;
+3. update the checked-in desired state and tests through a reviewed pull request;
+4. reactivate only after API read-back validation and a fresh negative/positive proof.
+
+Deleting this separate ruleset is a last-resort rollback. It does not modify the existing deletion/non-fast-forward `zweigschutz` ruleset.
+
+## Non-claims
+
+This proof does not establish:
+
+- test sufficiency;
+- absence of security findings;
+- CodeQL or Ruff correctness;
+- runtime correctness;
+- review completeness;
+- permanent GitHub availability;
+- merge readiness of any unrelated pull request.

--- a/docs/proofs/lenskit-main-required-checks-v1-proof.md
+++ b/docs/proofs/lenskit-main-required-checks-v1-proof.md
@@ -59,7 +59,19 @@ This demonstrates that a content-mergeable pull request is blocked when a config
 
 ## Positive implementation proof
 
-To be completed on the implementation pull request after the checked-in policy, validator, tests, and this proof have passed all five required checks on the current `main` base.
+Implementation pull request [#956](https://github.com/heimgewebe/lenskit/pull/956) ran head `d9b1b0478e0a7e8cc3fcbff2637d6a3a4da9f56f` against base `dcce9ae48606aad1ea7684a1205fe6c844cb4faf`.
+
+GitHub reported `mergeable=MERGEABLE` and `mergeStateStatus=CLEAN` after all configured required checks completed successfully:
+
+- `Lenskit CodeQL policy (python)`: `SUCCESS`;
+- `CodeQL`: `SUCCESS`;
+- `pytest-full`: `SUCCESS`;
+- `ruff`: `SUCCESS`;
+- `webui-js-tests`: `SUCCESS`.
+
+The uniquely named Lenskit CodeQL policy job and GitHub's separate default `Analyze (python)` job were both visible, demonstrating that the required context no longer relies on the ambiguous shared name.
+
+The final documentation-only proof commit must repeat the required checks before merge; the merge gate, not this paragraph, remains authoritative for the final head.
 
 ## Rollback
 

--- a/docs/tasks/index.json
+++ b/docs/tasks/index.json
@@ -1394,6 +1394,25 @@
         "No persistence store, CLI, MCP surface, runtime scheduler or automatic memory backend is introduced.",
         "No claim truth, repository completeness, answer correctness, review completeness, test sufficiency or remote freshness is established."
       ]
+    },
+    {
+      "id": "TASK-LENSKIT-MAIN-REQUIRED-CHECKS-001",
+      "title": "Lenskit Main Required CI and CodeQL Checks",
+      "status": "done",
+      "description": "Closed by Lenskit main required checks v1: a separate main-only GitHub ruleset requires the uniquely named Lenskit Python CodeQL policy workflow and GitHub Advanced Security result, the full Python suite, repository-wide Ruff, and Web UI JavaScript tests. The desired state is checked in, API read-back is validated offline, strict current-base validation is enabled, and disposable PR #955 proves a content-mergeable PR is blocked when Ruff fails.",
+      "evidence": [
+        "config/github-main-required-checks.v1.json",
+        "scripts/ci/check_github_main_ruleset.py",
+        "merger/lenskit/tests/test_github_main_ruleset.py",
+        "docs/proofs/lenskit-main-required-checks-v1-proof.md",
+        "https://github.com/heimgewebe/lenskit/rules/18784275",
+        "https://github.com/heimgewebe/lenskit/pull/955"
+      ],
+      "missing_evidence": [
+        "No test-sufficiency, security-correctness, runtime-correctness, or review-completeness claim is established.",
+        "No protection against future administrator edits, GitHub outages, or unobserved permission paths is established.",
+        "The checked-in validator proves API structure only; merge-time enforcement requires separate positive and negative GitHub evidence."
+      ]
     }
   ]
 }

--- a/merger/lenskit/tests/test_github_main_ruleset.py
+++ b/merger/lenskit/tests/test_github_main_ruleset.py
@@ -17,6 +17,8 @@ def _observed():
     policy = load_policy()
     observed = api_payload(policy)
     observed["id"] = 1234
+    observed["source"] = policy["repository"]
+    observed["source_type"] = policy["source_type"]
     return policy, observed
 
 
@@ -27,6 +29,8 @@ def test_required_checks_policy_matches_observed_ruleset():
 
     assert report["status"] == "pass"
     assert report["ruleset_id"] == 1234
+    assert report["observed_source"] == "heimgewebe/lenskit"
+    assert report["observed_source_type"] == "Repository"
     assert report["findings"] == []
     assert {item["context"] for item in report["required_checks"]} == {
         "Lenskit CodeQL policy (python)",
@@ -37,6 +41,25 @@ def test_required_checks_policy_matches_observed_ruleset():
     }
     assert "github_runtime_enforcement" in report["does_not_establish"]
 
+
+def test_required_checks_policy_detects_wrong_repository_source():
+    policy, observed = _observed()
+    observed["source"] = "other-owner/lenskit-fork"
+
+    report = validate_ruleset(policy, observed)
+
+    assert report["status"] == "fail"
+    assert any("source mismatch" in finding for finding in report["findings"])
+
+
+def test_required_checks_policy_detects_missing_or_wrong_source_type():
+    policy, observed = _observed()
+    observed["source_type"] = "Organization"
+
+    report = validate_ruleset(policy, observed)
+
+    assert report["status"] == "fail"
+    assert any("source_type mismatch" in finding for finding in report["findings"])
 
 def test_required_checks_policy_detects_missing_check():
     policy, observed = _observed()

--- a/merger/lenskit/tests/test_github_main_ruleset.py
+++ b/merger/lenskit/tests/test_github_main_ruleset.py
@@ -1,0 +1,111 @@
+import copy
+from pathlib import Path
+
+import pytest
+
+from scripts.ci.check_github_main_ruleset import (
+    RulesetValidationError,
+    api_payload,
+    load_policy,
+    validate_ruleset,
+)
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def _observed():
+    policy = load_policy()
+    observed = api_payload(policy)
+    observed["id"] = 1234
+    return policy, observed
+
+
+def test_required_checks_policy_matches_observed_ruleset():
+    policy, observed = _observed()
+
+    report = validate_ruleset(policy, observed)
+
+    assert report["status"] == "pass"
+    assert report["ruleset_id"] == 1234
+    assert report["findings"] == []
+    assert {item["context"] for item in report["required_checks"]} == {
+        "Lenskit CodeQL policy (python)",
+        "CodeQL",
+        "pytest-full",
+        "ruff",
+        "webui-js-tests",
+    }
+    assert "github_runtime_enforcement" in report["does_not_establish"]
+
+
+def test_required_checks_policy_detects_missing_check():
+    policy, observed = _observed()
+    observed["rules"][0]["parameters"]["required_status_checks"].pop()
+
+    report = validate_ruleset(policy, observed)
+
+    assert report["status"] == "fail"
+    assert any("missing required checks" in finding for finding in report["findings"])
+
+
+def test_required_checks_policy_detects_wrong_integration():
+    policy, observed = _observed()
+    observed["rules"][0]["parameters"]["required_status_checks"][0][
+        "integration_id"
+    ] = 999
+
+    report = validate_ruleset(policy, observed)
+
+    assert report["status"] == "fail"
+    assert any("missing required checks" in finding for finding in report["findings"])
+    assert any("unexpected required checks" in finding for finding in report["findings"])
+
+
+def test_required_checks_policy_detects_inactive_or_wrong_scope():
+    policy, observed = _observed()
+    observed["enforcement"] = "disabled"
+    observed["conditions"]["ref_name"]["include"] = ["refs/heads/release"]
+
+    report = validate_ruleset(policy, observed)
+
+    assert report["status"] == "fail"
+    assert any("enforcement mismatch" in finding for finding in report["findings"])
+    assert any("conditions mismatch" in finding for finding in report["findings"])
+
+
+def test_required_checks_policy_rejects_ambiguous_extra_rule():
+    policy, observed = _observed()
+    observed["rules"].append(copy.deepcopy(observed["rules"][0]))
+
+    report = validate_ruleset(policy, observed)
+
+    assert report["status"] == "fail"
+    assert any("exactly one rule" in finding for finding in report["findings"])
+
+
+def test_required_checks_policy_detects_bypass_actor():
+    policy, observed = _observed()
+    observed["bypass_actors"] = [
+        {"actor_id": 1, "actor_type": "RepositoryRole", "bypass_mode": "always"}
+    ]
+
+    report = validate_ruleset(policy, observed)
+
+    assert report["status"] == "fail"
+    assert any("bypass_actors mismatch" in finding for finding in report["findings"])
+
+
+def test_codeql_policy_context_is_unique_and_binds_both_policy_steps():
+    workflow = (ROOT / ".github" / "workflows" / "codeql.yml").read_text(encoding="utf-8")
+
+    assert workflow.count("name: Lenskit CodeQL policy (python)") == 1
+    assert "name: Validate CodeQL suppression inventory" in workflow
+    assert "name: Require clean raw CodeQL SARIF" in workflow
+
+
+def test_required_checks_policy_rejects_invalid_policy_rule_shape():
+    policy, observed = _observed()
+    policy["ruleset"]["rules"] = []
+
+    with pytest.raises(RulesetValidationError, match="exactly one"):
+        validate_ruleset(policy, observed)

--- a/scripts/ci/check_github_main_ruleset.py
+++ b/scripts/ci/check_github_main_ruleset.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Validate an observed GitHub ruleset against Lenskit's required-check policy.
+
+The observed ruleset JSON is read from stdin. This checker is deliberately
+read-only and network-free; callers remain responsible for obtaining current
+GitHub API data.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+POLICY_PATH = ROOT / "config" / "github-main-required-checks.v1.json"
+KIND = "lenskit.github_main_required_checks_validation"
+VERSION = "v1"
+
+
+class RulesetValidationError(ValueError):
+    """Raised when policy or observed ruleset input is structurally invalid."""
+
+
+def _load_object(raw: str, *, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RulesetValidationError(f"{label} is not valid JSON") from exc
+    if not isinstance(value, dict):
+        raise RulesetValidationError(f"{label} must be a JSON object")
+    return value
+
+
+def load_policy() -> dict[str, Any]:
+    try:
+        policy = _load_object(POLICY_PATH.read_text(encoding="utf-8"), label="policy")
+    except OSError as exc:
+        raise RulesetValidationError(f"cannot read policy: {POLICY_PATH}") from exc
+    if policy.get("schema_version") != 1:
+        raise RulesetValidationError("policy schema_version must be 1")
+    ruleset = policy.get("ruleset")
+    if not isinstance(ruleset, dict):
+        raise RulesetValidationError("policy ruleset must be an object")
+    return policy
+
+
+def api_payload(policy: dict[str, Any]) -> dict[str, Any]:
+    """Return the exact create/update payload encoded by the policy."""
+    ruleset = policy.get("ruleset")
+    if not isinstance(ruleset, dict):
+        raise RulesetValidationError("policy ruleset must be an object")
+    return json.loads(json.dumps(ruleset))
+
+
+def _required_rule(ruleset: dict[str, Any], *, label: str) -> dict[str, Any]:
+    rules = ruleset.get("rules")
+    if not isinstance(rules, list):
+        raise RulesetValidationError(f"{label}.rules must be a list")
+    if len(rules) != 1:
+        raise RulesetValidationError(
+            f"{label} must contain exactly one rule; found {len(rules)}"
+        )
+    rule = rules[0]
+    if not isinstance(rule, dict) or rule.get("type") != "required_status_checks":
+        raise RulesetValidationError(
+            f"{label} only rule must be required_status_checks"
+        )
+    return rule
+
+
+def _check_pairs(rule: dict[str, Any], *, label: str) -> Counter[tuple[str, int | None]]:
+    parameters = rule.get("parameters")
+    if not isinstance(parameters, dict):
+        raise RulesetValidationError(f"{label}.parameters must be an object")
+    checks = parameters.get("required_status_checks")
+    if not isinstance(checks, list):
+        raise RulesetValidationError(f"{label}.required_status_checks must be a list")
+    pairs: Counter[tuple[str, int | None]] = Counter()
+    for index, item in enumerate(checks):
+        if not isinstance(item, dict):
+            raise RulesetValidationError(f"{label}.required_status_checks[{index}] must be an object")
+        context = item.get("context")
+        integration_id = item.get("integration_id")
+        if not isinstance(context, str) or not context.strip():
+            raise RulesetValidationError(
+                f"{label}.required_status_checks[{index}].context must be non-empty"
+            )
+        if integration_id is not None and not isinstance(integration_id, int):
+            raise RulesetValidationError(
+                f"{label}.required_status_checks[{index}].integration_id must be an integer"
+            )
+        pairs[(context, integration_id)] += 1
+    return pairs
+
+
+def validate_ruleset(policy: dict[str, Any], observed: dict[str, Any]) -> dict[str, Any]:
+    expected = api_payload(policy)
+    findings: list[str] = []
+
+    for field in ("name", "target", "enforcement", "bypass_actors"):
+        if observed.get(field) != expected.get(field):
+            findings.append(
+                f"{field} mismatch: expected {expected.get(field)!r}, found {observed.get(field)!r}"
+            )
+
+    expected_conditions = expected.get("conditions")
+    observed_conditions = observed.get("conditions")
+    if observed_conditions != expected_conditions:
+        findings.append(
+            "conditions mismatch: expected "
+            + json.dumps(expected_conditions, sort_keys=True)
+            + ", found "
+            + json.dumps(observed_conditions, sort_keys=True)
+        )
+
+    expected_rule = _required_rule(expected, label="policy.ruleset")
+    try:
+        observed_rule = _required_rule(observed, label="observed")
+    except RulesetValidationError as exc:
+        findings.append(str(exc))
+        observed_rule = None
+
+    if observed_rule is not None:
+        expected_parameters = expected_rule["parameters"]
+        observed_parameters = observed_rule.get("parameters")
+        if not isinstance(observed_parameters, dict):
+            findings.append("observed required_status_checks parameters must be an object")
+        else:
+            for field in (
+                "strict_required_status_checks_policy",
+                "do_not_enforce_on_create",
+            ):
+                if observed_parameters.get(field) != expected_parameters.get(field):
+                    findings.append(
+                        f"{field} mismatch: expected {expected_parameters.get(field)!r}, "
+                        f"found {observed_parameters.get(field)!r}"
+                    )
+            try:
+                expected_pairs = _check_pairs(expected_rule, label="policy rule")
+                observed_pairs = _check_pairs(observed_rule, label="observed rule")
+            except RulesetValidationError as exc:
+                findings.append(str(exc))
+            else:
+                missing = expected_pairs - observed_pairs
+                unexpected = observed_pairs - expected_pairs
+                if missing:
+                    findings.append(
+                        "missing required checks: "
+                        + json.dumps(sorted(missing.elements()), sort_keys=True)
+                    )
+                if unexpected:
+                    findings.append(
+                        "unexpected required checks: "
+                        + json.dumps(sorted(unexpected.elements()), sort_keys=True)
+                    )
+
+    status = "pass" if not findings else "fail"
+    return {
+        "kind": KIND,
+        "version": VERSION,
+        "status": status,
+        "repository": policy.get("repository"),
+        "ruleset_id": observed.get("id"),
+        "ruleset_name": observed.get("name"),
+        "findings": findings,
+        "required_checks": [
+            {"context": context, "integration_id": integration_id}
+            for context, integration_id in sorted(_check_pairs(expected_rule, label="policy rule"))
+        ],
+        "does_not_establish": list(policy.get("does_not_establish", [])),
+    }
+
+
+def main() -> int:
+    try:
+        policy = load_policy()
+        observed = _load_object(sys.stdin.read(), label="observed ruleset")
+        report = validate_ruleset(policy, observed)
+    except RulesetValidationError as exc:
+        print(f"ruleset validation error: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0 if report["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check_github_main_ruleset.py
+++ b/scripts/ci/check_github_main_ruleset.py
@@ -41,6 +41,11 @@ def load_policy() -> dict[str, Any]:
         raise RulesetValidationError(f"cannot read policy: {POLICY_PATH}") from exc
     if policy.get("schema_version") != 1:
         raise RulesetValidationError("policy schema_version must be 1")
+    repository = policy.get("repository")
+    if not isinstance(repository, str) or not repository.strip():
+        raise RulesetValidationError("policy repository must be non-empty")
+    if policy.get("source_type") != "Repository":
+        raise RulesetValidationError("policy source_type must be Repository")
     ruleset = policy.get("ruleset")
     if not isinstance(ruleset, dict):
         raise RulesetValidationError("policy ruleset must be an object")
@@ -99,6 +104,18 @@ def _check_pairs(rule: dict[str, Any], *, label: str) -> Counter[tuple[str, int 
 def validate_ruleset(policy: dict[str, Any], observed: dict[str, Any]) -> dict[str, Any]:
     expected = api_payload(policy)
     findings: list[str] = []
+
+    expected_source = policy["repository"]
+    expected_source_type = policy["source_type"]
+    if observed.get("source") != expected_source:
+        findings.append(
+            f"source mismatch: expected {expected_source!r}, found {observed.get('source')!r}"
+        )
+    if observed.get("source_type") != expected_source_type:
+        findings.append(
+            "source_type mismatch: expected "
+            f"{expected_source_type!r}, found {observed.get('source_type')!r}"
+        )
 
     for field in ("name", "target", "enforcement", "bypass_actors"):
         if observed.get(field) != expected.get(field):
@@ -163,6 +180,8 @@ def validate_ruleset(policy: dict[str, Any], observed: dict[str, Any]) -> dict[s
         "version": VERSION,
         "status": status,
         "repository": policy.get("repository"),
+        "observed_source": observed.get("source"),
+        "observed_source_type": observed.get("source_type"),
         "ruleset_id": observed.get("id"),
         "ruleset_name": observed.get("name"),
         "findings": findings,


### PR DESCRIPTION
## Ziel

Bindet `main` an stabile, app-gebundene Required Checks und macht den GitHub-Regelzustand repo-lokal prüfbar.

## Änderungen

- eindeutiger Checkname `Lenskit CodeQL policy (python)` für den Workflow mit Suppressionsinventar und Roh-SARIF-Gate
- aktive main-only Ruleset-Policy ohne Bypass-Akteure und mit strict current-base validation
- verpflichtend: Lenskit-CodeQL-Policy, GHAS `CodeQL`, `pytest-full`, `ruff`, `webui-js-tests`
- read-only Offline-Validator für API-Rücklesedaten
- acht fokussierte Regressionstests
- Staged-Activation-, Negativ- und Rollback-Proof
- Task `TASK-LENSKIT-MAIN-REQUIRED-CHECKS-001` abgeschlossen

## Live-Belege

- Ruleset: `main-required-checks`, id `18784275`, API read-back validator PASS
- Negativ-PR #955: `ruff=FAILURE`, `mergeable=MERGEABLE`, `mergeStateStatus=BLOCKED`; anschließend ohne Merge geschlossen und Branch gelöscht

## Lokale Validierung

- fokussierte Pytests: 8 passed
- Ruff auf geänderten Python-Dateien: pass
- Workflow-YAML parse + eindeutiger Jobname: pass
- Planning-registration ratchet: pass
- WebUI-JS-Tests: pass
- lokaler Vollsuite-Lauf reproduziert den bereits registrierten Stillstand um 15 Prozent ohne Assertion; GitHub `pytest-full` ist deshalb das maßgebliche isolierte Vollsuite-Gate

## Grenzen

Dies belegt weder Testsuffizienz noch Sicherheits-, Runtime- oder Review-Vollständigkeit. Die Ruleset-Strukturprüfung ersetzt nicht den separaten Mergezeit-Enforcement-Beleg.