### PR TITLE
repobrief: harden latest-complete publication

### DIFF
--- a/docs/proofs/repobrief-latest-complete-registry-v1-proof.md
+++ b/docs/proofs/repobrief-latest-complete-registry-v1-proof.md
@@ -2,7 +2,7 @@
 
 Task: `RPU-V1-T003`
 
-Status: implementation proof for the latest-complete RepoBrief bundle registry and read-only freshness status path.
+Status: implementation proof for eligibility-bound, monotone and crash-durable latest-complete RepoBrief publication plus the read-only freshness/status path.
 
 ## Implemented surface
 
@@ -14,14 +14,16 @@ repobrief.latest_complete_registry
 
 The registry records:
 
-- bundle stem;
-- bundle manifest path;
-- bundle manifest SHA-256;
-- bundle run id;
-- bundle generation timestamp;
-- recorded source commit from `snapshot_provenance`;
-- health summary from available health sidecars;
+- bundle stem, manifest path and manifest SHA-256;
+- run id and normalized generation timestamp;
+- recorded source commit and stable source lane from `snapshot_provenance`;
+- health status and SHA-256 for the finalization sidecars;
+- an explicit eligibility result;
+- the deterministic selection key;
+- the publication durability contract;
 - freshness status vocabulary and explicit unknown state.
+
+A candidate is publishable only when its generation timestamp is not implausibly in the future, the recorded full source commit is unambiguous, the profile is known, the profile evaluation is not failed, and the required finalization surfaces are acceptable. In particular, `post_emit_health` and every profile-required export gate must pass.
 
 ## Read-only status path
 
@@ -57,6 +59,18 @@ or during explicit snapshot creation when the caller passes:
 
 Read paths do not update the registry.
 
+## Monotone durable publication
+
+Writers serialize on a persistent lane-local advisory lock file. The lock file is an explicit part of the write boundary. Under that lock they compare the candidate with the already published registry using:
+
+```text
+generated_at
+```
+
+An older or byte-identical candidate leaves the published file byte-identical. Equal timestamps with different manifest identities fail closed instead of choosing by an arbitrary hash or run-id ordering. A source-lane mismatch fails closed. A newer eligible candidate is written to a temporary file, file-synchronized, atomically replaced, followed by a parent-directory `fsync` and exact readback. This prevents a delayed older run from moving the pointer backwards and closes the rename-without-directory-sync durability gap.
+
+The status path rechecks the stored manifest hash, recomputes eligibility from the current sidecars and reports sidecar-hash drift without mutating the registry.
+
 ## Boundary
 
 The read-only status path does not:
@@ -74,21 +88,23 @@ The read-only status path does not:
 
 Tests cover:
 
-- registry field emission;
-- JSON-schema validation for emitted registries;
-- health signal projection;
+- registry field emission and JSON-schema validation;
+- eligibility rejection for incomplete candidates;
+- monotone and idempotent selection, future-timestamp rejection and fail-closed timestamp collisions;
+- source-lane mismatch rejection;
+- symlink-target rejection;
+- file and parent-directory synchronization;
+- health signal projection and sidecar hash drift;
 - fresh/stale/unknown freshness states;
-- stale not being a failure by itself;
 - read status not writing files or mutating the registry;
-- CLI write and CLI status commands;
-- optional explicit registry write during `snapshot create`.
+- CLI write/status and explicit publication during `snapshot create`.
 
 ## Non-claims
 
 This proof does not establish:
 
 - content truth;
-- bundle completeness;
+- semantic or domain completeness beyond the checked RepoBrief finalization contract;
 - runtime correctness;
 - test sufficiency beyond the checked scope;
 - review completeness;

--- a/merger/lenskit/contracts/repobrief-latest-complete-registry.v1.schema.json
+++ b/merger/lenskit/contracts/repobrief-latest-complete-registry.v1.schema.json
@@ -73,6 +73,58 @@
       },
       "additionalProperties": true
     },
