### PR TITLE
fix(repobrief): scope generator fingerprint inputs

### DIFF
--- a/docs/operations/repobrief-fleet-retention.md
+++ b/docs/operations/repobrief-fleet-retention.md
@@ -5,11 +5,13 @@
 The fleet publisher uses a content identity instead of a timestamp as the generation decision. A repository is regenerated only when at least one input that can alter the result changes:
 
 - the remote default-branch commit;
-- the Lenskit generator tree under `merger/lenskit`;
+- the canonical RepoBrief generator inputs: the two RepoBrief CLI entry files plus `core`, `contracts`, and `retrieval`;
 - the explicit publication configuration.
 - the collision-free publication identity (`owner__repository`).
 
 A timestamp remains in the directory name only to order the retained history. It is not sufficient to trigger generation.
+
+Service, Web UI, test and documentation-only changes are deliberately outside the generator-input digest. They cannot alter a RepoBrief bundle produced by the `external-manifest refresh` command and therefore must not regenerate the fleet. The digest is built from Git blob identities, modes and paths for the allowlisted generator inputs; missing mandatory CLI entry files fail closed.
 
 Stable external manifests and consumer-local bundle paths use `owner__repository` rather than the repository name alone. This prevents repositories with the same name under different GitHub owners from sharing one publication address. Existing name-only external paths are left in place as frozen compatibility data; the fleet publisher no longer updates them.
 
@@ -44,7 +46,7 @@ The enabled watcher uses `OnCalendar=hourly` with a bounded randomized delay. A 
 
 Legacy source-only state markers are intentionally not trusted as proof that generator and configuration inputs are unchanged. The first explicit reactivation can therefore produce one controlled publication per repository before normal fingerprint-based skipping begins.
 
-The publication fingerprint schema is now v2 because the owner-qualified publication identity is part of the content decision. Therefore the first enabled fleet cycle after this migration intentionally republishes each inventoried repository once into its collision-free address. A second immediate cycle with unchanged source commits, generator code and configuration must skip every repository.
+The publication fingerprint schema is v3 because it combines the owner-qualified publication identity with a scoped generator-input digest. Therefore the first enabled fleet cycle after this migration intentionally republishes each inventoried repository once into its collision-free address. A second immediate cycle with unchanged source commits, generator code and configuration must skip every repository.
 
 Dry-run current, legacy, and retired special storage:
 

--- a/merger/lenskit/tests/test_repobrief_fleet_runtime.py
+++ b/merger/lenskit/tests/test_repobrief_fleet_runtime.py
@@ -91,31 +91,31 @@ def test_fingerprint_is_stable_and_covers_all_output_inputs() -> None:
     config = module.PublicationConfig(profile="full-max")
     first, identity = module.build_fingerprint(
         source_sha="a" * 40,
-        tool_tree_sha="b" * 40,
+        generator_inputs_sha="b" * 40,
         publication_repository="heimgewebe__demo",
         config=config,
     )
     repeated, repeated_identity = module.build_fingerprint(
         source_sha="a" * 40,
-        tool_tree_sha="b" * 40,
+        generator_inputs_sha="b" * 40,
         publication_repository="heimgewebe__demo",
         config=config,
     )
     source_changed, _ = module.build_fingerprint(
         source_sha="c" * 40,
-        tool_tree_sha="b" * 40,
+        generator_inputs_sha="b" * 40,
         publication_repository="heimgewebe__demo",
         config=config,
     )
     tool_changed, _ = module.build_fingerprint(
         source_sha="a" * 40,
-        tool_tree_sha="d" * 40,
+        generator_inputs_sha="d" * 40,
         publication_repository="heimgewebe__demo",
         config=config,
     )
     config_changed, _ = module.build_fingerprint(
         source_sha="a" * 40,
-        tool_tree_sha="b" * 40,
+        generator_inputs_sha="b" * 40,
         publication_repository="heimgewebe__demo",
         config=module.PublicationConfig(profile="agent-portable"),
     )
@@ -125,13 +125,47 @@ def test_fingerprint_is_stable_and_covers_all_output_inputs() -> None:
     assert len(first) == 64
     namespace_changed, _ = module.build_fingerprint(
         source_sha="a" * 40,
-        tool_tree_sha="b" * 40,
+        generator_inputs_sha="b" * 40,
         publication_repository="other__demo",
         config=config,
     )
 
     assert len({first, source_changed, tool_changed, config_changed, namespace_changed}) == 5
 
