### PR TITLE
feat: add compact evidence navigation and fail-closed benchmark

### DIFF
--- a/docs/proofs/repoground-evidence-navigation-v1-proof.md
+++ b/docs/proofs/repoground-evidence-navigation-v1-proof.md
@@ -59,8 +59,13 @@ The decision is fail-closed and has three outcomes:
 The committed local report `repoground-vs-grep-read.v2.json` is
 `inconclusive`. On 20 fixed questions RepoGround missed 37 expected targets
 versus 60 for `grep/read`, but both conditions had 20 false-confidence cases.
-RepoGround used 566.081 ms versus 156.484 ms, emitted 292,150 raw bytes, and
-its 98,966-byte compact form was still larger than the 26,274-byte baseline.
+RepoGround used 551.335 ms versus 166.691 ms, emitted 292,150 raw bytes, and
+its 98,966-byte compact form was still larger than the 26,690-byte baseline.
+The committed run records `ripgrep` as the baseline search engine. When `rg` is
+not installed, the same harness uses a deterministic UTF-8 Python substring
+search, records `python_utf8_substring`, and starts no hidden subprocess. The
+report persists no absolute local paths and binds the benchmark script, index,
+question set and source tree by SHA-256.
 No category is recommended and no default activation follows from this slice.
 The benchmark does not claim repository understanding, answer correctness or
 quality beyond the measured cases.

--- a/docs/proofs/repoground-evidence-navigation-v1-proof.md
+++ b/docs/proofs/repoground-evidence-navigation-v1-proof.md
@@ -1,0 +1,66 @@
+# RepoGround Evidence Navigation v1 — Proof
+
+Scope: Bureau #672 and #481 follow-up. This slice adds a read-only navigation
+surface; it neither changes persisted, versioned identifiers nor reintroduces
+public compatibility aliases.
+
+## Delivered surface
+
+- `repoground evidence-query --bundle-manifest <manifest> --q <query>` emits
+  `repoground.compact_evidence_query/v1`.
+- Every hit contains either one exact `live_path_line` from a citation's
+  available `live_repo_address`, or an explicit deterministic
+  `non_resolution_reason`. It never substitutes a snapshot/canonical line for
+  a missing live address.
+- The projection strips excerpts and diagnostics but retains citation/range
+  state, source freshness and fallback information. It emits an explicit
+  `compaction_pass`; the CLI fails if its full resolved result is not at least
+  60 percent smaller.
+- Ask's only zero-hit retry remains deterministic: content tokens now retain a
+  snake_case identifier and its parts, form a quoted OR expression, and use
+  the existing FTS5 BM25 result ordering.
+- The Reading Pack contains `REPOSITORY_GUIDE`, including the navigation order,
+  live-address boundary and compact command.
+
+## Reproducible local benchmark
+
+`scripts/benchmarks/repoground_vs_grep_read.py` consumes the committed
+20-question `docs/retrieval/review_queries.v1.json` and an existing local index:
+
+```bash
+python3 scripts/benchmarks/repoground_vs_grep_read.py \
+  --index /absolute/path/to/bundle.index.sqlite \
+  --repo-root "$PWD" \
+  --out /tmp/repoground-vs-grep-read.json
+```
+
+It uses only local `rg` plus bounded file reads through RepoGround's existing
+review-intent FTS5/BM25 path. The v2 report hashes the index, fixed question
+set and local source tree. For every one of the same 20–30 questions and the
+same `k` limit, it records runtime, logical tool calls, spawned process calls,
+bounded source reads, response bytes, a documented bytes/4 token proxy,
+source/index freshness and false-confidence status. Aggregates contain the
+same measures and the total compact-response reduction.
+
+False confidence is recorded only when a condition returned a result and is
+therefore presented as useful, while one or more expected targets are absent
+or the checked source is stale/unavailable. RepoGround compact responses keep
+chunk identity, path/line range, content hash/range reference, freshness and
+fallback state.
+
+The decision is fail-closed and has three outcomes:
+
+- `pass` only when at least one named category has fewer missing gold targets,
+  fresh evidence, zero false-confidence cases and passing compaction;
+- `inconclusive` when measurement succeeds but no category meets that safe
+  benefit contract;
+- `fail` when compaction, freshness or relative quality regresses.
+
+The committed local report `repoground-vs-grep-read.v2.json` is
+`inconclusive`. On 20 fixed questions RepoGround missed 37 expected targets
+versus 60 for `grep/read`, but both conditions had 20 false-confidence cases.
+RepoGround used 566.081 ms versus 156.484 ms, emitted 292,150 raw bytes, and
+its 98,966-byte compact form was still larger than the 26,274-byte baseline.
+No category is recommended and no default activation follows from this slice.
+The benchmark does not claim repository understanding, answer correctness or
+quality beyond the measured cases.

--- a/docs/proofs/repoground-vs-grep-read.v2.json
+++ b/docs/proofs/repoground-vs-grep-read.v2.json
@@ -16,13 +16,13 @@
       "expected_targets_missing": 60,
       "false_confidence_cases": 20,
       "process_calls": 20,
-      "response_bytes": 26274,
-      "runtime_ms": 156.484,
+      "response_bytes": 26690,
+      "runtime_ms": 166.691,
       "source_index_freshness": {
         "fresh": 20
       },
       "source_read_calls": 200,
-      "token_proxy": 6575,
+      "token_proxy": 6677,
       "tool_calls": 20
     },
     "repoground": {
@@ -38,7 +38,7 @@
       "false_confidence_cases": 20,
       "process_calls": 0,
       "response_bytes": 292150,
-      "runtime_ms": 566.081,
+      "runtime_ms": 551.335,
       "source_index_freshness": {
         "fresh": 20
       },
@@ -69,18 +69,19 @@
         "paths": [
           "scripts/ops/repoground-publish-fleet",
           "scripts/release/check_release_contract.py",
-          "scripts/docmeta/check_planning_registration.py",
           "scripts/docmeta/check_status_truth.py",
-          "scripts/release/check_identity_distribution_decisions.py",
-          "scripts/ci/check_codeql_suppressions.py",
-          "scripts/ci/check_github_main_ruleset.py",
           "scripts/ci/check_graph_maintainability.py",
+          "scripts/release/check_identity_distribution_decisions.py",
+          "scripts/docmeta/tests/test_check_planning_registration.py",
           "scripts/ci/check_reusable_workflow_contracts.py",
-          "scripts/ci/check_browser_gate_environment.py"
+          "scripts/docmeta/check_planning_registration.py",
+          "scripts/ci/check_browser_gate_environment.py",
+          "scripts/ci/check_github_main_ruleset.py"
         ],
         "process_calls": 1,
-        "response_bytes": 1300,
-        "runtime_ms": 8.139,
+        "response_bytes": 1362,
+        "runtime_ms": 8.282,
+        "search_engine": "ripgrep",
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -88,7 +89,7 @@
           "status": "fresh"
         },
         "source_read_calls": 10,
-        "token_proxy": 325,
+        "token_proxy": 341,
         "tool_calls": 1,
         "useful_displayed": true
       },
@@ -141,7 +142,7 @@
         ],
         "process_calls": 0,
         "response_bytes": 14427,
-        "runtime_ms": 59.76,
+        "runtime_ms": 59.432,
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -172,19 +173,20 @@
         "false_confidence": true,
         "paths": [
           "scripts/ops/repoground-publish-fleet",
-          "scripts/release/check_release_contract.py",
-          "scripts/ci/assert_codeql_sarif_clean.py",
-          "scripts/ci/check_reusable_workflow_contracts.py",
-          "scripts/ci/check_graph_maintainability.py",
-          "scripts/docmeta/check_planning_registration.py",
+          "scripts/repoground-post-merge-surface-smoke.sh",
           "scripts/docmeta/check_status_truth.py",
+          "scripts/docmeta/check_planning_registration.py",
           "scripts/ci/check_browser_gate_environment.py",
+          "scripts/ci/check_graph_maintainability.py",
           "scripts/ci/check_github_main_ruleset.py",
-          "scripts/ci/check_codeql_suppressions.py"
+          "scripts/ci/check_codeql_suppressions.py",
+          "scripts/ci/assert_codeql_sarif_clean.py",
+          "scripts/ci/check_github_actions_pins.py"
         ],
         "process_calls": 1,
-        "response_bytes": 1260,
-        "runtime_ms": 8.56,
+        "response_bytes": 1280,
+        "runtime_ms": 8.942,
+        "search_engine": "ripgrep",
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -192,7 +194,7 @@
           "status": "fresh"
         },
         "source_read_calls": 10,
-        "token_proxy": 315,
+        "token_proxy": 320,
         "tool_calls": 1,
         "useful_displayed": true
       },
@@ -243,7 +245,7 @@
         ],
         "process_calls": 0,
         "response_bytes": 14705,
-        "runtime_ms": 17.248,
+        "runtime_ms": 17.871,
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -275,20 +277,21 @@
         },
         "false_confidence": true,
         "paths": [
-          "scripts/ops/repoground-publish-fleet",
+          "scripts/docmeta/check_status_truth.py",
           "scripts/docmeta/check_planning_registration.py",
           "scripts/release/check_release_contract.py",
-          "scripts/docmeta/check_status_truth.py",
           "scripts/release/check_identity_distribution_decisions.py",
-          "scripts/repoground-post-merge-surface-smoke.sh",
+          "scripts/ops/repoground-publish-fleet",
           "scripts/docmeta/tests/test_check_planning_registration.py",
+          "scripts/repoground-post-merge-surface-smoke.sh",
           "scripts/ci/check_github_actions_pins.py",
-          "scripts/ci/check_github_main_ruleset.py",
+          "scripts/ci/check_browser_gate_environment.py",
           "scripts/ci/check_graph_maintainability.py"
         ],
         "process_calls": 1,
-        "response_bytes": 1324,
-        "runtime_ms": 7.622,
+        "response_bytes": 1360,
+        "runtime_ms": 9.102,
+        "search_engine": "ripgrep",
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -296,7 +299,7 @@
           "status": "fresh"
         },
         "source_read_calls": 10,
-        "token_proxy": 331,
+        "token_proxy": 340,
         "tool_calls": 1,
         "useful_displayed": true
       },
@@ -349,7 +352,7 @@
         ],
         "process_calls": 0,
         "response_bytes": 14706,
-        "runtime_ms": 27.724,
+        "runtime_ms": 27.882,
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -381,20 +384,21 @@
         },
         "false_confidence": true,
         "paths": [
-          "CONTRIBUTING.md",
-          "scripts/docmeta/check_planning_registration.py",
-          "scripts/docmeta/check_status_truth.py",
           "scripts/ops/repoground-publish-fleet",
-          "scripts/repoground-post-merge-surface-smoke.sh",
-          "scripts/docmeta/tests/test_check_planning_registration.py",
-          "scripts/ci/assert_codeql_sarif_clean.py",
+          "scripts/docmeta/check_planning_registration.py",
           "scripts/release/check_identity_distribution_decisions.py",
+          "scripts/release/check_release_contract.py",
+          "scripts/ci/check_github_actions_pins.py",
+          "scripts/ci/check_reusable_workflow_contracts.py",
+          "scripts/ci/check_browser_gate_environment.py",
+          "scripts/ci/check_graph_maintainability.py",
           "scripts/ci/check_github_main_ruleset.py",
-          "scripts/ci/check_browser_gate_environment.py"
+          "scripts/ci/assert_codeql_sarif_clean.py"
         ],
         "process_calls": 1,
-        "response_bytes": 1276,
-        "runtime_ms": 7.245,
+        "response_bytes": 1328,
+        "runtime_ms": 7.475,
+        "search_engine": "ripgrep",
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -402,7 +406,7 @@
           "status": "fresh"
         },
         "source_read_calls": 10,
-        "token_proxy": 319,
+        "token_proxy": 332,
         "tool_calls": 1,
         "useful_displayed": true
       },
@@ -455,7 +459,7 @@
         ],
         "process_calls": 0,
         "response_bytes": 14643,
-        "runtime_ms": 28.585,
+        "runtime_ms": 27.417,
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -491,16 +495,17 @@
           "scripts/release/check_release_contract.py",
           "scripts/ops/repoground-publish-fleet",
           "scripts/release/check_identity_distribution_decisions.py",
-          "scripts/ci/check_graph_maintainability.py",
-          "scripts/docmeta/check_planning_registration.py",
           "scripts/docmeta/check_status_truth.py",
-          "scripts/ci/check_browser_gate_environment.py",
-          "scripts/ci/check_reusable_workflow_contracts.py",
-          "scripts/ci/check_github_main_ruleset.py"
+          "scripts/docmeta/check_planning_registration.py",
+          "scripts/docmeta/tests/test_check_planning_registration.py",
+          "scripts/ci/check_github_actions_pins.py",
+          "scripts/ci/check_github_main_ruleset.py",
+          "scripts/ci/check_reusable_workflow_contracts.py"
         ],
         "process_calls": 1,
-        "response_bytes": 1305,
-        "runtime_ms": 6.66,
+        "response_bytes": 1353,
+        "runtime_ms": 8.345,
+        "search_engine": "ripgrep",
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -508,7 +513,7 @@
           "status": "fresh"
         },
         "source_read_calls": 10,
-        "token_proxy": 327,
+        "token_proxy": 339,
         "tool_calls": 1,
         "useful_displayed": true
       },
@@ -561,7 +566,7 @@
         ],
         "process_calls": 0,
         "response_bytes": 14425,
-        "runtime_ms": 33.85,
+        "runtime_ms": 35.328,
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -593,20 +598,21 @@
         },
         "false_confidence": true,
         "paths": [
-          "scripts/release/check_release_contract.py",
-          "scripts/release/check_identity_distribution_decisions.py",
-          "scripts/ops/repoground-publish-fleet",
           "scripts/repoground-post-merge-surface-smoke.sh",
-          "scripts/docmeta/check_status_truth.py",
-          "scripts/docmeta/check_planning_registration.py",
-          "scripts/ci/check_codeql_suppressions.py",
+          "scripts/ops/repoground-publish-fleet",
+          "scripts/ci/check_github_main_ruleset.py",
+          "scripts/ci/assert_codeql_sarif_clean.py",
+          "scripts/ci/check_reusable_workflow_contracts.py",
           "scripts/ci/check_browser_gate_environment.py",
           "scripts/ci/check_graph_maintainability.py",
-          "scripts/ci/check_reusable_workflow_contracts.py"
+          "scripts/ci/check_codeql_suppressions.py",
+          "scripts/release/check_release_contract.py",
+          "scripts/ci/check_github_actions_pins.py"
         ],
         "process_calls": 1,
-        "response_bytes": 1322,
-        "runtime_ms": 6.845,
+        "response_bytes": 1304,
+        "runtime_ms": 9.29,
+        "search_engine": "ripgrep",
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -614,7 +620,7 @@
           "status": "fresh"
         },
         "source_read_calls": 10,
-        "token_proxy": 331,
+        "token_proxy": 326,
         "tool_calls": 1,
         "useful_displayed": true
       },
@@ -667,7 +673,7 @@
         ],
         "process_calls": 0,
         "response_bytes": 14866,
-        "runtime_ms": 30.414,
+        "runtime_ms": 30.908,
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -699,20 +705,21 @@
         },
         "false_confidence": true,
         "paths": [
-          "scripts/release/check_identity_distribution_decisions.py",
           "scripts/release/check_release_contract.py",
+          "scripts/release/check_identity_distribution_decisions.py",
           "scripts/ops/repoground-publish-fleet",
           "scripts/repoground-post-merge-surface-smoke.sh",
+          "config/codeql-path-suppressions.v1.json",
+          "config/github-main-required-checks.v1.json",
+          "config/repoground-c901-baseline.v1.json",
           "scripts/docmeta/check_status_truth.py",
-          "scripts/docmeta/check_planning_registration.py",
-          "scripts/ci/assert_codeql_sarif_clean.py",
-          "scripts/docmeta/tests/test_check_planning_registration.py",
           "scripts/ci/check_github_actions_pins.py",
           "scripts/ci/check_browser_gate_environment.py"
         ],
         "process_calls": 1,
-        "response_bytes": 1342,
-        "runtime_ms": 7.687,
+        "response_bytes": 1324,
+        "runtime_ms": 8.444,
+        "search_engine": "ripgrep",
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -720,7 +727,7 @@
           "status": "fresh"
         },
         "source_read_calls": 10,
-        "token_proxy": 336,
+        "token_proxy": 331,
         "tool_calls": 1,
         "useful_displayed": true
       },
@@ -773,7 +780,7 @@
         ],
         "process_calls": 0,
         "response_bytes": 14980,
-        "runtime_ms": 27.456,
+        "runtime_ms": 27.021,
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -805,20 +812,21 @@
         },
         "false_confidence": true,
         "paths": [
-          "scripts/release/check_release_contract.py",
           "scripts/release/check_identity_distribution_decisions.py",
+          "scripts/release/check_release_contract.py",
           "scripts/ops/repoground-publish-fleet",
           "scripts/repoground-post-merge-surface-smoke.sh",
           "scripts/docmeta/check_status_truth.py",
-          "scripts/docmeta/check_planning_registration.py",
-          "scripts/ci/check_github_actions_pins.py",
-          "scripts/ci/check_reusable_workflow_contracts.py",
+          "scripts/ci/check_codeql_suppressions.py",
+          "scripts/ci/assert_codeql_sarif_clean.py",
+          "scripts/ci/check_github_main_ruleset.py",
           "scripts/ci/check_browser_gate_environment.py",
-          "scripts/ci/check_graph_maintainability.py"
+          "scripts/ci/check_reusable_workflow_contracts.py"
         ],
         "process_calls": 1,
-        "response_bytes": 1332,
-        "runtime_ms": 9.128,
+        "response_bytes": 1340,
+        "runtime_ms": 7.75,
+        "search_engine": "ripgrep",
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -826,7 +834,7 @@
           "status": "fresh"
         },
         "source_read_calls": 10,
-        "token_proxy": 333,
+        "token_proxy": 335,
         "tool_calls": 1,
         "useful_displayed": true
       },
@@ -879,7 +887,7 @@
         ],
         "process_calls": 0,
         "response_bytes": 15033,
-        "runtime_ms": 23.962,
+        "runtime_ms": 23.128,
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -911,20 +919,21 @@
         },
         "false_confidence": true,
         "paths": [
+          "scripts/ops/repoground-publish-fleet",
           "scripts/release/check_identity_distribution_decisions.py",
           "scripts/release/check_release_contract.py",
-          "scripts/docmeta/check_status_truth.py",
-          "scripts/docmeta/check_planning_registration.py",
-          "scripts/docmeta/tests/test_check_planning_registration.py",
-          "scripts/ops/repoground-publish-fleet",
           "scripts/repoground-post-merge-surface-smoke.sh",
+          "scripts/docmeta/check_planning_registration.py",
           "scripts/ci/assert_codeql_sarif_clean.py",
-          "scripts/ci/check_graph_maintainability.py",
-          "scripts/ci/check_browser_gate_environment.py"
+          "scripts/docmeta/check_status_truth.py",
+          "scripts/ci/check_github_main_ruleset.py",
+          "scripts/ci/check_browser_gate_environment.py",
+          "scripts/ci/check_reusable_workflow_contracts.py"
         ],
         "process_calls": 1,
-        "response_bytes": 1332,
-        "runtime_ms": 7.471,
+        "response_bytes": 1334,
+        "runtime_ms": 7.598,
+        "search_engine": "ripgrep",
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -932,7 +941,7 @@
           "status": "fresh"
         },
         "source_read_calls": 10,
-        "token_proxy": 333,
+        "token_proxy": 334,
         "tool_calls": 1,
         "useful_displayed": true
       },
@@ -985,7 +994,7 @@
         ],
         "process_calls": 0,
         "response_bytes": 14621,
-        "runtime_ms": 34.087,
+        "runtime_ms": 34.198,
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -1017,20 +1026,21 @@
         },
         "false_confidence": true,
         "paths": [
-          "scripts/release/check_identity_distribution_decisions.py",
-          "scripts/release/check_release_contract.py",
-          "scripts/docmeta/check_status_truth.py",
           "scripts/ops/repoground-publish-fleet",
-          "scripts/docmeta/check_planning_registration.py",
-          "scripts/docmeta/tests/test_check_planning_registration.py",
-          "scripts/repoground-post-merge-surface-smoke.sh",
-          "scripts/ci/check_github_actions_pins.py",
+          "scripts/ci/check_reusable_workflow_contracts.py",
+          "scripts/ci/check_browser_gate_environment.py",
+          "scripts/release/check_release_contract.py",
+          "scripts/ci/check_graph_maintainability.py",
+          "scripts/ci/assert_codeql_sarif_clean.py",
           "scripts/ci/check_github_main_ruleset.py",
-          "scripts/ci/check_browser_gate_environment.py"
+          "scripts/ci/check_codeql_suppressions.py",
+          "scripts/ci/check_github_actions_pins.py",
+          "scripts/docmeta/check_planning_registration.py"
         ],
         "process_calls": 1,
-        "response_bytes": 1326,
-        "runtime_ms": 8.804,
+        "response_bytes": 1292,
+        "runtime_ms": 7.881,
+        "search_engine": "ripgrep",
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -1038,7 +1048,7 @@
           "status": "fresh"
         },
         "source_read_calls": 10,
-        "token_proxy": 332,
+        "token_proxy": 323,
         "tool_calls": 1,
         "useful_displayed": true
       },
