### PR TITLE
Clarify RepoBrief relation stream matching

### DIFF
--- a/merger/lenskit/core/repobrief_context_compiler.py
+++ b/merger/lenskit/core/repobrief_context_compiler.py
@@ -26,7 +26,7 @@ MAX_CONTEXT_BUDGET_TOKENS = 1_000_000
 MAX_SIGNAL_HITS = 50
 RELATION_ERROR_SAMPLE_LIMIT = 10
 # Preserve strict whole-artifact UTF-8 validation without retaining the unread tail.
-RELATION_STREAM_VALIDATION_CHUNK_CHARS = 64 * 1024
+RELATION_TAIL_VALIDATION_CHUNK_SIZE = 64 * 1024
 DEFAULT_BYTES_PER_TOKEN = 4.0
 
 DOES_NOT_ESTABLISH = (
@@ -300,6 +300,17 @@ def _relation_search_text(
     return " ".join(str(value) for value in values if value not in (None, "")).casefold()
 
 
+def _relation_query_matches(
+    haystack: str,
+    *,
+    query: str,
+    compact_query: str,
+) -> bool:
+    if not query or query in haystack:
+        return True
+    return bool(compact_query) and compact_query in _compact_match_text(haystack)
+
+
 def _relation_candidate_from_line(
     line: str,
     *,
@@ -325,9 +336,12 @@ def _relation_candidate_from_line(
         target_path=target_path,
         evidence=evidence,
     )
-    if query and query not in haystack:
-        if not compact_query or compact_query not in _compact_match_text(haystack):
-            return None, None
+    if not _relation_query_matches(
+        haystack,
+        query=query,
+        compact_query=compact_query,
+    ):
+        return None, None
 
     label = f"{source_path or '?'} -> {target_path or '?'} {card.get('relation') or ''}"
     return _candidate(
@@ -356,11 +370,12 @@ def _relation_candidate_from_line(
 
 
 def _consume_text_stream(handle: TextIO) -> bool:
-    """Strictly decode the tail in bounded chunks and report whether any tail existed."""
-    tail_present = False
-    while handle.read(RELATION_STREAM_VALIDATION_CHUNK_CHARS):
-        tail_present = True
-    return tail_present
+    """Strictly decode the tail; decode errors intentionally propagate to the caller."""
+    if not handle.read(RELATION_TAIL_VALIDATION_CHUNK_SIZE):
+        return False
+    while handle.read(RELATION_TAIL_VALIDATION_CHUNK_SIZE):
+        pass
+    return True
 
 
 def _relation_candidates(
@@ -390,7 +405,7 @@ def _relation_candidates(
 
     stripped_query = query.strip()
     q = stripped_query.casefold()
-    compact_query = _compact_match_text(stripped_query) if stripped_query else ""
+    compact_query = _compact_match_text(q) if q else ""
     candidates: list[dict[str, Any]] = []
     errors: list[dict[str, Any]] = []
     invalid_row_count = 0
@@ -414,8 +429,8 @@ def _relation_candidates(
                     if len(errors) < RELATION_ERROR_SAMPLE_LIMIT:
                         errors.append({
                             "row": row_number,
-                            "error": error["message"],
                             "error_type": error["error_type"],
+                            "message": error["message"],
                         })
                     continue
                 if candidate is None:

--- a/merger/lenskit/tests/test_repobrief_context_compiler.py
+++ b/merger/lenskit/tests/test_repobrief_context_compiler.py
@@ -300,6 +300,8 @@ def test_compile_context_plan_bounds_invalid_relation_row_details(tmp_path):
     assert relation_gap["row_errors_truncated"] is True
     assert len(relation_gap["row_errors"]) == 10
     assert {item["error_type"] for item in relation_gap["row_errors"]} == {"json_decode"}
+    assert all(item["message"] for item in relation_gap["row_errors"])
+    assert all("error" not in item for item in relation_gap["row_errors"])
 
 
 def test_compile_context_plan_does_not_match_missing_values_as_none(tmp_path):
@@ -323,6 +325,57 @@ def test_compile_context_plan_does_not_match_missing_values_as_none(tmp_path):
     assert signal["status"] == "available"
     assert signal["hit_count"] == 0
     assert not any(item["source"] == "relation_cards_jsonl" for item in plan["selected_context"])
+
+
+def test_compile_context_plan_compact_fallback_is_case_insensitive(tmp_path):
+    manifest = _write_complete_bundle(tmp_path)
+
+    plan = compile_context_plan(
+        manifest,
+        task="Explain the context compiler",
+        task_profile="basic_repo_question",
+        query="CONTEXT-COMPILER",
+        context_budget_tokens=120,
+        bytes_per_token=4.0,
+    )
+
+    signal = plan["signals"]["relation_cards_jsonl"]
+    assert signal["status"] == "available"
+    assert signal["hit_count"] == 1
+    assert any(item["source"] == "relation_cards_jsonl" for item in plan["selected_context"])
+
+
+def test_compile_context_plan_bounds_invalid_rows_before_hit_limit(tmp_path):
+    manifest = _write_complete_bundle(tmp_path)
+    relation_cards = tmp_path / "demo.relation_cards.jsonl"
+    valid_row = relation_cards.read_text(encoding="utf-8")
+    relation_cards.write_text(
+        "not-json\n" * 12 + valid_row + "unparsed-invalid-tail\n",
+        encoding="utf-8",
+    )
+    _refresh_artifact_metadata(manifest, role="relation_cards_jsonl", artifact_path=relation_cards)
+
+    plan = compile_context_plan(
+        manifest,
+        task="Explain the context compiler",
+        task_profile="basic_repo_question",
+        query="context compiler",
+        context_budget_tokens=120,
+        signal_k=1,
+        bytes_per_token=4.0,
+    )
+
+    signal = plan["signals"]["relation_cards_jsonl"]
+    relation_gap = next(gap for gap in plan["gaps"] if gap["source"] == "relation_cards_jsonl")
+    assert signal["status"] == "warn"
+    assert signal["candidate_limit_reached"] is True
+    assert signal["json_row_validation_complete"] is False
+    assert signal["invalid_row_count"] == 12
+    assert signal["invalid_row_count_scope"] == "parsed_prefix"
+    assert signal["row_error_sample_count"] == 10
+    assert signal["row_errors_truncated"] is True
+    assert relation_gap["row_errors_truncated"] is True
+    assert len(relation_gap["row_errors"]) == 10
 
 
 def test_compile_context_plan_prioritizes_relation_match_order_not_source_row(tmp_path):
@@ -458,6 +511,7 @@ def test_compile_context_plan_rejects_invalid_utf8_after_relation_hit(tmp_path, 
     assert relation_gap["error_code"] == "relation_cards_jsonl_unreadable"
     assert not any(item["source"] == "relation_cards_jsonl" for item in plan["selected_context"])
 
+
 def test_compile_context_plan_falls_back_to_required_reading_when_signals_missing(tmp_path):
     manifest = _write_fallback_bundle(tmp_path)
 
@@ -507,6 +561,20 @@ def test_compile_context_plan_rejects_invalid_budget(tmp_path):
 
     assert plan["status"] == "invalid"
     assert plan["error_code"] == "context_budget_out_of_bounds"
+    assert plan["mutation_boundary"]["writes"] == []
+
+
+def test_compile_context_plan_rejects_zero_signal_k(tmp_path):
+    manifest = _write_fallback_bundle(tmp_path)
+
+    plan = compile_context_plan(
+        manifest,
+        task="invalid",
+        signal_k=0,
+    )
+
+    assert plan["status"] == "invalid"
+    assert plan["error_code"] == "signal_k_out_of_bounds"
     assert plan["mutation_boundary"]["writes"] == []
 
 


### PR DESCRIPTION
## Zweck

Zweite Nachprüfung der externen Reviews zu PR #1031. Der Patch übernimmt nur bestätigte Klarheits-, Konsistenz- und Testverbesserungen. Die aktive Bundle-Generationshärtung bleibt unberührt.

## Bestätigte Verbesserungen

- Query-Matching liegt nun in `_relation_query_matches`: normaler casefolded Substring zuerst, danach kompakter Fallback.
- `compact_query` wird sichtbar aus dem casefolded Query erzeugt.
- Tail-Validierung liest den ersten Chunk einmal, verbraucht den Rest begrenzt und dokumentiert, dass Decode-Fehler absichtlich zum Aufrufer propagieren.
- Konstante auf `RELATION_TAIL_VALIDATION_CHUNK_SIZE` verkürzt.
- Fehlerbeispiele verwenden einheitlich `error_type` und `message`.
- Neue Tests decken case-insensitiven Compact-Fallback, `signal_k=0` und mehr als zehn ungültige Zeilen zusammen mit dem Trefferlimit ab.

## Nicht bestätigte Reviewbehauptungen

- Kein Case-Sensitivity-Regressionsbug: `_compact_match_text()` führt bereits selbst `casefold()` aus. Ein direkter Gegenbeweis liefert für `Context Compiler` und `context compiler` jeweils `contextcompiler`.
- `not compact_query` war nicht vollständig redundant: Queries nur aus Satzzeichen ergeben einen leeren Compact-Query. Die neue Hilfsfunktion macht diesen Fall explizit.
- Kein expliziter `except UnicodeDecodeError: raise`: Das wäre semantisch identisch und würde nur Rauschen hinzufügen; die Propagation ist stattdessen im Docstring festgehalten.
- Kein früher Abbruch nach vielen ungültigen Zeilen: Das würde gültige Treffer weiter hinten still verlieren und die diagnostische Zählung verfälschen.
- Kein Quick-Reject vor `json.loads()`: Er wäre bei JSON-Escapes und bei der Pflicht zur Invalid-Row-Zählung semantisch unsicher.

## Nachweise

- 16 gezielte Context-Compiler-Tests bestanden
- 95 relevante Tests bestanden
- Ruff bestanden
- Graph-/Komplexitätsratchet bestanden, keine Findings
- `git diff --check` bestanden
- kontrollierter 134,2-MB-Lauf, Query `CONTEXT-COMPILER`, früher Treffer:
  - 1 Treffer
  - ca. 280.818 Byte Python-Peak
  - ca. 0,022 s
  - Tail-UTF-8-Prüfung vollständig; JSON-Zeilenprüfung nach Trefferlimit transparent partiell

Die Laufzeit ist ein synthetischer Einzellauf und keine Produktionsgarantie.

## Scope

Geändert werden ausschließlich:

- `merger/lenskit/core/repobrief_context_compiler.py`
- `merger/lenskit/tests/test_repobrief_context_compiler.py`

Basis: `a92dc181c8c93ecbc813ef7f88b07c3b27c34719`.