### PR TITLE
fix(repobrief): schedule watcher on the calendar

### DIFF
--- a/docs/operations/repobrief-fleet-retention.md
+++ b/docs/operations/repobrief-fleet-retention.md
@@ -39,6 +39,9 @@ Keeping only one version saves more storage but removes useful comparison and re
 
 The installer leaves automatic publication paused unless invoked with `--enable`. This prevents an installation or migration from silently resuming generation.
 
+The enabled watcher uses `OnCalendar=hourly` with a bounded randomized delay. A calendar timer always receives a future deadline when enabled, even if the machine has already been running longer than the former boot-relative delay. `Persistent=true` performs one catch-up run after downtime.
+
+
 Legacy source-only state markers are intentionally not trusted as proof that generator and configuration inputs are unchanged. The first explicit reactivation can therefore produce one controlled publication per repository before normal fingerprint-based skipping begins.
 
 The publication fingerprint schema is now v2 because the owner-qualified publication identity is part of the content decision. Therefore the first enabled fleet cycle after this migration intentionally republishes each inventoried repository once into its collision-free address. A second immediate cycle with unchanged source commits, generator code and configuration must skip every repository.

--- a/merger/lenskit/tests/test_repobrief_fleet_runtime.py
+++ b/merger/lenskit/tests/test_repobrief_fleet_runtime.py
@@ -407,8 +407,11 @@ def test_runtime_has_one_hourly_changed_only_timer_and_no_force_fallback() -> No
     assert "--if-changed" in service
     assert "--retention 3" in service
     assert "--force" not in service
-    assert "OnUnitActiveSec=1h" in timer
+    assert "OnCalendar=hourly" in timer
+    assert "OnBootSec=" not in timer
+    assert "OnUnitActiveSec=" not in timer
     assert "RandomizedDelaySec=10min" in timer
+    assert "Persistent=true" in timer
     assert sorted(path.name for path in UNIT_DIR.iterdir()) == [
         "rb-publish-fleet-watch.service",
         "rb-publish-fleet-watch.timer",

--- a/ops/systemd/repobrief-fleet/rb-publish-fleet-watch.timer
+++ b/ops/systemd/repobrief-fleet/rb-publish-fleet-watch.timer
@@ -2,8 +2,7 @@
 Description=Hourly changed-only RepoBrief fleet publication
 
 [Timer]
-OnBootSec=15min
-OnUnitActiveSec=1h
+OnCalendar=hourly
 RandomizedDelaySec=10min
 Persistent=true
 Unit=rb-publish-fleet-watch.service


### PR DESCRIPTION
## Summary
- replace the boot-relative watcher trigger with `OnCalendar=hourly`
- preserve the bounded randomized delay and persistent catch-up behavior
- add a regression test that rejects the dead-start timer configuration

## Why
The first live activation after PR #1013 produced `enabled` but `SubState=elapsed` with no future deadline. `OnBootSec=15min` had already elapsed, and `OnUnitActiveSec=1h` had no service activation to anchor its first deadline.

## Verification
- 18 focused tests passed
- 4014 full-suite tests passed, 1 skipped, 13 deselected
- Ruff passed
- systemd calendar parser resolved `hourly` to a future wall-clock deadline
- two deterministic release candidates were identical and verified

## Diff evidence
- head: 9899c9e3c08e80c14a6f738d7139ebb1a8b783be
- base: 40b5f02c31cf213074a30529124d2ca67fc8f096
- diff SHA-256: 5cb082c3e3905f6fa804858c2b2a9c675109f86c2f595cf9b9ab62e763648123
- self-review receipt SHA-256: 5449fae79149d012da895e8d79c3672862b64ca970ae33d69f38c07473325ee8