### PR TITLE
Harden Python call graph contracts and diagnostics

### DIFF
--- a/merger/lenskit/architecture/call_graph.py
+++ b/merger/lenskit/architecture/call_graph.py
@@ -11,7 +11,7 @@ import os
 from operator import attrgetter
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Iterable, Sequence
 
 from merger.lenskit.architecture.symbol_index import (
     EXCLUDED_DIRS,
@@ -31,6 +31,7 @@ DOES_NOT_ESTABLISH = (
     "runtime_reachability",
     "dynamic_dispatch_resolution",
     "dependency_completeness",
+    "transitive_import_resolution",
     "import_success",
     "test_sufficiency",
     "review_completeness",
@@ -40,28 +41,18 @@ DOES_NOT_ESTABLISH = (
 _FUNCTION_KINDS = ("function", "async_function")
 
 
-@dataclass
+@dataclass(frozen=True)
 class _ScopeFrame:
+    """Immutable lexical-scope snapshot shared safely by recorded calls."""
+
     name: str | None
     kind: str
-    local_bindings: set[str] = field(default_factory=set)
-    global_names: set[str] = field(default_factory=set)
-    nonlocal_names: set[str] = field(default_factory=set)
+    local_bindings: frozenset[str] = field(default_factory=frozenset)
+    global_names: frozenset[str] = field(default_factory=frozenset)
+    nonlocal_names: frozenset[str] = field(default_factory=frozenset)
     start_line: int | None = None
     end_line: int | None = None
     receiver_name: str | None = None
-
-    def copy(self) -> "_ScopeFrame":
-        return _ScopeFrame(
-            name=self.name,
-            kind=self.kind,
-            local_bindings=set(self.local_bindings),
-            global_names=set(self.global_names),
-            nonlocal_names=set(self.nonlocal_names),
-            start_line=self.start_line,
-            end_line=self.end_line,
-            receiver_name=self.receiver_name,
-        )
 
 
 class _ModuleState:
@@ -191,9 +182,9 @@ def _function_frame(
     return _ScopeFrame(
         name=name,
         kind=kind,
-        local_bindings=collector.local,
-        global_names=collector.global_names,
-        nonlocal_names=collector.nonlocal_names,
+        local_bindings=frozenset(collector.local),
+        global_names=frozenset(collector.global_names),
+        nonlocal_names=frozenset(collector.nonlocal_names),
         start_line=int(getattr(node, "lineno", 0) or 0) or None,
         end_line=int(getattr(node, "end_lineno", 0) or 0) or None,
         receiver_name=receiver_name,
@@ -207,7 +198,7 @@ def _class_frame(node: ast.ClassDef) -> _ScopeFrame:
     return _ScopeFrame(
         name=node.name,
         kind="class",
-        local_bindings=collector.local,
+        local_bindings=frozenset(collector.local),
         start_line=int(getattr(node, "lineno", 0) or 0) or None,
         end_line=int(getattr(node, "end_lineno", 0) or 0) or None,
     )
@@ -327,7 +318,9 @@ class _CallGraphVisitor(ast.NodeVisitor):
         for child in ast.walk(node):
             if isinstance(child, ast.comprehension):
                 local.update(_target_names(child.target))
-        self.stack.append(_ScopeFrame(name=None, kind="comprehension", local_bindings=local))
+        self.stack.append(
+            _ScopeFrame(name=None, kind="comprehension", local_bindings=frozenset(local))
+        )
         self.generic_visit(node)
         self.stack.pop()
 
@@ -403,17 +396,31 @@ class _CallGraphVisitor(ast.NodeVisitor):
         return None
 
     def visit_Call(self, node: ast.Call) -> Any:
-        start = getattr(node, "lineno", None)
-        end = getattr(node, "end_lineno", None) or start
-        if isinstance(start, int) and isinstance(end, int):
+        start_line = getattr(node, "lineno", None)
+        if isinstance(start_line, int) and start_line >= 1:
+            start_col = max(int(getattr(node, "col_offset", 0) or 0), 0)
+            raw_end_line = getattr(node, "end_lineno", None)
+            end_line = (
+                raw_end_line
+                if isinstance(raw_end_line, int) and raw_end_line >= start_line
+                else start_line
+            )
+            raw_end_col = getattr(node, "end_col_offset", None)
+            if isinstance(raw_end_col, int) and raw_end_col >= 0:
+                end_col = raw_end_col
+            else:
+                end_col = start_col if end_line == start_line else 0
+            if end_line == start_line and end_col < start_col:
+                end_col = start_col
             self.state.calls.append(
                 {
-                    "start_line": start,
-                    "start_col": int(getattr(node, "col_offset", 0)),
-                    "end_line": end,
-                    "end_col": int(getattr(node, "end_col_offset", 0) or 0),
+                    "start_line": start_line,
+                    "start_col": start_col,
+                    "end_line": end_line,
+                    "end_col": end_col,
                     "func": node.func,
-                    "stack": [frame.copy() for frame in self.stack],
+                    # The stack list changes while traversing; its frozen frames do not.
+                    "stack": tuple(self.stack),
                 }
             )
         self.generic_visit(node)
@@ -432,11 +439,11 @@ def _dotted_parts(node: ast.expr) -> list[str] | None:
     return None
 
 
-def _named_frames(stack: list[_ScopeFrame]) -> list[_ScopeFrame]:
+def _named_frames(stack: Sequence[_ScopeFrame]) -> list[_ScopeFrame]:
     return [frame for frame in stack if frame.name and frame.kind in CALLER_KINDS]
 
 
-def _caller_fields(path: str, stack: list[_ScopeFrame]) -> dict[str, Any]:
+def _caller_fields(path: str, stack: Sequence[_ScopeFrame]) -> dict[str, Any]:
     named = _named_frames(stack)
     if not named:
         return {
@@ -523,7 +530,7 @@ class _Resolver:
         return _verdict("unresolved", f"{reason_prefix}_name_not_found")
 
     def _shadow_reason(
-        self, name: str, stack: list[_ScopeFrame]
+        self, name: str, stack: Sequence[_ScopeFrame]
     ) -> tuple[str | None, bool]:
         inside_function = False
         for frame in reversed(stack):
@@ -542,7 +549,7 @@ class _Resolver:
         return None, False
 
     def _recursive_target(
-        self, state: _ModuleState, name: str, stack: list[_ScopeFrame]
+        self, state: _ModuleState, name: str, stack: Sequence[_ScopeFrame]
     ) -> dict[str, Any] | None:
         for depth in range(len(stack), 0, -1):
             frame = stack[depth - 1]
@@ -618,7 +625,7 @@ class _Resolver:
         return _verdict("unresolved", "unknown_name")
 
     def _resolve_name(
-        self, state: _ModuleState, name: str, stack: list[_ScopeFrame]
+        self, state: _ModuleState, name: str, stack: Sequence[_ScopeFrame]
     ) -> dict[str, Any]:
         shadow_reason, force_module = self._shadow_reason(name, stack)
         if shadow_reason:
@@ -645,7 +652,7 @@ class _Resolver:
         return self._local_binding_verdict(local_functions, local_classes)
 
     def _direct_method_context(
-        self, root: str, stack: list[_ScopeFrame]
+        self, root: str, stack: Sequence[_ScopeFrame]
     ) -> tuple[_ScopeFrame, _ScopeFrame] | None:
         function_index: int | None = None
         for index in range(len(stack) - 1, -1, -1):
@@ -663,7 +670,7 @@ class _Resolver:
         return method, stack[function_index - 1]
 
     def _resolve_receiver_dotted(
-        self, state: _ModuleState, parts: list[str], stack: list[_ScopeFrame]
+        self, state: _ModuleState, parts: list[str], stack: Sequence[_ScopeFrame]
     ) -> dict[str, Any]:
         if len(parts) != 2:
             return _verdict("unresolved", "nested_receiver_attribute_call")
@@ -690,7 +697,7 @@ class _Resolver:
         return _verdict("unresolved", "method_not_defined_in_same_class")
 
     def _resolve_module_dotted(
-        self, state: _ModuleState, parts: list[str], stack: list[_ScopeFrame]
+        self, state: _ModuleState, parts: list[str], stack: Sequence[_ScopeFrame]
     ) -> dict[str, Any]:
         shadow_reason, _ = self._shadow_reason(parts[0], stack)
         if shadow_reason:
@@ -716,7 +723,7 @@ class _Resolver:
         return _verdict("unresolved", "dynamic_attribute_call")
 
     def _resolve_dotted(
-        self, state: _ModuleState, parts: list[str], stack: list[_ScopeFrame]
+        self, state: _ModuleState, parts: list[str], stack: Sequence[_ScopeFrame]
     ) -> dict[str, Any]:
         if parts[0] in ("self", "cls"):
             return self._resolve_receiver_dotted(state, parts, stack)
@@ -825,5 +832,7 @@ def generate_call_graph_document(
         "calls": calls,
         "skipped_files_count": skipped_count,
         "skipped_errors": skipped_errors,
+        "skipped_errors_total_count": skipped_count,
+        "skipped_errors_truncated": skipped_count > len(skipped_errors),
         "does_not_establish": list(DOES_NOT_ESTABLISH),
     }

--- a/merger/lenskit/contracts/python-call-graph.v1.schema.json
+++ b/merger/lenskit/contracts/python-call-graph.v1.schema.json
@@ -55,6 +55,8 @@
       "items": {"type": "string"},
       "maxItems": 20
     },
+    "skipped_errors_total_count": {"type": "integer", "minimum": 0},
+    "skipped_errors_truncated": {"type": "boolean"},
     "does_not_establish": {
       "type": "array",
       "items": {
@@ -64,6 +66,7 @@
           "runtime_reachability",
           "dynamic_dispatch_resolution",
           "dependency_completeness",
+          "transitive_import_resolution",
           "import_success",
           "test_sufficiency",
           "review_completeness",

--- a/merger/lenskit/core/repobrief_access.py
+++ b/merger/lenskit/core/repobrief_access.py
@@ -1340,7 +1340,7 @@ CALL_RESOLUTION_STATUSES = ("resolved", "candidate", "ambiguous", "unresolved")
 CALL_EVIDENCE_LEVELS = ("S0", "S1")
 CALL_RELATION_TYPES = ("calls", "constructs")
 _CALL_CALLER_KINDS = ("module", "class", "function", "async_function")
-_CALL_GRAPH_DOES_NOT_ESTABLISH = (
+_CALL_GRAPH_REQUIRED_NONCLAIMS = (
     "complete_call_graph",
     "runtime_reachability",
     "dynamic_dispatch_resolution",
@@ -1350,10 +1350,19 @@ _CALL_GRAPH_DOES_NOT_ESTABLISH = (
     "review_completeness",
     "merge_readiness",
 )
+_CALL_GRAPH_DOES_NOT_ESTABLISH = (
+    *_CALL_GRAPH_REQUIRED_NONCLAIMS,
+    "transitive_import_resolution",
+)
+
+
+_CALL_NAV_DOES_NOT_ESTABLISH = tuple(
+    dict.fromkeys([*_DOES_NOT_ESTABLISH, *_CALL_GRAPH_DOES_NOT_ESTABLISH])
+)
 
 
 def _call_nav_does_not_establish() -> list[str]:
-    return list(dict.fromkeys([*_DOES_NOT_ESTABLISH, *_CALL_GRAPH_DOES_NOT_ESTABLISH]))
+    return list(_CALL_NAV_DOES_NOT_ESTABLISH)
 
 
 def _string_list_valid(value: Any) -> bool:
@@ -1539,12 +1548,29 @@ def _call_graph_model_error(data: dict[str, Any]) -> dict[str, Any] | None:
             "python_call_graph_evidence_model_invalid",
             "python_call_graph_json evidence_model must define non-empty S0 and S1 semantics",
         )
+    skipped_files_count = data.get("skipped_files_count")
+    skipped_errors = data.get("skipped_errors")
+    skipped_errors_total_count = data.get(
+        "skipped_errors_total_count", skipped_files_count
+    )
+    skipped_errors_truncated = data.get(
+        "skipped_errors_truncated",
+        isinstance(skipped_errors, list)
+        and _is_int_not_bool(skipped_errors_total_count)
+        and skipped_errors_total_count > len(skipped_errors),
+    )
     diagnostics_valid = (
-        _is_int_not_bool(data.get("skipped_files_count"))
-        and data["skipped_files_count"] >= 0
-        and isinstance(data.get("skipped_errors"), list)
-        and len(data["skipped_errors"]) <= 20
-        and all(isinstance(item, str) for item in data["skipped_errors"])
+        _is_int_not_bool(skipped_files_count)
+        and skipped_files_count >= 0
+        and isinstance(skipped_errors, list)
+        and len(skipped_errors) <= 20
+        and all(isinstance(item, str) for item in skipped_errors)
+        and _is_int_not_bool(skipped_errors_total_count)
+        and skipped_errors_total_count == skipped_files_count
+        and skipped_errors_total_count >= len(skipped_errors)
+        and isinstance(skipped_errors_truncated, bool)
+        and skipped_errors_truncated
+        == (skipped_errors_total_count > len(skipped_errors))
     )
     if not diagnostics_valid:
         return _call_graph_error(
@@ -1554,7 +1580,7 @@ def _call_graph_model_error(data: dict[str, Any]) -> dict[str, Any] | None:
     nonclaims = data.get("does_not_establish")
     if (
         not _string_list_valid(nonclaims)
-        or not set(_CALL_GRAPH_DOES_NOT_ESTABLISH).issubset(nonclaims)
+        or not set(_CALL_GRAPH_REQUIRED_NONCLAIMS).issubset(nonclaims)
     ):
         return _call_graph_error(
             "python_call_graph_nonclaims_invalid",
@@ -1703,6 +1729,15 @@ def _call_graph_metadata(data: dict[str, Any]) -> dict[str, Any]:
         "relation_counts": data.get("relation_counts"),
         "skipped_files_count": data.get("skipped_files_count"),
         "skipped_errors": data.get("skipped_errors"),
+        "skipped_errors_total_count": data.get(
+            "skipped_errors_total_count", data.get("skipped_files_count")
+        ),
+        "skipped_errors_truncated": data.get(
+            "skipped_errors_truncated",
+            isinstance(data.get("skipped_errors"), list)
+            and _is_int_not_bool(data.get("skipped_files_count"))
+            and data["skipped_files_count"] > len(data["skipped_errors"]),
+        ),
     }
 
 
@@ -1723,7 +1758,13 @@ def _validated_call_query(
     path: Any,
 ) -> tuple[dict[str, Any], dict[str, Any] | None, str, str | None] | dict[str, Any]:
     def _extra(artifact: dict[str, Any] | None) -> dict[str, Any]:
-        return {"name": name, "k": k, "call_graph": artifact, **_call_empty(kind)}
+        return {
+            "name": name,
+            "k": k,
+            "filters": {"path": path},
+            "call_graph": artifact,
+            **_call_empty(kind),
+        }
 
     if not isinstance(name, str) or not name.strip():
         return _invalid_read_result(

--- a/merger/lenskit/core/repobrief_mcp_tools.py
+++ b/merger/lenskit/core/repobrief_mcp_tools.py
@@ -428,29 +428,6 @@ def _call_navigation_result(
     }
 
 
-def _invalid_call_navigation(
-    tool: str,
-    result_kind: str,
-    result_semantics: str,
-    empty_key: str,
-    error: str,
-    error_code: str,
-) -> dict[str, Any]:
-    return _call_navigation_result(
-        tool,
-        "invalid",
-        {
-            "kind": result_kind,
-            "version": "v1",
-            "status": "invalid",
-            "error": error,
-            "error_code": error_code,
-            empty_key: [],
-            "hit_count": 0,
-        },
-        result_semantics,
-    )
-
 
 def find_references(
     *,
@@ -469,19 +446,9 @@ def find_references(
     artifact yields a missing/invalid result and never triggers a refresh.
     """
     from merger.lenskit.core.repobrief_access import (
-        CALL_REFERENCES_KIND,
         find_references as access_find_references,
     )
 
-    if not isinstance(name, str) or not name.strip():
-        return _invalid_call_navigation(
-            "find_references",
-            CALL_REFERENCES_KIND,
-            "repobrief.call_reference_search.v1",
-            "hits",
-            "name must be a non-empty string",
-            "name_invalid",
-        )
     result = access_find_references(bundle_manifest, name, path=path, k=k)
     return _call_navigation_result(
         "find_references",
@@ -507,19 +474,9 @@ def get_callers(
     Fails closed like ``find_references``; reads never refresh the snapshot.
     """
     from merger.lenskit.core.repobrief_access import (
-        CALL_CALLERS_KIND,
         get_callers as access_get_callers,
     )
 
-    if not isinstance(name, str) or not name.strip():
-        return _invalid_call_navigation(
-            "get_callers",
-            CALL_CALLERS_KIND,
-            "repobrief.call_callers.v1",
-            "callers",
-            "name must be a non-empty string",
-            "name_invalid",
-        )
     result = access_get_callers(bundle_manifest, name, path=path, k=k)
     return _call_navigation_result(
         "get_callers",
@@ -544,19 +501,9 @@ def get_callees(
     Reads never refresh the snapshot and do not establish runtime reachability.
     """
     from merger.lenskit.core.repobrief_access import (
-        CALL_CALLEES_KIND,
         get_callees as access_get_callees,
     )
 
-    if not isinstance(name, str) or not name.strip():
-        return _invalid_call_navigation(
-            "get_callees",
-            CALL_CALLEES_KIND,
-            "repobrief.call_callees.v1",
-            "callees",
-            "name must be a non-empty string",
-            "name_invalid",
-        )
     result = access_get_callees(bundle_manifest, name, path=path, k=k)
     return _call_navigation_result(
         "get_callees",

--- a/merger/lenskit/tests/test_python_call_graph.py
+++ b/merger/lenskit/tests/test_python_call_graph.py
@@ -5,6 +5,7 @@ covers every safe resolution rule (local module function, imported internal
 name, module alias, self/cls method, direct recursion) plus the conservative
 outcomes (ambiguous, dynamic, foreign, module scope, parse errors).
 """
+import ast
 import json
 from pathlib import Path
 
@@ -12,9 +13,12 @@ import jsonschema
 
 from merger.lenskit.architecture.call_graph import (
     DOES_NOT_ESTABLISH,
+    _CallGraphVisitor,
+    _Resolver,
     extract_python_calls,
     generate_call_graph_document,
 )
+from merger.lenskit.core.repobrief_access import _call_record_is_valid
 
 GOLDSET_TEXT_PY = '''import os.path
 import utilkit.numbers as num
@@ -140,6 +144,7 @@ def test_call_graph_does_not_establish_contains_required_boundaries(tmp_path):
         "runtime_reachability",
         "dynamic_dispatch_resolution",
         "dependency_completeness",
+        "transitive_import_resolution",
         "import_success",
         "test_sufficiency",
         "review_completeness",
@@ -289,11 +294,43 @@ def test_parse_errors_are_counted_and_documented_bounded(tmp_path):
     doc = generate_call_graph_document(tmp_path, "run-1", "a" * 64)
 
     assert doc["skipped_files_count"] == 1
+    assert doc["skipped_errors_total_count"] == 1
+    assert doc["skipped_errors_truncated"] is False
     assert len(doc["skipped_errors"]) == 1
     assert "utilkit/broken.py" in doc["skipped_errors"][0]
     assert "SyntaxError" in doc["skipped_errors"][0]
     # The broken file contributes no call records.
     assert all(call["path"] != "utilkit/broken.py" for call in doc["calls"])
+
+
+def test_parse_error_truncation_is_explicit(tmp_path):
+    for index in range(25):
+        (tmp_path / f"broken_{index:02d}.py").write_text(
+            "def broken(:\n", encoding="utf-8"
+        )
+
+    doc = generate_call_graph_document(tmp_path, "run-1", "a" * 64)
+
+    assert doc["skipped_files_count"] == 25
+    assert doc["skipped_errors_total_count"] == 25
+    assert len(doc["skipped_errors"]) == 20
+    assert doc["skipped_errors_truncated"] is True
+
+
+def test_missing_ast_end_position_is_normalized_to_valid_range():
+    tree = ast.parse("def caller():\n    return target()\n")
+    call_node = next(node for node in ast.walk(tree) if isinstance(node, ast.Call))
+    call_node.end_lineno = None
+    call_node.end_col_offset = None
+
+    visitor = _CallGraphVisitor("sample.py", is_package=False)
+    visitor.visit(tree)
+    state = visitor.state
+    record = _Resolver({state.module: [state]}).resolve(state, state.calls[0])
+
+    assert record["start_line"] == record["end_line"] == 2
+    assert record["end_col"] == record["start_col"]
+    assert _call_record_is_valid(record) is True
 
 
 SCOPE_GOLDSET_PY = '''
@@ -499,9 +536,12 @@ def test_module_name_collision_preserves_all_calls_and_refuses_resolution(tmp_pa
         encoding="utf-8",
     )
     (tmp_path / "consumer.py").write_text(
+        "import foo\n"
         "from foo import target\n\n"
         "def caller():\n"
-        "    return target()\n",
+        "    return target()\n\n"
+        "def alias_caller():\n"
+        "    return foo.target()\n",
         encoding="utf-8",
     )
 
@@ -525,6 +565,22 @@ def test_module_name_collision_preserves_all_calls_and_refuses_resolution(tmp_pa
     assert imported["evidence_level"] == "S0"
     assert imported["resolution_reason"] == "imported_internal_name_module_collision"
     assert set(imported["candidate_target_ids"]) == {
+        "py:foo.py:function:target",
+        "py:foo:__init__.py:function:target",
+    }
+
+
+    aliased = next(
+        call
+        for call in calls
+        if call["path"] == "consumer.py"
+        and call["caller_qualified_name"] == "alias_caller"
+        and call["callee_expression"] == "foo.target"
+    )
+    assert aliased["resolution_status"] == "ambiguous"
+    assert aliased["evidence_level"] == "S0"
+    assert aliased["resolution_reason"] == "module_alias_call_module_collision"
+    assert set(aliased["candidate_target_ids"]) == {
         "py:foo.py:function:target",
         "py:foo:__init__.py:function:target",
     }

--- a/merger/lenskit/tests/test_repobrief_call_navigation.py
+++ b/merger/lenskit/tests/test_repobrief_call_navigation.py
@@ -363,6 +363,22 @@ def test_get_callees_returns_resolved_targets_and_unresolved_sites(tmp_path):
     assert result["unresolved_call_sites"][0]["evidence_level"] == "S0"
 
 
+def test_invalid_navigation_payloads_preserve_filters_and_full_shape(tmp_path):
+    manifest = _bundle(tmp_path)
+
+    access_result = find_references(manifest, "", path="pkg/a.py")
+    wrapped = repobrief_mcp_tools.find_references(
+        bundle_manifest=str(manifest), name="", path="pkg/a.py"
+    )
+
+    assert access_result["status"] == "invalid"
+    assert access_result["filters"] == {"path": "pkg/a.py"}
+    assert access_result["hits"] == []
+    assert access_result["call_graph"] is None
+    assert wrapped["status"] == "invalid"
+    assert wrapped["result"] == access_result
+
+
 def test_navigation_path_filter_and_invalid_k_fail_closed(tmp_path):
     manifest = _bundle(tmp_path)
     filtered = find_references(manifest, "target", path="pkg/b.py")

--- a/merger/lenskit/tests/test_repobrief_mcp_stdio.py
+++ b/merger/lenskit/tests/test_repobrief_mcp_stdio.py
@@ -331,6 +331,34 @@ def test_serve_stdio_returns_parse_error_without_traceback(tmp_path):
     assert response["error"] == {"code": -32700, "message": "parse error"}
 
 
+def test_mcp_stdio_rejects_invalid_call_navigation_params_at_transport(tmp_path):
+    manifest = _manifest(tmp_path)
+    server = RepoBriefMcpStdioServer(bundle_root=tmp_path)
+    _initialize(server)
+
+    response = server.handle_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": {
+                "name": "find_references",
+                "arguments": {
+                    "bundle_manifest": str(manifest),
+                    "name": "",
+                    "path": "pkg/a.py",
+                    "k": 25,
+                },
+            },
+        }
+    )
+
+    assert response["error"] == {
+        "code": -32602,
+        "message": "find_references requires a non-empty name",
+    }
+
+
 def test_mcp_stdio_dispatches_get_callees_and_adds_freshness(tmp_path, monkeypatch):
     manifest = _manifest(tmp_path)
     server = RepoBriefMcpStdioServer(bundle_root=tmp_path)


### PR DESCRIPTION
## Ziel
Behebt die nach PR #1018 verifizierten Contract- und Robustheitslücken, ohne die konservativen S0/S1-Beweisgrenzen zu erweitern.

## Änderungen
- normalisiert fehlende oder inkonsistente AST-Endpositionen zu gültigen Source-Ranges
- macht Scope-Snapshots unveränderlich und vermeidet tiefe Set-Kopien pro Call
- vereinheitlicht direkte Core-/MCP-Fehler-Payloads einschließlich `filters`
- weist abgeschnittene Parse-Diagnostik mit Gesamtzahl und Trunkierungsflag explizit aus
- dokumentiert fehlende transitive Importauflösung als Nichtbehauptung
- ergänzt Regressionstests für Range-Fallback, Modul-/Package-Kollision und Transport-/Core-Grenze

## Verifikation
- `ruff check --config ruff-ci.toml .`
- Maintainability-Ratchet: pass, keine neuen Befunde
- `pytest -q -m "not browser and not doc_freshness_live"`: 4106 passed, 1 skipped, 13 deselected
- Parity-Suite: 39 passed
- Release-Contract: pass
- zwei bytegleiche Release-Kandidaten, Archiv-SHA-256 `b617ba5f05ab4eb6b735acf7a287d2589ef15892fcf82ac0a9dd2c3dd3c8b235`

## Grenzen
Kein Anspruch auf vollständigen Call Graph, Laufzeit-Erreichbarkeit, dynamische Dispatch-Auflösung, transitive Importauflösung, Testhinlänglichkeit oder Merge-Reife allein durch das Artefakt.