### PR TITLE
feat(review): add deterministic audit lane planner v1

### DIFF
--- a/docs/architecture/audit-lane-adoption-v1.md
+++ b/docs/architecture/audit-lane-adoption-v1.md
@@ -66,7 +66,7 @@ Acceptance gate: malformed, stale or citation-less findings fail closed.
 
 ### Phase 3 — isolated pilot runner — registered follow-up
 
-Run only 5–10 selected lanes in an ephemeral container with read-only source, no user
+Run only 5–8 selected lanes in an ephemeral container with read-only source, no user
 credentials, local output only, fixed call/time budgets and no automatic issue creation.
 
 Acceptance gate: sandbox evidence, bounded cost and deterministic run manifest.
@@ -104,7 +104,7 @@ confirmed defects without unacceptable noise.
 | --- | --- |
 | Prompt injection | No execution in Lenskit; later runner must be isolated and credential-free |
 | False positives | Separate evidence adapter and independent verification |
-| Cost explosion | Maximum eight planned lanes; pilot executes only 5–10 selected lanes with budgets |
+| Cost explosion | Maximum eight planned lanes; pilot executes only 5–8 selected lanes with budgets |
 | Authority drift | `navigation_index`, `diagnostic`, explicit `does_not_establish` |
 | Correlated model errors | Goldset comparison and method diversity, not repeated `DONE` claims |
 | Stale findings | Revision binding and freshness validation in Phase 2 |

--- a/docs/architecture/audit-lane-adoption-v1.md
+++ b/docs/architecture/audit-lane-adoption-v1.md
@@ -1,0 +1,118 @@
+---
+doc_type: architecture_decision
+status: implemented
+task: BUREAU-LENSKIT-AUDIT-LANES-001
+---
+
+# Evidence-oriented audit lanes: adoption decision and rollout plan
+
+## Purpose
+
+This decision adopts the useful part of large specialist-lens audit systems without
+turning Lenskit into an agent runner or review authority. Lenskit plans a small,
+deterministic set of audit lanes from a concrete change surface. External operators
+may later execute those lanes in an isolated environment and must return evidence-bound
+results through separate contracts.
+
+## Dialectic
+
+### Thesis
+
+Narrow specialist perspectives reduce attention dilution. Concurrency, storage,
+authority, deployment, UI, performance and failure semantics should not compete in a
+single broad prompt.
+
+### Antithesis
+
+Hundreds of autonomous agent invocations amplify cost, correlated blind spots, prompt
+injection and false positives. Repeated self-declared completion is not evidence of
+review completeness.
+
+### Decision
+
+Adopt bounded **audit lanes**, not a mass agent runner:
+
+1. Plan at most eight lanes deterministically from changed paths and an optional review
+   question.
+2. Give concrete path signals more weight than natural-language hints.
+3. Require each lane to state the evidence it needs and the checks it merely suggests.
+4. Keep the output `navigation_index` / `diagnostic`; it cannot establish a defect,
+   correctness, severity or completeness.
+5. Do not execute agents, repository commands, issue creation, patches or merges in
+   Lenskit core.
+6. Measure usefulness against known findings before any default promotion.
+
+## Phases
+
+A phase is a bounded delivery step with its own acceptance gate.
+
+### Phase 1 — deterministic planning contract — implemented in this change
+
+- `plan_audit_lanes()` with a fixed, versioned lane catalog.
+- Safe repository-path validation and deterministic tie-breaking.
+- Bounded output with explicit negative semantics.
+- Draft-07 JSON Schema and unit coverage.
+
+Acceptance gate: stable output, schema-valid examples, no agent or write surface.
+
+### Phase 2 — evidence adapter — registered follow-up
+
+Define a separate result contract that binds every claimed finding to resolvable Lenskit
+citations, changed revision identity and the executed lane. It must distinguish
+`candidate`, `verified`, `stale`, `wrong` and `unresolved` without converting an LLM
+verdict into repository truth.
+
+Acceptance gate: malformed, stale or citation-less findings fail closed.
+
+### Phase 3 — isolated pilot runner — registered follow-up
+
+Run only 5–10 selected lanes in an ephemeral container with read-only source, no user
+credentials, local output only, fixed call/time budgets and no automatic issue creation.
+
+Acceptance gate: sandbox evidence, bounded cost and deterministic run manifest.
+
+### Phase 4 — measured comparison — registered follow-up
+
+Compare baseline review against audit-lane-assisted review on closed Lenskit changes with
+known true findings and known false positives.
+
+Metrics: precision, expected-finding recall, duplicate rate, validated findings per agent
+call, cost and elapsed time. Promotion requires no central category regression and no
+security-boundary relaxation.
+
+## Lane catalog v1
+
+- concurrency and TOCTOU
+- storage and migration integrity
+- cache and publication coherence
+- authentication and authority boundaries
+- deployment and rollback contracts
+- UI, touch and accessibility
+- performance and scale
+- tests and failure semantics
+
+## Alternative path
+
+A cheaper alternative is to use only the existing review-intent retrieval router and
+manual review profiles. This remains valid when cost or attack surface matters more than
+incremental breadth. Audit lanes are justified only when the measured pilot finds more
+confirmed defects without unacceptable noise.
+
+## Risks and controls
+
+| Risk | Control |
+| --- | --- |
+| Prompt injection | No execution in Lenskit; later runner must be isolated and credential-free |
+| False positives | Separate evidence adapter and independent verification |
+| Cost explosion | Maximum eight planned lanes; pilot executes only 5–10 selected lanes with budgets |
+| Authority drift | `navigation_index`, `diagnostic`, explicit `does_not_establish` |
+| Correlated model errors | Goldset comparison and method diversity, not repeated `DONE` claims |
+| Stale findings | Revision binding and freshness validation in Phase 2 |
+
+## Non-goals
+
+- copying external prompt inventories or implementation code
+- adding an LLM dependency to Lenskit core
+- claiming review completeness
+- automatically filing issues or modifying repositories
+- making audit lanes the default review path before measurement

