### PR TITLE
feat(repobrief): resilient ask retrieval + source-address surfacing

### DIFF
--- a/merger/lenskit/contracts/repobrief-ask-context-pack.v1.schema.json
+++ b/merger/lenskit/contracts/repobrief-ask-context-pack.v1.schema.json
@@ -227,6 +227,35 @@
         }
       }
     },
+    "retrieval": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "raw_query",
+        "strategy",
+        "match_count"
+      ],
+      "properties": {
+        "raw_query": {
+          "type": "string"
+        },
+        "fts_query": {
+          "type": ["string", "null"]
+        },
+        "strategy": {
+          "type": "string",
+          "enum": [
+            "exact_and",
+            "or_relaxed",
+            "none"
+          ]
+        },
+        "match_count": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
     "retrieval_hits": {
       "type": "array",
       "items": {
@@ -294,6 +323,17 @@
           "content_sha256": {
             "type": "string",
             "pattern": "^[a-f0-9]{64}$"
+          },
+          "source_path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "source_line_range": {
+            "type": "object"
+          },
+          "citation_id": {
+            "type": "string",
+            "pattern": "^cit_[a-f0-9]{16}$"
           }
         }
       }

--- a/merger/lenskit/core/repobrief_access.py
+++ b/merger/lenskit/core/repobrief_access.py
@@ -1031,6 +1031,7 @@ def query_existing_index(
     filters: dict[str, str | None] | None = None,
     resolve_evidence: bool = False,
     project_sources: bool = False,
+    prepared_fts_query: str | None = None,
 ) -> dict[str, Any]:
     manifest_path = Path(bundle_manifest).expanduser().resolve()
     if not isinstance(query, str):
