### PR TITLE
ops: version Systemkatalog RepoBrief publisher

### DIFF
--- a/merger/lenskit/tests/test_systemkatalog_publish_runtime.py
+++ b/merger/lenskit/tests/test_systemkatalog_publish_runtime.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+PUBLISH = ROOT / "scripts/ops/repobrief-publish-heimgewebe-katalog-main"
+WATCH = ROOT / "scripts/ops/repobrief-publish-heimgewebe-katalog-main-if-changed"
+INSTALLER = ROOT / "scripts/ops/install_systemkatalog_publish_runtime.sh"
+UNIT_DIR = ROOT / "ops/systemd/systemkatalog-publish"
+
+
+def test_publish_output_is_inside_publication_root() -> None:
+    text = PUBLISH.read_text(encoding="utf-8")
+    assert "PUB_ROOT=/home/alex/repos/manifest-publications" in text
+    assert 'OUT_BASE="$PUB_ROOT/repobrief-auto/heimgewebe-katalog-main"' in text
+    assert "/repos/merges/repobrief-auto/heimgewebe-katalog-main" not in text
+
+
+def test_runtime_uses_only_systemkatalog_names() -> None:
+    paths = [PUBLISH, WATCH, INSTALLER, *UNIT_DIR.iterdir()]
+    for path in paths:
+        assert "cabinet" not in path.name.lower()
+        assert "/home/alex/repos/cabinet" not in path.read_text(encoding="utf-8")
+
+
+def test_installer_enables_watcher_and_fallback() -> None:
+    text = INSTALLER.read_text(encoding="utf-8")
+    assert "repobrief-publish-heimgewebe-katalog-main-watch.timer" in text
+    assert "repobrief-publish-heimgewebe-katalog-main.timer" in text
+    assert text.count("enable --now") == 2

--- a/ops/systemd/systemkatalog-publish/repobrief-publish-heimgewebe-katalog-main-watch.service
+++ b/ops/systemd/systemkatalog-publish/repobrief-publish-heimgewebe-katalog-main-watch.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=RepoBrief Heimgewebe-Systemkatalog main watcher
+
+[Service]
+Type=oneshot
+ExecStart=/home/alex/.local/bin/repobrief-publish-heimgewebe-katalog-main-if-changed
+Nice=10
+IOSchedulingClass=best-effort
+IOSchedulingPriority=6

--- a/ops/systemd/systemkatalog-publish/repobrief-publish-heimgewebe-katalog-main-watch.timer
+++ b/ops/systemd/systemkatalog-publish/repobrief-publish-heimgewebe-katalog-main-watch.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=RepoBrief Heimgewebe-Systemkatalog main watcher timer
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+RandomizedDelaySec=30s
+Persistent=true
+Unit=repobrief-publish-heimgewebe-katalog-main-watch.service
+
+[Install]
+WantedBy=timers.target

--- a/ops/systemd/systemkatalog-publish/repobrief-publish-heimgewebe-katalog-main.service
+++ b/ops/systemd/systemkatalog-publish/repobrief-publish-heimgewebe-katalog-main.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=RepoBrief publish Heimgewebe-Systemkatalog external manifests
+Documentation=https://github.com/heimgewebe/lenskit/pull/980
+
+[Service]
+Type=oneshot
+ExecStart=/home/alex/.local/bin/repobrief-publish-heimgewebe-katalog-main
+Nice=10
+IOSchedulingClass=best-effort
+IOSchedulingPriority=6

