### PR TITLE
Bind RepoBrief live benchmark and redaction contracts

### DIFF
--- a/docs/usage/repobrief-agent-benchmark-v1.md
+++ b/docs/usage/repobrief-agent-benchmark-v1.md
@@ -19,6 +19,9 @@ damit ein anderes Experiment.
 `runner.json` enthält keine Zugangsdaten. Es bindet nur die Konfiguration, die
 später für beide Bedingungen identisch sein muss:
 
+Für einen generischen externen Runner kann die Datei weiterhin providerneutral
+bleiben:
+
 ```json
 {
   "provider": "provider-name",
@@ -28,6 +31,24 @@ später für beide Bedingungen identisch sein muss:
   }
 }
 ```
+
+Ein Grabowski-Liveplan über Claude Code muss dagegen den ausführbaren Vertrag
+explizit binden:
+
+```json
+{
+  "execution_contract": "grabowski-claude-code-live-v1",
+  "provider": "anthropic-claude-code",
+  "model": "claude-haiku-4-5-20251001",
+  "sampling": {}
+}
+```
+
+Der Vertrag wird in jeden erzeugten Request übernommen. Die mehrdeutige
+Providerkennung `anthropic`, ein anderer Provider unter diesem Vertrag, ein
+unbekannter Vertrag oder ein nicht leeres Samplingobjekt werden bereits beim
+Planen abgelehnt. Damit kann ein formal erzeugter Plan nicht erst beim späteren
+Live-Runner an diesen Identitätsunterschieden scheitern.
 
 Der externe Runner muss dieselbe Provider-, Modell- und Sampling-Identität in
 jeder Laufquittung zurückgeben.

--- a/docs/usage/repobrief-mcp-stdio.md
+++ b/docs/usage/repobrief-mcp-stdio.md
@@ -71,6 +71,12 @@ but it cannot choose another source repository or output root. The source remain
 when `--bundle-root` names one exact manifest. Existing timeout, size, path, and output-not-inside-
 repository guards still apply.
 
+Snapshot profiles whose canonical policy sets `redaction_required=true` now enable secret
+redaction by default before generation. An explicit `--no-redact-secrets` override for such a
+profile is rejected before the output directory is created. The JSON result records whether
+redaction was enabled, required by the profile, and selected explicitly or by the safe profile
+default.
+
 ## Exposed resources
 
 The server lists and reads the existing resource surface:

--- a/merger/lenskit/cli/cmd_repobrief.py
+++ b/merger/lenskit/cli/cmd_repobrief.py
@@ -141,6 +141,22 @@ def should_emit_export_safety_report(profile: str) -> bool:
     return _export_safety_requirement(profile) in {"required", "recommended"}
 
 
+def resolve_snapshot_redaction(
+    profile: str, requested: bool | None
+) -> tuple[bool, str, bool]:
+    required = bool(
+        profile_policy(profile)["export_semantics"].get("redaction_required")
+    )
+    if requested is None:
+        return required, "profile_required_default" if required else "profile_default", required
+    if required and requested is False:
+        raise ValueError(
+            f"profile {profile} requires secret redaction; "
+            "--no-redact-secrets is not permitted"
+        )
+    return bool(requested), "explicit", required
+
+
 def emit_export_safety_report(bundle_manifest: Path | None, profile: str) -> Path | None:
     if bundle_manifest is None or not should_emit_export_safety_report(profile):
         return None
@@ -514,13 +530,19 @@ def register_repobrief_command_groups(repobrief_parser: argparse.ArgumentParser)
     create_parser.add_argument("--path-filter")
     create_parser.add_argument("--ext", action="append")
     create_parser.add_argument("--output-mode", choices=["archive", "retrieval", "dual"])
-    create_parser.add_argument("--redact-secrets", action="store_true")
+    create_redaction = create_parser.add_mutually_exclusive_group()
+    create_redaction.add_argument(
+        "--redact-secrets", action="store_true", dest="redact_secrets"
+    )
+    create_redaction.add_argument(
+        "--no-redact-secrets", action="store_false", dest="redact_secrets"
+    )
     create_parser.add_argument("--no-include-hidden", action="store_false", dest="include_hidden")
     create_parser.add_argument(
         "--latest-complete-registry",
         help="Explicitly write/update a RepoBrief latest-complete registry JSON for this created snapshot",
     )
-    create_parser.set_defaults(include_hidden=True)
+    create_parser.set_defaults(include_hidden=True, redact_secrets=None)
 
     status_parser = snapshot_subparsers.add_parser("status", help="Read status for an existing Brief Snapshot")
     status_parser.add_argument("--bundle-manifest", required=True, help="Path to a Brief Bundle manifest")
