### PR TITLE
feat: add compact Lens Card collection density

### DIFF
--- a/docs/proofs/lens-card-compact-density-v1-proof.md
+++ b/docs/proofs/lens-card-compact-density-v1-proof.md
@@ -1,0 +1,16 @@
+# Lens Card Compact Density v1 Proof
+
+Bureau task: `RPU-V1-T018`.
+
+The opt-in `compact` collection density removes only repeated per-card `does_not_establish` arrays. The complete mandatory negative-semantics tuple remains once at collection level. The default `verbose` mode preserves self-contained cards.
+
+The new `produce_lens_card_collection()` helper is an in-memory consumer projection. It does not register a bundle artifact or replace the canonical single-card schema. The established `produce_lens_card()` and `produce_lens_cards()` APIs and their default outputs remain unchanged.
+
+Representative deterministic JSON measurement for three cards:
+
+- verbose bytes: 1799
+- compact bytes: 1274
+- saved bytes: 525
+- reduction: 29.2%
+
+The measurement establishes serialization-size reduction for the named fixture only. It does not establish runtime correctness, general token savings, test sufficiency, agent-quality improvement, or merge readiness.

--- a/merger/lenskit/core/lens_cards.py
+++ b/merger/lenskit/core/lens_cards.py
@@ -15,6 +15,7 @@ KIND = "lenskit.lens_card"
 VERSION = "1.0"
 AUTHORITY = "navigation_index"
 CANONICALITY = "derived"
+LENS_CARD_DENSITIES = ("verbose", "compact")
 
 
 def _canonical_path_after_facet_gate(path: str | PurePosixPath) -> str:
@@ -66,6 +67,45 @@ def produce_lens_card(path: str | PurePosixPath) -> dict[str, Any]:
         "matched_rule": matched_rule,
         "facets": facets,
         "navigation_refs": [{"kind": "repo_path", "target": posix}],
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }
+
+
+def produce_lens_card_collection(
+    paths: Iterable[str | PurePosixPath],
+    *,
+    density: str = "verbose",
+) -> dict[str, Any]:
+    """Produce an in-memory Lens Card collection for bounded consumers.
+
+    ``verbose`` preserves the existing self-contained card shape. ``compact``
+    removes only the repeated per-card ``does_not_establish`` field and carries
+    the same mandatory negative semantics once at collection level. This helper
+    does not register a bundle artifact or a new single-card schema.
+    """
+    if density not in LENS_CARD_DENSITIES:
+        raise ValueError(
+            f"density must be one of {LENS_CARD_DENSITIES}, got {density!r}"
+        )
+
+    cards = produce_lens_cards(paths)
+    if density == "compact":
+        cards = [
+            {
+                key: value
+                for key, value in card.items()
+                if key != "does_not_establish"
+            }
+            for card in cards
+        ]
+
+    return {
+        "kind": "lenskit.lens_card_collection",
+        "version": "1.0",
+        "authority": AUTHORITY,
+        "canonicality": CANONICALITY,
+        "density": density,
+        "cards": cards,
         "does_not_establish": list(DOES_NOT_ESTABLISH),
     }
 

--- a/merger/lenskit/tests/test_lens_card_density.py
+++ b/merger/lenskit/tests/test_lens_card_density.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+import unittest
+
+from merger.lenskit.core.lens_cards import produce_lens_card_collection
+from merger.lenskit.core.lens_facets import DOES_NOT_ESTABLISH
+
+
+PATHS = [
+    "merger/lenskit/core/lens_cards.py",
+    "merger/lenskit/core/lens_facets.py",
+    "docs/proofs/lens-card-v1-proof.md",
+]
+
+
+def _encoded(value: object) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+class LensCardDensityTests(unittest.TestCase):
+    def test_verbose_density_preserves_self_contained_cards(self) -> None:
+        collection = produce_lens_card_collection(PATHS)
+
+        self.assertEqual(collection["density"], "verbose")
+        self.assertEqual(
+            collection["does_not_establish"],
+            list(DOES_NOT_ESTABLISH),
+        )
+        self.assertTrue(
+            all(
+                card["does_not_establish"] == list(DOES_NOT_ESTABLISH)
+                for card in collection["cards"]
+            )
+        )
+
+    def test_compact_density_deduplicates_non_claims_at_collection_level(self) -> None:
+        collection = produce_lens_card_collection(PATHS, density="compact")
+
+        self.assertEqual(collection["density"], "compact")
+        self.assertEqual(
+            collection["does_not_establish"],
+            list(DOES_NOT_ESTABLISH),
+        )
+        self.assertTrue(
+            all(
+                "does_not_establish" not in card
+                for card in collection["cards"]
+            )
+        )
+
+    def test_compact_cards_match_verbose_cards_except_for_non_claims(self) -> None:
+        verbose = produce_lens_card_collection(PATHS, density="verbose")
+        compact = produce_lens_card_collection(PATHS, density="compact")
+        expected_cards = [
+            {
+                key: value
+                for key, value in card.items()
+                if key != "does_not_establish"
+            }
+            for card in verbose["cards"]
+        ]
+
+        self.assertEqual(compact["cards"], expected_cards)
+
+    def test_compact_density_reduces_serialized_size(self) -> None:
+        verbose = produce_lens_card_collection(PATHS, density="verbose")
+        compact = produce_lens_card_collection(PATHS, density="compact")
+
+        self.assertLess(len(_encoded(compact)), len(_encoded(verbose)))
+
+    def test_invalid_density_fails_closed(self) -> None:
+        with self.assertRaisesRegex(ValueError, "density must be one of"):
+            produce_lens_card_collection(PATHS, density="tiny")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements Bureau task `RPU-V1-T018`.

- adds opt-in `compact` density for in-memory Lens Card collections
- keeps the complete mandatory `does_not_establish` tuple once at collection level
- preserves existing single-card and list producer outputs by default
- records a deterministic byte-size comparison for three representative cards

## Validation

- `99 passed` across Lens Card producer, validator, and density tests
- `ruff check` passed for changed Python files
- `git diff --check` passed
- representative JSON: 1799 bytes verbose, 1274 bytes compact, 29.2% reduction

## Boundaries

This does not register a bundle artifact, replace the canonical single-card schema, prove general token savings, prove agent-quality improvement, or establish merge readiness.