### PR TITLE
perf(repobrief): index call navigation state

### DIFF
--- a/docs/proofs/repobrief-call-navigation-scale-index-v1-proof.md
+++ b/docs/proofs/repobrief-call-navigation-scale-index-v1-proof.md
@@ -1,0 +1,189 @@
+# RepoBrief Call-Navigation Scale Index v1 — T029 Proof
+
+Status: implemented and locally validated
+Bureau task: `RPU-V1-T029`
+Base commit: `fafa115c1bb291742f5a7e10ba5ab21e33baa902`
+Default implementation: bounded process-local in-memory index
+Persisted sidecar promotion: `false`
+Measurement artifact: `repobrief-call-navigation-scale-index-v1.measurement.json`
+Measurement SHA-256: `2a43ecf1ed82bf94900d623a3a75d8f5d75185b74379b841039c0d21addda336`
+
+## Problem
+
+Die drei Call-Navigation-Zugriffe `find_references`, `get_callers` und
+`get_callees` lasen und validierten bei jeder Anfrage den vollständigen
+Call-Graph erneut. Danach liefen sie erneut linear über sämtliche Call-Zeilen.
+Bei einem langlebigen MCP-Prozess wurden somit unveränderte, bereits geprüfte
+Artefakte immer wieder geparst, gezählt und durchsucht.
+
+T029 durfte diese Kosten nicht durch eine ungebundene zweite Wahrheit ersetzen.
+Deshalb wurden drei Kandidaten mit identischen Abfragen verglichen:
+
+1. der bisherige lineare Scan;
+2. ein beim ersten validierten Laden aufgebauter RAM-Index;
+3. ein vorab gespeicherter Sidecar-Index, der kryptografisch an die Call-Liste
+   gebunden wird.
+
+## Gewählter Vertrag
+
+Der Produktionspfad verwendet einen unveränderlichen RAM-Index mit
+Positionslisten. Die Positionslisten verweisen ausschließlich auf bereits
+validierte Call- und Symbolzeilen; sie kopieren oder verändern deren Wahrheit
+nicht.
+
+Der Cache ist auf zwei Bundles begrenzt. Seine Bindung umfasst:
+
+- SHA-256 des Manifests;
+- Artefaktrolle und absoluten Pfad;
+- im Manifest deklarierte SHA-256- und Bytewerte;
+- Gerät, Inode, Dateigröße sowie Nanosekunden-Mtime und -Ctime.
+
+Beim kalten Laden werden die tatsächlichen Bytes von Call-Graph und Symbolindex
+gegen SHA-256 und Bytezahl des Manifests geprüft. Ändert sich eine Quelle, wird
+der Cache verworfen und vollständig neu validiert. Auch eine gleich große
+Änderung mit künstlich zurückgesetzter Mtime wird über die Ctime erkannt.
+Ändert sich eine Quelle während des Ladens, schlägt der Zugriff geschlossen fehl.
+
+## Ergebnisgleichheit
+
+Für beide verpflichtenden Stufen waren die vollständigen linearen,
+RAM-indizierten und Sidecar-indizierten Ergebnisobjekte bytegleich:
+
+- synthetische 50.000-Call-Stufe:
+  `e63d575bccd2baeeba7c70caf2a65d59eecfc27c9d93751f1baa4522f7d71755`;
+- Lenskit-Repositorium mit 54.710 Calls:
+  `150c00d5dbea15aaf4b9d4d222276a736a87a824233fbfcde228844eb020065d`.
+
+Auch der kalte und warme MCP-Dreifachaufruf war bytegleich:
+`6aa5b6819149ea6e88df224b6bae599be10fe6cd05634bf9a2cd7f7f828b5dd7`.
+
+## Messaufbau
+
+Maschine:
+
+- CPython 3.10.12;
+- Linux-7.0.11-76070011-generic-x86_64-with-glibc2.35;
+- 32 logische CPUs.
+
+Konfiguration:
+
+- 50.000 deterministisch erzeugte Calls;
+- Lenskit als repräsentatives reales Repository;
+- je 20 Referenz-, 20 Caller- und 20 Callee-Abfragen pro Algorithmus-Batch;
+- 7 Wiederholungen für warme Algorithmus-Abfragen;
+- 3 Wiederholungen für kalte Ladepfade;
+- 10 Wiederholungen für warme MCP-Dreifachaufrufe.
+
+Die realen Lenskit-Fixtures enthalten zwei absichtlich syntaktisch ungültige
+Python-Dateien. Beide wurden als Parsefehler sichtbar gezählt und nicht
+verschwiegen.
+
+## Messergebnisse
+
+### Synthetische 50.000-Call-Stufe
+
+| Messwert | Linear | RAM-Index | Sidecar |
+| --- | ---: | ---: | ---: |
+| Warmer Abfrage-Batch, Median | 804,27 ms | 53,12 ms | 52,11 ms |
+| Beschleunigung gegenüber linear | 1,00× | 15,14× | 15,43× |
+| Kaltes Laden/Aufbauen, Median | 233,97 ms | 381,83 ms | 333,26 ms |
+| Indexaufbau | — | 311,52 ms | vorab |
+| nach Aufbau gebundener Indexspeicher | — | 7.352.413 Byte | — |
+| Spitzenbedarf beim Indexaufbau | — | 13.283.439 Byte | — |
+| zusätzliche Bundlegröße | 0 | 0 | 3.989.698 Byte / 13,25 % |
+
+### Lenskit mit 54.710 Calls
+
+| Messwert | Linear | RAM-Index | Sidecar |
+| --- | ---: | ---: | ---: |
+| Warmer Abfrage-Batch, Median | 966,90 ms | 38,28 ms | 38,00 ms |
+| Beschleunigung gegenüber linear | 1,00× | 25,26× | 25,44× |
+| Kaltes Laden/Aufbauen, Median | 370,37 ms | 500,01 ms | 524,45 ms |
+| Indexaufbau | — | 428,53 ms | vorab |
+| nach Aufbau gebundener Indexspeicher | — | 10.595.655 Byte | — |
+| Spitzenbedarf beim Indexaufbau | — | 19.569.429 Byte | — |
+| zusätzliche Bundlegröße | 0 | 0 | 6.590.421 Byte / 16,89 % |
+
+### Öffentlicher MCP-Pfad auf 50.000 Calls
+
+- erster kalter Dreifachaufruf: 1.581,73 ms;
+- kalter Dreifachaufruf, Median: 672,18 ms;
+- warmer Dreifachaufruf, Median: 5,30 ms;
+- warmer p95: 5,47 ms;
+- nach dem ersten kalten Dreifachaufruf gebundener Python-Speicher:
+  92.730.424 Byte;
+- beim ersten kalten Dreifachaufruf gemessener Python-Peak:
+  143.183.761 Byte.
+
+Der hohe erste Peak enthält neben den Indexstrukturen auch das vollständige
+synthetische Call-Graph- und Symbolindex-JSON, geparste Python-Objekte,
+öffentliche Ergebnisobjekte und `tracemalloc`-Messaufwand. Er ist deshalb nicht
+mit dem isolierten Indexaufbau-Peak gleichzusetzen.
+
+## Entscheidung
+
+Der RAM-Index wird gewählt:
+
+- Er beseitigt wiederholte lineare Scans und wiederholte Vollvalidierung.
+- Er verändert die öffentlichen Antworten nicht.
+- Er vergrößert das Bundle nicht.
+- Er ist klein genug, um auf zwei aktive Bundlezustände begrenzt zu werden.
+- Er kann nach jeder Quellenänderung vollständig neu aufgebaut werden.
+
+Der lineare Produktionspfad wird verworfen, weil seine Kosten mit jeder Anfrage
+erneut proportional zur Call-Anzahl wachsen.
+
+Der Sidecar wird nicht befördert. Er bietet im warmen Zustand praktisch keinen
+Vorteil gegenüber dem RAM-Index, vergrößert die gemessenen Bundles aber um
+13,25 % bis
+16,89 % und würde einen
+zusätzlichen Artefaktvertrag schaffen. Seine Implementierung bleibt nur im
+Benchmark erhalten, damit diese Entscheidung reproduzierbar überprüft werden
+kann.
+
+## Integrität und Regressionen
+
+Tests belegen insbesondere:
+
+- bytegleiche lineare und indizierte Ergebnisse;
+- exakte und Teilstring-Suche einschließlich kurzer Suchbegriffe;
+- Caller- und Callee-Auswahl über Symbolidentität;
+- unveränderliche Positionslisten;
+- deterministische und quellgebundene Sidecar-Projektion;
+- Cache-Wiederverwendung bei unveränderten Quellen;
+- Invalidierung nach Call-Graph- oder Symbolindexänderung;
+- Ablehnung von SHA-256- oder Bytezahlabweichungen;
+- Erkennung gleich großer Änderungen trotz zurückgesetzter Mtime;
+- identische kalte und warme öffentliche Antworten;
+- LRU-Begrenzung auf zwei Bundles;
+- MCP-Transport- und Fehlerverträge.
+
+## Reproduktion
+
+```bash
+python -m merger.lenskit.scripts.bench_call_navigation \
+  --repo . \
+  --output /tmp/repobrief-call-navigation-scale-index-v1.json
+```
+
+Der Standardlauf verwendet zwingend die 50.000-Call-Stufe. Kleinere Werte sind
+nur für schnelle Vertragstests vorgesehen und tragen
+`fixed_acceptance_tier=false`.
+
+## Nicht belegt
+
+Dieser Abschluss belegt nicht:
+
+- identische Laufzeiten auf anderen Maschinen;
+- identische Beschleunigung in jedem Repository;
+- vollständige statische oder dynamische Call-Graph-Auflösung;
+- Laufzeiterreichbarkeit oder dynamischen Dispatch;
+- dass zwei Cache-Einträge für jeden zukünftigen Dienst optimal sind;
+- dass ein persistierter Index nie sinnvoll werden kann;
+- allgemeine Produkt-, Review- oder Merge-Reife außerhalb des geprüften Diffs.
+
+## Nächste Aufgabe
+
+`RPU-V1-T030` darf die Producer- und Resolverstruktur refaktorieren und
+systematische AST-Varianten generieren. Es soll die hier eingeführte
+Call-Navigation-Indexierung nicht mit einer neuen Resolverwahrheit vermischen.

--- a/docs/proofs/repobrief-call-navigation-scale-index-v1-proof.md
+++ b/docs/proofs/repobrief-call-navigation-scale-index-v1-proof.md
@@ -6,7 +6,7 @@ Base commit: `fafa115c1bb291742f5a7e10ba5ab21e33baa902`
 Default implementation: bounded process-local in-memory index
 Persisted sidecar promotion: `false`
 Measurement artifact: `repobrief-call-navigation-scale-index-v1.measurement.json`
-Measurement SHA-256: `2a43ecf1ed82bf94900d623a3a75d8f5d75185b74379b841039c0d21addda336`
+Measurement SHA-256: `1c97af3a164b47039834efb7dca58f26fdbfb89ab16331de9b2135d2de0576f6`
 
 ## Problem
 

--- a/docs/proofs/repobrief-call-navigation-scale-index-v1-proof.md
+++ b/docs/proofs/repobrief-call-navigation-scale-index-v1-proof.md
@@ -6,7 +6,7 @@ Base commit: `fafa115c1bb291742f5a7e10ba5ab21e33baa902`
 Default implementation: bounded process-local in-memory index
 Persisted sidecar promotion: `false`
 Measurement artifact: `repobrief-call-navigation-scale-index-v1.measurement.json`
-Measurement SHA-256: `1c97af3a164b47039834efb7dca58f26fdbfb89ab16331de9b2135d2de0576f6`
+Measurement SHA-256: `ddd3b7e3a25d829683d0c75ca8f9f3020463fba9ce90a034db6b7f977b31e5d9`
 
 ## Problem
 
@@ -45,18 +45,14 @@ der Cache verworfen und vollständig neu validiert. Auch eine gleich große
 Ändert sich eine Quelle während des Ladens, schlägt der Zugriff geschlossen fehl.
 
 ## Ergebnisgleichheit
-
 Für beide verpflichtenden Stufen waren die vollständigen linearen,
 RAM-indizierten und Sidecar-indizierten Ergebnisobjekte bytegleich:
-
 - synthetische 50.000-Call-Stufe:
   `e63d575bccd2baeeba7c70caf2a65d59eecfc27c9d93751f1baa4522f7d71755`;
-- Lenskit-Repositorium mit 54.710 Calls:
-  `150c00d5dbea15aaf4b9d4d222276a736a87a824233fbfcde228844eb020065d`.
-
+- Lenskit-Repositorium mit 54.771 Calls:
+  `cd7299bdaa4642e7f1ae88cb30c3a7416ee85ec99346cb59c7d231ab82219c44`.
 Auch der kalte und warme MCP-Dreifachaufruf war bytegleich:
-`6aa5b6819149ea6e88df224b6bae599be10fe6cd05634bf9a2cd7f7f828b5dd7`.
-
+`4ff3d69e702d1e9d834b19cea6f2a72afab4bb86c62f5def47ff45879e1f8eac`.
 ## Messaufbau
 
 Maschine:
@@ -79,47 +75,39 @@ Python-Dateien. Beide wurden als Parsefehler sichtbar gezählt und nicht
 verschwiegen.
 
 ## Messergebnisse
-
 ### Synthetische 50.000-Call-Stufe
-
 | Messwert | Linear | RAM-Index | Sidecar |
 | --- | ---: | ---: | ---: |
-| Warmer Abfrage-Batch, Median | 804,27 ms | 53,12 ms | 52,11 ms |
-| Beschleunigung gegenüber linear | 1,00× | 15,14× | 15,43× |
-| Kaltes Laden/Aufbauen, Median | 233,97 ms | 381,83 ms | 333,26 ms |
-| Indexaufbau | — | 311,52 ms | vorab |
+| Warmer Abfrage-Batch, Median | 764,47 ms | 54,98 ms | 56,03 ms |
+| Beschleunigung gegenüber linear | 1,00× | 13,91× | 13,64× |
+| Kaltes Laden/Aufbauen, Median | 247,95 ms | 397,37 ms | 355,79 ms |
+| Indexaufbau | — | 314,06 ms | vorab |
 | nach Aufbau gebundener Indexspeicher | — | 7.352.413 Byte | — |
 | Spitzenbedarf beim Indexaufbau | — | 13.283.439 Byte | — |
 | zusätzliche Bundlegröße | 0 | 0 | 3.989.698 Byte / 13,25 % |
-
-### Lenskit mit 54.710 Calls
-
+### Lenskit mit 54.771 Calls
 | Messwert | Linear | RAM-Index | Sidecar |
 | --- | ---: | ---: | ---: |
-| Warmer Abfrage-Batch, Median | 966,90 ms | 38,28 ms | 38,00 ms |
-| Beschleunigung gegenüber linear | 1,00× | 25,26× | 25,44× |
-| Kaltes Laden/Aufbauen, Median | 370,37 ms | 500,01 ms | 524,45 ms |
-| Indexaufbau | — | 428,53 ms | vorab |
-| nach Aufbau gebundener Indexspeicher | — | 10.595.655 Byte | — |
-| Spitzenbedarf beim Indexaufbau | — | 19.569.429 Byte | — |
-| zusätzliche Bundlegröße | 0 | 0 | 6.590.421 Byte / 16,89 % |
-
+| Warmer Abfrage-Batch, Median | 978,85 ms | 43,35 ms | 41,73 ms |
+| Beschleunigung gegenüber linear | 1,00× | 22,58× | 23,46× |
+| Kaltes Laden/Aufbauen, Median | 381,19 ms | 524,88 ms | 540,70 ms |
+| Indexaufbau | — | 440,88 ms | vorab |
+| nach Aufbau gebundener Indexspeicher | — | 10.606.696 Byte | — |
+| Spitzenbedarf beim Indexaufbau | — | 19.589.982 Byte | — |
+| zusätzliche Bundlegröße | 0 | 0 | 6.598.947 Byte / 16,90 % |
 ### Öffentlicher MCP-Pfad auf 50.000 Calls
-
-- erster kalter Dreifachaufruf: 1.581,73 ms;
-- kalter Dreifachaufruf, Median: 672,18 ms;
-- warmer Dreifachaufruf, Median: 5,30 ms;
-- warmer p95: 5,47 ms;
+- erster kalter Dreifachaufruf: 1.642,02 ms;
+- kalter Dreifachaufruf, Median: 770,91 ms;
+- warmer Dreifachaufruf, Median: 5,65 ms;
+- warmer p95: 6,02 ms;
 - nach dem ersten kalten Dreifachaufruf gebundener Python-Speicher:
-  92.730.424 Byte;
+  92.761.368 Byte;
 - beim ersten kalten Dreifachaufruf gemessener Python-Peak:
