### PR TITLE
fix(ci): repair metrics schema contract

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -9,7 +9,8 @@ on:
     - cron: "0 * * * *"
 
 env:
-  METRICS_SCHEMA_URL: https://raw.githubusercontent.com/heimgewebe/metarepo/contracts-v1/contracts/wgx/metrics.json
+  METRICS_SCHEMA_URL: https://raw.githubusercontent.com/heimgewebe/metarepo/cba66e2b08d908aeff201e4e43aa902b96762b47/contracts/metrics.snapshot.schema.json
+  METRICS_SCHEMA_SHA256: 1b1de44ea326ce8de36da6fc6d8f2da0abe279df8c47ab10e58ddc2cf604b914
   HAUSKI_POST_URL: ${{ secrets.HAUSKI_METRICS_URL }}
 
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -29,13 +30,15 @@ jobs:
 
       - name: Snapshot metrics
         run: bash scripts/wgx-metrics-snapshot.sh --json
-      - name: Fetch AJV schema (local file)
+      - name: Fetch pinned AJV schema
         run: |
           mkdir -p .ci
-          curl -fsSL "$METRICS_SCHEMA_URL" -o .ci/metrics.schema.json
+          curl --fail --silent --show-error --location --retry 3 \
+            "$METRICS_SCHEMA_URL" -o .ci/metrics.schema.json
+          printf '%s  %s\n' "$METRICS_SCHEMA_SHA256" .ci/metrics.schema.json | sha256sum --check --strict
 
       - name: Validate metrics contract
-        run: npx --yes ajv-cli@5 validate -s .ci/metrics.schema.json -d metrics.json
+        run: npx --yes ajv-cli@5 validate --spec=draft2020 --strict=false -s .ci/metrics.schema.json -d metrics.json
 
       - name: Optional POST to hausKI
         if: ${{ env.HAUSKI_POST_URL && env.HAUSKI_POST_URL != '' }}

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -39,7 +39,7 @@ jobs:
           printf '%s  %s\n' "$METRICS_SCHEMA_SHA256" .ci/metrics.schema.json | sha256sum --check --strict
 
       - name: Validate metrics contract
-        run: npx --yes ajv-cli@5.0.0 validate --spec=draft2020 --strict=false -s .ci/metrics.schema.json -d metrics.json
+        run: npx --yes ajv-cli@5.0.0 validate --spec=draft2020 -c ./scripts/ci/ajv_metrics_keywords.cjs -s .ci/metrics.schema.json -d metrics.json
 
       - name: Optional POST to hausKI
         if: ${{ env.HAUSKI_POST_URL && env.HAUSKI_POST_URL != '' }}

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -38,7 +38,7 @@ jobs:
           printf '%s  %s\n' "$METRICS_SCHEMA_SHA256" .ci/metrics.schema.json | sha256sum --check --strict
 
       - name: Validate metrics contract
-        run: npx --yes ajv-cli@5 validate --spec=draft2020 --strict=false -s .ci/metrics.schema.json -d metrics.json
+        run: npx --yes ajv-cli@5.0.0 validate --spec=draft2020 --strict=false -s .ci/metrics.schema.json -d metrics.json
 
       - name: Optional POST to hausKI
         if: ${{ env.HAUSKI_POST_URL && env.HAUSKI_POST_URL != '' }}

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -33,7 +33,8 @@ jobs:
       - name: Fetch pinned AJV schema
         run: |
           mkdir -p .ci
-          curl --fail --silent --show-error --location --retry 3 \
+          curl --fail --silent --show-error --location \
+            --connect-timeout 5 --max-time 30 --retry 3 --retry-delay 2 \
             "$METRICS_SCHEMA_URL" -o .ci/metrics.schema.json
           printf '%s  %s\n' "$METRICS_SCHEMA_SHA256" .ci/metrics.schema.json | sha256sum --check --strict
 
@@ -43,7 +44,8 @@ jobs:
       - name: Optional POST to hausKI
         if: ${{ env.HAUSKI_POST_URL && env.HAUSKI_POST_URL != '' }}
         run: |
-          curl --fail --silent --show-error --retry 3 --retry-delay 2 \
+          curl --fail --silent --show-error \
+            --connect-timeout 5 --max-time 30 --retry 3 --retry-delay 2 \
             -H 'Content-Type: application/json' \
             --data @metrics.json \
             "$HAUSKI_POST_URL"

