### PR TITLE
Sichter: auto PR (lenskit)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ atlas_scan_*.md
 /core
 /core.*
 *.core
+.mcp.json

--- a/docs/usage/repobrief-mcp-stdio.md
+++ b/docs/usage/repobrief-mcp-stdio.md
@@ -1,0 +1,121 @@
+# RepoBrief MCP stdio
+
+RepoBrief can run as a local Model Context Protocol server over standard input and output.
+The server exposes existing RepoBrief bundles and handlers; it does not invent a second
+snapshot or grounding implementation.
+
+## Start
+
+Use the launcher by absolute path. It adds its own Lenskit checkout to the Python import path,
+so the MCP client does not need to start inside the repository:
+
+```bash
+python3 /absolute/path/to/lenskit/scripts/repobrief-mcp-stdio.py \
+  --bundle-root /absolute/path/to/briefs \
+  --repo-root /absolute/path/to/repository
+```
+
+`--bundle-root` may name either a directory containing `*.bundle.manifest.json` files or
+one exact bundle manifest. `--repo-root` is optional for the default read-only server, but
+without it live freshness is reported as `not_comparable` and no Git probe runs.
+
+The module form remains valid when the Lenskit checkout or installed package is already on
+Python's import path:
+
+```bash
+python3 -m merger.lenskit.cli.repobrief_mcp_stdio \
+  --bundle-root /absolute/path/to/briefs \
+  --repo-root /absolute/path/to/repository
+```
+
+## Generic MCP client configuration
+
+Clients that accept an MCP stdio command can use this shape:
+
+```json
+{
+  "mcpServers": {
+    "repobrief": {
+      "command": "python3",
+      "args": [
+        "/absolute/path/to/lenskit/scripts/repobrief-mcp-stdio.py",
+        "--bundle-root",
+        "/absolute/path/to/briefs",
+        "--repo-root",
+        "/absolute/path/to/repository"
+      ]
+    }
+  }
+}
+```
+
+The client-specific file location or registration command varies. The absolute launcher,
+bundle root, and optional repository root are the stable RepoBrief side of the contract.
+
+## Exposed tools
+
+Read-only by default:
+
+- `ask_context`: builds the existing cited context pack from one registered bundle;
+- `grounding_verify`: runs the existing declaration and evidence verifier;
+- `live_freshness`: compares the snapshot commit and cleanliness with the configured checkout;
+- `find_symbol`: locates Python symbol definitions by name in the snapshot's symbol index (exact matches first), answering "where is X defined?" with a path and line range; each call also attaches the live freshness of the snapshot.
+
+Optional explicit write tool:
+
+- `snapshot_create`: available only with `--enable-snapshot-create` and an explicit
+  `--repo-root` at server startup.
+
+When enabled, the MCP client may select the snapshot profile and bounded generation options,
+but it cannot choose another source repository or output root. The source remains the startup
+`--repo-root`; output remains the startup `--bundle-root` directory, or the parent directory
+when `--bundle-root` names one exact manifest. Existing timeout, size, path, and output-not-inside-
+repository guards still apply.
+
+Snapshot profiles whose canonical policy sets `redaction_required=true` now enable secret
+redaction by default before generation. An explicit `--no-redact-secrets` override for such a
+profile is rejected before the output directory is created. The JSON result records whether
+redaction was enabled, required by the profile, and selected explicitly or by the safe profile
+default.
+
+## Exposed resources
+
+The server lists and reads the existing resource surface:
+
+- `repobrief://snapshot/{stem}/manifest`
+- `repobrief://snapshot/{stem}/canonical`
+- `repobrief://snapshot/{stem}/reading-pack`
+- `repobrief://snapshot/{stem}/health`
+- `repobrief://snapshot/{stem}/availability`
+- `repobrief://snapshot/{stem}/artifact/{role}`
+
+Resource results retain the existing health, availability, and snapshot-bound freshness
+metadata. When `--repo-root` is configured, the result metadata also includes live freshness.
+
+## Freshness meanings
+
+- `fresh`: snapshot commit equals local `HEAD`, and both the snapshot and current tree are clean;
+- `stale`: the commit differs, the current tree is dirty, or the snapshot was created dirty;
+- `unknown`: required snapshot provenance or cleanliness evidence is missing or does not identify
+  the configured checkout;
+- `not_comparable`: no checkout was configured, Git is unavailable, or current cleanliness
+  cannot be established.
+
+A manifest-recorded local path is evidence, not permission. Only the operator-provided
+`--repo-root` authorizes a Git probe. A read never invokes `snapshot_create`, `git fetch`,
+`git pull`, or another repair action. Staleness is reported, not hidden.
+
+## Security boundary
+
+- tool-supplied manifests must remain inside the configured bundle root;
+- an optional citation map must remain inside the selected bundle directory;
+- the MCP client cannot select an arbitrary Git checkout: the probe is bound to `--repo-root`;
+- optional snapshot writes cannot replace the startup repository or output root;
+- the Git probe disables optional locks, fsmonitor, global Git configuration, system Git
+  configuration, and terminal prompts;
+- the server has no TCP or HTTP listener and writes only MCP JSON-RPC messages to stdout;
+- Git push/pull/fetch, shell execution, patches, pull requests, secrets, reviews, fixes, and
+  merges remain outside the server authority.
+
+Successful access or a `fresh` verdict does not establish repository truth, answer correctness,
+test sufficiency, review completeness, runtime correctness, or merge readiness.

