### PR TITLE
style(repobrief): format new call-navigation modules

### DIFF
--- a/merger/lenskit/core/call_navigation_index.py
+++ b/merger/lenskit/core/call_navigation_index.py
@@ -20,7 +20,9 @@ CallerIdentity = tuple[str | None, str, str | None, str | None, int | None, int 
 def _freeze_postings(
     values: Mapping[Any, list[int]],
 ) -> Mapping[Any, tuple[int, ...]]:
-    return MappingProxyType({key: tuple(positions) for key, positions in values.items()})
+    return MappingProxyType(
+        {key: tuple(positions) for key, positions in values.items()}
+    )
 
 
 def _trigrams(value: str) -> frozenset[str]:
@@ -59,9 +61,7 @@ def _call_position_key(call: CallRow) -> tuple[str, int, int]:
     )
 
 
-def _validated_positions(
-    value: Any, *, call_count: int, label: str
-) -> tuple[int, ...]:
+def _validated_positions(value: Any, *, call_count: int, label: str) -> tuple[int, ...]:
     if not isinstance(value, list):
         raise ValueError(f"persisted call navigation index {label} is invalid")
     positions = tuple(value)
@@ -89,9 +89,7 @@ def _persisted_postings(
     result: dict[str, tuple[int, ...]] = {}
     for key, positions in raw.items():
         if not isinstance(key, str):
-            raise ValueError(
-                f"persisted call navigation index {field} key is invalid"
-            )
+            raise ValueError(f"persisted call navigation index {field} key is invalid")
         result[key] = _validated_positions(
             positions,
             call_count=call_count,
@@ -221,7 +219,9 @@ class CallNavigationIndex:
         trigrams = _trigrams(query)
         if not trigrams:
             return set(range(len(self.calls)))
-        postings = [self.expression_trigram_positions.get(item, ()) for item in trigrams]
+        postings = [
+            self.expression_trigram_positions.get(item, ()) for item in trigrams
+        ]
         if not postings or any(not positions for positions in postings):
             return set()
         smallest, *remaining = sorted(postings, key=len)
@@ -260,7 +260,9 @@ class CallNavigationIndex:
 
     def calls_for_symbol(self, symbol: SymbolRow) -> list[CallRow]:
         identity = caller_identity_from_symbol(symbol)
-        return [self.calls[position] for position in self.caller_positions.get(identity, ())]
+        return [
+            self.calls[position] for position in self.caller_positions.get(identity, ())
+        ]
 
     def persisted_projection(self, source_calls_sha256: str) -> dict[str, Any]:
         """Create the deterministic sidecar candidate used only by the benchmark."""
@@ -272,7 +274,9 @@ class CallNavigationIndex:
             {"identity": list(key), "positions": list(self.caller_positions[key])}
             for key in sorted(
                 self.caller_positions,
-                key=lambda item: tuple("" if value is None else str(value) for value in item),
+                key=lambda item: tuple(
+                    "" if value is None else str(value) for value in item
+                ),
             )
         ]
         return {
@@ -324,7 +328,10 @@ class SymbolNavigationIndex:
         matches = []
         for position in self.exact_query_positions.get(query, ()):
             symbol = self.symbols[position]
-            if path_filter and path_filter not in str(symbol.get("path", "")).casefold():
+            if (
+                path_filter
+                and path_filter not in str(symbol.get("path", "")).casefold()
+            ):
                 continue
             matches.append(symbol)
         return sorted(

--- a/merger/lenskit/scripts/bench_call_navigation.py
+++ b/merger/lenskit/scripts/bench_call_navigation.py
@@ -165,7 +165,10 @@ def _query_set(calls: Sequence[dict[str, Any]], limit: int = 20) -> dict[str, An
         if call.get("simple_name")
     )
     references = [
-        name for name, _ in sorted(name_counts.items(), key=lambda item: (-item[1], item[0]))[:limit]
+        name
+        for name, _ in sorted(
+            name_counts.items(), key=lambda item: (-item[1], item[0])
+        )[:limit]
     ]
 
     targets: dict[tuple[str, str], None] = {}
@@ -325,7 +328,9 @@ def benchmark_tier(
     }
 
 
-def _count(calls: Sequence[dict[str, Any]], field: str, keys: Sequence[str]) -> dict[str, int]:
+def _count(
+    calls: Sequence[dict[str, Any]], field: str, keys: Sequence[str]
+) -> dict[str, int]:
     result = {key: 0 for key in keys}
     for call in calls:
         result[str(call[field])] += 1
@@ -509,7 +514,9 @@ def run_benchmark(
     skipped_files_count = None
     skipped_errors: list[str] = []
     if include_real_repo:
-        real_calls, skipped_files_count, skipped_errors = extract_python_calls(repo_path)
+        real_calls, skipped_files_count, skipped_errors = extract_python_calls(
+            repo_path
+        )
         tiers.append(
             benchmark_tier(
                 real_calls,
@@ -518,9 +525,7 @@ def run_benchmark(
                 cold_repetitions=cold_repetitions,
             )
         )
-    equivalence_pass = all(
-        tier["equivalence"]["byte_equivalent"] for tier in tiers
-    )
+    equivalence_pass = all(tier["equivalence"]["byte_equivalent"] for tier in tiers)
     report = {
         "kind": "repobrief.call_navigation_scale_benchmark",
         "version": "1.0",
@@ -572,7 +577,9 @@ def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo", default=".")
     parser.add_argument("--output")
-    parser.add_argument("--synthetic-call-count", type=int, default=DEFAULT_SYNTHETIC_CALL_COUNT)
+    parser.add_argument(
+        "--synthetic-call-count", type=int, default=DEFAULT_SYNTHETIC_CALL_COUNT
+    )
     parser.add_argument("--query-repetitions", type=int, default=7)
     parser.add_argument("--cold-repetitions", type=int, default=3)
     parser.add_argument("--mcp-repetitions", type=int, default=10)
@@ -582,12 +589,15 @@ def _parser() -> argparse.ArgumentParser:
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parser().parse_args(argv)
-    if min(
-        args.synthetic_call_count,
-        args.query_repetitions,
-        args.cold_repetitions,
-        args.mcp_repetitions,
-    ) < 1:
+    if (
+        min(
+            args.synthetic_call_count,
+            args.query_repetitions,
+            args.cold_repetitions,
+            args.mcp_repetitions,
+        )
+        < 1
+    ):
         raise SystemExit("benchmark counts must be positive")
     report = run_benchmark(
         args.repo,

--- a/merger/lenskit/tests/test_bench_call_navigation.py
+++ b/merger/lenskit/tests/test_bench_call_navigation.py
@@ -54,9 +54,10 @@ def test_small_benchmark_proves_equivalence_and_reports_all_candidates(tmp_path)
     assert tier["equivalence"]["byte_equivalent"] is True
     assert tier["linear_scan"]["bundle_bytes"] > 0
     assert tier["process_local_index"]["build_retained_bytes"] > 0
-    assert tier["process_local_index"]["build_peak_bytes"] >= tier[
-        "process_local_index"
-    ]["build_retained_bytes"]
+    assert (
+        tier["process_local_index"]["build_peak_bytes"]
+        >= tier["process_local_index"]["build_retained_bytes"]
+    )
     assert tier["persisted_sidecar"]["sidecar_bytes"] > 0
     assert tier["persisted_sidecar"]["source_hash_bound"] is True
 
@@ -70,10 +71,7 @@ def test_committed_measurement_and_proof_are_consistent():
         / "repobrief-call-navigation-scale-index-v1.measurement.json"
     )
     proof_path = (
-        root
-        / "docs"
-        / "proofs"
-        / "repobrief-call-navigation-scale-index-v1-proof.md"
+        root / "docs" / "proofs" / "repobrief-call-navigation-scale-index-v1-proof.md"
     )
     raw = measurement_path.read_bytes()
     measurement = json.loads(raw)
@@ -87,8 +85,7 @@ def test_committed_measurement_and_proof_are_consistent():
     assert measurement["decision"]["cache_max_entries"] == 2
     assert measurement["mcp"]["cold_warm_byte_equivalent"] is True
     assert all(
-        tier["equivalence"]["byte_equivalent"] is True
-        for tier in measurement["tiers"]
+        tier["equivalence"]["byte_equivalent"] is True for tier in measurement["tiers"]
     )
     assert all(
         tier["process_local_index"]["warm_query_batch"]["median_ms"]

--- a/merger/lenskit/tests/test_call_navigation_index.py
+++ b/merger/lenskit/tests/test_call_navigation_index.py
@@ -22,11 +22,7 @@ def _call(position: int) -> dict:
     status = ("resolved", "candidate", "unresolved")[position % 3]
     target_id = f"py:pkg:t{target}.py:function:target_{target}"
     simple_name = f"target_{target}"
-    expression = (
-        simple_name
-        if position % 5
-        else f"registry.handlers.{simple_name}"
-    )
+    expression = simple_name if position % 5 else f"registry.handlers.{simple_name}"
     return {
         "path": f"pkg/c{caller}.py",
         "start_line": position // 47 + 1,
@@ -99,9 +95,7 @@ def test_symbol_index_preserves_exact_selection_and_duplicate_order():
         "other/c1.py",
         "pkg/c1.py",
     ]
-    assert [row["path"] for row in index.select("caller_1", "pkg/")] == [
-        "pkg/c1.py"
-    ]
+    assert [row["path"] for row in index.select("caller_1", "pkg/")] == ["pkg/c1.py"]
     assert index.select("missing", None) == []
 
 
@@ -128,9 +122,7 @@ def test_persisted_candidate_reconstructs_equivalent_index_and_rejects_wrong_sou
     assert restored.reference_calls("target_7") == original.reference_calls("target_7")
     assert restored.target_related_calls(
         "py:pkg:t7.py:function:target_7", "target_7"
-    ) == original.target_related_calls(
-        "py:pkg:t7.py:function:target_7", "target_7"
-    )
+    ) == original.target_related_calls("py:pkg:t7.py:function:target_7", "target_7")
     with pytest.raises(ValueError, match="source binding mismatch"):
         CallNavigationIndex.from_persisted_projection(calls, projection, "0" * 64)
 


### PR DESCRIPTION
## Zweck

Formatiert ausschließlich die vier in #1022 neu angelegten Python-Dateien mit Ruff. Es gibt keine fachliche oder API-seitige Änderung.

## Hintergrund

PR #1022 wurde bereits mit dem inhaltlich geprüften Head gemergt. Die nachlaufende Formatkorrektur entstand erst danach und war daher nicht Teil des Squash-Merges. Die zwei bereits auf `main` vorhandenen, historisch nicht vollständig Ruff-formatierten Altdateien werden bewusst nicht großflächig verändert.

## Verifikation

- Ruff format --check: 4 Dateien bestanden
- Ruff check: bestanden
- AST-Gleichheit vor/nach Formatierung: 4 Dateien bestanden
- fokussierte Call-Navigation-Tests: 40 bestanden
- sämtliche RepoBrief-Tests: 463 bestanden
- git diff --check: bestanden