@@ -1091,7 +1101,7 @@
         ],
         "process_calls": 0,
         "response_bytes": 14242,
-        "runtime_ms": 21.741,
+        "runtime_ms": 21.787,
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -1123,20 +1133,21 @@
         },
         "false_confidence": true,
         "paths": [
-          "scripts/release/check_identity_distribution_decisions.py",
           "scripts/release/check_release_contract.py",
+          "scripts/release/check_identity_distribution_decisions.py",
+          "scripts/docmeta/check_planning_registration.py",
+          "scripts/docmeta/tests/test_check_planning_registration.py",
+          "scripts/docmeta/check_status_truth.py",
           "scripts/ops/repoground-publish-fleet",
           "scripts/repoground-post-merge-surface-smoke.sh",
-          "scripts/docmeta/check_planning_registration.py",
-          "scripts/docmeta/check_status_truth.py",
-          "scripts/ci/check_codeql_suppressions.py",
           "scripts/ci/check_github_actions_pins.py",
-          "scripts/ci/check_browser_gate_environment.py",
-          "scripts/ci/assert_codeql_sarif_clean.py"
+          "scripts/ci/assert_codeql_sarif_clean.py",
+          "scripts/ci/check_codeql_suppressions.py"
         ],
         "process_calls": 1,
-        "response_bytes": 1291,
-        "runtime_ms": 7.476,
+        "response_bytes": 1343,
+        "runtime_ms": 9.072,
+        "search_engine": "ripgrep",
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -1144,7 +1155,7 @@
           "status": "fresh"
         },
         "source_read_calls": 10,
-        "token_proxy": 323,
+        "token_proxy": 336,
         "tool_calls": 1,
         "useful_displayed": true
       },
@@ -1197,7 +1208,7 @@
         ],
         "process_calls": 0,
         "response_bytes": 14275,
-        "runtime_ms": 15.526,
+        "runtime_ms": 12.84,
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -1229,20 +1240,21 @@
         },
         "false_confidence": true,
         "paths": [
-          "scripts/repoground-post-merge-surface-smoke.sh",
           "scripts/ops/repoground-publish-fleet",
           "scripts/release/check_release_contract.py",
-          "scripts/docmeta/check_planning_registration.py",
-          "scripts/docmeta/check_status_truth.py",
           "scripts/release/check_identity_distribution_decisions.py",
+          "scripts/docmeta/check_status_truth.py",
+          "scripts/docmeta/check_planning_registration.py",
           "scripts/docmeta/tests/test_check_planning_registration.py",
+          "scripts/repoground-post-merge-surface-smoke.sh",
           "scripts/ci/check_codeql_suppressions.py",
-          "scripts/ci/check_graph_maintainability.py",
-          "scripts/ci/check_reusable_workflow_contracts.py"
+          "scripts/ci/check_browser_gate_environment.py",
+          "scripts/ci/check_graph_maintainability.py"
         ],
         "process_calls": 1,
-        "response_bytes": 1346,
-        "runtime_ms": 8.008,
+        "response_bytes": 1366,
+        "runtime_ms": 8.594,
+        "search_engine": "ripgrep",
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -1250,7 +1262,7 @@
           "status": "fresh"
         },
         "source_read_calls": 10,
-        "token_proxy": 337,
+        "token_proxy": 342,
         "tool_calls": 1,
         "useful_displayed": true
       },
@@ -1303,7 +1315,7 @@
         ],
         "process_calls": 0,
         "response_bytes": 14570,
-        "runtime_ms": 11.786,
+        "runtime_ms": 12.576,
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -1334,19 +1346,20 @@
         "false_confidence": true,
         "paths": [
           "scripts/repoground-post-merge-surface-smoke.sh",
-          "scripts/docmeta/check_planning_registration.py",
-          "scripts/docmeta/check_status_truth.py",
-          "scripts/release/check_release_contract.py",
           "scripts/release/check_identity_distribution_decisions.py",
-          "scripts/ci/check_github_actions_pins.py",
-          "scripts/ci/check_github_main_ruleset.py",
-          "scripts/ci/check_graph_maintainability.py",
+          "scripts/docmeta/check_planning_registration.py",
+          "scripts/release/check_release_contract.py",
+          "scripts/ops/repoground-publish-fleet",
+          "scripts/docmeta/check_status_truth.py",
+          "scripts/docmeta/tests/test_check_planning_registration.py",
+          "scripts/ci/assert_codeql_sarif_clean.py",
           "scripts/ci/check_browser_gate_environment.py",
-          "scripts/ci/assert_codeql_sarif_clean.py"
+          "scripts/ci/check_codeql_suppressions.py"
         ],
         "process_calls": 1,
-        "response_bytes": 1309,
-        "runtime_ms": 6.824,
+        "response_bytes": 1361,
+        "runtime_ms": 7.434,
+        "search_engine": "ripgrep",
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -1354,7 +1367,7 @@
           "status": "fresh"
         },
         "source_read_calls": 10,
-        "token_proxy": 328,
+        "token_proxy": 341,
         "tool_calls": 1,
         "useful_displayed": true
       },
@@ -1405,7 +1418,7 @@
         ],
         "process_calls": 0,
         "response_bytes": 14817,
-        "runtime_ms": 33.566,
+        "runtime_ms": 34.252,
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -1437,20 +1450,21 @@
         },
         "false_confidence": true,
         "paths": [
-          "scripts/release/check_release_contract.py",
-          "scripts/docmeta/check_status_truth.py",
-          "scripts/docmeta/check_planning_registration.py",
-          "scripts/ops/repoground-publish-fleet",
-          "scripts/release/check_identity_distribution_decisions.py",
-          "scripts/docmeta/tests/test_check_planning_registration.py",
-          "scripts/repoground-post-merge-surface-smoke.sh",
           "scripts/ci/check_github_actions_pins.py",
+          "scripts/ci/check_browser_gate_environment.py",
+          "scripts/ci/check_graph_maintainability.py",
+          "scripts/ci/check_github_main_ruleset.py",
+          "scripts/ci/assert_codeql_sarif_clean.py",
           "scripts/ci/check_codeql_suppressions.py",
-          "scripts/ci/check_browser_gate_environment.py"
+          "scripts/ci/check_reusable_workflow_contracts.py",
+          "scripts/release/check_release_contract.py",
+          "scripts/release/check_identity_distribution_decisions.py",
+          "scripts/ops/repoground-publish-fleet"
         ],
         "process_calls": 1,
-        "response_bytes": 1333,
-        "runtime_ms": 8.028,
+        "response_bytes": 1319,
+        "runtime_ms": 8.005,
+        "search_engine": "ripgrep",
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -1458,7 +1472,7 @@
           "status": "fresh"
         },
         "source_read_calls": 10,
-        "token_proxy": 334,
+        "token_proxy": 330,
         "tool_calls": 1,
         "useful_displayed": true
       },
@@ -1510,7 +1524,7 @@
         ],
         "process_calls": 0,
         "response_bytes": 14820,
-        "runtime_ms": 20.982,
+        "runtime_ms": 21.039,
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -1542,20 +1556,21 @@
         },
         "false_confidence": true,
         "paths": [
-          "scripts/ops/repoground-publish-fleet",
-          "scripts/docmeta/check_planning_registration.py",
-          "scripts/release/check_identity_distribution_decisions.py",
-          "scripts/ci/check_github_actions_pins.py",
           "scripts/release/check_release_contract.py",
-          "scripts/ci/check_graph_maintainability.py",
-          "scripts/ci/check_reusable_workflow_contracts.py",
-          "scripts/ci/assert_codeql_sarif_clean.py",
+          "scripts/release/check_identity_distribution_decisions.py",
+          "scripts/ops/repoground-publish-fleet",
+          "scripts/repoground-post-merge-surface-smoke.sh",
           "scripts/ci/check_github_main_ruleset.py",
-          "scripts/ci/check_browser_gate_environment.py"
+          "scripts/docmeta/check_planning_registration.py",
+          "scripts/ci/check_reusable_workflow_contracts.py",
+          "scripts/ci/check_graph_maintainability.py",
+          "scripts/ci/check_browser_gate_environment.py",
+          "scripts/ci/assert_codeql_sarif_clean.py"
         ],
         "process_calls": 1,
-        "response_bytes": 1312,
-        "runtime_ms": 7.394,
+        "response_bytes": 1352,
+        "runtime_ms": 9.523,
+        "search_engine": "ripgrep",
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -1563,7 +1578,7 @@
           "status": "fresh"
         },
         "source_read_calls": 10,
-        "token_proxy": 328,
+        "token_proxy": 338,
         "tool_calls": 1,
         "useful_displayed": true
       },
@@ -1616,7 +1631,7 @@
         ],
         "process_calls": 0,
         "response_bytes": 14566,
-        "runtime_ms": 20.125,
+        "runtime_ms": 19.553,
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -1647,19 +1662,20 @@
         "false_confidence": true,
         "paths": [
           "scripts/ops/repoground-publish-fleet",
-          "scripts/docmeta/check_planning_registration.py",
           "scripts/release/check_release_contract.py",
           "scripts/release/check_identity_distribution_decisions.py",
-          "scripts/docmeta/check_status_truth.py",
           "scripts/repoground-post-merge-surface-smoke.sh",
-          "scripts/docmeta/tests/test_check_planning_registration.py",
+          "scripts/docmeta/check_status_truth.py",
+          "scripts/docmeta/check_planning_registration.py",
           "scripts/ci/assert_codeql_sarif_clean.py",
-          "scripts/ci/check_browser_gate_environment.py",
-          "scripts/ci/check_codeql_suppressions.py"
+          "scripts/ci/check_graph_maintainability.py",
+          "scripts/docmeta/tests/test_check_planning_registration.py",
+          "scripts/ci/check_browser_gate_environment.py"
         ],
         "process_calls": 1,
-        "response_bytes": 1316,
-        "runtime_ms": 9.746,
+        "response_bytes": 1346,
+        "runtime_ms": 8.646,
+        "search_engine": "ripgrep",
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -1667,7 +1683,7 @@
           "status": "fresh"
         },
         "source_read_calls": 10,
-        "token_proxy": 329,
+        "token_proxy": 337,
         "tool_calls": 1,
         "useful_displayed": true
       },
@@ -1718,7 +1734,7 @@
         ],
         "process_calls": 0,
         "response_bytes": 14356,
-        "runtime_ms": 37.774,
+        "runtime_ms": 35.678,
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -1750,20 +1766,21 @@
         },
         "false_confidence": true,
         "paths": [
-          "scripts/release/check_identity_distribution_decisions.py",
-          "scripts/release/check_release_contract.py",
-          "scripts/docmeta/tests/test_check_planning_registration.py",
-          "scripts/ops/repoground-publish-fleet",
-          "scripts/docmeta/check_planning_registration.py",
-          "scripts/docmeta/check_status_truth.py",
-          "scripts/repoground-post-merge-surface-smoke.sh",
-          "scripts/ci/check_codeql_suppressions.py",
+          "scripts/ci/check_reusable_workflow_contracts.py",
+          "scripts/ci/check_graph_maintainability.py",
           "scripts/ci/check_browser_gate_environment.py",
-          "scripts/ci/check_reusable_workflow_contracts.py"
+          "scripts/ci/check_github_main_ruleset.py",
+          "scripts/ci/assert_codeql_sarif_clean.py",
+          "scripts/ci/check_codeql_suppressions.py",
+          "scripts/ci/check_github_actions_pins.py",
+          "scripts/release/check_release_contract.py",
+          "scripts/ops/repoground-publish-fleet",
+          "scripts/release/check_identity_distribution_decisions.py"
         ],
         "process_calls": 1,
-        "response_bytes": 1354,
-        "runtime_ms": 7.702,
+        "response_bytes": 1324,
+        "runtime_ms": 8.497,
+        "search_engine": "ripgrep",
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -1771,7 +1788,7 @@
           "status": "fresh"
         },
         "source_read_calls": 10,
-        "token_proxy": 339,
+        "token_proxy": 331,
         "tool_calls": 1,
         "useful_displayed": true
       },
@@ -1824,7 +1841,7 @@
         ],
         "process_calls": 0,
         "response_bytes": 14699,
-        "runtime_ms": 38.446,
+        "runtime_ms": 33.665,
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -1858,20 +1875,21 @@
         },
         "false_confidence": true,
         "paths": [
-          "scripts/ci/check_codeql_suppressions.py",
-          "scripts/ci/check_graph_maintainability.py",
-          "scripts/ci/check_reusable_workflow_contracts.py",
-          "scripts/ci/check_browser_gate_environment.py",
-          "scripts/ci/check_github_main_ruleset.py",
-          "scripts/ci/assert_codeql_sarif_clean.py",
-          "scripts/ci/check_github_actions_pins.py",
           "scripts/release/check_release_contract.py",
           "scripts/release/check_identity_distribution_decisions.py",
-          "scripts/ops/repoground-publish-fleet"
+          "scripts/docmeta/check_planning_registration.py",
+          "scripts/ops/repoground-publish-fleet",
+          "scripts/docmeta/check_status_truth.py",
+          "scripts/repoground-post-merge-surface-smoke.sh",
+          "scripts/docmeta/tests/test_check_planning_registration.py",
+          "scripts/ci/check_codeql_suppressions.py",
+          "scripts/ci/assert_codeql_sarif_clean.py",
+          "scripts/ci/check_browser_gate_environment.py"
         ],
         "process_calls": 1,
-        "response_bytes": 1298,
-        "runtime_ms": 8.775,
+        "response_bytes": 1364,
+        "runtime_ms": 8.238,
+        "search_engine": "ripgrep",
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -1879,7 +1897,7 @@
           "status": "fresh"
         },
         "source_read_calls": 10,
-        "token_proxy": 325,
+        "token_proxy": 341,
         "tool_calls": 1,
         "useful_displayed": true
       },
@@ -1934,7 +1952,7 @@
         ],
         "process_calls": 0,
         "response_bytes": 14562,
-        "runtime_ms": 44.181,
+        "runtime_ms": 39.865,
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -1970,20 +1988,21 @@
         },
         "false_confidence": true,
         "paths": [
-          "scripts/ci/check_github_actions_pins.py",
-          "scripts/ci/check_browser_gate_environment.py",
+          "scripts/ci/check_codeql_suppressions.py",
           "scripts/ci/check_graph_maintainability.py",
+          "scripts/ci/check_browser_gate_environment.py",
           "scripts/ci/check_reusable_workflow_contracts.py",
           "scripts/ci/assert_codeql_sarif_clean.py",
           "scripts/ci/check_github_main_ruleset.py",
-          "scripts/ci/check_codeql_suppressions.py",
+          "scripts/ci/check_github_actions_pins.py",
+          "scripts/release/check_release_contract.py",
           "scripts/ops/repoground-publish-fleet",
-          "scripts/repoground-post-merge-surface-smoke.sh",
-          "scripts/docmeta/check_status_truth.py"
+          "scripts/release/check_identity_distribution_decisions.py"
         ],
         "process_calls": 1,
-        "response_bytes": 1270,
-        "runtime_ms": 7.262,
+        "response_bytes": 1324,
+        "runtime_ms": 7.348,
+        "search_engine": "ripgrep",
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -1991,7 +2010,7 @@
           "status": "fresh"
         },
         "source_read_calls": 10,
-        "token_proxy": 318,
+        "token_proxy": 331,
         "tool_calls": 1,
         "useful_displayed": true
       },
@@ -2048,7 +2067,7 @@
         ],
         "process_calls": 0,
         "response_bytes": 14742,
-        "runtime_ms": 29.052,
+        "runtime_ms": 27.239,
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -2080,20 +2099,21 @@
         },
         "false_confidence": true,
         "paths": [
-          "scripts/ops/repoground-publish-fleet",
+          "CONTRIBUTING.md",
+          "config/codeql-path-suppressions.v1.json",
           "scripts/release/check_release_contract.py",
-          "scripts/docmeta/check_status_truth.py",
-          "scripts/docmeta/check_planning_registration.py",
+          "scripts/ops/repoground-publish-fleet",
           "scripts/release/check_identity_distribution_decisions.py",
-          "scripts/docmeta/tests/test_check_planning_registration.py",
           "scripts/repoground-post-merge-surface-smoke.sh",
-          "scripts/ci/check_github_actions_pins.py",
+          "scripts/docmeta/check_planning_registration.py",
           "scripts/ci/check_reusable_workflow_contracts.py",
-          "scripts/ci/check_graph_maintainability.py"
+          "scripts/ci/check_browser_gate_environment.py",
+          "scripts/docmeta/tests/test_check_planning_registration.py"
         ],
         "process_calls": 1,
-        "response_bytes": 1326,
-        "runtime_ms": 7.108,
+        "response_bytes": 1314,
+        "runtime_ms": 8.225,
+        "search_engine": "ripgrep",
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -2101,7 +2121,7 @@
           "status": "fresh"
         },
         "source_read_calls": 10,
-        "token_proxy": 332,
+        "token_proxy": 329,
         "tool_calls": 1,
         "useful_displayed": true
       },
@@ -2154,7 +2174,7 @@
         ],
         "process_calls": 0,
         "response_bytes": 14095,
-        "runtime_ms": 9.816,
+        "runtime_ms": 9.656,
         "source_index_freshness": {
           "checked_path_count": 10,
           "missing_paths": [],
@@ -2376,15 +2396,17 @@
     "unmeasured_query_quality"
   ],
   "environment": {
-    "pid": 2010052,
+    "pid": 2126213,
     "platform": "Linux-7.0.11-76070011-generic-x86_64-with-glibc2.35",
     "python": "3.10.12"
   },
   "inputs": {
-    "index_path": "/home/alex/repos/manifest-publications/bundles/heimgewebe__repoground/main/20260718T063017Z-dd3905c1eb07/heimgewebe__repoground__main-max-260718-0630_merge.chunk_index.index.sqlite",
+    "absolute_paths_persisted": false,
+    "benchmark_script_sha256": "27c597a15e51fa214ec8fde8d49ecc50b76594681329ec64bed7e280a14a2fc3",
+    "index_path": "heimgewebe__repoground__main-max-260718-0630_merge.chunk_index.index.sqlite",
     "index_sha256": "48df1af9afb2a32b01eb8ab4a64e10eff2126f46928d0c93b56b7221f037da76",
     "questions_sha256": "e6a123580e08d0d3cb3db3889b8a5f6b11981cc6f7528f3c90c00ae0bcb692a9",
-    "repo_root": "/home/alex/repos/.repoground-sources/heimgewebe__repoground__main",
+    "repo_root": ".",
     "repo_tree_sha256": "3cf72490e267182a8a294abfea310943c756db7b5091120f13cd0152e8e3c50a"
   },
   "kind": "repoground_vs_grep_read_benchmark",