-  143.183.761 Byte.
-
+  143.183.769 Byte.
 Der hohe erste Peak enthält neben den Indexstrukturen auch das vollständige
 synthetische Call-Graph- und Symbolindex-JSON, geparste Python-Objekte,
 öffentliche Ergebnisobjekte und `tracemalloc`-Messaufwand. Er ist deshalb nicht
 mit dem isolierten Indexaufbau-Peak gleichzusetzen.
-
 ## Entscheidung
 
 Der RAM-Index wird gewählt:
@@ -149,6 +137,7 @@ Tests belegen insbesondere:
 - exakte und Teilstring-Suche einschließlich kurzer Suchbegriffe;
 - Caller- und Callee-Auswahl über Symbolidentität;
 - unveränderliche Positionslisten;
+- von Cache-Daten vollständig abgetrennte öffentliche Listen, Wörterbücher und Artefaktmetadaten;
 - deterministische und quellgebundene Sidecar-Projektion;
 - Cache-Wiederverwendung bei unveränderten Quellen;
 - Invalidierung nach Call-Graph- oder Symbolindexänderung;

--- a/docs/proofs/repobrief-call-navigation-scale-index-v1.measurement.json
+++ b/docs/proofs/repobrief-call-navigation-scale-index-v1.measurement.json
@@ -4,7 +4,7 @@
     "fixed_acceptance_tier": true,
     "mcp_repetitions": 10,
     "query_repetitions": 7,
-    "representative_repo": "/home/alex/repos/.lenskit-worktrees/repobrief-call-navigation-scale-index-v1",
+    "representative_repo": "current_repository",
     "synthetic_call_count": 50000
   },
   "decision": {
@@ -35,22 +35,22 @@
   "mcp": {
     "call_count": 50000,
     "cold_batch": {
-      "max_ms": 754.568603,
-      "median_ms": 672.184264,
-      "min_ms": 658.49867,
-      "p95_ms": 672.184264,
+      "max_ms": 762.66987,
+      "median_ms": 703.091354,
+      "min_ms": 672.933684,
+      "p95_ms": 703.091354,
       "repetitions": 3
     },
-    "cold_first_ms": 1581.729994,
-    "cold_first_peak_bytes": 143183761,
-    "cold_first_retained_bytes": 92730424,
+    "cold_first_ms": 1605.92483,
+    "cold_first_peak_bytes": 143183337,
+    "cold_first_retained_bytes": 92730267,
     "cold_warm_byte_equivalent": true,
-    "result_sha256": "6aa5b6819149ea6e88df224b6bae599be10fe6cd05634bf9a2cd7f7f828b5dd7",
+    "result_sha256": "7e1b27768651187b206c2aa2c848818403512a3782e8a7fcea7b2ea57cca1dd3",
     "warm_repeated_batch": {
-      "max_ms": 6.241689,
-      "median_ms": 5.295808,
-      "min_ms": 5.081861,
-      "p95_ms": 5.472694,
+      "max_ms": 6.131759,
+      "median_ms": 5.2507085,
+      "min_ms": 5.120102,
+      "p95_ms": 5.433974,
       "repetitions": 10
     }
   },
@@ -75,17 +75,17 @@
       "linear_scan": {
         "bundle_bytes": 30107862,
         "cold_load": {
-          "max_ms": 236.820674,
-          "median_ms": 233.965465,
-          "min_ms": 187.016196,
-          "p95_ms": 233.965465,
+          "max_ms": 235.242517,
+          "median_ms": 206.606276,
+          "min_ms": 188.186549,
+          "p95_ms": 206.606276,
           "repetitions": 3
         },
         "warm_query_batch": {
-          "max_ms": 836.821821,
-          "median_ms": 804.27174,
-          "min_ms": 783.052609,
-          "p95_ms": 819.742882,
+          "max_ms": 851.007749,
+          "median_ms": 815.716666,
+          "min_ms": 796.055622,
+          "p95_ms": 837.318882,
           "repetitions": 7
         }
       },
@@ -93,39 +93,39 @@
         "bundle_bytes": 34097560,
         "bundle_overhead_ratio": 0.13251349431587006,
         "cold_load_and_restore": {
-          "max_ms": 340.227563,
-          "median_ms": 333.258619,
-          "min_ms": 286.002427,
-          "p95_ms": 333.258619,
+          "max_ms": 350.327555,
+          "median_ms": 331.775496,
+          "min_ms": 298.495867,
+          "p95_ms": 331.775496,
           "repetitions": 3
         },
         "sidecar_bytes": 3989698,
         "source_hash_bound": true,
         "warm_query_batch": {
-          "max_ms": 83.453836,
-          "median_ms": 52.112552,
-          "min_ms": 49.117984,
-          "p95_ms": 54.341386,
+          "max_ms": 90.17834,
+          "median_ms": 53.149096,
+          "min_ms": 51.990379,
+          "p95_ms": 87.01701,
           "repetitions": 7
         }
       },
       "process_local_index": {
-        "build_ms": 311.51748,
+        "build_ms": 318.597443,
         "build_peak_bytes": 13283439,
         "build_retained_bytes": 7352413,
         "bundle_bytes": 30107862,
         "cold_load_and_build": {
-          "max_ms": 398.659734,
-          "median_ms": 381.828149,
-          "min_ms": 344.964982,
-          "p95_ms": 381.828149,
+          "max_ms": 404.186695,
+          "median_ms": 381.32956,
+          "min_ms": 343.34903,
+          "p95_ms": 381.32956,
           "repetitions": 3
         },
         "warm_query_batch": {
-          "max_ms": 84.762404,
-          "median_ms": 53.123108,
-          "min_ms": 50.533243,
-          "p95_ms": 53.801962,
+          "max_ms": 85.888123,
+          "median_ms": 52.090609,
+          "min_ms": 51.508806,
+          "p95_ms": 53.167726,
           "repetitions": 7
         }
       },
@@ -136,73 +136,73 @@
       },
       "source_calls_sha256": "29ea11a7e4353ee31d66f865fbdf6249bc2732d26ee1e01fa1951a5d78087165",
       "speedup": {
-        "persisted_vs_linear_warm_median": 15.433359318115912,
-        "process_local_vs_linear_warm_median": 15.139771942560289
+        "persisted_vs_linear_warm_median": 15.347705368309558,
+        "process_local_vs_linear_warm_median": 15.659572457676585
       }
     },
     {
-      "call_count": 54710,
-      "call_json_bytes": 39008299,
+      "call_count": 54735,
+      "call_json_bytes": 39028877,
       "equivalence": {
         "byte_equivalent": true,
-        "result_sha256": "150c00d5dbea15aaf4b9d4d222276a736a87a824233fbfcde228844eb020065d",
+        "result_sha256": "0f18d641c470a76a96928ac6872308bb16843d53c29e7d24b2786c391c647336",
         "status": "pass"
       },
       "label": "representative_real_repo",
       "linear_scan": {
-        "bundle_bytes": 39008299,
+        "bundle_bytes": 39028877,
         "cold_load": {
-          "max_ms": 375.197879,
-          "median_ms": 370.373178,
-          "min_ms": 282.058533,
-          "p95_ms": 370.373178,
+          "max_ms": 409.543988,
+          "median_ms": 301.163664,
+          "min_ms": 295.014334,
+          "p95_ms": 301.163664,
           "repetitions": 3
         },
         "warm_query_batch": {
-          "max_ms": 999.182294,
-          "median_ms": 966.896946,
-          "min_ms": 947.531275,
-          "p95_ms": 976.118692,
+          "max_ms": 1103.544916,
+          "median_ms": 1014.18234,
+          "min_ms": 1005.026603,
+          "p95_ms": 1045.8325,
           "repetitions": 7
         }
       },
       "persisted_sidecar": {
-        "bundle_bytes": 45598720,
-        "bundle_overhead_ratio": 0.1689492023223058,
+        "bundle_bytes": 45623612,
+        "bundle_overhead_ratio": 0.168970657290498,
         "cold_load_and_restore": {
-          "max_ms": 540.941543,
-          "median_ms": 524.449571,
-          "min_ms": 439.001173,
-          "p95_ms": 524.449571,
+          "max_ms": 579.14813,
+          "median_ms": 548.797329,
+          "min_ms": 540.386695,
+          "p95_ms": 548.797329,
           "repetitions": 3
         },
-        "sidecar_bytes": 6590421,
+        "sidecar_bytes": 6594735,
         "source_hash_bound": true,
         "warm_query_batch": {
-          "max_ms": 38.982341,
-          "median_ms": 38.003985,
-          "min_ms": 37.599982,
-          "p95_ms": 38.151146,
+          "max_ms": 40.298255,
+          "median_ms": 39.790792,
+          "min_ms": 39.144038,
+          "p95_ms": 40.174304,
           "repetitions": 7
         }
       },
       "process_local_index": {
-        "build_ms": 428.532048,
-        "build_peak_bytes": 19569429,
-        "build_retained_bytes": 10595655,
-        "bundle_bytes": 39008299,
+        "build_ms": 420.85432,
+        "build_peak_bytes": 19576345,
+        "build_retained_bytes": 10600219,
+        "bundle_bytes": 39028877,
         "cold_load_and_build": {
-          "max_ms": 602.136411,
-          "median_ms": 500.0105,
-          "min_ms": 495.754174,
-          "p95_ms": 500.0105,
+          "max_ms": 619.542046,
+          "median_ms": 509.595671,
+          "min_ms": 498.714232,
+          "p95_ms": 509.595671,
           "repetitions": 3
         },
         "warm_query_batch": {
-          "max_ms": 111.71657,
-          "median_ms": 38.278157,
-          "min_ms": 36.793138,
-          "p95_ms": 42.238411,
+          "max_ms": 116.811208,
+          "median_ms": 41.052899,
+          "min_ms": 39.688321,
+          "p95_ms": 42.012375,
           "repetitions": 7
         }
       },
@@ -211,10 +211,10 @@
         "references": 20,
         "targets": 20
       },
-      "source_calls_sha256": "1a6453c92872688b53f60fd4fa170cb4d2860867d920c00d3dcefcf30f7bb60b",
+      "source_calls_sha256": "dcfcf33570b9477fb95f735044009f6b6e5023ea2221c6f4b6954de28abce4c5",
       "speedup": {
-        "persisted_vs_linear_warm_median": 25.441988412530947,
-        "process_local_vs_linear_warm_median": 25.259757046296663
+        "persisted_vs_linear_warm_median": 25.487865132214505,
+        "process_local_vs_linear_warm_median": 24.704280689166435
       }
     }
   ],

--- a/docs/proofs/repobrief-call-navigation-scale-index-v1.measurement.json
+++ b/docs/proofs/repobrief-call-navigation-scale-index-v1.measurement.json
@@ -1,0 +1,222 @@
+{
+  "configuration": {
+    "cold_repetitions": 3,
+    "fixed_acceptance_tier": true,
+    "mcp_repetitions": 10,
+    "query_repetitions": 7,
+    "representative_repo": "/home/alex/repos/.lenskit-worktrees/repobrief-call-navigation-scale-index-v1",
+    "synthetic_call_count": 50000
+  },
+  "decision": {
+    "cache_bound": "manifest hash plus artifact identity, declared hash and byte count",
+    "cache_max_entries": 2,
+    "rejected": {
+      "linear_scan": "repeated O(call_count) scans and repeated artifact validation",
+      "persisted_sidecar": "adds a second bundle artifact and measurable byte overhead without better warm queries"
+    },
+    "selected": "process_local_in_memory_index"
+  },
+  "does_not_establish": [
+    "performance_on_all_machines",
+    "performance_on_all_repositories",
+    "runtime_call_graph_completeness",
+    "dynamic_dispatch_resolution",
+    "default_promotion_without_equivalence_gates"
+  ],
+  "kind": "repobrief.call_navigation_scale_benchmark",
+  "machine_context": {
+    "implementation": "CPython",
+    "logical_cpu_count": 32,
+    "machine": "x86_64",
+    "platform": "Linux-7.0.11-76070011-generic-x86_64-with-glibc2.35",
+    "processor": "x86_64",
+    "python": "3.10.12"
+  },
+  "mcp": {
+    "call_count": 50000,
+    "cold_batch": {
+      "max_ms": 754.568603,
+      "median_ms": 672.184264,
+      "min_ms": 658.49867,
+      "p95_ms": 672.184264,
+      "repetitions": 3
+    },
+    "cold_first_ms": 1581.729994,
+    "cold_first_peak_bytes": 143183761,
+    "cold_first_retained_bytes": 92730424,
+    "cold_warm_byte_equivalent": true,
+    "result_sha256": "6aa5b6819149ea6e88df224b6bae599be10fe6cd05634bf9a2cd7f7f828b5dd7",
+    "warm_repeated_batch": {
+      "max_ms": 6.241689,
+      "median_ms": 5.295808,
+      "min_ms": 5.081861,
+      "p95_ms": 5.472694,
+      "repetitions": 10
+    }
+  },
+  "representative_repo_parse": {
+    "skipped_errors": [
+      "Failed to parse merger/lenskit/tests/fixtures/entrypoints_test_project/invalid.py: SyntaxError - '(' was never closed (invalid.py, line 1)",
+      "Failed to parse merger/lenskit/tests/fixtures/graph_quality_goldset/invalid_case/broken.py: SyntaxError - invalid syntax (broken.py, line 1)"
+    ],
+    "skipped_files_count": 2
+  },
+  "status": "pass",
+  "tiers": [
+    {
+      "call_count": 50000,
+      "call_json_bytes": 30107862,
+      "equivalence": {
+        "byte_equivalent": true,
+        "result_sha256": "e63d575bccd2baeeba7c70caf2a65d59eecfc27c9d93751f1baa4522f7d71755",
+        "status": "pass"
+      },
+      "label": "synthetic_50000",
+      "linear_scan": {
+        "bundle_bytes": 30107862,
+        "cold_load": {
+          "max_ms": 236.820674,
+          "median_ms": 233.965465,
+          "min_ms": 187.016196,
+          "p95_ms": 233.965465,
+          "repetitions": 3
+        },
+        "warm_query_batch": {
+          "max_ms": 836.821821,
+          "median_ms": 804.27174,
+          "min_ms": 783.052609,
+          "p95_ms": 819.742882,
+          "repetitions": 7
+        }
+      },
+      "persisted_sidecar": {
+        "bundle_bytes": 34097560,
+        "bundle_overhead_ratio": 0.13251349431587006,
+        "cold_load_and_restore": {
+          "max_ms": 340.227563,
+          "median_ms": 333.258619,
+          "min_ms": 286.002427,
+          "p95_ms": 333.258619,
+          "repetitions": 3
+        },
+        "sidecar_bytes": 3989698,
+        "source_hash_bound": true,
+        "warm_query_batch": {
+          "max_ms": 83.453836,
+          "median_ms": 52.112552,
+          "min_ms": 49.117984,
+          "p95_ms": 54.341386,
+          "repetitions": 7
+        }
+      },
+      "process_local_index": {
+        "build_ms": 311.51748,
+        "build_peak_bytes": 13283439,
+        "build_retained_bytes": 7352413,
+        "bundle_bytes": 30107862,
+        "cold_load_and_build": {
+          "max_ms": 398.659734,
+          "median_ms": 381.828149,
+          "min_ms": 344.964982,
+          "p95_ms": 381.828149,
+          "repetitions": 3
+        },
+        "warm_query_batch": {
+          "max_ms": 84.762404,
+          "median_ms": 53.123108,
+          "min_ms": 50.533243,
+          "p95_ms": 53.801962,
+          "repetitions": 7
+        }
+      },
+      "query_counts": {
+        "callers": 20,
+        "references": 20,
+        "targets": 20
+      },
+      "source_calls_sha256": "29ea11a7e4353ee31d66f865fbdf6249bc2732d26ee1e01fa1951a5d78087165",
+      "speedup": {
+        "persisted_vs_linear_warm_median": 15.433359318115912,
+        "process_local_vs_linear_warm_median": 15.139771942560289
+      }
+    },
+    {
+      "call_count": 54710,
+      "call_json_bytes": 39008299,
+      "equivalence": {
+        "byte_equivalent": true,
+        "result_sha256": "150c00d5dbea15aaf4b9d4d222276a736a87a824233fbfcde228844eb020065d",
+        "status": "pass"
+      },
+      "label": "representative_real_repo",
+      "linear_scan": {
+        "bundle_bytes": 39008299,
+        "cold_load": {
+          "max_ms": 375.197879,
+          "median_ms": 370.373178,
+          "min_ms": 282.058533,
+          "p95_ms": 370.373178,
+          "repetitions": 3
+        },
+        "warm_query_batch": {
+          "max_ms": 999.182294,
+          "median_ms": 966.896946,
+          "min_ms": 947.531275,
+          "p95_ms": 976.118692,
+          "repetitions": 7
+        }
+      },
+      "persisted_sidecar": {
+        "bundle_bytes": 45598720,
+        "bundle_overhead_ratio": 0.1689492023223058,
+        "cold_load_and_restore": {
+          "max_ms": 540.941543,
+          "median_ms": 524.449571,
+          "min_ms": 439.001173,
+          "p95_ms": 524.449571,
+          "repetitions": 3
+        },
+        "sidecar_bytes": 6590421,
+        "source_hash_bound": true,
+        "warm_query_batch": {
+          "max_ms": 38.982341,
+          "median_ms": 38.003985,
+          "min_ms": 37.599982,
+          "p95_ms": 38.151146,
+          "repetitions": 7
+        }
+      },
+      "process_local_index": {
+        "build_ms": 428.532048,
+        "build_peak_bytes": 19569429,
+        "build_retained_bytes": 10595655,
+        "bundle_bytes": 39008299,
+        "cold_load_and_build": {
+          "max_ms": 602.136411,
+          "median_ms": 500.0105,
+          "min_ms": 495.754174,
+          "p95_ms": 500.0105,
+          "repetitions": 3
+        },
+        "warm_query_batch": {
+          "max_ms": 111.71657,
+          "median_ms": 38.278157,
+          "min_ms": 36.793138,
+          "p95_ms": 42.238411,
+          "repetitions": 7
+        }
+      },
+      "query_counts": {
+        "callers": 20,
+        "references": 20,
+        "targets": 20
+      },
+      "source_calls_sha256": "1a6453c92872688b53f60fd4fa170cb4d2860867d920c00d3dcefcf30f7bb60b",
+      "speedup": {
+        "persisted_vs_linear_warm_median": 25.441988412530947,
+        "process_local_vs_linear_warm_median": 25.259757046296663
+      }
+    }
+  ],
+  "version": "1.0"
+}

