### PR TITLE
Stream RepoBrief relation-card context scans

### DIFF
--- a/merger/lenskit/core/repobrief_context_compiler.py
+++ b/merger/lenskit/core/repobrief_context_compiler.py
@@ -280,6 +280,66 @@ def _relation_path_value(value: Any) -> str | None:
     return None
 
 
+def _relation_candidate_from_line(
+    line: str,
+    *,
+    row_number: int,
+    query: str,
+    compact_query: str,
+    bytes_per_token: float,
+) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        card = json.loads(line)
+    except ValueError as exc:
+        return None, str(exc)
+    if not isinstance(card, dict):
+        return None, "row_not_object"
+
+    source_path = _relation_path_value(card.get("source"))
+    target_path = _relation_path_value(card.get("target"))
+    evidence = card.get("evidence") if isinstance(card.get("evidence"), dict) else {}
+    haystack = " ".join(
+        str(value)
+        for value in (
+            card.get("relation"),
+            source_path,
+            target_path,
+            evidence.get("source_path"),
+            evidence.get("start_line"),
+            evidence.get("end_line"),
+        )
+    ).casefold()
+    if query and query not in haystack:
+        compact_haystack = _compact_match_text(haystack)
+        if not compact_query or compact_query not in compact_haystack:
+            return None, None
+
+    label = f"{source_path or '?'} -> {target_path or '?'} {card.get('relation') or ''}"
+    return _candidate(
+        candidate_id=f"relation:{row_number}",
+        source="relation_cards_jsonl",
+        priority=25 + row_number,
+        estimated_tokens=_estimate_tokens_from_text(label, bytes_per_token),
+        selection_reason="relation_card_match",
+        citations=[{
+            "artifact_role": "relation_cards_jsonl",
+            "source_path": source_path,
+            "target_path": target_path,
+            "evidence": evidence,
+            "evidence_level": card.get("evidence_level"),
+        }],
+        payload={
+            "title": label,
+            "artifact_role": "relation_cards_jsonl",
+            "path": source_path,
+            "relation": card.get("relation"),
+            "source_path": source_path,
+            "target_path": target_path,
+            "evidence": evidence,
+        },
+    ), None
+
+
 def _relation_candidates(
     status: Mapping[str, Any],
     *,
@@ -304,6 +364,7 @@ def _relation_candidates(
             "error_code": "relation_cards_jsonl_file_missing",
             "reason": "relation_cards_jsonl artifact file does not exist",
         }]
+
     q = query.strip().casefold()
     compact_query = _compact_match_text(q) if q else ""
     candidates: list[dict[str, Any]] = []
