### PR TITLE
test(review): reject incomplete audit boundaries

### DIFF
--- a/merger/repoground/tests/test_audit_finding.py
+++ b/merger/repoground/tests/test_audit_finding.py
@@ -156,6 +156,13 @@ def test_rejects_invalid_verification_contracts(mutation):
         _adapt(verification_records=[record])
 
 
+def test_rejects_omitted_required_verification_negative_semantic():
+    record = _record()
+    record["does_not_prove"].pop()
+    with pytest.raises(AuditFindingError, match="does_not_prove"):
+        _adapt(verification_records=[record])
+
+
 def test_accepts_verification_negative_semantics_in_any_order():
     record = _record()
     record["does_not_prove"].reverse()

--- a/merger/repoground/tests/test_audit_finding_contract.py
+++ b/merger/repoground/tests/test_audit_finding_contract.py
@@ -17,6 +17,11 @@ def _schema(version="v2"):
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def _verification_schema():
+    path = Path(__file__).parents[1] / "contracts" / "audit-verification-record.v1.schema.json"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
 def _result():
     return adapt_audit_findings(
         plan_audit_lanes(["src/cache/publish.py"]),
@@ -108,6 +113,14 @@ def _accepted_record(result):
             "permission to create issues, patches, commits, pushes, or merges",
         ],
     }
+
+
+def test_verification_contract_rejects_omitted_required_negative_semantic():
+    schema = _verification_schema()
+    record = _accepted_record(_result())
+    record["does_not_prove"].pop()
+    with pytest.raises(ValidationError):
+        Draft7Validator(schema).validate(record)
 
 
 def test_contract_rejects_record_marked_not_supplied():

--- a/merger/repoground/tests/test_audit_lane.py
+++ b/merger/repoground/tests/test_audit_lane.py
@@ -153,6 +153,14 @@ def test_contract_rejects_weak_or_incomplete_negative_semantics():
         Draft7Validator(schema).validate(plan)
 
 
+def test_contract_rejects_omitted_required_negative_semantic():
+    schema = _schema()
+    plan = plan_audit_lanes(["src/auth/token.py"])
+    plan["does_not_establish"].pop()
+    with pytest.raises(ValidationError):
+        Draft7Validator(schema).validate(plan)
+
+
 def test_contract_accepts_negative_semantics_in_any_order():
     schema = _schema()
     plan = plan_audit_lanes(["src/auth/token.py"])


### PR DESCRIPTION
## Summary

Implements BUREAU-REPOGROUND-AUDIT-LANES-007 after the RepoGround 3.0 consolidation.

- rejects an `audit_lane_plan.v1` artifact when exactly one required `does_not_establish` sentence is omitted
- rejects an `audit_verification_record.v1` at the Python adapter boundary when exactly one required `does_not_prove` sentence is omitted
- rejects the same incomplete verification record through its standalone Draft-07 schema

## Rename and compatibility boundary

New paths and imports use RepoGround:

- repository: `heimgewebe/repoground`
- implementation package: `merger.repoground`

The persisted v2 identity `lenskit.audit_finding_id.v2` is intentionally unchanged. Renaming it without a new contract version would break artifact identity.

## Deliberate non-changes

- no production-code change
- no tokenizer or scoring change
- no `set().union(*generator)` change without benchmark evidence
- no frozenset refactor for four constants without measured benefit
- no Phase-3 runner implementation

## Diff scope

Base: `991a8b5e77cae333e3106a09ddfdde7739fe8d27`

- 3 test files
- 28 added lines
- 0 deleted lines

Repository CI is authoritative.