### PR TITLE
feat(review): bind audit findings to revision and citations

### DIFF
--- a/docs/architecture/audit-finding-adapter-v1.md
+++ b/docs/architecture/audit-finding-adapter-v1.md
@@ -23,7 +23,7 @@ A later signal may not silently override a stronger safety boundary:
 4. only a fresh, citation-resolved candidate may receive a verifier state;
 5. without a verifier state it remains `candidate`.
 
-A preserved verifier verdict is marked `verifier_verdict_applied=false` when revision or
+A preserved verification record is marked `verification_applied=false` when revision or
 citation freshness blocks it. This prevents evidence loss while avoiding a false verified
 state.
 

--- a/docs/architecture/audit-finding-adapter-v1.md
+++ b/docs/architecture/audit-finding-adapter-v1.md
@@ -1,0 +1,72 @@
+---
+doc_type: architecture_decision
+status: implemented
+task: BUREAU-LENSKIT-AUDIT-LANES-002
+---
+
+# Citation-bound audit finding adapter v1
+
+## Purpose
+
+The adapter turns untrusted audit-lane candidate claims into a deterministic diagnostic
+result set. It does not decide repository truth. It records whether a candidate belongs
+to a selected lane, points at resolvable Lenskit citations and was reviewed against the
+same repository revision that is current at adaptation time.
+
+## Priority order
+
+A later signal may not silently override a stronger safety boundary:
+
+1. malformed input is rejected;
+2. revision mismatch yields `stale`;
+3. an unknown citation yields `unresolved`;
+4. only a fresh, citation-resolved candidate may receive a verifier state;
+5. without a verifier state it remains `candidate`.
+
+A preserved verifier verdict is marked `verifier_verdict_applied=false` when revision or
+citation freshness blocks it. This prevents evidence loss while avoiding a false verified
+state.
+
+## States
+
+| State | Meaning | Does not mean |
+| --- | --- | --- |
+| `candidate` | syntactically admitted and evidence-addressed, not independently decided | defect exists |
+| `verified` | recorded verifier accepted the claim under the exact current revision and resolvable citations | repository truth or completeness |
+| `stale` | reviewed and current revisions differ | claim is wrong |
+| `wrong` | recorded verifier rejected the claim | surrounding code is correct |
+| `unresolved` | evidence address is missing or verifier could not decide | claim is false |
+
+## Identity
+
+`finding_id` is derived from the normalized lane id, normalized claim text and sorted
+unique citation ids. Input order therefore cannot change identity or output ordering.
+Duplicate semantic candidates are rejected instead of being counted twice.
+
+## Citation boundary
+
+Citation ids must use the existing `cit_<16 lower-hex>` address form. The adapter consumes
+an explicit registry of citation ids that the caller already resolved from a validated
+Lenskit citation map. It does not invent citations and does not claim that a structurally
+valid citation proves the candidate.
+
+## Authority
+
+The output declares:
+
+- `authority=diagnostic_signal`
+- `risk_class=diagnostic`
+
+It forbids inference of repository truth, review completeness, runtime correctness,
+severity correctness or permission to mutate GitHub or a repository.
+
+## Non-goals
+
+- running an LLM or verifier
+- reading repository files or bundle contents
+- creating issues, patches, commits, pushes or merges
+- assigning severity
+- deciding whether audit lanes improve review quality
+
+The isolated runner remains BUREAU-LENSKIT-AUDIT-LANES-003. Measurement and promotion
+remain BUREAU-LENSKIT-AUDIT-LANES-004.

--- a/docs/proofs/audit-finding-adapter-v1-proof.md
+++ b/docs/proofs/audit-finding-adapter-v1-proof.md
@@ -1,0 +1,38 @@
+# Audit finding adapter v1 proof
+
+## Scope
+
+This proof covers deterministic admission, revision freshness and citation resolution. It
+does not prove that a verifier is correct, that a cited range supports a claim or that a
+review is complete.
+
+## Implemented surface
+
+- `merger/lenskit/retrieval/audit_finding.py`
+- `merger/lenskit/contracts/audit-finding-set.v1.schema.json`
+- `merger/lenskit/tests/test_audit_finding.py`
+- `docs/architecture/audit-finding-adapter-v1.md`
+
+## Invariants
+
+1. Candidate identity is deterministic across whitespace and citation order.
+2. Candidates must reference a lane selected by `audit_lane_plan.v1`.
+3. Every candidate has at least one syntactically valid citation id.
+4. Duplicate semantic candidates and duplicate verifier verdicts fail closed.
+5. Revision mismatch takes precedence over verifier output and yields `stale`.
+6. Unresolvable citations take precedence over verifier output and yield `unresolved`.
+7. Blocked verifier output remains visible but is marked unapplied.
+8. Output ordering is stable by `finding_id`.
+9. The adapter performs no filesystem, network, subprocess, agent or repository write.
+10. Authority and forbidden inferences remain explicit and schema-bound.
+
+## Verification
+
+The focused verification command is:
+
+```text
+pytest -q merger/lenskit/tests/test_audit_lane.py merger/lenskit/tests/test_audit_finding.py
+```
+
+Repository-wide GitHub CI is authoritative for the published change. The PR must not be
+merged until tests, lint, contract validation, security checks and self-review are green.

--- a/docs/proofs/audit-finding-adapter-v1-proof.md
+++ b/docs/proofs/audit-finding-adapter-v1-proof.md
@@ -11,6 +11,7 @@ review is complete.
 - `merger/lenskit/retrieval/audit_finding.py`
 - `merger/lenskit/contracts/audit-finding-set.v1.schema.json`
 - `merger/lenskit/tests/test_audit_finding.py`
+- `merger/lenskit/tests/test_audit_finding_contract.py`
 - `docs/architecture/audit-finding-adapter-v1.md`
 
 ## Invariants
@@ -18,20 +19,24 @@ review is complete.
 1. Candidate identity is deterministic across whitespace and citation order.
 2. Candidates must reference a lane selected by `audit_lane_plan.v1`.
 3. Every candidate has at least one syntactically valid citation id.
-4. Duplicate semantic candidates and duplicate verifier verdicts fail closed.
+4. Duplicate semantic candidates and duplicate verifier decisions fail closed.
 5. Revision mismatch takes precedence over verifier output and yields `stale`.
-6. Unresolvable citations take precedence over verifier output and yield `unresolved`.
-7. Blocked verifier output remains visible but is marked unapplied.
+6. Unresolvable citations take precedence over verifier output and yields `unresolved`.
+7. Blocked verification records remain visible but are marked unapplied.
 8. Output ordering is stable by `finding_id`.
-9. The adapter performs no filesystem, network, subprocess, agent or repository write.
-10. Authority and forbidden inferences remain explicit and schema-bound.
+9. State-count ordering and applied-verification consistency are contract-bound.
+10. The adapter performs no filesystem, network, subprocess, agent or repository write.
+11. Authority and forbidden inferences remain explicit and schema-bound.
 
 ## Verification
 
 The focused verification command is:
 
 ```text
-pytest -q merger/lenskit/tests/test_audit_lane.py merger/lenskit/tests/test_audit_finding.py
+pytest -q \
+  merger/lenskit/tests/test_audit_lane.py \
+  merger/lenskit/tests/test_audit_finding.py \
+  merger/lenskit/tests/test_audit_finding_contract.py
 ```
 
 Repository-wide GitHub CI is authoritative for the published change. The PR must not be

--- a/docs/proofs/audit-finding-adapter-v1-proof.md
+++ b/docs/proofs/audit-finding-adapter-v1-proof.md
@@ -21,7 +21,7 @@ review is complete.
 3. Every candidate has at least one syntactically valid citation id.
 4. Duplicate semantic candidates and duplicate verifier decisions fail closed.
 5. Revision mismatch takes precedence over verifier output and yields `stale`.
