### PR TITLE
docs(release): decide namespace and public license boundary

### DIFF
--- a/docs/architecture/naming.md
+++ b/docs/architecture/naming.md
@@ -84,3 +84,7 @@ A later decision may choose one of these paths:
 4. compatibility bridge: `merger.lenskit` remains while `merger.repobrief` is introduced as a new alias layer.
 
 No later path is selected by this document.
+
+## 2026-07-12 namespace decision
+
+The 2.x line keeps the repository name `lenskit` and Python namespace `merger.lenskit`. RepoBrief remains the product and primary CLI name. The machine-readable consumer inventory and future breaking-major gate are in `../decisions/repobrief-package-namespace-decision.v1.json`.

--- a/docs/decisions/repobrief-package-namespace-decision.md
+++ b/docs/decisions/repobrief-package-namespace-decision.md
@@ -1,0 +1,32 @@
+# RepoBrief package namespace decision
+
+Status: decided on 2026-07-12
+
+## Decision
+
+The repository remains `heimgewebe/lenskit` and the Python namespace remains
+`merger.lenskit` throughout the 2.x line. **RepoBrief** remains the product name
+and `repobrief` remains the primary user-facing CLI name. `rlens` remains a
+compatibility/runtime name where already supported.
+
+This is not a branding compromise. It separates the stable internal import
+identity from the product vocabulary users and agents see.
+
+## Evidence
+
+The organization code search found external references in `infra`,
+`vault-gewebe`, `metarepo` and `vibe-lab`. Inside this repository,
+`merger.lenskit` appears 1,218 times across 356 files. The exact inventory and
+search limitations are recorded in
+`repobrief-package-namespace-decision.v1.json`.
+
+A same-major import rename would therefore create widespread churn, service and
+systemd migration risk, and a likely compatibility alias. It would not improve
+RepoBrief's evidence quality, runtime safety or user workflow.
+
+## Future gate
+
+A future breaking-major rename is allowed only with a complete consumer
+inventory, tested compatibility plan, deprecation period, service-entrypoint
+migration and rollback plan. Until then, new user documentation should say
+**RepoBrief** and code should continue to import `merger.lenskit`.

--- a/docs/decisions/repobrief-package-namespace-decision.v1.json
+++ b/docs/decisions/repobrief-package-namespace-decision.v1.json
@@ -1,0 +1,68 @@
+{
+  "kind": "repobrief.package_namespace_decision",
+  "version": "1.0",
+  "observed_on": "2026-07-12",
+  "decision": "keep_lenskit_namespace_for_2_x",
+  "repository_name": "lenskit",
+  "python_namespace": "merger.lenskit",
+  "product_name": "RepoBrief",
+  "primary_cli_name": "repobrief",
+  "compatibility_cli_name": "rlens",
+  "consumer_inventory": {
+    "github_scope": "organization heimgewebe default branches, GitHub code search",
+    "github_queries": [
+      {
+        "query": "\"merger.lenskit\" org:heimgewebe",
+        "result_count": 364,
+        "external_consumers": [
+          "heimgewebe/infra",
+          "heimgewebe/vault-gewebe"
+        ]
+      },
+      {
+        "query": "\"python -m merger.lenskit\" org:heimgewebe",
+        "result_count": 24,
+        "external_consumers": [
+          "heimgewebe/infra"
+        ]
+      },
+      {
+        "query": "\"heimgewebe/lenskit\" org:heimgewebe",
+        "result_count": 39,
+        "external_consumers": [
+          "heimgewebe/metarepo",
+          "heimgewebe/infra",
+          "heimgewebe/vibe-lab"
+        ]
+      }
+    ],
+    "repository_fork_count": 0,
+    "local_merger_lenskit_files": 356,
+    "local_merger_lenskit_occurrences": 1218,
+    "limitations": [
+      "GitHub code search is an indexed default-branch view and may omit private, unindexed, historic or local-only consumers."
+    ]
+  },
+  "rationale": [
+    "RepoBrief is already the user-facing product and CLI name.",
+    "The Python namespace is deeply embedded and has repo-external organization consumers.",
+    "A same-major rename would create broad migration risk without improving runtime behavior.",
+    "Keeping the internal namespace avoids a compatibility alias layer and duplicate import identity."
+  ],
+  "future_rename_gate": {
+    "eligible_release": "next intentional breaking major release only",
+    "required_evidence": [
+      "complete consumer inventory",
+      "tested compatibility/import migration plan",
+      "deprecation window",
+      "rollback plan",
+      "updated service and systemd entrypoints"
+    ]
+  },
+  "does_not_establish": [
+    "permanent prohibition on a future rename",
+    "absence of unknown consumers",
+    "public package publication readiness"
+  ],
+  "status": "decision_complete"
+}

--- a/docs/decisions/repobrief-public-license-decision.md
+++ b/docs/decisions/repobrief-public-license-decision.md
@@ -1,0 +1,35 @@
+# RepoBrief public license decision
+
+Status: decided on 2026-07-12
+
+## Decision
+
+No public redistribution license is granted at this time. The current
+`LicenseRef-RepoBrief-All-Rights-Reserved` text remains the
+controlling repository notice, and public release remains blocked without
+separate written permission.
+
+GitHub's official licensing guidance distinguishes public visibility from an
+open-source grant and notes that an explicit license is needed for others to
+use, change and distribute software. SPDX permits a `LicenseRef-...` identifier
+for terms that are not on the SPDX License List. These references support the
+metadata shape; this document is not legal advice.
+
+## Third-party review
+
+The three committed Python lock profiles were installed with
+`--require-hashes` in the pinned Python 3.12 Playwright container. Metadata for
+57 distributions is recorded in
+`docs/release/third-party-license-review.v1.json`.
+
+The current source candidate does not vendor those packages. Even so, some
+installed metadata is ambiguous or classifier-only. A later public source,
+wheel, container or binary release must review the exact included artifact,
+resolve ambiguous entries from upstream license texts, and generate applicable
+notices.
+
+## Reopening the decision
+
+This decision may be reopened when the owner names a proposed public license and
+an exact distribution form. Until both are explicit, internal deterministic
+release candidates may be built, but publication remains fail-closed.

