### PR TITLE
feat(repobrief): localize external bundle publication

### DIFF
--- a/merger/lenskit/core/external_manifest_reference.py
+++ b/merger/lenskit/core/external_manifest_reference.py
@@ -29,22 +29,6 @@ class ExternalManifestReferenceError(ValueError):
     """Raised when an external manifest reference cannot be built."""
 
 
-def _read_json_object(path: Path) -> dict[str, Any]:
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except FileNotFoundError as exc:
-        raise ExternalManifestReferenceError(
-            f"bundle manifest does not exist: {path}"
-        ) from exc
-    except json.JSONDecodeError as exc:
-        raise ExternalManifestReferenceError(
-            f"bundle manifest is not valid JSON: {path}"
-        ) from exc
-    if not isinstance(data, dict):
-        raise ExternalManifestReferenceError("bundle manifest must be a JSON object")
-    return data
-
-
 def _relative_path(target: Path, base_dir: Path) -> str:
     return Path(os.path.relpath(target.resolve(), base_dir.resolve())).as_posix()
 
@@ -83,17 +67,37 @@ def _open_regular_file(path: Path, label: str) -> tuple[int, int]:
 
 
 def _digest_regular_file(path: Path, label: str) -> tuple[int, str]:
-    fd, observed_bytes = _open_regular_file(path, label)
+    fd, _ = _open_regular_file(path, label)
     digest = hashlib.sha256()
+    observed_bytes = 0
     with os.fdopen(fd, "rb", closefd=True) as handle:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            observed_bytes += len(chunk)
             digest.update(chunk)
     return observed_bytes, digest.hexdigest()
 
 
