### PR TITLE
fix(repobrief): harden retention follow-ups

### DIFF
--- a/docs/blueprints/rlens-source-acquisition-blueprint.md
+++ b/docs/blueprints/rlens-source-acquisition-blueprint.md
@@ -151,6 +151,18 @@ through an existing symlinked path component, and every symlink, hardlink, FIFO
 or device member outright (v1: security before convenience — links are rejected,
 not followed). `tarfile.extract` is never used.
 
+## Snapshot retention
+
+Remote snapshots are temporary cache material, not permanent history. Cleanup is bounded by three independent defaults:
+
+- retain at most the three newest terminal-job snapshot roots;
+- retain unprotected snapshots for at most 24 hours;
+- retain at most 2 GiB of allocated snapshot data.
+
+Snapshots belonging to jobs in `queued`, `running` or `canceling` state are protected regardless of age or size. Cleanup runs after every job attempt and during lazy job garbage collection; deleting a job also removes exactly that job's snapshot root. If the snapshot root contains a symlink or another unexpected non-directory child, cleanup fails closed and deletes nothing. Every deletion is revalidated as a real direct child of `<merges_dir>/.rlens-source-snapshots` immediately before removal.
+
+These rules bound disk growth while preserving current work. They do not turn snapshots into a version archive; reproducible history belongs in the published RepoBrief bundles and their retention policy.
+
 ## Plan-only semantics
 
 `remote_snapshot + plan_only` is a **dry plan**: ref resolution via remote query
@@ -182,8 +194,7 @@ effective pre-pull). Active identical jobs are still reused.
   locally generated bundle. Reports and logs are credential-redacted via explicit
   redaction gates with tests; this reduces leakage, it is not an absolute
   guarantee that credentials can *never* appear.
-* Job-bound snapshots remain under `merges_dir` for the life of the job output;
-  no persistence/cleanup optimization is in scope for this PR.
+* Snapshot retention is operational cache hygiene, not evidence retention; active jobs are protected, while terminal snapshots can be removed by count, age or size limits.
 
 ## Non-goals
 

--- a/docs/operations/repobrief-fleet-retention.md
+++ b/docs/operations/repobrief-fleet-retention.md
@@ -7,8 +7,11 @@ The fleet publisher uses a content identity instead of a timestamp as the genera
 - the remote default-branch commit;
 - the Lenskit generator tree under `merger/lenskit`;
 - the explicit publication configuration.
+- the collision-free publication identity (`owner__repository`).
 
 A timestamp remains in the directory name only to order the retained history. It is not sufficient to trigger generation.
+
+Stable external manifests and consumer-local bundle paths use `owner__repository` rather than the repository name alone. This prevents repositories with the same name under different GitHub owners from sharing one publication address. Existing name-only external paths are left in place as frozen compatibility data; the fleet publisher no longer updates them.
 
 ## Retention
 
@@ -37,6 +40,8 @@ Keeping only one version saves more storage but removes useful comparison and re
 The installer leaves automatic publication paused unless invoked with `--enable`. This prevents an installation or migration from silently resuming generation.
 
 Legacy source-only state markers are intentionally not trusted as proof that generator and configuration inputs are unchanged. The first explicit reactivation can therefore produce one controlled publication per repository before normal fingerprint-based skipping begins.
+
+The publication fingerprint schema is now v2 because the owner-qualified publication identity is part of the content decision. Therefore the first enabled fleet cycle after this migration intentionally republishes each inventoried repository once into its collision-free address. A second immediate cycle with unchanged source commits, generator code and configuration must skip every repository.
 
 Dry-run current, legacy, and retired special storage:
 

--- a/merger/lenskit/service/app.py
+++ b/merger/lenskit/service/app.py
@@ -1076,6 +1076,13 @@ def api_query(request: QueryRequest):
 
     return projected
 
+
+def _cleanup_source_snapshots_after_gc() -> None:
+    snapshot_cleanup = state.job_store.cleanup_source_snapshots(apply=True)
+    if snapshot_cleanup.get("status") == "blocked":
+        logger.warning("Source snapshot cleanup blocked: %s", snapshot_cleanup)
+
+
 @app.post("/api/jobs", response_model=Job, dependencies=[Depends(verify_token)])
 def create_job(request: JobRequest):
     # Validate Hub in request
@@ -1108,9 +1115,7 @@ def create_job(request: JobRequest):
 
     # Lazy GC
     state.job_store.cleanup_jobs(max_jobs=GC_MAX_JOBS, max_age_hours=GC_MAX_AGE_HOURS)
-    snapshot_cleanup = state.job_store.cleanup_source_snapshots(apply=True)
-    if snapshot_cleanup.get("status") == "blocked":
-        logger.warning("Source snapshot cleanup blocked: %s", snapshot_cleanup)
+    _cleanup_source_snapshots_after_gc()
 
     existing = state.job_store.find_job_by_hash(content_hash)
     if existing and not request.force_new:

--- a/merger/lenskit/service/app.py
+++ b/merger/lenskit/service/app.py
@@ -1108,6 +1108,9 @@ def create_job(request: JobRequest):
 
     # Lazy GC
     state.job_store.cleanup_jobs(max_jobs=GC_MAX_JOBS, max_age_hours=GC_MAX_AGE_HOURS)
+    snapshot_cleanup = state.job_store.cleanup_source_snapshots(apply=True)
+    if snapshot_cleanup.get("status") == "blocked":
+        logger.warning("Source snapshot cleanup blocked: %s", snapshot_cleanup)
 
     existing = state.job_store.find_job_by_hash(content_hash)
     if existing and not request.force_new:

--- a/merger/lenskit/service/jobstore.py
+++ b/merger/lenskit/service/jobstore.py
@@ -10,6 +10,7 @@ from typing import List, Optional, Dict, Tuple, Callable
 from .models import Job, Artifact
 
 from merger.lenskit.core.merge import MERGES_DIR_NAME, get_merges_dir
+from .source_acquisition import prune_source_snapshots, remove_source_snapshot
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +29,7 @@ class JobStore:
         self._jobs_cache: Dict[str, Job] = {}
         self._artifacts_cache: Dict[str, Artifact] = {}
         self._log_subscribers: Dict[str, List[Callable[[], None]]] = collections.defaultdict(list)
+        self._snapshot_cleanup_lock = threading.Lock()
 
         self._load()
 
@@ -73,6 +75,10 @@ class JobStore:
     def subscribe_to_logs(self, job_id: str, callback: Callable[[], None]):
         with self._lock:
             self._log_subscribers[job_id].append(callback)
