### PR TITLE
chore(ci): use Node 24 native actions

### DIFF
--- a/.github/workflows/ai-context-guard.yml
+++ b/.github/workflows/ai-context-guard.yml
@@ -6,7 +6,6 @@ on:
     branches: [ main ]
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 permissions:
   contents: read
@@ -16,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -47,10 +46,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/anti-hallucination-lint.yml
+++ b/.github/workflows/anti-hallucination-lint.yml
@@ -39,10 +39,10 @@ jobs:
   anti-hallucination-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ github.token }}
           fetch-depth: 1
@@ -26,16 +26,16 @@ jobs:
         run: python3 scripts/ci/check_codeql_suppressions.py
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: python
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Analyze
         id: analyze
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           output: ${{ runner.temp }}/codeql-results
 

--- a/.github/workflows/contracts-validate.yml
+++ b/.github/workflows/contracts-validate.yml
@@ -20,7 +20,6 @@ defaults:
 env:
   FAIL_ON_NO_BASE: "1"
   ALLOW_REMOVALS: "0"
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   version-sync-check:
@@ -28,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -137,7 +136,7 @@ jobs:
       GH_PUSH_BEFORE: ${{ github.event.before }}
       PROTECTED_REGEX: '^(merger/lenskit/contracts/|docs/contracts/)'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/doc-freshness.yml
+++ b/.github/workflows/doc-freshness.yml
@@ -48,10 +48,10 @@ jobs:
   doc-freshness:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/forensic-preflight-canary.yml
+++ b/.github/workflows/forensic-preflight-canary.yml
@@ -63,10 +63,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           # Match the real service Python version (3.10.12 on the production host)
           # so the canary exercises the same runtime the actual dumps are produced on.
@@ -99,7 +99,7 @@ jobs:
 
       - name: Upload forensic preflight canary artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: forensic-preflight-canary
           path: .tmp/forensic-preflight-ci-canary/artifacts/

--- a/.github/workflows/graph-bundle-sources.yml
+++ b/.github/workflows/graph-bundle-sources.yml
@@ -44,17 +44,14 @@ name: Graph Bundle Sources
 permissions:
   contents: read
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   graph-bundle-sources:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -93,7 +90,7 @@ jobs:
 
       - name: Upload failing diagnostics
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: graph-bundle-sources-diagnostics
           path: graph-bundle-sources-tests.log

--- a/.github/workflows/graph-model.yml
+++ b/.github/workflows/graph-model.yml
@@ -64,18 +64,15 @@ name: Graph Model
 permissions:
   contents: read
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   graph-model:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -129,7 +126,7 @@ jobs:
 
       - name: Upload failing test diagnostics
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: graph-model-test-diagnostics
           path: graph-model-tests.log

--- a/.github/workflows/graph-quality-goldset.yml
+++ b/.github/workflows/graph-quality-goldset.yml
@@ -28,17 +28,14 @@ name: Graph Quality Goldset
 permissions:
   contents: read
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   graph-quality-goldset:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -62,7 +59,7 @@ jobs:
 
       - name: Upload failing diagnostics
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: graph-quality-goldset-diagnostics
           path: graph-quality-goldset-tests.log

--- a/.github/workflows/graph-source-roots.yml
+++ b/.github/workflows/graph-source-roots.yml
@@ -24,16 +24,13 @@ name: Graph Source Roots Contract
 permissions:
   contents: read
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   source-roots-contract:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install dependencies

--- a/.github/workflows/lens-model.yml
+++ b/.github/workflows/lens-model.yml
@@ -122,21 +122,18 @@ permissions:
 
 # Match the repo-wide convention in sibling workflows so any JavaScript GitHub
 # Action runs on Node 24.
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   validates-schema-target-proof:
     # Dedicated job: only this one needs full history for the fixed base snapshot.
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -216,10 +213,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -227,7 +224,7 @@ jobs:
         run: python --version
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,18 +9,15 @@ on:
 permissions:
   contents: read
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   ruff:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -13,18 +13,16 @@ env:
   METRICS_SCHEMA_SHA256: 1b1de44ea326ce8de36da6fc6d8f2da0abe279df8c47ab10e58ddc2cf604b914
   HAUSKI_POST_URL: ${{ secrets.HAUSKI_METRICS_URL }}
 
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   snapshot:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Ensure Node for ajv-cli
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
 