--- a/docs/proofs/repoground-vs-grep-read.v2.json
+++ b/docs/proofs/repoground-vs-grep-read.v2.json
@@ -1,0 +1,2393 @@
+{
+  "acceptance": {
+    "compaction_required_percent": 60.0,
+    "failure_reasons": [],
+    "inconclusive_reasons": [
+      "no_named_category_with_safe_reproducible_benefit"
+    ],
+    "preference_recommendation": null,
+    "recommended_categories": [],
+    "same_k": 10,
+    "same_question_set": true
+  },
+  "aggregates": {
+    "grep_read": {
+      "case_count": 20,
+      "expected_targets_missing": 60,
+      "false_confidence_cases": 20,
+      "process_calls": 20,
+      "response_bytes": 26274,
+      "runtime_ms": 156.484,
+      "source_index_freshness": {
+        "fresh": 20
+      },
+      "source_read_calls": 200,
+      "token_proxy": 6575,
+      "tool_calls": 20
+    },
+    "repoground": {
+      "case_count": 20,
+      "compaction": {
+        "aggregate_pass": true,
+        "all_cases_pass": true,
+        "byte_reduction_percent": 66.12,
+        "compact_response_bytes": 98966,
+        "required_percent": 60.0
+      },
+      "expected_targets_missing": 37,
+      "false_confidence_cases": 20,
+      "process_calls": 0,
+      "response_bytes": 292150,
+      "runtime_ms": 566.081,
+      "source_index_freshness": {
+        "fresh": 20
+      },
+      "source_read_calls": 0,
+      "token_proxy": 73046,
+      "tool_calls": 20
+    }
+  },
+  "cases": [
+    {
+      "category": "agent_pack",
+      "grep_read": {
+        "condition": "grep_read",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/core/agent_reading_pack.py",
+            "merger/repoground/tests/test_agent_reading_pack.py",
+            "produce_agent_reading_pack"
+          ],
+          "found": [],
+          "missing": [
+            "merger/repoground/core/agent_reading_pack.py",
+            "merger/repoground/tests/test_agent_reading_pack.py",
+            "produce_agent_reading_pack"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "scripts/ops/repoground-publish-fleet",
+          "scripts/release/check_release_contract.py",
+          "scripts/docmeta/check_planning_registration.py",
+          "scripts/docmeta/check_status_truth.py",
+          "scripts/release/check_identity_distribution_decisions.py",
+          "scripts/ci/check_codeql_suppressions.py",
+          "scripts/ci/check_github_main_ruleset.py",
+          "scripts/ci/check_graph_maintainability.py",
+          "scripts/ci/check_reusable_workflow_contracts.py",
+          "scripts/ci/check_browser_gate_environment.py"
+        ],
+        "process_calls": 1,
+        "response_bytes": 1300,
+        "runtime_ms": 8.139,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 10,
+        "token_proxy": 325,
+        "tool_calls": 1,
+        "useful_displayed": true
+      },
+      "k": 10,
+      "ordinal": 1,
+      "query": "Find the Agent Reading Pack producer and its primary tests",
+      "repoground": {
+        "compaction": {
+          "byte_reduction_percent": 65.81,
+          "compact_response_bytes": 4932,
+          "pass": true,
+          "preserved": [
+            "chunk_id",
+            "path",
+            "line_range",
+            "content_sha256",
+            "range_ref",
+            "freshness",
+            "fallback"
+          ],
+          "required_percent": 60.0
+        },
+        "condition": "repoground",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/core/agent_reading_pack.py",
+            "merger/repoground/tests/test_agent_reading_pack.py",
+            "produce_agent_reading_pack"
+          ],
+          "found": [
+            "merger/repoground/tests/test_agent_reading_pack.py"
+          ],
+          "missing": [
+            "merger/repoground/core/agent_reading_pack.py",
+            "produce_agent_reading_pack"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "docs/diagnostics/retrieval-v2-default-promotion-review-intent-20260708T152502Z.json",
+          "merger/repoground/tests/test_output_health.py",
+          "docs/diagnostics/retrieval-v2-default-promotion-legacy-20260708T152502Z.json",
+          "merger/repoground/cli/cmd_agent_pack.py",
+          "merger/repoground/tests/test_agent_reading_pack_usage_rules.py",
+          "docs/retrieval/review_queries.v1.json",
+          "merger/repoground/tests/test_agent_reading_pack.py",
+          "merger/repoground/tests/test_agent_export_gate.py",
+          "docs/proofs/lens-card-v1-proof.md",
+          "merger/repoground/core/bundle_surface_validate.py"
+        ],
+        "process_calls": 0,
+        "response_bytes": 14427,
+        "runtime_ms": 59.76,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 0,
+        "token_proxy": 3607,
+        "tool_calls": 1,
+        "useful_displayed": true
+      }
+    },
+    {
+      "category": "agent_pack",
+      "grep_read": {
+        "condition": "grep_read",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/tests/test_agent_reading_pack_usage_rules.py",
+            "REQUIRED_READING_BY_TASK"
+          ],
+          "found": [],
+          "missing": [
+            "merger/repoground/tests/test_agent_reading_pack_usage_rules.py",
+            "REQUIRED_READING_BY_TASK"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "scripts/ops/repoground-publish-fleet",
+          "scripts/release/check_release_contract.py",
+          "scripts/ci/assert_codeql_sarif_clean.py",
+          "scripts/ci/check_reusable_workflow_contracts.py",
+          "scripts/ci/check_graph_maintainability.py",
+          "scripts/docmeta/check_planning_registration.py",
+          "scripts/docmeta/check_status_truth.py",
+          "scripts/ci/check_browser_gate_environment.py",
+          "scripts/ci/check_github_main_ruleset.py",
+          "scripts/ci/check_codeql_suppressions.py"
+        ],
+        "process_calls": 1,
+        "response_bytes": 1260,
+        "runtime_ms": 8.56,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 10,
+        "token_proxy": 315,
+        "tool_calls": 1,
+        "useful_displayed": true
+      },
+      "k": 10,
+      "ordinal": 2,
+      "query": "Find the Agent Reading Pack task-profile usage rules",
+      "repoground": {
+        "compaction": {
+          "byte_reduction_percent": 66.4,
+          "compact_response_bytes": 4941,
+          "pass": true,
+          "preserved": [
+            "chunk_id",
+            "path",
+            "line_range",
+            "content_sha256",
+            "range_ref",
+            "freshness",
+            "fallback"
+          ],
+          "required_percent": 60.0
+        },
+        "condition": "repoground",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/tests/test_agent_reading_pack_usage_rules.py",
+            "REQUIRED_READING_BY_TASK"
+          ],
+          "found": [
+            "merger/repoground/tests/test_agent_reading_pack_usage_rules.py"
+          ],
+          "missing": [
+            "REQUIRED_READING_BY_TASK"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "merger/repoground/tests/test_agent_reading_pack_usage_rules.py",
+          "merger/repoground/tests/test_agent_reading_pack.py",
+          "merger/repoground/core/agent_reading_pack.py",
+          "docs/blueprints/lenskit-agent-front-door-hardening.md",
+          "docs/diagnostics/retrieval-v2-default-promotion-legacy-20260708T152502Z.json",
+          "docs/proofs/lens-card-v1-proof.md",
+          "docs/diagnostics/retrieval-v2-default-promotion-review-intent-20260708T152502Z.json",
+          "docs/retrieval/review_queries.v1.json",
+          "merger/repoground/core/required_reading.py",
+          "merger/repoground/tests/test_required_reading_protocol.py"
+        ],
+        "process_calls": 0,
+        "response_bytes": 14705,
+        "runtime_ms": 17.248,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 0,
+        "token_proxy": 3677,
+        "tool_calls": 1,
+        "useful_displayed": true
+      }
+    },
+    {
+      "category": "claim_evidence",
+      "grep_read": {
+        "condition": "grep_read",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/core/claim_evidence_map.py",
+            "merger/repoground/tests/test_claim_evidence_map.py",
+            "merger/repoground/contracts/claim-evidence-map.v1.schema.json"
+          ],
+          "found": [],
+          "missing": [
+            "merger/repoground/core/claim_evidence_map.py",
+            "merger/repoground/tests/test_claim_evidence_map.py",
+            "merger/repoground/contracts/claim-evidence-map.v1.schema.json"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "scripts/ops/repoground-publish-fleet",
+          "scripts/docmeta/check_planning_registration.py",
+          "scripts/release/check_release_contract.py",
+          "scripts/docmeta/check_status_truth.py",
+          "scripts/release/check_identity_distribution_decisions.py",
+          "scripts/repoground-post-merge-surface-smoke.sh",
+          "scripts/docmeta/tests/test_check_planning_registration.py",
+          "scripts/ci/check_github_actions_pins.py",
+          "scripts/ci/check_github_main_ruleset.py",
+          "scripts/ci/check_graph_maintainability.py"
+        ],
+        "process_calls": 1,
+        "response_bytes": 1324,
+        "runtime_ms": 7.622,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 10,
+        "token_proxy": 331,
+        "tool_calls": 1,
+        "useful_displayed": true
+      },
+      "k": 10,
+      "ordinal": 3,
+      "query": "Find claim-to-evidence map production, tests, and contract",
+      "repoground": {
+        "compaction": {
+          "byte_reduction_percent": 66.16,
+          "compact_response_bytes": 4977,
+          "pass": true,
+          "preserved": [
+            "chunk_id",
+            "path",
+            "line_range",
+            "content_sha256",
+            "range_ref",
+            "freshness",
+            "fallback"
+          ],
+          "required_percent": 60.0
+        },
+        "condition": "repoground",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/core/claim_evidence_map.py",
+            "merger/repoground/tests/test_claim_evidence_map.py",
+            "merger/repoground/contracts/claim-evidence-map.v1.schema.json"
+          ],
+          "found": [
+            "merger/repoground/tests/test_claim_evidence_map.py",
+            "merger/repoground/contracts/claim-evidence-map.v1.schema.json"
+          ],
+          "missing": [
+            "merger/repoground/core/claim_evidence_map.py"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "docs/diagnostics/retrieval-v2-default-promotion-legacy-20260708T152502Z.json",
+          "merger/repoground/tests/test_agent_reading_pack_usage_rules.py",
+          "merger/repoground/contracts/claim-evidence-map.v1.schema.json",
+          "docs/retrieval/review_queries.v1.json",
+          "merger/repoground/core/agent_reading_pack.py",
+          "merger/repoground/tests/test_claim_evidence_map.py",
+          "merger/repoground/contracts/post-emit-health.v1.schema.json",
+          "docs/diagnostics/retrieval-v2-default-promotion-review-intent-20260708T152502Z.json",
+          "merger/repoground/core/doc_freshness.py",
+          "merger/repoground/tests/test_bundle_manifest_schema.py"
+        ],
+        "process_calls": 0,
+        "response_bytes": 14706,
+        "runtime_ms": 27.724,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 0,
+        "token_proxy": 3677,
+        "tool_calls": 1,
+        "useful_displayed": true
+      }
+    },
+    {
+      "category": "citation_map",
+      "grep_read": {
+        "condition": "grep_read",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/core/citation_map.py",
+            "merger/repoground/tests/test_citation_map_producer.py",
+            "merger/repoground/contracts/citation-map.v1.schema.json"
+          ],
+          "found": [],
+          "missing": [
+            "merger/repoground/core/citation_map.py",
+            "merger/repoground/tests/test_citation_map_producer.py",
+            "merger/repoground/contracts/citation-map.v1.schema.json"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "CONTRIBUTING.md",
+          "scripts/docmeta/check_planning_registration.py",
+          "scripts/docmeta/check_status_truth.py",
+          "scripts/ops/repoground-publish-fleet",
+          "scripts/repoground-post-merge-surface-smoke.sh",
+          "scripts/docmeta/tests/test_check_planning_registration.py",
+          "scripts/ci/assert_codeql_sarif_clean.py",
+          "scripts/release/check_identity_distribution_decisions.py",
+          "scripts/ci/check_github_main_ruleset.py",
+          "scripts/ci/check_browser_gate_environment.py"
+        ],
+        "process_calls": 1,
+        "response_bytes": 1276,
+        "runtime_ms": 7.245,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 10,
+        "token_proxy": 319,
+        "tool_calls": 1,
+        "useful_displayed": true
+      },
+      "k": 10,
+      "ordinal": 4,
+      "query": "Find citation map production, producer tests, and schema",
+      "repoground": {
+        "compaction": {
+          "byte_reduction_percent": 65.92,
+          "compact_response_bytes": 4991,
+          "pass": true,
+          "preserved": [
+            "chunk_id",
+            "path",
+            "line_range",
+            "content_sha256",
+            "range_ref",
+            "freshness",
+            "fallback"
+          ],
+          "required_percent": 60.0
+        },
+        "condition": "repoground",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/core/citation_map.py",
+            "merger/repoground/tests/test_citation_map_producer.py",
+            "merger/repoground/contracts/citation-map.v1.schema.json"
+          ],
+          "found": [
+            "merger/repoground/contracts/citation-map.v1.schema.json"
+          ],
+          "missing": [
+            "merger/repoground/core/citation_map.py",
+            "merger/repoground/tests/test_citation_map_producer.py"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "docs/diagnostics/retrieval-v2-default-promotion-legacy-20260708T152502Z.json",
+          "merger/repoground/contracts/citation-map.v1.schema.json",
+          "merger/repoground/tests/test_agent_reading_pack_usage_rules.py",
+          "docs/diagnostics/retrieval-v2-default-promotion-review-intent-20260708T152502Z.json",
+          "docs/proofs/citation-map-pipeline-emission-proof.md",
+          "merger/repoground/tests/test_answer_grounding_delta.py",
+          "merger/repoground/contracts/bundle-manifest.v1.schema.json",
+          "docs/retrieval/review_queries.v1.json",
+          "merger/repoground/tests/test_answer_grounding_verifier.py",
+          "merger/repoground/contracts/bundle-manifest.v2.schema.json"
+        ],
+        "process_calls": 0,
+        "response_bytes": 14643,
+        "runtime_ms": 28.585,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 0,
+        "token_proxy": 3661,
+        "tool_calls": 1,
+        "useful_displayed": true
+      }
+    },
+    {
+      "category": "post_emit_health",
+      "grep_read": {
+        "condition": "grep_read",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/core/post_emit_health.py",
+            "merger/repoground/tests/test_post_emit_health.py",
+            "merger/repoground/contracts/post-emit-health.v1.schema.json"
+          ],
+          "found": [],
+          "missing": [
+            "merger/repoground/core/post_emit_health.py",
+            "merger/repoground/tests/test_post_emit_health.py",
+            "merger/repoground/contracts/post-emit-health.v1.schema.json"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "scripts/repoground-post-merge-surface-smoke.sh",
+          "scripts/release/check_release_contract.py",
+          "scripts/ops/repoground-publish-fleet",
+          "scripts/release/check_identity_distribution_decisions.py",
+          "scripts/ci/check_graph_maintainability.py",
+          "scripts/docmeta/check_planning_registration.py",
+          "scripts/docmeta/check_status_truth.py",
+          "scripts/ci/check_browser_gate_environment.py",
+          "scripts/ci/check_reusable_workflow_contracts.py",
+          "scripts/ci/check_github_main_ruleset.py"
+        ],
+        "process_calls": 1,
+        "response_bytes": 1305,
+        "runtime_ms": 6.66,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 10,
+        "token_proxy": 327,
+        "tool_calls": 1,
+        "useful_displayed": true
+      },
+      "k": 10,
+      "ordinal": 5,
+      "query": "Find post-emit health checks, tests, and contract",
+      "repoground": {
+        "compaction": {
+          "byte_reduction_percent": 65.74,
+          "compact_response_bytes": 4942,
+          "pass": true,
+          "preserved": [
+            "chunk_id",
+            "path",
+            "line_range",
+            "content_sha256",
+            "range_ref",
+            "freshness",
+            "fallback"
+          ],
+          "required_percent": 60.0
+        },
+        "condition": "repoground",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/core/post_emit_health.py",
+            "merger/repoground/tests/test_post_emit_health.py",
+            "merger/repoground/contracts/post-emit-health.v1.schema.json"
+          ],
+          "found": [
+            "merger/repoground/tests/test_post_emit_health.py"
+          ],
+          "missing": [
+            "merger/repoground/core/post_emit_health.py",
+            "merger/repoground/contracts/post-emit-health.v1.schema.json"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "docs/proofs/post-emit-health-checkview-bridge-proof.md",
+          "merger/repoground/core/export_safety_report.py",
+          "merger/repoground/tests/test_post_emit_health.py",
+          "merger/repoground/contracts/export-safety-report.v1.schema.json",
+          "docs/proofs/validation-check-shape-consistency-audit.md",
+          "merger/repoground/core/forensic_preflight.py",
+          "merger/repoground/tests/test_rlens_post_merge_surface_smoke.py",
+          "merger/repoground/contracts/bundle-manifest.v1.schema.json",
+          "merger/repoground/tests/test_bundle_surface_validate.py",
+          "merger/repoground/tests/test_snapshot_preflight.py"
+        ],
+        "process_calls": 0,
+        "response_bytes": 14425,
+        "runtime_ms": 33.85,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 0,
+        "token_proxy": 3607,
+        "tool_calls": 1,
+        "useful_displayed": true
+      }
+    },
+    {
+      "category": "bundle_surface",
+      "grep_read": {
+        "condition": "grep_read",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/core/bundle_surface_validate.py",
+            "merger/repoground/tests/test_bundle_surface_validate.py",
+            "merger/repoground/contracts/bundle-surface-validation.v1.schema.json"
+          ],
+          "found": [],
+          "missing": [
+            "merger/repoground/core/bundle_surface_validate.py",
+            "merger/repoground/tests/test_bundle_surface_validate.py",
+            "merger/repoground/contracts/bundle-surface-validation.v1.schema.json"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "scripts/release/check_release_contract.py",
+          "scripts/release/check_identity_distribution_decisions.py",
+          "scripts/ops/repoground-publish-fleet",
+          "scripts/repoground-post-merge-surface-smoke.sh",
+          "scripts/docmeta/check_status_truth.py",
+          "scripts/docmeta/check_planning_registration.py",
+          "scripts/ci/check_codeql_suppressions.py",
+          "scripts/ci/check_browser_gate_environment.py",
+          "scripts/ci/check_graph_maintainability.py",
+          "scripts/ci/check_reusable_workflow_contracts.py"
+        ],
+        "process_calls": 1,
+        "response_bytes": 1322,
+        "runtime_ms": 6.845,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 10,
+        "token_proxy": 331,
+        "tool_calls": 1,
+        "useful_displayed": true
+      },
+      "k": 10,
+      "ordinal": 6,
+      "query": "Find bundle surface validation implementation, tests, and contract",
+      "repoground": {
+        "compaction": {
+          "byte_reduction_percent": 66.48,
+          "compact_response_bytes": 4983,
+          "pass": true,
+          "preserved": [
+            "chunk_id",
+            "path",
+            "line_range",
+            "content_sha256",
+            "range_ref",
+            "freshness",
+            "fallback"
+          ],
+          "required_percent": 60.0
+        },
+        "condition": "repoground",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/core/bundle_surface_validate.py",
+            "merger/repoground/tests/test_bundle_surface_validate.py",
+            "merger/repoground/contracts/bundle-surface-validation.v1.schema.json"
+          ],
+          "found": [
+            "merger/repoground/tests/test_bundle_surface_validate.py",
+            "merger/repoground/contracts/bundle-surface-validation.v1.schema.json"
+          ],
+          "missing": [
+            "merger/repoground/core/bundle_surface_validate.py"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "docs/diagnostics/retrieval-v2-default-promotion-legacy-20260708T152502Z.json",
+          "merger/repoground/core/snapshot_preflight.py",
+          "merger/repoground/tests/test_bundle_surface_validate.py",
+          "merger/repoground/contracts/bundle-manifest.v1.schema.json",
+          "docs/retrieval/review_queries.v1.json",
+          "merger/repoground/tests/test_validation_check_shapes.py",
+          "merger/repoground/contracts/bundle-manifest.v2.schema.json",
+          "docs/proofs/validation-diagnostics-schema-alignment-proof.md",
+          "merger/repoground/tests/test_snapshot_preflight.py",
+          "merger/repoground/contracts/bundle-surface-validation.v1.schema.json"
+        ],
+        "process_calls": 0,
+        "response_bytes": 14866,
+        "runtime_ms": 30.414,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 0,
+        "token_proxy": 3717,
+        "tool_calls": 1,
+        "useful_displayed": true
+      }
+    },
+    {
+      "category": "bundle_manifest",
+      "grep_read": {
+        "condition": "grep_read",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/contracts/bundle-manifest.v1.schema.json",
+            "merger/repoground/tests/test_bundle_manifest_integration.py",
+            "merger/repoground/tests/test_bundle_manifest_schema.py"
+          ],
+          "found": [],
+          "missing": [
+            "merger/repoground/contracts/bundle-manifest.v1.schema.json",
+            "merger/repoground/tests/test_bundle_manifest_integration.py",
+            "merger/repoground/tests/test_bundle_manifest_schema.py"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "scripts/release/check_identity_distribution_decisions.py",
+          "scripts/release/check_release_contract.py",
+          "scripts/ops/repoground-publish-fleet",
+          "scripts/repoground-post-merge-surface-smoke.sh",
+          "scripts/docmeta/check_status_truth.py",
+          "scripts/docmeta/check_planning_registration.py",
+          "scripts/ci/assert_codeql_sarif_clean.py",
+          "scripts/docmeta/tests/test_check_planning_registration.py",
+          "scripts/ci/check_github_actions_pins.py",
+          "scripts/ci/check_browser_gate_environment.py"
+        ],
+        "process_calls": 1,
+        "response_bytes": 1342,
+        "runtime_ms": 7.687,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 10,
+        "token_proxy": 336,
+        "tool_calls": 1,
+        "useful_displayed": true
+      },
+      "k": 10,
+      "ordinal": 7,
+      "query": "Find the bundle manifest contract and its integration and schema tests",
+      "repoground": {
+        "compaction": {
+          "byte_reduction_percent": 67.3,
+          "compact_response_bytes": 4899,
+          "pass": true,
+          "preserved": [
+            "chunk_id",
+            "path",
+            "line_range",
+            "content_sha256",
+            "range_ref",
+            "freshness",
+            "fallback"
+          ],
+          "required_percent": 60.0
+        },
+        "condition": "repoground",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/contracts/bundle-manifest.v1.schema.json",
+            "merger/repoground/tests/test_bundle_manifest_integration.py",
+            "merger/repoground/tests/test_bundle_manifest_schema.py"
+          ],
+          "found": [
+            "merger/repoground/tests/test_bundle_manifest_integration.py"
+          ],
+          "missing": [
+            "merger/repoground/contracts/bundle-manifest.v1.schema.json",
+            "merger/repoground/tests/test_bundle_manifest_schema.py"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "docs/retrieval/review_queries.v1.json",
+          "docs/tasks/index.json",
+          "merger/repoground/tests/test_agent_reading_pack.py",
+          "docs/proofs/token-budget-report-v1-proof.md",
+          "docs/diagnostics/retrieval-v2-default-promotion-legacy-20260708T152502Z.json",
+          "docs/architecture/agent-consumption-contract.md",
+          "docs/testing/test-matrix.md",
+          "docs/diagnostics/retrieval-v2-default-promotion-review-intent-20260708T152502Z.json",
+          "docs/proofs/authority-contract-gap-audit.md",
+          "merger/repoground/tests/test_bundle_manifest_integration.py"
+        ],
+        "process_calls": 0,
+        "response_bytes": 14980,
+        "runtime_ms": 27.456,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 0,
+        "token_proxy": 3745,
+        "tool_calls": 1,
+        "useful_displayed": true
+      }
+    },
+    {
+      "category": "retrieval",
+      "grep_read": {
+        "condition": "grep_read",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/retrieval/eval_core.py",
+            "merger/repoground/tests/test_retrieval_eval.py",
+            "merger/repoground/contracts/retrieval-eval.v1.schema.json"
+          ],
+          "found": [],
+          "missing": [
+            "merger/repoground/retrieval/eval_core.py",
+            "merger/repoground/tests/test_retrieval_eval.py",
+            "merger/repoground/contracts/retrieval-eval.v1.schema.json"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "scripts/release/check_release_contract.py",
+          "scripts/release/check_identity_distribution_decisions.py",
+          "scripts/ops/repoground-publish-fleet",
+          "scripts/repoground-post-merge-surface-smoke.sh",
+          "scripts/docmeta/check_status_truth.py",
+          "scripts/docmeta/check_planning_registration.py",
+          "scripts/ci/check_github_actions_pins.py",
+          "scripts/ci/check_reusable_workflow_contracts.py",
+          "scripts/ci/check_browser_gate_environment.py",
+          "scripts/ci/check_graph_maintainability.py"
+        ],
+        "process_calls": 1,
+        "response_bytes": 1332,
+        "runtime_ms": 9.128,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 10,
+        "token_proxy": 333,
+        "tool_calls": 1,
+        "useful_displayed": true
+      },
+      "k": 10,
+      "ordinal": 8,
+      "query": "Find retrieval evaluation metrics implementation, tests, and output contract",
+      "repoground": {
+        "compaction": {
+          "byte_reduction_percent": 66.91,
+          "compact_response_bytes": 4975,
+          "pass": true,
+          "preserved": [
+            "chunk_id",
+            "path",
+            "line_range",
+            "content_sha256",
+            "range_ref",
+            "freshness",
+            "fallback"
+          ],
+          "required_percent": 60.0
+        },
+        "condition": "repoground",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/retrieval/eval_core.py",
+            "merger/repoground/tests/test_retrieval_eval.py",
+            "merger/repoground/contracts/retrieval-eval.v1.schema.json"
+          ],
+          "found": [
+            "merger/repoground/contracts/retrieval-eval.v1.schema.json"
+          ],
+          "missing": [
+            "merger/repoground/retrieval/eval_core.py",
+            "merger/repoground/tests/test_retrieval_eval.py"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "docs/diagnostics/retrieval-v2-default-promotion-legacy-20260708T152502Z.json",
+          "docs/retrieval/semantic-reranking.md",
+          "merger/repoground/tests/test_review_retrieval_metrics.py",
+          "merger/repoground/contracts/retrieval-eval.v1.schema.json",
+          "docs/diagnostics/retrieval-v2-default-promotion-review-intent-20260708T152502Z.json",
+          "docs/diagnostics/review-retrieval-baseline.md",
+          "merger/repoground/tests/test_eval_semantic.py",
+          "merger/repoground/contracts/retrieval-eval-diagnostics.v1.schema.json",
+          "docs/proofs/retrieval-miss-taxonomy-proof.md",
+          "merger/repoground/tests/test_ask_evaluation.py"
+        ],
+        "process_calls": 0,
+        "response_bytes": 15033,
+        "runtime_ms": 23.962,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 0,
+        "token_proxy": 3759,
+        "tool_calls": 1,
+        "useful_displayed": true
+      }
+    },
+    {
+      "category": "retrieval",
+      "grep_read": {
+        "condition": "grep_read",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/retrieval/eval_diagnostics.py",
+            "merger/repoground/tests/test_retrieval_eval_diagnostics.py",
+            "miss_taxonomy"
+          ],
+          "found": [],
+          "missing": [
+            "merger/repoground/retrieval/eval_diagnostics.py",
+            "merger/repoground/tests/test_retrieval_eval_diagnostics.py",
+            "miss_taxonomy"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "scripts/release/check_identity_distribution_decisions.py",
+          "scripts/release/check_release_contract.py",
+          "scripts/docmeta/check_status_truth.py",
+          "scripts/docmeta/check_planning_registration.py",
+          "scripts/docmeta/tests/test_check_planning_registration.py",
+          "scripts/ops/repoground-publish-fleet",
+          "scripts/repoground-post-merge-surface-smoke.sh",
+          "scripts/ci/assert_codeql_sarif_clean.py",
+          "scripts/ci/check_graph_maintainability.py",
+          "scripts/ci/check_browser_gate_environment.py"
+        ],
+        "process_calls": 1,
+        "response_bytes": 1332,
+        "runtime_ms": 7.471,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 10,
+        "token_proxy": 333,
+        "tool_calls": 1,
+        "useful_displayed": true
+      },
+      "k": 10,
+      "ordinal": 9,
+      "query": "Find retrieval miss diagnostics implementation and tests",
+      "repoground": {
+        "compaction": {
+          "byte_reduction_percent": 65.91,
+          "compact_response_bytes": 4984,
+          "pass": true,
+          "preserved": [
+            "chunk_id",
+            "path",
+            "line_range",
+            "content_sha256",
+            "range_ref",
+            "freshness",
+            "fallback"
+          ],
+          "required_percent": 60.0
+        },
+        "condition": "repoground",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/retrieval/eval_diagnostics.py",
+            "merger/repoground/tests/test_retrieval_eval_diagnostics.py",
+            "miss_taxonomy"
+          ],
+          "found": [
+            "merger/repoground/tests/test_retrieval_eval_diagnostics.py"
+          ],
+          "missing": [
+            "merger/repoground/retrieval/eval_diagnostics.py",
+            "miss_taxonomy"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "docs/diagnostics/retrieval-v2-default-promotion-review-intent-20260708T152502Z.json",
+          "merger/repoground/contracts/retrieval-eval-diagnostics.v1.schema.json",
+          "merger/repoground/tests/test_review_retrieval_metrics.py",
+          "docs/diagnostics/retrieval-v2-default-promotion-legacy-20260708T152502Z.json",
+          "merger/repoground/tests/test_retrieval_eval_diagnostics.py",
+          "docs/retrieval/review_queries.v1.json",
+          "docs/diagnostics/retrieval-eval-diagnostics.md",
+          "merger/repoground/tests/test_retrieval_eval.py",
+          "docs/diagnostics/review-retrieval-baseline.md",
+          "merger/repoground/retrieval/eval_diagnostics_integration.py"
+        ],
+        "process_calls": 0,
+        "response_bytes": 14621,
+        "runtime_ms": 34.087,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 0,
+        "token_proxy": 3656,
+        "tool_calls": 1,
+        "useful_displayed": true
+      }
+    },
+    {
+      "category": "router",
+      "grep_read": {
+        "condition": "grep_read",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/retrieval/router.py",
+            "merger/repoground/tests/test_router.py",
+            "route_query"
+          ],
+          "found": [],
+          "missing": [
+            "merger/repoground/retrieval/router.py",
+            "merger/repoground/tests/test_router.py",
+            "route_query"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "scripts/release/check_identity_distribution_decisions.py",
+          "scripts/release/check_release_contract.py",
+          "scripts/docmeta/check_status_truth.py",
+          "scripts/ops/repoground-publish-fleet",
+          "scripts/docmeta/check_planning_registration.py",
+          "scripts/docmeta/tests/test_check_planning_registration.py",
+          "scripts/repoground-post-merge-surface-smoke.sh",
+          "scripts/ci/check_github_actions_pins.py",
+          "scripts/ci/check_github_main_ruleset.py",
+          "scripts/ci/check_browser_gate_environment.py"
+        ],
+        "process_calls": 1,
+        "response_bytes": 1326,
+        "runtime_ms": 8.804,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 10,
+        "token_proxy": 332,
+        "tool_calls": 1,
+        "useful_displayed": true
+      },
+      "k": 10,
+      "ordinal": 10,
+      "query": "Find retrieval router selection logic and router tests",
+      "repoground": {
+        "compaction": {
+          "byte_reduction_percent": 65.62,
+          "compact_response_bytes": 4896,
+          "pass": true,
+          "preserved": [
+            "chunk_id",
+            "path",
+            "line_range",
+            "content_sha256",
+            "range_ref",
+            "freshness",
+            "fallback"
+          ],
+          "required_percent": 60.0
+        },
+        "condition": "repoground",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/retrieval/router.py",
+            "merger/repoground/tests/test_router.py",
+            "route_query"
+          ],
+          "found": [
+            "merger/repoground/tests/test_router.py"
+          ],
+          "missing": [
+            "merger/repoground/retrieval/router.py",
+            "route_query"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "docs/diagnostics/retrieval-v2-default-promotion-legacy-20260708T152502Z.json",
+          "merger/repoground/retrieval/review_router.py",
+          "merger/repoground/tests/test_review_router.py",
+          "docs/diagnostics/retrieval-v2-default-promotion-review-intent-20260708T152502Z.json",
+          "merger/repoground/tests/test_router.py",
+          "docs/retrieval/review_queries.v1.json",
+          "docs/tasks/index.json",
+          "merger/repoground/tests/test_review_query.py",
+          "docs/proofs/review-intent-router-v1-target-proof.md",
+          "merger/repoground/tests/test_review_query_hardening.py"
+        ],
+        "process_calls": 0,
+        "response_bytes": 14242,
+        "runtime_ms": 21.741,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 0,
+        "token_proxy": 3561,
+        "tool_calls": 1,
+        "useful_displayed": true
+      }
+    },
+    {
+      "category": "cli",
+      "grep_read": {
+        "condition": "grep_read",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/cli/cmd_query.py",
+            "merger/repoground/cli/main.py",
+            "run_query"
+          ],
+          "found": [],
+          "missing": [
+            "merger/repoground/cli/cmd_query.py",
+            "merger/repoground/cli/main.py",
+            "run_query"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "scripts/release/check_identity_distribution_decisions.py",
+          "scripts/release/check_release_contract.py",
+          "scripts/ops/repoground-publish-fleet",
+          "scripts/repoground-post-merge-surface-smoke.sh",
+          "scripts/docmeta/check_planning_registration.py",
+          "scripts/docmeta/check_status_truth.py",
+          "scripts/ci/check_codeql_suppressions.py",
+          "scripts/ci/check_github_actions_pins.py",
+          "scripts/ci/check_browser_gate_environment.py",
+          "scripts/ci/assert_codeql_sarif_clean.py"
+        ],
+        "process_calls": 1,
+        "response_bytes": 1291,
+        "runtime_ms": 7.476,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 10,
+        "token_proxy": 323,
+        "tool_calls": 1,
+        "useful_displayed": true
+      },
+      "k": 10,
+      "ordinal": 11,
+      "query": "Find the Lenskit query CLI command and its registration",
+      "repoground": {
+        "compaction": {
+          "byte_reduction_percent": 65.56,
+          "compact_response_bytes": 4916,
+          "pass": true,
+          "preserved": [
+            "chunk_id",
+            "path",
+            "line_range",
+            "content_sha256",
+            "range_ref",
+            "freshness",
+            "fallback"
+          ],
+          "required_percent": 60.0
+        },
+        "condition": "repoground",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/cli/cmd_query.py",
+            "merger/repoground/cli/main.py",
+            "run_query"
+          ],
+          "found": [
+            "merger/repoground/cli/main.py"
+          ],
+          "missing": [
+            "merger/repoground/cli/cmd_query.py",
+            "run_query"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "docs/diagnostics/retrieval-v2-default-promotion-legacy-20260708T152502Z.json",
+          "merger/repoground/cli/main.py",
+          "merger/repoground/tests/test_review_retrieval_goldset.py",
+          "docs/retrieval/review_queries.v1.json",
+          "merger/repoground/cli/cmd_eval.py",
+          "merger/repoground/tests/test_retrieval_eval.py",
+          "docs/diagnostics/retrieval-v2-default-promotion-review-intent-20260708T152502Z.json",
+          "merger/repoground/tests/test_federation_cli.py",
+          "merger/repoground/tests/test_review_retrieval_metrics.py",
+          "merger/repoground/retrieval/review_router.py"
+        ],
+        "process_calls": 0,
+        "response_bytes": 14275,
+        "runtime_ms": 15.526,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 0,
+        "token_proxy": 3569,
+        "tool_calls": 1,
+        "useful_displayed": true
+      }
+    },
+    {
+      "category": "cli",
+      "grep_read": {
+        "condition": "grep_read",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/cli/cmd_eval.py",
+            "merger/repoground/cli/main.py",
+            "run_eval"
+          ],
+          "found": [],
+          "missing": [
+            "merger/repoground/cli/cmd_eval.py",
+            "merger/repoground/cli/main.py",
+            "run_eval"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "scripts/repoground-post-merge-surface-smoke.sh",
+          "scripts/ops/repoground-publish-fleet",
+          "scripts/release/check_release_contract.py",
+          "scripts/docmeta/check_planning_registration.py",
+          "scripts/docmeta/check_status_truth.py",
+          "scripts/release/check_identity_distribution_decisions.py",
+          "scripts/docmeta/tests/test_check_planning_registration.py",
+          "scripts/ci/check_codeql_suppressions.py",
+          "scripts/ci/check_graph_maintainability.py",
+          "scripts/ci/check_reusable_workflow_contracts.py"
+        ],
+        "process_calls": 1,
+        "response_bytes": 1346,
+        "runtime_ms": 8.008,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 10,
+        "token_proxy": 337,
+        "tool_calls": 1,
+        "useful_displayed": true
+      },
+      "k": 10,
+      "ordinal": 12,
+      "query": "Find the Lenskit retrieval eval CLI command and its registration",
+      "repoground": {
+        "compaction": {
+          "byte_reduction_percent": 66.12,
+          "compact_response_bytes": 4936,
+          "pass": true,
+          "preserved": [
+            "chunk_id",
+            "path",
+            "line_range",
+            "content_sha256",
+            "range_ref",
+            "freshness",
+            "fallback"
+          ],
+          "required_percent": 60.0
+        },
+        "condition": "repoground",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/cli/cmd_eval.py",
+            "merger/repoground/cli/main.py",
+            "run_eval"
+          ],
+          "found": [
+            "merger/repoground/cli/cmd_eval.py"
+          ],
+          "missing": [
+            "merger/repoground/cli/main.py",
+            "run_eval"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "docs/diagnostics/retrieval-v2-default-promotion-legacy-20260708T152502Z.json",
+          "merger/repoground/cli/cmd_ground.py",
+          "docs/proofs/repobrief-ask-gold-query-eval-v1.self-review.md",
+          "docs/retrieval/review_queries.v1.json",
+          "docs/proofs/repobrief-ask-cli-v1.self-review.md",
+          "merger/repoground/retrieval/eval_diagnostics_integration.py",
+          "docs/diagnostics/retrieval-v2-default-promotion-review-intent-20260708T152502Z.json",
+          "merger/repoground/cli/cmd_eval.py",
+          "merger/repoground/tests/test_review_retrieval_metrics.py",
+          "merger/repoground/retrieval/review_router.py"
+        ],
+        "process_calls": 0,
+        "response_bytes": 14570,
+        "runtime_ms": 11.786,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 0,
+        "token_proxy": 3643,
+        "tool_calls": 1,
+        "useful_displayed": true
+      }
+    },
+    {
+      "category": "contracts",
+      "grep_read": {
+        "condition": "grep_read",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/contracts/",
+            "docs/contracts/contracts-matrix.md"
+          ],
+          "found": [],
+          "missing": [
+            "merger/repoground/contracts/",
+            "docs/contracts/contracts-matrix.md"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "scripts/repoground-post-merge-surface-smoke.sh",
+          "scripts/docmeta/check_planning_registration.py",
+          "scripts/docmeta/check_status_truth.py",
+          "scripts/release/check_release_contract.py",
+          "scripts/release/check_identity_distribution_decisions.py",
+          "scripts/ci/check_github_actions_pins.py",
+          "scripts/ci/check_github_main_ruleset.py",
+          "scripts/ci/check_graph_maintainability.py",
+          "scripts/ci/check_browser_gate_environment.py",
+          "scripts/ci/assert_codeql_sarif_clean.py"
+        ],
+        "process_calls": 1,
+        "response_bytes": 1309,
+        "runtime_ms": 6.824,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 10,
+        "token_proxy": 328,
+        "tool_calls": 1,
+        "useful_displayed": true
+      },
+      "k": 10,
+      "ordinal": 13,
+      "query": "Find the contracts inventory and contracts matrix documentation",
+      "repoground": {
+        "compaction": {
+          "byte_reduction_percent": 66.19,
+          "compact_response_bytes": 5009,
+          "pass": true,
+          "preserved": [
+            "chunk_id",
+            "path",
+            "line_range",
+            "content_sha256",
+            "range_ref",
+            "freshness",
+            "fallback"
+          ],
+          "required_percent": 60.0
+        },
+        "condition": "repoground",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/contracts/",
+            "docs/contracts/contracts-matrix.md"
+          ],
+          "found": [
+            "merger/repoground/contracts/"
+          ],
+          "missing": [
+            "docs/contracts/contracts-matrix.md"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "docs/diagnostics/retrieval-v2-default-promotion-legacy-20260708T152502Z.json",
+          "merger/repoground/contracts/answer-grounding-verdict.v1.schema.json",
+          "docs/proofs/repobrief-ask-frontdoor-contract-v1.self-review.md",
+          "merger/repoground/tests/test_reusable_workflow_contracts.py",
+          "docs/diagnostics/retrieval-v2-default-promotion-review-intent-20260708T152502Z.json",
+          "merger/repoground/contracts/repolens-delta.schema.json",
+          "docs/proofs/repobrief-ask-frontdoor-contract-v1-proof.md",
+          "merger/repoground/core/anti_hallucination_lint.py",
+          "docs/retrieval/review_queries.v1.json",
+          "merger/repoground/contracts/audit-finding-set.v1.schema.json"
+        ],
+        "process_calls": 0,
+        "response_bytes": 14817,
+        "runtime_ms": 33.566,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 0,
+        "token_proxy": 3705,
+        "tool_calls": 1,
+        "useful_displayed": true
+      }
+    },
+    {
+      "category": "contracts",
+      "grep_read": {
+        "condition": "grep_read",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/contracts/retrieval-eval.v1.schema.json",
+            "merger/repoground/contracts/claim-evidence-map.v1.schema.json",
+            "merger/repoground/contracts/citation-map.v1.schema.json"
+          ],
+          "found": [],
+          "missing": [
+            "merger/repoground/contracts/retrieval-eval.v1.schema.json",
+            "merger/repoground/contracts/claim-evidence-map.v1.schema.json",
+            "merger/repoground/contracts/citation-map.v1.schema.json"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "scripts/release/check_release_contract.py",
+          "scripts/docmeta/check_status_truth.py",
+          "scripts/docmeta/check_planning_registration.py",
+          "scripts/ops/repoground-publish-fleet",
+          "scripts/release/check_identity_distribution_decisions.py",
+          "scripts/docmeta/tests/test_check_planning_registration.py",
+          "scripts/repoground-post-merge-surface-smoke.sh",
+          "scripts/ci/check_github_actions_pins.py",
+          "scripts/ci/check_codeql_suppressions.py",
+          "scripts/ci/check_browser_gate_environment.py"
+        ],
+        "process_calls": 1,
+        "response_bytes": 1333,
+        "runtime_ms": 8.028,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 10,
+        "token_proxy": 334,
+        "tool_calls": 1,
+        "useful_displayed": true
+      },
+      "k": 10,
+      "ordinal": 14,
+      "query": "Find retrieval and evidence JSON contracts used during review",
+      "repoground": {
+        "compaction": {
+          "byte_reduction_percent": 66.4,
+          "compact_response_bytes": 4980,
+          "pass": true,
+          "preserved": [
+            "chunk_id",
+            "path",
+            "line_range",
+            "content_sha256",
+            "range_ref",
+            "freshness",
+            "fallback"
+          ],
+          "required_percent": 60.0
+        },
+        "condition": "repoground",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/contracts/retrieval-eval.v1.schema.json",
+            "merger/repoground/contracts/claim-evidence-map.v1.schema.json",
+            "merger/repoground/contracts/citation-map.v1.schema.json"
+          ],
+          "found": [],
+          "missing": [
+            "merger/repoground/contracts/retrieval-eval.v1.schema.json",
+            "merger/repoground/contracts/claim-evidence-map.v1.schema.json",
+            "merger/repoground/contracts/citation-map.v1.schema.json"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "docs/diagnostics/retrieval-v2-default-promotion-review-intent-20260708T152502Z.json",
+          "merger/repoground/contracts/retrieval-eval-diagnostics.v1.schema.json",
+          "docs/diagnostics/repobrief-workbench-usefulness-eval-20260712T2053Z.json",
+          "docs/diagnostics/retrieval-v2-default-promotion-legacy-20260708T152502Z.json",
+          "merger/repoground/contracts/review-retrieval-goldset.v1.schema.json",
+          "docs/tasks/index.json",
+          "docs/retrieval/review_queries.v1.json",
+          "merger/repoground/contracts/bundle-manifest.v1.schema.json",
+          "merger/repoground/core/context_quality.py",
+          "merger/repoground/retrieval/review_router.py"
+        ],
+        "process_calls": 0,
+        "response_bytes": 14820,
+        "runtime_ms": 20.982,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 0,
+        "token_proxy": 3705,
+        "tool_calls": 1,
+        "useful_displayed": true
+      }
+    },
+    {
+      "category": "security",
+      "grep_read": {
+        "condition": "grep_read",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/core/path_security.py",
+            "merger/repoground/tests/test_merge_security.py",
+            "safe_join"
+          ],
+          "found": [],
+          "missing": [
+            "merger/repoground/core/path_security.py",
+            "merger/repoground/tests/test_merge_security.py",
+            "safe_join"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "scripts/ops/repoground-publish-fleet",
+          "scripts/docmeta/check_planning_registration.py",
+          "scripts/release/check_identity_distribution_decisions.py",
+          "scripts/ci/check_github_actions_pins.py",
+          "scripts/release/check_release_contract.py",
+          "scripts/ci/check_graph_maintainability.py",
+          "scripts/ci/check_reusable_workflow_contracts.py",
+          "scripts/ci/assert_codeql_sarif_clean.py",
+          "scripts/ci/check_github_main_ruleset.py",
+          "scripts/ci/check_browser_gate_environment.py"
+        ],
+        "process_calls": 1,
+        "response_bytes": 1312,
+        "runtime_ms": 7.394,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 10,
+        "token_proxy": 328,
+        "tool_calls": 1,
+        "useful_displayed": true
+      },
+      "k": 10,
+      "ordinal": 15,
+      "query": "Find repository path security enforcement and merge security tests",
+      "repoground": {
+        "compaction": {
+          "byte_reduction_percent": 65.74,
+          "compact_response_bytes": 4991,
+          "pass": true,
+          "preserved": [
+            "chunk_id",
+            "path",
+            "line_range",
+            "content_sha256",
+            "range_ref",
+            "freshness",
+            "fallback"
+          ],
+          "required_percent": 60.0
+        },
+        "condition": "repoground",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/core/path_security.py",
+            "merger/repoground/tests/test_merge_security.py",
+            "safe_join"
+          ],
+          "found": [
+            "merger/repoground/tests/test_merge_security.py"
+          ],
+          "missing": [
+            "merger/repoground/core/path_security.py",
+            "safe_join"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "docs/diagnostics/retrieval-v2-default-promotion-legacy-20260708T152502Z.json",
+          "docs/diagnostics/retrieval-v2-default-promotion-review-intent-20260708T152502Z.json",
+          "merger/repoground/tests/test_code_scanning_security.py",
+          "docs/proofs/lenskit-main-required-checks-v1-proof.md",
+          "config/codeql-path-suppressions.v1.json",
+          "merger/repoground/tests/test_merge_security.py",
+          "docs/proofs/rlens-sensitive-filesystem-access-v1.external-review.json",
+          "merger/repoground/tests/test_review_retrieval_metrics.py",
+          "docs/proofs/code-scanning-hardening-v1.external-review.json",
+          "merger/repoground/tests/test_merges_dir_drift.py"
+        ],
+        "process_calls": 0,
+        "response_bytes": 14566,
+        "runtime_ms": 20.125,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 0,
+        "token_proxy": 3642,
+        "tool_calls": 1,
+        "useful_displayed": true
+      }
+    },
+    {
+      "category": "security",
+      "grep_read": {
+        "condition": "grep_read",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/tests/test_service_artifact_security.py",
+            "artifact_path"
+          ],
+          "found": [],
+          "missing": [
+            "merger/repoground/tests/test_service_artifact_security.py",
+            "artifact_path"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "scripts/ops/repoground-publish-fleet",
+          "scripts/docmeta/check_planning_registration.py",
+          "scripts/release/check_release_contract.py",
+          "scripts/release/check_identity_distribution_decisions.py",
+          "scripts/docmeta/check_status_truth.py",
+          "scripts/repoground-post-merge-surface-smoke.sh",
+          "scripts/docmeta/tests/test_check_planning_registration.py",
+          "scripts/ci/assert_codeql_sarif_clean.py",
+          "scripts/ci/check_browser_gate_environment.py",
+          "scripts/ci/check_codeql_suppressions.py"
+        ],
+        "process_calls": 1,
+        "response_bytes": 1316,
+        "runtime_ms": 9.746,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 10,
+        "token_proxy": 329,
+        "tool_calls": 1,
+        "useful_displayed": true
+      },
+      "k": 10,
+      "ordinal": 16,
+      "query": "Find service artifact path security coverage",
+      "repoground": {
+        "compaction": {
+          "byte_reduction_percent": 65.83,
+          "compact_response_bytes": 4906,
+          "pass": true,
+          "preserved": [
+            "chunk_id",
+            "path",
+            "line_range",
+            "content_sha256",
+            "range_ref",
+            "freshness",
+            "fallback"
+          ],
+          "required_percent": 60.0
+        },
+        "condition": "repoground",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/tests/test_service_artifact_security.py",
+            "artifact_path"
+          ],
+          "found": [
+            "merger/repoground/tests/test_service_artifact_security.py"
+          ],
+          "missing": [
+            "artifact_path"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "docs/diagnostics/retrieval-v2-default-promotion-legacy-20260708T152502Z.json",
+          "merger/repoground/tests/test_merges_dir_drift.py",
+          "docs/diagnostics/retrieval-v2-default-promotion-review-intent-20260708T152502Z.json",
+          "merger/repoground/tests/test_service_runner_pre_pull.py",
+          "docs/retrieval/review_queries.v1.json",
+          "merger/repoground/tests/test_service_artifact_security.py",
+          "docs/proofs/facet-model-v1-proof.md",
+          "merger/repoground/tests/test_atlas_system.py",
+          "docs/testing/test-matrix.md",
+          "docs/proofs/code-scanning-hardening-v1-proof.md"
+        ],
+        "process_calls": 0,
+        "response_bytes": 14356,
+        "runtime_ms": 37.774,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 0,
+        "token_proxy": 3589,
+        "tool_calls": 1,
+        "useful_displayed": true
+      }
+    },
+    {
+      "category": "source_acquisition",
+      "grep_read": {
+        "condition": "grep_read",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/service/source_acquisition.py",
+            "merger/repoground/tests/test_source_acquisition.py",
+            "merger/repoground/contracts/source-acquisition-report.v1.schema.json"
+          ],
+          "found": [],
+          "missing": [
+            "merger/repoground/service/source_acquisition.py",
+            "merger/repoground/tests/test_source_acquisition.py",
+            "merger/repoground/contracts/source-acquisition-report.v1.schema.json"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "scripts/release/check_identity_distribution_decisions.py",
+          "scripts/release/check_release_contract.py",
+          "scripts/docmeta/tests/test_check_planning_registration.py",
+          "scripts/ops/repoground-publish-fleet",
+          "scripts/docmeta/check_planning_registration.py",
+          "scripts/docmeta/check_status_truth.py",
+          "scripts/repoground-post-merge-surface-smoke.sh",
+          "scripts/ci/check_codeql_suppressions.py",
+          "scripts/ci/check_browser_gate_environment.py",
+          "scripts/ci/check_reusable_workflow_contracts.py"
+        ],
+        "process_calls": 1,
+        "response_bytes": 1354,
+        "runtime_ms": 7.702,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 10,
+        "token_proxy": 339,
+        "tool_calls": 1,
+        "useful_displayed": true
+      },
+      "k": 10,
+      "ordinal": 17,
+      "query": "Find source acquisition implementation, tests, and report contract",
+      "repoground": {
+        "compaction": {
+          "byte_reduction_percent": 66.47,
+          "compact_response_bytes": 4929,
+          "pass": true,
+          "preserved": [
+            "chunk_id",
+            "path",
+            "line_range",
+            "content_sha256",
+            "range_ref",
+            "freshness",
+            "fallback"
+          ],
+          "required_percent": 60.0
+        },
+        "condition": "repoground",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/service/source_acquisition.py",
+            "merger/repoground/tests/test_source_acquisition.py",
+            "merger/repoground/contracts/source-acquisition-report.v1.schema.json"
+          ],
+          "found": [
+            "merger/repoground/contracts/source-acquisition-report.v1.schema.json"
+          ],
+          "missing": [
+            "merger/repoground/service/source_acquisition.py",
+            "merger/repoground/tests/test_source_acquisition.py"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "docs/retrieval/review_queries.v1.json",
+          "docs/tasks/board.md",
+          "merger/repoground/tests/test_service_runner_pre_pull.py",
+          "merger/repoground/contracts/review-retrieval-goldset.v1.schema.json",
+          "docs/diagnostics/retrieval-v2-default-promotion-legacy-20260708T152502Z.json",
+          "docs/testing/test-matrix.md",
+          "merger/repoground/contracts/source-acquisition-report.v1.schema.json",
+          "docs/diagnostics/retrieval-v2-default-promotion-review-intent-20260708T152502Z.json",
+          "merger/repoground/tests/test_pythonista_pre_pull.py",
+          "docs/contracts/contracts-matrix.md"
+        ],
+        "process_calls": 0,
+        "response_bytes": 14699,
+        "runtime_ms": 38.446,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 0,
+        "token_proxy": 3675,
+        "tool_calls": 1,
+        "useful_displayed": true
+      }
+    },
+    {
+      "category": "pr_schau",
+      "grep_read": {
+        "condition": "grep_read",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/core/pr_schau_bundle.py",
+            "merger/repoground/cli/pr_schau_verify.py",
+            "merger/repoground/tests/test_pr_schau_verify_units.py",
+            "merger/repoground/contracts/pr-schau.v1.schema.json"
+          ],
+          "found": [],
+          "missing": [
+            "merger/repoground/core/pr_schau_bundle.py",
+            "merger/repoground/cli/pr_schau_verify.py",
+            "merger/repoground/tests/test_pr_schau_verify_units.py",
+            "merger/repoground/contracts/pr-schau.v1.schema.json"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "scripts/ci/check_codeql_suppressions.py",
+          "scripts/ci/check_graph_maintainability.py",
+          "scripts/ci/check_reusable_workflow_contracts.py",
+          "scripts/ci/check_browser_gate_environment.py",
+          "scripts/ci/check_github_main_ruleset.py",
+          "scripts/ci/assert_codeql_sarif_clean.py",
+          "scripts/ci/check_github_actions_pins.py",
+          "scripts/release/check_release_contract.py",
+          "scripts/release/check_identity_distribution_decisions.py",
+          "scripts/ops/repoground-publish-fleet"
+        ],
+        "process_calls": 1,
+        "response_bytes": 1298,
+        "runtime_ms": 8.775,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 10,
+        "token_proxy": 325,
+        "tool_calls": 1,
+        "useful_displayed": true
+      },
+      "k": 10,
+      "ordinal": 18,
+      "query": "Find PR-Schau bundle production, verification, tests, and contract",
+      "repoground": {
+        "compaction": {
+          "byte_reduction_percent": 66.14,
+          "compact_response_bytes": 4931,
+          "pass": true,
+          "preserved": [
+            "chunk_id",
+            "path",
+            "line_range",
+            "content_sha256",
+            "range_ref",
+            "freshness",
+            "fallback"
+          ],
+          "required_percent": 60.0
+        },
+        "condition": "repoground",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/core/pr_schau_bundle.py",
+            "merger/repoground/cli/pr_schau_verify.py",
+            "merger/repoground/tests/test_pr_schau_verify_units.py",
+            "merger/repoground/contracts/pr-schau.v1.schema.json"
+          ],
+          "found": [
+            "merger/repoground/cli/pr_schau_verify.py",
+            "merger/repoground/contracts/pr-schau.v1.schema.json"
+          ],
+          "missing": [
+            "merger/repoground/core/pr_schau_bundle.py",
+            "merger/repoground/tests/test_pr_schau_verify_units.py"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "docs/diagnostics/retrieval-v2-default-promotion-legacy-20260708T152502Z.json",
+          "merger/repoground/tests/test_pr_schau_loader.py",
+          "merger/repoground/cli/pr_schau_verify.py",
+          "merger/repoground/tests/test_pr_schau_consumer_gate.py",
+          "merger/repoground/contracts/pr-schau-delta.v1.schema.json",
+          "docs/diagnostics/retrieval-v2-default-promotion-review-intent-20260708T152502Z.json",
+          "merger/repoground/cli/main.py",
+          "merger/repoground/contracts/pr-schau.v1.schema.json",
+          "docs/retrieval/review_queries.v1.json",
+          "merger/repoground/core/PR_SCHAU_SMOKE.md"
+        ],
+        "process_calls": 0,
+        "response_bytes": 14562,
+        "runtime_ms": 44.181,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 0,
+        "token_proxy": 3641,
+        "tool_calls": 1,
+        "useful_displayed": true
+      }
+    },
+    {
+      "category": "range_ref",
+      "grep_read": {
+        "condition": "grep_read",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/core/range_resolver.py",
+            "merger/repoground/tests/test_range_resolver.py",
+            "merger/repoground/contracts/range-ref.v1.schema.json",
+            "merger/repoground/contracts/range-ref.v2.schema.json",
+            "range_ref_resolution"
+          ],
+          "found": [],
+          "missing": [
+            "merger/repoground/core/range_resolver.py",
+            "merger/repoground/tests/test_range_resolver.py",
+            "merger/repoground/contracts/range-ref.v1.schema.json",
+            "merger/repoground/contracts/range-ref.v2.schema.json",
+            "range_ref_resolution"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "scripts/ci/check_github_actions_pins.py",
+          "scripts/ci/check_browser_gate_environment.py",
+          "scripts/ci/check_graph_maintainability.py",
+          "scripts/ci/check_reusable_workflow_contracts.py",
+          "scripts/ci/assert_codeql_sarif_clean.py",
+          "scripts/ci/check_github_main_ruleset.py",
+          "scripts/ci/check_codeql_suppressions.py",
+          "scripts/ops/repoground-publish-fleet",
+          "scripts/repoground-post-merge-surface-smoke.sh",
+          "scripts/docmeta/check_status_truth.py"
+        ],
+        "process_calls": 1,
+        "response_bytes": 1270,
+        "runtime_ms": 7.262,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 10,
+        "token_proxy": 318,
+        "tool_calls": 1,
+        "useful_displayed": true
+      },
+      "k": 10,
+      "ordinal": 19,
+      "query": "Find range reference resolution, tests, and both contract versions",
+      "repoground": {
+        "compaction": {
+          "byte_reduction_percent": 66.45,
+          "compact_response_bytes": 4946,
+          "pass": true,
+          "preserved": [
+            "chunk_id",
+            "path",
+            "line_range",
+            "content_sha256",
+            "range_ref",
+            "freshness",
+            "fallback"
+          ],
+          "required_percent": 60.0
+        },
+        "condition": "repoground",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/core/range_resolver.py",
+            "merger/repoground/tests/test_range_resolver.py",
+            "merger/repoground/contracts/range-ref.v1.schema.json",
+            "merger/repoground/contracts/range-ref.v2.schema.json",
+            "range_ref_resolution"
+          ],
+          "found": [
+            "merger/repoground/contracts/range-ref.v1.schema.json",
+            "merger/repoground/contracts/range-ref.v2.schema.json"
+          ],
+          "missing": [
+            "merger/repoground/core/range_resolver.py",
+            "merger/repoground/tests/test_range_resolver.py",
+            "range_ref_resolution"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "docs/diagnostics/retrieval-v2-default-promotion-legacy-20260708T152502Z.json",
+          "merger/repoground/scripts/bench_call_navigation.py",
+          "merger/repoground/tests/test_output_candidate_surface.py",
+          "merger/repoground/contracts/range-ref.v1.schema.json",
+          "docs/diagnostics/retrieval-v2-default-promotion-review-intent-20260708T152502Z.json",
+          "merger/repoground/cli/cmd_ground.py",
+          "merger/repoground/tests/test_call_navigation.py",
+          "merger/repoground/contracts/range-ref.v2.schema.json",
+          "docs/retrieval/review_queries.v1.json",
+          "scripts/ci/check_codeql_suppressions.py"
+        ],
+        "process_calls": 0,
+        "response_bytes": 14742,
+        "runtime_ms": 29.052,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 0,
+        "token_proxy": 3686,
+        "tool_calls": 1,
+        "useful_displayed": true
+      }
+    },
+    {
+      "category": "lenses",
+      "grep_read": {
+        "condition": "grep_read",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/core/lenses.py",
+            "merger/repoground/tests/test_lenses.py",
+            "infer_lens"
+          ],
+          "found": [],
+          "missing": [
+            "merger/repoground/core/lenses.py",
+            "merger/repoground/tests/test_lenses.py",
+            "infer_lens"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "scripts/ops/repoground-publish-fleet",
+          "scripts/release/check_release_contract.py",
+          "scripts/docmeta/check_status_truth.py",
+          "scripts/docmeta/check_planning_registration.py",
+          "scripts/release/check_identity_distribution_decisions.py",
+          "scripts/docmeta/tests/test_check_planning_registration.py",
+          "scripts/repoground-post-merge-surface-smoke.sh",
+          "scripts/ci/check_github_actions_pins.py",
+          "scripts/ci/check_reusable_workflow_contracts.py",
+          "scripts/ci/check_graph_maintainability.py"
+        ],
+        "process_calls": 1,
+        "response_bytes": 1326,
+        "runtime_ms": 7.108,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 10,
+        "token_proxy": 332,
+        "tool_calls": 1,
+        "useful_displayed": true
+      },
+      "k": 10,
+      "ordinal": 20,
+      "query": "Find lens selection implementation and tests",
+      "repoground": {
+        "compaction": {
+          "byte_reduction_percent": 65.22,
+          "compact_response_bytes": 4902,
+          "pass": true,
+          "preserved": [
+            "chunk_id",
+            "path",
+            "line_range",
+            "content_sha256",
+            "range_ref",
+            "freshness",
+            "fallback"
+          ],
+          "required_percent": 60.0
+        },
+        "condition": "repoground",
+        "expected_targets": {
+          "expected": [
+            "merger/repoground/core/lenses.py",
+            "merger/repoground/tests/test_lenses.py",
+            "infer_lens"
+          ],
+          "found": [
+            "merger/repoground/tests/test_lenses.py"
+          ],
+          "missing": [
+            "merger/repoground/core/lenses.py",
+            "infer_lens"
+          ]
+        },
+        "false_confidence": true,
+        "paths": [
+          "merger/repoground/tests/test_review_router.py",
+          "merger/repoground/tests/test_primary_lens_audit.py",
+          "docs/diagnostics/retrieval-v2-default-promotion-legacy-20260708T152502Z.json",
+          "merger/repoground/tests/test_lens_cards.py",
+          "docs/retrieval/review_queries.v1.json",
+          "merger/repoground/tests/test_lens_card_validate.py",
+          "merger/repoground/tests/test_lenses.py",
+          "docs/diagnostics/retrieval-v2-default-promotion-review-intent-20260708T152502Z.json",
+          "docs/proofs/checkview-consumer-inventory-v1.md",
+          "merger/repoground/core/merge.py"
+        ],
+        "process_calls": 0,
+        "response_bytes": 14095,
+        "runtime_ms": 9.816,
+        "source_index_freshness": {
+          "checked_path_count": 10,
+          "missing_paths": [],
+          "newer_than_index_paths": [],
+          "status": "fresh"
+        },
+        "source_read_calls": 0,
+        "token_proxy": 3524,
+        "tool_calls": 1,
+        "useful_displayed": true
+      }
+    }
+  ],
+  "category_decisions": {
+    "agent_pack": {
+      "case_count": 2,
+      "compaction_pass": true,
+      "evidence_safe": false,
+      "grep_read_expected_targets_missing": 5,
+      "grep_read_false_confidence_cases": 2,
+      "measurable_benefit": true,
+      "no_quality_regression": true,
+      "recommended": false,
+      "repoground_expected_targets_missing": 3,
+      "repoground_false_confidence_cases": 2,
+      "repoground_unsafe_freshness_cases": 0
+    },
+    "bundle_manifest": {
+      "case_count": 1,
+      "compaction_pass": true,
+      "evidence_safe": false,
+      "grep_read_expected_targets_missing": 3,
+      "grep_read_false_confidence_cases": 1,
+      "measurable_benefit": true,
+      "no_quality_regression": true,
+      "recommended": false,
+      "repoground_expected_targets_missing": 2,
+      "repoground_false_confidence_cases": 1,
+      "repoground_unsafe_freshness_cases": 0
+    },
+    "bundle_surface": {
+      "case_count": 1,
+      "compaction_pass": true,
+      "evidence_safe": false,
+      "grep_read_expected_targets_missing": 3,
+      "grep_read_false_confidence_cases": 1,
+      "measurable_benefit": true,
+      "no_quality_regression": true,
+      "recommended": false,
+      "repoground_expected_targets_missing": 1,
+      "repoground_false_confidence_cases": 1,
+      "repoground_unsafe_freshness_cases": 0
+    },
+    "citation_map": {
+      "case_count": 1,
+      "compaction_pass": true,
+      "evidence_safe": false,
+      "grep_read_expected_targets_missing": 3,
+      "grep_read_false_confidence_cases": 1,
+      "measurable_benefit": true,
+      "no_quality_regression": true,
+      "recommended": false,
+      "repoground_expected_targets_missing": 2,
+      "repoground_false_confidence_cases": 1,
+      "repoground_unsafe_freshness_cases": 0
+    },
+    "claim_evidence": {
+      "case_count": 1,
+      "compaction_pass": true,
+      "evidence_safe": false,
+      "grep_read_expected_targets_missing": 3,
+      "grep_read_false_confidence_cases": 1,
+      "measurable_benefit": true,
+      "no_quality_regression": true,
+      "recommended": false,
+      "repoground_expected_targets_missing": 1,
+      "repoground_false_confidence_cases": 1,
+      "repoground_unsafe_freshness_cases": 0
+    },
+    "cli": {
+      "case_count": 2,
+      "compaction_pass": true,
+      "evidence_safe": false,
+      "grep_read_expected_targets_missing": 6,
+      "grep_read_false_confidence_cases": 2,
+      "measurable_benefit": true,
+      "no_quality_regression": true,
+      "recommended": false,
+      "repoground_expected_targets_missing": 4,
+      "repoground_false_confidence_cases": 2,
+      "repoground_unsafe_freshness_cases": 0
+    },
+    "contracts": {
+      "case_count": 2,
+      "compaction_pass": true,
+      "evidence_safe": false,
+      "grep_read_expected_targets_missing": 5,
+      "grep_read_false_confidence_cases": 2,
+      "measurable_benefit": true,
+      "no_quality_regression": true,
+      "recommended": false,
+      "repoground_expected_targets_missing": 4,
+      "repoground_false_confidence_cases": 2,
+      "repoground_unsafe_freshness_cases": 0
+    },
+    "lenses": {
+      "case_count": 1,
+      "compaction_pass": true,
+      "evidence_safe": false,
+      "grep_read_expected_targets_missing": 3,
+      "grep_read_false_confidence_cases": 1,
+      "measurable_benefit": true,
+      "no_quality_regression": true,
+      "recommended": false,
+      "repoground_expected_targets_missing": 2,
+      "repoground_false_confidence_cases": 1,
+      "repoground_unsafe_freshness_cases": 0
+    },
+    "post_emit_health": {
+      "case_count": 1,
+      "compaction_pass": true,
+      "evidence_safe": false,
+      "grep_read_expected_targets_missing": 3,
+      "grep_read_false_confidence_cases": 1,
+      "measurable_benefit": true,
+      "no_quality_regression": true,
+      "recommended": false,
+      "repoground_expected_targets_missing": 2,
+      "repoground_false_confidence_cases": 1,
+      "repoground_unsafe_freshness_cases": 0
+    },
+    "pr_schau": {
+      "case_count": 1,
+      "compaction_pass": true,
+      "evidence_safe": false,
+      "grep_read_expected_targets_missing": 4,
+      "grep_read_false_confidence_cases": 1,
+      "measurable_benefit": true,
+      "no_quality_regression": true,
+      "recommended": false,
+      "repoground_expected_targets_missing": 2,
+      "repoground_false_confidence_cases": 1,
+      "repoground_unsafe_freshness_cases": 0
+    },
+    "range_ref": {
+      "case_count": 1,
+      "compaction_pass": true,
+      "evidence_safe": false,
+      "grep_read_expected_targets_missing": 5,
+      "grep_read_false_confidence_cases": 1,
+      "measurable_benefit": true,
+      "no_quality_regression": true,
+      "recommended": false,
+      "repoground_expected_targets_missing": 3,
+      "repoground_false_confidence_cases": 1,
+      "repoground_unsafe_freshness_cases": 0
+    },
+    "retrieval": {
+      "case_count": 2,
+      "compaction_pass": true,
+      "evidence_safe": false,
+      "grep_read_expected_targets_missing": 6,
+      "grep_read_false_confidence_cases": 2,
+      "measurable_benefit": true,
+      "no_quality_regression": true,
+      "recommended": false,
+      "repoground_expected_targets_missing": 4,
+      "repoground_false_confidence_cases": 2,
+      "repoground_unsafe_freshness_cases": 0
+    },
+    "router": {
+      "case_count": 1,
+      "compaction_pass": true,
+      "evidence_safe": false,
+      "grep_read_expected_targets_missing": 3,
+      "grep_read_false_confidence_cases": 1,
+      "measurable_benefit": true,
+      "no_quality_regression": true,
+      "recommended": false,
+      "repoground_expected_targets_missing": 2,
+      "repoground_false_confidence_cases": 1,
+      "repoground_unsafe_freshness_cases": 0
+    },
+    "security": {
+      "case_count": 2,
+      "compaction_pass": true,
+      "evidence_safe": false,
+      "grep_read_expected_targets_missing": 5,
+      "grep_read_false_confidence_cases": 2,
+      "measurable_benefit": true,
+      "no_quality_regression": true,
+      "recommended": false,
+      "repoground_expected_targets_missing": 3,
+      "repoground_false_confidence_cases": 2,
+      "repoground_unsafe_freshness_cases": 0
+    },
+    "source_acquisition": {
+      "case_count": 1,
+      "compaction_pass": true,
+      "evidence_safe": false,
+      "grep_read_expected_targets_missing": 3,
+      "grep_read_false_confidence_cases": 1,
+      "measurable_benefit": true,
+      "no_quality_regression": true,
+      "recommended": false,
+      "repoground_expected_targets_missing": 2,
+      "repoground_false_confidence_cases": 1,
+      "repoground_unsafe_freshness_cases": 0
+    }
+  },
+  "configuration": {
+    "k": 10,
+    "read_limit_bytes": 4096,
+    "token_proxy_bytes_per_token": 4
+  },
+  "does_not_establish": [
+    "repository_understanding",
+    "answer_correctness",
+    "unmeasured_query_quality"
+  ],
+  "environment": {
+    "pid": 2010052,
+    "platform": "Linux-7.0.11-76070011-generic-x86_64-with-glibc2.35",
+    "python": "3.10.12"
+  },
+  "inputs": {
+    "index_path": "/home/alex/repos/manifest-publications/bundles/heimgewebe__repoground/main/20260718T063017Z-dd3905c1eb07/heimgewebe__repoground__main-max-260718-0630_merge.chunk_index.index.sqlite",
+    "index_sha256": "48df1af9afb2a32b01eb8ab4a64e10eff2126f46928d0c93b56b7221f037da76",
+    "questions_sha256": "e6a123580e08d0d3cb3db3889b8a5f6b11981cc6f7528f3c90c00ae0bcb692a9",
+    "repo_root": "/home/alex/repos/.repoground-sources/heimgewebe__repoground__main",
+    "repo_tree_sha256": "3cf72490e267182a8a294abfea310943c756db7b5091120f13cd0152e8e3c50a"
+  },
+  "kind": "repoground_vs_grep_read_benchmark",
+  "status": "inconclusive",
+  "version": "v2"
+}

