### PR TITLE
fix(runtime): remove legacy fleet timer after cutover

### DIFF
--- a/merger/repoground/tests/test_fleet_runtime.py
+++ b/merger/repoground/tests/test_fleet_runtime.py
@@ -1087,6 +1087,9 @@ def test_regression_canonical_unit_names_and_installer_cutover_order() -> None:
     assert "rb-publish-fleet-watch.timer" in installer
     assert "rb-publish-fleet-watch.service" in installer
     assert "systemctl --user disable --now" in installer
+    assert 'for unit in "${OLD_TIMERS[@]}" "${OLD_UNITS[@]}"' in installer
+    assert 'rm -f -- "$UNIT_DIR/$unit"' in installer
+    assert 'systemctl --user reset-failed "$unit"' in installer
     install_position = installer.index("ops/systemd/repoground-fleet")
     reload_position = installer.index("systemctl --user daemon-reload")
     enable_position = installer.index(

--- a/scripts/ops/install_repoground_publish_fleet_runtime.sh
+++ b/scripts/ops/install_repoground_publish_fleet_runtime.sh
@@ -50,11 +50,14 @@ install -m 0755 "$ROOT/scripts/ops/repobrief-publish-systemkatalog-main-if-chang
 for unit in "$ROOT"/ops/systemd/repoground-fleet/*.{service,timer}; do
   install -m 0644 "$unit" "$UNIT_DIR/$(basename "$unit")"
 done
-for unit in "${OLD_UNITS[@]}"; do
+for unit in "${OLD_TIMERS[@]}" "${OLD_UNITS[@]}"; do
   rm -f -- "$UNIT_DIR/$unit"
 done
 
 systemctl --user daemon-reload
+for unit in "${OLD_TIMERS[@]}" "${OLD_UNITS[@]}"; do
+  systemctl --user reset-failed "$unit" 2>/dev/null || true
+done
 systemctl --user reset-failed repoground-publish-fleet-watch.service 2>/dev/null || true
 if (( ENABLE )); then
   systemctl --user enable --now repoground-publish-fleet-watch.timer


### PR DESCRIPTION
## Live-Befund

Beim kontrollierten Cutover aus RepoGround-Main `98798afc…` wurde die neue Unit korrekt aktiviert, aber `/home/alex/.config/systemd/user/rb-publish-fleet-watch.timer` blieb als deaktivierte Altdatei liegen. Ursache: Der Installer deaktivierte `OLD_TIMERS`, entfernte anschließend aber nur `OLD_UNITS`.

## Korrektur

- entfernt nach dem Deaktivieren sowohl alte Timer/Pfade als auch alte Services;
- setzt deren gespeicherte Fehlerzustände nach `daemon-reload` zurück;
- ergänzt einen statischen Regressionstest für Entfernung und Reset aller Altunit-Klassen.

## Verifikation

- `test_fleet_runtime.py`: 39 bestanden;
- Ruff: PASS;
- `git diff --check`: PASS;
- vollständiger Diff: `/home/alex/iCloud/Drive/halde/repoground-fleet-cutover-cleanup-v1.patch`;
- Diff SHA-256: `4003724a14be2475e941fd59f4595e6a48854b652be46a3331e55c2dd1986398`.

## Wahrheitsgrenze

Der Installer wird erst nach Merge erneut aus dem unveränderlichen Main-Commit ausgeführt. Bureau #671 bleibt bis zum vollständigen Unit-, Bundle-, Zweitlauf- und Negativlauf-Readback offen.