### PR TITLE
fix(repobrief): bind publication to trusted dirfds

### DIFF
--- a/docs/proofs/external-publish-dirfd-v1-proof.md
+++ b/docs/proofs/external-publish-dirfd-v1-proof.md
@@ -1,0 +1,141 @@
+# RepoBrief External Publish — trusted dirfd proof
+
+Date: 2026-07-15
+Task: `RBV1-T025`
+
+## Decision
+
+Security-sensitive RepoBrief external publication no longer relies on a sequence of pathname checks followed by pathname-based writes. Source bundle access and publication access are anchored to already-open directory file descriptors (`dirfd`). Descendant traversal, creation, inspection, locking, replacement, tree verification and cleanup use `openat`-equivalent Python operations with `dir_fd`.
+
+The public RepoBrief API remains unchanged. Successful publication reports:
+
+```json
+{
+  "generation": {
+    "filesystemBinding": "trusted_dirfd_openat"
+  }
+}
+```
+
+## Threat model
+
+In scope:
+
+- an accidental or hostile same-host actor replaces a source or publication parent directory while RepoBrief is operating;
+- a path component is changed into a symbolic link;
+- a regular file is replaced by a symbolic link or special file;
+- publication-root, lane, generation, pointer or compatibility parents are renamed concurrently;
+- a source file or source parent changes identity while it is being copied;
+- a concurrent operation creates an already expected content-addressed destination;
+- an interrupted write leaves a temporary file or unselected generation.
+
+The implementation must not escape the intended source/publication trees, must not write into a replacement path, and must not report success when the visible path no longer identifies the directory used for the operation.
+
+## Supported platform contract
+
+The hardened path requires a POSIX platform exposing all of these primitives through Python:
+
+- directory-relative `open`, `mkdir`, `rename`, `stat`, `unlink` and `rmdir`;
+- `O_DIRECTORY`;
+- `O_NOFOLLOW`;
+- advisory `flock` for the publication lane.
+
+Every absolute directory is opened component by component from `/`. Every component is opened with `O_DIRECTORY | O_NOFOLLOW`. Missing components may be created only through their already-open parent directory and are then reopened with the same no-follow flags.
+
+A platform without these primitives fails closed with `RootedFilesystemError`. There is no silent fallback to weaker pathname operations.
+
+## Identity binding
+
+A `DirectoryBinding` records the device and inode of an open root directory. Descendant operations select the longest matching active binding and traverse from a duplicated root descriptor.
+
+After security-sensitive reads or writes, RepoBrief reopens the visible path without following links and compares device/inode identity with the descriptor used for the operation. A mismatch is a hard error even when bytes were safely written into the old, renamed directory. This prevents a hidden anchored write from being misreported as a visible successful publication.
+
+Regular-file reads and copies similarly reopen the visible file path and compare identity before a copy is committed.
+
+## Write and replacement protocol
+
+Atomic file replacement:
+
+1. open the target parent directory through the trusted binding;
+2. create a random temporary regular file with `O_EXCL | O_NOFOLLOW` relative to that descriptor;
+3. write and `fsync` the temporary file;
+4. rename it to the target name with source and destination `dir_fd`;
+5. `fsync` the parent directory;
+6. verify that the visible parent path still identifies that descriptor.
+
+Generation and bundle directories are built as temporary directory trees below an anchored parent and committed by directory-relative rename. Reused content-addressed trees are enumerated through directory descriptors and reject symbolic links, special files, missing entries, unexpected entries and byte/hash mismatches.
+
+The publication lock is opened through its anchored parent, must be a regular file, and verifies the parent identity both before and after the critical section.
+
+## Reader protocol
+
+The authoritative generation reader binds the publication root before reading the pointer. Pointer, descriptor, source bundle and family manifests are opened without following links. The existing generation integrity contract remains in force: canonical paths, byte counts, SHA-256 values, family set, source binding and shared generation identity must all match.
+
+After readback, the publication-root identity is checked again. A root rename during the read therefore fails instead of returning a selection from a no-longer-visible tree.
+
+## Compatibility
+
+The public functions and historical stable family paths remain available. Compatibility projections are still non-authoritative; only the verified generation pointer selects a cross-family state.
+
+Consumers do not need a new CLI flag. Unsupported hosts receive a fail-closed error rather than silently weaker publication.
+
+## Focused adversarial evidence
+
+The focused suites cover:
+
+- symlinked publication-root components;
+- symlinked files and linked/special tree entries;
+- publication-root replacement before pointer commit;
+- source-parent replacement during materialization;
+- pointer-parent replacement during atomic pointer write;
+- root replacement during authoritative readback;
+- parent replacement during a low-level atomic write;
+- lock-parent replacement while holding the lock;
+- unsupported-platform failure before publication;
+- ordinary publication, readback, recovery, crash and concurrent-publisher behavior from the generation protocol;
+- source-file identity replacement after copying but before destination commit.
+
+Run:
+
+```text
+python3 -m pytest -q \
+  merger/lenskit/tests/test_external_manifest_reference.py \
+  merger/lenskit/tests/test_external_manifest_generation.py \
+  merger/lenskit/tests/test_rooted_filesystem.py \
+  merger/lenskit/tests/test_external_manifest_dirfd.py
+
+python3 scripts/ci/check_graph_maintainability.py --root . --format json
+```
+
+Current focused result on the final implementation: `60 passed`.
+
+Complete Lenskit suite on the final pre-commit tree: `4003 passed, 1 skipped`.
+
+## CLI dogfood evidence
+
+A real `repobrief external-manifest refresh` run created an agent-portable snapshot of a temporary Git repository and published both families below one bound publication root.
+
+Observed:
+
+- publication status: `committed`;
+- generation: `dac4de5d36518fe81cf8c27f8828370032eec020627e07f11fe3995877a8b18b`;
+- filesystem binding: `trusted_dirfd_openat`;
+- pointer durability: `durable`;
+- compatibility status: `ok`;
+- independent authoritative readback selected the same generation and both `lenskit` and `repobrief` families;
+- pointer SHA-256: `8d434e0b1a902d4a9bdf1d5835607ff1c1febe6c007f41671d160005f66149cc`;
+- descriptor SHA-256: `48e2937624a2d7ef0c717fe187c56564040e37448b88e7a26cff22c0247febd1`;
+- 200 low-level write/read/lock cycles changed the open-file-descriptor count by `0`.
+
+## Non-claims
+
+This change does not establish:
+
+- resistance to kernel bugs;
+- equivalence of network or distributed filesystems to the tested local filesystem semantics;
+- a privilege boundary against a more privileged process;
+- security on untested platforms;
+- distributed consensus or cross-host transactionality;
+- remote freshness or semantic truth.
+
+The implementation is a local-filesystem identity and integrity protocol. It is not a sandbox, mandatory access-control system, distributed lock or remote attestation mechanism.

--- a/merger/lenskit/core/external_manifest_generation.py
+++ b/merger/lenskit/core/external_manifest_generation.py
@@ -2,16 +2,29 @@
 
 from __future__ import annotations
 
-import fcntl
 import hashlib
 import json
 import os
