### PR TITLE
chore(ci): update reviewed GitHub Actions pins

### DIFF
--- a/.github/workflows/ai-context-guard.yml
+++ b/.github/workflows/ai-context-guard.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Setup Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Setup Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6

--- a/.github/workflows/anti-hallucination-lint.yml
+++ b/.github/workflows/anti-hallucination-lint.yml
@@ -41,7 +41,7 @@ jobs:
   anti-hallucination-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -28,12 +28,12 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342  # v1
+        uses: anthropics/claude-code-action@f1bd27ca5b54584506e40e17884d90bdaaa1a9b3  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           token: ${{ github.token }}
           fetch-depth: 1

--- a/.github/workflows/contracts-validate.yml
+++ b/.github/workflows/contracts-validate.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -152,7 +152,7 @@ jobs:
       GH_PUSH_BEFORE: ${{ github.event.before }}
       PROTECTED_REGEX: '^(merger/lenskit/contracts/|docs/contracts/)'
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/doc-freshness.yml
+++ b/.github/workflows/doc-freshness.yml
@@ -50,7 +50,7 @@ jobs:
   doc-freshness:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6

--- a/.github/workflows/forensic-preflight-canary.yml
+++ b/.github/workflows/forensic-preflight-canary.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
@@ -99,7 +99,7 @@ jobs:
 
       - name: Upload forensic preflight canary artifact
         if: always()
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: forensic-preflight-canary
           path: .tmp/forensic-preflight-ci-canary/artifacts/

--- a/.github/workflows/graph-bundle-sources.yml
+++ b/.github/workflows/graph-bundle-sources.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
@@ -91,7 +91,7 @@ jobs:
 
       - name: Upload failing diagnostics
         if: failure()
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: graph-bundle-sources-diagnostics
           path: graph-bundle-sources-tests.log

--- a/.github/workflows/graph-model.yml
+++ b/.github/workflows/graph-model.yml
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
@@ -127,7 +127,7 @@ jobs:
 
       - name: Upload failing test diagnostics
         if: failure()
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: graph-model-test-diagnostics
           path: graph-model-tests.log

--- a/.github/workflows/graph-quality-goldset.yml
+++ b/.github/workflows/graph-quality-goldset.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
@@ -60,7 +60,7 @@ jobs:
 
       - name: Upload failing diagnostics
         if: failure()
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: graph-quality-goldset-diagnostics
           path: graph-quality-goldset-tests.log

--- a/.github/workflows/graph-source-roots.yml
+++ b/.github/workflows/graph-source-roots.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
           python-version: "3.12"

--- a/.github/workflows/lens-model.yml
+++ b/.github/workflows/lens-model.yml
@@ -130,7 +130,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
 
@@ -214,7 +214,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
@@ -225,7 +225,7 @@ jobs:
         run: python --version
 
       - name: Set up Node
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: '24'
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -17,10 +17,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Ensure Node for ajv-cli
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: '24'
 
@@ -48,7 +48,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload metrics.json artifact
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: metrics-snapshot
           path: metrics.json

--- a/.github/workflows/parity-gate.yml
+++ b/.github/workflows/parity-gate.yml
@@ -54,7 +54,7 @@ jobs:
   parity-gate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6

--- a/.github/workflows/parity_check.yml
+++ b/.github/workflows/parity_check.yml
@@ -33,7 +33,7 @@ jobs:
   parity-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6

--- a/.github/workflows/task-index.yml
+++ b/.github/workflows/task-index.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Setup Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
@@ -92,7 +92,7 @@ jobs:
 
       - name: Upload planning registration report
         if: always()
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: planning-registration-report
           path: planning-registration-report.json
@@ -119,7 +119,7 @@ jobs:
 
       - name: Upload status truth report
         if: always()
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: status-truth-report
           path: status-truth-report.json

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -79,7 +79,7 @@ jobs:
     env:
       PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Install pinned browser-test dependencies
         run: python -m pip install --disable-pip-version-check --require-hashes -r requirements/repobrief-browser.lock.txt
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload browser diagnostics after failure
         if: failure()
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: browser-test-results-${{ github.run_id }}
           path: test-results