+    "eligibility": {
+      "type": "object",
+      "required": ["status", "profile", "manifest_name", "generated_at", "checks", "errors"],
+      "properties": {
+        "status": {"const": "pass"},
+        "profile": {"type": "string", "minLength": 1},
+        "manifest_name": {"type": "string", "minLength": 1},
+        "generated_at": {"type": "string", "minLength": 1},
+        "checks": {"type": "object"},
+        "errors": {"type": "array", "maxItems": 0}
+      },
+      "additionalProperties": true
+    },
+    "selection": {
+      "type": "object",
+      "required": ["basis", "generated_at", "run_id", "manifest_sha256", "source_lane", "order_key"],
+      "properties": {
+        "basis": {"const": "generated_at_fail_closed_ties_v1"},
+        "generated_at": {"type": "string", "minLength": 1},
+        "run_id": {"type": ["string", "null"]},
+        "manifest_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "source_lane": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "array",
+            "items": [{"type": "string"}, {"type": "string"}],
+            "minItems": 2,
+            "maxItems": 2
+          }
+        },
+        "order_key": {
+          "type": "array",
+          "items": [{"type": "string"}],
+          "minItems": 1,
+          "maxItems": 1
+        }
+      },
+      "additionalProperties": true
+    },
+    "publication": {
+      "type": "object",
+      "required": ["serialization", "atomic_replace", "file_fsync", "directory_fsync", "readback_verified"],
+      "properties": {
+        "serialization": {"const": "advisory_file_lock"},
+        "atomic_replace": {"const": true},
+        "file_fsync": {"const": true},
+        "directory_fsync": {"const": true},
+        "readback_verified": {"const": true}
+      },
+      "additionalProperties": false
+    },
     "mutation_boundary": {
       "type": "object",
       "required": ["writes", "does_not_mutate", "read_paths_do_not_refresh", "hidden_refresh_allowed"],

--- a/merger/lenskit/core/repobrief_latest_complete.py
+++ b/merger/lenskit/core/repobrief_latest_complete.py
@@ -6,12 +6,15 @@ Read paths may compare recorded snapshot provenance to an explicitly supplied
 local repo HEAD, but they must never create snapshots, mutate Git, or update the
 registry as a side effect.
 """
+
 from __future__ import annotations
 
 import datetime as _dt
+import fcntl
 import hashlib
 import json
 import os
+import stat as statmod
 import subprocess
 import tempfile
 from pathlib import Path
@@ -24,6 +27,7 @@ WRITE_KIND = "repobrief.latest_complete_registry_write"
 
 FRESHNESS_VALUES = ("fresh", "stale", "unknown", "not_comparable")
 HEALTH_VALUES = ("pass", "warn", "fail", "unknown")
+MAX_FUTURE_SKEW_SECONDS = 300
 
 DOES_NOT_ESTABLISH = (
     "truth",
@@ -98,7 +102,9 @@ def _safe_bundle_path(registry_path: Path, raw_path: Any) -> Path | None:
 
 def _source_repositories(manifest: Mapping[str, Any]) -> list[dict[str, Any]]:
     provenance = manifest.get("snapshot_provenance")
-    repositories = provenance.get("repositories") if isinstance(provenance, dict) else None
+    repositories = (
+        provenance.get("repositories") if isinstance(provenance, dict) else None
+    )
     if not isinstance(repositories, list):
         return []
     result: list[dict[str, Any]] = []
@@ -108,22 +114,40 @@ def _source_repositories(manifest: Mapping[str, Any]) -> list[dict[str, Any]]:
         result.append(
             {
                 "name": repo.get("name") if isinstance(repo.get("name"), str) else None,
-                "repo_remote": repo.get("repo_remote") if isinstance(repo.get("repo_remote"), str) else None,
-                "repo_root_recorded": isinstance(repo.get("repo_root"), str) and bool(repo.get("repo_root")),
-                "git_commit": repo.get("git_commit") if isinstance(repo.get("git_commit"), str) else None,
-                "git_dirty": repo.get("git_dirty") if isinstance(repo.get("git_dirty"), bool) else None,
-                "git_branch": repo.get("git_branch") if isinstance(repo.get("git_branch"), str) else None,
-                "provenance_status": repo.get("provenance_status") if isinstance(repo.get("provenance_status"), str) else "unknown",
-                "freshness_basis": repo.get("freshness_basis") if isinstance(repo.get("freshness_basis"), str) else "unknown",
+                "repo_remote": repo.get("repo_remote")
+                if isinstance(repo.get("repo_remote"), str)
+                else None,
+                "repo_root_recorded": isinstance(repo.get("repo_root"), str)
+                and bool(repo.get("repo_root")),
+                "git_commit": repo.get("git_commit")
+                if isinstance(repo.get("git_commit"), str)
+                else None,
+                "git_dirty": repo.get("git_dirty")
+                if isinstance(repo.get("git_dirty"), bool)
+                else None,
+                "git_branch": repo.get("git_branch")
+                if isinstance(repo.get("git_branch"), str)
+                else None,
+                "provenance_status": repo.get("provenance_status")
+                if isinstance(repo.get("provenance_status"), str)
+                else "unknown",
+                "freshness_basis": repo.get("freshness_basis")
+                if isinstance(repo.get("freshness_basis"), str)
+                else "unknown",
             }
         )
     return result
 
 
-def _primary_source_commit(repositories: list[dict[str, Any]]) -> tuple[str | None, str]:
+def _primary_source_commit(
+    repositories: list[dict[str, Any]],
+) -> tuple[str | None, str]:
     present = [
-        repo for repo in repositories
-        if repo.get("provenance_status") == "present" and isinstance(repo.get("git_commit"), str) and repo.get("git_commit")
+        repo
+        for repo in repositories
+        if repo.get("provenance_status") == "present"
+        and isinstance(repo.get("git_commit"), str)
+        and repo.get("git_commit")
     ]
     if not present:
         return None, "snapshot_commit_missing"
@@ -154,6 +178,8 @@ def _linked_path_for_role(manifest: Mapping[str, Any], role: str) -> str | None:
         "post_emit_health": "post_emit_health_path",
         "bundle_surface_validation": "bundle_surface_validation_path",
         "output_health": "output_health_path",
+        "agent_export_gate": "agent_export_gate_path",
+        "export_safety_report": "export_safety_report_path",
     }
     links = manifest.get("links")
     key = role_to_link.get(role)
@@ -177,7 +203,13 @@ def _status_from_doc(role: str, doc: Mapping[str, Any]) -> str | None:
 def _health_signals(manifest_path: Path, manifest: Mapping[str, Any]) -> dict[str, Any]:
     artifacts = _artifact_by_role(manifest)
     signals: dict[str, Any] = {}
-    for role in ("output_health", "post_emit_health", "bundle_surface_validation"):
+    for role in (
+        "output_health",
+        "post_emit_health",
+        "bundle_surface_validation",
+        "agent_export_gate",
+        "export_safety_report",
+    ):
         artifact = artifacts.get(role)
         raw_path = artifact.get("path") if isinstance(artifact, dict) else None
         if raw_path is None:
@@ -189,15 +221,29 @@ def _health_signals(manifest_path: Path, manifest: Mapping[str, Any]) -> dict[st
         try:
             candidate.relative_to(manifest_path.parent.resolve())
         except ValueError:
-            signals[role] = {"status": "fail", "path": raw_path, "reason": "path_escapes_bundle_root"}
+            signals[role] = {
+                "status": "fail",
+                "path": raw_path,
+                "reason": "path_escapes_bundle_root",
+            }
             continue
         if not candidate.is_file():
-            signals[role] = {"status": "unknown", "path": raw_path, "reason": "file_missing"}
+            signals[role] = {
+                "status": "unknown",
+                "path": raw_path,
+                "reason": "file_missing",
+            }
             continue
         try:
-            doc = json.loads(candidate.read_text(encoding="utf-8"))
+            payload = candidate.read_bytes()
+            doc = json.loads(payload.decode("utf-8"))
         except (OSError, UnicodeError, json.JSONDecodeError) as exc:
-            signals[role] = {"status": "fail", "path": raw_path, "reason": "unreadable", "error": str(exc)}
+            signals[role] = {
+                "status": "fail",
+                "path": raw_path,
+                "reason": "unreadable",
+                "error": str(exc),
+            }
             continue
         if not isinstance(doc, dict):
             signals[role] = {"status": "fail", "path": raw_path, "reason": "not_object"}
@@ -208,6 +254,7 @@ def _health_signals(manifest_path: Path, manifest: Mapping[str, Any]) -> dict[st
             "path": raw_path,
             "reason": None if status else "status_missing_or_unrecognized",
             "kind": doc.get("kind") if isinstance(doc.get("kind"), str) else None,
+            "sha256": hashlib.sha256(payload).hexdigest(),
         }
     return signals
 
@@ -262,7 +309,11 @@ def evaluate_registry_freshness(
     checked_at: str | None = None,
 ) -> dict[str, Any]:
     checked_at = checked_at or _now_iso()
-    snapshot_commit = registry.get("source", {}).get("commit") if isinstance(registry.get("source"), Mapping) else None
+    snapshot_commit = (
+        registry.get("source", {}).get("commit")
+        if isinstance(registry.get("source"), Mapping)
+        else None
+    )
     if not isinstance(snapshot_commit, str) or not snapshot_commit:
         return _unknown_freshness("snapshot_commit_missing", checked_at=checked_at)
     if repo is None:
@@ -295,6 +346,322 @@ def evaluate_registry_freshness(
     }
 
 
+def _parse_timestamp(value: Any, *, label: str) -> _dt.datetime:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{label} is missing")
+    text = value.strip()
+    try:
+        parsed = _dt.datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"{label} is not RFC3339") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{label} must include a timezone")
+    return parsed.astimezone(_dt.timezone.utc)
+
+
+def _normalized_generated_at(value: Any) -> str:
+    return (
+        _parse_timestamp(value, label="latest-complete candidate generated_at")
+        .isoformat(timespec="microseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def _source_lane(source: Mapping[str, Any]) -> list[list[str]]:
+    repositories = source.get("repositories")
+    if not isinstance(repositories, list):
+        return []
+    lane: set[tuple[str, str]] = set()
+    for repository in repositories:
+        if not isinstance(repository, Mapping):
+            continue
+        name = repository.get("name") if isinstance(repository.get("name"), str) else ""
+        remote = (
+            repository.get("repo_remote")
+            if isinstance(repository.get("repo_remote"), str)
+            else ""
+        )
+        if name or remote:
+            lane.add((name, remote))
+    return [[name, remote] for name, remote in sorted(lane)]
+
+
+def _latest_complete_eligibility(
+    manifest_path: Path,
+    manifest: Mapping[str, Any],
+    *,
+    signals: Mapping[str, Any],
+    source_commit: str | None,
+    reference_time: str,
+) -> dict[str, Any]:
+    from merger.lenskit.core.repobrief_profiles import (
+        REQ_RECOMMENDED,
+        REQ_REQUIRED,
+        profile_export_semantics,
+        profile_policy,
+    )
+
+    checks: dict[str, dict[str, Any]] = {}
+    errors: list[str] = []
+
+    def record(name: str, passed: bool, observed: Any, expected: Any) -> None:
+        checks[name] = {
+            "status": "pass" if passed else "fail",
+            "observed": observed,
+            "expected": expected,
+        }
+        if not passed:
+            errors.append(name)
+
+    record(
+        "manifest_kind",
+        manifest.get("kind") == "repolens.bundle.manifest",
+        manifest.get("kind"),
+        "repolens.bundle.manifest",
+    )
+    commit_valid = (
+        isinstance(source_commit, str)
+        and len(source_commit) in {40, 64}
+        and all(character in "0123456789abcdef" for character in source_commit)
+    )
+    record(
+        "source_commit_unambiguous",
+        commit_valid,
+        source_commit,
+        "one full lowercase hexadecimal Git object id",
+    )
+
+    bundle_generated_at = manifest.get("created_at")
+    generated_time: _dt.datetime | None = None
+    try:
+        generated_time = _parse_timestamp(
+            bundle_generated_at,
+            label="latest-complete candidate generated_at",
+        )
+        normalized_generated_at = generated_time.isoformat(
+            timespec="microseconds"
+        ).replace("+00:00", "Z")
+    except ValueError:
+        normalized_generated_at = None
+    record(
+        "generated_at_rfc3339",
+        generated_time is not None,
+        bundle_generated_at,
+        "timezone-aware RFC3339 timestamp",
+    )
+    reference = _parse_timestamp(
+        reference_time,
+        label="latest-complete publication time",
+    )
+    generated_not_future = (
+        generated_time is not None
+        and generated_time <= reference + _dt.timedelta(seconds=MAX_FUTURE_SKEW_SECONDS)
+    )
+    record(
+        "generated_at_not_future",
+        generated_not_future,
+        normalized_generated_at,
+        f"not later than publication time plus {MAX_FUTURE_SKEW_SECONDS} seconds",
+    )
+
+    capabilities = manifest.get("capabilities")
+    capabilities = capabilities if isinstance(capabilities, Mapping) else {}
+    profile = capabilities.get("repobrief_profile")
+    profile_evaluation = capabilities.get("repobrief_profile_evaluation")
+    profile_status = (
+        profile_evaluation.get("status")
+        if isinstance(profile_evaluation, Mapping)
+        else None
+    )
+    profile_known = False
+    export_semantics: dict[str, bool] = {}
+    export_safety_requirement = None
+    if isinstance(profile, str):
+        try:
+            export_semantics = profile_export_semantics(profile)
+            export_safety_requirement = profile_policy(profile)["artifact_rules"][
+                "export_safety_report"
+            ]
+            profile_known = True
+        except ValueError:
+            pass
+    record("profile_known", profile_known, profile, "known RepoBrief profile")
+    record(
+        "profile_evaluation",
+        profile_status in {"pass", "warn"},
+        profile_status,
+        ["pass", "warn"],
+    )
+
+    def signal_status(role: str) -> str | None:
+        signal = signals.get(role)
+        return signal.get("status") if isinstance(signal, Mapping) else None
+
+    expected_signals = {
+        "output_health": ({"pass", "warn"}, ["pass", "warn"]),
+        "post_emit_health": ({"pass"}, "pass"),
+        "bundle_surface_validation": ({"pass", "warn"}, ["pass", "warn"]),
+    }
+    for role, (accepted, expected) in expected_signals.items():
+        status = signal_status(role)
+        record(role, status in accepted, status, expected)
+
+    gate_required = (
+        bool(export_semantics.get("agent_export_gate_required"))
+        if profile_known
+        else True
+    )
+    gate_status = signal_status("agent_export_gate")
+    record(
+        "agent_export_gate",
+        not gate_required or gate_status == "pass",
+        gate_status,
+        "pass" if gate_required else "not_required",
+    )
+    export_safety_required = export_safety_requirement in {
+        REQ_REQUIRED,
+        REQ_RECOMMENDED,
+    }
+    export_status = signal_status("export_safety_report")
+    record(
+        "export_safety_report",
+        not export_safety_required or export_status == "pass",
+        export_status,
+        "pass" if export_safety_required else "not_required",
+    )
+
+    return {
+        "status": "pass" if not errors else "fail",
+        "profile": profile if isinstance(profile, str) else None,
+        "manifest_name": manifest_path.name,
+        "generated_at": normalized_generated_at,
+        "reference_time": reference.isoformat(timespec="microseconds").replace(
+            "+00:00", "Z"
+        ),
+        "checks": checks,
+        "errors": errors,
+    }
+
+
+def _selection_from_registry(registry: Mapping[str, Any]) -> dict[str, Any]:
+    bundle = (
+        registry.get("bundle") if isinstance(registry.get("bundle"), Mapping) else {}
+    )
+    source = (
+        registry.get("source") if isinstance(registry.get("source"), Mapping) else {}
+    )
+    generated_at = _normalized_generated_at(bundle.get("generated_at"))
+    run_id = bundle.get("run_id") if isinstance(bundle.get("run_id"), str) else None
+    manifest_sha256 = bundle.get("manifest_sha256")
+    if (
+        not isinstance(manifest_sha256, str)
+        or len(manifest_sha256) != 64
+        or any(character not in "0123456789abcdef" for character in manifest_sha256)
+    ):
+        raise ValueError(
+            "latest-complete registry manifest SHA-256 is missing or invalid"
+        )
+    source_lane = _source_lane(source)
+    if not source_lane:
+        raise ValueError("latest-complete registry source lane is missing")
+    return {
+        "basis": "generated_at_fail_closed_ties_v1",
+        "generated_at": generated_at,
+        "run_id": run_id,
+        "manifest_sha256": manifest_sha256,
+        "source_lane": source_lane,
+        "order_key": [generated_at],
+    }
+
+
+def _publication_target(output_path: str | Path) -> Path:
+    raw = Path(output_path).expanduser()
+    parent = raw.parent.resolve()
+    out = parent / raw.name
+    if out.is_symlink():
+        raise ValueError(
+            f"latest-complete registry target must not be a symlink: {out}"
+        )
+    if out.exists() and not out.is_file():
+        raise ValueError(
+            f"latest-complete registry target must be a regular file: {out}"
+        )
+    return out
+
+
+def _open_lock_file(path: Path) -> int:
+    flags = (
+        os.O_CREAT
+        | os.O_RDWR
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    try:
+        fd = os.open(path, flags, 0o600)
+    except OSError as exc:
+        raise ValueError(
+            f"latest-complete lock cannot be opened safely: {path}"
+        ) from exc
+    try:
+        metadata = os.fstat(fd)
+        if not statmod.S_ISREG(metadata.st_mode):
+            raise ValueError(f"latest-complete lock must be a regular file: {path}")
+        if metadata.st_uid != os.geteuid() or metadata.st_nlink != 1:
+            raise ValueError(
+                f"latest-complete lock must be singly linked and owned by the current user: {path}"
+            )
+    except Exception:
+        os.close(fd)
+        raise
+    return fd
+
+
+def _fsync_directory(path: Path) -> None:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_CLOEXEC", 0)
+    fd = os.open(path, flags)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _read_existing_registry(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    if path.is_symlink() or not path.is_file():
+        raise ValueError(
+            f"latest-complete registry target must be a regular file: {path}"
+        )
+    registry = _read_json_object(path, label="existing latest-complete registry")
+    if registry.get("kind") != KIND or registry.get("version") != VERSION:
+        raise ValueError("existing latest-complete registry kind/version mismatch")
+    return registry
+
+
+def _atomic_publish_registry(path: Path, registry: Mapping[str, Any]) -> None:
+    payload = (json.dumps(registry, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    tmp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            delete=False,
+            dir=str(path.parent),
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+        ) as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+            tmp_path = Path(handle.name)
+        os.replace(tmp_path, path)
+        _fsync_directory(path.parent)
+        if path.read_bytes() != payload:
+            raise OSError(f"latest-complete registry readback mismatch: {path}")
+    finally:
+        if tmp_path is not None and tmp_path.exists():
+            tmp_path.unlink()
+
+
 def build_latest_complete_registry(
     bundle_manifest: str | Path,
     *,
@@ -303,21 +670,43 @@ def build_latest_complete_registry(
 ) -> dict[str, Any]:
     manifest_path = Path(bundle_manifest).expanduser().resolve()
     manifest = _read_json_object(manifest_path, label="bundle manifest")
-    registry_target = Path(registry_path).expanduser().resolve() if registry_path is not None else None
+    registry_target = (
+        Path(registry_path).expanduser().resolve()
+        if registry_path is not None
+        else None
+    )
     base_dir = registry_target.parent if registry_target is not None else None
+    publication_time = checked_at or _now_iso()
+    _parse_timestamp(publication_time, label="latest-complete publication time")
     repositories = _source_repositories(manifest)
     source_commit, source_reason = _primary_source_commit(repositories)
     signals = _health_signals(manifest_path, manifest)
+    eligibility = _latest_complete_eligibility(
+        manifest_path,
+        manifest,
+        signals=signals,
+        source_commit=source_commit,
+        reference_time=publication_time,
+    )
+    if eligibility["status"] != "pass":
+        raise ValueError(
+            "bundle manifest is not eligible for latest-complete publication: "
+            + ", ".join(eligibility["errors"])
+        )
     registry: dict[str, Any] = {
         "kind": KIND,
         "version": VERSION,
-        "updated_at": checked_at or _now_iso(),
+        "updated_at": publication_time,
         "bundle": {
             "stem": _manifest_stem(manifest_path),
             "manifest_path": _relative_or_absolute(manifest_path, base_dir),
             "manifest_sha256": _sha256_file(manifest_path),
-            "run_id": manifest.get("run_id") if isinstance(manifest.get("run_id"), str) else None,
-            "generated_at": manifest.get("created_at") if isinstance(manifest.get("created_at"), str) else None,
+            "run_id": manifest.get("run_id")
+            if isinstance(manifest.get("run_id"), str)
+            else None,
+            "generated_at": manifest.get("created_at")
+            if isinstance(manifest.get("created_at"), str)
+            else None,
         },
         "source": {
             "commit": source_commit,
@@ -339,14 +728,34 @@ def build_latest_complete_registry(
             "basis": "git_commit" if source_commit else "unknown",
             "freshness_values": list(FRESHNESS_VALUES),
         },
+        "eligibility": eligibility,
+        "publication": {
+            "serialization": "advisory_file_lock",
+            "atomic_replace": True,
+            "file_fsync": True,
+            "directory_fsync": True,
+            "readback_verified": True,
+        },
         "mutation_boundary": {
-            "writes": ["latest_complete_registry"] if registry_target is not None else [],
-            "does_not_mutate": ["git", "pull_requests", "patches", "source_working_tree", "brief_bundle_artifacts"],
+            "writes": [
+                "latest_complete_registry",
+                "latest_complete_registry_lock",
+            ]
+            if registry_target is not None
+            else [],
+            "does_not_mutate": [
+                "git",
+                "pull_requests",
+                "patches",
+                "source_working_tree",
+                "brief_bundle_artifacts",
+            ],
             "read_paths_do_not_refresh": True,
             "hidden_refresh_allowed": False,
         },
         "does_not_establish": list(DOES_NOT_ESTABLISH),
     }
+    registry["selection"] = _selection_from_registry(registry)
     return registry
 
 
@@ -356,41 +765,79 @@ def write_latest_complete_registry(
     *,
     checked_at: str | None = None,
 ) -> dict[str, Any]:
-    out = Path(output_path).expanduser().resolve()
-    registry = build_latest_complete_registry(
+    out = _publication_target(output_path)
+    candidate = build_latest_complete_registry(
         bundle_manifest,
         registry_path=out,
         checked_at=checked_at,
     )
+    candidate_selection = _selection_from_registry(candidate)
     out.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path: Path | None = None
+    out = _publication_target(out)
+    lock_path = out.parent / f".{out.name}.lock"
+    lock_fd = _open_lock_file(lock_path)
+    publication_result = "published"
+    published_registry: dict[str, Any] = candidate
+    reason = "first_publication"
     try:
-        with tempfile.NamedTemporaryFile(
-            mode="w",
-            encoding="utf-8",
-            delete=False,
-            dir=str(out.parent),
-            prefix=f".{out.name}.",
-            suffix=".tmp",
-        ) as handle:
-            json.dump(registry, handle, indent=2, sort_keys=True)
-            handle.write("\n")
-            handle.flush()
-            os.fsync(handle.fileno())
-            tmp_path = Path(handle.name)
-        os.replace(tmp_path, out)
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        existing = _read_existing_registry(out)
+        if existing is not None:
+            existing_selection = _selection_from_registry(existing)
+            if existing_selection["source_lane"] != candidate_selection["source_lane"]:
+                raise ValueError("latest-complete registry source lane mismatch")
+            candidate_time = candidate_selection["generated_at"]
+            existing_time = existing_selection["generated_at"]
+            if candidate_time < existing_time:
+                publication_result = "unchanged"
+                published_registry = existing
+                reason = "candidate_older_than_published"
+            elif candidate_time == existing_time:
+                if (
+                    candidate_selection["manifest_sha256"]
+                    != existing_selection["manifest_sha256"]
+                ):
+                    raise ValueError(
+                        "latest-complete candidate order is ambiguous: generated_at collision"
+                    )
+                publication_result = "unchanged"
+                published_registry = existing
+                reason = "candidate_already_published"
+            else:
+                reason = "candidate_newer_than_published"
+        if publication_result == "published":
+            _atomic_publish_registry(out, candidate)
     finally:
-        if tmp_path is not None and tmp_path.exists():
-            tmp_path.unlink()
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        finally:
+            os.close(lock_fd)
+    observed_writes = ["latest_complete_registry_lock"]
+    if publication_result == "published":
+        observed_writes.insert(0, "latest_complete_registry")
     return {
         "kind": WRITE_KIND,
         "version": VERSION,
         "status": "ok",
+        "publication_result": publication_result,
+        "reason": reason,
         "registry_path": str(out),
-        "registry": registry,
+        "lock_path": str(lock_path),
+        "registry": published_registry,
+        "candidate_registry": candidate,
         "mutation_boundary": {
-            "writes": ["latest_complete_registry"],
-            "does_not_mutate": ["git", "pull_requests", "patches", "source_working_tree", "brief_bundle_artifacts"],
+            "writes": [
+                "latest_complete_registry",
+                "latest_complete_registry_lock",
+            ],
+            "observed_writes": observed_writes,
+            "does_not_mutate": [
+                "git",
+                "pull_requests",
+                "patches",
+                "source_working_tree",
+                "brief_bundle_artifacts",
+            ],
             "read_paths_do_not_refresh": True,
             "hidden_refresh_allowed": False,
         },
@@ -408,19 +855,87 @@ def latest_complete_status(
     registry = _read_json_object(path, label="latest-complete registry")
     if registry.get("kind") != KIND:
         raise ValueError(f"latest-complete registry kind must be {KIND}")
-    bundle_info = registry.get("bundle") if isinstance(registry.get("bundle"), dict) else {}
-    bundle_path = _safe_bundle_path(path, bundle_info.get("manifest_path") if isinstance(bundle_info, dict) else None)
+    bundle_info = (
+        registry.get("bundle") if isinstance(registry.get("bundle"), dict) else {}
+    )
+    bundle_path = _safe_bundle_path(
+        path,
+        bundle_info.get("manifest_path") if isinstance(bundle_info, dict) else None,
+    )
     manifest_hash_status = "unknown"
     observed_manifest_sha256 = None
     if bundle_path is not None and bundle_path.is_file():
         observed_manifest_sha256 = _sha256_file(bundle_path)
-        expected = bundle_info.get("manifest_sha256") if isinstance(bundle_info, dict) else None
-        manifest_hash_status = "match" if expected == observed_manifest_sha256 else "mismatch"
+        expected = (
+            bundle_info.get("manifest_sha256")
+            if isinstance(bundle_info, dict)
+            else None
+        )
+        manifest_hash_status = (
+            "match" if expected == observed_manifest_sha256 else "mismatch"
+        )
     elif bundle_path is not None:
         manifest_hash_status = "missing"
     freshness = evaluate_registry_freshness(registry, repo=repo, checked_at=checked_at)
+    stored_eligibility = (
+        registry.get("eligibility")
+        if isinstance(registry.get("eligibility"), dict)
+        else None
+    )
+    observed_eligibility: dict[str, Any] | None = None
+    sidecar_hash_drift: list[str] = []
+    if (
+        bundle_path is not None
+        and bundle_path.is_file()
+        and manifest_hash_status == "match"
+    ):
+        try:
+            manifest = _read_json_object(bundle_path, label="bundle manifest")
+            repositories = _source_repositories(manifest)
+            source_commit, _ = _primary_source_commit(repositories)
+            observed_signals = _health_signals(bundle_path, manifest)
+            observed_eligibility = _latest_complete_eligibility(
+                bundle_path,
+                manifest,
+                signals=observed_signals,
+                source_commit=source_commit,
+                reference_time=str(
+                    registry.get("updated_at") or checked_at or _now_iso()
+                ),
+            )
+            stored_signals = (
+                registry.get("health", {}).get("signals")
+                if isinstance(registry.get("health"), dict)
+                else {}
+            )
+            if isinstance(stored_signals, dict):
+                for role, signal in observed_signals.items():
+                    stored = stored_signals.get(role)
+                    stored_sha = (
+                        stored.get("sha256") if isinstance(stored, dict) else None
+                    )
+                    observed_sha = (
+                        signal.get("sha256") if isinstance(signal, dict) else None
+                    )
+                    if stored_sha is not None and stored_sha != observed_sha:
+                        sidecar_hash_drift.append(role)
+        except (OSError, ValueError) as exc:
+            observed_eligibility = {
+                "status": "fail",
+                "errors": [str(exc)],
+                "checks": {},
+            }
     status = "ok"
     if manifest_hash_status in {"mismatch", "missing"}:
+        status = "warn"
+    if stored_eligibility is None or stored_eligibility.get("status") != "pass":
+        status = "warn"
+    if (
+        observed_eligibility is not None
+        and observed_eligibility.get("status") != "pass"
+    ):
+        status = "warn"
+    if sidecar_hash_drift:
         status = "warn"
     return {
         "kind": STATUS_KIND,
@@ -431,13 +946,27 @@ def latest_complete_status(
         "bundle_manifest": str(bundle_path) if bundle_path is not None else None,
         "manifest_hash": {
             "status": manifest_hash_status,
-            "expected_sha256": bundle_info.get("manifest_sha256") if isinstance(bundle_info, dict) else None,
+            "expected_sha256": bundle_info.get("manifest_sha256")
+            if isinstance(bundle_info, dict)
+            else None,
             "observed_sha256": observed_manifest_sha256,
+        },
+        "eligibility": {
+            "stored": stored_eligibility,
+            "observed": observed_eligibility,
+            "sidecar_hash_drift": sorted(sidecar_hash_drift),
         },
         "freshness": freshness,
         "mutation_boundary": {
             "writes": [],
-            "does_not_mutate": ["git", "pull_requests", "patches", "source_working_tree", "brief_bundle_artifacts", "latest_complete_registry"],
+            "does_not_mutate": [
+                "git",
+                "pull_requests",
+                "patches",
+                "source_working_tree",
+                "brief_bundle_artifacts",
+                "latest_complete_registry",
+            ],
             "read_paths_do_not_refresh": True,
             "hidden_refresh_allowed": False,
         },

--- a/merger/lenskit/tests/test_repobrief_latest_complete.py
+++ b/merger/lenskit/tests/test_repobrief_latest_complete.py
@@ -1,9 +1,13 @@
 import hashlib
 import json
+import os
+import stat
 import subprocess
+import sys
 from pathlib import Path
 
 import jsonschema
+import pytest
 
 from merger.lenskit.cli.main import main
 from merger.lenskit.cli import cmd_repobrief
@@ -40,20 +44,99 @@ def _git_repo(tmp_path: Path) -> tuple[Path, str]:
     return repo, _git(repo, "rev-parse", "HEAD")
 
 
-def _manifest(tmp_path: Path, *, commit: str | None = None, health_status: str = "pass") -> Path:
+def _make_latest_complete_eligible(
+    manifest: Path,
+    *,
+    profile: str = "agent-portable",
+    output_status: str = "pass",
+    post_status: str = "pass",
+    surface_status: str = "pass",
+    gate_status: str = "pass",
+    export_status: str = "pass",
+) -> None:
+    data = json.loads(manifest.read_text(encoding="utf-8"))
+    stem = manifest.name.removesuffix(".bundle.manifest.json")
+    sidecars = {
+        "output_health": (
+            manifest.with_name(f"{stem}.output_health.json"),
+            {"kind": "lenskit.output_health", "verdict": output_status},
+        ),
+        "post_emit_health": (
+            manifest.with_name(f"{stem}.post_emit_health.json"),
+            {"kind": "lenskit.post_emit_health", "status": post_status},
+        ),
+        "bundle_surface_validation": (
+            manifest.with_name(f"{stem}.bundle_surface_validation.json"),
+            {"kind": "lenskit.bundle_surface_validation", "status": surface_status},
+        ),
+        "agent_export_gate": (
+            manifest.with_name(f"{stem}.agent_export_gate.json"),
+            {"kind": "lenskit.agent_export_gate", "status": gate_status},
+        ),
+        "export_safety_report": (
+            manifest.with_name(f"{stem}.export_safety_report.json"),
+            {"kind": "lenskit.export_safety_report", "status": export_status},
+        ),
+    }
+    for _, (path, document) in sidecars.items():
+        path.write_text(json.dumps(document), encoding="utf-8")
+
+    artifacts = data.setdefault("artifacts", [])
+    output_path = sidecars["output_health"][0]
+    artifacts[:] = [
+        artifact
+        for artifact in artifacts
+        if not (isinstance(artifact, dict) and artifact.get("role") == "output_health")
+    ]
+    artifacts.append(
+        {
+            "role": "output_health",
+            "path": output_path.name,
+            "content_type": "application/json",
+            "bytes": output_path.stat().st_size,
+            "sha256": _sha(output_path),
+        }
+    )
+    links = data.setdefault("links", {})
+    links.update(
+        {
+            "post_emit_health_path": sidecars["post_emit_health"][0].name,
+            "bundle_surface_validation_path": sidecars["bundle_surface_validation"][
+                0
+            ].name,
+            "agent_export_gate_path": sidecars["agent_export_gate"][0].name,
+            "agent_export_gate_status": gate_status,
+            "export_safety_report_path": sidecars["export_safety_report"][0].name,
+            "export_safety_report_status": export_status,
+        }
+    )
+    capabilities = data.setdefault("capabilities", {})
+    capabilities["repobrief_profile"] = profile
+    capabilities["repobrief_profile_evaluation"] = {
+        "status": "pass",
+        "profile": profile,
+    }
+    manifest.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def _manifest(
+    tmp_path: Path,
+    *,
+    commit: str | None = None,
+    health_status: str = "pass",
+    created_at: str = "2026-07-08T10:00:00Z",
+    run_id: str = "run-1",
+    repo_name: str = "repo",
+    repo_remote: str | None = None,
+) -> Path:
     canonical = tmp_path / "demo.md"
     canonical.write_text("# demo\n", encoding="utf-8")
-    output_health = tmp_path / "demo.output_health.json"
-    output_health.write_text(
-        json.dumps({"kind": "lenskit.output_health", "verdict": health_status}),
-        encoding="utf-8",
-    )
     manifest = tmp_path / "demo.bundle.manifest.json"
     data = {
         "kind": "repolens.bundle.manifest",
         "version": "1.0",
-        "run_id": "run-1",
-        "created_at": "2026-07-08T10:00:00Z",
+        "run_id": run_id,
+        "created_at": created_at,
         "artifacts": [
             {
                 "role": "canonical_md",
@@ -62,27 +145,22 @@ def _manifest(tmp_path: Path, *, commit: str | None = None, health_status: str =
                 "bytes": canonical.stat().st_size,
                 "sha256": _sha(canonical),
             },
-            {
-                "role": "output_health",
-                "path": output_health.name,
-                "content_type": "application/json",
-                "bytes": output_health.stat().st_size,
-                "sha256": _sha(output_health),
-            },
         ],
         "links": {},
-        "capabilities": {"repobrief_profile": "agent-portable"},
+        "capabilities": {},
         "snapshot_provenance": {
             "version": "v1",
             "repositories": [
                 {
-                    "name": "repo",
+                    "name": repo_name,
                     "repo_root": str(tmp_path / "repo"),
-                    "repo_remote": None,
+                    "repo_remote": repo_remote,
                     "git_commit": commit,
                     "git_dirty": False,
                     "git_branch": "main",
-                    "provenance_status": "present" if commit else "producer_did_not_collect",
+                    "provenance_status": "present"
+                    if commit
+                    else "producer_did_not_collect",
                     "freshness_basis": "git_commit" if commit else "unknown",
                 }
             ],
@@ -90,6 +168,7 @@ def _manifest(tmp_path: Path, *, commit: str | None = None, health_status: str =
         },
     }
     manifest.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    _make_latest_complete_eligible(manifest, output_status=health_status)
     return manifest
 
 
@@ -112,9 +191,15 @@ def test_build_latest_complete_registry_records_manifest_source_and_health(tmp_p
     assert registry["source"]["commit_status"] == "single_repo_commit"
     assert registry["health"]["status"] == "pass"
     assert registry["health"]["signals"]["output_health"]["status"] == "pass"
+    assert registry["eligibility"]["status"] == "pass"
+    assert registry["selection"]["basis"] == "generated_at_fail_closed_ties_v1"
+    assert registry["publication"]["directory_fsync"] is True
     assert registry["freshness"]["status"] == "unknown"
     assert registry["freshness"]["reason"] == "live_repo_not_checked"
-    assert registry["mutation_boundary"]["writes"] == ["latest_complete_registry"]
+    assert registry["mutation_boundary"]["writes"] == [
+        "latest_complete_registry",
+        "latest_complete_registry_lock",
+    ]
     assert registry["mutation_boundary"]["hidden_refresh_allowed"] is False
 
 
@@ -123,13 +208,16 @@ def test_latest_complete_registry_schema_accepts_emitted_registry(tmp_path):
     registry_path = tmp_path / "latest.json"
     result = write_latest_complete_registry(manifest, registry_path)
     schema = json.loads(
-        Path("merger/lenskit/contracts/repobrief-latest-complete-registry.v1.schema.json").read_text(
-            encoding="utf-8"
-        )
+        Path(
+            "merger/lenskit/contracts/repobrief-latest-complete-registry.v1.schema.json"
+        ).read_text(encoding="utf-8")
     )
 
     assert result["status"] == "ok"
-    jsonschema.validate(instance=json.loads(registry_path.read_text(encoding="utf-8")), schema=schema)
+    assert result["publication_result"] == "published"
+    jsonschema.validate(
+        instance=json.loads(registry_path.read_text(encoding="utf-8")), schema=schema
+    )
 
 
 def test_latest_complete_status_detects_head_drift_without_writing(tmp_path):
@@ -193,37 +281,270 @@ def test_latest_complete_cli_write_and_status(tmp_path, capsys):
     manifest = _manifest(tmp_path, commit=commit)
     registry_path = tmp_path / "latest.json"
 
-    rc = main([
-        "repobrief",
-        "latest-complete",
-        "write",
-        "--bundle-manifest",
-        str(manifest),
-        "--out",
-        str(registry_path),
-    ])
+    rc = main(
+        [
+            "repobrief",
+            "latest-complete",
+            "write",
+            "--bundle-manifest",
+            str(manifest),
+            "--out",
+            str(registry_path),
+        ]
+    )
 
     write_out = json.loads(capsys.readouterr().out)
     assert rc == 0
     assert registry_path.exists()
     assert write_out["kind"] == "repobrief.latest_complete_registry_write"
-    assert write_out["mutation_boundary"]["writes"] == ["latest_complete_registry"]
+    assert write_out["mutation_boundary"]["writes"] == [
+        "latest_complete_registry",
+        "latest_complete_registry_lock",
+    ]
 
-    rc = main([
-        "repobrief",
-        "latest-complete",
-        "status",
-        "--registry",
-        str(registry_path),
-        "--repo",
-        str(repo),
-    ])
+    rc = main(
+        [
+            "repobrief",
+            "latest-complete",
+            "status",
+            "--registry",
+            str(registry_path),
+            "--repo",
+            str(repo),
+        ]
+    )
 
     status_out = json.loads(capsys.readouterr().out)
     assert rc == 0
     assert status_out["kind"] == "repobrief.latest_complete_status"
     assert status_out["freshness"]["status"] == "fresh"
     assert status_out["mutation_boundary"]["writes"] == []
+
+
+def test_write_is_monotone_and_idempotent(tmp_path):
+    older_dir = tmp_path / "older"
+    newer_dir = tmp_path / "newer"
+    older_dir.mkdir()
+    newer_dir.mkdir()
+    older = _manifest(
+        older_dir,
+        commit="1" * 40,
+        created_at="2026-07-08T10:00:00Z",
+        run_id="run-old",
+    )
+    newer = _manifest(
+        newer_dir,
+        commit="2" * 40,
+        created_at="2026-07-08T11:00:00Z",
+        run_id="run-new",
+    )
+    registry_path = tmp_path / "latest.json"
+
+    first = write_latest_complete_registry(newer, registry_path)
+    first_hash = _sha(registry_path)
+    older_result = write_latest_complete_registry(older, registry_path)
+    same_result = write_latest_complete_registry(newer, registry_path)
+
+    assert first["publication_result"] == "published"
+    assert older_result["publication_result"] == "unchanged"
+    assert older_result["reason"] == "candidate_older_than_published"
+    assert same_result["publication_result"] == "unchanged"
+    assert same_result["reason"] == "candidate_already_published"
+    assert _sha(registry_path) == first_hash
+    assert (
+        json.loads(registry_path.read_text(encoding="utf-8"))["bundle"]["run_id"]
+        == "run-new"
+    )
+
+
+def test_concurrent_writers_publish_the_newest_candidate(tmp_path):
+    older_dir = tmp_path / "older-concurrent"
+    newer_dir = tmp_path / "newer-concurrent"
+    older_dir.mkdir()
+    newer_dir.mkdir()
+    older = _manifest(
+        older_dir,
+        commit="a" * 40,
+        created_at="2026-07-08T10:00:00Z",
+        run_id="run-old",
+    )
+    newer = _manifest(
+        newer_dir,
+        commit="b" * 40,
+        created_at="2026-07-08T11:00:00Z",
+        run_id="run-new",
+    )
+    registry_path = tmp_path / "latest.json"
+    script = (
+        "from merger.lenskit.core.repobrief_latest_complete import "
+        "write_latest_complete_registry; "
+        "import sys; write_latest_complete_registry(sys.argv[1], sys.argv[2])"
+    )
+    processes = [
+        subprocess.Popen(
+            [sys.executable, "-c", script, str(manifest), str(registry_path)],
+            cwd=Path.cwd(),
+        )
+        for manifest in (older, newer)
+    ]
+
+    returncodes = [process.wait(timeout=20) for process in processes]
+
+    assert returncodes == [0, 0]
+    published = json.loads(registry_path.read_text(encoding="utf-8"))
+    assert published["bundle"]["run_id"] == "run-new"
+    assert published["source"]["commit"] == "b" * 40
+
+
+def test_write_rejects_equal_timestamp_with_different_manifest(tmp_path):
+    first_dir = tmp_path / "first-tie"
+    second_dir = tmp_path / "second-tie"
+    first_dir.mkdir()
+    second_dir.mkdir()
+    first = _manifest(first_dir, commit="c" * 40, run_id="run-first")
+    second = _manifest(second_dir, commit="d" * 40, run_id="run-second")
+    registry_path = tmp_path / "latest.json"
+    write_latest_complete_registry(first, registry_path)
+    before = registry_path.read_bytes()
+
+    with pytest.raises(ValueError, match="generated_at collision"):
+        write_latest_complete_registry(second, registry_path)
+
+    assert registry_path.read_bytes() == before
+
+
+def test_write_rejects_future_timestamp_without_creating_target_directory(tmp_path):
+    manifest = _manifest(
+        tmp_path,
+        commit="e" * 40,
+        created_at="2026-07-08T12:10:01Z",
+    )
+    target_dir = tmp_path / "missing-target"
+    registry_path = target_dir / "latest.json"
+
+    with pytest.raises(ValueError, match="generated_at_not_future"):
+        write_latest_complete_registry(
+            manifest,
+            registry_path,
+            checked_at="2026-07-08T12:00:00Z",
+        )
+
+    assert not target_dir.exists()
+
+
+def test_write_rejects_symlink_lock(tmp_path):
+    manifest = _manifest(tmp_path, commit="f" * 40)
+    registry_path = tmp_path / "latest.json"
+    external = tmp_path / "external.lock"
+    external.write_text("sentinel\n", encoding="utf-8")
+    lock_path = tmp_path / ".latest.json.lock"
+    lock_path.symlink_to(external)
+
+    with pytest.raises(ValueError, match="lock cannot be opened safely"):
+        write_latest_complete_registry(manifest, registry_path)
+
+    assert not registry_path.exists()
+    assert external.read_text(encoding="utf-8") == "sentinel\n"
+
+
+def test_write_rejects_incomplete_candidate_without_replacing_registry(tmp_path):
+    valid_dir = tmp_path / "valid"
+    invalid_dir = tmp_path / "invalid"
+    valid_dir.mkdir()
+    invalid_dir.mkdir()
+    valid = _manifest(valid_dir, commit="3" * 40)
+    invalid = _manifest(
+        invalid_dir,
+        commit="4" * 40,
+        created_at="2026-07-08T12:00:00Z",
+    )
+    invalid_data = json.loads(invalid.read_text(encoding="utf-8"))
+    post_path = invalid.parent / invalid_data["links"]["post_emit_health_path"]
+    post_path.write_text(
+        json.dumps({"kind": "lenskit.post_emit_health", "status": "fail"}),
+        encoding="utf-8",
+    )
+    registry_path = tmp_path / "latest.json"
+    write_latest_complete_registry(valid, registry_path)
+    before = registry_path.read_bytes()
+
+    with pytest.raises(ValueError, match="post_emit_health"):
+        write_latest_complete_registry(invalid, registry_path)
+
+    assert registry_path.read_bytes() == before
+
+
+def test_write_rejects_source_lane_mismatch(tmp_path):
+    first_dir = tmp_path / "first"
+    second_dir = tmp_path / "second"
+    first_dir.mkdir()
+    second_dir.mkdir()
+    first = _manifest(first_dir, commit="5" * 40, repo_name="alpha")
+    second = _manifest(
+        second_dir,
+        commit="6" * 40,
+        repo_name="beta",
+        created_at="2026-07-08T12:00:00Z",
+    )
+    registry_path = tmp_path / "latest.json"
+    write_latest_complete_registry(first, registry_path)
+    before = registry_path.read_bytes()
+
+    with pytest.raises(ValueError, match="source lane mismatch"):
+        write_latest_complete_registry(second, registry_path)
+
+    assert registry_path.read_bytes() == before
+
+
+def test_write_fsyncs_file_and_directory(monkeypatch, tmp_path):
+    manifest = _manifest(tmp_path, commit="7" * 40)
+    registry_path = tmp_path / "latest.json"
+    observed_modes: list[int] = []
+    real_fsync = os.fsync
+
+    def recording_fsync(fd: int) -> None:
+        observed_modes.append(os.fstat(fd).st_mode)
+        real_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", recording_fsync)
+    write_latest_complete_registry(manifest, registry_path)
+
+    assert any(stat.S_ISREG(mode) for mode in observed_modes)
+    assert any(stat.S_ISDIR(mode) for mode in observed_modes)
+
+
+def test_write_rejects_symlink_target(tmp_path):
+    manifest = _manifest(tmp_path, commit="8" * 40)
+    actual = tmp_path / "actual.json"
+    actual.write_text("sentinel\n", encoding="utf-8")
+    link = tmp_path / "latest.json"
+    link.symlink_to(actual)
+
+    with pytest.raises(ValueError, match="must not be a symlink"):
+        write_latest_complete_registry(manifest, link)
+
+    assert actual.read_text(encoding="utf-8") == "sentinel\n"
+
+
+def test_status_warns_when_published_sidecar_drifts(tmp_path):
+    manifest = _manifest(tmp_path, commit="9" * 40)
+    registry_path = tmp_path / "latest.json"
+    write_latest_complete_registry(manifest, registry_path)
+    data = json.loads(manifest.read_text(encoding="utf-8"))
+    output_path = manifest.parent / next(
+        artifact["path"]
+        for artifact in data["artifacts"]
+        if artifact.get("role") == "output_health"
+    )
+    output_path.write_text(
+        json.dumps({"kind": "lenskit.output_health", "verdict": "warn"}),
+        encoding="utf-8",
+    )
+
+    status_result = latest_complete_status(registry_path)
+
+    assert status_result["status"] == "warn"
+    assert status_result["eligibility"]["sidecar_hash_drift"] == ["output_health"]
 
 
 class _FakeArtifacts:
@@ -236,13 +557,22 @@ class _FakeArtifacts:
         return [self.bundle_manifest, self.canonical_md]
 
 
-def test_snapshot_create_can_explicitly_write_latest_complete_registry(monkeypatch, tmp_path, capsys):
+def test_snapshot_create_can_explicitly_write_latest_complete_registry(
+    monkeypatch, tmp_path, capsys
+):
     repo, commit = _git_repo(tmp_path)
     out = tmp_path / "briefs"
     registry_path = tmp_path / "latest" / "registry.json"
 
     def fake_scan_repo(*args, **kwargs):
-        return {"name": "repo", "root": repo, "files": [], "total_files": 0, "total_bytes": 0, "ext_hist": {}}
+        return {
+            "name": "repo",
+            "root": repo,
+            "files": [],
+            "total_files": 0,
+            "total_bytes": 0,
+            "ext_hist": {},
+        }
 
     def fake_write_reports_v2(*args, **kwargs):
         manifest = out / "repo_merge.bundle.manifest.json"
@@ -280,31 +610,34 @@ def test_snapshot_create_can_explicitly_write_latest_complete_registry(monkeypat
 
     monkeypatch.setattr(cmd_repobrief, "scan_repo", fake_scan_repo)
     monkeypatch.setattr(cmd_repobrief, "write_reports_v2", fake_write_reports_v2)
-    monkeypatch.setattr(
-        cmd_repobrief,
-        "finalize_snapshot_bundle",
-        lambda manifest, profile: {
+
+    def fake_finalize(manifest, profile):
+        _make_latest_complete_eligible(manifest, profile=profile)
+        return {
             "status": "pass",
             "errors": [],
             "profile_evaluation": {"status": "pass", "profile": profile},
             "control_paths": [],
             "refreshed_paths": [],
-        },
-    )
+        }
 
-    rc = main([
-        "repobrief",
-        "snapshot",
-        "create",
-        "--repo",
-        str(repo),
-        "--out",
-        str(out),
-        "--profile",
-        "agent-portable",
-        "--latest-complete-registry",
-        str(registry_path),
-    ])
+    monkeypatch.setattr(cmd_repobrief, "finalize_snapshot_bundle", fake_finalize)
+
+    rc = main(
+        [
+            "repobrief",
+            "snapshot",
+            "create",
+            "--repo",
+            str(repo),
+            "--out",
+            str(out),
+            "--profile",
+            "agent-portable",
+            "--latest-complete-registry",
+            str(registry_path),
+        ]
+    )
 
     emitted = json.loads(capsys.readouterr().out)
     assert rc == 0
@@ -312,7 +645,10 @@ def test_snapshot_create_can_explicitly_write_latest_complete_registry(monkeypat
     assert emitted["latest_complete_registry"]["status"] == "ok"
     registry = json.loads(registry_path.read_text(encoding="utf-8"))
     assert registry["source"]["commit"] == commit
-    assert registry["mutation_boundary"]["writes"] == ["latest_complete_registry"]
+    assert registry["mutation_boundary"]["writes"] == [
+        "latest_complete_registry",
+        "latest_complete_registry_lock",
+    ]
 
 
 def test_snapshot_create_does_not_advance_latest_registry_when_finalization_fails(
@@ -362,19 +698,21 @@ def test_snapshot_create_does_not_advance_latest_registry_when_finalization_fail
         },
     )
 
-    rc = main([
-        "repobrief",
-        "snapshot",
-        "create",
-        "--repo",
-        str(repo),
-        "--out",
-        str(out),
-        "--profile",
-        "agent-portable",
-        "--latest-complete-registry",
-        str(registry_path),
-    ])
+    rc = main(
+        [
+            "repobrief",
+            "snapshot",
+            "create",
+            "--repo",
+            str(repo),
+            "--out",
+            str(out),
+            "--profile",
+            "agent-portable",
+            "--latest-complete-registry",
+            str(registry_path),
+        ]
+    )
 
     emitted = json.loads(capsys.readouterr().out)
     assert rc == 1


### PR DESCRIPTION
## Summary
- publish only bundles that pass the RepoBrief finalization contract
- serialize writers with an explicit owner-bound lock and reject unsafe targets
- prevent rollback by delayed older runs and fail closed on equal-time ambiguity
- fsync file and parent directory, verify readback, and expose sidecar drift
- preserve v1 read compatibility while adding optional eligibility/selection/publication evidence

## Validation
- repo-wide `ruff check --config ruff-ci.toml .`
- 92 dependent tests passed
- full non-browser suite: 3767 passed, 1 skipped, 13 deselected
- head-bound self-review: PASS_LOCAL
- diff SHA-256: `326757352ff5c62705365ce6f4be1609a29dabf959d729f79e0a884e7ca0fdbb`