-import shutil
-import stat
-import tempfile
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Iterable
+
+from .rooted_filesystem import (
+    RootedFilesystemError,
+    atomic_write_bytes,
+    bind_directory,
+    exclusive_file_lock,
+    exclusive_write_bytes,
+    fsync_directory,
+    make_directories,
+    make_temporary_directory,
+    path_exists,
+    read_regular_bytes,
+    read_tree,
+    remove_tree,
+    rename_path,
+    secure_absolute,
+)
 
 from .external_manifest_reference import (
     BUNDLE_KIND,
@@ -20,7 +33,6 @@ from .external_manifest_reference import (
     ExternalManifestReferenceError,
     _digest_regular_file,
     _normalized_artifact_families,
-    _open_regular_file,
     _registry_segment,
     _relative_path,
     _require_path_inside_root,
@@ -40,12 +52,12 @@ def _json_bytes(data: dict[str, Any]) -> bytes:
 
 
 def _read_regular_bytes(path: Path, label: str) -> bytes:
-    fd, _ = _open_regular_file(path, label)
-    chunks: list[bytes] = []
-    with os.fdopen(fd, "rb", closefd=True) as handle:
-        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-            chunks.append(chunk)
-    return b"".join(chunks)
+    try:
+        return read_regular_bytes(path)
+    except RootedFilesystemError as exc:
+        raise ExternalManifestReferenceError(
+            f"{label} must be an existing regular file with stable identity: {path}"
+        ) from exc
 
 
 def _read_json_regular_file(
@@ -65,82 +77,41 @@ def _read_json_regular_file(
 
 
 def _fsync_directory(path: Path) -> None:
-    flags = (
-        os.O_RDONLY
-        | getattr(os, "O_CLOEXEC", 0)
-        | getattr(os, "O_DIRECTORY", 0)
-        | getattr(os, "O_NOFOLLOW", 0)
-    )
-    fd = os.open(path, flags)
     try:
-        os.fsync(fd)
-    finally:
-        os.close(fd)
+        fsync_directory(path)
+    except RootedFilesystemError as exc:
+        raise OSError(str(exc)) from exc
 
 
 def _atomic_write_json(path: Path, data: dict[str, Any]) -> dict[str, Any]:
     payload = _json_bytes(data)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path: Path | None = None
-    replaced = False
     try:
-        with tempfile.NamedTemporaryFile(
-            mode="wb",
-            delete=False,
-            dir=str(path.parent),
-            prefix=f".{path.name}.",
-            suffix=".tmp",
-        ) as tmp_file:
-            tmp_file.write(payload)
-            tmp_file.flush()
-            os.fsync(tmp_file.fileno())
-            tmp_path = Path(tmp_file.name)
-        os.replace(tmp_path, path)
-        replaced = True
-        try:
-            _fsync_directory(path.parent)
-        except OSError as exc:
+        result = atomic_write_bytes(path, payload)
+        if result["durability"] == "durable":
             try:
-                visible = _read_regular_bytes(path, "replaced JSON file") == payload
-            except ExternalManifestReferenceError:
-                visible = False
-            if visible:
-                return {
-                    "bytes": len(payload),
-                    "sha256": hashlib.sha256(payload).hexdigest(),
-                    "durability": "uncertain_after_directory_fsync",
-                    "error": str(exc),
-                }
-            raise
-    except OSError as exc:
-        phase = "after replace" if replaced else "before replace"
+                _fsync_directory(path.parent)
+            except OSError as exc:
+                if _read_regular_bytes(path, "replaced JSON file") == payload:
+                    return {
+                        "bytes": len(payload),
+                        "sha256": hashlib.sha256(payload).hexdigest(),
+                        "durability": "uncertain_after_directory_fsync",
+                        "error": str(exc),
+                    }
+                raise
+        return result
+    except RootedFilesystemError as exc:
         raise ExternalManifestReferenceError(
-            f"atomic JSON write failed {phase}: {path}: {exc}"
+            f"atomic JSON write failed through trusted descriptors: {path}: {exc}"
         ) from exc
-    finally:
-        if tmp_path is not None and tmp_path.exists():
-            try:
-                tmp_path.unlink()
-            except OSError:
-                pass
-    return {
-        "bytes": len(payload),
-        "sha256": hashlib.sha256(payload).hexdigest(),
-        "durability": "durable",
-    }
 
 
 def _write_generation_manifest_file(path: Path, data: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    payload = _json_bytes(data)
     try:
-        with path.open("xb") as handle:
-            handle.write(payload)
-            handle.flush()
-            os.fsync(handle.fileno())
-    except OSError as exc:
+        exclusive_write_bytes(path, _json_bytes(data))
+    except RootedFilesystemError as exc:
         raise ExternalManifestReferenceError(
-            f"generation manifest write failed: {path}: {exc}"
+            f"generation manifest write failed through trusted descriptors: {path}: {exc}"
         ) from exc
 
 
@@ -166,7 +137,7 @@ def publication_generation_pointer_path(
     repository = _registry_segment(repository, "repository")
     ref = _registry_segment(ref, "ref")
     return (
-        Path(publication_root).expanduser().resolve()
+        secure_absolute(publication_root)
         / "external"
         / "_current"
         / repository
@@ -351,35 +322,12 @@ def _prepare_generation_package(
 
 def _regular_generation_files(root: Path) -> dict[str, bytes]:
     try:
-        root_stat = root.lstat()
-    except OSError as exc:
+        observed, _ = read_tree(root)
+        return observed
+    except RootedFilesystemError as exc:
         raise ExternalManifestReferenceError(
-            f"generation directory is unavailable: {root}"
+            f"generation tree must contain only trusted regular files and directories: {root}: {exc}"
         ) from exc
-    if not stat.S_ISDIR(root_stat.st_mode):
-        raise ExternalManifestReferenceError(
-            f"generation path must be a real directory: {root}"
-        )
-    observed: dict[str, bytes] = {}
-    for current, directories, filenames in os.walk(root, followlinks=False):
-        current_path = Path(current)
-        for name in directories:
-            candidate = current_path / name
-            if not stat.S_ISDIR(candidate.lstat().st_mode):
-                raise ExternalManifestReferenceError(
-                    f"generation tree must not contain linked directories: {candidate}"
-                )
-        for name in filenames:
-            candidate = current_path / name
-            if not stat.S_ISREG(candidate.lstat().st_mode):
-                raise ExternalManifestReferenceError(
-                    f"generation tree must contain only regular files: {candidate}"
-                )
-            observed[candidate.relative_to(root).as_posix()] = _read_regular_bytes(
-                candidate,
-                "generation file",
-            )
-    return observed
 
 
 def _expected_generation_files(package: dict[str, Any]) -> dict[str, bytes]:
@@ -392,40 +340,42 @@ def _expected_generation_files(package: dict[str, Any]) -> dict[str, bytes]:
 def _install_generation(package: dict[str, Any]) -> bool:
     generation_dir = Path(package["generationDirectory"])
     expected = _expected_generation_files(package)
-    generation_dir.parent.mkdir(parents=True, exist_ok=True)
-    if generation_dir.exists() or generation_dir.is_symlink():
-        observed = _regular_generation_files(generation_dir)
-        if observed != expected:
-            raise ExternalManifestReferenceError(
-                "existing generation directory does not match the expected immutable generation"
-            )
-        return True
-
-    stage = Path(
-        tempfile.mkdtemp(
-            prefix=f".{package['generationId']}.",
-            suffix=".tmp",
-            dir=str(generation_dir.parent),
-        )
-    )
     try:
-        for row in package["families"]:
-            relative_path = Path(str(row["relativePath"]))
-            _write_generation_manifest_file(stage / relative_path, row["manifest"])
-        _write_generation_descriptor(stage / "generation.json", package["descriptor"])
-        for family in package["families"]:
-            _fsync_directory(stage / "families" / str(family["artifactFamily"]))
-        _fsync_directory(stage / "families")
-        _fsync_directory(stage)
-        os.replace(stage, generation_dir)
-        _fsync_directory(generation_dir.parent)
-    except OSError as exc:
+        make_directories(generation_dir.parent)
+        if path_exists(generation_dir):
+            observed = _regular_generation_files(generation_dir)
+            if observed != expected:
+                raise ExternalManifestReferenceError(
+                    "existing generation directory does not match the expected immutable generation"
+                )
+            return True
+
+        stage = make_temporary_directory(
+            generation_dir.parent,
+            prefix=str(package["generationId"]),
+        )
+        try:
+            for row in package["families"]:
+                relative_path = Path(str(row["relativePath"]))
+                _write_generation_manifest_file(stage / relative_path, row["manifest"])
+            _write_generation_descriptor(
+                stage / "generation.json", package["descriptor"]
+            )
+            for family in package["families"]:
+                _fsync_directory(stage / "families" / str(family["artifactFamily"]))
+            _fsync_directory(stage / "families")
+            _fsync_directory(stage)
+            rename_path(stage, generation_dir)
+            _fsync_directory(generation_dir.parent)
+        finally:
+            try:
+                remove_tree(stage)
+            except RootedFilesystemError:
+                pass
+    except RootedFilesystemError as exc:
         raise ExternalManifestReferenceError(
             f"generation installation failed before pointer commit: {exc}"
         ) from exc
-    finally:
-        if stage.exists():
-            shutil.rmtree(stage)
     return False
 
 
@@ -438,7 +388,7 @@ def _resolve_declared_path(
 ) -> Path:
     if not isinstance(raw_path, str) or not raw_path or Path(raw_path).is_absolute():
         raise ExternalManifestReferenceError(f"{label} path must be relative")
-    candidate = (base / raw_path).resolve()
+    candidate = secure_absolute(base / raw_path)
     _require_path_inside_root(candidate, publication_root, label)
     return candidate
 
@@ -677,7 +627,7 @@ def _read_generation_family(
     }
 
 
-def read_external_manifest_publication(
+def _read_external_manifest_publication_bound(
     publication_root: str | Path,
     *,
     repository: str,
@@ -686,7 +636,7 @@ def read_external_manifest_publication(
     """Read one authoritative, complete generation through its atomic pointer."""
     repository = _registry_segment(repository, "repository")
     ref = _registry_segment(ref, "ref")
-    root = Path(publication_root).expanduser().resolve()
+    root = secure_absolute(publication_root)
     pointer_path = publication_generation_pointer_path(
         root,
         repository=repository,
@@ -774,6 +724,29 @@ def read_external_manifest_publication(
     }
 
 
+def read_external_manifest_publication(
+    publication_root: str | Path,
+    *,
+    repository: str,
+    ref: str,
+) -> dict[str, Any]:
+    """Read one complete generation through a bound publication-root identity."""
+    root = secure_absolute(publication_root)
+    try:
+        with bind_directory(root, create=False) as binding:
+            result = _read_external_manifest_publication_bound(
+                root,
+                repository=repository,
+                ref=ref,
+            )
+            binding.assert_current_path_identity()
+            return result
+    except RootedFilesystemError as exc:
+        raise ExternalManifestReferenceError(
+            f"publication read lost its trusted root identity: {root}: {exc}"
+        ) from exc
+
+
 @contextmanager
 def _publication_lock(
     publication_root: Path,
@@ -784,37 +757,12 @@ def _publication_lock(
         publication_root / "external" / "_locks" / repository / ref / "publish.lock"
     )
     try:
-        lock_path.parent.mkdir(parents=True, exist_ok=True)
-    except OSError as exc:
+        with exclusive_file_lock(lock_path):
+            yield lock_path
+    except RootedFilesystemError as exc:
         raise ExternalManifestReferenceError(
-            f"publication lock directory cannot be prepared: {lock_path.parent}"
+            f"publication lock lost its trusted directory identity: {lock_path}: {exc}"
         ) from exc
-    flags = (
-        os.O_RDWR
-        | os.O_CREAT
-        | getattr(os, "O_CLOEXEC", 0)
-        | getattr(os, "O_NOFOLLOW", 0)
-    )
-    try:
-        fd = os.open(lock_path, flags, 0o600)
-    except OSError as exc:
-        raise ExternalManifestReferenceError(
-            f"publication lock cannot be opened: {lock_path}"
-        ) from exc
-    try:
-        if not stat.S_ISREG(os.fstat(fd).st_mode):
-            raise ExternalManifestReferenceError(
-                f"publication lock must be a regular file: {lock_path}"
-            )
-        try:
-            fcntl.flock(fd, fcntl.LOCK_EX)
-        except OSError as exc:
-            raise ExternalManifestReferenceError(
-                f"publication lock cannot be acquired: {lock_path}: {exc}"
-            ) from exc
-        yield lock_path
-    finally:
-        os.close(fd)
 
 
 def _compatibility_projection(
@@ -913,22 +861,29 @@ def recover_external_manifest_publication(
     repository: str,
     ref: str,
 ) -> dict[str, Any]:
-    """Rebuild legacy stable family projections from the committed generation."""
+    """Rebuild compatibility projections below one bound publication root."""
     repository = _registry_segment(repository, "repository")
     ref = _registry_segment(ref, "ref")
-    root = Path(publication_root).expanduser().resolve()
-    with _publication_lock(root, repository, ref):
-        selection = read_external_manifest_publication(
-            root,
-            repository=repository,
-            ref=ref,
-        )
-        compatibility = _compatibility_projection(
-            selection=selection,
-            publication_root=root,
-            repository=repository,
-            ref=ref,
-        )
+    root = secure_absolute(publication_root)
+    try:
+        with bind_directory(root, create=False) as binding:
+            with _publication_lock(root, repository, ref):
+                selection = read_external_manifest_publication(
+                    root,
+                    repository=repository,
+                    ref=ref,
+                )
+                compatibility = _compatibility_projection(
+                    selection=selection,
+                    publication_root=root,
+                    repository=repository,
+                    ref=ref,
+                )
+            binding.assert_current_path_identity()
+    except RootedFilesystemError as exc:
+        raise ExternalManifestReferenceError(
+            f"publication recovery lost its trusted root identity: {root}: {exc}"
+        ) from exc
     return {
         "kind": "repobrief.external_manifest_publication_recovery",
         "version": GENERATION_VERSION,
@@ -948,47 +903,55 @@ def publish_external_manifest_references(
     ref: str,
     artifact_families: Iterable[str] | None = None,
 ) -> dict[str, Any]:
-    """Publish one complete generation and then refresh legacy stable projections."""
+    """Publish one complete generation below one trusted publication-root identity."""
     families = sorted(_normalized_artifact_families(artifact_families))
     repository = _registry_segment(repository, "repository")
     ref = _registry_segment(ref, "ref")
-    root = Path(publication_root).expanduser().resolve()
-    with _publication_lock(root, repository, ref) as lock_path:
-        materialization = materialize_external_bundle(
-            bundle_manifest_path,
-            root,
-            repository=repository,
-            ref=ref,
-        )
-        localized_manifest = Path(str(materialization["bundleManifest"]))
-        package = _prepare_generation_package(
-            localized_manifest=localized_manifest,
-            materialization=materialization,
-            publication_root=root,
-            repository=repository,
-            ref=ref,
-            families=families,
-        )
-        generation_reused = _install_generation(package)
-        pointer_write = _write_generation_pointer(
-            Path(package["pointerPath"]),
-            package["pointer"],
-        )
-        selection = read_external_manifest_publication(
-            root,
-            repository=repository,
-            ref=ref,
-        )
-        if selection["generationId"] != package["generationId"]:
-            raise ExternalManifestReferenceError(
-                "generation pointer readback selected an unexpected generation"
-            )
-        compatibility = _compatibility_projection(
-            selection=selection,
-            publication_root=root,
-            repository=repository,
-            ref=ref,
-        )
+    root = secure_absolute(publication_root)
+    try:
+        with bind_directory(root, create=True) as binding:
+            with _publication_lock(root, repository, ref) as lock_path:
+                materialization = materialize_external_bundle(
+                    bundle_manifest_path,
+                    root,
+                    repository=repository,
+                    ref=ref,
+                )
+                localized_manifest = Path(str(materialization["bundleManifest"]))
+                package = _prepare_generation_package(
+                    localized_manifest=localized_manifest,
+                    materialization=materialization,
+                    publication_root=root,
+                    repository=repository,
+                    ref=ref,
+                    families=families,
+                )
+                generation_reused = _install_generation(package)
+                pointer_write = _write_generation_pointer(
+                    Path(package["pointerPath"]),
+                    package["pointer"],
+                )
+                selection = read_external_manifest_publication(
+                    root,
+                    repository=repository,
+                    ref=ref,
+                )
+                if selection["generationId"] != package["generationId"]:
+                    raise ExternalManifestReferenceError(
+                        "generation pointer readback selected an unexpected generation"
+                    )
+                compatibility = _compatibility_projection(
+                    selection=selection,
+                    publication_root=root,
+                    repository=repository,
+                    ref=ref,
+                )
+            binding.assert_current_path_identity()
+    except RootedFilesystemError as exc:
+        raise ExternalManifestReferenceError(
+            f"publication lost a trusted directory identity: {root}: {exc}"
+        ) from exc
+
     if compatibility["status"] != "ok":
         status = "committed_compatibility_degraded"
     elif pointer_write["durability"] != "durable":
@@ -1003,7 +966,7 @@ def publish_external_manifest_references(
         "repository": repository,
         "ref": ref,
         "publicationRoot": str(root),
-        "sourceBundleManifest": str(Path(bundle_manifest_path).expanduser().resolve()),
+        "sourceBundleManifest": str(secure_absolute(bundle_manifest_path)),
         "bundleManifest": str(localized_manifest),
         "materialization": materialization,
         "generation": {
@@ -1016,6 +979,7 @@ def publish_external_manifest_references(
             "selectionRule": "read_pointer_once_then_verify_complete_generation",
             "serialization": "exclusive_lane_flock",
             "lockPath": str(lock_path),
+            "filesystemBinding": "trusted_dirfd_openat",
         },
         "authoritativePublished": selection["published"],
         "published": compatibility["published"],

--- a/merger/lenskit/core/external_manifest_reference.py
+++ b/merger/lenskit/core/external_manifest_reference.py
@@ -5,11 +5,26 @@ from __future__ import annotations
 import hashlib
 import json
 import os
-import shutil
-import stat
-import tempfile
 from pathlib import Path
 from typing import Any, Iterable
+
+from .rooted_filesystem import (
+    RootedFilesystemError,
+    atomic_write_bytes,
+    bind_directory,
+    copy_verified_file,
+    digest_regular_file,
+    make_directories,
+    make_temporary_directory,
+    open_regular_file,
+    path_exists,
+    path_is_real_directory,
+    read_regular_bytes,
+    read_tree,
+    remove_tree,
+    rename_path,
+    secure_absolute,
+)
 
 SUPPORTED_FAMILIES = {"repobrief", "lenskit"}
 BUNDLE_KIND = "repolens.bundle.manifest"
@@ -25,6 +40,10 @@ DOES_NOT_ESTABLISH = (
     "distributed_consensus",
     "cross_host_transactionality",
     "remote_freshness",
+    "kernel_bug_resistance",
+    "network_filesystem_equivalence",
+    "privilege_boundary_isolation",
+    "untested_platform_security",
 )
 
 
@@ -33,7 +52,9 @@ class ExternalManifestReferenceError(ValueError):
 
 
 def _relative_path(target: Path, base_dir: Path) -> str:
-    return Path(os.path.relpath(target.resolve(), base_dir.resolve())).as_posix()
+    return Path(
+        os.path.relpath(secure_absolute(target), secure_absolute(base_dir))
+    ).as_posix()
 
 
 def _registry_segment(value: str, label: str) -> str:
@@ -53,54 +74,41 @@ def _registry_segment(value: str, label: str) -> str:
 
 
 def _open_regular_file(path: Path, label: str) -> tuple[int, int]:
-    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
     try:
-        fd = os.open(path, flags)
-    except OSError as exc:
+        return open_regular_file(path)
+    except RootedFilesystemError as exc:
         raise ExternalManifestReferenceError(
             f"{label} must be an existing regular file: {path}"
         ) from exc
-    metadata = os.fstat(fd)
-    if not stat.S_ISREG(metadata.st_mode):
-        os.close(fd)
-        raise ExternalManifestReferenceError(
-            f"{label} must be an existing regular file: {path}"
-        )
-    return fd, metadata.st_size
 
 
 def _digest_regular_file(path: Path, label: str) -> tuple[int, str]:
-    fd, _ = _open_regular_file(path, label)
-    digest = hashlib.sha256()
-    observed_bytes = 0
-    with os.fdopen(fd, "rb", closefd=True) as handle:
-        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-            observed_bytes += len(chunk)
-            digest.update(chunk)
-    return observed_bytes, digest.hexdigest()
+    try:
+        return digest_regular_file(path)
+    except RootedFilesystemError as exc:
+        raise ExternalManifestReferenceError(
+            f"{label} must be an existing stable regular file: {path}"
+        ) from exc
 
 
 def _read_json_object_with_integrity(
     path: Path,
 ) -> tuple[dict[str, Any], int, str]:
-    fd, _ = _open_regular_file(path, "bundle manifest")
-    digest = hashlib.sha256()
-    chunks: list[bytes] = []
-    observed_bytes = 0
-    with os.fdopen(fd, "rb", closefd=True) as handle:
-        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-            observed_bytes += len(chunk)
-            digest.update(chunk)
-            chunks.append(chunk)
     try:
-        data = json.loads(b"".join(chunks).decode("utf-8"))
+        payload = read_regular_bytes(path)
+    except RootedFilesystemError as exc:
+        raise ExternalManifestReferenceError(
+            f"bundle manifest must be an existing regular file with stable identity: {path}"
+        ) from exc
+    try:
+        data = json.loads(payload.decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise ExternalManifestReferenceError(
             f"bundle manifest is not valid UTF-8 JSON: {path}"
         ) from exc
     if not isinstance(data, dict):
         raise ExternalManifestReferenceError("bundle manifest must be a JSON object")
-    return data, observed_bytes, digest.hexdigest()
+    return data, len(payload), hashlib.sha256(payload).hexdigest()
 
 
 def _bundle_member(bundle_dir: Path, raw_path: str, label: str) -> tuple[Path, str]:
@@ -117,15 +125,18 @@ def _bundle_member(bundle_dir: Path, raw_path: str, label: str) -> tuple[Path, s
         raise ExternalManifestReferenceError(
             f"{label} must stay inside the bundle directory"
         )
-    resolved = (bundle_dir / relative).resolve()
+    trusted_bundle_dir = secure_absolute(bundle_dir)
+    resolved = secure_absolute(trusted_bundle_dir / relative)
     try:
-        normalized = resolved.relative_to(bundle_dir)
+        normalized = resolved.relative_to(trusted_bundle_dir)
     except ValueError as exc:
         raise ExternalManifestReferenceError(
             f"{label} must stay inside the bundle directory"
         ) from exc
-    if not resolved.is_file():
+    if not path_exists(resolved):
         raise ExternalManifestReferenceError(f"{label} does not exist: {raw_path}")
+    fd, _ = _open_regular_file(resolved, label)
+    os.close(fd)
     return resolved, normalized.as_posix()
 
 
@@ -138,7 +149,7 @@ def _artifact_rows(
     if not isinstance(artifacts, list):
         raise ExternalManifestReferenceError("bundle manifest artifacts must be a list")
     rows: list[dict[str, Any]] = []
-    bundle_dir = bundle_manifest_path.parent.resolve()
+    bundle_dir = secure_absolute(bundle_manifest_path.parent)
     for artifact in artifacts:
         if not isinstance(artifact, dict):
             continue
@@ -177,7 +188,7 @@ def _linked_sidecar_rows(
         "surface_validation_path": "bundle_surface_validation",
     }
     rows: list[dict[str, Any]] = []
-    bundle_dir = bundle_manifest_path.parent.resolve()
+    bundle_dir = secure_absolute(bundle_manifest_path.parent)
     seen_paths: set[str] = set()
     for link_key, role in linked_roles.items():
         raw_path = links.get(link_key)
@@ -248,52 +259,22 @@ def _copy_verified_file(
     expected_bytes: int,
     label: str,
 ) -> None:
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    source_fd, source_bytes = _open_regular_file(source, label)
-    if source_bytes != expected_bytes:
-        os.close(source_fd)
-        raise ExternalManifestReferenceError(
-            f"{label} byte count mismatch: expected {expected_bytes}, observed {source_bytes}"
-        )
-    tmp_path: Path | None = None
-    digest = hashlib.sha256()
-    observed_bytes = 0
     try:
-        with (
-            os.fdopen(source_fd, "rb", closefd=True) as source_handle,
-            tempfile.NamedTemporaryFile(
-                mode="wb",
-                delete=False,
-                dir=str(destination.parent),
-                prefix=f".{destination.name}.",
-                suffix=".tmp",
-            ) as tmp_file,
-        ):
-            for chunk in iter(lambda: source_handle.read(1024 * 1024), b""):
-                observed_bytes += len(chunk)
-                digest.update(chunk)
-                tmp_file.write(chunk)
-            tmp_file.flush()
-            os.fsync(tmp_file.fileno())
-            tmp_path = Path(tmp_file.name)
-        observed_sha256 = digest.hexdigest()
-        if observed_bytes != expected_bytes:
-            raise ExternalManifestReferenceError(
-                f"{label} byte count mismatch: expected {expected_bytes}, observed {observed_bytes}"
-            )
-        if observed_sha256 != expected_sha256:
-            raise ExternalManifestReferenceError(
-                f"{label} sha256 mismatch: expected {expected_sha256}, observed {observed_sha256}"
-            )
-        os.replace(tmp_path, destination)
-    finally:
-        if tmp_path is not None and tmp_path.exists():
-            tmp_path.unlink()
+        copy_verified_file(
+            source,
+            destination,
+            expected_sha256=expected_sha256,
+            expected_bytes=expected_bytes,
+        )
+    except RootedFilesystemError as exc:
+        raise ExternalManifestReferenceError(
+            f"{label} could not be copied through trusted directory descriptors: {exc}"
+        ) from exc
 
 
 def _require_path_inside_root(path: Path, root: Path, label: str) -> None:
     try:
-        path.resolve().relative_to(root.resolve())
+        secure_absolute(path).relative_to(secure_absolute(root))
     except ValueError as exc:
         raise ExternalManifestReferenceError(
             f"{label} must stay inside publication_root"
@@ -320,7 +301,7 @@ def _declared_materialization_rows(
     artifacts = bundle.get("artifacts")
     if not isinstance(artifacts, list):
         raise ExternalManifestReferenceError("bundle manifest artifacts must be a list")
-    source_dir = source_manifest.parent.resolve()
+    source_dir = secure_absolute(source_manifest.parent)
     rows: list[dict[str, Any]] = []
     for index, artifact in enumerate(artifacts):
         if not isinstance(artifact, dict):
@@ -417,41 +398,13 @@ def _expected_materialized_entries(
 
 def _observed_materialized_entries(localized_dir: Path) -> tuple[set[str], set[str]]:
     try:
-        root_metadata = localized_dir.lstat()
-    except OSError as exc:
+        files, directories = read_tree(localized_dir)
+    except RootedFilesystemError as exc:
         raise ExternalManifestReferenceError(
-            f"localized bundle path must be an existing directory: {localized_dir}"
+            "localized bundle tree must contain only regular files and directories: "
+            f"{localized_dir}: {exc}"
         ) from exc
-    if not stat.S_ISDIR(root_metadata.st_mode):
-        raise ExternalManifestReferenceError(
-            f"localized bundle path must be an existing directory: {localized_dir}"
-        )
-
-    actual_files: set[str] = set()
-    actual_directories: set[str] = set()
-    for current_root, directory_names, file_names in os.walk(
-        localized_dir, topdown=True, followlinks=False
-    ):
-        current = Path(current_root)
-        for name in directory_names:
-            candidate = current / name
-            metadata = candidate.lstat()
-            if not stat.S_ISDIR(metadata.st_mode):
-                raise ExternalManifestReferenceError(
-                    "localized bundle tree must contain only regular files and "
-                    f"directories: {candidate}"
-                )
-            actual_directories.add(candidate.relative_to(localized_dir).as_posix())
-        for name in file_names:
-            candidate = current / name
-            metadata = candidate.lstat()
-            if not stat.S_ISREG(metadata.st_mode):
-                raise ExternalManifestReferenceError(
-                    "localized bundle tree must contain only regular files and "
-                    f"directories: {candidate}"
-                )
-            actual_files.add(candidate.relative_to(localized_dir).as_posix())
-    return actual_files, actual_directories
+    return set(files), directories
 
 
 def _verify_materialized_tree(
@@ -505,13 +458,19 @@ def _build_materialization_stage(
     manifest_bytes: int,
     members: dict[str, dict[str, Any]],
 ) -> Path:
-    localized_dir.parent.mkdir(parents=True, exist_ok=True)
-    _require_path_inside_root(
-        localized_dir.parent, publication_root, "localized bundle parent"
-    )
-    stage = Path(
-        tempfile.mkdtemp(prefix=f".{manifest_sha256}.", dir=str(localized_dir.parent))
-    )
+    try:
+        make_directories(localized_dir.parent)
+        _require_path_inside_root(
+            localized_dir.parent, publication_root, "localized bundle parent"
+        )
+        stage = make_temporary_directory(
+            localized_dir.parent,
+            prefix=manifest_sha256,
+        )
+    except RootedFilesystemError as exc:
+        raise ExternalManifestReferenceError(
+            f"localized bundle stage cannot be prepared safely: {exc}"
+        ) from exc
     try:
         for relative_path, member in sorted(members.items()):
             _copy_verified_file(
@@ -529,7 +488,10 @@ def _build_materialization_stage(
             label="bundle manifest",
         )
     except Exception:
-        shutil.rmtree(stage)
+        try:
+            remove_tree(stage)
+        except RootedFilesystemError:
+            pass
         raise
     return stage
 
@@ -544,8 +506,8 @@ def _install_materialized_tree(
     manifest_bytes: int,
     members: dict[str, dict[str, Any]],
 ) -> bool:
-    if localized_dir.exists():
-        if not localized_dir.is_dir():
+    if path_exists(localized_dir):
+        if not path_is_real_directory(localized_dir):
             raise ExternalManifestReferenceError(
                 f"localized bundle path is not a directory: {localized_dir}"
             )
@@ -568,9 +530,9 @@ def _install_materialized_tree(
     )
     try:
         try:
-            os.replace(stage, localized_dir)
-        except OSError:
-            if not localized_dir.is_dir():
+            rename_path(stage, localized_dir)
+        except RootedFilesystemError:
+            if not path_is_real_directory(localized_dir):
                 raise
             _verify_materialized_tree(
                 localized_dir,
@@ -589,27 +551,23 @@ def _install_materialized_tree(
         )
         return False
     finally:
-        if stage.exists():
-            shutil.rmtree(stage)
+        try:
+            remove_tree(stage)
+        except RootedFilesystemError:
+            pass
 
 
-def materialize_external_bundle(
-    bundle_manifest_path: str | Path,
-    publication_root: str | Path,
+def _materialize_external_bundle_bound(
+    source_manifest: Path,
+    root: Path,
     *,
     repository: str,
     ref: str,
 ) -> dict[str, Any]:
-    """Copy one verified bundle into a consumer-local content-addressed subtree."""
-    repository = _registry_segment(repository, "repository")
-    ref = _registry_segment(ref, "ref")
-    source_manifest = Path(bundle_manifest_path).expanduser().resolve()
     bundle, manifest_bytes, manifest_sha256 = _read_materialization_manifest(
         source_manifest
     )
 
-    root = Path(publication_root).expanduser().resolve()
-    root.mkdir(parents=True, exist_ok=True)
     localized_dir = root / "external" / "_bundles" / repository / ref / manifest_sha256
     localized_manifest = localized_dir / source_manifest.name
     _require_path_inside_root(localized_dir, root, "localized bundle directory")
@@ -639,12 +597,42 @@ def materialize_external_bundle(
     }
 
 
+def materialize_external_bundle(
+    bundle_manifest_path: str | Path,
+    publication_root: str | Path,
+    *,
+    repository: str,
+    ref: str,
+) -> dict[str, Any]:
+    """Copy one bundle through source- and publication-root directory bindings."""
+    repository = _registry_segment(repository, "repository")
+    ref = _registry_segment(ref, "ref")
+    source_manifest = secure_absolute(bundle_manifest_path)
+    root = secure_absolute(publication_root)
+    try:
+        with bind_directory(root, create=True) as root_binding:
+            with bind_directory(source_manifest.parent) as source_binding:
+                result = _materialize_external_bundle_bound(
+                    source_manifest,
+                    root,
+                    repository=repository,
+                    ref=ref,
+                )
+                source_binding.assert_current_path_identity()
+                root_binding.assert_current_path_identity()
+                return result
+    except RootedFilesystemError as exc:
+        raise ExternalManifestReferenceError(
+            f"external bundle materialization lost a trusted directory identity: {exc}"
+        ) from exc
+
+
 def _require_inside_publication_root(
     bundle_manifest_path: Path, publication_root: Path | None
 ) -> None:
     if publication_root is None:
         return
-    root = publication_root.expanduser().resolve()
+    root = secure_absolute(publication_root)
     try:
         bundle_manifest_path.relative_to(root)
     except ValueError as exc:
@@ -653,28 +641,14 @@ def _require_inside_publication_root(
         ) from exc
 
 
-def build_external_manifest_reference(
-    bundle_manifest_path: str | Path,
+def _build_external_manifest_reference_bound(
+    manifest_path: Path,
     *,
+    family: str,
     repository: str,
     ref: str,
-    artifact_family: str = "repobrief",
-    output_path: str | Path | None = None,
-    publication_root: str | Path | None = None,
+    output_base: Path,
 ) -> dict[str, Any]:
-    """Build a bounded external manifest reference from an existing bundle manifest."""
-    family = artifact_family.strip().lower() if isinstance(artifact_family, str) else ""
-    if family not in SUPPORTED_FAMILIES:
-        raise ExternalManifestReferenceError(
-            "artifact_family must be repobrief or lenskit"
-        )
-    repository = _registry_segment(repository, "repository")
-    ref = _registry_segment(ref, "ref")
-    manifest_path = Path(bundle_manifest_path).expanduser().resolve()
-    _require_inside_publication_root(
-        manifest_path,
-        Path(publication_root) if publication_root is not None else None,
-    )
     bundle, manifest_bytes, manifest_sha256 = _read_json_object_with_integrity(
         manifest_path
     )
@@ -687,11 +661,6 @@ def build_external_manifest_reference(
         raise ExternalManifestReferenceError(
             "bundle manifest created_at must be present"
         )
-    output_base = (
-        Path(output_path).expanduser().resolve().parent
-        if output_path is not None
-        else manifest_path.parent
-    )
     snapshot_provenance = bundle.get("snapshot_provenance")
     return {
         "kind": f"{family}_bundle_manifest",
@@ -715,6 +684,50 @@ def build_external_manifest_reference(
         "artifacts": _combined_artifact_rows(manifest_path, bundle, output_base),
         "doesNotEstablish": list(DOES_NOT_ESTABLISH),
     }
+
+
+def build_external_manifest_reference(
+    bundle_manifest_path: str | Path,
+    *,
+    repository: str,
+    ref: str,
+    artifact_family: str = "repobrief",
+    output_path: str | Path | None = None,
+    publication_root: str | Path | None = None,
+) -> dict[str, Any]:
+    """Build a bounded reference while holding one source-directory identity."""
+    family = artifact_family.strip().lower() if isinstance(artifact_family, str) else ""
+    if family not in SUPPORTED_FAMILIES:
+        raise ExternalManifestReferenceError(
+            "artifact_family must be repobrief or lenskit"
+        )
+    repository = _registry_segment(repository, "repository")
+    ref = _registry_segment(ref, "ref")
+    manifest_path = secure_absolute(bundle_manifest_path)
+    _require_inside_publication_root(
+        manifest_path,
+        Path(publication_root) if publication_root is not None else None,
+    )
+    output_base = (
+        secure_absolute(output_path).parent
+        if output_path is not None
+        else manifest_path.parent
+    )
+    try:
+        with bind_directory(manifest_path.parent) as source_binding:
+            result = _build_external_manifest_reference_bound(
+                manifest_path,
+                family=family,
+                repository=repository,
+                ref=ref,
+                output_base=output_base,
+            )
+            source_binding.assert_current_path_identity()
+            return result
+    except RootedFilesystemError as exc:
+        raise ExternalManifestReferenceError(
+            f"external manifest build lost its source-directory identity: {manifest_path.parent}: {exc}"
+        ) from exc
 
 
 def publication_generation_pointer_path(
@@ -785,7 +798,7 @@ def publication_manifest_path(
     repository = _registry_segment(repository, "repository")
     ref = _registry_segment(ref, "ref")
     return (
-        Path(publication_root).expanduser().resolve()
+        secure_absolute(publication_root)
         / "external"
         / family
         / repository
@@ -845,40 +858,30 @@ def write_external_manifest_reference(
     artifact_family: str = "repobrief",
     publication_root: str | Path | None = None,
 ) -> dict[str, Any]:
-    """Write an external manifest reference atomically and return it."""
-    out = Path(output_path).expanduser().resolve()
-    if publication_root is not None:
-        _require_path_inside_root(
-            out,
-            Path(publication_root).expanduser().resolve(),
-            "external manifest output",
-        )
-    data = build_external_manifest_reference(
-        bundle_manifest_path,
-        repository=repository,
-        ref=ref,
-        artifact_family=artifact_family,
-        output_path=out,
-        publication_root=publication_root,
+    """Write one reference through trusted source and output directory identities."""
+    out = secure_absolute(output_path)
+    root = (
+        secure_absolute(publication_root)
+        if publication_root is not None
+        else out.parent
     )
-    out.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path: Path | None = None
     try:
-        with tempfile.NamedTemporaryFile(
-            mode="w",
-            encoding="utf-8",
-            delete=False,
-            dir=str(out.parent),
-            prefix=f".{out.name}.",
-            suffix=".tmp",
-        ) as tmp_file:
-            json.dump(data, tmp_file, indent=2, sort_keys=True)
-            tmp_file.write("\n")
-            tmp_file.flush()
-            os.fsync(tmp_file.fileno())
-            tmp_path = Path(tmp_file.name)
-        os.replace(tmp_path, out)
-    finally:
-        if tmp_path is not None and tmp_path.exists():
-            tmp_path.unlink()
-    return data
+        with bind_directory(root, create=True) as root_binding:
+            _require_path_inside_root(out, root, "external manifest output")
+            data = build_external_manifest_reference(
+                bundle_manifest_path,
+                repository=repository,
+                ref=ref,
+                artifact_family=artifact_family,
+                output_path=out,
+                publication_root=publication_root,
+            )
+            atomic_write_bytes(
+                out, (json.dumps(data, indent=2, sort_keys=True) + "\n").encode("utf-8")
+            )
+            root_binding.assert_current_path_identity()
+            return data
+    except RootedFilesystemError as exc:
+        raise ExternalManifestReferenceError(
+            f"external manifest write lost a trusted directory identity: {out}: {exc}"
+        ) from exc

--- a/merger/lenskit/core/rooted_filesystem.py
+++ b/merger/lenskit/core/rooted_filesystem.py
@@ -1,0 +1,821 @@
+"""Trusted-directory-descriptor filesystem primitives for local publication.
+
+The module intentionally supports only POSIX platforms that expose the dir_fd,
+O_DIRECTORY and O_NOFOLLOW primitives required by the declared threat model.
+Unsupported platforms fail closed instead of silently falling back to pathname
+operations.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import contextvars
+import errno
+import fcntl
+import hashlib
+import os
+import secrets
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator
+
+
+class RootedFilesystemError(OSError):
+    """Raised when a rooted filesystem operation cannot preserve its contract."""
+
+
+_DIRECTORY_FLAGS = (
+    os.O_RDONLY
+    | getattr(os, "O_CLOEXEC", 0)
+    | getattr(os, "O_DIRECTORY", 0)
+    | getattr(os, "O_NOFOLLOW", 0)
+)
+_FILE_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+_SELECTION = contextvars.ContextVar[tuple["DirectoryBinding", ...]](
+    "lenskit_rooted_filesystem_bindings",
+    default=(),
+)
+
+
+def _required_primitives_supported() -> bool:
+    required_dir_fd = (os.open, os.mkdir, os.rename, os.stat, os.unlink, os.rmdir)
+    return (
+        os.name == "posix"
+        and hasattr(os, "O_DIRECTORY")
+        and hasattr(os, "O_NOFOLLOW")
+        and all(function in os.supports_dir_fd for function in required_dir_fd)
+    )
+
+
+def require_rooted_filesystem_support() -> None:
+    """Fail closed when the host cannot provide the required path semantics."""
+    if not _required_primitives_supported():
+        raise RootedFilesystemError(
+            "trusted dirfd filesystem operations are unsupported on this platform"
+        )
+
+
+def secure_absolute(path: str | Path) -> Path:
+    """Return an absolute lexical path without following any symlink."""
+    expanded = os.path.expanduser(os.fspath(path))
+    if not os.path.isabs(expanded):
+        expanded = os.path.join(os.getcwd(), expanded)
+    normalized = os.path.normpath(expanded)
+    if not os.path.isabs(normalized):
+        raise RootedFilesystemError(
+            f"path did not normalize to an absolute path: {path}"
+        )
+    return Path(normalized)
+
+
+def _relative_parts(path: str | Path, *, allow_root: bool = True) -> tuple[str, ...]:
+    raw = os.fspath(path)
+    if not raw or os.path.isabs(raw) or "\\" in raw:
+        raise RootedFilesystemError(
+            f"path must be a non-empty relative POSIX path: {path}"
+        )
+    parts = tuple(part for part in Path(raw).parts if part != ".")
+    if any(part in {"", ".", ".."} for part in parts):
+        raise RootedFilesystemError(f"path contains a traversal component: {path}")
+    if not parts and not allow_root:
+        raise RootedFilesystemError(f"path must name an entry: {path}")
+    return parts
+
+
+def _absolute_parts(path: Path) -> tuple[str, ...]:
+    absolute = secure_absolute(path)
+    return tuple(
+        part for part in absolute.parts if part not in {absolute.anchor, "/", ""}
+    )
+
+
+def _open_child_directory(
+    parent_fd: int,
+    name: str,
+    *,
+    create: bool,
+    mode: int,
+    label: str,
+) -> int:
+    try:
+        return os.open(name, _DIRECTORY_FLAGS, dir_fd=parent_fd)
+    except FileNotFoundError:
+        if not create:
+            raise
+        try:
+            os.mkdir(name, mode=mode, dir_fd=parent_fd)
+        except FileExistsError:
+            pass
+        try:
+            return os.open(name, _DIRECTORY_FLAGS, dir_fd=parent_fd)
+        except OSError as exc:
+            raise RootedFilesystemError(
+                f"directory component is not a trusted real directory: {label}: {name}"
+            ) from exc
+    except OSError as exc:
+        raise RootedFilesystemError(
+            f"directory component is not a trusted real directory: {label}: {name}"
+        ) from exc
+
+
+def _open_absolute_directory(path: Path, *, create: bool, mode: int = 0o755) -> int:
+    require_rooted_filesystem_support()
+    absolute = secure_absolute(path)
+    current_fd = os.open("/", _DIRECTORY_FLAGS)
+    try:
+        for part in _absolute_parts(absolute):
+            next_fd = _open_child_directory(
+                current_fd,
+                part,
+                create=create,
+                mode=mode,
+                label=str(absolute),
+            )
+            os.close(current_fd)
+            current_fd = next_fd
+        metadata = os.fstat(current_fd)
+        if not stat.S_ISDIR(metadata.st_mode):
+            raise RootedFilesystemError(f"path is not a directory: {absolute}")
+        return current_fd
+    except Exception:
+        os.close(current_fd)
+        raise
+
+
+@dataclass(frozen=True)
+class DirectoryBinding:
+    """One open directory identity used as an anchor for descendant operations."""
+
+    path: Path
+    fd: int
+    device: int
+    inode: int
+
+    @classmethod
+    def open(cls, path: str | Path, *, create: bool = False) -> "DirectoryBinding":
+        absolute = secure_absolute(path)
+        try:
+            fd = _open_absolute_directory(absolute, create=create)
+        except OSError as exc:
+            if isinstance(exc, RootedFilesystemError):
+                raise
+            raise RootedFilesystemError(
+                f"trusted directory cannot be opened: {absolute}"
+            ) from exc
+        metadata = os.fstat(fd)
+        return cls(
+            path=absolute,
+            fd=fd,
+            device=metadata.st_dev,
+            inode=metadata.st_ino,
+        )
+
+    def close(self) -> None:
+        os.close(self.fd)
+
+    def assert_current_path_identity(self) -> None:
+        """Verify that the user-visible path still names the anchored directory."""
+        try:
+            current_fd = _open_absolute_directory(self.path, create=False)
+        except OSError as exc:
+            raise RootedFilesystemError(
+                f"bound directory path no longer resolves to its trusted identity: {self.path}"
+            ) from exc
+        try:
+            metadata = os.fstat(current_fd)
+            if (metadata.st_dev, metadata.st_ino) != (self.device, self.inode):
+                raise RootedFilesystemError(
+                    f"bound directory path identity changed during operation: {self.path}"
+                )
+        finally:
+            os.close(current_fd)
+
+
+@contextlib.contextmanager
+def bind_directory(
+    path: str | Path,
+    *,
+    create: bool = False,
+) -> Iterator[DirectoryBinding]:
+    """Bind a path to one directory identity for all nested secure operations."""
+    absolute = secure_absolute(path)
+    for existing in reversed(_SELECTION.get()):
+        if existing.path == absolute:
+            yield existing
+            return
+    binding = DirectoryBinding.open(absolute, create=create)
+    token = _SELECTION.set((*_SELECTION.get(), binding))
+    try:
+        yield binding
+    finally:
+        _SELECTION.reset(token)
+        binding.close()
+
+
+def _matching_binding(path: Path) -> tuple[DirectoryBinding, Path] | None:
+    absolute = secure_absolute(path)
+    matches: list[tuple[int, DirectoryBinding, Path]] = []
+    for binding in _SELECTION.get():
+        try:
+            relative = absolute.relative_to(binding.path)
+        except ValueError:
+            continue
+        matches.append((len(binding.path.parts), binding, relative))
+    if not matches:
+        return None
+    _, binding, relative = max(matches, key=lambda row: row[0])
+    return binding, relative
+
+
+def _open_descendant_directory(
+    binding: DirectoryBinding,
+    relative: Path,
+    *,
+    create: bool,
+    mode: int = 0o755,
+) -> int:
+    current_fd = os.dup(binding.fd)
+    try:
+        if relative == Path("."):
+            return current_fd
+        for part in _relative_parts(relative):
+            next_fd = _open_child_directory(
+                current_fd,
+                part,
+                create=create,
+                mode=mode,
+                label=str(binding.path / relative),
+            )
+            os.close(current_fd)
+            current_fd = next_fd
+        return current_fd
+    except Exception:
+        os.close(current_fd)
+        raise
+
+
+def _open_directory(path: str | Path, *, create: bool = False) -> int:
+    absolute = secure_absolute(path)
+    matched = _matching_binding(absolute)
+    if matched is None:
+        return _open_absolute_directory(absolute, create=create)
+    binding, relative = matched
+    return _open_descendant_directory(binding, relative, create=create)
+
+
+def _open_parent(
+    path: str | Path,
+    *,
+    create: bool,
+) -> tuple[int, str, Path]:
+    absolute = secure_absolute(path)
+    if absolute == Path("/"):
+        raise RootedFilesystemError("filesystem root cannot be used as a file entry")
+    parent_fd = _open_directory(absolute.parent, create=create)
+    return parent_fd, absolute.name, absolute
+
+
+def _identity(metadata: os.stat_result) -> tuple[int, int]:
+    return metadata.st_dev, metadata.st_ino
+
+
+def _assert_directory_fd_matches_path(fd: int, path: str | Path) -> None:
+    expected = _identity(os.fstat(fd))
+    current_fd = _open_absolute_directory(secure_absolute(path), create=False)
+    try:
+        if _identity(os.fstat(current_fd)) != expected:
+            raise RootedFilesystemError(
+                f"directory path identity changed during rooted operation: {secure_absolute(path)}"
+            )
+    finally:
+        os.close(current_fd)
+
+
+def _open_absolute_regular_file(path: str | Path) -> tuple[int, int]:
+    absolute = secure_absolute(path)
+    parent_fd = _open_absolute_directory(absolute.parent, create=False)
+    try:
+        fd = os.open(
+            absolute.name,
+            os.O_RDONLY | _FILE_NOFOLLOW,
+            dir_fd=parent_fd,
+        )
+    except OSError as exc:
+        raise RootedFilesystemError(
+            f"entry must be an existing regular file: {absolute}"
+        ) from exc
+    finally:
+        os.close(parent_fd)
+    metadata = os.fstat(fd)
+    if not stat.S_ISREG(metadata.st_mode):
+        os.close(fd)
+        raise RootedFilesystemError(f"entry must be a regular file: {absolute}")
+    return fd, metadata.st_size
+
+
+def _assert_regular_fd_matches_path(fd: int, path: str | Path) -> None:
+    expected = _identity(os.fstat(fd))
+    current_fd, _ = _open_absolute_regular_file(path)
+    try:
+        if _identity(os.fstat(current_fd)) != expected:
+            raise RootedFilesystemError(
+                f"regular file path identity changed during rooted operation: {secure_absolute(path)}"
+            )
+    finally:
+        os.close(current_fd)
+
+
+def open_regular_file(path: str | Path, *, flags: int = os.O_RDONLY) -> tuple[int, int]:
+    """Open a regular file without following the file or any bound ancestor."""
+    parent_fd, name, absolute = _open_parent(path, create=False)
+    fd: int | None = None
+    try:
+        fd = os.open(name, flags | _FILE_NOFOLLOW, dir_fd=parent_fd)
+        _assert_directory_fd_matches_path(parent_fd, absolute.parent)
+    except OSError as exc:
+        if fd is not None:
+            os.close(fd)
+        raise RootedFilesystemError(
+            f"entry must be an existing regular file: {absolute}"
+        ) from exc
+    finally:
+        os.close(parent_fd)
+    assert fd is not None
+    metadata = os.fstat(fd)
+    if not stat.S_ISREG(metadata.st_mode):
+        os.close(fd)
+        raise RootedFilesystemError(f"entry must be a regular file: {absolute}")
+    return fd, metadata.st_size
+
+
+def read_regular_bytes(path: str | Path) -> bytes:
+    fd, _ = open_regular_file(path)
+    chunks: list[bytes] = []
+    try:
+        with os.fdopen(os.dup(fd), "rb", closefd=True) as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                chunks.append(chunk)
+        _assert_regular_fd_matches_path(fd, path)
+        return b"".join(chunks)
+    finally:
+        os.close(fd)
+
+
+def digest_regular_file(path: str | Path) -> tuple[int, str]:
+    fd, _ = open_regular_file(path)
+    digest = hashlib.sha256()
+    observed = 0
+    try:
+        with os.fdopen(os.dup(fd), "rb", closefd=True) as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                observed += len(chunk)
+                digest.update(chunk)
+        _assert_regular_fd_matches_path(fd, path)
+        return observed, digest.hexdigest()
+    finally:
+        os.close(fd)
+
+
+def make_directories(path: str | Path, *, mode: int = 0o755) -> None:
+    fd = _open_directory(path, create=True)
+    try:
+        os.fsync(fd)
+        _assert_directory_fd_matches_path(fd, path)
+    finally:
+        os.close(fd)
+
+
+def fsync_directory(path: str | Path) -> None:
+    fd = _open_directory(path, create=False)
+    try:
+        os.fsync(fd)
+        _assert_directory_fd_matches_path(fd, path)
+    finally:
+        os.close(fd)
+
+
+def lstat_path(path: str | Path) -> os.stat_result:
+    parent_fd, name, absolute = _open_parent(path, create=False)
+    try:
+        metadata = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+        _assert_directory_fd_matches_path(parent_fd, absolute.parent)
+        return metadata
+    except OSError as exc:
+        raise RootedFilesystemError(f"entry cannot be inspected: {absolute}") from exc
+    finally:
+        os.close(parent_fd)
+
+
+def path_exists(path: str | Path) -> bool:
+    try:
+        lstat_path(path)
+    except FileNotFoundError:
+        return False
+    except RootedFilesystemError as exc:
+        if (
+            exc.__cause__ is not None
+            and getattr(exc.__cause__, "errno", None) == errno.ENOENT
+        ):
+            return False
+        raise
+    return True
+
+
+def path_is_real_directory(path: str | Path) -> bool:
+    try:
+        metadata = lstat_path(path)
+    except (FileNotFoundError, RootedFilesystemError):
+        return False
+    return stat.S_ISDIR(metadata.st_mode)
+
+
+def _write_all(fd: int, payload: bytes) -> None:
+    view = memoryview(payload)
+    while view:
+        written = os.write(fd, view)
+        if written <= 0:
+            raise RootedFilesystemError("short write while writing rooted file")
+        view = view[written:]
+
+
+def _new_temp_name(prefix: str) -> str:
+    return f".{prefix}.{secrets.token_hex(12)}.tmp"
+
+
+def atomic_write_bytes(
+    path: str | Path,
+    payload: bytes,
+    *,
+    mode: int = 0o600,
+) -> dict[str, object]:
+    """Atomically replace one file through its already-open parent directory."""
+    parent_fd, name, absolute = _open_parent(path, create=True)
+    temp_name = _new_temp_name(name)
+    temp_created = False
+    replaced = False
+    try:
+        fd = os.open(
+            temp_name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | _FILE_NOFOLLOW,
+            mode,
+            dir_fd=parent_fd,
+        )
+        temp_created = True
+        try:
+            _write_all(fd, payload)
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+        os.rename(
+            temp_name,
+            name,
+            src_dir_fd=parent_fd,
+            dst_dir_fd=parent_fd,
+        )
+        replaced = True
+        temp_created = False
+        try:
+            os.fsync(parent_fd)
+            _assert_directory_fd_matches_path(parent_fd, absolute.parent)
+        except RootedFilesystemError:
+            raise
+        except OSError as exc:
+            visible_fd = os.open(name, os.O_RDONLY | _FILE_NOFOLLOW, dir_fd=parent_fd)
+            try:
+                visible_chunks: list[bytes] = []
+                while True:
+                    chunk = os.read(visible_fd, 1024 * 1024)
+                    if not chunk:
+                        break
+                    visible_chunks.append(chunk)
+            finally:
+                os.close(visible_fd)
+            if b"".join(visible_chunks) == payload:
+                _assert_directory_fd_matches_path(parent_fd, absolute.parent)
+                return {
+                    "bytes": len(payload),
+                    "sha256": hashlib.sha256(payload).hexdigest(),
+                    "durability": "uncertain_after_directory_fsync",
+                    "error": str(exc),
+                }
+            raise
+    except OSError as exc:
+        phase = "after replace" if replaced else "before replace"
+        raise RootedFilesystemError(
+            f"rooted atomic write failed {phase}: {absolute}: {exc}"
+        ) from exc
+    finally:
+        if temp_created:
+            try:
+                os.unlink(temp_name, dir_fd=parent_fd)
+            except OSError:
+                pass
+        os.close(parent_fd)
+    return {
+        "bytes": len(payload),
+        "sha256": hashlib.sha256(payload).hexdigest(),
+        "durability": "durable",
+    }
+
+
+def exclusive_write_bytes(
+    path: str | Path,
+    payload: bytes,
+    *,
+    mode: int = 0o600,
+) -> None:
+    parent_fd, name, absolute = _open_parent(path, create=True)
+    try:
+        fd = os.open(
+            name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | _FILE_NOFOLLOW,
+            mode,
+            dir_fd=parent_fd,
+        )
+        try:
+            _write_all(fd, payload)
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+        os.fsync(parent_fd)
+        _assert_directory_fd_matches_path(parent_fd, absolute.parent)
+    except OSError as exc:
+        raise RootedFilesystemError(
+            f"rooted exclusive write failed: {absolute}: {exc}"
+        ) from exc
+    finally:
+        os.close(parent_fd)
+
+
+def _copy_stream(source_fd: int, destination_fd: int) -> tuple[int, str]:
+    digest = hashlib.sha256()
+    observed = 0
+    while True:
+        chunk = os.read(source_fd, 1024 * 1024)
+        if not chunk:
+            break
+        observed += len(chunk)
+        digest.update(chunk)
+        _write_all(destination_fd, chunk)
+    os.fsync(destination_fd)
+    return observed, digest.hexdigest()
+
+
+def _verify_copy_integrity(
+    *,
+    observed_bytes: int,
+    observed_sha256: str,
+    expected_bytes: int,
+    expected_sha256: str,
+) -> None:
+    if observed_bytes != expected_bytes:
+        raise RootedFilesystemError(
+            f"source byte count mismatch: expected {expected_bytes}, observed {observed_bytes}"
+        )
+    if observed_sha256 != expected_sha256:
+        raise RootedFilesystemError(
+            f"source sha256 mismatch: expected {expected_sha256}, observed {observed_sha256}"
+        )
+
+
+def _commit_temporary_file(parent_fd: int, temp_name: str, name: str) -> None:
+    os.rename(
+        temp_name,
+        name,
+        src_dir_fd=parent_fd,
+        dst_dir_fd=parent_fd,
+    )
+    os.fsync(parent_fd)
+
+
+def copy_verified_file(
+    source: str | Path,
+    destination: str | Path,
+    *,
+    expected_sha256: str,
+    expected_bytes: int,
+) -> None:
+    """Copy one verified regular file and commit it through the destination dirfd."""
+    source_fd, source_size = open_regular_file(source)
+    if source_size != expected_bytes:
+        os.close(source_fd)
+        raise RootedFilesystemError(
+            f"source byte count mismatch: expected {expected_bytes}, observed {source_size}"
+        )
+    try:
+        parent_fd, name, absolute = _open_parent(destination, create=True)
+    except OSError:
+        os.close(source_fd)
+        raise
+    temp_name = _new_temp_name(name)
+    temp_created = False
+    try:
+        destination_fd = os.open(
+            temp_name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | _FILE_NOFOLLOW,
+            0o600,
+            dir_fd=parent_fd,
+        )
+        temp_created = True
+        try:
+            observed, observed_sha = _copy_stream(source_fd, destination_fd)
+        finally:
+            os.close(destination_fd)
+        _verify_copy_integrity(
+            observed_bytes=observed,
+            observed_sha256=observed_sha,
+            expected_bytes=expected_bytes,
+            expected_sha256=expected_sha256,
+        )
+        _assert_regular_fd_matches_path(source_fd, source)
+        _commit_temporary_file(parent_fd, temp_name, name)
+        temp_created = False
+        _assert_directory_fd_matches_path(parent_fd, absolute.parent)
+    except RootedFilesystemError:
+        raise
+    except OSError as exc:
+        raise RootedFilesystemError(
+            f"rooted verified copy failed: {absolute}: {exc}"
+        ) from exc
+    finally:
+        os.close(source_fd)
+        if temp_created:
+            try:
+                os.unlink(temp_name, dir_fd=parent_fd)
+            except OSError:
+                pass
+        os.close(parent_fd)
+
+
+def make_temporary_directory(parent: str | Path, *, prefix: str) -> Path:
+    parent_absolute = secure_absolute(parent)
+    parent_fd = _open_directory(parent_absolute, create=True)
+    try:
+        for _ in range(128):
+            name = f".{prefix}.{secrets.token_hex(12)}.tmp"
+            try:
+                os.mkdir(name, mode=0o700, dir_fd=parent_fd)
+            except FileExistsError:
+                continue
+            os.fsync(parent_fd)
+            try:
+                _assert_directory_fd_matches_path(parent_fd, parent_absolute)
+            except RootedFilesystemError:
+                os.rmdir(name, dir_fd=parent_fd)
+                raise
+            return parent_absolute / name
+    finally:
+        os.close(parent_fd)
+    raise RootedFilesystemError(f"could not create temporary directory below {parent}")
+
+
+def rename_path(source: str | Path, destination: str | Path) -> None:
+    source_parent, source_name, source_absolute = _open_parent(source, create=False)
+    try:
+        destination_parent, destination_name, destination_absolute = _open_parent(
+            destination,
+            create=True,
+        )
+    except OSError:
+        os.close(source_parent)
+        raise
+    try:
+        os.rename(
+            source_name,
+            destination_name,
+            src_dir_fd=source_parent,
+            dst_dir_fd=destination_parent,
+        )
+        os.fsync(destination_parent)
+        _assert_directory_fd_matches_path(source_parent, source_absolute.parent)
+        _assert_directory_fd_matches_path(
+            destination_parent, destination_absolute.parent
+        )
+    except OSError as exc:
+        raise RootedFilesystemError(
+            f"rooted rename failed: {source_absolute} -> {destination_absolute}: {exc}"
+        ) from exc
+    finally:
+        os.close(source_parent)
+        os.close(destination_parent)
+
+
+def _read_tree_fd(fd: int, prefix: Path) -> tuple[dict[str, bytes], set[str]]:
+    files: dict[str, bytes] = {}
+    directories: set[str] = set()
+    try:
+        entries = sorted(os.scandir(fd), key=lambda entry: entry.name)
+    except OSError as exc:
+        raise RootedFilesystemError("rooted directory cannot be enumerated") from exc
+    for entry in entries:
+        metadata = os.stat(entry.name, dir_fd=fd, follow_symlinks=False)
+        relative = prefix / entry.name
+        relative_text = relative.as_posix()
+        if stat.S_ISDIR(metadata.st_mode):
+            child_fd = os.open(entry.name, _DIRECTORY_FLAGS, dir_fd=fd)
+            try:
+                directories.add(relative_text)
+                child_files, child_directories = _read_tree_fd(child_fd, relative)
+                files.update(child_files)
+                directories.update(child_directories)
+            finally:
+                os.close(child_fd)
+        elif stat.S_ISREG(metadata.st_mode):
+            child_fd = os.open(
+                entry.name,
+                os.O_RDONLY | _FILE_NOFOLLOW,
+                dir_fd=fd,
+            )
+            try:
+                chunks: list[bytes] = []
+                while True:
+                    chunk = os.read(child_fd, 1024 * 1024)
+                    if not chunk:
+                        break
+                    chunks.append(chunk)
+                files[relative_text] = b"".join(chunks)
+            finally:
+                os.close(child_fd)
+        else:
+            raise RootedFilesystemError(
+                f"rooted tree contains a symlink or special entry: {relative_text}"
+            )
+    return files, directories
+
+
+def read_tree(path: str | Path) -> tuple[dict[str, bytes], set[str]]:
+    fd = _open_directory(path, create=False)
+    try:
+        result = _read_tree_fd(fd, Path("."))
+        _assert_directory_fd_matches_path(fd, path)
+        return result
+    finally:
+        os.close(fd)
+
+
+def _remove_tree_fd(parent_fd: int, name: str) -> None:
+    child_fd = os.open(name, _DIRECTORY_FLAGS, dir_fd=parent_fd)
+    try:
+        entries = list(os.scandir(child_fd))
+        for entry in entries:
+            metadata = os.stat(entry.name, dir_fd=child_fd, follow_symlinks=False)
+            if stat.S_ISDIR(metadata.st_mode):
+                _remove_tree_fd(child_fd, entry.name)
+            elif stat.S_ISREG(metadata.st_mode):
+                os.unlink(entry.name, dir_fd=child_fd)
+            else:
+                raise RootedFilesystemError(
+                    f"refusing to remove symlink or special entry: {entry.name}"
+                )
+        os.fsync(child_fd)
+    finally:
+        os.close(child_fd)
+    os.rmdir(name, dir_fd=parent_fd)
+
+
+def remove_tree(path: str | Path) -> None:
+    if not path_exists(path):
+        return
+    parent_fd, name, absolute = _open_parent(path, create=False)
+    try:
+        metadata = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+        if not stat.S_ISDIR(metadata.st_mode):
+            raise RootedFilesystemError(
+                f"refusing to remove a non-directory tree root: {absolute}"
+            )
+        _remove_tree_fd(parent_fd, name)
+        os.fsync(parent_fd)
+        _assert_directory_fd_matches_path(parent_fd, absolute.parent)
+    finally:
+        os.close(parent_fd)
+
+
+@contextlib.contextmanager
+def exclusive_file_lock(path: str | Path, *, mode: int = 0o600) -> Iterator[None]:
+    parent_fd, name, absolute = _open_parent(path, create=True)
+    try:
+        fd = os.open(
+            name,
+            os.O_RDWR | os.O_CREAT | _FILE_NOFOLLOW,
+            mode,
+            dir_fd=parent_fd,
+        )
+    except OSError as exc:
+        os.close(parent_fd)
+        raise RootedFilesystemError(f"lock file cannot be opened: {absolute}") from exc
+    try:
+        metadata = os.fstat(fd)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise RootedFilesystemError(f"lock entry is not a regular file: {absolute}")
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        _assert_directory_fd_matches_path(parent_fd, absolute.parent)
+        yield
+        _assert_directory_fd_matches_path(parent_fd, absolute.parent)
+    except OSError as exc:
+        if isinstance(exc, RootedFilesystemError):
+            raise
+        raise RootedFilesystemError(f"lock cannot be acquired: {absolute}") from exc
+    finally:
+        os.close(fd)
+        os.close(parent_fd)

--- a/merger/lenskit/tests/test_external_manifest_dirfd.py
+++ b/merger/lenskit/tests/test_external_manifest_dirfd.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from merger.lenskit.core import external_manifest_generation
+from merger.lenskit.core import external_manifest_reference
+from merger.lenskit.core import rooted_filesystem
+from merger.lenskit.core.external_manifest_reference import (
+    ExternalManifestReferenceError,
+    publication_generation_pointer_path,
+    publish_external_manifest_references,
+    read_external_manifest_publication,
+)
+
+
+def write_bundle(root: Path) -> Path:
+    bundle_dir = root / "bundle"
+    bundle_dir.mkdir(parents=True)
+    artifact = b"trusted artifact\n"
+    (bundle_dir / "artifact.md").write_bytes(artifact)
+    manifest = {
+        "kind": "repolens.bundle.manifest",
+        "version": "1.0",
+        "run_id": "dirfd-run",
+        "created_at": "2026-07-15T03:00:00Z",
+        "generator": {
+            "name": "repobrief",
+            "version": "dev",
+            "config_sha256": "a" * 64,
+        },
+        "artifacts": [
+            {
+                "role": "canonical_md",
+                "path": "artifact.md",
+                "content_type": "text/markdown",
+                "bytes": len(artifact),
+                "sha256": hashlib.sha256(artifact).hexdigest(),
+            }
+        ],
+        "links": {},
+        "capabilities": {},
+        "snapshot_provenance": {
+            "version": "v1",
+            "repositories": [],
+            "does_not_establish": ["freshness_against_remote"],
+        },
+    }
+    path = bundle_dir / "bundle.manifest.json"
+    path.write_text(json.dumps(manifest), encoding="utf-8")
+    return path
+
+
+def test_publish_rejects_symlinked_publication_root_component(tmp_path: Path) -> None:
+    bundle = write_bundle(tmp_path / "source")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    linked = tmp_path / "linked"
+    linked.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(
+        ExternalManifestReferenceError,
+        match="trusted directory identity|trusted real directory",
+    ):
+        publish_external_manifest_references(
+            bundle,
+            linked / "publication",
+            repository="sample",
+            ref="main",
+        )
+
+    assert list(outside.iterdir()) == []
+
+
+def test_publish_fails_closed_when_root_identity_changes_before_pointer_commit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bundle = write_bundle(tmp_path / "source")
+    root = tmp_path / "publication"
+    moved = tmp_path / "publication-before-swap"
+    original = external_manifest_generation._write_generation_pointer
+    swapped = False
+
+    def swap_root_then_write(path: Path, data: dict[str, object]) -> dict[str, object]:
+        nonlocal swapped
+        if not swapped:
+            swapped = True
+            root.rename(moved)
+            root.mkdir()
+        return original(path, data)
+
+    monkeypatch.setattr(
+        external_manifest_generation,
+        "_write_generation_pointer",
+        swap_root_then_write,
+    )
+
+    with pytest.raises(ExternalManifestReferenceError, match="trusted"):
+        publish_external_manifest_references(
+            bundle,
+            root,
+            repository="sample",
+            ref="main",
+        )
+
+    current_pointer = publication_generation_pointer_path(
+        root,
+        repository="sample",
+        ref="main",
+    )
+    moved_pointer = publication_generation_pointer_path(
+        moved,
+        repository="sample",
+        ref="main",
+    )
+    assert not current_pointer.exists()
+    assert moved_pointer.is_file()
+
+
+def test_publish_rejects_source_parent_replacement_before_materialization_commit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bundle = write_bundle(tmp_path / "source")
+    source_dir = bundle.parent
+    moved_source = tmp_path / "source-bundle-before-swap"
+    publication = tmp_path / "publication"
+    original = external_manifest_reference.copy_verified_file
+    swapped = False
+
+    def swap_source_then_copy(*args: object, **kwargs: object) -> None:
+        nonlocal swapped
+        if not swapped:
+            swapped = True
+            source_dir.rename(moved_source)
+            source_dir.mkdir()
+        original(*args, **kwargs)
+
+    monkeypatch.setattr(
+        external_manifest_reference,
+        "copy_verified_file",
+        swap_source_then_copy,
+    )
+
+    with pytest.raises(ExternalManifestReferenceError, match="source|trusted"):
+        publish_external_manifest_references(
+            bundle,
+            publication,
+            repository="sample",
+            ref="main",
+        )
+
+    assert not publication_generation_pointer_path(
+        publication,
+        repository="sample",
+        ref="main",
+    ).exists()
+
+
+def test_pointer_parent_swap_is_detected_and_not_exposed_as_current(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bundle = write_bundle(tmp_path / "source")
+    root = tmp_path / "publication"
+    pointer_parent = root / "external" / "_current" / "sample" / "main"
+    moved_parent = root / "external" / "_current" / "sample" / "main-before-swap"
+    original = rooted_filesystem._write_all
+    swapped = False
+
+    def swap_pointer_parent(fd: int, payload: bytes) -> None:
+        nonlocal swapped
+        if not swapped and b"external_manifest_generation_pointer" in payload:
+            swapped = True
+            pointer_parent.rename(moved_parent)
+            pointer_parent.mkdir()
+        original(fd, payload)
+
+    monkeypatch.setattr(rooted_filesystem, "_write_all", swap_pointer_parent)
+
+    with pytest.raises(
+        ExternalManifestReferenceError, match="trusted descriptors|identity"
+    ):
+        publish_external_manifest_references(
+            bundle,
+            root,
+            repository="sample",
+            ref="main",
+        )
+
+    assert not (pointer_parent / "generation.json").exists()
+    assert (moved_parent / "generation.json").is_file()
+
+
+def test_reader_rejects_root_replacement_during_readback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bundle = write_bundle(tmp_path / "source")
+    root = tmp_path / "publication"
+    publish_external_manifest_references(
+        bundle,
+        root,
+        repository="sample",
+        ref="main",
+    )
+    moved = tmp_path / "publication-before-read-swap"
+    original = external_manifest_generation._read_json_regular_file
+    swapped = False
+
+    def swap_root_then_read(
+        path: Path, label: str
+    ) -> tuple[dict[str, object], int, str]:
+        nonlocal swapped
+        if not swapped:
+            swapped = True
+            root.rename(moved)
+            root.mkdir()
+        return original(path, label)
+
+    monkeypatch.setattr(
+        external_manifest_generation,
+        "_read_json_regular_file",
+        swap_root_then_read,
+    )
+
+    with pytest.raises(
+        ExternalManifestReferenceError, match="stable identity|trusted root identity"
+    ):
+        read_external_manifest_publication(
+            root,
+            repository="sample",
+            ref="main",
+        )
+
+
+def test_unsupported_platform_fails_closed_end_to_end(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bundle = write_bundle(tmp_path / "source")
+    root = tmp_path / "publication"
+    monkeypatch.setattr(
+        rooted_filesystem,
+        "_required_primitives_supported",
+        lambda: False,
+    )
+
+    with pytest.raises(
+        ExternalManifestReferenceError, match="unsupported|trusted directory identity"
+    ):
+        publish_external_manifest_references(
+            bundle,
+            root,
+            repository="sample",
+            ref="main",
+        )
+
+    assert not root.exists()
+
+
+def test_successful_publication_reports_dirfd_binding(tmp_path: Path) -> None:
+    result = publish_external_manifest_references(
+        write_bundle(tmp_path / "source"),
+        tmp_path / "publication",
+        repository="sample",
+        ref="main",
+    )
+
+    assert result["status"] == "committed"
+    assert result["generation"]["filesystemBinding"] == "trusted_dirfd_openat"

--- a/merger/lenskit/tests/test_rooted_filesystem.py
+++ b/merger/lenskit/tests/test_rooted_filesystem.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from merger.lenskit.core import rooted_filesystem
+from merger.lenskit.core.rooted_filesystem import (
+    RootedFilesystemError,
+    atomic_write_bytes,
+    bind_directory,
+    copy_verified_file,
+    exclusive_file_lock,
+    read_regular_bytes,
+    read_tree,
+)
+
+
+def test_atomic_write_uses_bound_directory_and_reads_back(tmp_path: Path) -> None:
+    root = tmp_path / "publication"
+    with bind_directory(root, create=True) as binding:
+        result = atomic_write_bytes(root / "external" / "manifest.json", b"ok\n")
+        assert result["durability"] == "durable"
+        assert read_regular_bytes(root / "external" / "manifest.json") == b"ok\n"
+        binding.assert_current_path_identity()
+
+
+def test_bound_traversal_rejects_symlinked_parent_component(tmp_path: Path) -> None:
+    root = tmp_path / "publication"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    root.mkdir()
+    (root / "linked").symlink_to(outside, target_is_directory=True)
+
+    with bind_directory(root):
+        with pytest.raises(RootedFilesystemError, match="not a trusted|not trusted"):
+            atomic_write_bytes(root / "linked" / "escaped.json", b"no\n")
+
+    assert not (outside / "escaped.json").exists()
+
+
+def test_atomic_write_detects_parent_replacement_without_writing_replacement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "publication"
+    lane = root / "lane"
+    lane.mkdir(parents=True)
+    old_lane = root / "lane-before-swap"
+    original_write_all = rooted_filesystem._write_all
+    swapped = False
+
+    def swap_parent_then_write(fd: int, payload: bytes) -> None:
+        nonlocal swapped
+        if not swapped:
+            swapped = True
+            lane.rename(old_lane)
+            lane.mkdir()
+        original_write_all(fd, payload)
+
+    monkeypatch.setattr(rooted_filesystem, "_write_all", swap_parent_then_write)
+
+    with bind_directory(root):
+        with pytest.raises(RootedFilesystemError, match="after replace"):
+            atomic_write_bytes(lane / "manifest.json", b"anchored\n")
+
+    assert (old_lane / "manifest.json").read_bytes() == b"anchored\n"
+    assert not (lane / "manifest.json").exists()
+
+
+def test_binding_detects_replacement_of_publication_root(tmp_path: Path) -> None:
+    root = tmp_path / "publication"
+    root.mkdir()
+    moved = tmp_path / "publication-moved"
+
+    with bind_directory(root) as binding:
+        root.rename(moved)
+        root.mkdir()
+        with pytest.raises(RootedFilesystemError, match="identity changed"):
+            binding.assert_current_path_identity()
+
+
+def test_regular_file_open_rejects_symlink(tmp_path: Path) -> None:
+    root = tmp_path / "publication"
+    root.mkdir()
+    target = tmp_path / "target.json"
+    target.write_text("outside", encoding="utf-8")
+    linked = root / "manifest.json"
+    linked.symlink_to(target)
+
+    with bind_directory(root):
+        with pytest.raises(RootedFilesystemError, match="regular file"):
+            read_regular_bytes(linked)
+
+
+def test_tree_read_rejects_symlink_and_special_entries(tmp_path: Path) -> None:
+    root = tmp_path / "publication"
+    root.mkdir()
+    (root / "regular.txt").write_text("ok", encoding="utf-8")
+    (root / "linked.txt").symlink_to(root / "regular.txt")
+
+    with bind_directory(root):
+        with pytest.raises(RootedFilesystemError, match="symlink or special"):
+            read_tree(root)
+
+
+def test_lock_rejects_parent_identity_change(tmp_path: Path) -> None:
+    root = tmp_path / "publication"
+    lane = root / "lane"
+    lane.mkdir(parents=True)
+    old_lane = root / "lane-before-swap"
+
+    with bind_directory(root):
+        with pytest.raises(RootedFilesystemError, match="identity changed"):
+            with exclusive_file_lock(lane / "publish.lock"):
+                lane.rename(old_lane)
+                lane.mkdir()
+
+    assert (old_lane / "publish.lock").is_file()
+    assert not (lane / "publish.lock").exists()
+
+
+def test_unsupported_platform_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        rooted_filesystem,
+        "_required_primitives_supported",
+        lambda: False,
+    )
+
+    with pytest.raises(RootedFilesystemError, match="unsupported"):
+        with bind_directory(tmp_path / "publication", create=True):
+            pass
+
+
+def test_read_tree_returns_only_bound_regular_tree(tmp_path: Path) -> None:
+    root = tmp_path / "publication"
+    (root / "a" / "b").mkdir(parents=True)
+    (root / "a" / "b" / "manifest.json").write_bytes(b"{}\n")
+
+    with bind_directory(root):
+        files, directories = read_tree(root)
+
+    assert files == {"a/b/manifest.json": b"{}\n"}
+    assert directories == {"a", "a/b"}
+    assert os.path.samefile(root, root)
+
+
+def test_verified_copy_rejects_source_file_identity_swap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "source.txt"
+    source.write_bytes(b"trusted\n")
+    replacement = tmp_path / "replacement.txt"
+    replacement.write_bytes(b"trusted\n")
+    destination = tmp_path / "publication" / "copy.txt"
+    original = rooted_filesystem._copy_stream
+
+    def copy_then_swap(source_fd: int, destination_fd: int) -> tuple[int, str]:
+        result = original(source_fd, destination_fd)
+        source.unlink()
+        replacement.rename(source)
+        return result
+
+    monkeypatch.setattr(rooted_filesystem, "_copy_stream", copy_then_swap)
+
+    with pytest.raises(RootedFilesystemError, match="identity changed"):
+        copy_verified_file(
+            source,
+            destination,
+            expected_bytes=8,
+            expected_sha256="7bd39a7cbcf687fd60f819645b8bcaf731a9f19cb102484a7b84530516d7e8b8",
+        )
+
+    assert not destination.exists()


### PR DESCRIPTION
Bureau: RBV1-T025

## Problem

Die RepoBrief-Publikation prüfte bisher einzelne Dateien mit `O_NOFOLLOW`, verwendete für übergeordnete Pfade aber weiterhin normale Pfadnamen. Wird ein Elternverzeichnis zwischen Prüfung und Zugriff umbenannt oder durch einen Symlink ersetzt, kann eine pfadbasierte Operation eine andere Verzeichnisidentität erreichen als die zuvor geprüfte.

## Lösung

- führt eine POSIX-Dateisystemschicht ein, die absolute Verzeichnisse komponentenweise ab `/` mit `O_DIRECTORY | O_NOFOLLOW` öffnet;
- bindet Quell- und Publikationswurzeln über offene Verzeichnisdeskriptoren sowie Geräte-/Inode-Identität;
- führt Traversierung, Verzeichniserstellung, reguläre Dateizugriffe, atomare Ersetzung, Verzeichnis-Rename, Tree-Verifikation, Cleanup und Lane-Lock über `dir_fd`/`openat`-äquivalente Operationen aus;
- prüft nach sicherheitsrelevanten Zugriffen zusätzlich, dass der sichtbare absolute Pfad weiterhin dieselbe Verzeichnis- oder Dateiidentität bezeichnet;
- verweigert auf Plattformen ohne die benötigten POSIX-Primitive den Betrieb, statt still auf schwächere Pfadoperationen zurückzufallen;
- erhält die öffentliche RepoBrief-API und weist erfolgreiche Publikation maschinenlesbar als `trusted_dirfd_openat` aus;
- bindet die bestehenden generationskohärenten Pointer-, Recovery- und Kompatibilitätsregeln an dieselbe Dateisystemidentität.

## Exakte Bindung

- Basis: `ea57b08cf8acc580818ba11950c22f77f6dd1901`
- Head: `706a397ba48ccea4e6271070d99e968eedae3d6a`
- vollständiger lokaler Commit-Diff: SHA-256 `f27861c14e764a3e2e60e26356a8dc8dc29367244ae57761f314d3c25366852b`, 93.949 Bytes, 2.586 Zeilen
- Umfang: 6 Dateien, 1.795 Einfügungen, 412 Löschungen

Exakter GitHub-PR-Patch: SHA-256 `feee4334a188a91b22d0645d9e5850d99e37a16747ec698f05fe7e0efacf4612`, 94.781 Bytes, 2.604 Zeilen; direkter `.patch`-Download am PR.

## Belege auf dem exakten Head

- 60 fokussierte Alt-, Adversarial-, Plattform-, Crash-, Recovery- und Konkurrenztests: PASS
- vollständige Suite nach konfliktfreiem Rebase auf PR #1011: 4021 passed, 1 skipped
- Ruff mit CI-Konfiguration: PASS
- Ruff-Formatprüfung: PASS
- `git show --check`: PASS
- Graph-Maintainability-Ratchet: PASS; keine neue C901-Verletzung, eine bestehende Verletzung weniger
- Dateideskriptor-Stresstest: 200 Schreib-/Lese-/Lock-Zyklen, Delta 0
- reale CLI-Publikation: Status `committed`, Generation `dac4de5d36518fe81cf8c27f8828370032eec020627e07f11fe3995877a8b18b`, Binding `trusted_dirfd_openat`, Pointer dauerhaft
- unabhängiger autoritativer Readback bestätigte dieselbe Generation sowie beide Familien `lenskit` und `repobrief`

## Geprüfte Angriffe

- Symlink in einer Publikationswurzel-Komponente;
- Symlink oder Spezialdatei statt regulärer Datei bzw. Verzeichnis;
- Austausch der gesamten Publikationswurzel vor dem Pointer-Commit;
- Austausch des Quell-Elternverzeichnisses während der Materialisierung;
- Austausch des Pointer-Elternverzeichnisses während des atomaren Writes;
- Austausch der Quelldatei nach dem Kopieren, aber vor dem Ziel-Commit;
- Austausch der Root während des autoritativen Readbacks;
- Austausch des Lock-Elternverzeichnisses während gehaltener Sperre;
- Plattform ohne erforderliche `dir_fd`-/`O_NOFOLLOW`-Primitive.

## Restrisiken und Nichtaussagen

Der PR etabliert keine Resistenz gegen Kernel-Fehler, keine Gleichwertigkeit von Netzwerkdateisystemen, keine Privileggrenze gegen höher privilegierte Prozesse, keine Sicherheit auf ungetesteten Plattformen, keinen verteilten Konsens, keine hostübergreifende Transaktionalität, keine Remote-Frische und keine semantische Wahrheit.