--- a/merger/lenskit/cli/repobrief_mcp_stdio.py
+++ b/merger/lenskit/cli/repobrief_mcp_stdio.py
@@ -1,0 +1,543 @@
+"""Minimal newline-delimited MCP stdio transport for RepoBrief."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, TextIO
+
+from merger.lenskit.core import repobrief_mcp_resources, repobrief_mcp_tools
+from merger.lenskit.core.repobrief_live_freshness import (
+    DOES_NOT_ESTABLISH as FRESHNESS_DOES_NOT_ESTABLISH,
+)
+from merger.lenskit.core.repobrief_live_freshness import evaluate_live_freshness
+
+PROTOCOL_VERSION = "2025-06-18"
+SUPPORTED_PROTOCOL_VERSIONS = (PROTOCOL_VERSION, "2025-03-26", "2024-11-05")
+SERVER_NAME = "repobrief"
+SERVER_VERSION = "1.0"
+MANIFEST_SUFFIX = ".bundle.manifest.json"
+
+
+class McpProtocolError(ValueError):
+    """JSON-RPC error that can be returned without leaking a traceback."""
+
+    def __init__(self, code: int, message: str, data: Any = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.data = data
+
+
+def _read_annotations() -> dict[str, bool]:
+    return {
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+    }
+
+
+def _tool_definitions(enable_snapshot_create: bool) -> list[dict[str, Any]]:
+    tools: list[dict[str, Any]] = [
+        {
+            "name": "ask_context",
+            "title": "RepoBrief context pack",
+            "description": "Build a cited context pack from one existing RepoBrief bundle.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "bundle_manifest": {"type": "string"},
+                    "query": {"type": "string"},
+                    "task_profile": {"type": "string", "default": "basic_repo_question"},
+                    "max_context_tokens": {"type": "integer", "minimum": 1, "default": 8000},
+                    "max_answer_tokens": {"type": "integer", "minimum": 1, "default": 1200},
+                    "k": {"type": "integer", "minimum": 1, "maximum": 100, "default": 5},
+                },
+                "required": ["bundle_manifest", "query"],
+                "additionalProperties": False,
+            },
+            "annotations": _read_annotations(),
+        },
+        {
+            "name": "grounding_verify",
+            "title": "RepoBrief grounding verifier",
+            "description": "Verify declared citations and ranges against an existing RepoBrief bundle.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "declaration": {"type": "object"},
+                    "bundle_manifest": {"type": "string"},
+                    "citation_map": {"type": ["string", "null"]},
+                    "task_profile": {"type": ["string", "null"]},
+                },
+                "required": ["declaration", "bundle_manifest"],
+                "additionalProperties": False,
+            },
+            "annotations": _read_annotations(),
+        },
+        {
+            "name": "live_freshness",
+            "title": "RepoBrief live freshness",
+            "description": (
+                "Compare snapshot Git provenance with the configured local checkout "
+                "without refreshing it."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {"bundle_manifest": {"type": "string"}},
+                "required": ["bundle_manifest"],
+                "additionalProperties": False,
+            },
+            "annotations": _read_annotations(),
+        },
+        {
+            "name": "find_symbol",
+            "title": "RepoBrief symbol locator",
+            "description": (
+                "Locate Python symbol definitions (function/class/async_function) by name "
+                "in an existing RepoBrief bundle. Answers 'where is X defined?' with an "
+                "exact path and line range."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "bundle_manifest": {"type": "string"},
+                    "name": {"type": "string", "minLength": 1},
+                    "kind": {
+                        "type": ["string", "null"],
+                        "enum": [None, "class", "function", "async_function"],
+                    },
+                    "path": {"type": ["string", "null"]},
+                    "k": {"type": "integer", "minimum": 1, "maximum": 200, "default": 25},
+                },
+                "required": ["bundle_manifest", "name"],
+                "additionalProperties": False,
+            },
+            "annotations": _read_annotations(),
+        },
+    ]
+    if enable_snapshot_create:
+        tools.append(
+            {
+                "name": "snapshot_create",
+                "title": "RepoBrief snapshot create",
+                "description": (
+                    "Create RepoBrief bundle artifacts for the startup-bound repository "
+                    "inside the startup-bound bundle root."
+                ),
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "profile": {"type": "string"},
+                        "output_subdir": {"type": ["string", "null"]},
+                        "output_mode": {"type": ["string", "null"]},
+                        "timeout_seconds": {"type": "integer", "minimum": 1, "maximum": 1800},
+                        "max_file_bytes": {"type": "string"},
+                        "max_total_bytes": {"type": "string"},
+                        "split_size": {"type": "string"},
+                        "include_hidden": {"type": "boolean"},
+                        "path_filter": {"type": ["string", "null"]},
+                        "ext": {"type": ["array", "null"], "items": {"type": "string"}},
+                        "redact_secrets": {"type": "boolean"},
+                    },
+                    "required": ["profile"],
+                    "additionalProperties": False,
+                },
+                "annotations": {
+                    "readOnlyHint": False,
+                    "destructiveHint": False,
+                    "idempotentHint": False,
+                },
+            }
+        )
+    return tools
+
+
+class RepoBriefMcpStdioServer:
+    """Bind existing RepoBrief handlers to the MCP JSON-RPC lifecycle."""
+
+    def __init__(
+        self,
+        *,
+        bundle_root: str | Path,
+        repo_root: str | Path | None = None,
+        enable_snapshot_create: bool = False,
+    ) -> None:
+        self.bundle_root = Path(bundle_root).expanduser().resolve()
+        if not self.bundle_root.exists():
+            raise ValueError(f"bundle root does not exist: {self.bundle_root}")
+        if self.bundle_root.is_file() and not self.bundle_root.name.endswith(MANIFEST_SUFFIX):
+            raise ValueError("file-valued bundle root must be a *.bundle.manifest.json file")
+        self.repo_root = Path(repo_root).expanduser().resolve() if repo_root is not None else None
+        if self.repo_root is not None and not self.repo_root.is_dir():
+            raise ValueError(f"repo root is not a directory: {self.repo_root}")
+        if enable_snapshot_create and self.repo_root is None:
+            raise ValueError("--enable-snapshot-create requires an explicit --repo-root")
+        self.enable_snapshot_create = enable_snapshot_create
+        self.snapshot_output_root = (
+            self.bundle_root if self.bundle_root.is_dir() else self.bundle_root.parent
+        )
+        self._negotiated = False
+
+    def _initialize(self, params: Mapping[str, Any]) -> dict[str, Any]:
+        requested = params.get("protocolVersion")
+        negotiated = requested if requested in SUPPORTED_PROTOCOL_VERSIONS else PROTOCOL_VERSION
+        self._negotiated = True
+        return {
+            "protocolVersion": negotiated,
+            "capabilities": {
+                "resources": {"subscribe": False, "listChanged": False},
+                "tools": {"listChanged": False},
+            },
+            "serverInfo": {"name": SERVER_NAME, "title": "RepoBrief", "version": SERVER_VERSION},
+            "instructions": (
+                "RepoBrief reads existing deterministic bundles. Reads never refresh snapshots. "
+                "Use live_freshness before relying on a snapshot. snapshot_create is exposed only "
+                "when the operator starts the server with --enable-snapshot-create."
+            ),
+        }
+
+    def _require_operation(self) -> None:
+        if not self._negotiated:
+            raise McpProtocolError(-32002, "server is not initialized")
+
+    def _guard_manifest(self, raw_path: Any) -> Path:
+        if not isinstance(raw_path, str) or not raw_path:
+            raise McpProtocolError(-32602, "bundle_manifest must be a non-empty string")
+        manifest = Path(raw_path).expanduser().resolve()
+        if not manifest.name.endswith(MANIFEST_SUFFIX):
+            raise McpProtocolError(-32602, "bundle_manifest must name a RepoBrief bundle manifest")
+        if self.bundle_root.is_file():
+            allowed = manifest == self.bundle_root
+        else:
+            try:
+                manifest.relative_to(self.bundle_root)
+            except ValueError:
+                allowed = False
+            else:
+                allowed = True
+        if not allowed:
+            raise McpProtocolError(-32602, "bundle_manifest is outside the configured bundle root")
+        if not manifest.is_file():
+            raise McpProtocolError(-32602, "bundle_manifest does not exist")
+        return manifest
+
+    @staticmethod
+    def _guard_bundle_path(raw_path: Any, manifest: Path, *, label: str) -> str | None:
+        if raw_path is None:
+            return None
+        if not isinstance(raw_path, str) or not raw_path:
+            raise McpProtocolError(-32602, f"{label} must be null or a non-empty string")
+        path = Path(raw_path).expanduser().resolve()
+        try:
+            path.relative_to(manifest.parent.resolve())
+        except ValueError as exc:
+            raise McpProtocolError(-32602, f"{label} is outside the bundle directory") from exc
+        if not path.is_file():
+            raise McpProtocolError(-32602, f"{label} does not exist")
+        return str(path)
+
+    def _safe_live_freshness(
+        self,
+        manifest: str | Path,
+        repo_root: str | Path | None = None,
+    ) -> dict[str, Any]:
+        selected_root = self.repo_root if repo_root is None else repo_root
+        if selected_root is None:
+            return {
+                "kind": "repobrief.live_freshness",
+                "version": "v1",
+                "status": "not_comparable",
+                "reason": "repo_root_not_configured",
+                "bundle_manifest": str(manifest),
+                "repo_root": None,
+                "read_only_git_probe": False,
+                "implicit_refresh": False,
+                "does_not_establish": list(FRESHNESS_DOES_NOT_ESTABLISH),
+            }
+        try:
+            return evaluate_live_freshness(manifest, repo_root=selected_root)
+        except Exception as exc:
+            return {
+                "kind": "repobrief.live_freshness",
+                "version": "v1",
+                "status": "unknown",
+                "reason": str(exc),
+                "bundle_manifest": str(manifest),
+                "repo_root": str(selected_root),
+                "read_only_git_probe": True,
+                "implicit_refresh": False,
+                "does_not_establish": list(FRESHNESS_DOES_NOT_ESTABLISH),
+            }
+
+    def _resource_list(self) -> dict[str, Any]:
+        listed = repobrief_mcp_resources.list_mcp_resources(self.bundle_root)
+        resources = []
+        for item in listed.get("resources", []):
+            if not isinstance(item, dict) or not isinstance(item.get("uri"), str):
+                continue
+            resource_name = item.get("resource")
+            mime_type = (
+                "text/markdown"
+                if resource_name in {"canonical", "reading-pack"}
+                else "application/json"
+            )
+            resources.append(
+                {
+                    "uri": item["uri"],
+                    "name": item["uri"],
+                    "description": "Existing RepoBrief bundle resource; no implicit refresh.",
+                    "mimeType": mime_type,
+                }
+            )
+        return {"resources": resources}
+
+    def _resource_templates(self) -> dict[str, Any]:
+        return {
+            "resourceTemplates": [
+                {
+                    "uriTemplate": uri_template,
+                    "name": uri_template,
+                    "description": "Read-only RepoBrief snapshot resource template.",
+                    "mimeType": "application/json",
+                }
+                for uri_template in repobrief_mcp_resources.resource_templates().get(
+                    "templates", []
+                )
+            ]
+        }
+
+    def _resource_read(self, params: Mapping[str, Any]) -> dict[str, Any]:
+        uri = params.get("uri")
+        if not isinstance(uri, str) or not uri:
+            raise McpProtocolError(-32602, "resources/read requires a non-empty uri")
+        result = repobrief_mcp_resources.read_mcp_resource(uri, bundle_root=self.bundle_root)
+        manifest = result.get("bundle_manifest")
+        live = None
+        if isinstance(manifest, str) and manifest:
+            live = self._safe_live_freshness(self._guard_manifest(manifest))
+        text = result.get("content_text")
+        if not isinstance(text, str):
+            text = json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True)
+        content_type = result.get("content_type")
+        mime_type = content_type if isinstance(content_type, str) else "application/json"
+        return {
+            "contents": [{"uri": uri, "mimeType": mime_type, "text": text}],
+            "_meta": {
+                "repobrief": {
+                    "status": result.get("status"),
+                    "snapshotContext": result.get("snapshot_context"),
+                    "liveFreshness": live,
+                    "implicitRefresh": False,
+                }
+            },
+        }
+
+    def _call_ask_context(self, arguments: Mapping[str, Any]) -> dict[str, Any]:
+        call_args = dict(arguments)
+        manifest = self._guard_manifest(call_args.get("bundle_manifest"))
+        call_args["bundle_manifest"] = str(manifest)
+        payload = repobrief_mcp_tools.ask_context(**call_args)
+        payload["live_freshness"] = self._safe_live_freshness(manifest)
+        return payload
+
+    def _call_grounding_verify(self, arguments: Mapping[str, Any]) -> dict[str, Any]:
+        call_args = dict(arguments)
+        manifest = self._guard_manifest(call_args.get("bundle_manifest"))
+        call_args["bundle_manifest"] = str(manifest)
+        call_args["citation_map"] = self._guard_bundle_path(
+            call_args.get("citation_map"),
+            manifest,
+            label="citation_map",
+        )
+        payload = repobrief_mcp_tools.grounding_verify(**call_args)
+        payload["live_freshness"] = self._safe_live_freshness(manifest)
+        return payload
+
+    def _call_find_symbol(self, arguments: Mapping[str, Any]) -> dict[str, Any]:
+        call_args = dict(arguments)
+        # Fail closed at the transport boundary: reject an empty name (which would
+        # otherwise list the first k symbols) or an unknown kind, independent of
+        # any client-side inputSchema enforcement.
+        name = call_args.get("name")
+        if not isinstance(name, str) or not name.strip():
+            raise McpProtocolError(-32602, "find_symbol requires a non-empty name")
+        kind = call_args.get("kind")
+        if kind is not None and kind not in repobrief_mcp_tools.FIND_SYMBOL_KINDS:
+            raise McpProtocolError(
+                -32602,
+                "find_symbol kind must be one of class, function, async_function, or null",
+                {"allowed_kinds": list(repobrief_mcp_tools.FIND_SYMBOL_KINDS)},
+            )
+        manifest = self._guard_manifest(call_args.get("bundle_manifest"))
+        call_args["bundle_manifest"] = str(manifest)
+        payload = repobrief_mcp_tools.find_symbol(**call_args)
+        # Nav results reflect the snapshot; surface freshness so the agent knows
+        # whether the index may lag the live working tree.
+        payload["live_freshness"] = self._safe_live_freshness(manifest)
+        return payload
+
+    def _call_snapshot_create(self, arguments: Mapping[str, Any]) -> dict[str, Any]:
+        if not self.enable_snapshot_create or self.repo_root is None:
+            raise McpProtocolError(-32602, "snapshot_create is disabled")
+        forbidden = sorted({"repo", "output_root"}.intersection(arguments))
+        if forbidden:
+            raise McpProtocolError(
+                -32602,
+                "snapshot_create repository and output roots are fixed at server startup",
+                {"forbidden_arguments": forbidden},
+            )
+        call_args = dict(arguments)
+        call_args["repo"] = str(self.repo_root)
+        call_args["output_root"] = str(self.snapshot_output_root)
+        return repobrief_mcp_tools.snapshot_create(**call_args)
+
+    def _tool_payload(self, name: str, arguments: Mapping[str, Any]) -> dict[str, Any]:
+        if name == "ask_context":
+            return self._call_ask_context(arguments)
+        if name == "grounding_verify":
+            return self._call_grounding_verify(arguments)
+        if name == "live_freshness":
+            manifest = self._guard_manifest(arguments.get("bundle_manifest"))
+            return self._safe_live_freshness(manifest)
+        if name == "find_symbol":
+            return self._call_find_symbol(arguments)
+        if name == "snapshot_create":
+            return self._call_snapshot_create(arguments)
+        raise McpProtocolError(-32602, f"unknown or disabled tool: {name}")
+
+    def _tool_call(self, params: Mapping[str, Any]) -> dict[str, Any]:
+        name = params.get("name")
+        arguments = params.get("arguments", {})
+        if not isinstance(name, str) or not isinstance(arguments, dict):
+            raise McpProtocolError(-32602, "tools/call requires name and object arguments")
+        try:
+            payload = self._tool_payload(name, arguments)
+        except McpProtocolError:
+            raise
+        except Exception as exc:
+            error_payload = {"status": "error", "tool": name, "error": str(exc)}
+            return {
+                "content": [
+                    {"type": "text", "text": json.dumps(error_payload, ensure_ascii=False)}
+                ],
+                "structuredContent": error_payload,
+                "isError": True,
+            }
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True),
+                }
+            ],
+            "structuredContent": payload,
+            "isError": False,
+        }
+
+    def dispatch(self, method: str, params: Mapping[str, Any]) -> dict[str, Any]:
+        if method == "initialize":
+            return self._initialize(params)
+        if method == "ping":
+            return {}
+        self._require_operation()
+        if method == "tools/list":
+            return {"tools": _tool_definitions(self.enable_snapshot_create)}
+        if method == "tools/call":
+            return self._tool_call(params)
+        if method == "resources/list":
+            return self._resource_list()
+        if method == "resources/templates/list":
+            return self._resource_templates()
+        if method == "resources/read":
+            return self._resource_read(params)
+        raise McpProtocolError(-32601, f"method not found: {method}")
+
+    def handle_message(self, message: Any) -> dict[str, Any] | None:
+        if not isinstance(message, dict) or message.get("jsonrpc") != "2.0":
+            return _error_response(None, -32600, "invalid JSON-RPC request")
+        method = message.get("method")
+        if not isinstance(method, str):
+            return _error_response(message.get("id"), -32600, "request method is required")
+        if "id" not in message:
+            return None
+        request_id = message.get("id")
+        params = message.get("params", {})
+        if not isinstance(params, dict):
+            return _error_response(request_id, -32602, "params must be an object")
+        try:
+            result = self.dispatch(method, params)
+        except McpProtocolError as exc:
+            return _error_response(request_id, exc.code, exc.message, exc.data)
+        except Exception as exc:
+            return _error_response(request_id, -32603, "internal error", {"detail": str(exc)})
+        return {"jsonrpc": "2.0", "id": request_id, "result": result}
+
+
+def _error_response(request_id: Any, code: int, message: str, data: Any = None) -> dict[str, Any]:
+    error: dict[str, Any] = {"code": code, "message": message}
+    if data is not None:
+        error["data"] = data
+    return {"jsonrpc": "2.0", "id": request_id, "error": error}
+
+
+def serve_stdio(
+    server: RepoBriefMcpStdioServer,
+    input_stream: TextIO = sys.stdin,
+    output_stream: TextIO = sys.stdout,
+) -> int:
+    for raw_line in input_stream:
+        try:
+            message = json.loads(raw_line)
+        except json.JSONDecodeError:
+            response = _error_response(None, -32700, "parse error")
+        else:
+            response = server.handle_message(message)
+        if response is not None:
+            output_stream.write(
+                json.dumps(response, ensure_ascii=False, separators=(",", ":")) + "\n"
+            )
+            output_stream.flush()
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Serve RepoBrief over MCP stdio.")
+    parser.add_argument(
+        "--bundle-root",
+        required=True,
+        help="Directory or exact RepoBrief bundle manifest.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        help="Optional explicit local checkout for live freshness comparison.",
+    )
+    parser.add_argument(
+        "--enable-snapshot-create",
+        action="store_true",
+        help=(
+            "Expose snapshot_create bound to --repo-root and --bundle-root. "
+            "Requires --repo-root and is disabled by default."
+        ),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        server = RepoBriefMcpStdioServer(
+            bundle_root=args.bundle_root,
+            repo_root=args.repo_root,
+            enable_snapshot_create=args.enable_snapshot_create,
+        )
+    except ValueError as exc:
+        print(f"repobrief mcp stdio: {exc}", file=sys.stderr)
+        return 2
+    return serve_stdio(server)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/merger/lenskit/core/repobrief_access.py
+++ b/merger/lenskit/core/repobrief_access.py
@@ -1,0 +1,1378 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+_DOES_NOT_ESTABLISH = (
+    "truth",
+    "correctness",
+    "completeness",
+    "runtime_behavior",
+    "test_sufficiency",
+    "regression_absence",
+    "repo_understood",
+    "claims_true",
+    "forensic_ready",
+    "freshness",
+)
+
+CITATION_MAP_ROLE = "citation_map_jsonl"
+RESOLVED_EVIDENCE_KIND = "repobrief.resolved_evidence"
+RESOLVED_EVIDENCE_VERSION = "v1"
+SOURCE_CITATION_PROJECTION_KIND = "repobrief.source_citation_projection"
+SOURCE_CITATION_PROJECTION_VERSION = "v1"
+TEXT_EXCERPT_MAX_CHARS = 1200
+_CITATION_ID_RE = re.compile(r"^cit_[a-f0-9]{16}$")
+_SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
+_CITATION_RANGE_KEY_FIELDS = ("file_path", "start_byte", "end_byte")
+
+
+def _read_json_object(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(f"bundle manifest does not exist: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"bundle manifest is not valid JSON: {path}") from exc
+    if not isinstance(data, dict):
+        raise ValueError("bundle manifest must be a JSON object")
+    return data
+
+
+def _artifact_list(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    artifacts = manifest.get("artifacts", [])
+    if not isinstance(artifacts, list):
+        raise ValueError("bundle manifest artifacts must be an array")
+    return [a for a in artifacts if isinstance(a, dict)]
+
+
+def _safe_artifact_path(root: Path, raw_path: Any) -> Path | None:
+    if not isinstance(raw_path, str) or not raw_path:
+        return None
+    candidate = (root / raw_path).resolve()
+    try:
+        candidate.relative_to(root.resolve())
+    except ValueError:
+        return None
+    return candidate
+
+
+def _artifact_record(bundle_manifest: Path, artifact: dict[str, Any]) -> dict[str, Any]:
+    root = bundle_manifest.parent
+    artifact_path = _safe_artifact_path(root, artifact.get("path"))
+    file_exists = bool(artifact_path and artifact_path.exists())
+    return {
+        "role": artifact.get("role"),
+        "path": artifact.get("path"),
+        "absolute_path": str(artifact_path) if artifact_path else None,
+        "file_exists": file_exists,
+        "content_type": artifact.get("content_type"),
+        "bytes": artifact.get("bytes"),
+        "sha256": artifact.get("sha256"),
+        "authority": artifact.get("authority"),
+        "canonicality": artifact.get("canonicality"),
+        "risk_class": artifact.get("risk_class"),
+        "contract": artifact.get("contract"),
+        "interpretation": artifact.get("interpretation"),
+    }
+
+
+def available_roles(bundle_manifest: str | Path) -> list[str]:
+    manifest_path = Path(bundle_manifest).expanduser().resolve()
+    manifest = _read_json_object(manifest_path)
+    roles: set[str] = {"bundle_manifest"}
+    for artifact in _artifact_list(manifest):
+        role = artifact.get("role")
+        if isinstance(role, str) and role:
+            roles.add(role)
+    links = manifest.get("links")
+    if isinstance(links, dict):
+        linked_roles = {
+            "post_emit_health_path": "post_emit_health",
+            "bundle_surface_validation_path": "bundle_surface_validation",
+            "export_safety_report_path": "export_safety_report",
+        }
+        for key, role in linked_roles.items():
+            if links.get(key):
+                roles.add(role)
+    return sorted(roles)
+
+
+def resolve_required_reading_for_bundle(
+    bundle_manifest: str | Path,
+    task_profile: str,
+) -> dict[str, Any]:
+    from merger.lenskit.core.required_reading import (
+        default_required_reading_protocol,
+        resolve_required_reading,
+    )
+
+    manifest_path = Path(bundle_manifest).expanduser().resolve()
+    roles = available_roles(manifest_path)
+    required = resolve_required_reading(
+        default_required_reading_protocol(),
+        set(roles),
+        task_profile,
+    )
+    return {
+        "kind": "repobrief.required_reading_resolution",
+        "version": "v1",
+        "status": required.get("status"),
+        "bundle_manifest": str(manifest_path),
+        "task_profile": task_profile,
+        "available_roles": roles,
+        "required_reading": required,
+        "mutation_boundary": {
+            "writes": [],
+            "does_not_mutate": ["git", "pull_requests", "patches", "source_working_tree", "brief_bundle_artifacts"],
+            "read_paths_do_not_refresh": True,
+        },
+        "does_not_establish": list(_DOES_NOT_ESTABLISH),
+    }
+
+
+def snapshot_status(bundle_manifest: str | Path) -> dict[str, Any]:
+    manifest_path = Path(bundle_manifest).expanduser().resolve()
+    manifest = _read_json_object(manifest_path)
+    artifacts = [_artifact_record(manifest_path, a) for a in _artifact_list(manifest)]
+    roles = sorted(str(a["role"]) for a in artifacts if isinstance(a.get("role"), str))
+    capabilities = manifest.get("capabilities") if isinstance(manifest.get("capabilities"), dict) else {}
+    from merger.lenskit.core.repobrief_availability import snapshot_availability_model
+
+    availability_model = snapshot_availability_model(manifest_path, manifest)
+    return {
+        "kind": "repobrief.snapshot_status",
+        "version": "v1",
+        "status": "ok",
+        "bundle_manifest": str(manifest_path),
+        "bundle_run_id": manifest.get("run_id"),
+        "profile": capabilities.get("repobrief_profile"),
+        "profile_evaluation": capabilities.get("repobrief_profile_evaluation"),
+        "availability_model": availability_model,
+        "freshness": availability_model.get("freshness"),
+        "artifact_count": len(artifacts),
+        "roles": roles,
+        "artifacts": artifacts,
+        "mutation_boundary": {
+            "writes": [],
+            "does_not_mutate": ["git", "pull_requests", "patches", "source_working_tree", "brief_bundle_artifacts"],
+            "read_paths_do_not_refresh": True,
+        },
+        "does_not_establish": list(_DOES_NOT_ESTABLISH),
+    }
+
+
+def list_artifacts(bundle_manifest: str | Path) -> dict[str, Any]:
+    status = snapshot_status(bundle_manifest)
+    return {
+        "kind": "repobrief.artifact_list",
+        "version": "v1",
+        "status": status["status"],
+        "bundle_manifest": status["bundle_manifest"],
+        "bundle_run_id": status["bundle_run_id"],
+        "profile": status["profile"],
+        "artifact_count": status["artifact_count"],
+        "roles": status["roles"],
+        "artifacts": status["artifacts"],
+        "mutation_boundary": status["mutation_boundary"],
+        "does_not_establish": status["does_not_establish"],
+    }
+
+
+def get_artifact(bundle_manifest: str | Path, role: str) -> dict[str, Any]:
+    manifest_path = Path(bundle_manifest).expanduser().resolve()
+    manifest = _read_json_object(manifest_path)
+    matches = [a for a in _artifact_list(manifest) if a.get("role") == role]
+    if not matches:
+        return {
+            "kind": "repobrief.artifact_ref",
+            "version": "v1",
+            "status": "missing",
+            "bundle_manifest": str(manifest_path),
+            "role": role,
+            "artifact": None,
+            "mutation_boundary": {
+                "writes": [],
+                "does_not_mutate": ["git", "pull_requests", "patches", "source_working_tree", "brief_bundle_artifacts"],
+                "read_paths_do_not_refresh": True,
+            },
+            "does_not_establish": list(_DOES_NOT_ESTABLISH),
+        }
+    return {
+        "kind": "repobrief.artifact_ref",
+        "version": "v1",
+        "status": "available",
+        "bundle_manifest": str(manifest_path),
+        "role": role,
+        "artifact": _artifact_record(manifest_path, matches[0]),
+        "mutation_boundary": {
+            "writes": [],
+            "does_not_mutate": ["git", "pull_requests", "patches", "source_working_tree", "brief_bundle_artifacts"],
+            "read_paths_do_not_refresh": True,
+        },
+        "does_not_establish": list(_DOES_NOT_ESTABLISH),
+    }
+
+
+MAX_QUERY_EXISTING_INDEX_K = 100
+
+
+def _read_only_mutation_boundary() -> dict[str, Any]:
+    return {
+        "writes": [],
+        "does_not_mutate": [
+            "git",
+            "pull_requests",
+            "patches",
+            "source_working_tree",
+            "brief_bundle_artifacts",
+        ],
+        "read_paths_do_not_refresh": True,
+    }
+
+
+def _invalid_read_result(
+    *,
+    kind: str,
+    bundle_manifest: Path,
+    status: str,
+    error: str,
+    error_code: str,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    result = {
+        "kind": kind,
+        "version": "v1",
+        "status": status,
+        "bundle_manifest": str(bundle_manifest),
+        "error": error,
+        "error_code": error_code,
+        "mutation_boundary": _read_only_mutation_boundary(),
+        "does_not_establish": list(_DOES_NOT_ESTABLISH),
+    }
+    if extra:
+        result.update(extra)
+    return result
+
+
+def _range_error_code(exc: Exception) -> tuple[str, str]:
+    if isinstance(exc, FileNotFoundError):
+        return "missing", "missing_artifact"
+    message = str(exc).lower()
+    if "not found in manifest" in message or "not found" in message:
+        return "missing", "missing_artifact"
+    if "hash mismatch" in message or "content hash mismatch" in message:
+        return "invalid", "content_hash_mismatch"
+    if "schema" in message or "range_ref" in message or "artifact_role" in message:
+        return "invalid", "range_ref_invalid"
+    return "invalid", "range_resolution_failed"
+
+
+def range_get(bundle_manifest: str | Path, range_ref: dict[str, Any]) -> dict[str, Any]:
+    manifest_path = Path(bundle_manifest).expanduser().resolve()
+    if not isinstance(range_ref, dict):
+        return _invalid_read_result(
+            kind="repobrief.range_get",
+            bundle_manifest=manifest_path,
+            status="invalid",
+            error="range_ref must be a JSON object",
+            error_code="range_ref_invalid",
+            extra={"range_ref": range_ref, "range": None},
+        )
+
+    if range_ref.get("artifact_role") == "source_file":
+        return _invalid_read_result(
+            kind="repobrief.range_get",
+            bundle_manifest=manifest_path,
+            status="invalid",
+            error=(
+                "source_file range_refs are outside the read-only RepoBrief "
+                "bundle artifact boundary"
+            ),
+            error_code="source_file_outside_bundle_boundary",
+            extra={"range_ref": range_ref, "range": None},
+        )
+
+    from merger.lenskit.core.range_resolver import resolve_range_ref
+
+    try:
+        resolved = resolve_range_ref(manifest_path, range_ref)
+    except Exception as exc:
+        status, error_code = _range_error_code(exc)
+        return _invalid_read_result(
+            kind="repobrief.range_get",
+            bundle_manifest=manifest_path,
+            status=status,
+            error=str(exc),
+            error_code=error_code,
+            extra={"range_ref": range_ref, "range": None},
+        )
+
+    return {
+        "kind": "repobrief.range_get",
+        "version": "v1",
+        "status": "available",
+        "bundle_manifest": str(manifest_path),
+        "range_ref": range_ref,
+        "range": resolved,
+        "mutation_boundary": _read_only_mutation_boundary(),
+        "does_not_establish": list(_DOES_NOT_ESTABLISH),
+    }
+
+
+def _empty_citation_map_status(
+    *,
+    status: str,
+    error_code: str | None,
+    artifact_path: str | None,
+    error: str | None = None,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "status": status,
+        "error_code": error_code,
+        "artifact_path": artifact_path,
+        "row_count": 0,
+        "invalid_row_count": 0,
+    }
+    if error is not None:
+        result["error"] = error
+    return result
+
+
+def _is_non_empty_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value)
+
+
+def _is_sha256(value: Any) -> bool:
+    return isinstance(value, str) and _SHA256_RE.fullmatch(value) is not None
+
+
+def _is_int_not_bool(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _citation_range_key(value: Any) -> tuple[Any, ...] | None:
+    if not isinstance(value, dict):
+        return None
+    file_path, start_byte, end_byte = (
+        value.get(field) for field in _CITATION_RANGE_KEY_FIELDS
+    )
+    content_sha256 = value.get("range_content_sha256") or value.get("content_sha256")
+    if not _is_non_empty_string(file_path):
+        return None
+    if not _is_int_not_bool(start_byte) or not _is_int_not_bool(end_byte):
+        return None
+    if start_byte < 0 or end_byte <= start_byte:
+        return None
+    if not _is_sha256(content_sha256):
+        return None
+    return (file_path, start_byte, end_byte, content_sha256)
+
+
+def _range_ref_from_citation_row(row: dict[str, Any]) -> dict[str, Any] | None:
+    citation_id = row.get("citation_id")
+    repo_id = row.get("repo_id")
+    canonical_range = row.get("canonical_range")
+    if not isinstance(canonical_range, dict) or not _is_non_empty_string(repo_id):
+        return None
+    result = {
+        "artifact_role": "canonical_md",
+        "repo_id": repo_id,
+        "file_path": canonical_range.get("file_path"),
+        "start_byte": canonical_range.get("start_byte"),
+        "end_byte": canonical_range.get("end_byte"),
+        "start_line": canonical_range.get("start_line"),
+        "end_line": canonical_range.get("end_line"),
+        "content_sha256": canonical_range.get("content_sha256"),
+    }
+    chunk_id = row.get("chunk_id")
+    if _is_non_empty_string(chunk_id):
+        result["chunk_id"] = chunk_id
+    # Preserve citation identity outside the strict range_ref itself; range-ref.v1
+    # does not allow citation_id as an additional property.
+    if not _is_non_empty_string(citation_id):
+        return None
+    return result
+
+
+def _range_ref_is_valid_for_citation_row(value: Any, row: dict[str, Any]) -> bool:
+    if not isinstance(value, dict):
+        return False
+    expected = _range_ref_from_citation_row(row)
+    if expected is None:
+        return False
+    for key, expected_value in expected.items():
+        if value.get(key) != expected_value:
+            return False
+    allowed_keys = set(expected) | {"chunk_id"}
+    if set(value) - allowed_keys:
+        return False
+    return True
+
+
+def _citation_row_is_valid(row: dict[str, Any]) -> bool:
+    citation_id = row.get("citation_id")
+    if not isinstance(citation_id, str) or _CITATION_ID_RE.fullmatch(citation_id) is None:
+        return False
+    if not _is_non_empty_string(row.get("repo_id")):
+        return False
+
+    snapshot = row.get("snapshot")
+    if not isinstance(snapshot, dict):
+        return False
+    if not _is_non_empty_string(snapshot.get("run_id")):
+        return False
+    if not _is_non_empty_string(snapshot.get("canonical_md_path")):
+        return False
+    if not _is_sha256(snapshot.get("canonical_md_sha256")):
+        return False
+
+    canonical_range = row.get("canonical_range")
+    if _citation_range_key(canonical_range) is None:
+        return False
+    if not isinstance(canonical_range, dict):
+        return False
+    start_line = canonical_range.get("start_line")
+    end_line = canonical_range.get("end_line")
+    if not _is_int_not_bool(start_line) or not _is_int_not_bool(end_line):
+        return False
+    if start_line < 1 or end_line < start_line:
+        return False
+
+    chunk_id = row.get("chunk_id")
+    if chunk_id is not None and not _is_non_empty_string(chunk_id):
+        return False
+    range_ref = row.get("range_ref")
+    if range_ref is not None and not _range_ref_is_valid_for_citation_row(range_ref, row):
+        return False
+    return True
+
+def _load_citation_lookup(
+    manifest_path: Path,
+) -> tuple[dict[str, dict[str, Any]], dict[tuple[Any, ...], dict[str, Any]], dict[str, Any]]:
+    artifact_result = get_artifact(manifest_path, CITATION_MAP_ROLE)
+    artifact = artifact_result.get("artifact") if isinstance(artifact_result, dict) else None
+    artifact_path_str = artifact.get("absolute_path") if isinstance(artifact, dict) else None
+    if not artifact_path_str:
+        return {}, {}, _empty_citation_map_status(
+            status="missing",
+            error_code="citation_map_jsonl_missing",
+            artifact_path=None,
+        )
+    artifact_path = Path(str(artifact_path_str))
+    if not artifact_path.exists():
+        return {}, {}, _empty_citation_map_status(
+            status="missing",
+            error_code="citation_map_jsonl_file_missing",
+            artifact_path=str(artifact_path),
+        )
+
+    by_chunk_id: dict[str, dict[str, Any]] = {}
+    by_range: dict[tuple[Any, ...], dict[str, Any]] = {}
+    row_count = 0
+    invalid_row_count = 0
+    try:
+        with artifact_path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    invalid_row_count += 1
+                    continue
+                if not isinstance(row, dict) or not _citation_row_is_valid(row):
+                    invalid_row_count += 1
+                    continue
+                row_count += 1
+                chunk_id = row.get("chunk_id")
+                if isinstance(chunk_id, str) and chunk_id and chunk_id not in by_chunk_id:
+                    by_chunk_id[chunk_id] = row
+                range_key = _citation_range_key(row.get("canonical_range"))
+                if range_key is not None and range_key not in by_range:
+                    by_range[range_key] = row
+    except (OSError, UnicodeDecodeError) as exc:
+        return {}, {}, _empty_citation_map_status(
+            status="invalid",
+            error_code="citation_map_jsonl_unreadable",
+            artifact_path=str(artifact_path),
+            error=str(exc),
+        )
+
+    return by_chunk_id, by_range, {
+        "status": "available",
+        "error_code": None,
+        "artifact_path": str(artifact_path),
+        "row_count": row_count,
+        "invalid_row_count": invalid_row_count,
+    }
+
+
+def _citation_record(row: dict[str, Any]) -> dict[str, Any]:
+    emitted_range_ref = row.get("range_ref")
+    range_ref = (
+        emitted_range_ref
+        if _range_ref_is_valid_for_citation_row(emitted_range_ref, row)
+        else _range_ref_from_citation_row(row)
+    )
+    return {
+        "citation_id": row.get("citation_id"),
+        "repo_id": row.get("repo_id"),
+        "chunk_id": row.get("chunk_id"),
+        "snapshot": row.get("snapshot"),
+        "canonical_range": row.get("canonical_range"),
+        "range_ref": range_ref,
+        "source_range": row.get("source_range") if isinstance(row.get("source_range"), dict) else None,
+        "live_repo_address": row.get("live_repo_address") if isinstance(row.get("live_repo_address"), dict) else None,
+        "produced_by": row.get("produced_by"),
+    }
+
+
+def _artifact_availability(availability_model: dict[str, Any] | None, role: str) -> dict[str, Any]:
+    if not isinstance(availability_model, dict):
+        return {
+            "role": role,
+            "availability": "unknown",
+            "requirement": None,
+            "reason": "availability_model_unavailable",
+        }
+    artifacts = availability_model.get("artifacts")
+    if isinstance(artifacts, list):
+        for artifact in artifacts:
+            if isinstance(artifact, dict) and artifact.get("role") == role:
+                return {
+                    "role": role,
+                    "availability": artifact.get("availability"),
+                    "requirement": artifact.get("requirement"),
+                    "reason": artifact.get("reason"),
+                }
+    return {
+        "role": role,
+        "availability": "missing",
+        "requirement": None,
+        "reason": "role_not_reported_in_availability_model",
+    }
+
+
+def _line_range(start_line: Any, end_line: Any) -> dict[str, Any] | None:
+    if not _is_int_not_bool(start_line) or not _is_int_not_bool(end_line):
+        return None
+    if start_line < 1 or end_line < start_line:
+        return None
+    return {
+        "start_line": start_line,
+        "end_line": end_line,
+        "display": f"{start_line}-{end_line}",
+    }
+
+
+def _enrich_resolved_hit_for_direct_use(
+    hit: dict[str, Any],
+    *,
+    availability_model: dict[str, Any] | None,
+) -> None:
+    range_value = hit.get("range")
+    text = range_value.get("text") if isinstance(range_value, dict) else None
+    raw_citation = hit.get("citation")
+    citation = raw_citation if isinstance(raw_citation, dict) else None
+    canonical_range = _source_range_projection(
+        citation.get("canonical_range") if citation else None
+    )
+    citation_source_range = _source_range_projection(
+        citation.get("source_range") if citation else None
+    )
+    live_repo_address = (
+        citation.get("live_repo_address")
+        if citation and isinstance(citation.get("live_repo_address"), dict)
+        else None
+    )
+    range_ref_projection = (
+        _source_range_projection(hit.get("range_ref"))
+        if hit.get("range_status") == "resolved"
+        else None
+    )
+    range_projection = _source_range_projection(range_value)
+    candidates = [citation_source_range, range_ref_projection, canonical_range, range_projection]
+    source_range = next(
+        (candidate for candidate in candidates if _has_range_identity(candidate)),
+        None,
+    )
+    if source_range is None:
+        source_range = next(
+            (candidate for candidate in candidates if isinstance(candidate, dict)),
+            None,
+        )
+
+    source_path = None
+    source_line_range = None
+    artifact_path = None
+    artifact_line_range = None
+    artifact_role = None
+    if isinstance(live_repo_address, dict):
+        source_path = live_repo_address.get("path")
+        source_line_range = _line_range(
+            live_repo_address.get("start_line"),
+            live_repo_address.get("end_line"),
+        )
+    if isinstance(source_range, dict):
+        source_path = _first_not_none(
+            source_path,
+            source_range.get("source_file_path"),
+            source_range.get("file_path"),
+            hit.get("path"),
+        )
+        source_line_range = source_line_range or _line_range(
+            _first_not_none(source_range.get("source_start_line"), source_range.get("start_line")),
+            _first_not_none(source_range.get("source_end_line"), source_range.get("end_line")),
+        )
+        artifact_path = _first_not_none(source_range.get("artifact_path"), source_range.get("file_path"))
+        artifact_line_range = _line_range(
+            _first_not_none(source_range.get("artifact_start_line"), source_range.get("start_line")),
+            _first_not_none(source_range.get("artifact_end_line"), source_range.get("end_line")),
+        )
+        artifact_role = source_range.get("artifact_role")
+    if source_path is None:
+        source_path = hit.get("path")
+
+    hit["text_excerpt"] = text[:TEXT_EXCERPT_MAX_CHARS] if isinstance(text, str) else None
+    hit["text_truncated"] = isinstance(text, str) and len(text) > TEXT_EXCERPT_MAX_CHARS
+    hit["source_path"] = source_path
+    hit["line_range"] = source_line_range or artifact_line_range
+    hit["source_line_range"] = source_line_range
+    hit["artifact_path"] = artifact_path
+    hit["artifact_role"] = artifact_role
+    hit["artifact_line_range"] = artifact_line_range
+    hit["canonical_authority"] = {
+        "authority": "canonical_brief_source",
+        "artifact_role": "canonical_md",
+        "range": canonical_range,
+        "citation_id": hit.get("citation_id"),
+    }
+    hit["live_repo_address"] = live_repo_address
+    hit["live_repo_address_status"] = (
+        live_repo_address.get("status")
+        if isinstance(live_repo_address, dict)
+        else "unavailable"
+    )
+    hit["range_ref_verified"] = hit.get("range_status") == "resolved"
+    hit["citation_verified"] = hit.get("citation_status") == "resolved" and isinstance(
+        hit.get("citation_id"),
+        str,
+    )
+    hit["availability"] = {
+        "snapshot_status": availability_model.get("status")
+        if isinstance(availability_model, dict)
+        else "unknown",
+        "artifact": _artifact_availability(
+            availability_model,
+            str(artifact_role or "canonical_md"),
+        ),
+        "index_artifact": _artifact_availability(availability_model, "sqlite_index"),
+    }
+    hit["freshness"] = (
+        availability_model.get("freshness") if isinstance(availability_model, dict) else None
+    )
+
+
+def _resolve_hit_evidence(
+    manifest_path: Path,
+    hit: dict[str, Any],
+    by_chunk_id: dict[str, dict[str, Any]],
+    by_range: dict[tuple[Any, ...], dict[str, Any]],
+    citation_map_available: bool,
+    *,
+    availability_model: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    range_candidates: list[tuple[str, dict[str, Any]]] = []
+    range_ref = hit.get("range_ref")
+    if isinstance(range_ref, dict):
+        range_candidates.append(("range_ref", range_ref))
+    derived_range_ref = hit.get("derived_range_ref")
+    if isinstance(derived_range_ref, dict):
+        range_candidates.append(("derived_range_ref", derived_range_ref))
+
+    selected_range_ref: dict[str, Any] | None = None
+    range_ref_source = range_candidates[0][0] if range_candidates else None
+
+    record: dict[str, Any] = {
+        "chunk_id": hit.get("chunk_id"),
+        "path": hit.get("path"),
+        "range_ref_source": range_ref_source,
+        "range_ref": None,
+        "range_status": "unresolved",
+        "range": None,
+        "range_error": None,
+        "range_error_code": None,
+        "citation_status": "unmatched" if citation_map_available else "unavailable",
+        "citation_id": None,
+        "citation": None,
+    }
+
+    if not range_candidates:
+        record["range_error_code"] = "range_ref_missing"
+    else:
+        for candidate_source, candidate_ref in range_candidates:
+            range_result = range_get(manifest_path, candidate_ref)
+            record["range_ref_source"] = candidate_source
+            if range_result.get("status") == "available":
+                selected_range_ref = candidate_ref
+                record["range_ref"] = selected_range_ref
+                record["range_status"] = "resolved"
+                record["range"] = range_result.get("range")
+                record["range_error"] = None
+                record["range_error_code"] = None
+                break
+            record["range_error"] = range_result.get("error")
+            record["range_error_code"] = range_result.get("error_code")
+
+    if citation_map_available:
+        row = None
+        chunk_id = hit.get("chunk_id")
+        if isinstance(chunk_id, str):
+            row = by_chunk_id.get(chunk_id)
+        range_key = _citation_range_key(selected_range_ref)
+        if row is None and range_key is not None:
+            row = by_range.get(range_key)
+        if row is not None:
+            record["citation_status"] = "resolved"
+            record["citation_id"] = row.get("citation_id")
+            record["citation"] = _citation_record(row)
+
+    _enrich_resolved_hit_for_direct_use(record, availability_model=availability_model)
+    return record
+
+
+def _availability_model_for_manifest(manifest_path: Path) -> dict[str, Any]:
+    from merger.lenskit.core.repobrief_availability import snapshot_availability_model
+
+    manifest = _read_json_object(manifest_path)
+    return snapshot_availability_model(manifest_path, manifest)
+
+
+def _resolve_query_evidence(
+    manifest_path: Path,
+    query_result: Any,
+    *,
+    availability_model: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    hits = query_result.get("results") if isinstance(query_result, dict) else None
+    hit_list = [hit for hit in (hits if isinstance(hits, list) else []) if isinstance(hit, dict)]
+    if availability_model is None:
+        availability_model = _availability_model_for_manifest(manifest_path)
+    freshness = availability_model.get("freshness") if isinstance(availability_model, dict) else None
+    if not hit_list:
+        return {
+            "kind": RESOLVED_EVIDENCE_KIND,
+            "version": RESOLVED_EVIDENCE_VERSION,
+            "availability": availability_model,
+            "freshness": freshness,
+            "citation_map": {
+                "status": "skipped",
+                "error_code": None,
+                "artifact_path": None,
+                "row_count": 0,
+                "invalid_row_count": 0,
+                "reason": "no_hits",
+            },
+            "hit_count": 0,
+            "hits": [],
+            "does_not_establish": list(_DOES_NOT_ESTABLISH),
+        }
+
+    by_chunk_id, by_range, citation_map_status = _load_citation_lookup(manifest_path)
+    citation_map_available = citation_map_status["status"] == "available"
+    resolved_hits = [
+        _resolve_hit_evidence(
+            manifest_path,
+            hit,
+            by_chunk_id,
+            by_range,
+            citation_map_available,
+            availability_model=availability_model,
+        )
+        for hit in hit_list
+    ]
+    return {
+        "kind": RESOLVED_EVIDENCE_KIND,
+        "version": RESOLVED_EVIDENCE_VERSION,
+        "availability": availability_model,
+        "freshness": freshness,
+        "citation_map": citation_map_status,
+        "hit_count": len(resolved_hits),
+        "hits": resolved_hits,
+        "does_not_establish": list(_DOES_NOT_ESTABLISH),
+    }
+
+
+def _first_not_none(*values: Any) -> Any:
+    for value in values:
+        if value is not None:
+            return value
+    return None
+
+
+def _line_pair(value: Any) -> tuple[int | None, int | None]:
+    if not isinstance(value, list) or len(value) != 2:
+        return None, None
+    start, end = value
+    if isinstance(start, bool) or isinstance(end, bool):
+        return None, None
+    if not isinstance(start, int) or not isinstance(end, int):
+        return None, None
+    return start, end
+
+
+def _has_range_identity(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+    file_path = value.get("file_path")
+    start_byte = value.get("start_byte")
+    end_byte = value.get("end_byte")
+    if not _is_non_empty_string(file_path):
+        return False
+    if not _is_int_not_bool(start_byte) or not _is_int_not_bool(end_byte):
+        return False
+    return start_byte >= 0 and end_byte > start_byte
+
+
+def _source_range_projection(range_value: Any) -> dict[str, Any] | None:
+    if not isinstance(range_value, dict):
+        return None
+    provenance = range_value.get("provenance")
+    if not isinstance(provenance, dict):
+        provenance = {}
+    start_line, end_line = _line_pair(range_value.get("lines"))
+    artifact_path = _first_not_none(
+        range_value.get("artifact_path"),
+        range_value.get("file_path"),
+        range_value.get("path"),
+        provenance.get("artifact_path"),
+        provenance.get("file_path"),
+    )
+    artifact_start_byte = _first_not_none(
+        range_value.get("artifact_byte_start"),
+        range_value.get("start_byte"),
+        provenance.get("artifact_byte_start"),
+        provenance.get("start_byte"),
+    )
+    artifact_end_byte = _first_not_none(
+        range_value.get("artifact_byte_end"),
+        range_value.get("end_byte"),
+        provenance.get("artifact_byte_end"),
+        provenance.get("end_byte"),
+    )
+    artifact_start_line = _first_not_none(
+        range_value.get("artifact_line_start"),
+        range_value.get("start_line"),
+        start_line,
+    )
+    artifact_end_line = _first_not_none(
+        range_value.get("artifact_line_end"),
+        range_value.get("end_line"),
+        end_line,
+    )
+    source_file_path = _first_not_none(
+        range_value.get("source_file_path"),
+        provenance.get("source_file_path"),
+    )
+    source_start_line = _first_not_none(
+        range_value.get("source_line_start"),
+        provenance.get("source_line_start"),
+    )
+    source_end_line = _first_not_none(
+        range_value.get("source_line_end"),
+        provenance.get("source_line_end"),
+    )
+    has_source_axis = _is_non_empty_string(source_file_path)
+    return {
+        "artifact_role": _first_not_none(range_value.get("artifact_role"), provenance.get("artifact_role")),
+        "file_path": artifact_path,
+        "start_byte": artifact_start_byte,
+        "end_byte": artifact_end_byte,
+        "start_line": artifact_start_line,
+        "end_line": artifact_end_line,
+        "content_sha256": _first_not_none(range_value.get("range_content_sha256"), range_value.get("content_sha256"), range_value.get("sha256")),
+        "artifact_path": artifact_path,
+        "artifact_start_byte": artifact_start_byte,
+        "artifact_end_byte": artifact_end_byte,
+        "artifact_start_line": artifact_start_line,
+        "artifact_end_line": artifact_end_line,
+        "source_file_path": source_file_path,
+        "source_start_line": source_start_line,
+        "source_end_line": source_end_line,
+        "coordinate_basis": "artifact_bytes_with_source_lines" if has_source_axis else "artifact_bytes",
+    }
+
+
+def _empty_source_citation_projection(status: str = "unavailable") -> dict[str, Any]:
+    return {
+        "kind": SOURCE_CITATION_PROJECTION_KIND,
+        "version": SOURCE_CITATION_PROJECTION_VERSION,
+        "status": status,
+        "hit_count": 0,
+        "citation_count": 0,
+        "unresolved_count": 0,
+        "range_unresolved_count": 0,
+        "citation_unresolved_count": 0,
+        "text_excerpt_max_chars": TEXT_EXCERPT_MAX_CHARS,
+        "items": [],
+        "does_not_establish": list(_DOES_NOT_ESTABLISH),
+    }
+
+
+def _project_source_citations(resolved_evidence: Any) -> dict[str, Any]:
+    if not isinstance(resolved_evidence, dict):
+        return _empty_source_citation_projection()
+
+    hits = resolved_evidence.get("hits")
+    hit_list = [hit for hit in (hits if isinstance(hits, list) else []) if isinstance(hit, dict)]
+    items: list[dict[str, Any]] = []
+    citation_count = 0
+    unresolved_count = 0
+    range_unresolved_count = 0
+    citation_unresolved_count = 0
+    for ordinal, hit in enumerate(hit_list):
+        range_value = hit.get("range")
+        text = range_value.get("text") if isinstance(range_value, dict) else None
+        raw_citation = hit.get("citation")
+        citation = raw_citation if isinstance(raw_citation, dict) else None
+        citation_range = _source_range_projection(
+            citation.get("canonical_range") if citation else None
+        )
+        citation_source_range = _source_range_projection(
+            citation.get("source_range") if citation else None
+        )
+        live_repo_address = (
+            citation.get("live_repo_address")
+            if citation and isinstance(citation.get("live_repo_address"), dict)
+            else None
+        )
+        range_ref_projection = (
+            _source_range_projection(hit.get("range_ref"))
+            if hit.get("range_status") == "resolved"
+            else None
+        )
+        range_projection = _source_range_projection(range_value)
+        candidates = [citation_source_range, range_ref_projection, citation_range, range_projection]
+        source_range = next(
+            (candidate for candidate in candidates if _has_range_identity(candidate)),
+            None,
+        )
+        if source_range is None:
+            source_range = next(
+                (candidate for candidate in candidates if isinstance(candidate, dict)),
+                None,
+            )
+        range_status = hit.get("range_status")
+        citation_status = hit.get("citation_status")
+        citation_id = hit.get("citation_id")
+        if range_status != "resolved":
+            range_unresolved_count += 1
+        citation_resolved = (
+            citation_status == "resolved"
+            and isinstance(citation_id, str)
+            and _CITATION_ID_RE.fullmatch(citation_id) is not None
+        )
+        if citation_resolved:
+            citation_count += 1
+        else:
+            citation_unresolved_count += 1
+        if range_status != "resolved" or not citation_resolved:
+            unresolved_count += 1
+        items.append({
+            "ordinal": ordinal,
+            "chunk_id": hit.get("chunk_id"),
+            "path": hit.get("path"),
+            "range_status": range_status,
+            "range_ref_source": hit.get("range_ref_source"),
+            "source_range": source_range,
+            "text_excerpt": text[:TEXT_EXCERPT_MAX_CHARS] if isinstance(text, str) else None,
+            "text_truncated": isinstance(text, str) and len(text) > TEXT_EXCERPT_MAX_CHARS,
+            "citation_status": citation_status,
+            "citation_resolved": citation_resolved,
+            "citation_id": citation_id,
+            "citation_range": citation_range,
+            "citation_source_range": citation_source_range,
+            "live_repo_address": live_repo_address,
+            "live_repo_address_status": (
+                live_repo_address.get("status")
+                if isinstance(live_repo_address, dict)
+                else "unavailable"
+            ),
+            "canonical_authority": {
+                "authority": "canonical_brief_source",
+                "artifact_role": "canonical_md",
+                "range": citation_range,
+                "citation_id": citation_id,
+            },
+        })
+    return {
+        "kind": SOURCE_CITATION_PROJECTION_KIND,
+        "version": SOURCE_CITATION_PROJECTION_VERSION,
+        "status": "available",
+        "hit_count": len(items),
+        "citation_count": citation_count,
+        "unresolved_count": unresolved_count,
+        "range_unresolved_count": range_unresolved_count,
+        "citation_unresolved_count": citation_unresolved_count,
+        "text_excerpt_max_chars": TEXT_EXCERPT_MAX_CHARS,
+        "items": items,
+        "does_not_establish": list(_DOES_NOT_ESTABLISH),
+    }
+
+
+def query_existing_index(
+    bundle_manifest: str | Path,
+    query: str,
+    k: int = 10,
+    filters: dict[str, str | None] | None = None,
+    resolve_evidence: bool = False,
+    project_sources: bool = False,
+    prepared_fts_query: str | None = None,
+) -> dict[str, Any]:
+    manifest_path = Path(bundle_manifest).expanduser().resolve()
+    if not isinstance(query, str):
+        return _invalid_read_result(
+            kind="repobrief.query_existing_index",
+            bundle_manifest=manifest_path,
+            status="invalid",
+            error="query must be a string",
+            error_code="query_invalid",
+            extra={"query": query, "k": k, "query_result": None, "index_artifact": None},
+        )
+    if not isinstance(k, int) or isinstance(k, bool) or k < 1 or k > MAX_QUERY_EXISTING_INDEX_K:
+        return _invalid_read_result(
+            kind="repobrief.query_existing_index",
+            bundle_manifest=manifest_path,
+            status="invalid",
+            error=f"k must be an integer between 1 and {MAX_QUERY_EXISTING_INDEX_K}",
+            error_code="k_out_of_bounds",
+            extra={"query": query, "k": k, "query_result": None, "index_artifact": None},
+        )
+    if not isinstance(resolve_evidence, bool):
+        return _invalid_read_result(
+            kind="repobrief.query_existing_index",
+            bundle_manifest=manifest_path,
+            status="invalid",
+            error="resolve_evidence must be a boolean",
+            error_code="resolve_evidence_invalid",
+            extra={"query": query, "k": k, "query_result": None, "index_artifact": None},
+        )
+
+    if not isinstance(project_sources, bool):
+        return _invalid_read_result(
+            kind="repobrief.query_existing_index",
+            bundle_manifest=manifest_path,
+            status="invalid",
+            error="project_sources must be a boolean",
+            error_code="project_sources_invalid",
+            extra={"query": query, "k": k, "query_result": None, "index_artifact": None},
+        )
+
+    artifact_result = get_artifact(manifest_path, "sqlite_index")
+    artifact = artifact_result.get("artifact") if isinstance(artifact_result, dict) else None
+    if not isinstance(artifact, dict) or not artifact.get("absolute_path"):
+        return _invalid_read_result(
+            kind="repobrief.query_existing_index",
+            bundle_manifest=manifest_path,
+            status="missing",
+            error="sqlite_index artifact is not present in the bundle manifest",
+            error_code="sqlite_index_missing",
+            extra={"query": query, "k": k, "query_result": None, "index_artifact": artifact},
+        )
+
+    index_path = Path(str(artifact["absolute_path"]))
+    if not index_path.exists():
+        return _invalid_read_result(
+            kind="repobrief.query_existing_index",
+            bundle_manifest=manifest_path,
+            status="missing",
+            error="sqlite_index artifact file does not exist",
+            error_code="sqlite_index_file_missing",
+            extra={"query": query, "k": k, "query_result": None, "index_artifact": artifact},
+        )
+
+    from merger.lenskit.retrieval.query_core import execute_query
+
+    try:
+        query_result = execute_query(
+            index_path,
+            query,
+            k=k,
+            filters=filters or {},
+            trace=False,
+            build_context=False,
+            read_only=True,
+            _prepared_fts_query=prepared_fts_query,
+        )
+    except Exception as exc:
+        return _invalid_read_result(
+            kind="repobrief.query_existing_index",
+            bundle_manifest=manifest_path,
+            status="invalid",
+            error=str(exc),
+            error_code="query_execution_failed",
+            extra={"query": query, "k": k, "query_result": None, "index_artifact": artifact},
+        )
+
+    availability_model = _availability_model_for_manifest(manifest_path)
+    freshness = availability_model.get("freshness") if isinstance(availability_model, dict) else None
+    resolved_evidence = (
+        _resolve_query_evidence(
+            manifest_path,
+            query_result,
+            availability_model=availability_model,
+        )
+        if (resolve_evidence or project_sources)
+        else None
+    )
+    source_citation_projection = (
+        _project_source_citations(resolved_evidence) if project_sources else None
+    )
+
+    return {
+        "kind": "repobrief.query_existing_index",
+        "version": "v1",
+        "status": "available",
+        "bundle_manifest": str(manifest_path),
+        "query": query,
+        "k": k,
+        "filters": filters or {},
+        "resolve_evidence": resolve_evidence,
+        "project_sources": project_sources,
+        "index_artifact": artifact,
+        "availability": availability_model,
+        "freshness": freshness,
+        "query_result": query_result,
+        "evidence_resolution_used": resolve_evidence or project_sources,
+        "resolved_evidence": resolved_evidence if resolve_evidence else None,
+        "source_citation_projection": source_citation_projection,
+        "mutation_boundary": _read_only_mutation_boundary(),
+        "does_not_establish": list(_DOES_NOT_ESTABLISH),
+    }
+
+
+SYMBOL_INDEX_ROLE = "python_symbol_index_json"
+SYMBOL_SEARCH_KIND = "repobrief.symbol_search"
+MAX_SYMBOL_SEARCH_K = 200
+
+
+def _symbol_source_range(symbol: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "path": symbol.get("path"),
+        "start_line": symbol.get("start_line"),
+        "end_line": symbol.get("end_line"),
+        "range_ref": symbol.get("range_ref"),
+        "coordinate_basis": "source_lines",
+    }
+
+
+def _symbol_record(symbol: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": symbol.get("id"),
+        "kind": symbol.get("kind"),
+        "name": symbol.get("name"),
+        "qualified_name": symbol.get("qualified_name"),
+        "module": symbol.get("module"),
+        "path": symbol.get("path"),
+        "start_line": symbol.get("start_line"),
+        "end_line": symbol.get("end_line"),
+        "range_ref": symbol.get("range_ref"),
+        "source_range": _symbol_source_range(symbol),
+        "decorators": symbol.get("decorators") if isinstance(symbol.get("decorators"), list) else [],
+    }
+
+
+def _load_symbol_index(manifest_path: Path) -> tuple[dict[str, Any] | None, dict[str, Any] | None, dict[str, Any] | None]:
+    artifact_result = get_artifact(manifest_path, SYMBOL_INDEX_ROLE)
+    artifact = artifact_result.get("artifact") if isinstance(artifact_result, dict) else None
+    if not isinstance(artifact, dict) or not artifact.get("absolute_path"):
+        return None, artifact, {
+            "status": "missing",
+            "error_code": "python_symbol_index_json_missing",
+            "error": "python_symbol_index_json artifact is not present in the bundle manifest",
+        }
+    index_path = Path(str(artifact["absolute_path"]))
+    if not index_path.exists():
+        return None, artifact, {
+            "status": "missing",
+            "error_code": "python_symbol_index_json_file_missing",
+            "error": "python_symbol_index_json artifact file does not exist",
+        }
+    try:
+        data = json.loads(index_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return None, artifact, {
+            "status": "invalid",
+            "error_code": "python_symbol_index_json_unreadable",
+            "error": str(exc),
+        }
+    if not isinstance(data, dict) or data.get("kind") != "lenskit.python_symbol_index":
+        return None, artifact, {
+            "status": "invalid",
+            "error_code": "python_symbol_index_json_invalid_kind",
+            "error": "python_symbol_index_json must be a lenskit.python_symbol_index object",
+        }
+    symbols = data.get("symbols")
+    if not isinstance(symbols, list):
+        return None, artifact, {
+            "status": "invalid",
+            "error_code": "python_symbol_index_symbols_invalid",
+            "error": "python_symbol_index_json symbols must be an array",
+        }
+    return data, artifact, None
+
+
+def search_symbol_index(
+    bundle_manifest: str | Path,
+    query: str = "",
+    *,
+    k: int = 25,
+    kind: str | None = None,
+    path: str | None = None,
+) -> dict[str, Any]:
+    manifest_path = Path(bundle_manifest).expanduser().resolve()
+    if not isinstance(query, str):
+        return _invalid_read_result(
+            kind=SYMBOL_SEARCH_KIND,
+            bundle_manifest=manifest_path,
+            status="invalid",
+            error="query must be a string",
+            error_code="query_invalid",
+            extra={"query": query, "k": k, "symbol_index": None, "hits": []},
+        )
+    if not isinstance(k, int) or isinstance(k, bool) or k < 1 or k > MAX_SYMBOL_SEARCH_K:
+        return _invalid_read_result(
+            kind=SYMBOL_SEARCH_KIND,
+            bundle_manifest=manifest_path,
+            status="invalid",
+            error=f"k must be an integer between 1 and {MAX_SYMBOL_SEARCH_K}",
+            error_code="k_out_of_bounds",
+            extra={"query": query, "k": k, "symbol_index": None, "hits": []},
+        )
+    data, artifact, error = _load_symbol_index(manifest_path)
+    if error is not None:
+        return _invalid_read_result(
+            kind=SYMBOL_SEARCH_KIND,
+            bundle_manifest=manifest_path,
+            status=error["status"],
+            error=error["error"],
+            error_code=error["error_code"],
+            extra={"query": query, "k": k, "symbol_index": artifact, "hits": []},
+        )
+    assert data is not None
+    symbols = [item for item in data.get("symbols", []) if isinstance(item, dict)]
+    q = query.strip().casefold()
+    kind_filter = kind.strip() if isinstance(kind, str) and kind.strip() else None
+    path_filter = path.strip().casefold() if isinstance(path, str) and path.strip() else None
+    matched: list[tuple[int, int, dict[str, Any]]] = []
+    omitted_by_filter = 0
+    for position, symbol in enumerate(symbols):
+        haystack = " ".join(
+            str(symbol.get(field, ""))
+            for field in ("name", "qualified_name", "module", "path", "kind")
+        ).casefold()
+        if q and q not in haystack:
+            omitted_by_filter += 1
+            continue
+        if kind_filter and symbol.get("kind") != kind_filter:
+            omitted_by_filter += 1
+            continue
+        if path_filter and path_filter not in str(symbol.get("path", "")).casefold():
+            omitted_by_filter += 1
+            continue
+        # Rank exact name/qualified_name matches before substring matches so a
+        # definition lookup surfaces the symbol itself first. Ties keep index
+        # order (stable), preserving prior behavior when no exact match exists.
+        exact = 0 if q and (
+            str(symbol.get("name", "")).casefold() == q
+            or str(symbol.get("qualified_name", "")).casefold() == q
+        ) else 1
+        matched.append((exact, position, symbol))
+    matched.sort(key=lambda item: (item[0], item[1]))
+    # Build the (heavier) records only for the k rows that are actually returned.
+    hits = [_symbol_record(symbol) for _, _, symbol in matched[:k]]
+    availability = _availability_model_for_manifest(manifest_path)
+    return {
+        "kind": SYMBOL_SEARCH_KIND,
+        "version": "v1",
+        "status": "available",
+        "bundle_manifest": str(manifest_path),
+        "query": query,
+        "k": k,
+        "filters": {"kind": kind, "path": path},
+        "symbol_index": artifact,
+        "symbol_index_metadata": {
+            "language": data.get("language"),
+            "symbol_kinds": data.get("symbol_kinds"),
+            "skipped_files_count": data.get("skipped_files_count"),
+            "skipped_errors": data.get("skipped_errors"),
+            "canonical_dump_index_sha256": data.get("canonical_dump_index_sha256"),
+        },
+        "availability": availability,
+        "freshness": availability.get("freshness") if isinstance(availability, dict) else None,
+        "hit_count": len(hits),
+        "omitted_by_filter_count": omitted_by_filter,
+        "truncated": len(matched) > k,
+        "hits": hits,
+        "mutation_boundary": _read_only_mutation_boundary(),
+        "does_not_establish": list(_DOES_NOT_ESTABLISH) + [
+            "call_graph_completeness",
+            "dependency_completeness",
+            "import_success",
+            "review_impact",
+            "merge_readiness",
+        ],
+    }
+
+
+def snapshot_check(
+    bundle_manifest: str | Path,
+    task_profile: str = "basic_repo_question",
+) -> dict[str, Any]:
+    status = snapshot_status(bundle_manifest)
+    artifacts = list_artifacts(bundle_manifest)
+    required = resolve_required_reading_for_bundle(bundle_manifest, task_profile)
+    required_status = str(required.get("status", "unknown"))
+    profile_eval = status.get("profile_evaluation")
+    profile_status = None
+    if isinstance(profile_eval, dict):
+        raw_profile_status = profile_eval.get("status")
+        if isinstance(raw_profile_status, str):
+            profile_status = raw_profile_status
+
+    statuses = [required_status]
+    if profile_status:
+        statuses.append(profile_status)
+    if "fail" in statuses or "not_applicable" in statuses:
+        check_status = "fail"
+    elif "warn" in statuses:
+        check_status = "warn"
+    elif all(item == "pass" for item in statuses):
+        check_status = "pass"
+    else:
+        check_status = "unknown"
+    return {
+        "kind": "repobrief.snapshot_check",
+        "version": "v1",
+        "status": check_status,
+        "bundle_manifest": status["bundle_manifest"],
+        "bundle_run_id": status["bundle_run_id"],
+        "profile": status["profile"],
+        "profile_evaluation_status": profile_status,
+        "task_profile": task_profile,
+        "artifact_count": artifacts["artifact_count"],
+        "roles": artifacts["roles"],
+        "snapshot_status": status,
+        "artifact_list": artifacts,
+        "required_reading": required,
+        "mutation_boundary": {
+            "writes": [],
+            "does_not_mutate": ["git", "pull_requests", "patches", "source_working_tree", "brief_bundle_artifacts"],
+            "read_paths_do_not_refresh": True,
+        },
+        "does_not_establish": list(_DOES_NOT_ESTABLISH),
+    }

--- a/merger/lenskit/core/repobrief_mcp_tools.py
+++ b/merger/lenskit/core/repobrief_mcp_tools.py
@@ -1,0 +1,407 @@
+"""Explicit RepoBrief MCP-shaped tools.
+
+This module is not a protocol server. It provides deterministic tool handlers
+that a future MCP adapter can expose. Read-only RepoBrief access helpers must
+not call these handlers as a fallback or side effect.
+"""
+from __future__ import annotations
+
+import argparse
+import signal
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator
+
+from merger.lenskit.cli.cmd_repobrief import build_snapshot_create_result
+from merger.lenskit.core.merge import parse_human_size
+from merger.lenskit.core.repobrief_profiles import profile_names
+
+KIND = "repobrief.mcp.snapshot_create"
+VERSION = "v1"
+DEFAULT_TIMEOUT_SECONDS = 300
+MAX_TIMEOUT_SECONDS = 1800
+DEFAULT_MAX_FILE_BYTES = "25MB"
+DEFAULT_MAX_TOTAL_BYTES = "512MB"
+DEFAULT_SPLIT_SIZE = "25MB"
+MCP_PLATFORM = "mcp-explicit-tool"
+
+DOES_NOT_ESTABLISH = (
+    "truth",
+    "correctness",
+    "completeness",
+    "runtime_behavior",
+    "test_sufficiency",
+    "regression_absence",
+    "repo_understood",
+    "claims_true",
+    "forensic_ready",
+    "review_complete",
+    "pr_mergeable",
+    "mcp_server_available",
+)
+
+FORBIDDEN_OPERATIONS = (
+    "git_push",
+    "git_pull",
+    "git_fetch",
+    "create_pr",
+    "apply_patch",
+    "run_shell",
+    "auto_review",
+    "auto_fix",
+    "auto_merge",
+    "secret_read",
+)
+
+
+class RepoBriefMcpToolError(ValueError):
+    """Raised when an explicit MCP tool request violates RepoBrief bounds."""
+
+
+class RepoBriefMcpToolTimeout(TimeoutError):
+    """Raised when an explicit MCP tool exceeds its timeout guard."""
+
+
+@contextmanager
+def _timeout_guard(seconds: int) -> Iterator[None]:
+    if seconds <= 0:
+        raise RepoBriefMcpToolError("timeout_seconds must be positive")
+    if threading.current_thread() is not threading.main_thread():
+        raise RepoBriefMcpToolError(
+            "timeout guard requires main thread or an external process-level timeout wrapper"
+        )
+    previous_handler = signal.getsignal(signal.SIGALRM)
+    previous_timer = signal.setitimer(signal.ITIMER_REAL, 0)
+
+    def _handler(_signum: int, _frame: object) -> None:
+        raise RepoBriefMcpToolTimeout(f"snapshot_create exceeded {seconds}s timeout")
+
+    signal.signal(signal.SIGALRM, _handler)
+    signal.setitimer(signal.ITIMER_REAL, float(seconds))
+    try:
+        yield
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, previous_handler)
+        if previous_timer[0] > 0:
+            signal.setitimer(signal.ITIMER_REAL, previous_timer[0], previous_timer[1])
+
+
+def _guarded_path(raw: str | Path, *, label: str) -> Path:
+    path = Path(raw).expanduser().resolve()
+    if not str(path):
+        raise RepoBriefMcpToolError(f"{label} is required")
+    return path
+
+
+def _path_is_within(child: Path, parent: Path) -> bool:
+    try:
+        child.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _resolve_output_dir(output_root: str | Path, output_subdir: str | None) -> tuple[Path, Path]:
+    root = _guarded_path(output_root, label="output_root")
+    if output_subdir is None or output_subdir == "":
+        return root, root
+    raw = Path(output_subdir)
+    if raw.is_absolute() or ".." in raw.parts:
+        raise RepoBriefMcpToolError("output_subdir must be relative and must not contain '..'")
+    out = (root / raw).resolve()
+    if not _path_is_within(out, root):
+        raise RepoBriefMcpToolError("output_subdir must remain inside output_root")
+    return root, out
+
+
+def _file_visible(path: Path, repo: Path, include_hidden: bool) -> bool:
+    try:
+        rel = path.relative_to(repo)
+    except ValueError:
+        return False
+    if ".git" in rel.parts:
+        return False
+    if include_hidden:
+        return True
+    return not any(part.startswith(".") for part in rel.parts)
+
+
+def _estimate_repo_bytes(repo: Path, *, include_hidden: bool) -> int:
+    total = 0
+    for path in repo.rglob("*"):
+        if not path.is_file() or not _file_visible(path, repo, include_hidden):
+            continue
+        total += path.stat().st_size
+    return total
+
+
+def _mutation_boundary() -> dict[str, Any]:
+    return {
+        "writes": ["brief_bundle_artifacts"],
+        "does_not_mutate": ["git", "pull_requests", "patches", "source_working_tree"],
+        "read_paths_do_not_refresh": True,
+        "explicit_write_tool": True,
+        "not_reachable_from_read_tools": True,
+        "forbidden_operations": list(FORBIDDEN_OPERATIONS),
+    }
+
+
+def _tool_args(
+    *,
+    repo: Path,
+    out: Path,
+    profile: str,
+    output_mode: str | None,
+    max_file_bytes: str,
+    split_size: str,
+    include_hidden: bool,
+    path_filter: str | None,
+    ext: list[str] | None,
+    redact_secrets: bool,
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        repo=str(repo),
+        out=str(out),
+        profile=profile,
+        output_mode=output_mode,
+        mode="gesamt",
+        max_bytes=max_file_bytes,
+        split_size=split_size,
+        path_filter=path_filter,
+        ext=ext,
+        include_hidden=include_hidden,
+        redact_secrets=redact_secrets,
+        platform=MCP_PLATFORM,
+    )
+
+
+def snapshot_create(
+    *,
+    repo: str | Path,
+    output_root: str | Path,
+    profile: str,
+    output_subdir: str | None = None,
+    output_mode: str | None = None,
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+    max_file_bytes: str = DEFAULT_MAX_FILE_BYTES,
+    max_total_bytes: str = DEFAULT_MAX_TOTAL_BYTES,
+    split_size: str = DEFAULT_SPLIT_SIZE,
+    include_hidden: bool = False,
+    path_filter: str | None = None,
+    ext: list[str] | None = None,
+    redact_secrets: bool = True,
+) -> dict[str, Any]:
+    """Run the explicit RepoBrief snapshot_create tool under MCP guards."""
+    repo_path = _guarded_path(repo, label="repo")
+    if not repo_path.is_dir():
+        raise RepoBriefMcpToolError(f"repo is not a directory: {repo_path}")
+    output_root_path, out_path = _resolve_output_dir(output_root, output_subdir)
+    if out_path == repo_path or _path_is_within(out_path, repo_path):
+        raise RepoBriefMcpToolError("output directory must not be the repository or inside it")
+    if profile not in profile_names():
+        raise RepoBriefMcpToolError(f"unsupported profile: {profile}")
+    if timeout_seconds > MAX_TIMEOUT_SECONDS:
+        raise RepoBriefMcpToolError(
+            f"timeout_seconds exceeds maximum {MAX_TIMEOUT_SECONDS}: {timeout_seconds}"
+        )
+    max_total = parse_human_size(max_total_bytes)
+    estimated_total = _estimate_repo_bytes(repo_path, include_hidden=include_hidden)
+    if max_total and estimated_total > max_total:
+        raise RepoBriefMcpToolError(
+            f"repo content estimate {estimated_total} exceeds max_total_bytes {max_total}"
+        )
+    args = _tool_args(
+        repo=repo_path,
+        out=out_path,
+        profile=profile,
+        output_mode=output_mode,
+        max_file_bytes=max_file_bytes,
+        split_size=split_size,
+        include_hidden=include_hidden,
+        path_filter=path_filter,
+        ext=ext,
+        redact_secrets=redact_secrets,
+    )
+    with _timeout_guard(timeout_seconds):
+        created = build_snapshot_create_result(args)
+    return {
+        "kind": KIND,
+        "version": VERSION,
+        "status": "ok",
+        "tool": "snapshot_create",
+        "repo": str(repo_path),
+        "output_root": str(output_root_path),
+        "out": str(out_path),
+        "profile": profile,
+        "timeout_seconds": timeout_seconds,
+        "size_guards": {
+            "max_file_bytes": max_file_bytes,
+            "max_total_bytes": max_total_bytes,
+            "estimated_repo_bytes": estimated_total,
+            "include_hidden": include_hidden,
+        },
+        "created_snapshot": created,
+        "bundle_manifest": created.get("bundle_manifest"),
+        "mutation_boundary": _mutation_boundary(),
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }
+
+READ_ONLY_KIND = "repobrief.mcp.read_only_frontdoor"
+READ_ONLY_VERSION = "v1"
+READ_ONLY_FORBIDDEN_OPERATIONS = (
+    "git_push",
+    "git_pull",
+    "git_fetch",
+    "create_pr",
+    "apply_patch",
+    "run_shell",
+    "auto_review",
+    "auto_fix",
+    "auto_merge",
+    "secret_read",
+    "snapshot_create_side_effect",
+)
+
+
+def _read_only_boundary() -> dict[str, Any]:
+    return {
+        "writes": [],
+        "does_not_mutate": [
+            "git",
+            "pull_requests",
+            "patches",
+            "source_working_tree",
+            "brief_bundle_artifacts",
+            "secrets",
+        ],
+        "read_paths_do_not_refresh": True,
+        "explicit_write_tool": False,
+        "not_reachable_from_snapshot_create": True,
+        "forbidden_operations": list(READ_ONLY_FORBIDDEN_OPERATIONS),
+    }
+
+
+def ask_context(
+    *,
+    bundle_manifest: str | Path,
+    query: str,
+    task_profile: str = "basic_repo_question",
+    max_context_tokens: int = 8000,
+    max_answer_tokens: int = 1200,
+    k: int = 5,
+) -> dict[str, Any]:
+    """MCP-shaped read-only frontdoor for RepoBrief ask context packs."""
+    from merger.lenskit.core.repobrief_ask import build_ask_context_pack
+
+    context_pack = build_ask_context_pack(
+        bundle_manifest,
+        query=query,
+        task_profile=task_profile,
+        max_context_tokens=max_context_tokens,
+        max_answer_tokens=max_answer_tokens,
+        k=k,
+    )
+    return {
+        "kind": READ_ONLY_KIND,
+        "version": READ_ONLY_VERSION,
+        "tool": "ask_context",
+        "status": "ok",
+        "context_pack": context_pack,
+        "request_semantics": "repobrief.ask_request.v1",
+        "context_pack_semantics": "repobrief.ask_context_pack.v1",
+        "mutation_boundary": _read_only_boundary(),
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }
+
+
+def grounding_verify(
+    *,
+    declaration: dict[str, Any],
+    bundle_manifest: str | Path,
+    citation_map: str | Path | None = None,
+    task_profile: str | None = None,
+) -> dict[str, Any]:
+    """MCP-shaped read-only frontdoor for Answer Grounding verification."""
+    from merger.lenskit.core.answer_grounding import verify_answer_grounding_for_task_profile
+
+    verdict = verify_answer_grounding_for_task_profile(
+        declaration,
+        bundle_manifest=bundle_manifest,
+        citation_map=citation_map,
+        task_profile=task_profile,
+    )
+    return {
+        "kind": READ_ONLY_KIND,
+        "version": READ_ONLY_VERSION,
+        "tool": "grounding_verify",
+        "status": verdict.get("status", "degraded"),
+        "verdict": verdict,
+        "declaration_semantics": "repobrief.answer_grounding_declaration.v1",
+        "verdict_semantics": "repobrief.answer_grounding_verdict.v1",
+        "mutation_boundary": _read_only_boundary(),
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }
+
+
+FIND_SYMBOL_KINDS = ("class", "function", "async_function")
+
+
+def _find_symbol_result(status: str, result: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "kind": READ_ONLY_KIND,
+        "version": READ_ONLY_VERSION,
+        "tool": "find_symbol",
+        "status": status,
+        "result": result,
+        "result_semantics": "repobrief.symbol_search.v1",
+        "mutation_boundary": _read_only_boundary(),
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }
+
+
+def find_symbol(
+    *,
+    bundle_manifest: str | Path,
+    name: str,
+    kind: str | None = None,
+    path: str | None = None,
+    k: int = 25,
+) -> dict[str, Any]:
+    """MCP-shaped read-only frontdoor for symbol-definition lookup.
+
+    Locates Python symbol definitions (function/class/async_function) in the
+    snapshot's deterministic symbol index, ranking exact matches first. Answers
+    "where is X defined?" with a path and line range — the navigation primitive
+    that content retrieval (ask_context) does not provide. It does not establish
+    that a symbol is called, correct, or fresh against the working tree.
+
+    Fails closed: an empty name or an unknown kind is rejected rather than
+    silently listing the first ``k`` symbols.
+    """
+    from merger.lenskit.core.repobrief_access import search_symbol_index
+
+    def _invalid(error: str, error_code: str) -> dict[str, Any]:
+        return _find_symbol_result(
+            "invalid",
+            {
+                "kind": "repobrief.symbol_search",
+                "version": "v1",
+                "status": "invalid",
+                "error": error,
+                "error_code": error_code,
+                "hits": [],
+                "hit_count": 0,
+            },
+        )
+
+    if not isinstance(name, str) or not name.strip():
+        return _invalid("name must be a non-empty string", "name_invalid")
+    if kind is not None and kind not in FIND_SYMBOL_KINDS:
+        return _invalid(
+            f"kind must be one of {list(FIND_SYMBOL_KINDS)} or null", "kind_invalid"
+        )
+
+    result = search_symbol_index(bundle_manifest, name, k=k, kind=kind, path=path)
+    return _find_symbol_result(result.get("status", "invalid"), result)

--- a/merger/lenskit/tests/test_repobrief_find_symbol.py
+++ b/merger/lenskit/tests/test_repobrief_find_symbol.py
@@ -1,0 +1,171 @@
+"""find_symbol MCP tool + exact-first ranking in the shared symbol search.
+
+find_symbol is the navigation primitive ("where is X defined?") that content
+retrieval (ask_context) does not provide. It reuses the existing
+``search_symbol_index`` core, which now ranks exact name matches before
+substring matches so a definition lookup surfaces the symbol itself first.
+"""
+import hashlib
+import json
+from pathlib import Path
+
+from merger.lenskit.core import repobrief_mcp_tools
+from merger.lenskit.core.repobrief_access import search_symbol_index
+
+
+def _sha(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _symbol_bundle(tmp_path: Path) -> Path:
+    symbol_index = tmp_path / "demo.python_symbol_index.json"
+    symbol_index.write_text(
+        json.dumps(
+            {
+                "kind": "lenskit.python_symbol_index",
+                "version": "1.0",
+                "run_id": "run-1",
+                "canonical_dump_index_sha256": "a" * 64,
+                "language": "python",
+                "symbol_kinds": ["class", "function", "async_function"],
+                "symbols": [
+                    # A substring match declared BEFORE the exact match, to prove
+                    # exact-first ranking reorders regardless of index position.
+                    {
+                        "id": "py:pkg:mod.py:function:run_pipeline",
+                        "kind": "function",
+                        "name": "run_pipeline",
+                        "qualified_name": "run_pipeline",
+                        "module": "pkg.mod",
+                        "path": "pkg/mod.py",
+                        "start_line": 3,
+                        "end_line": 5,
+                        "range_ref": "file:pkg/mod.py#L3-L5",
+                    },
+                    {
+                        "id": "py:pkg:mod.py:function:run",
+                        "kind": "function",
+                        "name": "run",
+                        "qualified_name": "run",
+                        "module": "pkg.mod",
+                        "path": "pkg/mod.py",
+                        "start_line": 8,
+                        "end_line": 10,
+                        "range_ref": "file:pkg/mod.py#L8-L10",
+                    },
+                    {
+                        "id": "py:pkg:mod.py:class:Runner",
+                        "kind": "class",
+                        "name": "Runner",
+                        "qualified_name": "Runner",
+                        "module": "pkg.mod",
+                        "path": "pkg/mod.py",
+                        "start_line": 13,
+                        "end_line": 20,
+                        "range_ref": "file:pkg/mod.py#L13-L20",
+                    },
+                ],
+                "skipped_files_count": 0,
+                "skipped_errors": [],
+                "does_not_establish": ["call_graph_completeness"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    manifest = tmp_path / "demo.bundle.manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "kind": "repolens.bundle.manifest",
+                "run_id": "run-1",
+                "artifacts": [
+                    {
+                        "role": "python_symbol_index_json",
+                        "path": symbol_index.name,
+                        "content_type": "application/json",
+                        "bytes": symbol_index.stat().st_size,
+                        "sha256": _sha(symbol_index),
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def test_exact_match_ranks_before_substring(tmp_path):
+    manifest = _symbol_bundle(tmp_path)
+
+    result = search_symbol_index(manifest, "run", k=10)
+
+    assert result["status"] == "available"
+    # 'run' matches run (exact), run_pipeline and Runner (substring); the exact
+    # match wins the top slot even though it is declared after run_pipeline.
+    names = [hit["qualified_name"] for hit in result["hits"]]
+    assert names[0] == "run"
+    assert set(names) == {"run", "run_pipeline", "Runner"}
+
+
+def test_find_symbol_tool_locates_definition_with_range(tmp_path):
+    manifest = _symbol_bundle(tmp_path)
+
+    payload = repobrief_mcp_tools.find_symbol(bundle_manifest=str(manifest), name="run")
+
+    assert payload["kind"] == "repobrief.mcp.read_only_frontdoor"
+    assert payload["tool"] == "find_symbol"
+    assert payload["status"] == "available"
+    assert payload["mutation_boundary"]["writes"] == []
+    top = payload["result"]["hits"][0]
+    assert top["qualified_name"] == "run"
+    assert top["path"] == "pkg/mod.py"
+    assert top["start_line"] == 8
+    assert top["range_ref"] == "file:pkg/mod.py#L8-L10"
+
+
+def test_find_symbol_tool_filters_by_kind(tmp_path):
+    manifest = _symbol_bundle(tmp_path)
+
+    payload = repobrief_mcp_tools.find_symbol(
+        bundle_manifest=str(manifest), name="run", kind="class"
+    )
+
+    hits = payload["result"]["hits"]
+    assert [hit["qualified_name"] for hit in hits] == ["Runner"]
+
+
+def test_find_symbol_tool_rejects_empty_name(tmp_path):
+    manifest = _symbol_bundle(tmp_path)
+
+    for empty in ("", "   "):
+        payload = repobrief_mcp_tools.find_symbol(bundle_manifest=str(manifest), name=empty)
+        assert payload["status"] == "invalid"
+        assert payload["result"]["error_code"] == "name_invalid"
+        # Fails closed: no symbols are listed for an empty query.
+        assert payload["result"]["hits"] == []
+        assert payload["result"]["hit_count"] == 0
+
+
+def test_find_symbol_tool_rejects_unknown_kind(tmp_path):
+    manifest = _symbol_bundle(tmp_path)
+
+    payload = repobrief_mcp_tools.find_symbol(
+        bundle_manifest=str(manifest), name="run", kind="macro"
+    )
+
+    assert payload["status"] == "invalid"
+    assert payload["result"]["error_code"] == "kind_invalid"
+    assert payload["result"]["hits"] == []
+
+
+def test_find_symbol_tool_reports_missing_symbol_index(tmp_path):
+    manifest = tmp_path / "empty.bundle.manifest.json"
+    manifest.write_text(
+        json.dumps({"kind": "repolens.bundle.manifest", "run_id": "x", "artifacts": []}),
+        encoding="utf-8",
+    )
+
+    payload = repobrief_mcp_tools.find_symbol(bundle_manifest=str(manifest), name="run")
+
+    assert payload["status"] == "missing"
+    assert payload["result"]["error_code"] == "python_symbol_index_json_missing"

--- a/merger/lenskit/tests/test_repobrief_mcp_stdio.py
+++ b/merger/lenskit/tests/test_repobrief_mcp_stdio.py
@@ -1,0 +1,328 @@
+import json
+from io import StringIO
+from pathlib import Path
+
+import pytest
+
+from merger.lenskit.cli.repobrief_mcp_stdio import (
+    PROTOCOL_VERSION,
+    RepoBriefMcpStdioServer,
+    serve_stdio,
+)
+from merger.lenskit.core import repobrief_mcp_resources, repobrief_mcp_tools
+
+
+def _manifest(tmp_path: Path) -> Path:
+    path = tmp_path / "demo.bundle.manifest.json"
+    path.write_text(
+        json.dumps(
+            {
+                "kind": "repolens.bundle.manifest",
+                "run_id": "demo",
+                "artifacts": [],
+                "snapshot_provenance": {"version": "v1", "repositories": []},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _initialize(server: RepoBriefMcpStdioServer):
+    response = server.handle_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "test", "version": "1"},
+            },
+        }
+    )
+    assert response is not None
+    return response
+
+
+def _tools(server: RepoBriefMcpStdioServer) -> list[dict]:
+    response = server.handle_message(
+        {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}
+    )
+    return response["result"]["tools"]
+
+
+def test_mcp_stdio_requires_initialization(tmp_path):
+    server = RepoBriefMcpStdioServer(bundle_root=tmp_path)
+
+    response = server.handle_message(
+        {"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}
+    )
+
+    assert response["error"]["code"] == -32002
+
+
+def test_initialized_notification_does_not_replace_initialize(tmp_path):
+    server = RepoBriefMcpStdioServer(bundle_root=tmp_path)
+
+    notification = server.handle_message(
+        {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}}
+    )
+    response = server.handle_message(
+        {"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}
+    )
+
+    assert notification is None
+    assert response["error"]["code"] == -32002
+
+
+def test_mcp_stdio_lists_read_tools_and_hides_snapshot_create_by_default(tmp_path):
+    server = RepoBriefMcpStdioServer(bundle_root=tmp_path)
+    initialized = _initialize(server)
+
+    assert initialized["result"]["protocolVersion"] == PROTOCOL_VERSION
+    assert initialized["result"]["capabilities"]["tools"]["listChanged"] is False
+    assert {tool["name"] for tool in _tools(server)} == {
+        "ask_context",
+        "grounding_verify",
+        "live_freshness",
+        "find_symbol",
+    }
+
+
+def test_snapshot_create_enable_requires_explicit_repo_root(tmp_path):
+    with pytest.raises(ValueError, match="requires an explicit --repo-root"):
+        RepoBriefMcpStdioServer(
+            bundle_root=tmp_path,
+            enable_snapshot_create=True,
+        )
+
+
+def test_mcp_stdio_exposes_startup_bound_snapshot_create_schema(tmp_path):
+    repo = tmp_path / "repo"
+    bundles = tmp_path / "bundles"
+    repo.mkdir()
+    bundles.mkdir()
+    server = RepoBriefMcpStdioServer(
+        bundle_root=bundles,
+        repo_root=repo,
+        enable_snapshot_create=True,
+    )
+    _initialize(server)
+
+    definition = next(tool for tool in _tools(server) if tool["name"] == "snapshot_create")
+    properties = definition["inputSchema"]["properties"]
+
+    assert definition["inputSchema"]["required"] == ["profile"]
+    assert "repo" not in properties
+    assert "output_root" not in properties
+
+
+def test_snapshot_create_injects_startup_roots_and_rejects_overrides(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    bundles = tmp_path / "bundles"
+    repo.mkdir()
+    bundles.mkdir()
+    server = RepoBriefMcpStdioServer(
+        bundle_root=bundles,
+        repo_root=repo,
+        enable_snapshot_create=True,
+    )
+    _initialize(server)
+    seen = {}
+
+    def fake_snapshot_create(**arguments):
+        seen.update(arguments)
+        return {"status": "ok"}
+
+    monkeypatch.setattr(repobrief_mcp_tools, "snapshot_create", fake_snapshot_create)
+    response = server.handle_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "snapshot_create",
+                "arguments": {"profile": "agent-review", "output_subdir": "demo"},
+            },
+        }
+    )
+
+    assert response["result"]["isError"] is False
+    assert seen["repo"] == str(repo.resolve())
+    assert seen["output_root"] == str(bundles.resolve())
+    assert seen["profile"] == "agent-review"
+
+    rejected = server.handle_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "snapshot_create",
+                "arguments": {
+                    "profile": "agent-review",
+                    "repo": str(tmp_path / "other"),
+                    "output_root": str(tmp_path / "outside"),
+                },
+            },
+        }
+    )
+
+    assert rejected["error"]["code"] == -32602
+    assert rejected["error"]["data"]["forbidden_arguments"] == ["output_root", "repo"]
+
+
+def test_mcp_stdio_tool_call_is_bundle_root_bound(tmp_path):
+    manifest = _manifest(tmp_path)
+    outside = tmp_path.parent / "outside.bundle.manifest.json"
+    outside.write_text(manifest.read_text(encoding="utf-8"), encoding="utf-8")
+    server = RepoBriefMcpStdioServer(bundle_root=tmp_path)
+    _initialize(server)
+
+    response = server.handle_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "ask_context",
+                "arguments": {"bundle_manifest": str(outside), "query": "hello"},
+            },
+        }
+    )
+
+    assert response["error"]["code"] == -32602
+    assert "outside the configured bundle root" in response["error"]["message"]
+
+
+def test_mcp_stdio_calls_existing_ask_handler_and_adds_freshness(tmp_path, monkeypatch):
+    manifest = _manifest(tmp_path)
+    server = RepoBriefMcpStdioServer(bundle_root=tmp_path)
+    _initialize(server)
+    seen = {}
+
+    def fake_ask_context(**arguments):
+        seen.update(arguments)
+        return {"kind": "repobrief.mcp.read_only_frontdoor", "status": "ok"}
+
+    monkeypatch.setattr(repobrief_mcp_tools, "ask_context", fake_ask_context)
+    monkeypatch.setattr(
+        server,
+        "_safe_live_freshness",
+        lambda *_args, **_kwargs: {"status": "fresh", "implicit_refresh": False},
+    )
+
+    response = server.handle_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "ask_context",
+                "arguments": {"bundle_manifest": str(manifest), "query": "hello"},
+            },
+        }
+    )
+
+    result = response["result"]
+    assert result["isError"] is False
+    assert result["structuredContent"]["live_freshness"]["status"] == "fresh"
+    assert seen["bundle_manifest"] == str(manifest.resolve())
+
+
+def test_mcp_stdio_resource_read_preserves_content_and_adds_metadata(tmp_path, monkeypatch):
+    manifest = _manifest(tmp_path)
+    server = RepoBriefMcpStdioServer(bundle_root=tmp_path, repo_root=tmp_path)
+    _initialize(server)
+    uri = "repobrief://snapshot/demo/canonical"
+
+    monkeypatch.setattr(
+        repobrief_mcp_resources,
+        "read_mcp_resource",
+        lambda *_args, **_kwargs: {
+            "status": "available",
+            "bundle_manifest": str(manifest),
+            "content_type": "text/markdown",
+            "content_text": "# Demo\n",
+            "snapshot_context": {"freshness": {"status": "not_comparable"}},
+        },
+    )
+    monkeypatch.setattr(
+        server,
+        "_safe_live_freshness",
+        lambda *_args, **_kwargs: {"status": "stale", "implicit_refresh": False},
+    )
+
+    response = server.handle_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "resources/read",
+            "params": {"uri": uri},
+        }
+    )
+
+    result = response["result"]
+    assert result["contents"] == [
+        {"uri": uri, "mimeType": "text/markdown", "text": "# Demo\n"}
+    ]
+    assert result["_meta"]["repobrief"]["liveFreshness"]["status"] == "stale"
+    assert result["_meta"]["repobrief"]["implicitRefresh"] is False
+
+
+def test_mcp_stdio_without_configured_repo_reports_not_comparable(tmp_path):
+    manifest = _manifest(tmp_path)
+    server = RepoBriefMcpStdioServer(bundle_root=tmp_path)
+    _initialize(server)
+
+    response = server.handle_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "live_freshness",
+                "arguments": {"bundle_manifest": str(manifest)},
+            },
+        }
+    )
+
+    freshness = response["result"]["structuredContent"]
+    assert freshness["status"] == "not_comparable"
+    assert freshness["reason"] == "repo_root_not_configured"
+    assert freshness["read_only_git_probe"] is False
+
+
+def test_serve_stdio_uses_one_json_object_per_line(tmp_path):
+    server = RepoBriefMcpStdioServer(bundle_root=tmp_path)
+    source = StringIO(
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {"protocolVersion": PROTOCOL_VERSION},
+            }
+        )
+        + "\n"
+        + json.dumps({"jsonrpc": "2.0", "id": 2, "method": "ping", "params": {}})
+        + "\n"
+    )
+    target = StringIO()
+
+    assert serve_stdio(server, source, target) == 0
+
+    lines = target.getvalue().splitlines()
+    assert len(lines) == 2
+    assert [json.loads(line)["id"] for line in lines] == [1, 2]
+
+
+def test_serve_stdio_returns_parse_error_without_traceback(tmp_path):
+    server = RepoBriefMcpStdioServer(bundle_root=tmp_path)
+    target = StringIO()
+
+    serve_stdio(server, StringIO("{bad json\n"), target)
+
+    response = json.loads(target.getvalue())
+    assert response["error"] == {"code": -32700, "message": "parse error"}

--- a/merger/lenskit/tests/test_repobrief_mcp_stdio_e2e.py
+++ b/merger/lenskit/tests/test_repobrief_mcp_stdio_e2e.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from merger.lenskit.cli.repobrief_mcp_stdio import PROTOCOL_VERSION
+from merger.lenskit.core.repobrief_live_freshness import evaluate_live_freshness
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MCP_LAUNCHER = REPO_ROOT / "scripts/repobrief-mcp-stdio.py"
+
+
+def _git(repo: Path, *args: str) -> str:
+    completed = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    return completed.stdout.strip()
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _manifest(path: Path, *, repo: Path, commit: str) -> Path:
+    manifest = path / "demo.bundle.manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "kind": "repolens.bundle.manifest",
+                "run_id": "demo",
+                "artifacts": [],
+                "snapshot_provenance": {
+                    "version": "v1",
+                    "repositories": [
+                        {
+                            "name": repo.name,
+                            "repo_root": str(repo.resolve()),
+                            "git_commit": commit,
+                            "git_dirty": False,
+                            "git_branch": "main",
+                            "provenance_status": "present",
+                            "freshness_basis": "git_commit_and_working_tree",
+                        }
+                    ],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def test_mcp_stdio_launcher_completes_handshake_outside_checkout(tmp_path: Path) -> None:
+    client_cwd = tmp_path / "client-cwd"
+    bundle_root = tmp_path / "bundles"
+    client_cwd.mkdir()
+    bundle_root.mkdir()
+    requests = [
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "pytest", "version": "1"},
+            },
+        },
+        {
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized",
+            "params": {},
+        },
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+            "params": {},
+        },
+    ]
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(MCP_LAUNCHER),
+            "--bundle-root",
+            str(bundle_root),
+        ],
+        cwd=client_cwd,
+        input="".join(json.dumps(request) + "\n" for request in requests),
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stderr == ""
+    responses = [json.loads(line) for line in completed.stdout.splitlines()]
+    assert [response["id"] for response in responses] == [1, 2]
+    assert responses[0]["result"]["protocolVersion"] == PROTOCOL_VERSION
+    assert {
+        tool["name"] for tool in responses[1]["result"]["tools"]
+    } == {"ask_context", "grounding_verify", "live_freshness", "find_symbol"}
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git executable unavailable")
+def test_live_freshness_real_git_probe_is_read_only_and_detects_dirtiness(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "--initial-branch=main")
+    _git(repo, "config", "user.name", "RepoBrief Test")
+    _git(repo, "config", "user.email", "repobrief@example.invalid")
+    source = repo / "example.py"
+    source.write_text("value = 1\n", encoding="utf-8")
+    _git(repo, "add", "example.py")
+    _git(repo, "commit", "-q", "-m", "initial")
+    commit = _git(repo, "rev-parse", "HEAD")
+    manifest = _manifest(tmp_path, repo=repo, commit=commit)
+    index_path = repo / ".git" / "index"
+    index_before = _sha256(index_path)
+
+    clean = evaluate_live_freshness(manifest, repo_root=repo)
+
+    assert clean["status"] == "fresh"
+    assert clean["current_provenance"]["git_commit"] == commit
+    assert _sha256(index_path) == index_before
+    assert _git(repo, "rev-parse", "HEAD") == commit
+
+    source.write_text("value = 2\n", encoding="utf-8")
+    dirty = evaluate_live_freshness(manifest, repo_root=repo)
+
+    assert dirty["status"] == "stale"
+    assert dirty["reason"] == "current_working_tree_is_dirty"
+    assert _sha256(index_path) == index_before
+    assert _git(repo, "rev-parse", "HEAD") == commit
+
+
+def _symbol_manifest(bundle_root: Path, *, repo: Path, commit: str) -> Path:
+    index = bundle_root / "demo.python_symbol_index.json"
+    index.write_text(
+        json.dumps(
+            {
+                "kind": "lenskit.python_symbol_index",
+                "version": "1.0",
+                "run_id": "demo",
+                "canonical_dump_index_sha256": "a" * 64,
+                "language": "python",
+                "symbol_kinds": ["class", "function", "async_function"],
+                "symbols": [
+                    # Substring match declared before the exact match, to prove
+                    # exact-first ranking over the transport.
+                    {
+                        "id": "py:pkg:mod.py:function:run_pipeline",
+                        "kind": "function",
+                        "name": "run_pipeline",
+                        "qualified_name": "run_pipeline",
+                        "module": "pkg.mod",
+                        "path": "pkg/mod.py",
+                        "start_line": 3,
+                        "end_line": 5,
+                        "range_ref": "file:pkg/mod.py#L3-L5",
+                    },
+                    {
+                        "id": "py:pkg:mod.py:function:run",
+                        "kind": "function",
+                        "name": "run",
+                        "qualified_name": "run",
+                        "module": "pkg.mod",
+                        "path": "pkg/mod.py",
+                        "start_line": 8,
+                        "end_line": 10,
+                        "range_ref": "file:pkg/mod.py#L8-L10",
+                    },
+                ],
+                "skipped_files_count": 0,
+                "skipped_errors": [],
+                "does_not_establish": ["call_graph_completeness"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    manifest = bundle_root / "demo.bundle.manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "kind": "repolens.bundle.manifest",
+                "run_id": "demo",
+                "artifacts": [
+                    {
+                        "role": "python_symbol_index_json",
+                        "path": index.name,
+                        "content_type": "application/json",
+                        "bytes": index.stat().st_size,
+                        "sha256": _sha256(index),
+                    }
+                ],
+                "snapshot_provenance": {
+                    "version": "v1",
+                    "repositories": [
+                        {
+                            "name": repo.name,
+                            "repo_root": str(repo.resolve()),
+                            "git_commit": commit,
+                            "git_dirty": False,
+                            "git_branch": "main",
+                            "provenance_status": "present",
+                            "freshness_basis": "git_commit_and_working_tree",
+                        }
+                    ],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def _run_launcher(bundle_root: Path, repo_root: Path | None, requests: list[dict]) -> list[dict]:
+    args = [sys.executable, str(MCP_LAUNCHER), "--bundle-root", str(bundle_root)]
+    if repo_root is not None:
+        args += ["--repo-root", str(repo_root)]
+    completed = subprocess.run(
+        args,
+        input="".join(json.dumps(request) + "\n" for request in requests),
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    return [json.loads(line) for line in completed.stdout.splitlines() if line.strip()]
+
+
+def _handshake(next_id: int, *calls: dict) -> list[dict]:
+    requests: list[dict] = [
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {"protocolVersion": PROTOCOL_VERSION, "capabilities": {}},
+        },
+        {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
+    ]
+    requests.extend(calls)
+    return requests
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git executable unavailable")
+def test_find_symbol_tools_call_returns_ranked_location_and_freshness(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "--initial-branch=main")
+    _git(repo, "config", "user.name", "RepoBrief Test")
+    _git(repo, "config", "user.email", "repobrief@example.invalid")
+    (repo / "example.py").write_text("value = 1\n", encoding="utf-8")
+    _git(repo, "add", "example.py")
+    _git(repo, "commit", "-q", "-m", "initial")
+    commit = _git(repo, "rev-parse", "HEAD")
+
+    bundle_root = tmp_path / "bundles"
+    bundle_root.mkdir()
+    manifest = _symbol_manifest(bundle_root, repo=repo, commit=commit)
+
+    requests = _handshake(
+        2,
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "find_symbol",
+                "arguments": {"bundle_manifest": str(manifest), "name": "run"},
+            },
+        },
+    )
+    responses = _run_launcher(bundle_root, repo, requests)
+    call_response = next(r for r in responses if r.get("id") == 2)
+    assert "error" not in call_response, call_response
+    payload = json.loads(call_response["result"]["content"][0]["text"])
+
+    assert payload["tool"] == "find_symbol"
+    assert payload["status"] == "available"
+    hits = payload["result"]["hits"]
+    # exact 'run' ranks before the 'run_pipeline' substring match
+    assert hits[0]["qualified_name"] == "run"
+    assert hits[0]["path"] == "pkg/mod.py"
+    assert hits[0]["start_line"] == 8
+    assert hits[0]["end_line"] == 10
+    assert hits[0]["range_ref"] == "file:pkg/mod.py#L8-L10"
+    # navigation results carry the snapshot's live freshness against the checkout
+    assert payload["live_freshness"]["status"] == "fresh"
+    assert payload["live_freshness"]["current_provenance"]["git_commit"] == commit
+
+
+def test_find_symbol_tools_call_rejects_empty_name_and_invalid_kind(tmp_path: Path) -> None:
+    bundle_root = tmp_path / "bundles"
+    bundle_root.mkdir()
+    manifest = bundle_root / "demo.bundle.manifest.json"
+    manifest.write_text(
+        json.dumps({"kind": "repolens.bundle.manifest", "run_id": "demo", "artifacts": []}),
+        encoding="utf-8",
+    )
+
+    requests = _handshake(
+        2,
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "find_symbol",
+                "arguments": {"bundle_manifest": str(manifest), "name": ""},
+            },
+        },
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "find_symbol",
+                "arguments": {"bundle_manifest": str(manifest), "name": "run", "kind": "macro"},
+            },
+        },
+    )
+    responses = _run_launcher(bundle_root, None, requests)
+    by_id = {r.get("id"): r for r in responses}
+
+    # Fail closed: neither request returns a symbol listing; both are rejected.
+    assert by_id[2]["error"]["code"] == -32602
+    assert "non-empty name" in by_id[2]["error"]["message"]
+    assert by_id[3]["error"]["code"] == -32602
+    assert "kind" in by_id[3]["error"]["message"]


### PR DESCRIPTION
- **feat(repobrief): expose find_symbol MCP navigation tool (#1005)**
- **chore(ci): update reviewed GitHub Actions pins (#1006)**
- **feat(repobrief): harden latest-complete publication v2 (#1007)**
- **RepoBrief: optionalen semantischen Stack reproduzierbar sperren (#1008)**
- **feat(repobrief): localize external bundle publication (#1009)**
- **feat(repobrief): publish coherent manifest generations**
- **fix(repobrief): bound fleet publication retention**
- **fix(repobrief): bind publication to trusted dirfds**
- **fix(repobrief): harden retention follow-ups**
- **refactor(service): preserve complexity ratchets**
- **fix(repobrief): schedule watcher on the calendar**
- **fix(repobrief): scope generator fingerprint inputs**
- **fix(repobrief): make retention fail closed**
- **Add RepoBrief publication lifecycle policy**
- **refactor(repobrief): satisfy publication policy complexity ratchet**
- **fix(repobrief): harden publication lifecycle policy**
- **feat(repobrief): add evidence-bound Python call graph**
- **Harden Python call graph contracts and diagnostics**
- **Harden comprehension scopes and call graph contracts**
- **Fix repoLens on iPad without jsonschema (#1021)**
- **perf(repobrief): index call navigation state (#1022)**
- **style(repobrief): format new navigation modules (#1023)**
- **fix(repobrief): bind navigation cache to source bytes (#1024)**
- **fix(repobrief): preserve hardened cache performance (#1025)**
- **fix(repobrief): harden cache validation portability (#1026)**
- **fix(repobrief): close cache coherence review gaps (#1027)**
- **feat(repobrief): publish immutable bundle generations (#1028)**
- **perf(repobrief): stream generation verification (#1029)**
- **perf(repobrief): stream relation card context scan (#1030)**
- **fix(repobrief): clarify relation stream validation**
- **fix(repobrief): harden generation publication rollback**
- **refactor(repobrief): clarify relation stream matching (#1032)**
- **feat(review): add deterministic audit lane planner**
- **feat(review): add audit lane plan contract**
- **test(review): cover audit lane planning contract**
- **docs(review): record audit lane adoption plan**
- **docs(review): add audit lane planner proof**
- **fix(review): harden audit lane token and input handling**
- **test(review): cover aliases and malformed path collections**
- **fix(review): encode safe repository paths in audit lane schema**
- **docs(review): align pilot lane bound with planner contract**
- **docs(review): refresh audit lane verification proof**
- **refactor(review): keep audit lane planner below complexity ratchet**
- **feat(review): add citation-bound audit finding adapter**
- **feat(review): add audit finding set contract**
- **test(review): cover audit finding admission boundaries**
- **docs(review): define audit finding evidence boundary**
- **docs(review): add audit finding adapter proof**
- **fix(review): align finding contract with inference boundaries**
- **fix(review): add governed inference boundary to finding contract**
- **test(review): harden finding adapter malformed inputs**
- **fix(review): neutralize verifier record and validate identifiers**
- **fix(review): model verification as a diagnostic record**
- **test(review): cover neutral verification records and ids**
- **docs(review): align verification record terminology**
- **fix(review): bind verification and state count semantics**
- **test(review): reject inconsistent finding contract states**
- **docs(review): include contract consistency proof**
- **docs(review): correct finding proof wording**
- **fix(review): harden audit planner and evidence contracts**
- **fix(review): bind verification state machine bidirectionally**
- **ci(review): capture transient audit hardening diagnostics**
- **fix(review): repair uploaded finding adapter syntax**
- **fix(review): repair uploaded finding adapter syntax v2**
- **ci(review): export exact substantive PR diff**
- **ci(review): remove temporary diff exporter**
- **feat: consolidate Lenskit as RepoGround 3.0**
- **fix(ci): harden RepoGround migration gates**
- **fix(webui): bind forms before startup fetch**
- **fix(tests): render RepoGround WebUI tokens**
- **test(review): reject omitted audit lane boundary**
- **test(review): reject incomplete verifier boundary**
- **test(review): bind verifier omission in schema**
- **chore: remove high-confidence legacy debris (#1039)**
- **feat: bound RepoGround compatibility exit (#1040)**
- **chore: finish RepoGround CodeQL context cutover (#1042)**
- **fix(runtime): bind health and retrieval content contracts (#1041)**
- **feat: open RepoGround and protect its community identity (#1043)**
- **fix(fleet): address review findings for repoground-publish-fleet**
- **fix(runtime): remove legacy fleet timer after cutover**
- **feat: hard cut RepoGround compatibility aliases**
- **test: stabilize hard-cut validation**
- **test: close hard-cut browser and parity gates**
- **feat: add compact evidence navigation and honest benchmark**
- **fix: remove remaining active legacy command labels**
- **test: make evidence benchmark portable and fail closed**
- **feat: add explicit incremental retrieval snapshots**
- **test: redact local paths from incremental measurements**
- **refactor: bound incremental watcher complexity**
- **docs: bind rebased incremental retrieval measurement**
- **sichter: automated sweep**