@@ -736,9 +758,15 @@ def register_repobrief_command_groups(repobrief_parser: argparse.ArgumentParser)
     external_refresh_parser.add_argument("--path-filter")
     external_refresh_parser.add_argument("--ext", action="append")
     external_refresh_parser.add_argument("--output-mode", choices=["archive", "retrieval", "dual"])
-    external_refresh_parser.add_argument("--redact-secrets", action="store_true")
+    refresh_redaction = external_refresh_parser.add_mutually_exclusive_group()
+    refresh_redaction.add_argument(
+        "--redact-secrets", action="store_true", dest="redact_secrets"
+    )
+    refresh_redaction.add_argument(
+        "--no-redact-secrets", action="store_false", dest="redact_secrets"
+    )
     external_refresh_parser.add_argument("--no-include-hidden", action="store_false", dest="include_hidden")
-    external_refresh_parser.set_defaults(include_hidden=True)
+    external_refresh_parser.set_defaults(include_hidden=True, redact_secrets=None)
 
     latest_parser = repobrief_subparsers.add_parser(
         "latest-complete",
@@ -1319,6 +1347,9 @@ def build_snapshot_create_result(args: argparse.Namespace) -> dict[str, Any]:
     if out == repo or repo in out.parents:
         raise ValueError("bad output path")
 
+    redact_secrets, redaction_source, redaction_required = resolve_snapshot_redaction(
+        profile, getattr(args, "redact_secrets", None)
+    )
     output_plan = profile_output_mode_plan(profile, args.output_mode)
     output_mode = output_plan["selected_output_mode"]
     conflicts = tuple(output_plan["conflicts"])
@@ -1364,7 +1395,7 @@ def build_snapshot_create_result(args: argparse.Namespace) -> dict[str, Any]:
         ext_filter=ext_filter,
         extras=extras,
         output_mode=output_mode,
-        redact_secrets=args.redact_secrets,
+        redact_secrets=redact_secrets,
         include_hidden=args.include_hidden,
         generator_info=generator_info,
     )
@@ -1407,6 +1438,11 @@ def build_snapshot_create_result(args: argparse.Namespace) -> dict[str, Any]:
         "profile": profile,
         "output_mode": output_mode,
         "output_plan": output_plan,
+        "redaction": {
+            "enabled": redact_secrets,
+            "required": redaction_required,
+            "source": redaction_source,
+        },
         "repo": str(repo),
         "out": str(out),
         "bundle_manifest": str(artifacts.bundle_manifest) if artifacts.bundle_manifest else None,