--- a/docs/decisions/repobrief-public-license-decision.v1.json
+++ b/docs/decisions/repobrief-public-license-decision.v1.json
@@ -1,0 +1,49 @@
+{
+  "kind": "repobrief.public_license_decision",
+  "version": "1.0",
+  "observed_on": "2026-07-12",
+  "decision": "do_not_grant_public_redistribution_license",
+  "current_license_expression": "LicenseRef-RepoBrief-All-Rights-Reserved",
+  "license_file": "LICENSE",
+  "repository_visibility": "public",
+  "distribution_status": "blocked_without_separate_written_permission",
+  "reasoning": [
+    "Public visibility is not treated as an open-source grant.",
+    "No explicit owner decision selected an OSI-approved license.",
+    "The dependency review is bounded and contains ambiguous metadata entries requiring exact-artifact review before redistribution.",
+    "The current release process is an internal deterministic candidate path, not a public publication workflow."
+  ],
+  "references": [
+    {
+      "title": "GitHub Docs: Licensing a repository",
+      "url": "https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository"
+    },
+    {
+      "title": "SPDX 2.3: Other licensing information detected",
+      "url": "https://spdx.github.io/spdx-spec/v2.3/other-licensing-information-detected/"
+    },
+    {
+      "title": "Python Core Metadata: License-Expression",
+      "url": "https://packaging.python.org/en/latest/specifications/core-metadata/#license-expression"
+    }
+  ],
+  "reviewed_evidence": [
+    "LICENSE",
+    "docs/release/licensing.md",
+    "docs/release/release-policy.md",
+    "docs/release/third-party-license-review.v1.json"
+  ],
+  "reopen_conditions": [
+    "owner explicitly requests public open-source distribution",
+    "proposed license and exact distribution artifact are named",
+    "third-party obligations are re-evaluated for that artifact"
+  ],
+  "does_not_establish": [
+    "legal advice",
+    "that the restrictive terms are enforceable in every jurisdiction",
+    "permission to redistribute",
+    "permanent rejection of open-source publication"
+  ],
+  "status": "decision_complete_public_distribution_blocked",
+  "current_license_notice": "All rights reserved; no public distribution without separate written permission."
+}

--- a/docs/release/licensing.md
+++ b/docs/release/licensing.md
@@ -25,3 +25,7 @@ The `LicenseRef-...` value is a project-local identifier for a license text
 that is not represented by a standard SPDX short identifier. It is carried in
 release manifests so tooling does not silently infer a permissive license from
 repository visibility.
+
+## Owner decision recorded on 2026-07-12
+
+The public-license decision is closed as **do not grant public redistribution rights at this time**. The controlling `LICENSE` text is unchanged. Third-party metadata review is recorded in `third-party-license-review.v1.json`; it does not authorize redistribution.

