### PR TITLE
fix(ci): advance Lenskit WGX guard pin

### DIFF
--- a/.github/reusable-workflow-contracts.json
+++ b/.github/reusable-workflow-contracts.json
@@ -20,6 +20,17 @@
         "github.event.issue.pull_request != null",
         "github.event.comment.user.type != 'Bot'"
       ]
+    },
+    {
+      "caller_path": ".github/workflows/wgx-guard.yml",
+      "job": "guard",
+      "uses": "heimgewebe/wgx/.github/workflows/wgx-guard.yml@3d823f9d26be276eef97742335dee857a64e1715",
+      "source_content_sha256": "d184d82ab3dbc6d956a02b10b2645465bedcb6be2475bb3bee0a9f4aa091e82d",
+      "required_permissions": {
+        "contents": "read"
+      },
+      "required_secrets": [],
+      "required_if_fragments": []
     }
   ],
   "does_not_establish": [

--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -15,4 +15,4 @@ jobs:
   guard:
     # Fleet-Repos, die von metarepo aus via wgx up Templates beziehen,
     # werden auf den kanonischen Guard-Workflow aus heimgewebe/wgx gesetzt.
-    uses: heimgewebe/wgx/.github/workflows/wgx-guard.yml@44069602da536e781675a788e8d9d4c45c7c1f75  # main resolved 2026-07-11
+    uses: heimgewebe/wgx/.github/workflows/wgx-guard.yml@3d823f9d26be276eef97742335dee857a64e1715  # WGX PR #636 merge 2026-07-11

--- a/merger/lenskit/tests/test_reusable_workflow_contracts.py
+++ b/merger/lenskit/tests/test_reusable_workflow_contracts.py
@@ -22,9 +22,48 @@ def test_contract_rejects_lower_permission_and_secret_fanout(tmp_path: Path) -> 
         """\npermissions:\n  contents: read\njobs:\n  dispatch:\n    if: github.event.issue.pull_request != null\n    uses: heimgewebe/metarepo/.github/workflows/heimgewebe-command-dispatch.yml@10daa1c84469dce76e93cdc24c47c1dfc5e156d6\n    secrets:\n      inherit: true\n""",
         encoding="utf-8",
     )
+    wgx_source = _repo_root() / ".github/workflows/wgx-guard.yml"
+    wgx_target = tmp_path / ".github/workflows/wgx-guard.yml"
+    wgx_target.write_bytes(wgx_source.read_bytes())
     codes = {finding.code for finding in scan(tmp_path)}
     assert codes == {
         "insufficient_caller_permission",
         "caller_secret_contract_mismatch",
         "missing_caller_condition",
+    }
+
+
+def test_contract_rejects_stale_wgx_guard_pin(tmp_path: Path) -> None:
+    contract_source = _repo_root() / ".github/reusable-workflow-contracts.json"
+    contract_target = tmp_path / ".github/reusable-workflow-contracts.json"
+    contract_target.parent.mkdir(parents=True)
+    contract_target.write_bytes(contract_source.read_bytes())
+
+    command_caller_source = _repo_root() / ".github/workflows/pr-heimgewebe-commands.yml"
+    command_caller_target = tmp_path / ".github/workflows/pr-heimgewebe-commands.yml"
+    command_caller_target.parent.mkdir(parents=True, exist_ok=True)
+    command_caller_target.write_bytes(command_caller_source.read_bytes())
+
+    wgx_caller = tmp_path / ".github/workflows/wgx-guard.yml"
+    wgx_caller.write_text(
+        """\npermissions:\n  contents: read\njobs:\n  guard:\n    uses: heimgewebe/wgx/.github/workflows/wgx-guard.yml@44069602da536e781675a788e8d9d4c45c7c1f75\n""",
+        encoding="utf-8",
+    )
+
+    findings = scan(tmp_path)
+    assert [(finding.caller_path, finding.code) for finding in findings] == [
+        (".github/workflows/wgx-guard.yml", "reusable_workflow_pin_mismatch")
+    ]
+
+
+def test_contract_reports_missing_caller_file(tmp_path: Path) -> None:
+    contract_source = _repo_root() / ".github/reusable-workflow-contracts.json"
+    contract_target = tmp_path / ".github/reusable-workflow-contracts.json"
+    contract_target.parent.mkdir(parents=True)
+    contract_target.write_bytes(contract_source.read_bytes())
+
+    findings = scan(tmp_path)
+    assert {(finding.caller_path, finding.code) for finding in findings} == {
+        (".github/workflows/pr-heimgewebe-commands.yml", "missing_caller_file"),
+        (".github/workflows/wgx-guard.yml", "missing_caller_file"),
     }

--- a/scripts/ci/check_reusable_workflow_contracts.py
+++ b/scripts/ci/check_reusable_workflow_contracts.py
@@ -59,7 +59,11 @@ def scan(root: Path, contract_path: Path = DEFAULT_CONTRACT) -> list[Finding]:
     findings: list[Finding] = []
     for contract in data.get("contracts", []):
         relative = str(contract["caller_path"])
-        caller = _load_mapping(root / relative)
+        caller_path = root / relative
+        if not caller_path.is_file():
+            findings.append(Finding(relative, "missing_caller_file", str(caller_path)))
+            continue
+        caller = _load_mapping(caller_path)
         job_name = str(contract["job"])
         jobs = caller.get("jobs") or {}
         job = jobs.get(job_name)


### PR DESCRIPTION
## Zweck

Der bereits gemergte und auf WGX `main` verifizierte Guard aus PR #636 wird in Lenskit als unveränderlicher Caller-Pin übernommen.

## Änderungen

- Lenskit-WGX-Caller `44069602…` → `3d823f9d…`
- exakter Caller-Vertrag inklusive Quellinhalt-SHA-256
- Negativtest gegen Rückkehr zum alten Pin
- strukturierter `missing_caller_file`-Befund statt Traceback

## Lokale Prüfung

- 30 fokussierte Tests bestanden
- Ruff bestanden
- Action-Pin-Ratchet: pass, 0 Findings
- Reusable-Workflow-Vertrag: pass, 0 Findings
- Zielcommit liegt auf WGX `main`; alle vier externen `uses:`-Referenzen sind vollständige Commit-SHAs

## Grenze

Dieser PR schließt nur die bereits belegte WGX-Guard-Hälfte des offenen transitive-supply-chain-Tasks. Der metarepo-Caller bleibt bis zum Merge von heimgewebe/metarepo#646 unverändert. Der Task bleibt daher offen.