### PR TITLE
fix(repobrief): enforce portable refresh output root

### DIFF
--- a/docs/architecture/repobrief.md
+++ b/docs/architecture/repobrief.md
@@ -133,6 +133,8 @@ The migration is deliberately narrow:
 
 Create-style RepoBrief commands, such as `snapshot create` and `external-manifest publish`, may write explicit output artifacts selected by their arguments. Read-style RepoBrief commands, such as `snapshot status`, `artifact list`, `artifact get`, `required-reading resolve`, `snapshot check`, `range get`, and `query`, must not refresh snapshots, mutate Git, create pull requests, apply patches, or infer approval.
 
+`external-manifest refresh` combines explicit snapshot creation and portable publication. Its `--out` directory must be the publication root itself or a descendant such as `<publication-root>/bundles/<repository>/<ref>/<generation>`. This is checked before snapshot generation. The stable manifests remain under `<publication-root>/external/...`, and their relative bundle paths therefore stay resolvable when the whole publication root is moved or synchronized.
+
 A successful CLI command or alias smoke test does not establish source freshness, runtime correctness, test sufficiency, review completeness, regression absence, repo understanding, or merge readiness.
 
 ## Read-only access CLI

--- a/docs/proofs/external-publish-v1-proof.md
+++ b/docs/proofs/external-publish-v1-proof.md
@@ -37,8 +37,12 @@ The external reference also includes linked post-emit sidecars from the bundle m
 Additional regression coverage:
 
 - `test_publish_rejects_bundle_manifest_outside_publication_root`
+- `test_external_manifest_refresh_rejects_output_outside_publication_root`
+- `test_external_manifest_refresh_creates_portable_bundle_and_references`
 - `test_build_includes_linked_post_emit_health_sidecar`
 - `test_linked_sidecar_must_remain_inside_bundle_directory`
+
+The refresh path now validates containment before generating a snapshot. A caller must place `--out` at or below the explicit publication root; the portable publisher boundary is not weakened to accommodate legacy callers that generated bundles elsewhere.
 
 ## Target proof
 

--- a/merger/lenskit/cli/cmd_repobrief.py
+++ b/merger/lenskit/cli/cmd_repobrief.py
@@ -602,9 +602,17 @@ def run_external_manifest_refresh(args: argparse.Namespace) -> int:
     import io
 
     repo_path = Path(args.repo).expanduser().resolve()
+    out_path = Path(args.out).expanduser().resolve()
     publication_root = Path(args.publication_root).expanduser().resolve()
     if publication_root == repo_path or repo_path in publication_root.parents:
         print("repobrief external-manifest refresh: publication root must not be inside the source repo", file=sys.stderr)
