### PR TITLE
fix(repobrief): make retention fail closed

### DIFF
--- a/docs/operations/repobrief-fleet-retention.md
+++ b/docs/operations/repobrief-fleet-retention.md
@@ -6,57 +6,126 @@ The fleet publisher uses a content identity instead of a timestamp as the genera
 
 - the remote default-branch commit;
 - the canonical RepoBrief generator inputs: the two RepoBrief CLI entry files plus `core`, `contracts`, and `retrieval`;
-- the explicit publication configuration.
+- the explicit publication configuration;
 - the collision-free publication identity (`owner__repository`).
 
-A timestamp remains in the directory name only to order the retained history. It is not sufficient to trigger generation.
+A timestamp remains in the directory name only to order retained history. It is not sufficient to trigger generation.
 
-Service, Web UI, test and documentation-only changes are deliberately outside the generator-input digest. They cannot alter a RepoBrief bundle produced by the `external-manifest refresh` command and therefore must not regenerate the fleet. The digest is built from Git blob identities, modes and paths for the allowlisted generator inputs; missing mandatory CLI entry files fail closed.
+Service, Web UI, test, and documentation-only changes are deliberately outside the generator-input digest. They cannot alter a RepoBrief bundle produced by `external-manifest refresh` and therefore must not regenerate the fleet. The digest is built from Git blob identities, modes, and paths for the allowlisted generator inputs; missing mandatory CLI entry files fail closed.
 
-Stable external manifests and consumer-local bundle paths use `owner__repository` rather than the repository name alone. This prevents repositories with the same name under different GitHub owners from sharing one publication address. Existing name-only external paths are left in place as frozen compatibility data; the fleet publisher no longer updates them.
+Stable external manifests and consumer-local bundle paths use `owner__repository` rather than the repository name alone. This prevents repositories with the same name under different GitHub owners from sharing one publication address. Only these owner-qualified stable manifests are authoritative reachability roots. Existing name-only external paths remain frozen compatibility data: the fleet publisher neither updates them nor uses their possibly stale targets to authorize or block canonical retention.
 
-## Retention
+## Retention policy
 
-Each repository and ref keeps the latest three successful publication directories. The consumer-local content-addressed bundle copies are pruned to the hashes still referenced by those three versions or by the stable external manifests.
+Each repository and ref keeps the latest three successful publication directories. Consumer-local content-addressed copies are retained while their SHA-256 is referenced by one of those versions or by a stable external manifest.
 
-Three versions are the default compromise:
+Three versions provide:
 
-1. current state;
-2. previous state for a direct comparison;
+1. the current state;
+2. the previous state for direct comparison;
 3. one additional rollback or trend point.
 
-Keeping only one version saves more storage but removes useful comparison and recovery evidence. Keeping eight versions multiplied full bundles without enough operational benefit.
+Keeping only one version saves more storage but removes useful comparison and recovery evidence. Keeping many complete generations multiplies storage without equivalent operational benefit. Operators may choose a value from 1 through 10, but the fleet default remains 3.
 
-## Safety
+## Reachability roots
 
-- The old unrestricted `--force` option is rejected.
-- A forced republish is possible only for explicitly named repositories and requires a reason.
-- Concurrent fleet runs are blocked by a process lock.
-- Dedicated tool and source worktrees must be clean, detached, and belong to the expected repository. Dirty, ignored, foreign, or branch-attached worktrees abort the run and are never cleaned or force-removed.
-- A failed generation is removed only from its newly allocated output directory and is never written as the current state.
-- Bulk cleanup is dry-run by default. Deletion requires `--apply-prune`.
-- Exact paths can be protected from cleanup with repeated `--protect-path` options.
+A reachability root is authoritative evidence that a publication is still in use. Retention must not remove a directory that is equal to, contains, or is contained by any current root.
 
-## Runtime state
+The publisher rebuilds the protected set before every destructive step from:
 
-The installer leaves automatic publication paused unless invoked with `--enable`. This prevents an installation or migration from silently resuming generation.
+- canonical owner-qualified stable external manifests;
+- every valid fleet state file and its `publication_dir`;
+- active publication markers under `STATE_ROOT/active-publications`;
+- explicit repeated `--protect-path` arguments.
 
-The enabled watcher uses `OnCalendar=hourly` with a bounded randomized delay. A calendar timer always receives a future deadline when enabled, even if the machine has already been running longer than the former boot-relative delay. `Persistent=true` performs one catch-up run after downtime.
+State and marker files are parsed strictly. An unsupported schema, missing `publication_dir`, missing current state target, symlink, or path outside the managed RepoBrief roots aborts cleanup. A stale active marker therefore retains data rather than guessing that a publication is dead. Removing such a marker requires separate operator inspection; retention never expires it automatically.
 
+## Active publication markers
 
-Legacy source-only state markers are intentionally not trusted as proof that generator and configuration inputs are unchanged. The first explicit reactivation can therefore produce one controlled publication per repository before normal fingerprint-based skipping begins.
+Before generation starts, the publisher writes a marker containing the repository, ref, fingerprint, process ID, and intended publication directory. The marker is cleared only after the generated bundle has been validated and the new state pointer has been written.
 
-The publication fingerprint schema is v3 because it combines the owner-qualified publication identity with a scoped generator-input digest. Therefore the first enabled fleet cycle after this migration intentionally republishes each inventoried repository once into its collision-free address. A second immediate cycle with unchanged source commits, generator code and configuration must skip every repository.
+This closes the interval in which cleanup could otherwise remove a directory that another publisher is still creating. If generation fails, only its newly allocated output is discarded. If the process stops after producing valid output but before committing state, the remaining marker deliberately protects the output until it is inspected.
 
-Dry-run current, legacy, and retired special storage:
+## Strict storage classification
+
+Cleanup recognises only declared layouts:
+
+- current bundles: `bundles/<owner__repo>/<ref>/<timestamp-fingerprint>`;
+- modern legacy bundles: `repobrief-auto/<owner__repo>/<ref>/<timestamp>`;
+- older direct legacy bundles: `repobrief-auto/<legacy-group>/<timestamp>`;
+- retired special bundles: `repobrief-auto/<group>/<timestamp>`;
+- localised copies: `external/_bundles/<owner__repo>/<ref>/<sha256>`.
+
+Timestamp directories must match the canonical UTC naming pattern. Localised directories must be exact lowercase SHA-256 values. Files, symlinks, mixed legacy layouts, malformed names, or any other unexpected entry abort cleanup instead of being ignored or guessed about.
+
+## Transactional deletion
+
+Deletion is not performed directly on the selected source directory.
+
+For every candidate the publisher:
+
+1. records a tree snapshot containing device and inode identity, file metadata, and SHA-256 digests;
+2. recomputes all reachability roots;
+3. verifies that the tree still matches the snapshot;
+4. writes a transaction journal under `STATE_ROOT/retention-transactions`;
+5. atomically renames the directory into a quarantine directory on the same filesystem;
+6. verifies the quarantined identity and recomputes reachability again;
+7. restores the source if it became protected;
+8. otherwise deletes only the quarantined copy and records the terminal result.
+
+The source and its exact group must resolve below one of the three managed RepoBrief roots. Symlinks and non-regular files inside a candidate are rejected. These checks are repeated immediately before the irreversible step, so a parallel state or manifest change causes retention to preserve or restore the data.
+
+## Crash recovery
+
+Every normal fleet run first reconciles unfinished retention transactions. Reconciliation is idempotent: repeating it produces the same safe outcome.
+
+- A planned transaction whose source is still present is terminalised without deleting it.
+- A source already moved into quarantine is restored when it has become reachable, otherwise the quarantined copy is deleted.
+- A transaction journal that says `quarantined` while both copies are absent is recorded as an already completed delete.
+- Two copies, an identity mismatch, malformed metadata, an unknown state, or loss of both copies from a merely planned transaction aborts reconciliation.
+
+Preview reconciliation without modifying data:
+
+```bash
+rb-publish-fleet --reconcile-prune
+```
+
+Apply the deterministic reconciliation decision:
+
+```bash
+rb-publish-fleet --reconcile-prune --apply-prune
+```
+
+## Cleanup operation
+
+Bulk cleanup is dry-run by default. It writes a machine-readable receipt and does not delete data:
 
 ```bash
 rb-publish-fleet --prune-current --prune-legacy --prune-special --retention 3
 ```
 
-Apply only after reviewing the receipt and protecting any referenced historical paths:
+Apply only after reviewing that receipt and protecting any additional historical evidence:
 
 ```bash
 rb-publish-fleet --prune-current --prune-legacy --prune-special --retention 3 --apply-prune \
   --protect-path /exact/path/to/protected/version
 ```
+
+An apply run uses the same strict classification and fresh reachability checks as the dry run. A cleanup error is written to the receipt and returns a failing exit status.
+
+## General safety controls
+
+- The old unrestricted `--force` option is rejected.
+- A forced republish is possible only for explicitly named repositories and requires a reason.
+- Concurrent fleet runs are blocked by a process lock.
+- Dedicated tool and source worktrees must be clean, detached, and belong to the expected repository. Dirty, ignored, foreign, or branch-attached worktrees abort the run and are never cleaned or force-removed.
+- A failed generation is never written as the current state.
+- Deletion requires the explicit `--apply-prune` switch.
+
+## Runtime state
+
+The installer leaves automatic publication paused unless invoked with `--enable`. Installation or migration must not silently resume generation.
+
+When enabled, the watcher uses `OnCalendar=hourly` with a bounded randomized delay. `Persistent=true` performs one catch-up run after downtime.
+
+Legacy source-only state markers are not trusted as proof that generator and configuration inputs are unchanged. The publication fingerprint schema is v3 because it combines the owner-qualified publication identity with the scoped generator-input digest. The first explicit reactivation after migration can therefore produce one controlled publication per repository; the next unchanged cycle must skip every repository.

