### PR TITLE
feat(atlas): account for sparse file allocation

### DIFF
--- a/docs/atlas-blaupause.md
+++ b/docs/atlas-blaupause.md
@@ -82,7 +82,15 @@ Sekundär darf Atlas:
 
 Das sind Aufbauten, nicht das Mandat selbst.
 
-### 2.3 Was Atlas ausdrücklich nicht sein soll
+### 2.3 Größen- und Speichersemantik
+Atlas unterscheidet zwei Größen, weil dünn belegte Dateien sonst ein falsches Kapazitätsbild erzeugen:
+
+* **logische Größe** (`size_bytes`, `total_bytes`): Länge des Dateiraums aus `stat.st_size`; bestehende Verbraucher behalten dieses kompatible Feld.
+* **belegte Größe** (`allocated_size_bytes`, `total_allocated_bytes`): tatsächlich zugeordnete Dateisystemblöcke aus `st_blocks * 512`, mit Rückfall auf die logische Größe, falls die Plattform keine Blockzahl liefert.
+
+`is_sparse` bedeutet dabei ausschließlich, dass die logische Größe größer als die gemeldete Blockbelegung ist. Die belegte Größe ist weder Backupgröße noch komprimierte Übertragungsgröße, Quotenabrechnung oder Wiederherstellungsbeleg. Konventionelle Core-Dump-Namen werden standardmäßig aus maschinenweiten Scans ausgeschlossen; Atlas löscht sie nicht.
+
+### 2.4 Was Atlas ausdrücklich nicht sein soll
 Atlas soll nicht primär sein:
 * Git-Analyse-Engine
 * Code-Intelligence-Monolith

--- a/docs/proofs/atlas-sparse-accounting-v1-proof.md
+++ b/docs/proofs/atlas-sparse-accounting-v1-proof.md
@@ -1,0 +1,46 @@
+# Atlas sparse-file accounting v1 — proof
+
+Date: 2026-07-10
+
+## Problem
+
+The historical home snapshot represented file length only. A live read-only census on `heim-pc` found 3,842 readable `core`, `core.<pid>` or `*.core` files with approximately 33.6 TB apparent length but only approximately 15.3 GB allocated blocks. The filesystem itself used about 426 GB. Treating apparent length as disk consumption therefore produced a materially misleading result.
+
+## Contract
+
+Atlas keeps existing fields for compatibility:
+
+- `size_bytes` and `stats.total_bytes` are apparent/logical lengths from `stat.st_size`;
+- `bytes` in `top_dirs` remains apparent/logical size.
+
+Atlas adds:
+
+- per-file `allocated_size_bytes` and `is_sparse`;
+- `stats.total_allocated_bytes`;
+- sparse file count plus apparent and allocated sparse totals;
+- directory `subtree_allocated_bytes`;
+- `allocated_bytes` beside apparent `bytes` in top-directory rows.
+
+On POSIX, allocated size uses `st_blocks * 512`. On platforms without `st_blocks`, Atlas falls back to apparent size and records the basis as `st_blocks_512_or_apparent_fallback`.
+
+## Core-dump boundary
+
+Default Atlas scans exclude only conventional dump names:
+
+- `core`;
+- `core.<digit...>`;
+- `*.core`.
+
+This deliberately does not exclude legitimate source files such as `core.py`. Callers may still opt out of all default excludes with the existing `no_default_excludes` boundary. System-preset requests show the same core patterns in their effective hard-exclude list.
+
+## Presentation
+
+The generated Markdown and Web UI display allocated and logical sizes separately. Historical artifacts without the new field remain readable by falling back to `total_bytes`.
+
+## Operational decision
+
+No core file is deleted by this change. Atlas is an observer and map, not a cleanup engine or backup. File deletion requires separate ownership, retention and recovery decisions.
+
+## Non-claims
+
+Allocated blocks do not equal backup size, compressed transfer size, deduplicated storage, quota billing or recoverability. A terminal Atlas snapshot does not prove that the filesystem is healthy, complete, backed up or free of sensitive data.

--- a/merger/lenskit/adapters/atlas.py
+++ b/merger/lenskit/adapters/atlas.py
@@ -150,6 +150,20 @@ def detect_encoding(path: Path) -> Optional[str]:
 
 logger = logging.getLogger(__name__)
 