--- a/docs/proofs/audit-lane-planner-v1-proof.md
+++ b/docs/proofs/audit-lane-planner-v1-proof.md
@@ -31,6 +31,6 @@ python -m py_compile merger/lenskit/retrieval/audit_lane.py
 pytest -q merger/lenskit/tests/test_audit_lane.py
 ```
 
-Result: `15 passed`.
+Result: `19 passed`.
 
 The GitHub PR remains responsible for repository-wide CI and integration validation.

--- a/docs/proofs/audit-lane-planner-v1-proof.md
+++ b/docs/proofs/audit-lane-planner-v1-proof.md
@@ -1,0 +1,36 @@
+# Audit lane planner v1 proof
+
+## Scope
+
+This proof covers only deterministic planning. It does not prove that an external agent
+review is correct, complete, safe or useful.
+
+## Implemented surface
+
+- `merger/lenskit/retrieval/audit_lane.py`
+- `merger/lenskit/contracts/audit-lane-plan.v1.schema.json`
+- `merger/lenskit/tests/test_audit_lane.py`
+- `docs/architecture/audit-lane-adoption-v1.md`
+
+## Invariants
+
+1. The planner performs no filesystem, network, subprocess, agent or repository write.
+2. Changed paths must be relative normalized POSIX repository paths.
+3. Path evidence has weight two; query hints have weight one.
+4. Ties follow the immutable catalog order.
+5. Output contains between one and eight lanes.
+6. No-match input receives one general integrity lane rather than a false absence claim.
+7. The contract records diagnostic authority and explicit forbidden inferences.
+
+## Local verification before publication
+
+Executed against the isolated file set:
+
+```text
+python -m py_compile merger/lenskit/retrieval/audit_lane.py
+pytest -q merger/lenskit/tests/test_audit_lane.py
+```
+
+Result: `15 passed`.
+
+The GitHub PR remains responsible for repository-wide CI and integration validation.

--- a/merger/lenskit/contracts/audit-lane-plan.v1.schema.json
+++ b/merger/lenskit/contracts/audit-lane-plan.v1.schema.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://lenskit.merger/schemas/audit-lane-plan.v1.json",
+  "title": "Lenskit Audit Lane Plan",
+  "description": "Deterministic, planning-only routing of a bounded change surface into specialist audit lanes.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "authority",
+    "risk_class",
+    "inputs",
+    "routing",
+    "lanes",
+    "does_not_establish"
+  ],
+  "properties": {
+    "version": {"const": "audit_lane_plan.v1"},
+    "authority": {"const": "navigation_index"},
+    "risk_class": {"const": "diagnostic"},
+    "inputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["changed_paths", "review_query", "max_lanes"],
+      "properties": {
+        "changed_paths": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "review_query": {"type": "string"},
+        "max_lanes": {"type": "integer", "minimum": 1, "maximum": 8}
+      }
+    },
+    "routing": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "method",
+        "path_signal_weight",
+        "query_signal_weight",
+        "tie_break",
+        "selected_count"
+      ],
+      "properties": {
+        "method": {"const": "weighted_signal_match"},
+        "path_signal_weight": {"const": 2},
+        "query_signal_weight": {"const": 1},
+        "tie_break": {"const": "catalog_order"},
+        "selected_count": {"type": "integer", "minimum": 1, "maximum": 8}
+      }
+    },
+    "lanes": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 8,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "title", "score", "reasons", "required_evidence", "suggested_checks"],
+        "properties": {
+          "id": {"type": "string", "pattern": "^[a-z][a-z0-9_]*$"},
+          "title": {"type": "string", "minLength": 1},
+          "score": {"type": "integer", "minimum": 0},
+          "reasons": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["path_signals", "query_signals"],
+            "properties": {
+              "path_signals": {"type": "array", "uniqueItems": true, "items": {"type": "string"}},
+              "query_signals": {"type": "array", "uniqueItems": true, "items": {"type": "string"}}
+            }
+          },
+          "required_evidence": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {"type": "string", "minLength": 1}
+          },
+          "suggested_checks": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {"type": "string", "minLength": 1}
+          }
+        }
+      }
+    },
+    "does_not_establish": {
+      "type": "array",
+      "minItems": 5,
+      "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1}
+    }
+  }
+}

--- a/merger/lenskit/contracts/audit-lane-plan.v1.schema.json
+++ b/merger/lenskit/contracts/audit-lane-plan.v1.schema.json
@@ -26,7 +26,11 @@
         "changed_paths": {
           "type": "array",
           "uniqueItems": true,
-          "items": {"type": "string", "minLength": 1}
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$))(?!.*\\\\).+$"
+          }
         },
         "review_query": {"type": "string"},
         "max_lanes": {"type": "integer", "minimum": 1, "maximum": 8}

--- a/merger/lenskit/retrieval/audit_lane.py
+++ b/merger/lenskit/retrieval/audit_lane.py
@@ -153,8 +153,85 @@ def _normalize_paths(changed_paths: Iterable[str]) -> list[str]:
     return normalized
 
 
+def _validate_inputs(
+    changed_paths: Iterable[str], review_query: str, max_lanes: int
+) -> list[str]:
+    if isinstance(changed_paths, (str, bytes)):
+        raise ValueError("changed_paths must be an iterable of repository paths")
+    try:
+        iter(changed_paths)
+    except TypeError as exc:
+        raise ValueError("changed_paths must be an iterable of repository paths") from exc
+    if not isinstance(review_query, str):
+        raise ValueError("review_query must be a string")
+    if isinstance(max_lanes, bool) or not isinstance(max_lanes, int):
+        raise ValueError("max_lanes must be an integer")
+    if not 1 <= max_lanes <= _MAX_LANES:
+        raise ValueError(f"max_lanes must be between 1 and {_MAX_LANES}")
+    return _normalize_paths(changed_paths)
+
+
 def _matching_signals(tokens: set[str], signals: Sequence[str]) -> list[str]:
     return [signal for signal in signals if signal in tokens]
+
+
+def _rank_lanes(
+    paths: Sequence[str], review_query: str
+) -> list[tuple[int, int, AuditLaneDefinition, list[str], list[str]]]:
+    query_tokens = _tokens(review_query)
+    path_tokens: set[str] = set()
+    for path in paths:
+        path_tokens.update(_tokens(path))
+
+    ranked: list[tuple[int, int, AuditLaneDefinition, list[str], list[str]]] = []
+    for order, lane in enumerate(_LANES):
+        path_matches = _matching_signals(path_tokens, lane.path_signals)
+        query_matches = _matching_signals(query_tokens, lane.query_signals)
+        score = (2 * len(path_matches)) + len(query_matches)
+        if score:
+            ranked.append((score, order, lane, path_matches, query_matches))
+    return sorted(ranked, key=lambda item: (-item[0], item[1]))
+
+
+def _render_lane(
+    score: int,
+    lane: AuditLaneDefinition,
+    path_matches: Sequence[str],
+    query_matches: Sequence[str],
+) -> dict[str, Any]:
+    return {
+        "id": lane.lane_id,
+        "title": lane.title,
+        "score": score,
+        "reasons": {
+            "path_signals": list(path_matches),
+            "query_signals": list(query_matches),
+        },
+        "required_evidence": list(lane.required_evidence),
+        "suggested_checks": list(lane.suggested_checks),
+    }
+
+
+def _render_lanes(
+    ranked: Sequence[tuple[int, int, AuditLaneDefinition, list[str], list[str]]],
+    max_lanes: int,
+) -> list[dict[str, Any]]:
+    selected = [
+        _render_lane(score, lane, path_matches, query_matches)
+        for score, _order, lane, path_matches, query_matches in ranked[:max_lanes]
+    ]
+    if selected:
+        return selected
+    return [
+        {
+            "id": "general_change_integrity",
+            "title": "General change integrity",
+            "score": 0,
+            "reasons": {"path_signals": [], "query_signals": []},
+            "required_evidence": ["implementation", "tests", "error_paths"],
+            "suggested_checks": ["contract_review", "regression_review", "failure_path_review"],
+        }
+    ]
 
 
 def plan_audit_lanes(
@@ -171,64 +248,8 @@ def plan_audit_lanes(
     order. If nothing matches, a single general integrity lane is emitted.
     """
 
-    if isinstance(changed_paths, (str, bytes)):
-        raise ValueError("changed_paths must be an iterable of repository paths")
-    try:
-        iter(changed_paths)
-    except TypeError as exc:
-        raise ValueError("changed_paths must be an iterable of repository paths") from exc
-    if not isinstance(review_query, str):
-        raise ValueError("review_query must be a string")
-    if isinstance(max_lanes, bool) or not isinstance(max_lanes, int):
-        raise ValueError("max_lanes must be an integer")
-    if not 1 <= max_lanes <= _MAX_LANES:
-        raise ValueError(f"max_lanes must be between 1 and {_MAX_LANES}")
-
-    paths = _normalize_paths(changed_paths)
-    query_tokens = _tokens(review_query)
-    path_tokens: set[str] = set()
-    for path in paths:
-        path_tokens.update(_tokens(path))
-
-    ranked: list[tuple[int, int, AuditLaneDefinition, list[str], list[str]]] = []
-    for order, lane in enumerate(_LANES):
-        path_matches = _matching_signals(path_tokens, lane.path_signals)
-        query_matches = _matching_signals(query_tokens, lane.query_signals)
-        score = (2 * len(path_matches)) + len(query_matches)
-        if score:
-            ranked.append((score, order, lane, path_matches, query_matches))
-
-    ranked.sort(key=lambda item: (-item[0], item[1]))
-    selected = ranked[:max_lanes]
-
-    lane_plans: list[dict[str, Any]] = []
-    for score, _order, lane, path_matches, query_matches in selected:
-        lane_plans.append(
-            {
-                "id": lane.lane_id,
-                "title": lane.title,
-                "score": score,
-                "reasons": {
-                    "path_signals": path_matches,
-                    "query_signals": query_matches,
-                },
-                "required_evidence": list(lane.required_evidence),
-                "suggested_checks": list(lane.suggested_checks),
-            }
-        )
-
-    if not lane_plans:
-        lane_plans.append(
-            {
-                "id": "general_change_integrity",
-                "title": "General change integrity",
-                "score": 0,
-                "reasons": {"path_signals": [], "query_signals": []},
-                "required_evidence": ["implementation", "tests", "error_paths"],
-                "suggested_checks": ["contract_review", "regression_review", "failure_path_review"],
-            }
-        )
-
+    paths = _validate_inputs(changed_paths, review_query, max_lanes)
+    lane_plans = _render_lanes(_rank_lanes(paths, review_query), max_lanes)
     return {
         "version": "audit_lane_plan.v1",
         "authority": "navigation_index",

--- a/merger/lenskit/retrieval/audit_lane.py
+++ b/merger/lenskit/retrieval/audit_lane.py
@@ -14,6 +14,26 @@ from typing import Any, Iterable, Sequence
 
 _TOKEN_RE = re.compile(r"[a-z0-9]+")
 _MAX_LANES = 8
+_PHRASE_ALIASES = {
+    "false positives": "falsepositive",
+    "false positive": "falsepositive",
+    "n+1": "nplusone",
+}
+_TOKEN_ALIASES = {
+    "caches": "cache",
+    "deployments": "deploy",
+    "errors": "error",
+    "failures": "failure",
+    "indices": "index",
+    "migrations": "migration",
+    "permissions": "permission",
+    "queries": "query",
+    "races": "race",
+    "releases": "release",
+    "secrets": "secret",
+    "tests": "test",
+    "tokens": "token",
+}
 
 
 @dataclass(frozen=True)
@@ -79,7 +99,7 @@ _LANES: tuple[AuditLaneDefinition, ...] = (
         lane_id="performance_scale",
         title="Performance and scale",
         path_signals=("index", "stream", "scan", "query", "graph", "cache", "batch"),
-        query_signals=("performance", "scale", "memory", "latency", "stream", "n+1"),
+        query_signals=("performance", "scale", "memory", "latency", "stream", "nplusone"),
         required_evidence=("hot_path", "boundedness", "measurement_or_regression_test"),
         suggested_checks=("full_scan_review", "allocation_review", "complexity_review"),
     ),
@@ -87,9 +107,13 @@ _LANES: tuple[AuditLaneDefinition, ...] = (
         lane_id="test_failure_semantics",
         title="Tests and failure semantics",
         path_signals=("test", "validator", "error", "exception", "result", "status"),
-        query_signals=("test", "failure", "error", "exception", "fallback", "false positive"),
+        query_signals=("test", "failure", "error", "exception", "fallback", "falsepositive"),
         required_evidence=("implementation", "negative_tests", "error_contract"),
-        suggested_checks=("fail_open_review", "error_propagation_review", "assertion_quality_review"),
+        suggested_checks=(
+            "fail_open_review",
+            "error_propagation_review",
+            "assertion_quality_review",
+        ),
     ),
 )
 
@@ -103,7 +127,12 @@ _DOES_NOT_ESTABLISH = (
 
 
 def _tokens(value: str) -> set[str]:
-    return set(_TOKEN_RE.findall(value.lower()))
+    normalized = value.lower()
+    for phrase, replacement in _PHRASE_ALIASES.items():
+        normalized = normalized.replace(phrase, replacement)
+    tokens = set(_TOKEN_RE.findall(normalized))
+    tokens.update(_TOKEN_ALIASES[token] for token in tuple(tokens) if token in _TOKEN_ALIASES)
+    return tokens
 
 
 def _normalize_paths(changed_paths: Iterable[str]) -> list[str]:
@@ -142,6 +171,12 @@ def plan_audit_lanes(
     order. If nothing matches, a single general integrity lane is emitted.
     """
 
+    if isinstance(changed_paths, (str, bytes)):
+        raise ValueError("changed_paths must be an iterable of repository paths")
+    try:
+        iter(changed_paths)
+    except TypeError as exc:
+        raise ValueError("changed_paths must be an iterable of repository paths") from exc
     if not isinstance(review_query, str):
         raise ValueError("review_query must be a string")
     if isinstance(max_lanes, bool) or not isinstance(max_lanes, int):

--- a/merger/lenskit/retrieval/audit_lane.py
+++ b/merger/lenskit/retrieval/audit_lane.py
@@ -1,0 +1,215 @@
+"""Deterministic planning for bounded, evidence-oriented audit lanes.
+
+The planner turns changed repository paths and an optional review question into a
+small, ordered set of specialist audit lanes. It does not execute agents, inspect
+repository contents, produce findings, or claim review completeness.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import Any, Iterable, Sequence
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+_MAX_LANES = 8
+
+
+@dataclass(frozen=True)
+class AuditLaneDefinition:
+    lane_id: str
+    title: str
+    path_signals: tuple[str, ...]
+    query_signals: tuple[str, ...]
+    required_evidence: tuple[str, ...]
+    suggested_checks: tuple[str, ...]
+
+
+_LANES: tuple[AuditLaneDefinition, ...] = (
+    AuditLaneDefinition(
+        lane_id="concurrency_toctou",
+        title="Concurrency and TOCTOU",
+        path_signals=("lock", "lease", "atomic", "publish", "generation", "transaction"),
+        query_signals=("race", "toctou", "concurrent", "atomic", "lock", "lease"),
+        required_evidence=("implementation", "negative_tests", "state_transition"),
+        suggested_checks=("interleaving_review", "failure_window_review", "rollback_review"),
+    ),
+    AuditLaneDefinition(
+        lane_id="storage_integrity",
+        title="Storage and migration integrity",
+        path_signals=("migration", "schema", "database", "sqlite", "store", "registry"),
+        query_signals=("migration", "database", "integrity", "schema", "corruption"),
+        required_evidence=("schema_or_contract", "implementation", "migration_tests"),
+        suggested_checks=("transaction_boundary_review", "backward_compatibility_review"),
+    ),
+    AuditLaneDefinition(
+        lane_id="cache_publication",
+        title="Cache and publication coherence",
+        path_signals=("cache", "bundle", "manifest", "generation", "pointer", "publish"),
+        query_signals=("cache", "stale", "publication", "coherence", "generation"),
+        required_evidence=("producer", "consumer", "invalidation_tests"),
+        suggested_checks=("staleness_review", "partial_write_review", "reader_visibility_review"),
+    ),
+    AuditLaneDefinition(
+        lane_id="auth_boundaries",
+        title="Authentication and authority boundaries",
+        path_signals=("auth", "permission", "token", "secret", "session", "policy"),
+        query_signals=("auth", "permission", "privilege", "token", "secret", "authority"),
+        required_evidence=("policy_or_contract", "enforcement", "negative_tests"),
+        suggested_checks=("bypass_review", "default_deny_review", "credential_scope_review"),
+    ),
+    AuditLaneDefinition(
+        lane_id="deploy_rollback",
+        title="Deployment and rollback contracts",
+        path_signals=("deploy", "release", "rollback", "workflow", "systemd", "kubernetes"),
+        query_signals=("deploy", "release", "rollback", "live", "reconcile"),
+        required_evidence=("deployment_path", "rollback_path", "operational_tests"),
+        suggested_checks=("failure_recovery_review", "source_identity_review", "readback_review"),
+    ),
+    AuditLaneDefinition(
+        lane_id="ui_accessibility",
+        title="UI, touch and accessibility",
+        path_signals=("ui", "webui", "component", "css", "svelte", "accessibility", "touch"),
+        query_signals=("ui", "ux", "touch", "focus", "keyboard", "accessibility", "responsive"),
+        required_evidence=("implementation", "interaction_tests", "viewport_or_a11y_evidence"),
+        suggested_checks=("focus_review", "touch_target_review", "layering_review"),
+    ),
+    AuditLaneDefinition(
+        lane_id="performance_scale",
+        title="Performance and scale",
+        path_signals=("index", "stream", "scan", "query", "graph", "cache", "batch"),
+        query_signals=("performance", "scale", "memory", "latency", "stream", "n+1"),
+        required_evidence=("hot_path", "boundedness", "measurement_or_regression_test"),
+        suggested_checks=("full_scan_review", "allocation_review", "complexity_review"),
+    ),
+    AuditLaneDefinition(
+        lane_id="test_failure_semantics",
+        title="Tests and failure semantics",
+        path_signals=("test", "validator", "error", "exception", "result", "status"),
+        query_signals=("test", "failure", "error", "exception", "fallback", "false positive"),
+        required_evidence=("implementation", "negative_tests", "error_contract"),
+        suggested_checks=("fail_open_review", "error_propagation_review", "assertion_quality_review"),
+    ),
+)
+
+_DOES_NOT_ESTABLISH = (
+    "The plan does not establish that any defect exists.",
+    "A selected lane does not establish relevance, correctness, severity, or completeness.",
+    "An unselected lane does not establish that its risk is absent.",
+    "Suggested checks are planning hints, not executed evidence.",
+    "The plan does not authorize agent execution, repository writes, issue creation, or merges.",
+)
+
+
+def _tokens(value: str) -> set[str]:
+    return set(_TOKEN_RE.findall(value.lower()))
+
+
+def _normalize_paths(changed_paths: Iterable[str]) -> list[str]:
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw in changed_paths:
+        if not isinstance(raw, str):
+            raise ValueError("changed_paths must contain strings")
+        if not raw or "\x00" in raw or "\\" in raw:
+            raise ValueError("changed_paths must contain non-empty POSIX repository paths")
+        path = PurePosixPath(raw)
+        if path.is_absolute() or ".." in path.parts or "." in path.parts:
+            raise ValueError("changed_paths must be normalized relative repository paths")
+        text = str(path)
+        if text not in seen:
+            seen.add(text)
+            normalized.append(text)
+    return normalized
+
+
+def _matching_signals(tokens: set[str], signals: Sequence[str]) -> list[str]:
+    return [signal for signal in signals if signal in tokens]
+
+
+def plan_audit_lanes(
+    changed_paths: Iterable[str],
+    *,
+    review_query: str = "",
+    max_lanes: int = 6,
+) -> dict[str, Any]:
+    """Return a deterministic, bounded audit-lane plan.
+
+    Path matches carry weight two because they are tied to the concrete change
+    surface. Query matches carry weight one because natural-language requests are
+    useful routing hints but weaker evidence. Ties preserve the fixed lane catalog
+    order. If nothing matches, a single general integrity lane is emitted.
+    """
+
+    if not isinstance(review_query, str):
+        raise ValueError("review_query must be a string")
+    if isinstance(max_lanes, bool) or not isinstance(max_lanes, int):
+        raise ValueError("max_lanes must be an integer")
+    if not 1 <= max_lanes <= _MAX_LANES:
+        raise ValueError(f"max_lanes must be between 1 and {_MAX_LANES}")
+
+    paths = _normalize_paths(changed_paths)
+    query_tokens = _tokens(review_query)
+    path_tokens: set[str] = set()
+    for path in paths:
+        path_tokens.update(_tokens(path))
+
+    ranked: list[tuple[int, int, AuditLaneDefinition, list[str], list[str]]] = []
+    for order, lane in enumerate(_LANES):
+        path_matches = _matching_signals(path_tokens, lane.path_signals)
+        query_matches = _matching_signals(query_tokens, lane.query_signals)
+        score = (2 * len(path_matches)) + len(query_matches)
+        if score:
+            ranked.append((score, order, lane, path_matches, query_matches))
+
+    ranked.sort(key=lambda item: (-item[0], item[1]))
+    selected = ranked[:max_lanes]
+
+    lane_plans: list[dict[str, Any]] = []
+    for score, _order, lane, path_matches, query_matches in selected:
+        lane_plans.append(
+            {
+                "id": lane.lane_id,
+                "title": lane.title,
+                "score": score,
+                "reasons": {
+                    "path_signals": path_matches,
+                    "query_signals": query_matches,
+                },
+                "required_evidence": list(lane.required_evidence),
+                "suggested_checks": list(lane.suggested_checks),
+            }
+        )
+
+    if not lane_plans:
+        lane_plans.append(
+            {
+                "id": "general_change_integrity",
+                "title": "General change integrity",
+                "score": 0,
+                "reasons": {"path_signals": [], "query_signals": []},
+                "required_evidence": ["implementation", "tests", "error_paths"],
+                "suggested_checks": ["contract_review", "regression_review", "failure_path_review"],
+            }
+        )
+
+    return {
+        "version": "audit_lane_plan.v1",
+        "authority": "navigation_index",
+        "risk_class": "diagnostic",
+        "inputs": {
+            "changed_paths": paths,
+            "review_query": review_query,
+            "max_lanes": max_lanes,
+        },
+        "routing": {
+            "method": "weighted_signal_match",
+            "path_signal_weight": 2,
+            "query_signal_weight": 1,
+            "tie_break": "catalog_order",
+            "selected_count": len(lane_plans),
+        },
+        "lanes": lane_plans,
+        "does_not_establish": list(_DOES_NOT_ESTABLISH),
+    }

--- a/merger/lenskit/tests/test_audit_lane.py
+++ b/merger/lenskit/tests/test_audit_lane.py
@@ -59,6 +59,9 @@ def test_emits_general_lane_when_no_signal_matches():
         ["src\\windows.py"],
         [""],
         [123],
+        "src/file.py",
+        None,
+        123,
     ],
 )
 def test_rejects_non_repository_paths(paths):
@@ -84,6 +87,19 @@ def test_output_validates_against_contract():
 
     Draft7Validator.check_schema(schema)
     Draft7Validator(schema).validate(plan)
+
+
+def test_normalizes_bounded_plural_and_phrase_aliases():
+    plan = plan_audit_lanes(
+        ["src/domain/widget.py"],
+        review_query="races, migrations, N+1 queries and false positives",
+    )
+
+    ids = [lane["id"] for lane in plan["lanes"]]
+    assert "concurrency_toctou" in ids
+    assert "storage_integrity" in ids
+    assert "performance_scale" in ids
+    assert "test_failure_semantics" in ids
 
 
 def test_plan_has_explicit_negative_semantics():

--- a/merger/lenskit/tests/test_audit_lane.py
+++ b/merger/lenskit/tests/test_audit_lane.py
@@ -1,0 +1,95 @@
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft7Validator
+
+from merger.lenskit.retrieval.audit_lane import plan_audit_lanes
+
+
+def test_routes_concrete_change_surface_before_query_hints():
+    plan = plan_audit_lanes(
+        [
+            "merger/lenskit/core/bundle_generation.py",
+            "merger/lenskit/tests/test_bundle_generation.py",
+        ],
+        review_query="Check races, rollback and stale cache behaviour",
+    )
+
+    ids = [lane["id"] for lane in plan["lanes"]]
+    assert ids[0] in {"concurrency_toctou", "cache_publication"}
+    assert "test_failure_semantics" in ids
+    assert plan["routing"]["path_signal_weight"] == 2
+    assert plan["authority"] == "navigation_index"
+
+
+def test_is_deterministic_and_deduplicates_paths():
+    paths = ["src/auth/session.py", "src/auth/session.py", "tests/test_auth.py"]
+    first = plan_audit_lanes(paths, review_query="permission bypass")
+    second = plan_audit_lanes(paths, review_query="permission bypass")
+
+    assert first == second
+    assert first["inputs"]["changed_paths"] == ["src/auth/session.py", "tests/test_auth.py"]
+    assert first["lanes"][0]["id"] == "auth_boundaries"
+
+
+def test_respects_lane_bound_and_uses_catalog_order_for_ties():
+    plan = plan_audit_lanes(
+        ["src/cache/auth/deploy/ui/index/test.py"],
+        review_query="race migration release accessibility performance failure",
+        max_lanes=3,
+    )
+
+    assert len(plan["lanes"]) == 3
+    assert plan["routing"]["selected_count"] == 3
+
+
+def test_emits_general_lane_when_no_signal_matches():
+    plan = plan_audit_lanes(["src/domain/widget.py"])
+
+    assert [lane["id"] for lane in plan["lanes"]] == ["general_change_integrity"]
+    assert plan["lanes"][0]["score"] == 0
+
+
+@pytest.mark.parametrize(
+    "paths",
+    [
+        ["/absolute/path.py"],
+        ["../escape.py"],
+        ["src\\windows.py"],
+        [""],
+        [123],
+    ],
+)
+def test_rejects_non_repository_paths(paths):
+    with pytest.raises(ValueError):
+        plan_audit_lanes(paths)
+
+
+@pytest.mark.parametrize("value", [0, 9, True, 1.5])
+def test_rejects_invalid_lane_limits(value):
+    with pytest.raises(ValueError):
+        plan_audit_lanes(["src/file.py"], max_lanes=value)
+
+
+def test_output_validates_against_contract():
+    schema_path = (
+        Path(__file__).parents[1] / "contracts" / "audit-lane-plan.v1.schema.json"
+    )
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    plan = plan_audit_lanes(
+        ["src/migrations/001_add_index.py", "tests/test_migration.py"],
+        review_query="database integrity and rollback",
+    )
+
+    Draft7Validator.check_schema(schema)
+    Draft7Validator(schema).validate(plan)
+
+
+def test_plan_has_explicit_negative_semantics():
+    plan = plan_audit_lanes(["src/auth/token.py"])
+    boundary = " ".join(plan["does_not_establish"]).lower()
+
+    assert "defect" in boundary
+    assert "completeness" in boundary
+    assert "authorize" in boundary


### PR DESCRIPTION
## Summary

Adopts the bounded, evidence-oriented part of specialist-lens review systems without adding an autonomous agent runner to Lenskit.

- plans 1–8 specialist audit lanes from changed repository paths and an optional review question
- weights concrete path signals above natural-language hints
- emits required evidence and suggested checks separately
- marks output as `navigation_index` / `diagnostic`
- records explicit negative semantics
- adds Draft-07 contract, architecture decision, proof and focused tests

Bureau registration: heimgewebe/bureau#635

## Safety boundary

This change performs no filesystem scan, network access, subprocess execution, agent dispatch, repository write, issue creation or merge action. It does not establish defects, correctness, severity or review completeness.

## Verification

Isolated pre-publication verification:

```text
python -m py_compile merger/lenskit/retrieval/audit_lane.py
pytest -q merger/lenskit/tests/test_audit_lane.py
19 passed
```

Self-review follow-up hardened plural/phrase routing, malformed iterable rejection, contract-level repository path constraints and lane-bound consistency.

Repository-wide CI remains authoritative.

## Follow-ups

The registered later phases are: citation-bound finding adapter, isolated credential-free pilot runner, and a measured comparison against known findings before any default promotion.