### PR TITLE
Harden comprehension scopes and call graph contracts

### DIFF
--- a/merger/lenskit/architecture/call_graph.py
+++ b/merger/lenskit/architecture/call_graph.py
@@ -13,6 +13,10 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable, Sequence
 
+from merger.lenskit.architecture.call_graph_contract import (
+    MAX_SKIPPED_ERRORS,
+    PRODUCER_NONCLAIMS,
+)
 from merger.lenskit.architecture.symbol_index import (
     EXCLUDED_DIRS,
     _module_name,
@@ -24,24 +28,12 @@ RESOLUTION_STATUSES = ("resolved", "candidate", "ambiguous", "unresolved")
 EVIDENCE_LEVELS = ("S0", "S1")
 RELATION_TYPES = ("calls", "constructs")
 CALLER_KINDS = ("module", "class", "function", "async_function")
-MAX_SKIPPED_ERRORS = 20
-
-DOES_NOT_ESTABLISH = (
-    "complete_call_graph",
-    "runtime_reachability",
-    "dynamic_dispatch_resolution",
-    "dependency_completeness",
-    "transitive_import_resolution",
-    "import_success",
-    "test_sufficiency",
-    "review_completeness",
-    "merge_readiness",
-)
+DOES_NOT_ESTABLISH = PRODUCER_NONCLAIMS
 
 _FUNCTION_KINDS = ("function", "async_function")
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class _ScopeFrame:
     """Immutable lexical-scope snapshot shared safely by recorded calls."""
 
@@ -313,16 +305,41 @@ class _CallGraphVisitor(ast.NodeVisitor):
         self.stack.pop()
         return None
 
-    def _visit_comprehension(self, node: ast.AST) -> None:
+    def _visit_comprehension(
+        self,
+        node: ast.ListComp | ast.SetComp | ast.DictComp | ast.GeneratorExp,
+    ) -> None:
+        generators = node.generators
+        if not generators:
+            return
+
+        # Python evaluates the outermost iterable before entering the implicit
+        # comprehension scope. Later iterables see only targets bound by earlier
+        # generators; nested comprehensions create their own frames when visited.
+        self.visit(generators[0].iter)
         local: set[str] = set()
-        for child in ast.walk(node):
-            if isinstance(child, ast.comprehension):
-                local.update(_target_names(child.target))
-        self.stack.append(
-            _ScopeFrame(name=None, kind="comprehension", local_bindings=frozenset(local))
-        )
-        self.generic_visit(node)
-        self.stack.pop()
+        self.stack.append(_ScopeFrame(name=None, kind="comprehension"))
+        try:
+            for index, generator in enumerate(generators):
+                if index:
+                    self.visit(generator.iter)
+                local.update(_target_names(generator.target))
+                self.stack[-1] = _ScopeFrame(
+                    name=None,
+                    kind="comprehension",
+                    local_bindings=frozenset(local),
+                )
+                self.visit(generator.target)
+                for condition in generator.ifs:
+                    self.visit(condition)
+
+            if isinstance(node, ast.DictComp):
+                self.visit(node.key)
+                self.visit(node.value)
+            else:
+                self.visit(node.elt)
+        finally:
+            self.stack.pop()
 
     def visit_ListComp(self, node: ast.ListComp) -> Any:
         self._visit_comprehension(node)

--- a/merger/lenskit/architecture/call_graph_contract.py
+++ b/merger/lenskit/architecture/call_graph_contract.py
@@ -1,0 +1,26 @@
+"""Shared Python Call Graph v1 limits and negative semantics.
+
+``transitive_import_resolution`` means the static producer does not follow
+multi-hop imports, package re-exports, star-export expansion, module
+``__getattr__`` hooks, or other runtime import indirection. A unique local
+resolution therefore never implies that those transitive paths were searched.
+"""
+
+MAX_SKIPPED_ERRORS = 20
+
+REQUIRED_NONCLAIMS = (
+    "complete_call_graph",
+    "runtime_reachability",
+    "dynamic_dispatch_resolution",
+    "dependency_completeness",
+    "import_success",
+    "test_sufficiency",
+    "review_completeness",
+    "merge_readiness",
+)
+
+PRODUCER_NONCLAIMS = (
+    *REQUIRED_NONCLAIMS[:4],
+    "transitive_import_resolution",
+    *REQUIRED_NONCLAIMS[4:],
+)

--- a/merger/lenskit/core/agent_reading_pack.py
+++ b/merger/lenskit/core/agent_reading_pack.py
@@ -451,8 +451,8 @@ def _append_call_graph_section(lines: List[str], model: PackModel) -> None:
     )
     lines.append(
         "- does_not_establish: complete call graph, runtime reachability, dynamic "
-        "dispatch resolution, dependency completeness, test sufficiency, review "
-        "completeness or merge readiness."
+        "dispatch resolution, dependency completeness, transitive import resolution, "
+        "import success, test sufficiency, review completeness or merge readiness."
     )
     lines.append("")
 