-6. Unresolvable citations take precedence over verifier output and yields `unresolved`.
+6. Unresolvable citations take precedence over verifier output and yield `unresolved`.
 7. Blocked verification records remain visible but are marked unapplied.
 8. Output ordering is stable by `finding_id`.
 9. State-count ordering and applied-verification consistency are contract-bound.

--- a/merger/lenskit/contracts/audit-finding-set.v1.schema.json
+++ b/merger/lenskit/contracts/audit-finding-set.v1.schema.json
@@ -39,8 +39,8 @@
           "state",
           "state_reason",
           "unresolved_citation_ids",
-          "verifier_verdict",
-          "verifier_verdict_applied"
+          "verification_record",
+          "verification_applied"
         ],
         "properties": {
           "finding_id": {"type": "string", "pattern": "^af_[a-f0-9]{16}$"},
@@ -71,7 +71,7 @@
             "uniqueItems": true,
             "items": {"type": "string", "pattern": "^cit_[a-f0-9]{16}$"}
           },
-          "verifier_verdict": {
+          "verification_record": {
             "oneOf": [
               {"type": "null"},
               {
@@ -87,7 +87,7 @@
               }
             ]
           },
-          "verifier_verdict_applied": {"type": "boolean"}
+          "verification_applied": {"type": "boolean"}
         }
       }
     },

--- a/merger/lenskit/contracts/audit-finding-set.v1.schema.json
+++ b/merger/lenskit/contracts/audit-finding-set.v1.schema.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://lenskit.merger/schemas/audit-finding-set.v1.json",
+  "title": "Lenskit Audit Finding Set",
+  "description": "Diagnostic result set binding audit-lane candidates to an exact revision and resolvable Lenskit citations.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "authority",
+    "risk_class",
+    "plan_version",
+    "reviewed_revision",
+    "current_revision",
+    "revision_fresh",
+    "findings",
+    "summary",
+    "allowed_inferences",
+    "forbidden_inferences"
+  ],
+  "properties": {
+    "version": {"const": "audit_finding_set.v1"},
+    "authority": {"const": "diagnostic_signal"},
+    "risk_class": {"const": "diagnostic"},
+    "plan_version": {"const": "audit_lane_plan.v1"},
+    "reviewed_revision": {"type": "string", "pattern": "^[a-f0-9]{40}$"},
+    "current_revision": {"type": "string", "pattern": "^[a-f0-9]{40}$"},
+    "revision_fresh": {"type": "boolean"},
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "finding_id",
+          "lane_id",
+          "claim",
+          "citation_ids",
+          "state",
+          "state_reason",
+          "unresolved_citation_ids",
+          "verifier_verdict",
+          "verifier_verdict_applied"
+        ],
+        "properties": {
+          "finding_id": {"type": "string", "pattern": "^af_[a-f0-9]{16}$"},
+          "lane_id": {"type": "string", "pattern": "^[a-z][a-z0-9_]*$"},
+          "claim": {"type": "string", "minLength": 1},
+          "citation_ids": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {"type": "string", "pattern": "^cit_[a-f0-9]{16}$"}
+          },
+          "state": {
+            "type": "string",
+            "enum": ["candidate", "verified", "stale", "wrong", "unresolved"]
+          },
+          "state_reason": {
+            "type": "string",
+            "enum": [
+              "verification_missing",
+              "verifier_verdict",
+              "revision_mismatch",
+              "citation_unresolved"
+            ]
+          },
+          "unresolved_citation_ids": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {"type": "string", "pattern": "^cit_[a-f0-9]{16}$"}
+          },
+          "verifier_verdict": {
+            "oneOf": [
+              {"type": "null"},
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["finding_id", "state", "verifier_id", "note"],
+                "properties": {
+                  "finding_id": {"type": "string", "pattern": "^af_[a-f0-9]{16}$"},
+                  "state": {"type": "string", "enum": ["verified", "wrong", "unresolved"]},
+                  "verifier_id": {"type": "string", "minLength": 1},
+                  "note": {"type": "string", "minLength": 1}
+                }
+              }
+            ]
+          },
+          "verifier_verdict_applied": {"type": "boolean"}
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["candidate", "verified", "stale", "wrong", "unresolved"],
+      "properties": {
+        "candidate": {"type": "integer", "minimum": 0},
+        "verified": {"type": "integer", "minimum": 0},
+        "stale": {"type": "integer", "minimum": 0},
+        "wrong": {"type": "integer", "minimum": 0},
+        "unresolved": {"type": "integer", "minimum": 0}
+      }
+    },
+    "allowed_inferences": {
+      "type": "array",
+      "minItems": 2,
+      "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "forbidden_inferences": {
+      "type": "array",
+      "minItems": 5,
+      "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1}
+    }
+  }
+}

--- a/merger/lenskit/contracts/audit-finding-set.v1.schema.json
+++ b/merger/lenskit/contracts/audit-finding-set.v1.schema.json
@@ -14,9 +14,9 @@
     "current_revision",
     "revision_fresh",
     "findings",
-    "summary",
+    "state_counts",
     "allowed_inferences",
-    "forbidden_inferences"
+    "does_not_prove"
   ],
   "properties": {
     "version": {"const": "audit_finding_set.v1"},
@@ -45,10 +45,11 @@
         "properties": {
           "finding_id": {"type": "string", "pattern": "^af_[a-f0-9]{16}$"},
           "lane_id": {"type": "string", "pattern": "^[a-z][a-z0-9_]*$"},
-          "claim": {"type": "string", "minLength": 1},
+          "claim": {"type": "string", "minLength": 1, "maxLength": 8192},
           "citation_ids": {
             "type": "array",
             "minItems": 1,
+            "maxItems": 64,
             "uniqueItems": true,
             "items": {"type": "string", "pattern": "^cit_[a-f0-9]{16}$"}
           },
@@ -80,8 +81,8 @@
                 "properties": {
                   "finding_id": {"type": "string", "pattern": "^af_[a-f0-9]{16}$"},
                   "state": {"type": "string", "enum": ["verified", "wrong", "unresolved"]},
-                  "verifier_id": {"type": "string", "minLength": 1},
-                  "note": {"type": "string", "minLength": 1}
+                  "verifier_id": {"type": "string", "minLength": 1, "maxLength": 8192},
+                  "note": {"type": "string", "minLength": 1, "maxLength": 8192}
                 }
               }
             ]
@@ -90,16 +91,21 @@
         }
       }
     },
-    "summary": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["candidate", "verified", "stale", "wrong", "unresolved"],
-      "properties": {
-        "candidate": {"type": "integer", "minimum": 0},
-        "verified": {"type": "integer", "minimum": 0},
-        "stale": {"type": "integer", "minimum": 0},
-        "wrong": {"type": "integer", "minimum": 0},
-        "unresolved": {"type": "integer", "minimum": 0}
+    "state_counts": {
+      "type": "array",
+      "minItems": 5,
+      "maxItems": 5,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["state", "count"],
+        "properties": {
+          "state": {
+            "type": "string",
+            "enum": ["candidate", "verified", "stale", "wrong", "unresolved"]
+          },
+          "count": {"type": "integer", "minimum": 0}
+        }
       }
     },
     "allowed_inferences": {
@@ -108,7 +114,7 @@
       "uniqueItems": true,
       "items": {"type": "string", "minLength": 1}
     },
-    "forbidden_inferences": {
+    "does_not_prove": {
       "type": "array",
       "minItems": 5,
       "uniqueItems": true,

--- a/merger/lenskit/contracts/audit-finding-set.v1.schema.json
+++ b/merger/lenskit/contracts/audit-finding-set.v1.schema.json
@@ -88,25 +88,85 @@
             ]
           },
           "verification_applied": {"type": "boolean"}
