### PR TITLE
fix(repobrief): close cache coherence review gaps

### DIFF
--- a/merger/lenskit/core/repobrief_access.py
+++ b/merger/lenskit/core/repobrief_access.py
@@ -1533,6 +1533,12 @@ def _read_stable_artifact_bytes(
         return None, None, "unreadable", str(exc)
     if _file_identity(stat_before) != _file_identity(stat_after):
         return None, None, "source_changed", None
+    try:
+        path_stat_after = artifact_path.stat()
+    except OSError as exc:
+        return None, None, "source_changed", str(exc)
+    if _file_identity(path_stat_after) != _file_identity(stat_after):
+        return None, None, "source_changed", None
     return raw, stat_after, None, None
 
 
@@ -1552,12 +1558,13 @@ def _read_registered_artifact_source(
     if not isinstance(manifest, dict):
         return None, None, "unreadable", "bundle manifest must be a JSON object"
     try:
-        artifact_payload = next(
-            (item for item in _artifact_list(manifest) if item.get("role") == role),
-            None,
-        )
+        artifacts = _artifact_list(manifest)
     except ValueError as exc:
         return None, None, "unreadable", str(exc)
+    artifact_payload = next(
+        (item for item in artifacts if item.get("role") == role),
+        None,
+    )
     if not isinstance(artifact_payload, dict):
         return None, None, "missing", None
     artifact = _artifact_record(manifest_path, artifact_payload)
@@ -1606,13 +1613,31 @@ def _read_registered_artifact_source(
     )
 
 
-def _artifact_source_fingerprint(
-    manifest_path: Path, role: str
-) -> _ArtifactSourceFingerprint | None:
-    source, _artifact, _failure, _detail = _read_registered_artifact_source(
-        manifest_path, role
+def _artifact_content_is_current(
+    fingerprint: _ArtifactSourceFingerprint,
+    manifest_path: Path,
+    artifact_path: Path,
+    expected_identity: tuple[int, int, int, int, int],
+) -> bool:
+    """Verify one generation through pinned bytes and final pathname identity."""
+    artifact_bytes, artifact_stat, failure, _detail = (
+        _read_stable_artifact_bytes(artifact_path)
     )
-    return source.fingerprint if source is not None else None
+    if failure is not None or artifact_bytes is None or artifact_stat is None:
+        return False
+    if _file_identity(artifact_stat) != expected_identity:
+        return False
+    if hashlib.sha256(artifact_bytes).hexdigest() != fingerprint.artifact_sha256:
+        return False
+    try:
+        manifest_after = manifest_path.read_bytes()
+        path_stat_after = artifact_path.stat()
+    except OSError:
+        return False
+    return (
+        hashlib.sha256(manifest_after).hexdigest() == fingerprint.manifest_sha256
+        and _file_identity(path_stat_after) == expected_identity
+    )
 
 
 def _artifact_source_is_current(
@@ -1644,31 +1669,17 @@ def _artifact_source_is_current(
         return False
     if hashlib.sha256(manifest_before).hexdigest() != fingerprint.manifest_sha256:
         return False
-
-    requires_content = _source_content_verification_required(
-        fingerprint,
-        verify_content=verify_content,
-    )
-    if not requires_content:
-        try:
-            return _file_identity(artifact_path.stat()) == expected_identity
-        except OSError:
-            return False
-
-    artifact_bytes, artifact_stat, failure, _detail = (
-        _read_stable_artifact_bytes(artifact_path)
-    )
-    if failure is not None or artifact_bytes is None or artifact_stat is None:
-        return False
-    if _file_identity(artifact_stat) != expected_identity:
-        return False
-    if hashlib.sha256(artifact_bytes).hexdigest() != fingerprint.artifact_sha256:
-        return False
+    if _source_content_verification_required(
+        fingerprint, verify_content=verify_content
+    ):
+        return _artifact_content_is_current(
+            fingerprint, manifest_path, artifact_path, expected_identity
+        )
     try:
-        manifest_after = manifest_path.read_bytes()
+        return _file_identity(artifact_path.stat()) == expected_identity
     except OSError:
         return False
-    return hashlib.sha256(manifest_after).hexdigest() == fingerprint.manifest_sha256
+
 
 def _cache_state(
     cache: OrderedDict[Any, Any], key: Any, state: Any
@@ -1677,6 +1688,34 @@ def _cache_state(
     cache.move_to_end(key)
     while len(cache) > _CALL_NAVIGATION_CACHE_MAX_ENTRIES:
         cache.popitem(last=False)
+
+
+def _evict_call_navigation_state(
+    fingerprint: _ArtifactSourceFingerprint,
+    state: _CallNavigationState,
+) -> None:
+    """Remove one stale call generation and symbol states derived from it."""
+    with _CALL_NAVIGATION_CACHE_LOCK:
+        if _CALL_NAVIGATION_CACHE.get(fingerprint) is not state:
+            return
+        _CALL_NAVIGATION_CACHE.pop(fingerprint, None)
+        stale_symbol_keys = [
+            cache_key
+            for cache_key in _SYMBOL_NAVIGATION_CACHE
+            if cache_key[0] == fingerprint
+        ]
+        for cache_key in stale_symbol_keys:
+            _SYMBOL_NAVIGATION_CACHE.pop(cache_key, None)
+
+
+def _evict_symbol_navigation_state(
+    cache_key: tuple[_ArtifactSourceFingerprint, _ArtifactSourceFingerprint],
+    state: _SymbolNavigationState,
+) -> None:
+    """Remove one stale symbol generation without touching a replacement."""
+    with _CALL_NAVIGATION_CACHE_LOCK:
+        if _SYMBOL_NAVIGATION_CACHE.get(cache_key) is state:
+            _SYMBOL_NAVIGATION_CACHE.pop(cache_key, None)
 
 
 def _cached_call_navigation_state(
@@ -1691,6 +1730,7 @@ def _cached_call_navigation_state(
         ]
     for fingerprint, state in candidates:
         if not _artifact_source_is_current(fingerprint):
+            _evict_call_navigation_state(fingerprint, state)
             continue
         with _CALL_NAVIGATION_CACHE_LOCK:
             if _CALL_NAVIGATION_CACHE.get(fingerprint) is state:
@@ -1712,8 +1752,10 @@ def _cached_symbol_navigation_state(
         ]
     for cache_key, state in candidates:
         if not _artifact_source_is_current(cache_key[1]):
+            _evict_symbol_navigation_state(cache_key, state)
             continue
         if not _artifact_source_is_current(call_state.fingerprint):
+            _evict_call_navigation_state(call_state.fingerprint, call_state)
             return None
         with _CALL_NAVIGATION_CACHE_LOCK:
             if _SYMBOL_NAVIGATION_CACHE.get(cache_key) is state:

--- a/merger/lenskit/tests/test_repobrief_call_navigation.py
+++ b/merger/lenskit/tests/test_repobrief_call_navigation.py
@@ -459,6 +459,55 @@ def test_symbol_change_invalidates_cached_symbol_state(tmp_path, monkeypatch):
     assert loads == 2
 
 
+def test_stale_call_generation_is_evicted_with_dependent_symbol_state(tmp_path):
+    manifest, call_graph, _ = _write_bundle(tmp_path)
+    assert get_callers(
+        manifest, "target", path="pkg/target.py", k=10
+    )["status"] == "available"
+    stale_call_fingerprint = next(iter(repobrief_access._CALL_NAVIGATION_CACHE))
+    assert any(
+        cache_key[0] == stale_call_fingerprint
+        for cache_key in repobrief_access._SYMBOL_NAVIGATION_CACHE
+    )
+
+    payload = json.loads(call_graph.read_text(encoding="utf-8"))
+    payload["calls"][0]["simple_name"] = "renamed"
+    payload["calls"][0]["callee_expression"] = "renamed"
+    call_graph.write_text(json.dumps(payload), encoding="utf-8")
+    _refresh_manifest_artifact(manifest, "python_call_graph_json", call_graph)
+
+    result = get_callers(manifest, "target", path="pkg/target.py", k=10)
+
+    assert result["status"] == "available"
+    assert stale_call_fingerprint not in repobrief_access._CALL_NAVIGATION_CACHE
+    assert not any(
+        cache_key[0] == stale_call_fingerprint
+        for cache_key in repobrief_access._SYMBOL_NAVIGATION_CACHE
+    )
+    assert len(repobrief_access._CALL_NAVIGATION_CACHE) == 1
+    assert len(repobrief_access._SYMBOL_NAVIGATION_CACHE) == 1
+
+
+def test_stale_symbol_generation_is_evicted_before_replacement(tmp_path):
+    manifest, _, symbol_index = _write_bundle(tmp_path)
+    assert get_callers(
+        manifest, "target", path="pkg/target.py", k=10
+    )["status"] == "available"
+    stale_symbol_key = next(iter(repobrief_access._SYMBOL_NAVIGATION_CACHE))
+
+    payload = json.loads(symbol_index.read_text(encoding="utf-8"))
+    target = next(item for item in payload["symbols"] if item["id"] == TARGET_ID)
+    target["decorators"] = ["updated"]
+    symbol_index.write_text(json.dumps(payload), encoding="utf-8")
+    _refresh_manifest_artifact(manifest, "python_symbol_index_json", symbol_index)
+
+    result = get_callers(manifest, "target", path="pkg/target.py", k=10)
+
+    assert result["status"] == "available"
+    assert stale_symbol_key not in repobrief_access._SYMBOL_NAVIGATION_CACHE
+    assert len(repobrief_access._SYMBOL_NAVIGATION_CACHE) == 1
+
+
 def test_cold_and_warm_navigation_results_are_byte_equivalent(tmp_path):
     manifest = _bundle(tmp_path)
     queries = (
@@ -941,8 +990,10 @@ def test_navigation_uses_actual_hash_when_manifest_omits_bytes_and_sha256(tmp_pa
     assert after["status"] == "available"
     assert after["total_match_count"] == 3
     assert after_callers["status"] == "available"
-    assert len(repobrief_access._CALL_NAVIGATION_CACHE) == 2
-    assert len({key.artifact_sha256 for key in repobrief_access._CALL_NAVIGATION_CACHE}) == 2
+    assert len(repobrief_access._CALL_NAVIGATION_CACHE) == 1
+    assert {
+        key.artifact_sha256 for key in repobrief_access._CALL_NAVIGATION_CACHE
+    } == {hashlib.sha256(call_graph.read_bytes()).hexdigest()}
 
 
 def test_parallel_navigation_is_isolated_for_same_and_different_bundles(tmp_path):
@@ -991,6 +1042,35 @@ def test_warm_navigation_fast_path_does_not_reread_call_graph_bytes(
 
     result = get_callers(manifest, "target", path="pkg/target.py")
     assert result["status"] == "available"
+
+
+def test_descriptor_pinned_read_rejects_atomic_path_replacement(
+    tmp_path, monkeypatch
+):
+    artifact = tmp_path / "artifact.json"
+    replacement = tmp_path / "replacement.json"
+    artifact.write_bytes(b"original")
+    replacement.write_bytes(b"replaced")
+    original_stat = Path.stat
+    replaced = False
+
+    def replacing_stat(path, *args, **kwargs):
+        nonlocal replaced
+        if path == artifact and not replaced:
+            replaced = True
+            os.replace(replacement, artifact)
+        return original_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", replacing_stat)
+
+    raw, stat_result, failure, _detail = (
+        repobrief_access._read_stable_artifact_bytes(artifact)
+    )
+
+    assert replaced is True
+    assert raw is None
+    assert stat_result is None
+    assert failure == "source_changed"
 
 
 def test_strict_navigation_cache_hash_uses_descriptor_pinned_read(
@@ -1055,22 +1135,36 @@ def test_weak_file_identity_automatically_uses_content_hash(
 
     class WeakStat:
         def __init__(self, source):
+            self._source = source
             self.st_dev = 0
             self.st_ino = 0
             self.st_size = source.st_size
             self.st_mtime_ns = source.st_mtime_ns
             self.st_ctime_ns = source.st_ctime_ns
 
+        def __getattr__(self, name):
+            return getattr(self._source, name)
+
+    original_fstat = os.fstat
+    original_path_stat = Path.stat
+
+    def weak_fstat(descriptor):
+        return WeakStat(original_fstat(descriptor))
+
+    def weak_path_stat(path, *args, **kwargs):
+        return WeakStat(original_path_stat(path, *args, **kwargs))
+
     def weak_identity_reader(path):
         nonlocal call_graph_reads
         raw, stat_result, failure, detail = original_reader(path)
         if path.resolve() == call_graph_path and stat_result is not None:
             call_graph_reads += 1
-            stat_result = WeakStat(stat_result)
         return raw, stat_result, failure, detail
 
     monkeypatch.delenv("LENSKIT_REPOBRIEF_CACHE_VALIDATION", raising=False)
     monkeypatch.delenv("LENSKIT_REPOBRIEF_STRICT_CACHE_HASH", raising=False)
+    monkeypatch.setattr(os, "fstat", weak_fstat)
+    monkeypatch.setattr(Path, "stat", weak_path_stat)
     monkeypatch.setattr(
         repobrief_access,
         "_read_stable_artifact_bytes",


### PR DESCRIPTION
## Anlass

PR #1026 wurde während der finalen Review gemergt. Dieser lineare Nachlauf schließt drei anschließend bestätigte Restlücken aus der Review zu #1024/#1026, ohne den bereits wiederhergestellten Warm-Fast-Path zu verändern.

## Änderungen

- Atomare Pathname-Ersetzung nach einem descriptorgebundenen Read erkennen: Nach `fstat()` vor/nach dem Lesen wird der Pfad erneut statiert und muss weiterhin auf dieselbe Dateiidentität zeigen.
- Strikte Inhaltsprüfung zusätzlich nach Manifest-Readback erneut an die aktuelle Pfadidentität binden.
- Veraltete Call-Cachegenerationen sofort entfernen und abhängige Symbolgenerationen miträumen.
- Veraltete Symbolgenerationen sofort entfernen, ohne eine parallel eingesetzte Ersatzgeneration zu löschen.
- Unbenutzten, voll-I/O-lastigen `_artifact_source_fingerprint`-Helper entfernen.
- `ValueError`-Grenze um `_artifact_list()` klarstellen; der Fehlerpfad ist real, aber nicht Teil von `next(..., None)`.

## Review-Einordnung

- Der massive Vollhash-Warmpfad aus #1024 wurde bereits durch #1025 behoben.
- Der `reversed(list(...))`-Lookup bleibt bei einem harten LRU-Limit von zwei Einträgen bewusst unverändert; I/O findet außerhalb des Locks statt.
- `_detached_json_value` bleibt bestehen, weil die Daten aus `json.loads` stammen und der Mutationstest die Isolation belegt.
- `str(resolve())` bleibt als interner Namespace-Key bestehen; dafür wurde kein reproduzierbarer Fehler gefunden.

## Verifikation

- `python3 -m ruff check ...` — bestanden
- fokussierte Navigation-, Index- und Benchmark-Verträge — 53 bestanden
- sämtliche RepoBrief-Tests — 479 bestanden
- Maintainability-Ratchet — bestanden, 0 neue und 1 aufgelöste Komplexitätsverletzung
- `git diff --check` — bestanden
- 50.000 synthetische Calls:
  - MCP-Warmmedian: 6,06 ms
  - Prozessindex-Warmmedian: 54,94 ms
  - Speedup gegen linearen Scan: 14,53×
  - Byteäquivalenz: bestanden

## Sicherheitsgrenze

Die Prüfung stellt einen stabilen descriptorgebundenen Snapshot und dieselbe Pfadidentität am finalen Validierungspunkt fest. Sie behauptet keine Unveränderlichkeit nach Rückkehr der Prüffunktion und keinen Schutz gegen einen Angreifer, der Kernel, SHA-256 und sämtliche Dateisystemmetadaten kontrolliert.