@@ -314,62 +375,21 @@ def _relation_candidates(
             for row_number, line in enumerate(rows, start=1):
                 if not line.strip():
                     continue
-                try:
-                    card = json.loads(line)
-                except ValueError as exc:
-                    invalid_row_count += 1
-                    if len(errors) < 10:
-                        errors.append({"row": row_number, "error": str(exc)})
-                    continue
-                if not isinstance(card, dict):
-                    invalid_row_count += 1
-                    if len(errors) < 10:
-                        errors.append({"row": row_number, "error": "row_not_object"})
-                    continue
-                source_path = _relation_path_value(card.get("source"))
-                target_path = _relation_path_value(card.get("target"))
-                evidence = card.get("evidence") if isinstance(card.get("evidence"), dict) else {}
-                haystack = " ".join(
-                    str(value)
-                    for value in (
-                        card.get("relation"),
-                        source_path,
-                        target_path,
-                        evidence.get("source_path"),
-                        evidence.get("start_line"),
-                        evidence.get("end_line"),
-                    )
-                ).casefold()
-                if q and q not in haystack:
-                    compact_haystack = _compact_match_text(haystack)
-                    if not compact_query or compact_query not in compact_haystack:
-                        continue
-                label = f"{source_path or '?'} -> {target_path or '?'} {card.get('relation') or ''}"
-                candidates.append(
-                    _candidate(
-                        candidate_id=f"relation:{row_number}",
-                        source="relation_cards_jsonl",
-                        priority=25 + row_number,
-                        estimated_tokens=_estimate_tokens_from_text(label, bytes_per_token),
-                        selection_reason="relation_card_match",
-                        citations=[{
-                            "artifact_role": "relation_cards_jsonl",
-                            "source_path": source_path,
-                            "target_path": target_path,
-                            "evidence": evidence,
-                            "evidence_level": card.get("evidence_level"),
-                        }],
-                        payload={
-                            "title": label,
-                            "artifact_role": "relation_cards_jsonl",
-                            "path": source_path,
-                            "relation": card.get("relation"),
-                            "source_path": source_path,
-                            "target_path": target_path,
-                            "evidence": evidence,
-                        },
-                    )
+                candidate, error = _relation_candidate_from_line(
+                    line,
+                    row_number=row_number,
+                    query=q,
+                    compact_query=compact_query,
+                    bytes_per_token=bytes_per_token,
                 )
+                if error is not None:
+                    invalid_row_count += 1
+                    if len(errors) < 10:
+                        errors.append({"row": row_number, "error": error})
+                    continue
+                if candidate is None:
+                    continue
+                candidates.append(candidate)
                 if len(candidates) >= signal_k:
                     while rows.read(RELATION_STREAM_VALIDATION_CHARS):
                         pass
@@ -381,6 +401,7 @@ def _relation_candidates(
             "error_code": "relation_cards_jsonl_unreadable",
             "reason": str(exc),
         }]
+
     gaps: list[dict[str, Any]] = []
     if invalid_row_count:
         gaps.append({"source": "relation_cards_jsonl", "status": "invalid_rows", "row_errors": errors})
@@ -388,7 +409,6 @@ def _relation_candidates(
         gaps.append({"source": "relation_cards_jsonl", "status": "empty", "reason": "relation card search returned no candidates"})
     signal_status = "warn" if invalid_row_count else "available"
     return candidates, {"status": signal_status, "hit_count": len(candidates), "invalid_row_count": invalid_row_count}, gaps
-
 
 def _required_reading_candidates(
     status: Mapping[str, Any],

--- a/merger/lenskit/core/repobrief_context_compiler.py
+++ b/merger/lenskit/core/repobrief_context_compiler.py
@@ -24,6 +24,7 @@ KIND = "repobrief.context_compiler"
 VERSION = "v1"
 MAX_CONTEXT_BUDGET_TOKENS = 1_000_000
 MAX_SIGNAL_HITS = 50
+RELATION_STREAM_VALIDATION_CHARS = 64 * 1024
 DEFAULT_BYTES_PER_TOKEN = 4.0
 
 DOES_NOT_ESTABLISH = (
@@ -304,10 +305,75 @@ def _relation_candidates(
             "reason": "relation_cards_jsonl artifact file does not exist",
         }]
     q = query.strip().casefold()
+    compact_query = _compact_match_text(q) if q else ""
     candidates: list[dict[str, Any]] = []
     errors: list[dict[str, Any]] = []
+    invalid_row_count = 0
     try:
-        rows = path.read_text(encoding="utf-8").splitlines()
+        with path.open("r", encoding="utf-8") as rows:
+            for row_number, line in enumerate(rows, start=1):
+                if not line.strip():
+                    continue
+                try:
+                    card = json.loads(line)
+                except ValueError as exc:
+                    invalid_row_count += 1
+                    if len(errors) < 10:
+                        errors.append({"row": row_number, "error": str(exc)})
+                    continue
+                if not isinstance(card, dict):
+                    invalid_row_count += 1
+                    if len(errors) < 10:
+                        errors.append({"row": row_number, "error": "row_not_object"})
+                    continue
+                source_path = _relation_path_value(card.get("source"))
+                target_path = _relation_path_value(card.get("target"))
+                evidence = card.get("evidence") if isinstance(card.get("evidence"), dict) else {}
+                haystack = " ".join(
+                    str(value)
+                    for value in (
+                        card.get("relation"),
+                        source_path,
+                        target_path,
+                        evidence.get("source_path"),
+                        evidence.get("start_line"),
+                        evidence.get("end_line"),
+                    )
+                ).casefold()
+                if q and q not in haystack:
+                    compact_haystack = _compact_match_text(haystack)
+                    if not compact_query or compact_query not in compact_haystack:
+                        continue
+                label = f"{source_path or '?'} -> {target_path or '?'} {card.get('relation') or ''}"
+                candidates.append(
+                    _candidate(
+                        candidate_id=f"relation:{row_number}",
+                        source="relation_cards_jsonl",
+                        priority=25 + row_number,
+                        estimated_tokens=_estimate_tokens_from_text(label, bytes_per_token),
+                        selection_reason="relation_card_match",
+                        citations=[{
+                            "artifact_role": "relation_cards_jsonl",
+                            "source_path": source_path,
+                            "target_path": target_path,
+                            "evidence": evidence,
+                            "evidence_level": card.get("evidence_level"),
+                        }],
+                        payload={
+                            "title": label,
+                            "artifact_role": "relation_cards_jsonl",
+                            "path": source_path,
+                            "relation": card.get("relation"),
+                            "source_path": source_path,
+                            "target_path": target_path,
+                            "evidence": evidence,
+                        },
+                    )
+                )
+                if len(candidates) >= signal_k:
+                    while rows.read(RELATION_STREAM_VALIDATION_CHARS):
+                        pass
+                    break
     except (OSError, UnicodeError) as exc:
         return [], {"status": "invalid", "error_code": "relation_cards_jsonl_unreadable"}, [{
             "source": "relation_cards_jsonl",
@@ -315,71 +381,14 @@ def _relation_candidates(
             "error_code": "relation_cards_jsonl_unreadable",
             "reason": str(exc),
         }]
-    for row_number, line in enumerate(rows, start=1):
-        if not line.strip():
-            continue
-        try:
-            card = json.loads(line)
-        except ValueError as exc:
-            errors.append({"row": row_number, "error": str(exc)})
-            continue
-        if not isinstance(card, dict):
-            errors.append({"row": row_number, "error": "row_not_object"})
-            continue
-        source_path = _relation_path_value(card.get("source"))
-        target_path = _relation_path_value(card.get("target"))
-        evidence = card.get("evidence") if isinstance(card.get("evidence"), dict) else {}
-        haystack = " ".join(
-            str(value)
-            for value in (
-                card.get("relation"),
-                source_path,
-                target_path,
-                evidence.get("source_path"),
-                evidence.get("start_line"),
-                evidence.get("end_line"),
-            )
-        ).casefold()
-        if q and q not in haystack:
-            compact_query = _compact_match_text(q)
-            compact_haystack = _compact_match_text(haystack)
-            if not compact_query or compact_query not in compact_haystack:
-                continue
-        label = f"{source_path or '?'} -> {target_path or '?'} {card.get('relation') or ''}"
-        candidates.append(
-            _candidate(
-                candidate_id=f"relation:{row_number}",
-                source="relation_cards_jsonl",
-                priority=25 + row_number,
-                estimated_tokens=_estimate_tokens_from_text(label, bytes_per_token),
-                selection_reason="relation_card_match",
-                citations=[{
-                    "artifact_role": "relation_cards_jsonl",
-                    "source_path": source_path,
-                    "target_path": target_path,
-                    "evidence": evidence,
-                    "evidence_level": card.get("evidence_level"),
-                }],
-                payload={
-                    "title": label,
-                    "artifact_role": "relation_cards_jsonl",
-                    "path": source_path,
-                    "relation": card.get("relation"),
-                    "source_path": source_path,
-                    "target_path": target_path,
-                    "evidence": evidence,
-                },
-            )
-        )
-        if len(candidates) >= signal_k:
-            break
     gaps: list[dict[str, Any]] = []
-    if errors:
-        gaps.append({"source": "relation_cards_jsonl", "status": "invalid_rows", "row_errors": errors[:10]})
+    if invalid_row_count:
+        gaps.append({"source": "relation_cards_jsonl", "status": "invalid_rows", "row_errors": errors})
     if not candidates:
         gaps.append({"source": "relation_cards_jsonl", "status": "empty", "reason": "relation card search returned no candidates"})
-    signal_status = "warn" if errors else "available"
-    return candidates, {"status": signal_status, "hit_count": len(candidates), "invalid_row_count": len(errors)}, gaps
+    signal_status = "warn" if invalid_row_count else "available"
+    return candidates, {"status": signal_status, "hit_count": len(candidates), "invalid_row_count": invalid_row_count}, gaps
+
 
 def _required_reading_candidates(
     status: Mapping[str, Any],

--- a/merger/lenskit/tests/test_repobrief_context_compiler.py
+++ b/merger/lenskit/tests/test_repobrief_context_compiler.py
@@ -231,6 +231,96 @@ def test_compile_context_plan_selects_ordered_evidence_with_citations(tmp_path):
     assert "exact_token_count" in plan["does_not_establish"]
 
 
+def test_compile_context_plan_streams_relation_cards_without_read_text(tmp_path, monkeypatch):
+    manifest = _write_complete_bundle(tmp_path)
+    relation_cards = tmp_path / "demo.relation_cards.jsonl"
+    original_read_text = Path.read_text
+
+    def guarded_read_text(path, *args, **kwargs):
+        if path == relation_cards:
+            raise AssertionError("relation cards must be streamed instead of loaded wholesale")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", guarded_read_text)
+
+    plan = compile_context_plan(
+        manifest,
+        task="Explain the context compiler",
+        task_profile="basic_repo_question",
+        query="context compiler",
+        context_budget_tokens=120,
+        bytes_per_token=4.0,
+    )
+
+    assert plan["signals"]["relation_cards_jsonl"]["status"] == "available"
+    assert any(item["source"] == "relation_cards_jsonl" for item in plan["selected_context"])
+
+
+def test_compile_context_plan_bounds_invalid_relation_row_details(tmp_path):
+    manifest = _write_complete_bundle(tmp_path)
+    relation_cards = tmp_path / "demo.relation_cards.jsonl"
+    valid_row = relation_cards.read_text(encoding="utf-8")
+    relation_cards.write_text("not-json\n" * 12 + valid_row, encoding="utf-8")
+
+    manifest_payload = json.loads(manifest.read_text(encoding="utf-8"))
+    relation_artifact = next(
+        artifact
+        for artifact in manifest_payload["artifacts"]
+        if artifact["role"] == "relation_cards_jsonl"
+    )
+    relation_artifact["bytes"] = relation_cards.stat().st_size
+    relation_artifact["sha256"] = _sha256(relation_cards)
+    manifest.write_text(json.dumps(manifest_payload), encoding="utf-8")
+
+    plan = compile_context_plan(
+        manifest,
+        task="Explain the context compiler",
+        task_profile="basic_repo_question",
+        query="context compiler",
+        context_budget_tokens=120,
+        bytes_per_token=4.0,
+    )
+
+    signal = plan["signals"]["relation_cards_jsonl"]
+    relation_gap = next(gap for gap in plan["gaps"] if gap["source"] == "relation_cards_jsonl")
+    assert signal["status"] == "warn"
+    assert signal["invalid_row_count"] == 12
+    assert len(relation_gap["row_errors"]) == 10
+
+
+def test_compile_context_plan_rejects_invalid_utf8_after_relation_hit(tmp_path):
+    manifest = _write_complete_bundle(tmp_path)
+    relation_cards = tmp_path / "demo.relation_cards.jsonl"
+    relation_cards.write_bytes(relation_cards.read_bytes() + b"\xff")
+
+    manifest_payload = json.loads(manifest.read_text(encoding="utf-8"))
+    relation_artifact = next(
+        artifact
+        for artifact in manifest_payload["artifacts"]
+        if artifact["role"] == "relation_cards_jsonl"
+    )
+    relation_artifact["bytes"] = relation_cards.stat().st_size
+    relation_artifact["sha256"] = _sha256(relation_cards)
+    manifest.write_text(json.dumps(manifest_payload), encoding="utf-8")
+
+    plan = compile_context_plan(
+        manifest,
+        task="Explain the context compiler",
+        task_profile="basic_repo_question",
+        query="context compiler",
+        context_budget_tokens=120,
+        signal_k=1,
+        bytes_per_token=4.0,
+    )
+
+    signal = plan["signals"]["relation_cards_jsonl"]
+    relation_gap = next(gap for gap in plan["gaps"] if gap["source"] == "relation_cards_jsonl")
+    assert signal["status"] == "invalid"
+    assert signal["error_code"] == "relation_cards_jsonl_unreadable"
+    assert relation_gap["error_code"] == "relation_cards_jsonl_unreadable"
+    assert not any(item["source"] == "relation_cards_jsonl" for item in plan["selected_context"])
+
+
 def test_compile_context_plan_falls_back_to_required_reading_when_signals_missing(tmp_path):
     manifest = _write_fallback_bundle(tmp_path)
 


### PR DESCRIPTION
## Zweck

Der RepoBrief-Kontext-Compiler soll große `relation_cards_jsonl`-Artefakte mit begrenztem Spitzenspeicher lesen, ohne seine bisherige Validierungssemantik zu lockern.

## Änderungen

- Relation Cards werden zeilenweise statt über `read_text().splitlines()` verarbeitet.
- Nach Erreichen von `signal_k` wird der restliche Text weiterhin in begrenzten Blöcken gelesen, damit ungültiges UTF-8 am Dateiende weiterhin erkannt wird.
- Parsing und Kandidatenbildung sind in eine kleine Hilfsfunktion ausgelagert; die Komplexitäts-Ratchet bleibt eingehalten.
- Der kompakt normalisierte Suchterm wird einmal statt pro Zeile berechnet.
- Die exakte Zahl ungültiger gescannter Zeilen bleibt erhalten; detaillierte Fehlerbeispiele werden auf zehn begrenzt.
- Regressionstests sichern Streaming, begrenzte Fehlerdetails und vollständige UTF-8-Prüfung.

## Konfliktfreiheit

Bewusst nicht verändert: Call Navigation, Call Graph, Cache Coherence, Bundle Generation/Publication, MCP und `find_symbol`. Der Slice basiert exakt auf `d1ffdefb00a15173e3ae3713ebe024f841d8bdb2` und wurde in einem isolierten Worktree erstellt.

## Nachweise

- Head: `29162abd1b9952cf3d329c9c4826c7edc0ad5cb0`
- vollständiger Diff: SHA-256 `c1a25355b1ddb736c04d0deef21e92e1b0b7b81680c2dadc20f2d879903d0295`
- `88 passed` in Kontext-Compiler-, Relation-Card- und Relation-Validation-Suiten
- Graph-/Komplexitäts-Ratchet: `pass`, keine Findings
- Ruff: sauber
- `git diff --check`: sauber
- GitHub Actions: `task-index`, `lint`, `ai-context guard`, `contracts-validate`, `CodeQL` und `test-suite` erfolgreich
- synthetischer 10,3-MB-Vergleich mit Treffer in der ersten Zeile und vollständiger UTF-8-Restvalidierung:
  - vorher: 26.181.076 Byte Python-Peak
  - nachher: 213.745 Byte Python-Peak
  - Verhältnis: 122,49× weniger Peak-Speicher

Der Mikrobenchmark ist ein kontrollierter Synthesetest und kein Beleg für identische Produktionswerte.