--- a/merger/lenskit/tests/test_metrics_workflow_contract.py
+++ b/merger/lenskit/tests/test_metrics_workflow_contract.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+
+WORKFLOW_PATH = Path(".github/workflows/metrics.yml")
+EXPECTED_SCHEMA_COMMIT = "cba66e2b08d908aeff201e4e43aa902b96762b47"
+EXPECTED_SCHEMA_SHA256 = "1b1de44ea326ce8de36da6fc6d8f2da0abe279df8c47ab10e58ddc2cf604b914"
+EXPECTED_SCHEMA_URL = (
+    "https://raw.githubusercontent.com/heimgewebe/metarepo/"
+    f"{EXPECTED_SCHEMA_COMMIT}/contracts/metrics.snapshot.schema.json"
+)
+
+
+def _workflow() -> dict[str, object]:
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def test_metrics_schema_is_bound_to_immutable_metarepo_content() -> None:
+    workflow = _workflow()
+    env = workflow["env"]
+
+    assert env["METRICS_SCHEMA_URL"] == EXPECTED_SCHEMA_URL
+    assert env["METRICS_SCHEMA_SHA256"] == EXPECTED_SCHEMA_SHA256
+    assert re.fullmatch(r"[0-9a-f]{40}", EXPECTED_SCHEMA_COMMIT)
+    assert re.fullmatch(r"[0-9a-f]{64}", env["METRICS_SCHEMA_SHA256"])
+    assert "contracts-v1" not in env["METRICS_SCHEMA_URL"]
+
+
+def test_metrics_workflow_verifies_download_before_ajv_validation() -> None:
+    workflow = _workflow()
+    steps = workflow["jobs"]["snapshot"]["steps"]
+    fetch_index = next(i for i, step in enumerate(steps) if step.get("name") == "Fetch pinned AJV schema")
+    validate_index = next(i for i, step in enumerate(steps) if step.get("name") == "Validate metrics contract")
+    fetch_script = steps[fetch_index]["run"]
+    validate_script = steps[validate_index]["run"]
+
+    assert fetch_index < validate_index
+    assert '"$METRICS_SCHEMA_URL"' in fetch_script
+    assert '"$METRICS_SCHEMA_SHA256"' in fetch_script
+    assert "sha256sum --check --strict" in fetch_script
+    assert "--spec=draft2020" in validate_script
+    assert "--strict=false" in validate_script
+    assert workflow["jobs"]["snapshot"]["timeout-minutes"] == 10
+
+
+def test_optional_hauski_post_remains_non_blocking() -> None:
+    workflow = _workflow()
+    steps = workflow["jobs"]["snapshot"]["steps"]
+    post = next(step for step in steps if step.get("name") == "Optional POST to hausKI")
+
+    assert post["continue-on-error"] is True
+    assert "HAUSKI_POST_URL" in str(post["if"])

--- a/merger/lenskit/tests/test_metrics_workflow_contract.py
+++ b/merger/lenskit/tests/test_metrics_workflow_contract.py
@@ -42,6 +42,7 @@ def test_metrics_workflow_verifies_download_before_ajv_validation() -> None:
     assert '"$METRICS_SCHEMA_URL"' in fetch_script
     assert '"$METRICS_SCHEMA_SHA256"' in fetch_script
     assert "sha256sum --check --strict" in fetch_script
+    assert "npx --yes ajv-cli@5.0.0 validate" in validate_script
     assert "--spec=draft2020" in validate_script
     assert "--strict=false" in validate_script
     assert workflow["jobs"]["snapshot"]["timeout-minutes"] == 10

--- a/merger/lenskit/tests/test_metrics_workflow_contract.py
+++ b/merger/lenskit/tests/test_metrics_workflow_contract.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+import json
 import re
+import subprocess
 from pathlib import Path
 
 import yaml
 
 
 WORKFLOW_PATH = Path(".github/workflows/metrics.yml")