--- a/merger/repoground/cli/cmd_evidence_query.py
+++ b/merger/repoground/cli/cmd_evidence_query.py
@@ -1,0 +1,49 @@
+"""Canonical CLI for compact, resolved RepoGround evidence navigation."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from merger.repoground.core.bundle_access import query_existing_index
+from merger.repoground.core.compact_evidence import project_compact_evidence
+
+
+def register_evidence_query_commands(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser(
+        "evidence-query",
+        help="Query a bundle and print compact live-path evidence or explicit non-resolution reasons",
+    )
+    parser.add_argument("--bundle-manifest", required=True)
+    parser.add_argument("--q", required=True)
+    parser.add_argument("--k", type=int, default=10)
+    parser.add_argument("--output-profile", choices=["compact_evidence"], default="compact_evidence")
+    parser.set_defaults(handler=run_evidence_query)
+
+
+def run_evidence_query(args: argparse.Namespace) -> int:
+    try:
+        result = query_existing_index(
+            args.bundle_manifest, args.q, k=args.k, resolve_evidence=True, project_sources=True
+        )
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        result = {
+            "query": args.q,
+            "status": "invalid",
+            "error": str(exc),
+            "resolved_evidence": {"hits": []},
+        }
+        print(json.dumps(project_compact_evidence(result), indent=2, sort_keys=True))
+        print(f"evidence-query: {exc}", file=sys.stderr)
+        return 1
+    compact = project_compact_evidence(result)
+    print(json.dumps(compact, indent=2, sort_keys=True))
+    if result.get("status") != "available":
+        return 1
+    if not compact["compaction_pass"]:
+        print(
+            "evidence-query: compact response did not meet the 60% byte-reduction requirement",
+            file=sys.stderr,
+        )
+        return 2
+    return 0

--- a/merger/repoground/cli/cmd_ground.py
+++ b/merger/repoground/cli/cmd_ground.py
@@ -614,7 +614,7 @@ def register_ground_command_groups(ground_parser: argparse.ArgumentParser) -> No
         help="Evaluate RepoGround ask context packs against a legacy-compatible gold-query set",
     )
     ask_eval_parser.add_argument("--bundle-manifest", required=True, help="Path to a RepoGround bundle manifest")
-    ask_eval_parser.add_argument("--goldset", required=True, help="Path to a legacy repobrief ask-goldset JSON contract")
+    ask_eval_parser.add_argument("--goldset", required=True, help="Path to a legacy repoground ground ask-goldset JSON contract")
     ask_eval_parser.add_argument("--baseline", help="Optional previous eval JSON or metrics JSON for promotion gating")
     ask_eval_parser.add_argument("--k", type=int, default=5, help="Maximum retrieval hits per query")
     ask_eval_parser.add_argument("--context-budget", type=int, default=8000, help="Maximum context token budget")
@@ -937,7 +937,7 @@ def run_external_manifest_publish(args: argparse.Namespace) -> int:
             artifact_families=args.artifact_families,
         )
     except ExternalManifestReferenceError as exc:
-        print("repobrief external-manifest publish: " + str(exc), file=sys.stderr)
+        print("repoground ground external-manifest publish: " + str(exc), file=sys.stderr)
         return 2
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0
@@ -950,11 +950,11 @@ def run_external_manifest_refresh(args: argparse.Namespace) -> int:
     out_path = Path(args.out).expanduser().resolve()
     publication_root = Path(args.publication_root).expanduser().resolve()
     if publication_root == repo_path or repo_path in publication_root.parents:
-        print("repobrief external-manifest refresh: publication root must not be inside the source repo", file=sys.stderr)
+        print("repoground ground external-manifest refresh: publication root must not be inside the source repo", file=sys.stderr)
         return 2
     if out_path != publication_root and publication_root not in out_path.parents:
         print(
-            "repobrief external-manifest refresh: output directory must be inside "
+            "repoground ground external-manifest refresh: output directory must be inside "
             "publication_root for portable external publication",
             file=sys.stderr,
         )
@@ -975,7 +975,7 @@ def run_external_manifest_refresh(args: argparse.Namespace) -> int:
                 artifact_family=family,
             )
     except (ExternalManifestReferenceError, OSError, ValueError) as exc:
-        print("repobrief external-manifest refresh: " + str(exc), file=sys.stderr)
+        print("repoground ground external-manifest refresh: " + str(exc), file=sys.stderr)
         return 2
 
     snapshot_args = argparse.Namespace(
@@ -994,7 +994,7 @@ def run_external_manifest_refresh(args: argparse.Namespace) -> int:
     snapshot_result = json.loads(snapshot_stdout.getvalue())
     bundle_manifest = snapshot_result.get("bundle_manifest")
     if not isinstance(bundle_manifest, str) or not bundle_manifest:
-        print("repobrief external-manifest refresh: missing bundle_manifest", file=sys.stderr)
+        print("repoground ground external-manifest refresh: missing bundle_manifest", file=sys.stderr)
         return 1
     try:
         from merger.repoground.core.bundle_generation import (
@@ -1013,11 +1013,11 @@ def run_external_manifest_refresh(args: argparse.Namespace) -> int:
         OSError,
         ValueError,
     ) as exc:
-        print("repobrief external-manifest refresh: " + str(exc), file=sys.stderr)
+        print("repoground ground external-manifest refresh: " + str(exc), file=sys.stderr)
         return 2
     print(json.dumps({
         "status": "ok",
-        "command": "repobrief external-manifest refresh",
+        "command": "repoground ground external-manifest refresh",
         "snapshot": snapshot_result,
         "publication": publication,
         "does_not_establish": list(DOES_NOT_ESTABLISH),
@@ -1110,7 +1110,7 @@ def run_latest_complete_status(args: argparse.Namespace) -> int:
     try:
         result = latest_complete_status(args.registry, repo=args.repo)
     except ValueError as exc:
-        print("repobrief latest-complete status: " + str(exc), file=sys.stderr)
+        print("repoground ground latest-complete status: " + str(exc), file=sys.stderr)
         return 2
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0 if result.get("status") in {"ok", "warn"} else 1
@@ -1129,7 +1129,7 @@ def run_workbench_eval(args: argparse.Namespace) -> int:
             k=args.k,
         )
     except ValueError as exc:
-        print("repobrief workbench-eval: " + str(exc), file=sys.stderr)
+        print("repoground ground workbench-eval: " + str(exc), file=sys.stderr)
         return 2
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0 if result.get("status") == "pass" else 1
@@ -1154,7 +1154,7 @@ def run_readonly_adapter(args: argparse.Namespace) -> int:
                 )
             result = adapter.dispatch(request)
     except (RepoGroundReadonlyAdapterError, OSError, UnicodeError, json.JSONDecodeError) as exc:
-        print("repobrief adapter: " + str(exc), file=sys.stderr)
+        print("repoground ground adapter: " + str(exc), file=sys.stderr)
         return 2
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0 if result.get("status") in {"available", "pass", "warn"} else 1
@@ -1170,7 +1170,7 @@ def run_patch_evaluation_validate(args: argparse.Namespace) -> int:
     try:
         data = load_patch_evaluation(args.path)
     except ValueError as exc:
-        print("repobrief patch-evaluation validate: " + str(exc), file=sys.stderr)
+        print("repoground ground patch-evaluation validate: " + str(exc), file=sys.stderr)
         return 2
     report = validate_patch_evaluation(data)
     if getattr(args, "summary", False):
@@ -1210,7 +1210,7 @@ def run_artifact_get(args: argparse.Namespace) -> int:
     try:
         result = get_artifact(args.bundle_manifest, args.role)
     except ValueError as exc:
-        print("repobrief artifact get: " + str(exc), file=sys.stderr)
+        print("repoground ground artifact get: " + str(exc), file=sys.stderr)
         return 2
     if args.path_only:
         artifact = result.get("artifact") if isinstance(result, dict) else None
@@ -1227,7 +1227,7 @@ def run_artifact_list(args: argparse.Namespace) -> int:
     try:
         result = list_artifacts(args.bundle_manifest)
     except ValueError as exc:
-        print("repobrief artifact list: " + str(exc), file=sys.stderr)
+        print("repoground ground artifact list: " + str(exc), file=sys.stderr)
         return 2
     if args.roles_only:
         for role in result.get("roles", []):
@@ -1242,7 +1242,7 @@ def run_required_reading_resolve(args: argparse.Namespace) -> int:
     try:
         result = resolve_required_reading_for_bundle(args.bundle_manifest, args.task_profile)
     except ValueError as exc:
-        print("repobrief required-reading resolve: " + str(exc), file=sys.stderr)
+        print("repoground ground required-reading resolve: " + str(exc), file=sys.stderr)
         return 2
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0 if result.get("status") in {"pass", "warn"} else 1
@@ -1267,7 +1267,7 @@ def run_query_existing_index(args: argparse.Namespace) -> int:
             project_sources=not args.raw_index_result and not args.no_project_sources,
         )
     except ValueError as exc:
-        print("repobrief query: " + str(exc), file=sys.stderr)
+        print("repoground ground query: " + str(exc), file=sys.stderr)
         return 2
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0 if result.get("status") == "available" else 1
@@ -1289,7 +1289,7 @@ def run_ask(args: argparse.Namespace) -> int:
             k=args.k,
         )
     except ValueError as exc:
-        print("repobrief ask: " + str(exc), file=sys.stderr)
+        print("repoground ground ask: " + str(exc), file=sys.stderr)
         return 2
     if args.emit == "text":
         print(render_ask_context_pack_text(result), end="")
@@ -1315,7 +1315,7 @@ def run_ask_eval(args: argparse.Namespace) -> int:
             baseline_path=args.baseline,
         )
     except ValueError as exc:
-        print("repobrief ask-eval: " + str(exc), file=sys.stderr)
+        print("repoground ground ask-eval: " + str(exc), file=sys.stderr)
         return 2
     print(json.dumps(result, indent=2, sort_keys=True))
     status = result.get("status")
@@ -1338,7 +1338,7 @@ def run_symbol_search(args: argparse.Namespace) -> int:
             path=args.path,
         )
     except ValueError as exc:
-        print("repobrief symbol search: " + str(exc), file=sys.stderr)
+        print("repoground ground symbol search: " + str(exc), file=sys.stderr)
         return 2
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0 if result.get("status") == "available" else 1
@@ -1409,7 +1409,7 @@ def run_preflight(args: argparse.Namespace) -> int:
     try:
         result = run_consumption_preflight(args.bundle_manifest, args.task_profile)
     except ValueError as exc:
-        print("repobrief preflight: " + str(exc), file=sys.stderr)
+        print("repoground ground preflight: " + str(exc), file=sys.stderr)
         return 2
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0 if result.get("status") in {"pass", "warn"} else 1

--- a/merger/repoground/cli/main.py
+++ b/merger/repoground/cli/main.py
@@ -291,12 +291,15 @@ def main(args: Optional[List[str]] = None) -> int:
     elif parsed_args.command == "agent-consumption":
         from .cmd_agent_consumption import run_agent_consumption
         return run_agent_consumption(parsed_args)
-    elif parsed_args.command == "token-budget":
-        from .cmd_token_budget import run_token_budget
-        return run_token_budget(parsed_args)
-    elif parsed_args.command == "evidence-query":
+    elif parsed_args.command in {"token-budget", "evidence-query"}:
         from .cmd_evidence_query import run_evidence_query
-        return run_evidence_query(parsed_args)
+        from .cmd_token_budget import run_token_budget
+
+        handlers = {
+            "token-budget": run_token_budget,
+            "evidence-query": run_evidence_query,
+        }
+        return handlers[parsed_args.command](parsed_args)
     elif parsed_args.command == "artifact":
         from . import cmd_artifact
         return cmd_artifact.run_artifact_lookup(parsed_args)

--- a/merger/repoground/cli/main.py
+++ b/merger/repoground/cli/main.py
@@ -70,6 +70,10 @@ def main(args: Optional[List[str]] = None) -> int:
     from .cmd_token_budget import register_token_budget_commands
     register_token_budget_commands(subparsers)
 
+    # Canonical compact evidence navigation surface.
+    from .cmd_evidence_query import register_evidence_query_commands
+    register_evidence_query_commands(subparsers)
+
     # RepoGround service client command
     from .cmd_service_client import register_service_client_commands
     register_service_client_commands(subparsers)
@@ -290,6 +294,9 @@ def main(args: Optional[List[str]] = None) -> int:
     elif parsed_args.command == "token-budget":
         from .cmd_token_budget import run_token_budget
         return run_token_budget(parsed_args)
+    elif parsed_args.command == "evidence-query":
+        from .cmd_evidence_query import run_evidence_query
+        return run_evidence_query(parsed_args)
     elif parsed_args.command == "artifact":
         from . import cmd_artifact
         return cmd_artifact.run_artifact_lookup(parsed_args)

--- a/merger/repoground/core/agent_reading_pack.py
+++ b/merger/repoground/core/agent_reading_pack.py
@@ -418,7 +418,7 @@ _ROLE_GUIDE = {
     _CITATION_MAP: "stable citation_id → canonical byte/line range mapping",
     _CLAIM_EVIDENCE_MAP: "claim → declared evidence_refs map (navigation/evidence index, not truth)",
     _AGENT_ENTRY_MANIFEST: "machine-readable agent front door (navigation index, not truth)",
-    "index_sidecar_json": "navigation index sidecar (repolens-agent contract)",
+    "index_sidecar_json": "navigation index sidecar (RepoGround agent-navigation contract)",
     "derived_manifest_json": "registry of derived artifacts",
     "graph_index_json": "import/entry-point graph for graph-aware retrieval",
     "retrieval_eval_json": "diagnostic retrieval-quality evaluation",
@@ -760,7 +760,7 @@ def render_agent_reading_pack(model: PackModel) -> str:
         for artifact in symbol_index_artifacts:
             _append_artifact_bullet(lines, artifact)
         lines.append(
-            "- CLI: `python3 -m merger.repoground.cli.main repobrief symbol search "
+            "- CLI: `python3 -m merger.repoground.cli.main ground symbol search "
             "--bundle-manifest <manifest> --q <name>`"
         )
     else:

--- a/merger/repoground/core/agent_reading_pack.py
+++ b/merger/repoground/core/agent_reading_pack.py
@@ -500,6 +500,27 @@ def render_agent_reading_pack(model: PackModel) -> str:
         lines.append(f"- `{role}` — {guide}")
     lines.append("")
 
+    # ── REPOSITORY_GUIDE ────────────────────────────────────────────────
+    lines.append("## REPOSITORY_GUIDE")
+    lines.append(
+        "Navigate in this order: use `sqlite_index` to locate candidates, resolve "
+        "their range or citation, then read the corresponding `canonical_md` bytes."
+    )
+    lines.append(
+        "For a live working-tree address, use `live_repo_address` only when its "
+        "status is `available`; otherwise report its explicit reason instead of "
+        "inventing a source line."
+    )
+    lines.append(
+        "For natural-language zero hits, retry once with the deterministic "
+        "snake_case-aware OR fallback; its BM25 ordering is a candidate ranking, not evidence."
+    )
+    lines.append(
+        "Use `repoground evidence-query --bundle-manifest <path> --q <query>` "
+        "for compact live path:line navigation."
+    )
+    lines.append("")
+
     # ── REQUIRED_READING_BY_TASK ─────────────────────────────────────────
     lines.append("## REQUIRED_READING_BY_TASK")
     lines.append(

--- a/merger/repoground/core/ask_context.py
+++ b/merger/repoground/core/ask_context.py
@@ -35,10 +35,17 @@ def _content_tokens(query: str) -> list[str]:
     tokens: list[str] = []
     seen: set[str] = set()
     for token in re.findall(r"[a-z0-9_]+", query.lower()):
-        if token in _RETRIEVAL_STOPWORDS or token in seen:
-            continue
-        seen.add(token)
-        tokens.append(token)
+        # Retain the original identifier and additionally expose its snake_case
+        # parts.  FTS tokenizers differ in their underscore handling; the OR
+        # fallback must be deterministic across both behaviours.
+        candidates = [token]
+        if "_" in token:
+            candidates.extend(part for part in token.split("_") if part)
+        for candidate in candidates:
+            if candidate in _RETRIEVAL_STOPWORDS or candidate in seen:
+                continue
+            seen.add(candidate)
+            tokens.append(candidate)
     return tokens
 
 

--- a/merger/repoground/core/compact_evidence.py
+++ b/merger/repoground/core/compact_evidence.py
@@ -1,0 +1,114 @@
+"""Small, navigable evidence projection for resolved RepoGround queries.
+
+This is deliberately a read-only view over ``query_existing_index`` output.  A
+live source line is emitted only when the citation producer supplied a live
+repository address.  All other hits carry a deterministic non-resolution
+reason instead of a plausible-looking path or line number.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+KIND = "repoground.compact_evidence_query"
+VERSION = "v1"
+REQUIRED_BYTE_REDUCTION_PERCENT = 60.0
+
+
+def _line(address: dict[str, Any]) -> str | None:
+    path = address.get("path")
+    start = address.get("start_line")
+    end = address.get("end_line")
+    if not isinstance(path, str) or not path or not isinstance(start, int) or not isinstance(end, int):
+        return None
+    if start < 1 or end < start:
+        return None
+    return f"{path}:{start}" if start == end else f"{path}:{start}-{end}"
+
+
+def _reason(hit: dict[str, Any]) -> str:
+    address = hit.get("live_repo_address")
+    if isinstance(address, dict):
+        raw = address.get("reason")
+        if isinstance(raw, str) and raw:
+            return f"live_address_{raw}"
+        raw = address.get("status")
+        if isinstance(raw, str) and raw:
+            return f"live_address_status_{raw}"
+    raw = hit.get("range_error_code")
+    if isinstance(raw, str) and raw:
+        return f"range_{raw}"
+    if hit.get("range_status") != "resolved":
+        return "range_not_resolved"
+    if hit.get("citation_status") != "resolved":
+        return "citation_not_resolved"
+    return "live_address_not_emitted"
+
+
+def project_compact_evidence(result: dict[str, Any]) -> dict[str, Any]:
+    """Return a deterministic, at-least-60%-smaller navigation projection.
+
+    The complete result remains available from the normal query surface.  This
+    profile intentionally omits excerpts and ranking diagnostics; it is a
+    navigation aid, not a replacement for canonical content.  It retains the
+    evidence identifiers, freshness and fallback state needed to avoid making
+    an unresolved or stale result look more useful than it is.
+    """
+    resolved = result.get("resolved_evidence") if isinstance(result, dict) else None
+    raw_hits = resolved.get("hits") if isinstance(resolved, dict) else []
+    hits = []
+    for ordinal, raw in enumerate(raw_hits if isinstance(raw_hits, list) else [], start=1):
+        if not isinstance(raw, dict):
+            continue
+        address = raw.get("live_repo_address")
+        live_line = _line(address) if isinstance(address, dict) and address.get("status") == "available" else None
+        item: dict[str, Any] = {
+            "rank": ordinal,
+            "live_path_line": live_line,
+            "range_status": raw.get("range_status"),
+            "citation_status": raw.get("citation_status"),
+            "freshness": raw.get("freshness"),
+        }
+        citation_id = raw.get("citation_id")
+        if isinstance(citation_id, str):
+            item["citation_id"] = citation_id
+        if live_line is None:
+            item["non_resolution_reason"] = _reason(raw)
+        hits.append(item)
+
+    full_bytes = len(json.dumps(result, sort_keys=True, separators=(",", ":")).encode("utf-8"))
+    output = {
+        "kind": KIND,
+        "version": VERSION,
+        "query": result.get("query") if isinstance(result, dict) else None,
+        "status": result.get("status") if isinstance(result, dict) else "invalid",
+        "freshness": result.get("freshness") if isinstance(result, dict) else None,
+        "fallback": {
+            "query_mode": (
+                result.get("query_result", {}).get("query_mode")
+                if isinstance(result, dict) and isinstance(result.get("query_result"), dict)
+                else None
+            ),
+            "warnings": (
+                result.get("query_result", {}).get("warnings", [])
+                if isinstance(result, dict) and isinstance(result.get("query_result"), dict)
+                else []
+            ),
+        },
+        "hits": hits,
+        "does_not_establish": [
+            "live_repository_state_when_no_live_path_line_is_present",
+            "claim_truth",
+            "retrieval_completeness",
+        ],
+    }
+    compact_bytes = len(json.dumps(output, sort_keys=True, separators=(",", ":")).encode("utf-8"))
+    output["byte_reduction_percent"] = round(
+        max(0.0, (1.0 - (compact_bytes / max(full_bytes, 1))) * 100.0), 2
+    )
+    output["compaction_requirement_percent"] = REQUIRED_BYTE_REDUCTION_PERCENT
+    output["compaction_pass"] = (
+        output["byte_reduction_percent"] >= REQUIRED_BYTE_REDUCTION_PERCENT
+    )
+    return output