--- a/merger/lenskit/core/repobrief_access.py
+++ b/merger/lenskit/core/repobrief_access.py
@@ -5,6 +5,12 @@ import re
 from pathlib import Path
 from typing import Any
 
+from merger.lenskit.architecture.call_graph_contract import (
+    MAX_SKIPPED_ERRORS as MAX_CALL_GRAPH_SKIPPED_ERRORS,
+    PRODUCER_NONCLAIMS as CALL_GRAPH_PRODUCER_NONCLAIMS,
+    REQUIRED_NONCLAIMS as CALL_GRAPH_REQUIRED_NONCLAIMS,
+)
+
 _DOES_NOT_ESTABLISH = (
     "truth",
     "correctness",
@@ -1340,20 +1346,8 @@ CALL_RESOLUTION_STATUSES = ("resolved", "candidate", "ambiguous", "unresolved")
 CALL_EVIDENCE_LEVELS = ("S0", "S1")
 CALL_RELATION_TYPES = ("calls", "constructs")
 _CALL_CALLER_KINDS = ("module", "class", "function", "async_function")
-_CALL_GRAPH_REQUIRED_NONCLAIMS = (
-    "complete_call_graph",
-    "runtime_reachability",
-    "dynamic_dispatch_resolution",
-    "dependency_completeness",
-    "import_success",
-    "test_sufficiency",
-    "review_completeness",
-    "merge_readiness",
-)
-_CALL_GRAPH_DOES_NOT_ESTABLISH = (
-    *_CALL_GRAPH_REQUIRED_NONCLAIMS,
-    "transitive_import_resolution",
-)
+_CALL_GRAPH_REQUIRED_NONCLAIMS = CALL_GRAPH_REQUIRED_NONCLAIMS
+_CALL_GRAPH_DOES_NOT_ESTABLISH = CALL_GRAPH_PRODUCER_NONCLAIMS
 
 
 _CALL_NAV_DOES_NOT_ESTABLISH = tuple(
@@ -1527,6 +1521,27 @@ def _call_graph_identity_error(data: Any) -> dict[str, Any] | None:
     return None
 
 
+def _call_graph_parse_diagnostics(data: dict[str, Any]) -> dict[str, Any]:
+    """Project current and legacy parse diagnostics through one code path."""
+    skipped_files_count = data.get("skipped_files_count")
+    skipped_errors = data.get("skipped_errors")
+    skipped_errors_total_count = data.get(
+        "skipped_errors_total_count", skipped_files_count
+    )
+    skipped_errors_truncated = data.get(
+        "skipped_errors_truncated",
+        isinstance(skipped_errors, list)
+        and _is_int_not_bool(skipped_errors_total_count)
+        and skipped_errors_total_count > len(skipped_errors),
+    )
+    return {
+        "skipped_files_count": skipped_files_count,
+        "skipped_errors": skipped_errors,
+        "skipped_errors_total_count": skipped_errors_total_count,
+        "skipped_errors_truncated": skipped_errors_truncated,
+    }
+
+
 def _call_graph_model_error(data: dict[str, Any]) -> dict[str, Any] | None:
     if data.get("resolution_statuses") != list(CALL_RESOLUTION_STATUSES):
         return _call_graph_error(
@@ -1548,22 +1563,16 @@ def _call_graph_model_error(data: dict[str, Any]) -> dict[str, Any] | None:
             "python_call_graph_evidence_model_invalid",
             "python_call_graph_json evidence_model must define non-empty S0 and S1 semantics",
         )
-    skipped_files_count = data.get("skipped_files_count")
-    skipped_errors = data.get("skipped_errors")
-    skipped_errors_total_count = data.get(
-        "skipped_errors_total_count", skipped_files_count
-    )
-    skipped_errors_truncated = data.get(
-        "skipped_errors_truncated",
-        isinstance(skipped_errors, list)
-        and _is_int_not_bool(skipped_errors_total_count)
-        and skipped_errors_total_count > len(skipped_errors),
-    )
+    diagnostics = _call_graph_parse_diagnostics(data)
+    skipped_files_count = diagnostics["skipped_files_count"]
+    skipped_errors = diagnostics["skipped_errors"]
+    skipped_errors_total_count = diagnostics["skipped_errors_total_count"]
+    skipped_errors_truncated = diagnostics["skipped_errors_truncated"]
     diagnostics_valid = (
         _is_int_not_bool(skipped_files_count)
         and skipped_files_count >= 0
         and isinstance(skipped_errors, list)
-        and len(skipped_errors) <= 20
+        and len(skipped_errors) <= MAX_CALL_GRAPH_SKIPPED_ERRORS
         and all(isinstance(item, str) for item in skipped_errors)
         and _is_int_not_bool(skipped_errors_total_count)
         and skipped_errors_total_count == skipped_files_count
@@ -1727,17 +1736,7 @@ def _call_graph_metadata(data: dict[str, Any]) -> dict[str, Any]:
         "resolution_counts": data.get("resolution_counts"),
         "evidence_counts": data.get("evidence_counts"),
         "relation_counts": data.get("relation_counts"),
-        "skipped_files_count": data.get("skipped_files_count"),
-        "skipped_errors": data.get("skipped_errors"),
-        "skipped_errors_total_count": data.get(
-            "skipped_errors_total_count", data.get("skipped_files_count")
-        ),
-        "skipped_errors_truncated": data.get(
-            "skipped_errors_truncated",
-            isinstance(data.get("skipped_errors"), list)
-            and _is_int_not_bool(data.get("skipped_files_count"))
-            and data["skipped_files_count"] > len(data["skipped_errors"]),
-        ),
+        **_call_graph_parse_diagnostics(data),
     }
 
 

--- a/merger/lenskit/tests/test_python_call_graph.py
+++ b/merger/lenskit/tests/test_python_call_graph.py
@@ -13,6 +13,7 @@ import jsonschema
 
 from merger.lenskit.architecture.call_graph import (
     DOES_NOT_ESTABLISH,
+    MAX_SKIPPED_ERRORS,
     _CallGraphVisitor,
     _Resolver,
     extract_python_calls,
@@ -313,8 +314,20 @@ def test_parse_error_truncation_is_explicit(tmp_path):
 
     assert doc["skipped_files_count"] == 25
     assert doc["skipped_errors_total_count"] == 25
-    assert len(doc["skipped_errors"]) == 20
+    assert len(doc["skipped_errors"]) == MAX_SKIPPED_ERRORS
     assert doc["skipped_errors_truncated"] is True
+
+
+def test_call_graph_schema_matches_shared_diagnostic_limit():
+    schema_path = (
+        Path(__file__).parents[1] / "contracts" / "python-call-graph.v1.schema.json"
+    )
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+
+    assert schema["properties"]["skipped_errors"]["maxItems"] == MAX_SKIPPED_ERRORS
+    assert set(DOES_NOT_ESTABLISH) <= set(
+        schema["properties"]["does_not_establish"]["items"]["enum"]
+    )
 
 
 def test_missing_ast_end_position_is_normalized_to_valid_range():
@@ -469,6 +482,55 @@ def test_lexical_shadowing_never_upgrades_to_s1(tmp_path):
         and call["caller_qualified_name"] == "lambda_shadow"
     ]
     assert len(lambda_call) == 1
+
+
+def test_nested_comprehension_targets_do_not_leak_into_outer_scope(tmp_path):
+    (tmp_path / "sample.py").write_text(
+        "def target():\n"
+        "    return 1\n\n"
+        "def caller(items):\n"
+        "    return [target() for item in [item for target in items]]\n",
+        encoding="utf-8",
+    )
+
+    calls, _, _ = extract_python_calls(tmp_path)
+    call = next(
+        row
+        for row in calls
+        if row["caller_qualified_name"] == "caller"
+        and row["callee_expression"] == "target"
+    )
+
+    assert call["resolution_status"] == "resolved"
+    assert call["resolution_reason"] == "local_module_function"
+
+
+def test_comprehension_generator_bindings_follow_python_evaluation_order(tmp_path):
+    (tmp_path / "sample.py").write_text(
+        "def target():\n"
+        "    return [1]\n\n"
+        "def before_binding(items):\n"
+        "    return [item for target in target()]\n\n"
+        "def later_binding(items):\n"
+        "    return [item for item in target() for target in items]\n\n"
+        "def prior_binding(items):\n"
+        "    return [item for target in items for item in target()]\n",
+        encoding="utf-8",
+    )
+
+    calls, _, _ = extract_python_calls(tmp_path)
+    by_caller = {
+        row["caller_qualified_name"]: row
+        for row in calls
+        if row["callee_expression"] == "target"
+    }
+
+    assert by_caller["before_binding"]["resolution_status"] == "resolved"
+    assert by_caller["before_binding"]["resolution_reason"] == "local_module_function"
+    assert by_caller["later_binding"]["resolution_status"] == "resolved"
+    assert by_caller["later_binding"]["resolution_reason"] == "local_module_function"
+    assert by_caller["prior_binding"]["resolution_status"] == "unresolved"
+    assert by_caller["prior_binding"]["resolution_reason"] == "comprehension_binding"
 
 
 def test_global_binding_can_resolve_module_symbol(tmp_path):

--- a/merger/lenskit/tests/test_repobrief_call_navigation.py
+++ b/merger/lenskit/tests/test_repobrief_call_navigation.py
@@ -3,7 +3,9 @@ import hashlib
 import json
 from pathlib import Path
 
-from merger.lenskit.core import repobrief_mcp_tools
+import pytest
+
+from merger.lenskit.core import repobrief_access, repobrief_mcp_tools
 from merger.lenskit.core.repobrief_access import (
     find_references,
     get_callees,
@@ -379,6 +381,20 @@ def test_invalid_navigation_payloads_preserve_filters_and_full_shape(tmp_path):
     assert wrapped["result"] == access_result
 
 
+@pytest.mark.parametrize("reader", [find_references, get_callers, get_callees])
+def test_invalid_navigation_name_fails_before_artifact_io(tmp_path, monkeypatch, reader):
+    def fail_if_loaded(_manifest_path):
+        raise AssertionError("invalid primitive input must not load the call graph")
+
+    monkeypatch.setattr(repobrief_access, "_load_call_graph", fail_if_loaded)
+
+    result = reader(tmp_path / "missing.bundle.manifest.json", "")
+
+    assert result["status"] == "invalid"
+    assert result["error_code"] == "name_invalid"
+    assert result["call_graph"] is None
+
+
 def test_navigation_path_filter_and_invalid_k_fail_closed(tmp_path):
     manifest = _bundle(tmp_path)
     filtered = find_references(manifest, "target", path="pkg/b.py")
@@ -402,6 +418,41 @@ def test_navigation_rejects_mismatched_symbol_binding(tmp_path):
     assert result["status"] == "invalid"
     assert result["error_code"] == "call_symbol_run_id_mismatch"
     assert result["callers"] == []
+
+
+def test_navigation_rejects_inconsistent_parse_diagnostic_counts(tmp_path):
+    manifest, call_graph, _ = _write_bundle(tmp_path)
+    payload = json.loads(call_graph.read_text(encoding="utf-8"))
+    payload["skipped_files_count"] = 1
+    payload["skipped_errors"] = ["broken.py: SyntaxError"]
+    payload["skipped_errors_total_count"] = 2
+    payload["skipped_errors_truncated"] = True
+    call_graph.write_text(json.dumps(payload), encoding="utf-8")
+    _refresh_manifest_artifact(manifest, "python_call_graph_json", call_graph)
+
+    result = find_references(manifest, "target")
+
+    assert result["status"] == "invalid"
+    assert result["error_code"] == "python_call_graph_parse_diagnostics_invalid"
+    assert result["hits"] == []
+
+
+def test_legacy_parse_diagnostics_use_one_normalized_metadata_projection(tmp_path):
+    manifest, call_graph, _ = _write_bundle(tmp_path)
+    payload = json.loads(call_graph.read_text(encoding="utf-8"))
+    payload["skipped_files_count"] = 2
+    payload["skipped_errors"] = ["broken.py: SyntaxError"]
+    payload.pop("skipped_errors_total_count", None)
+    payload.pop("skipped_errors_truncated", None)
+    call_graph.write_text(json.dumps(payload), encoding="utf-8")
+    _refresh_manifest_artifact(manifest, "python_call_graph_json", call_graph)
+
+    result = find_references(manifest, "target")
+
+    assert result["status"] == "available"
+    assert result["call_graph_metadata"]["skipped_files_count"] == 2
+    assert result["call_graph_metadata"]["skipped_errors_total_count"] == 2
+    assert result["call_graph_metadata"]["skipped_errors_truncated"] is True
 
 
 def test_navigation_rejects_invalid_aggregate_counts(tmp_path):


### PR DESCRIPTION
## Anlass
Prüft die externen Nachreviews zum gemergten PR #1019 gegen den Live-Stand und übernimmt nur bestätigte Befunde.

## Bestätigte Änderungen
- besucht Comprehensions in echter Python-Auswertungsreihenfolge
- verhindert, dass Ziele verschachtelter Comprehensions in äußere Scope-Snapshots leaken
- vermeidet den bisherigen doppelten vollständigen `ast.walk`/`generic_visit`-Durchlauf
- ergänzt `slots=True` für unveränderliche Scope-Frames
- zentralisiert Diagnosegrenze und Call-Graph-Nichtbehauptungen
- projiziert aktuelle und ältere Parse-Diagnostik über einen gemeinsamen Pfad
- dokumentiert `transitive_import_resolution` als fehlende Auflösung mehrstufiger Imports, Re-Exports, Star-Exports und dynamischer Importindirektion

## Verifizierte Nichtbefunde
- Zählermismatch wurde bereits fail-closed abgewiesen; ein `assert` oder `ValueError` wäre für untrusted Bundle-Daten ungeeignet
- direkte Access-Aufrufe validieren `name` bereits vor Artefakt-I/O; MCP bleibt zusätzlich transportseitig fail-fast
- das JSON-Schema besitzt bereits `additionalProperties: false`
- `_ScopeFrame` enthält bereits nur unveränderliche Felder
- `tuple(self.stack)` ist O(Scope-Tiefe), nicht O(1); eine alternative Stack-Repräsentation bleibt getrennte Ausbauarbeit

## Verifikation
- Ruff: bestanden
- Maintainability-Ratchet: bestanden
- fokussiert: 117 Tests bestanden
- Gesamtsuite: 4114 bestanden, 1 übersprungen, 13 abgewählt
- Parity: 39 bestanden
- Release-Vertrag: bestanden
- zwei bytegleiche, quellgebundene Release-Kandidaten
- Archiv-SHA-256: `294a05742463ebb0cf03513821fa8ec6b2db2e4f40ceb236bc2f7f5c1885617e`

## Grenzen
Keine Erweiterung der S1-Auflösung, keine transitive Importauflösung und keine neue persistierte Stack-/Indexstruktur. Diese größeren Achsen bleiben in RPU-V1-T029/T030 getrennt.