--- a/docs/proofs/repobrief-call-navigation-scale-index-v1.measurement.json
+++ b/docs/proofs/repobrief-call-navigation-scale-index-v1.measurement.json
@@ -35,22 +35,22 @@
   "mcp": {
     "call_count": 50000,
     "cold_batch": {
-      "max_ms": 762.66987,
-      "median_ms": 703.091354,
-      "min_ms": 672.933684,
-      "p95_ms": 703.091354,
+      "max_ms": 816.304255,
+      "median_ms": 770.910111,
+      "min_ms": 677.752407,
+      "p95_ms": 770.910111,
       "repetitions": 3
     },
-    "cold_first_ms": 1605.92483,
-    "cold_first_peak_bytes": 143183337,
-    "cold_first_retained_bytes": 92730267,
+    "cold_first_ms": 1642.021105,
+    "cold_first_peak_bytes": 143183769,
+    "cold_first_retained_bytes": 92761368,
     "cold_warm_byte_equivalent": true,
-    "result_sha256": "7e1b27768651187b206c2aa2c848818403512a3782e8a7fcea7b2ea57cca1dd3",
+    "result_sha256": "4ff3d69e702d1e9d834b19cea6f2a72afab4bb86c62f5def47ff45879e1f8eac",
     "warm_repeated_batch": {
-      "max_ms": 6.131759,
-      "median_ms": 5.2507085,
-      "min_ms": 5.120102,
-      "p95_ms": 5.433974,
+      "max_ms": 6.184592,
+      "median_ms": 5.650798,
+      "min_ms": 5.473927,
+      "p95_ms": 6.01503,
       "repetitions": 10
     }
   },
@@ -75,17 +75,17 @@
       "linear_scan": {
         "bundle_bytes": 30107862,
         "cold_load": {
-          "max_ms": 235.242517,
-          "median_ms": 206.606276,
-          "min_ms": 188.186549,
-          "p95_ms": 206.606276,
+          "max_ms": 250.889013,
+          "median_ms": 247.948554,
+          "min_ms": 196.076265,
+          "p95_ms": 247.948554,
           "repetitions": 3
         },
         "warm_query_batch": {
-          "max_ms": 851.007749,
-          "median_ms": 815.716666,
-          "min_ms": 796.055622,
-          "p95_ms": 837.318882,
+          "max_ms": 812.577431,
+          "median_ms": 764.467798,
+          "min_ms": 745.937654,
+          "p95_ms": 810.516677,
           "repetitions": 7
         }
       },
@@ -93,39 +93,39 @@
         "bundle_bytes": 34097560,
         "bundle_overhead_ratio": 0.13251349431587006,
         "cold_load_and_restore": {
-          "max_ms": 350.327555,
-          "median_ms": 331.775496,
-          "min_ms": 298.495867,
-          "p95_ms": 331.775496,
+          "max_ms": 358.401704,
+          "median_ms": 355.790887,
+          "min_ms": 303.595717,
+          "p95_ms": 355.790887,
           "repetitions": 3
         },
         "sidecar_bytes": 3989698,
         "source_hash_bound": true,
         "warm_query_batch": {
-          "max_ms": 90.17834,
-          "median_ms": 53.149096,
-          "min_ms": 51.990379,
-          "p95_ms": 87.01701,
+          "max_ms": 87.533237,
+          "median_ms": 56.030235,
+          "min_ms": 51.056253,
+          "p95_ms": 57.373135,
           "repetitions": 7
         }
       },
       "process_local_index": {
-        "build_ms": 318.597443,
+        "build_ms": 314.055917,
         "build_peak_bytes": 13283439,
         "build_retained_bytes": 7352413,
         "bundle_bytes": 30107862,
         "cold_load_and_build": {
-          "max_ms": 404.186695,
-          "median_ms": 381.32956,
-          "min_ms": 343.34903,
-          "p95_ms": 381.32956,
+          "max_ms": 412.888869,
+          "median_ms": 397.374996,
+          "min_ms": 374.907145,
+          "p95_ms": 397.374996,
           "repetitions": 3
         },
         "warm_query_batch": {
-          "max_ms": 85.888123,
-          "median_ms": 52.090609,
-          "min_ms": 51.508806,
-          "p95_ms": 53.167726,
+          "max_ms": 87.305836,
+          "median_ms": 54.977449,
+          "min_ms": 51.580727,
+          "p95_ms": 55.711883,
           "repetitions": 7
         }
       },
@@ -136,73 +136,73 @@
       },
       "source_calls_sha256": "29ea11a7e4353ee31d66f865fbdf6249bc2732d26ee1e01fa1951a5d78087165",
       "speedup": {
-        "persisted_vs_linear_warm_median": 15.347705368309558,
-        "process_local_vs_linear_warm_median": 15.659572457676585
+        "persisted_vs_linear_warm_median": 13.643844220892523,
+        "process_local_vs_linear_warm_median": 13.905115859413558
       }
     },
     {
-      "call_count": 54735,
-      "call_json_bytes": 39028877,
+      "call_count": 54771,
+      "call_json_bytes": 39055543,
       "equivalence": {
         "byte_equivalent": true,
-        "result_sha256": "0f18d641c470a76a96928ac6872308bb16843d53c29e7d24b2786c391c647336",
+        "result_sha256": "cd7299bdaa4642e7f1ae88cb30c3a7416ee85ec99346cb59c7d231ab82219c44",
         "status": "pass"
       },
       "label": "representative_real_repo",
       "linear_scan": {
-        "bundle_bytes": 39028877,
+        "bundle_bytes": 39055543,
         "cold_load": {
-          "max_ms": 409.543988,
-          "median_ms": 301.163664,
-          "min_ms": 295.014334,
-          "p95_ms": 301.163664,
+          "max_ms": 395.323931,
+          "median_ms": 381.185547,
+          "min_ms": 290.162577,
+          "p95_ms": 381.185547,
           "repetitions": 3
         },
         "warm_query_batch": {
-          "max_ms": 1103.544916,
-          "median_ms": 1014.18234,
-          "min_ms": 1005.026603,
-          "p95_ms": 1045.8325,
+          "max_ms": 1014.773777,
+          "median_ms": 978.852047,
+          "min_ms": 965.872919,
+          "p95_ms": 994.025408,
           "repetitions": 7
         }
       },
       "persisted_sidecar": {
-        "bundle_bytes": 45623612,
-        "bundle_overhead_ratio": 0.168970657290498,
+        "bundle_bytes": 45654490,
+        "bundle_overhead_ratio": 0.1689631353992441,
         "cold_load_and_restore": {
-          "max_ms": 579.14813,
-          "median_ms": 548.797329,
-          "min_ms": 540.386695,
-          "p95_ms": 548.797329,
+          "max_ms": 558.776868,
+          "median_ms": 540.697256,
+          "min_ms": 456.503792,
+          "p95_ms": 540.697256,
           "repetitions": 3
         },
-        "sidecar_bytes": 6594735,
+        "sidecar_bytes": 6598947,
         "source_hash_bound": true,
         "warm_query_batch": {
-          "max_ms": 40.298255,
-          "median_ms": 39.790792,
-          "min_ms": 39.144038,
-          "p95_ms": 40.174304,
+          "max_ms": 42.733977,
+          "median_ms": 41.72925,
+          "min_ms": 40.993295,
+          "p95_ms": 41.944181,
           "repetitions": 7
         }
       },
       "process_local_index": {
-        "build_ms": 420.85432,
-        "build_peak_bytes": 19576345,
-        "build_retained_bytes": 10600219,
-        "bundle_bytes": 39028877,
+        "build_ms": 440.881597,
+        "build_peak_bytes": 19589982,
+        "build_retained_bytes": 10606696,
+        "bundle_bytes": 39055543,
         "cold_load_and_build": {
-          "max_ms": 619.542046,
-          "median_ms": 509.595671,
-          "min_ms": 498.714232,
-          "p95_ms": 509.595671,
+          "max_ms": 648.433379,
+          "median_ms": 524.878861,
+          "min_ms": 522.809907,
+          "p95_ms": 524.878861,
           "repetitions": 3
         },
         "warm_query_batch": {
-          "max_ms": 116.811208,
-          "median_ms": 41.052899,
-          "min_ms": 39.688321,
-          "p95_ms": 42.012375,
+          "max_ms": 122.551512,
+          "median_ms": 43.350291,
+          "min_ms": 41.230177,
+          "p95_ms": 44.313617,
           "repetitions": 7
         }
       },
@@ -211,10 +211,10 @@
         "references": 20,
         "targets": 20
       },
-      "source_calls_sha256": "dcfcf33570b9477fb95f735044009f6b6e5023ea2221c6f4b6954de28abce4c5",
+      "source_calls_sha256": "94d02a0a5ca5aa27d477b655ddf3b6eca51f3520b867f8f7807ea71307b28fef",
       "speedup": {
-        "persisted_vs_linear_warm_median": 25.487865132214505,
-        "process_local_vs_linear_warm_median": 24.704280689166435
+        "persisted_vs_linear_warm_median": 23.457216388983746,
+        "process_local_vs_linear_warm_median": 22.580057121185185
       }
     }
   ],