-        }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": {"verification_applied": {"const": true}}
+            },
+            "then": {
+              "properties": {
+                "verification_record": {"type": "object"},
+                "state_reason": {"const": "verifier_verdict"}
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {"state_reason": {"const": "verifier_verdict"}}
+            },
+            "then": {
+              "properties": {
+                "verification_record": {"type": "object"},
+                "verification_applied": {"const": true}
+              }
+            }
+          }
+        ]
       }
     },
     "state_counts": {
       "type": "array",
       "minItems": 5,
       "maxItems": 5,
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["state", "count"],
-        "properties": {
-          "state": {
-            "type": "string",
-            "enum": ["candidate", "verified", "stale", "wrong", "unresolved"]
-          },
-          "count": {"type": "integer", "minimum": 0}
+      "items": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["state", "count"],
+          "properties": {
+            "state": {"const": "candidate"},
+            "count": {"type": "integer", "minimum": 0}
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["state", "count"],
+          "properties": {
+            "state": {"const": "verified"},
+            "count": {"type": "integer", "minimum": 0}
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["state", "count"],
+          "properties": {
+            "state": {"const": "stale"},
+            "count": {"type": "integer", "minimum": 0}
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["state", "count"],
+          "properties": {
+            "state": {"const": "wrong"},
+            "count": {"type": "integer", "minimum": 0}
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["state", "count"],
+          "properties": {
+            "state": {"const": "unresolved"},
+            "count": {"type": "integer", "minimum": 0}
+          }
         }
-      }
+      ],
+      "additionalItems": false
     },
     "allowed_inferences": {
       "type": "array",

--- a/merger/lenskit/retrieval/audit_finding.py
+++ b/merger/lenskit/retrieval/audit_finding.py
@@ -17,6 +17,10 @@ _REVISION_RE = re.compile(r"^[a-f0-9]{40}$")
 _CITATION_RE = re.compile(r"^cit_[a-f0-9]{16}$")
 _VERIFIER_STATES = frozenset({"verified", "wrong", "unresolved"})
 _STATES = ("candidate", "verified", "stale", "wrong", "unresolved")
+_MAX_TEXT_CHARS = 8192
+_MAX_CITATIONS = 64
+_CANDIDATE_KEYS = frozenset({"lane_id", "claim", "citation_ids"})
+_VERDICT_KEYS = frozenset({"finding_id", "state", "verifier_id", "note"})
 
 
 class AuditFindingError(ValueError):
@@ -32,18 +36,34 @@ def _require_revision(value: str, field: str) -> str:
 def _require_string(value: Any, field: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise AuditFindingError(f"{field} must be a non-empty string")
-    return " ".join(value.split())
+    normalized = " ".join(value.split())
+    if len(normalized) > _MAX_TEXT_CHARS:
+        raise AuditFindingError(f"{field} exceeds {_MAX_TEXT_CHARS} characters")
+    return normalized
+
+
+def _require_items(values: Any, field: str) -> list[Any]:
+    if isinstance(values, (str, bytes)):
+        raise AuditFindingError(f"{field} must be an iterable")
+    try:
+        return list(values)
+    except TypeError as exc:
+        raise AuditFindingError(f"{field} must be an iterable") from exc
 
 
 def _normalize_citations(values: Any) -> tuple[str, ...]:
-    if isinstance(values, (str, bytes)) or not isinstance(values, Sequence) or not values:
+    if not isinstance(values, Sequence) or isinstance(values, (str, bytes)) or not values:
         raise AuditFindingError("citation_ids must be a non-empty array")
-    normalized = tuple(sorted(set(values)))
-    if len(normalized) != len(values):
+    if len(values) > _MAX_CITATIONS:
+        raise AuditFindingError(f"citation_ids must contain at most {_MAX_CITATIONS} entries")
+    checked: list[str] = []
+    for value in values:
+        if not isinstance(value, str) or _CITATION_RE.fullmatch(value) is None:
+            raise AuditFindingError("citation_ids must use the cit_<16 lower-hex> form")
+        checked.append(value)
+    if len(checked) != len(set(checked)):
         raise AuditFindingError("citation_ids must not contain duplicates")
-    if any(not isinstance(value, str) or _CITATION_RE.fullmatch(value) is None for value in normalized):
-        raise AuditFindingError("citation_ids must use the cit_<16 lower-hex> form")
-    return normalized
+    return tuple(sorted(checked))
 
 
 def make_audit_finding_id(lane_id: str, claim: str, citation_ids: Sequence[str]) -> str:
@@ -61,6 +81,8 @@ def make_audit_finding_id(lane_id: str, claim: str, citation_ids: Sequence[str])
 def _plan_lane_ids(plan: Mapping[str, Any]) -> frozenset[str]:
     if not isinstance(plan, Mapping) or plan.get("version") != "audit_lane_plan.v1":
         raise AuditFindingError("plan must be an audit_lane_plan.v1 object")
+    if plan.get("authority") != "navigation_index" or plan.get("risk_class") != "diagnostic":
+        raise AuditFindingError("plan authority and risk class must match audit_lane_plan.v1")
     lanes = plan.get("lanes")
     if not isinstance(lanes, Sequence) or isinstance(lanes, (str, bytes)) or not lanes:
         raise AuditFindingError("plan lanes must be a non-empty array")
@@ -75,20 +97,18 @@ def _plan_lane_ids(plan: Mapping[str, Any]) -> frozenset[str]:
 
 
 def _citation_registry(values: Iterable[str]) -> frozenset[str]:
-    if isinstance(values, (str, bytes)):
-        raise AuditFindingError("resolvable_citation_ids must be an iterable of citation ids")
-    try:
-        normalized = frozenset(values)
-    except TypeError as exc:
-        raise AuditFindingError("resolvable_citation_ids must be iterable") from exc
-    if any(not isinstance(value, str) or _CITATION_RE.fullmatch(value) is None for value in normalized):
-        raise AuditFindingError("resolvable_citation_ids contains an invalid citation id")
-    return normalized
+    items = _require_items(values, "resolvable_citation_ids")
+    for value in items:
+        if not isinstance(value, str) or _CITATION_RE.fullmatch(value) is None:
+            raise AuditFindingError("resolvable_citation_ids contains an invalid citation id")
+    return frozenset(items)
 
 
 def _normalize_candidate(candidate: Any, lane_ids: frozenset[str]) -> dict[str, Any]:
     if not isinstance(candidate, Mapping):
         raise AuditFindingError("candidates must contain objects")
+    if set(candidate) != _CANDIDATE_KEYS:
+        raise AuditFindingError("candidate fields must be exactly lane_id, claim, citation_ids")
     lane_id = _require_string(candidate.get("lane_id"), "lane_id")
     if lane_id not in lane_ids:
         raise AuditFindingError(f"candidate references unselected lane: {lane_id}")
@@ -103,12 +123,14 @@ def _normalize_candidate(candidate: Any, lane_ids: frozenset[str]) -> dict[str, 
 
 
 def _normalize_verdicts(values: Iterable[Mapping[str, Any]]) -> dict[str, dict[str, str]]:
-    if isinstance(values, (str, bytes)):
-        raise AuditFindingError("verifier_verdicts must be an iterable of objects")
     verdicts: dict[str, dict[str, str]] = {}
-    for value in values:
+    for value in _require_items(values, "verifier_verdicts"):
         if not isinstance(value, Mapping):
             raise AuditFindingError("verifier_verdicts must contain objects")
+        if set(value) != _VERDICT_KEYS:
+            raise AuditFindingError(
+                "verdict fields must be exactly finding_id, state, verifier_id, note"
+            )
         finding_id = _require_string(value.get("finding_id"), "verdict finding_id")
         state = _require_string(value.get("state"), "verdict state")
         if state not in _VERIFIER_STATES:
@@ -173,9 +195,10 @@ def adapt_audit_findings(
     current = _require_revision(current_revision, "current_revision")
     lane_ids = _plan_lane_ids(plan)
     citation_registry = _citation_registry(resolvable_citation_ids)
-    if isinstance(candidates, (str, bytes)):
-        raise AuditFindingError("candidates must be an iterable of objects")
-    normalized = [_normalize_candidate(value, lane_ids) for value in candidates]
+    normalized = [
+        _normalize_candidate(value, lane_ids)
+        for value in _require_items(candidates, "candidates")
+    ]
     by_id = {value["finding_id"]: value for value in normalized}
     if len(by_id) != len(normalized):
         raise AuditFindingError("duplicate semantic candidate finding")
@@ -204,12 +227,15 @@ def adapt_audit_findings(
         "current_revision": current,
         "revision_fresh": not stale,
         "findings": findings,
-        "summary": {state: counts[state] for state in _STATES},
+        "state_counts": [
+            {"state": state, "count": counts[state]}
+            for state in _STATES
+        ],
         "allowed_inferences": [
             "which candidate claims were bound to selected lanes and known citations",
             "whether verifier verdicts were applied under the recorded revision",
         ],
-        "forbidden_inferences": [
+        "does_not_prove": [
             "repository truth",
             "review completeness",
             "runtime correctness",

--- a/merger/lenskit/retrieval/audit_finding.py
+++ b/merger/lenskit/retrieval/audit_finding.py
@@ -1,0 +1,219 @@
+"""Bind audit-lane candidates to revision identity and resolvable citations.
+
+The adapter is deterministic and non-agentic. It preserves candidate and verifier
+provenance while preventing stale or citation-unresolved claims from becoming verified.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections import Counter
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any
+
+_REVISION_RE = re.compile(r"^[a-f0-9]{40}$")
+_CITATION_RE = re.compile(r"^cit_[a-f0-9]{16}$")
+_VERIFIER_STATES = frozenset({"verified", "wrong", "unresolved"})
+_STATES = ("candidate", "verified", "stale", "wrong", "unresolved")
+
+
+class AuditFindingError(ValueError):
+    """Raised when audit finding input cannot be admitted safely."""
+
+
+def _require_revision(value: str, field: str) -> str:
+    if not isinstance(value, str) or _REVISION_RE.fullmatch(value) is None:
+        raise AuditFindingError(f"{field} must be a lowercase 40-hex revision")
+    return value
+
+
+def _require_string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise AuditFindingError(f"{field} must be a non-empty string")
+    return " ".join(value.split())
+
+
+def _normalize_citations(values: Any) -> tuple[str, ...]:
+    if isinstance(values, (str, bytes)) or not isinstance(values, Sequence) or not values:
+        raise AuditFindingError("citation_ids must be a non-empty array")
+    normalized = tuple(sorted(set(values)))
+    if len(normalized) != len(values):
+        raise AuditFindingError("citation_ids must not contain duplicates")
+    if any(not isinstance(value, str) or _CITATION_RE.fullmatch(value) is None for value in normalized):
+        raise AuditFindingError("citation_ids must use the cit_<16 lower-hex> form")
+    return normalized
+
+
+def make_audit_finding_id(lane_id: str, claim: str, citation_ids: Sequence[str]) -> str:
+    """Return a stable semantic id for one normalized candidate."""
+
+    payload = {
+        "lane_id": _require_string(lane_id, "lane_id"),
+        "claim": _require_string(claim, "claim"),
+        "citation_ids": list(_normalize_citations(citation_ids)),
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return f"af_{hashlib.sha256(encoded).hexdigest()[:16]}"
+
+
+def _plan_lane_ids(plan: Mapping[str, Any]) -> frozenset[str]:
+    if not isinstance(plan, Mapping) or plan.get("version") != "audit_lane_plan.v1":
+        raise AuditFindingError("plan must be an audit_lane_plan.v1 object")
+    lanes = plan.get("lanes")
+    if not isinstance(lanes, Sequence) or isinstance(lanes, (str, bytes)) or not lanes:
+        raise AuditFindingError("plan lanes must be a non-empty array")
+    lane_ids = []
+    for lane in lanes:
+        if not isinstance(lane, Mapping):
+            raise AuditFindingError("plan lanes must be objects")
+        lane_ids.append(_require_string(lane.get("id"), "plan lane id"))
+    if len(lane_ids) != len(set(lane_ids)):
+        raise AuditFindingError("plan lane ids must be unique")
+    return frozenset(lane_ids)
+
+
+def _citation_registry(values: Iterable[str]) -> frozenset[str]:
+    if isinstance(values, (str, bytes)):
+        raise AuditFindingError("resolvable_citation_ids must be an iterable of citation ids")
+    try:
+        normalized = frozenset(values)
+    except TypeError as exc:
+        raise AuditFindingError("resolvable_citation_ids must be iterable") from exc
+    if any(not isinstance(value, str) or _CITATION_RE.fullmatch(value) is None for value in normalized):
+        raise AuditFindingError("resolvable_citation_ids contains an invalid citation id")
+    return normalized
+
+
+def _normalize_candidate(candidate: Any, lane_ids: frozenset[str]) -> dict[str, Any]:
+    if not isinstance(candidate, Mapping):
+        raise AuditFindingError("candidates must contain objects")
+    lane_id = _require_string(candidate.get("lane_id"), "lane_id")
+    if lane_id not in lane_ids:
+        raise AuditFindingError(f"candidate references unselected lane: {lane_id}")
+    claim = _require_string(candidate.get("claim"), "claim")
+    citation_ids = _normalize_citations(candidate.get("citation_ids"))
+    return {
+        "finding_id": make_audit_finding_id(lane_id, claim, citation_ids),
+        "lane_id": lane_id,
+        "claim": claim,
+        "citation_ids": list(citation_ids),
+    }
+
+
+def _normalize_verdicts(values: Iterable[Mapping[str, Any]]) -> dict[str, dict[str, str]]:
+    if isinstance(values, (str, bytes)):
+        raise AuditFindingError("verifier_verdicts must be an iterable of objects")
+    verdicts: dict[str, dict[str, str]] = {}
+    for value in values:
+        if not isinstance(value, Mapping):
+            raise AuditFindingError("verifier_verdicts must contain objects")
+        finding_id = _require_string(value.get("finding_id"), "verdict finding_id")
+        state = _require_string(value.get("state"), "verdict state")
+        if state not in _VERIFIER_STATES:
+            raise AuditFindingError(f"unsupported verifier state: {state}")
+        if finding_id in verdicts:
+            raise AuditFindingError(f"duplicate verifier verdict: {finding_id}")
+        verdicts[finding_id] = {
+            "finding_id": finding_id,
+            "state": state,
+            "verifier_id": _require_string(value.get("verifier_id"), "verifier_id"),
+            "note": _require_string(value.get("note"), "verifier note"),
+        }
+    return verdicts
+
+
+def _classify(
+    candidate: dict[str, Any],
+    *,
+    stale: bool,
+    citation_registry: frozenset[str],
+    verdict: dict[str, str] | None,
+) -> dict[str, Any]:
+    unresolved = [cid for cid in candidate["citation_ids"] if cid not in citation_registry]
+    if stale:
+        state = "stale"
+        reason = "revision_mismatch"
+    elif unresolved:
+        state = "unresolved"
+        reason = "citation_unresolved"
+    elif verdict is None:
+        state = "candidate"
+        reason = "verification_missing"
+    else:
+        state = verdict["state"]
+        reason = "verifier_verdict"
+    return {
+        **candidate,
+        "state": state,
+        "state_reason": reason,
+        "unresolved_citation_ids": unresolved,
+        "verifier_verdict": verdict,
+        "verifier_verdict_applied": verdict is not None and reason == "verifier_verdict",
+    }
+
+
+def adapt_audit_findings(
+    plan: Mapping[str, Any],
+    candidates: Iterable[Mapping[str, Any]],
+    *,
+    reviewed_revision: str,
+    current_revision: str,
+    resolvable_citation_ids: Iterable[str],
+    verifier_verdicts: Iterable[Mapping[str, Any]] = (),
+) -> dict[str, Any]:
+    """Return a deterministic, evidence-bound finding set.
+
+    Revision mismatch and unresolved citations take precedence over a verifier verdict.
+    The verdict remains preserved but is marked unapplied.
+    """
+
+    reviewed = _require_revision(reviewed_revision, "reviewed_revision")
+    current = _require_revision(current_revision, "current_revision")
+    lane_ids = _plan_lane_ids(plan)
+    citation_registry = _citation_registry(resolvable_citation_ids)
+    if isinstance(candidates, (str, bytes)):
+        raise AuditFindingError("candidates must be an iterable of objects")
+    normalized = [_normalize_candidate(value, lane_ids) for value in candidates]
+    by_id = {value["finding_id"]: value for value in normalized}
+    if len(by_id) != len(normalized):
+        raise AuditFindingError("duplicate semantic candidate finding")
+    verdicts = _normalize_verdicts(verifier_verdicts)
+    unknown_verdicts = sorted(set(verdicts) - set(by_id))
+    if unknown_verdicts:
+        raise AuditFindingError(f"verdict references unknown finding: {unknown_verdicts[0]}")
+
+    stale = reviewed != current
+    findings = [
+        _classify(
+            by_id[finding_id],
+            stale=stale,
+            citation_registry=citation_registry,
+            verdict=verdicts.get(finding_id),
+        )
+        for finding_id in sorted(by_id)
+    ]
+    counts = Counter(finding["state"] for finding in findings)
+    return {
+        "version": "audit_finding_set.v1",
+        "authority": "diagnostic_signal",
+        "risk_class": "diagnostic",
+        "plan_version": "audit_lane_plan.v1",
+        "reviewed_revision": reviewed,
+        "current_revision": current,
+        "revision_fresh": not stale,
+        "findings": findings,
+        "summary": {state: counts[state] for state in _STATES},
+        "allowed_inferences": [
+            "which candidate claims were bound to selected lanes and known citations",
+            "whether verifier verdicts were applied under the recorded revision",
+        ],
+        "forbidden_inferences": [
+            "repository truth",
+            "review completeness",
+            "runtime correctness",
+            "severity correctness",
+            "permission to create issues, patches, commits, pushes, or merges",
+        ],
+    }

--- a/merger/lenskit/retrieval/audit_finding.py
+++ b/merger/lenskit/retrieval/audit_finding.py
@@ -15,6 +15,8 @@ from typing import Any
 
 _REVISION_RE = re.compile(r"^[a-f0-9]{40}$")
 _CITATION_RE = re.compile(r"^cit_[a-f0-9]{16}$")
+_LANE_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+_FINDING_RE = re.compile(r"^af_[a-f0-9]{16}$")
 _VERIFIER_STATES = frozenset({"verified", "wrong", "unresolved"})
 _STATES = ("candidate", "verified", "stale", "wrong", "unresolved")
 _MAX_TEXT_CHARS = 8192
@@ -30,6 +32,12 @@ class AuditFindingError(ValueError):
 def _require_revision(value: str, field: str) -> str:
     if not isinstance(value, str) or _REVISION_RE.fullmatch(value) is None:
         raise AuditFindingError(f"{field} must be a lowercase 40-hex revision")
+    return value
+
+
+def _require_identifier(value: Any, field: str, pattern: re.Pattern[str]) -> str:
+    if not isinstance(value, str) or pattern.fullmatch(value) is None:
+        raise AuditFindingError(f"{field} has an invalid identifier format")
     return value
 
 
@@ -70,7 +78,7 @@ def make_audit_finding_id(lane_id: str, claim: str, citation_ids: Sequence[str])
     """Return a stable semantic id for one normalized candidate."""
 
     payload = {
-        "lane_id": _require_string(lane_id, "lane_id"),
+        "lane_id": _require_identifier(lane_id, "lane_id", _LANE_RE),
         "claim": _require_string(claim, "claim"),
         "citation_ids": list(_normalize_citations(citation_ids)),
     }
@@ -90,7 +98,9 @@ def _plan_lane_ids(plan: Mapping[str, Any]) -> frozenset[str]:
     for lane in lanes:
         if not isinstance(lane, Mapping):
             raise AuditFindingError("plan lanes must be objects")
-        lane_ids.append(_require_string(lane.get("id"), "plan lane id"))
+        lane_ids.append(
+            _require_identifier(lane.get("id"), "plan lane id", _LANE_RE)
+        )
     if len(lane_ids) != len(set(lane_ids)):
         raise AuditFindingError("plan lane ids must be unique")
     return frozenset(lane_ids)
@@ -109,7 +119,7 @@ def _normalize_candidate(candidate: Any, lane_ids: frozenset[str]) -> dict[str, 
         raise AuditFindingError("candidates must contain objects")
     if set(candidate) != _CANDIDATE_KEYS:
         raise AuditFindingError("candidate fields must be exactly lane_id, claim, citation_ids")
-    lane_id = _require_string(candidate.get("lane_id"), "lane_id")
+    lane_id = _require_identifier(candidate.get("lane_id"), "lane_id", _LANE_RE)
     if lane_id not in lane_ids:
         raise AuditFindingError(f"candidate references unselected lane: {lane_id}")
     claim = _require_string(candidate.get("claim"), "claim")
@@ -131,7 +141,9 @@ def _normalize_verdicts(values: Iterable[Mapping[str, Any]]) -> dict[str, dict[s
             raise AuditFindingError(
                 "verdict fields must be exactly finding_id, state, verifier_id, note"
             )
-        finding_id = _require_string(value.get("finding_id"), "verdict finding_id")
+        finding_id = _require_identifier(
+            value.get("finding_id"), "verdict finding_id", _FINDING_RE
+        )
         state = _require_string(value.get("state"), "verdict state")
         if state not in _VERIFIER_STATES:
             raise AuditFindingError(f"unsupported verifier state: {state}")
@@ -171,8 +183,8 @@ def _classify(
         "state": state,
         "state_reason": reason,
         "unresolved_citation_ids": unresolved,
-        "verifier_verdict": verdict,
-        "verifier_verdict_applied": verdict is not None and reason == "verifier_verdict",
+        "verification_record": verdict,
+        "verification_applied": verdict is not None and reason == "verifier_verdict",
     }
 
 
@@ -233,7 +245,7 @@ def adapt_audit_findings(
         ],
         "allowed_inferences": [
             "which candidate claims were bound to selected lanes and known citations",
-            "whether verifier verdicts were applied under the recorded revision",
+            "whether verifier decisions were applied under the recorded revision",
         ],
         "does_not_prove": [
             "repository truth",

--- a/merger/lenskit/tests/test_audit_finding.py
+++ b/merger/lenskit/tests/test_audit_finding.py
@@ -41,6 +41,25 @@ def _adapt(**overrides):
     return adapt_audit_findings(**kwargs)
 
 
+def _finding_id():
+    return make_audit_finding_id(
+        "cache_publication", _candidate()["claim"], [CIT_A, CIT_B]
+    )
+
+
+def _verdict(state="verified"):
+    return {
+        "finding_id": _finding_id(),
+        "state": state,
+        "verifier_id": "independent-reviewer-v1",
+        "note": "Citation ranges reproduce the recorded review decision.",
+    }
+
+
+def _count(result, state):
+    return next(row["count"] for row in result["state_counts"] if row["state"] == state)
+
+
 def test_finding_id_is_stable_across_whitespace_and_citation_order():
     first = make_audit_finding_id(
         "cache_publication",
@@ -61,44 +80,19 @@ def test_fresh_unverified_candidate_remains_candidate():
     finding = result["findings"][0]
     assert finding["state"] == "candidate"
     assert finding["state_reason"] == "verification_missing"
-    assert result["summary"]["candidate"] == 1
+    assert _count(result, "candidate") == 1
 
 
 def test_fresh_resolved_verdict_can_be_applied():
-    finding_id = make_audit_finding_id(
-        "cache_publication", _candidate()["claim"], [CIT_A, CIT_B]
-    )
-    result = _adapt(
-        verifier_verdicts=[
-            {
-                "finding_id": finding_id,
-                "state": "verified",
-                "verifier_id": "independent-reviewer-v1",
-                "note": "Citation ranges reproduce the claimed publication window.",
-            }
-        ]
-    )
+    result = _adapt(verifier_verdicts=[_verdict()])
     finding = result["findings"][0]
     assert finding["state"] == "verified"
     assert finding["verifier_verdict_applied"] is True
-    assert result["summary"]["verified"] == 1
+    assert _count(result, "verified") == 1
 
 
 def test_stale_revision_overrides_but_preserves_verifier_verdict():
-    finding_id = make_audit_finding_id(
-        "cache_publication", _candidate()["claim"], [CIT_A, CIT_B]
-    )
-    result = _adapt(
-        current_revision=REV_B,
-        verifier_verdicts=[
-            {
-                "finding_id": finding_id,
-                "state": "verified",
-                "verifier_id": "reviewer",
-                "note": "Verdict belongs to the older revision.",
-            }
-        ],
-    )
+    result = _adapt(current_revision=REV_B, verifier_verdicts=[_verdict()])
     finding = result["findings"][0]
     assert finding["state"] == "stale"
     assert finding["verifier_verdict"]["state"] == "verified"
@@ -107,19 +101,9 @@ def test_stale_revision_overrides_but_preserves_verifier_verdict():
 
 
 def test_unresolved_citation_overrides_verifier_verdict():
-    finding_id = make_audit_finding_id(
-        "cache_publication", _candidate()["claim"], [CIT_A, CIT_B]
-    )
     result = _adapt(
         resolvable_citation_ids=[CIT_A],
-        verifier_verdicts=[
-            {
-                "finding_id": finding_id,
-                "state": "verified",
-                "verifier_id": "reviewer",
-                "note": "One address is no longer resolvable.",
-            }
-        ],
+        verifier_verdicts=[_verdict()],
     )
     finding = result["findings"][0]
     assert finding["state"] == "unresolved"
@@ -129,19 +113,7 @@ def test_unresolved_citation_overrides_verifier_verdict():
 
 @pytest.mark.parametrize("state", ["wrong", "unresolved"])
 def test_supported_negative_verdicts_are_preserved(state):
-    finding_id = make_audit_finding_id(
-        "cache_publication", _candidate()["claim"], [CIT_A, CIT_B]
-    )
-    result = _adapt(
-        verifier_verdicts=[
-            {
-                "finding_id": finding_id,
-                "state": state,
-                "verifier_id": "reviewer",
-                "note": "Independent result.",
-            }
-        ]
-    )
+    result = _adapt(verifier_verdicts=[_verdict(state)])
     assert result["findings"][0]["state"] == state
     assert result["findings"][0]["verifier_verdict_applied"] is True
 
@@ -177,12 +149,25 @@ def test_output_order_is_stable_by_finding_id():
         {"lane_id": "cache_publication", "claim": "x", "citation_ids": []},
         {"lane_id": "cache_publication", "claim": "x", "citation_ids": ["bad"]},
         {"lane_id": "cache_publication", "claim": "x", "citation_ids": [CIT_A, CIT_A]},
+        {"lane_id": "cache_publication", "claim": "x", "citation_ids": [1]},
+        {
+            "lane_id": "cache_publication",
+            "claim": "x",
+            "citation_ids": [CIT_A],
+            "hidden": "not admitted",
+        },
         "not-an-object",
     ],
 )
 def test_rejects_malformed_or_unselected_candidates(candidate):
     with pytest.raises(AuditFindingError):
         _adapt(candidates=[candidate])
+
+
+@pytest.mark.parametrize("candidates", [None, "candidate", 123])
+def test_rejects_malformed_candidate_collections(candidates):
+    with pytest.raises(AuditFindingError):
+        _adapt(candidates=candidates)
 
 
 def test_rejects_duplicate_semantic_candidates():
@@ -196,32 +181,54 @@ def test_rejects_invalid_revisions(revision):
         _adapt(reviewed_revision=revision)
 
 
+def test_rejects_plan_with_wrong_authority():
+    plan = _plan()
+    plan["authority"] = "diagnostic_signal"
+    with pytest.raises(AuditFindingError, match="authority"):
+        _adapt(plan=plan)
+
+
 def test_rejects_verdict_for_unknown_finding():
+    verdict = _verdict()
+    verdict["finding_id"] = "af_0000000000000000"
     with pytest.raises(AuditFindingError, match="unknown finding"):
-        _adapt(
-            verifier_verdicts=[
-                {
-                    "finding_id": "af_0000000000000000",
-                    "state": "verified",
-                    "verifier_id": "reviewer",
-                    "note": "No matching candidate.",
-                }
-            ]
-        )
+        _adapt(verifier_verdicts=[verdict])
 
 
 def test_rejects_duplicate_verdicts():
-    finding_id = make_audit_finding_id(
-        "cache_publication", _candidate()["claim"], [CIT_A, CIT_B]
-    )
-    verdict = {
-        "finding_id": finding_id,
-        "state": "verified",
-        "verifier_id": "reviewer",
-        "note": "Repeated verdict.",
-    }
+    verdict = _verdict()
     with pytest.raises(AuditFindingError, match="duplicate verifier verdict"):
         _adapt(verifier_verdicts=[verdict, verdict])
+
+
+@pytest.mark.parametrize("verdicts", [None, "verdict", 123])
+def test_rejects_malformed_verdict_collections(verdicts):
+    with pytest.raises(AuditFindingError):
+        _adapt(verifier_verdicts=verdicts)
+
+
+def test_rejects_extra_verdict_fields():
+    verdict = _verdict()
+    verdict["hidden"] = "not admitted"
+    with pytest.raises(AuditFindingError, match="verdict fields"):
+        _adapt(verifier_verdicts=[verdict])
+
+
+def test_rejects_invalid_citation_registry():
+    with pytest.raises(AuditFindingError):
+        _adapt(resolvable_citation_ids=[CIT_A, 1])
+
+
+def test_rejects_oversized_claim_and_citation_set():
+    candidate = _candidate()
+    candidate["claim"] = "x" * 8193
+    with pytest.raises(AuditFindingError, match="exceeds"):
+        _adapt(candidates=[candidate])
+
+    candidate = _candidate()
+    candidate["citation_ids"] = [f"cit_{index:016x}" for index in range(65)]
+    with pytest.raises(AuditFindingError, match="at most"):
+        _adapt(candidates=[candidate])
 
 
 def test_output_validates_against_contract():
@@ -234,9 +241,9 @@ def test_output_validates_against_contract():
     Draft7Validator(schema).validate(result)
 
 
-def test_forbidden_inferences_block_authority_upgrade():
+def test_does_not_prove_blocks_authority_upgrade():
     result = _adapt()
-    forbidden = " ".join(result["forbidden_inferences"])
-    assert "repository truth" in forbidden
-    assert "review completeness" in forbidden
-    assert "merges" in forbidden
+    boundary = " ".join(result["does_not_prove"])
+    assert "repository truth" in boundary
+    assert "review completeness" in boundary
+    assert "merges" in boundary

--- a/merger/lenskit/tests/test_audit_finding.py
+++ b/merger/lenskit/tests/test_audit_finding.py
@@ -87,20 +87,20 @@ def test_fresh_resolved_verdict_can_be_applied():
     result = _adapt(verifier_verdicts=[_verdict()])
     finding = result["findings"][0]
     assert finding["state"] == "verified"
-    assert finding["verifier_verdict_applied"] is True
+    assert finding["verification_applied"] is True
     assert _count(result, "verified") == 1
 
 
-def test_stale_revision_overrides_but_preserves_verifier_verdict():
+def test_stale_revision_overrides_but_preserves_verifier_decision():
     result = _adapt(current_revision=REV_B, verifier_verdicts=[_verdict()])
     finding = result["findings"][0]
     assert finding["state"] == "stale"
-    assert finding["verifier_verdict"]["state"] == "verified"
-    assert finding["verifier_verdict_applied"] is False
+    assert finding["verification_record"]["state"] == "verified"
+    assert finding["verification_applied"] is False
     assert result["revision_fresh"] is False
 
 
-def test_unresolved_citation_overrides_verifier_verdict():
+def test_unresolved_citation_overrides_verifier_decision():
     result = _adapt(
         resolvable_citation_ids=[CIT_A],
         verifier_verdicts=[_verdict()],
@@ -108,14 +108,14 @@ def test_unresolved_citation_overrides_verifier_verdict():
     finding = result["findings"][0]
     assert finding["state"] == "unresolved"
     assert finding["unresolved_citation_ids"] == [CIT_B]
-    assert finding["verifier_verdict_applied"] is False
+    assert finding["verification_applied"] is False
 
 
 @pytest.mark.parametrize("state", ["wrong", "unresolved"])
 def test_supported_negative_verdicts_are_preserved(state):
     result = _adapt(verifier_verdicts=[_verdict(state)])
     assert result["findings"][0]["state"] == state
-    assert result["findings"][0]["verifier_verdict_applied"] is True
+    assert result["findings"][0]["verification_applied"] is True
 
 
 def test_output_order_is_stable_by_finding_id():
@@ -145,6 +145,7 @@ def test_output_order_is_stable_by_finding_id():
     "candidate",
     [
         {"lane_id": "unknown", "claim": "x", "citation_ids": [CIT_A]},
+        {"lane_id": "Bad-Lane", "claim": "x", "citation_ids": [CIT_A]},
         {"lane_id": "cache_publication", "claim": "", "citation_ids": [CIT_A]},
         {"lane_id": "cache_publication", "claim": "x", "citation_ids": []},
         {"lane_id": "cache_publication", "claim": "x", "citation_ids": ["bad"]},
@@ -188,10 +189,24 @@ def test_rejects_plan_with_wrong_authority():
         _adapt(plan=plan)
 
 
+def test_rejects_plan_with_invalid_lane_identifier():
+    plan = _plan()
+    plan["lanes"][0]["id"] = "Bad-Lane"
+    with pytest.raises(AuditFindingError, match="identifier"):
+        _adapt(plan=plan)
+
+
 def test_rejects_verdict_for_unknown_finding():
     verdict = _verdict()
     verdict["finding_id"] = "af_0000000000000000"
     with pytest.raises(AuditFindingError, match="unknown finding"):
+        _adapt(verifier_verdicts=[verdict])
+
+
+def test_rejects_invalid_verdict_finding_identifier():
+    verdict = _verdict()
+    verdict["finding_id"] = "finding-1"
+    with pytest.raises(AuditFindingError, match="identifier"):
         _adapt(verifier_verdicts=[verdict])
 
 

--- a/merger/lenskit/tests/test_audit_finding.py
+++ b/merger/lenskit/tests/test_audit_finding.py
@@ -1,0 +1,242 @@
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft7Validator
+
+from merger.lenskit.retrieval.audit_finding import (
+    AuditFindingError,
+    adapt_audit_findings,
+    make_audit_finding_id,
+)
+from merger.lenskit.retrieval.audit_lane import plan_audit_lanes
+
+REV_A = "a" * 40
+REV_B = "b" * 40
+CIT_A = "cit_1111111111111111"
+CIT_B = "cit_2222222222222222"
+
+
+def _plan():
+    return plan_audit_lanes(["src/cache/publish.py"], review_query="race stale cache")
+
+
+def _candidate():
+    return {
+        "lane_id": "cache_publication",
+        "claim": "Pointer publication can expose stale content.",
+        "citation_ids": [CIT_A, CIT_B],
+    }
+
+
+def _adapt(**overrides):
+    kwargs = {
+        "plan": _plan(),
+        "candidates": [_candidate()],
+        "reviewed_revision": REV_A,
+        "current_revision": REV_A,
+        "resolvable_citation_ids": [CIT_A, CIT_B],
+    }
+    kwargs.update(overrides)
+    return adapt_audit_findings(**kwargs)
+
+
+def test_finding_id_is_stable_across_whitespace_and_citation_order():
+    first = make_audit_finding_id(
+        "cache_publication",
+        "Pointer  publication\ncan expose stale content.",
+        [CIT_B, CIT_A],
+    )
+    second = make_audit_finding_id(
+        "cache_publication",
+        "Pointer publication can expose stale content.",
+        [CIT_A, CIT_B],
+    )
+    assert first == second
+    assert first.startswith("af_")
+
+
+def test_fresh_unverified_candidate_remains_candidate():
+    result = _adapt()
+    finding = result["findings"][0]
+    assert finding["state"] == "candidate"
+    assert finding["state_reason"] == "verification_missing"
+    assert result["summary"]["candidate"] == 1
+
+
+def test_fresh_resolved_verdict_can_be_applied():
+    finding_id = make_audit_finding_id(
+        "cache_publication", _candidate()["claim"], [CIT_A, CIT_B]
+    )
+    result = _adapt(
+        verifier_verdicts=[
+            {
+                "finding_id": finding_id,
+                "state": "verified",
+                "verifier_id": "independent-reviewer-v1",
+                "note": "Citation ranges reproduce the claimed publication window.",
+            }
+        ]
+    )
+    finding = result["findings"][0]
+    assert finding["state"] == "verified"
+    assert finding["verifier_verdict_applied"] is True
+    assert result["summary"]["verified"] == 1
+
+
+def test_stale_revision_overrides_but_preserves_verifier_verdict():
+    finding_id = make_audit_finding_id(
+        "cache_publication", _candidate()["claim"], [CIT_A, CIT_B]
+    )
+    result = _adapt(
+        current_revision=REV_B,
+        verifier_verdicts=[
+            {
+                "finding_id": finding_id,
+                "state": "verified",
+                "verifier_id": "reviewer",
+                "note": "Verdict belongs to the older revision.",
+            }
+        ],
+    )
+    finding = result["findings"][0]
+    assert finding["state"] == "stale"
+    assert finding["verifier_verdict"]["state"] == "verified"
+    assert finding["verifier_verdict_applied"] is False
+    assert result["revision_fresh"] is False
+
+
+def test_unresolved_citation_overrides_verifier_verdict():
+    finding_id = make_audit_finding_id(
+        "cache_publication", _candidate()["claim"], [CIT_A, CIT_B]
+    )
+    result = _adapt(
+        resolvable_citation_ids=[CIT_A],
+        verifier_verdicts=[
+            {
+                "finding_id": finding_id,
+                "state": "verified",
+                "verifier_id": "reviewer",
+                "note": "One address is no longer resolvable.",
+            }
+        ],
+    )
+    finding = result["findings"][0]
+    assert finding["state"] == "unresolved"
+    assert finding["unresolved_citation_ids"] == [CIT_B]
+    assert finding["verifier_verdict_applied"] is False
+
+
+@pytest.mark.parametrize("state", ["wrong", "unresolved"])
+def test_supported_negative_verdicts_are_preserved(state):
+    finding_id = make_audit_finding_id(
+        "cache_publication", _candidate()["claim"], [CIT_A, CIT_B]
+    )
+    result = _adapt(
+        verifier_verdicts=[
+            {
+                "finding_id": finding_id,
+                "state": state,
+                "verifier_id": "reviewer",
+                "note": "Independent result.",
+            }
+        ]
+    )
+    assert result["findings"][0]["state"] == state
+    assert result["findings"][0]["verifier_verdict_applied"] is True
+
+
+def test_output_order_is_stable_by_finding_id():
+    second = {
+        "lane_id": "concurrency_toctou",
+        "claim": "Lock acquisition can race with pointer replacement.",
+        "citation_ids": [CIT_A],
+    }
+    first = adapt_audit_findings(
+        _plan(),
+        [_candidate(), second],
+        reviewed_revision=REV_A,
+        current_revision=REV_A,
+        resolvable_citation_ids=[CIT_A, CIT_B],
+    )
+    reversed_input = adapt_audit_findings(
+        _plan(),
+        [second, _candidate()],
+        reviewed_revision=REV_A,
+        current_revision=REV_A,
+        resolvable_citation_ids=[CIT_A, CIT_B],
+    )
+    assert first == reversed_input
+
+
+@pytest.mark.parametrize(
+    "candidate",
+    [
+        {"lane_id": "unknown", "claim": "x", "citation_ids": [CIT_A]},
+        {"lane_id": "cache_publication", "claim": "", "citation_ids": [CIT_A]},
+        {"lane_id": "cache_publication", "claim": "x", "citation_ids": []},
+        {"lane_id": "cache_publication", "claim": "x", "citation_ids": ["bad"]},
+        {"lane_id": "cache_publication", "claim": "x", "citation_ids": [CIT_A, CIT_A]},
+        "not-an-object",
+    ],
+)
+def test_rejects_malformed_or_unselected_candidates(candidate):
+    with pytest.raises(AuditFindingError):
+        _adapt(candidates=[candidate])
+
+
+def test_rejects_duplicate_semantic_candidates():
+    with pytest.raises(AuditFindingError, match="duplicate semantic candidate"):
+        _adapt(candidates=[_candidate(), _candidate()])
+
+
+@pytest.mark.parametrize("revision", ["", "A" * 40, "a" * 39, "g" * 40])
+def test_rejects_invalid_revisions(revision):
+    with pytest.raises(AuditFindingError):
+        _adapt(reviewed_revision=revision)
+
+
+def test_rejects_verdict_for_unknown_finding():
+    with pytest.raises(AuditFindingError, match="unknown finding"):
+        _adapt(
+            verifier_verdicts=[
+                {
+                    "finding_id": "af_0000000000000000",
+                    "state": "verified",
+                    "verifier_id": "reviewer",
+                    "note": "No matching candidate.",
+                }
+            ]
+        )
+
+
+def test_rejects_duplicate_verdicts():
+    finding_id = make_audit_finding_id(
+        "cache_publication", _candidate()["claim"], [CIT_A, CIT_B]
+    )
+    verdict = {
+        "finding_id": finding_id,
+        "state": "verified",
+        "verifier_id": "reviewer",
+        "note": "Repeated verdict.",
+    }
+    with pytest.raises(AuditFindingError, match="duplicate verifier verdict"):
+        _adapt(verifier_verdicts=[verdict, verdict])
+
+
+def test_output_validates_against_contract():
+    schema_path = (
+        Path(__file__).parents[1] / "contracts" / "audit-finding-set.v1.schema.json"
+    )
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    result = _adapt()
+    Draft7Validator.check_schema(schema)
+    Draft7Validator(schema).validate(result)
+
+
+def test_forbidden_inferences_block_authority_upgrade():
+    result = _adapt()
+    forbidden = " ".join(result["forbidden_inferences"])
+    assert "repository truth" in forbidden
+    assert "review completeness" in forbidden
+    assert "merges" in forbidden

--- a/merger/lenskit/tests/test_audit_finding_contract.py
+++ b/merger/lenskit/tests/test_audit_finding_contract.py
@@ -1,0 +1,65 @@
+import copy
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft7Validator, ValidationError
+
+from merger.lenskit.retrieval.audit_finding import adapt_audit_findings
+from merger.lenskit.retrieval.audit_lane import plan_audit_lanes
+
+REVISION = "a" * 40
+CITATION = "cit_1111111111111111"
+
+
+def _schema():
+    path = Path(__file__).parents[1] / "contracts" / "audit-finding-set.v1.schema.json"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _result():
+    return adapt_audit_findings(
+        plan_audit_lanes(["src/cache/publish.py"]),
+        [
+            {
+                "lane_id": "cache_publication",
+                "claim": "Pointer publication can expose stale content.",
+                "citation_ids": [CITATION],
+            }
+        ],
+        reviewed_revision=REVISION,
+        current_revision=REVISION,
+        resolvable_citation_ids=[CITATION],
+    )
+
+
+def test_contract_binds_state_count_order():
+    schema = _schema()
+    result = _result()
+    result["state_counts"][0], result["state_counts"][1] = (
+        result["state_counts"][1],
+        result["state_counts"][0],
+    )
+
+    with pytest.raises(ValidationError):
+        Draft7Validator(schema).validate(result)
+
+
+def test_contract_rejects_applied_verification_without_record():
+    schema = _schema()
+    result = _result()
+    finding = result["findings"][0]
+    finding["verification_applied"] = True
+    finding["state_reason"] = "verifier_verdict"
+
+    with pytest.raises(ValidationError):
+        Draft7Validator(schema).validate(result)
+
+
+def test_contract_rejects_verifier_reason_without_applied_record():
+    schema = _schema()
+    result = copy.deepcopy(_result())
+    result["findings"][0]["state_reason"] = "verifier_verdict"
+
+    with pytest.raises(ValidationError):
+        Draft7Validator(schema).validate(result)


### PR DESCRIPTION
## Summary

Implements BUREAU-LENSKIT-AUDIT-LANES-002, the evidence adapter following the merged audit-lane planner.

- derives stable finding ids from lane, normalized claim and citation ids
- admits only lanes selected by `audit_lane_plan.v1`
- binds results to reviewed and current 40-hex revisions
- requires existing Lenskit citation-id form and an explicit resolved-citation registry
- preserves verification records while preventing stale or unresolved claims from becoming verified
- distinguishes `candidate`, `verified`, `stale`, `wrong` and `unresolved`
- binds applied-verification and state-count consistency in the Draft-07 contract
- adds architecture decision, proof and focused negative tests

Bureau: heimgewebe/bureau#636
Parent: heimgewebe/bureau#635

## Safety boundary

No filesystem access, network access, subprocess, agent execution, issue creation, patching, commits, pushes or merges. `verified` remains a diagnostic verifier decision, not repository truth.

## Verification

Focused command:

```text
pytest -q \
  merger/lenskit/tests/test_audit_lane.py \
  merger/lenskit/tests/test_audit_finding.py \
  merger/lenskit/tests/test_audit_finding_contract.py
```

All ten repository checks are green on head `d62b03c00bc834402c6a5796e5e4b91236abdaf8`. Repository-wide GitHub CI remains authoritative.

## Review artifact

The immutable pre-merge review surface is the GitHub-generated diff for this exact PR head:

`https://github.com/heimgewebe/lenskit/pull/1035.diff`