@@ -52,7 +50,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload metrics.json artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: metrics-snapshot
           path: metrics.json

--- a/.github/workflows/parity-gate.yml
+++ b/.github/workflows/parity-gate.yml
@@ -52,10 +52,10 @@ jobs:
   parity-gate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/parity_check.yml
+++ b/.github/workflows/parity_check.yml
@@ -27,17 +27,14 @@ on:
 permissions:
   contents: read
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   parity-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/pr-heimgewebe-commands.yml
+++ b/.github/workflows/pr-heimgewebe-commands.yml
@@ -10,9 +10,6 @@ permissions:
   issues: write
   pull-requests: write
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   dispatch:
     if: github.event.issue.pull_request != null

--- a/.github/workflows/task-index.yml
+++ b/.github/workflows/task-index.yml
@@ -8,19 +8,16 @@ on:
 permissions:
   contents: read
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   planning-registration:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -95,7 +92,7 @@ jobs:
 
       - name: Upload planning registration report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: planning-registration-report
           path: planning-registration-report.json

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -23,18 +23,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   pytest-full:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -51,10 +48,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "24"
 

--- a/.github/workflows/validate-merges.yml
+++ b/.github/workflows/validate-merges.yml
@@ -11,19 +11,16 @@ on:
 permissions:
   contents: read
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   validate-merge-meta:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -11,9 +11,6 @@ name: wgx-guard
 permissions:
   contents: read
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   guard:
     # Fleet-Repos, die von metarepo aus via wgx up Templates beziehen,

--- a/docs/proofs/github-actions-node24-native-v1-proof.md
+++ b/docs/proofs/github-actions-node24-native-v1-proof.md
@@ -1,0 +1,42 @@
+# GitHub Actions Node 24 native migration — proof
+
+Date: 2026-07-10
+
+## Decision
+
+Lenskit no longer forces Node 24 onto actions that declare an older runtime. Instead, each locally referenced first-party JavaScript action uses the smallest reviewed major that declares `runs.using: node24` upstream:
+
+| Action | Lenskit minimum | Upstream declaration |
+|---|---:|---|
+| `actions/checkout` | v5 | `node24` |
+| `actions/setup-node` | v5 | `node24` |
+| `actions/setup-python` | v6 | `node24` |
+| `actions/upload-artifact` | v6 | `node24` |
+| `github/codeql-action/{init,autobuild,analyze}` | v4 | `node24` |
+
+Observed upstream `action.yml` blobs during this review:
+
+- `actions/checkout@v5`: `767c416494ebd353bb13c8e2a97af6c539648576`
+- `actions/setup-node@v5`: `fbc851b6e56c64db8ad81b50878c5cfe4531505d`
+- `actions/setup-python@v6`: `7a9a7b634ec348b35b882f1f14fcaa4d41836a8e`
+- `actions/upload-artifact@v6`: `28f04cc696830ad0609506e0888d8b3b83d5d616`
+- CodeQL `init@v4`: `1b64e8d2a37962e01818d0ff1bba97bb56d045c6`
+- CodeQL `autobuild@v4`: `b87da541d66725fab4511394c5e143ef16d1105c`
+- CodeQL `analyze@v4`: `d70401c0a48ad4246c1ef34787e79f5cad4d8281`
+
+The repository-wide `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` override is removed. A test ratchets the minimum major for every occurrence in `.github/workflows` and rejects any reintroduction of the override.
+
+The external Claude action is a composite action and was not covered by the removed override in its workflow. Reusable workflows remain independently versioned producers; this change does not claim their internal action runtimes.
+
+## Validation
+
+```text
+python3 -m pytest merger/lenskit/tests/test_github_actions_node_runtime.py -q
+actionlint .github/workflows/*.yml
+```
+
+GitHub-hosted PR checks are the integration proof for action input/output compatibility.
+
+## Non-claims
+
+Major tags are mutable upstream references. This migration establishes the declared Node runtime and successful reviewed CI, not immutable supply-chain pinning, future compatibility, absence of upstream compromise, or correctness of reusable workflows maintained in other repositories.