+
+def allocated_bytes_from_stat(stat_result: os.stat_result) -> int:
+    """Return filesystem blocks in bytes, falling back to apparent size.
+
+    POSIX ``st_blocks`` is defined in 512-byte units and reflects allocated
+    storage for sparse files.  Platforms without that field retain the legacy
+    apparent-size semantics rather than reporting a fabricated zero.
+    """
+    blocks = getattr(stat_result, "st_blocks", None)
+    if isinstance(blocks, int) and blocks >= 0:
+        return blocks * 512
+    return max(0, int(stat_result.st_size))
+
+
 # Heuristic threshold (in files) for the file-count-based progress gate.
 # The scanner fires on_progress when this many *new* files have been seen
 # since the last emit, even if the time-based 1-second gate has not elapsed.
@@ -171,7 +185,10 @@ class AtlasScanner:
         "tmp/**",
         "var/tmp/**",
         "var/run/**",
-        "lost+found/**"
+        "lost+found/**",
+        "**/core",
+        "**/core.[0-9]*",
+        "**/*.core"
     )
 
     WORKSPACE_SIGNALS = (
@@ -265,7 +282,12 @@ class AtlasScanner:
         self.stats = {
             "total_files": 0,     # result: definitive file count after scan completes
             "total_dirs": 0,      # result: definitive directory count after scan completes
-            "total_bytes": 0,     # result: definitive byte sum after scan completes
+            "total_bytes": 0,     # compatibility: apparent/logical byte sum
+            "total_allocated_bytes": 0,  # filesystem blocks, or apparent-size fallback
+            "sparse_files_count": 0,
+            "sparse_apparent_bytes": 0,
+            "sparse_allocated_bytes": 0,
+            "allocation_basis": "st_blocks_512_or_apparent_fallback",
             "start_time": None,
             "end_time": None,
             "duration_seconds": 0,
@@ -425,7 +447,8 @@ class AtlasScanner:
         except OSError as e:
             logger.error("Failed to open inventory files: %s", e)
 
-        dir_sizes = {} # path -> size
+        dir_sizes = {} # path -> apparent size
+        dir_allocated_sizes = {} # path -> allocated size
         dir_file_counts = {}
         dir_depths = {}
         dir_signal_counts = {}
@@ -542,6 +565,7 @@ class AtlasScanner:
                 dirs[:] = kept_dirs
 
                 dir_bytes = 0
+                dir_allocated_bytes = 0
 
                 # Filter files for this directory
                 # Store Tuple[str, str] -> (filename, relative_path)
@@ -614,7 +638,8 @@ class AtlasScanner:
                         "mtime": dir_mtime,
                         "subtree_file_count": len(kept_files),
                         "subtree_dir_count": len(dirs), # Will accumulate (counts descendants without self)
-                        "subtree_total_bytes": 0, # Will accumulate
+                        "subtree_total_bytes": 0, # Apparent bytes; will accumulate
+                        "subtree_allocated_bytes": 0, # Allocated blocks; will accumulate
                         "max_descendant_mtime": dir_mtime,
                         "direct_children_fingerprint": direct_children_fingerprint,
                         "direct_file_signatures": [], # Will hold stable file signatures for hashing
@@ -641,6 +666,8 @@ class AtlasScanner:
                     try:
                         stat = f_path.stat()
                         size = stat.st_size
+                        allocated_size = allocated_bytes_from_stat(stat)
+                        is_sparse = size > allocated_size
 
                         is_huge = self.max_file_size is not None and size > self.max_file_size
 
@@ -654,9 +681,15 @@ class AtlasScanner:
 
                         self.stats["total_files"] += 1
                         self.stats["total_bytes"] += size
+                        self.stats["total_allocated_bytes"] += allocated_size
+                        if is_sparse:
+                            self.stats["sparse_files_count"] += 1
+                            self.stats["sparse_apparent_bytes"] += size
+                            self.stats["sparse_allocated_bytes"] += allocated_size
                         self.stats["extensions"][ext] = self.stats["extensions"].get(ext, 0) + 1
 
                         dir_bytes += size
+                        dir_allocated_bytes += allocated_size
 
                         # Update aggregate max mtime
                         if collect_dir_aggregates and mtime_iso > dir_aggregates[rel_path_str]["max_descendant_mtime"]:
@@ -785,6 +818,8 @@ class AtlasScanner:
                                 "name": f,
                                 "ext": ext,
                                 "size_bytes": size,
+                                "allocated_size_bytes": allocated_size,
+                                "is_sparse": is_sparse,
                                 "mtime": mtime_iso,
                                 "is_symlink": is_sym,
                                 "inode": inode,
@@ -817,8 +852,10 @@ class AtlasScanner:
 
                 self.stats["total_dirs"] += 1
                 dir_sizes[rel_path_str] = dir_bytes
+                dir_allocated_sizes[rel_path_str] = dir_allocated_bytes
                 if collect_dir_aggregates:
                     dir_aggregates[rel_path_str]["subtree_total_bytes"] += dir_bytes
+                    dir_aggregates[rel_path_str]["subtree_allocated_bytes"] += dir_allocated_bytes
 
                 # Fire progress callback (throttled: at most once per second OR
                 # every _PROGRESS_FILE_COUNT_THRESHOLD new files, whichever
@@ -891,6 +928,7 @@ class AtlasScanner:
                             parent_agg["subtree_file_count"] += child_agg["subtree_file_count"]
                             parent_agg["subtree_dir_count"] += child_agg.get("subtree_dir_count", child_agg.get("n_dirs", 0))
                             parent_agg["subtree_total_bytes"] += child_agg["subtree_total_bytes"]
+                            parent_agg["subtree_allocated_bytes"] += child_agg["subtree_allocated_bytes"]
                             if child_agg["max_descendant_mtime"] > parent_agg["max_descendant_mtime"]:
                                 parent_agg["max_descendant_mtime"] = child_agg["max_descendant_mtime"]
 
@@ -929,6 +967,7 @@ class AtlasScanner:
         # Find Top Dirs (Hotspots) - simplistic aggregation
         all_paths = sorted(dir_sizes.keys(), key=lambda p: len(Path(p).parts), reverse=True)
         recursive_sizes = dir_sizes.copy()
+        recursive_allocated_sizes = dir_allocated_sizes.copy()
 
         for p_str in all_paths:
             if p_str == ".":
@@ -940,9 +979,17 @@ class AtlasScanner:
 
             if parent in recursive_sizes:
                 recursive_sizes[parent] += recursive_sizes[p_str]
+                recursive_allocated_sizes[parent] += recursive_allocated_sizes[p_str]
 
         sorted_dirs = sorted(recursive_sizes.items(), key=lambda x: x[1], reverse=True)
-        self.stats["top_dirs"] = [{"path": p, "bytes": s} for p, s in sorted_dirs[:50]]
+        self.stats["top_dirs"] = [
+            {
+                "path": path,
+                "bytes": apparent_bytes,
+                "allocated_bytes": recursive_allocated_sizes.get(path, apparent_bytes),
+            }
+            for path, apparent_bytes in sorted_dirs[:50]
+        ]
 
         # Enhanced Hotspots
         highest_file_density = sorted(dir_file_counts.items(), key=lambda x: x[1], reverse=True)[:50]
@@ -1195,15 +1242,18 @@ def render_atlas_md(atlas_data: Dict[str, Any]) -> str:
     lines.append("## 📊 Overview")
     lines.append(f"- **Total Directories:** {stats.get('total_dirs')}")
     lines.append(f"- **Total Files:** {stats.get('total_files')}")
-    lines.append(f"- **Total Size:** {stats.get('total_bytes') / (1024*1024):.2f} MB")
+    lines.append(f"- **Logical Size:** {stats.get('total_bytes', 0) / (1024*1024):.2f} MB")
+    lines.append(f"- **Allocated Size:** {stats.get('total_allocated_bytes', stats.get('total_bytes', 0)) / (1024*1024):.2f} MB")
+    lines.append(f"- **Sparse Files:** {stats.get('sparse_files_count', 0)}")
     lines.append("")
 
     lines.append("## 📁 Top Folders (Hotspots)")
-    lines.append("| Path | Size (MB) |")
-    lines.append("|---|---|")
+    lines.append("| Path | Logical (MB) | Allocated (MB) |")
+    lines.append("|---|---:|---:|")
     for d in stats.get("top_dirs", [])[:20]:
-        mb = d['bytes'] / (1024*1024)
-        lines.append(f"| `{d['path']}` | {mb:.2f} |")
+        apparent_mb = d['bytes'] / (1024*1024)
+        allocated_mb = d.get('allocated_bytes', d['bytes']) / (1024*1024)
+        lines.append(f"| `{d['path']}` | {apparent_mb:.2f} | {allocated_mb:.2f} |")
     lines.append("")
 
     lines.append("## 🏷️ File Types")

--- a/merger/lenskit/contracts/atlas-inventory.v1.schema.json
+++ b/merger/lenskit/contracts/atlas-inventory.v1.schema.json
@@ -31,7 +31,7 @@
     },
     "size_bytes": {
       "type": "integer",
-      "description": "The size of the file in bytes."
+      "description": "The apparent/logical file length in bytes (stat.st_size)."
     },
     "mtime": {
       "type": "string",
@@ -78,6 +78,15 @@
     "is_huge": {
       "type": "boolean",
       "description": "Optional boolean indicating whether the file size exceeded max_file_size during scan. When true, content analysis is typically skipped due to size constraints; as a result, content-enrichment fields (e.g. mime_type, is_text, encoding, line_count, quick_hash) may be absent."
+    },
+    "allocated_size_bytes": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Filesystem blocks allocated to the file in bytes when available; otherwise falls back to size_bytes."
+    },
+    "is_sparse": {
+      "type": "boolean",
+      "description": "True when apparent size is greater than allocated_size_bytes."
     }
   }
 }