--- a/docs/release/third-party-license-review.v1.json
+++ b/docs/release/third-party-license-review.v1.json
@@ -1,0 +1,1072 @@
+{
+  "kind": "repobrief.third_party_license_review",
+  "version": "1.0",
+  "observed_on": "2026-07-12",
+  "environment": {
+    "python": "3.12.3",
+    "platform": "Linux x86_64 container",
+    "container": "mcr.microsoft.com/playwright/python:v1.61.0-noble@sha256:a9731514f24121d1dcd25d58d0a38146646d290a5998fd80d3e533e7b5e21c69",
+    "locks": [
+      "requirements/repobrief-runtime.lock.txt",
+      "requirements/repobrief-dev.lock.txt",
+      "requirements/repobrief-browser.lock.txt"
+    ],
+    "install_mode": "pip --require-hashes --target isolated container directory"
+  },
+  "distribution_boundary": {
+    "source_candidate_embeds_third_party_packages": false,
+    "dependencies_are_referenced_not_vendored": true,
+    "public_distribution_allowed": false,
+    "decision": "The review supports internal source-candidate construction only. It is not a legal clearance for public source, wheel, container, binary, or dependency redistribution."
+  },
+  "summary": {
+    "package_count": 57,
+    "identified_count": 53,
+    "ambiguous_count": 4,
+    "unresolved_count": 0
+  },
+  "packages": [
+    {
+      "name": "annotated-doc",
+      "version": "0.0.4",
+      "identified_license": "MIT",
+      "metadata_status": "identified",
+      "metadata_basis": "license_expression",
+      "license_expression": "MIT",
+      "license_field": "",
+      "license_classifiers": [],
+      "homepage": null,
+      "project_urls": [
+        "Homepage, https://github.com/fastapi/annotated-doc",
+        "Documentation, https://github.com/fastapi/annotated-doc",
+        "Repository, https://github.com/fastapi/annotated-doc",
+        "Issues, https://github.com/fastapi/annotated-doc/issues",
+        "Changelog, https://github.com/fastapi/annotated-doc/release-notes.md"
+      ],
+      "notes": []
+    },
+    {
+      "name": "annotated-types",
+      "version": "0.7.0",
+      "identified_license": "MIT",
+      "metadata_status": "identified",
+      "metadata_basis": "classifier",
+      "license_expression": null,
+      "license_field": "",
+      "license_classifiers": [
+        "License :: OSI Approved :: MIT License"
+      ],
+      "homepage": null,
+      "project_urls": [
+        "Homepage, https://github.com/annotated-types/annotated-types",
+        "Source, https://github.com/annotated-types/annotated-types",
+        "Changelog, https://github.com/annotated-types/annotated-types/releases"
+      ],
+      "notes": []
+    },
+    {
+      "name": "anyio",
+      "version": "4.14.1",
+      "identified_license": "MIT",
+      "metadata_status": "identified",
+      "metadata_basis": "license_expression",
+      "license_expression": "MIT",
+      "license_field": "",
+      "license_classifiers": [],
+      "homepage": null,
+      "project_urls": [
+        "Documentation, https://anyio.readthedocs.io/en/latest/",
+        "Changelog, https://anyio.readthedocs.io/en/stable/versionhistory.html",
+        "Source code, https://github.com/agronholm/anyio",
+        "Issue tracker, https://github.com/agronholm/anyio/issues"
+      ],
+      "notes": []
+    },
+    {
+      "name": "arrow",
+      "version": "1.4.0",
+      "identified_license": "Apache-2.0",
+      "metadata_status": "identified",
+      "metadata_basis": "classifier",
+      "license_expression": null,
+      "license_field": "",
+      "license_classifiers": [
+        "License :: OSI Approved :: Apache Software License"
+      ],
+      "homepage": null,
+      "project_urls": [
+        "Documentation, https://arrow.readthedocs.io",
+        "Issues, https://github.com/arrow-py/arrow/issues",
+        "Source, https://github.com/arrow-py/arrow"
+      ],
+      "notes": []
+    },
+    {
+      "name": "attrs",
+      "version": "26.1.0",
+      "identified_license": "MIT",
+      "metadata_status": "identified",
+      "metadata_basis": "license_expression",
+      "license_expression": "MIT",
+      "license_field": "",
+      "license_classifiers": [],
+      "homepage": null,
+      "project_urls": [
+        "Documentation, https://www.attrs.org/",
+        "Changelog, https://www.attrs.org/en/stable/changelog.html",
+        "GitHub, https://github.com/python-attrs/attrs",
+        "Funding, https://github.com/sponsors/hynek",
+        "Tidelift, https://tidelift.com/subscription/pkg/pypi-attrs?utm_source=pypi-attrs&utm_medium=pypi"
+      ],
+      "notes": []
+    },
+    {
+      "name": "certifi",
+      "version": "2026.6.17",
+      "identified_license": "MPL-2.0",
+      "metadata_status": "identified",
+      "metadata_basis": "license_field",
+      "license_expression": null,
+      "license_field": "MPL-2.0",
+      "license_classifiers": [
+        "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)"
+      ],
+      "homepage": "https://github.com/certifi/python-certifi",
+      "project_urls": [
+        "Source, https://github.com/certifi/python-certifi"
+      ],
+      "notes": []
+    },
+    {
+      "name": "charset-normalizer",
+      "version": "3.4.9",
+      "identified_license": "MIT",
+      "metadata_status": "identified",
+      "metadata_basis": "license_field",
+      "license_expression": null,
+      "license_field": "MIT",
+      "license_classifiers": [],
+      "homepage": null,
+      "project_urls": [
+        "Changelog, https://github.com/jawah/charset_normalizer/blob/master/CHANGELOG.md",
+        "Documentation, https://charset-normalizer.readthedocs.io/",
+        "Code, https://github.com/jawah/charset_normalizer",
+        "Issue tracker, https://github.com/jawah/charset_normalizer/issues"
+      ],
+      "notes": []
+    },
+    {
+      "name": "click",
+      "version": "8.4.2",
+      "identified_license": "BSD-3-Clause",
+      "metadata_status": "identified",
+      "metadata_basis": "license_expression",
+      "license_expression": "BSD-3-Clause",
+      "license_field": "",
+      "license_classifiers": [],
+      "homepage": null,
+      "project_urls": [
+        "Changes, https://click.palletsprojects.com/page/changes/",
+        "Chat, https://discord.gg/pallets",
+        "Documentation, https://click.palletsprojects.com/",
+        "Donate, https://palletsprojects.com/donate",
+        "Source, https://github.com/pallets/click/"
+      ],
+      "notes": []
+    },
+    {
+      "name": "fastapi",
+      "version": "0.139.0",
+      "identified_license": "MIT",
+      "metadata_status": "identified",
+      "metadata_basis": "license_expression",
+      "license_expression": "MIT",
+      "license_field": "",
+      "license_classifiers": [],
+      "homepage": null,
+      "project_urls": [
+        "Homepage, https://github.com/fastapi/fastapi",
+        "Documentation, https://fastapi.tiangolo.com/",
+        "Repository, https://github.com/fastapi/fastapi",
+        "Issues, https://github.com/fastapi/fastapi/issues",
+        "Changelog, https://fastapi.tiangolo.com/release-notes/"
+      ],
+      "notes": []
+    },
+    {
+      "name": "fqdn",
+      "version": "1.5.1",
+      "identified_license": "MPL 2.0",
+      "metadata_status": "identified",
+      "metadata_basis": "license_field",
+      "license_expression": null,
+      "license_field": "MPL 2.0",
+      "license_classifiers": [
+        "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)"
+      ],
+      "homepage": "https://github.com/ypcrts/fqdn",
+      "project_urls": [],
+      "notes": []
+    },
+    {
+      "name": "greenlet",
+      "version": "3.5.3",
+      "identified_license": "MIT AND PSF-2.0",
+      "metadata_status": "identified",
+      "metadata_basis": "license_expression",
+      "license_expression": "MIT AND PSF-2.0",
+      "license_field": "",
+      "license_classifiers": [],
+      "homepage": null,
+      "project_urls": [
+        "Homepage, https://greenlet.readthedocs.io",
+        "Documentation, https://greenlet.readthedocs.io",
+        "Repository, https://github.com/python-greenlet/greenlet",
+        "Issues, https://github.com/python-greenlet/greenlet/issues",
+        "Changelog, https://greenlet.readthedocs.io/en/latest/changes.html"
+      ],
+      "notes": []
+    },
+    {
+      "name": "h11",
+      "version": "0.16.0",
+      "identified_license": "MIT",
+      "metadata_status": "identified",
+      "metadata_basis": "license_field",
+      "license_expression": null,
+      "license_field": "MIT",
+      "license_classifiers": [
+        "License :: OSI Approved :: MIT License"
+      ],
+      "homepage": "https://github.com/python-hyper/h11",
+      "project_urls": [],
+      "notes": []
+    },
+    {
+      "name": "httpcore",
+      "version": "1.0.9",
+      "identified_license": "BSD-3-Clause",
+      "metadata_status": "identified",
+      "metadata_basis": "license_expression",
+      "license_expression": "BSD-3-Clause",
+      "license_field": "",
+      "license_classifiers": [
+        "License :: OSI Approved :: BSD License"
+      ],
+      "homepage": null,
+      "project_urls": [
+        "Documentation, https://www.encode.io/httpcore",
+        "Homepage, https://www.encode.io/httpcore/",
+        "Source, https://github.com/encode/httpcore"
+      ],
+      "notes": []
+    },
+    {
+      "name": "httptools",
+      "version": "0.8.0",
+      "identified_license": "MIT",
+      "metadata_status": "identified",
+      "metadata_basis": "license_expression",
+      "license_expression": "MIT",
+      "license_field": "",
+      "license_classifiers": [],
+      "homepage": null,
+      "project_urls": [
+        "Homepage, https://github.com/MagicStack/httptools"
+      ],
+      "notes": []
+    },
+    {
+      "name": "httpx",
+      "version": "0.28.1",
+      "identified_license": "BSD-3-Clause",
+      "metadata_status": "identified",
+      "metadata_basis": "license_field",
+      "license_expression": null,
+      "license_field": "BSD-3-Clause",
+      "license_classifiers": [
+        "License :: OSI Approved :: BSD License"
+      ],
+      "homepage": null,
+      "project_urls": [
+        "Changelog, https://github.com/encode/httpx/blob/master/CHANGELOG.md",
+        "Documentation, https://www.python-httpx.org",
+        "Homepage, https://github.com/encode/httpx",
+        "Source, https://github.com/encode/httpx"
+      ],
+      "notes": []
+    },
+    {
+      "name": "idna",
+      "version": "3.18",
+      "identified_license": "BSD-3-Clause",
+      "metadata_status": "identified",
+      "metadata_basis": "license_expression",
+      "license_expression": "BSD-3-Clause",
+      "license_field": "",
+      "license_classifiers": [],
+      "homepage": null,
+      "project_urls": [
+        "Changelog, https://github.com/kjd/idna/blob/master/HISTORY.md",
+        "Issue tracker, https://github.com/kjd/idna/issues",
+        "Source, https://github.com/kjd/idna"
+      ],
+      "notes": []
+    },
+    {
+      "name": "iniconfig",
+      "version": "2.3.0",
+      "identified_license": "MIT",
+      "metadata_status": "identified",
+      "metadata_basis": "license_expression",
+      "license_expression": "MIT",
+      "license_field": "",
+      "license_classifiers": [],
+      "homepage": null,
+      "project_urls": [
+        "Homepage, https://github.com/pytest-dev/iniconfig"
+      ],
+      "notes": []
+    },
+    {
+      "name": "isoduration",
+      "version": "20.11.0",
+      "identified_license": "ISC",
+      "metadata_status": "identified",
+      "metadata_basis": "classifier",
+      "license_expression": null,
+      "license_field": "UNKNOWN",
+      "license_classifiers": [
+        "License :: OSI Approved :: ISC License (ISCL)"
+      ],
+      "homepage": "https://github.com/bolsote/isoduration",
+      "project_urls": [
+        "Repository, https://github.com/bolsote/isoduration",
+        "Bug Reports, https://github.com/bolsote/isoduration/issues",
+        "Changelog, https://github.com/bolsote/isoduration/blob/master/CHANGELOG"
+      ],
+      "notes": []
+    },
+    {
+      "name": "jsonpointer",
+      "version": "3.1.1",
+      "identified_license": "Modified BSD License",
+      "metadata_status": "identified",
+      "metadata_basis": "license_field",
+      "license_expression": null,
+      "license_field": "Modified BSD License",
+      "license_classifiers": [
+        "License :: OSI Approved :: BSD License"
+      ],
+      "homepage": "https://github.com/stefankoegl/python-json-pointer",
+      "project_urls": [],
+      "notes": []
+    },
+    {
+      "name": "jsonschema",
+      "version": "4.26.0",
+      "identified_license": "MIT",
+      "metadata_status": "identified",
+      "metadata_basis": "license_expression",
+      "license_expression": "MIT",
+      "license_field": "",
+      "license_classifiers": [],
+      "homepage": null,
+      "project_urls": [
+        "Homepage, https://github.com/python-jsonschema/jsonschema",
+        "Documentation, https://python-jsonschema.readthedocs.io/",
+        "Issues, https://github.com/python-jsonschema/jsonschema/issues/",
+        "Funding, https://github.com/sponsors/Julian",
+        "Tidelift, https://tidelift.com/subscription/pkg/pypi-jsonschema?utm_source=pypi-jsonschema&utm_medium=referral&utm_campaign=pypi-link",
+        "Changelog, https://github.com/python-jsonschema/jsonschema/blob/main/CHANGELOG.rst",
+        "Source, https://github.com/python-jsonschema/jsonschema"
+      ],
+      "notes": []
+    },
+    {
+      "name": "jsonschema-specifications",
+      "version": "2025.9.1",
+      "identified_license": "MIT",
+      "metadata_status": "identified",
+      "metadata_basis": "license_expression",
+      "license_expression": "MIT",
+      "license_field": "",
+      "license_classifiers": [],
+      "homepage": null,
+      "project_urls": [
+        "Documentation, https://jsonschema-specifications.readthedocs.io/",
+        "Homepage, https://github.com/python-jsonschema/jsonschema-specifications",
+        "Issues, https://github.com/python-jsonschema/jsonschema-specifications/issues/",
+        "Funding, https://github.com/sponsors/Julian",
+        "Tidelift, https://tidelift.com/subscription/pkg/pypi-jsonschema-specifications?utm_source=pypi-jsonschema-specifications&utm_medium=referral&utm_campaign=pypi-link",
+        "Source, https://github.com/python-jsonschema/jsonschema-specifications"
+      ],
+      "notes": []
+    },
+    {
+      "name": "lark",
+      "version": "1.3.1",
+      "identified_license": "MIT",
+      "metadata_status": "identified",
+      "metadata_basis": "license_field",
+      "license_expression": null,
+      "license_field": "MIT",
+      "license_classifiers": [
+        "License :: OSI Approved :: MIT License"
+      ],
+      "homepage": null,
+      "project_urls": [
+        "Homepage, https://github.com/lark-parser/lark",
+        "Download, https://github.com/lark-parser/lark/tarball/master"
+      ],
+      "notes": []
+    },
+    {
+      "name": "packaging",
+      "version": "26.2",
+      "identified_license": "Apache-2.0 OR BSD-2-Clause",
+      "metadata_status": "identified",
+      "metadata_basis": "license_expression",
+      "license_expression": "Apache-2.0 OR BSD-2-Clause",
+      "license_field": "",
+      "license_classifiers": [],
+      "homepage": null,
+      "project_urls": [
+        "Documentation, https://packaging.pypa.io/",
+        "Source, https://github.com/pypa/packaging"
+      ],
+      "notes": []
+    },
+    {
+      "name": "playwright",
+      "version": "1.61.0",
+      "identified_license": "Apache-2.0",
+      "metadata_status": "identified",
+      "metadata_basis": "license_expression",
+      "license_expression": "Apache-2.0",
+      "license_field": "",
+      "license_classifiers": [],
+      "homepage": null,
+      "project_urls": [
+        "homepage, https://github.com/Microsoft/playwright-python",
+        "Release notes, https://github.com/microsoft/playwright-python/releases"
+      ],
+      "notes": []
+    },
+    {
+      "name": "pluggy",
+      "version": "1.6.0",
+      "identified_license": "MIT",
+      "metadata_status": "identified",
+      "metadata_basis": "license_field",
+      "license_expression": null,
+      "license_field": "MIT",
+      "license_classifiers": [
+        "License :: OSI Approved :: MIT License"
+      ],
+      "homepage": null,
+      "project_urls": [],
+      "notes": []
+    },
+    {
+      "name": "pydantic",
+      "version": "2.13.4",
+      "identified_license": "MIT",
+      "metadata_status": "identified",
+      "metadata_basis": "license_expression",
+      "license_expression": "MIT",
+      "license_field": "",
+      "license_classifiers": [],
+      "homepage": null,
+      "project_urls": [
+        "Homepage, https://github.com/pydantic/pydantic",
+        "Documentation, https://docs.pydantic.dev",
+        "Funding, https://github.com/sponsors/samuelcolvin",
+        "Source, https://github.com/pydantic/pydantic",
+        "Changelog, https://docs.pydantic.dev/latest/changelog/"
+      ],
+      "notes": []
+    },
+    {
+      "name": "pydantic_core",
+      "version": "2.46.4",
+      "identified_license": "MIT",
+      "metadata_status": "identified",
+      "metadata_basis": "license_expression",
+      "license_expression": "MIT",
+      "license_field": "",
+      "license_classifiers": [],
+      "homepage": "https://github.com/pydantic/pydantic",
+      "project_urls": [
+        "Funding, https://github.com/sponsors/samuelcolvin",
+        "Homepage, https://github.com/pydantic",
+        "Source, https://github.com/pydantic/pydantic/tree/main/pydantic-core"
+      ],
+      "notes": []
+    },
+    {
+      "name": "pyee",
+      "version": "13.0.1",
+      "identified_license": "MIT",
+      "metadata_status": "identified",
+      "metadata_basis": "license_field",
+      "license_expression": null,
+      "license_field": "MIT",
+      "license_classifiers": [
+        "License :: OSI Approved :: MIT License"
+      ],
+      "homepage": null,
+      "project_urls": [
+        "Repository, https://github.com/jfhbrook/pyee",
+        "Documentation, https://pyee.readthedocs.io"
+      ],
+      "notes": []
+    },
+    {
+      "name": "Pygments",
+      "version": "2.20.0",
+      "identified_license": "BSD-2-Clause",
+      "metadata_status": "identified",
+      "metadata_basis": "license_expression",
+      "license_expression": "BSD-2-Clause",
+      "license_field": "",
+      "license_classifiers": [],
+      "homepage": null,
+      "project_urls": [
+        "Homepage, https://pygments.org",
+        "Documentation, https://pygments.org/docs",
+        "Source, https://github.com/pygments/pygments",
+        "Bug Tracker, https://github.com/pygments/pygments/issues",
+        "Changelog, https://github.com/pygments/pygments/blob/master/CHANGES"
+      ],
+      "notes": []
+    },
+    {
+      "name": "pytest",
+      "version": "9.0.3",
+      "identified_license": "MIT",
+      "metadata_status": "identified",
+      "metadata_basis": "license_expression",
+      "license_expression": "MIT",
+      "license_field": "",
+      "license_classifiers": [],
+      "homepage": null,
+      "project_urls": [
+        "Changelog, https://docs.pytest.org/en/stable/changelog.html",
+        "Contact, https://docs.pytest.org/en/stable/contact.html",
+        "Funding, https://docs.pytest.org/en/stable/sponsor.html",
+        "Homepage, https://docs.pytest.org/en/latest/",
+        "Source, https://github.com/pytest-dev/pytest",
+        "Tracker, https://github.com/pytest-dev/pytest/issues"
+      ],
+      "notes": []
+    },
+    {
+      "name": "pytest-asyncio",
+      "version": "1.4.0",
+      "identified_license": "Apache-2.0",
+      "metadata_status": "identified",
+      "metadata_basis": "license_expression",
+      "license_expression": "Apache-2.0",
+      "license_field": "",
+      "license_classifiers": [],
+      "homepage": null,
+      "project_urls": [
+        "Bug Tracker, https://github.com/pytest-dev/pytest-asyncio/issues",
+        "Changelog, https://pytest-asyncio.readthedocs.io/en/stable/reference/changelog.html",
+        "Documentation, https://pytest-asyncio.readthedocs.io",
+        "Homepage, https://github.com/pytest-dev/pytest-asyncio",
+        "Source Code, https://github.com/pytest-dev/pytest-asyncio"
+      ],
+      "notes": []
+    },
+    {
+      "name": "pytest-base-url",
+      "version": "2.1.0",
+      "identified_license": "MPL-2.0",
+      "metadata_status": "identified",
+      "metadata_basis": "license_expression",
+      "license_expression": "MPL-2.0",
+      "license_field": "",
+      "license_classifiers": [
+        "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)"
+      ],
+      "homepage": null,
+      "project_urls": [
+        "Homepage, https://github.com/pytest-dev/pytest-base-url",
+        "Tracker, https://github.com/pytest-dev/pytest-base-url/issues",
+        "Source, https://github.com/pytest-dev/pytest-base-url"
+      ],
+      "notes": []
+    },
+    {
+      "name": "pytest-playwright",
+      "version": "0.8.0",
+      "identified_license": "Apache-2.0",
+      "metadata_status": "identified",
+      "metadata_basis": "license_field",
+      "license_expression": null,
+      "license_field": "Apache License\n                           Version 2.0, January 2004\n                        http://www.apache.org/licenses/\n\n   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n   1. Definitions.\n\n      \"License\" shall mean the terms and conditions for use, reproduction,\n      and distribution as defined by Sections 1 through 9 of this document.\n\n      \"Licensor\" shall mean the cop...",
+      "license_classifiers": [
+        "License :: OSI Approved :: Apache Software License"
+      ],
+      "homepage": null,
+      "project_urls": [
+        "homepage, https://github.com/microsoft/playwright-pytest"
+      ],
+      "notes": [
+        "Full Apache-2.0 text is embedded in package metadata."
+      ]
+    },
+    {
+      "name": "python-dateutil",
+      "version": "2.9.0.post0",
+      "identified_license": "BSD-family OR Apache-2.0",
+      "metadata_status": "metadata_ambiguous",
+      "metadata_basis": "classifier",
+      "license_expression": null,
+      "license_field": "Dual License",
+      "license_classifiers": [
+        "License :: OSI Approved :: BSD License",
+        "License :: OSI Approved :: Apache Software License"
+      ],
+      "homepage": "https://github.com/dateutil/dateutil",
+      "project_urls": [
+        "Documentation, https://dateutil.readthedocs.io/en/stable/",
+        "Source, https://github.com/dateutil/dateutil"
+      ],
+      "notes": [
+        "Multiple license classifiers require package-specific interpretation before redistribution."
+      ]
+    },
+    {
+      "name": "python-dotenv",
+      "version": "1.2.2",
+      "identified_license": "BSD-3-Clause",
+      "metadata_status": "identified",
+      "metadata_basis": "license_field",
+      "license_expression": null,
+      "license_field": "BSD-3-Clause",
+      "license_classifiers": [],
+      "homepage": null,
+      "project_urls": [
+        "Source, https://github.com/theskumar/python-dotenv"
+      ],
+      "notes": []
+    },
+    {
+      "name": "python-slugify",
+      "version": "8.0.4",
+      "identified_license": "MIT",
+      "metadata_status": "identified",
+      "metadata_basis": "license_field",
+      "license_expression": null,
+      "license_field": "MIT",
+      "license_classifiers": [
+        "License :: OSI Approved :: MIT License"
+      ],
+      "homepage": "https://github.com/un33k/python-slugify",
+      "project_urls": [],
+      "notes": []
+    },
+    {
+      "name": "PyYAML",
+      "version": "6.0.3",
+      "identified_license": "MIT",
+      "metadata_status": "identified",
+      "metadata_basis": "license_field",
+      "license_expression": null,
+      "license_field": "MIT",
+      "license_classifiers": [
+        "License :: OSI Approved :: MIT License"
+      ],
+      "homepage": "https://pyyaml.org/",
+      "project_urls": [
+        "Bug Tracker, https://github.com/yaml/pyyaml/issues",
+        "CI, https://github.com/yaml/pyyaml/actions",
+        "Documentation, https://pyyaml.org/wiki/PyYAMLDocumentation",
+        "Mailing lists, http://lists.sourceforge.net/lists/listinfo/yaml-core",
+        "Source Code, https://github.com/yaml/pyyaml"
+      ],
+      "notes": []
+    },
+    {
+      "name": "referencing",
+      "version": "0.37.0",
+      "identified_license": "MIT",
+      "metadata_status": "identified",
+      "metadata_basis": "license_expression",
+      "license_expression": "MIT",
+      "license_field": "",
+      "license_classifiers": [],
+      "homepage": null,
+      "project_urls": [
+        "Documentation, https://referencing.readthedocs.io/",
+        "Homepage, https://github.com/python-jsonschema/referencing",
+        "Issues, https://github.com/python-jsonschema/referencing/issues/",
+        "Funding, https://github.com/sponsors/Julian",
+        "Tidelift, https://tidelift.com/subscription/pkg/pypi-referencing?utm_source=pypi-referencing&utm_medium=referral&utm_campaign=pypi-link",
+        "Changelog, https://referencing.readthedocs.io/en/stable/changes/",
+        "Source, https://github.com/python-jsonschema/referencing"
+      ],
+      "notes": []
+    },
+    {
+      "name": "requests",
+      "version": "2.34.2",
+      "identified_license": "Apache-2.0",
+      "metadata_status": "identified",
+      "metadata_basis": "license_field",
+      "license_expression": null,
+      "license_field": "Apache-2.0",
+      "license_classifiers": [
+        "License :: OSI Approved :: Apache Software License"
+      ],
+      "homepage": null,
+      "project_urls": [
+        "Documentation, https://requests.readthedocs.io",
+        "Source, https://github.com/psf/requests"
+      ],
+      "notes": []
+    },
+    {
+      "name": "rfc3339-validator",
+      "version": "0.1.4",
+      "identified_license": "MIT license",
+      "metadata_status": "identified",
+      "metadata_basis": "license_field",
+      "license_expression": null,
+      "license_field": "MIT license",
+      "license_classifiers": [
+        "License :: OSI Approved :: MIT License"
+      ],
+      "homepage": "https://github.com/naimetti/rfc3339-validator",
+      "project_urls": [],
+      "notes": []
+    },
+    {
+      "name": "rfc3986-validator",
+      "version": "0.1.1",
+      "identified_license": "MIT license",
+      "metadata_status": "identified",
+      "metadata_basis": "license_field",
+      "license_expression": null,
+      "license_field": "MIT license",
+      "license_classifiers": [
+        "License :: OSI Approved :: MIT License"
+      ],
+      "homepage": "https://github.com/naimetti/rfc3986-validator",
+      "project_urls": [],
+      "notes": []
+    },
+    {
+      "name": "rfc3987-syntax",
+      "version": "1.1.0",
+      "identified_license": "MIT",
+      "metadata_status": "metadata_ambiguous",
+      "metadata_basis": "license_expression",
+      "license_expression": "MIT",
+      "license_field": "",
+      "license_classifiers": [
+        "License :: OSI Approved :: Apache Software License"
+      ],
+      "homepage": null,
+      "project_urls": [
+        "Homepage, https://github.com/willynilly/rfc3987-syntax",
+        "Documentation, https://github.com/willynilly/rfc3987-syntax#readme",
+        "Issues, https://github.com/willynilly/rfc3987-syntax/issues",
+        "Source, https://github.com/willynilly/rfc3987-syntax"
+      ],
+      "notes": [
+        "License expression and classifier metadata are not identical; use upstream license text before redistribution."
+      ]
+    },
+    {
+      "name": "rpds-py",
+      "version": "2026.6.3",
+      "identified_license": "MIT",
+      "metadata_status": "identified",
+      "metadata_basis": "license_expression",
+      "license_expression": "MIT",
+      "license_field": "",
+      "license_classifiers": [],
+      "homepage": null,
+      "project_urls": [
+        "Documentation, https://rpds.readthedocs.io/",
+        "Funding, https://github.com/sponsors/Julian",
+        "Homepage, https://github.com/crate-py/rpds",
+        "Issues, https://github.com/crate-py/rpds/issues/",
+        "Source, https://github.com/crate-py/rpds",
+        "Tidelift, https://tidelift.com/subscription/pkg/pypi-rpds-py?utm_source=pypi-rpds-py&utm_medium=referral&utm_campaign=pypi-link",
+        "Upstream, https://github.com/orium/rpds"
+      ],
+      "notes": []
+    },
+    {
+      "name": "ruff",
+      "version": "0.15.13",
+      "identified_license": "MIT",
+      "metadata_status": "identified",
+      "metadata_basis": "license_expression",
+      "license_expression": "MIT",
+      "license_field": "",
+      "license_classifiers": [],
+      "homepage": "https://docs.astral.sh/ruff",
+      "project_urls": [
+        "Changelog, https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md",
+        "Documentation, https://docs.astral.sh/ruff/",
+        "Repository, https://github.com/astral-sh/ruff"
+      ],
+      "notes": []
+    },
+    {
+      "name": "six",
+      "version": "1.17.0",
+      "identified_license": "MIT",
+      "metadata_status": "identified",
+      "metadata_basis": "license_field",
+      "license_expression": null,
+      "license_field": "MIT",
+      "license_classifiers": [
+        "License :: OSI Approved :: MIT License"
+      ],
+      "homepage": "https://github.com/benjaminp/six",
+      "project_urls": [],
+      "notes": []
+    },
+    {
+      "name": "starlette",
+      "version": "1.3.1",
+      "identified_license": "BSD-3-Clause",
+      "metadata_status": "identified",
+      "metadata_basis": "license_expression",
+      "license_expression": "BSD-3-Clause",
+      "license_field": "",
+      "license_classifiers": [],
+      "homepage": null,
+      "project_urls": [
+        "Homepage, https://github.com/Kludex/starlette",
+        "Documentation, https://starlette.dev/",
+        "Changelog, https://starlette.dev/release-notes/",
+        "Funding, https://github.com/sponsors/Kludex",
+        "Source, https://github.com/Kludex/starlette"
+      ],
+      "notes": []
+    },
+    {
+      "name": "text-unidecode",
+      "version": "1.3",
+      "identified_license": "Artistic License",
+      "metadata_status": "metadata_ambiguous",
+      "metadata_basis": "license_field",
+      "license_expression": null,
+      "license_field": "Artistic License",
+      "license_classifiers": [
+        "License :: OSI Approved :: Artistic License",
+        "License :: OSI Approved :: GNU General Public License (GPL)",
+        "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)"
+      ],
+      "homepage": "https://github.com/kmike/text-unidecode/",
+      "project_urls": [],
+      "notes": []
+    },
+    {
+      "name": "typing-inspection",
+      "version": "0.4.2",
+      "identified_license": "MIT",
+      "metadata_status": "identified",
+      "metadata_basis": "license_expression",
+      "license_expression": "MIT",
+      "license_field": "",
+      "license_classifiers": [],
+      "homepage": null,
+      "project_urls": [
+        "Homepage, https://github.com/pydantic/typing-inspection",
+        "Documentation, https://pydantic.github.io/typing-inspection/dev/",
+        "Source, https://github.com/pydantic/typing-inspection",
+        "Changelog, https://github.com/pydantic/typing-inspection/blob/main/HISTORY.md"
+      ],
+      "notes": []
+    },
+    {
+      "name": "typing_extensions",
+      "version": "4.16.0",
+      "identified_license": "PSF-2.0",
+      "metadata_status": "identified",
+      "metadata_basis": "license_expression",
+      "license_expression": "PSF-2.0",
+      "license_field": "",
+      "license_classifiers": [],
+      "homepage": null,
+      "project_urls": [
+        "Bug Tracker, https://github.com/python/typing_extensions/issues",
+        "Changes, https://github.com/python/typing_extensions/blob/main/CHANGELOG.md",
+        "Documentation, https://typing-extensions.readthedocs.io/",
+        "Home, https://github.com/python/typing_extensions",
+        "Q & A, https://github.com/python/typing/discussions",
+        "Repository, https://github.com/python/typing_extensions"
+      ],
+      "notes": []
+    },
+    {
+      "name": "tzdata",
+      "version": "2026.3",
+      "identified_license": "Apache-2.0",
+      "metadata_status": "identified",
+      "metadata_basis": "license_field",
+      "license_expression": null,
+      "license_field": "Apache-2.0",
+      "license_classifiers": [],
+      "homepage": "https://github.com/python/tzdata",
+      "project_urls": [
+        "Bug Reports, https://github.com/python/tzdata/issues",
+        "Source, https://github.com/python/tzdata",
+        "Documentation, https://tzdata.python.org"
+      ],
+      "notes": []
+    },
+    {
+      "name": "uri-template",
+      "version": "1.3.0",
+      "identified_license": "MIT License",
+      "metadata_status": "identified",
+      "metadata_basis": "license_field",
+      "license_expression": null,
+      "license_field": "MIT License",
+      "license_classifiers": [
+        "License :: OSI Approved :: MIT License"
+      ],
+      "homepage": null,
+      "project_urls": [
+        "homepage, https://gitlab.linss.com/open-source/python/uri-template"
+      ],
+      "notes": []
+    },
+    {
+      "name": "urllib3",
+      "version": "2.7.0",
+      "identified_license": "MIT",
+      "metadata_status": "identified",
+      "metadata_basis": "license_expression",
+      "license_expression": "MIT",
+      "license_field": "",
+      "license_classifiers": [],
+      "homepage": null,
+      "project_urls": [
+        "Changelog, https://github.com/urllib3/urllib3/blob/main/CHANGES.rst",
+        "Documentation, https://urllib3.readthedocs.io",
+        "Code, https://github.com/urllib3/urllib3",
+        "Issue tracker, https://github.com/urllib3/urllib3/issues"
+      ],
+      "notes": []
+    },
+    {
+      "name": "uvicorn",
+      "version": "0.51.0",
+      "identified_license": "BSD-3-Clause",
+      "metadata_status": "identified",
+      "metadata_basis": "license_expression",
+      "license_expression": "BSD-3-Clause",
+      "license_field": "",
+      "license_classifiers": [],
+      "homepage": null,
+      "project_urls": [
+        "Changelog, https://uvicorn.dev/release-notes",
+        "Funding, https://github.com/sponsors/encode",
+        "Homepage, https://uvicorn.dev/",
+        "Source, https://github.com/Kludex/uvicorn"
+      ],
+      "notes": []
+    },
+    {
+      "name": "uvloop",
+      "version": "0.22.1",
+      "identified_license": "MIT License",
+      "metadata_status": "metadata_ambiguous",
+      "metadata_basis": "license_field",
+      "license_expression": null,
+      "license_field": "MIT License",
+      "license_classifiers": [
+        "License :: OSI Approved :: Apache Software License",
+        "License :: OSI Approved :: MIT License"
+      ],
+      "homepage": null,
+      "project_urls": [
+        "github, https://github.com/MagicStack/uvloop"
+      ],
+      "notes": []
+    },
+    {
+      "name": "watchfiles",
+      "version": "1.2.0",
+      "identified_license": "MIT",
+      "metadata_status": "identified",
+      "metadata_basis": "license_field",
+      "license_expression": null,
+      "license_field": "MIT",
+      "license_classifiers": [
+        "License :: OSI Approved :: MIT License"
+      ],
+      "homepage": "https://github.com/samuelcolvin/watchfiles",
+      "project_urls": [
+        "Changelog, https://github.com/samuelcolvin/watchfiles/releases",
+        "Documentation, https://watchfiles.helpmanual.io",
+        "Funding, https://github.com/sponsors/samuelcolvin",
+        "Homepage, https://github.com/samuelcolvin/watchfiles",
+        "Source, https://github.com/samuelcolvin/watchfiles"
+      ],
+      "notes": []
+    },
+    {
+      "name": "webcolors",
+      "version": "25.10.0",
+      "identified_license": "BSD-3-Clause",
+      "metadata_status": "identified",
+      "metadata_basis": "license_field",
+      "license_expression": null,
+      "license_field": "BSD-3-Clause",
+      "license_classifiers": [
+        "License :: OSI Approved :: BSD License"
+      ],
+      "homepage": null,
+      "project_urls": [
+        "Documentation, https://webcolors.readthedocs.io",
+        "Source Code, https://github.com/ubernostrum/webcolors"
+      ],
+      "notes": []
+    },
+    {
+      "name": "websockets",
+      "version": "16.1",
+      "identified_license": "BSD-3-Clause",
+      "metadata_status": "identified",
+      "metadata_basis": "license_expression",
+      "license_expression": "BSD-3-Clause",
+      "license_field": "",
+      "license_classifiers": [],
+      "homepage": null,
+      "project_urls": [
+        "Homepage, https://github.com/python-websockets/websockets",
+        "Changelog, https://websockets.readthedocs.io/en/stable/project/changelog.html",
+        "Documentation, https://websockets.readthedocs.io/",
+        "Funding, https://tidelift.com/subscription/pkg/pypi-websockets?utm_source=pypi-websockets&utm_medium=referral&utm_campaign=readme",
+        "Tracker, https://github.com/python-websockets/websockets/issues"
+      ],
+      "notes": []
+    }
+  ],
+  "required_before_public_distribution": [
+    "Choose and approve a public license for RepoBrief itself.",
+    "Recheck every dependency version actually included in the intended distribution artifact.",
+    "Resolve every metadata_ambiguous or metadata_unresolved entry against the upstream license text.",
+    "Generate the applicable notices and license-text bundle for the exact distribution form.",
+    "Review source, wheel, container and binary distribution separately because their obligations differ."
+  ],
+  "does_not_establish": [
+    "legal advice",
+    "license compatibility for an unchosen public RepoBrief license",
+    "permission to redistribute RepoBrief or any dependency",
+    "absence of additional notices, patent terms, trademarks or export restrictions"
+  ],
+  "status": "bounded_review_complete_public_distribution_blocked"
+}