+
+
+def test_generator_inputs_sha_ignores_service_and_test_only_changes(tmp_path: Path) -> None:
+    module = load_publisher()
+    repo, _ = initialize_repository(tmp_path, "lenskit")
+    tracked = {
+        "merger/lenskit/__init__.py": "",
+        "merger/lenskit/cli/__init__.py": "",
+        "merger/lenskit/cli/repobrief.py": "entrypoint\n",
+        "merger/lenskit/cli/cmd_repobrief.py": "command\n",
+        "merger/lenskit/core/merge.py": "generator v1\n",
+        "merger/lenskit/contracts/bundle.json": "{}\n",
+        "merger/lenskit/retrieval/query.py": "query v1\n",
+        "merger/lenskit/service/app.py": "service v1\n",
+        "merger/lenskit/tests/test_only.py": "test v1\n",
+    }
+    for relative, content in tracked.items():
+        path = repo / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    git(repo, "add", ".")
+    git(repo, "commit", "-m", "generator baseline")
+    baseline = module.generator_inputs_sha(repo)
+
+    (repo / "merger/lenskit/service/app.py").write_text("service v2\n", encoding="utf-8")
+    (repo / "merger/lenskit/tests/test_only.py").write_text("test v2\n", encoding="utf-8")
+    git(repo, "add", ".")
+    git(repo, "commit", "-m", "non-generator changes")
+    assert module.generator_inputs_sha(repo) == baseline
+
+    (repo / "merger/lenskit/core/merge.py").write_text("generator v2\n", encoding="utf-8")
+    git(repo, "add", ".")
+    git(repo, "commit", "-m", "generator change")
+    assert module.generator_inputs_sha(repo) != baseline
 
 def test_version_dirs_accepts_old_and_fingerprinted_names_only(tmp_path: Path) -> None:
     module = load_publisher()

--- a/scripts/ops/rb-publish-fleet
+++ b/scripts/ops/rb-publish-fleet
@@ -39,8 +39,17 @@ FLEET_LOG = LOG_ROOT / "fleet.log"
 LOCK_PATH = STATE_ROOT.parent / "fleet.lock"
 DEFAULT_RETENTION = 3
 MAX_RETENTION = 10
-FINGERPRINT_SCHEMA = "repobrief.fleet-publication-fingerprint.v2"
+FINGERPRINT_SCHEMA = "repobrief.fleet-publication-fingerprint.v3"
 STATE_SCHEMA = "repobrief.fleet-publication-state.v1"