-def _sha256_file(path: Path) -> str:
-    _, digest = _digest_regular_file(path, "file")
-    return digest
+def _read_json_object_with_integrity(
+    path: Path,
+) -> tuple[dict[str, Any], int, str]:
+    fd, _ = _open_regular_file(path, "bundle manifest")
+    digest = hashlib.sha256()
+    chunks: list[bytes] = []
+    observed_bytes = 0
+    with os.fdopen(fd, "rb", closefd=True) as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            observed_bytes += len(chunk)
+            digest.update(chunk)
+            chunks.append(chunk)
+    try:
+        data = json.loads(b"".join(chunks).decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ExternalManifestReferenceError(
+            f"bundle manifest is not valid UTF-8 JSON: {path}"
+        ) from exc
+    if not isinstance(data, dict):
+        raise ExternalManifestReferenceError("bundle manifest must be a JSON object")
+    return data, observed_bytes, digest.hexdigest()
 
 
 def _bundle_member(bundle_dir: Path, raw_path: str, label: str) -> tuple[Path, str]:
@@ -182,12 +186,15 @@ def _linked_sidecar_rows(
         if normalized in seen_paths:
             continue
         seen_paths.add(normalized)
+        linked_bytes, linked_sha256 = _digest_regular_file(
+            linked_path, f"bundle manifest link {link_key}"
+        )
         rows.append(
             {
                 "role": role,
                 "path": _relative_path(linked_path, output_base),
-                "sha256": _sha256_file(linked_path),
-                "bytes": linked_path.stat().st_size,
+                "sha256": linked_sha256,
+                "bytes": linked_bytes,
                 "contentType": "application/json",
             }
         )
@@ -400,87 +407,6 @@ def _materialization_members(
             "bundle artifact path must not collide with the bundle manifest filename"
         )
     return members
-
-
-def _require_materialized_directory(localized_dir: Path) -> None:
-    try:
-        metadata = localized_dir.lstat()
-    except OSError as exc:
-        raise ExternalManifestReferenceError(
-            f"localized bundle path must be an existing directory: {localized_dir}"
-        ) from exc
-    if not stat.S_ISDIR(metadata.st_mode):
-        raise ExternalManifestReferenceError(
-            f"localized bundle path must be an existing directory: {localized_dir}"
-        )
-
-
-def _expected_materialized_tree_entries(
-    localized_manifest: Path, members: dict[str, dict[str, Any]]
-) -> tuple[set[str], set[str]]:
-    files = {localized_manifest.name, *members.keys()}
-    directories: set[str] = set()
-    for relative_path in files:
-        parent = Path(relative_path).parent
-        while parent != Path("."):
-            directories.add(parent.as_posix())
-            parent = parent.parent
-    return files, directories
-
-
-def _require_materialized_tree_entry(candidate: Path, *, expected_type: str) -> None:
-    metadata = candidate.lstat()
-    valid = (
-        stat.S_ISDIR(metadata.st_mode)
-        if expected_type == "directory"
-        else stat.S_ISREG(metadata.st_mode)
-    )
-    if not valid:
-        raise ExternalManifestReferenceError(
-            "localized bundle tree must contain only regular files and "
-            f"directories: {candidate}"
-        )
-
-
-def _observed_materialized_tree_entries(
-    localized_dir: Path,
-) -> tuple[set[str], set[str]]:
-    files: set[str] = set()
-    directories: set[str] = set()
-    for current_root, directory_names, file_names in os.walk(
-        localized_dir, topdown=True, followlinks=False
-    ):
-        current = Path(current_root)
-        for name in directory_names:
-            candidate = current / name
-            _require_materialized_tree_entry(candidate, expected_type="directory")
-            directories.add(candidate.relative_to(localized_dir).as_posix())
-        for name in file_names:
-            candidate = current / name
-            _require_materialized_tree_entry(candidate, expected_type="file")
-            files.add(candidate.relative_to(localized_dir).as_posix())
-    return files, directories
-
-
-def _require_exact_materialized_tree_entries(
-    *,
-    expected_files: set[str],
-    expected_directories: set[str],
-    actual_files: set[str],
-    actual_directories: set[str],
-) -> None:
-    if actual_files == expected_files and actual_directories == expected_directories:
-        return
-    missing = sorted(
-        (expected_files - actual_files) | (expected_directories - actual_directories)
-    )
-    unexpected = sorted(
-        (actual_files - expected_files) | (actual_directories - expected_directories)
-    )
-    raise ExternalManifestReferenceError(
-        "localized bundle tree entries mismatch: "
-        f"missing={missing}, unexpected={unexpected}"
-    )
 
 
 def _expected_materialized_entries(
@@ -757,7 +683,9 @@ def build_external_manifest_reference(
         manifest_path,
         Path(publication_root) if publication_root is not None else None,
     )
-    bundle = _read_json_object(manifest_path)
+    bundle, manifest_bytes, manifest_sha256 = _read_json_object_with_integrity(
+        manifest_path
+    )
     if bundle.get("kind") != BUNDLE_KIND:
         raise ExternalManifestReferenceError(
             "bundle manifest kind must be repolens.bundle.manifest"
@@ -786,8 +714,8 @@ def build_external_manifest_reference(
             "path": _relative_path(manifest_path, output_base),
             "runId": bundle.get("run_id"),
             "createdAt": created_at,
-            "sha256": _sha256_file(manifest_path),
-            "bytes": manifest_path.stat().st_size,
+            "sha256": manifest_sha256,
+            "bytes": manifest_bytes,
         },
         "snapshotProvenance": snapshot_provenance
         if isinstance(snapshot_provenance, dict)

--- a/merger/lenskit/core/external_manifest_reference.py
+++ b/merger/lenskit/core/external_manifest_reference.py
@@ -299,26 +299,15 @@ def _require_path_inside_root(path: Path, root: Path, label: str) -> None:
 
 def _read_materialization_manifest(
     source_manifest: Path,
-) -> tuple[bytes, dict[str, Any]]:
-    try:
-        manifest_bytes = source_manifest.read_bytes()
-    except FileNotFoundError as exc:
-        raise ExternalManifestReferenceError(
-            f"bundle manifest does not exist: {source_manifest}"
-        ) from exc
-    try:
-        bundle = json.loads(manifest_bytes.decode("utf-8"))
-    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-        raise ExternalManifestReferenceError(
-            f"bundle manifest is not valid UTF-8 JSON: {source_manifest}"
-        ) from exc
-    if not isinstance(bundle, dict):
-        raise ExternalManifestReferenceError("bundle manifest must be a JSON object")
+) -> tuple[dict[str, Any], int, str]:
+    bundle, manifest_bytes, manifest_sha256 = _read_json_object_with_integrity(
+        source_manifest
+    )
     if bundle.get("kind") != BUNDLE_KIND:
         raise ExternalManifestReferenceError(
             "bundle manifest kind must be repolens.bundle.manifest"
         )
-    return manifest_bytes, bundle
+    return bundle, manifest_bytes, manifest_sha256
 
 
 def _declared_materialization_rows(
@@ -612,12 +601,12 @@ def materialize_external_bundle(
     repository = _registry_segment(repository, "repository")
     ref = _registry_segment(ref, "ref")
     source_manifest = Path(bundle_manifest_path).expanduser().resolve()
-    manifest_content, bundle = _read_materialization_manifest(source_manifest)
+    bundle, manifest_bytes, manifest_sha256 = _read_materialization_manifest(
+        source_manifest
+    )
 
     root = Path(publication_root).expanduser().resolve()
     root.mkdir(parents=True, exist_ok=True)
-    manifest_sha256 = hashlib.sha256(manifest_content).hexdigest()
-    manifest_bytes = len(manifest_content)
     localized_dir = root / "external" / "_bundles" / repository / ref / manifest_sha256
     localized_manifest = localized_dir / source_manifest.name
     _require_path_inside_root(localized_dir, root, "localized bundle directory")

--- a/merger/lenskit/core/external_manifest_reference.py
+++ b/merger/lenskit/core/external_manifest_reference.py
@@ -1,9 +1,12 @@
 """External manifest reference surface for RepoBrief/Lenskit consumers."""
+
 from __future__ import annotations
 
 import hashlib
 import json
 import os
+import shutil
+import stat
 import tempfile
 from pathlib import Path
 from typing import Any, Iterable
@@ -30,9 +33,13 @@ def _read_json_object(path: Path) -> dict[str, Any]:
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError as exc:
-        raise ExternalManifestReferenceError(f"bundle manifest does not exist: {path}") from exc
+        raise ExternalManifestReferenceError(
+            f"bundle manifest does not exist: {path}"
+        ) from exc
     except json.JSONDecodeError as exc:
-        raise ExternalManifestReferenceError(f"bundle manifest is not valid JSON: {path}") from exc
+        raise ExternalManifestReferenceError(
+            f"bundle manifest is not valid JSON: {path}"
+        ) from exc
     if not isinstance(data, dict):
         raise ExternalManifestReferenceError("bundle manifest must be a JSON object")
     return data
@@ -43,37 +50,102 @@ def _relative_path(target: Path, base_dir: Path) -> str:
 
 
 def _registry_segment(value: str, label: str) -> str:
-    if not isinstance(value, str) or not value or value.strip() != value or "/" in value or "\\" in value:
-        raise ExternalManifestReferenceError(f"{label} must be a non-empty registry segment")
+    if (
+        not isinstance(value, str)
+        or not value
+        or value.strip() != value
+        or "/" in value
+        or "\\" in value
+    ):
+        raise ExternalManifestReferenceError(
+            f"{label} must be a non-empty registry segment"
+        )
     if value in {".", ".."}:
         raise ExternalManifestReferenceError(f"{label} must not be a traversal segment")
     return value
 
 
-def _sha256_file(path: Path) -> str:
+def _open_regular_file(path: Path, label: str) -> tuple[int, int]:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(path, flags)
+    except OSError as exc:
+        raise ExternalManifestReferenceError(
+            f"{label} must be an existing regular file: {path}"
+        ) from exc
+    metadata = os.fstat(fd)
+    if not stat.S_ISREG(metadata.st_mode):
+        os.close(fd)
+        raise ExternalManifestReferenceError(
+            f"{label} must be an existing regular file: {path}"
+        )
+    return fd, metadata.st_size
+
+
+def _digest_regular_file(path: Path, label: str) -> tuple[int, str]:
+    fd, observed_bytes = _open_regular_file(path, label)
     digest = hashlib.sha256()
-    with path.open("rb") as handle:
+    with os.fdopen(fd, "rb", closefd=True) as handle:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
             digest.update(chunk)
-    return digest.hexdigest()
+    return observed_bytes, digest.hexdigest()
 
 
-def _artifact_rows(bundle_manifest: dict[str, Any]) -> list[dict[str, Any]]:
+def _sha256_file(path: Path) -> str:
+    _, digest = _digest_regular_file(path, "file")
+    return digest
+
+
+def _bundle_member(bundle_dir: Path, raw_path: str, label: str) -> tuple[Path, str]:
+    if not isinstance(raw_path, str) or not raw_path or raw_path.strip() != raw_path:
+        raise ExternalManifestReferenceError(
+            f"{label} must be a non-empty relative path"
+        )
+    relative = Path(raw_path)
+    if (
+        relative.is_absolute()
+        or "\\" in raw_path
+        or any(part in {".", ".."} for part in relative.parts)
+    ):
+        raise ExternalManifestReferenceError(
+            f"{label} must stay inside the bundle directory"
+        )
+    resolved = (bundle_dir / relative).resolve()
+    try:
+        normalized = resolved.relative_to(bundle_dir)
+    except ValueError as exc:
+        raise ExternalManifestReferenceError(
+            f"{label} must stay inside the bundle directory"
+        ) from exc
+    if not resolved.is_file():
+        raise ExternalManifestReferenceError(f"{label} does not exist: {raw_path}")
+    return resolved, normalized.as_posix()
+
+
+def _artifact_rows(
+    bundle_manifest_path: Path,
+    bundle_manifest: dict[str, Any],
+    output_base: Path,
+) -> list[dict[str, Any]]:
     artifacts = bundle_manifest.get("artifacts")
     if not isinstance(artifacts, list):
         raise ExternalManifestReferenceError("bundle manifest artifacts must be a list")
     rows: list[dict[str, Any]] = []
+    bundle_dir = bundle_manifest_path.parent.resolve()
     for artifact in artifacts:
         if not isinstance(artifact, dict):
             continue
         role = artifact.get("role")
-        path = artifact.get("path")
+        raw_path = artifact.get("path")
         sha256 = artifact.get("sha256")
-        if not isinstance(role, str) or not isinstance(path, str):
+        if not isinstance(role, str) or not isinstance(raw_path, str):
             continue
+        artifact_path, _ = _bundle_member(
+            bundle_dir, raw_path, f"bundle artifact {role}"
+        )
         row: dict[str, Any] = {
             "role": role,
-            "path": path,
+            "path": _relative_path(artifact_path, output_base),
             "sha256": sha256 if isinstance(sha256, str) else None,
         }
         if isinstance(artifact.get("bytes"), int):
@@ -84,7 +156,11 @@ def _artifact_rows(bundle_manifest: dict[str, Any]) -> list[dict[str, Any]]:
     return rows
 
 
-def _linked_sidecar_rows(bundle_manifest_path: Path, bundle_manifest: dict[str, Any]) -> list[dict[str, Any]]:
+def _linked_sidecar_rows(
+    bundle_manifest_path: Path,
+    bundle_manifest: dict[str, Any],
+    output_base: Path,
+) -> list[dict[str, Any]]:
     links = bundle_manifest.get("links")
     if not isinstance(links, dict):
         return []
@@ -100,39 +176,554 @@ def _linked_sidecar_rows(bundle_manifest_path: Path, bundle_manifest: dict[str, 
         raw_path = links.get(link_key)
         if not isinstance(raw_path, str) or not raw_path:
             continue
-        linked_path = (bundle_dir / raw_path).resolve()
-        try:
-            linked_path.relative_to(bundle_dir)
-        except ValueError as exc:
-            raise ExternalManifestReferenceError(
-                f"bundle manifest link {link_key} must stay inside the bundle directory"
-            ) from exc
-        if not linked_path.is_file():
-            raise ExternalManifestReferenceError(
-                f"bundle manifest link {link_key} does not exist: {raw_path}"
-            )
-        path_value = Path(raw_path).as_posix()
-        if path_value in seen_paths:
+        linked_path, normalized = _bundle_member(
+            bundle_dir, raw_path, f"bundle manifest link {link_key}"
+        )
+        if normalized in seen_paths:
             continue
-        seen_paths.add(path_value)
-        rows.append({
-            "role": role,
-            "path": path_value,
-            "sha256": _sha256_file(linked_path),
-            "bytes": linked_path.stat().st_size,
-            "contentType": "application/json",
-        })
+        seen_paths.add(normalized)
+        rows.append(
+            {
+                "role": role,
+                "path": _relative_path(linked_path, output_base),
+                "sha256": _sha256_file(linked_path),
+                "bytes": linked_path.stat().st_size,
+                "contentType": "application/json",
+            }
+        )
     return rows
 
 
-def _combined_artifact_rows(bundle_manifest_path: Path, bundle_manifest: dict[str, Any]) -> list[dict[str, Any]]:
+def _combined_artifact_rows(
+    bundle_manifest_path: Path,
+    bundle_manifest: dict[str, Any],
+    output_base: Path,
+) -> list[dict[str, Any]]:
     rows_by_key: dict[tuple[str, str], dict[str, Any]] = {}
-    for row in _artifact_rows(bundle_manifest) + _linked_sidecar_rows(bundle_manifest_path, bundle_manifest):
+    rows = _artifact_rows(bundle_manifest_path, bundle_manifest, output_base)
+    rows += _linked_sidecar_rows(bundle_manifest_path, bundle_manifest, output_base)
+    for row in rows:
         rows_by_key[(row["role"], row["path"])] = row
     return sorted(rows_by_key.values(), key=lambda item: (item["role"], item["path"]))
 
 
-def _require_inside_publication_root(bundle_manifest_path: Path, publication_root: Path | None) -> None:
+def _valid_sha256(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and value == value.lower()
+        and len(value) == 64
+        and all(ch in "0123456789abcdef" for ch in value)
+    )
+
+
+def _verify_file(
+    path: Path, *, expected_sha256: str, expected_bytes: int, label: str
+) -> None:
+    observed_bytes, observed_sha256 = _digest_regular_file(path, label)
+    if observed_bytes != expected_bytes:
+        raise ExternalManifestReferenceError(
+            f"{label} byte count mismatch: expected {expected_bytes}, observed {observed_bytes}"
+        )
+    if observed_sha256 != expected_sha256:
+        raise ExternalManifestReferenceError(
+            f"{label} sha256 mismatch: expected {expected_sha256}, observed {observed_sha256}"
+        )
+
+
+def _copy_verified_file(
+    source: Path,
+    destination: Path,
+    *,
+    expected_sha256: str,
+    expected_bytes: int,
+    label: str,
+) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    source_fd, source_bytes = _open_regular_file(source, label)
+    if source_bytes != expected_bytes:
+        os.close(source_fd)
+        raise ExternalManifestReferenceError(
+            f"{label} byte count mismatch: expected {expected_bytes}, observed {source_bytes}"
+        )
+    tmp_path: Path | None = None
+    digest = hashlib.sha256()
+    observed_bytes = 0
+    try:
+        with (
+            os.fdopen(source_fd, "rb", closefd=True) as source_handle,
+            tempfile.NamedTemporaryFile(
+                mode="wb",
+                delete=False,
+                dir=str(destination.parent),
+                prefix=f".{destination.name}.",
+                suffix=".tmp",
+            ) as tmp_file,
+        ):
+            for chunk in iter(lambda: source_handle.read(1024 * 1024), b""):
+                observed_bytes += len(chunk)
+                digest.update(chunk)
+                tmp_file.write(chunk)
+            tmp_file.flush()
+            os.fsync(tmp_file.fileno())
+            tmp_path = Path(tmp_file.name)
+        observed_sha256 = digest.hexdigest()
+        if observed_bytes != expected_bytes:
+            raise ExternalManifestReferenceError(
+                f"{label} byte count mismatch: expected {expected_bytes}, observed {observed_bytes}"
+            )
+        if observed_sha256 != expected_sha256:
+            raise ExternalManifestReferenceError(
+                f"{label} sha256 mismatch: expected {expected_sha256}, observed {observed_sha256}"
+            )
+        os.replace(tmp_path, destination)
+    finally:
+        if tmp_path is not None and tmp_path.exists():
+            tmp_path.unlink()
+
+
+def _require_path_inside_root(path: Path, root: Path, label: str) -> None:
+    try:
+        path.resolve().relative_to(root.resolve())
+    except ValueError as exc:
+        raise ExternalManifestReferenceError(
+            f"{label} must stay inside publication_root"
+        ) from exc
+
+
+def _read_materialization_manifest(
+    source_manifest: Path,
+) -> tuple[bytes, dict[str, Any]]:
+    try:
+        manifest_bytes = source_manifest.read_bytes()
+    except FileNotFoundError as exc:
+        raise ExternalManifestReferenceError(
+            f"bundle manifest does not exist: {source_manifest}"
+        ) from exc
+    try:
+        bundle = json.loads(manifest_bytes.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ExternalManifestReferenceError(
+            f"bundle manifest is not valid UTF-8 JSON: {source_manifest}"
+        ) from exc
+    if not isinstance(bundle, dict):
+        raise ExternalManifestReferenceError("bundle manifest must be a JSON object")
+    if bundle.get("kind") != BUNDLE_KIND:
+        raise ExternalManifestReferenceError(
+            "bundle manifest kind must be repolens.bundle.manifest"
+        )
+    return manifest_bytes, bundle
+
+
+def _declared_materialization_rows(
+    source_manifest: Path,
+    bundle: dict[str, Any],
+) -> list[dict[str, Any]]:
+    artifacts = bundle.get("artifacts")
+    if not isinstance(artifacts, list):
+        raise ExternalManifestReferenceError("bundle manifest artifacts must be a list")
+    source_dir = source_manifest.parent.resolve()
+    rows: list[dict[str, Any]] = []
+    for index, artifact in enumerate(artifacts):
+        if not isinstance(artifact, dict):
+            raise ExternalManifestReferenceError(
+                f"bundle artifact at index {index} must be a JSON object"
+            )
+        role = artifact.get("role")
+        raw_path = artifact.get("path")
+        expected_sha256 = artifact.get("sha256")
+        expected_bytes = artifact.get("bytes")
+        if not isinstance(role, str) or not role:
+            raise ExternalManifestReferenceError(
+                f"bundle artifact at index {index} must declare a non-empty role"
+            )
+        source_path, normalized = _bundle_member(
+            source_dir,
+            raw_path,
+            f"bundle artifact {role}",
+        )
+        if (
+            not _valid_sha256(expected_sha256)
+            or not isinstance(expected_bytes, int)
+            or expected_bytes < 0
+        ):
+            raise ExternalManifestReferenceError(
+                f"bundle artifact {role} must declare valid sha256 and bytes for materialization"
+            )
+        rows.append(
+            {
+                "role": role,
+                "path": normalized,
+                "source": source_path,
+                "sha256": expected_sha256,
+                "bytes": expected_bytes,
+            }
+        )
+    for row in _linked_sidecar_rows(source_manifest, bundle, source_dir):
+        source_path, normalized = _bundle_member(
+            source_dir,
+            row["path"],
+            f"bundle artifact {row['role']}",
+        )
+        rows.append(
+            {
+                "role": row["role"],
+                "path": normalized,
+                "source": source_path,
+                "sha256": row["sha256"],
+                "bytes": row["bytes"],
+            }
+        )
+    return rows
+
+
+def _materialization_members(
+    source_manifest: Path,
+    bundle: dict[str, Any],
+) -> dict[str, dict[str, Any]]:
+    members: dict[str, dict[str, Any]] = {}
+    for row in _declared_materialization_rows(source_manifest, bundle):
+        normalized = row["path"]
+        previous = members.get(normalized)
+        if previous is not None and (
+            previous["sha256"] != row["sha256"] or previous["bytes"] != row["bytes"]
+        ):
+            raise ExternalManifestReferenceError(
+                f"bundle artifact path has conflicting integrity declarations: {normalized}"
+            )
+        members[normalized] = {
+            "source": row["source"],
+            "sha256": row["sha256"],
+            "bytes": row["bytes"],
+        }
+    if source_manifest.name in members:
+        raise ExternalManifestReferenceError(
+            "bundle artifact path must not collide with the bundle manifest filename"
+        )
+    return members
+
+
+def _require_materialized_directory(localized_dir: Path) -> None:
+    try:
+        metadata = localized_dir.lstat()
+    except OSError as exc:
+        raise ExternalManifestReferenceError(
+            f"localized bundle path must be an existing directory: {localized_dir}"
+        ) from exc
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise ExternalManifestReferenceError(
+            f"localized bundle path must be an existing directory: {localized_dir}"
+        )
+
+
+def _expected_materialized_tree_entries(
+    localized_manifest: Path, members: dict[str, dict[str, Any]]
+) -> tuple[set[str], set[str]]:
+    files = {localized_manifest.name, *members.keys()}
+    directories: set[str] = set()
+    for relative_path in files:
+        parent = Path(relative_path).parent
+        while parent != Path("."):
+            directories.add(parent.as_posix())
+            parent = parent.parent
+    return files, directories
+
+
+def _require_materialized_tree_entry(candidate: Path, *, expected_type: str) -> None:
+    metadata = candidate.lstat()
+    valid = (
+        stat.S_ISDIR(metadata.st_mode)
+        if expected_type == "directory"
+        else stat.S_ISREG(metadata.st_mode)
+    )
+    if not valid:
+        raise ExternalManifestReferenceError(
+            "localized bundle tree must contain only regular files and "
+            f"directories: {candidate}"
+        )
+
+
+def _observed_materialized_tree_entries(
+    localized_dir: Path,
+) -> tuple[set[str], set[str]]:
+    files: set[str] = set()
+    directories: set[str] = set()
+    for current_root, directory_names, file_names in os.walk(
+        localized_dir, topdown=True, followlinks=False
+    ):
+        current = Path(current_root)
+        for name in directory_names:
+            candidate = current / name
+            _require_materialized_tree_entry(candidate, expected_type="directory")
+            directories.add(candidate.relative_to(localized_dir).as_posix())
+        for name in file_names:
+            candidate = current / name
+            _require_materialized_tree_entry(candidate, expected_type="file")
+            files.add(candidate.relative_to(localized_dir).as_posix())
+    return files, directories
+
+
+def _require_exact_materialized_tree_entries(
+    *,
+    expected_files: set[str],
+    expected_directories: set[str],
+    actual_files: set[str],
+    actual_directories: set[str],
+) -> None:
+    if actual_files == expected_files and actual_directories == expected_directories:
+        return
+    missing = sorted(
+        (expected_files - actual_files) | (expected_directories - actual_directories)
+    )
+    unexpected = sorted(
+        (actual_files - expected_files) | (actual_directories - expected_directories)
+    )
+    raise ExternalManifestReferenceError(
+        "localized bundle tree entries mismatch: "
+        f"missing={missing}, unexpected={unexpected}"
+    )
+
+
+def _expected_materialized_entries(
+    localized_manifest: Path,
+    members: dict[str, dict[str, Any]],
+) -> tuple[set[str], set[str]]:
+    expected_files = {localized_manifest.name, *members.keys()}
+    expected_directories: set[str] = set()
+    for relative_path in expected_files:
+        parent = Path(relative_path).parent
+        while parent != Path("."):
+            expected_directories.add(parent.as_posix())
+            parent = parent.parent
+    return expected_files, expected_directories
+
+
+def _observed_materialized_entries(localized_dir: Path) -> tuple[set[str], set[str]]:
+    try:
+        root_metadata = localized_dir.lstat()
+    except OSError as exc:
+        raise ExternalManifestReferenceError(
+            f"localized bundle path must be an existing directory: {localized_dir}"
+        ) from exc
+    if not stat.S_ISDIR(root_metadata.st_mode):
+        raise ExternalManifestReferenceError(
+            f"localized bundle path must be an existing directory: {localized_dir}"
+        )
+
+    actual_files: set[str] = set()
+    actual_directories: set[str] = set()
+    for current_root, directory_names, file_names in os.walk(
+        localized_dir, topdown=True, followlinks=False
+    ):
+        current = Path(current_root)
+        for name in directory_names:
+            candidate = current / name
+            metadata = candidate.lstat()
+            if not stat.S_ISDIR(metadata.st_mode):
+                raise ExternalManifestReferenceError(
+                    "localized bundle tree must contain only regular files and "
+                    f"directories: {candidate}"
+                )
+            actual_directories.add(candidate.relative_to(localized_dir).as_posix())
+        for name in file_names:
+            candidate = current / name
+            metadata = candidate.lstat()
+            if not stat.S_ISREG(metadata.st_mode):
+                raise ExternalManifestReferenceError(
+                    "localized bundle tree must contain only regular files and "
+                    f"directories: {candidate}"
+                )
+            actual_files.add(candidate.relative_to(localized_dir).as_posix())
+    return actual_files, actual_directories
+
+
+def _verify_materialized_tree(
+    localized_dir: Path,
+    localized_manifest: Path,
+    *,
+    manifest_sha256: str,
+    manifest_bytes: int,
+    members: dict[str, dict[str, Any]],
+) -> None:
+    expected_files, expected_directories = _expected_materialized_entries(
+        localized_manifest,
+        members,
+    )
+    actual_files, actual_directories = _observed_materialized_entries(localized_dir)
+    if actual_files != expected_files or actual_directories != expected_directories:
+        missing = sorted(
+            (expected_files - actual_files)
+            | (expected_directories - actual_directories)
+        )
+        unexpected = sorted(
+            (actual_files - expected_files)
+            | (actual_directories - expected_directories)
+        )
+        raise ExternalManifestReferenceError(
+            "localized bundle tree entries mismatch: "
+            f"missing={missing}, unexpected={unexpected}"
+        )
+
+    _verify_file(
+        localized_manifest,
+        expected_sha256=manifest_sha256,
+        expected_bytes=manifest_bytes,
+        label="localized bundle manifest",
+    )
+    for relative_path, member in members.items():
+        _verify_file(
+            localized_dir / relative_path,
+            expected_sha256=member["sha256"],
+            expected_bytes=member["bytes"],
+            label=f"localized bundle artifact {relative_path}",
+        )
+
+
+def _build_materialization_stage(
+    source_manifest: Path,
+    localized_dir: Path,
+    *,
+    publication_root: Path,
+    manifest_sha256: str,
+    manifest_bytes: int,
+    members: dict[str, dict[str, Any]],
+) -> Path:
+    localized_dir.parent.mkdir(parents=True, exist_ok=True)
+    _require_path_inside_root(
+        localized_dir.parent, publication_root, "localized bundle parent"
+    )
+    stage = Path(
+        tempfile.mkdtemp(prefix=f".{manifest_sha256}.", dir=str(localized_dir.parent))
+    )
+    try:
+        for relative_path, member in sorted(members.items()):
+            _copy_verified_file(
+                member["source"],
+                stage / relative_path,
+                expected_sha256=member["sha256"],
+                expected_bytes=member["bytes"],
+                label=f"bundle artifact {relative_path}",
+            )
+        _copy_verified_file(
+            source_manifest,
+            stage / source_manifest.name,
+            expected_sha256=manifest_sha256,
+            expected_bytes=manifest_bytes,
+            label="bundle manifest",
+        )
+    except Exception:
+        shutil.rmtree(stage)
+        raise
+    return stage
+
+
+def _install_materialized_tree(
+    source_manifest: Path,
+    localized_dir: Path,
+    localized_manifest: Path,
+    *,
+    publication_root: Path,
+    manifest_sha256: str,
+    manifest_bytes: int,
+    members: dict[str, dict[str, Any]],
+) -> bool:
+    if localized_dir.exists():
+        if not localized_dir.is_dir():
+            raise ExternalManifestReferenceError(
+                f"localized bundle path is not a directory: {localized_dir}"
+            )
+        _verify_materialized_tree(
+            localized_dir,
+            localized_manifest,
+            manifest_sha256=manifest_sha256,
+            manifest_bytes=manifest_bytes,
+            members=members,
+        )
+        return True
+
+    stage = _build_materialization_stage(
+        source_manifest,
+        localized_dir,
+        publication_root=publication_root,
+        manifest_sha256=manifest_sha256,
+        manifest_bytes=manifest_bytes,
+        members=members,
+    )
+    try:
+        try:
+            os.replace(stage, localized_dir)
+        except OSError:
+            if not localized_dir.is_dir():
+                raise
+            _verify_materialized_tree(
+                localized_dir,
+                localized_manifest,
+                manifest_sha256=manifest_sha256,
+                manifest_bytes=manifest_bytes,
+                members=members,
+            )
+            return True
+        _verify_materialized_tree(
+            localized_dir,
+            localized_manifest,
+            manifest_sha256=manifest_sha256,
+            manifest_bytes=manifest_bytes,
+            members=members,
+        )
+        return False
+    finally:
+        if stage.exists():
+            shutil.rmtree(stage)
+
+
+def materialize_external_bundle(
+    bundle_manifest_path: str | Path,
+    publication_root: str | Path,
+    *,
+    repository: str,
+    ref: str,
+) -> dict[str, Any]:
+    """Copy one verified bundle into a consumer-local content-addressed subtree."""
+    repository = _registry_segment(repository, "repository")
+    ref = _registry_segment(ref, "ref")
+    source_manifest = Path(bundle_manifest_path).expanduser().resolve()
+    manifest_content, bundle = _read_materialization_manifest(source_manifest)
+
+    root = Path(publication_root).expanduser().resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    manifest_sha256 = hashlib.sha256(manifest_content).hexdigest()
+    manifest_bytes = len(manifest_content)
+    localized_dir = root / "external" / "_bundles" / repository / ref / manifest_sha256
+    localized_manifest = localized_dir / source_manifest.name
+    _require_path_inside_root(localized_dir, root, "localized bundle directory")
+
+    members = _materialization_members(source_manifest, bundle)
+    reused = _install_materialized_tree(
+        source_manifest,
+        localized_dir,
+        localized_manifest,
+        publication_root=root,
+        manifest_sha256=manifest_sha256,
+        manifest_bytes=manifest_bytes,
+        members=members,
+    )
+
+    return {
+        "kind": "repobrief.external_bundle_materialization",
+        "version": "1",
+        "sourceBundleManifest": str(source_manifest),
+        "sourceManifestSha256": manifest_sha256,
+        "sourceManifestBytes": manifest_bytes,
+        "localizedRoot": str(localized_dir),
+        "bundleManifest": str(localized_manifest),
+        "artifactCount": len(members),
+        "reused": reused,
+        "doesNotEstablish": list(DOES_NOT_ESTABLISH),
+    }
+
+
+def _require_inside_publication_root(
+    bundle_manifest_path: Path, publication_root: Path | None
+) -> None:
     if publication_root is None:
         return
     root = publication_root.expanduser().resolve()
@@ -156,7 +747,9 @@ def build_external_manifest_reference(
     """Build a bounded external manifest reference from an existing bundle manifest."""
     family = artifact_family.strip().lower() if isinstance(artifact_family, str) else ""
     if family not in SUPPORTED_FAMILIES:
-        raise ExternalManifestReferenceError("artifact_family must be repobrief or lenskit")
+        raise ExternalManifestReferenceError(
+            "artifact_family must be repobrief or lenskit"
+        )
     repository = _registry_segment(repository, "repository")
     ref = _registry_segment(ref, "ref")
     manifest_path = Path(bundle_manifest_path).expanduser().resolve()
@@ -166,11 +759,19 @@ def build_external_manifest_reference(
     )
     bundle = _read_json_object(manifest_path)
     if bundle.get("kind") != BUNDLE_KIND:
-        raise ExternalManifestReferenceError("bundle manifest kind must be repolens.bundle.manifest")
+        raise ExternalManifestReferenceError(
+            "bundle manifest kind must be repolens.bundle.manifest"
+        )
     created_at = bundle.get("created_at")
     if not isinstance(created_at, str) or not created_at:
-        raise ExternalManifestReferenceError("bundle manifest created_at must be present")
-    output_base = Path(output_path).expanduser().resolve().parent if output_path is not None else manifest_path.parent
+        raise ExternalManifestReferenceError(
+            "bundle manifest created_at must be present"
+        )
+    output_base = (
+        Path(output_path).expanduser().resolve().parent
+        if output_path is not None
+        else manifest_path.parent
+    )
     snapshot_provenance = bundle.get("snapshot_provenance")
     return {
         "kind": f"{family}_bundle_manifest",
@@ -185,9 +786,13 @@ def build_external_manifest_reference(
             "path": _relative_path(manifest_path, output_base),
             "runId": bundle.get("run_id"),
             "createdAt": created_at,
+            "sha256": _sha256_file(manifest_path),
+            "bytes": manifest_path.stat().st_size,
         },
-        "snapshotProvenance": snapshot_provenance if isinstance(snapshot_provenance, dict) else None,
-        "artifacts": _combined_artifact_rows(manifest_path, bundle),
+        "snapshotProvenance": snapshot_provenance
+        if isinstance(snapshot_provenance, dict)
+        else None,
+        "artifacts": _combined_artifact_rows(manifest_path, bundle, output_base),
         "doesNotEstablish": list(DOES_NOT_ESTABLISH),
     }
 
@@ -202,10 +807,39 @@ def publication_manifest_path(
     """Return the stable external manifest publication path for a registry segment."""
     family = artifact_family.strip().lower() if isinstance(artifact_family, str) else ""
     if family not in SUPPORTED_FAMILIES:
-        raise ExternalManifestReferenceError("artifact_family must be repobrief or lenskit")
+        raise ExternalManifestReferenceError(
+            "artifact_family must be repobrief or lenskit"
+        )
     repository = _registry_segment(repository, "repository")
     ref = _registry_segment(ref, "ref")
-    return Path(publication_root).expanduser().resolve() / "external" / family / repository / ref / "manifest.json"
+    return (
+        Path(publication_root).expanduser().resolve()
+        / "external"
+        / family
+        / repository
+        / ref
+        / "manifest.json"
+    )
+
+
+def _normalized_artifact_families(
+    artifact_families: Iterable[str] | None,
+) -> list[str]:
+    requested = (
+        sorted(SUPPORTED_FAMILIES) if artifact_families is None else artifact_families
+    )
+    families: list[str] = []
+    for raw_family in requested:
+        family = raw_family.strip().lower() if isinstance(raw_family, str) else ""
+        if family not in SUPPORTED_FAMILIES:
+            raise ExternalManifestReferenceError(
+                "artifact family must be repobrief or lenskit"
+            )
+        if family not in families:
+            families.append(family)
+    if not families:
+        raise ExternalManifestReferenceError("at least one artifact family is required")
+    return families
 
 
 def publish_external_manifest_references(
@@ -216,10 +850,15 @@ def publish_external_manifest_references(
     ref: str,
     artifact_families: Iterable[str] | None = None,
 ) -> dict[str, Any]:
-    """Publish one or more external manifest references under a stable root."""
-    families = list(dict.fromkeys(artifact_families)) if artifact_families is not None else sorted(SUPPORTED_FAMILIES)
-    if not families:
-        raise ExternalManifestReferenceError("at least one artifact family is required")
+    """Publish consumer-local references and a verified content-addressed bundle copy."""
+    families = _normalized_artifact_families(artifact_families)
+    materialization = materialize_external_bundle(
+        bundle_manifest_path,
+        publication_root,
+        repository=repository,
+        ref=ref,
+    )
+    localized_manifest = materialization["bundleManifest"]
     published = []
     for family in families:
         out = publication_manifest_path(
@@ -229,27 +868,33 @@ def publish_external_manifest_references(
             artifact_family=family,
         )
         manifest = write_external_manifest_reference(
-            bundle_manifest_path,
+            localized_manifest,
             out,
             repository=repository,
             ref=ref,
             artifact_family=family,
             publication_root=publication_root,
         )
-        published.append({
-            "artifactFamily": manifest["artifactFamily"],
-            "kind": manifest["kind"],
-            "path": str(out),
-            "generatedAt": manifest["generatedAt"],
-            "relativePublicationPath": Path(os.path.relpath(out, Path(publication_root).expanduser().resolve())).as_posix(),
-        })
+        published.append(
+            {
+                "artifactFamily": manifest["artifactFamily"],
+                "kind": manifest["kind"],
+                "path": str(out),
+                "generatedAt": manifest["generatedAt"],
+                "relativePublicationPath": Path(
+                    os.path.relpath(out, Path(publication_root).expanduser().resolve())
+                ).as_posix(),
+            }
+        )
     return {
         "kind": "repobrief.external_manifest_publication",
         "version": "1",
         "repository": _registry_segment(repository, "repository"),
         "ref": _registry_segment(ref, "ref"),
         "publicationRoot": str(Path(publication_root).expanduser().resolve()),
-        "bundleManifest": str(Path(bundle_manifest_path).expanduser().resolve()),
+        "sourceBundleManifest": str(Path(bundle_manifest_path).expanduser().resolve()),
+        "bundleManifest": localized_manifest,
+        "materialization": materialization,
         "published": published,
         "doesNotEstablish": list(DOES_NOT_ESTABLISH),
     }
@@ -266,6 +911,12 @@ def write_external_manifest_reference(
 ) -> dict[str, Any]:
     """Write an external manifest reference atomically and return it."""
     out = Path(output_path).expanduser().resolve()
+    if publication_root is not None:
+        _require_path_inside_root(
+            out,
+            Path(publication_root).expanduser().resolve(),
+            "external manifest output",
+        )
     data = build_external_manifest_reference(
         bundle_manifest_path,
         repository=repository,

--- a/merger/lenskit/tests/test_external_manifest_reference.py
+++ b/merger/lenskit/tests/test_external_manifest_reference.py
@@ -6,6 +6,9 @@ from pathlib import Path
 
 import pytest
 
+from merger.lenskit.core import (
+    external_manifest_reference as external_manifest_reference_module,
+)
 from merger.lenskit.core.external_manifest_reference import (
     ExternalManifestReferenceError,
     build_external_manifest_reference,
@@ -160,6 +163,34 @@ def test_rejects_non_bundle_manifest(tmp_path: Path) -> None:
     ):
         build_external_manifest_reference(
             path, repository="heimgewebe-katalog", ref="main"
+        )
+
+
+def test_build_rejects_manifest_swapped_to_symlink_after_path_check(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bundle_path = write_bundle(tmp_path)
+    outside = tmp_path / "outside.bundle.manifest.json"
+    outside.write_bytes(bundle_path.read_bytes())
+    original_guard = external_manifest_reference_module._require_inside_publication_root
+
+    def swap_after_guard(path: Path, publication_root: Path | None) -> None:
+        original_guard(path, publication_root)
+        path.unlink()
+        path.symlink_to(outside)
+
+    monkeypatch.setattr(
+        external_manifest_reference_module,
+        "_require_inside_publication_root",
+        swap_after_guard,
+    )
+
+    with pytest.raises(ExternalManifestReferenceError, match="existing regular file"):
+        build_external_manifest_reference(
+            bundle_path,
+            repository="heimgewebe-katalog",
+            ref="main",
+            publication_root=tmp_path,
         )
 
 

--- a/merger/lenskit/tests/test_external_manifest_reference.py
+++ b/merger/lenskit/tests/test_external_manifest_reference.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 
@@ -15,6 +16,14 @@ from merger.lenskit.core.external_manifest_reference import (
 
 
 def write_bundle(tmp_path: Path) -> Path:
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+    canonical_bytes = b"hello world\n"
+    reading_pack_bytes = b"pack\n"
+    (bundle_dir / "heimgewebe_katalog_merge.md").write_bytes(canonical_bytes)
+    (bundle_dir / "heimgewebe_katalog_merge.agent_reading_pack.md").write_bytes(
+        reading_pack_bytes
+    )
     bundle = {
         "kind": "repolens.bundle.manifest",
         "version": "1.0",
@@ -26,15 +35,15 @@ def write_bundle(tmp_path: Path) -> Path:
                 "role": "canonical_md",
                 "path": "heimgewebe_katalog_merge.md",
                 "content_type": "text/markdown",
-                "bytes": 12,
-                "sha256": "b" * 64,
+                "bytes": len(canonical_bytes),
+                "sha256": hashlib.sha256(canonical_bytes).hexdigest(),
             },
             {
                 "role": "agent_reading_pack",
                 "path": "heimgewebe_katalog_merge.agent_reading_pack.md",
                 "content_type": "text/markdown",
-                "bytes": 5,
-                "sha256": "c" * 64,
+                "bytes": len(reading_pack_bytes),
+                "sha256": hashlib.sha256(reading_pack_bytes).hexdigest(),
             },
         ],
         "links": {},
@@ -56,15 +65,21 @@ def write_bundle(tmp_path: Path) -> Path:
             "does_not_establish": ["freshness_against_remote"],
         },
     }
-    path = tmp_path / "bundle" / "heimgewebe_katalog_merge.bundle.manifest.json"
-    path.parent.mkdir(parents=True, exist_ok=True)
+    path = bundle_dir / "heimgewebe_katalog_merge.bundle.manifest.json"
     path.write_text(json.dumps(bundle), encoding="utf-8")
     return path
 
 
 def test_builds_system_catalog_repobrief_manifest_reference(tmp_path: Path) -> None:
     bundle_path = write_bundle(tmp_path)
-    out = tmp_path / "external" / "repobrief" / "heimgewebe-katalog" / "main" / "manifest.json"
+    out = (
+        tmp_path
+        / "external"
+        / "repobrief"
+        / "heimgewebe-katalog"
+        / "main"
+        / "manifest.json"
+    )
 
     result = build_external_manifest_reference(
         bundle_path,
@@ -79,16 +94,29 @@ def test_builds_system_catalog_repobrief_manifest_reference(tmp_path: Path) -> N
     assert result["freshnessBasis"] == "bundle_manifest.created_at"
     assert result["repository"] == "heimgewebe-katalog"
     assert result["ref"] == "main"
-    assert result["bundleManifest"]["path"] == "../../../../bundle/heimgewebe_katalog_merge.bundle.manifest.json"
+    assert (
+        result["bundleManifest"]["path"]
+        == "../../../../bundle/heimgewebe_katalog_merge.bundle.manifest.json"
+    )
     assert result["snapshotProvenance"]["repositories"][0]["git_commit"] == "d" * 40
-    assert [row["role"] for row in result["artifacts"]] == ["agent_reading_pack", "canonical_md"]
+    assert [row["role"] for row in result["artifacts"]] == [
+        "agent_reading_pack",
+        "canonical_md",
+    ]
     assert "claim_truth" in result["doesNotEstablish"]
     assert "dump_generation_permission" in result["doesNotEstablish"]
 
 
 def test_writes_manifest_reference_atomically(tmp_path: Path) -> None:
     bundle_path = write_bundle(tmp_path)
-    out = tmp_path / "external" / "lenskit" / "heimgewebe-katalog" / "main" / "manifest.json"
+    out = (
+        tmp_path
+        / "external"
+        / "lenskit"
+        / "heimgewebe-katalog"
+        / "main"
+        / "manifest.json"
+    )
 
     result = write_external_manifest_reference(
         bundle_path,
@@ -105,9 +133,15 @@ def test_writes_manifest_reference_atomically(tmp_path: Path) -> None:
 
 @pytest.mark.parametrize(
     ("repository", "ref"),
-    [("heimgewebe/heimgewebe-katalog", "main"), ("heimgewebe-katalog", "feature/x"), (" heimgewebe-katalog", "main")],
+    [
+        ("heimgewebe/heimgewebe-katalog", "main"),
+        ("heimgewebe-katalog", "feature/x"),
+        (" heimgewebe-katalog", "main"),
+    ],
 )
-def test_rejects_registry_segments_with_slashes_or_whitespace(tmp_path: Path, repository: str, ref: str) -> None:
+def test_rejects_registry_segments_with_slashes_or_whitespace(
+    tmp_path: Path, repository: str, ref: str
+) -> None:
     bundle_path = write_bundle(tmp_path)
 
     with pytest.raises(ExternalManifestReferenceError):
@@ -116,10 +150,18 @@ def test_rejects_registry_segments_with_slashes_or_whitespace(tmp_path: Path, re
 
 def test_rejects_non_bundle_manifest(tmp_path: Path) -> None:
     path = tmp_path / "manifest.json"
-    path.write_text(json.dumps({"kind": "other", "created_at": "2026-07-06T13:00:00Z"}), encoding="utf-8")
+    path.write_text(
+        json.dumps({"kind": "other", "created_at": "2026-07-06T13:00:00Z"}),
+        encoding="utf-8",
+    )
 
-    with pytest.raises(ExternalManifestReferenceError, match="repolens.bundle.manifest"):
-        build_external_manifest_reference(path, repository="heimgewebe-katalog", ref="main")
+    with pytest.raises(
+        ExternalManifestReferenceError, match="repolens.bundle.manifest"
+    ):
+        build_external_manifest_reference(
+            path, repository="heimgewebe-katalog", ref="main"
+        )
+
 
 def test_publication_manifest_path_uses_stable_external_layout(tmp_path: Path) -> None:
     path = publication_manifest_path(
@@ -129,10 +171,21 @@ def test_publication_manifest_path_uses_stable_external_layout(tmp_path: Path) -
         artifact_family="repobrief",
     )
 
-    assert path == tmp_path / "published" / "external" / "repobrief" / "heimgewebe-katalog" / "main" / "manifest.json"
+    assert (
+        path
+        == tmp_path
+        / "published"
+        / "external"
+        / "repobrief"
+        / "heimgewebe-katalog"
+        / "main"
+        / "manifest.json"
+    )
 
 
-def test_publish_external_manifest_references_can_publish_one_family(tmp_path: Path) -> None:
+def test_publish_external_manifest_references_can_publish_one_family(
+    tmp_path: Path,
+) -> None:
     root = tmp_path / "published"
     bundle_path = write_bundle(root)
 
@@ -145,8 +198,17 @@ def test_publish_external_manifest_references_can_publish_one_family(tmp_path: P
     )
 
     assert [row["artifactFamily"] for row in result["published"]] == ["repobrief"]
-    assert (root / "external" / "repobrief" / "heimgewebe-katalog" / "main" / "manifest.json").is_file()
-    assert not (root / "external" / "lenskit" / "heimgewebe-katalog" / "main" / "manifest.json").exists()
+    assert (
+        root
+        / "external"
+        / "repobrief"
+        / "heimgewebe-katalog"
+        / "main"
+        / "manifest.json"
+    ).is_file()
+    assert not (
+        root / "external" / "lenskit" / "heimgewebe-katalog" / "main" / "manifest.json"
+    ).exists()
 
 
 def test_repobrief_cli_publishes_external_manifest_references(tmp_path: Path) -> None:
@@ -155,28 +217,41 @@ def test_repobrief_cli_publishes_external_manifest_references(tmp_path: Path) ->
     root = tmp_path / "published"
     bundle_path = write_bundle(root)
 
-    rc = repobrief_main([
-        "external-manifest",
-        "publish",
-        "--bundle-manifest",
-        str(bundle_path),
-        "--publication-root",
-        str(root),
-        "--repository",
-        "heimgewebe-katalog",
-        "--ref",
-        "main",
-    ])
+    rc = repobrief_main(
+        [
+            "external-manifest",
+            "publish",
+            "--bundle-manifest",
+            str(bundle_path),
+            "--publication-root",
+            str(root),
+            "--repository",
+            "heimgewebe-katalog",
+            "--ref",
+            "main",
+        ]
+    )
 
     assert rc == 0
-    assert (root / "external" / "repobrief" / "heimgewebe-katalog" / "main" / "manifest.json").is_file()
-    assert (root / "external" / "lenskit" / "heimgewebe-katalog" / "main" / "manifest.json").is_file()
+    assert (
+        root
+        / "external"
+        / "repobrief"
+        / "heimgewebe-katalog"
+        / "main"
+        / "manifest.json"
+    ).is_file()
+    assert (
+        root / "external" / "lenskit" / "heimgewebe-katalog" / "main" / "manifest.json"
+    ).is_file()
 
 
 def test_build_includes_linked_post_emit_health_sidecar(tmp_path: Path) -> None:
     bundle_path = write_bundle(tmp_path)
     sidecar = bundle_path.with_name("heimgewebe_katalog_merge.bundle_health.post.json")
-    sidecar.write_text('{"kind":"lenskit.post_emit_health","status":"pass"}\n', encoding="utf-8")
+    sidecar.write_text(
+        '{"kind":"lenskit.post_emit_health","status":"pass"}\n', encoding="utf-8"
+    )
     bundle = json.loads(bundle_path.read_text(encoding="utf-8"))
     bundle["links"]["post_emit_health_path"] = sidecar.name
     bundle_path.write_text(json.dumps(bundle), encoding="utf-8")
@@ -188,24 +263,55 @@ def test_build_includes_linked_post_emit_health_sidecar(tmp_path: Path) -> None:
         artifact_family="repobrief",
     )
 
-    row = next(artifact for artifact in result["artifacts"] if artifact["role"] == "post_emit_health")
+    row = next(
+        artifact
+        for artifact in result["artifacts"]
+        if artifact["role"] == "post_emit_health"
+    )
     assert row["path"] == "heimgewebe_katalog_merge.bundle_health.post.json"
     assert row["contentType"] == "application/json"
     assert row["bytes"] == sidecar.stat().st_size
     assert len(row["sha256"]) == 64
 
 
-def test_publish_rejects_bundle_manifest_outside_publication_root(tmp_path: Path) -> None:
+def test_publish_materializes_bundle_from_outside_publication_root(
+    tmp_path: Path,
+) -> None:
     bundle_path = write_bundle(tmp_path / "bundle-source")
     root = tmp_path / "published"
 
-    with pytest.raises(ExternalManifestReferenceError, match="inside publication_root"):
-        publish_external_manifest_references(
-            bundle_path,
-            root,
-            repository="heimgewebe-katalog",
-            ref="main",
+    result = publish_external_manifest_references(
+        bundle_path,
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+
+    localized_manifest = Path(result["bundleManifest"])
+    assert localized_manifest.is_file()
+    assert localized_manifest.is_relative_to(root)
+    assert localized_manifest != bundle_path
+    assert (
+        localized_manifest.parent.name
+        == result["materialization"]["sourceManifestSha256"]
+    )
+    for family in ("lenskit", "repobrief"):
+        manifest_path = (
+            root / "external" / family / "heimgewebe-katalog" / "main" / "manifest.json"
         )
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        resolved_bundle = (
+            manifest_path.parent / manifest["bundleManifest"]["path"]
+        ).resolve()
+        assert resolved_bundle == localized_manifest
+        assert (
+            manifest["bundleManifest"]["sha256"]
+            == hashlib.sha256(localized_manifest.read_bytes()).hexdigest()
+        )
+        for artifact in manifest["artifacts"]:
+            resolved_artifact = (manifest_path.parent / artifact["path"]).resolve()
+            assert resolved_artifact.is_relative_to(root)
+            assert resolved_artifact.is_file()
 
 
 def test_linked_sidecar_must_remain_inside_bundle_directory(tmp_path: Path) -> None:
@@ -216,8 +322,12 @@ def test_linked_sidecar_must_remain_inside_bundle_directory(tmp_path: Path) -> N
     bundle["links"]["post_emit_health_path"] = "../outside.bundle_health.post.json"
     bundle_path.write_text(json.dumps(bundle), encoding="utf-8")
 
-    with pytest.raises(ExternalManifestReferenceError, match="inside the bundle directory"):
-        build_external_manifest_reference(bundle_path, repository="heimgewebe-katalog", ref="main")
+    with pytest.raises(
+        ExternalManifestReferenceError, match="inside the bundle directory"
+    ):
+        build_external_manifest_reference(
+            bundle_path, repository="heimgewebe-katalog", ref="main"
+        )
 
 
 def test_external_manifest_refresh_rejects_output_outside_publication_root(
@@ -231,20 +341,22 @@ def test_external_manifest_refresh_rejects_output_outside_publication_root(
     publication_root = tmp_path / "published"
     outside = tmp_path / "legacy-output"
 
-    rc = repobrief_main([
-        "external-manifest",
-        "refresh",
-        "--repo",
-        str(repo),
-        "--out",
-        str(outside),
-        "--publication-root",
-        str(publication_root),
-        "--repository",
-        "source",
-        "--ref",
-        "main",
-    ])
+    rc = repobrief_main(
+        [
+            "external-manifest",
+            "refresh",
+            "--repo",
+            str(repo),
+            "--out",
+            str(outside),
+            "--publication-root",
+            str(publication_root),
+            "--repository",
+            "source",
+            "--ref",
+            "main",
+        ]
+    )
 
     captured = capsys.readouterr()
     assert rc == 2
@@ -263,36 +375,50 @@ def test_external_manifest_refresh_creates_portable_bundle_and_references(
     publication_root = tmp_path / "published"
     out = publication_root / "bundles" / "source" / "main" / "run-1"
 
-    rc = repobrief_main([
-        "external-manifest",
-        "refresh",
-        "--repo",
-        str(repo),
-        "--out",
-        str(out),
-        "--publication-root",
-        str(publication_root),
-        "--repository",
-        "source",
-        "--ref",
-        "main",
-        "--profile",
-        "agent-portable",
-        "--redact-secrets",
-    ])
+    rc = repobrief_main(
+        [
+            "external-manifest",
+            "refresh",
+            "--repo",
+            str(repo),
+            "--out",
+            str(out),
+            "--publication-root",
+            str(publication_root),
+            "--repository",
+            "source",
+            "--ref",
+            "main",
+            "--profile",
+            "agent-portable",
+            "--redact-secrets",
+        ]
+    )
 
     captured = capsys.readouterr()
     result = json.loads(captured.out)
-    bundle_manifest = Path(result["snapshot"]["bundle_manifest"])
+    source_bundle_manifest = Path(result["snapshot"]["bundle_manifest"])
+    localized_bundle_manifest = Path(result["publication"]["bundleManifest"])
     assert rc == 0
-    assert bundle_manifest.is_file()
-    assert bundle_manifest.is_relative_to(publication_root)
+    assert source_bundle_manifest.is_file()
+    assert source_bundle_manifest.is_relative_to(publication_root)
+    assert localized_bundle_manifest.is_file()
+    assert localized_bundle_manifest.is_relative_to(publication_root)
+    assert localized_bundle_manifest != source_bundle_manifest
     for family in ("lenskit", "repobrief"):
-        manifest = publication_root / "external" / family / "source" / "main" / "manifest.json"
+        manifest = (
+            publication_root / "external" / family / "source" / "main" / "manifest.json"
+        )
         assert manifest.is_file()
         published = json.loads(manifest.read_text(encoding="utf-8"))
-        resolved_bundle = (manifest.parent / published["bundleManifest"]["path"]).resolve()
-        assert resolved_bundle == bundle_manifest.resolve()
+        resolved_bundle = (
+            manifest.parent / published["bundleManifest"]["path"]
+        ).resolve()
+        assert resolved_bundle == localized_bundle_manifest.resolve()
+        for artifact in published["artifacts"]:
+            resolved_artifact = (manifest.parent / artifact["path"]).resolve()
+            assert resolved_artifact.is_relative_to(publication_root)
+            assert resolved_artifact.is_file()
 
 
 def test_external_manifest_refresh_rejects_symlink_escape_from_publication_root(
@@ -310,22 +436,294 @@ def test_external_manifest_refresh_rejects_symlink_escape_from_publication_root(
     escaped = publication_root / "bundles"
     escaped.symlink_to(outside, target_is_directory=True)
 
-    rc = repobrief_main([
-        "external-manifest",
-        "refresh",
-        "--repo",
-        str(repo),
-        "--out",
-        str(escaped / "source" / "main" / "run-1"),
-        "--publication-root",
-        str(publication_root),
-        "--repository",
-        "source",
-        "--ref",
-        "main",
-    ])
+    rc = repobrief_main(
+        [
+            "external-manifest",
+            "refresh",
+            "--repo",
+            str(repo),
+            "--out",
+            str(escaped / "source" / "main" / "run-1"),
+            "--publication-root",
+            str(publication_root),
+            "--repository",
+            "source",
+            "--ref",
+            "main",
+        ]
+    )
 
     captured = capsys.readouterr()
     assert rc == 2
     assert "output directory must be inside publication_root" in captured.err
     assert list(outside.iterdir()) == []
+
+
+def test_publish_rejects_tampered_artifact_before_external_manifest_write(
+    tmp_path: Path,
+) -> None:
+    bundle_path = write_bundle(tmp_path / "source")
+    root = tmp_path / "published"
+    (bundle_path.parent / "heimgewebe_katalog_merge.md").write_text(
+        "tampered\n", encoding="utf-8"
+    )
+
+    with pytest.raises(
+        ExternalManifestReferenceError, match=r"(?:byte count|sha256) mismatch"
+    ):
+        publish_external_manifest_references(
+            bundle_path,
+            root,
+            repository="heimgewebe-katalog",
+            ref="main",
+        )
+
+    assert not (
+        root
+        / "external"
+        / "repobrief"
+        / "heimgewebe-katalog"
+        / "main"
+        / "manifest.json"
+    ).exists()
+
+
+def test_publish_rejects_artifact_traversal_before_materialization(
+    tmp_path: Path,
+) -> None:
+    bundle_path = write_bundle(tmp_path / "source")
+    bundle = json.loads(bundle_path.read_text(encoding="utf-8"))
+    bundle["artifacts"][0]["path"] = "../outside.md"
+    bundle_path.write_text(json.dumps(bundle), encoding="utf-8")
+
+    with pytest.raises(
+        ExternalManifestReferenceError, match="inside the bundle directory"
+    ):
+        publish_external_manifest_references(
+            bundle_path,
+            tmp_path / "published",
+            repository="heimgewebe-katalog",
+            ref="main",
+        )
+
+
+def test_publish_rejects_malformed_artifact_row_without_partial_output(
+    tmp_path: Path,
+) -> None:
+    bundle_path = write_bundle(tmp_path / "source")
+    bundle = json.loads(bundle_path.read_text(encoding="utf-8"))
+    bundle["artifacts"].append({"role": "missing-integrity", "path": "missing.md"})
+    bundle_path.write_text(json.dumps(bundle), encoding="utf-8")
+    root = tmp_path / "published"
+
+    with pytest.raises(ExternalManifestReferenceError, match="does not exist"):
+        publish_external_manifest_references(
+            bundle_path,
+            root,
+            repository="heimgewebe-katalog",
+            ref="main",
+        )
+
+    assert not (
+        root
+        / "external"
+        / "repobrief"
+        / "heimgewebe-katalog"
+        / "main"
+        / "manifest.json"
+    ).exists()
+    assert not (
+        root / "external" / "lenskit" / "heimgewebe-katalog" / "main" / "manifest.json"
+    ).exists()
+
+
+def test_publish_prevalidates_all_families_before_materialization(
+    tmp_path: Path,
+) -> None:
+    bundle_path = write_bundle(tmp_path / "source")
+    root = tmp_path / "published"
+
+    with pytest.raises(ExternalManifestReferenceError, match="artifact family"):
+        publish_external_manifest_references(
+            bundle_path,
+            root,
+            repository="heimgewebe-katalog",
+            ref="main",
+            artifact_families=["repobrief", "invalid"],
+        )
+
+    assert not root.exists()
+
+
+def test_publish_normalizes_and_deduplicates_artifact_families(tmp_path: Path) -> None:
+    bundle_path = write_bundle(tmp_path / "source")
+    root = tmp_path / "published"
+
+    result = publish_external_manifest_references(
+        bundle_path,
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+        artifact_families=[" RepoBrief ", "repobrief"],
+    )
+
+    assert [row["artifactFamily"] for row in result["published"]] == ["repobrief"]
+    assert (
+        root
+        / "external"
+        / "repobrief"
+        / "heimgewebe-katalog"
+        / "main"
+        / "manifest.json"
+    ).is_file()
+    assert not (
+        root / "external" / "lenskit" / "heimgewebe-katalog" / "main" / "manifest.json"
+    ).exists()
+
+
+def test_publish_rejects_noncanonical_uppercase_artifact_hash(tmp_path: Path) -> None:
+    bundle_path = write_bundle(tmp_path / "source")
+    bundle = json.loads(bundle_path.read_text(encoding="utf-8"))
+    bundle["artifacts"][0]["sha256"] = bundle["artifacts"][0]["sha256"].upper()
+    bundle_path.write_text(json.dumps(bundle), encoding="utf-8")
+
+    with pytest.raises(ExternalManifestReferenceError, match="valid sha256 and bytes"):
+        publish_external_manifest_references(
+            bundle_path,
+            tmp_path / "published",
+            repository="heimgewebe-katalog",
+            ref="main",
+        )
+
+
+def test_publish_reuses_identical_content_addressed_materialization(
+    tmp_path: Path,
+) -> None:
+    bundle_path = write_bundle(tmp_path / "source")
+    root = tmp_path / "published"
+
+    first = publish_external_manifest_references(
+        bundle_path,
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+    second = publish_external_manifest_references(
+        bundle_path,
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+
+    assert first["bundleManifest"] == second["bundleManifest"]
+    assert first["materialization"]["reused"] is False
+    assert second["materialization"]["reused"] is True
+
+
+def test_publish_rejects_artifact_path_colliding_with_manifest(
+    tmp_path: Path,
+) -> None:
+    bundle_path = write_bundle(tmp_path / "source")
+    bundle = json.loads(bundle_path.read_text(encoding="utf-8"))
+    bundle["artifacts"][0]["path"] = bundle_path.name
+    bundle_path.write_text(json.dumps(bundle), encoding="utf-8")
+
+    with pytest.raises(ExternalManifestReferenceError, match="must not collide"):
+        publish_external_manifest_references(
+            bundle_path,
+            tmp_path / "published",
+            repository="heimgewebe-katalog",
+            ref="main",
+        )
+
+
+def test_publish_rejects_symlinked_member_in_reused_materialization(
+    tmp_path: Path,
+) -> None:
+    bundle_path = write_bundle(tmp_path / "source")
+    root = tmp_path / "published"
+    first = publish_external_manifest_references(
+        bundle_path,
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+    localized_manifest = Path(first["bundleManifest"])
+    localized_artifact = localized_manifest.parent / "heimgewebe_katalog_merge.md"
+    outside = tmp_path / "outside.md"
+    outside.write_bytes(localized_artifact.read_bytes())
+    localized_artifact.unlink()
+    localized_artifact.symlink_to(outside)
+
+    with pytest.raises(ExternalManifestReferenceError, match="regular files"):
+        publish_external_manifest_references(
+            bundle_path,
+            root,
+            repository="heimgewebe-katalog",
+            ref="main",
+        )
+
+
+def test_publish_rejects_unexpected_file_in_reused_materialization(
+    tmp_path: Path,
+) -> None:
+    bundle_path = write_bundle(tmp_path / "source")
+    root = tmp_path / "published"
+    first = publish_external_manifest_references(
+        bundle_path,
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+    localized_manifest = Path(first["bundleManifest"])
+    (localized_manifest.parent / "unexpected.txt").write_text(
+        "unexpected\n", encoding="utf-8"
+    )
+
+    with pytest.raises(ExternalManifestReferenceError, match="tree entries mismatch"):
+        publish_external_manifest_references(
+            bundle_path,
+            root,
+            repository="heimgewebe-katalog",
+            ref="main",
+        )
+
+
+def test_localized_publication_survives_source_bundle_removal(tmp_path: Path) -> None:
+    source_root = tmp_path / "source"
+    bundle_path = write_bundle(source_root)
+    root = tmp_path / "consumer"
+    result = publish_external_manifest_references(
+        bundle_path,
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+        artifact_families=["repobrief"],
+    )
+    source_files = list(bundle_path.parent.iterdir())
+    for path in source_files:
+        path.unlink()
+    bundle_path.parent.rmdir()
+
+    external_manifest_path = (
+        root
+        / "external"
+        / "repobrief"
+        / "heimgewebe-katalog"
+        / "main"
+        / "manifest.json"
+    )
+    external_manifest = json.loads(external_manifest_path.read_text(encoding="utf-8"))
+    localized_manifest = (
+        external_manifest_path.parent / external_manifest["bundleManifest"]["path"]
+    ).resolve()
+    assert localized_manifest == Path(result["bundleManifest"])
+    assert localized_manifest.is_file()
+    for artifact in external_manifest["artifacts"]:
+        resolved_artifact = (external_manifest_path.parent / artifact["path"]).resolve()
+        assert resolved_artifact.is_file()
+        assert resolved_artifact.stat().st_size == artifact["bytes"]
+        assert (
+            hashlib.sha256(resolved_artifact.read_bytes()).hexdigest()
+            == artifact["sha256"]
+        )


### PR DESCRIPTION
Bureau: RBV1-T023

## Problem

Externe RepoBrief-Manifeste konnten auf ein zentral erzeugtes Bundle außerhalb der Consumer-Publikationswurzel zeigen. Strenge Consumer lehnten diesen Pfad zu Recht als `invalid_manifest_path` ab.

## Lösung

- materialisiert Bundle-Manifest, deklarierte Artefakte und unterstützte Sidecars in einem consumerlokalen, inhaltsadressierten Unterbaum;
- prüft beim Kopieren SHA-256 und Bytezahl und schreibt über temporäre Dateien atomar;
- verifiziert wiederverwendete Bäume vollständig und lehnt fehlende, fremde oder symlinkartige Einträge fail-closed ab;
- bindet JSON-Inhalt, SHA-256 und Bytezahl an dieselbe geöffnete reguläre Datei statt an getrennte Pfadbeobachtungen;
- prüft zusätzlich den Austausch eines Manifestpfads gegen einen Symlink nach der Pfadgrenzenprüfung;
- normalisiert und validiert Publikationsfamilien vor dem ersten Schreibvorgang;
- veröffentlicht nur relative Pfade innerhalb der bestehenden Consumer-Grenze;
- lockert keine Consumer-Validierung.

## Exakte Bindung

- Basis: `db2df91a51354cb6972e197afc7456087a43e70b`
- Head: `7421452caa239e73bedde2acfe93a6516612757d`
- vollständiger Binärdiff: SHA-256 `8aaf128720739f43f0013b77868535221a8d68bd7517b11b3b675d2f8b1b8370`, 60125 Bytes

## Belege auf dem exakten Head

- 27 gezielte Tests: PASS
- vollständige lokale Suite: 3970 passed, 1 skipped
- Ruff: PASS
- Graph-Maintainability-Ratchet: PASS; keine neue C901-Verletzung, eine bestehende Verletzung weniger
- `git diff --check`: PASS
- CLI-Dogfood: Quelle veröffentlicht und anschließend gelöscht; lokales Manifest und Artefakt bleiben vorhanden, Manifest-Hash und Bytezahl stimmen mit derselben lokalen Dateiinstanz überein
- GitHub: alle Pflichtchecks erfolgreich, einschließlich `pytest-full`, Browser-Tests, Ruff, Planning-Registration, Verträge und CodeQL
- diff-gebundene Selbstreview: PASS nach Entfernung eines während Parallelarbeit entstandenen toten Hilfsfunktionssatzes und Schließung getrennter Hash-/Größen-Reads

## Reviewherkunft

Claude und Codex konnten wegen ausgeschöpfter Sitzungskontingente keine unabhängige Review ausführen. Das ist ausdrücklich **keine** externe Review. Die Freigabegrundlage ist eine dokumentierte Selbstreview gegen den vollständigen Head-Diff sowie lokale und GitHub-Gates.

## Restrisiken und Nichtaussagen

Der PR etabliert keine Remote-Frische, semantische Wahrheit, Retention oder Garbage Collection alter lokalisierter Bundles, öffentliche Distributionsfreigabe oder über die beobachteten Gates hinausgehende Fehlerfreiheit.

Die stabilen Familienmanifeste werden jeweils atomar geschrieben, aber nicht als gemeinsame Mehrdatei-Transaktion. Ein Prozessabbruch zwischen zwei Familienwrites kann daher vorübergehend unterschiedliche Generationen hinterlassen. Vollständig hostile Multi-User-Dateisystemsicherheit gegen den Austausch übergeordneter Verzeichniskomponenten würde zusätzlich dirfd-/`openat2`-gebundene Operationen erfordern und wird hier nicht behauptet.

Diese Restthemen sind in Bureau PR #582 als `RBV1-T024`, `RBV1-T025` und `RBV1-T026` registriert.
