### PR TITLE
chore: finish RepoGround CodeQL context cutover

### DIFF
--- a/.github/grabowski-required-checks.json
+++ b/.github/grabowski-required-checks.json
@@ -4,7 +4,7 @@
     "ai-context-guard",
     "browser-tests",
     "CodeQL",
-    "Lenskit CodeQL policy (python)",
+    "RepoGround CodeQL policy (python)",
     "pytest-full",
     "release-candidate",
     "ruff",

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,15 +43,3 @@ jobs:
         run: >-
           python3 scripts/ci/assert_codeql_sarif_clean.py
           "${{ steps.analyze.outputs.sarif-output }}"
-
-  legacy-context:
-    name: Lenskit CodeQL policy (python)
-    needs: analyze
-    if: ${{ always() }}
-    permissions: {}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Require canonical RepoGround CodeQL policy
-        env:
-          CANONICAL_RESULT: ${{ needs.analyze.result }}
-        run: test "$CANONICAL_RESULT" = success

--- a/config/github-main-required-checks.v1.json
+++ b/config/github-main-required-checks.v1.json
@@ -37,7 +37,7 @@
               "integration_id": 57789
             },
             {
-              "context": "Lenskit CodeQL policy (python)",
+              "context": "RepoGround CodeQL policy (python)",
               "integration_id": 15368
             },
             {

--- a/docs/contracts/repoground-compatibility-exit.v1.json
+++ b/docs/contracts/repoground-compatibility-exit.v1.json
@@ -46,7 +46,7 @@
       "id": "legacy-codeql-required-context",
       "surface": "Lenskit CodeQL policy (python)",
       "category": "github-ruleset-compatibility",
-      "status": "result-bound-transition-proxy",
+      "status": "retired-after-ruleset-cutover",
       "owner": "RepoGround maintainers",
       "canonical": "RepoGround CodeQL policy (python)",
       "review_by": "2026-07-19",
@@ -55,7 +55,14 @@
         "the GitHub main ruleset requires RepoGround CodeQL policy (python)",
         "the repository ruleset contract and required-check catalog match the live ruleset",
         "the legacy proxy job is removed in a follow-up commit"
-      ]
+      ],
+      "retired_at": "2026-07-18T05:34:52+02:00",
+      "evidence": {
+        "ruleset_id": 18784275,
+        "ruleset_name": "main-required-checks",
+        "live_required_context": "RepoGround CodeQL policy (python)",
+        "source_merge_commit": "2f34dbe1b394a2858ce60430872152abd4e70496"
+      }
     },
     {
       "id": "legacy-environment",

--- a/merger/repoground/tests/test_github_main_ruleset.py
+++ b/merger/repoground/tests/test_github_main_ruleset.py
@@ -34,7 +34,7 @@ def test_required_checks_policy_matches_observed_ruleset():
     assert report["observed_source_type"] == "Repository"
     assert report["findings"] == []
     assert {item["context"] for item in report["required_checks"]} == {
-        "Lenskit CodeQL policy (python)",
+        "RepoGround CodeQL policy (python)",
         "CodeQL",
         "pytest-full",
         "release-candidate",
@@ -125,19 +125,16 @@ def test_required_checks_policy_detects_bypass_actor():
     assert any("bypass_actors mismatch" in finding for finding in report["findings"])
 
 
-def test_codeql_transition_context_is_bound_to_canonical_policy():
+def test_codeql_policy_context_is_canonical_and_unique():
     workflow = (ROOT / ".github" / "workflows" / "codeql.yml").read_text(
         encoding="utf-8"
     )
 
     assert workflow.count("name: RepoGround CodeQL policy (python)") == 1
-    assert workflow.count("name: Lenskit CodeQL policy (python)") == 1
+    assert "name: Lenskit CodeQL policy (python)" not in workflow
     assert "name: Validate CodeQL suppression inventory" in workflow
     assert "name: Require clean raw CodeQL SARIF" in workflow
-    assert "legacy-context:" in workflow
-    assert "needs: analyze" in workflow
-    assert "CANONICAL_RESULT: ${{ needs.analyze.result }}" in workflow
-    assert 'run: test "$CANONICAL_RESULT" = success' in workflow
+    assert "legacy-context:" not in workflow
 
 
 def test_required_checks_policy_rejects_invalid_policy_rule_shape():

--- a/scripts/ci/check_github_main_ruleset.py
+++ b/scripts/ci/check_github_main_ruleset.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate an observed GitHub ruleset against Lenskit's required-check policy.
+"""Validate an observed GitHub ruleset against RepoGround's required-check policy.
 
 The observed ruleset JSON is read from stdin. This checker is deliberately
 read-only and network-free; callers remain responsible for obtaining current
@@ -16,7 +16,7 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[2]
 POLICY_PATH = ROOT / "config" / "github-main-required-checks.v1.json"
-KIND = "lenskit.github_main_required_checks_validation"
+KIND = "repoground.github_main_required_checks_validation"
 VERSION = "v1"
 
 


### PR DESCRIPTION
## Zweck
Entfernt den temporären alten CodeQL-Pflichtkontext, nachdem die GitHub-Live-Regel kontrolliert auf `RepoGround CodeQL policy (python)` umgestellt und zurückgelesen wurde.

## Live-Beleg
- Ruleset: `main-required-checks`
- Ruleset-ID: `18784275`
- Enforcement: `active`
- Ziel: `refs/heads/main`
- verpflichtender Kontext: `RepoGround CodeQL policy (python)` mit Integration `15368`
- übrige erforderliche Checks und Integrations-IDs unverändert
- strikte Aktualitätsregel weiterhin aktiv

## Änderungen
- entfernt den result-bound Übergangsjob `Lenskit CodeQL policy (python)`
- aktualisiert Repository-Sollvertrag und Grabowski-Prüfkatalog
- markiert die Übergangsfläche im Kompatibilitätsvertrag als retired
- benennt den aktiven Ruleset-Validator intern auf RepoGround um
- Tests verlangen nun genau einen kanonischen CodeQL-Kontext

## Prüfungen
- Live-Ruleset gegen Repository-Sollvertrag: PASS
- 20 fokussierte Tests: PASS
- Ruff: PASS
- CodeQL-YAML enthält ausschließlich den Job `analyze`
- `git diff --check`: PASS

## Historische Grenze
Alte Proofs und Diagnosen behalten den damals gültigen Lenskit-Kontextnamen und werden nicht rückwirkend geändert.