@@ -109,10 +109,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up Node
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: "24"
 

--- a/.github/workflows/validate-merges.yml
+++ b/.github/workflows/validate-merges.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Setup Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6

--- a/merger/lenskit/tests/test_browser_gate_contract.py
+++ b/merger/lenskit/tests/test_browser_gate_contract.py
@@ -1,4 +1,5 @@
 import ast
+import re
 from pathlib import Path
 
 import yaml
@@ -10,6 +11,8 @@ IMAGE = (
     "mcr.microsoft.com/playwright/python:v1.61.0-noble@sha256:"
     "a9731514f24121d1dcd25d58d0a38146646d290a5998fd80d3e533e7b5e21c69"
 )
+SHA40_RE = re.compile(r"^[0-9a-f]{40}$")
+
 
 def _requirements() -> dict[str, str]:
     observed: dict[str, str] = {}
@@ -21,6 +24,13 @@ def _requirements() -> dict[str, str]:
         name, version = line.split("==", 1)
         observed[name] = version
     return observed
+
+
+def _assert_sha_pinned_action(raw_use: str, expected_action: str) -> None:
+    action, separator, ref = raw_use.rpartition("@")
+    assert separator == "@"
+    assert action == expected_action
+    assert SHA40_RE.fullmatch(ref) is not None
 
 
 def test_browser_requirements_are_minimal_and_compatible() -> None:
@@ -36,24 +46,21 @@ def test_browser_job_uses_digest_pinned_matching_playwright_image() -> None:
     assert job["env"] == {"PLAYWRIGHT_BROWSERS_PATH": "/ms-playwright"}
 
     steps = job["steps"]
-    assert steps[0]["uses"] == (
-        "actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd"
-    )
+    _assert_sha_pinned_action(steps[0]["uses"], "actions/checkout")
     commands = "\n".join(str(step.get("run", "")) for step in steps)
-    assert (
-        "--require-hashes -r requirements/repobrief-browser.lock.txt"
-        in commands
-    )
+    assert "--require-hashes -r requirements/repobrief-browser.lock.txt" in commands
     assert "scripts/ci/check_browser_gate_environment.py" in commands
     assert "-m browser merger/lenskit/tests/test_webui_payload.py" in commands
     assert "--browser chromium" in commands
     assert "--tracing retain-on-failure" in commands
 