--- a/merger/lenskit/core/call_navigation_index.py
+++ b/merger/lenskit/core/call_navigation_index.py
@@ -1,0 +1,372 @@
+"""Deterministic process-local indexes for validated call navigation records.
+
+The indexes contain only integer positions into their validated source arrays. They
+are not a second source of truth and must be rebuilt whenever the bound source
+artifact changes.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Iterable, Mapping, Sequence
+
+CallRow = dict[str, Any]
+SymbolRow = dict[str, Any]
+CallerIdentity = tuple[str | None, str, str | None, str | None, int | None, int | None]
+
+
+def _freeze_postings(
+    values: Mapping[Any, list[int]],
+) -> Mapping[Any, tuple[int, ...]]:
+    return MappingProxyType({key: tuple(positions) for key, positions in values.items()})
+
+
+def _trigrams(value: str) -> frozenset[str]:
+    if len(value) < 3:
+        return frozenset()
+    return frozenset(value[index : index + 3] for index in range(len(value) - 2))
+
+
+def caller_identity_from_call(call: CallRow) -> CallerIdentity:
+    return (
+        call.get("caller_symbol_id"),
+        str(call.get("path", "")),
+        call.get("caller_qualified_name"),
+        call.get("caller_kind"),
+        call.get("caller_start_line"),
+        call.get("caller_end_line"),
+    )
+
+
+def caller_identity_from_symbol(symbol: SymbolRow) -> CallerIdentity:
+    return (
+        symbol.get("id"),
+        str(symbol.get("path", "")),
+        symbol.get("qualified_name"),
+        symbol.get("kind"),
+        symbol.get("start_line"),
+        symbol.get("end_line"),
+    )
+
+
+def _call_position_key(call: CallRow) -> tuple[str, int, int]:
+    return (
+        str(call.get("path", "")),
+        int(call.get("start_line", 0) or 0),
+        int(call.get("start_col", 0) or 0),
+    )
+
+
+def _validated_positions(
+    value: Any, *, call_count: int, label: str
+) -> tuple[int, ...]:
+    if not isinstance(value, list):
+        raise ValueError(f"persisted call navigation index {label} is invalid")
+    positions = tuple(value)
+    valid = all(
+        isinstance(position, int)
+        and not isinstance(position, bool)
+        and 0 <= position < call_count
+        for position in positions
+    )
+    if (
+        not valid
+        or len(positions) != len(set(positions))
+        or positions != tuple(sorted(positions))
+    ):
+        raise ValueError(f"persisted call navigation index {label} is invalid")
+    return positions
+
+
+def _persisted_postings(
+    projection: Mapping[str, Any], field: str, call_count: int
+) -> Mapping[str, tuple[int, ...]]:
+    raw = projection.get(field)
+    if not isinstance(raw, dict):
+        raise ValueError(f"persisted call navigation index {field} is invalid")
+    result: dict[str, tuple[int, ...]] = {}
+    for key, positions in raw.items():
+        if not isinstance(key, str):
+            raise ValueError(
+                f"persisted call navigation index {field} key is invalid"
+            )
+        result[key] = _validated_positions(
+            positions,
+            call_count=call_count,
+            label=f"{field} positions",
+        )
+    return MappingProxyType(result)
+
+
+def _caller_identity(value: Any) -> CallerIdentity:
+    if not isinstance(value, list) or len(value) != 6:
+        raise ValueError("persisted caller identity is invalid")
+    symbol_id, path, qualified_name, kind, start_line, end_line = value
+    if symbol_id is not None and not isinstance(symbol_id, str):
+        raise ValueError("persisted caller symbol id is invalid")
+    if not isinstance(path, str):
+        raise ValueError("persisted caller path is invalid")
+    if qualified_name is not None and not isinstance(qualified_name, str):
+        raise ValueError("persisted caller qualified name is invalid")
+    if kind is not None and not isinstance(kind, str):
+        raise ValueError("persisted caller kind is invalid")
+    for line in (start_line, end_line):
+        if line is not None and (
+            not isinstance(line, int) or isinstance(line, bool) or line < 1
+        ):
+            raise ValueError("persisted caller line is invalid")
+    return symbol_id, path, qualified_name, kind, start_line, end_line
+
+
+def _persisted_caller_positions(
+    projection: Mapping[str, Any], call_count: int
+) -> Mapping[CallerIdentity, tuple[int, ...]]:
+    raw = projection.get("caller_positions")
+    if not isinstance(raw, list):
+        raise ValueError("persisted call navigation caller_positions is invalid")
+    callers: dict[CallerIdentity, tuple[int, ...]] = {}
+    for item in raw:
+        if not isinstance(item, dict):
+            raise ValueError("persisted caller position entry is invalid")
+        identity = _caller_identity(item.get("identity"))
+        if identity in callers:
+            raise ValueError("persisted caller identity is duplicated")
+        callers[identity] = _validated_positions(
+            item.get("positions"),
+            call_count=call_count,
+            label="caller positions",
+        )
+    return MappingProxyType(callers)
+
+
+@dataclass(frozen=True, slots=True)
+class CallNavigationIndex:
+    """Bounded lookup tables over one validated call-record sequence."""
+
+    calls: tuple[CallRow, ...]
+    simple_name_positions: Mapping[str, tuple[int, ...]]
+    expression_trigram_positions: Mapping[str, tuple[int, ...]]
+    resolved_target_positions: Mapping[str, tuple[int, ...]]
+    candidate_target_positions: Mapping[str, tuple[int, ...]]
+    caller_positions: Mapping[CallerIdentity, tuple[int, ...]]
+
+    @classmethod
+    def build(cls, calls: Sequence[CallRow]) -> CallNavigationIndex:
+        simple_names: defaultdict[str, list[int]] = defaultdict(list)
+        expression_trigrams: defaultdict[str, list[int]] = defaultdict(list)
+        resolved_targets: defaultdict[str, list[int]] = defaultdict(list)
+        candidate_targets: defaultdict[str, list[int]] = defaultdict(list)
+        callers: defaultdict[CallerIdentity, list[int]] = defaultdict(list)
+
+        frozen_calls = tuple(calls)
+        for position, call in enumerate(frozen_calls):
+            simple_name = str(call.get("simple_name", "") or "").casefold()
+            expression = str(call.get("callee_expression", "") or "").casefold()
+            if simple_name:
+                simple_names[simple_name].append(position)
+            for trigram in _trigrams(expression):
+                expression_trigrams[trigram].append(position)
+            for target_id in call.get("resolved_target_ids", []):
+                resolved_targets[str(target_id)].append(position)
+            for target_id in call.get("candidate_target_ids", []):
+                candidate_targets[str(target_id)].append(position)
+            callers[caller_identity_from_call(call)].append(position)
+
+        return cls(
+            calls=frozen_calls,
+            simple_name_positions=_freeze_postings(simple_names),
+            expression_trigram_positions=_freeze_postings(expression_trigrams),
+            resolved_target_positions=_freeze_postings(resolved_targets),
+            candidate_target_positions=_freeze_postings(candidate_targets),
+            caller_positions=_freeze_postings(callers),
+        )
+
+    @classmethod
+    def from_persisted_projection(
+        cls,
+        calls: Sequence[CallRow],
+        projection: Mapping[str, Any],
+        source_calls_sha256: str,
+    ) -> CallNavigationIndex:
+        """Reconstruct the benchmark sidecar only when it matches its call source."""
+        frozen_calls = tuple(calls)
+        if (
+            projection.get("kind") != "lenskit.python_call_navigation_index"
+            or projection.get("version") != "1.0"
+            or projection.get("source_calls_sha256") != source_calls_sha256
+            or projection.get("source_call_count") != len(frozen_calls)
+        ):
+            raise ValueError("persisted call navigation index source binding mismatch")
+        call_count = len(frozen_calls)
+        return cls(
+            calls=frozen_calls,
+            simple_name_positions=_persisted_postings(
+                projection, "simple_name_positions", call_count
+            ),
+            expression_trigram_positions=_persisted_postings(
+                projection, "expression_trigram_positions", call_count
+            ),
+            resolved_target_positions=_persisted_postings(
+                projection, "resolved_target_positions", call_count
+            ),
+            candidate_target_positions=_persisted_postings(
+                projection, "candidate_target_positions", call_count
+            ),
+            caller_positions=_persisted_caller_positions(projection, call_count),
+        )
+
+    def _expression_candidates(self, query: str) -> set[int]:
+        trigrams = _trigrams(query)
+        if not trigrams:
+            return set(range(len(self.calls)))
+        postings = [self.expression_trigram_positions.get(item, ()) for item in trigrams]
+        if not postings or any(not positions for positions in postings):
+            return set()
+        smallest, *remaining = sorted(postings, key=len)
+        candidates = set(smallest)
+        for positions in remaining:
+            candidates.intersection_update(positions)
+            if not candidates:
+                break
+        return candidates
+
+    def reference_calls(self, query: str) -> list[CallRow]:
+        """Return the same ordered call rows as the v1 linear reference search."""
+        exact_positions = set(self.simple_name_positions.get(query, ()))
+        candidate_positions = exact_positions | self._expression_candidates(query)
+        matched: list[tuple[int, str, int, int, int, CallRow]] = []
+        for position in candidate_positions:
+            call = self.calls[position]
+            simple_name = str(call.get("simple_name", "") or "").casefold()
+            expression = str(call.get("callee_expression", "") or "").casefold()
+            exact = simple_name == query
+            if not exact and query not in expression:
+                continue
+            path, line, col = _call_position_key(call)
+            matched.append((0 if exact else 1, path, line, col, position, call))
+        matched.sort(key=lambda item: item[:5])
+        return [item[-1] for item in matched]
+
+    def target_related_calls(self, target_id: str, query: str) -> list[CallRow]:
+        """Return rows relevant to get_callers without scanning unrelated calls."""
+        positions = (
+            set(self.resolved_target_positions.get(target_id, ()))
+            | set(self.candidate_target_positions.get(target_id, ()))
+            | set(self.simple_name_positions.get(query, ()))
+        )
+        return [self.calls[position] for position in sorted(positions)]
+
+    def calls_for_symbol(self, symbol: SymbolRow) -> list[CallRow]:
+        identity = caller_identity_from_symbol(symbol)
+        return [self.calls[position] for position in self.caller_positions.get(identity, ())]
+
+    def persisted_projection(self, source_calls_sha256: str) -> dict[str, Any]:
+        """Create the deterministic sidecar candidate used only by the benchmark."""
+
+        def string_map(values: Mapping[str, tuple[int, ...]]) -> dict[str, list[int]]:
+            return {key: list(values[key]) for key in sorted(values)}
+
+        callers = [
+            {"identity": list(key), "positions": list(self.caller_positions[key])}
+            for key in sorted(
+                self.caller_positions,
+                key=lambda item: tuple("" if value is None else str(value) for value in item),
+            )
+        ]
+        return {
+            "kind": "lenskit.python_call_navigation_index",
+            "version": "1.0",
+            "source_calls_sha256": source_calls_sha256,
+            "source_call_count": len(self.calls),
+            "simple_name_positions": string_map(self.simple_name_positions),
+            "expression_trigram_positions": string_map(
+                self.expression_trigram_positions
+            ),
+            "resolved_target_positions": string_map(self.resolved_target_positions),
+            "candidate_target_positions": string_map(self.candidate_target_positions),
+            "caller_positions": callers,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class SymbolNavigationIndex:
+    """Exact-name lookup over one validated Python symbol-index sequence."""
+
+    symbols: tuple[SymbolRow, ...]
+    rows_by_id: Mapping[str, tuple[SymbolRow, ...]]
+    exact_query_positions: Mapping[str, tuple[int, ...]]
+
+    @classmethod
+    def build(cls, symbols: Sequence[SymbolRow]) -> SymbolNavigationIndex:
+        rows_by_id: defaultdict[str, list[SymbolRow]] = defaultdict(list)
+        exact_queries: defaultdict[str, list[int]] = defaultdict(list)
+        frozen_symbols = tuple(symbols)
+        for position, symbol in enumerate(frozen_symbols):
+            rows_by_id[str(symbol["id"])].append(symbol)
+            queries = {
+                str(symbol.get("name", "")).casefold(),
+                str(symbol.get("qualified_name", "")).casefold(),
+            }
+            for query in queries:
+                if query:
+                    exact_queries[query].append(position)
+        return cls(
+            symbols=frozen_symbols,
+            rows_by_id=MappingProxyType(
+                {key: tuple(rows) for key, rows in rows_by_id.items()}
+            ),
+            exact_query_positions=_freeze_postings(exact_queries),
+        )
+
+    def select(self, query: str, path_filter: str | None) -> list[SymbolRow]:
+        matches = []
+        for position in self.exact_query_positions.get(query, ()):
+            symbol = self.symbols[position]
+            if path_filter and path_filter not in str(symbol.get("path", "")).casefold():
+                continue
+            matches.append(symbol)
+        return sorted(
+            matches,
+            key=lambda item: (
+                str(item.get("path", "")),
+                int(item.get("start_line", 0) or 0),
+                str(item.get("qualified_name", "")),
+                str(item.get("id", "")),
+            ),
+        )
+
+
+def linear_reference_calls(calls: Iterable[CallRow], query: str) -> list[CallRow]:
+    """Reference implementation retained for benchmark and equivalence tests."""
+    matched: list[tuple[int, str, int, int, int, CallRow]] = []
+    for position, call in enumerate(calls):
+        simple_name = str(call.get("simple_name", "") or "").casefold()
+        expression = str(call.get("callee_expression", "") or "").casefold()
+        exact = simple_name == query
+        if not exact and query not in expression:
+            continue
+        path, line, col = _call_position_key(call)
+        matched.append((0 if exact else 1, path, line, col, position, call))
+    matched.sort(key=lambda item: item[:5])
+    return [item[-1] for item in matched]
+
+
+def linear_target_related_calls(
+    calls: Iterable[CallRow], target_id: str, query: str
+) -> list[CallRow]:
+    return [
+        call
+        for call in calls
+        if target_id in call.get("resolved_target_ids", [])
+        or target_id in call.get("candidate_target_ids", [])
+        or str(call.get("simple_name", "") or "").casefold() == query
+    ]
+
+
+def linear_calls_for_symbol(
+    calls: Iterable[CallRow], symbol: SymbolRow
+) -> list[CallRow]:
+    identity = caller_identity_from_symbol(symbol)
+    return [call for call in calls if caller_identity_from_call(call) == identity]

--- a/merger/lenskit/core/repobrief_access.py
+++ b/merger/lenskit/core/repobrief_access.py
@@ -1875,6 +1875,7 @@ def _load_call_navigation_state(
             _SYMBOL_NAVIGATION_CACHE.pop(cache_key, None)
         return None, artifact, error
     assert data is not None
+    index = CallNavigationIndex.build(data["calls"])
     after = _artifact_source_fingerprint(manifest_path, CALL_GRAPH_ROLE)
     if before is None or after is None or before != after:
         return None, artifact, _call_graph_error(
@@ -1884,7 +1885,7 @@ def _load_call_navigation_state(
     state = _CallNavigationState(
         data=data,
         artifact=artifact,
-        index=CallNavigationIndex.build(data["calls"]),
+        index=index,
         fingerprint=after,
     )
     with _CALL_NAVIGATION_CACHE_LOCK:
@@ -1928,16 +1929,23 @@ def _load_symbol_navigation_state(
     error = _call_symbol_reference_error(call_state.data, rows_by_id)
     if error is not None:
         return None, symbol_artifact, error
+    index = SymbolNavigationIndex.build(symbols)
     after = _artifact_source_fingerprint(manifest_path, SYMBOL_INDEX_ROLE)
     if before is None or after is None or before != after:
         return None, symbol_artifact, _call_graph_error(
             "python_symbol_index_source_changed_during_load",
             "python_symbol_index_json source changed while navigation state was loading",
         )
+    after_call = _artifact_source_fingerprint(manifest_path, CALL_GRAPH_ROLE)
+    if after_call is None or after_call != call_state.fingerprint:
+        return None, symbol_artifact, _call_graph_error(
+            "python_call_graph_source_changed_during_load",
+            "python_call_graph_json source changed while navigation state was loading",
+        )
     state = _SymbolNavigationState(
         data=symbol_data,
         artifact=symbol_artifact,
-        index=SymbolNavigationIndex.build(symbols),
+        index=index,
         call_fingerprint=call_state.fingerprint,
         symbol_fingerprint=after,
     )

--- a/merger/lenskit/core/repobrief_access.py
+++ b/merger/lenskit/core/repobrief_access.py
@@ -1,14 +1,22 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import re
+from collections import OrderedDict
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from threading import RLock
+from typing import Any, Mapping, Sequence
 
 from merger.lenskit.architecture.call_graph_contract import (
     MAX_SKIPPED_ERRORS as MAX_CALL_GRAPH_SKIPPED_ERRORS,
     PRODUCER_NONCLAIMS as CALL_GRAPH_PRODUCER_NONCLAIMS,
     REQUIRED_NONCLAIMS as CALL_GRAPH_REQUIRED_NONCLAIMS,
+)
+from merger.lenskit.core.call_navigation_index import (
+    CallNavigationIndex,
+    SymbolNavigationIndex,
 )
 
 _DOES_NOT_ESTABLISH = (
@@ -1209,8 +1217,34 @@ def _load_symbol_index(manifest_path: Path) -> tuple[dict[str, Any] | None, dict
             "error": "python_symbol_index_json artifact file does not exist",
         }
     try:
-        data = json.loads(index_path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raw = index_path.read_bytes()
+    except OSError as exc:
+        return None, artifact, {
+            "status": "invalid",
+            "error_code": "python_symbol_index_json_unreadable",
+            "error": str(exc),
+        }
+    declared_bytes = artifact.get("bytes")
+    if (
+        isinstance(declared_bytes, int)
+        and not isinstance(declared_bytes, bool)
+        and declared_bytes != len(raw)
+    ):
+        return None, artifact, {
+            "status": "invalid",
+            "error_code": "python_symbol_index_json_bytes_mismatch",
+            "error": "python_symbol_index_json byte count does not match the bundle manifest",
+        }
+    declared_sha256 = artifact.get("sha256")
+    if _is_sha256(declared_sha256) and hashlib.sha256(raw).hexdigest() != declared_sha256:
+        return None, artifact, {
+            "status": "invalid",
+            "error_code": "python_symbol_index_json_sha256_mismatch",
+            "error": "python_symbol_index_json content hash does not match the bundle manifest",
+        }
+    try:
+        data = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
         return None, artifact, {
             "status": "invalid",
             "error_code": "python_symbol_index_json_unreadable",
@@ -1353,6 +1387,113 @@ _CALL_GRAPH_DOES_NOT_ESTABLISH = CALL_GRAPH_PRODUCER_NONCLAIMS
 _CALL_NAV_DOES_NOT_ESTABLISH = tuple(
     dict.fromkeys([*_DOES_NOT_ESTABLISH, *_CALL_GRAPH_DOES_NOT_ESTABLISH])
 )
+_CALL_NAVIGATION_CACHE_MAX_ENTRIES = 2
+
+
+@dataclass(frozen=True, slots=True)
+class _ArtifactSourceFingerprint:
+    manifest_sha256: str
+    role: str
+    absolute_path: str
+    declared_sha256: str | None
+    declared_bytes: int | None
+    device: int
+    inode: int
+    size: int
+    mtime_ns: int
+    ctime_ns: int
+
+
+@dataclass(frozen=True, slots=True)
+class _CallNavigationState:
+    data: dict[str, Any]
+    artifact: dict[str, Any] | None
+    index: CallNavigationIndex
+    fingerprint: _ArtifactSourceFingerprint
+
+
+@dataclass(frozen=True, slots=True)
+class _SymbolNavigationState:
+    data: dict[str, Any]
+    artifact: dict[str, Any] | None
+    index: SymbolNavigationIndex
+    call_fingerprint: _ArtifactSourceFingerprint
+    symbol_fingerprint: _ArtifactSourceFingerprint
+
+
+@dataclass(frozen=True, slots=True)
+class _ValidatedCallQuery:
+    state: _CallNavigationState
+    query: str
+    path_filter: str | None
+
+
+_CALL_NAVIGATION_CACHE: OrderedDict[str, _CallNavigationState] = OrderedDict()
+_SYMBOL_NAVIGATION_CACHE: OrderedDict[str, _SymbolNavigationState] = OrderedDict()
+_CALL_NAVIGATION_CACHE_LOCK = RLock()
+
+
+def _clear_call_navigation_caches() -> None:
+    """Clear process-local derived state; intended for bounded tests and diagnostics."""
+    with _CALL_NAVIGATION_CACHE_LOCK:
+        _CALL_NAVIGATION_CACHE.clear()
+        _SYMBOL_NAVIGATION_CACHE.clear()
+
+
+def _artifact_source_fingerprint(
+    manifest_path: Path, role: str
+) -> _ArtifactSourceFingerprint | None:
+    try:
+        manifest_bytes = manifest_path.read_bytes()
+        manifest = json.loads(manifest_bytes)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(manifest, dict):
+        return None
+    artifact = next(
+        (
+            item
+            for item in _artifact_list(manifest)
+            if item.get("role") == role
+        ),
+        None,
+    )
+    if not isinstance(artifact, dict):
+        return None
+    artifact_path = _safe_artifact_path(manifest_path.parent, artifact.get("path"))
+    if artifact_path is None:
+        return None
+    try:
+        stat = artifact_path.stat()
+    except OSError:
+        return None
+    declared_sha256 = artifact.get("sha256")
+    declared_bytes = artifact.get("bytes")
+    return _ArtifactSourceFingerprint(
+        manifest_sha256=hashlib.sha256(manifest_bytes).hexdigest(),
+        role=role,
+        absolute_path=str(artifact_path),
+        declared_sha256=declared_sha256 if isinstance(declared_sha256, str) else None,
+        declared_bytes=(
+            declared_bytes
+            if isinstance(declared_bytes, int) and not isinstance(declared_bytes, bool)
+            else None
+        ),
+        device=stat.st_dev,
+        inode=stat.st_ino,
+        size=stat.st_size,
+        mtime_ns=stat.st_mtime_ns,
+        ctime_ns=stat.st_ctime_ns,
+    )
+
+
+def _cache_state(
+    cache: OrderedDict[str, Any], key: str, state: Any
+) -> None:
+    cache[key] = state
+    cache.move_to_end(key)
+    while len(cache) > _CALL_NAVIGATION_CACHE_MAX_ENTRIES:
+        cache.popitem(last=False)
 
 
 def _call_nav_does_not_establish() -> list[str]:
@@ -1487,8 +1628,30 @@ def _read_call_graph_artifact(
             status="missing",
         )
     try:
-        data = json.loads(graph_path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raw = graph_path.read_bytes()
+    except OSError as exc:
+        return None, artifact, _call_graph_error(
+            "python_call_graph_json_unreadable", str(exc)
+        )
+    declared_bytes = artifact.get("bytes")
+    if (
+        isinstance(declared_bytes, int)
+        and not isinstance(declared_bytes, bool)
+        and declared_bytes != len(raw)
+    ):
+        return None, artifact, _call_graph_error(
+            "python_call_graph_json_bytes_mismatch",
+            "python_call_graph_json byte count does not match the bundle manifest",
+        )
+    declared_sha256 = artifact.get("sha256")
+    if _is_sha256(declared_sha256) and hashlib.sha256(raw).hexdigest() != declared_sha256:
+        return None, artifact, _call_graph_error(
+            "python_call_graph_json_sha256_mismatch",
+            "python_call_graph_json content hash does not match the bundle manifest",
+        )
+    try:
+        data = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
         return None, artifact, _call_graph_error(
             "python_call_graph_json_unreadable", str(exc)
         )
@@ -1692,6 +1855,97 @@ def _load_call_graph(
     return data, artifact, None
 
 
+def _load_call_navigation_state(
+    manifest_path: Path,
+) -> tuple[_CallNavigationState | None, dict[str, Any] | None, dict[str, Any] | None]:
+    """Load and index one call graph, reusing it only while its source is unchanged."""
+    cache_key = str(manifest_path)
+    before = _artifact_source_fingerprint(manifest_path, CALL_GRAPH_ROLE)
+    if before is not None:
+        with _CALL_NAVIGATION_CACHE_LOCK:
+            cached = _CALL_NAVIGATION_CACHE.get(cache_key)
+            if cached is not None and cached.fingerprint == before:
+                _CALL_NAVIGATION_CACHE.move_to_end(cache_key)
+                return cached, cached.artifact, None
+
+    data, artifact, error = _load_call_graph(manifest_path)
+    if error is not None:
+        with _CALL_NAVIGATION_CACHE_LOCK:
+            _CALL_NAVIGATION_CACHE.pop(cache_key, None)
+            _SYMBOL_NAVIGATION_CACHE.pop(cache_key, None)
+        return None, artifact, error
+    assert data is not None
+    after = _artifact_source_fingerprint(manifest_path, CALL_GRAPH_ROLE)
+    if before is None or after is None or before != after:
+        return None, artifact, _call_graph_error(
+            "python_call_graph_source_changed_during_load",
+            "python_call_graph_json source changed while navigation state was loading",
+        )
+    state = _CallNavigationState(
+        data=data,
+        artifact=artifact,
+        index=CallNavigationIndex.build(data["calls"]),
+        fingerprint=after,
+    )
+    with _CALL_NAVIGATION_CACHE_LOCK:
+        _cache_state(_CALL_NAVIGATION_CACHE, cache_key, state)
+        symbol_state = _SYMBOL_NAVIGATION_CACHE.get(cache_key)
+        if symbol_state is not None and symbol_state.call_fingerprint != after:
+            _SYMBOL_NAVIGATION_CACHE.pop(cache_key, None)
+    return state, artifact, None
+
+
+def _load_symbol_navigation_state(
+    manifest_path: Path, call_state: _CallNavigationState
+) -> tuple[_SymbolNavigationState | None, dict[str, Any] | None, dict[str, Any] | None]:
+    """Load a coherent symbol index bound to the cached call-graph source."""
+    cache_key = str(manifest_path)
+    before = _artifact_source_fingerprint(manifest_path, SYMBOL_INDEX_ROLE)
+    if before is not None:
+        with _CALL_NAVIGATION_CACHE_LOCK:
+            cached = _SYMBOL_NAVIGATION_CACHE.get(cache_key)
+            if (
+                cached is not None
+                and cached.call_fingerprint == call_state.fingerprint
+                and cached.symbol_fingerprint == before
+            ):
+                _SYMBOL_NAVIGATION_CACHE.move_to_end(cache_key)
+                return cached, cached.artifact, None
+
+    symbol_data, symbol_artifact, error = _load_symbol_index(manifest_path)
+    if error is not None:
+        with _CALL_NAVIGATION_CACHE_LOCK:
+            _SYMBOL_NAVIGATION_CACHE.pop(cache_key, None)
+        return None, symbol_artifact, error
+    assert symbol_data is not None
+    error = _symbol_index_identity_error(symbol_data, call_state.data)
+    if error is not None:
+        return None, symbol_artifact, error
+    symbols, rows_by_id, error = _validated_symbol_rows(symbol_data)
+    if error is not None:
+        return None, symbol_artifact, error
+    assert symbols is not None and rows_by_id is not None
+    error = _call_symbol_reference_error(call_state.data, rows_by_id)
+    if error is not None:
+        return None, symbol_artifact, error
+    after = _artifact_source_fingerprint(manifest_path, SYMBOL_INDEX_ROLE)
+    if before is None or after is None or before != after:
+        return None, symbol_artifact, _call_graph_error(
+            "python_symbol_index_source_changed_during_load",
+            "python_symbol_index_json source changed while navigation state was loading",
+        )
+    state = _SymbolNavigationState(
+        data=symbol_data,
+        artifact=symbol_artifact,
+        index=SymbolNavigationIndex.build(symbols),
+        call_fingerprint=call_state.fingerprint,
+        symbol_fingerprint=after,
+    )
+    with _CALL_NAVIGATION_CACHE_LOCK:
+        _cache_state(_SYMBOL_NAVIGATION_CACHE, cache_key, state)
+    return state, symbol_artifact, None
+
+
 def _call_source_range(call: dict[str, Any]) -> dict[str, Any]:
     return {
         "path": call.get("path"),
@@ -1755,7 +2009,7 @@ def _validated_call_query(
     name: Any,
     k: Any,
     path: Any,
-) -> tuple[dict[str, Any], dict[str, Any] | None, str, str | None] | dict[str, Any]:
+) -> _ValidatedCallQuery | dict[str, Any]:
     def _extra(artifact: dict[str, Any] | None) -> dict[str, Any]:
         return {
             "name": name,
@@ -1792,7 +2046,7 @@ def _validated_call_query(
             error_code="path_invalid",
             extra=_extra(None),
         )
-    data, artifact, error = _load_call_graph(manifest_path)
+    state, artifact, error = _load_call_navigation_state(manifest_path)
     if error is not None:
         return _invalid_read_result(
             kind=kind,
@@ -1802,9 +2056,13 @@ def _validated_call_query(
             error_code=error["error_code"],
             extra=_extra(artifact),
         )
-    assert data is not None
+    assert state is not None
     path_filter = path.strip().casefold() if isinstance(path, str) and path.strip() else None
-    return data, artifact, name.strip().casefold(), path_filter
+    return _ValidatedCallQuery(
+        state=state,
+        query=name.strip().casefold(),
+        path_filter=path_filter,
+    )
 
 
 def _symbol_index_identity_error(
@@ -1878,7 +2136,8 @@ def _validated_symbol_rows(
 
 
 def _matching_caller_symbol_rows(
-    call: dict[str, Any], rows_by_id: dict[str, list[dict[str, Any]]]
+    call: dict[str, Any],
+    rows_by_id: Mapping[str, Sequence[dict[str, Any]]],
 ) -> list[dict[str, Any]]:
     caller_id = call.get("caller_symbol_id")
     if not isinstance(caller_id, str):
@@ -1895,7 +2154,8 @@ def _matching_caller_symbol_rows(
 
 
 def _call_symbol_reference_error(
-    call_data: dict[str, Any], rows_by_id: dict[str, list[dict[str, Any]]]
+    call_data: dict[str, Any],
+    rows_by_id: Mapping[str, Sequence[dict[str, Any]]],
 ) -> dict[str, Any] | None:
     for position, call in enumerate(call_data.get("calls", [])):
         if call.get("caller_scope") == "symbol":
@@ -1990,15 +2250,14 @@ def _selected_symbol_or_error(
     name: str,
     k: int,
     path: str | None,
-    call_data: dict[str, Any],
-    call_artifact: dict[str, Any] | None,
+    call_state: _CallNavigationState,
     query: str,
     path_filter: str | None,
     caller_mode: bool,
-) -> tuple[
-    dict[str, Any], dict[str, Any] | None, dict[str, Any]
-] | dict[str, Any]:
-    symbol_data, symbol_artifact, error = _coherent_symbol_index(manifest_path, call_data)
+) -> tuple[dict[str, Any], _SymbolNavigationState] | dict[str, Any]:
+    symbol_state, symbol_artifact, error = _load_symbol_navigation_state(
+        manifest_path, call_state
+    )
     candidate_key = "caller_candidates" if caller_mode else "target_candidates"
     symbol_key = "caller_symbol" if caller_mode else "target_symbol"
     empty = _call_empty(kind)
@@ -2013,13 +2272,13 @@ def _selected_symbol_or_error(
                 "name": name,
                 "k": k,
                 "filters": {"path": path},
-                "call_graph": call_artifact,
+                "call_graph": call_state.artifact,
                 "symbol_index": symbol_artifact,
                 **empty,
             },
         )
-    assert symbol_data is not None
-    matches = _select_symbols(symbol_data, query, path_filter)
+    assert symbol_state is not None
+    matches = symbol_state.index.select(query, path_filter)
     if len(matches) != 1:
         status = "missing" if not matches else "invalid"
         error_code = "symbol_not_found" if not matches else "symbol_ambiguous"
@@ -2040,12 +2299,12 @@ def _selected_symbol_or_error(
                 "name": name,
                 "k": k,
                 "filters": {"path": path},
-                "call_graph": call_artifact,
-                "symbol_index": symbol_artifact,
+                "call_graph": call_state.artifact,
+                "symbol_index": symbol_state.artifact,
                 **empty,
             },
         )
-    return _symbol_record(matches[0]), symbol_artifact, symbol_data
+    return _symbol_record(matches[0]), symbol_state
 
 
 def find_references(
@@ -2065,23 +2324,24 @@ def find_references(
     )
     if isinstance(validated, dict):
         return validated
-    data, artifact, query, path_filter = validated
-    matched: list[tuple[int, str, int, int, dict[str, Any]]] = []
-    exact_match_count = 0
-    for call in data.get("calls", []):
-        if path_filter and path_filter not in str(call.get("path", "")).casefold():
-            continue
-        simple_name = call.get("simple_name")
-        exact = isinstance(simple_name, str) and simple_name.casefold() == query
-        if not exact and query not in str(call.get("callee_expression", "")).casefold():
-            continue
-        if exact:
-            exact_match_count += 1
-        matched.append(
-            (0 if exact else 1, str(call["path"]), call["start_line"], call["start_col"], call)
-        )
-    matched.sort(key=lambda item: item[:4])
-    hits = [_call_site_record(call) for *_, call in matched[:k]]
+    state = validated.state
+    data = state.data
+    artifact = state.artifact
+    query = validated.query
+    path_filter = validated.path_filter
+    matched = [
+        call
+        for call in state.index.reference_calls(query)
+        if not path_filter
+        or path_filter in str(call.get("path", "")).casefold()
+    ]
+    exact_match_count = sum(
+        1
+        for call in matched
+        if isinstance(call.get("simple_name"), str)
+        and call["simple_name"].casefold() == query
+    )
+    hits = [_call_site_record(call) for call in matched[:k]]
     availability = _availability_model_for_manifest(manifest_path)
     return {
         "kind": CALL_REFERENCES_KIND,
@@ -2122,28 +2382,32 @@ def get_callers(
     )
     if isinstance(validated, dict):
         return validated
-    data, artifact, query, path_filter = validated
+    state = validated.state
+    data = state.data
+    artifact = state.artifact
+    query = validated.query
+    path_filter = validated.path_filter
     selected = _selected_symbol_or_error(
         kind=CALL_CALLERS_KIND,
         manifest_path=manifest_path,
         name=name,
         k=k,
         path=path,
-        call_data=data,
-        call_artifact=artifact,
+        call_state=state,
         query=query,
         path_filter=path_filter,
         caller_mode=False,
     )
     if isinstance(selected, dict):
         return selected
-    target_symbol, symbol_artifact, symbol_data = selected
+    target_symbol, symbol_state = selected
+    symbol_artifact = symbol_state.artifact
     target_id = target_symbol["id"]
-    rows_by_id = _symbol_rows_by_id(symbol_data)
+    rows_by_id = symbol_state.index.rows_by_id
     groups: dict[str, dict[str, Any]] = {}
     unresolved_references: list[dict[str, Any]] = []
     total_call_site_count = 0
-    for call in data.get("calls", []):
+    for call in state.index.target_related_calls(target_id, query):
         if target_id in call.get("resolved_target_ids", []):
             total_call_site_count += 1
             caller_symbol_id = call.get("caller_symbol_id")
@@ -2245,30 +2509,30 @@ def get_callees(
     )
     if isinstance(validated, dict):
         return validated
-    data, artifact, query, path_filter = validated
+    state = validated.state
+    data = state.data
+    artifact = state.artifact
+    query = validated.query
+    path_filter = validated.path_filter
     selected = _selected_symbol_or_error(
         kind=CALL_CALLEES_KIND,
         manifest_path=manifest_path,
         name=name,
         k=k,
         path=path,
-        call_data=data,
-        call_artifact=artifact,
+        call_state=state,
         query=query,
         path_filter=path_filter,
         caller_mode=True,
     )
     if isinstance(selected, dict):
         return selected
-    caller_symbol, symbol_artifact, symbol_data = selected
-    rows_by_id = _symbol_rows_by_id(symbol_data)
+    caller_symbol, symbol_state = selected
+    symbol_artifact = symbol_state.artifact
+    rows_by_id = symbol_state.index.rows_by_id
     groups: dict[str, dict[str, Any]] = {}
     unresolved_call_sites: list[dict[str, Any]] = []
-    caller_sites = [
-        call
-        for call in data.get("calls", [])
-        if _call_belongs_to_symbol(call, caller_symbol)
-    ]
+    caller_sites = state.index.calls_for_symbol(caller_symbol)
     for call in caller_sites:
         if call.get("resolution_status") == "resolved":
             target_id = call["resolved_target_ids"][0]

--- a/merger/lenskit/core/repobrief_access.py
+++ b/merger/lenskit/core/repobrief_access.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+from copy import deepcopy
 from collections import OrderedDict
 from dataclasses import dataclass
 from pathlib import Path
@@ -1185,6 +1186,7 @@ def _symbol_source_range(symbol: dict[str, Any]) -> dict[str, Any]:
 
 
 def _symbol_record(symbol: dict[str, Any]) -> dict[str, Any]:
+    decorators = symbol.get("decorators")
     return {
         "id": symbol.get("id"),
         "kind": symbol.get("kind"),
@@ -1196,7 +1198,7 @@ def _symbol_record(symbol: dict[str, Any]) -> dict[str, Any]:
         "end_line": symbol.get("end_line"),
         "range_ref": symbol.get("range_ref"),
         "source_range": _symbol_source_range(symbol),
-        "decorators": symbol.get("decorators") if isinstance(symbol.get("decorators"), list) else [],
+        "decorators": list(decorators) if isinstance(decorators, list) else [],
     }
 
 
@@ -1699,7 +1701,7 @@ def _call_graph_parse_diagnostics(data: dict[str, Any]) -> dict[str, Any]:
     )
     return {
         "skipped_files_count": skipped_files_count,
-        "skipped_errors": skipped_errors,
+        "skipped_errors": list(skipped_errors) if isinstance(skipped_errors, list) else skipped_errors,
         "skipped_errors_total_count": skipped_errors_total_count,
         "skipped_errors_truncated": skipped_errors_truncated,
     }
@@ -1965,6 +1967,8 @@ def _call_source_range(call: dict[str, Any]) -> dict[str, Any]:
 
 
 def _call_site_record(call: dict[str, Any]) -> dict[str, Any]:
+    resolved_target_ids = call.get("resolved_target_ids")
+    candidate_target_ids = call.get("candidate_target_ids")
     return {
         "path": call.get("path"),
         "start_line": call.get("start_line"),
@@ -1984,10 +1988,18 @@ def _call_site_record(call: dict[str, Any]) -> dict[str, Any]:
         "evidence_level": call.get("evidence_level"),
         "resolution_status": call.get("resolution_status"),
         "resolution_reason": call.get("resolution_reason"),
-        "resolved_target_ids": call.get("resolved_target_ids"),
-        "candidate_target_ids": call.get("candidate_target_ids"),
+        "resolved_target_ids": (
+            list(resolved_target_ids) if isinstance(resolved_target_ids, list) else []
+        ),
+        "candidate_target_ids": (
+            list(candidate_target_ids) if isinstance(candidate_target_ids, list) else []
+        ),
         "source_range": _call_source_range(call),
     }
+
+
+def _detached_record(value: Any) -> dict[str, Any] | None:
+    return deepcopy(value) if isinstance(value, dict) else None
 
 
 def _call_graph_metadata(data: dict[str, Any]) -> dict[str, Any]:
@@ -1995,9 +2007,9 @@ def _call_graph_metadata(data: dict[str, Any]) -> dict[str, Any]:
         "run_id": data.get("run_id"),
         "canonical_dump_index_sha256": data.get("canonical_dump_index_sha256"),
         "call_count": data.get("call_count"),
-        "resolution_counts": data.get("resolution_counts"),
-        "evidence_counts": data.get("evidence_counts"),
-        "relation_counts": data.get("relation_counts"),
+        "resolution_counts": _detached_record(data.get("resolution_counts")),
+        "evidence_counts": _detached_record(data.get("evidence_counts")),
+        "relation_counts": _detached_record(data.get("relation_counts")),
         **_call_graph_parse_diagnostics(data),
     }
 
@@ -2023,7 +2035,7 @@ def _validated_call_query(
             "name": name,
             "k": k,
             "filters": {"path": path},
-            "call_graph": artifact,
+            "call_graph": _detached_record(artifact),
             **_call_empty(kind),
         }
 
@@ -2280,8 +2292,8 @@ def _selected_symbol_or_error(
                 "name": name,
                 "k": k,
                 "filters": {"path": path},
-                "call_graph": call_state.artifact,
-                "symbol_index": symbol_artifact,
+                "call_graph": _detached_record(call_state.artifact),
+                "symbol_index": _detached_record(symbol_artifact),
                 **empty,
             },
         )
@@ -2307,8 +2319,8 @@ def _selected_symbol_or_error(
                 "name": name,
                 "k": k,
                 "filters": {"path": path},
-                "call_graph": call_state.artifact,
-                "symbol_index": symbol_state.artifact,
+                "call_graph": _detached_record(call_state.artifact),
+                "symbol_index": _detached_record(symbol_state.artifact),
                 **empty,
             },
         )
@@ -2359,7 +2371,7 @@ def find_references(
         "name": name,
         "k": k,
         "filters": {"path": path},
-        "call_graph": artifact,
+        "call_graph": _detached_record(artifact),
         "call_graph_metadata": _call_graph_metadata(data),
         "availability": availability,
         "freshness": availability.get("freshness") if isinstance(availability, dict) else None,
@@ -2482,8 +2494,8 @@ def get_callers(
         "filters": {"path": path},
         "target_symbol": target_symbol,
         "target_candidates": [],
-        "call_graph": artifact,
-        "symbol_index": symbol_artifact,
+        "call_graph": _detached_record(artifact),
+        "symbol_index": _detached_record(symbol_artifact),
         "call_graph_metadata": _call_graph_metadata(data),
         "availability": availability,
         "freshness": availability.get("freshness") if isinstance(availability, dict) else None,
@@ -2558,8 +2570,8 @@ def get_callees(
                         "filters": {"path": path},
                         "caller_symbol": caller_symbol,
                         "caller_candidates": [],
-                        "call_graph": artifact,
-                        "symbol_index": symbol_artifact,
+                        "call_graph": _detached_record(artifact),
+                        "symbol_index": _detached_record(symbol_artifact),
                         "callees": [],
                         "unresolved_call_sites": [],
                     },
@@ -2605,8 +2617,8 @@ def get_callees(
         "filters": {"path": path},
         "caller_symbol": caller_symbol,
         "caller_candidates": [],
-        "call_graph": artifact,
-        "symbol_index": symbol_artifact,
+        "call_graph": _detached_record(artifact),
+        "symbol_index": _detached_record(symbol_artifact),
         "call_graph_metadata": _call_graph_metadata(data),
         "availability": availability,
         "freshness": availability.get("freshness") if isinstance(availability, dict) else None,

--- a/merger/lenskit/scripts/bench_call_navigation.py
+++ b/merger/lenskit/scripts/bench_call_navigation.py
@@ -533,7 +533,7 @@ def run_benchmark(
             "query_repetitions": query_repetitions,
             "cold_repetitions": cold_repetitions,
             "mcp_repetitions": mcp_repetitions,
-            "representative_repo": str(repo_path) if include_real_repo else None,
+            "representative_repo": "current_repository" if include_real_repo else None,
         },
         "representative_repo_parse": {
             "skipped_files_count": skipped_files_count,

--- a/merger/lenskit/scripts/bench_call_navigation.py
+++ b/merger/lenskit/scripts/bench_call_navigation.py
@@ -1,0 +1,608 @@
+"""Benchmark linear, process-local and persisted call-navigation strategies."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import statistics
+import tempfile
+import time
+import tracemalloc
+from collections import Counter
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+from merger.lenskit.architecture.call_graph import extract_python_calls
+from merger.lenskit.core import repobrief_mcp_tools
+from merger.lenskit.core.call_navigation_index import (
+    CallNavigationIndex,
+    linear_calls_for_symbol,
+    linear_reference_calls,
+    linear_target_related_calls,
+)
+from merger.lenskit.core.repobrief_access import _clear_call_navigation_caches
+
+DEFAULT_SYNTHETIC_CALL_COUNT = 50_000
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _sha256(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _distribution(fn: Callable[[], Any], repetitions: int) -> dict[str, Any]:
+    samples = []
+    for _ in range(repetitions):
+        started = time.perf_counter_ns()
+        fn()
+        samples.append((time.perf_counter_ns() - started) / 1_000_000)
+    ordered = sorted(samples)
+    p95_index = max(0, min(len(ordered) - 1, int(len(ordered) * 0.95) - 1))
+    return {
+        "repetitions": repetitions,
+        "median_ms": statistics.median(ordered),
+        "p95_ms": ordered[p95_index],
+        "min_ms": ordered[0],
+        "max_ms": ordered[-1],
+    }
+
+
+def _timed_memory(fn: Callable[[], Any]) -> tuple[Any, float, int, int]:
+    tracemalloc.start()
+    started = time.perf_counter_ns()
+    try:
+        value = fn()
+        elapsed_ms = (time.perf_counter_ns() - started) / 1_000_000
+        retained, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+    return value, elapsed_ms, retained, peak
+
+
+def _synthetic_symbol(
+    symbol_id: str,
+    *,
+    name: str,
+    path: str,
+    start_line: int = 1,
+    end_line: int = 100_000,
+) -> dict[str, Any]:
+    return {
+        "id": symbol_id,
+        "kind": "function",
+        "name": name,
+        "qualified_name": name,
+        "module": path.removesuffix(".py").replace("/", "."),
+        "path": path,
+        "start_line": start_line,
+        "end_line": end_line,
+        "range_ref": f"file:{path}#L{start_line}-L{end_line}",
+        "decorators": [],
+    }
+
+
+def synthetic_corpus(
+    call_count: int,
+    *,
+    target_count: int = 500,
+    caller_count: int = 1_000,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    calls = []
+    for position in range(call_count):
+        target = position % target_count
+        caller = position % caller_count
+        status_slot = position % 10
+        if status_slot < 8:
+            status = "resolved"
+            evidence = "S1"
+        elif status_slot == 8:
+            status = "candidate"
+            evidence = "S0"
+        else:
+            status = "unresolved"
+            evidence = "S0"
+        target_id = f"py:pkg:targets/t{target}.py:function:target_{target}"
+        caller_id = f"py:pkg:callers/c{caller}.py:function:caller_{caller}"
+        line = position // caller_count + 2
+        expression = (
+            f"registry.handlers.target_{target}"
+            if position % 7 == 0
+            else f"target_{target}"
+        )
+        calls.append(
+            {
+                "path": f"pkg/callers/c{caller}.py",
+                "start_line": line,
+                "start_col": position % 17,
+                "end_line": line,
+                "end_col": position % 17 + len(expression) + 2,
+                "range_ref": f"file:pkg/callers/c{caller}.py#L{line}-L{line}",
+                "callee_expression": expression,
+                "simple_name": f"target_{target}",
+                "caller_scope": "symbol",
+                "caller_symbol_id": caller_id,
+                "caller_qualified_name": f"caller_{caller}",
+                "caller_kind": "function",
+                "caller_start_line": 1,
+                "caller_end_line": 100_000,
+                "relation_type": "calls",
+                "evidence_level": evidence,
+                "resolution_status": status,
+                "resolution_reason": f"synthetic_{status}",
+                "resolved_target_ids": [target_id] if status == "resolved" else [],
+                "candidate_target_ids": [target_id] if status == "candidate" else [],
+            }
+        )
+    symbols = [
+        _synthetic_symbol(
+            f"py:pkg:targets/t{target}.py:function:target_{target}",
+            name=f"target_{target}",
+            path=f"pkg/targets/t{target}.py",
+        )
+        for target in range(target_count)
+    ]
+    symbols.extend(
+        _synthetic_symbol(
+            f"py:pkg:callers/c{caller}.py:function:caller_{caller}",
+            name=f"caller_{caller}",
+            path=f"pkg/callers/c{caller}.py",
+        )
+        for caller in range(caller_count)
+    )
+    return calls, symbols
+
+
+def _query_set(calls: Sequence[dict[str, Any]], limit: int = 20) -> dict[str, Any]:
+    name_counts = Counter(
+        str(call.get("simple_name", "")).casefold()
+        for call in calls
+        if call.get("simple_name")
+    )
+    references = [
+        name for name, _ in sorted(name_counts.items(), key=lambda item: (-item[1], item[0]))[:limit]
+    ]
+
+    targets: dict[tuple[str, str], None] = {}
+    callers: dict[tuple[Any, ...], dict[str, Any]] = {}
+    for call in calls:
+        simple_name = str(call.get("simple_name", "")).casefold()
+        for target_id in [
+            *call.get("resolved_target_ids", []),
+            *call.get("candidate_target_ids", []),
+        ]:
+            targets.setdefault((str(target_id), simple_name), None)
+        caller_id = call.get("caller_symbol_id")
+        if isinstance(caller_id, str):
+            identity = (
+                caller_id,
+                call.get("path"),
+                call.get("caller_qualified_name"),
+                call.get("caller_kind"),
+                call.get("caller_start_line"),
+                call.get("caller_end_line"),
+            )
+            callers.setdefault(
+                identity,
+                {
+                    "id": caller_id,
+                    "path": call.get("path"),
+                    "qualified_name": call.get("caller_qualified_name"),
+                    "kind": call.get("caller_kind"),
+                    "start_line": call.get("caller_start_line"),
+                    "end_line": call.get("caller_end_line"),
+                },
+            )
+    return {
+        "references": references,
+        "targets": [list(item) for item in sorted(targets)[:limit]],
+        "callers": [callers[key] for key in sorted(callers)[:limit]],
+    }
+
+
+def _linear_result(
+    calls: Sequence[dict[str, Any]], queries: dict[str, Any]
+) -> dict[str, Any]:
+    return {
+        "references": [
+            linear_reference_calls(calls, query) for query in queries["references"]
+        ],
+        "targets": [
+            linear_target_related_calls(calls, target_id, query)
+            for target_id, query in queries["targets"]
+        ],
+        "callers": [
+            linear_calls_for_symbol(calls, symbol) for symbol in queries["callers"]
+        ],
+    }
+
+
+def _indexed_result(
+    index: CallNavigationIndex, queries: dict[str, Any]
+) -> dict[str, Any]:
+    return {
+        "references": [index.reference_calls(query) for query in queries["references"]],
+        "targets": [
+            index.target_related_calls(target_id, query)
+            for target_id, query in queries["targets"]
+        ],
+        "callers": [index.calls_for_symbol(symbol) for symbol in queries["callers"]],
+    }
+
+
+def benchmark_tier(
+    calls: Sequence[dict[str, Any]],
+    *,
+    label: str,
+    query_repetitions: int,
+    cold_repetitions: int,
+) -> dict[str, Any]:
+    call_bytes = _canonical_bytes(list(calls))
+    source_sha = _sha256(call_bytes)
+    queries = _query_set(calls)
+
+    index, build_ms, index_retained_bytes, index_peak_bytes = _timed_memory(
+        lambda: CallNavigationIndex.build(calls)
+    )
+    projection = index.persisted_projection(source_sha)
+    sidecar_bytes = _canonical_bytes(projection)
+    restored = CallNavigationIndex.from_persisted_projection(
+        calls, json.loads(sidecar_bytes), source_sha
+    )
+
+    linear_bytes = _canonical_bytes(_linear_result(calls, queries))
+    indexed_bytes = _canonical_bytes(_indexed_result(index, queries))
+    restored_bytes = _canonical_bytes(_indexed_result(restored, queries))
+    equivalent = linear_bytes == indexed_bytes == restored_bytes
+
+    linear_query = _distribution(
+        lambda: _linear_result(calls, queries), query_repetitions
+    )
+    indexed_query = _distribution(
+        lambda: _indexed_result(index, queries), query_repetitions
+    )
+    restored_query = _distribution(
+        lambda: _indexed_result(restored, queries), query_repetitions
+    )
+
+    def cold_linear() -> None:
+        json.loads(call_bytes)
+
+    def cold_memory() -> None:
+        parsed = json.loads(call_bytes)
+        CallNavigationIndex.build(parsed)
+
+    def cold_persisted() -> None:
+        parsed_calls = json.loads(call_bytes)
+        parsed_projection = json.loads(sidecar_bytes)
+        CallNavigationIndex.from_persisted_projection(
+            parsed_calls, parsed_projection, source_sha
+        )
+
+    return {
+        "label": label,
+        "call_count": len(calls),
+        "query_counts": {key: len(value) for key, value in queries.items()},
+        "call_json_bytes": len(call_bytes),
+        "source_calls_sha256": source_sha,
+        "equivalence": {
+            "status": "pass" if equivalent else "fail",
+            "byte_equivalent": equivalent,
+            "result_sha256": _sha256(linear_bytes),
+        },
+        "linear_scan": {
+            "bundle_bytes": len(call_bytes),
+            "cold_load": _distribution(cold_linear, cold_repetitions),
+            "warm_query_batch": linear_query,
+        },
+        "process_local_index": {
+            "bundle_bytes": len(call_bytes),
+            "build_ms": build_ms,
+            "build_retained_bytes": index_retained_bytes,
+            "build_peak_bytes": index_peak_bytes,
+            "cold_load_and_build": _distribution(cold_memory, cold_repetitions),
+            "warm_query_batch": indexed_query,
+        },
+        "persisted_sidecar": {
+            "bundle_bytes": len(call_bytes) + len(sidecar_bytes),
+            "sidecar_bytes": len(sidecar_bytes),
+            "bundle_overhead_ratio": len(sidecar_bytes) / max(1, len(call_bytes)),
+            "source_hash_bound": True,
+            "cold_load_and_restore": _distribution(cold_persisted, cold_repetitions),
+            "warm_query_batch": restored_query,
+        },
+        "speedup": {
+            "process_local_vs_linear_warm_median": linear_query["median_ms"]
+            / max(indexed_query["median_ms"], 1e-9),
+            "persisted_vs_linear_warm_median": linear_query["median_ms"]
+            / max(restored_query["median_ms"], 1e-9),
+        },
+    }
+
+
+def _count(calls: Sequence[dict[str, Any]], field: str, keys: Sequence[str]) -> dict[str, int]:
+    result = {key: 0 for key in keys}
+    for call in calls:
+        result[str(call[field])] += 1
+    return result
+
+
+def _write_synthetic_bundle(
+    root: Path,
+    calls: Sequence[dict[str, Any]],
+    symbols: Sequence[dict[str, Any]],
+) -> Path:
+    run_id = "call-navigation-benchmark"
+    canonical_sha = "a" * 64
+    call_graph = root / "benchmark.python_call_graph.json"
+    symbol_index = root / "benchmark.python_symbol_index.json"
+    call_payload = {
+        "kind": "lenskit.python_call_graph",
+        "version": "1.0",
+        "run_id": run_id,
+        "canonical_dump_index_sha256": canonical_sha,
+        "language": "python",
+        "evidence_model": {
+            "S0": "unresolved or ambiguous static candidate",
+            "S1": "one uniquely resolved local target",
+        },
+        "resolution_statuses": ["resolved", "candidate", "ambiguous", "unresolved"],
+        "relation_types": ["calls", "constructs"],
+        "call_count": len(calls),
+        "resolution_counts": _count(
+            calls,
+            "resolution_status",
+            ("resolved", "candidate", "ambiguous", "unresolved"),
+        ),
+        "evidence_counts": _count(calls, "evidence_level", ("S0", "S1")),
+        "relation_counts": _count(calls, "relation_type", ("calls", "constructs")),
+        "calls": list(calls),
+        "skipped_files_count": 0,
+        "skipped_errors": [],
+        "skipped_errors_total_count": 0,
+        "skipped_errors_truncated": False,
+        "does_not_establish": [
+            "complete_call_graph",
+            "runtime_reachability",
+            "dynamic_dispatch_resolution",
+            "dependency_completeness",
+            "transitive_import_resolution",
+            "import_success",
+            "test_sufficiency",
+            "review_completeness",
+            "merge_readiness",
+        ],
+    }
+    symbol_payload = {
+        "kind": "lenskit.python_symbol_index",
+        "version": "1.0",
+        "run_id": run_id,
+        "canonical_dump_index_sha256": canonical_sha,
+        "language": "python",
+        "symbol_kinds": ["class", "function", "async_function"],
+        "symbols": list(symbols),
+        "skipped_files_count": 0,
+        "skipped_errors": [],
+        "does_not_establish": ["call_graph_completeness"],
+    }
+    call_graph.write_bytes(_canonical_bytes(call_payload))
+    symbol_index.write_bytes(_canonical_bytes(symbol_payload))
+    manifest = root / "benchmark.bundle.manifest.json"
+    manifest.write_bytes(
+        _canonical_bytes(
+            {
+                "kind": "repolens.bundle.manifest",
+                "run_id": run_id,
+                "artifacts": [
+                    {
+                        "role": "python_symbol_index_json",
+                        "path": symbol_index.name,
+                        "content_type": "application/json",
+                        "bytes": symbol_index.stat().st_size,
+                        "sha256": _sha256(symbol_index.read_bytes()),
+                    },
+                    {
+                        "role": "python_call_graph_json",
+                        "path": call_graph.name,
+                        "content_type": "application/json",
+                        "bytes": call_graph.stat().st_size,
+                        "sha256": _sha256(call_graph.read_bytes()),
+                    },
+                ],
+            }
+        )
+    )
+    return manifest
+
+
+def benchmark_mcp(
+    calls: Sequence[dict[str, Any]],
+    symbols: Sequence[dict[str, Any]],
+    *,
+    cold_repetitions: int,
+    warm_repetitions: int,
+) -> dict[str, Any]:
+    with tempfile.TemporaryDirectory(prefix="lenskit-call-navigation-bench-") as raw:
+        manifest = _write_synthetic_bundle(Path(raw), calls, symbols)
+
+        def batch() -> dict[str, Any]:
+            return {
+                "references": repobrief_mcp_tools.find_references(
+                    bundle_manifest=manifest, name="target_7", k=25
+                ),
+                "callers": repobrief_mcp_tools.get_callers(
+                    bundle_manifest=manifest,
+                    name="target_7",
+                    path="pkg/targets/t7.py",
+                    k=25,
+                ),
+                "callees": repobrief_mcp_tools.get_callees(
+                    bundle_manifest=manifest,
+                    name="caller_7",
+                    path="pkg/callers/c7.py",
+                    k=25,
+                ),
+            }
+
+        def cold_batch() -> None:
+            _clear_call_navigation_caches()
+            batch()
+
+        _clear_call_navigation_caches()
+        cold_result, cold_first_ms, cold_retained_bytes, cold_peak_bytes = (
+            _timed_memory(batch)
+        )
+        warm_result = batch()
+        byte_equivalent = _canonical_bytes(cold_result) == _canonical_bytes(warm_result)
+        cold_distribution = _distribution(cold_batch, cold_repetitions)
+        _clear_call_navigation_caches()
+        batch()
+        warm_distribution = _distribution(batch, warm_repetitions)
+        _clear_call_navigation_caches()
+        return {
+            "call_count": len(calls),
+            "cold_first_ms": cold_first_ms,
+            "cold_first_retained_bytes": cold_retained_bytes,
+            "cold_first_peak_bytes": cold_peak_bytes,
+            "cold_batch": cold_distribution,
+            "warm_repeated_batch": warm_distribution,
+            "cold_warm_byte_equivalent": byte_equivalent,
+            "result_sha256": _sha256(_canonical_bytes(cold_result)),
+        }
+
+
+def _machine_context() -> dict[str, Any]:
+    return {
+        "python": platform.python_version(),
+        "implementation": platform.python_implementation(),
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "processor": platform.processor(),
+        "logical_cpu_count": os.cpu_count(),
+    }
+
+
+def run_benchmark(
+    repo: str | Path,
+    *,
+    synthetic_call_count: int = DEFAULT_SYNTHETIC_CALL_COUNT,
+    query_repetitions: int = 7,
+    cold_repetitions: int = 3,
+    mcp_repetitions: int = 10,
+    include_real_repo: bool = True,
+) -> dict[str, Any]:
+    repo_path = Path(repo).expanduser().resolve()
+    synthetic_calls, synthetic_symbols = synthetic_corpus(synthetic_call_count)
+    tiers = [
+        benchmark_tier(
+            synthetic_calls,
+            label=f"synthetic_{synthetic_call_count}",
+            query_repetitions=query_repetitions,
+            cold_repetitions=cold_repetitions,
+        )
+    ]
+    skipped_files_count = None
+    skipped_errors: list[str] = []
+    if include_real_repo:
+        real_calls, skipped_files_count, skipped_errors = extract_python_calls(repo_path)
+        tiers.append(
+            benchmark_tier(
+                real_calls,
+                label="representative_real_repo",
+                query_repetitions=query_repetitions,
+                cold_repetitions=cold_repetitions,
+            )
+        )
+    equivalence_pass = all(
+        tier["equivalence"]["byte_equivalent"] for tier in tiers
+    )
+    report = {
+        "kind": "repobrief.call_navigation_scale_benchmark",
+        "version": "1.0",
+        "status": "pass" if equivalence_pass else "fail",
+        "machine_context": _machine_context(),
+        "configuration": {
+            "synthetic_call_count": synthetic_call_count,
+            "fixed_acceptance_tier": synthetic_call_count
+            == DEFAULT_SYNTHETIC_CALL_COUNT,
+            "query_repetitions": query_repetitions,
+            "cold_repetitions": cold_repetitions,
+            "mcp_repetitions": mcp_repetitions,
+            "representative_repo": str(repo_path) if include_real_repo else None,
+        },
+        "representative_repo_parse": {
+            "skipped_files_count": skipped_files_count,
+            "skipped_errors": skipped_errors[:20],
+        },
+        "tiers": tiers,
+        "mcp": benchmark_mcp(
+            synthetic_calls,
+            synthetic_symbols,
+            cold_repetitions=cold_repetitions,
+            warm_repetitions=mcp_repetitions,
+        ),
+        "decision": {
+            "selected": "process_local_in_memory_index",
+            "rejected": {
+                "linear_scan": "repeated O(call_count) scans and repeated artifact validation",
+                "persisted_sidecar": "adds a second bundle artifact and measurable byte overhead without better warm queries",
+            },
+            "cache_bound": "manifest hash plus artifact identity, declared hash and byte count",
+            "cache_max_entries": 2,
+        },
+        "does_not_establish": [
+            "performance_on_all_machines",
+            "performance_on_all_repositories",
+            "runtime_call_graph_completeness",
+            "dynamic_dispatch_resolution",
+            "default_promotion_without_equivalence_gates",
+        ],
+    }
+    if not report["mcp"]["cold_warm_byte_equivalent"]:
+        report["status"] = "fail"
+    return report
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=".")
+    parser.add_argument("--output")
+    parser.add_argument("--synthetic-call-count", type=int, default=DEFAULT_SYNTHETIC_CALL_COUNT)
+    parser.add_argument("--query-repetitions", type=int, default=7)
+    parser.add_argument("--cold-repetitions", type=int, default=3)
+    parser.add_argument("--mcp-repetitions", type=int, default=10)
+    parser.add_argument("--skip-real-repo", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if min(
+        args.synthetic_call_count,
+        args.query_repetitions,
+        args.cold_repetitions,
+        args.mcp_repetitions,
+    ) < 1:
+        raise SystemExit("benchmark counts must be positive")
+    report = run_benchmark(
+        args.repo,
+        synthetic_call_count=args.synthetic_call_count,
+        query_repetitions=args.query_repetitions,
+        cold_repetitions=args.cold_repetitions,
+        mcp_repetitions=args.mcp_repetitions,
+        include_real_repo=not args.skip_real_repo,
+    )
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        Path(args.output).expanduser().resolve().write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+    return 0 if report["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/merger/lenskit/tests/test_bench_call_navigation.py
+++ b/merger/lenskit/tests/test_bench_call_navigation.py
@@ -1,0 +1,102 @@
+"""Contract tests for the reproducible call-navigation scale benchmark."""
+
+import hashlib
+import json
+from pathlib import Path
+
+from merger.lenskit.scripts.bench_call_navigation import (
+    DEFAULT_SYNTHETIC_CALL_COUNT,
+    run_benchmark,
+    synthetic_corpus,
+)
+
+
+def test_acceptance_tier_is_fixed_at_fifty_thousand_calls():
+    assert DEFAULT_SYNTHETIC_CALL_COUNT == 50_000
+
+
+def test_synthetic_corpus_is_deterministic_and_coherent():
+    first_calls, first_symbols = synthetic_corpus(500)
+    second_calls, second_symbols = synthetic_corpus(500)
+
+    assert first_calls == second_calls
+    assert first_symbols == second_symbols
+    assert len(first_calls) == 500
+    symbol_ids = {symbol["id"] for symbol in first_symbols}
+    assert all(
+        target_id in symbol_ids
+        for call in first_calls
+        for target_id in [
+            *call["resolved_target_ids"],
+            *call["candidate_target_ids"],
+        ]
+    )
+    assert all(call["caller_symbol_id"] in symbol_ids for call in first_calls)
+
+
+def test_small_benchmark_proves_equivalence_and_reports_all_candidates(tmp_path):
+    report = run_benchmark(
+        tmp_path,
+        synthetic_call_count=600,
+        query_repetitions=2,
+        cold_repetitions=2,
+        mcp_repetitions=2,
+        include_real_repo=False,
+    )
+
+    assert report["status"] == "pass"
+    assert report["configuration"]["fixed_acceptance_tier"] is False
+    assert report["decision"]["selected"] == "process_local_in_memory_index"
+    assert report["mcp"]["cold_warm_byte_equivalent"] is True
+    assert len(report["tiers"]) == 1
+    tier = report["tiers"][0]
+    assert tier["call_count"] == 600
+    assert tier["equivalence"]["byte_equivalent"] is True
+    assert tier["linear_scan"]["bundle_bytes"] > 0
+    assert tier["process_local_index"]["build_retained_bytes"] > 0
+    assert tier["process_local_index"]["build_peak_bytes"] >= tier[
+        "process_local_index"
+    ]["build_retained_bytes"]
+    assert tier["persisted_sidecar"]["sidecar_bytes"] > 0
+    assert tier["persisted_sidecar"]["source_hash_bound"] is True
+
+
+def test_committed_measurement_and_proof_are_consistent():
+    root = Path(__file__).parents[3]
+    measurement_path = (
+        root
+        / "docs"
+        / "proofs"
+        / "repobrief-call-navigation-scale-index-v1.measurement.json"
+    )
+    proof_path = (
+        root
+        / "docs"
+        / "proofs"
+        / "repobrief-call-navigation-scale-index-v1-proof.md"
+    )
+    raw = measurement_path.read_bytes()
+    measurement = json.loads(raw)
+    digest = hashlib.sha256(raw).hexdigest()
+    proof = proof_path.read_text(encoding="utf-8")
+
+    assert measurement["status"] == "pass"
+    assert measurement["configuration"]["synthetic_call_count"] == 50_000
+    assert measurement["configuration"]["fixed_acceptance_tier"] is True
+    assert measurement["decision"]["selected"] == "process_local_in_memory_index"
+    assert measurement["decision"]["cache_max_entries"] == 2
+    assert measurement["mcp"]["cold_warm_byte_equivalent"] is True
+    assert all(
+        tier["equivalence"]["byte_equivalent"] is True
+        for tier in measurement["tiers"]
+    )
+    assert all(
+        tier["process_local_index"]["warm_query_batch"]["median_ms"]
+        < tier["linear_scan"]["warm_query_batch"]["median_ms"]
+        for tier in measurement["tiers"]
+    )
+    assert all(
+        tier["persisted_sidecar"]["bundle_overhead_ratio"] > 0
+        for tier in measurement["tiers"]
+    )
+    assert digest in proof

--- a/merger/lenskit/tests/test_call_navigation_index.py
+++ b/merger/lenskit/tests/test_call_navigation_index.py
@@ -1,0 +1,155 @@
+"""Equivalence and source-binding tests for process-local call navigation indexes."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+
+from merger.lenskit.core.call_navigation_index import (
+    CallNavigationIndex,
+    SymbolNavigationIndex,
+    linear_calls_for_symbol,
+    linear_reference_calls,
+    linear_target_related_calls,
+)
+
+
+def _call(position: int) -> dict:
+    target = position % 31
+    caller = position % 47
+    status = ("resolved", "candidate", "unresolved")[position % 3]
+    target_id = f"py:pkg:t{target}.py:function:target_{target}"
+    simple_name = f"target_{target}"
+    expression = (
+        simple_name
+        if position % 5
+        else f"registry.handlers.{simple_name}"
+    )
+    return {
+        "path": f"pkg/c{caller}.py",
+        "start_line": position // 47 + 1,
+        "start_col": position % 13,
+        "end_line": position // 47 + 1,
+        "end_col": position % 13 + 8,
+        "range_ref": f"file:pkg/c{caller}.py#L{position // 47 + 1}-L{position // 47 + 1}",
+        "callee_expression": expression,
+        "simple_name": simple_name,
+        "caller_scope": "symbol",
+        "caller_symbol_id": f"py:pkg:c{caller}.py:function:caller_{caller}",
+        "caller_qualified_name": f"caller_{caller}",
+        "caller_kind": "function",
+        "caller_start_line": 1,
+        "caller_end_line": 100,
+        "relation_type": "calls",
+        "evidence_level": "S1" if status == "resolved" else "S0",
+        "resolution_status": status,
+        "resolution_reason": f"fixture_{status}",
+        "resolved_target_ids": [target_id] if status == "resolved" else [],
+        "candidate_target_ids": [target_id] if status == "candidate" else [],
+    }
+
+
+def _symbol(caller: int) -> dict:
+    return {
+        "id": f"py:pkg:c{caller}.py:function:caller_{caller}",
+        "kind": "function",
+        "name": f"caller_{caller}",
+        "qualified_name": f"caller_{caller}",
+        "module": f"pkg.c{caller}",
+        "path": f"pkg/c{caller}.py",
+        "start_line": 1,
+        "end_line": 100,
+        "range_ref": f"file:pkg/c{caller}.py#L1-L100",
+    }
+
+
+def test_indexed_reference_search_is_order_equivalent_for_exact_substring_and_short_queries():
+    calls = [_call(position) for position in range(2500)]
+    calls.reverse()  # Prove ordering does not depend on canonical producer order.
+    index = CallNavigationIndex.build(calls)
+
+    for query in ("target_7", "handlers", "get", "tar", "missing"):
+        assert index.reference_calls(query) == linear_reference_calls(calls, query)
+
+
+def test_indexed_target_and_caller_navigation_are_row_equivalent():
+    calls = [_call(position) for position in range(2500)]
+    index = CallNavigationIndex.build(calls)
+    target_id = "py:pkg:t11.py:function:target_11"
+    query = "target_11"
+    symbol = _symbol(19)
+
+    assert index.target_related_calls(target_id, query) == linear_target_related_calls(
+        calls, target_id, query
+    )
+    assert index.calls_for_symbol(symbol) == linear_calls_for_symbol(calls, symbol)
+
+
+def test_symbol_index_preserves_exact_selection_and_duplicate_order():
+    symbols = [_symbol(3), _symbol(1), _symbol(2)]
+    duplicate = dict(_symbol(1))
+    duplicate["path"] = "other/c1.py"
+    duplicate["module"] = "other.c1"
+    symbols.append(duplicate)
+    index = SymbolNavigationIndex.build(symbols)
+
+    assert [row["path"] for row in index.select("caller_1", None)] == [
+        "other/c1.py",
+        "pkg/c1.py",
+    ]
+    assert [row["path"] for row in index.select("caller_1", "pkg/")] == [
+        "pkg/c1.py"
+    ]
+    assert index.select("missing", None) == []
+
+
+def test_index_postings_are_immutable_and_retain_source_row_identity():
+    calls = [_call(0), _call(1)]
+    index = CallNavigationIndex.build(calls)
+
+    assert index.calls[0] is calls[0]
+    with pytest.raises(TypeError):
+        index.simple_name_positions["new"] = (0,)  # type: ignore[index]
+
+
+def test_persisted_candidate_reconstructs_equivalent_index_and_rejects_wrong_source():
+    calls = [_call(position) for position in range(500)]
+    source_bytes = json.dumps(calls, sort_keys=True, separators=(",", ":")).encode()
+    source_sha = hashlib.sha256(source_bytes).hexdigest()
+    original = CallNavigationIndex.build(calls)
+    projection = original.persisted_projection(source_sha)
+
+    restored = CallNavigationIndex.from_persisted_projection(
+        calls, projection, source_sha
+    )
+
+    assert restored.reference_calls("target_7") == original.reference_calls("target_7")
+    assert restored.target_related_calls(
+        "py:pkg:t7.py:function:target_7", "target_7"
+    ) == original.target_related_calls(
+        "py:pkg:t7.py:function:target_7", "target_7"
+    )
+    with pytest.raises(ValueError, match="source binding mismatch"):
+        CallNavigationIndex.from_persisted_projection(calls, projection, "0" * 64)
+
+
+def test_persisted_candidate_is_deterministic_and_source_hash_bound():
+    calls = [_call(position) for position in range(200)]
+    index = CallNavigationIndex.build(calls)
+    source_bytes = json.dumps(calls, sort_keys=True, separators=(",", ":")).encode()
+    source_sha = hashlib.sha256(source_bytes).hexdigest()
+
+    first = json.dumps(
+        index.persisted_projection(source_sha), sort_keys=True, separators=(",", ":")
+    ).encode()
+    second = json.dumps(
+        index.persisted_projection(source_sha), sort_keys=True, separators=(",", ":")
+    ).encode()
+
+    assert first == second
+    payload = json.loads(first)
+    assert payload["source_calls_sha256"] == source_sha
+    assert payload["source_call_count"] == len(calls)
+    assert payload["kind"] == "lenskit.python_call_navigation_index"

--- a/merger/lenskit/tests/test_repobrief_call_navigation.py
+++ b/merger/lenskit/tests/test_repobrief_call_navigation.py
@@ -324,6 +324,28 @@ def test_navigation_cache_reuses_validated_call_state(tmp_path, monkeypatch):
     assert len(repobrief_access._CALL_NAVIGATION_CACHE) == 1
 
 
+def test_public_navigation_results_cannot_mutate_cached_state(tmp_path):
+    manifest, _, symbol_index = _write_bundle(tmp_path)
+    symbol_payload = json.loads(symbol_index.read_text(encoding="utf-8"))
+    target = next(item for item in symbol_payload["symbols"] if item["id"] == TARGET_ID)
+    target["decorators"] = ["registered"]
+    symbol_index.write_text(json.dumps(symbol_payload), encoding="utf-8")
+    _refresh_manifest_artifact(manifest, "python_symbol_index_json", symbol_index)
+
+    first = get_callers(manifest, "target", path="pkg/target.py", k=10)
+    expected = json.loads(json.dumps(first))
+
+    first["target_symbol"]["decorators"].append("mutated")
+    first["call_graph"]["sha256"] = "mutated"
+    first["symbol_index"]["sha256"] = "mutated"
+    first["call_graph_metadata"]["resolution_counts"]["resolved"] = 0
+    first["callers"][0]["call_sites"][0]["resolved_target_ids"].clear()
+    first["unresolved_references"][0]["candidate_target_ids"].append("mutated")
+
+    second = get_callers(manifest, "target", path="pkg/target.py", k=10)
+
+    assert second == expected
+
 def test_call_graph_content_must_match_manifest_hash(tmp_path):
     manifest, call_graph, _ = _write_bundle(tmp_path)
     assert find_references(manifest, "target")["status"] == "available"
@@ -487,7 +509,10 @@ def test_find_references_returns_bounded_s0_and_s1_evidence(tmp_path):
 
 
 def test_get_callers_fails_closed_when_target_name_is_ambiguous(tmp_path):
-    result = get_callers(_bundle(tmp_path), "target", k=10)
+    manifest = _bundle(tmp_path)
+    result = get_callers(manifest, "target", k=10)
+    expected = json.loads(json.dumps(result))
+
     assert result["status"] == "invalid"
     assert result["error_code"] == "symbol_ambiguous"
     assert [item["path"] for item in result["target_candidates"]] == [
@@ -495,6 +520,11 @@ def test_get_callers_fails_closed_when_target_name_is_ambiguous(tmp_path):
         "pkg/target.py",
     ]
     assert result["callers"] == []
+
+    result["symbol_index"]["sha256"] = "mutated"
+    result["target_candidates"][0]["decorators"].append("mutated")
+
+    assert get_callers(manifest, "target", k=10) == expected
 
 
 def test_get_callers_uses_target_identity_and_separates_textual_matches(tmp_path):

--- a/merger/lenskit/tests/test_repobrief_call_navigation.py
+++ b/merger/lenskit/tests/test_repobrief_call_navigation.py
@@ -775,3 +775,61 @@ def test_navigation_rejects_call_range_that_disagrees_with_source_fields(tmp_pat
 
     assert result["status"] == "invalid"
     assert result["error_code"] == "python_call_graph_call_record_invalid"
+
+def test_call_graph_change_during_index_build_fails_closed(tmp_path, monkeypatch):
+    manifest, call_graph, _ = _write_bundle(tmp_path)
+    from merger.lenskit.core.call_navigation_index import CallNavigationIndex
+
+    original_build = CallNavigationIndex.build
+
+    def tampered_build(calls):
+        payload = json.loads(call_graph.read_text(encoding="utf-8"))
+        payload["calls"][0]["simple_name"] = "tampered"
+        call_graph.write_text(json.dumps(payload), encoding="utf-8")
+        return original_build(calls)
+
+    monkeypatch.setattr(CallNavigationIndex, "build", tampered_build)
+
+    result = find_references(manifest, "target")
+    assert result["status"] == "invalid"
+    assert result["error_code"] == "python_call_graph_source_changed_during_load"
+
+
+def test_symbol_index_change_during_index_build_fails_closed(tmp_path, monkeypatch):
+    manifest, _, symbol_index = _write_bundle(tmp_path)
+    from merger.lenskit.core.call_navigation_index import SymbolNavigationIndex
+
+    original_build = SymbolNavigationIndex.build
+
+    def tampered_build(symbols):
+        payload = json.loads(symbol_index.read_text(encoding="utf-8"))
+        payload["symbols"][0]["name"] = "tampered"
+        symbol_index.write_text(json.dumps(payload), encoding="utf-8")
+        return original_build(symbols)
+
+    monkeypatch.setattr(SymbolNavigationIndex, "build", tampered_build)
+
+    result = get_callers(manifest, "target", path="pkg/target.py")
+    assert result["status"] == "invalid"
+    assert result["error_code"] == "python_symbol_index_source_changed_during_load"
+
+
+def test_call_graph_change_during_symbol_index_build_fails_closed(
+    tmp_path, monkeypatch
+):
+    manifest, call_graph, _ = _write_bundle(tmp_path)
+    from merger.lenskit.core.call_navigation_index import SymbolNavigationIndex
+
+    original_build = SymbolNavigationIndex.build
+
+    def tampered_build(symbols):
+        payload = json.loads(call_graph.read_text(encoding="utf-8"))
+        payload["calls"][0]["simple_name"] = "tampered"
+        call_graph.write_text(json.dumps(payload), encoding="utf-8")
+        return original_build(symbols)
+
+    monkeypatch.setattr(SymbolNavigationIndex, "build", tampered_build)
+
+    result = get_callers(manifest, "target", path="pkg/target.py")
+    assert result["status"] == "invalid"
+    assert result["error_code"] == "python_call_graph_source_changed_during_load"

--- a/merger/lenskit/tests/test_repobrief_call_navigation.py
+++ b/merger/lenskit/tests/test_repobrief_call_navigation.py
@@ -1,6 +1,7 @@
 """Bounded read-only RepoBrief call navigation over coherent v1 artifacts."""
 import hashlib
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -20,6 +21,13 @@ HELPER_ID = "py:pkg:helper.py:function:helper"
 CALLER_ONE_ID = "py:pkg:a.py:function:caller_one"
 CALLER_TWO_ID = "py:pkg:b.py:function:caller_two"
 OTHER_CALLER_ID = "py:pkg:c.py:function:other_caller"
+
+
+@pytest.fixture(autouse=True)
+def _reset_call_navigation_caches():
+    repobrief_access._clear_call_navigation_caches()
+    yield
+    repobrief_access._clear_call_navigation_caches()
 
 
 def _sha(path: Path) -> str:
@@ -294,6 +302,175 @@ def _refresh_manifest_artifact(manifest: Path, role: str, artifact: Path) -> Non
     record["bytes"] = artifact.stat().st_size
     record["sha256"] = _sha(artifact)
     manifest.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_navigation_cache_reuses_validated_call_state(tmp_path, monkeypatch):
+    manifest = _bundle(tmp_path)
+    original = repobrief_access._load_call_graph
+    calls = 0
+
+    def counted(manifest_path):
+        nonlocal calls
+        calls += 1
+        return original(manifest_path)
+
+    monkeypatch.setattr(repobrief_access, "_load_call_graph", counted)
+
+    cold = find_references(manifest, "target", k=10)
+    warm = find_references(manifest, "target", k=10)
+
+    assert cold == warm
+    assert calls == 1
+    assert len(repobrief_access._CALL_NAVIGATION_CACHE) == 1
+
+
+def test_call_graph_content_must_match_manifest_hash(tmp_path):
+    manifest, call_graph, _ = _write_bundle(tmp_path)
+    assert find_references(manifest, "target")["status"] == "available"
+    repobrief_access._clear_call_navigation_caches()
+
+    payload = json.loads(call_graph.read_text(encoding="utf-8"))
+    payload["calls"][0]["simple_name"] = "tampered"
+    call_graph.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = find_references(manifest, "target")
+
+    assert result["status"] == "invalid"
+    assert result["error_code"] in {
+        "python_call_graph_json_bytes_mismatch",
+        "python_call_graph_json_sha256_mismatch",
+    }
+
+
+def test_symbol_index_content_must_match_manifest_hash(tmp_path):
+    manifest, _, symbol_index = _write_bundle(tmp_path)
+    assert get_callers(
+        manifest, "target", path="pkg/target.py"
+    )["status"] == "available"
+    repobrief_access._clear_call_navigation_caches()
+
+    payload = json.loads(symbol_index.read_text(encoding="utf-8"))
+    payload["symbols"][0]["name"] = "tampered"
+    symbol_index.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = get_callers(manifest, "target", path="pkg/target.py")
+
+    assert result["status"] == "invalid"
+    assert result["error_code"] in {
+        "python_symbol_index_json_bytes_mismatch",
+        "python_symbol_index_json_sha256_mismatch",
+    }
+
+
+def test_cache_detects_same_size_change_with_restored_mtime(tmp_path):
+    manifest, call_graph, _ = _write_bundle(tmp_path)
+    assert find_references(manifest, "target")["status"] == "available"
+    before = call_graph.stat()
+    raw = call_graph.read_bytes()
+    tampered = raw.replace(b"target", b"tamper", 1)
+    assert len(tampered) == len(raw)
+
+    call_graph.write_bytes(tampered)
+    os.utime(call_graph, ns=(before.st_atime_ns, before.st_mtime_ns))
+    after = call_graph.stat()
+    assert after.st_size == before.st_size
+    assert after.st_mtime_ns == before.st_mtime_ns
+    assert after.st_ctime_ns != before.st_ctime_ns
+
+    result = find_references(manifest, "target")
+
+    assert result["status"] == "invalid"
+    assert result["error_code"] == "python_call_graph_json_sha256_mismatch"
+
+
+def test_call_graph_change_invalidates_cached_navigation_state(tmp_path, monkeypatch):
+    manifest, call_graph, _ = _write_bundle(tmp_path)
+    original = repobrief_access._load_call_graph
+    loads = 0
+
+    def counted(manifest_path):
+        nonlocal loads
+        loads += 1
+        return original(manifest_path)
+
+    monkeypatch.setattr(repobrief_access, "_load_call_graph", counted)
+    before = find_references(manifest, "target", k=10)
+
+    payload = json.loads(call_graph.read_text(encoding="utf-8"))
+    payload["calls"][0]["simple_name"] = "renamed"
+    payload["calls"][0]["callee_expression"] = "renamed"
+    call_graph.write_text(json.dumps(payload), encoding="utf-8")
+    _refresh_manifest_artifact(manifest, "python_call_graph_json", call_graph)
+
+    after = find_references(manifest, "target", k=10)
+
+    assert before["total_match_count"] == 4
+    assert after["total_match_count"] == 3
+    assert loads == 2
+
+
+def test_symbol_change_invalidates_cached_symbol_state(tmp_path, monkeypatch):
+    manifest, _, symbol_index = _write_bundle(tmp_path)
+    original = repobrief_access._load_symbol_index
+    loads = 0
+
+    def counted(manifest_path):
+        nonlocal loads
+        loads += 1
+        return original(manifest_path)
+
+    monkeypatch.setattr(repobrief_access, "_load_symbol_index", counted)
+    before = get_callers(manifest, "target", path="pkg/target.py", k=10)
+
+    payload = json.loads(symbol_index.read_text(encoding="utf-8"))
+    payload["symbols"][0]["name"] = "renamed"
+    payload["symbols"][0]["qualified_name"] = "renamed"
+    symbol_index.write_text(json.dumps(payload), encoding="utf-8")
+    _refresh_manifest_artifact(manifest, "python_symbol_index_json", symbol_index)
+
+    after = get_callers(manifest, "target", path="pkg/target.py", k=10)
+
+    assert before["status"] == "available"
+    assert after["status"] == "missing"
+    assert after["error_code"] == "symbol_not_found"
+    assert loads == 2
+
+
+def test_cold_and_warm_navigation_results_are_byte_equivalent(tmp_path):
+    manifest = _bundle(tmp_path)
+    queries = (
+        (find_references, (manifest, "target"), {"k": 3}),
+        (
+            get_callers,
+            (manifest, "target"),
+            {"path": "pkg/target.py", "k": 3},
+        ),
+        (
+            get_callees,
+            (manifest, "caller_one"),
+            {"path": "pkg/a.py", "k": 3},
+        ),
+    )
+
+    for reader, args, kwargs in queries:
+        repobrief_access._clear_call_navigation_caches()
+        cold = json.dumps(reader(*args, **kwargs), sort_keys=True, separators=(",", ":"))
+        warm = json.dumps(reader(*args, **kwargs), sort_keys=True, separators=(",", ":"))
+        assert cold == warm
+
+
+def test_navigation_cache_is_lru_bounded(tmp_path):
+    manifests = []
+    for index in range(repobrief_access._CALL_NAVIGATION_CACHE_MAX_ENTRIES + 1):
+        bundle_dir = tmp_path / f"bundle-{index}"
+        bundle_dir.mkdir()
+        manifest = _bundle(bundle_dir)
+        manifests.append(str(manifest.resolve()))
+        assert find_references(manifest, "target")["status"] == "available"
+
+    assert len(repobrief_access._CALL_NAVIGATION_CACHE) == 2
+    assert manifests[0] not in repobrief_access._CALL_NAVIGATION_CACHE
+    assert manifests[-1] in repobrief_access._CALL_NAVIGATION_CACHE
 
 
 def test_find_references_returns_bounded_s0_and_s1_evidence(tmp_path):


### PR DESCRIPTION
## Zusammenfassung

- ersetzt wiederholte lineare Scans für `find_references`, `get_callers` und `get_callees` durch deterministische, prozesslokale Indizes
- bindet Cache-Einträge an Manifestinhalt, Artefaktidentität, deklarierte Prüfsumme/Bytezahl und Dateimetadaten
- verwirft den Aufbau fail-closed, wenn Call-Graph oder Symbolindex während Laden oder Indexbau wechseln
- trennt alle veränderbaren öffentlichen Listen, Wörterbücher und Artefaktmetadaten vom internen Cachezustand
- vergleicht linearen Scan, In-Memory-Index und persistierten Sidecar bei 50.000 synthetischen sowie 54.771 realen Call-Stellen
- wählt den In-Memory-Index; ein persistierter Sidecar wird wegen zusätzlicher Bundle-Größe ohne relevanten Warmzugriffsvorteil nicht eingeführt

## Gemessener Nutzen

- reale wiederholte Navigation: ca. 22,58× schneller als linear
- synthetische 50.000-Call-Stufe: ca. 13,91× schneller als linear
- kalte und warme öffentliche Antworten sind bytegleich
- Messartefakt SHA-256: `ddd3b7e3a25d829683d0c75ca8f9f3020463fba9ce90a034db6b7f977b31e5d9`

## Verifikation

- `4137 passed, 1 skipped, 13 deselected`
- Repo-weites Ruff-Gate: PASS
- Graph-/Maintainability-Ratchet: PASS; 0 neue und 1 aufgelöste C901-Stelle
- fokussierte Navigationssuite: `40 passed`
- öffentliche Cache-Isolation auf Erfolgs- und Mehrdeutigkeitsfehlerpfad getestet
- `git diff --check`: PASS

## Grenzen

- keine Aussage über vollständige statische oder dynamische Call-Graph-Auflösung
- keine persistierte zweite Wahrheitsquelle
- Cache ist auf zwei Bundles begrenzt und bleibt rein abgeleitet

Bureau: `RPU-V1-T029`
