### PR TITLE
feat(repobrief): publish coherent manifest generations

### DIFF
--- a/docs/proofs/external-publish-v1-proof.md
+++ b/docs/proofs/external-publish-v1-proof.md
@@ -1,6 +1,7 @@
 # RepoBrief External Publish v1 — Proof
 
 Date: 2026-07-06
+Last hardened: 2026-07-14
 
 ## Decision
 
@@ -8,46 +9,125 @@ External manifest publication belongs to RepoBrief/Lenskit, not the Heimgewebe-S
 
 ## Boundary
 
-The new publish command takes an existing Brief Bundle manifest and a caller-chosen publication root. It writes bounded manifest references under this deterministic layout:
+The `publish` command takes an existing Brief Bundle manifest and a caller-chosen publication root. The publication root is explicit. RepoBrief does not decide whether that root is a Git checkout, object-store synchronization directory, web root, or local artifact directory.
+
+The portable bundle copy remains content-addressed below:
+
+```text
+<publication-root>/external/_bundles/<repository>/<ref>/<source-manifest-sha256>/...
+```
+
+## Generation-coherent publication contract
+
+Since the 2026-07-14 RBV1-T024 hardening, one publication creates an immutable generation containing all requested family manifests:
+
+```text
+<publication-root>/external/_generations/<repository>/<ref>/<generation-id>/generation.json
+<publication-root>/external/_generations/<repository>/<ref>/<generation-id>/families/repobrief/manifest.json
+<publication-root>/external/_generations/<repository>/<ref>/<generation-id>/families/lenskit/manifest.json
+```
+
+The generation identifier is a deterministic SHA-256 over the repository, ref, source bundle-manifest SHA-256, and sorted family set. Every authoritative family manifest records the same generation identifier and the same generation timestamp.
+
+A complete generation becomes authoritative only through one atomically replaced pointer:
+
+```text
+<publication-root>/external/_current/<repository>/<ref>/generation.json
+```
+
+The reader rule is deliberately singular:
+
+1. Read the pointer exactly once.
+2. Validate its repository, ref, generation identifier, and canonical descriptor path.
+3. Validate the descriptor bytes and SHA-256.
+4. Validate the source bundle manifest and every declared family manifest by canonical path, byte count, SHA-256, and generation binding.
+5. Reject the publication if any check fails.
+
+Consumers must not independently select the newest family files by timestamp or directory enumeration. That could recreate the mixed-generation problem the pointer contract prevents.
+
+## Compatibility path and migration rule
+
+The historical stable paths remain available for single-family consumers:
 
 ```text
 <publication-root>/external/repobrief/<repository>/<ref>/manifest.json
 <publication-root>/external/lenskit/<repository>/<ref>/manifest.json
 ```
 
-The publication root is explicit. RepoBrief does not decide whether that root is a Git checkout, object store sync directory, web root, or local artifact directory.
+These files are compatibility projections, not the authoritative multi-family commit point. Each projection records:
 
-## Difference from write
+- `publicationGeneration.id`;
+- `publicationGeneration.authoritative: false`;
+- the authoritative generation-manifest path;
+- the atomic pointer path;
+- the selection rule `read_pointer_once_then_verify_complete_generation`.
 
-`write` writes one manifest to one explicit output path.
+Existing consumers can continue reading one stable family path. Consumers that need cross-family coherence must migrate to `read_external_manifest_publication(...)` or implement the documented pointer-verification rule.
 
-`publish` writes one or more manifest families to the stable external layout below a publication root.
+`recover_external_manifest_publication(...)` deterministically rebuilds the stable compatibility projections from the already committed generation. It never chooses a generation by directory order and never promotes an unpointed generation.
 
-## Non-goals
+## Interruption and recovery semantics
 
-The command does not create or refresh a source snapshot, mutate the Heimgewebe-Systemkatalog, import into Bureau, dispatch agents, or claim semantic truth, merge readiness, runtime correctness, or repo understanding.
-
-
-## 2026-07-09 hardening follow-up
-
-External manifest publication is now portable-root strict for the stable `publish` path: the referenced bundle manifest must live inside the explicit publication root. This prevents producer output such as `../../../../../merges/...` from being published into a Git checkout where consumers cannot resolve the bundle.
-
-The external reference also includes linked post-emit sidecars from the bundle manifest `links` surface, specifically `post_emit_health_path` and bundle-surface validation links, without mutating the bundle manifest. These sidecars are intentionally not normal bundle artifacts because they would otherwise create self-hash circularity; the external publication surface may still advertise them as observed companion artifacts with bytes and sha256.
-
-Additional regression coverage:
-
-- `test_publish_rejects_bundle_manifest_outside_publication_root`
-- `test_external_manifest_refresh_rejects_output_outside_publication_root`
-- `test_external_manifest_refresh_creates_portable_bundle_and_references`
-- `test_build_includes_linked_post_emit_health_sidecar`
-- `test_linked_sidecar_must_remain_inside_bundle_directory`
-
-The refresh path now validates containment before generating a snapshot. A caller must place `--out` at or below the explicit publication root; the portable publisher boundary is not weakened to accommodate legacy callers that generated bundles elsewhere.
-
-## Target proof
+Publication is serialized per repository/ref lane with an exclusive advisory `flock` at:
 
 ```text
-python3 -m pytest merger/lenskit/tests/test_external_manifest_reference.py -q
+<publication-root>/external/_locks/<repository>/<ref>/publish.lock
 ```
 
-Expected: publication path helper, core publisher, and CLI publish path pass.
+The write order is:
+
+1. verify and materialize the source bundle;
+2. build all family manifests in a temporary generation directory;
+3. fsync files and directories;
+4. atomically install the immutable generation directory;
+5. atomically replace and read back the one generation pointer;
+6. refresh the non-authoritative compatibility projections.
+
+Consequences:
+
+- Failure before or between family writes cannot change the authoritative pointer.
+- Failure after generation installation but before pointer replacement leaves only an unselected immutable generation.
+- Failure after pointer replacement cannot produce a mixed authoritative generation because the pointer selects one complete descriptor-bound set.
+- Failure while refreshing historical stable paths produces `committed_compatibility_degraded`; authoritative generation reading remains complete, and recovery can rebuild the projections.
+- A visible pointer whose parent-directory fsync failed is reported as `committed_durability_uncertain`; the exact pointer and generation are still read back and verified rather than silently declared durable.
+- Concurrent publishers are serialized. The later lock holder may become the winner only after publishing and verifying its own complete generation.
+
+## Difference from `write`
+
+`write` writes one manifest to one explicit output path. It does not establish a multi-family generation.
+
+`publish` uses the generation protocol above and then maintains the historical stable paths as compatibility projections.
+
+## Portable-root and integrity hardening
+
+The referenced bundle manifest must live inside the explicit publication root after consumer-local materialization. This prevents producer paths such as `../../../../../merges/...` from being advertised where consumers cannot resolve them.
+
+The external reference includes linked post-emit sidecars from the bundle manifest `links` surface, specifically `post_emit_health_path` and bundle-surface validation links, without mutating the bundle manifest. These sidecars are intentionally not normal bundle artifacts because that would create self-hash circularity; the external publication may still advertise them as observed companion artifacts with byte count and SHA-256.
+
+Regular-file reads use no-follow semantics. Reused content-addressed bundles and generation directories reject symlinks, missing entries, unexpected entries, byte mismatches, and SHA-256 mismatches.
+
+## Focused evidence
+
+The focused suite covers, among other cases:
+
+- one committed generation shared by all families;
+- failure between family writes preserving the old authoritative generation;
+- pointer-write failure preserving the old authoritative generation;
+- post-pointer compatibility failure plus deterministic recovery;
+- visible pointer with uncertain directory-fsync durability;
+- tampered family-manifest rejection;
+- symlinked pointer rejection;
+- concurrent publisher serialization;
+- idempotent immutable-generation reuse;
+- portable bundle survival after producer-source removal.
+
+Run:
+
+```text
+python3 -m pytest -q merger/lenskit/tests/test_external_manifest_reference.py merger/lenskit/tests/test_external_manifest_generation.py
+python3 scripts/ci/check_graph_maintainability.py --root . --format json
+```
+
+## Non-goals and non-claims
+
+The publication protocol does not create or refresh a source snapshot, mutate the Heimgewebe-Systemkatalog, import into Bureau, dispatch agents, or establish semantic truth, merge readiness, runtime correctness, repo understanding, distributed consensus, cross-host transactionality, remote freshness, or guarantees beyond the local filesystem and explicit readback evidence.

