### PR TITLE
feat(service): add credential-safe access logging

### DIFF
--- a/docs/proofs/rlens-safe-access-log-v1-proof.md
+++ b/docs/proofs/rlens-safe-access-log-v1-proof.md
@@ -1,0 +1,47 @@
+# rLens credential-safe HTTP access log v1 — proof
+
+Date: 2026-07-10
+
+## Decision
+
+Uvicorn's raw access log remains disabled because it formats the concrete request target and can therefore expose query-string credentials used by browser-native EventSource and direct-download clients.
+
+rLens restores bounded operational visibility with a service-owned ASGI middleware. The middleware emits one compact JSON record containing only:
+
+- event name `http_access`;
+- bounded HTTP method;
+- static route template after routing, for example `/jobs/{job_id}`;
+- response status;
+- elapsed milliseconds.
+
+## Data-minimization boundary
+
+The middleware does not read or serialize:
+
+- the concrete URL path;
+- query strings;
+- request or response headers;
+- authorization values;
+- cookies;
+- client addresses;
+- request or response bodies;
+- exception messages or tracebacks.
+
+Unmatched requests use the constant route label `<unmatched>`. Dynamic path values are never copied into the record. Non-HTTP ASGI scopes pass through without access records. Logging failures are swallowed after the request so an observability backend cannot break a completed response.
+
+## Proof surface
+
+```text
+python3 -m pytest -q \
+  merger/lenskit/tests/test_safe_access_log.py \
+  merger/lenskit/tests/test_rlens_server_security.py \
+  merger/lenskit/tests/test_service_auth_hardening.py \
+  merger/lenskit/tests/test_service_security.py \
+  merger/lenskit/tests/test_service_hardening.py
+```
+
+The tests inject the same secret into the query string, Bearer header, cookie, body and dynamic path value, then assert it is absent from every emitted record. They also cover unmatched routes, exceptions, non-HTTP scopes, production middleware registration and a failing logging backend.
+
+## Non-claims
+
+A passing test does not establish that every external proxy, process supervisor or future middleware is credential-safe. It does not prove authentication correctness, intrusion detection, audit completeness, request attribution, service availability, test sufficiency or regression absence. The proof is limited to the rLens-owned middleware and launcher configuration on the reviewed revision.

--- a/merger/lenskit/cli/rlens.py
+++ b/merger/lenskit/cli/rlens.py
@@ -165,9 +165,9 @@ def main():
         host=args.host,
         port=args.port,
         log_level="info",
-        # Disabled so query-string auth tokens (used by EventSource / direct
-        # download clients that cannot set an Authorization header) are never
-        # written to the request log.
+        # Keep Uvicorn's raw URL logger disabled.  The application emits a
+        # bounded structured access record from static route metadata without
+        # reading query strings, headers, cookies, client addresses, or bodies.
         access_log=False,
     )
 

