### PR TITLE
fix(repobrief): harden cache validation portability

### DIFF
--- a/merger/lenskit/core/repobrief_access.py
+++ b/merger/lenskit/core/repobrief_access.py
@@ -1402,6 +1402,7 @@ _CALL_NAV_DOES_NOT_ESTABLISH = tuple(
     dict.fromkeys([*_DOES_NOT_ESTABLISH, *_CALL_GRAPH_DOES_NOT_ESTABLISH])
 )
 _CALL_NAVIGATION_CACHE_MAX_ENTRIES = 2
+_CALL_NAVIGATION_CACHE_VALIDATION_ENV = "LENSKIT_REPOBRIEF_CACHE_VALIDATION"
 _CALL_NAVIGATION_STRICT_SOURCE_HASH_ENV = "LENSKIT_REPOBRIEF_STRICT_CACHE_HASH"
 
 
@@ -1473,13 +1474,49 @@ def _file_identity(stat_result: os.stat_result) -> tuple[int, int, int, int, int
     )
 
 
-def _strict_source_hash_enabled() -> bool:
-    return os.environ.get(_CALL_NAVIGATION_STRICT_SOURCE_HASH_ENV, "").strip().lower() in {
-        "1",
-        "true",
-        "yes",
-        "on",
-    }
+def _cache_validation_mode() -> str:
+    """Return the explicit cache-validation mode, failing closed on typos."""
+    configured = os.environ.get(
+        _CALL_NAVIGATION_CACHE_VALIDATION_ENV, ""
+    ).strip().lower()
+    if configured in {"auto", "strict"}:
+        return configured
+    if configured:
+        return "strict"
+
+    legacy = os.environ.get(
+        _CALL_NAVIGATION_STRICT_SOURCE_HASH_ENV, ""
+    ).strip().lower()
+    if legacy in {"", "0", "false", "no", "off"}:
+        return "auto"
+    return "strict"
+
+
+def _source_identity_is_strong(
+    fingerprint: _ArtifactSourceFingerprint,
+) -> bool:
+    """Whether metadata can support the fast warm-cache validation path."""
+    return all(
+        value != 0
+        for value in (
+            fingerprint.device,
+            fingerprint.inode,
+            fingerprint.mtime_ns,
+            fingerprint.ctime_ns,
+        )
+    )
+
+
+def _source_content_verification_required(
+    fingerprint: _ArtifactSourceFingerprint,
+    *,
+    verify_content: bool,
+) -> bool:
+    return (
+        verify_content
+        or _cache_validation_mode() == "strict"
+        or not _source_identity_is_strong(fingerprint)
+    )
 
 
 def _read_stable_artifact_bytes(
@@ -1585,20 +1622,15 @@ def _artifact_source_is_current(
 ) -> bool:
     """Validate one cached generation without reparsing its JSON payload.
 
-    Cold loads and post-build checks always hash the exact artifact bytes. Warm
-    lookups use the manifest hash plus file identity metadata to preserve the
-    index speedup; deployments on filesystems with weak metadata semantics can
-    set ``LENSKIT_REPOBRIEF_STRICT_CACHE_HASH=1`` to hash on every lookup.
+    Cold loads and post-build checks always hash bytes read from one pinned file
+    descriptor. Warm lookups use the manifest hash plus strong file identity
+    metadata. ``LENSKIT_REPOBRIEF_CACHE_VALIDATION=strict`` forces a full hash
+    on every lookup; the legacy strict-hash switch remains supported. Weak
+    identities such as zero device or inode values automatically use strict
+    validation.
     """
     manifest_path = Path(fingerprint.manifest_path)
     artifact_path = Path(fingerprint.absolute_path)
-    try:
-        manifest_before = manifest_path.read_bytes()
-        if hashlib.sha256(manifest_before).hexdigest() != fingerprint.manifest_sha256:
-            return False
-        stat_before = artifact_path.stat()
-    except OSError:
-        return False
     expected_identity = (
         fingerprint.device,
         fingerprint.inode,
@@ -1606,22 +1638,37 @@ def _artifact_source_is_current(
         fingerprint.mtime_ns,
         fingerprint.ctime_ns,
     )
-    if _file_identity(stat_before) != expected_identity:
-        return False
-    if not verify_content and not _strict_source_hash_enabled():
-        return True
     try:
-        artifact_bytes = artifact_path.read_bytes()
-        stat_after = artifact_path.stat()
+        manifest_before = manifest_path.read_bytes()
+    except OSError:
+        return False
+    if hashlib.sha256(manifest_before).hexdigest() != fingerprint.manifest_sha256:
+        return False
+
+    requires_content = _source_content_verification_required(
+        fingerprint,
+        verify_content=verify_content,
+    )
+    if not requires_content:
+        try:
+            return _file_identity(artifact_path.stat()) == expected_identity
+        except OSError:
+            return False
+
+    artifact_bytes, artifact_stat, failure, _detail = (
+        _read_stable_artifact_bytes(artifact_path)
+    )
+    if failure is not None or artifact_bytes is None or artifact_stat is None:
+        return False
+    if _file_identity(artifact_stat) != expected_identity:
+        return False
+    if hashlib.sha256(artifact_bytes).hexdigest() != fingerprint.artifact_sha256:
+        return False
+    try:
         manifest_after = manifest_path.read_bytes()
     except OSError:
         return False
-    return (
-        _file_identity(stat_after) == expected_identity
-        and hashlib.sha256(artifact_bytes).hexdigest() == fingerprint.artifact_sha256
-        and hashlib.sha256(manifest_after).hexdigest() == fingerprint.manifest_sha256
-    )
-
+    return hashlib.sha256(manifest_after).hexdigest() == fingerprint.manifest_sha256
 
 def _cache_state(
     cache: OrderedDict[Any, Any], key: Any, state: Any

--- a/merger/lenskit/tests/test_repobrief_call_navigation.py
+++ b/merger/lenskit/tests/test_repobrief_call_navigation.py
@@ -985,6 +985,7 @@ def test_warm_navigation_fast_path_does_not_reread_call_graph_bytes(
             raise AssertionError("default warm cache hit must not reread call-graph bytes")
         return original_read_bytes(path)
 
+    monkeypatch.delenv("LENSKIT_REPOBRIEF_CACHE_VALIDATION", raising=False)
     monkeypatch.delenv("LENSKIT_REPOBRIEF_STRICT_CACHE_HASH", raising=False)
     monkeypatch.setattr(Path, "read_bytes", guarded_read_bytes)
 
@@ -992,22 +993,154 @@ def test_warm_navigation_fast_path_does_not_reread_call_graph_bytes(
     assert result["status"] == "available"
 
 
-def test_strict_navigation_cache_hash_rereads_call_graph_bytes(tmp_path, monkeypatch):
+def test_strict_navigation_cache_hash_uses_descriptor_pinned_read(
+    tmp_path, monkeypatch
+):
     manifest, call_graph, _ = _write_bundle(tmp_path)
     assert get_callers(manifest, "target", path="pkg/target.py")["status"] == "available"
 
-    original_read_bytes = Path.read_bytes
+    original_reader = repobrief_access._read_stable_artifact_bytes
     call_graph_path = call_graph.resolve()
     call_graph_reads = 0
 
-    def counting_read_bytes(path):
+    def counting_reader(path):
         nonlocal call_graph_reads
         if path.resolve() == call_graph_path:
             call_graph_reads += 1
-        return original_read_bytes(path)
+        return original_reader(path)
 
+    monkeypatch.setenv("LENSKIT_REPOBRIEF_CACHE_VALIDATION", "strict")
+    monkeypatch.setattr(
+        repobrief_access, "_read_stable_artifact_bytes", counting_reader
+    )
+
+    result = get_callers(manifest, "target", path="pkg/target.py")
+    assert result["status"] == "available"
+    assert call_graph_reads >= 1
+
+
+def test_invalid_cache_validation_mode_fails_closed_to_strict(
+    tmp_path, monkeypatch
+):
+    manifest, call_graph, _ = _write_bundle(tmp_path)
+    assert get_callers(manifest, "target", path="pkg/target.py")["status"] == "available"
+
+    original_reader = repobrief_access._read_stable_artifact_bytes
+    call_graph_path = call_graph.resolve()
+    call_graph_reads = 0
+
+    def counting_reader(path):
+        nonlocal call_graph_reads
+        if path.resolve() == call_graph_path:
+            call_graph_reads += 1
+        return original_reader(path)
+
+    monkeypatch.setenv("LENSKIT_REPOBRIEF_CACHE_VALIDATION", "typo")
+    monkeypatch.setattr(
+        repobrief_access, "_read_stable_artifact_bytes", counting_reader
+    )
+
+    result = get_callers(manifest, "target", path="pkg/target.py")
+    assert result["status"] == "available"
+    assert call_graph_reads >= 1
+
+
+def test_weak_file_identity_automatically_uses_content_hash(
+    tmp_path, monkeypatch
+):
+    manifest, call_graph, _ = _write_bundle(tmp_path)
+    original_reader = repobrief_access._read_stable_artifact_bytes
+    call_graph_path = call_graph.resolve()
+    call_graph_reads = 0
+
+    class WeakStat:
+        def __init__(self, source):
+            self.st_dev = 0
+            self.st_ino = 0
+            self.st_size = source.st_size
+            self.st_mtime_ns = source.st_mtime_ns
+            self.st_ctime_ns = source.st_ctime_ns
+
+    def weak_identity_reader(path):
+        nonlocal call_graph_reads
+        raw, stat_result, failure, detail = original_reader(path)
+        if path.resolve() == call_graph_path and stat_result is not None:
+            call_graph_reads += 1
+            stat_result = WeakStat(stat_result)
+        return raw, stat_result, failure, detail
+
+    monkeypatch.delenv("LENSKIT_REPOBRIEF_CACHE_VALIDATION", raising=False)
+    monkeypatch.delenv("LENSKIT_REPOBRIEF_STRICT_CACHE_HASH", raising=False)
+    monkeypatch.setattr(
+        repobrief_access,
+        "_read_stable_artifact_bytes",
+        weak_identity_reader,
+    )
+
+    result = get_callers(manifest, "target", path="pkg/target.py")
+    assert result["status"] == "available"
+    reads_after_cold_load = call_graph_reads
+    assert reads_after_cold_load >= 2
+
+    result = get_callers(manifest, "target", path="pkg/target.py")
+    assert result["status"] == "available"
+    assert call_graph_reads > reads_after_cold_load
+
+
+def test_strict_warm_validation_rejects_tampered_bytes_with_same_identity(
+    tmp_path, monkeypatch
+):
+    manifest, call_graph, _ = _write_bundle(tmp_path)
+    assert get_callers(manifest, "target", path="pkg/target.py")["status"] == "available"
+
+    fingerprint = next(
+        key
+        for key in repobrief_access._CALL_NAVIGATION_CACHE
+        if key.absolute_path == str(call_graph.resolve())
+    )
+    original_reader = repobrief_access._read_stable_artifact_bytes
+
+    def tampered_reader(path):
+        raw, stat_result, failure, detail = original_reader(path)
+        if path.resolve() != call_graph.resolve() or raw is None:
+            return raw, stat_result, failure, detail
+        tampered = bytearray(raw)
+        tampered[-2] = ord(" ") if tampered[-2] != ord(" ") else ord("\t")
+        return bytes(tampered), stat_result, failure, detail
+
+    monkeypatch.setattr(
+        repobrief_access,
+        "_read_stable_artifact_bytes",
+        tampered_reader,
+    )
+
+    assert not repobrief_access._artifact_source_is_current(
+        fingerprint,
+        verify_content=True,
+    )
+
+
+def test_legacy_strict_hash_switch_remains_supported(tmp_path, monkeypatch):
+    manifest, call_graph, _ = _write_bundle(tmp_path)
+    assert get_callers(manifest, "target", path="pkg/target.py")["status"] == "available"
+
+    original_reader = repobrief_access._read_stable_artifact_bytes
+    call_graph_path = call_graph.resolve()
+    call_graph_reads = 0
+
+    def counting_reader(path):
+        nonlocal call_graph_reads
+        if path.resolve() == call_graph_path:
+            call_graph_reads += 1
+        return original_reader(path)
+
+    monkeypatch.delenv("LENSKIT_REPOBRIEF_CACHE_VALIDATION", raising=False)
     monkeypatch.setenv("LENSKIT_REPOBRIEF_STRICT_CACHE_HASH", "1")
-    monkeypatch.setattr(Path, "read_bytes", counting_read_bytes)
+    monkeypatch.setattr(
+        repobrief_access,
+        "_read_stable_artifact_bytes",
+        counting_reader,
+    )
 
     result = get_callers(manifest, "target", path="pkg/target.py")
     assert result["status"] == "available"


### PR DESCRIPTION
## Anlass

Eine externe Review beanstandete den TOCTOU- und Portabilitätsvertrag der Call-/Symbol-Navigationscaches. Der zentrale Vorwurf eines fehlenden zweiten `fstat()` beim Kaltladen traf den bestehenden Code nicht: Der Lader öffnet die Datei einmal, prüft den Dateideskriptor vor und nach dem Lesen, hasht die tatsächlich gelesenen Bytes und prüft nach dem Indexbau erneut.

Bestätigt wurden jedoch zwei sinnvolle Härtungen des Warmpfads:

- Strikte Vollhash-Prüfungen sollen denselben descriptorgebundenen Lesevertrag wie das Kaltladen verwenden.
- Dateisysteme mit schwachen Identitätsmerkmalen, insbesondere `st_dev == 0` oder `st_ino == 0`, dürfen nicht auf den schnellen Metadatenpfad vertrauen.

## Änderung

- `LENSKIT_REPOBRIEF_CACHE_VALIDATION=auto|strict` als klar benannter Modus.
- Unbekannte Werte fallen sicher auf `strict` zurück.
- Der bisherige Schalter `LENSKIT_REPOBRIEF_STRICT_CACHE_HASH` bleibt kompatibel.
- `auto` nutzt den schnellen Metadatenpfad nur bei starker Identität.
- Schwache Identitäten wechseln automatisch zur vollständigen SHA-256-Prüfung.
- Strict- und schwache Warmpfade lesen das Artefakt über einen offenen Dateideskriptor mit `fstat()` vor und nach dem Lesen.
- Manifest-Hash wird vor und nach der Vollprüfung kontrolliert.

## Verifikation

- 46 fokussierte Call-Navigation-Tests: bestanden
- 473 RepoBrief-Tests: bestanden
- Ruff: bestanden
- Maintainability-Ratchet: bestanden, 0 neue Verletzungen
- direkter Tampering-Test: veränderte Bytes bei identischer simulierter Dateidentität werden verworfen
- schwache Device-/Inode-Werte erzwingen automatisch Vollhash
- ungültiger Konfigurationswert fällt auf Strict zurück
- Legacy-Schalter bleibt getestet
- 50.000 synthetische Calls:
  - MCP-Warmmedian: 5,44 ms
  - Prozessindex-Warmmedian: 51,88 ms
  - Speedup gegen linearen Scan: 15,42×
  - Byteäquivalenz: bestanden

## Sicherheitsgrenze

Auf Dateisystemen mit starken Metadaten bleibt `auto` schnell. Bei erkennbar schwacher Identität oder explizitem `strict` wird jede warme Verwendung vollständig inhaltsgehasht. Ein Angreifer, der Kernel-Dateideskriptoren, SHA-256 und sämtliche Dateisystemmetadaten kontrolliert, liegt außerhalb des lokalen Dateisystemvertrags.