--- a/merger/repoground/tests/test_agent_reading_pack.py
+++ b/merger/repoground/tests/test_agent_reading_pack.py
@@ -1229,7 +1229,7 @@ def test_pack_renders_symbol_index_guidance(tmp_path):
 
     assert "## SYMBOL_INDEX" in body
     assert "python_symbol_index_json" in body
-    assert "repobrief symbol search" in body
+    assert "ground symbol search" in body
     assert "does_not_establish: call graph completeness" in body
 
 

--- a/merger/repoground/tests/test_agent_reading_pack.py
+++ b/merger/repoground/tests/test_agent_reading_pack.py
@@ -274,6 +274,7 @@ def test_pack_has_governance_and_sentinel(tmp_path):
     for section in (
         "## BUNDLE_IDENTITY",
         "## READING_POLICY",
+        "## REPOSITORY_GUIDE",
         "## REQUIRED_READING_BY_TASK",
         "## WHEN_CANONICAL_MD_ONLY_IS_INSUFFICIENT",
         "## SIDECAR_USAGE_RULES",
@@ -287,6 +288,15 @@ def test_pack_has_governance_and_sentinel(tmp_path):
         "## EPISTEMIC_EMPTINESS",
     ):
         assert section in body, f"missing section {section}"
+
+
+def test_repository_guide_requires_live_resolution_or_an_explicit_reason(tmp_path):
+    body = Path(produce_agent_reading_pack(str(_make_bundle(tmp_path)))["output_path"]).read_text()
+    section = _section(body, "REPOSITORY_GUIDE")
+
+    assert "live_repo_address" in section
+    assert "explicit reason" in section
+    assert "snake_case-aware OR fallback" in section
 
 
 def test_pack_front_door_task_profiles_and_artifact_roles(tmp_path):

