### PR TITLE
Harden RepoBrief relation stream review semantics

### DIFF
--- a/merger/lenskit/core/repobrief_context_compiler.py
+++ b/merger/lenskit/core/repobrief_context_compiler.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json
 import math
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Mapping, TextIO
 
 from merger.lenskit.core.graph_degradation import graph_gap_from_availability
 from merger.lenskit.core.repobrief_access import (
@@ -24,7 +24,9 @@ KIND = "repobrief.context_compiler"
 VERSION = "v1"
 MAX_CONTEXT_BUDGET_TOKENS = 1_000_000
 MAX_SIGNAL_HITS = 50
-RELATION_STREAM_VALIDATION_CHARS = 64 * 1024
+RELATION_ERROR_SAMPLE_LIMIT = 10
+# Preserve strict whole-artifact UTF-8 validation without retaining the unread tail.
+RELATION_STREAM_VALIDATION_CHUNK_CHARS = 64 * 1024
 DEFAULT_BYTES_PER_TOKEN = 4.0
 
 DOES_NOT_ESTABLISH = (
@@ -280,45 +282,58 @@ def _relation_path_value(value: Any) -> str | None:
     return None
 
 
+def _relation_search_text(
+    card: Mapping[str, Any],
+    *,
+    source_path: str | None,
+    target_path: str | None,
+    evidence: Mapping[str, Any],
+) -> str:
+    values = (
+        card.get("relation"),
+        source_path,
+        target_path,
+        evidence.get("source_path"),
+        evidence.get("start_line"),
+        evidence.get("end_line"),
+    )
+    return " ".join(str(value) for value in values if value not in (None, "")).casefold()
+
+
 def _relation_candidate_from_line(
     line: str,
     *,
     row_number: int,
+    match_ordinal: int,
     query: str,
     compact_query: str,
     bytes_per_token: float,
-) -> tuple[dict[str, Any] | None, str | None]:
+) -> tuple[dict[str, Any] | None, dict[str, str] | None]:
     try:
         card = json.loads(line)
-    except ValueError as exc:
-        return None, str(exc)
+    except json.JSONDecodeError as exc:
+        return None, {"error_type": "json_decode", "message": str(exc)}
     if not isinstance(card, dict):
-        return None, "row_not_object"
+        return None, {"error_type": "row_not_object", "message": "row_not_object"}
 
     source_path = _relation_path_value(card.get("source"))
     target_path = _relation_path_value(card.get("target"))
     evidence = card.get("evidence") if isinstance(card.get("evidence"), dict) else {}
-    haystack = " ".join(
-        str(value)
-        for value in (
-            card.get("relation"),
-            source_path,
-            target_path,
-            evidence.get("source_path"),
-            evidence.get("start_line"),
-            evidence.get("end_line"),
-        )
-    ).casefold()
+    haystack = _relation_search_text(
+        card,
+        source_path=source_path,
+        target_path=target_path,
+        evidence=evidence,
+    )
     if query and query not in haystack:
-        compact_haystack = _compact_match_text(haystack)
-        if not compact_query or compact_query not in compact_haystack:
+        if not compact_query or compact_query not in _compact_match_text(haystack):
             return None, None
 
     label = f"{source_path or '?'} -> {target_path or '?'} {card.get('relation') or ''}"
     return _candidate(
         candidate_id=f"relation:{row_number}",
         source="relation_cards_jsonl",
-        priority=25 + row_number,
+        priority=25 + match_ordinal,
         estimated_tokens=_estimate_tokens_from_text(label, bytes_per_token),
         selection_reason="relation_card_match",
         citations=[{
@@ -338,6 +353,14 @@ def _relation_candidate_from_line(
             "evidence": evidence,
         },
     ), None
+
+
+def _consume_text_stream(handle: TextIO) -> bool:
+    """Strictly decode the tail in bounded chunks and report whether any tail existed."""
+    tail_present = False
+    while handle.read(RELATION_STREAM_VALIDATION_CHUNK_CHARS):
+        tail_present = True
+    return tail_present
 
 
 def _relation_candidates(
@@ -365,34 +388,42 @@ def _relation_candidates(
             "reason": "relation_cards_jsonl artifact file does not exist",
         }]
 
-    q = query.strip().casefold()
-    compact_query = _compact_match_text(q) if q else ""
+    stripped_query = query.strip()
+    q = stripped_query.casefold()
+    compact_query = _compact_match_text(stripped_query) if stripped_query else ""
     candidates: list[dict[str, Any]] = []
     errors: list[dict[str, Any]] = []
     invalid_row_count = 0
+    candidate_limit_reached = False
+    unparsed_tail_present = False
     try:
-        with path.open("r", encoding="utf-8") as rows:
+        with path.open("r", encoding="utf-8", errors="strict") as rows:
             for row_number, line in enumerate(rows, start=1):
                 if not line.strip():
                     continue
                 candidate, error = _relation_candidate_from_line(
                     line,
                     row_number=row_number,
+                    match_ordinal=len(candidates),
                     query=q,
                     compact_query=compact_query,
                     bytes_per_token=bytes_per_token,
                 )
                 if error is not None:
                     invalid_row_count += 1
-                    if len(errors) < 10:
-                        errors.append({"row": row_number, "error": error})
+                    if len(errors) < RELATION_ERROR_SAMPLE_LIMIT:
+                        errors.append({
+                            "row": row_number,
+                            "error": error["message"],
+                            "error_type": error["error_type"],
+                        })
                     continue
                 if candidate is None:
                     continue
                 candidates.append(candidate)
                 if len(candidates) >= signal_k:
-                    while rows.read(RELATION_STREAM_VALIDATION_CHARS):
-                        pass
+                    candidate_limit_reached = True
+                    unparsed_tail_present = _consume_text_stream(rows)
                     break
     except (OSError, UnicodeError) as exc:
         return [], {"status": "invalid", "error_code": "relation_cards_jsonl_unreadable"}, [{
@@ -402,13 +433,34 @@ def _relation_candidates(
             "reason": str(exc),
         }]
 
+    errors_truncated = invalid_row_count > len(errors)
+    json_row_validation_complete = not unparsed_tail_present
+    invalid_row_count_scope = "complete_artifact" if json_row_validation_complete else "parsed_prefix"
     gaps: list[dict[str, Any]] = []
     if invalid_row_count:
-        gaps.append({"source": "relation_cards_jsonl", "status": "invalid_rows", "row_errors": errors})
+        gaps.append({
+            "source": "relation_cards_jsonl",
+            "status": "invalid_rows",
+            "invalid_row_count": invalid_row_count,
+            "invalid_row_count_scope": invalid_row_count_scope,
+            "row_errors": errors,
+            "row_error_sample_limit": RELATION_ERROR_SAMPLE_LIMIT,
+            "row_errors_truncated": errors_truncated,
+        })
     if not candidates:
         gaps.append({"source": "relation_cards_jsonl", "status": "empty", "reason": "relation card search returned no candidates"})
     signal_status = "warn" if invalid_row_count else "available"
-    return candidates, {"status": signal_status, "hit_count": len(candidates), "invalid_row_count": invalid_row_count}, gaps
+    return candidates, {
+        "status": signal_status,
+        "hit_count": len(candidates),
+        "invalid_row_count": invalid_row_count,
+        "invalid_row_count_scope": invalid_row_count_scope,
+        "row_error_sample_count": len(errors),
+        "row_errors_truncated": errors_truncated,
+        "candidate_limit_reached": candidate_limit_reached,
+        "json_row_validation_complete": json_row_validation_complete,
+        "tail_utf8_validation_complete": True,
+    }, gaps
 
 def _required_reading_candidates(
     status: Mapping[str, Any],

--- a/merger/lenskit/tests/test_repobrief_context_compiler.py
+++ b/merger/lenskit/tests/test_repobrief_context_compiler.py
@@ -3,6 +3,7 @@ import json
 from pathlib import Path
 
 from merger.lenskit.cli.main import main
+from merger.lenskit.core import repobrief_context_compiler
 from merger.lenskit.core.citation_id import make_citation_id
 from merger.lenskit.core.repobrief_context_compiler import compile_context_plan
 
@@ -205,6 +206,18 @@ def _write_fallback_bundle(tmp_path: Path) -> Path:
     return manifest
 
 
+def _refresh_artifact_metadata(manifest: Path, *, role: str, artifact_path: Path) -> None:
+    manifest_payload = json.loads(manifest.read_text(encoding="utf-8"))
+    artifact = next(
+        item
+        for item in manifest_payload["artifacts"]
+        if item["role"] == role
+    )
+    artifact["bytes"] = artifact_path.stat().st_size
+    artifact["sha256"] = _sha256(artifact_path)
+    manifest.write_text(json.dumps(manifest_payload), encoding="utf-8")
+
+
 def test_compile_context_plan_selects_ordered_evidence_with_citations(tmp_path):
     manifest = _write_complete_bundle(tmp_path)
 
@@ -262,15 +275,7 @@ def test_compile_context_plan_bounds_invalid_relation_row_details(tmp_path):
     valid_row = relation_cards.read_text(encoding="utf-8")
     relation_cards.write_text("not-json\n" * 12 + valid_row, encoding="utf-8")
 
-    manifest_payload = json.loads(manifest.read_text(encoding="utf-8"))
-    relation_artifact = next(
-        artifact
-        for artifact in manifest_payload["artifacts"]
-        if artifact["role"] == "relation_cards_jsonl"
-    )
-    relation_artifact["bytes"] = relation_cards.stat().st_size
-    relation_artifact["sha256"] = _sha256(relation_cards)
-    manifest.write_text(json.dumps(manifest_payload), encoding="utf-8")
+    _refresh_artifact_metadata(manifest, role="relation_cards_jsonl", artifact_path=relation_cards)
 
     plan = compile_context_plan(
         manifest,
@@ -285,23 +290,118 @@ def test_compile_context_plan_bounds_invalid_relation_row_details(tmp_path):
     relation_gap = next(gap for gap in plan["gaps"] if gap["source"] == "relation_cards_jsonl")
     assert signal["status"] == "warn"
     assert signal["invalid_row_count"] == 12
+    assert signal["invalid_row_count_scope"] == "complete_artifact"
+    assert signal["json_row_validation_complete"] is True
+    assert signal["candidate_limit_reached"] is False
+    assert signal["row_error_sample_count"] == 10
+    assert signal["row_errors_truncated"] is True
+    assert relation_gap["invalid_row_count"] == 12
+    assert relation_gap["row_error_sample_limit"] == 10
+    assert relation_gap["row_errors_truncated"] is True
     assert len(relation_gap["row_errors"]) == 10
+    assert {item["error_type"] for item in relation_gap["row_errors"]} == {"json_decode"}
 
 
-def test_compile_context_plan_rejects_invalid_utf8_after_relation_hit(tmp_path):
+def test_compile_context_plan_does_not_match_missing_values_as_none(tmp_path):
     manifest = _write_complete_bundle(tmp_path)
     relation_cards = tmp_path / "demo.relation_cards.jsonl"
-    relation_cards.write_bytes(relation_cards.read_bytes() + b"\xff")
+    relation_card = json.loads(relation_cards.read_text(encoding="utf-8"))
+    relation_card.pop("relation")
+    relation_cards.write_text(json.dumps(relation_card) + "\n", encoding="utf-8")
+    _refresh_artifact_metadata(manifest, role="relation_cards_jsonl", artifact_path=relation_cards)
 
-    manifest_payload = json.loads(manifest.read_text(encoding="utf-8"))
-    relation_artifact = next(
-        artifact
-        for artifact in manifest_payload["artifacts"]
-        if artifact["role"] == "relation_cards_jsonl"
+    plan = compile_context_plan(
+        manifest,
+        task="Find none",
+        task_profile="basic_repo_question",
+        query="none",
+        context_budget_tokens=120,
+        bytes_per_token=4.0,
     )
-    relation_artifact["bytes"] = relation_cards.stat().st_size
-    relation_artifact["sha256"] = _sha256(relation_cards)
-    manifest.write_text(json.dumps(manifest_payload), encoding="utf-8")
+
+    signal = plan["signals"]["relation_cards_jsonl"]
+    assert signal["status"] == "available"
+    assert signal["hit_count"] == 0
+    assert not any(item["source"] == "relation_cards_jsonl" for item in plan["selected_context"])
+
+
+def test_compile_context_plan_prioritizes_relation_match_order_not_source_row(tmp_path):
+    manifest = _write_complete_bundle(tmp_path)
+    relation_cards = tmp_path / "demo.relation_cards.jsonl"
+    matching_card = json.loads(relation_cards.read_text(encoding="utf-8"))
+    filler_cards = [
+        {
+            "kind": "lenskit.relation_card",
+            "version": "1.0",
+            "id": f"filler-{index}",
+            "relation": "imports",
+            "source": {"kind": "repo_path", "path": f"pkg/filler_{index}.py"},
+            "target": {"kind": "repo_path", "path": "pkg/other.py"},
+            "evidence": {},
+            "evidence_level": "S1",
+        }
+        for index in range(100)
+    ]
+    rows = [*filler_cards, matching_card]
+    relation_cards.write_text(
+        "".join(json.dumps(row) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+    _refresh_artifact_metadata(manifest, role="relation_cards_jsonl", artifact_path=relation_cards)
+
+    plan = compile_context_plan(
+        manifest,
+        task="Explain the context compiler",
+        task_profile="basic_repo_question",
+        query="context compiler",
+        context_budget_tokens=120,
+        signal_k=1,
+        bytes_per_token=4.0,
+    )
+
+    relation_items = [
+        item
+        for item in plan["selected_context"] + plan["omitted_context"]
+        if item["source"] == "relation_cards_jsonl"
+    ]
+    assert len(relation_items) == 1
+    assert relation_items[0]["id"] == "relation:101"
+    assert relation_items[0]["priority"] == 25
+
+
+def test_compile_context_plan_reports_json_validation_scope_after_hit_limit(tmp_path):
+    manifest = _write_complete_bundle(tmp_path)
+    relation_cards = tmp_path / "demo.relation_cards.jsonl"
+    relation_cards.write_text(
+        relation_cards.read_text(encoding="utf-8") + "not-json\n",
+        encoding="utf-8",
+    )
+    _refresh_artifact_metadata(manifest, role="relation_cards_jsonl", artifact_path=relation_cards)
+
+    plan = compile_context_plan(
+        manifest,
+        task="Explain the context compiler",
+        task_profile="basic_repo_question",
+        query="context compiler",
+        context_budget_tokens=120,
+        signal_k=1,
+        bytes_per_token=4.0,
+    )
+
+    signal = plan["signals"]["relation_cards_jsonl"]
+    assert signal["status"] == "available"
+    assert signal["candidate_limit_reached"] is True
+    assert signal["json_row_validation_complete"] is False
+    assert signal["tail_utf8_validation_complete"] is True
+    assert signal["invalid_row_count"] == 0
+    assert signal["invalid_row_count_scope"] == "parsed_prefix"
+
+
+def test_compile_context_plan_rejects_invalid_utf8_before_relation_hit(tmp_path):
+    manifest = _write_complete_bundle(tmp_path)
+    relation_cards = tmp_path / "demo.relation_cards.jsonl"
+    relation_cards.write_bytes(b"\xff" + relation_cards.read_bytes())
+    _refresh_artifact_metadata(manifest, role="relation_cards_jsonl", artifact_path=relation_cards)
 
     plan = compile_context_plan(
         manifest,
@@ -320,6 +420,43 @@ def test_compile_context_plan_rejects_invalid_utf8_after_relation_hit(tmp_path):
     assert relation_gap["error_code"] == "relation_cards_jsonl_unreadable"
     assert not any(item["source"] == "relation_cards_jsonl" for item in plan["selected_context"])
 
+
+def test_compile_context_plan_rejects_invalid_utf8_after_relation_hit(tmp_path, monkeypatch):
+    manifest = _write_complete_bundle(tmp_path)
+    relation_cards = tmp_path / "demo.relation_cards.jsonl"
+    relation_cards.write_bytes(
+        relation_cards.read_bytes()
+        + b" " * (256 * 1024)
+        + b"\xff"
+    )
+    _refresh_artifact_metadata(manifest, role="relation_cards_jsonl", artifact_path=relation_cards)
+    consumed_tail = False
+    original_consume = repobrief_context_compiler._consume_text_stream
+
+    def tracking_consume(handle):
+        nonlocal consumed_tail
+        consumed_tail = True
+        return original_consume(handle)
+
+    monkeypatch.setattr(repobrief_context_compiler, "_consume_text_stream", tracking_consume)
+
+    plan = compile_context_plan(
+        manifest,
+        task="Explain the context compiler",
+        task_profile="basic_repo_question",
+        query="context compiler",
+        context_budget_tokens=120,
+        signal_k=1,
+        bytes_per_token=4.0,
+    )
+
+    signal = plan["signals"]["relation_cards_jsonl"]
+    relation_gap = next(gap for gap in plan["gaps"] if gap["source"] == "relation_cards_jsonl")
+    assert consumed_tail is True
+    assert signal["status"] == "invalid"
+    assert signal["error_code"] == "relation_cards_jsonl_unreadable"
+    assert relation_gap["error_code"] == "relation_cards_jsonl_unreadable"
+    assert not any(item["source"] == "relation_cards_jsonl" for item in plan["selected_context"])
 
 def test_compile_context_plan_falls_back_to_required_reading_when_signals_missing(tmp_path):
     manifest = _write_fallback_bundle(tmp_path)


### PR DESCRIPTION
## Zweck

Nachprüfung der externen Review zu PR #1030. Bestätigte Defekte werden behoben, ohne die strikte UTF-8-Gesamtvalidierung oder den begrenzten Speicherverbrauch aufzugeben.

## Bestätigte und behobene Befunde

- Fehlende optionale Felder wurden bisher als String `None` in den Suchtext aufgenommen und konnten falsche Treffer für `none` erzeugen.
- `invalid_row_count` und die auf zehn Einträge begrenzte Fehlerliste waren nicht als Vollzählung plus Stichprobe gekennzeichnet.
- Nach Erreichen von `signal_k` blieb unsichtbar, dass der Rest nur noch streng auf UTF-8 dekodiert, aber nicht mehr zeilenweise als JSON geprüft wird.
- `priority=25+row_number` ließ späte, aber erste relevante Treffer unnötig hinter andere Kontextquellen fallen.
- Der Inline-Restverbrauch war schwer lesbar und der UTF-8-Test belegte den tatsächlichen Early-Hit-Pfad nicht robust.

## Umsetzung

- Suchtext filtert `None` und leere Strings.
- JSON-Zeilenfehler erhalten `error_type`; Fehlerdetails melden Sample-Limit und Trunkierung explizit.
- Signale melden `candidate_limit_reached`, `json_row_validation_complete`, `tail_utf8_validation_complete` und den Gültigkeitsbereich von `invalid_row_count`.
- Relation-Priorität richtet sich nach Trefferrang, während die Zeilennummer in der Kandidaten-ID erhalten bleibt.
- Der begrenzte Restverbrauch liegt in `_consume_text_stream`; `errors="strict"` macht die UTF-8-Policy explizit.
- Zusätzliche Tests decken `None`-Fehltreffer, späte Treffer, partielle JSON-Prüfung sowie UTF-8-Fehler vor und tatsächlich nach einem Treffer ab.

## Nicht übernommene Reviewvorschläge

- `rows.read()` ohne Größenlimit würde den ungelesenen Rest erneut vollständig im RAM materialisieren.
- Binäres Lesen allein validiert keine UTF-8-Dekodierung.
- `deque(rows, maxlen=0)` war im kontrollierten 133-MB-Vergleich etwa 8,7-mal langsamer als begrenztes Text-Chunk-Lesen.

## Nachweise

- 92 relevante Tests bestanden
- Ruff bestanden
- Graph-/Komplexitätsratchet bestanden, keine Findings
- `git diff --check` bestanden
- kontrollierter 134,2-MB-Lauf mit frühem Treffer:
  - alter Voll-Ladepfad: 268.442.658 Byte Peak, 0,244 s
  - Follow-up: 214.809 Byte Peak, 0,020 s
  - rund 1.250-mal weniger Python-Peak

Die Zeitwerte sind ein synthetischer Einzellauf und keine Produktionsgarantie.

## Konfliktfreiheit

Nicht verändert: Bundle-Generation, Rooted Filesystem, Call Navigation, Call Graph, MCP und `find_symbol`. Basis: `ac313b55b7fdc94eebc357207220ecac4961dfa6`.