### PR TITLE
fix(repobrief): preserve hardened cache performance

### DIFF
--- a/merger/lenskit/core/repobrief_access.py
+++ b/merger/lenskit/core/repobrief_access.py
@@ -1482,6 +1482,23 @@ def _strict_source_hash_enabled() -> bool:
     }
 
 
+def _read_stable_artifact_bytes(
+    artifact_path: Path,
+) -> tuple[bytes | None, os.stat_result | None, str | None, str | None]:
+    try:
+        with artifact_path.open("rb") as stream:
+            stat_before = os.fstat(stream.fileno())
+            raw = stream.read()
+            stat_after = os.fstat(stream.fileno())
+    except FileNotFoundError:
+        return None, None, "file_missing", None
+    except OSError as exc:
+        return None, None, "unreadable", str(exc)
+    if _file_identity(stat_before) != _file_identity(stat_after):
+        return None, None, "source_changed", None
+    return raw, stat_after, None, None
+
+
 def _read_registered_artifact_source(
     manifest_path: Path, role: str
 ) -> tuple[
@@ -1512,17 +1529,10 @@ def _read_registered_artifact_source(
     )
     if artifact_path is None:
         return None, artifact, "missing", None
-    try:
-        with artifact_path.open("rb") as stream:
-            stat_before = os.fstat(stream.fileno())
-            raw = stream.read()
-            stat_after = os.fstat(stream.fileno())
-    except FileNotFoundError:
-        return None, artifact, "file_missing", None
-    except OSError as exc:
-        return None, artifact, "unreadable", str(exc)
-    if _file_identity(stat_before) != _file_identity(stat_after):
-        return None, artifact, "source_changed", None
+    raw, artifact_stat, failure, detail = _read_stable_artifact_bytes(artifact_path)
+    if failure is not None:
+        return None, artifact, failure, detail
+    assert raw is not None and artifact_stat is not None
     declared_bytes = artifact_payload.get("bytes")
     if (
         isinstance(declared_bytes, int)
@@ -1540,11 +1550,11 @@ def _read_registered_artifact_source(
         role=role,
         absolute_path=str(artifact_path),
         artifact_sha256=actual_sha256,
-        device=stat_after.st_dev,
-        inode=stat_after.st_ino,
-        size=stat_after.st_size,
-        mtime_ns=stat_after.st_mtime_ns,
-        ctime_ns=stat_after.st_ctime_ns,
+        device=artifact_stat.st_dev,
+        inode=artifact_stat.st_ino,
+        size=artifact_stat.st_size,
+        mtime_ns=artifact_stat.st_mtime_ns,
+        ctime_ns=artifact_stat.st_ctime_ns,
     )
     return (
         _LoadedArtifactSource(

--- a/merger/lenskit/core/repobrief_access.py
+++ b/merger/lenskit/core/repobrief_access.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
 from collections import OrderedDict
 from dataclasses import dataclass
@@ -1236,6 +1237,12 @@ def _load_symbol_index_source(
             "error_code": "python_symbol_index_json_sha256_mismatch",
             "error": "python_symbol_index_json content hash does not match the bundle manifest",
         }
+    if failure == "source_changed":
+        return None, artifact, None, {
+            "status": "invalid",
+            "error_code": "python_symbol_index_source_changed_during_load",
+            "error": "python_symbol_index_json source changed while navigation state was loading",
+        }
     if source is None:
         return None, artifact, None, {
             "status": "invalid",
@@ -1395,6 +1402,7 @@ _CALL_NAV_DOES_NOT_ESTABLISH = tuple(
     dict.fromkeys([*_DOES_NOT_ESTABLISH, *_CALL_GRAPH_DOES_NOT_ESTABLISH])
 )
 _CALL_NAVIGATION_CACHE_MAX_ENTRIES = 2
+_CALL_NAVIGATION_STRICT_SOURCE_HASH_ENV = "LENSKIT_REPOBRIEF_STRICT_CACHE_HASH"
 
 
 @dataclass(frozen=True, slots=True)
@@ -1404,6 +1412,11 @@ class _ArtifactSourceFingerprint:
     role: str
     absolute_path: str
     artifact_sha256: str
+    device: int
+    inode: int
+    size: int
+    mtime_ns: int
+    ctime_ns: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -1450,6 +1463,25 @@ def _clear_call_navigation_caches() -> None:
         _SYMBOL_NAVIGATION_CACHE.clear()
 
 
+def _file_identity(stat_result: os.stat_result) -> tuple[int, int, int, int, int]:
+    return (
+        stat_result.st_dev,
+        stat_result.st_ino,
+        stat_result.st_size,
+        stat_result.st_mtime_ns,
+        stat_result.st_ctime_ns,
+    )
+
+
+def _strict_source_hash_enabled() -> bool:
+    return os.environ.get(_CALL_NAVIGATION_STRICT_SOURCE_HASH_ENV, "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
 def _read_registered_artifact_source(
     manifest_path: Path, role: str
 ) -> tuple[
@@ -1480,12 +1512,17 @@ def _read_registered_artifact_source(
     )
     if artifact_path is None:
         return None, artifact, "missing", None
-    if not artifact_path.exists():
-        return None, artifact, "file_missing", None
     try:
-        raw = artifact_path.read_bytes()
+        with artifact_path.open("rb") as stream:
+            stat_before = os.fstat(stream.fileno())
+            raw = stream.read()
+            stat_after = os.fstat(stream.fileno())
+    except FileNotFoundError:
+        return None, artifact, "file_missing", None
     except OSError as exc:
         return None, artifact, "unreadable", str(exc)
+    if _file_identity(stat_before) != _file_identity(stat_after):
+        return None, artifact, "source_changed", None
     declared_bytes = artifact_payload.get("bytes")
     if (
         isinstance(declared_bytes, int)
@@ -1503,6 +1540,11 @@ def _read_registered_artifact_source(
         role=role,
         absolute_path=str(artifact_path),
         artifact_sha256=actual_sha256,
+        device=stat_after.st_dev,
+        inode=stat_after.st_ino,
+        size=stat_after.st_size,
+        mtime_ns=stat_after.st_mtime_ns,
+        ctime_ns=stat_after.st_ctime_ns,
     )
     return (
         _LoadedArtifactSource(
@@ -1526,17 +1568,47 @@ def _artifact_source_fingerprint(
     return source.fingerprint if source is not None else None
 
 
-def _artifact_source_is_current(fingerprint: _ArtifactSourceFingerprint) -> bool:
+def _artifact_source_is_current(
+    fingerprint: _ArtifactSourceFingerprint,
+    *,
+    verify_content: bool = False,
+) -> bool:
+    """Validate one cached generation without reparsing its JSON payload.
+
+    Cold loads and post-build checks always hash the exact artifact bytes. Warm
+    lookups use the manifest hash plus file identity metadata to preserve the
+    index speedup; deployments on filesystems with weak metadata semantics can
+    set ``LENSKIT_REPOBRIEF_STRICT_CACHE_HASH=1`` to hash on every lookup.
+    """
+    manifest_path = Path(fingerprint.manifest_path)
+    artifact_path = Path(fingerprint.absolute_path)
     try:
-        manifest_before = Path(fingerprint.manifest_path).read_bytes()
+        manifest_before = manifest_path.read_bytes()
         if hashlib.sha256(manifest_before).hexdigest() != fingerprint.manifest_sha256:
             return False
-        artifact_bytes = Path(fingerprint.absolute_path).read_bytes()
-        manifest_after = Path(fingerprint.manifest_path).read_bytes()
+        stat_before = artifact_path.stat()
+    except OSError:
+        return False
+    expected_identity = (
+        fingerprint.device,
+        fingerprint.inode,
+        fingerprint.size,
+        fingerprint.mtime_ns,
+        fingerprint.ctime_ns,
+    )
+    if _file_identity(stat_before) != expected_identity:
+        return False
+    if not verify_content and not _strict_source_hash_enabled():
+        return True
+    try:
+        artifact_bytes = artifact_path.read_bytes()
+        stat_after = artifact_path.stat()
+        manifest_after = manifest_path.read_bytes()
     except OSError:
         return False
     return (
-        hashlib.sha256(artifact_bytes).hexdigest() == fingerprint.artifact_sha256
+        _file_identity(stat_after) == expected_identity
+        and hashlib.sha256(artifact_bytes).hexdigest() == fingerprint.artifact_sha256
         and hashlib.sha256(manifest_after).hexdigest() == fingerprint.manifest_sha256
     )
 
@@ -1738,6 +1810,11 @@ def _read_call_graph_source(
         return None, artifact, None, _call_graph_error(
             "python_call_graph_json_sha256_mismatch",
             "python_call_graph_json content hash does not match the bundle manifest",
+        )
+    if failure == "source_changed":
+        return None, artifact, None, _call_graph_error(
+            "python_call_graph_source_changed_during_load",
+            "python_call_graph_json source changed while navigation state was loading",
         )
     if source is None:
         return None, artifact, None, _call_graph_error(
@@ -1992,7 +2069,7 @@ def _load_call_navigation_state(
         return None, artifact, error
     assert data is not None and source is not None
     index = CallNavigationIndex.build(data["calls"])
-    if not _artifact_source_is_current(source.fingerprint):
+    if not _artifact_source_is_current(source.fingerprint, verify_content=True):
         return None, artifact, _call_graph_error(
             "python_call_graph_source_changed_during_load",
             "python_call_graph_json source changed while navigation state was loading",
@@ -2033,12 +2110,14 @@ def _load_symbol_navigation_state(
     if error is not None:
         return None, symbol_artifact, error
     index = SymbolNavigationIndex.build(symbols)
-    if not _artifact_source_is_current(source.fingerprint):
+    if not _artifact_source_is_current(source.fingerprint, verify_content=True):
         return None, symbol_artifact, _call_graph_error(
             "python_symbol_index_source_changed_during_load",
             "python_symbol_index_json source changed while navigation state was loading",
         )
-    if not _artifact_source_is_current(call_state.fingerprint):
+    if not _artifact_source_is_current(
+        call_state.fingerprint, verify_content=True
+    ):
         return None, symbol_artifact, _call_graph_error(
             "python_call_graph_source_changed_during_load",
             "python_call_graph_json source changed while navigation state was loading",

--- a/merger/lenskit/tests/test_repobrief_call_navigation.py
+++ b/merger/lenskit/tests/test_repobrief_call_navigation.py
@@ -969,3 +969,46 @@ def test_parallel_navigation_is_isolated_for_same_and_different_bundles(tmp_path
     assert {
         key.manifest_path for key in repobrief_access._CALL_NAVIGATION_CACHE
     } == {str(first.resolve()), str(second.resolve())}
+
+
+def test_warm_navigation_fast_path_does_not_reread_call_graph_bytes(
+    tmp_path, monkeypatch
+):
+    manifest, call_graph, _ = _write_bundle(tmp_path)
+    assert get_callers(manifest, "target", path="pkg/target.py")["status"] == "available"
+
+    original_read_bytes = Path.read_bytes
+    call_graph_path = call_graph.resolve()
+
+    def guarded_read_bytes(path):
+        if path.resolve() == call_graph_path:
+            raise AssertionError("default warm cache hit must not reread call-graph bytes")
+        return original_read_bytes(path)
+
+    monkeypatch.delenv("LENSKIT_REPOBRIEF_STRICT_CACHE_HASH", raising=False)
+    monkeypatch.setattr(Path, "read_bytes", guarded_read_bytes)
+
+    result = get_callers(manifest, "target", path="pkg/target.py")
+    assert result["status"] == "available"
+
+
+def test_strict_navigation_cache_hash_rereads_call_graph_bytes(tmp_path, monkeypatch):
+    manifest, call_graph, _ = _write_bundle(tmp_path)
+    assert get_callers(manifest, "target", path="pkg/target.py")["status"] == "available"
+
+    original_read_bytes = Path.read_bytes
+    call_graph_path = call_graph.resolve()
+    call_graph_reads = 0
+
+    def counting_read_bytes(path):
+        nonlocal call_graph_reads
+        if path.resolve() == call_graph_path:
+            call_graph_reads += 1
+        return original_read_bytes(path)
+
+    monkeypatch.setenv("LENSKIT_REPOBRIEF_STRICT_CACHE_HASH", "1")
+    monkeypatch.setattr(Path, "read_bytes", counting_read_bytes)
+
+    result = get_callers(manifest, "target", path="pkg/target.py")
+    assert result["status"] == "available"
+    assert call_graph_reads >= 1


### PR DESCRIPTION
## Problem

PR #1024 bindet Navigation-Indizes korrekt an die tatsächlich gelesenen Quellbytes. Die erste Umsetzung hat jedoch bei jedem warmen Cachezugriff das vollständige, im Benchmark rund 30 MB große Call-Graph-Artefakt erneut gelesen und gehasht. Dadurch stieg der MCP-Warmmedian von 5,36 ms auf 89,85 ms.

## Änderung

- Kalter Ladevorgang liest über einen offenen Dateideskriptor und prüft Dateidentität vor und nach dem Lesen.
- Der Fingerprint enthält tatsächlichen Inhalts-Hash sowie Device, Inode, Größe, mtime und ctime.
- Nach Call- und Symbol-Indexbau wird weiterhin der vollständige Inhalt erneut gehasht; veränderte Quellen werden nicht gecacht.
- Normale Warmzugriffe prüfen Manifest-Hash und Dateidentität ohne erneutes JSON-Parsing oder Vollhash.
- `LENSKIT_REPOBRIEF_STRICT_CACHE_HASH=1` erzwingt für Dateisysteme mit schwachen Metadaten bei jedem Warmzugriff den vollständigen Inhalts-Hash.
- Zwei Vertragstests sichern Fast- und Strict-Modus.

## Verifikation

- Ruff: bestanden
- fokussierte Call-Navigation-Tests: 42 bestanden
- sämtliche RepoBrief-Tests: 469 bestanden
- 50.000 synthetische Calls, identische Benchmarkparameter:
  - Baseline vor #1024: MCP warm 5,36 ms
  - erster #1024-Stand: MCP warm 89,85 ms
  - dieser Fix: MCP warm 5,39 ms
  - Prozessindex-Warmbatch: 54,43 ms
  - Warm-Speedup gegenüber linearem Scan: 14,04×
- Byteäquivalenz: bestanden
- git diff --check: bestanden

## Sicherheitsgrenze

Der Standard-Warmmodus vertraut auf Manifest-Hash plus Device/Inode/Größe/mtime/ctime. Gegen Umgebungen, die sämtliche Dateimetadaten kontrolliert fälschen können, ist der Strict-Modus vorgesehen; sein Vollhash pro Zugriff ist bewusst teurer.