--- a/merger/lenskit/tests/test_repobrief_fleet_runtime.py
+++ b/merger/lenskit/tests/test_repobrief_fleet_runtime.py
@@ -86,6 +86,24 @@ def write_version(
     return version, digest
 
 
+def isolate_retention_roots(
+    module: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> dict[str, Path]:
+    roots = {
+        "publication": tmp_path / "publication",
+        "legacy": tmp_path / "legacy",
+        "special": tmp_path / "special",
+        "state": tmp_path / "state",
+        "log": tmp_path / "log",
+    }
+    monkeypatch.setattr(module, "PUB_ROOT", roots["publication"])
+    monkeypatch.setattr(module, "LEGACY_OUT_ROOT", roots["legacy"])
+    monkeypatch.setattr(module, "SPECIAL_OUT_ROOT", roots["special"])
+    monkeypatch.setattr(module, "STATE_ROOT", roots["state"])
+    monkeypatch.setattr(module, "LOG_ROOT", roots["log"])
+    return roots
+
+
 def test_fingerprint_is_stable_and_covers_all_output_inputs() -> None:
     module = load_publisher()
     config = module.PublicationConfig(profile="full-max")
@@ -130,11 +148,15 @@ def test_fingerprint_is_stable_and_covers_all_output_inputs() -> None:
         config=config,
     )
 
-    assert len({first, source_changed, tool_changed, config_changed, namespace_changed}) == 5
+    assert (
+        len({first, source_changed, tool_changed, config_changed, namespace_changed})
+        == 5
+    )
 
 
-
-def test_generator_inputs_sha_ignores_service_and_test_only_changes(tmp_path: Path) -> None:
+def test_generator_inputs_sha_ignores_service_and_test_only_changes(
+    tmp_path: Path,
+) -> None:
     module = load_publisher()
     repo, _ = initialize_repository(tmp_path, "lenskit")
     tracked = {
@@ -156,36 +178,47 @@ def test_generator_inputs_sha_ignores_service_and_test_only_changes(tmp_path: Pa
     git(repo, "commit", "-m", "generator baseline")
     baseline = module.generator_inputs_sha(repo)
 
-    (repo / "merger/lenskit/service/app.py").write_text("service v2\n", encoding="utf-8")
-    (repo / "merger/lenskit/tests/test_only.py").write_text("test v2\n", encoding="utf-8")
+    (repo / "merger/lenskit/service/app.py").write_text(
+        "service v2\n", encoding="utf-8"
+    )
+    (repo / "merger/lenskit/tests/test_only.py").write_text(
+        "test v2\n", encoding="utf-8"
+    )
     git(repo, "add", ".")
     git(repo, "commit", "-m", "non-generator changes")
     assert module.generator_inputs_sha(repo) == baseline
 
-    (repo / "merger/lenskit/core/merge.py").write_text("generator v2\n", encoding="utf-8")
+    (repo / "merger/lenskit/core/merge.py").write_text(
+        "generator v2\n", encoding="utf-8"
+    )
     git(repo, "add", ".")
     git(repo, "commit", "-m", "generator change")
     assert module.generator_inputs_sha(repo) != baseline
 
-def test_version_dirs_accepts_old_and_fingerprinted_names_only(tmp_path: Path) -> None:
+
+def test_version_dirs_accepts_only_declared_version_names(tmp_path: Path) -> None:
     module = load_publisher()
     group = tmp_path / "group"
     old = group / "20260714T100000Z"
     new = group / "20260714T110000Z-abcdef123456"
-    ignored = group / "scratch"
     old.mkdir(parents=True)
     new.mkdir()
-    ignored.mkdir()
-    (group / "20260714T120000Z-deadbeef0000").symlink_to(new, target_is_directory=True)
     os.utime(old, (100, 100))
     os.utime(new, (200, 200))
 
     assert module.version_dirs(group) == [new, old]
 
+    (group / "scratch").mkdir()
+    with pytest.raises(RuntimeError, match="unexpected retention entries"):
+        module.version_dirs(group)
 
-def test_prune_group_is_dry_run_by_default_and_reports_bytes(tmp_path: Path) -> None:
+
+def test_prune_group_is_dry_run_by_default_and_reports_bytes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     module = load_publisher()
-    group = tmp_path / "group"
+    roots = isolate_retention_roots(module, tmp_path, monkeypatch)
+    group = roots["publication"] / "bundles" / "demo" / "main"
     versions = [
         write_version(group, f"20260714T10000{index}Z", bytes([index + 1]), index)[0]
         for index in range(5)
@@ -197,13 +230,15 @@ def test_prune_group_is_dry_run_by_default_and_reports_bytes(tmp_path: Path) -> 
     assert report["would_remove_bytes"] > 0
     assert report["removed"] == []
     assert all(path.exists() for path in versions)
+    assert not module.prune_transaction_root().exists()
 
 
 def test_prune_group_keeps_newest_three_and_protected_older_version(
-    tmp_path: Path,
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     module = load_publisher()
-    group = tmp_path / "group"
+    roots = isolate_retention_roots(module, tmp_path, monkeypatch)
+    group = roots["publication"] / "bundles" / "demo" / "main"
     versions = [
         write_version(group, f"20260714T10000{index}Z", bytes([index + 1]), index)[0]
         for index in range(6)
@@ -225,14 +260,19 @@ def test_prune_group_keeps_newest_three_and_protected_older_version(
     }
     assert str(versions[1]) in report["protected_old"]
     assert report["removed_bytes"] > 0
+    transactions = sorted(module.prune_transaction_root().glob("*.json"))
+    assert len(transactions) == 2
+    assert all(
+        json.loads(path.read_text())["state"] == "deleted" for path in transactions
+    )
 
 
 def test_current_prune_keeps_localized_hashes_for_history_protection_and_stable_manifest(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     module = load_publisher()
-    publication_root = tmp_path / "publication"
-    monkeypatch.setattr(module, "PUB_ROOT", publication_root)
+    roots = isolate_retention_roots(module, tmp_path, monkeypatch)
+    publication_root = roots["publication"]
     group = publication_root / "bundles" / "heimgewebe__demo" / "main"
     versions_and_hashes = [
         write_version(
@@ -248,7 +288,12 @@ def test_current_prune_keeps_localized_hashes_for_history_protection_and_stable_
     stable_target = stable_version / "repo_merge.bundle.manifest.json"
     newest_hashes = {digest for _, digest in versions_and_hashes[-3:]}
     stable_manifest = (
-        publication_root / "external" / "repobrief" / "heimgewebe__demo" / "main" / "manifest.json"
+        publication_root
+        / "external"
+        / "repobrief"
+        / "heimgewebe__demo"
+        / "main"
+        / "manifest.json"
     )
     stable_manifest.parent.mkdir(parents=True)
     stable_manifest.write_text(
@@ -294,7 +339,12 @@ def test_stable_manifest_target_is_fail_closed_for_missing_target(
     publication_root = tmp_path / "publication"
     monkeypatch.setattr(module, "PUB_ROOT", publication_root)
     manifest = (
-        publication_root / "external" / "repobrief" / "heimgewebe__demo" / "main" / "manifest.json"
+        publication_root
+        / "external"
+        / "repobrief"
+        / "heimgewebe__demo"
+        / "main"
+        / "manifest.json"
     )
     manifest.parent.mkdir(parents=True)
     manifest.write_text(
@@ -304,6 +354,56 @@ def test_stable_manifest_target_is_fail_closed_for_missing_target(
 
     with pytest.raises(RuntimeError, match="target is unavailable"):
         module.stable_manifest_target(manifest)
+
+
+def test_global_reachability_uses_only_canonical_owner_qualified_manifests(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    publication_root = tmp_path / "publication"
+    monkeypatch.setattr(module, "PUB_ROOT", publication_root)
+
+    canonical_target = (
+        publication_root
+        / "bundles"
+        / "heimgewebe__demo"
+        / "main"
+        / "version"
+        / "manifest.json"
+    )
+    canonical_target.parent.mkdir(parents=True)
+    canonical_target.write_text("{}", encoding="utf-8")
+    canonical_manifest = (
+        publication_root
+        / "external"
+        / "repobrief"
+        / "heimgewebe__demo"
+        / "main"
+        / "manifest.json"
+    )
+    canonical_manifest.parent.mkdir(parents=True)
+    canonical_manifest.write_text(
+        json.dumps(
+            {
+                "bundleManifest": {
+                    "path": os.path.relpath(canonical_target, canonical_manifest.parent)
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    frozen_manifest = (
+        publication_root / "external" / "repobrief" / "demo" / "main" / "manifest.json"
+    )
+    frozen_manifest.parent.mkdir(parents=True)
+    frozen_manifest.write_text(
+        json.dumps({"bundleManifest": {"path": "../../../../missing.json"}}),
+        encoding="utf-8",
+    )
+
+    assert module.canonical_stable_manifest_paths() == [canonical_manifest]
+    assert module.all_stable_manifest_targets() == {canonical_target.resolve()}
 
 
 def test_managed_worktree_accepts_only_clean_detached_expected_repository(
@@ -482,8 +582,8 @@ def test_special_history_pruning_keeps_referenced_evidence(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     module = load_publisher()
-    special_root = tmp_path / "repobrief-auto"
-    monkeypatch.setattr(module, "SPECIAL_OUT_ROOT", special_root)
+    roots = isolate_retention_roots(module, tmp_path, monkeypatch)
+    special_root = roots["special"]
     group = special_root / "systemkatalog-main"
     versions = [
         write_version(group, f"20260714T10000{index}Z", bytes([index + 1]), index)[0]
@@ -523,3 +623,283 @@ def test_state_identity_does_not_trust_legacy_source_only_marker(
 
     assert path == tmp_path / "heimgewebe__demo__main.state.json"
     assert not path.name.endswith(".last-sha")
+
+
+def test_state_and_active_publication_targets_protect_old_versions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    roots = isolate_retention_roots(module, tmp_path, monkeypatch)
+    group = roots["publication"] / "bundles" / "heimgewebe__demo" / "main"
+    versions = [
+        write_version(group, f"20260714T10000{index}Z", bytes([index + 1]), index)[0]
+        for index in range(7)
+    ]
+    module.atomic_write_json(
+        roots["state"] / "heimgewebe__demo__main.state.json",
+        {
+            "schema": module.STATE_SCHEMA,
+            "publication_dir": str(versions[0]),
+        },
+    )
+    active = module.create_active_publication_lease(
+        repository="heimgewebe__demo",
+        ref="main",
+        fingerprint="a" * 64,
+        publication_dir=versions[1],
+    )
+
+    report = module.prune_group(group, keep=3, apply=True, protected=set())
+
+    assert versions[0].is_dir()
+    assert versions[1].is_dir()
+    assert not versions[2].exists()
+    assert {str(versions[0]), str(versions[1])}.issubset(set(report["protected_old"]))
+    module.clear_active_publication_lease(active)
+
+
+def test_transaction_rechecks_protection_after_quarantine(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    roots = isolate_retention_roots(module, tmp_path, monkeypatch)
+    group = roots["publication"] / "bundles" / "demo" / "main"
+    candidate, _ = write_version(group, "20260714T100000Z", b"payload", 1)
+    snapshot = module.tree_snapshot(candidate)
+    calls = 0
+
+    def changing_protection(explicit: set[Path]) -> set[Path]:
+        nonlocal calls
+        calls += 1
+        return {candidate.resolve()} if calls >= 3 else set(explicit)
+
+    monkeypatch.setattr(module, "dynamic_protected_paths", changing_protection)
+    result = module.transactional_prune(
+        candidate,
+        root=group,
+        expected_snapshot=snapshot,
+        removed_bytes=module.tree_bytes(candidate),
+        protected=set(),
+    )
+
+    assert result["state"] == "retained_newly_protected"
+    assert candidate.is_dir()
+    transaction = next(module.prune_transaction_root().glob("*.json"))
+    assert json.loads(transaction.read_text())["state"] == "restored_newly_protected"
+
+
+def test_transaction_refuses_candidate_changed_after_planning(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    roots = isolate_retention_roots(module, tmp_path, monkeypatch)
+    group = roots["publication"] / "bundles" / "demo" / "main"
+    candidate, _ = write_version(group, "20260714T100000Z", b"payload", 1)
+    snapshot = module.tree_snapshot(candidate)
+    (candidate / "repo_merge.md").write_text("changed", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="changed after planning"):
+        module.transactional_prune(
+            candidate,
+            root=group,
+            expected_snapshot=snapshot,
+            removed_bytes=1,
+            protected=set(),
+        )
+
+    assert candidate.is_dir()
+    assert not module.prune_transaction_root().exists()
+
+
+def test_transactional_delete_is_journaled_and_confined(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    roots = isolate_retention_roots(module, tmp_path, monkeypatch)
+    group = roots["publication"] / "bundles" / "demo" / "main"
+    candidate, _ = write_version(group, "20260714T100000Z", b"payload", 1)
+    snapshot = module.tree_snapshot(candidate)
+
+    result = module.transactional_prune(
+        candidate,
+        root=group,
+        expected_snapshot=snapshot,
+        removed_bytes=module.tree_bytes(candidate),
+        protected=set(),
+    )
+
+    assert result["state"] == "deleted"
+    assert not candidate.exists()
+    transaction = next(module.prune_transaction_root().glob("*.json"))
+    payload = json.loads(transaction.read_text())
+    assert payload["state"] == "deleted"
+    assert payload["source"] == str(candidate.resolve(strict=False))
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    with pytest.raises(RuntimeError, match="escapes managed roots"):
+        module.transactional_prune(
+            outside,
+            root=outside.parent,
+            expected_snapshot=module.tree_snapshot(outside),
+            removed_bytes=0,
+            protected=set(),
+        )
+
+
+def test_reconciliation_restores_planned_move_that_became_protected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    roots = isolate_retention_roots(module, tmp_path, monkeypatch)
+    group = roots["publication"] / "bundles" / "demo" / "main"
+    source, _ = write_version(group, "20260714T100000Z", b"payload", 1)
+    snapshot = module.tree_snapshot(source)
+    transaction_id = "b" * 32
+    quarantine = group / module.QUARANTINE_DIR_NAME / transaction_id / source.name
+    quarantine.parent.mkdir(parents=True)
+    os.replace(source, quarantine)
+    module.atomic_write_json(
+        module.prune_transaction_root() / f"{transaction_id}.json",
+        {
+            "schema": module.PRUNE_TRANSACTION_SCHEMA,
+            "transaction_id": transaction_id,
+            "state": "planned",
+            "source": str(source.resolve(strict=False)),
+            "quarantine": str(quarantine.resolve(strict=False)),
+            "root": str(group.resolve()),
+            "snapshot": snapshot,
+            "removed_bytes": 1,
+        },
+    )
+
+    reports = module.reconcile_prune_transactions(protected={source}, apply=True)
+
+    assert reports[0]["applied"] == "restore"
+    assert source.is_dir()
+    assert not quarantine.exists()
+    transaction = module.prune_transaction_root() / f"{transaction_id}.json"
+    assert json.loads(transaction.read_text())["state"] == "restored"
+
+
+def test_reconciliation_records_completed_delete_after_crash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    roots = isolate_retention_roots(module, tmp_path, monkeypatch)
+    group = roots["publication"] / "bundles" / "demo" / "main"
+    group.mkdir(parents=True)
+    source = group / "20260714T100000Z"
+    quarantine = group / module.QUARANTINE_DIR_NAME / ("c" * 32) / source.name
+    module.atomic_write_json(
+        module.prune_transaction_root() / f"{'c' * 32}.json",
+        {
+            "schema": module.PRUNE_TRANSACTION_SCHEMA,
+            "transaction_id": "c" * 32,
+            "state": "quarantined",
+            "source": str(source.resolve(strict=False)),
+            "quarantine": str(quarantine.resolve(strict=False)),
+            "root": str(group.resolve()),
+            "snapshot": {"device": 1, "inode": 2, "tree_sha256": "d" * 64},
+            "removed_bytes": 1,
+        },
+    )
+
+    reports = module.reconcile_prune_transactions(protected=set(), apply=True)
+
+    assert reports[0]["applied"] == "record_deleted"
+    transaction = module.prune_transaction_root() / f"{'c' * 32}.json"
+    assert json.loads(transaction.read_text())["state"] == "deleted"
+
+
+def test_tree_snapshot_and_localized_groups_reject_ambiguous_content(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    roots = isolate_retention_roots(module, tmp_path, monkeypatch)
+    group = roots["publication"] / "bundles" / "demo" / "main"
+    candidate, _ = write_version(group, "20260714T100000Z", b"payload", 1)
+    target = tmp_path / "target"
+    target.mkdir()
+    (candidate / "link").symlink_to(target, target_is_directory=True)
+    with pytest.raises(RuntimeError, match="contains a symlink"):
+        module.tree_snapshot(candidate)
+
+    localized = roots["publication"] / "external" / "_bundles" / "demo" / "main"
+    (localized / ("a" * 64)).mkdir(parents=True)
+    (localized / "not-a-hash").mkdir()
+    with pytest.raises(RuntimeError, match="unexpected localized bundle entries"):
+        module.localized_hash_dirs(localized)
+
+
+def test_legacy_layout_discovery_supports_both_known_shapes_and_rejects_mixing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    roots = isolate_retention_roots(module, tmp_path, monkeypatch)
+    modern = roots["legacy"] / "heimgewebe__demo" / "main"
+    direct = roots["legacy"] / "cabinet-main"
+    write_version(modern, "20260714T100000Z", b"modern", 1)
+    write_version(direct, "20260714T100000Z", b"direct", 1)
+
+    assert module.legacy_version_groups() == [direct, modern]
+
+    (direct / "main").mkdir()
+    with pytest.raises(RuntimeError, match="mixed legacy layouts"):
+        module.legacy_version_groups()
+
+
+def test_reconciliation_rejects_forged_quarantine_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    roots = isolate_retention_roots(module, tmp_path, monkeypatch)
+    group = roots["publication"] / "bundles" / "demo" / "main"
+    forged, _ = write_version(group, "20260714T100000Z", b"forged", 1)
+    transaction_id = "d" * 32
+    source = group / "20260714T100001Z"
+    module.atomic_write_json(
+        module.prune_transaction_root() / f"{transaction_id}.json",
+        {
+            "schema": module.PRUNE_TRANSACTION_SCHEMA,
+            "transaction_id": transaction_id,
+            "state": "quarantined",
+            "source": str(source.resolve(strict=False)),
+            "quarantine": str(forged.resolve()),
+            "root": str(group.resolve()),
+            "snapshot": module.tree_snapshot(forged),
+            "removed_bytes": module.tree_bytes(forged),
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="quarantine path mismatch"):
+        module.reconcile_prune_transactions(protected=set(), apply=True)
+
+    assert forged.is_dir()
+
+
+def test_unjournaled_quarantine_entry_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    roots = isolate_retention_roots(module, tmp_path, monkeypatch)
+    group = roots["publication"] / "bundles" / "demo" / "main"
+    write_version(group, "20260714T100000Z", b"payload", 1)
+    orphan = group / module.QUARANTINE_DIR_NAME / ("e" * 32) / "20260714T090000Z"
+    orphan.mkdir(parents=True)
+
+    with pytest.raises(RuntimeError, match="unexpected retention quarantine entries"):
+        module.version_dirs(group)
+
+
+def test_transaction_journal_rejects_unexpected_entries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    isolate_retention_roots(module, tmp_path, monkeypatch)
+    transaction_root = module.prune_transaction_root()
+    transaction_root.mkdir(parents=True)
+    (transaction_root / "notes.txt").write_text("not a journal", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="unexpected retention transaction entries"):
+        module.reconcile_prune_transactions(protected=set(), apply=False)

--- a/scripts/ops/rb-publish-fleet
+++ b/scripts/ops/rb-publish-fleet
@@ -16,10 +16,12 @@ import json
 import os
 import re
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
 import time
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable
@@ -41,6 +43,9 @@ DEFAULT_RETENTION = 3
 MAX_RETENTION = 10
 FINGERPRINT_SCHEMA = "repobrief.fleet-publication-fingerprint.v3"
 STATE_SCHEMA = "repobrief.fleet-publication-state.v1"
+ACTIVE_LEASE_SCHEMA = "repobrief.active-publication-lease.v1"
+PRUNE_TRANSACTION_SCHEMA = "repobrief.retention-transaction.v1"
+QUARANTINE_DIR_NAME = ".rb-prune-quarantine"
 GENERATOR_INPUT_PATHS = (
     "merger/lenskit/__init__.py",
     "merger/lenskit/cli/__init__.py",
@@ -51,6 +56,8 @@ GENERATOR_INPUT_PATHS = (
     "merger/lenskit/retrieval",
 )
 VERSION_DIR_RE = re.compile(r"^\d{8}T\d{6}Z(?:-[0-9a-f]{12})?$")
+SHA256_DIR_RE = re.compile(r"^[0-9a-f]{64}$")
+TRANSACTION_ID_RE = re.compile(r"^[0-9a-f]{32}$")
 EXCLUDE = {
     ".repobrief-tools",
     ".repobrief-sources",
@@ -86,6 +93,13 @@ class PublicationConfig:
             "max_bytes": self.max_bytes,
             "split_size": self.split_size,
         }
+
+
+@dataclass(frozen=True)
+class PrunePlan:
+    path: Path
+    snapshot: dict[str, object]
+    bytes: int
 
 
 def run(
@@ -341,7 +355,9 @@ def generator_inputs_sha(worktree: Path) -> str:
                 "path": path,
             }
         )
-    entries.sort(key=lambda entry: entry["path"].encode("utf-8", errors="surrogateescape"))
+    entries.sort(
+        key=lambda entry: entry["path"].encode("utf-8", errors="surrogateescape")
+    )
     required_files = {
         "merger/lenskit/cli/repobrief.py",
         "merger/lenskit/cli/cmd_repobrief.py",
@@ -487,23 +503,268 @@ def ensure_source_worktree(entry: RepoEntry, ref_segment: str, sha: str) -> Path
     return source_wt
 
 
+def active_lease_root() -> Path:
+    return STATE_ROOT / "active-publications"
+
+
+def prune_transaction_root() -> Path:
+    return STATE_ROOT / "retention-transactions"
+
+
+def retention_roots() -> tuple[Path, ...]:
+    return (PUB_ROOT, LEGACY_OUT_ROOT, SPECIAL_OUT_ROOT)
+
+
+def _path_under(path: Path, root: Path) -> bool:
+    resolved_path = path.resolve(strict=False)
+    resolved_root = root.resolve(strict=False)
+    return resolved_path == resolved_root or resolved_root in resolved_path.parents
+
+
+def _assert_retention_target(path: Path) -> Path:
+    resolved = path.expanduser().resolve(strict=False)
+    if not any(_path_under(resolved, root) for root in retention_roots()):
+        raise RuntimeError(f"retention reference escapes managed roots: {path}")
+    return resolved
+
+
+def _strict_json_object(path: Path) -> dict[str, Any]:
+    if not path.is_file() or path.is_symlink():
+        raise RuntimeError(f"retention metadata is not a regular file: {path}")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"cannot read retention metadata {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise RuntimeError(f"retention metadata is not an object: {path}")
+    return value
+
+
+def prune_transaction_files() -> list[Path]:
+    root = prune_transaction_root()
+    if not root.exists():
+        return []
+    if root.is_symlink() or not root.is_dir():
+        raise RuntimeError(f"retention transaction root is not a directory: {root}")
+    files: list[Path] = []
+    unexpected: list[Path] = []
+    for path in root.iterdir():
+        if (
+            path.is_file()
+            and not path.is_symlink()
+            and path.suffix == ".json"
+            and TRANSACTION_ID_RE.fullmatch(path.stem)
+        ):
+            files.append(path)
+        else:
+            unexpected.append(path)
+    if unexpected:
+        rendered = ", ".join(str(path) for path in sorted(unexpected))
+        raise RuntimeError(f"unexpected retention transaction entries: {rendered}")
+    return sorted(files)
+
+
+def validate_quarantine_directory(group: Path) -> None:
+    quarantine_root = group / QUARANTINE_DIR_NAME
+    if not quarantine_root.exists():
+        return
+    if quarantine_root.is_symlink() or not quarantine_root.is_dir():
+        raise RuntimeError(
+            f"retention quarantine is not a directory: {quarantine_root}"
+        )
+    unexpected: list[Path] = []
+    for transaction_dir in quarantine_root.iterdir():
+        transaction_file = prune_transaction_root() / f"{transaction_dir.name}.json"
+        valid_transaction_dir = (
+            transaction_dir.is_dir()
+            and not transaction_dir.is_symlink()
+            and TRANSACTION_ID_RE.fullmatch(transaction_dir.name)
+            and transaction_file.is_file()
+            and not transaction_file.is_symlink()
+        )
+        if not valid_transaction_dir:
+            unexpected.append(transaction_dir)
+            continue
+        children = list(transaction_dir.iterdir())
+        if len(children) > 1 or any(
+            child.is_symlink() or not child.is_dir() for child in children
+        ):
+            unexpected.extend(children or [transaction_dir])
+    if unexpected:
+        rendered = ", ".join(str(path) for path in sorted(unexpected))
+        raise RuntimeError(f"unexpected retention quarantine entries: {rendered}")
+
+
+def _validated_transaction_paths(
+    payload: dict[str, object], transaction_file: Path
+) -> tuple[str, Path, Path, Path, dict[str, object]]:
+    transaction_id = payload.get("transaction_id")
+    source_raw = payload.get("source")
+    quarantine_raw = payload.get("quarantine")
+    root_raw = payload.get("root")
+    snapshot = payload.get("snapshot")
+    removed_bytes = payload.get("removed_bytes")
+    if (
+        not isinstance(transaction_id, str)
+        or not TRANSACTION_ID_RE.fullmatch(transaction_id)
+        or transaction_file.stem != transaction_id
+        or not isinstance(source_raw, str)
+        or not isinstance(quarantine_raw, str)
+        or not isinstance(root_raw, str)
+        or not isinstance(snapshot, dict)
+        or not isinstance(removed_bytes, int)
+        or isinstance(removed_bytes, bool)
+        or removed_bytes < 0
+    ):
+        raise RuntimeError(f"malformed prune transaction: {transaction_file}")
+    device = snapshot.get("device")
+    inode = snapshot.get("inode")
+    tree_digest = snapshot.get("tree_sha256")
+    if (
+        not isinstance(device, int)
+        or isinstance(device, bool)
+        or not isinstance(inode, int)
+        or isinstance(inode, bool)
+        or not isinstance(tree_digest, str)
+        or not SHA256_DIR_RE.fullmatch(tree_digest)
+    ):
+        raise RuntimeError(f"malformed prune transaction snapshot: {transaction_file}")
+    source = _assert_retention_target(Path(source_raw))
+    quarantine = _assert_retention_target(Path(quarantine_raw))
+    managed_root = _assert_retention_target(Path(root_raw))
+    if source.parent != managed_root:
+        raise RuntimeError(
+            f"prune transaction source is not a direct group child: {transaction_file}"
+        )
+    expected_quarantine = (
+        managed_root / QUARANTINE_DIR_NAME / transaction_id / source.name
+    ).resolve(strict=False)
+    if quarantine != expected_quarantine:
+        raise RuntimeError(
+            f"prune transaction quarantine path mismatch: {transaction_file}"
+        )
+    return transaction_id, source, quarantine, managed_root, snapshot
+
+
+def state_publication_targets() -> set[Path]:
+    targets: set[Path] = set()
+    if not STATE_ROOT.exists():
+        return targets
+    for state_file in sorted(STATE_ROOT.glob("*.state.json")):
+        data = _strict_json_object(state_file)
+        if data.get("schema") != STATE_SCHEMA:
+            raise RuntimeError(f"unsupported publication state schema: {state_file}")
+        raw_target = data.get("publication_dir")
+        if not isinstance(raw_target, str) or not raw_target:
+            raise RuntimeError(f"publication state lacks publication_dir: {state_file}")
+        target = _assert_retention_target(Path(raw_target))
+        if target.is_symlink() or not target.is_dir():
+            raise RuntimeError(f"publication state target is unavailable: {target}")
+        targets.add(target)
+    return targets
+
+
+def active_publication_targets() -> set[Path]:
+    targets: set[Path] = set()
+    root = active_lease_root()
+    if not root.exists():
+        return targets
+    for lease_file in sorted(root.glob("*.json")):
+        data = _strict_json_object(lease_file)
+        if data.get("schema") != ACTIVE_LEASE_SCHEMA:
+            raise RuntimeError(f"unsupported active publication lease: {lease_file}")
+        raw_target = data.get("publication_dir")
+        if not isinstance(raw_target, str) or not raw_target:
+            raise RuntimeError(
+                f"active publication lease lacks publication_dir: {lease_file}"
+            )
+        targets.add(_assert_retention_target(Path(raw_target)))
+    return targets
+
+
+def create_active_publication_lease(
+    *, repository: str, ref: str, fingerprint: str, publication_dir: Path
+) -> Path:
+    target = _assert_retention_target(publication_dir)
+    lease_id = hashlib.sha256(
+        f"{repository}\0{ref}\0{fingerprint}\0{os.getpid()}\0{time.time_ns()}".encode()
+    ).hexdigest()
+    lease_path = active_lease_root() / f"{lease_id}.json"
+    atomic_write_json(
+        lease_path,
+        {
+            "schema": ACTIVE_LEASE_SCHEMA,
+            "lease_id": lease_id,
+            "repository": repository,
+            "ref": ref,
+            "fingerprint": fingerprint,
+            "publication_dir": str(target),
+            "pid": os.getpid(),
+            "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        },
+    )
+    return lease_path
+
+
+def clear_active_publication_lease(path: Path) -> None:
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return
+
+
 def version_dirs(group: Path) -> list[Path]:
     if not group.exists():
         return []
-    rows = [
-        path
-        for path in group.iterdir()
-        if path.is_dir()
-        and not path.is_symlink()
-        and VERSION_DIR_RE.fullmatch(path.name)
-    ]
+    validate_quarantine_directory(group)
+    rows: list[Path] = []
+    unexpected: list[Path] = []
+    for path in group.iterdir():
+        if path.name == QUARANTINE_DIR_NAME and path.is_dir() and not path.is_symlink():
+            continue
+        if (
+            path.is_dir()
+            and not path.is_symlink()
+            and VERSION_DIR_RE.fullmatch(path.name)
+        ):
+            rows.append(path)
+        else:
+            unexpected.append(path)
+    if unexpected:
+        rendered = ", ".join(str(path) for path in sorted(unexpected))
+        raise RuntimeError(f"unexpected retention entries in {group}: {rendered}")
     return sorted(
         rows, key=lambda path: (path.stat().st_mtime_ns, path.name), reverse=True
     )
 
 
+def localized_hash_dirs(group: Path) -> list[Path]:
+    if not group.exists():
+        return []
+    validate_quarantine_directory(group)
+    rows: list[Path] = []
+    unexpected: list[Path] = []
+    for path in group.iterdir():
+        if path.name == QUARANTINE_DIR_NAME and path.is_dir() and not path.is_symlink():
+            continue
+        if (
+            path.is_dir()
+            and not path.is_symlink()
+            and SHA256_DIR_RE.fullmatch(path.name)
+        ):
+            rows.append(path)
+        else:
+            unexpected.append(path)
+    if unexpected:
+        rendered = ", ".join(str(path) for path in sorted(unexpected))
+        raise RuntimeError(
+            f"unexpected localized bundle entries in {group}: {rendered}"
+        )
+    return sorted(rows, key=lambda path: path.name)
+
+
 def path_is_protected(path: Path, protected: set[Path]) -> bool:
-    resolved = path.resolve()
+    resolved = path.resolve(strict=False)
     return any(
         resolved == item or item in resolved.parents or resolved in item.parents
         for item in protected
@@ -514,18 +775,81 @@ def tree_bytes(path: Path) -> int:
     total = 0
     for root, directories, files in os.walk(path, followlinks=False):
         root_path = Path(root)
-        directories[:] = [
-            name for name in directories if not (root_path / name).is_symlink()
-        ]
-        for name in files:
+        directories[:] = sorted(directories)
+        for name in directories:
+            if (root_path / name).is_symlink():
+                raise RuntimeError(
+                    f"retention candidate contains a symlink: {root_path / name}"
+                )
+        for name in sorted(files):
             candidate = root_path / name
             if candidate.is_symlink():
-                continue
-            try:
-                total += candidate.stat().st_size
-            except FileNotFoundError:
-                continue
+                raise RuntimeError(
+                    f"retention candidate contains a symlink: {candidate}"
+                )
+            total += candidate.stat().st_size
     return total
+
+
+def tree_snapshot(path: Path) -> dict[str, object]:
+    if path.is_symlink() or not path.is_dir():
+        raise RuntimeError(f"retention candidate is not a directory: {path}")
+    root_stat = path.lstat()
+    if not stat.S_ISDIR(root_stat.st_mode):
+        raise RuntimeError(f"retention candidate is not a directory: {path}")
+    rows: list[list[object]] = []
+    for root, directories, files in os.walk(path, followlinks=False):
+        root_path = Path(root)
+        directories[:] = sorted(directories)
+        relative_root = root_path.relative_to(path).as_posix()
+        root_metadata = root_path.lstat()
+        rows.append(
+            [
+                "d",
+                relative_root,
+                stat.S_IMODE(root_metadata.st_mode),
+                root_metadata.st_mtime_ns,
+            ]
+        )
+        for name in directories:
+            candidate = root_path / name
+            if candidate.is_symlink():
+                raise RuntimeError(
+                    f"retention candidate contains a symlink: {candidate}"
+                )
+        for name in sorted(files):
+            candidate = root_path / name
+            metadata = candidate.lstat()
+            if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+                raise RuntimeError(
+                    f"retention candidate contains a non-regular file: {candidate}"
+                )
+            rows.append(
+                [
+                    "f",
+                    candidate.relative_to(path).as_posix(),
+                    stat.S_IMODE(metadata.st_mode),
+                    metadata.st_size,
+                    metadata.st_mtime_ns,
+                    sha256_file(candidate),
+                ]
+            )
+    digest = hashlib.sha256(
+        json.dumps(rows, sort_keys=False, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return {
+        "device": root_stat.st_dev,
+        "inode": root_stat.st_ino,
+        "tree_sha256": digest,
+    }
+
+
+def dynamic_protected_paths(explicit: set[Path]) -> set[Path]:
+    protected = {path.expanduser().resolve(strict=False) for path in explicit}
+    protected.update(all_stable_manifest_targets())
+    protected.update(state_publication_targets())
+    protected.update(active_publication_targets())
+    return protected
 
 
 def remove_tree(path: Path, *, apply: bool, root: Path) -> None:
@@ -545,6 +869,227 @@ def discard_generated_output(path: Path, *, root: Path) -> None:
     if not path.exists() and not path.is_symlink():
         return
     remove_tree(path, apply=True, root=root)
+
+
+def _write_prune_transaction(payload: dict[str, object]) -> Path:
+    transaction_id = payload.get("transaction_id")
+    if not isinstance(transaction_id, str) or not TRANSACTION_ID_RE.fullmatch(
+        transaction_id
+    ):
+        raise RuntimeError("prune transaction lacks a valid id")
+    path = prune_transaction_root() / f"{transaction_id}.json"
+    atomic_write_json(path, payload)
+    return path
+
+
+def _set_transaction_state(payload: dict[str, object], state_value: str) -> None:
+    payload["state"] = state_value
+    payload["updated_at"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    _write_prune_transaction(payload)
+
+
+def _cleanup_quarantine_parents(quarantine: Path, managed_root: Path) -> None:
+    try:
+        quarantine.parent.rmdir()
+    except OSError:
+        pass
+    try:
+        managed_root.joinpath(QUARANTINE_DIR_NAME).rmdir()
+    except OSError:
+        pass
+
+
+def transactional_prune(
+    path: Path,
+    *,
+    root: Path,
+    expected_snapshot: dict[str, object],
+    removed_bytes: int,
+    protected: set[Path],
+) -> dict[str, object]:
+    managed_root = _assert_retention_target(root)
+    source = _assert_retention_target(path)
+    if source == managed_root or managed_root not in source.parents:
+        raise RuntimeError(
+            f"retention candidate is outside its managed group {managed_root}: {source}"
+        )
+    refreshed = dynamic_protected_paths(protected)
+    if path_is_protected(source, refreshed):
+        return {"state": "retained_newly_protected", "path": str(source)}
+    if tree_snapshot(source) != expected_snapshot:
+        raise RuntimeError(f"retention candidate changed after planning: {source}")
+
+    transaction_id = uuid.uuid4().hex
+    quarantine_parent = managed_root / QUARANTINE_DIR_NAME
+    quarantine = quarantine_parent / transaction_id / path.name
+    payload: dict[str, object] = {
+        "schema": PRUNE_TRANSACTION_SCHEMA,
+        "transaction_id": transaction_id,
+        "state": "planned",
+        "source": str(source),
+        "quarantine": str(quarantine.resolve(strict=False)),
+        "root": str(managed_root),
+        "snapshot": expected_snapshot,
+        "removed_bytes": removed_bytes,
+        "updated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+    _write_prune_transaction(payload)
+    quarantine.parent.mkdir(parents=True, exist_ok=False)
+
+    refreshed = dynamic_protected_paths(protected)
+    if path_is_protected(source, refreshed):
+        _set_transaction_state(payload, "aborted_protected")
+        _cleanup_quarantine_parents(quarantine, managed_root)
+        return {"state": "retained_newly_protected", "path": str(source)}
+    if tree_snapshot(source) != expected_snapshot:
+        _set_transaction_state(payload, "aborted_changed")
+        _cleanup_quarantine_parents(quarantine, managed_root)
+        raise RuntimeError(f"retention candidate changed before quarantine: {source}")
+
+    os.replace(source, quarantine)
+    if tree_snapshot(quarantine) != expected_snapshot:
+        if not source.exists():
+            os.replace(quarantine, source)
+        _set_transaction_state(payload, "restored_identity_mismatch")
+        _cleanup_quarantine_parents(quarantine, managed_root)
+        raise RuntimeError(f"quarantined candidate identity changed: {source}")
+
+    refreshed = dynamic_protected_paths(protected)
+    if path_is_protected(source, refreshed):
+        os.replace(quarantine, source)
+        _set_transaction_state(payload, "restored_newly_protected")
+        _cleanup_quarantine_parents(quarantine, managed_root)
+        return {"state": "retained_newly_protected", "path": str(source)}
+
+    _set_transaction_state(payload, "quarantined")
+    refreshed = dynamic_protected_paths(protected)
+    if path_is_protected(source, refreshed):
+        os.replace(quarantine, source)
+        _set_transaction_state(payload, "restored_newly_protected")
+        _cleanup_quarantine_parents(quarantine, managed_root)
+        return {"state": "retained_newly_protected", "path": str(source)}
+
+    shutil.rmtree(quarantine)
+    _cleanup_quarantine_parents(quarantine, managed_root)
+    _set_transaction_state(payload, "deleted")
+    return {
+        "state": "deleted",
+        "path": str(source),
+        "transaction_id": transaction_id,
+        "removed_bytes": removed_bytes,
+    }
+
+
+def reconcile_prune_transactions(
+    *, protected: set[Path], apply: bool
+) -> list[dict[str, object]]:
+    transaction_root = prune_transaction_root()
+    if not transaction_root.exists():
+        return []
+    reports: list[dict[str, object]] = []
+    terminal_states = {
+        "deleted",
+        "restored",
+        "restored_newly_protected",
+        "aborted_protected",
+        "aborted_changed",
+        "aborted_safe_source",
+        "restored_identity_mismatch",
+    }
+    for transaction_file in prune_transaction_files():
+        payload = _strict_json_object(transaction_file)
+        if payload.get("schema") != PRUNE_TRANSACTION_SCHEMA:
+            raise RuntimeError(f"unsupported prune transaction: {transaction_file}")
+        state_value = payload.get("state")
+        if not isinstance(state_value, str):
+            raise RuntimeError(f"malformed prune transaction: {transaction_file}")
+        _, source, quarantine, managed_root, snapshot = _validated_transaction_paths(
+            payload, transaction_file
+        )
+        if state_value in terminal_states:
+            reports.append({"transaction": str(transaction_file), "state": state_value})
+            continue
+        if state_value not in {"planned", "quarantined"}:
+            raise RuntimeError(f"unknown prune transaction state: {state_value}")
+
+        source_exists = source.exists() or source.is_symlink()
+        quarantine_exists = quarantine.exists() or quarantine.is_symlink()
+        if source_exists and quarantine_exists:
+            raise RuntimeError(
+                f"ambiguous prune transaction has two copies: {transaction_file}"
+            )
+
+        if source_exists:
+            if tree_snapshot(source) != snapshot:
+                raise RuntimeError(f"source identity mismatch: {transaction_file}")
+            if state_value == "planned":
+                if apply:
+                    _set_transaction_state(payload, "aborted_safe_source")
+                    _cleanup_quarantine_parents(quarantine, managed_root)
+                reports.append(
+                    {
+                        "transaction": str(transaction_file),
+                        "state": state_value,
+                        "would": "leave_source",
+                        "applied": "leave_source" if apply else None,
+                    }
+                )
+                continue
+            if apply:
+                _set_transaction_state(payload, "restored")
+                _cleanup_quarantine_parents(quarantine, managed_root)
+            reports.append(
+                {
+                    "transaction": str(transaction_file),
+                    "state": state_value,
+                    "would": "record_restored",
+                    "applied": "record_restored" if apply else None,
+                }
+            )
+            continue
+
+        if not quarantine_exists:
+            if state_value == "quarantined":
+                if apply:
+                    _set_transaction_state(payload, "deleted")
+                    _cleanup_quarantine_parents(quarantine, managed_root)
+                reports.append(
+                    {
+                        "transaction": str(transaction_file),
+                        "state": state_value,
+                        "would": "record_deleted",
+                        "applied": "record_deleted" if apply else None,
+                    }
+                )
+                continue
+            raise RuntimeError(
+                f"planned transaction lost both copies: {transaction_file}"
+            )
+
+        if tree_snapshot(quarantine) != snapshot:
+            raise RuntimeError(f"quarantine identity mismatch: {transaction_file}")
+        refreshed = dynamic_protected_paths(protected)
+        action = "restore" if path_is_protected(source, refreshed) else "delete"
+        if apply:
+            if state_value == "planned":
+                _set_transaction_state(payload, "quarantined")
+            if action == "restore":
+                source.parent.mkdir(parents=True, exist_ok=True)
+                os.replace(quarantine, source)
+                _set_transaction_state(payload, "restored")
+            else:
+                shutil.rmtree(quarantine)
+                _set_transaction_state(payload, "deleted")
+            _cleanup_quarantine_parents(quarantine, managed_root)
+        reports.append(
+            {
+                "transaction": str(transaction_file),
+                "state": state_value,
+                "would": action if not apply else None,
+                "applied": action if apply else None,
+            }
+        )
+    return reports
 
 
 def retained_manifest_hashes(versions: Iterable[Path]) -> set[str]:
@@ -589,16 +1134,30 @@ def stable_manifest_targets(repository: str, ref: str) -> set[Path]:
     return retained
 
 
-def all_stable_manifest_targets() -> set[Path]:
-    retained: set[Path] = set()
+def is_canonical_publication_identity(value: str) -> bool:
+    owner, separator, repository = value.partition("__")
+    return bool(separator and owner and repository)
+
+
+def canonical_stable_manifest_paths() -> list[Path]:
+    manifests: list[Path] = []
     external_root = PUB_ROOT / "external"
     for family in ("repobrief", "lenskit"):
         family_root = external_root / family
         if not family_root.exists():
             continue
         for manifest in sorted(family_root.glob("*/*/manifest.json")):
-            retained.add(stable_manifest_target(manifest))
-    return retained
+            repository = manifest.parent.parent.name
+            if is_canonical_publication_identity(repository):
+                manifests.append(manifest)
+    return manifests
+
+
+def all_stable_manifest_targets() -> set[Path]:
+    return {
+        stable_manifest_target(manifest)
+        for manifest in canonical_stable_manifest_paths()
+    }
 
 
 def stable_manifest_hashes(repository: str, ref: str) -> set[str]:
@@ -612,25 +1171,48 @@ def prune_group(
     apply: bool,
     protected: set[Path],
 ) -> dict[str, object]:
+    effective_protected = dynamic_protected_paths(protected)
     versions = version_dirs(group)
     retained = versions[:keep]
     removable = [
-        path for path in versions[keep:] if not path_is_protected(path, protected)
+        path
+        for path in versions[keep:]
+        if not path_is_protected(path, effective_protected)
     ]
     protected_old = [
-        path for path in versions[keep:] if path_is_protected(path, protected)
+        path for path in versions[keep:] if path_is_protected(path, effective_protected)
     ]
-    removable_bytes = sum(tree_bytes(path) for path in removable)
-    for path in removable:
-        remove_tree(path, apply=apply, root=group)
+    plans = [
+        PrunePlan(path=path, snapshot=tree_snapshot(path), bytes=tree_bytes(path))
+        for path in removable
+    ]
+    removed: list[str] = []
+    newly_protected: list[str] = []
+    removed_bytes = 0
+    if apply:
+        for plan in plans:
+            result = transactional_prune(
+                plan.path,
+                root=group,
+                expected_snapshot=plan.snapshot,
+                removed_bytes=plan.bytes,
+                protected=protected,
+            )
+            if result["state"] == "deleted":
+                removed.append(str(plan.path))
+                removed_bytes += int(plan.bytes)
+            else:
+                newly_protected.append(str(plan.path))
+    removable_bytes = sum(int(plan.bytes) for plan in plans)
     return {
         "group": str(group),
         "found": len(versions),
         "retained": [str(path) for path in retained],
         "protected_old": [str(path) for path in protected_old],
-        "removed": [str(path) for path in removable] if apply else [],
+        "newly_protected": newly_protected,
+        "removed": removed,
         "would_remove": [] if apply else [str(path) for path in removable],
-        "removed_bytes": removable_bytes if apply else 0,
+        "removed_bytes": removed_bytes,
         "would_remove_bytes": 0 if apply else removable_bytes,
     }
 
@@ -645,7 +1227,7 @@ def prune_current_group(
     protected: set[Path],
 ) -> dict[str, object]:
     stable_targets = stable_manifest_targets(repository, ref)
-    effective_protected = set(protected) | stable_targets
+    effective_protected = dynamic_protected_paths(set(protected) | stable_targets)
     versions = version_dirs(group)
     retained_versions = versions[:keep] + [
         path for path in versions[keep:] if path_is_protected(path, effective_protected)
@@ -654,41 +1236,71 @@ def prune_current_group(
         group,
         keep=keep,
         apply=apply,
-        protected=effective_protected,
+        protected=set(protected) | stable_targets,
     )
-    keep_hashes = retained_manifest_hashes(retained_versions)
+    retained_after = version_dirs(group) if apply else retained_versions
+    keep_hashes = retained_manifest_hashes(retained_after)
     keep_hashes.update(sha256_file(target) for target in stable_targets)
     report["stable_manifest_targets"] = sorted(str(path) for path in stable_targets)
     localized = PUB_ROOT / "external" / "_bundles" / repository / ref
-    localized_dirs = (
-        [
-            path
-            for path in localized.iterdir()
-            if path.is_dir() and not path.is_symlink()
-        ]
-        if localized.exists()
-        else []
-    )
+    localized_dirs = localized_hash_dirs(localized)
+    effective_protected = dynamic_protected_paths(set(protected) | stable_targets)
     localized_removable = [
         path
         for path in localized_dirs
         if path.name not in keep_hashes
         and not path_is_protected(path, effective_protected)
     ]
-    localized_removable_bytes = sum(tree_bytes(path) for path in localized_removable)
-    for path in localized_removable:
-        remove_tree(path, apply=apply, root=localized)
+    localized_plans = [
+        PrunePlan(path=path, snapshot=tree_snapshot(path), bytes=tree_bytes(path))
+        for path in localized_removable
+    ]
+    localized_removed: list[str] = []
+    localized_newly_protected: list[str] = []
+    localized_removed_bytes = 0
+    if apply:
+        for plan in localized_plans:
+            result = transactional_prune(
+                plan.path,
+                root=localized,
+                expected_snapshot=plan.snapshot,
+                removed_bytes=plan.bytes,
+                protected=set(protected) | stable_targets,
+            )
+            if result["state"] == "deleted":
+                localized_removed.append(str(plan.path))
+                localized_removed_bytes += int(plan.bytes)
+            else:
+                localized_newly_protected.append(str(plan.path))
+    localized_removable_bytes = sum(int(plan.bytes) for plan in localized_plans)
     report["localized_group"] = str(localized)
     report["retained_manifest_hashes"] = sorted(keep_hashes)
-    report["localized_removed"] = (
-        [str(path) for path in localized_removable] if apply else []
-    )
+    report["localized_newly_protected"] = localized_newly_protected
+    report["localized_removed"] = localized_removed
     report["localized_would_remove"] = (
         [] if apply else [str(path) for path in localized_removable]
     )
-    report["localized_removed_bytes"] = localized_removable_bytes if apply else 0
+    report["localized_removed_bytes"] = localized_removed_bytes
     report["localized_would_remove_bytes"] = 0 if apply else localized_removable_bytes
     return report
+
+
+def managed_directories(root: Path, *, label: str) -> list[Path]:
+    if not root.exists():
+        return []
+    if root.is_symlink() or not root.is_dir():
+        raise RuntimeError(f"{label} root is not a regular directory: {root}")
+    directories: list[Path] = []
+    unexpected: list[Path] = []
+    for path in root.iterdir():
+        if path.is_dir() and not path.is_symlink():
+            directories.append(path)
+        else:
+            unexpected.append(path)
+    if unexpected:
+        rendered = ", ".join(str(path) for path in sorted(unexpected))
+        raise RuntimeError(f"unexpected entries below {label} root {root}: {rendered}")
+    return sorted(directories)
 
 
 def prune_all_current(
@@ -696,15 +1308,11 @@ def prune_all_current(
 ) -> list[dict[str, object]]:
     root = PUB_ROOT / "bundles"
     reports: list[dict[str, object]] = []
-    if not root.exists():
-        return reports
-    for repo_group in sorted(root.iterdir()):
-        if not repo_group.is_dir() or repo_group.is_symlink():
-            continue
+    for repo_group in managed_directories(root, label="current publication"):
         repository = repo_group.name
-        for ref_group in sorted(repo_group.iterdir()):
-            if not ref_group.is_dir() or ref_group.is_symlink():
-                continue
+        for ref_group in managed_directories(
+            repo_group, label=f"current repository {repository}"
+        ):
             reports.append(
                 prune_current_group(
                     ref_group,
@@ -718,47 +1326,50 @@ def prune_all_current(
     return reports
 
 
+def legacy_version_groups() -> list[Path]:
+    groups: list[Path] = []
+    for repository_group in managed_directories(
+        LEGACY_OUT_ROOT, label="legacy publication"
+    ):
+        children = managed_directories(
+            repository_group, label=f"legacy repository {repository_group.name}"
+        )
+        if not children:
+            continue
+        direct_versions = [
+            child for child in children if VERSION_DIR_RE.fullmatch(child.name)
+        ]
+        if direct_versions:
+            if len(direct_versions) != len(children):
+                raise RuntimeError(
+                    f"mixed legacy layouts below {repository_group}: "
+                    "version and ref directories coexist"
+                )
+            version_dirs(repository_group)
+            groups.append(repository_group)
+            continue
+        for ref_group in children:
+            version_dirs(ref_group)
+            groups.append(ref_group)
+    return groups
+
+
 def prune_all_legacy(
     *, keep: int, apply: bool, protected: set[Path]
 ) -> list[dict[str, object]]:
-    reports: list[dict[str, object]] = []
-    if not LEGACY_OUT_ROOT.exists():
-        return reports
-    for repo_group in sorted(LEGACY_OUT_ROOT.iterdir()):
-        if not repo_group.is_dir() or repo_group.is_symlink():
-            continue
-        for ref_group in sorted(repo_group.iterdir()):
-            if not ref_group.is_dir() or ref_group.is_symlink():
-                continue
-            reports.append(
-                prune_group(
-                    ref_group,
-                    keep=keep,
-                    apply=apply,
-                    protected=protected,
-                )
-            )
-    return reports
+    return [
+        prune_group(group, keep=keep, apply=apply, protected=protected)
+        for group in legacy_version_groups()
+    ]
 
 
 def prune_all_special(
     *, keep: int, apply: bool, protected: set[Path]
 ) -> list[dict[str, object]]:
-    reports: list[dict[str, object]] = []
-    if not SPECIAL_OUT_ROOT.exists():
-        return reports
-    for group in sorted(SPECIAL_OUT_ROOT.iterdir()):
-        if not group.is_dir() or group.is_symlink():
-            continue
-        reports.append(
-            prune_group(
-                group,
-                keep=keep,
-                apply=apply,
-                protected=protected,
-            )
-        )
-    return reports
+    return [
+        prune_group(group, keep=keep, apply=apply, protected=protected)
+        for group in managed_directories(SPECIAL_OUT_ROOT, label="special publication")
+    ]
 
 
 def publish(
@@ -770,7 +1381,7 @@ def publish(
     tool_sha: str,
     fingerprint: str,
     config: PublicationConfig,
-) -> tuple[dict[str, object], Path]:
+) -> tuple[dict[str, object], Path, Path]:
     repository = safe_segment(entry.repo)
     registry_repository = publication_repository(entry)
     ref_segment = safe_segment(branch)
@@ -784,6 +1395,12 @@ def publish(
     stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
     out_dir = out_base / f"{stamp}-{fingerprint[:12]}"
     out_base.mkdir(parents=True, exist_ok=True)
+    active_lease = create_active_publication_lease(
+        repository=registry_repository,
+        ref=ref_segment,
+        fingerprint=fingerprint,
+        publication_dir=out_dir,
+    )
     command = [
         "python3",
         "-B",
@@ -812,43 +1429,48 @@ def publish(
     ]
     if config.redact_secrets:
         command.append("--redact-secrets")
-    cp = run(command, cwd=TOOL_WT, check=False)
-    LOG_ROOT.mkdir(parents=True, exist_ok=True)
-    raw_log = LOG_ROOT / f"fleet-{safe_segment(entry.owner)}__{repository}.stdout.txt"
-    raw_log.write_text(cp.stdout, encoding="utf-8")
-    if cp.returncode != 0:
-        discard_generated_output(out_dir, root=out_base)
-        tail = cp.stdout[-2000:] if cp.stdout else "<empty stdout>"
-        raise RuntimeError(f"repobrief refresh failed rc={cp.returncode}: {tail}")
-    data = parse_cli_json(cp.stdout)
-    manifests = list(out_dir.glob("*_merge.bundle.manifest.json"))
-    if not out_dir.is_dir() or not manifests:
-        discard_generated_output(out_dir, root=out_base)
-        raise RuntimeError(
-            "RepoBrief refresh returned success without a bundle manifest"
+    try:
+        cp = run(command, cwd=TOOL_WT, check=False)
+        LOG_ROOT.mkdir(parents=True, exist_ok=True)
+        raw_log = (
+            LOG_ROOT / f"fleet-{safe_segment(entry.owner)}__{repository}.stdout.txt"
         )
-    repo_log = LOG_ROOT / f"fleet-{safe_segment(entry.owner)}__{repository}.json"
-    repo_log.write_text(
-        json.dumps(
-            {
-                "entry": {
-                    "key": entry.key,
-                    "path": str(entry.path),
-                    "remote": entry.remote,
+        raw_log.write_text(cp.stdout, encoding="utf-8")
+        if cp.returncode != 0:
+            tail = cp.stdout[-2000:] if cp.stdout else "<empty stdout>"
+            raise RuntimeError(f"repobrief refresh failed rc={cp.returncode}: {tail}")
+        data = parse_cli_json(cp.stdout)
+        manifests = list(out_dir.glob("*_merge.bundle.manifest.json"))
+        if not out_dir.is_dir() or not manifests:
+            raise RuntimeError(
+                "RepoBrief refresh returned success without a bundle manifest"
+            )
+        repo_log = LOG_ROOT / f"fleet-{safe_segment(entry.owner)}__{repository}.json"
+        repo_log.write_text(
+            json.dumps(
+                {
+                    "entry": {
+                        "key": entry.key,
+                        "path": str(entry.path),
+                        "remote": entry.remote,
+                    },
+                    "remote_ref": remote_ref,
+                    "sha": sha,
+                    "tool_sha": tool_sha,
+                    "fingerprint": fingerprint,
+                    "result": data,
                 },
-                "remote_ref": remote_ref,
-                "sha": sha,
-                "tool_sha": tool_sha,
-                "fingerprint": fingerprint,
-                "result": data,
-            },
-            indent=2,
-            sort_keys=True,
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
         )
-        + "\n",
-        encoding="utf-8",
-    )
-    return data, out_dir
+        return data, out_dir, active_lease
+    except Exception:
+        discard_generated_output(out_dir, root=out_base)
+        clear_active_publication_lease(active_lease)
+        raise
 
 
 def validate_retention(value: int) -> int:
@@ -869,29 +1491,46 @@ def acquire_lock() -> Any:
 
 
 def cleanup_mode(args: argparse.Namespace) -> int:
-    protected = {Path(raw).expanduser().resolve() for raw in args.protect_path}
-    stable_targets = all_stable_manifest_targets()
-    protected.update(stable_targets)
+    explicit = {
+        Path(raw).expanduser().resolve(strict=False) for raw in args.protect_path
+    }
     apply = bool(args.apply_prune)
     reports: dict[str, object] = {
         "status": "ok",
         "mode": "apply" if apply else "dry-run",
         "retention": args.retention,
-        "protected_paths": sorted(str(path) for path in protected),
-        "stable_manifest_targets": sorted(str(path) for path in stable_targets),
+        "explicit_protected_paths": sorted(str(path) for path in explicit),
     }
-    if args.prune_current:
-        reports["current"] = prune_all_current(
-            keep=args.retention, apply=apply, protected=protected
+    try:
+        reports["reconciliation"] = reconcile_prune_transactions(
+            protected=explicit, apply=apply
         )
-    if args.prune_legacy:
-        reports["legacy"] = prune_all_legacy(
-            keep=args.retention, apply=apply, protected=protected
+        protected = dynamic_protected_paths(explicit)
+        reports["protected_paths"] = sorted(str(path) for path in protected)
+        reports["stable_manifest_targets"] = sorted(
+            str(path) for path in all_stable_manifest_targets()
         )
-    if args.prune_special:
-        reports["special"] = prune_all_special(
-            keep=args.retention, apply=apply, protected=protected
+        reports["state_publication_targets"] = sorted(
+            str(path) for path in state_publication_targets()
         )
+        reports["active_publication_targets"] = sorted(
+            str(path) for path in active_publication_targets()
+        )
+        if args.prune_current:
+            reports["current"] = prune_all_current(
+                keep=args.retention, apply=apply, protected=explicit
+            )
+        if args.prune_legacy:
+            reports["legacy"] = prune_all_legacy(
+                keep=args.retention, apply=apply, protected=explicit
+            )
+        if args.prune_special:
+            reports["special"] = prune_all_special(
+                keep=args.retention, apply=apply, protected=explicit
+            )
+    except Exception as exc:
+        reports["status"] = "error"
+        reports["error"] = str(exc)[:4000]
     LOG_ROOT.mkdir(parents=True, exist_ok=True)
     receipt = LOG_ROOT / (
         "fleet-prune-apply-last.json" if apply else "fleet-prune-dry-run-last.json"
@@ -899,7 +1538,7 @@ def cleanup_mode(args: argparse.Namespace) -> int:
     reports["receipt"] = str(receipt)
     atomic_write_json(receipt, reports)
     print(json.dumps(reports, indent=2, sort_keys=True))
-    return 0
+    return 0 if reports["status"] == "ok" else 1
 
 
 def main(argv: list[str]) -> int:
@@ -920,6 +1559,7 @@ def main(argv: list[str]) -> int:
     parser.add_argument("--prune-current", action="store_true")
     parser.add_argument("--prune-legacy", action="store_true")
     parser.add_argument("--prune-special", action="store_true")
+    parser.add_argument("--reconcile-prune", action="store_true")
     parser.add_argument("--apply-prune", action="store_true")
     parser.add_argument("--protect-path", action="append", default=[])
     args = parser.parse_args(argv)
@@ -935,11 +1575,14 @@ def main(argv: list[str]) -> int:
         parser.error(
             "--force-republish requires at least one --repo and a non-empty --reason"
         )
-    cleanup_requested = args.prune_current or args.prune_legacy or args.prune_special
+    cleanup_requested = (
+        args.prune_current
+        or args.prune_legacy
+        or args.prune_special
+        or args.reconcile_prune
+    )
     if args.apply_prune and not cleanup_requested:
-        parser.error(
-            "--apply-prune requires --prune-current, --prune-legacy, or --prune-special"
-        )
+        parser.error("--apply-prune requires a prune or reconciliation mode")
     if cleanup_requested:
         cleanup_lock = acquire_lock()
         if cleanup_lock is None:
@@ -1002,6 +1645,7 @@ def main(argv: list[str]) -> int:
         changed = published = skipped = failed = queued = prune_failed = 0
         details: list[dict[str, object]] = []
         protected: set[Path] = set()
+        reconciliation = reconcile_prune_transactions(protected=protected, apply=True)
         for entry in entries:
             try:
                 remote_ref, branch, source_sha = remote_head(entry.path)
@@ -1043,7 +1687,7 @@ def main(argv: list[str]) -> int:
                         }
                     )
                     continue
-                data, out_dir = publish(
+                data, out_dir, active_lease = publish(
                     entry,
                     remote_ref=remote_ref,
                     branch=branch,
@@ -1060,6 +1704,7 @@ def main(argv: list[str]) -> int:
                     ref=ref_segment,
                     publication_dir=out_dir,
                 )
+                clear_active_publication_lease(active_lease)
                 published += 1
                 try:
                     prune_report = prune_current_group(
@@ -1114,6 +1759,7 @@ def main(argv: list[str]) -> int:
             "tool_sha": tool_sha,
             "generator_inputs_sha": generator_sha,
             "force_reason": args.reason if args.force_republish else None,
+            "retention_reconciliation": reconciliation,
             "details": details,
         }
         atomic_write_json(LOG_ROOT / "fleet-last.json", summary)


### PR DESCRIPTION
## Summary

- protect current publication state, canonical stable manifests, explicit paths, and active generation markers as reachability roots
- replace direct cleanup with identity-bound quarantine transactions and idempotent crash reconciliation
- fail closed on malformed layouts, symlinks, unexpected journal entries, forged quarantine paths, and parallel changes
- support both known legacy directory layouts while keeping name-only compatibility manifests non-authoritative
- document the retention and recovery contract

## Verification

- `python3 -m pytest -q`: 4040 passed, 1 skipped
- focused retention suite: 31 passed
- `ruff check --config ruff-ci.toml .`: pass
- graph maintainability ratchet: pass, no new findings
- `git diff --check`: pass
- live dry-run: status ok; 40 state roots and 40 canonical stable roots protected; 0 current removals; 0 special removals; exactly 2 old cabinet-main legacy candidates (10,101,936 bytes total)

## Evidence

- base: `ff7a48607547aa23020b04e8af0d1b7a58b8cb66`
- head: `697fb6d8f3624a615da022d90402d59a0768289a`
- patch SHA-256: `e4354ed108baf8f6e35857fc47688874512d8bea44723e933ccba2d90d9be7ce`
- dry-run receipt SHA-256: `796075e990e9581c20129b61bbe2e8f2a53bfed57cdbef582da3f99a33273410`

Closes the implementation scope of `RBV1-T026`; destructive apply remains post-merge and receipt-bound.