@@ -1105,6 +1106,7 @@ def query_existing_index(
             trace=False,
             build_context=False,
             read_only=True,
+            _prepared_fts_query=prepared_fts_query,
         )
     except Exception as exc:
         return _invalid_read_result(

--- a/merger/lenskit/core/repobrief_ask.py
+++ b/merger/lenskit/core/repobrief_ask.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import re
 from pathlib import Path
 from typing import Any
 
@@ -9,6 +10,53 @@ from merger.lenskit.core.repobrief_access import (
     resolve_required_reading_for_bundle,
     snapshot_status,
 )
+
+# Bilingual (EN/DE) function-word stoplist. These words carry no retrieval
+# signal but, because the FTS router AND-joins every term, a single one that is
+# absent from a chunk zeroes an otherwise good match. Removing them for the
+# relaxed OR retry is safe: the set holds only unambiguous function words, never
+# code identifiers or content terms.
+_RETRIEVAL_STOPWORDS = frozenset({
+    # English
+    "how", "does", "do", "did", "is", "are", "was", "were", "be", "been",
+    "the", "a", "an", "of", "to", "into", "in", "on", "for", "and", "or",
+    "with", "what", "which", "where", "when", "why", "who", "that", "this",
+    "these", "those", "its", "it", "as", "at", "by",
+    # German
+    "wie", "was", "welche", "welcher", "welches", "wo", "wann", "warum", "wer",
+    "ist", "sind", "war", "den", "dem", "der", "die", "das", "ein", "eine",
+    "einen", "und", "oder", "mit", "fuer", "von", "zu", "im", "auf", "ob",
+    "des", "als",
+})
+
+
+def _content_tokens(query: str) -> list[str]:
+    """Deterministic, order-preserving content tokens for relaxed retrieval."""
+    tokens: list[str] = []
+    seen: set[str] = set()
+    for token in re.findall(r"[a-z0-9_]+", query.lower()):
+        if token in _RETRIEVAL_STOPWORDS or token in seen:
+            continue
+        seen.add(token)
+        tokens.append(token)
+    return tokens
+
+
+def _or_fts_query(tokens: list[str]) -> str:
+    """Build a safe FTS5 OR query; quoting keeps terms literal (no operators)."""
+    return " OR ".join(f'"{token}"' for token in tokens)
+
+
+def _run_query(manifest_path: Path, query: str, k: int, prepared_fts_query: str | None = None) -> dict[str, Any]:
+    return query_existing_index(
+        manifest_path,
+        query,
+        k=k,
+        filters={},
+        resolve_evidence=True,
+        project_sources=True,
+        prepared_fts_query=prepared_fts_query,
+    )
 
 KIND = "repobrief.ask_context_pack"
 VERSION = "1.0"
@@ -106,6 +154,12 @@ def _snapshot_ref(snapshot: dict[str, Any], manifest_path: Path, freshness: dict
     return result
 
 
+def _fts_query_of(query_result: dict[str, Any]) -> str | None:
+    inner = query_result.get("query_result") if isinstance(query_result, dict) else None
+    fts = inner.get("fts_query") if isinstance(inner, dict) else None
+    return fts if isinstance(fts, str) and fts else None
+
+
 def _retrieval_hits(query_result: dict[str, Any]) -> list[dict[str, Any]]:
     raw = query_result.get("query_result") if isinstance(query_result, dict) else None
     hits = raw.get("results") if isinstance(raw, dict) else []
@@ -132,6 +186,30 @@ def _retrieval_hits(query_result: dict[str, Any]) -> list[dict[str, Any]]:
             item["citation_id"] = citation_id
         result.append(item)
     return result
+
+
+def _source_address_fields(hit: dict[str, Any]) -> dict[str, Any]:
+    """Original repository address for a hit, so navigation tasks need not parse
+    it out of the excerpt. The canonical_md range_ref stays the authority; these
+    are source-address conveniences.
+    """
+    fields: dict[str, Any] = {}
+    source_path = hit.get("source_path") or hit.get("path")
+    if isinstance(source_path, str) and source_path:
+        fields["source_path"] = source_path
+    source_line_range = hit.get("source_line_range")
+    if isinstance(source_line_range, dict):
+        projected = {
+            key: source_line_range[key]
+            for key in ("start_line", "end_line", "display")
+            if key in source_line_range
+        }
+        if projected:
+            fields["source_line_range"] = projected
+    citation_id = hit.get("citation_id")
+    if isinstance(citation_id, str) and citation_id.startswith("cit_"):
+        fields["citation_id"] = citation_id
+    return fields
 
 
 def _resolved_ranges(query_result: dict[str, Any], max_context_tokens: int) -> tuple[list[dict[str, Any]], int, bool]:
@@ -167,6 +245,7 @@ def _resolved_ranges(query_result: dict[str, Any], max_context_tokens: int) -> t
             content_sha = range_value.get("content_sha256") or range_value.get("sha256")
         if isinstance(content_sha, str) and len(content_sha) == 64:
             item["content_sha256"] = content_sha
+        item.update(_source_address_fields(hit))
         result.append(item)
     return result, used_chars, truncated
 
@@ -205,21 +284,62 @@ def build_ask_context_pack(
     freshness = _freshness_block(snapshot)
     availability = _availability_block(snapshot)
     required_reading = _required_reading_block(resolve_required_reading_for_bundle(manifest_path, task_profile))
-    query_result = query_existing_index(
-        manifest_path,
-        query,
-        k=k,
-        filters={},
-        resolve_evidence=True,
-        project_sources=True,
-    )
+    query_result = _run_query(manifest_path, query, k)
     retrieval_hits = _retrieval_hits(query_result)
     resolved_ranges, used_chars, truncated = _resolved_ranges(query_result, max_context_tokens)
+    executed_fts = _fts_query_of(query_result)
+    strategy = "exact_and"
+    relaxed = False
+
+    # Recall fallback: the FTS router AND-joins every term, so one word absent
+    # from a chunk zeroes an otherwise good match (common for natural-language
+    # questions). When the exact match is empty, retry once with a relaxed OR
+    # over content tokens. Adopt only if it recovers ranges, and label it so the
+    # agent treats these as lower-precision candidates rather than exact hits.
+    if not resolved_ranges and query_result.get("status") == "available":
+        tokens = _content_tokens(query)
+        if len(tokens) >= 2:
+            or_query = _or_fts_query(tokens)
+            relaxed_result = _run_query(manifest_path, query, k, prepared_fts_query=or_query)
+            relaxed_ranges, relaxed_chars, relaxed_truncated = _resolved_ranges(relaxed_result, max_context_tokens)
+            if relaxed_ranges:
+                query_result = relaxed_result
+                retrieval_hits = _retrieval_hits(relaxed_result)
+                resolved_ranges, used_chars, truncated = relaxed_ranges, relaxed_chars, relaxed_truncated
+                executed_fts = or_query
+                strategy = "or_relaxed"
+                relaxed = True
+
+    retrieval = {
+        "raw_query": query,
+        "fts_query": executed_fts,
+        "strategy": strategy if resolved_ranges else "none",
+        "match_count": len(resolved_ranges),
+    }
+
     caveats = list(freshness.get("caveats") or []) + list(availability.get("caveats") or [])
     if query_result.get("status") != "available":
         caveats.append({"kind": "missing_artifact", "detail": str(query_result.get("error") or "Query evidence unavailable.")})
     if truncated:
         caveats.append({"kind": "other", "detail": "Context excerpts were truncated to respect max_context_tokens."})
+    if relaxed:
+        caveats.append({
+            "kind": "other",
+            "detail": (
+                "No exact (AND) retrieval match; results are relaxed OR-matches ranked by "
+                "relevance and may be less precise. Rephrase with specific code identifiers "
+                "for a tighter match."
+            ),
+        })
+    elif not resolved_ranges:
+        caveats.append({
+            "kind": "other",
+            "detail": (
+                "No evidence matched the query. RepoBrief retrieval is keyword/identifier-based "
+                f"(executed FTS: {executed_fts or query!r}). Rephrase with concrete code "
+                "identifiers or terms."
+            ),
+        })
     citation_obligations = [
         "Cite every strong repository claim with resolved RepoBrief evidence where available.",
         "Surface freshness, availability and non-claim caveats in the answer.",
@@ -232,6 +352,7 @@ def build_ask_context_pack(
         "freshness": freshness,
         "availability": availability,
         "required_reading": required_reading,
+        "retrieval": retrieval,
         "retrieval_hits": retrieval_hits,
         "resolved_ranges": resolved_ranges,
         "answer_scaffold": {

--- a/merger/lenskit/tests/test_repobrief_ask_retrieval_resilience.py
+++ b/merger/lenskit/tests/test_repobrief_ask_retrieval_resilience.py
@@ -1,0 +1,86 @@
+"""Retrieval resilience and source-address surfacing for RepoBrief ask packs.
+
+Covers two guarantees added on top of the deterministic FTS retrieval:
+
+* the ask pack never returns silently empty context — it reports the executed
+  FTS query, a strategy, and a caveat, and falls back to a labelled relaxed OR
+  match when the strict AND query finds nothing;
+* resolved ranges surface the original repository source address so navigation
+  tasks do not have to parse it out of the excerpt text.
+"""
+from merger.lenskit.core.repobrief_ask import (
+    _content_tokens,
+    _or_fts_query,
+    build_ask_context_pack,
+)
+from merger.lenskit.tests.test_repobrief_ask_cli import (
+    _complete_basic_bundle,
+    _validate_context_pack,
+)
+
+
+def test_exact_match_reports_strategy_and_source_address(tmp_path):
+    bundle = _complete_basic_bundle(tmp_path)
+
+    pack = build_ask_context_pack(bundle["manifest"], query="hello", k=5)
+
+    _validate_context_pack(pack)
+    assert pack["retrieval"]["strategy"] == "exact_and"
+    assert pack["retrieval"]["match_count"] >= 1
+    assert pack["retrieval"]["fts_query"] == "hello"
+
+    first = pack["resolved_ranges"][0]
+    assert first["source_path"] == "brief.md"
+    assert first["source_line_range"]["start_line"] == 3
+    assert first["citation_id"].startswith("cit_")
+
+
+def test_natural_language_query_falls_back_to_labelled_or(tmp_path):
+    bundle = _complete_basic_bundle(tmp_path)
+
+    # "work" is absent from the indexed chunk, so the strict AND query is empty;
+    # the OR relaxation over content tokens recovers a candidate.
+    pack = build_ask_context_pack(
+        bundle["manifest"], query="How does hello resolved work?", k=5
+    )
+
+    _validate_context_pack(pack)
+    assert pack["retrieval"]["strategy"] == "or_relaxed"
+    assert pack["retrieval"]["match_count"] >= 1
+    assert " OR " in pack["retrieval"]["fts_query"]
+    assert any(
+        caveat["kind"] == "other" and "relaxed OR-matches" in caveat["detail"]
+        for caveat in pack["answer_scaffold"]["caveats_to_surface"]
+    )
+
+
+def test_no_match_query_signals_emptiness_instead_of_silence(tmp_path):
+    bundle = _complete_basic_bundle(tmp_path)
+
+    pack = build_ask_context_pack(
+        bundle["manifest"], query="zzznosuchterm qqqmissing", k=5
+    )
+
+    _validate_context_pack(pack)
+    assert pack["retrieval"]["strategy"] == "none"
+    assert pack["retrieval"]["match_count"] == 0
+    assert pack["resolved_ranges"] == []
+    assert any(
+        caveat["kind"] == "other" and "No evidence matched" in caveat["detail"]
+        for caveat in pack["answer_scaffold"]["caveats_to_surface"]
+    )
+
+
+def test_content_tokens_drop_stopwords_and_dedupe():
+    assert _content_tokens("How does the live freshness live check work?") == [
+        "live",
+        "freshness",
+        "check",
+        "work",
+    ]
+    # An all-stopword query yields no content tokens, so no OR retry is attempted.
+    assert _content_tokens("how does the is are") == []
+
+
+def test_or_fts_query_quotes_terms_to_keep_them_literal():
+    assert _or_fts_query(["live", "freshness"]) == '"live" OR "freshness"'


### PR DESCRIPTION
## Summary

Two consumption-facing improvements to the RepoBrief **ask context pack**, found by driving the MCP server as a coding agent against a real lenskit bundle (the A/B from the last review). Both are additive and backward-compatible.

### 1. Retrieval resilience — no more silent-empty context
The FTS router AND-joins every query term (`live AND freshness AND comparison AND work`), so a single word absent from a chunk zeroes an otherwise good match. Natural-language questions ("How does X work?") routinely returned **0 ranges while `status` stayed `ok`** — the agent got silent empty context with no signal why.

The pack now:
- reports a `retrieval` block — `raw_query`, executed `fts_query`, `strategy` (`exact_and` / `or_relaxed` / `none`), `match_count` — so the agent sees exactly what was searched;
- on an empty strict-AND match, retries **once** with a relaxed **OR** over content tokens (deterministic function-word stoplist, EN+DE), adopting it only if it recovers ranges and labelling it `or_relaxed` with a *"less precise, rephrase with identifiers"* caveat;
- emits an explicit *"no evidence matched"* caveat (with the executed FTS query) when nothing resolves.

Zero regression: queries that already matched keep `exact_and` and identical results — the OR path only triggers on empty.

### 2. Source-address surfacing — navigation first-class
Resolved ranges referenced only the canonical_md span, forcing agents to parse the original path out of the excerpt text (this lost the navigation A/B to plain `grep`). Ranges now carry `source_path`, `source_line_range`, and `citation_id` — data already present in the evidence hit but dropped by the serializer. canonical_md stays the authority; these are source-address conveniences.

## Implementation
- Threads an optional `prepared_fts_query` through `query_existing_index` to reach the existing `_prepared_fts_query` seam in `execute_query` (no change to the shared router / `overmatch_guard`).
- Schema gains (`retrieval` object; `source_path`/`source_line_range`/`citation_id` on ranges) are **additive and optional** — `required[]` unchanged, so existing bundles and producers still validate.

## Testing
- New `test_repobrief_ask_retrieval_resilience.py` (5 cases): exact/relaxed/none strategies, source-address fields, token normalization.
- Verified live through the actual MCP stdio server end-to-end.
- No regressions: 177 repobrief/ask/mcp tests + 67 parity/schema-audit + 270 retrieval/citation tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)