### PR TITLE
Fix repoLens on iPad without jsonschema

### DIFF
--- a/merger/lenskit/core/merge.py
+++ b/merger/lenskit/core/merge.py
@@ -5149,6 +5149,19 @@ def generate_derived_manifest(base_name_func, run_id, dump_sha256, artifacts_map
     out_path.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
     return out_path
 
+
+def _handle_snapshot_retrieval_measurement_error(exc, *, debug: bool) -> None:
+    """Degrade only an unavailable optional validator; re-raise all data errors."""
+
+    if exc.code != "canonical_validation_unavailable":
+        raise exc
+    if debug:
+        print(
+            "Skipping canonical retrieval evaluation: jsonschema is unavailable",
+            file=sys.stderr,
+        )
+
+
 def build_derived_artifacts(dump_index_path, chunk_path, base_name_func, run_id, hub_path, generator_info, repo_names, debug, repo_summaries=None) -> List[Path]:
     derived_paths = []
     sqlite_index_path = None
@@ -5203,15 +5216,7 @@ def build_derived_artifacts(dump_index_path, chunk_path, base_name_func, run_id,
                 )
                 derived_paths.append(eval_json_path)
         except SnapshotRetrievalMeasurementError as exc:
-            if exc.code == "canonical_validation_unavailable":
-                if debug:
-                    print(
-                        "Skipping canonical retrieval evaluation: "
-                        "jsonschema is unavailable",
-                        file=sys.stderr,
-                    )
-            else:
-                raise
+            _handle_snapshot_retrieval_measurement_error(exc, debug=debug)
         except Exception as e:
             if debug:
                 print(f"Error building derived index or evaluating: {e}", file=sys.stderr)

--- a/merger/lenskit/core/merge.py
+++ b/merger/lenskit/core/merge.py
@@ -5202,8 +5202,16 @@ def build_derived_artifacts(dump_index_path, chunk_path, base_name_func, run_id,
                     encoding="utf-8",
                 )
                 derived_paths.append(eval_json_path)
-        except SnapshotRetrievalMeasurementError:
-            raise
+        except SnapshotRetrievalMeasurementError as exc:
+            if exc.code == "canonical_validation_unavailable":
+                if debug:
+                    print(
+                        "Skipping canonical retrieval evaluation: "
+                        "jsonschema is unavailable",
+                        file=sys.stderr,
+                    )
+            else:
+                raise
         except Exception as e:
             if debug:
                 print(f"Error building derived index or evaluating: {e}", file=sys.stderr)

--- a/merger/lenskit/tests/test_graph_bundle_integration.py
+++ b/merger/lenskit/tests/test_graph_bundle_integration.py
@@ -1,3 +1,4 @@
+import builtins
 import hashlib
 import json
 from pathlib import Path
@@ -260,3 +261,38 @@ def test_derived_snapshot_does_not_swallow_invalid_canonical_goldset(tmp_path):
         SnapshotRetrievalMeasurementError, match="canonical_goldset_invalid"
     ):
         build_derived_artifacts(**args)
+
+
+def test_derived_snapshot_degrades_when_jsonschema_is_unavailable(
+    tmp_path, monkeypatch
+):
+    base, _, args = _setup(tmp_path)
+    repo_root = tmp_path / "repo1"
+    goldset = repo_root / "docs/retrieval/review_queries.v1.json"
+    goldset.parent.mkdir(parents=True)
+    source_goldset = (
+        Path(__file__).resolve().parents[3]
+        / "docs/retrieval/review_queries.v1.json"
+    )
+    goldset.write_bytes(source_goldset.read_bytes())
+    args["repo_summaries"] = [{"root": repo_root, "name": "repo1"}]
+
+    original_import = builtins.__import__
+
+    def import_without_jsonschema(name, *import_args, **import_kwargs):
+        if name == "jsonschema":
+            raise ImportError("simulated Pythonista runtime without jsonschema")
+        return original_import(name, *import_args, **import_kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_jsonschema)
+
+    derived_paths = build_derived_artifacts(**args)
+
+    sqlite_path = args["chunk_path"].with_suffix(".index.sqlite")
+    eval_path = base.with_suffix(".retrieval_eval.json")
+    graph_path = base.with_suffix(".graph_index.json")
+    assert sqlite_path in derived_paths
+    assert eval_path not in derived_paths
+    assert not eval_path.exists()
+    assert graph_path in derived_paths
+


### PR DESCRIPTION
## Problem

The Pythonista repoLens frontend aborts a complete bundle run when a repository-local canonical review goldset is present but the optional `jsonschema` package is unavailable.

## Change

- degrade only `canonical_validation_unavailable` by omitting the optional retrieval evaluation artifact
- preserve fail-closed behavior for invalid canonical goldsets and all other retrieval measurement errors
- add an integration regression test simulating the Pythonista import failure

## Verification

- `python3 -m pytest -q merger/lenskit/tests/test_graph_bundle_integration.py` — 10 passed
- `python3 -m pytest -q merger/lenskit/tests/test_pythonista_validation_capability.py merger/lenskit/tests/test_review_retrieval_metrics.py` — 35 passed
- `ruff check --config ruff-ci.toml .` — passed

## Boundaries

This does not add `jsonschema` to Pythonista and does not claim that the skipped retrieval evaluation was validated. The primary repoLens bundle generation continues; invalid canonical benchmark data still blocks.