+KEYWORDS_PATH = Path("scripts/ci/ajv_metrics_keywords.cjs")
 EXPECTED_SCHEMA_COMMIT = "cba66e2b08d908aeff201e4e43aa902b96762b47"
 EXPECTED_SCHEMA_SHA256 = "1b1de44ea326ce8de36da6fc6d8f2da0abe279df8c47ab10e58ddc2cf604b914"
 EXPECTED_SCHEMA_URL = (
@@ -46,7 +49,8 @@ def test_metrics_workflow_verifies_download_before_ajv_validation() -> None:
     assert "--max-time 30" in fetch_script
     assert "npx --yes ajv-cli@5.0.0 validate" in validate_script
     assert "--spec=draft2020" in validate_script
-    assert "--strict=false" in validate_script
+    assert "-c ./scripts/ci/ajv_metrics_keywords.cjs" in validate_script
+    assert "--strict=false" not in validate_script
     assert workflow["jobs"]["snapshot"]["timeout-minutes"] == 10
 
 
@@ -59,3 +63,23 @@ def test_optional_hauski_post_remains_non_blocking() -> None:
     assert "HAUSKI_POST_URL" in str(post["if"])
     assert "--connect-timeout 5" in post["run"]
     assert "--max-time 30" in post["run"]
+
+
+def test_metrics_ajv_extension_registers_only_declared_metadata_keywords() -> None:
+    program = f"""
+const addKeywords = require({json.dumps(str(KEYWORDS_PATH.resolve()))});
+const rows = [];
+addKeywords({{ addKeyword: (value) => rows.push(value) }});
+process.stdout.write(JSON.stringify(rows));
+"""
+    completed = subprocess.run(
+        ["node", "-e", program],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert json.loads(completed.stdout) == [
+        {"keyword": "x-producers", "schemaType": "array", "valid": True},
+        {"keyword": "x-consumers", "schemaType": "array", "valid": True},
+    ]

--- a/merger/lenskit/tests/test_metrics_workflow_contract.py
+++ b/merger/lenskit/tests/test_metrics_workflow_contract.py
@@ -42,6 +42,8 @@ def test_metrics_workflow_verifies_download_before_ajv_validation() -> None:
     assert '"$METRICS_SCHEMA_URL"' in fetch_script
     assert '"$METRICS_SCHEMA_SHA256"' in fetch_script
     assert "sha256sum --check --strict" in fetch_script
+    assert "--connect-timeout 5" in fetch_script
+    assert "--max-time 30" in fetch_script
     assert "npx --yes ajv-cli@5.0.0 validate" in validate_script
     assert "--spec=draft2020" in validate_script
     assert "--strict=false" in validate_script
@@ -55,3 +57,5 @@ def test_optional_hauski_post_remains_non_blocking() -> None:
 
     assert post["continue-on-error"] is True
     assert "HAUSKI_POST_URL" in str(post["if"])
+    assert "--connect-timeout 5" in post["run"]
+    assert "--max-time 30" in post["run"]

--- a/scripts/ci/ajv_metrics_keywords.cjs
+++ b/scripts/ci/ajv_metrics_keywords.cjs
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = function addMetricsMetadataKeywords(ajv) {
+  for (const keyword of ["x-producers", "x-consumers"]) {
+    ajv.addKeyword({ keyword, schemaType: "array", valid: true });
+  }
+};


### PR DESCRIPTION
## Ziel

Repariert den seit mehreren Stunden roten stündlichen Metrics-Workflow.

## Ursache

Der Workflow lud ein Schema von dem nicht mehr existierenden Metarepo-Ref `contracts-v1` und dem veralteten Pfad `contracts/wgx/metrics.json`. Nach Korrektur des Pfads zeigte der lokale Realtest zwei weitere Vertragsanforderungen: JSON Schema 2020-12 und erlaubte `x-*`-Metadatenfelder.

## Änderung

- Schema-URL auf Metarepo-Commit `cba66e2b08d908aeff201e4e43aa902b96762b47` und `contracts/metrics.snapshot.schema.json` fest gebunden
- heruntergeladene Bytes zusätzlich per SHA-256 geprüft
- AJV explizit mit Draft 2020 und `strict=false` für producer-eigene `x-*`-Schema-Metadaten ausgeführt
- Vertragstests sichern Pin, Hashprüfung, Reihenfolge und nicht blockierenden optionalen hausKI-POST

## Lokale Belege

- 3 Vertragstests grün
- Ruff grün
- erzeugtes `metrics.json` gegen das tatsächlich gepinnte Schema validiert
- `git diff --check` grün

## Nicht behauptet

Der Fix behauptet keine hausKI-Erreichbarkeit und keine semantische Aussage über die Messwerte. Der optionale POST bleibt bewusst nicht blockierend.