--- a/merger/lenskit/contracts/agent-benchmark-run-request.v1.schema.json
+++ b/merger/lenskit/contracts/agent-benchmark-run-request.v1.schema.json
@@ -83,7 +83,11 @@
       "properties": {
         "provider": {"type": "string", "minLength": 1},
         "model": {"type": "string", "minLength": 1},
-        "sampling": {"type": "object"}
+        "sampling": {"type": "object"},
+        "execution_contract": {
+          "type": "string",
+          "enum": ["grabowski-claude-code-live-v1"]
+        }
       }
     },
     "repobrief": {

--- a/merger/lenskit/core/agent_benchmark.py
+++ b/merger/lenskit/core/agent_benchmark.py
@@ -36,6 +36,42 @@ from merger.lenskit.core.agent_benchmark_policy import BENCHMARK_REPETITIONS
 from merger.lenskit.core.agent_benchmark_receipts import validate_receipt
 
 
+CLAUDE_CODE_LIVE_CONTRACT = "grabowski-claude-code-live-v1"
+CLAUDE_CODE_PROVIDER = "anthropic-claude-code"
+
+
+def _validate_runner_configuration(runner: Mapping[str, Any]) -> None:
+    provider = runner.get("provider")
+    model = runner.get("model")
+    if not isinstance(provider, str) or not provider:
+        raise AgentBenchmarkError("runner provider and model are required")
+    if not isinstance(model, str) or not model:
+        raise AgentBenchmarkError("runner provider and model are required")
+
+    sampling_value = runner.get("sampling")
+    sampling = mapping_value(sampling_value)
+    execution_contract = runner.get("execution_contract")
+    if execution_contract is not None and execution_contract != CLAUDE_CODE_LIVE_CONTRACT:
+        raise AgentBenchmarkError(
+            f"unsupported runner execution contract: {execution_contract}"
+        )
+    if provider == "anthropic":
+        raise AgentBenchmarkError(
+            "ambiguous provider anthropic is not executable; use anthropic-claude-code"
+        )
+    if execution_contract == CLAUDE_CODE_LIVE_CONTRACT and provider != CLAUDE_CODE_PROVIDER:
+        raise AgentBenchmarkError(
+            f"runner contract {CLAUDE_CODE_LIVE_CONTRACT} requires provider "
+            f"{CLAUDE_CODE_PROVIDER}"
+        )
+    if provider == CLAUDE_CODE_PROVIDER and (
+        not isinstance(sampling_value, Mapping) or sampling
+    ):
+        raise AgentBenchmarkError(
+            "provider anthropic-claude-code requires an explicit empty sampling object"
+        )
+
+
 def _repository_map(taskset: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
     return {
         str(item["id"]): dict(item)
@@ -130,6 +166,11 @@ def _build_request(
             "provider": str(runner["provider"]),
             "model": str(runner["model"]),
             "sampling": dict(mapping_value(runner.get("sampling"))),
+            **(
+                {"execution_contract": str(runner["execution_contract"])}
+                if runner.get("execution_contract") is not None
+                else {}
+            ),
         },
         "repobrief": _repobrief_binding(
             condition, repository_id, manifest_bindings
@@ -157,8 +198,7 @@ def build_run_requests(
         raise AgentBenchmarkError(
             f"benchmark v1 requires exactly {BENCHMARK_REPETITIONS} repetitions"
         )
-    if not runner.get("provider") or not runner.get("model"):
-        raise AgentBenchmarkError("runner provider and model are required")
+    _validate_runner_configuration(runner)
     repositories = _repository_map(taskset)
     taskset_hash = sha256_json(taskset)
     requests: list[dict[str, Any]] = []

--- a/merger/lenskit/tests/test_agent_benchmark.py
+++ b/merger/lenskit/tests/test_agent_benchmark.py
@@ -260,6 +260,95 @@ def test_pair_plan_rejects_non_frozen_repetition_count() -> None:
         )
 
 
+def test_claude_code_live_contract_is_bound_into_requests() -> None:
+    runner = {
+        "execution_contract": "grabowski-claude-code-live-v1",
+        "provider": "anthropic-claude-code",
+        "model": "claude-haiku-4-5-20251001",
+        "sampling": {},
+    }
+
+    requests = build_run_requests(
+        _taskset(),
+        runner=runner,
+        manifest_bindings=BINDINGS,
+        repetitions=2,
+    )
+
+    assert requests
+    assert all(request["runner"] == runner for request in requests)
+    Draft7Validator(_schema("request")).validate(requests[0])
+
+
+@pytest.mark.parametrize(
+    ("runner", "expected"),
+    [
+        (
+            {
+                "provider": "anthropic",
+                "model": "claude-haiku-4-5-20251001",
+                "sampling": {},
+            },
+            "ambiguous provider anthropic",
+        ),
+        (
+            {
+                "execution_contract": "grabowski-claude-code-live-v1",
+                "provider": "fixture-provider",
+                "model": "fixture-model",
+                "sampling": {},
+            },
+            "requires provider anthropic-claude-code",
+        ),
+        (
+            {
+                "execution_contract": "grabowski-claude-code-live-v1",
+                "provider": "anthropic-claude-code",
+                "model": "claude-haiku-4-5-20251001",
+                "sampling": {"temperature": 0},
+            },
+            "requires an explicit empty sampling object",
+        ),
+        (
+            {
+                "execution_contract": "grabowski-claude-code-live-v1",
+                "provider": "anthropic-claude-code",
+                "model": "claude-haiku-4-5-20251001",
+            },
+            "requires an explicit empty sampling object",
+        ),
+        (
+            {
+                "execution_contract": "grabowski-claude-code-live-v1",
+                "provider": "anthropic-claude-code",
+                "model": "claude-haiku-4-5-20251001",
+                "sampling": [],
+            },
+            "requires an explicit empty sampling object",
+        ),
+        (
+            {
+                "execution_contract": "unknown-live-contract",
+                "provider": "fixture-provider",
+                "model": "fixture-model",
+                "sampling": {},
+            },
+            "unsupported runner execution contract",
+        ),
+    ],
+)
+def test_runner_contract_rejects_non_executable_configuration(
+    runner: dict, expected: str
+) -> None:
+    with pytest.raises(AgentBenchmarkError, match=expected):
+        build_run_requests(
+            _taskset(),
+            runner=runner,
+            manifest_bindings=BINDINGS,
+            repetitions=2,
+        )
+
+
 def test_pair_plan_requires_treatment_manifest_binding() -> None:
     taskset = _taskset()
     incomplete = dict(BINDINGS)

--- a/merger/lenskit/tests/test_repobrief_snapshot_cli.py
+++ b/merger/lenskit/tests/test_repobrief_snapshot_cli.py
@@ -931,10 +931,13 @@ def test_snapshot_create_finalizes_every_manifest_artifact(tmp_path, capsys):
     ]
 
 
-def test_snapshot_create_blocks_agent_export_without_redaction(tmp_path, capsys):
+@pytest.mark.parametrize("profile", ["agent-portable", "public-share"])
+def test_snapshot_create_defaults_required_profiles_to_redaction(
+    profile, tmp_path, capsys
+):
     repo = tmp_path / "repo"
     repo.mkdir()
-    (repo / "README.md").write_text("# blocked\n", encoding="utf-8")
+    (repo / "README.md").write_text("# safe default\n", encoding="utf-8")
     out = tmp_path / "briefs"
 
     rc = main([
@@ -946,24 +949,28 @@ def test_snapshot_create_blocks_agent_export_without_redaction(tmp_path, capsys)
         "--out",
         str(out),
         "--profile",
-        "agent-portable",
+        profile,
     ])
 
     result = json.loads(capsys.readouterr().out)
-    finalization = result["finalization"]
-    assert rc == 1
-    assert result["status"] == "fail"
-    assert finalization["post_emit_health_status"] == "pass"
-    assert finalization["agent_export_gate_status"] == "fail"
-    assert finalization["export_safety_status"] == "fail"
-    assert "agent_export_gate:fail" in finalization["errors"]
-    assert "export_safety_report:fail" in finalization["errors"]
+    assert rc == 0
+    assert result["status"] == "ok"
+    assert result["redaction"] == {
+        "enabled": True,
+        "required": True,
+        "source": "profile_required_default",
+    }
+    assert result["finalization"]["agent_export_gate_status"] == "pass"
+    assert result["finalization"]["export_safety_status"] == "pass"
 
 
-def test_snapshot_create_blocks_public_export_without_redaction(tmp_path, capsys):
+@pytest.mark.parametrize("profile", ["agent-portable", "public-share"])
+def test_snapshot_create_rejects_explicit_redaction_disable_before_output(
+    profile, tmp_path, capsys
+):
     repo = tmp_path / "repo"
     repo.mkdir()
-    (repo / "README.md").write_text("# blocked public export\n", encoding="utf-8")
+    (repo / "README.md").write_text("# reject unsafe override\n", encoding="utf-8")
     out = tmp_path / "briefs"
 
     rc = main([
@@ -975,18 +982,15 @@ def test_snapshot_create_blocks_public_export_without_redaction(tmp_path, capsys
         "--out",
         str(out),
         "--profile",
-        "public-share",
+        profile,
+        "--no-redact-secrets",
     ])
 
-    result = json.loads(capsys.readouterr().out)
-    finalization = result["finalization"]
-    assert rc == 1
-    assert result["status"] == "fail"
-    assert finalization["post_emit_health_status"] == "pass"
-    assert finalization["agent_export_gate_status"] == "fail"
-    assert finalization["export_safety_status"] == "fail"
-    assert "agent_export_gate:fail" in finalization["errors"]
-    assert "export_safety_report:fail" in finalization["errors"]
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "requires secret redaction" in captured.err
+    assert not captured.out
+    assert not out.exists()
 
 
 def test_add_manifest_artifact_preserves_existing_contract_metadata(tmp_path):


### PR DESCRIPTION
## Zweck

Schließt RAB-V1-T002E auf der Lenskit-Seite providerfrei ab.

## Änderungen

- bindet den ausführbaren Vertrag `grabowski-claude-code-live-v1` in geplante Requests;
- verlangt `anthropic-claude-code` und ein tatsächlich vorhandenes leeres Samplingobjekt;
- lehnt mehrdeutige oder nicht ausführbare Runner-Konfigurationen vor der Planung ab;
- aktiviert Redaktion standardmäßig für Profile mit `redaction_required=true`;
- verweigert deren ausdrückliche Abschaltung vor der Ausgabeerzeugung;
- ergänzt Schema, Tests und Bedienungsdokumentation.

## Prüfung

- Volltest: 3.890 bestanden, 1 übersprungen, 13 bewusst abgewählt;
- Ruff, Maintainability-Ratchet und Release-Vertrag grün;
- repositoryübergreifende synthetische Simulation mit Grabowski: zwei Fixture-Intents, null Provider-Intents, kein Retry, 0,00 USD;
- End-to-End-Evidenz SHA-256: `4dc760003deb5230aa041fa206993375b7acd6b82a31d08d4904d52dd2978219`.

## Grenzen

Belegt keinen Providerlauf und keinen Nutzen von RepoBrief. RAB-V1-T002F und der Vollbenchmark bleiben nicht autorisiert.