--- a/merger/lenskit/frontends/webui/app.js
+++ b/merger/lenskit/frontends/webui/app.js
@@ -2018,7 +2018,9 @@ async function loadAtlasArtifacts() {
             }
 
             if (art.stats && art.stats.total_files !== undefined) {
-                const mb = (art.stats.total_bytes / (1024*1024)).toFixed(2);
+                const logicalMb = (art.stats.total_bytes / (1024*1024)).toFixed(2);
+                const allocatedBytes = art.stats.total_allocated_bytes ?? art.stats.total_bytes;
+                const allocatedMb = (allocatedBytes / (1024*1024)).toFixed(2);
                 const statsDiv = document.createElement('div');
                 statsDiv.className = "mt-2 text-xs grid grid-cols-2 gap-2 text-gray-400";
 
@@ -2042,7 +2044,7 @@ async function loadAtlasArtifacts() {
                 sizeDiv.textContent = 'Size: ';
                 const sizeSpan = document.createElement('span');
                 sizeSpan.className = "text-white";
-                sizeSpan.textContent = `${mb} MB`;
+                sizeSpan.textContent = `${allocatedMb} MB allocated / ${logicalMb} MB logical`;
                 sizeDiv.appendChild(sizeSpan);
                 statsDiv.appendChild(sizeDiv);
 

--- a/merger/lenskit/service/app.py
+++ b/merger/lenskit/service/app.py
@@ -1703,7 +1703,8 @@ async def create_atlas(request: AtlasRequest, background_tasks: BackgroundTasks)
                 "**/.aws/**", "**/.kube/**",
                 "**/.mozilla/**", "**/.config/google-chrome/**", "**/.config/chromium/**",
                 "**/.local/share/keyrings/**",
-                "**/Keychain/**", "**/Safari/**"
+                "**/Keychain/**", "**/Safari/**",
+                "**/core", "**/core.[0-9]*", "**/*.core"
             ]
 
             for ex in hard_excludes:

--- a/merger/lenskit/tests/test_atlas_excludes.py
+++ b/merger/lenskit/tests/test_atlas_excludes.py
@@ -82,3 +82,31 @@ def test_atlas_default_strict_excludes_claude_worktrees(tmp_path: Path) -> None:
     # In strict mode, node_modules is NOT in the default excludes
     # (strict = minimal excludes; callers control what's excluded beyond git/venv/worktrees)
     assert scanner._is_excluded("node_modules/pkg/index.js") is False
+
+
+def test_atlas_default_excludes_core_dumps_at_any_depth(tmp_path: Path) -> None:
+    scanner = AtlasScanner(tmp_path, snapshot_id="dummy_snap")
+
+    for path in (
+        "core",
+        "core.61224",
+        "process.core",
+        "nested/core",
+        "nested/core.2",
+        "nested/process.core",
+    ):
+        assert scanner._is_excluded(path) is True
+
+    assert scanner._is_excluded("core.py") is False
+    assert scanner._is_excluded("nested/score.txt") is False
+
+
+def test_atlas_can_explicitly_disable_default_core_excludes(tmp_path: Path) -> None:
+    scanner = AtlasScanner(
+        tmp_path,
+        snapshot_id="dummy_snap",
+        no_default_excludes=True,
+        exclude_globs=[],
+    )
+
+    assert scanner._is_excluded("core.123") is False

--- a/merger/lenskit/tests/test_atlas_inventory.py
+++ b/merger/lenskit/tests/test_atlas_inventory.py
@@ -143,3 +143,87 @@ def test_atlas_dirs_inventory_excludes_files(tmp_path):
 
     mixed_dir = next(i for i in items if i["rel_path"] == "mixed")
     assert mixed_dir["n_files"] == 1
+
+
+def test_atlas_reports_apparent_allocated_and_sparse_bytes(tmp_path, monkeypatch):
+    import merger.lenskit.adapters.atlas as atlas_module
+
+    root = tmp_path / "source"
+    root.mkdir()
+    target = root / "sparse.bin"
+    with target.open("wb") as handle:
+        handle.seek(1024 * 1024 - 1)
+        handle.write(b"x")
+
+    monkeypatch.setattr(atlas_module, "allocated_bytes_from_stat", lambda _stat: 4096)
+    inventory_file = tmp_path / "sparse.inventory.jsonl"
+    result = AtlasScanner(root, snapshot_id="snap_sparse").scan(
+        inventory_file=inventory_file
+    )
+
+    item = json.loads(inventory_file.read_text(encoding="utf-8").splitlines()[0])
+    assert item["size_bytes"] == 1024 * 1024
+    assert item["allocated_size_bytes"] == 4096
+    assert item["is_sparse"] is True
+    assert result["stats"]["total_bytes"] == 1024 * 1024
+    assert result["stats"]["total_allocated_bytes"] == 4096
+    assert result["stats"]["sparse_files_count"] == 1
+    assert result["stats"]["sparse_apparent_bytes"] == 1024 * 1024
+    assert result["stats"]["sparse_allocated_bytes"] == 4096
+
+
+def test_allocated_bytes_falls_back_to_apparent_size_without_st_blocks():
+    from types import SimpleNamespace
+
+    from merger.lenskit.adapters.atlas import allocated_bytes_from_stat
+
+    assert allocated_bytes_from_stat(SimpleNamespace(st_size=1234)) == 1234
+
+
+def test_atlas_directory_rollups_include_allocated_bytes(tmp_path, monkeypatch):
+    import merger.lenskit.adapters.atlas as atlas_module
+
+    root = tmp_path / "source"
+    nested = root / "nested"
+    nested.mkdir(parents=True)
+    (root / "top.txt").write_bytes(b"a" * 10)
+    (nested / "child.txt").write_bytes(b"b" * 20)
+
+    monkeypatch.setattr(atlas_module, "allocated_bytes_from_stat", lambda stat: stat.st_size + 100)
+    dirs_file = tmp_path / "dirs.jsonl"
+    result = AtlasScanner(root, snapshot_id="snap_rollup").scan(
+        dirs_inventory_file=dirs_file
+    )
+
+    rows = {
+        row["rel_path"]: row
+        for row in map(json.loads, dirs_file.read_text(encoding="utf-8").splitlines())
+    }
+    assert rows["nested"]["subtree_total_bytes"] == 20
+    assert rows["nested"]["subtree_allocated_bytes"] == 120
+    assert rows["."]["subtree_total_bytes"] == 30
+    assert rows["."]["subtree_allocated_bytes"] == 230
+    assert result["stats"]["top_dirs"][0] == {
+        "path": ".",
+        "bytes": 30,
+        "allocated_bytes": 230,
+    }
+
+
+def test_generated_inventory_row_validates_against_contract(tmp_path):
+    from jsonschema import Draft7Validator
+    from pathlib import Path
+
+    root = tmp_path / "source"
+    root.mkdir()
+    (root / "file.txt").write_text("content", encoding="utf-8")
+    inventory_file = tmp_path / "inventory.jsonl"
+
+    AtlasScanner(root, snapshot_id="snap_contract").scan(inventory_file=inventory_file)
+    row = json.loads(inventory_file.read_text(encoding="utf-8").splitlines()[0])
+    schema_path = Path("merger/lenskit/contracts/atlas-inventory.v1.schema.json")
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+
+    Draft7Validator(schema).validate(row)
+    assert row["allocated_size_bytes"] >= 0
+    assert isinstance(row["is_sparse"], bool)

--- a/merger/lenskit/tests/test_atlas_inventory.py
+++ b/merger/lenskit/tests/test_atlas_inventory.py
@@ -1,5 +1,7 @@
 import json
-from merger.lenskit.adapters.atlas import AtlasScanner
+from merger.lenskit.adapters import atlas as atlas_module
+
+AtlasScanner = atlas_module.AtlasScanner
 
 def test_atlas_inventory_includes_all_titles(tmp_path):
     # Setup: Create folder structure
@@ -146,8 +148,6 @@ def test_atlas_dirs_inventory_excludes_files(tmp_path):
 
 
 def test_atlas_reports_apparent_allocated_and_sparse_bytes(tmp_path, monkeypatch):
-    import merger.lenskit.adapters.atlas as atlas_module
-
     root = tmp_path / "source"
     root.mkdir()
     target = root / "sparse.bin"
@@ -175,14 +175,10 @@ def test_atlas_reports_apparent_allocated_and_sparse_bytes(tmp_path, monkeypatch
 def test_allocated_bytes_falls_back_to_apparent_size_without_st_blocks():
     from types import SimpleNamespace
 
-    from merger.lenskit.adapters.atlas import allocated_bytes_from_stat
-
-    assert allocated_bytes_from_stat(SimpleNamespace(st_size=1234)) == 1234
+    assert atlas_module.allocated_bytes_from_stat(SimpleNamespace(st_size=1234)) == 1234
 
 
 def test_atlas_directory_rollups_include_allocated_bytes(tmp_path, monkeypatch):
-    import merger.lenskit.adapters.atlas as atlas_module
-
     root = tmp_path / "source"
     nested = root / "nested"
     nested.mkdir(parents=True)

--- a/merger/lenskit/tests/test_atlas_system.py
+++ b/merger/lenskit/tests/test_atlas_system.py
@@ -53,6 +53,9 @@ def test_create_atlas_system_root(service_client, tmp_path, monkeypatch):
     assert effective["max_entries"] == 200000
     assert "**/.ssh/**" in effective["exclude_globs"]
     assert "**/.password-store/**" in effective["exclude_globs"]
+    assert "**/core" in effective["exclude_globs"]
+    assert "**/core.[0-9]*" in effective["exclude_globs"]
+    assert "**/*.core" in effective["exclude_globs"]
 
     # TestClient waits for the background task.  Reading the canonical artifact
     # proves the bounded fixture was actually scanned, not merely accepted.


### PR DESCRIPTION
## Problem

Der historische Home-Atlas meldete rund 16,85 TB, obwohl das Dateisystem nur rund 398 GB belegt hatte. Ein aktueller read-only Zensus fand 3.842 Core-Dateien mit 33,6 TB logischer Länge, aber nur 15,3 GB belegten Blöcken. Ursache sind dünn belegte Core-Dumps.

## Änderung

- bestehende `size_bytes`, `total_bytes` und `top_dirs[].bytes` bleiben als logische/apparent Größe kompatibel
- neu: belegte Bytes aus `st_blocks * 512`, mit Plattform-Fallback
- neu: per-file `allocated_size_bytes`, `is_sparse`
- neu: Gesamt-, Sparse- und Directory-Rollup-Statistiken für belegte Bytes
- Markdown und WebUI zeigen belegte und logische Größe getrennt
- Standardscans schließen `core`, `core.<Ziffer…>` und `*.core` aus, aber nicht `core.py`
- System-Preset zeigt diese Muster auch in den effektiven Hard-Excludes
- Schema und Atlas-Blaupause dokumentieren die Semantik

## Tests

- 146 Atlas-Tests grün
- sämtliche WebUI-JavaScript-Tests grün
- 19 Service-/Security-Tests grün
- Ruff, JavaScript-Syntax und diff-check grün
- Inventarzeile gegen das erweiterte Draft-07-Schema validiert

## Betriebsgrenze

Keine Core-Datei wird gelöscht. Atlas ist Beobachter und Karte, kein Aufräumer und kein Backup. Nach Merge folgt ein begrenzter terminaler Live-Snapshot und die kleine Rollen-Dokumentation in heim-pc/infra.