--- a/merger/lenskit/tests/test_github_actions_node_runtime.py
+++ b/merger/lenskit/tests/test_github_actions_node_runtime.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+WORKFLOW_ROOT = Path(".github/workflows")
+MINIMUM_NODE24_MAJORS = {
+    "actions/checkout": 5,
+    "actions/setup-node": 5,
+    "actions/setup-python": 6,
+    "actions/upload-artifact": 6,
+    "github/codeql-action/analyze": 4,
+    "github/codeql-action/autobuild": 4,
+    "github/codeql-action/init": 4,
+}
+USES_RE = re.compile(r"\buses:\s*([^\s#]+)")
+MAJOR_RE = re.compile(r"^v(\d+)$")
+
+
+def _workflow_texts() -> dict[Path, str]:
+    return {path: path.read_text(encoding="utf-8") for path in sorted(WORKFLOW_ROOT.glob("*.y*ml"))}
+
+
+def test_node24_compatibility_override_is_absent() -> None:
+    occurrences = [
+        str(path)
+        for path, text in _workflow_texts().items()
+        if "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24" in text
+    ]
+
+    assert occurrences == []
+
+
+def test_known_javascript_actions_use_node24_native_majors() -> None:
+    seen: dict[str, set[int]] = {name: set() for name in MINIMUM_NODE24_MAJORS}
+    invalid: list[str] = []
+
+    for path, text in _workflow_texts().items():
+        for raw_use in USES_RE.findall(text):
+            if "@" not in raw_use:
+                continue
+            action, ref = raw_use.rsplit("@", 1)
+            if action not in MINIMUM_NODE24_MAJORS:
+                continue
+            match = MAJOR_RE.fullmatch(ref)
+            if match is None:
+                invalid.append(f"{path}: {raw_use} is not a reviewable major tag")
+                continue
+            major = int(match.group(1))
+            seen[action].add(major)
+            minimum = MINIMUM_NODE24_MAJORS[action]
+            if major < minimum:
+                invalid.append(f"{path}: {raw_use} is below Node-24 major v{minimum}")
+
+    missing = sorted(action for action, majors in seen.items() if not majors)
+    assert missing == []
+    assert invalid == []


### PR DESCRIPTION
## Ziel

Entfernt den globalen `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`-Kompatibilitätsschalter und verwendet stattdessen Actions, die Node 24 selbst deklarieren.

## Minimalmigration

- `actions/checkout`: v4 → v5
- `actions/setup-node`: v4 → v5
- `actions/setup-python`: v5 → v6
- `actions/upload-artifact`: v4 → v6
- `github/codeql-action/{init,autobuild,analyze}`: v3 → v4
- bestehendes `checkout@v6` bleibt bestehen

Diese Hauptversionen sind jeweils die kleinsten geprüften Node-24-nativen Versionen. Die bei der Prüfung gelesenen Upstream-`action.yml`-Blob-Hashes stehen im Proof.

## Ratchet

Ein neuer Test scannt alle lokalen Workflows, verlangt die Node-24-Mindestversionen und verbietet die Wiederkehr des Override-Schalters.

## Lokale Belege

- Ratchet-Tests grün
- alle Workflow-YAMLs parsebar
- keine alte Action-Referenz und kein Override mehr vorhanden
- Ruff und diff-check grün

## Abgrenzung

Major-Tags sind keine unveränderlichen Supply-Chain-Pins. Reusable Workflows anderer Repositories verwalten ihre internen Actions selbst. GitHub-CI dieses PR ist der Integrationsbeleg für die lokal geänderten Action-Aufrufe.