--- a/ops/systemd/systemkatalog-publish/repobrief-publish-heimgewebe-katalog-main.timer
+++ b/ops/systemd/systemkatalog-publish/repobrief-publish-heimgewebe-katalog-main.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=RepoBrief Heimgewebe-Systemkatalog fallback timer
+
+[Timer]
+OnCalendar=daily
+RandomizedDelaySec=15min
+Persistent=true
+Unit=repobrief-publish-heimgewebe-katalog-main.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/ops/install_systemkatalog_publish_runtime.sh
+++ b/scripts/ops/install_systemkatalog_publish_runtime.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+BIN_DIR=${HOME}/.local/bin
+UNIT_DIR=${HOME}/.config/systemd/user
+
+install -d -m 0755 "$BIN_DIR" "$UNIT_DIR"
+install -m 0755 "$ROOT/scripts/ops/repobrief-publish-heimgewebe-katalog-main" "$BIN_DIR/repobrief-publish-heimgewebe-katalog-main"
+install -m 0755 "$ROOT/scripts/ops/repobrief-publish-heimgewebe-katalog-main-if-changed" "$BIN_DIR/repobrief-publish-heimgewebe-katalog-main-if-changed"
+for unit in "$ROOT"/ops/systemd/systemkatalog-publish/*.{service,timer}; do
+  install -m 0644 "$unit" "$UNIT_DIR/$(basename "$unit")"
+done
+systemctl --user daemon-reload
+systemctl --user enable --now repobrief-publish-heimgewebe-katalog-main-watch.timer
+systemctl --user enable --now repobrief-publish-heimgewebe-katalog-main.timer

--- a/scripts/ops/repobrief-publish-heimgewebe-katalog-main
+++ b/scripts/ops/repobrief-publish-heimgewebe-katalog-main
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LOCK=/tmp/repobrief-publish-heimgewebe-katalog-main.lock
+exec 9>"$LOCK"
+flock -n 9 || { echo "repobrief-publish-heimgewebe-katalog-main: already running" >&2; exit 0; }
+
+LENSKIT_REPO=/home/alex/repos/lenskit
+SYSTEMKATALOG_REPO=/home/alex/repos/heimgewebe-katalog
+TOOL_WT=/home/alex/repos/.repobrief-tools/lenskit-main
+SOURCE_WT=/home/alex/repos/.repobrief-sources/heimgewebe__heimgewebe-katalog__main
+PUB_ROOT=/home/alex/repos/manifest-publications
+OUT_BASE="$PUB_ROOT/repobrief-auto/heimgewebe-katalog-main"
+LOG_DIR=/home/alex/logs/repobrief-publish
+STAMP=$(date -u +%Y%m%dT%H%M%SZ)
+OUT="$OUT_BASE/$STAMP"
+TMP_JSON="$LOG_DIR/heimgewebe-katalog-main-$STAMP.json.tmp"
+LAST_JSON="$LOG_DIR/heimgewebe-katalog-main-last.json"
+LOG="$LOG_DIR/heimgewebe-katalog-main.log"
+
+mkdir -p "$OUT_BASE" "$PUB_ROOT" "$LOG_DIR"
+{
+  echo "== repobrief-publish-heimgewebe-katalog-main $STAMP =="
+  git -C "$LENSKIT_REPO" fetch origin --prune
+  if git -C "$TOOL_WT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git -C "$TOOL_WT" reset --hard origin/main
+    git -C "$TOOL_WT" clean -fdx
+  else
+    rm -rf "$TOOL_WT"
+    git -C "$LENSKIT_REPO" worktree add --detach "$TOOL_WT" origin/main
+  fi
+
+  git -C "$SYSTEMKATALOG_REPO" fetch origin --prune
+  if git -C "$SOURCE_WT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git -C "$SOURCE_WT" reset --hard origin/main
+    git -C "$SOURCE_WT" clean -fdx
+  else
+    rm -rf "$SOURCE_WT"
+    git -C "$SYSTEMKATALOG_REPO" worktree add --detach "$SOURCE_WT" origin/main
+  fi
+
+  echo "tool=$(git -C "$TOOL_WT" rev-parse HEAD)"
+  echo "source=$(git -C "$SOURCE_WT" rev-parse HEAD)"
+  cd "$TOOL_WT"
+  python3 -m merger.lenskit.cli.repobrief external-manifest refresh \
+    --repo "$SOURCE_WT" \
+    --out "$OUT" \
+    --publication-root "$PUB_ROOT" \
+    --repository heimgewebe-katalog \
+    --ref main \
+    --profile full-max \
+    --output-mode dual \
+    --redact-secrets \
+    --max-bytes 0 \
+    --split-size 25MB > "$TMP_JSON"
+  mv "$TMP_JSON" "$LAST_JSON"
+  python3 - <<'PY'
+import json
+from pathlib import Path
+path = Path('/home/alex/logs/repobrief-publish/heimgewebe-katalog-main-last.json')
+data = json.loads(path.read_text())
+print('status=' + str(data.get('status')))
+print('bundle=' + str(data.get('snapshot', {}).get('bundle_manifest')))
+for row in data.get('publication', {}).get('published', []):
+    print(str(row.get('artifactFamily')) + '=' + str(row.get('relativePublicationPath')) + ' generatedAt=' + str(row.get('generatedAt')))
+PY
+  find "$OUT_BASE" -mindepth 1 -maxdepth 1 -type d -printf '%T@ %p\n' | sort -rn | awk 'NR>24 {print $2}' | xargs -r rm -rf
+  echo "done"
+} >> "$LOG" 2>&1

--- a/scripts/ops/repobrief-publish-heimgewebe-katalog-main-if-changed
+++ b/scripts/ops/repobrief-publish-heimgewebe-katalog-main-if-changed
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LOCK=/tmp/repobrief-publish-heimgewebe-katalog-main-if-changed.lock
+exec 9>"$LOCK"
+flock -n 9 || { echo "repobrief-publish-heimgewebe-katalog-main-if-changed: already running" >&2; exit 0; }
+
+SYSTEMKATALOG_REPO=/home/alex/repos/heimgewebe-katalog
+PUBLISH=/home/alex/.local/bin/repobrief-publish-heimgewebe-katalog-main
+STATE_DIR=/home/alex/.local/state/repobrief-publish
+LOG=/home/alex/logs/repobrief-publish/heimgewebe-katalog-main-watch.log
+LAST_SHA_FILE="$STATE_DIR/heimgewebe-katalog-main.last-sha"
+
+mkdir -p "$STATE_DIR" "$(dirname "$LOG")"
+{
+  echo "== repobrief-publish-heimgewebe-katalog-main-if-changed $(date -u +%Y%m%dT%H%M%SZ) =="
+  git -C "$SYSTEMKATALOG_REPO" fetch origin main --prune
+  current=$(git -C "$SYSTEMKATALOG_REPO" rev-parse origin/main)
+  previous=""
+  if [[ -f "$LAST_SHA_FILE" ]]; then
+    previous=$(cat "$LAST_SHA_FILE")
+  fi
+  echo "previous=$previous"
+  echo "current=$current"
+  if [[ "$current" == "$previous" ]]; then
+    echo "unchanged"
+    exit 0
+  fi
+  echo "changed: publishing"
+  "$PUBLISH"
+  printf '%s\n' "$current" > "$LAST_SHA_FILE.tmp"
+  mv "$LAST_SHA_FILE.tmp" "$LAST_SHA_FILE"
+  echo "state-updated=$current"
+} >> "$LOG" 2>&1


### PR DESCRIPTION
## Ergebnis
- versioniert die aktive Heimgewebe-Systemkatalog RepoBrief-Publish-Runtime
- enthält Watcher, täglichen Fallback, zwei Wrapper und Installer
- korrigiert den Outputpfad in den Publication-Root
- schützt gegen Rückfall auf Cabinet-Namen und den ungültigen alten Outputpfad

## Validierung
- 18 fokussierte Tests bestanden
- Ruff bestanden
- Shell-Syntax bestanden
- realer Publish erfolgreich: Status ok, Lenskit- und RepoBrief-Manifeste aktualisiert
- Diff SHA-256: `3a67876a1504a0fd11ba6f11e540f8c6ca478b2a59a3028df1e7cf0377948b7c`
- Vollständiger Diff: https://gist.github.com/alexdermohr/cbfe8e933f476742e99ca6e9cfd2747b