### PR TITLE
feat(repobrief): expose find_symbol MCP navigation tool

### DIFF
--- a/docs/usage/repobrief-mcp-stdio.md
+++ b/docs/usage/repobrief-mcp-stdio.md
@@ -58,7 +58,8 @@ Read-only by default:
 
 - `ask_context`: builds the existing cited context pack from one registered bundle;
 - `grounding_verify`: runs the existing declaration and evidence verifier;
-- `live_freshness`: compares the snapshot commit and cleanliness with the configured checkout.
+- `live_freshness`: compares the snapshot commit and cleanliness with the configured checkout;
+- `find_symbol`: locates Python symbol definitions by name in the snapshot's symbol index (exact matches first), answering "where is X defined?" with a path and line range; each call also attaches the live freshness of the snapshot.
 
 Optional explicit write tool:
 

--- a/merger/lenskit/cli/repobrief_mcp_stdio.py
+++ b/merger/lenskit/cli/repobrief_mcp_stdio.py
@@ -92,6 +92,28 @@ def _tool_definitions(enable_snapshot_create: bool) -> list[dict[str, Any]]:
             },
             "annotations": _read_annotations(),
         },
+        {
+            "name": "find_symbol",
+            "title": "RepoBrief symbol locator",
+            "description": (
+                "Locate Python symbol definitions (function/class/async_function) by name "
+                "in an existing RepoBrief bundle. Answers 'where is X defined?' with an "
+                "exact path and line range."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "bundle_manifest": {"type": "string"},
+                    "name": {"type": "string"},
+                    "kind": {"type": ["string", "null"]},
+                    "path": {"type": ["string", "null"]},
+                    "k": {"type": "integer", "minimum": 1, "maximum": 200, "default": 25},
+                },
+                "required": ["bundle_manifest", "name"],
+                "additionalProperties": False,
+            },
+            "annotations": _read_annotations(),
+        },
     ]
     if enable_snapshot_create:
         tools.append(
@@ -331,6 +353,16 @@ class RepoBriefMcpStdioServer:
         payload["live_freshness"] = self._safe_live_freshness(manifest)
         return payload
 
+    def _call_find_symbol(self, arguments: Mapping[str, Any]) -> dict[str, Any]:
+        call_args = dict(arguments)
+        manifest = self._guard_manifest(call_args.get("bundle_manifest"))
+        call_args["bundle_manifest"] = str(manifest)
+        payload = repobrief_mcp_tools.find_symbol(**call_args)
+        # Nav results reflect the snapshot; surface freshness so the agent knows
+        # whether the index may lag the live working tree.
+        payload["live_freshness"] = self._safe_live_freshness(manifest)
+        return payload
+
     def _call_snapshot_create(self, arguments: Mapping[str, Any]) -> dict[str, Any]:
         if not self.enable_snapshot_create or self.repo_root is None:
             raise McpProtocolError(-32602, "snapshot_create is disabled")
@@ -354,6 +386,8 @@ class RepoBriefMcpStdioServer:
         if name == "live_freshness":
             manifest = self._guard_manifest(arguments.get("bundle_manifest"))
             return self._safe_live_freshness(manifest)
+        if name == "find_symbol":
+            return self._call_find_symbol(arguments)
         if name == "snapshot_create":
             return self._call_snapshot_create(arguments)
         raise McpProtocolError(-32602, f"unknown or disabled tool: {name}")

--- a/merger/lenskit/cli/repobrief_mcp_stdio.py
+++ b/merger/lenskit/cli/repobrief_mcp_stdio.py
@@ -104,8 +104,11 @@ def _tool_definitions(enable_snapshot_create: bool) -> list[dict[str, Any]]:
                 "type": "object",
                 "properties": {
                     "bundle_manifest": {"type": "string"},
-                    "name": {"type": "string"},
-                    "kind": {"type": ["string", "null"]},
+                    "name": {"type": "string", "minLength": 1},
+                    "kind": {
+                        "type": ["string", "null"],
+                        "enum": [None, "class", "function", "async_function"],
+                    },
                     "path": {"type": ["string", "null"]},
                     "k": {"type": "integer", "minimum": 1, "maximum": 200, "default": 25},
                 },
@@ -355,6 +358,19 @@ class RepoBriefMcpStdioServer:
 
     def _call_find_symbol(self, arguments: Mapping[str, Any]) -> dict[str, Any]:
         call_args = dict(arguments)
+        # Fail closed at the transport boundary: reject an empty name (which would
+        # otherwise list the first k symbols) or an unknown kind, independent of
+        # any client-side inputSchema enforcement.
+        name = call_args.get("name")
+        if not isinstance(name, str) or not name.strip():
+            raise McpProtocolError(-32602, "find_symbol requires a non-empty name")
+        kind = call_args.get("kind")
+        if kind is not None and kind not in repobrief_mcp_tools.FIND_SYMBOL_KINDS:
+            raise McpProtocolError(
+                -32602,
+                "find_symbol kind must be one of class, function, async_function, or null",
+                {"allowed_kinds": list(repobrief_mcp_tools.FIND_SYMBOL_KINDS)},
+            )
         manifest = self._guard_manifest(call_args.get("bundle_manifest"))
         call_args["bundle_manifest"] = str(manifest)
         payload = repobrief_mcp_tools.find_symbol(**call_args)

--- a/merger/lenskit/core/repobrief_access.py
+++ b/merger/lenskit/core/repobrief_access.py
@@ -1268,9 +1268,9 @@ def search_symbol_index(
     q = query.strip().casefold()
     kind_filter = kind.strip() if isinstance(kind, str) and kind.strip() else None
     path_filter = path.strip().casefold() if isinstance(path, str) and path.strip() else None
-    matched: list[dict[str, Any]] = []
+    matched: list[tuple[int, int, dict[str, Any]]] = []
     omitted_by_filter = 0
-    for symbol in symbols:
+    for position, symbol in enumerate(symbols):
         haystack = " ".join(
             str(symbol.get(field, ""))
             for field in ("name", "qualified_name", "module", "path", "kind")
@@ -1284,10 +1284,16 @@ def search_symbol_index(
         if path_filter and path_filter not in str(symbol.get("path", "")).casefold():
             omitted_by_filter += 1
             continue
-        matched.append(_symbol_record(symbol))
-        if len(matched) > k:
-            break
-    hits = matched[:k]
+        # Rank exact name/qualified_name matches before substring matches so a
+        # definition lookup surfaces the symbol itself first. Ties keep index
+        # order (stable), preserving prior behavior when no exact match exists.
+        exact = 0 if q and (
+            str(symbol.get("name", "")).casefold() == q
+            or str(symbol.get("qualified_name", "")).casefold() == q
+        ) else 1
+        matched.append((exact, position, _symbol_record(symbol)))
+    matched.sort(key=lambda item: (item[0], item[1]))
+    hits = [record for _, _, record in matched[:k]]
     availability = _availability_model_for_manifest(manifest_path)
     return {
         "kind": SYMBOL_SEARCH_KIND,

--- a/merger/lenskit/core/repobrief_access.py
+++ b/merger/lenskit/core/repobrief_access.py
@@ -1291,9 +1291,10 @@ def search_symbol_index(
             str(symbol.get("name", "")).casefold() == q
             or str(symbol.get("qualified_name", "")).casefold() == q
         ) else 1
-        matched.append((exact, position, _symbol_record(symbol)))
+        matched.append((exact, position, symbol))
     matched.sort(key=lambda item: (item[0], item[1]))
-    hits = [record for _, _, record in matched[:k]]
+    # Build the (heavier) records only for the k rows that are actually returned.
+    hits = [_symbol_record(symbol) for _, _, symbol in matched[:k]]
     availability = _availability_model_for_manifest(manifest_path)
     return {
         "kind": SYMBOL_SEARCH_KIND,

--- a/merger/lenskit/core/repobrief_mcp_tools.py
+++ b/merger/lenskit/core/repobrief_mcp_tools.py
@@ -343,3 +343,34 @@ def grounding_verify(
         "mutation_boundary": _read_only_boundary(),
         "does_not_establish": list(DOES_NOT_ESTABLISH),
     }
+
+
+def find_symbol(
+    *,
+    bundle_manifest: str | Path,
+    name: str,
+    kind: str | None = None,
+    path: str | None = None,
+    k: int = 25,
+) -> dict[str, Any]:
+    """MCP-shaped read-only frontdoor for symbol-definition lookup.
+
+    Locates Python symbol definitions (function/class/async_function) in the
+    snapshot's deterministic symbol index, ranking exact matches first. Answers
+    "where is X defined?" with a path and line range — the navigation primitive
+    that content retrieval (ask_context) does not provide. It does not establish
+    that a symbol is called, correct, or fresh against the working tree.
+    """
+    from merger.lenskit.core.repobrief_access import search_symbol_index
+
+    result = search_symbol_index(bundle_manifest, name, k=k, kind=kind, path=path)
+    return {
+        "kind": READ_ONLY_KIND,
+        "version": READ_ONLY_VERSION,
+        "tool": "find_symbol",
+        "status": result.get("status", "invalid"),
+        "result": result,
+        "result_semantics": "repobrief.symbol_search.v1",
+        "mutation_boundary": _read_only_boundary(),
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }

--- a/merger/lenskit/core/repobrief_mcp_tools.py
+++ b/merger/lenskit/core/repobrief_mcp_tools.py
@@ -345,6 +345,22 @@ def grounding_verify(
     }
 
 
+FIND_SYMBOL_KINDS = ("class", "function", "async_function")
+
+
+def _find_symbol_result(status: str, result: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "kind": READ_ONLY_KIND,
+        "version": READ_ONLY_VERSION,
+        "tool": "find_symbol",
+        "status": status,
+        "result": result,
+        "result_semantics": "repobrief.symbol_search.v1",
+        "mutation_boundary": _read_only_boundary(),
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }
+
+
 def find_symbol(
     *,
     bundle_manifest: str | Path,
@@ -360,17 +376,32 @@ def find_symbol(
     "where is X defined?" with a path and line range — the navigation primitive
     that content retrieval (ask_context) does not provide. It does not establish
     that a symbol is called, correct, or fresh against the working tree.
+
+    Fails closed: an empty name or an unknown kind is rejected rather than
+    silently listing the first ``k`` symbols.
     """
     from merger.lenskit.core.repobrief_access import search_symbol_index
 
+    def _invalid(error: str, error_code: str) -> dict[str, Any]:
+        return _find_symbol_result(
+            "invalid",
+            {
+                "kind": "repobrief.symbol_search",
+                "version": "v1",
+                "status": "invalid",
+                "error": error,
+                "error_code": error_code,
+                "hits": [],
+                "hit_count": 0,
+            },
+        )
+
+    if not isinstance(name, str) or not name.strip():
+        return _invalid("name must be a non-empty string", "name_invalid")
+    if kind is not None and kind not in FIND_SYMBOL_KINDS:
+        return _invalid(
+            f"kind must be one of {list(FIND_SYMBOL_KINDS)} or null", "kind_invalid"
+        )
+
     result = search_symbol_index(bundle_manifest, name, k=k, kind=kind, path=path)
-    return {
-        "kind": READ_ONLY_KIND,
-        "version": READ_ONLY_VERSION,
-        "tool": "find_symbol",
-        "status": result.get("status", "invalid"),
-        "result": result,
-        "result_semantics": "repobrief.symbol_search.v1",
-        "mutation_boundary": _read_only_boundary(),
-        "does_not_establish": list(DOES_NOT_ESTABLISH),
-    }
+    return _find_symbol_result(result.get("status", "invalid"), result)

--- a/merger/lenskit/tests/test_repobrief_find_symbol.py
+++ b/merger/lenskit/tests/test_repobrief_find_symbol.py
@@ -1,0 +1,147 @@
+"""find_symbol MCP tool + exact-first ranking in the shared symbol search.
+
+find_symbol is the navigation primitive ("where is X defined?") that content
+retrieval (ask_context) does not provide. It reuses the existing
+``search_symbol_index`` core, which now ranks exact name matches before
+substring matches so a definition lookup surfaces the symbol itself first.
+"""
+import hashlib
+import json
+from pathlib import Path
+
+from merger.lenskit.core import repobrief_mcp_tools
+from merger.lenskit.core.repobrief_access import search_symbol_index
+
+
+def _sha(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _symbol_bundle(tmp_path: Path) -> Path:
+    symbol_index = tmp_path / "demo.python_symbol_index.json"
+    symbol_index.write_text(
+        json.dumps(
+            {
+                "kind": "lenskit.python_symbol_index",
+                "version": "1.0",
+                "run_id": "run-1",
+                "canonical_dump_index_sha256": "a" * 64,
+                "language": "python",
+                "symbol_kinds": ["class", "function", "async_function"],
+                "symbols": [
+                    # A substring match declared BEFORE the exact match, to prove
+                    # exact-first ranking reorders regardless of index position.
+                    {
+                        "id": "py:pkg:mod.py:function:run_pipeline",
+                        "kind": "function",
+                        "name": "run_pipeline",
+                        "qualified_name": "run_pipeline",
+                        "module": "pkg.mod",
+                        "path": "pkg/mod.py",
+                        "start_line": 3,
+                        "end_line": 5,
+                        "range_ref": "file:pkg/mod.py#L3-L5",
+                    },
+                    {
+                        "id": "py:pkg:mod.py:function:run",
+                        "kind": "function",
+                        "name": "run",
+                        "qualified_name": "run",
+                        "module": "pkg.mod",
+                        "path": "pkg/mod.py",
+                        "start_line": 8,
+                        "end_line": 10,
+                        "range_ref": "file:pkg/mod.py#L8-L10",
+                    },
+                    {
+                        "id": "py:pkg:mod.py:class:Runner",
+                        "kind": "class",
+                        "name": "Runner",
+                        "qualified_name": "Runner",
+                        "module": "pkg.mod",
+                        "path": "pkg/mod.py",
+                        "start_line": 13,
+                        "end_line": 20,
+                        "range_ref": "file:pkg/mod.py#L13-L20",
+                    },
+                ],
+                "skipped_files_count": 0,
+                "skipped_errors": [],
+                "does_not_establish": ["call_graph_completeness"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    manifest = tmp_path / "demo.bundle.manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "kind": "repolens.bundle.manifest",
+                "run_id": "run-1",
+                "artifacts": [
+                    {
+                        "role": "python_symbol_index_json",
+                        "path": symbol_index.name,
+                        "content_type": "application/json",
+                        "bytes": symbol_index.stat().st_size,
+                        "sha256": _sha(symbol_index),
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def test_exact_match_ranks_before_substring(tmp_path):
+    manifest = _symbol_bundle(tmp_path)
+
+    result = search_symbol_index(manifest, "run", k=10)
+
+    assert result["status"] == "available"
+    # 'run' matches run (exact), run_pipeline and Runner (substring); the exact
+    # match wins the top slot even though it is declared after run_pipeline.
+    names = [hit["qualified_name"] for hit in result["hits"]]
+    assert names[0] == "run"
+    assert set(names) == {"run", "run_pipeline", "Runner"}
+
+
+def test_find_symbol_tool_locates_definition_with_range(tmp_path):
+    manifest = _symbol_bundle(tmp_path)
+
+    payload = repobrief_mcp_tools.find_symbol(bundle_manifest=str(manifest), name="run")
+
+    assert payload["kind"] == "repobrief.mcp.read_only_frontdoor"
+    assert payload["tool"] == "find_symbol"
+    assert payload["status"] == "available"
+    assert payload["mutation_boundary"]["writes"] == []
+    top = payload["result"]["hits"][0]
+    assert top["qualified_name"] == "run"
+    assert top["path"] == "pkg/mod.py"
+    assert top["start_line"] == 8
+    assert top["range_ref"] == "file:pkg/mod.py#L8-L10"
+
+
+def test_find_symbol_tool_filters_by_kind(tmp_path):
+    manifest = _symbol_bundle(tmp_path)
+
+    payload = repobrief_mcp_tools.find_symbol(
+        bundle_manifest=str(manifest), name="run", kind="class"
+    )
+
+    hits = payload["result"]["hits"]
+    assert [hit["qualified_name"] for hit in hits] == ["Runner"]
+
+
+def test_find_symbol_tool_reports_missing_symbol_index(tmp_path):
+    manifest = tmp_path / "empty.bundle.manifest.json"
+    manifest.write_text(
+        json.dumps({"kind": "repolens.bundle.manifest", "run_id": "x", "artifacts": []}),
+        encoding="utf-8",
+    )
+
+    payload = repobrief_mcp_tools.find_symbol(bundle_manifest=str(manifest), name="run")
+
+    assert payload["status"] == "missing"
+    assert payload["result"]["error_code"] == "python_symbol_index_json_missing"

--- a/merger/lenskit/tests/test_repobrief_find_symbol.py
+++ b/merger/lenskit/tests/test_repobrief_find_symbol.py
@@ -134,6 +134,30 @@ def test_find_symbol_tool_filters_by_kind(tmp_path):
     assert [hit["qualified_name"] for hit in hits] == ["Runner"]
 
 
+def test_find_symbol_tool_rejects_empty_name(tmp_path):
+    manifest = _symbol_bundle(tmp_path)
+
+    for empty in ("", "   "):
+        payload = repobrief_mcp_tools.find_symbol(bundle_manifest=str(manifest), name=empty)
+        assert payload["status"] == "invalid"
+        assert payload["result"]["error_code"] == "name_invalid"
+        # Fails closed: no symbols are listed for an empty query.
+        assert payload["result"]["hits"] == []
+        assert payload["result"]["hit_count"] == 0
+
+
+def test_find_symbol_tool_rejects_unknown_kind(tmp_path):
+    manifest = _symbol_bundle(tmp_path)
+
+    payload = repobrief_mcp_tools.find_symbol(
+        bundle_manifest=str(manifest), name="run", kind="macro"
+    )
+
+    assert payload["status"] == "invalid"
+    assert payload["result"]["error_code"] == "kind_invalid"
+    assert payload["result"]["hits"] == []
+
+
 def test_find_symbol_tool_reports_missing_symbol_index(tmp_path):
     manifest = tmp_path / "empty.bundle.manifest.json"
     manifest.write_text(

--- a/merger/lenskit/tests/test_repobrief_mcp_stdio.py
+++ b/merger/lenskit/tests/test_repobrief_mcp_stdio.py
@@ -86,6 +86,7 @@ def test_mcp_stdio_lists_read_tools_and_hides_snapshot_create_by_default(tmp_pat
         "ask_context",
         "grounding_verify",
         "live_freshness",
+        "find_symbol",
     }
 
 

--- a/merger/lenskit/tests/test_repobrief_mcp_stdio_e2e.py
+++ b/merger/lenskit/tests/test_repobrief_mcp_stdio_e2e.py
@@ -110,7 +110,7 @@ def test_mcp_stdio_launcher_completes_handshake_outside_checkout(tmp_path: Path)
     assert responses[0]["result"]["protocolVersion"] == PROTOCOL_VERSION
     assert {
         tool["name"] for tool in responses[1]["result"]["tools"]
-    } == {"ask_context", "grounding_verify", "live_freshness"}
+    } == {"ask_context", "grounding_verify", "live_freshness", "find_symbol"}
 
 
 @pytest.mark.skipif(shutil.which("git") is None, reason="git executable unavailable")

--- a/merger/lenskit/tests/test_repobrief_mcp_stdio_e2e.py
+++ b/merger/lenskit/tests/test_repobrief_mcp_stdio_e2e.py
@@ -145,3 +145,200 @@ def test_live_freshness_real_git_probe_is_read_only_and_detects_dirtiness(
     assert dirty["reason"] == "current_working_tree_is_dirty"
     assert _sha256(index_path) == index_before
     assert _git(repo, "rev-parse", "HEAD") == commit
+
+
+def _symbol_manifest(bundle_root: Path, *, repo: Path, commit: str) -> Path:
+    index = bundle_root / "demo.python_symbol_index.json"
+    index.write_text(
+        json.dumps(
+            {
+                "kind": "lenskit.python_symbol_index",
+                "version": "1.0",
+                "run_id": "demo",
+                "canonical_dump_index_sha256": "a" * 64,
+                "language": "python",
+                "symbol_kinds": ["class", "function", "async_function"],
+                "symbols": [
+                    # Substring match declared before the exact match, to prove
+                    # exact-first ranking over the transport.
+                    {
+                        "id": "py:pkg:mod.py:function:run_pipeline",
+                        "kind": "function",
+                        "name": "run_pipeline",
+                        "qualified_name": "run_pipeline",
+                        "module": "pkg.mod",
+                        "path": "pkg/mod.py",
+                        "start_line": 3,
+                        "end_line": 5,
+                        "range_ref": "file:pkg/mod.py#L3-L5",
+                    },
+                    {
+                        "id": "py:pkg:mod.py:function:run",
+                        "kind": "function",
+                        "name": "run",
+                        "qualified_name": "run",
+                        "module": "pkg.mod",
+                        "path": "pkg/mod.py",
+                        "start_line": 8,
+                        "end_line": 10,
+                        "range_ref": "file:pkg/mod.py#L8-L10",
+                    },
+                ],
+                "skipped_files_count": 0,
+                "skipped_errors": [],
+                "does_not_establish": ["call_graph_completeness"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    manifest = bundle_root / "demo.bundle.manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "kind": "repolens.bundle.manifest",
+                "run_id": "demo",
+                "artifacts": [
+                    {
+                        "role": "python_symbol_index_json",
+                        "path": index.name,
+                        "content_type": "application/json",
+                        "bytes": index.stat().st_size,
+                        "sha256": _sha256(index),
+                    }
+                ],
+                "snapshot_provenance": {
+                    "version": "v1",
+                    "repositories": [
+                        {
+                            "name": repo.name,
+                            "repo_root": str(repo.resolve()),
+                            "git_commit": commit,
+                            "git_dirty": False,
+                            "git_branch": "main",
+                            "provenance_status": "present",
+                            "freshness_basis": "git_commit_and_working_tree",
+                        }
+                    ],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def _run_launcher(bundle_root: Path, repo_root: Path | None, requests: list[dict]) -> list[dict]:
+    args = [sys.executable, str(MCP_LAUNCHER), "--bundle-root", str(bundle_root)]
+    if repo_root is not None:
+        args += ["--repo-root", str(repo_root)]
+    completed = subprocess.run(
+        args,
+        input="".join(json.dumps(request) + "\n" for request in requests),
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    return [json.loads(line) for line in completed.stdout.splitlines() if line.strip()]
+
+
+def _handshake(next_id: int, *calls: dict) -> list[dict]:
+    requests: list[dict] = [
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {"protocolVersion": PROTOCOL_VERSION, "capabilities": {}},
+        },
+        {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
+    ]
+    requests.extend(calls)
+    return requests
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git executable unavailable")
+def test_find_symbol_tools_call_returns_ranked_location_and_freshness(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "--initial-branch=main")
+    _git(repo, "config", "user.name", "RepoBrief Test")
+    _git(repo, "config", "user.email", "repobrief@example.invalid")
+    (repo / "example.py").write_text("value = 1\n", encoding="utf-8")
+    _git(repo, "add", "example.py")
+    _git(repo, "commit", "-q", "-m", "initial")
+    commit = _git(repo, "rev-parse", "HEAD")
+
+    bundle_root = tmp_path / "bundles"
+    bundle_root.mkdir()
+    manifest = _symbol_manifest(bundle_root, repo=repo, commit=commit)
+
+    requests = _handshake(
+        2,
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "find_symbol",
+                "arguments": {"bundle_manifest": str(manifest), "name": "run"},
+            },
+        },
+    )
+    responses = _run_launcher(bundle_root, repo, requests)
+    call_response = next(r for r in responses if r.get("id") == 2)
+    assert "error" not in call_response, call_response
+    payload = json.loads(call_response["result"]["content"][0]["text"])
+
+    assert payload["tool"] == "find_symbol"
+    assert payload["status"] == "available"
+    hits = payload["result"]["hits"]
+    # exact 'run' ranks before the 'run_pipeline' substring match
+    assert hits[0]["qualified_name"] == "run"
+    assert hits[0]["path"] == "pkg/mod.py"
+    assert hits[0]["start_line"] == 8
+    assert hits[0]["end_line"] == 10
+    assert hits[0]["range_ref"] == "file:pkg/mod.py#L8-L10"
+    # navigation results carry the snapshot's live freshness against the checkout
+    assert payload["live_freshness"]["status"] == "fresh"
+    assert payload["live_freshness"]["current_provenance"]["git_commit"] == commit
+
+
+def test_find_symbol_tools_call_rejects_empty_name_and_invalid_kind(tmp_path: Path) -> None:
+    bundle_root = tmp_path / "bundles"
+    bundle_root.mkdir()
+    manifest = bundle_root / "demo.bundle.manifest.json"
+    manifest.write_text(
+        json.dumps({"kind": "repolens.bundle.manifest", "run_id": "demo", "artifacts": []}),
+        encoding="utf-8",
+    )
+
+    requests = _handshake(
+        2,
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "find_symbol",
+                "arguments": {"bundle_manifest": str(manifest), "name": ""},
+            },
+        },
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "find_symbol",
+                "arguments": {"bundle_manifest": str(manifest), "name": "run", "kind": "macro"},
+            },
+        },
+    )
+    responses = _run_launcher(bundle_root, None, requests)
+    by_id = {r.get("id"): r for r in responses}
+
+    # Fail closed: neither request returns a symbol listing; both are rejected.
+    assert by_id[2]["error"]["code"] == -32602
+    assert "non-empty name" in by_id[2]["error"]["message"]
+    assert by_id[3]["error"]["code"] == -32602
+    assert "kind" in by_id[3]["error"]["message"]


### PR DESCRIPTION
## Summary

Adds a **`find_symbol`** read-only MCP tool that answers *"where is X defined?"* with a path and line range — the navigation primitive that content retrieval (`ask_context`) structurally cannot provide. The A/B benchmark from the prior review measured `ask_context` at **~38% path recall** on navigation tasks (it retrieves *content* chunks, not definitions); `find_symbol` returns the exact definition in one call.

This is the P0 step from the navigation vision: it exposes an index that **already ships in every bundle** (`python_symbol_index_json`) — no new indexing.

## Design (no duplication)
- Reuses the existing, tested `search_symbol_index` core rather than adding a parallel path.
- Adds **exact-first ranking** to that shared function: exact `name`/`qualified_name` matches rank before substring matches, via a **stable sort over the same hit set**. When no exact match exists, ordering and results are unchanged — so prior `search_symbol_index` behavior and the CLI consumer are preserved (verified: existing tests green).
- The stdio server attaches `live_freshness` to every `find_symbol` response, so the agent knows the snapshot index may lag the working tree — **freshness-aware navigation**, which no other nav tool offers.

## Wiring
| Layer | Change |
|---|---|
| `repobrief_access.search_symbol_index` | exact-first stable ranking |
| `repobrief_mcp_tools.find_symbol` | read-only MCP frontdoor wrapper |
| `repobrief_mcp_stdio` | tool definition + dispatch (+ attached freshness) |
| `docs/usage/repobrief-mcp-stdio.md` | documents the tool |

## Example (live server)
`find_symbol(name="evaluate_live_freshness")` →
`merger/lenskit/core/repobrief_live_freshness.py:267` (`file:...#L267-L330`), `live_freshness: stale`.

## Testing
- New `test_repobrief_find_symbol.py`: exact-first ranking, tool shape, kind filter, missing-index.
- Existing MCP tool-set assertions updated to include `find_symbol`.
- Verified end-to-end through the actual stdio server.
- No regressions: 219 symbol/mcp/ask/access/parity tests green; CI lint + complexity ratchet clean (`new_count: 0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)