--- a/merger/lenskit/service/access_log.py
+++ b/merger/lenskit/service/access_log.py
@@ -1,0 +1,94 @@
+"""Credential-safe HTTP access logging for the rLens service.
+
+The middleware deliberately observes only ASGI protocol metadata required for
+operational visibility.  It never reads request headers, cookies, query
+strings, client addresses, or request/response bodies.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import time
+from collections.abc import Awaitable, Callable, MutableMapping
+from typing import Any
+
+
+_ACCESS_LOGGER = logging.getLogger("uvicorn.error.rlens_access")
+_MAX_METHOD_CHARS = 16
+_MAX_ROUTE_CHARS = 256
+
+
+def _bounded_ascii(value: object, *, fallback: str, max_chars: int) -> str:
+    raw = str(value or fallback)[:max_chars]
+    normalized = "".join(char if 0x20 <= ord(char) < 0x7F else "?" for char in raw)
+    return normalized or fallback
+
+
+def _route_template(scope: MutableMapping[str, Any]) -> str:
+    """Return a code-defined route template, never the user-supplied URL path."""
+    route = scope.get("route")
+    template = getattr(route, "path", None)
+    if not isinstance(template, str) or not template:
+        return "<unmatched>"
+    return _bounded_ascii(template, fallback="<unmatched>", max_chars=_MAX_ROUTE_CHARS)
+
+
+class SafeAccessLogMiddleware:
+    """Emit one bounded JSON record for each completed HTTP request.
+
+    The downstream router may add ``scope["route"]`` while handling the request;
+    logging after completion lets us use that static route template instead of
+    the concrete, potentially sensitive request path.
+    """
+
+    def __init__(
+        self,
+        app: Callable[[MutableMapping[str, Any], Callable[..., Awaitable[dict[str, Any]]], Callable[..., Awaitable[None]]], Awaitable[None]],
+        *,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self.app = app
+        self.logger = logger or _ACCESS_LOGGER
+
+    async def __call__(
+        self,
+        scope: MutableMapping[str, Any],
+        receive: Callable[..., Awaitable[dict[str, Any]]],
+        send: Callable[..., Awaitable[None]],
+    ) -> None:
+        if scope.get("type") != "http":
+            await self.app(scope, receive, send)
+            return
+
+        started = time.perf_counter()
+        status_code = 500
+
+        async def capture_status(message: dict[str, Any]) -> None:
+            nonlocal status_code
+            if message.get("type") == "http.response.start":
+                raw_status = message.get("status")
+                if isinstance(raw_status, int) and 100 <= raw_status <= 599:
+                    status_code = raw_status
+            await send(message)
+
+        try:
+            await self.app(scope, receive, capture_status)
+        finally:
+            duration_ms = max(0.0, (time.perf_counter() - started) * 1000.0)
+            record = {
+                "duration_ms": round(duration_ms, 3),
+                "event": "http_access",
+                "method": _bounded_ascii(
+                    scope.get("method"), fallback="UNKNOWN", max_chars=_MAX_METHOD_CHARS
+                ),
+                "route": _route_template(scope),
+                "status": status_code,
+            }
+            try:
+                self.logger.info(
+                    json.dumps(record, ensure_ascii=True, separators=(",", ":"), sort_keys=True)
+                )
+            except Exception:
+                # Observability is best-effort.  A broken custom handler must not
+                # turn a completed HTTP response into an application failure.
+                pass

--- a/merger/lenskit/service/app.py
+++ b/merger/lenskit/service/app.py
@@ -25,6 +25,7 @@ from .runner import JobRunner
 from .source_acquisition import resolve_effective_source_mode
 from .logging_provider import LogProvider, FileLogProvider
 from .auth import verify_token
+from .access_log import SafeAccessLogMiddleware
 from ..adapters.security import (
     get_security_config,
     validate_hub_path,
@@ -199,6 +200,7 @@ def _schedule_service_restart(unit: str) -> None:
         raise RuntimeError(detail) from exc
 
 app = FastAPI(title="rLens", version=SERVER_VERSION)
+app.add_middleware(SafeAccessLogMiddleware)
 
 @app.exception_handler(InvalidPathError)
 async def invalid_path_handler(request: Request, exc: InvalidPathError):

--- a/merger/lenskit/service/auth.py
+++ b/merger/lenskit/service/auth.py
@@ -26,7 +26,8 @@ def verify_token(
 
     # Bearer header is the preferred channel. The query parameter is retained
     # only for browser-native clients that cannot set headers (EventSource /
-    # direct downloads); server access logging is disabled so it is not logged.
+    # direct downloads).  Uvicorn's raw URL logger remains disabled and the
+    # service's bounded access logger never reads the query string.
     if _token_matches(creds.credentials if creds else None, config.token):
         return
 

--- a/merger/lenskit/tests/test_safe_access_log.py
+++ b/merger/lenskit/tests/test_safe_access_log.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from merger.lenskit.service.access_log import SafeAccessLogMiddleware
+
+
+LOGGER_NAME = "uvicorn.error.rlens_access"
+
+
+def _records(caplog: pytest.LogCaptureFixture) -> list[dict[str, object]]:
+    return [json.loads(record.message) for record in caplog.records if record.name == LOGGER_NAME]
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(SafeAccessLogMiddleware)
+
+    @app.post("/items/{item_id}")
+    async def item(item_id: str) -> dict[str, str]:
+        return {"item_id": item_id}
+
+    @app.get("/boom")
+    async def boom() -> None:
+        raise RuntimeError("synthetic secret must not be logged")
+
+    return app
+
+
+def test_access_log_uses_route_template_without_credentials_or_dynamic_values(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    secret = "token-DO-NOT-LOG"
+    app = _app()
+
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        response = TestClient(app).post(
+            f"/items/private-item?token={secret}&next=confidential",
+            headers={"Authorization": f"Bearer {secret}", "Cookie": f"session={secret}"},
+            content=f"body={secret}",
+        )
+
+    assert response.status_code == 200
+    records = _records(caplog)
+    assert len(records) == 1
+    assert records[0]["event"] == "http_access"
+    assert records[0]["method"] == "POST"
+    assert records[0]["route"] == "/items/{item_id}"
+    assert records[0]["status"] == 200
+    assert isinstance(records[0]["duration_ms"], float)
+
+    rendered = "\n".join(record.message for record in caplog.records)
+    assert secret not in rendered
+    assert "private-item" not in rendered
+    assert "confidential" not in rendered
+    assert "Authorization" not in rendered
+    assert "Cookie" not in rendered
+
+
+def test_unmatched_request_does_not_log_concrete_path(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    app = _app()
+
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        response = TestClient(app).get("/missing/private-file-name?token=secret")
+
+    assert response.status_code == 404
+    record = _records(caplog)[0]
+    assert record["route"] == "<unmatched>"
+    assert record["status"] == 404
+    assert "private-file-name" not in caplog.text
+    assert "secret" not in caplog.text
+
+
+def test_exception_is_logged_as_500_without_exception_text(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    app = _app()
+
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        response = TestClient(app, raise_server_exceptions=False).get("/boom?token=secret")
+
+    assert response.status_code == 500
+    record = _records(caplog)[0]
+    assert record["route"] == "/boom"
+    assert record["status"] == 500
+    assert "synthetic secret" not in caplog.text
+    assert "token=secret" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_non_http_scope_is_forwarded_without_access_record(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    called = []
+
+    async def inner(scope, receive, send):
+        called.append(scope["type"])
+
+    middleware = SafeAccessLogMiddleware(inner)
+
+    async def receive():
+        return {"type": "websocket.disconnect"}
+
+    async def send(_message):
+        return None
+
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        await middleware({"type": "websocket"}, receive, send)
+
+    assert called == ["websocket"]
+    assert _records(caplog) == []
+
+
+def test_logging_handler_failure_does_not_break_response() -> None:
+    class BrokenLogger:
+        def info(self, _message: str) -> None:
+            raise RuntimeError("logging backend unavailable")
+
+    app = FastAPI()
+    app.add_middleware(SafeAccessLogMiddleware, logger=BrokenLogger())
+
+    @app.get("/health")
+    async def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    response = TestClient(app).get("/health?token=secret")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_production_app_registers_safe_access_log_middleware() -> None:
+    from merger.lenskit.service.app import app
+
+    assert any(middleware.cls is SafeAccessLogMiddleware for middleware in app.user_middleware)
+
+
+@pytest.mark.asyncio
+async def test_access_fields_are_ascii_single_line_and_bounded() -> None:
+    messages: list[str] = []
+
+    class CapturingLogger:
+        def info(self, message: str) -> None:
+            messages.append(message)
+
+    class SyntheticRoute:
+        path = "/safe\nroute/" + ("x" * 400)
+
+    async def inner(scope, receive, send):
+        scope["route"] = SyntheticRoute()
+        await send({"type": "http.response.start", "status": 204, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+
+    middleware = SafeAccessLogMiddleware(inner, logger=CapturingLogger())
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(_message):
+        return None
+
+    await middleware(
+        {"type": "http", "method": "GET\nINJECT" + ("A" * 100)},
+        receive,
+        send,
+    )
+
+    assert len(messages) == 1
+    assert "\n" not in messages[0]
+    record = json.loads(messages[0])
+    assert record["method"] == "GET?INJECTAAAAAA"
+    assert len(record["method"]) == 16
+    assert record["route"].startswith("/safe?route/")
+    assert len(record["route"]) == 256
+    assert record["status"] == 204


### PR DESCRIPTION
## Ziel

Stellt HTTP-Betriebsbeobachtung wieder her, ohne die in Query-Parametern benötigten Browser-Zugangstoken zu protokollieren.

## Sicherheitsmodell

Uvicorns Roh-Access-Log bleibt deaktiviert. Eine rLens-eigene reine ASGI-Middleware liest ausschließlich:

- HTTP-Methode, begrenzt auf 16 ASCII-Zeichen
- statisches Routenmuster nach dem Routing, begrenzt auf 256 ASCII-Zeichen
- Statuscode
- Laufzeit

Sie liest ausdrücklich keinen konkreten Pfad, Querystring, Header, Cookie, Clientadresse, Body oder Exceptiontext. Unbekannte Routen werden als `<unmatched>` protokolliert.

## Tests

Die Tests injizieren dasselbe Geheimnis in Querystring, Bearer-Header, Cookie, Body und dynamischen Pfadwert und prüfen dessen vollständige Abwesenheit im Log. Zusätzlich geprüft: 404, 500, Nicht-HTTP-ASGI, Längen-/Steuerzeichengrenzen, Produktionsregistrierung und defekter Logging-Handler.

## Lokale Belege

- 26 relevante Service-/Security-Tests grün
- Ruff grün
- compileall grün
- git diff --check grün

## Nicht behauptet

Keine Aussage über externe Proxies, Supervisor-Logs, Authentifizierungskorrektheit, vollständige Auditierbarkeit, Angriffserkennung oder Testsuffizienz.