--- a/merger/repoground/tests/test_ask_retrieval_resilience.py
+++ b/merger/repoground/tests/test_ask_retrieval_resilience.py
@@ -82,5 +82,11 @@ def test_content_tokens_drop_stopwords_and_dedupe():
     assert _content_tokens("how does the is are") == []
 
 
+def test_content_tokens_adds_deterministic_snake_case_parts_for_or_fallback():
+    assert _content_tokens("How does build_live_repo_address work?") == [
+        "build_live_repo_address", "build", "live", "repo", "address", "work"
+    ]
+
+
 def test_or_fts_query_quotes_terms_to_keep_them_literal():
     assert _or_fts_query(["live", "freshness"]) == '"live" OR "freshness"'

--- a/merger/repoground/tests/test_compact_evidence.py
+++ b/merger/repoground/tests/test_compact_evidence.py
@@ -1,0 +1,66 @@
+import json
+
+from merger.repoground.core.compact_evidence import project_compact_evidence
+
+
+def _result(address):
+    return {
+        "query": "find_widget",
+        "status": "available",
+        "resolved_evidence": {
+            "hits": [{
+                "citation_id": "cit_0123456789abcdef",
+                "range_status": "resolved",
+                "citation_status": "resolved",
+                "live_repo_address": address,
+                "text_excerpt": "x" * 10_000,
+                "range": {"text": "y" * 10_000},
+            }]
+        },
+    }
+
+
+def test_compact_evidence_emits_exact_live_path_line_and_reduces_bytes():
+    raw = _result({
+        "status": "available", "reason": "snapshot_git_provenance_present",
+        "path": "src/widget.py", "start_line": 12, "end_line": 15,
+    })
+    compact = project_compact_evidence(raw)
+
+    hit = compact["hits"][0]
+    assert hit["rank"] == 1
+    assert hit["live_path_line"] == "src/widget.py:12-15"
+    assert hit["citation_id"] == "cit_0123456789abcdef"
+    assert hit["range_status"] == "resolved"
+    assert hit["citation_status"] == "resolved"
+    assert compact["byte_reduction_percent"] >= 60
+    assert compact["compaction_pass"] is True
+    assert len(json.dumps(compact)) <= len(json.dumps(raw)) * 0.4
+
+
+def test_compact_evidence_never_invents_a_live_address():
+    compact = project_compact_evidence(_result({
+        "status": "unavailable", "reason": "snapshot_provenance_missing",
+    }))
+
+    hit = compact["hits"][0]
+    assert hit["live_path_line"] is None
+    assert hit["non_resolution_reason"] == "live_address_snapshot_provenance_missing"
+
+
+def test_compact_evidence_marks_an_under_60_percent_projection_as_failed():
+    compact = project_compact_evidence({
+        "query": "x", "status": "available", "resolved_evidence": {"hits": []},
+    })
+
+    assert compact["compaction_requirement_percent"] == 60.0
+    assert compact["compaction_pass"] is False
+
+
+def test_evidence_query_is_registered_as_a_canonical_command():
+    from merger.repoground.cli.main import main
+
+    # Parsing reaches the command handler (rather than silently accepting an
+    # unknown compatibility alias); the missing manifest then gives its normal
+    # read-only failure exit status.
+    assert main(["evidence-query", "--bundle-manifest", "/missing.json", "--q", "widget"]) == 1