--- a/merger/lenskit/tests/test_identity_distribution_decisions.py
+++ b/merger/lenskit/tests/test_identity_distribution_decisions.py
@@ -1,0 +1,50 @@
+import json
+from pathlib import Path
+
+from scripts.release.check_identity_distribution_decisions import check
+
+ROOT = Path(__file__).resolve().parents[3]
+FIXTURE_PATHS = (
+    "docs/decisions/repobrief-package-namespace-decision.v1.json",
+    "docs/decisions/repobrief-public-license-decision.v1.json",
+    "docs/release/third-party-license-review.v1.json",
+    "docs/architecture/naming.md",
+    "docs/release/release-policy.md",
+    "LICENSE",
+)
+
+
+def test_repository_identity_distribution_decisions_pass() -> None:
+    assert check(ROOT) == []
+
+
+def _copy_fixture(tmp_path: Path) -> None:
+    for relative in FIXTURE_PATHS:
+        target = tmp_path / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes((ROOT / relative).read_bytes())
+
+
+def test_checker_rejects_distribution_enablement(tmp_path: Path) -> None:
+    _copy_fixture(tmp_path)
+    policy = tmp_path / "docs/release/release-policy.md"
+    policy.write_text(
+        "Public release is allowed and artifacts are published.\n",
+        encoding="utf-8",
+    )
+    assert "release policy distribution must remain blocked" in check(tmp_path)
+
+
+def test_checker_rejects_license_drift(tmp_path: Path) -> None:
+    _copy_fixture(tmp_path)
+    (tmp_path / "LICENSE").write_text("MIT\n", encoding="utf-8")
+    assert "LICENSE does not match decision" in check(tmp_path)
+
+
+def test_checker_rejects_third_party_count_drift(tmp_path: Path) -> None:
+    _copy_fixture(tmp_path)
+    review_path = tmp_path / "docs/release/third-party-license-review.v1.json"
+    review = json.loads(review_path.read_text(encoding="utf-8"))
+    review["summary"]["package_count"] += 1
+    review_path.write_text(json.dumps(review), encoding="utf-8")
+    assert "third-party inventory count mismatch" in check(tmp_path)