+
+    def log_subscriber_count(self, job_id: str) -> int:
+        with self._lock:
+            return len(self._log_subscribers.get(job_id, []))
 
     def unsubscribe_from_logs(self, job_id: str, callback: Callable[[], None]):
         with self._lock:
@@ -195,6 +201,12 @@ class JobStore:
                     logger.warning("Failed to clean up artifact %s for job %s: %s", art_id, job_id, exc)
                 del self._artifacts_cache[art_id]
 
+        try:
+            with self._snapshot_cleanup_lock:
+                remove_source_snapshot(get_merges_dir(self.hub_path), job_id)
+        except Exception as exc:
+            logger.warning("Failed to delete source snapshot for job %s: %s", job_id, exc)
+
         log_p = self.logs_dir / f"{job_id}.log"
         try:
             if log_p.exists():
@@ -239,6 +251,32 @@ class JobStore:
                 return max(active, key=lambda x: x.created_at)
 
             return max(candidates, key=lambda x: x.created_at)
+
+    def cleanup_source_snapshots(
+        self,
+        *,
+        merges_dir: Path | None = None,
+        apply: bool = True,
+        keep: int = 3,
+        max_age_hours: int = 24,
+        max_bytes: int = 2 * 1024 * 1024 * 1024,
+    ) -> dict:
+        root = Path(merges_dir) if merges_dir is not None else get_merges_dir(self.hub_path)
+        with self._lock:
+            protected = {
+                job.id
+                for job in self._jobs_cache.values()
+                if job.status in {"queued", "running", "canceling"}
+            }
+            with self._snapshot_cleanup_lock:
+                return prune_source_snapshots(
+                    root,
+                    protected_job_ids=protected,
+                    keep=keep,
+                    max_age_hours=max_age_hours,
+                    max_bytes=max_bytes,
+                    apply=apply,
+                )
 
     def cleanup_jobs(self, max_jobs: int = 100, max_age_hours: int = 24):
         now = datetime.now(timezone.utc)

--- a/merger/lenskit/service/jobstore.py
+++ b/merger/lenskit/service/jobstore.py
@@ -201,11 +201,7 @@ class JobStore:
                     logger.warning("Failed to clean up artifact %s for job %s: %s", art_id, job_id, exc)
                 del self._artifacts_cache[art_id]
 
-        try:
-            with self._snapshot_cleanup_lock:
-                remove_source_snapshot(get_merges_dir(self.hub_path), job_id)
-        except Exception as exc:
-            logger.warning("Failed to delete source snapshot for job %s: %s", job_id, exc)
+        self._remove_source_snapshot_for_job(job_id)
 
         log_p = self.logs_dir / f"{job_id}.log"
         try:
@@ -221,6 +217,13 @@ class JobStore:
             # Cleanup subscribers to prevent memory leaks if streams don't exit.
             self._log_subscribers.pop(job_id, None)
             self._jobs_cache.pop(job_id, None)
+
+    def _remove_source_snapshot_for_job(self, job_id: str) -> None:
+        try:
+            with self._snapshot_cleanup_lock:
+                remove_source_snapshot(get_merges_dir(self.hub_path), job_id)
+        except Exception as exc:
+            logger.warning("Failed to delete source snapshot for job %s: %s", job_id, exc)
 
     def get_job(self, job_id: str) -> Optional[Job]:
         with self._lock:

--- a/merger/lenskit/service/runner.py
+++ b/merger/lenskit/service/runner.py
@@ -28,15 +28,6 @@ from .source_acquisition import (
     RemoteSnapshotResult,
     SourceStatus,
 )