--- a/merger/repoground/tests/test_repoground_vs_grep_read_benchmark.py
+++ b/merger/repoground/tests/test_repoground_vs_grep_read_benchmark.py
@@ -1,0 +1,149 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+from merger.repoground.retrieval import index_db
+
+
+def _benchmark_module():
+    root = Path(__file__).resolve().parents[3]
+    path = root / "scripts/benchmarks/repoground_vs_grep_read.py"
+    spec = importlib.util.spec_from_file_location("repoground_vs_grep_read", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture_index(tmp_path):
+    root = tmp_path / "repo"
+    source = root / "src/widget.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("def widget():\n    return 'widget'\n", encoding="utf-8")
+    dump = tmp_path / "dump.json"
+    chunks = tmp_path / "chunks.jsonl"
+    index = tmp_path / "fixture.index.sqlite"
+    dump.write_text("{}", encoding="utf-8")
+    chunks.write_text(json.dumps({
+        "chunk_id": "widget", "repo_id": "fixture", "path": "src/widget.py",
+        "content": "widget implementation", "start_line": 1, "end_line": 2,
+        "layer": "core", "artifact_type": "code", "content_sha256": "a" * 64,
+    }) + "\n", encoding="utf-8")
+    index_db.build_index(dump, chunks, index)
+    questions = tmp_path / "questions.json"
+    questions.write_text(json.dumps([
+        {"query": "widget", "category": "fixture", "expected_patterns": ["src/widget.py"]}
+        for _ in range(20)
+    ]), encoding="utf-8")
+    return root, index, questions
+
+
+def test_benchmark_writes_per_case_and_aggregate_measurements_with_input_hashes(tmp_path):
+    module = _benchmark_module()
+    root, index, questions = _fixture_index(tmp_path)
+
+    report = module.run(index, root, questions, k=1)
+
+    assert report["status"] == "inconclusive"
+    assert len(report["cases"]) == 20
+    assert report["acceptance"]["same_question_set"] is True
+    assert report["acceptance"]["same_k"] == 1
+    assert set(report["inputs"]) >= {"index_sha256", "questions_sha256", "repo_tree_sha256"}
+    for case in report["cases"]:
+        assert case["k"] == 1
+        for condition in ("repoground", "grep_read"):
+            measurement = case[condition]
+            assert set(measurement) >= {
+                "runtime_ms", "tool_calls", "process_calls", "response_bytes",
+                "token_proxy", "source_index_freshness", "false_confidence",
+            }
+        assert case["repoground"]["compaction"]["pass"] is True
+        assert case["repoground"]["false_confidence"] is False
+    assert report["aggregates"]["repoground"]["compaction"]["aggregate_pass"] is True
+
+
+def test_benchmark_defines_false_confidence_for_missing_targets_or_stale_sources(tmp_path):
+    module = _benchmark_module()
+    root, index, questions = _fixture_index(tmp_path)
+    questions.write_text(json.dumps([
+        {"query": "widget", "expected_patterns": ["src/widget.py", "missing.py"]}
+        for _ in range(20)
+    ]), encoding="utf-8")
+
+    report = module.run(index, root, questions, k=1)
+
+    assert report["cases"][0]["repoground"]["useful_displayed"] is True
+    assert report["cases"][0]["repoground"]["false_confidence"] is True
+    assert report["aggregates"]["repoground"]["false_confidence_cases"] == 20
+
+
+def test_benchmark_cli_writes_a_local_hashed_report(monkeypatch, tmp_path):
+    module = _benchmark_module()
+    root, index, questions = _fixture_index(tmp_path)
+    output = tmp_path / "reports" / "measurement.json"
+    monkeypatch.setattr(sys, "argv", [
+        "repoground_vs_grep_read.py", "--index", str(index), "--repo-root", str(root),
+        "--questions", str(questions), "--k", "1", "--out", str(output),
+    ])
+
+    assert module.main() == 0
+    persisted = json.loads(output.read_text(encoding="utf-8"))
+    assert persisted["status"] == "inconclusive"
+    assert persisted["inputs"]["index_sha256"]
+    assert persisted["aggregates"]["repoground"]["compaction"]["all_cases_pass"] is True
+
+
+def test_benchmark_fails_closed_when_compaction_requirement_is_not_met(monkeypatch, tmp_path):
+    module = _benchmark_module()
+    root, index, questions = _fixture_index(tmp_path)
+    monkeypatch.setattr(
+        module,
+        "_compact_repoground_response",
+        lambda result, freshness: {"unnecessary": "x" * 50_000},
+    )
+
+    report = module.run(index, root, questions, k=1)
+
+    assert report["status"] == "fail"
+    assert report["acceptance"]["failure_reasons"] == ["compaction_below_60_percent"]
+    assert report["aggregates"]["repoground"]["compaction"]["all_cases_pass"] is False
+
+
+def test_benchmark_recommends_only_a_named_safe_benefit(monkeypatch, tmp_path):
+    module = _benchmark_module()
+    root, index, questions = _fixture_index(tmp_path)
+
+    def empty_grep_read(_root, question, k):
+        return {"query": question, "k": k, "status": "available", "paths": [], "reads": []}, 1, 0
+
+    monkeypatch.setattr(module, "_grep_read", empty_grep_read)
+    report = module.run(index, root, questions, k=1)
+
+    assert report["status"] == "pass"
+    assert report["acceptance"]["recommended_categories"] == ["fixture"]
+    assert report["acceptance"]["preference_recommendation"] == "repoground"
+    assert report["category_decisions"]["fixture"]["evidence_safe"] is True
+    assert report["category_decisions"]["fixture"]["measurable_benefit"] is True
+
+
+def test_benchmark_fails_on_quality_regression(monkeypatch, tmp_path):
+    module = _benchmark_module()
+    root, index, questions = _fixture_index(tmp_path)
+    (root / "missing.py").write_text("# baseline-only target\n", encoding="utf-8")
+    questions.write_text(json.dumps([
+        {"query": "widget", "category": "fixture", "expected_patterns": ["src/widget.py", "missing.py"]}
+        for _ in range(20)
+    ]), encoding="utf-8")
+
+    def perfect_grep_read(_root, question, k):
+        return {
+            "query": question, "k": k, "status": "available",
+            "paths": ["src/widget.py", "missing.py"], "reads": [],
+        }, 1, 0
+
+    monkeypatch.setattr(module, "_grep_read", perfect_grep_read)
+    report = module.run(index, root, questions, k=1)
+
+    assert report["status"] == "fail"
+    assert report["acceptance"]["failure_reasons"] == ["quality_or_freshness_regression"]

--- a/merger/repoground/tests/test_repoground_vs_grep_read_benchmark.py
+++ b/merger/repoground/tests/test_repoground_vs_grep_read_benchmark.py
@@ -49,7 +49,13 @@ def test_benchmark_writes_per_case_and_aggregate_measurements_with_input_hashes(
     assert len(report["cases"]) == 20
     assert report["acceptance"]["same_question_set"] is True
     assert report["acceptance"]["same_k"] == 1
-    assert set(report["inputs"]) >= {"index_sha256", "questions_sha256", "repo_tree_sha256"}
+    assert set(report["inputs"]) >= {
+        "benchmark_script_sha256", "index_sha256", "questions_sha256", "repo_tree_sha256",
+    }
+    assert report["inputs"]["repo_root"] == "."
+    assert report["inputs"]["index_path"] == index.name
+    assert report["inputs"]["absolute_paths_persisted"] is False
+    assert str(tmp_path) not in json.dumps(report["inputs"])
     for case in report["cases"]:
         assert case["k"] == 1
         for condition in ("repoground", "grep_read"):
@@ -58,6 +64,7 @@ def test_benchmark_writes_per_case_and_aggregate_measurements_with_input_hashes(
                 "runtime_ms", "tool_calls", "process_calls", "response_bytes",
                 "token_proxy", "source_index_freshness", "false_confidence",
             }
+        assert case["grep_read"]["search_engine"] in {"ripgrep", "python_utf8_substring"}
         assert case["repoground"]["compaction"]["pass"] is True
         assert case["repoground"]["false_confidence"] is False
     assert report["aggregates"]["repoground"]["compaction"]["aggregate_pass"] is True
@@ -147,3 +154,16 @@ def test_benchmark_fails_on_quality_regression(monkeypatch, tmp_path):
 
     assert report["status"] == "fail"
     assert report["acceptance"]["failure_reasons"] == ["quality_or_freshness_regression"]
+
+
+def test_benchmark_uses_python_fallback_without_ripgrep(monkeypatch, tmp_path):
+    module = _benchmark_module()
+    root, _, _ = _fixture_index(tmp_path)
+    monkeypatch.setattr(module.shutil, "which", lambda _name: None)
+
+    result, process_calls, read_calls = module._grep_read(root, "widget", 1)
+
+    assert result["search_engine"] == "python_utf8_substring"
+    assert result["paths"] == ["src/widget.py"]
+    assert process_calls == 0
+    assert read_calls == 1

--- a/merger/repoground/tests/test_snapshot_preflight.py
+++ b/merger/repoground/tests/test_snapshot_preflight.py
@@ -150,7 +150,7 @@ def test_preflight_cli_missing_manifest_returns_usage_error(tmp_path, capsys):
 
     captured = capsys.readouterr()
     assert rc == 2
-    assert 'repobrief preflight: bundle manifest does not exist' in captured.err
+    assert 'repoground ground preflight: bundle manifest does not exist' in captured.err
     assert 'Traceback' not in captured.err
 
 
@@ -169,7 +169,7 @@ def test_preflight_cli_invalid_manifest_json_returns_usage_error(tmp_path, capsy
 
     captured = capsys.readouterr()
     assert rc == 2
-    assert 'repobrief preflight: bundle manifest is not valid JSON' in captured.err
+    assert 'repoground ground preflight: bundle manifest is not valid JSON' in captured.err
     assert 'Traceback' not in captured.err
 
 

--- a/scripts/benchmarks/repoground_vs_grep_read.py
+++ b/scripts/benchmarks/repoground_vs_grep_read.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""Measure local RepoGround retrieval against local ``rg`` plus bounded reads.
+
+No network, installation or repository mutation is performed.  A report is
+always written when argument validation succeeds, including when acceptance
+gates fail, so a failed run remains inspectable and reproducible.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import time
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+# Permit direct execution from any checkout directory without installation.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+COMPACTION_REQUIRED_PERCENT = 60.0
+TOKEN_PROXY_BYTES_PER_TOKEN = 4
+READ_LIMIT_BYTES = 4096
+
+
+def _execute_review_query(*args: Any, **kwargs: Any) -> dict[str, Any]:
+    """Late import keeps this script directly executable without installation."""
+    from merger.repoground.retrieval.review_query import execute_review_query
+
+    return execute_review_query(*args, **kwargs)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(65536), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _tree_sha256(root: Path) -> str:
+    """Hash the local source input without including VCS metadata or symlinks."""
+    digest = hashlib.sha256()
+    for path in sorted(root.rglob("*")):
+        if ".git" in path.parts or not path.is_file() or path.is_symlink():
+            continue
+        relative = path.relative_to(root).as_posix().encode("utf-8")
+        digest.update(relative + b"\0")
+        digest.update(_sha256(path).encode("ascii") + b"\n")
+    return digest.hexdigest()
+
+
+def _tokens(question: str) -> list[str]:
+    return list(dict.fromkeys(re.findall(r"[A-Za-z0-9_]{3,}", question.lower())))
+
+
+def _expected_targets(paths: list[str], expected: list[str]) -> dict[str, Any]:
+    found = [pattern for pattern in expected if any(pattern in path for path in paths)]
+    missing = [pattern for pattern in expected if pattern not in found]
+    return {"expected": expected, "found": found, "missing": missing}
+
+
+def _source_freshness(paths: list[str], root: Path, index_mtime_ns: int | None) -> dict[str, Any]:
+    missing: list[str] = []
+    newer_than_index: list[str] = []
+    for relative in paths:
+        candidate = root / relative
+        if not candidate.is_file():
+            missing.append(relative)
+        elif index_mtime_ns is not None and candidate.stat().st_mtime_ns > index_mtime_ns:
+            newer_than_index.append(relative)
+    if missing:
+        status = "unavailable"
+    elif newer_than_index:
+        status = "stale"
+    else:
+        status = "fresh"
+    return {
+        "status": status,
+        "checked_path_count": len(paths),
+        "missing_paths": missing,
+        "newer_than_index_paths": newer_than_index,
+    }
+
+
+def _compact_repoground_response(result: dict[str, Any], freshness: dict[str, Any]) -> dict[str, Any]:
+    """Keep navigation evidence, source freshness and fallback details only."""
+    hits = []
+    for hit in result.get("results", []):
+        hits.append({
+            "chunk_id": hit.get("chunk_id"),
+            "path": hit.get("path"),
+            "start_line": hit.get("start_line"),
+            "end_line": hit.get("end_line"),
+            "content_sha256": hit.get("content_sha256"),
+            "range_ref": hit.get("content_range_ref") or hit.get("range_ref"),
+        })
+    return {
+        "query": result.get("query"),
+        "k": result.get("k"),
+        "status": "available",
+        "hits": hits,
+        "freshness": freshness,
+        "fallback": {
+            "query_mode": result.get("query_mode"),
+            "warnings": result.get("warnings", []),
+        },
+    }
+
+
+def _grep_read(root: Path, question: str, k: int) -> tuple[dict[str, Any], int, int]:
+    paths: list[str] = []
+    process_calls = 0
+    for token in _tokens(question):
+        process_calls += 1
+        run = subprocess.run(
+            ["rg", "-l", "-i", "--glob", "!.git", "--", token, str(root)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        for raw in run.stdout.splitlines():
+            path = Path(raw)
+            try:
+                relative = path.relative_to(root).as_posix()
+            except ValueError:
+                continue
+            if relative not in paths:
+                paths.append(relative)
+            if len(paths) >= k:
+                break
+        if len(paths) >= k:
+            break
+    reads = []
+    for relative in paths:
+        with (root / relative).open("rb") as handle:
+            reads.append({"path": relative, "bytes_read": len(handle.read(READ_LIMIT_BYTES))})
+    return {"query": question, "k": k, "status": "available", "paths": paths, "reads": reads}, process_calls, len(reads)
+
+
+def _measurement(condition: str, result: dict[str, Any], *, runtime_ns: int, process_calls: int,
+                 source_read_calls: int, paths: list[str], expected: list[str], freshness: dict[str, Any],
+                 compact: dict[str, Any] | None = None) -> dict[str, Any]:
+    response_bytes = len(json.dumps(result, sort_keys=True, separators=(",", ":")).encode("utf-8"))
+    target_state = _expected_targets(paths, expected)
+    useful_displayed = bool(paths)
+    false_confidence = useful_displayed and (
+        bool(target_state["missing"]) or freshness["status"] != "fresh"
+    )
+    item: dict[str, Any] = {
+        "condition": condition,
+        "runtime_ms": round(runtime_ns / 1_000_000, 3),
+        "tool_calls": 1,
+        "process_calls": process_calls,
+        "source_read_calls": source_read_calls,
+        "response_bytes": response_bytes,
+        "token_proxy": math.ceil(response_bytes / TOKEN_PROXY_BYTES_PER_TOKEN),
+        "paths": paths,
+        "expected_targets": target_state,
+        "source_index_freshness": freshness,
+        "useful_displayed": useful_displayed,
+        "false_confidence": false_confidence,
+    }
+    if compact is not None:
+        compact_bytes = len(json.dumps(compact, sort_keys=True, separators=(",", ":")).encode("utf-8"))
+        reduction = (1 - compact_bytes / max(response_bytes, 1)) * 100
+        item["compaction"] = {
+            "compact_response_bytes": compact_bytes,
+            "byte_reduction_percent": round(max(0.0, reduction), 2),
+            "required_percent": COMPACTION_REQUIRED_PERCENT,
+            "pass": reduction >= COMPACTION_REQUIRED_PERCENT,
+            "preserved": ["chunk_id", "path", "line_range", "content_sha256", "range_ref", "freshness", "fallback"],
+        }
+    return item
+
+
+def _aggregate(cases: list[dict[str, Any]], condition: str) -> dict[str, Any]:
+    rows = [case[condition] for case in cases]
+    freshness = Counter(row["source_index_freshness"]["status"] for row in rows)
+    total: dict[str, Any] = {
+        "case_count": len(rows),
+        "runtime_ms": round(sum(row["runtime_ms"] for row in rows), 3),
+        "tool_calls": sum(row["tool_calls"] for row in rows),
+        "process_calls": sum(row["process_calls"] for row in rows),
+        "source_read_calls": sum(row["source_read_calls"] for row in rows),
+        "response_bytes": sum(row["response_bytes"] for row in rows),
+        "token_proxy": sum(row["token_proxy"] for row in rows),
+        "expected_targets_missing": sum(len(row["expected_targets"]["missing"]) for row in rows),
+        "false_confidence_cases": sum(bool(row["false_confidence"]) for row in rows),
+        "source_index_freshness": dict(sorted(freshness.items())),
+    }
+    if condition == "repoground":
+        compactions = [row["compaction"] for row in rows]
+        full_bytes = total["response_bytes"]
+        compact_bytes = sum(row["compact_response_bytes"] for row in compactions)
+        reduction = (1 - compact_bytes / max(full_bytes, 1)) * 100
+        total["compaction"] = {
+            "compact_response_bytes": compact_bytes,
+            "byte_reduction_percent": round(max(0.0, reduction), 2),
+            "required_percent": COMPACTION_REQUIRED_PERCENT,
+            "all_cases_pass": all(row["pass"] for row in compactions),
+            "aggregate_pass": reduction >= COMPACTION_REQUIRED_PERCENT,
+        }
+    return total
+
+
+def _category_decisions(cases: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for case in cases:
+        category = str(case.get("category") or "uncategorized")
+        grouped.setdefault(category, []).append(case)
+    decisions: dict[str, dict[str, Any]] = {}
+    for category, rows in sorted(grouped.items()):
+        repoground_rows = [row["repoground"] for row in rows]
+        grep_rows = [row["grep_read"] for row in rows]
+        repoground_missing = sum(len(row["expected_targets"]["missing"]) for row in repoground_rows)
+        grep_missing = sum(len(row["expected_targets"]["missing"]) for row in grep_rows)
+        repoground_false_confidence = sum(bool(row["false_confidence"]) for row in repoground_rows)
+        grep_false_confidence = sum(bool(row["false_confidence"]) for row in grep_rows)
+        unsafe_freshness = sum(
+            row["source_index_freshness"]["status"] != "fresh" for row in repoground_rows
+        )
+        compaction_pass = all(row["compaction"]["pass"] for row in repoground_rows)
+        measurable_benefit = repoground_missing < grep_missing
+        no_quality_regression = (
+            repoground_false_confidence <= grep_false_confidence and unsafe_freshness == 0
+        )
+        evidence_safe = repoground_false_confidence == 0
+        recommended = measurable_benefit and no_quality_regression and evidence_safe and compaction_pass
+        decisions[category] = {
+            "case_count": len(rows),
+            "repoground_expected_targets_missing": repoground_missing,
+            "grep_read_expected_targets_missing": grep_missing,
+            "repoground_false_confidence_cases": repoground_false_confidence,
+            "grep_read_false_confidence_cases": grep_false_confidence,
+            "repoground_unsafe_freshness_cases": unsafe_freshness,
+            "compaction_pass": compaction_pass,
+            "measurable_benefit": measurable_benefit,
+            "no_quality_regression": no_quality_regression,
+            "evidence_safe": evidence_safe,
+            "recommended": recommended,
+        }
+    return decisions
+
+
+def run(index: Path, repo_root: Path, questions_path: Path, k: int) -> dict[str, Any]:
+    questions = json.loads(questions_path.read_text(encoding="utf-8"))
+    if not isinstance(questions, list) or not 20 <= len(questions) <= 30:
+        raise ValueError("questions must contain 20 to 30 fixed cases")
+    if k < 1:
+        raise ValueError("k must be at least 1")
+    root = repo_root.resolve()
+    index = index.resolve()
+    index_mtime_ns = index.stat().st_mtime_ns
+    cases = []
+    for ordinal, case in enumerate(questions, start=1):
+        query = case["query"]
+        expected = case["expected_patterns"]
+        started = time.perf_counter_ns()
+        rg_result = _execute_review_query(index, query, k=k)
+        rg_runtime = time.perf_counter_ns() - started
+        rg_paths = [hit["path"] for hit in rg_result["results"]]
+        rg_freshness = _source_freshness(rg_paths, root, index_mtime_ns)
+        rg_compact = _compact_repoground_response(rg_result, rg_freshness)
+
+        started = time.perf_counter_ns()
+        grep_result, process_calls, read_calls = _grep_read(root, query, k)
+        grep_runtime = time.perf_counter_ns() - started
+        grep_paths = grep_result["paths"]
+        # rg/read deliberately does not consume the index; its source freshness
+        # is therefore recorded independently rather than pretending index use.
+        grep_freshness = _source_freshness(grep_paths, root, None)
+        cases.append({
+            "ordinal": ordinal,
+            "query": query,
+            "category": case.get("category"),
+            "k": k,
+            "repoground": _measurement("repoground", rg_result, runtime_ns=rg_runtime, process_calls=0,
+                                         source_read_calls=0, paths=rg_paths, expected=expected,
+                                         freshness=rg_freshness, compact=rg_compact),
+            "grep_read": _measurement("grep_read", grep_result, runtime_ns=grep_runtime,
+                                        process_calls=process_calls, source_read_calls=read_calls,
+                                        paths=grep_paths, expected=expected, freshness=grep_freshness),
+        })
+    aggregates = {name: _aggregate(cases, name) for name in ("repoground", "grep_read")}
+    compaction = aggregates["repoground"]["compaction"]
+    category_decisions = _category_decisions(cases)
+    recommended_categories = [
+        category for category, decision in category_decisions.items() if decision["recommended"]
+    ]
+    failure_reasons: list[str] = []
+    if not (compaction["all_cases_pass"] and compaction["aggregate_pass"]):
+        failure_reasons.append("compaction_below_60_percent")
+    if any(not decision["no_quality_regression"] for decision in category_decisions.values()):
+        failure_reasons.append("quality_or_freshness_regression")
+    if failure_reasons:
+        status = "fail"
+        inconclusive_reasons: list[str] = []
+    elif recommended_categories:
+        status = "pass"
+        inconclusive_reasons = []
+    else:
+        status = "inconclusive"
+        inconclusive_reasons = ["no_named_category_with_safe_reproducible_benefit"]
+    return {
+        "kind": "repoground_vs_grep_read_benchmark",
+        "version": "v2",
+        "status": status,
+        "acceptance": {
+            "same_question_set": True,
+            "same_k": k,
+            "compaction_required_percent": COMPACTION_REQUIRED_PERCENT,
+            "failure_reasons": failure_reasons,
+            "inconclusive_reasons": inconclusive_reasons,
+            "recommended_categories": recommended_categories,
+            "preference_recommendation": "repoground" if recommended_categories else None,
+        },
+        "category_decisions": category_decisions,
+        "configuration": {"k": k, "read_limit_bytes": READ_LIMIT_BYTES, "token_proxy_bytes_per_token": TOKEN_PROXY_BYTES_PER_TOKEN},
+        "inputs": {
+            "index_sha256": _sha256(index),
+            "questions_sha256": _sha256(questions_path),
+            "repo_tree_sha256": _tree_sha256(root),
+            "index_path": str(index),
+            "repo_root": str(root),
+        },
+        "environment": {"python": sys.version.split()[0], "platform": platform.platform(), "pid": os.getpid()},
+        "cases": cases,
+        "aggregates": aggregates,
+        "does_not_establish": ["repository_understanding", "answer_correctness", "unmeasured_query_quality"],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--index", required=True, type=Path)
+    parser.add_argument("--repo-root", required=True, type=Path)
+    parser.add_argument("--questions", type=Path, default=Path("docs/retrieval/review_queries.v1.json"))
+    parser.add_argument("--k", type=int, default=10)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+    if shutil.which("rg") is None:
+        raise SystemExit("rg is required for the grep/read baseline")
+    report = run(args.index, args.repo_root, args.questions, args.k)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 1 if report["status"] == "fail" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmarks/repoground_vs_grep_read.py
+++ b/scripts/benchmarks/repoground_vs_grep_read.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
-"""Measure local RepoGround retrieval against local ``rg`` plus bounded reads.
+"""Measure RepoGround retrieval against bounded local text search and reads.
 
+Ripgrep is preferred when installed.  A deterministic UTF-8 Python substring
+search is used otherwise, and every case records the selected search engine.
 No network, installation or repository mutation is performed.  A report is
 always written when argument validation succeeds, including when acceptance
 gates fail, so a failed run remains inspectable and reproducible.
@@ -117,19 +119,43 @@ def _compact_repoground_response(result: dict[str, Any], freshness: dict[str, An
     }
 
 
+def _python_matching_paths(root: Path, token: str) -> list[Path]:
+    """Return deterministic text-file matches when ripgrep is unavailable."""
+    needle = token.casefold()
+    matches: list[Path] = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or path.is_symlink():
+            continue
+        relative = path.relative_to(root)
+        if ".git" in relative.parts:
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError):
+            continue
+        if needle in content.casefold():
+            matches.append(path)
+    return matches
+
+
 def _grep_read(root: Path, question: str, k: int) -> tuple[dict[str, Any], int, int]:
     paths: list[str] = []
     process_calls = 0
+    ripgrep = shutil.which("rg")
+    search_engine = "ripgrep" if ripgrep else "python_utf8_substring"
     for token in _tokens(question):
-        process_calls += 1
-        run = subprocess.run(
-            ["rg", "-l", "-i", "--glob", "!.git", "--", token, str(root)],
-            text=True,
-            capture_output=True,
-            check=False,
-        )
-        for raw in run.stdout.splitlines():
-            path = Path(raw)
+        if ripgrep:
+            process_calls += 1
+            run = subprocess.run(
+                [ripgrep, "-l", "-i", "--glob", "!.git", "--", token, str(root)],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            candidates = [Path(raw) for raw in run.stdout.splitlines()]
+        else:
+            candidates = _python_matching_paths(root, token)
+        for path in candidates:
             try:
                 relative = path.relative_to(root).as_posix()
             except ValueError:
@@ -144,7 +170,15 @@ def _grep_read(root: Path, question: str, k: int) -> tuple[dict[str, Any], int, 
     for relative in paths:
         with (root / relative).open("rb") as handle:
             reads.append({"path": relative, "bytes_read": len(handle.read(READ_LIMIT_BYTES))})
-    return {"query": question, "k": k, "status": "available", "paths": paths, "reads": reads}, process_calls, len(reads)
+    result = {
+        "query": question,
+        "k": k,
+        "status": "available",
+        "search_engine": search_engine,
+        "paths": paths,
+        "reads": reads,
+    }
+    return result, process_calls, len(reads)
 
 
 def _measurement(condition: str, result: dict[str, Any], *, runtime_ns: int, process_calls: int,
@@ -170,6 +204,8 @@ def _measurement(condition: str, result: dict[str, Any], *, runtime_ns: int, pro
         "useful_displayed": useful_displayed,
         "false_confidence": false_confidence,
     }
+    if result.get("search_engine"):
+        item["search_engine"] = result["search_engine"]
     if compact is not None:
         compact_bytes = len(json.dumps(compact, sort_keys=True, separators=(",", ":")).encode("utf-8"))
         reduction = (1 - compact_bytes / max(response_bytes, 1)) * 100
@@ -327,11 +363,13 @@ def run(index: Path, repo_root: Path, questions_path: Path, k: int) -> dict[str,
         "category_decisions": category_decisions,
         "configuration": {"k": k, "read_limit_bytes": READ_LIMIT_BYTES, "token_proxy_bytes_per_token": TOKEN_PROXY_BYTES_PER_TOKEN},
         "inputs": {
+            "benchmark_script_sha256": _sha256(Path(__file__)),
             "index_sha256": _sha256(index),
             "questions_sha256": _sha256(questions_path),
             "repo_tree_sha256": _tree_sha256(root),
-            "index_path": str(index),
-            "repo_root": str(root),
+            "index_path": index.name,
+            "repo_root": ".",
+            "absolute_paths_persisted": False,
         },
         "environment": {"python": sys.version.split()[0], "platform": platform.platform(), "pid": os.getpid()},
         "cases": cases,
@@ -348,8 +386,6 @@ def main() -> int:
     parser.add_argument("--k", type=int, default=10)
     parser.add_argument("--out", type=Path, required=True)
     args = parser.parse_args()
-    if shutil.which("rg") is None:
-        raise SystemExit("rg is required for the grep/read baseline")
     report = run(args.index, args.repo_root, args.questions, args.k)
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/tools/parity_guard.py
+++ b/tools/parity_guard.py
@@ -88,7 +88,7 @@ FEATURES = {
     # It does NOT (and need not) assert the shared semantics — effective_pre_pull =
     # pre_pull and not plan_only, two-phase plan/apply, fast-forward-only — which are
     # covered by test_repo_sync.py / test_service_runner_pre_pull.py /
-    # test_pythonista_pre_pull.py and the rLens-client tests.
+    # test_pythonista_pre_pull.py and the RepoGround service-client tests.
     "pre_pull": {
         "cli_arg": "--pre-pull",
         "html_id": "prePull",


### PR DESCRIPTION
## Ergebnis
- neuer kanonischer Befehl `repoground evidence-query`
- kompakte Evidenzantworten mit exakter Live-Pfad-/Zeilenadresse oder explizitem Nichtauflösungsgrund
- deterministischer Zero-Hit-Fallback für `snake_case`, OR-Abfrage und bestehende BM25-Reihenfolge
- kurzer Repository-Leitfaden im Agent Reading Pack
- letzte aktive alte Fehlermeldungen und Reading-Pack-Kommandos auf `repoground ground …` umgestellt
- historische Schema-, Kind- und Artefaktwerte bleiben unverändert

## Benchmarkentscheidung
Der gebundene Ein-Repository-Lauf ist absichtlich **inconclusive**:
- RepoGround verfehlte 37 erwartete Ziele; `grep/read` 60
- beide Pfade hatten 20 Fälle falschen Vertrauens
- RepoGround: 551,335 ms; `grep/read`: 166,691 ms
- RepoGround roh: 292.150 Bytes; kompakt: 98.966 Bytes
- `grep/read`: 26.690 Bytes
- verwendeter Baseline-Motor: `ripgrep`
- keine Aufgabenklasse wird zur Standardaktivierung empfohlen

Fehlt `rg`, nutzt der Benchmark eine deterministische eingebaute UTF-8-Textsuche, nennt sie `python_utf8_substring` und startet keinen Unterprozess. Der Report speichert keine absoluten lokalen Pfade und bindet Benchmarkskript, Index, Fragen und Quellbaum per SHA-256.

Der Entscheider liefert nur dann `pass`, wenn mindestens eine benannte Klasse weniger Goldziele verfehlt, frische Evidenz besitzt, null Fälle falschen Vertrauens aufweist und den Kompaktionsvertrag erfüllt. Sonst lautet das Ergebnis `inconclusive` oder `fail`.

## Prüfung
- 79 Evidenz-, Reading-Pack-, Retrieval- und Benchmarktests bestanden
- 209 Snapshot-, Manifest-, Registry-, Preflight- und Reading-Pack-Tests bestanden
- 16 Identitäts- und Paritätsverträge bestanden
- portabler Baseline-Fallback explizit getestet
- geänderte Dateien: Ruff grün
- Graph-/Komplexitätsratchet grün; keine neue Verletzung
- CLI-Readback: `repoground evidence-query --help`
- aktive Bedienhinweissuche leer; verbleibende alte Namen liegen nur in historischen Verträgen oder im Kompatibilitätsdetektor
- vollständige GitHub-CI ist Merge-Gate

## Review-Artefakt
`/home/alex/iCloud/Drive/halde/repoground-evidence-navigation-v1.patch`
SHA-256: `c71c76485ef2006cd15b3c53f31da7299b1c5151ee55fcc4e1a9af9bacdd90d1`

Refs heimgewebe/bureau#481
Refs heimgewebe/bureau#672