--- a/scripts/release/check_identity_distribution_decisions.py
+++ b/scripts/release/check_identity_distribution_decisions.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Fail-closed checks for RepoBrief naming and distribution decisions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+NAMESPACE = Path("docs/decisions/repobrief-package-namespace-decision.v1.json")
+LICENSE_DECISION = Path("docs/decisions/repobrief-public-license-decision.v1.json")
+THIRD_PARTY = Path("docs/release/third-party-license-review.v1.json")
+ALLOWED_METADATA_STATUSES = {
+    "identified",
+    "metadata_ambiguous",
+    "metadata_unresolved",
+}
+
+
+def check(root: Path) -> list[str]:
+    """Return decision drift findings for a repository root."""
+
+    findings: list[str] = []
+    namespace = json.loads((root / NAMESPACE).read_text(encoding="utf-8"))
+    license_decision = json.loads(
+        (root / LICENSE_DECISION).read_text(encoding="utf-8")
+    )
+    third_party = json.loads((root / THIRD_PARTY).read_text(encoding="utf-8"))
+    license_text = (root / "LICENSE").read_text(encoding="utf-8")
+    naming_text = (root / "docs/architecture/naming.md").read_text(encoding="utf-8")
+    release_policy = (root / "docs/release/release-policy.md").read_text(
+        encoding="utf-8"
+    )
+
+    if namespace.get("decision") != "keep_lenskit_namespace_for_2_x":
+        findings.append("namespace decision changed")
+    if (
+        namespace.get("python_namespace") != "merger.lenskit"
+        or namespace.get("product_name") != "RepoBrief"
+    ):
+        findings.append("namespace identity mismatch")
+    inventory = namespace.get("consumer_inventory") or {}
+    if int(inventory.get("local_merger_lenskit_occurrences", 0)) < 1:
+        findings.append("consumer inventory missing")
+    if "RepoBrief" not in naming_text or "merger.lenskit" not in naming_text:
+        findings.append("naming document drift")
+
+    expression = license_decision.get("current_license_expression")
+    if expression != "LicenseRef-RepoBrief-All-Rights-Reserved":
+        findings.append("license expression changed")
+    if expression not in license_text:
+        findings.append("LICENSE does not match decision")
+    if (
+        license_decision.get("distribution_status")
+        != "blocked_without_separate_written_permission"
+    ):
+        findings.append("public distribution unexpectedly enabled")
+
+    normalized_policy = release_policy.casefold()
+    if (
+        "does not grant distribution permission" not in normalized_policy
+        or "not upload or publish" not in normalized_policy
+    ):
+        findings.append("release policy distribution must remain blocked")
+
+    summary = third_party.get("summary") or {}
+    packages = third_party.get("packages") or []
+    if summary.get("package_count") != len(packages) or not packages:
+        findings.append("third-party inventory count mismatch")
+    for item in packages:
+        if not item.get("name") or not item.get("version"):
+            findings.append("third-party package identity incomplete")
+        if item.get("metadata_status") not in ALLOWED_METADATA_STATUSES:
+            findings.append(f"invalid metadata status: {item.get('name')}")
+    if (
+        third_party.get("distribution_boundary", {}).get(
+            "public_distribution_allowed"
+        )
+        is not False
+    ):
+        findings.append("third-party review must not authorize publication")
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=ROOT)
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    args = parser.parse_args(argv)
+    findings = check(args.root.resolve())
+    report = {
+        "kind": "repobrief.identity_distribution_decision_check",
+        "version": "1.0",
+        "status": "pass" if not findings else "fail",
+        "findings": findings,
+    }
+    if args.format == "json":
+        print(json.dumps(report, indent=2))
+    elif findings:
+        print("\n".join(findings))
+    else:
+        print("Identity/distribution decisions: pass")
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Zweck