--- a/merger/lenskit/core/external_manifest_generation.py
+++ b/merger/lenskit/core/external_manifest_generation.py
@@ -1,0 +1,1024 @@
+"""Generation-coherent external RepoBrief/Lenskit publication protocol."""
+
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import os
+import shutil
+import stat
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterable
+
+from .external_manifest_reference import (
+    BUNDLE_KIND,
+    DOES_NOT_ESTABLISH,
+    SUPPORTED_FAMILIES,
+    ExternalManifestReferenceError,
+    _digest_regular_file,
+    _normalized_artifact_families,
+    _open_regular_file,
+    _registry_segment,
+    _relative_path,
+    _require_path_inside_root,
+    build_external_manifest_reference,
+    materialize_external_bundle,
+    publication_manifest_path,
+)
+
+GENERATION_KIND = "repobrief.external_manifest_generation"
+GENERATION_POINTER_KIND = "repobrief.external_manifest_generation_pointer"
+GENERATION_SELECTION_KIND = "repobrief.external_manifest_generation_selection"
+GENERATION_VERSION = "1"
+
+
+def _json_bytes(data: dict[str, Any]) -> bytes:
+    return (json.dumps(data, indent=2, sort_keys=True) + "\n").encode("utf-8")
+
+
+def _read_regular_bytes(path: Path, label: str) -> bytes:
+    fd, _ = _open_regular_file(path, label)
+    chunks: list[bytes] = []
+    with os.fdopen(fd, "rb", closefd=True) as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def _read_json_regular_file(
+    path: Path,
+    label: str,
+) -> tuple[dict[str, Any], int, str]:
+    payload = _read_regular_bytes(path, label)
+    try:
+        parsed = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ExternalManifestReferenceError(
+            f"{label} must be valid UTF-8 JSON"
+        ) from exc
+    if not isinstance(parsed, dict):
+        raise ExternalManifestReferenceError(f"{label} must be a JSON object")
+    return parsed, len(payload), hashlib.sha256(payload).hexdigest()
+
+
+def _fsync_directory(path: Path) -> None:
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    fd = os.open(path, flags)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _atomic_write_json(path: Path, data: dict[str, Any]) -> dict[str, Any]:
+    payload = _json_bytes(data)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path: Path | None = None
+    replaced = False
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            delete=False,
+            dir=str(path.parent),
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+        ) as tmp_file:
+            tmp_file.write(payload)
+            tmp_file.flush()
+            os.fsync(tmp_file.fileno())
+            tmp_path = Path(tmp_file.name)
+        os.replace(tmp_path, path)
+        replaced = True
+        try:
+            _fsync_directory(path.parent)
+        except OSError as exc:
+            try:
+                visible = _read_regular_bytes(path, "replaced JSON file") == payload
+            except ExternalManifestReferenceError:
+                visible = False
+            if visible:
+                return {
+                    "bytes": len(payload),
+                    "sha256": hashlib.sha256(payload).hexdigest(),
+                    "durability": "uncertain_after_directory_fsync",
+                    "error": str(exc),
+                }
+            raise
+    except OSError as exc:
+        phase = "after replace" if replaced else "before replace"
+        raise ExternalManifestReferenceError(
+            f"atomic JSON write failed {phase}: {path}: {exc}"
+        ) from exc
+    finally:
+        if tmp_path is not None and tmp_path.exists():
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
+    return {
+        "bytes": len(payload),
+        "sha256": hashlib.sha256(payload).hexdigest(),
+        "durability": "durable",
+    }
+
+
+def _write_generation_manifest_file(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = _json_bytes(data)
+    try:
+        with path.open("xb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+    except OSError as exc:
+        raise ExternalManifestReferenceError(
+            f"generation manifest write failed: {path}: {exc}"
+        ) from exc
+
+
+def _write_generation_descriptor(path: Path, data: dict[str, Any]) -> None:
+    _write_generation_manifest_file(path, data)
+
+
+def _write_generation_pointer(path: Path, data: dict[str, Any]) -> dict[str, Any]:
+    return _atomic_write_json(path, data)
+
+
+def _write_compatibility_manifest(path: Path, data: dict[str, Any]) -> dict[str, Any]:
+    return _atomic_write_json(path, data)
+
+
+def publication_generation_pointer_path(
+    publication_root: str | Path,
+    *,
+    repository: str,
+    ref: str,
+) -> Path:
+    """Return the one authoritative generation-selection pointer for a lane."""
+    repository = _registry_segment(repository, "repository")
+    ref = _registry_segment(ref, "ref")
+    return (
+        Path(publication_root).expanduser().resolve()
+        / "external"
+        / "_current"
+        / repository
+        / ref
+        / "generation.json"
+    )
+
+
+def _generation_directory(
+    publication_root: Path,
+    repository: str,
+    ref: str,
+    generation_id: str,
+) -> Path:
+    return (
+        publication_root
+        / "external"
+        / "_generations"
+        / repository
+        / ref
+        / generation_id
+    )
+
+
+def _generation_identity(
+    *,
+    repository: str,
+    ref: str,
+    source_manifest_sha256: str,
+    artifact_families: Iterable[str],
+) -> str:
+    seed = {
+        "kind": GENERATION_KIND,
+        "version": GENERATION_VERSION,
+        "repository": repository,
+        "ref": ref,
+        "sourceManifestSha256": source_manifest_sha256,
+        "artifactFamilies": sorted(artifact_families),
+    }
+    compact = json.dumps(seed, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return hashlib.sha256(compact).hexdigest()
+
+
+def _generation_binding(
+    *,
+    generation_id: str,
+    pointer_path: Path,
+    manifest_path: Path,
+    authoritative: bool,
+    authoritative_manifest_path: Path | None = None,
+) -> dict[str, Any]:
+    binding: dict[str, Any] = {
+        "kind": GENERATION_KIND,
+        "version": GENERATION_VERSION,
+        "id": generation_id,
+        "authoritative": authoritative,
+        "pointerPath": _relative_path(pointer_path, manifest_path.parent),
+        "selectionRule": "read_pointer_once_then_verify_complete_generation",
+    }
+    if authoritative_manifest_path is not None:
+        binding["authoritativeManifestPath"] = _relative_path(
+            authoritative_manifest_path,
+            manifest_path.parent,
+        )
+    return binding
+
+
+def _prepare_generation_package(
+    *,
+    localized_manifest: Path,
+    materialization: dict[str, Any],
+    publication_root: Path,
+    repository: str,
+    ref: str,
+    families: list[str],
+) -> dict[str, Any]:
+    generation_id = _generation_identity(
+        repository=repository,
+        ref=ref,
+        source_manifest_sha256=str(materialization["sourceManifestSha256"]),
+        artifact_families=families,
+    )
+    generation_dir = _generation_directory(
+        publication_root,
+        repository,
+        ref,
+        generation_id,
+    )
+    pointer_path = publication_generation_pointer_path(
+        publication_root,
+        repository=repository,
+        ref=ref,
+    )
+    family_rows: list[dict[str, Any]] = []
+    generated_at: str | None = None
+    for family in families:
+        manifest_path = generation_dir / "families" / family / "manifest.json"
+        manifest = build_external_manifest_reference(
+            localized_manifest,
+            repository=repository,
+            ref=ref,
+            artifact_family=family,
+            output_path=manifest_path,
+            publication_root=publication_root,
+        )
+        generated_at = generated_at or str(manifest["generatedAt"])
+        manifest["generatedAt"] = generated_at
+        manifest["publicationGeneration"] = _generation_binding(
+            generation_id=generation_id,
+            pointer_path=pointer_path,
+            manifest_path=manifest_path,
+            authoritative=True,
+        )
+        payload = _json_bytes(manifest)
+        family_rows.append(
+            {
+                "artifactFamily": family,
+                "kind": manifest["kind"],
+                "path": str(manifest_path),
+                "relativePath": _relative_path(manifest_path, generation_dir),
+                "bytes": len(payload),
+                "sha256": hashlib.sha256(payload).hexdigest(),
+                "manifest": manifest,
+            }
+        )
+    descriptor_path = generation_dir / "generation.json"
+    descriptor = {
+        "kind": GENERATION_KIND,
+        "version": GENERATION_VERSION,
+        "generationId": generation_id,
+        "repository": repository,
+        "ref": ref,
+        "generatedAt": generated_at,
+        "complete": True,
+        "artifactFamilies": list(families),
+        "sourceBundleManifest": {
+            "path": _relative_path(localized_manifest, generation_dir),
+            "sha256": materialization["sourceManifestSha256"],
+            "bytes": materialization["sourceManifestBytes"],
+        },
+        "familyManifests": [
+            {
+                "artifactFamily": row["artifactFamily"],
+                "kind": row["kind"],
+                "path": row["relativePath"],
+                "bytes": row["bytes"],
+                "sha256": row["sha256"],
+            }
+            for row in family_rows
+        ],
+        "selectionRule": "only a verified pointer selects this complete generation",
+        "doesNotEstablish": list(DOES_NOT_ESTABLISH),
+    }
+    descriptor_payload = _json_bytes(descriptor)
+    pointer = {
+        "kind": GENERATION_POINTER_KIND,
+        "version": GENERATION_VERSION,
+        "repository": repository,
+        "ref": ref,
+        "generationId": generation_id,
+        "generatedAt": generated_at,
+        "artifactFamilies": list(families),
+        "generationDescriptor": {
+            "path": Path(os.path.relpath(descriptor_path, publication_root)).as_posix(),
+            "bytes": len(descriptor_payload),
+            "sha256": hashlib.sha256(descriptor_payload).hexdigest(),
+        },
+        "selectionRule": "read this file once, then verify the descriptor and every declared family manifest; fail closed on any mismatch",
+        "doesNotEstablish": list(DOES_NOT_ESTABLISH),
+    }
+    return {
+        "generationId": generation_id,
+        "generationDirectory": generation_dir,
+        "descriptorPath": descriptor_path,
+        "descriptor": descriptor,
+        "descriptorPayload": descriptor_payload,
+        "pointerPath": pointer_path,
+        "pointer": pointer,
+        "families": family_rows,
+    }
+
+
+def _regular_generation_files(root: Path) -> dict[str, bytes]:
+    try:
+        root_stat = root.lstat()
+    except OSError as exc:
+        raise ExternalManifestReferenceError(
+            f"generation directory is unavailable: {root}"
+        ) from exc
+    if not stat.S_ISDIR(root_stat.st_mode):
+        raise ExternalManifestReferenceError(
+            f"generation path must be a real directory: {root}"
+        )
+    observed: dict[str, bytes] = {}
+    for current, directories, filenames in os.walk(root, followlinks=False):
+        current_path = Path(current)
+        for name in directories:
+            candidate = current_path / name
+            if not stat.S_ISDIR(candidate.lstat().st_mode):
+                raise ExternalManifestReferenceError(
+                    f"generation tree must not contain linked directories: {candidate}"
+                )
+        for name in filenames:
+            candidate = current_path / name
+            if not stat.S_ISREG(candidate.lstat().st_mode):
+                raise ExternalManifestReferenceError(
+                    f"generation tree must contain only regular files: {candidate}"
+                )
+            observed[candidate.relative_to(root).as_posix()] = _read_regular_bytes(
+                candidate,
+                "generation file",
+            )
+    return observed
+
+
+def _expected_generation_files(package: dict[str, Any]) -> dict[str, bytes]:
+    expected = {"generation.json": package["descriptorPayload"]}
+    for row in package["families"]:
+        expected[str(row["relativePath"])] = _json_bytes(row["manifest"])
+    return expected
+
+
+def _install_generation(package: dict[str, Any]) -> bool:
+    generation_dir = Path(package["generationDirectory"])
+    expected = _expected_generation_files(package)
+    generation_dir.parent.mkdir(parents=True, exist_ok=True)
+    if generation_dir.exists() or generation_dir.is_symlink():
+        observed = _regular_generation_files(generation_dir)
+        if observed != expected:
+            raise ExternalManifestReferenceError(
+                "existing generation directory does not match the expected immutable generation"
+            )
+        return True
+
+    stage = Path(
+        tempfile.mkdtemp(
+            prefix=f".{package['generationId']}.",
+            suffix=".tmp",
+            dir=str(generation_dir.parent),
+        )
+    )
+    try:
+        for row in package["families"]:
+            relative_path = Path(str(row["relativePath"]))
+            _write_generation_manifest_file(stage / relative_path, row["manifest"])
+        _write_generation_descriptor(stage / "generation.json", package["descriptor"])
+        for family in package["families"]:
+            _fsync_directory(stage / "families" / str(family["artifactFamily"]))
+        _fsync_directory(stage / "families")
+        _fsync_directory(stage)
+        os.replace(stage, generation_dir)
+        _fsync_directory(generation_dir.parent)
+    except OSError as exc:
+        raise ExternalManifestReferenceError(
+            f"generation installation failed before pointer commit: {exc}"
+        ) from exc
+    finally:
+        if stage.exists():
+            shutil.rmtree(stage)
+    return False
+
+
+def _resolve_declared_path(
+    *,
+    base: Path,
+    raw_path: Any,
+    publication_root: Path,
+    label: str,
+) -> Path:
+    if not isinstance(raw_path, str) or not raw_path or Path(raw_path).is_absolute():
+        raise ExternalManifestReferenceError(f"{label} path must be relative")
+    candidate = (base / raw_path).resolve()
+    _require_path_inside_root(candidate, publication_root, label)
+    return candidate
+
+
+def _verify_integrity_row(
+    path: Path,
+    row: dict[str, Any],
+    label: str,
+) -> tuple[dict[str, Any], int, str]:
+    expected_sha = row.get("sha256")
+    expected_bytes = row.get("bytes")
+    if (
+        not isinstance(expected_sha, str)
+        or len(expected_sha) != 64
+        or any(char not in "0123456789abcdef" for char in expected_sha)
+        or not isinstance(expected_bytes, int)
+        or isinstance(expected_bytes, bool)
+        or expected_bytes < 0
+    ):
+        raise ExternalManifestReferenceError(f"{label} integrity row is invalid")
+    data, observed_bytes, observed_sha = _read_json_regular_file(path, label)
+    if observed_bytes != expected_bytes or observed_sha != expected_sha:
+        raise ExternalManifestReferenceError(f"{label} integrity mismatch")
+    return data, observed_bytes, observed_sha
+
+
+def _is_sha256(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(char in "0123456789abcdef" for char in value)
+    )
+
+
+def _validated_generation_pointer(
+    pointer: dict[str, Any],
+    *,
+    repository: str,
+    ref: str,
+) -> tuple[str, dict[str, Any]]:
+    if (
+        pointer.get("kind") != GENERATION_POINTER_KIND
+        or pointer.get("version") != GENERATION_VERSION
+        or pointer.get("repository") != repository
+        or pointer.get("ref") != ref
+        or pointer.get("selectionRule")
+        != "read this file once, then verify the descriptor and every declared family manifest; fail closed on any mismatch"
+    ):
+        raise ExternalManifestReferenceError("generation pointer contract mismatch")
+    generation_id = pointer.get("generationId")
+    if not _is_sha256(generation_id):
+        raise ExternalManifestReferenceError("generation pointer id is invalid")
+    descriptor_row = pointer.get("generationDescriptor")
+    if not isinstance(descriptor_row, dict):
+        raise ExternalManifestReferenceError("generation pointer descriptor is invalid")
+    return generation_id, descriptor_row
+
+
+def _read_generation_descriptor(
+    *,
+    root: Path,
+    repository: str,
+    ref: str,
+    generation_id: str,
+    descriptor_row: dict[str, Any],
+) -> tuple[Path, dict[str, Any], int, str]:
+    descriptor_path = _resolve_declared_path(
+        base=root,
+        raw_path=descriptor_row.get("path"),
+        publication_root=root,
+        label="generation descriptor",
+    )
+    expected_path = (
+        _generation_directory(root, repository, ref, generation_id) / "generation.json"
+    )
+    if descriptor_path != expected_path:
+        raise ExternalManifestReferenceError(
+            "generation descriptor path is not canonical"
+        )
+    descriptor, descriptor_bytes, descriptor_sha = _verify_integrity_row(
+        descriptor_path,
+        descriptor_row,
+        "generation descriptor",
+    )
+    return descriptor_path, descriptor, descriptor_bytes, descriptor_sha
+
+
+def _validated_generation_descriptor(
+    descriptor: dict[str, Any],
+    *,
+    repository: str,
+    ref: str,
+    generation_id: str,
+) -> tuple[list[Any], list[str], dict[str, Any]]:
+    if (
+        descriptor.get("kind") != GENERATION_KIND
+        or descriptor.get("version") != GENERATION_VERSION
+        or descriptor.get("generationId") != generation_id
+        or descriptor.get("repository") != repository
+        or descriptor.get("ref") != ref
+        or descriptor.get("complete") is not True
+        or descriptor.get("selectionRule")
+        != "only a verified pointer selects this complete generation"
+    ):
+        raise ExternalManifestReferenceError("generation descriptor contract mismatch")
+    family_rows = descriptor.get("familyManifests")
+    artifact_families = descriptor.get("artifactFamilies")
+    source_row = descriptor.get("sourceBundleManifest")
+    if (
+        not isinstance(family_rows, list)
+        or not family_rows
+        or not isinstance(artifact_families, list)
+        or not isinstance(source_row, dict)
+    ):
+        raise ExternalManifestReferenceError("generation descriptor is incomplete")
+    normalized_families = _normalized_artifact_families(artifact_families)
+    if normalized_families != sorted(normalized_families):
+        raise ExternalManifestReferenceError(
+            "generation artifact families are not canonical"
+        )
+    expected_generation_id = _generation_identity(
+        repository=repository,
+        ref=ref,
+        source_manifest_sha256=str(source_row.get("sha256")),
+        artifact_families=normalized_families,
+    )
+    if expected_generation_id != generation_id:
+        raise ExternalManifestReferenceError("generation identity mismatch")
+    return family_rows, normalized_families, source_row
+
+
+def _verify_generation_source(
+    *,
+    root: Path,
+    descriptor_path: Path,
+    source_row: dict[str, Any],
+) -> Path:
+    source_path = _resolve_declared_path(
+        base=descriptor_path.parent,
+        raw_path=source_row.get("path"),
+        publication_root=root,
+        label="generation source bundle manifest",
+    )
+    source_bytes, source_sha = _digest_regular_file(
+        source_path,
+        "generation source bundle manifest",
+    )
+    if source_bytes != source_row.get("bytes") or source_sha != source_row.get(
+        "sha256"
+    ):
+        raise ExternalManifestReferenceError(
+            "generation source bundle integrity mismatch"
+        )
+    return source_path
+
+
+def _read_generation_family(
+    row: Any,
+    *,
+    root: Path,
+    descriptor_path: Path,
+    pointer_path: Path,
+    generation_id: str,
+    repository: str,
+    ref: str,
+    descriptor_generated_at: Any,
+    source_path: Path,
+    source_row: dict[str, Any],
+    seen_families: set[str],
+) -> dict[str, Any]:
+    if not isinstance(row, dict):
+        raise ExternalManifestReferenceError("generation family row must be an object")
+    family = row.get("artifactFamily")
+    if family not in SUPPORTED_FAMILIES or family in seen_families:
+        raise ExternalManifestReferenceError("generation family row is invalid")
+    family_name = str(family)
+    seen_families.add(family_name)
+    manifest_path = _resolve_declared_path(
+        base=descriptor_path.parent,
+        raw_path=row.get("path"),
+        publication_root=root,
+        label=f"{family_name} generation manifest",
+    )
+    expected_path = descriptor_path.parent / "families" / family_name / "manifest.json"
+    if manifest_path != expected_path:
+        raise ExternalManifestReferenceError(
+            f"{family_name} generation manifest path is not canonical"
+        )
+    manifest, manifest_bytes, manifest_sha = _verify_integrity_row(
+        manifest_path,
+        row,
+        f"{family_name} generation manifest",
+    )
+    binding = manifest.get("publicationGeneration")
+    bundle_row = manifest.get("bundleManifest")
+    expected_pointer_path = _relative_path(pointer_path, manifest_path.parent)
+    expected_bundle_path = _relative_path(source_path, manifest_path.parent)
+    if (
+        row.get("kind") != manifest.get("kind")
+        or manifest.get("kind") != f"{family_name}_bundle_manifest"
+        or manifest.get("version") != "1"
+        or manifest.get("artifactFamily") != family_name
+        or manifest.get("repository") != repository
+        or manifest.get("ref") != ref
+        or manifest.get("generatedAt") != descriptor_generated_at
+        or manifest.get("freshnessBasis") != "bundle_manifest.created_at"
+        or not isinstance(bundle_row, dict)
+        or bundle_row.get("kind") != BUNDLE_KIND
+        or bundle_row.get("path") != expected_bundle_path
+        or bundle_row.get("sha256") != source_row.get("sha256")
+        or bundle_row.get("bytes") != source_row.get("bytes")
+        or bundle_row.get("createdAt") != descriptor_generated_at
+        or not isinstance(binding, dict)
+        or binding.get("kind") != GENERATION_KIND
+        or binding.get("version") != GENERATION_VERSION
+        or binding.get("id") != generation_id
+        or binding.get("authoritative") is not True
+        or binding.get("pointerPath") != expected_pointer_path
+        or binding.get("selectionRule")
+        != "read_pointer_once_then_verify_complete_generation"
+    ):
+        raise ExternalManifestReferenceError(
+            f"{family_name} generation manifest binding mismatch"
+        )
+    return {
+        "artifactFamily": family_name,
+        "kind": manifest.get("kind"),
+        "path": str(manifest_path),
+        "relativePublicationPath": Path(
+            os.path.relpath(manifest_path, root)
+        ).as_posix(),
+        "generatedAt": manifest.get("generatedAt"),
+        "generationId": generation_id,
+        "bytes": manifest_bytes,
+        "sha256": manifest_sha,
+    }
+
+
+def read_external_manifest_publication(
+    publication_root: str | Path,
+    *,
+    repository: str,
+    ref: str,
+) -> dict[str, Any]:
+    """Read one authoritative, complete generation through its atomic pointer."""
+    repository = _registry_segment(repository, "repository")
+    ref = _registry_segment(ref, "ref")
+    root = Path(publication_root).expanduser().resolve()
+    pointer_path = publication_generation_pointer_path(
+        root,
+        repository=repository,
+        ref=ref,
+    )
+    pointer, pointer_bytes, pointer_sha = _read_json_regular_file(
+        pointer_path,
+        "generation pointer",
+    )
+    generation_id, descriptor_row = _validated_generation_pointer(
+        pointer,
+        repository=repository,
+        ref=ref,
+    )
+    descriptor_path, descriptor, descriptor_bytes, descriptor_sha = (
+        _read_generation_descriptor(
+            root=root,
+            repository=repository,
+            ref=ref,
+            generation_id=generation_id,
+            descriptor_row=descriptor_row,
+        )
+    )
+    family_rows, normalized_families, source_row = _validated_generation_descriptor(
+        descriptor,
+        repository=repository,
+        ref=ref,
+        generation_id=generation_id,
+    )
+    pointer_families = pointer.get("artifactFamilies")
+    if not isinstance(pointer_families, list):
+        raise ExternalManifestReferenceError(
+            "generation pointer artifact families are invalid"
+        )
+    normalized_pointer_families = _normalized_artifact_families(pointer_families)
+    if (
+        normalized_pointer_families != sorted(normalized_pointer_families)
+        or normalized_pointer_families != normalized_families
+        or pointer.get("generatedAt") != descriptor.get("generatedAt")
+    ):
+        raise ExternalManifestReferenceError(
+            "generation pointer and descriptor metadata mismatch"
+        )
+    source_path = _verify_generation_source(
+        root=root,
+        descriptor_path=descriptor_path,
+        source_row=source_row,
+    )
+    seen_families: set[str] = set()
+    published = [
+        _read_generation_family(
+            row,
+            root=root,
+            descriptor_path=descriptor_path,
+            pointer_path=pointer_path,
+            generation_id=generation_id,
+            repository=repository,
+            ref=ref,
+            descriptor_generated_at=descriptor.get("generatedAt"),
+            source_path=source_path,
+            source_row=source_row,
+            seen_families=seen_families,
+        )
+        for row in family_rows
+    ]
+    if seen_families != set(normalized_families):
+        raise ExternalManifestReferenceError("generation family set mismatch")
+    return {
+        "kind": GENERATION_SELECTION_KIND,
+        "version": GENERATION_VERSION,
+        "status": "committed",
+        "repository": repository,
+        "ref": ref,
+        "publicationRoot": str(root),
+        "generationId": generation_id,
+        "pointerPath": str(pointer_path),
+        "pointerBytes": pointer_bytes,
+        "pointerSha256": pointer_sha,
+        "descriptorPath": str(descriptor_path),
+        "descriptorBytes": descriptor_bytes,
+        "descriptorSha256": descriptor_sha,
+        "sourceBundleManifest": str(source_path),
+        "published": published,
+        "doesNotEstablish": list(DOES_NOT_ESTABLISH),
+    }
+
+
+@contextmanager
+def _publication_lock(
+    publication_root: Path,
+    repository: str,
+    ref: str,
+):
+    lock_path = (
+        publication_root / "external" / "_locks" / repository / ref / "publish.lock"
+    )
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise ExternalManifestReferenceError(
+            f"publication lock directory cannot be prepared: {lock_path.parent}"
+        ) from exc
+    flags = (
+        os.O_RDWR
+        | os.O_CREAT
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    try:
+        fd = os.open(lock_path, flags, 0o600)
+    except OSError as exc:
+        raise ExternalManifestReferenceError(
+            f"publication lock cannot be opened: {lock_path}"
+        ) from exc
+    try:
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            raise ExternalManifestReferenceError(
+                f"publication lock must be a regular file: {lock_path}"
+            )
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        except OSError as exc:
+            raise ExternalManifestReferenceError(
+                f"publication lock cannot be acquired: {lock_path}: {exc}"
+            ) from exc
+        yield lock_path
+    finally:
+        os.close(fd)
+
+
+def _compatibility_projection(
+    *,
+    selection: dict[str, Any],
+    publication_root: Path,
+    repository: str,
+    ref: str,
+) -> dict[str, Any]:
+    published: list[dict[str, Any]] = []
+    errors: list[dict[str, str]] = []
+    pointer_path = Path(str(selection["pointerPath"]))
+    generation_id = str(selection["generationId"])
+    for row in selection["published"]:
+        family = str(row["artifactFamily"])
+        authoritative_path = Path(str(row["path"]))
+        try:
+            authoritative, _, _ = _read_json_regular_file(
+                authoritative_path,
+                f"{family} authoritative generation manifest",
+            )
+            bundle_row = authoritative.get("bundleManifest")
+            if not isinstance(bundle_row, dict):
+                raise ExternalManifestReferenceError(
+                    f"{family} authoritative manifest has no bundleManifest"
+                )
+            localized_manifest = _resolve_declared_path(
+                base=authoritative_path.parent,
+                raw_path=bundle_row.get("path"),
+                publication_root=publication_root,
+                label=f"{family} localized bundle manifest",
+            )
+            stable_path = publication_manifest_path(
+                publication_root,
+                repository=repository,
+                ref=ref,
+                artifact_family=family,
+            )
+            compatibility = build_external_manifest_reference(
+                localized_manifest,
+                repository=repository,
+                ref=ref,
+                artifact_family=family,
+                output_path=stable_path,
+                publication_root=publication_root,
+            )
+            compatibility["publicationGeneration"] = _generation_binding(
+                generation_id=generation_id,
+                pointer_path=pointer_path,
+                manifest_path=stable_path,
+                authoritative=False,
+                authoritative_manifest_path=authoritative_path,
+            )
+            write_result = _write_compatibility_manifest(
+                stable_path,
+                compatibility,
+            )
+            published.append(
+                {
+                    "artifactFamily": family,
+                    "kind": compatibility["kind"],
+                    "path": str(stable_path),
+                    "generatedAt": compatibility["generatedAt"],
+                    "relativePublicationPath": Path(
+                        os.path.relpath(stable_path, publication_root)
+                    ).as_posix(),
+                    "generationId": generation_id,
+                    "authoritative": False,
+                    "authoritativePath": str(authoritative_path),
+                    "durability": write_result["durability"],
+                }
+            )
+        except (ExternalManifestReferenceError, OSError) as exc:
+            errors.append({"artifactFamily": family, "error": str(exc)})
+    uncertain = [
+        {
+            "artifactFamily": str(row["artifactFamily"]),
+            "durability": str(row["durability"]),
+        }
+        for row in published
+        if row["durability"] != "durable"
+    ]
+    status = "degraded" if errors else "uncertain" if uncertain else "ok"
+    return {
+        "status": status,
+        "published": published,
+        "errors": errors,
+        "uncertain": uncertain,
+        "migrationRule": "legacy stable family paths are compatibility projections; authoritative readers must use the generation pointer",
+    }
+
+
+def recover_external_manifest_publication(
+    publication_root: str | Path,
+    *,
+    repository: str,
+    ref: str,
+) -> dict[str, Any]:
+    """Rebuild legacy stable family projections from the committed generation."""
+    repository = _registry_segment(repository, "repository")
+    ref = _registry_segment(ref, "ref")
+    root = Path(publication_root).expanduser().resolve()
+    with _publication_lock(root, repository, ref):
+        selection = read_external_manifest_publication(
+            root,
+            repository=repository,
+            ref=ref,
+        )
+        compatibility = _compatibility_projection(
+            selection=selection,
+            publication_root=root,
+            repository=repository,
+            ref=ref,
+        )
+    return {
+        "kind": "repobrief.external_manifest_publication_recovery",
+        "version": GENERATION_VERSION,
+        "status": "recovered" if compatibility["status"] == "ok" else "degraded",
+        "generationId": selection["generationId"],
+        "selection": selection,
+        "compatibility": compatibility,
+        "doesNotEstablish": list(DOES_NOT_ESTABLISH),
+    }
+
+
+def publish_external_manifest_references(
+    bundle_manifest_path: str | Path,
+    publication_root: str | Path,
+    *,
+    repository: str,
+    ref: str,
+    artifact_families: Iterable[str] | None = None,
+) -> dict[str, Any]:
+    """Publish one complete generation and then refresh legacy stable projections."""
+    families = sorted(_normalized_artifact_families(artifact_families))
+    repository = _registry_segment(repository, "repository")
+    ref = _registry_segment(ref, "ref")
+    root = Path(publication_root).expanduser().resolve()
+    with _publication_lock(root, repository, ref) as lock_path:
+        materialization = materialize_external_bundle(
+            bundle_manifest_path,
+            root,
+            repository=repository,
+            ref=ref,
+        )
+        localized_manifest = Path(str(materialization["bundleManifest"]))
+        package = _prepare_generation_package(
+            localized_manifest=localized_manifest,
+            materialization=materialization,
+            publication_root=root,
+            repository=repository,
+            ref=ref,
+            families=families,
+        )
+        generation_reused = _install_generation(package)
+        pointer_write = _write_generation_pointer(
+            Path(package["pointerPath"]),
+            package["pointer"],
+        )
+        selection = read_external_manifest_publication(
+            root,
+            repository=repository,
+            ref=ref,
+        )
+        if selection["generationId"] != package["generationId"]:
+            raise ExternalManifestReferenceError(
+                "generation pointer readback selected an unexpected generation"
+            )
+        compatibility = _compatibility_projection(
+            selection=selection,
+            publication_root=root,
+            repository=repository,
+            ref=ref,
+        )
+    if compatibility["status"] != "ok":
+        status = "committed_compatibility_degraded"
+    elif pointer_write["durability"] != "durable":
+        status = "committed_durability_uncertain"
+    else:
+        status = "committed"
+    return {
+        "kind": "repobrief.external_manifest_publication",
+        "version": "1",
+        "publicationProtocolVersion": GENERATION_VERSION,
+        "status": status,
+        "repository": repository,
+        "ref": ref,
+        "publicationRoot": str(root),
+        "sourceBundleManifest": str(Path(bundle_manifest_path).expanduser().resolve()),
+        "bundleManifest": str(localized_manifest),
+        "materialization": materialization,
+        "generation": {
+            "id": package["generationId"],
+            "directory": str(package["generationDirectory"]),
+            "descriptorPath": str(package["descriptorPath"]),
+            "pointerPath": str(package["pointerPath"]),
+            "reused": generation_reused,
+            "pointerDurability": pointer_write["durability"],
+            "selectionRule": "read_pointer_once_then_verify_complete_generation",
+            "serialization": "exclusive_lane_flock",
+            "lockPath": str(lock_path),
+        },
+        "authoritativePublished": selection["published"],
+        "published": compatibility["published"],
+        "compatibility": compatibility,
+        "doesNotEstablish": list(DOES_NOT_ESTABLISH),
+    }

--- a/merger/lenskit/core/external_manifest_reference.py
+++ b/merger/lenskit/core/external_manifest_reference.py
@@ -22,6 +22,9 @@ DOES_NOT_ESTABLISH = (
     "dump_generation_permission",
     "repo_understood",
     "merge_readiness",
+    "distributed_consensus",
+    "cross_host_transactionality",
+    "remote_freshness",
 )
 
 
@@ -714,6 +717,58 @@ def build_external_manifest_reference(
     }
 
 
+def publication_generation_pointer_path(
+    publication_root: str | Path,
+    *,
+    repository: str,
+    ref: str,
+) -> Path:
+    """Return the authoritative generation pointer while preserving the public API."""
+    from .external_manifest_generation import (
+        publication_generation_pointer_path as impl,
+    )
+
+    return impl(
+        publication_root,
+        repository=repository,
+        ref=ref,
+    )
+
+
+def read_external_manifest_publication(
+    publication_root: str | Path,
+    *,
+    repository: str,
+    ref: str,
+) -> dict[str, Any]:
+    """Read one verified committed generation through the public API."""
+    from .external_manifest_generation import read_external_manifest_publication as impl
+
+    return impl(
+        publication_root,
+        repository=repository,
+        ref=ref,
+    )
+
+
+def recover_external_manifest_publication(
+    publication_root: str | Path,
+    *,
+    repository: str,
+    ref: str,
+) -> dict[str, Any]:
+    """Rebuild compatibility projections from the committed generation."""
+    from .external_manifest_generation import (
+        recover_external_manifest_publication as impl,
+    )
+
+    return impl(
+        publication_root,
+        repository=repository,
+        ref=ref,
+    )
+
+
 def publication_manifest_path(
     publication_root: str | Path,
     *,
@@ -767,54 +822,18 @@ def publish_external_manifest_references(
     ref: str,
     artifact_families: Iterable[str] | None = None,
 ) -> dict[str, Any]:
-    """Publish consumer-local references and a verified content-addressed bundle copy."""
-    families = _normalized_artifact_families(artifact_families)
-    materialization = materialize_external_bundle(
+    """Publish one complete generation while preserving the public API."""
+    from .external_manifest_generation import (
+        publish_external_manifest_references as impl,
+    )
+
+    return impl(
         bundle_manifest_path,
         publication_root,
         repository=repository,
         ref=ref,
+        artifact_families=artifact_families,
     )
-    localized_manifest = materialization["bundleManifest"]
-    published = []
-    for family in families:
-        out = publication_manifest_path(
-            publication_root,
-            repository=repository,
-            ref=ref,
-            artifact_family=family,
-        )
-        manifest = write_external_manifest_reference(
-            localized_manifest,
-            out,
-            repository=repository,
-            ref=ref,
-            artifact_family=family,
-            publication_root=publication_root,
-        )
-        published.append(
-            {
-                "artifactFamily": manifest["artifactFamily"],
-                "kind": manifest["kind"],
-                "path": str(out),
-                "generatedAt": manifest["generatedAt"],
-                "relativePublicationPath": Path(
-                    os.path.relpath(out, Path(publication_root).expanduser().resolve())
-                ).as_posix(),
-            }
-        )
-    return {
-        "kind": "repobrief.external_manifest_publication",
-        "version": "1",
-        "repository": _registry_segment(repository, "repository"),
-        "ref": _registry_segment(ref, "ref"),
-        "publicationRoot": str(Path(publication_root).expanduser().resolve()),
-        "sourceBundleManifest": str(Path(bundle_manifest_path).expanduser().resolve()),
-        "bundleManifest": localized_manifest,
-        "materialization": materialization,
-        "published": published,
-        "doesNotEstablish": list(DOES_NOT_ESTABLISH),
-    }
 
 
 def write_external_manifest_reference(

--- a/merger/lenskit/tests/test_external_manifest_generation.py
+++ b/merger/lenskit/tests/test_external_manifest_generation.py
@@ -1,0 +1,815 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from merger.lenskit.core import (
+    external_manifest_generation as external_manifest_generation_module,
+)
+from merger.lenskit.core.external_manifest_reference import (
+    ExternalManifestReferenceError,
+    publication_generation_pointer_path,
+    publish_external_manifest_references,
+    read_external_manifest_publication,
+    recover_external_manifest_publication,
+)
+
+
+def write_bundle(tmp_path: Path) -> Path:
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+    canonical_bytes = b"hello world\n"
+    reading_pack_bytes = b"pack\n"
+    (bundle_dir / "heimgewebe_katalog_merge.md").write_bytes(canonical_bytes)
+    (bundle_dir / "heimgewebe_katalog_merge.agent_reading_pack.md").write_bytes(
+        reading_pack_bytes
+    )
+    bundle = {
+        "kind": "repolens.bundle.manifest",
+        "version": "1.0",
+        "run_id": "run-1",
+        "created_at": "2026-07-06T13:00:00Z",
+        "generator": {"name": "repobrief", "version": "dev", "config_sha256": "a" * 64},
+        "artifacts": [
+            {
+                "role": "canonical_md",
+                "path": "heimgewebe_katalog_merge.md",
+                "content_type": "text/markdown",
+                "bytes": len(canonical_bytes),
+                "sha256": hashlib.sha256(canonical_bytes).hexdigest(),
+            },
+            {
+                "role": "agent_reading_pack",
+                "path": "heimgewebe_katalog_merge.agent_reading_pack.md",
+                "content_type": "text/markdown",
+                "bytes": len(reading_pack_bytes),
+                "sha256": hashlib.sha256(reading_pack_bytes).hexdigest(),
+            },
+        ],
+        "links": {},
+        "capabilities": {},
+        "snapshot_provenance": {
+            "version": "v1",
+            "repositories": [
+                {
+                    "name": "heimgewebe-katalog",
+                    "repo_root": None,
+                    "repo_remote": "git@github.com:heimgewebe/heimgewebe-katalog.git",
+                    "git_commit": "d" * 40,
+                    "git_dirty": False,
+                    "git_branch": "main",
+                    "provenance_status": "present",
+                    "freshness_basis": "git_commit",
+                }
+            ],
+            "does_not_establish": ["freshness_against_remote"],
+        },
+    }
+    path = bundle_dir / "heimgewebe_katalog_merge.bundle.manifest.json"
+    path.write_text(json.dumps(bundle), encoding="utf-8")
+    return path
+
+
+def write_bundle_variant(
+    tmp_path: Path,
+    *,
+    canonical_bytes: bytes,
+    created_at: str,
+    run_id: str,
+) -> Path:
+    path = write_bundle(tmp_path)
+    artifact_path = path.parent / "heimgewebe_katalog_merge.md"
+    artifact_path.write_bytes(canonical_bytes)
+    bundle = json.loads(path.read_text(encoding="utf-8"))
+    bundle["run_id"] = run_id
+    bundle["created_at"] = created_at
+    canonical_row = next(
+        row for row in bundle["artifacts"] if row["role"] == "canonical_md"
+    )
+    canonical_row["bytes"] = len(canonical_bytes)
+    canonical_row["sha256"] = hashlib.sha256(canonical_bytes).hexdigest()
+    path.write_text(json.dumps(bundle), encoding="utf-8")
+    return path
+
+
+def test_publish_commits_one_verified_generation_for_all_families(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "published"
+    bundle_path = write_bundle(tmp_path / "source")
+
+    result = publish_external_manifest_references(
+        bundle_path,
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+    selection = read_external_manifest_publication(
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+
+    generation_id = result["generation"]["id"]
+    assert result["status"] == "committed"
+    assert selection["status"] == "committed"
+    assert selection["generationId"] == generation_id
+    assert Path(selection["pointerPath"]) == publication_generation_pointer_path(
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+    assert {row["artifactFamily"] for row in selection["published"]} == {
+        "lenskit",
+        "repobrief",
+    }
+    assert {row["generationId"] for row in selection["published"]} == {generation_id}
+    descriptor = json.loads(
+        Path(selection["descriptorPath"]).read_text(encoding="utf-8")
+    )
+    assert {row["generatedAt"] for row in selection["published"]} == {
+        descriptor["generatedAt"]
+    }
+    assert {row["generationId"] for row in result["authoritativePublished"]} == {
+        generation_id
+    }
+    for row in result["published"]:
+        compatibility = json.loads(Path(row["path"]).read_text(encoding="utf-8"))
+        binding = compatibility["publicationGeneration"]
+        assert binding["id"] == generation_id
+        assert binding["authoritative"] is False
+        assert binding["selectionRule"] == (
+            "read_pointer_once_then_verify_complete_generation"
+        )
+
+
+def test_publish_failure_between_family_writes_keeps_old_generation_authoritative(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "published"
+    first_bundle = write_bundle_variant(
+        tmp_path / "first",
+        canonical_bytes=b"first generation\n",
+        created_at="2026-07-06T13:00:00Z",
+        run_id="run-first",
+    )
+    first = publish_external_manifest_references(
+        first_bundle,
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+    second_bundle = write_bundle_variant(
+        tmp_path / "second",
+        canonical_bytes=b"second generation\n",
+        created_at="2026-07-06T14:00:00Z",
+        run_id="run-second",
+    )
+
+    original = external_manifest_generation_module._write_generation_manifest_file
+    calls = 0
+
+    def fail_between_family_writes(path: Path, data: dict[str, object]) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise ExternalManifestReferenceError("injected between family writes")
+        original(path, data)
+
+    monkeypatch.setattr(
+        external_manifest_generation_module,
+        "_write_generation_manifest_file",
+        fail_between_family_writes,
+    )
+
+    with pytest.raises(
+        ExternalManifestReferenceError,
+        match="injected between family writes",
+    ):
+        publish_external_manifest_references(
+            second_bundle,
+            root,
+            repository="heimgewebe-katalog",
+            ref="main",
+        )
+
+    selection = read_external_manifest_publication(
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+    assert selection["generationId"] == first["generation"]["id"]
+    assert {row["generationId"] for row in selection["published"]} == {
+        first["generation"]["id"]
+    }
+
+
+def test_publish_pointer_failure_keeps_old_generation_authoritative(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "published"
+    first = publish_external_manifest_references(
+        write_bundle_variant(
+            tmp_path / "first",
+            canonical_bytes=b"first\n",
+            created_at="2026-07-06T13:00:00Z",
+            run_id="run-first",
+        ),
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+
+    def fail_pointer_write(path: Path, data: dict[str, object]) -> dict[str, object]:
+        raise ExternalManifestReferenceError("injected pointer failure")
+
+    monkeypatch.setattr(
+        external_manifest_generation_module,
+        "_write_generation_pointer",
+        fail_pointer_write,
+    )
+    with pytest.raises(
+        ExternalManifestReferenceError, match="injected pointer failure"
+    ):
+        publish_external_manifest_references(
+            write_bundle_variant(
+                tmp_path / "second",
+                canonical_bytes=b"second\n",
+                created_at="2026-07-06T14:00:00Z",
+                run_id="run-second",
+            ),
+            root,
+            repository="heimgewebe-katalog",
+            ref="main",
+        )
+
+    selection = read_external_manifest_publication(
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+    assert selection["generationId"] == first["generation"]["id"]
+
+
+def test_publish_after_pointer_failure_degrades_only_legacy_projection_and_recovers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "published"
+    publish_external_manifest_references(
+        write_bundle_variant(
+            tmp_path / "first",
+            canonical_bytes=b"first\n",
+            created_at="2026-07-06T13:00:00Z",
+            run_id="run-first",
+        ),
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+    second_bundle = write_bundle_variant(
+        tmp_path / "second",
+        canonical_bytes=b"second\n",
+        created_at="2026-07-06T14:00:00Z",
+        run_id="run-second",
+    )
+
+    original = external_manifest_generation_module._write_compatibility_manifest
+    calls = 0
+
+    def fail_second_compatibility(
+        path: Path,
+        data: dict[str, object],
+    ) -> dict[str, object]:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise ExternalManifestReferenceError("injected compatibility failure")
+        return original(path, data)
+
+    monkeypatch.setattr(
+        external_manifest_generation_module,
+        "_write_compatibility_manifest",
+        fail_second_compatibility,
+    )
+    result = publish_external_manifest_references(
+        second_bundle,
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+
+    assert result["status"] == "committed_compatibility_degraded"
+    assert result["compatibility"]["status"] == "degraded"
+    assert len(result["compatibility"]["errors"]) == 1
+    selection = read_external_manifest_publication(
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+    assert selection["generationId"] == result["generation"]["id"]
+    assert {row["generationId"] for row in selection["published"]} == {
+        result["generation"]["id"]
+    }
+
+    monkeypatch.setattr(
+        external_manifest_generation_module,
+        "_write_compatibility_manifest",
+        original,
+    )
+    recovery = recover_external_manifest_publication(
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+    assert recovery["status"] == "recovered"
+    assert recovery["generationId"] == result["generation"]["id"]
+    for row in recovery["compatibility"]["published"]:
+        stable_manifest = json.loads(Path(row["path"]).read_text(encoding="utf-8"))
+        binding = stable_manifest["publicationGeneration"]
+        assert binding["id"] == result["generation"]["id"]
+        assert binding["authoritative"] is False
+
+
+def test_publish_reports_uncertain_pointer_durability_but_readback_is_complete(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "published"
+    bundle_path = write_bundle(tmp_path / "source")
+    original = external_manifest_generation_module._fsync_directory
+
+    def fail_current_pointer_directory(path: Path) -> None:
+        if "_current" in path.parts:
+            raise OSError("injected current-pointer directory fsync failure")
+        original(path)
+
+    monkeypatch.setattr(
+        external_manifest_generation_module,
+        "_fsync_directory",
+        fail_current_pointer_directory,
+    )
+    result = publish_external_manifest_references(
+        bundle_path,
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+
+    assert result["status"] == "committed_durability_uncertain"
+    assert result["generation"]["pointerDurability"] == (
+        "uncertain_after_directory_fsync"
+    )
+    selection = read_external_manifest_publication(
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+    assert selection["generationId"] == result["generation"]["id"]
+    assert {row["generationId"] for row in selection["published"]} == {
+        result["generation"]["id"]
+    }
+
+
+def test_generation_reader_rejects_tampered_family_manifest(tmp_path: Path) -> None:
+    root = tmp_path / "published"
+    result = publish_external_manifest_references(
+        write_bundle(tmp_path / "source"),
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+    family_path = Path(result["authoritativePublished"][0]["path"])
+    manifest = json.loads(family_path.read_text(encoding="utf-8"))
+    manifest["generatedAt"] = "tampered"
+    family_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(ExternalManifestReferenceError, match="integrity mismatch"):
+        read_external_manifest_publication(
+            root,
+            repository="heimgewebe-katalog",
+            ref="main",
+        )
+
+
+def test_generation_reader_rejects_symlinked_pointer(tmp_path: Path) -> None:
+    root = tmp_path / "published"
+    publish_external_manifest_references(
+        write_bundle(tmp_path / "source"),
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+    pointer_path = publication_generation_pointer_path(
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+    outside = tmp_path / "outside-pointer.json"
+    outside.write_bytes(pointer_path.read_bytes())
+    pointer_path.unlink()
+    pointer_path.symlink_to(outside)
+
+    with pytest.raises(
+        ExternalManifestReferenceError,
+        match="existing regular file",
+    ):
+        read_external_manifest_publication(
+            root,
+            repository="heimgewebe-katalog",
+            ref="main",
+        )
+
+
+def test_concurrent_publishers_are_serialized_by_lane_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "published"
+    first_bundle = write_bundle_variant(
+        tmp_path / "first",
+        canonical_bytes=b"first concurrent generation\n",
+        created_at="2026-07-06T13:00:00Z",
+        run_id="run-first",
+    )
+    second_bundle = write_bundle_variant(
+        tmp_path / "second",
+        canonical_bytes=b"second concurrent generation\n",
+        created_at="2026-07-06T14:00:00Z",
+        run_id="run-second",
+    )
+    original = external_manifest_generation_module._write_generation_pointer
+    first_entered = threading.Event()
+    release_first = threading.Event()
+    second_entered = threading.Event()
+    counter_lock = threading.Lock()
+    calls = 0
+
+    def block_first_pointer(
+        path: Path,
+        data: dict[str, object],
+    ) -> dict[str, object]:
+        nonlocal calls
+        with counter_lock:
+            calls += 1
+            call_number = calls
+        if call_number == 1:
+            first_entered.set()
+            assert release_first.wait(timeout=5)
+        else:
+            second_entered.set()
+        return original(path, data)
+
+    monkeypatch.setattr(
+        external_manifest_generation_module,
+        "_write_generation_pointer",
+        block_first_pointer,
+    )
+
+    def publish(path: Path) -> dict[str, object]:
+        return publish_external_manifest_references(
+            path,
+            root,
+            repository="heimgewebe-katalog",
+            ref="main",
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first_future = executor.submit(publish, first_bundle)
+        assert first_entered.wait(timeout=5)
+        second_future = executor.submit(publish, second_bundle)
+        assert second_entered.wait(timeout=0.2) is False
+        release_first.set()
+        first_result = first_future.result(timeout=10)
+        second_result = second_future.result(timeout=10)
+
+    assert first_result["status"] == "committed"
+    assert second_result["status"] == "committed"
+    assert first_result["generation"]["id"] != second_result["generation"]["id"]
+    selection = read_external_manifest_publication(
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+    assert selection["generationId"] == second_result["generation"]["id"]
+    assert {row["generationId"] for row in selection["published"]} == {
+        second_result["generation"]["id"]
+    }
+
+
+def test_republishing_identical_bundle_reuses_immutable_generation(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "published"
+    bundle_path = write_bundle(tmp_path / "source")
+    first = publish_external_manifest_references(
+        bundle_path,
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+    second = publish_external_manifest_references(
+        bundle_path,
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+
+    assert second["generation"]["id"] == first["generation"]["id"]
+    assert first["generation"]["reused"] is False
+    assert second["generation"]["reused"] is True
+
+
+def test_same_bundle_publishers_serialize_before_materialization(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "published"
+    bundle_path = write_bundle(tmp_path / "source")
+    original = external_manifest_generation_module.materialize_external_bundle
+    first_entered = threading.Event()
+    release_first = threading.Event()
+    second_entered = threading.Event()
+    counter_lock = threading.Lock()
+    calls = 0
+
+    def block_first_materialization(
+        *args: object, **kwargs: object
+    ) -> dict[str, object]:
+        nonlocal calls
+        with counter_lock:
+            calls += 1
+            call_number = calls
+        if call_number == 1:
+            first_entered.set()
+            assert release_first.wait(timeout=5)
+        else:
+            second_entered.set()
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(
+        external_manifest_generation_module,
+        "materialize_external_bundle",
+        block_first_materialization,
+    )
+
+    def publish() -> dict[str, object]:
+        return publish_external_manifest_references(
+            bundle_path,
+            root,
+            repository="heimgewebe-katalog",
+            ref="main",
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first_future = executor.submit(publish)
+        assert first_entered.wait(timeout=5)
+        second_future = executor.submit(publish)
+        assert second_entered.wait(timeout=0.2) is False
+        release_first.set()
+        first_result = first_future.result(timeout=10)
+        second_result = second_future.result(timeout=10)
+
+    assert first_result["status"] == "committed"
+    assert second_result["status"] == "committed"
+    assert first_result["generation"]["id"] == second_result["generation"]["id"]
+    assert first_result["materialization"]["reused"] is False
+    assert second_result["materialization"]["reused"] is True
+    assert first_result["generation"]["reused"] is False
+    assert second_result["generation"]["reused"] is True
+
+
+def test_generation_reader_rejects_pointer_descriptor_traversal(tmp_path: Path) -> None:
+    root = tmp_path / "published"
+    publish_external_manifest_references(
+        write_bundle(tmp_path / "source"),
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+    pointer_path = publication_generation_pointer_path(
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+    pointer = json.loads(pointer_path.read_text(encoding="utf-8"))
+    pointer["generationDescriptor"]["path"] = "../../../../outside.json"
+    pointer_path.write_text(json.dumps(pointer), encoding="utf-8")
+
+    with pytest.raises(
+        ExternalManifestReferenceError,
+        match="must stay inside publication_root",
+    ):
+        read_external_manifest_publication(
+            root,
+            repository="heimgewebe-katalog",
+            ref="main",
+        )
+
+
+def test_generation_reader_rejects_pointer_family_metadata_mismatch(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "published"
+    publish_external_manifest_references(
+        write_bundle(tmp_path / "source"),
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+    pointer_path = publication_generation_pointer_path(
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+    pointer = json.loads(pointer_path.read_text(encoding="utf-8"))
+    pointer["artifactFamilies"] = ["repobrief"]
+    pointer_path.write_bytes(external_manifest_generation_module._json_bytes(pointer))
+
+    with pytest.raises(
+        ExternalManifestReferenceError,
+        match="pointer and descriptor metadata mismatch",
+    ):
+        read_external_manifest_publication(
+            root,
+            repository="heimgewebe-katalog",
+            ref="main",
+        )
+
+
+def test_generation_reader_rejects_rehashed_wrong_pointer_binding(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "published"
+    publish_external_manifest_references(
+        write_bundle(tmp_path / "source"),
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+    pointer_path = publication_generation_pointer_path(
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+    pointer = json.loads(pointer_path.read_text(encoding="utf-8"))
+    descriptor_path = root / pointer["generationDescriptor"]["path"]
+    descriptor = json.loads(descriptor_path.read_text(encoding="utf-8"))
+    family_row = descriptor["familyManifests"][0]
+    family_path = descriptor_path.parent / family_row["path"]
+    family_manifest = json.loads(family_path.read_text(encoding="utf-8"))
+    family_manifest["publicationGeneration"]["pointerPath"] = "wrong-pointer.json"
+    family_payload = external_manifest_generation_module._json_bytes(family_manifest)
+    family_path.write_bytes(family_payload)
+    family_row["bytes"] = len(family_payload)
+    family_row["sha256"] = hashlib.sha256(family_payload).hexdigest()
+
+    descriptor_payload = external_manifest_generation_module._json_bytes(descriptor)
+    descriptor_path.write_bytes(descriptor_payload)
+    pointer["generationDescriptor"]["bytes"] = len(descriptor_payload)
+    pointer["generationDescriptor"]["sha256"] = hashlib.sha256(
+        descriptor_payload
+    ).hexdigest()
+    pointer_path.write_bytes(external_manifest_generation_module._json_bytes(pointer))
+
+    with pytest.raises(
+        ExternalManifestReferenceError,
+        match="generation manifest binding mismatch",
+    ):
+        read_external_manifest_publication(
+            root,
+            repository="heimgewebe-katalog",
+            ref="main",
+        )
+
+
+def test_publish_reports_uncertain_compatibility_projection_truthfully(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "published"
+    bundle_path = write_bundle(tmp_path / "source")
+    original = external_manifest_generation_module._write_compatibility_manifest
+    calls = 0
+
+    def report_uncertain_compatibility(
+        path: Path,
+        data: dict[str, object],
+    ) -> dict[str, object]:
+        nonlocal calls
+        calls += 1
+        result = original(path, data)
+        if calls == 1:
+            return {**result, "durability": "uncertain_after_directory_fsync"}
+        return result
+
+    monkeypatch.setattr(
+        external_manifest_generation_module,
+        "_write_compatibility_manifest",
+        report_uncertain_compatibility,
+    )
+    result = publish_external_manifest_references(
+        bundle_path,
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+
+    assert result["status"] == "committed_compatibility_degraded"
+    assert result["compatibility"]["status"] == "uncertain"
+    assert result["compatibility"]["errors"] == []
+    assert result["compatibility"]["uncertain"] == [
+        {
+            "artifactFamily": "lenskit",
+            "durability": "uncertain_after_directory_fsync",
+        }
+    ]
+    selection = read_external_manifest_publication(
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+    assert selection["generationId"] == result["generation"]["id"]
+
+
+def test_generation_reader_rejects_rehashed_selection_rule_change(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "published"
+    publish_external_manifest_references(
+        write_bundle(tmp_path / "source"),
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+    pointer_path = publication_generation_pointer_path(
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+    pointer = json.loads(pointer_path.read_text(encoding="utf-8"))
+    pointer["selectionRule"] = "select newest directory"
+    pointer_path.write_bytes(external_manifest_generation_module._json_bytes(pointer))
+
+    with pytest.raises(
+        ExternalManifestReferenceError,
+        match="generation pointer contract mismatch",
+    ):
+        read_external_manifest_publication(
+            root,
+            repository="heimgewebe-katalog",
+            ref="main",
+        )
+
+
+def test_generation_reader_rejects_rehashed_family_source_mismatch(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "published"
+    publish_external_manifest_references(
+        write_bundle(tmp_path / "source"),
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+    pointer_path = publication_generation_pointer_path(
+        root,
+        repository="heimgewebe-katalog",
+        ref="main",
+    )
+    pointer = json.loads(pointer_path.read_text(encoding="utf-8"))
+    descriptor_path = root / pointer["generationDescriptor"]["path"]
+    descriptor = json.loads(descriptor_path.read_text(encoding="utf-8"))
+    family_row = descriptor["familyManifests"][0]
+    family_path = descriptor_path.parent / family_row["path"]
+    family_manifest = json.loads(family_path.read_text(encoding="utf-8"))
+    family_manifest["bundleManifest"]["sha256"] = "0" * 64
+    family_payload = external_manifest_generation_module._json_bytes(family_manifest)
+    family_path.write_bytes(family_payload)
+    family_row["bytes"] = len(family_payload)
+    family_row["sha256"] = hashlib.sha256(family_payload).hexdigest()
+
+    descriptor_payload = external_manifest_generation_module._json_bytes(descriptor)
+    descriptor_path.write_bytes(descriptor_payload)
+    pointer["generationDescriptor"]["bytes"] = len(descriptor_payload)
+    pointer["generationDescriptor"]["sha256"] = hashlib.sha256(
+        descriptor_payload
+    ).hexdigest()
+    pointer_path.write_bytes(external_manifest_generation_module._json_bytes(pointer))
+
+    with pytest.raises(
+        ExternalManifestReferenceError,
+        match="generation manifest binding mismatch",
+    ):
+        read_external_manifest_publication(
+            root,
+            repository="heimgewebe-katalog",
+            ref="main",
+        )


### PR DESCRIPTION
Bureau: RBV1-T024

## Problem

Die stabilen RepoBrief- und Lenskit-Familienmanifeste wurden bislang einzeln atomar geschrieben. Ein Prozessabbruch zwischen den beiden Writes konnte deshalb vorübergehend unterschiedliche Generationen als scheinbar aktuelle Familienansicht hinterlassen.

## Lösung

- veröffentlicht alle angeforderten Familien in einer unveränderlichen, inhaltsadressierten Generation;
- bindet Familienmanifeste, Deskriptor und Quelle an dieselbe Generations-ID und denselben Generationzeitstempel;
- aktiviert eine Generation ausschließlich über einen atomar ausgetauschten `current`-Zeiger;
- liest den Zeiger genau einmal und prüft danach kanonische Pfade, Bytezahlen, SHA-256, Familienmenge, Auswahlregeln und semantische Quellbindung fail-closed;
- serialisiert konkurrierende Publisher pro Repository/Ref-Lane mit einem exklusiven `flock`, bereits vor der Bundle-Materialisierung;
- erhält die historischen stabilen Einzelpfade als ausdrücklich nicht-autoritative Kompatibilitätsprojektionen;
- bietet eine deterministische Recovery, die diese Projektionen ausschließlich aus der bereits ausgewählten Generation rekonstruiert;
- unterscheidet ehrlich zwischen vollständig dauerhaft, sichtbar aber dauerunsicher sowie autoritativ committed mit degradierter Kompatibilitätsprojektion;
- dokumentiert den Migrationsweg für Verbraucher, die Familien gemeinsam kohärent lesen müssen.

## Exakte Bindung

- Basis: `9203f8928cdaa571cdfd099b10b2414ee7450789`
- Head: `480a4322a1b2d03cdc9a0645d65ceb5a7386d3de`
- lokaler vollständiger Commit-Diff: SHA-256 `73c731c666c8537e781b7d43e90a15d6ab52a6b12c8a84cee649b4bda5af9799`, 79.441 Bytes
- Umfang: 4 Dateien, 2.001 Einfügungen, 63 Löschungen

Exakter GitHub-PR-Patch: SHA-256 `305f92a1f0e9f35be84e4050beef9d602b68a2edb01c78c30de875ea1caa9696`, 80.117 Bytes, 2.158 Zeilen; als dauerhafter `.patch`-Download direkt am PR bereitgestellt.

## Belege auf dem exakten Head

- 43 fokussierte Publikations-, Crash-, Manipulations-, Recovery- und Konkurrenztests: PASS
- vollständige lokale Suite nach Commit: 3986 passed, 1 skipped
- Ruff CI-Konfiguration: PASS
- Ruff-Formatprüfung der vier Dateien: PASS
- Graph-Maintainability-Ratchet: PASS; keine neue C901-Verletzung, eine bestehende Verletzung weniger
- `git diff --check`: PASS
- CLI-Dogfood: reale RepoBrief-Publikation beider Familien unter Generation `45e17f6a123dacca71c9e3618359ebf955b2d14fad29195ce323bcd54c8d2323`; unabhängiger Readback bestätigt exakt eine Generation und einen gemeinsamen Zeitstempel
- Recovery-Dogfood: eine stabile RepoBrief-Kompatibilitätsprojektion wurde gelöscht und deterministisch aus derselben autoritativen Generation wiederhergestellt
- diff-gebundene Selbstreview: PASS nach Schließung der Gleichinhalt-Materialisierungsrace, Vereinheitlichung der Generationsmetadaten und zusätzlicher semantischer Quellbindung

## Geprüfte Abbruch- und Konkurrenzfälle

- Abbruch zwischen Familienwrites lässt den alten Zeiger autoritativ;
- Abbruch beim Zeigerwrite lässt den alten Zeiger autoritativ;
- Fehler nach Zeigercommit degradiert nur die nicht-autoritative Altprojektion;
- sichtbarer Zeiger bei fehlgeschlagenem Verzeichnis-`fsync` wird als dauerunsicher ausgewiesen;
- parallele unterschiedliche und identische Publisher werden lane-weit serialisiert;
- manipulierte, symlinkartige, traversalartige oder intern neu gehashte widersprüchliche Ketten werden abgelehnt.

## Restrisiken und Nichtaussagen

Der PR etabliert keine verteilte Konsensbildung, hostübergreifende Transaktionalität, Remote-Frische, semantische Wahrheit oder Schutz gegen den feindlichen Austausch übergeordneter Verzeichniskomponenten. Der letzte Punkt bleibt ausdrücklich Aufgabe von RBV1-T025 mit dirfd-/`openat2`-gebundenen Pfadoperationen.