+GENERATOR_INPUT_PATHS = (
+    "merger/lenskit/__init__.py",
+    "merger/lenskit/cli/__init__.py",
+    "merger/lenskit/cli/repobrief.py",
+    "merger/lenskit/cli/cmd_repobrief.py",
+    "merger/lenskit/core",
+    "merger/lenskit/contracts",
+    "merger/lenskit/retrieval",
+)
 VERSION_DIR_RE = re.compile(r"^\d{8}T\d{6}Z(?:-[0-9a-f]{12})?$")
 EXCLUDE = {
     ".repobrief-tools",
@@ -301,6 +310,49 @@ def prepare_managed_worktree(
     assert_managed_worktree_clean(path, expected_repo)
 
 
+def generator_inputs_sha(worktree: Path) -> str:
+    raw = run(
+        [
+            "git",
+            "-C",
+            str(worktree),
+            "ls-tree",
+            "-rz",
+            "--full-tree",
+            "HEAD",
+            "--",
+            *GENERATOR_INPUT_PATHS,
+        ]
+    ).stdout
+    entries: list[dict[str, str]] = []
+    for record in raw.split("\0"):
+        if not record:
+            continue
+        metadata, path = record.split("\t", 1)
+        mode, object_type, object_id = metadata.split(" ")
+        if object_type != "blob":
+            raise RuntimeError(
+                f"unexpected generator input object {object_type!r} at {path!r}"
+            )
+        entries.append(
+            {
+                "mode": mode,
+                "object_id": object_id,
+                "path": path,
+            }
+        )
+    entries.sort(key=lambda entry: entry["path"].encode("utf-8", errors="surrogateescape"))
+    required_files = {
+        "merger/lenskit/cli/repobrief.py",
+        "merger/lenskit/cli/cmd_repobrief.py",
+    }
+    present_paths = {entry["path"] for entry in entries}
+    missing = sorted(required_files - present_paths)
+    if missing:
+        raise RuntimeError(f"missing required generator inputs: {missing}")
+    return canonical_sha256(entries)
+
+
 def ensure_tool_worktree() -> tuple[str, str]:
     run(["git", "-C", str(LENSKIT_REPO), "fetch", "origin", "--prune"])
     prepare_managed_worktree(
@@ -309,10 +361,7 @@ def ensure_tool_worktree() -> tuple[str, str]:
         target="origin/main",
     )
     tool_sha = run(["git", "-C", str(TOOL_WT), "rev-parse", "HEAD"]).stdout.strip()
-    tool_tree = run(
-        ["git", "-C", str(TOOL_WT), "rev-parse", "HEAD:merger/lenskit"]
-    ).stdout.strip()
-    return tool_sha, tool_tree
+    return tool_sha, generator_inputs_sha(TOOL_WT)
 
 
 def remote_head(repo_path: Path) -> tuple[str, str, str]:
@@ -364,14 +413,14 @@ def state_path(entry: RepoEntry, ref_segment: str) -> Path:
 def build_fingerprint(
     *,
     source_sha: str,
-    tool_tree_sha: str,
+    generator_inputs_sha: str,
     publication_repository: str,
     config: PublicationConfig,
 ) -> tuple[str, dict[str, object]]:
     identity: dict[str, object] = {
         "schema": FINGERPRINT_SCHEMA,
         "source_sha": source_sha,
-        "tool_tree_sha": tool_tree_sha,
+        "generator_inputs_sha": generator_inputs_sha,
         "publication_repository": publication_repository,
         "configuration": config.as_dict(),
     }
@@ -949,7 +998,7 @@ def main(argv: list[str]) -> int:
             f"== fleet {mode} {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())} "
             f"entries={len(entries)} limit={args.limit} retention={args.retention} =="
         )
-        tool_sha, tool_tree_sha = ensure_tool_worktree()
+        tool_sha, generator_sha = ensure_tool_worktree()
         changed = published = skipped = failed = queued = prune_failed = 0
         details: list[dict[str, object]] = []
         protected: set[Path] = set()
@@ -961,7 +1010,7 @@ def main(argv: list[str]) -> int:
                 registry_repository = publication_repository(entry)
                 fingerprint, identity = build_fingerprint(
                     source_sha=source_sha,
-                    tool_tree_sha=tool_tree_sha,
+                    generator_inputs_sha=generator_sha,
                     publication_repository=registry_repository,
                     config=config,
                 )
@@ -1063,7 +1112,7 @@ def main(argv: list[str]) -> int:
             "prune_failed": prune_failed,
             "retention": args.retention,
             "tool_sha": tool_sha,
-            "tool_tree_sha": tool_tree_sha,
+            "generator_inputs_sha": generator_sha,
             "force_reason": args.reason if args.force_republish else None,
             "details": details,
         }


### PR DESCRIPTION
## Summary
- replace the broad `merger/lenskit` tree identity with a canonical digest of actual RepoBrief generator inputs
- include RepoBrief CLI entry files plus `core`, `contracts`, and `retrieval`
- exclude service, Web UI, test, and documentation-only changes from fleet regeneration
- fail closed if mandatory generator entry files are missing

## Verification
- 19 focused tests passed
- 4015 full-suite tests passed, 1 skipped, 13 deselected
- Ruff and diff checks passed
- two deterministic release candidates were identical and verified
- regression test proves service/test-only commits preserve the digest while core changes alter it

## Diff evidence
- head: fa582701f9f4b9726a23c5191acfdaf6aac8b8bb
- base: 55f841f08c3b76ab6fa5d40e9bebda6b3fb687ba
- diff SHA-256: b187382973f97a6b4f34e0151babdb0ed0a0e203d5d0744af49fd93c8dae1a49