-    upload = next(step for step in steps if step.get("name") == "Upload browser diagnostics after failure")
-    assert upload["if"] == "failure()"
-    assert upload["uses"] == (
-        "actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f"
+    upload = next(
+        step
+        for step in steps
+        if step.get("name") == "Upload browser diagnostics after failure"
     )
+    assert upload["if"] == "failure()"
+    _assert_sha_pinned_action(upload["uses"], "actions/upload-artifact")
 
 
 def test_browser_suite_contains_all_current_browser_flows() -> None:

--- a/merger/lenskit/tests/test_github_actions_node_runtime.py
+++ b/merger/lenskit/tests/test_github_actions_node_runtime.py
@@ -5,25 +5,28 @@ from pathlib import Path
 
 
 WORKFLOW_ROOT = Path(".github/workflows")
-MINIMUM_NODE24_MAJORS = {
-    "actions/checkout": 5,
-    "actions/setup-node": 5,
-    "actions/setup-python": 6,
-    "actions/upload-artifact": 6,
-    "github/codeql-action/analyze": 4,
-    "github/codeql-action/autobuild": 4,
-    "github/codeql-action/init": 4,
+ALLOWED_NODE24_MAJORS = {
+    "actions/checkout": {5, 6, 7},
+    "actions/setup-node": {5, 6, 7},
+    "actions/setup-python": {6},
+    "actions/upload-artifact": {6, 7},
+    "github/codeql-action/analyze": {4},
+    "github/codeql-action/autobuild": {4},
+    "github/codeql-action/init": {4},
 }
 USES_LINE_RE = re.compile(
     r"^\s*(?:-\s*)?uses:\s*([^\s#]+)(?:\s+#\s*(.*?))?\s*$",
     re.MULTILINE,
 )
 SHA40_RE = re.compile(r"^[0-9a-f]{40}$")
-MAJOR_COMMENT_RE = re.compile(r"^v(\d+)(?:\s|$)")
+VERSION_COMMENT_RE = re.compile(r"^v(\d+)(?:\.\d+){0,2}(?:\s|$)")
 
 
 def _workflow_texts() -> dict[Path, str]:
-    return {path: path.read_text(encoding="utf-8") for path in sorted(WORKFLOW_ROOT.glob("*.y*ml"))}
+    return {
+        path: path.read_text(encoding="utf-8")
+        for path in sorted(WORKFLOW_ROOT.glob("*.y*ml"))
+    }
 
 
 def test_node24_compatibility_override_is_absent() -> None:
@@ -36,8 +39,8 @@ def test_node24_compatibility_override_is_absent() -> None:
     assert occurrences == []
 
 
-def test_known_javascript_actions_use_node24_native_majors() -> None:
-    seen: dict[str, set[int]] = {name: set() for name in MINIMUM_NODE24_MAJORS}
+def test_known_javascript_actions_use_reviewed_node24_majors() -> None:
+    seen: dict[str, set[int]] = {name: set() for name in ALLOWED_NODE24_MAJORS}
     invalid: list[str] = []
 
     for path, text in _workflow_texts().items():
@@ -45,23 +48,24 @@ def test_known_javascript_actions_use_node24_native_majors() -> None:
             if "@" not in raw_use:
                 continue
             action, ref = raw_use.rsplit("@", 1)
-            if action not in MINIMUM_NODE24_MAJORS:
+            if action not in ALLOWED_NODE24_MAJORS:
                 continue
             if SHA40_RE.fullmatch(ref) is None:
                 invalid.append(f"{path}: {raw_use} is not pinned to a full commit SHA")
                 continue
-            match = MAJOR_COMMENT_RE.match(comment)
+            match = VERSION_COMMENT_RE.match(comment)
             if match is None:
                 invalid.append(
-                    f"{path}: {raw_use} lacks a reviewable '# vN' major comment"
+                    f"{path}: {raw_use} lacks a reviewable '# vN' or '# vN.N.N' comment"
                 )
                 continue
             major = int(match.group(1))
             seen[action].add(major)
-            minimum = MINIMUM_NODE24_MAJORS[action]
-            if major < minimum:
+            allowed = ALLOWED_NODE24_MAJORS[action]
+            if major not in allowed:
+                rendered = ", ".join(f"v{item}" for item in sorted(allowed))
                 invalid.append(
-                    f"{path}: {raw_use} claims a major below Node-24 v{minimum}"
+                    f"{path}: {raw_use} claims unreviewed major v{major}; allowed: {rendered}"
                 )
 
     missing = sorted(action for action, majors in seen.items() if not majors)


### PR DESCRIPTION
## Bureau task

- Task: `RBV1-T022`
- Supersedes: Dependabot PR #1004
- Provider execution: none

## Problem

Dependabot correctly updated several GitHub Actions to newer full-SHA pins, but two Lenskit contract tests rejected the update for maintenance reasons rather than runtime incompatibility:

- one test hard-coded a single obsolete checkout commit;
- one parser accepted only comments such as `# v7`, while Dependabot writes reviewable semantic versions such as `# v7.0.0`.

## Change

- preserve all full 40-character commit SHA pins from the Dependabot update;
- accept `vN`, `vN.N`, or `vN.N.N` comments only when their major is explicitly allowlisted;
- continue rejecting unknown future majors rather than treating every newer major as safe;
- verify the browser workflow by action identity plus full SHA pin, not one stale commit value.

## Local validation

- focused workflow contract tests: 5 passed;
- full non-browser suite: 3,903 passed, 1 skipped, 13 deselected;
- Ruff: passed;
- GitHub Actions pin and reusable-workflow checks: passed;
- graph maintainability ratchet: passed;
- five WebUI JavaScript suites: passed;
- deterministic release candidates A/B: byte-identical and source-bound;
- release contract: passed;
- `git diff --check`: clean.

## Non-claims

This PR does not establish arbitrary future action-major compatibility, upstream supply-chain safety beyond reviewed SHA pins, public distribution permission, or provider execution.