-from ..adapters.security import validate_source_dir, get_security_config, SecurityViolationError
-
-logger = logging.getLogger(__name__)
-
-# Import core logic.
-# Since this file is in merger/repoLens/service/runner.py,
-# and merger/repoLens is usually in sys.path when running repolens.py.
-# We can try absolute import first.
-
 from ..core.merge import (
     get_merges_dir,
     scan_repo,
@@ -47,6 +38,15 @@ from ..core.merge import (
     MERGES_DIR_NAME,
     parse_human_size,
 )
+from ..adapters.security import validate_source_dir, get_security_config, SecurityViolationError
+
+logger = logging.getLogger(__name__)
+
+# Import core logic.
+# Since this file is in merger/repoLens/service/runner.py,
+# and merger/repoLens is usually in sys.path when running repolens.py.
+# We can try absolute import first.
+
 
 def _find_repos(hub: Path) -> List[str]:
     from ..adapters.security import validate_source_dir
@@ -254,9 +254,9 @@ class JobRunner:
             # To avoid excessive writes, we DON'T call update_job for every log line anymore.
             pass
 
+        merges_dir: Path | None = None
         try:
             req = job.request
-            merges_dir: Path | None = None
             repo_names = list(job.request.repos or [])
             pre_pull_report_path: Path | None = None
             pre_pull_report_artifact_registered = False
@@ -928,3 +928,21 @@ class JobRunner:
             log(f"Error: {safe_error}")
             logger.error("Job %s failed: %s", job_id, safe_error)
             self.job_store.update_job(job)
+
+        finally:
+            try:
+                cleanup_report = self.job_store.cleanup_source_snapshots(
+                    merges_dir=merges_dir, apply=True
+                )
+                if cleanup_report.get("status") == "blocked":
+                    logger.warning(
+                        "Source snapshot cleanup blocked after job %s: %s",
+                        job_id,
+                        cleanup_report,
+                    )
+            except Exception as cleanup_error:
+                logger.warning(
+                    "Source snapshot cleanup failed after job %s: %s",
+                    job_id,
+                    cleanup_error,
+                )

--- a/merger/lenskit/service/runner.py
+++ b/merger/lenskit/service/runner.py
@@ -224,6 +224,26 @@ class JobRunner:
         future = self.executor.submit(self._run_job, job_id)
         self.futures[job_id] = future
 
+    def _cleanup_source_snapshots_after_job(
+        self, job_id: str, merges_dir: Path | None
+    ) -> None:
+        try:
+            cleanup_report = self.job_store.cleanup_source_snapshots(
+                merges_dir=merges_dir, apply=True
+            )
+            if cleanup_report.get("status") == "blocked":
+                logger.warning(
+                    "Source snapshot cleanup blocked after job %s: %s",
+                    job_id,
+                    cleanup_report,
+                )
+        except Exception as cleanup_error:
+            logger.warning(
+                "Source snapshot cleanup failed after job %s: %s",
+                job_id,
+                cleanup_error,
+            )
+
     def _run_job(self, job_id: str) -> None:
         job = self.job_store.get_job(job_id)
         if not job:
@@ -930,19 +950,4 @@ class JobRunner:
             self.job_store.update_job(job)
 
         finally:
-            try:
-                cleanup_report = self.job_store.cleanup_source_snapshots(
-                    merges_dir=merges_dir, apply=True
-                )
-                if cleanup_report.get("status") == "blocked":
-                    logger.warning(
-                        "Source snapshot cleanup blocked after job %s: %s",
-                        job_id,
-                        cleanup_report,
-                    )
-            except Exception as cleanup_error:
-                logger.warning(
-                    "Source snapshot cleanup failed after job %s: %s",
-                    job_id,
-                    cleanup_error,
-                )
+            self._cleanup_source_snapshots_after_job(job_id, merges_dir)

--- a/merger/lenskit/service/source_acquisition.py
+++ b/merger/lenskit/service/source_acquisition.py
@@ -32,6 +32,7 @@ import re
 import shutil
 import subprocess
 import tarfile
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List, Optional, Sequence
@@ -42,11 +43,163 @@ DEFAULT_TIMEOUT_SECONDS = 60
 
 # Job-bound snapshot root, created under the (already validated) merges_dir.
 SNAPSHOT_DIR_NAME = ".rlens-source-snapshots"
+DEFAULT_SNAPSHOT_RETENTION_COUNT = 3
+DEFAULT_SNAPSHOT_MAX_AGE_HOURS = 24
+DEFAULT_SNAPSHOT_MAX_BYTES = 2 * 1024 * 1024 * 1024
 
 # Report warning codes (v1 known limits).
 WARN_SUBMODULES_NOT_EXPANDED = "submodules_not_expanded"
 WARN_LFS_NOT_SMUDGED = "lfs_not_smudged"
 
+
+def _allocated_tree_bytes(path: Path) -> int:
+    total = 0
+    for root, dirs, files in os.walk(path, followlinks=False):
+        root_path = Path(root)
+        dirs[:] = [name for name in dirs if not (root_path / name).is_symlink()]
+        for name in files:
+            candidate = root_path / name
+            if candidate.is_symlink():
+                continue
+            try:
+                total += candidate.stat().st_blocks * 512
+            except FileNotFoundError:
+                continue
+    return total
+
+
+def prune_source_snapshots(
+    cache_root: Path,
+    *,
+    protected_job_ids: set[str] | None = None,
+    keep: int = DEFAULT_SNAPSHOT_RETENTION_COUNT,
+    max_age_hours: int = DEFAULT_SNAPSHOT_MAX_AGE_HOURS,
+    max_bytes: int = DEFAULT_SNAPSHOT_MAX_BYTES,
+    apply: bool = False,
+    now: float | None = None,
+) -> dict:
+    """Plan or apply bounded cleanup of job-scoped remote source snapshots.
+
+    Active job ids are always protected. Any symlink or non-directory child blocks
+    the whole cleanup before deletion, rather than guessing what is safe.
+    """
+    if keep < 0 or max_age_hours < 0 or max_bytes < 0:
+        raise ValueError("snapshot retention bounds must be non-negative")
+    protected = set(protected_job_ids or set())
+    root = Path(cache_root) / SNAPSHOT_DIR_NAME
+    report = {
+        "status": "ok",
+        "mode": "apply" if apply else "dry-run",
+        "root": str(root),
+        "keep": keep,
+        "max_age_hours": max_age_hours,
+        "max_bytes": max_bytes,
+        "protected_job_ids": sorted(protected),
+        "retained": [],
+        "protected": [],
+        "would_remove": [],
+        "removed": [],
+        "would_remove_bytes": 0,
+        "removed_bytes": 0,
+    }
+    if not root.exists():
+        return report
+    if root.is_symlink() or not root.is_dir():
+        report.update(status="blocked", error="snapshot root is not a real directory")
+        return report
+
+    rows = []
+    unsafe = []
+    for child in root.iterdir():
+        if child.is_symlink() or not child.is_dir():
+            unsafe.append(str(child))
+            continue
+        try:
+            stat_result = child.stat()
+        except FileNotFoundError:
+            continue
+        rows.append(
+            {
+                "path": child,
+                "job_id": child.name,
+                "mtime": stat_result.st_mtime,
+                "bytes": _allocated_tree_bytes(child),
+            }
+        )
+    if unsafe:
+        report.update(
+            status="blocked",
+            error="unsafe snapshot children",
+            unsafe_children=sorted(unsafe),
+        )
+        return report
+
+    current_time = time.time() if now is None else now
+    rows.sort(key=lambda row: (row["mtime"], row["job_id"]), reverse=True)
+    unprotected = [row for row in rows if row["job_id"] not in protected]
+    retained_ids = {row["job_id"] for row in unprotected[:keep]}
+    removable = []
+    retained = []
+    max_age_seconds = max_age_hours * 3600
+    for row in rows:
+        if row["job_id"] in protected:
+            report["protected"].append(str(row["path"]))
+            retained.append(row)
+            continue
+        too_old = current_time - row["mtime"] > max_age_seconds
+        if row["job_id"] not in retained_ids or too_old:
+            removable.append(row)
+        else:
+            retained.append(row)
+
+    retained_unprotected = [row for row in retained if row["job_id"] not in protected]
+    retained_unprotected.sort(
+        key=lambda row: (row["mtime"], row["job_id"]), reverse=True
+    )
+    while (
+        sum(row["bytes"] for row in retained_unprotected) > max_bytes
+        and retained_unprotected
+    ):
+        oldest = retained_unprotected.pop()
+        retained.remove(oldest)
+        removable.append(oldest)
+
+    removable.sort(key=lambda row: (row["mtime"], row["job_id"]))
+    report["retained"] = sorted(str(row["path"]) for row in retained)
+    bytes_to_remove = sum(row["bytes"] for row in removable)
+    if apply:
+        root_resolved = root.resolve()
+        for row in removable:
+            candidate = row["path"]
+            if (
+                candidate.is_symlink()
+                or not candidate.is_dir()
+                or candidate.resolve().parent != root_resolved
+            ):
+                raise RuntimeError(
+                    f"snapshot cleanup target changed or escaped root: {candidate}"
+                )
+            shutil.rmtree(candidate)
+            report["removed"].append(str(candidate))
+        report["removed_bytes"] = bytes_to_remove
+    else:
+        report["would_remove"] = [str(row["path"]) for row in removable]
+        report["would_remove_bytes"] = bytes_to_remove
+    return report
+
+
+def remove_source_snapshot(cache_root: Path, job_id: str) -> bool:
+    """Remove exactly one job snapshot with path-containment checks."""
+    root = Path(cache_root) / SNAPSHOT_DIR_NAME
+    target = root / job_id
+    if not target.exists():
+        return False
+    if root.is_symlink() or target.is_symlink() or not target.is_dir():
+        raise RuntimeError(f"unsafe source snapshot path: {target}")
+    if target.resolve().parent != root.resolve():
+        raise RuntimeError(f"source snapshot escaped root: {target}")
+    shutil.rmtree(target)
+    return True
 
 class SourceStatus:
     """String-constant status vocabulary (no enums)."""
@@ -413,7 +566,7 @@ def resolve_remote_ref(
             remote_url, _ = _read_remote_url(repo_path, "origin", timeout_seconds)
             if not remote_url:
                 return make(SourceStatus.MISSING_REMOTE, f"{repo_name} has no 'origin' remote configured", remote_url=remote_url)
-            return make(SourceStatus.RESOLVED, f"using explicit commit SHA; availability will be verified during fetch/materialization",
+            return make(SourceStatus.RESOLVED, "using explicit commit SHA; availability will be verified during fetch/materialization",
                         resolved_ref=remote_ref,
                         resolved_commit=remote_ref if _HEX_SHA_RE.match(remote_ref.strip()) else None,
                         remote_url=remote_url, remote_name="origin")

--- a/merger/lenskit/service/source_acquisition.py
+++ b/merger/lenskit/service/source_acquisition.py
@@ -68,6 +68,121 @@ def _allocated_tree_bytes(path: Path) -> int:
     return total
 
 
+def _snapshot_retention_report(
+    root: Path,
+    *,
+    protected: set[str],
+    keep: int,
+    max_age_hours: int,
+    max_bytes: int,
+    apply: bool,
+) -> dict:
+    return {
+        "status": "ok",
+        "mode": "apply" if apply else "dry-run",
+        "root": str(root),
+        "keep": keep,
+        "max_age_hours": max_age_hours,
+        "max_bytes": max_bytes,
+        "protected_job_ids": sorted(protected),
+        "retained": [],
+        "protected": [],
+        "would_remove": [],
+        "removed": [],
+        "would_remove_bytes": 0,
+        "removed_bytes": 0,
+    }
+
+
+def _collect_snapshot_rows(root: Path) -> tuple[list[dict], list[str]]:
+    rows: list[dict] = []
+    unsafe: list[str] = []
+    for child in root.iterdir():
+        if child.is_symlink() or not child.is_dir():
+            unsafe.append(str(child))
+            continue
+        try:
+            stat_result = child.stat()
+        except FileNotFoundError:
+            continue
+        rows.append(
+            {
+                "path": child,
+                "job_id": child.name,
+                "mtime": stat_result.st_mtime,
+                "bytes": _allocated_tree_bytes(child),
+            }
+        )
+    return rows, unsafe
+
+
+def _partition_snapshot_rows(
+    rows: list[dict],
+    *,
+    protected: set[str],
+    keep: int,
+    current_time: float,
+    max_age_hours: int,
+) -> tuple[list[dict], list[dict], list[str]]:
+    rows.sort(key=lambda row: (row["mtime"], row["job_id"]), reverse=True)
+    unprotected = [row for row in rows if row["job_id"] not in protected]
+    retained_ids = {row["job_id"] for row in unprotected[:keep]}
+    retained: list[dict] = []
+    removable: list[dict] = []
+    protected_paths: list[str] = []
+    max_age_seconds = max_age_hours * 3600
+
+    for row in rows:
+        if row["job_id"] in protected:
+            protected_paths.append(str(row["path"]))
+            retained.append(row)
+        elif (
+            row["job_id"] not in retained_ids
+            or current_time - row["mtime"] > max_age_seconds
+        ):
+            removable.append(row)
+        else:
+            retained.append(row)
+    return retained, removable, protected_paths
+
+
+def _enforce_snapshot_size_limit(
+    retained: list[dict],
+    removable: list[dict],
+    *,
+    protected: set[str],
+    max_bytes: int,
+) -> None:
+    retained_unprotected = [row for row in retained if row["job_id"] not in protected]
+    retained_unprotected.sort(
+        key=lambda row: (row["mtime"], row["job_id"]), reverse=True
+    )
+    retained_bytes = sum(row["bytes"] for row in retained_unprotected)
+    while retained_bytes > max_bytes and retained_unprotected:
+        oldest = retained_unprotected.pop()
+        retained_bytes -= oldest["bytes"]
+        retained.remove(oldest)
+        removable.append(oldest)
+
+
+def _remove_snapshot_rows(root: Path, removable: list[dict]) -> list[str]:
+    root_resolved = root.resolve()
+    removed: list[str] = []
+    for row in removable:
+        candidate = row["path"]
+        if (
+            candidate.is_symlink()
+            or not candidate.is_dir()
+            or candidate.resolve().parent != root_resolved
+        ):
+            raise RuntimeError(
+                f"snapshot cleanup target changed or escaped root: {candidate}"
+            )
+        shutil.rmtree(candidate)
+        removed.append(str(candidate))
+    return removed
+
+
 def prune_source_snapshots(
     cache_root: Path,
     *,
@@ -85,47 +200,24 @@ def prune_source_snapshots(
     """
     if keep < 0 or max_age_hours < 0 or max_bytes < 0:
         raise ValueError("snapshot retention bounds must be non-negative")
+
     protected = set(protected_job_ids or set())
     root = Path(cache_root) / SNAPSHOT_DIR_NAME
-    report = {
-        "status": "ok",
-        "mode": "apply" if apply else "dry-run",
-        "root": str(root),
-        "keep": keep,
-        "max_age_hours": max_age_hours,
-        "max_bytes": max_bytes,
-        "protected_job_ids": sorted(protected),
-        "retained": [],
-        "protected": [],
-        "would_remove": [],
-        "removed": [],
-        "would_remove_bytes": 0,
-        "removed_bytes": 0,
-    }
+    report = _snapshot_retention_report(
+        root,
+        protected=protected,
+        keep=keep,
+        max_age_hours=max_age_hours,
+        max_bytes=max_bytes,
+        apply=apply,
+    )
     if not root.exists():
         return report
     if root.is_symlink() or not root.is_dir():
         report.update(status="blocked", error="snapshot root is not a real directory")
         return report
 
-    rows = []
-    unsafe = []
-    for child in root.iterdir():
-        if child.is_symlink() or not child.is_dir():
-            unsafe.append(str(child))
-            continue
-        try:
-            stat_result = child.stat()
-        except FileNotFoundError:
-            continue
-        rows.append(
-            {
-                "path": child,
-                "job_id": child.name,
-                "mtime": stat_result.st_mtime,
-                "bytes": _allocated_tree_bytes(child),
-            }
-        )
+    rows, unsafe = _collect_snapshot_rows(root)
     if unsafe:
         report.update(
             status="blocked",
@@ -134,53 +226,23 @@ def prune_source_snapshots(
         )
         return report
 
-    current_time = time.time() if now is None else now
-    rows.sort(key=lambda row: (row["mtime"], row["job_id"]), reverse=True)
-    unprotected = [row for row in rows if row["job_id"] not in protected]
-    retained_ids = {row["job_id"] for row in unprotected[:keep]}
-    removable = []
-    retained = []
-    max_age_seconds = max_age_hours * 3600
-    for row in rows:
-        if row["job_id"] in protected:
-            report["protected"].append(str(row["path"]))
-            retained.append(row)
-            continue
-        too_old = current_time - row["mtime"] > max_age_seconds
-        if row["job_id"] not in retained_ids or too_old:
-            removable.append(row)
-        else:
-            retained.append(row)
-
-    retained_unprotected = [row for row in retained if row["job_id"] not in protected]
-    retained_unprotected.sort(
-        key=lambda row: (row["mtime"], row["job_id"]), reverse=True
+    retained, removable, protected_paths = _partition_snapshot_rows(
+        rows,
+        protected=protected,
+        keep=keep,
+        current_time=time.time() if now is None else now,
+        max_age_hours=max_age_hours,
     )
-    while (
-        sum(row["bytes"] for row in retained_unprotected) > max_bytes
-        and retained_unprotected
-    ):
-        oldest = retained_unprotected.pop()
-        retained.remove(oldest)
-        removable.append(oldest)
-
+    _enforce_snapshot_size_limit(
+        retained, removable, protected=protected, max_bytes=max_bytes
+    )
     removable.sort(key=lambda row: (row["mtime"], row["job_id"]))
+    report["protected"] = protected_paths
     report["retained"] = sorted(str(row["path"]) for row in retained)
     bytes_to_remove = sum(row["bytes"] for row in removable)
+
     if apply:
-        root_resolved = root.resolve()
-        for row in removable:
-            candidate = row["path"]
-            if (
-                candidate.is_symlink()
-                or not candidate.is_dir()
-                or candidate.resolve().parent != root_resolved
-            ):
-                raise RuntimeError(
-                    f"snapshot cleanup target changed or escaped root: {candidate}"
-                )
-            shutil.rmtree(candidate)
-            report["removed"].append(str(candidate))
+        report["removed"] = _remove_snapshot_rows(root, removable)
         report["removed_bytes"] = bytes_to_remove
     else:
         report["would_remove"] = [str(row["path"]) for row in removable]
@@ -200,6 +262,7 @@ def remove_source_snapshot(cache_root: Path, job_id: str) -> bool:
         raise RuntimeError(f"source snapshot escaped root: {target}")
     shutil.rmtree(target)
     return True
+
 
 class SourceStatus:
     """String-constant status vocabulary (no enums)."""

--- a/merger/lenskit/tests/test_repobrief_fleet_runtime.py
+++ b/merger/lenskit/tests/test_repobrief_fleet_runtime.py
@@ -92,33 +92,45 @@ def test_fingerprint_is_stable_and_covers_all_output_inputs() -> None:
     first, identity = module.build_fingerprint(
         source_sha="a" * 40,
         tool_tree_sha="b" * 40,
+        publication_repository="heimgewebe__demo",
         config=config,
     )
     repeated, repeated_identity = module.build_fingerprint(
         source_sha="a" * 40,
         tool_tree_sha="b" * 40,
+        publication_repository="heimgewebe__demo",
         config=config,
     )
     source_changed, _ = module.build_fingerprint(
         source_sha="c" * 40,
         tool_tree_sha="b" * 40,
+        publication_repository="heimgewebe__demo",
         config=config,
     )
     tool_changed, _ = module.build_fingerprint(
         source_sha="a" * 40,
         tool_tree_sha="d" * 40,
+        publication_repository="heimgewebe__demo",
         config=config,
     )
     config_changed, _ = module.build_fingerprint(
         source_sha="a" * 40,
         tool_tree_sha="b" * 40,
+        publication_repository="heimgewebe__demo",
         config=module.PublicationConfig(profile="agent-portable"),
     )
 
     assert first == repeated
     assert identity == repeated_identity
     assert len(first) == 64
-    assert len({first, source_changed, tool_changed, config_changed}) == 4
+    namespace_changed, _ = module.build_fingerprint(
+        source_sha="a" * 40,
+        tool_tree_sha="b" * 40,
+        publication_repository="other__demo",
+        config=config,
+    )
+
+    assert len({first, source_changed, tool_changed, config_changed, namespace_changed}) == 5
 
 
 def test_version_dirs_accepts_old_and_fingerprinted_names_only(tmp_path: Path) -> None:
@@ -202,7 +214,7 @@ def test_current_prune_keeps_localized_hashes_for_history_protection_and_stable_
     stable_target = stable_version / "repo_merge.bundle.manifest.json"
     newest_hashes = {digest for _, digest in versions_and_hashes[-3:]}
     stable_manifest = (
-        publication_root / "external" / "repobrief" / "demo" / "main" / "manifest.json"
+        publication_root / "external" / "repobrief" / "heimgewebe__demo" / "main" / "manifest.json"
     )
     stable_manifest.parent.mkdir(parents=True)
     stable_manifest.write_text(
@@ -215,7 +227,7 @@ def test_current_prune_keeps_localized_hashes_for_history_protection_and_stable_
         ),
         encoding="utf-8",
     )
-    localized = publication_root / "external" / "_bundles" / "demo" / "main"
+    localized = publication_root / "external" / "_bundles" / "heimgewebe__demo" / "main"
     unused_hash = "e" * 64
     for digest in newest_hashes | {protected_hash, stable_hash, unused_hash}:
         candidate = localized / digest
@@ -224,7 +236,7 @@ def test_current_prune_keeps_localized_hashes_for_history_protection_and_stable_
 
     report = module.prune_current_group(
         group,
-        repository="demo",
+        repository="heimgewebe__demo",
         ref="main",
         keep=3,
         apply=True,
@@ -248,7 +260,7 @@ def test_stable_manifest_target_is_fail_closed_for_missing_target(
     publication_root = tmp_path / "publication"
     monkeypatch.setattr(module, "PUB_ROOT", publication_root)
     manifest = (
-        publication_root / "external" / "repobrief" / "demo" / "main" / "manifest.json"
+        publication_root / "external" / "repobrief" / "heimgewebe__demo" / "main" / "manifest.json"
     )
     manifest.parent.mkdir(parents=True)
     manifest.write_text(

--- a/merger/lenskit/tests/test_service_gc.py
+++ b/merger/lenskit/tests/test_service_gc.py
@@ -1,6 +1,7 @@
 
 import uuid
 import logging
+import os
 from pathlib import Path
 from merger.lenskit.service.models import Job, Artifact, JobRequest
 
@@ -151,3 +152,42 @@ def test_cleanup_jobs_logs_warning_for_invalid_created_at(service_client, caplog
 
     assert ctx.store.get_job(job.id) is not None
     assert any("Skipping cleanup age check" in rec.message for rec in caplog.records)
+
+
+def test_snapshot_cleanup_protects_active_jobs_and_removes_terminal_old_jobs(
+    service_client,
+):
+    ctx = service_client
+    root = ctx.merges_dir / ".rlens-source-snapshots"
+    active = Job.create(JobRequest())
+    active.status = "running"
+    terminal = Job.create(JobRequest())
+    terminal.status = "succeeded"
+    ctx.store.add_job(active)
+    ctx.store.add_job(terminal)
+    for job in (active, terminal):
+        directory = root / job.id
+        directory.mkdir(parents=True)
+        (directory / "payload").write_text(job.id, encoding="utf-8")
+        os.utime(directory, (1, 1))
+
+    report = ctx.store.cleanup_source_snapshots(
+        apply=True, keep=0, max_age_hours=0, max_bytes=0
+    )
+
+    assert report["status"] == "ok"
+    assert (root / active.id).is_dir()
+    assert not (root / terminal.id).exists()
+
+
+def test_remove_job_removes_its_source_snapshot(service_client):
+    ctx = service_client
+    job = Job.create(JobRequest())
+    ctx.store.add_job(job)
+    snapshot = ctx.merges_dir / ".rlens-source-snapshots" / job.id
+    snapshot.mkdir(parents=True)
+    (snapshot / "payload").write_text("data", encoding="utf-8")
+
+    ctx.store.remove_job(job.id)
+
+    assert not snapshot.exists()

--- a/merger/lenskit/tests/test_service_sse_lifecycle.py
+++ b/merger/lenskit/tests/test_service_sse_lifecycle.py
@@ -1,166 +1,136 @@
-import pytest
 import asyncio
+
 import httpx
+import pytest
 from httpx import ASGITransport
-from merger.lenskit.service.app import app, state, init_service
-from merger.lenskit.service.models import JobRequest, Job
+
+from merger.lenskit.service.app import app, init_service, state
+from merger.lenskit.service.models import Job, JobRequest
+
 
 @pytest.fixture
 def lifecycle_env(tmp_path):
     init_service(hub_path=tmp_path)
     return tmp_path
 
-@pytest.mark.asyncio
-async def test_stream_wakes_on_appended_logs(lifecycle_env):
-    job_id = "test-wake"
-    req = JobRequest(repos=[])
-    job = Job.create(request=req)
+
+async def _wait_for_subscription(job_id: str, *, present: bool = True) -> None:
+    async def observed() -> None:
+        while (state.job_store.log_subscriber_count(job_id) > 0) is not present:
+            await asyncio.sleep(0)
+
+    await asyncio.wait_for(observed(), timeout=2.0)
+
+
+def _job(job_id: str) -> Job:
+    job = Job.create(request=JobRequest(repos=[]))
     job.id = job_id
     state.job_store.add_job(job)
+    return job
 
-    lines_received = []
 
-    async def run_stream():
-        transport = ASGITransport(app=app)
-        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
-            async with client.stream("GET", f"/api/jobs/{job_id}/logs") as response:
-                async for line in response.aiter_lines():
-                    if line.startswith("data: "):
-                        data = line[6:]
-                        if data == "end":
-                            break
-                        lines_received.append(data)
+async def _stream(job_id: str, lines_received: list[str]) -> None:
+    transport = ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://testserver"
+    ) as client:
+        async with client.stream("GET", f"/api/jobs/{job_id}/logs") as response:
+            async for line in response.aiter_lines():
+                if not line.startswith("data: "):
+                    continue
+                data = line[6:]
+                if data == "end":
+                    break
+                lines_received.append(data)
 
-    stream_task = asyncio.create_task(run_stream())
 
-    # Wait for stream to start and subscribe
-    await asyncio.sleep(0.1)
+def _observe_log_reads(
+    monkeypatch, expected_lines: set[str]
+) -> dict[str, asyncio.Event]:
+    events = {line: asyncio.Event() for line in expected_lines}
+    original = state.job_store.read_log_chunk
 
+    def observed(job_id: str, last_line_id: int):
+        rows = original(job_id, last_line_id)
+        for line, _line_id in rows:
+            event = events.get(line)
+            if event is not None:
+                event.set()
+        return rows
+
+    monkeypatch.setattr(state.job_store, "read_log_chunk", observed)
+    return events
+
+
+@pytest.mark.asyncio
+async def test_stream_wakes_on_appended_logs(lifecycle_env, monkeypatch):
+    job_id = "test-wake"
+    job = _job(job_id)
+    lines_received: list[str] = []
+    line_events = _observe_log_reads(monkeypatch, {"hello world 1", "hello world 2"})
+    stream_task = asyncio.create_task(_stream(job_id, lines_received))
+
+    await _wait_for_subscription(job_id)
     state.job_store.append_log_line(job_id, "hello world 1")
-    await asyncio.sleep(0.1)
-
+    await asyncio.wait_for(line_events["hello world 1"].wait(), timeout=2.0)
     state.job_store.append_log_line(job_id, "hello world 2")
-    await asyncio.sleep(0.1)
-
-    # End job
+    await asyncio.wait_for(line_events["hello world 2"].wait(), timeout=2.0)
     job.status = "succeeded"
     state.job_store.update_job(job)
 
     await asyncio.wait_for(stream_task, timeout=2.0)
-
     assert lines_received == ["hello world 1", "hello world 2"]
+
 
 @pytest.mark.asyncio
 async def test_stream_ends_on_terminal_status(lifecycle_env):
     job_id = "test-term"
-    req = JobRequest(repos=[])
-    job = Job.create(request=req)
-    job.id = job_id
-    state.job_store.add_job(job)
-
+    job = _job(job_id)
     state.job_store.append_log_line(job_id, "start")
+    lines_received: list[str] = []
+    stream_task = asyncio.create_task(_stream(job_id, lines_received))
 
-    lines_received = []
-
-    async def run_stream():
-        transport = ASGITransport(app=app)
-        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
-            async with client.stream("GET", f"/api/jobs/{job_id}/logs") as response:
-                async for line in response.aiter_lines():
-                    if line.startswith("data: "):
-                        data = line[6:]
-                        if data == "end":
-                            break
-                        lines_received.append(data)
-
-    stream_task = asyncio.create_task(run_stream())
-
-    await asyncio.sleep(0.1)
-
-    # Just update job status to failed.
-    # We shouldn't hang.
+    await _wait_for_subscription(job_id)
     job.status = "failed"
     state.job_store.update_job(job)
 
     await asyncio.wait_for(stream_task, timeout=2.0)
-
     assert lines_received == ["start"]
-    # Verify cleanup happened correctly
-    assert job_id not in state.job_store._log_subscribers
+    await _wait_for_subscription(job_id, present=False)
+
 
 @pytest.mark.asyncio
 async def test_stream_exits_on_job_removal(lifecycle_env):
     job_id = "test-remove"
-    req = JobRequest(repos=[])
-    job = Job.create(request=req)
-    job.id = job_id
-    state.job_store.add_job(job)
+    _job(job_id)
+    lines_received: list[str] = []
+    stream_task = asyncio.create_task(_stream(job_id, lines_received))
 
-    lines_received = []
-
-    async def run_stream():
-        transport = ASGITransport(app=app)
-        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
-            async with client.stream("GET", f"/api/jobs/{job_id}/logs") as response:
-                async for line in response.aiter_lines():
-                    if line.startswith("data: "):
-                        data = line[6:]
-                        if data == "end":
-                            break
-                        lines_received.append(data)
-
-    stream_task = asyncio.create_task(run_stream())
-
-    await asyncio.sleep(0.1)
-    assert job_id in state.job_store._log_subscribers
-
-    # Remove job, should trigger exit of loop
+    await _wait_for_subscription(job_id)
     state.job_store.remove_job(job_id)
 
     await asyncio.wait_for(stream_task, timeout=2.0)
+    assert lines_received == []
+    assert state.job_store.log_subscriber_count(job_id) == 0
 
-    assert len(lines_received) == 0
-    # Subscriber cleanup verified
-    assert job_id not in state.job_store._log_subscribers
 
 @pytest.mark.asyncio
 async def test_stream_idle_timeout_path(lifecycle_env, monkeypatch):
-    job_id = "test-idle"
-    req = JobRequest(repos=[])
-    job = Job.create(request=req)
-    job.id = job_id
-    state.job_store.add_job(job)
-
-    # Monkeypatch the idle timeout to a very small value to trigger it instantly
-    # without affecting the global asyncio.wait_for behavior
     import merger.lenskit.service.app
+
+    job_id = "test-idle"
+    job = _job(job_id)
     monkeypatch.setattr(merger.lenskit.service.app, "SSE_IDLE_RECHECK_SEC", 0.01)
+    lines_received: list[str] = []
+    line_events = _observe_log_reads(monkeypatch, {"survived idle"})
+    stream_task = asyncio.create_task(_stream(job_id, lines_received))
 
-    lines_received = []
-
-    async def run_stream():
-        transport = ASGITransport(app=app)
-        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
-            async with client.stream("GET", f"/api/jobs/{job_id}/logs") as response:
-                async for line in response.aiter_lines():
-                    if line.startswith("data: "):
-                        data = line[6:]
-                        if data == "end":
-                            break
-                        lines_received.append(data)
-
-    stream_task = asyncio.create_task(run_stream())
-
-    # Let it spin a bit through the mock timeouts
-    await asyncio.sleep(0.1)
-
-    # Send a log to ensure it's still alive and reacts
+    await _wait_for_subscription(job_id)
+    await asyncio.sleep(0.03)
     state.job_store.append_log_line(job_id, "survived idle")
-    await asyncio.sleep(0.1)
-
+    await asyncio.wait_for(line_events["survived idle"].wait(), timeout=2.0)
     job.status = "succeeded"
     state.job_store.update_job(job)
 
     await asyncio.wait_for(stream_task, timeout=2.0)
-
     assert lines_received == ["survived idle"]

--- a/merger/lenskit/tests/test_source_acquisition.py
+++ b/merger/lenskit/tests/test_source_acquisition.py
@@ -21,6 +21,8 @@ from merger.lenskit.service.source_acquisition import (
     SourceStatus,
     SnapshotExtractionError,
     materialize_remote_snapshot,
+    prune_source_snapshots,
+    remove_source_snapshot,
     resolve_remote_ref,
     resolve_effective_source_mode,
     safe_extract_tar,
@@ -914,3 +916,80 @@ def test_safe_extract_tar_wraps_fs_collision_as_extraction_error(tmp_path):
     members = [_reg("a", b"i am a file"), _reg("a/b.txt", b"x")]
     with pytest.raises(SnapshotExtractionError):
         safe_extract_tar(_build_tar(members), dest)
+
+
+def _snapshot_dir(root: Path, job_id: str, *, mtime: float, blocks: int = 1) -> Path:
+    directory = root / ".rlens-source-snapshots" / job_id
+    directory.mkdir(parents=True)
+    (directory / "payload.bin").write_bytes(b"x" * max(1, blocks))
+    os.utime(directory, (mtime, mtime))
+    return directory
+
+
+def test_source_snapshot_retention_is_dry_run_and_protects_active_jobs(tmp_path):
+    now = 10_000.0
+    old = _snapshot_dir(tmp_path, "old", mtime=now - 1000)
+    recent = _snapshot_dir(tmp_path, "recent", mtime=now - 10)
+    active = _snapshot_dir(tmp_path, "active", mtime=now - 5000)
+
+    report = prune_source_snapshots(
+        tmp_path,
+        protected_job_ids={"active"},
+        keep=1,
+        max_age_hours=1,
+        max_bytes=1024 * 1024,
+        apply=False,
+        now=now,
+    )
+
+    assert report["status"] == "ok"
+    assert report["would_remove"] == [str(old)]
+    assert str(active) in report["protected"]
+    assert old.is_dir() and recent.is_dir() and active.is_dir()
+
+
+def test_source_snapshot_retention_applies_count_age_and_size_bounds(tmp_path):
+    now = 20_000.0
+    oldest = _snapshot_dir(tmp_path, "oldest", mtime=now - 7200, blocks=10)
+    middle = _snapshot_dir(tmp_path, "middle", mtime=now - 20, blocks=10)
+    newest = _snapshot_dir(tmp_path, "newest", mtime=now - 10, blocks=10)
+
+    report = prune_source_snapshots(
+        tmp_path,
+        keep=2,
+        max_age_hours=1,
+        max_bytes=0,
+        apply=True,
+        now=now,
+    )
+
+    assert report["status"] == "ok"
+    assert set(report["removed"]) == {str(oldest), str(middle), str(newest)}
+    assert not oldest.exists() and not middle.exists() and not newest.exists()
+    assert report["removed_bytes"] > 0
+
+
+def test_source_snapshot_retention_blocks_before_delete_on_unsafe_child(tmp_path):
+    safe = _snapshot_dir(tmp_path, "safe", mtime=1)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    link = tmp_path / ".rlens-source-snapshots" / "link"
+    link.symlink_to(outside, target_is_directory=True)
+
+    report = prune_source_snapshots(
+        tmp_path, keep=0, max_age_hours=0, max_bytes=0, apply=True, now=100
+    )
+
+    assert report["status"] == "blocked"
+    assert safe.is_dir()
+    assert outside.is_dir()
+
+
+def test_remove_source_snapshot_is_exact_and_confined(tmp_path):
+    target = _snapshot_dir(tmp_path, "job-1", mtime=1)
+    other = _snapshot_dir(tmp_path, "job-2", mtime=1)
+
+    assert remove_source_snapshot(tmp_path, "job-1") is True
+    assert not target.exists()
+    assert other.is_dir()
+    assert remove_source_snapshot(tmp_path, "missing") is False

--- a/scripts/ops/rb-publish-fleet
+++ b/scripts/ops/rb-publish-fleet
@@ -39,7 +39,7 @@ FLEET_LOG = LOG_ROOT / "fleet.log"
 LOCK_PATH = STATE_ROOT.parent / "fleet.lock"
 DEFAULT_RETENTION = 3
 MAX_RETENTION = 10
-FINGERPRINT_SCHEMA = "repobrief.fleet-publication-fingerprint.v1"
+FINGERPRINT_SCHEMA = "repobrief.fleet-publication-fingerprint.v2"
 STATE_SCHEMA = "repobrief.fleet-publication-state.v1"
 VERSION_DIR_RE = re.compile(r"^\d{8}T\d{6}Z(?:-[0-9a-f]{12})?$")
 EXCLUDE = {
@@ -221,6 +221,11 @@ def publication_config(entry: RepoEntry) -> PublicationConfig:
     return PublicationConfig(profile=profile)
 
 
+def publication_repository(entry: RepoEntry) -> str:
+    """Return the collision-free registry segment for one GitHub repository."""
+    return safe_segment(entry.owner) + "__" + safe_segment(entry.repo)
+
+
 def git_common_dir(repo: Path) -> Path:
     cp = run(
         ["git", "-C", str(repo), "rev-parse", "--git-common-dir"],
@@ -360,12 +365,14 @@ def build_fingerprint(
     *,
     source_sha: str,
     tool_tree_sha: str,
+    publication_repository: str,
     config: PublicationConfig,
 ) -> tuple[str, dict[str, object]]:
     identity: dict[str, object] = {
         "schema": FINGERPRINT_SCHEMA,
         "source_sha": source_sha,
         "tool_tree_sha": tool_tree_sha,
+        "publication_repository": publication_repository,
         "configuration": config.as_dict(),
     }
     return canonical_sha256(identity), identity
@@ -645,7 +652,7 @@ def prune_all_current(
     for repo_group in sorted(root.iterdir()):
         if not repo_group.is_dir() or repo_group.is_symlink():
             continue
-        repository = repo_group.name.rsplit("__", 1)[-1]
+        repository = repo_group.name
         for ref_group in sorted(repo_group.iterdir()):
             if not ref_group.is_dir() or ref_group.is_symlink():
                 continue
@@ -716,6 +723,7 @@ def publish(
     config: PublicationConfig,
 ) -> tuple[dict[str, object], Path]:
     repository = safe_segment(entry.repo)
+    registry_repository = publication_repository(entry)
     ref_segment = safe_segment(branch)
     source_wt = ensure_source_worktree(entry, ref_segment, sha)
     out_base = (
@@ -741,7 +749,7 @@ def publish(
         "--publication-root",
         str(PUB_ROOT),
         "--repository",
-        repository,
+        registry_repository,
         "--ref",
         ref_segment,
         "--profile",
@@ -950,9 +958,11 @@ def main(argv: list[str]) -> int:
                 remote_ref, branch, source_sha = remote_head(entry.path)
                 ref_segment = safe_segment(branch)
                 config = publication_config(entry)
+                registry_repository = publication_repository(entry)
                 fingerprint, identity = build_fingerprint(
                     source_sha=source_sha,
                     tool_tree_sha=tool_tree_sha,
+                    publication_repository=registry_repository,
                     config=config,
                 )
                 publication_state_path = state_path(entry, ref_segment)
@@ -1005,7 +1015,7 @@ def main(argv: list[str]) -> int:
                 try:
                     prune_report = prune_current_group(
                         out_dir.parent,
-                        repository=safe_segment(entry.repo),
+                        repository=registry_repository,
                         ref=ref_segment,
                         keep=args.retention,
                         apply=True,


### PR DESCRIPTION
## Summary
- use owner-qualified publication identities to prevent cross-owner repository-name collisions
- bound rLens remote-source snapshots by count, age and allocated size while protecting active jobs
- replace timing-based SSE lifecycle synchronization with observable server-side subscription evidence
- preserve the repository complexity ratchets through small cleanup helpers

## Verification
- 4014 passed, 1 skipped, 13 deselected
- adjacent service and retention suites: 152 passed, 1 skipped
- SSE lifecycle suite repeated 30/30 successfully
- graph maintainability ratchet, Ruff, ShellCheck and release contract passed
- two deterministic release candidates were identical and independently verified

## Diff evidence
- head: 2860229c656d12bd762dfdf77c8a7ec6ca5de4bb
- base: 61caa5b7a04fb1e5ed53f1d0026d841b27f3df66
- diff SHA-256: 893855d7945e6cf78664d09a1a37e4624d4060ddb3b799212c79b7d28aa8317c
- self-review receipt SHA-256: a234ff8c315d47709e0e3e87a52b9118192c761fa2e24ae202d608b49e676c37