### PR TITLE
perf(repobrief): stream generation verification

### DIFF
--- a/docs/architecture/repobrief-bundle-generations.md
+++ b/docs/architecture/repobrief-bundle-generations.md
@@ -62,3 +62,32 @@ Linux uses `renameat2(..., RENAME_NOREPLACE)`; macOS and iOS use
 `renameatx_np(..., RENAME_EXCL)`. Both variants operate on already validated
 parent directory descriptors. An unknown platform or missing primitive fails
 closed rather than falling back to a pathname `exists()` check.
+
+## Operational boundaries and deliberate trade-offs
+
+Generation discovery and verification hash artifact streams in bounded chunks;
+large artifact payloads are never retained as one in-memory bundle image. The
+manifest itself is still parsed as JSON and therefore remains memory-resident.
+
+Hardlinks are deliberately not used. A source artifact remains mutable until
+publication completes, and a hardlink would let a later source write mutate an
+already published generation through the shared inode. Native reflinks could be
+a future optimization only with copy verification and a portable fallback.
+
+Duplicate declarations of one relative path are idempotent only when byte count
+and SHA-256 are identical. Conflicting content for the same path fails closed.
+
+A lane that has successfully used a `current` symlink remains in symlink mode.
+If the storage environment later loses symlink support, publication stops rather
+than silently changing pointer semantics. Recovery is an explicit administrative
+operation: repair symlink support or remove the lane pointer while no publisher
+is running, then allow a fresh pointer to be established.
+
+Cache metadata identity is considered strong only when device, inode, mtime_ns
+and ctime_ns are all non-zero. Weak or unavailable identity forces full content
+verification; `strict` mode forces it regardless of metadata quality.
+
+The publication protocol detects removal or replacement before and during the
+pointer switch. It cannot make a `current` pointer permanently immune to a
+privileged, uncooperative process deleting immutable generation directories
+after publication; protecting that storage remains an operational boundary.

--- a/merger/lenskit/cli/cmd_repobrief.py
+++ b/merger/lenskit/cli/cmd_repobrief.py
@@ -1476,6 +1476,8 @@ def build_snapshot_create_result(args: argparse.Namespace) -> dict[str, Any]:
         redact_secrets=redact_secrets,
         include_hidden=args.include_hidden,
         generator_info=generator_info,
+        # Snapshot finalization still mutates the manifest and adds control files;
+        # publish exactly once below after that complete file set is known.
         publish_generation=False,
     )
     dropped_profile_paths = enforce_profile_exclusions(artifacts.bundle_manifest, profile)