Schließt die fachliche Entscheidungsebene für zwei offene RepoBrief-Aufgaben, ohne sie vor PR- und Main-Verifikation als erledigt zu markieren:

- Paket-/Repository-Namensentscheidung
- öffentliche Lizenz- und Verteilungsentscheidung

## Entscheidungen

- `heimgewebe/lenskit` und `merger.lenskit` bleiben für die 2.x-Linie stabil.
- RepoBrief bleibt Produktname und primärer CLI-Name.
- Es wird derzeit keine öffentliche Weiterverteilungslizenz erteilt.
- Die bestehende All-Rights-Reserved-Lizenz und der fail-closed Release-Kandidat bleiben unverändert maßgeblich.

## Evidenz

- GitHub-Codeinventur der bekannten Organisationverbraucher
- 1.218 lokale `merger.lenskit`-Vorkommen in 356 Dateien
- hashgebundene Installation der Runtime-, Dev- und Browser-Locks im gepinnten Python-3.12-Container
- Metadateninventur von 57 Distributionen: 53 identifiziert, 4 bewusst als mehrdeutig markiert
- maschinenlesbare Entscheidungsdateien und Negativtests gegen Lizenz- oder Policy-Drift

## Lokale Prüfung

- 18 fokussierte Tests grün
- Ruff grün
- Release-Vertrag grün
- zwei bytegleiche, gegen Git verifizierte Release-Kandidaten
- Verteilungsstatus weiterhin `blocked_without_separate_written_permission`

## Grenzen

Die Metadateninventur ist keine Rechtsberatung und keine Freigabe zur Weiterverteilung. Sie bewertet auch nicht automatisch Lizenzkompatibilität für eine künftig erst zu wählende öffentliche Lizenz oder ein bestimmtes Binär-/Containerartefakt.