+        return 2
+    if out_path != publication_root and publication_root not in out_path.parents:
+        print(
+            "repobrief external-manifest refresh: output directory must be inside "
+            "publication_root for portable external publication",
+            file=sys.stderr,
+        )
         return 2
 
     from merger.lenskit.core.external_manifest_reference import (

--- a/merger/lenskit/cli/cmd_repobrief.py
+++ b/merger/lenskit/cli/cmd_repobrief.py
@@ -634,7 +634,7 @@ def run_external_manifest_refresh(args: argparse.Namespace) -> int:
         return 2
 
     snapshot_args = argparse.Namespace(
-        repo=args.repo, out=args.out, profile=args.profile, mode=args.mode,
+        repo=args.repo, out=str(out_path), profile=args.profile, mode=args.mode,
         max_bytes=args.max_bytes, split_size=args.split_size, path_filter=args.path_filter,
         ext=args.ext, output_mode=args.output_mode, redact_secrets=args.redact_secrets,
         include_hidden=args.include_hidden,

--- a/merger/lenskit/tests/test_external_manifest_reference.py
+++ b/merger/lenskit/tests/test_external_manifest_reference.py
@@ -218,3 +218,78 @@ def test_linked_sidecar_must_remain_inside_bundle_directory(tmp_path: Path) -> N
 
     with pytest.raises(ExternalManifestReferenceError, match="inside the bundle directory"):
         build_external_manifest_reference(bundle_path, repository="cabinet", ref="main")
+
+
+def test_external_manifest_refresh_rejects_output_outside_publication_root(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from merger.lenskit.cli.repobrief import main as repobrief_main
+
+    repo = tmp_path / "source"
+    repo.mkdir()
+    (repo / "README.md").write_text("# source\n", encoding="utf-8")
+    publication_root = tmp_path / "published"
+    outside = tmp_path / "legacy-output"
+
+    rc = repobrief_main([
+        "external-manifest",
+        "refresh",
+        "--repo",
+        str(repo),
+        "--out",
+        str(outside),
+        "--publication-root",
+        str(publication_root),
+        "--repository",
+        "source",
+        "--ref",
+        "main",
+    ])
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "output directory must be inside publication_root" in captured.err
+    assert not outside.exists()
+
+
+def test_external_manifest_refresh_creates_portable_bundle_and_references(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from merger.lenskit.cli.repobrief import main as repobrief_main
+
+    repo = tmp_path / "source"
+    repo.mkdir()
+    (repo / "README.md").write_text("# source\n", encoding="utf-8")
+    publication_root = tmp_path / "published"
+    out = publication_root / "bundles" / "source" / "main" / "run-1"
+
+    rc = repobrief_main([
+        "external-manifest",
+        "refresh",
+        "--repo",
+        str(repo),
+        "--out",
+        str(out),
+        "--publication-root",
+        str(publication_root),
+        "--repository",
+        "source",
+        "--ref",
+        "main",
+        "--profile",
+        "agent-portable",
+        "--redact-secrets",
+    ])
+
+    captured = capsys.readouterr()
+    result = json.loads(captured.out)
+    bundle_manifest = Path(result["snapshot"]["bundle_manifest"])
+    assert rc == 0
+    assert bundle_manifest.is_file()
+    assert bundle_manifest.is_relative_to(publication_root)
+    for family in ("lenskit", "repobrief"):
+        manifest = publication_root / "external" / family / "source" / "main" / "manifest.json"
+        assert manifest.is_file()
+        published = json.loads(manifest.read_text(encoding="utf-8"))
+        resolved_bundle = (manifest.parent / published["bundleManifest"]["path"]).resolve()
+        assert resolved_bundle == bundle_manifest.resolve()

--- a/merger/lenskit/tests/test_external_manifest_reference.py
+++ b/merger/lenskit/tests/test_external_manifest_reference.py
@@ -293,3 +293,39 @@ def test_external_manifest_refresh_creates_portable_bundle_and_references(
         published = json.loads(manifest.read_text(encoding="utf-8"))
         resolved_bundle = (manifest.parent / published["bundleManifest"]["path"]).resolve()
         assert resolved_bundle == bundle_manifest.resolve()
+
+
+def test_external_manifest_refresh_rejects_symlink_escape_from_publication_root(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from merger.lenskit.cli.repobrief import main as repobrief_main
+
+    repo = tmp_path / "source"
+    repo.mkdir()
+    (repo / "README.md").write_text("# source\n", encoding="utf-8")
+    publication_root = tmp_path / "published"
+    publication_root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    escaped = publication_root / "bundles"
+    escaped.symlink_to(outside, target_is_directory=True)
+
+    rc = repobrief_main([
+        "external-manifest",
+        "refresh",
+        "--repo",
+        str(repo),
+        "--out",
+        str(escaped / "source" / "main" / "run-1"),
+        "--publication-root",
+        str(publication_root),
+        "--repository",
+        "source",
+        "--ref",
+        "main",
+    ])
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "output directory must be inside publication_root" in captured.err
+    assert list(outside.iterdir()) == []


### PR DESCRIPTION
## Ziel

Repariert den RepoBrief-Flottenfehler, bei dem `external-manifest refresh` zuerst ein Bundle außerhalb der Publikationswurzel erzeugte und anschließend zu Recht an der Portabilitätsgrenze scheiterte.

## Änderung

- `refresh --out` muss vor Snapshot-Erzeugung innerhalb von `--publication-root` liegen
- die bestehende strikte Publisher-Grenze bleibt unverändert
- End-to-End-Test erzeugt Bundle und beide Manifestfamilien unter einer portablen Wurzel
- Architektur und Proof dokumentieren den Aufrufervertrag

## Live-Befund

Vorher: Fleet-Watcher 14 Fehler, 0 Publikationen.
Nach Umstellung des lokalen Aufrufers auf `<publication-root>/bundles/...`: kontrollierter Bureau-Smoke erfolgreich; anschließende Charge veröffentlichte 8 Repositories. Der verbleibende Heimlern-Fehler ist ein getrennt registrierter ungültiger Doc-Freshness-Produzentenvertrag und wird nicht durch Lockerung dieser Grenze kaschiert.

## Lokale Validierung

- 65 relevante Tests grün
- Ruff grün
- compileall grün
- git diff --check grün

## Nicht behauptet

Keine Aussage über Testsuffizienz, semantische Wahrheit der Bundles, vollständige Flottenfrische oder Heimlern-Vertragskorrektheit. Voll-Neupublikation und Flottenabschluss folgen nach Merge.