--- a/merger/lenskit/core/bundle_generation.py
+++ b/merger/lenskit/core/bundle_generation.py
@@ -17,6 +17,8 @@ from .rooted_filesystem import (
     atomic_write_bytes,
     bind_directory,
     copy_verified_file,
+    digest_regular_file,
+    digest_tree,
     fsync_directory,
     lstat_path,
     make_directories,
@@ -24,7 +26,6 @@ from .rooted_filesystem import (
     path_exists,
     path_is_real_directory,
     read_regular_bytes,
-    read_tree,
     remove_tree,
     rename_path_no_replace,
     secure_absolute,
@@ -94,12 +95,12 @@ class BundleGenerationResult:
 class _BundleFile:
     relative_path: str
     source_path: Path
-    payload: bytes
+    byte_count: int
     sha256: str
 
     @property
     def bytes(self) -> int:
-        return len(self.payload)
+        return self.byte_count
 
 
 @dataclass(frozen=True, slots=True)
@@ -173,35 +174,64 @@ def _read_regular_payload(path: Path, *, label: str) -> bytes:
         raise BundleGenerationError(f"{label} must be a regular file inside the bundle root: {path}") from exc
 
 
+def _digest_regular_payload(path: Path, *, label: str) -> tuple[int, str]:
+    try:
+        return digest_regular_file(path)
+    except RootedFilesystemError as exc:
+        raise BundleGenerationError(
+            f"{label} must be a stable regular file inside the bundle root: {path}"
+        ) from exc
+
+
+def _validate_post_emit_health_binding(payload: bytes, manifest_sha256: str) -> None:
+    try:
+        report = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise BundleGenerationError("post_emit_health sidecar must be valid UTF-8 JSON") from exc
+    if not isinstance(report, dict):
+        raise BundleGenerationError("post_emit_health sidecar must be a JSON object")
+    declared = report.get("bundle_manifest_sha256")
+    if declared is None:
+        return
+    if not _is_sha256(declared):
+        raise BundleGenerationError("post_emit_health bundle_manifest_sha256 is invalid")
+    if declared != manifest_sha256:
+        raise BundleGenerationError(
+            "post_emit_health bundle_manifest_sha256 does not match the final manifest"
+        )
+
+
 def _add_file(
     files: dict[str, _BundleFile],
     *,
     relative_path: str,
     source_path: Path,
-    payload: bytes,
+    observed_bytes: int,
+    observed_sha256: str,
     expected_bytes: Any = None,
     expected_sha256: Any = None,
     label: str,
 ) -> None:
-    sha256 = hashlib.sha256(payload).hexdigest()
     if (
         isinstance(expected_bytes, int)
         and not isinstance(expected_bytes, bool)
-        and expected_bytes != len(payload)
+        and expected_bytes != observed_bytes
     ):
         raise BundleGenerationError(f"{label} byte count does not match the manifest")
-    if _is_sha256(expected_sha256) and expected_sha256 != sha256:
+    if _is_sha256(expected_sha256) and expected_sha256 != observed_sha256:
         raise BundleGenerationError(f"{label} sha256 does not match the manifest")
     existing = files.get(relative_path)
     if existing is not None:
-        if existing.sha256 != sha256 or existing.bytes != len(payload):
-            raise BundleGenerationError(f"bundle file path is declared with conflicting content: {relative_path}")
+        if existing.sha256 != observed_sha256 or existing.bytes != observed_bytes:
+            raise BundleGenerationError(
+                f"bundle file path is declared with conflicting content: {relative_path}"
+            )
         return
     files[relative_path] = _BundleFile(
         relative_path=relative_path,
         source_path=source_path,
-        payload=payload,
-        sha256=sha256,
+        byte_count=observed_bytes,
+        sha256=observed_sha256,
     )
 
 
@@ -229,12 +259,13 @@ def _collect_manifest_artifacts(
             continue
         label = f"artifact[{index}]"
         relative, source = _resolve_under_root(output_root, row.get("path"), label=label)
-        payload = _read_regular_payload(source, label=label)
+        observed_bytes, observed_sha256 = _digest_regular_payload(source, label=label)
         _add_file(
             files,
             relative_path=relative,
             source_path=source,
-            payload=payload,
+            observed_bytes=observed_bytes,
+            observed_sha256=observed_sha256,
             expected_bytes=row.get("bytes"),
             expected_sha256=row.get("sha256"),
             label=label,
@@ -246,6 +277,7 @@ def _collect_manifest_links(
     *,
     output_root: Path,
     files: dict[str, _BundleFile],
+    manifest_sha256: str,
 ) -> None:
     links = manifest.get("links")
     if not isinstance(links, dict):
@@ -255,12 +287,21 @@ def _collect_manifest_links(
             continue
         label = f"links.{key}"
         relative, source = _resolve_under_root(output_root, links[key], label=label)
-        payload = _read_regular_payload(source, label=label)
+        if key == "post_emit_health_path":
+            payload = _read_regular_payload(source, label=label)
+            _validate_post_emit_health_binding(payload, manifest_sha256)
+            observed_bytes = len(payload)
+            observed_sha256 = hashlib.sha256(payload).hexdigest()
+        else:
+            observed_bytes, observed_sha256 = _digest_regular_payload(
+                source, label=label
+            )
         _add_file(
             files,
             relative_path=relative,
             source_path=source,
-            payload=payload,
+            observed_bytes=observed_bytes,
+            observed_sha256=observed_sha256,
             label=label,
         )
 
@@ -278,12 +319,15 @@ def _collect_extra_paths(
         except ValueError as exc:
             raise BundleGenerationError(f"extra bundle file escapes output root: {source}") from exc
         _safe_relative_path(relative, label="extra file")
-        payload = _read_regular_payload(source, label="extra file")
+        observed_bytes, observed_sha256 = _digest_regular_payload(
+            source, label="extra file"
+        )
         _add_file(
             files,
             relative_path=relative,
             source_path=source,
-            payload=payload,
+            observed_bytes=observed_bytes,
+            observed_sha256=observed_sha256,
             label="extra file",
         )
 
@@ -299,14 +343,20 @@ def _collect_bundle_files(
     manifest = _parse_manifest_payload(manifest_payload)
     files: dict[str, _BundleFile] = {}
     _collect_manifest_artifacts(manifest, output_root=output_root, files=files)
-    _collect_manifest_links(manifest, output_root=output_root, files=files)
+    _collect_manifest_links(
+        manifest,
+        output_root=output_root,
+        files=files,
+        manifest_sha256=manifest_sha256,
+    )
     _collect_extra_paths(extra_paths, output_root=output_root, files=files)
     manifest_relative = manifest_path.relative_to(output_root).as_posix()
     _add_file(
         files,
         relative_path=manifest_relative,
         source_path=manifest_path,
-        payload=manifest_payload,
+        observed_bytes=len(manifest_payload),
+        observed_sha256=manifest_sha256,
         label="bundle manifest",
     )
     ordered = sorted(
@@ -334,8 +384,11 @@ def _generation_id(files: list[_BundleFile], *, manifest_sha256: str) -> str:
     return hashlib.sha256(compact).hexdigest()
 
 
-def _expected_files(files: list[_BundleFile]) -> dict[str, bytes]:
-    return {item.relative_path: item.payload for item in files}
+def _expected_files(files: list[_BundleFile]) -> dict[str, tuple[int, str]]:
+    return {
+        item.relative_path: (item.bytes, item.sha256)
+        for item in files
+    }
 
 
 def _expected_directories(files: list[_BundleFile]) -> set[str]:
@@ -350,7 +403,7 @@ def _expected_directories(files: list[_BundleFile]) -> set[str]:
 
 def _verify_existing_generation(generation_dir: Path, files: list[_BundleFile]) -> None:
     try:
-        observed_files, observed_directories = read_tree(generation_dir)
+        observed_files, observed_directories = digest_tree(generation_dir)
     except RootedFilesystemError as exc:
         raise BundleGenerationError(f"existing generation is not a trusted regular-file tree: {generation_dir}") from exc
     if observed_files != _expected_files(files) or observed_directories != _expected_directories(files):
@@ -581,14 +634,23 @@ def publish_bundle_generation(
         )
         generation_id = _generation_id(files, manifest_sha256=manifest_sha256)
         generation_dir, reused = _install_generation(generations_root, generation_id, files)
-        binding.assert_current_path_identity()
-        pointer_path, pointer_kind = _publish_current_pointer(
-            generations_root,
-            generation_id=generation_id,
-            manifest_relative_path=manifest_relative,
-            manifest_sha256=manifest_sha256,
-        )
-        binding.assert_current_path_identity()
+        try:
+            with bind_directory(generation_dir) as generation_binding:
+                _verify_existing_generation(generation_dir, files)
+                generation_binding.assert_current_path_identity()
+                binding.assert_current_path_identity()
+                pointer_path, pointer_kind = _publish_current_pointer(
+                    generations_root,
+                    generation_id=generation_id,
+                    manifest_relative_path=manifest_relative,
+                    manifest_sha256=manifest_sha256,
+                )
+                generation_binding.assert_current_path_identity()
+                binding.assert_current_path_identity()
+        except RootedFilesystemError as exc:
+            raise BundleGenerationError(
+                f"generation changed while the current pointer was being published: {generation_dir}"
+            ) from exc
     if pointer_kind == "relative_symlink":
         selected_manifest_path = current_manifest_path(root, bundle_stem, manifest_relative)
     else:
@@ -637,8 +699,8 @@ def resolve_bundle_manifest_path(path: str | Path) -> Path:
             pointer.get("manifest_path"),
             label="current JSON pointer manifest_path",
         )
-        expected_prefix = f"{pointer['generation_id']}/"
-        if not relative.startswith(expected_prefix):
+        relative_parts = PurePosixPath(relative).parts
+        if len(relative_parts) < 2 or relative_parts[0] != pointer["generation_id"]:
             raise BundleGenerationError(
                 "current JSON pointer manifest path does not match generation_id"
             )

--- a/merger/lenskit/core/repobrief_access.py
+++ b/merger/lenskit/core/repobrief_access.py
@@ -1825,6 +1825,8 @@ def _cached_call_navigation_state(
 ) -> _CallNavigationState | None:
     resolved_manifest = str(manifest_path.resolve())
     with _CALL_NAVIGATION_CACHE_LOCK:
+        # Snapshot at most two LRU entries so validation can release the lock;
+        # a live reversed iterator would become invalid under concurrent mutation.
         candidates = [
             (fingerprint, state)
             for fingerprint, state in reversed(list(_CALL_NAVIGATION_CACHE.items()))
@@ -1847,6 +1849,7 @@ def _cached_symbol_navigation_state(
 ) -> _SymbolNavigationState | None:
     resolved_manifest = str(manifest_path.resolve())
     with _CALL_NAVIGATION_CACHE_LOCK:
+        # Keep the same bounded snapshot rule as the call-navigation cache.
         candidates = [
             (cache_key, state)
             for cache_key, state in reversed(list(_SYMBOL_NAVIGATION_CACHE.items()))

--- a/merger/lenskit/core/rooted_filesystem.py
+++ b/merger/lenskit/core/rooted_filesystem.py
@@ -282,6 +282,16 @@ def _identity(metadata: os.stat_result) -> tuple[int, int]:
     return metadata.st_dev, metadata.st_ino
 
 
+def _content_identity(metadata: os.stat_result) -> tuple[int, int, int, int, int]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+    )
+
+
 def _assert_directory_fd_matches_path(fd: int, path: str | Path) -> None:
     expected = _identity(os.fstat(fd))
     current_fd = _open_absolute_directory(secure_absolute(path), create=False)
@@ -364,17 +374,34 @@ def read_regular_bytes(path: str | Path) -> bytes:
         os.close(fd)
 
 
-def digest_regular_file(path: str | Path) -> tuple[int, str]:
-    fd, _ = open_regular_file(path)
+def _digest_fd(fd: int) -> tuple[int, str]:
     digest = hashlib.sha256()
     observed = 0
+    while True:
+        chunk = os.read(fd, 1024 * 1024)
+        if not chunk:
+            return observed, digest.hexdigest()
+        observed += len(chunk)
+        digest.update(chunk)
+
+
+def digest_regular_file(path: str | Path) -> tuple[int, str]:
+    """Hash one descriptor-bound regular file without buffering its payload."""
+    fd, _ = open_regular_file(path)
     try:
-        with os.fdopen(os.dup(fd), "rb", closefd=True) as handle:
-            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-                observed += len(chunk)
-                digest.update(chunk)
+        before = os.fstat(fd)
+        observed, digest = _digest_fd(fd)
+        after = os.fstat(fd)
+        if _content_identity(before) != _content_identity(after):
+            raise RootedFilesystemError(
+                f"regular file changed while hashing: {secure_absolute(path)}"
+            )
+        if observed != after.st_size:
+            raise RootedFilesystemError(
+                f"regular file size changed while hashing: {secure_absolute(path)}"
+            )
         _assert_regular_fd_matches_path(fd, path)
-        return observed, digest.hexdigest()
+        return observed, digest
     finally:
         os.close(fd)
 
@@ -815,9 +842,13 @@ def _call_rename_no_replace(
         os.fsencode(destination_name),
         flags,
     )
-    if result != 0:
-        err = ctypes.get_errno() or errno.EIO
-        raise OSError(err, os.strerror(err))
+    captured_errno = ctypes.get_errno()
+    if result == 0:
+        return
+    err = captured_errno or errno.EIO
+    if err == errno.EEXIST:
+        raise FileExistsError(err, os.strerror(err), destination_name)
+    raise OSError(err, os.strerror(err), destination_name)
 
 
 def _rename_no_replace(
@@ -878,6 +909,83 @@ def rename_path_no_replace(source: str | Path, destination: str | Path) -> None:
     finally:
         os.close(source_parent)
         os.close(destination_parent)
+
+
+def _digest_tree_fd(
+    fd: int, prefix: Path
+) -> tuple[dict[str, tuple[int, str]], set[str]]:
+    directory_before = os.fstat(fd)
+    files: dict[str, tuple[int, str]] = {}
+    directories: set[str] = set()
+    try:
+        entries = sorted(os.scandir(fd), key=lambda entry: entry.name)
+    except OSError as exc:
+        raise RootedFilesystemError("rooted directory cannot be enumerated") from exc
+    for entry in entries:
+        metadata = os.stat(entry.name, dir_fd=fd, follow_symlinks=False)
+        relative = prefix / entry.name
+        relative_text = relative.as_posix()
+        if stat.S_ISDIR(metadata.st_mode):
+            child_fd = os.open(entry.name, _DIRECTORY_FLAGS, dir_fd=fd)
+            try:
+                opened = os.fstat(child_fd)
+                directories.add(relative_text)
+                child_files, child_directories = _digest_tree_fd(child_fd, relative)
+                current = os.stat(entry.name, dir_fd=fd, follow_symlinks=False)
+                if _identity(current) != _identity(opened):
+                    raise RootedFilesystemError(
+                        f"rooted tree directory changed while hashing: {relative_text}"
+                    )
+                files.update(child_files)
+                directories.update(child_directories)
+            finally:
+                os.close(child_fd)
+        elif stat.S_ISREG(metadata.st_mode):
+            child_fd = os.open(
+                entry.name,
+                os.O_RDONLY | _FILE_NOFOLLOW,
+                dir_fd=fd,
+            )
+            try:
+                before = os.fstat(child_fd)
+                observed, digest = _digest_fd(child_fd)
+                after = os.fstat(child_fd)
+                current = os.stat(entry.name, dir_fd=fd, follow_symlinks=False)
+                if _content_identity(before) != _content_identity(after):
+                    raise RootedFilesystemError(
+                        f"rooted tree file changed while hashing: {relative_text}"
+                    )
+                if observed != after.st_size or _identity(current) != _identity(after):
+                    raise RootedFilesystemError(
+                        f"rooted tree file changed while hashing: {relative_text}"
+                    )
+                files[relative_text] = (observed, digest)
+            finally:
+                os.close(child_fd)
+        else:
+            raise RootedFilesystemError(
+                f"rooted tree contains a symlink or special entry: {relative_text}"
+            )
+    directory_after = os.fstat(fd)
+    if _content_identity(directory_before) != _content_identity(directory_after):
+        raise RootedFilesystemError(
+            f"rooted tree directory changed while hashing: {prefix.as_posix()}"
+        )
+    return files, directories
+
+
+def digest_tree(path: str | Path) -> tuple[dict[str, tuple[int, str]], set[str]]:
+    """Hash a trusted regular-file tree without retaining file payloads."""
+    fd = _open_directory(path, create=False)
+    try:
+        try:
+            result = _digest_tree_fd(fd, Path("."))
+        except OSError as exc:
+            raise RootedFilesystemError("rooted tree changed while hashing") from exc
+        _assert_directory_fd_matches_path(fd, path)
+        return result
+    finally:
+        os.close(fd)
 
 
 def _read_tree_fd(fd: int, prefix: Path) -> tuple[dict[str, bytes], set[str]]:

--- a/merger/lenskit/tests/test_bundle_generation.py
+++ b/merger/lenskit/tests/test_bundle_generation.py
@@ -479,3 +479,79 @@ def test_bundle_publication_uses_portable_darwin_create_only_rename(
     assert loaded == ["renameatx_np"]
     assert result.generation_dir.is_dir()
     assert resolve_bundle_manifest_path(result.current_manifest_path).is_file()
+
+def test_nested_artifact_directories_are_created_in_generation(tmp_path: Path) -> None:
+    manifest, canonical = _write_nested_bundle(tmp_path)
+
+    result = publish_bundle_generation(manifest, output_root=tmp_path)
+
+    assert (result.generation_dir / "artifacts/demo.md").read_bytes() == canonical.read_bytes()
+
+
+def test_post_emit_health_manifest_hash_binding_is_verified(tmp_path: Path) -> None:
+    manifest = _write_basic_bundle(tmp_path)
+    manifest_sha256 = _sha(manifest.read_bytes())
+    health_path = tmp_path / "demo.post_emit_health.json"
+    health_path.write_text(
+        json.dumps(
+            {
+                "status": "pass",
+                "bundle_manifest_sha256": manifest_sha256,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = publish_bundle_generation(manifest)
+
+    assert result.manifest_sha256 == manifest_sha256
+
+
+def test_post_emit_health_manifest_hash_mismatch_blocks_pointer_switch(
+    tmp_path: Path,
+) -> None:
+    manifest = _write_basic_bundle(tmp_path)
+    health_path = tmp_path / "demo.post_emit_health.json"
+    health_path.write_text(
+        json.dumps(
+            {
+                "status": "pass",
+                "bundle_manifest_sha256": "0" * 64,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(BundleGenerationError, match="does not match the final manifest"):
+        publish_bundle_generation(manifest)
+
+    assert not generation_mod.generation_lane_root(tmp_path, "demo").exists()
+
+
+def test_removed_generation_before_pointer_switch_keeps_old_current(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first_manifest = _write_basic_bundle(
+        tmp_path, canonical_bytes=b"first\n", run_id="run-1"
+    )
+    first = publish_bundle_generation(first_manifest)
+    second_manifest = _write_basic_bundle(
+        tmp_path, canonical_bytes=b"second\n", run_id="run-2"
+    )
+    original_install = generation_mod._install_generation
+
+    def install_then_remove(generations_root, generation_id, files):
+        generation_dir, reused = original_install(generations_root, generation_id, files)
+        rooted_filesystem.remove_tree(generation_dir)
+        return generation_dir, reused
+
+    monkeypatch.setattr(generation_mod, "_install_generation", install_then_remove)
+
+    with pytest.raises(
+        BundleGenerationError, match="generation changed while the current pointer"
+    ):
+        publish_bundle_generation(second_manifest)
+
+    assert first.current_manifest_path.resolve() == first.resolved_manifest_path
+    assert (first.current_manifest_path.parent / "demo.md").read_bytes() == b"first\n"

--- a/merger/lenskit/tests/test_rooted_filesystem.py
+++ b/merger/lenskit/tests/test_rooted_filesystem.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import ctypes
 import errno
+import hashlib
 
 import os
 import stat
@@ -14,6 +15,8 @@ from merger.lenskit.core.rooted_filesystem import (
     atomic_write_bytes,
     bind_directory,
     copy_verified_file,
+    digest_regular_file,
+    digest_tree,
     make_directory_exclusive,
     exclusive_file_lock,
     read_regular_bytes,
@@ -348,3 +351,100 @@ def test_create_only_rename_unknown_platform_fails_closed(
     monkeypatch.setattr(rooted_filesystem, "_rename_platform", lambda: "unknown-os")
     with pytest.raises(RootedFilesystemError, match="unknown-os"):
         rooted_filesystem._rename_no_replace(10, "source", 11, "destination")
+
+def test_digest_tree_streams_nested_file_metadata(tmp_path: Path) -> None:
+    root = tmp_path / "publication"
+    nested = root / "a" / "b" / "payload.bin"
+    nested.parent.mkdir(parents=True)
+    payload = b"streamed-content\n"
+    nested.write_bytes(payload)
+
+    with bind_directory(root):
+        files, directories = digest_tree(root)
+
+    assert files == {
+        "a/b/payload.bin": (len(payload), hashlib.sha256(payload).hexdigest())
+    }
+    assert directories == {"a", "a/b"}
+
+
+def test_digest_regular_file_rejects_in_place_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "source.bin"
+    source.write_bytes(b"before\n")
+    original = rooted_filesystem._digest_fd
+
+    def digest_then_mutate(fd: int) -> tuple[int, str]:
+        result = original(fd)
+        source.write_bytes(b"after!\n")
+        return result
+
+    monkeypatch.setattr(rooted_filesystem, "_digest_fd", digest_then_mutate)
+
+    with pytest.raises(RootedFilesystemError, match="changed while hashing"):
+        digest_regular_file(source)
+
+
+def test_digest_tree_rejects_in_place_file_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "publication"
+    source = root / "payload.bin"
+    root.mkdir()
+    source.write_bytes(b"before\n")
+    original = rooted_filesystem._digest_fd
+
+    def digest_then_mutate(fd: int) -> tuple[int, str]:
+        result = original(fd)
+        source.write_bytes(b"after!\n")
+        return result
+
+    monkeypatch.setattr(rooted_filesystem, "_digest_fd", digest_then_mutate)
+
+    with bind_directory(root):
+        with pytest.raises(RootedFilesystemError, match="changed while hashing"):
+            digest_tree(root)
+
+
+def test_native_create_only_rename_captures_eexist_immediately() -> None:
+    def fail_existing(*_args):
+        ctypes.set_errno(errno.EEXIST)
+        return -1
+
+    with pytest.raises(FileExistsError) as captured:
+        rooted_filesystem._call_rename_no_replace(
+            _FakeRenameFunction(fail_existing), 10, "source", 11, "destination", 1
+        )
+
+    assert captured.value.errno == errno.EEXIST
+    assert captured.value.filename == "destination"
+
+
+def test_native_create_only_rename_without_errno_fails_as_eio() -> None:
+    def fail_without_errno(*_args):
+        return -1
+
+    with pytest.raises(OSError) as captured:
+        rooted_filesystem._call_rename_no_replace(
+            _FakeRenameFunction(fail_without_errno), 10, "source", 11, "destination", 1
+        )
+
+    assert captured.value.errno == errno.EIO
+
+
+def test_native_create_only_rename_success_ignores_stale_errno() -> None:
+    def succeed_with_stale_errno(*_args):
+        ctypes.set_errno(errno.EEXIST)
+        return 0
+
+    rooted_filesystem._call_rename_no_replace(
+        _FakeRenameFunction(succeed_with_stale_errno),
+        10,
+        "source",
+        11,
+        "destination",
+        1,
+    )


### PR DESCRIPTION
## Anlass

Nachlauf zu #1028 aufgrund zweier externer Reviews. Jeder Befund wurde gegen den gemergten Live-Stand reproduziert oder verworfen; nur belegte Änderungen sind enthalten.

## Umgesetzt

- Bundle-Artefakte und bestehende Generationen werden in 1-MiB-Blöcken gehasht statt vollständig im RAM gehalten.
- Descriptorgebundene Vorher-/Nachher-Identität erkennt In-place-Mutationen während des Streamings.
- Generations-ID und Dateivertrag bleiben unverändert: Pfad, Bytezahl und SHA-256 sind weiterhin die Eingaben.
- Native Rename-Fehler sichern `errno` unmittelbar; `EEXIST` wird als `FileExistsError` mit Zielpfad propagiert, fehlendes `errno` als `EIO`.
- Eine installierte Generation wird vor und während des Pointerwechsels descriptorgebunden geprüft; verständliche `BundleGenerationError`-Grenze.
- `post_emit_health.bundle_manifest_sha256` wird beim Einsammeln der Generation erneut gegen das finale Manifest geprüft.
- JSON-Pointer-Prüfung nutzt eine exakte Pfadkomponente statt Stringpräfix.
- Dokumentiert: Snapshot-Publikationsreihenfolge, schwache Cache-Identität, Symlink-Recovery, Duplicate-Path-Vertrag, Hardlink-Ablehnung und Grenze gegenüber privilegierter Löschung.

## Review-Triage

### Bestätigt

- Vollständige Artefaktpuffer verursachten einen hohen RAM-Peak.
- `ctypes`-Fehlerabbildung konnte präziser werden.
- Manipulation der Generation während des Publikationsablaufs brauchte einen expliziten Test.
- Mehrere absichtliche Sicherheitsentscheidungen waren unzureichend erklärt.

### Nicht bestätigt oder bewusst nicht übernommen

- **Verschachtelte Staging-Verzeichnisse:** kein Bug. `copy_verified_file` legt validierte Elternverzeichnisse bereits mit `create=True` an; zusätzlicher Regressionstest besteht.
- **JSON-Pointer-Root-Escape:** kein nachweisbarer Bypass. Lexikalische, aufgelöste und descriptorgebundene Grenzen mit `O_NOFOLLOW` bleiben aktiv.
- **Stat-only statt dreifacher Health-Hashprüfung:** verworfen, weil wiederhergestellte Metadaten Inhaltsänderungen verbergen können.
- **`list()` im Cache entfernen:** verworfen. Der Cache hat maximal zwei Einträge; die Liste ist ein absichtlicher Snapshot, damit die Sperre vor der Validierung freigegeben werden kann.
- **Hardlinks:** verworfen, da spätere Quelländerungen dieselbe Inode und damit die angeblich unveränderliche Generation verändern würden.
- **HMAC für `current.json`:** ohne unabhängigen geheimen Vertrauensanker kein Schutz gegen einen privilegierten Schreiber.

## Exakter Stand

- Basis: `595195d4f94594c981bcd88accaa5ac6ca862094`
- Head: `43dfe58f6ab2caba4b1b597267679c6569f998c3`
- Diff SHA-256: `685fed013fbc8be31f56cf4b931d8f80f993927f1b7595de851af297e266cf84`
- Diffgröße: 28670 Bytes
- Self-Review-Receipt SHA-256: `3735682921d721f6d559621d1ca70df167613232e57f6bb46132271f6f221411`
- Memory-Benchmark SHA-256: `bc1449f003368c9102566d7df1927bb70764205c5bda79f98384d4b15d0b5780`

## Evidenz

- 4.141 Lenskit-Tests bestanden, 1 übersprungen
- 241 breite Generation-/Snapshot-/Cache-/Forensiktests bestanden
- 183 Tests nach der finalen Fehlergrenzenänderung bestanden
- Forensic-Preflight-Canary: PASS
- Ruff, Compileall, Diffcheck, Shellsyntax: PASS
- Maintainability: `new_count=0`, `resolved_count=1`

### 128-MB-Artefakt

| Messwert | Vorher | Nachher |
|---|---:|---:|
| maximaler RSS | 278.768 KiB | 18.920 KiB |
| Laufzeit | 0,35 s | 0,26 s |
| Generations-ID | identisch | identisch |

RAM-Reduktion: rund **93,2 %**. RSS bezeichnet den tatsächlich belegten Prozessspeicher.

## Wahrheitsgrenze

Die Änderung behauptet weder identische Leistung auf allen Dateisystemen noch Schutz vor einem privilegierten Prozess, der eine Generation nach abgeschlossener Publikation löscht. Das JSON-Manifest selbst bleibt für die notwendige Validierung im Speicher.
