### PR TITLE
Scope RepoGround naming audit to active aliases

### DIFF
--- a/merger/repoground/core/naming_audit.py
+++ b/merger/repoground/core/naming_audit.py
@@ -26,6 +26,36 @@ FORMER_SERVICE_UNIT = "r" + "lens" + ".service"
 SOURCE_ROOTS = ("merger/repoground", "repoground", "scripts", "tests")
 SOURCE_SUFFIXES = {".py", ".sh", ".js", ".html"}
 
+PROMPT_EXECUTABLES = frozenset({"agy", "chatgpt", "claude", "cline", "codex"})
+PROMPT_ARGUMENT_FLAGS = frozenset(
+    {
+        "--prompt",
+        "-p",
+        "--system-prompt",
+        "--append-system-prompt",
+        "--message",
+        "--instructions",
+    }
+)
+CONFIG_VALUE_KEYS = frozenset(
+    {
+        "args",
+        "argv",
+        "bundle_root",
+        "command",
+        "env",
+        "environment",
+        "executable",
+        "module",
+        "path",
+        "program",
+        "root",
+        "unit",
+        "uri",
+        "url",
+    }
+)
+
 # These are executable aliases or runtime locations. Versioned kind/schema values
 # are deliberately not listed: they remain exact persisted-data contracts.
 def _active_alias_patterns() -> dict[str, tuple[str, ...]]:
@@ -82,11 +112,178 @@ def _matched_active_aliases(text: str) -> list[str]:
     )
 
 
+def _external_alias_patterns() -> dict[str, tuple[str, ...]]:
+    old_cache_prefix = ("lens" + "kit_repo" + "brief").upper()
+    old_profile_var = ("lens" + "kit_repo" + "ground_profiles").upper()
+    return {
+        "former-command-alias": (
+            "repo" + "brief-mcp-stdio.py",
+            "r" + "lens-client",
+            "r" + "lens-launcher.sh",
+        ),
+        "former-resource-scheme": ("repo" + "brief://",),
+        "former-environment": (
+            old_cache_prefix + "_CACHE_VALIDATION",
+            old_cache_prefix + "_STRICT_CACHE_HASH",
+            old_profile_var,
+            ("r" + "lens_").upper(),
+            ("repo" + "lens_").upper(),
+        ),
+        "former-runtime-storage": (
+            "." + "r" + "lens-service",
+            "." + "r" + "lens-source-snapshots",
+            "r" + "lens-job-",
+            ".repo" + "Lens-state.json",
+            ".repo" + "lens/pr-schau",
+        ),
+        "former-service-unit": (FORMER_SERVICE_UNIT,),
+        "former-python-module": ("merger." + "lens" + "kit",),
+        "former-repository-path": ("/repos/" + "lens" + "kit",),
+        "former-bundle-storage": (
+            "/.local/share/" + "repo" + "brief/",
+            "lens" + "kit-briefs",
+        ),
+        "former-ui-global": (
+            "__" + ("r" + "lens").upper() + "_UI_VERSION__",
+        ),
+    }
+
+
+EXTERNAL_ALIAS_PATTERNS = _external_alias_patterns()
+
+
 def _matched_external_names(text: str) -> list[str]:
     lowered = text.casefold()
     return sorted(
         term for term in FORMER_PRODUCT_TERMS if term.casefold() in lowered
     )
+
+
+def _matched_external_aliases(text: str) -> list[str]:
+    return sorted(
+        category
+        for category, patterns in EXTERNAL_ALIAS_PATTERNS.items()
+        if any(pattern in text for pattern in patterns)
+    )
+
+
+def _is_prompt_process(argv: list[str]) -> bool:
+    for token in argv[:3]:
+        name = Path(token).name.casefold()
+        stem = Path(name).stem
+        if name in PROMPT_EXECUTABLES or stem in PROMPT_EXECUTABLES:
+            return True
+    return False
+
+
+def _matched_process_aliases(argv: list[str]) -> list[str]:
+    matches: set[str] = set()
+    former_command = "repo" + "brief"
+    prompt_process = _is_prompt_process(argv)
+    skip_next_as_prompt = False
+    for token in argv:
+        if skip_next_as_prompt:
+            skip_next_as_prompt = False
+            continue
+        if prompt_process and token in PROMPT_ARGUMENT_FLAGS:
+            skip_next_as_prompt = True
+            continue
+        if prompt_process and any(
+            token.startswith(flag + "=") for flag in PROMPT_ARGUMENT_FLAGS
+        ):
+            continue
+        # A long argument containing whitespace is commonly an agent prompt or
+        # explanatory text. It is not an executable command, URI, env assignment
+        # or path token and therefore must not block a live cutover.
+        if prompt_process and any(character.isspace() for character in token):
+            continue
+        if token == former_command:
+            matches.add("former-command-alias")
+        matches.update(_matched_external_aliases(token))
+        basename = Path(token).name
+        if basename == former_command:
+            matches.add("former-command-alias")
+        matches.update(_matched_external_aliases(basename))
+    return sorted(matches)
+
+
+def _config_string_aliases(value: str, *, command_value: bool = False) -> set[str]:
+    matches = set(_matched_external_aliases(value))
+    if command_value and value == "repo" + "brief":
+        matches.add("former-command-alias")
+    return matches
+
+
+def _json_config_aliases(
+    payload: Any,
+    *,
+    semantic_context: bool = False,
+) -> set[str]:
+    matches: set[str] = set()
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            key_text = str(key)
+            matches.update(_matched_external_aliases(key_text))
+            child_semantic = semantic_context or key_text.casefold() in CONFIG_VALUE_KEYS
+            if child_semantic and isinstance(value, str):
+                matches.update(
+                    _config_string_aliases(
+                        value,
+                        command_value=key_text.casefold() == "command",
+                    )
+                )
+            elif isinstance(value, (dict, list)):
+                matches.update(
+                    _json_config_aliases(
+                        value,
+                        semantic_context=child_semantic,
+                    )
+                )
+    elif isinstance(payload, list):
+        for item in payload:
+            if semantic_context and isinstance(item, str):
+                matches.update(_config_string_aliases(item))
+            elif isinstance(item, (dict, list)):
+                matches.update(
+                    _json_config_aliases(
+                        item,
+                        semantic_context=semantic_context,
+                    )
+                )
+    return matches
+
+
+def _line_config_aliases(text: str) -> set[str]:
+    matches: set[str] = set()
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        separator = "=" if "=" in line else ":" if ":" in line else ""
+        if not separator:
+            continue
+        key, value = line.split(separator, 1)
+        key = key.strip().strip("\"'")
+        value = value.strip().strip("\"'")
+        matches.update(_matched_external_aliases(key))
+        if key.casefold() in CONFIG_VALUE_KEYS:
+            matches.update(
+                _config_string_aliases(
+                    value,
+                    command_value=key.casefold() == "command",
+                )
+            )
+    return matches
+
+
+def _matched_config_aliases(text: str) -> list[str]:
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        matches = _line_config_aliases(text)
+    else:
+        matches = _json_config_aliases(payload)
+    return sorted(matches)
 
 
 def scan_processes(proc_root: str | Path = "/proc") -> list[dict[str, Any]]:
@@ -108,14 +305,19 @@ def scan_processes(proc_root: str | Path = "/proc") -> list[dict[str, Any]]:
             continue
         if not raw or len(raw) > MAX_CMDLINE_BYTES:
             continue
-        text = raw.replace(b"\0", b" ").decode("utf-8", errors="replace")
-        matches = _matched_external_names(text)
+        argv = [
+            token.decode("utf-8", errors="replace")
+            for token in raw.split(b"\0")
+            if token
+        ]
+        matches = _matched_process_aliases(argv)
         if matches:
             findings.append(
                 {
                     "pid": int(entry.name),
-                    "executable": Path(text.split(" ", 1)[0]).name,
-                    "matched_names": matches,
+                    "executable": Path(argv[0]).name,
+                    "matched_aliases": matches,
+                    "matched_names": _matched_external_names(" ".join(argv)),
                     "argv_sha256": _sha256(raw),
                 }
             )
@@ -135,22 +337,24 @@ def scan_configs(paths: Iterable[str | Path]) -> list[dict[str, Any]]:
         except OSError as exc:
             findings.append({
                 "path": str(path), "status": "unavailable",
-                "reason": type(exc).__name__, "matched_names": [],
+                "reason": type(exc).__name__,
+                "matched_aliases": [], "matched_names": [],
             })
             continue
         if len(data) > MAX_CONFIG_BYTES:
             findings.append({
                 "path": str(path), "status": "blocked",
                 "reason": "config_too_large", "max_bytes": MAX_CONFIG_BYTES,
-                "matched_names": [],
+                "matched_aliases": [], "matched_names": [],
             })
             continue
+        decoded = data.decode("utf-8", errors="replace")
+        aliases = _matched_config_aliases(decoded)
         findings.append({
             "path": str(path), "status": "scanned", "bytes": len(data),
             "sha256": _sha256(data),
-            "matched_names": _matched_external_names(
-                data.decode("utf-8", errors="replace")
-            ),
+            "matched_aliases": aliases,
+            "matched_names": _matched_external_names(decoded) if aliases else [],
         })
     return findings
 
@@ -246,7 +450,7 @@ def build_audit(
     processes = scan_processes(proc_root)
     configs = scan_configs(config_paths)
     repository = scan_repository(repo_root) if repo_root is not None else []
-    config_matches = [item for item in configs if item.get("matched_names")]
+    config_matches = [item for item in configs if item.get("matched_aliases")]
     active_aliases_zero = not processes and not config_matches and not repository
     services = (
         [service_state("repoground.service"), service_state(FORMER_SERVICE_UNIT)]

--- a/merger/repoground/tests/test_naming_audit.py
+++ b/merger/repoground/tests/test_naming_audit.py
@@ -17,37 +17,201 @@ def _former_product() -> str:
     return "repo" + "brief"
 
 
+def _former_mcp_script() -> str:
+    return _former_product() + "-mcp-stdio.py"
+
+
+def _former_resource_uri() -> str:
+    return _former_product() + "://snapshot/demo/manifest"
+
+
 def _init_repo(root: Path) -> None:
     subprocess.run(["git", "init", "-q"], cwd=root, check=True)
     subprocess.run(["git", "add", "."], cwd=root, check=True)
 
 
-def test_process_audit_redacts_raw_argv(tmp_path: Path) -> None:
-    proc = tmp_path / "proc"
-    process = proc / "123"
+def _write_process(proc: Path, pid: int, *argv: str) -> None:
+    process = proc / str(pid)
     process.mkdir(parents=True)
-    raw = f"python3\0{_former_product()}-mcp.py\0".encode()
-    (process / "cmdline").write_bytes(raw)
+    (process / "cmdline").write_bytes(
+        b"\0".join(argument.encode() for argument in argv) + b"\0"
+    )
+
+
+def test_process_audit_redacts_concrete_command_alias(tmp_path: Path) -> None:
+    proc = tmp_path / "proc"
+    _write_process(proc, 123, "python3", f"/opt/bin/{_former_mcp_script()}")
 
     findings = scan_processes(proc)
 
-    assert len(findings) == 1
-    assert findings[0]["pid"] == 123
-    assert _former_product() in findings[0]["matched_names"]
-    assert "argv_sha256" in findings[0]
-    assert _former_product() + "-mcp.py" not in json.dumps(findings)
+    assert findings == [
+        {
+            "pid": 123,
+            "executable": "python3",
+            "matched_aliases": ["former-command-alias"],
+            "matched_names": [_former_product()],
+            "argv_sha256": findings[0]["argv_sha256"],
+        }
+    ]
+    serialized = json.dumps(findings)
+    assert _former_mcp_script() not in serialized
 
 
-def test_config_audit_is_hash_only(tmp_path: Path) -> None:
+def test_process_audit_detects_former_executable_basename(tmp_path: Path) -> None:
+    proc = tmp_path / "proc"
+    _write_process(proc, 123, f"/opt/bin/{_former_product()}")
+
+    assert scan_processes(proc)[0]["matched_aliases"] == [
+        "former-command-alias"
+    ]
+
+
+def test_process_audit_ignores_prompt_only_name_mentions(tmp_path: Path) -> None:
+    proc = tmp_path / "proc"
+    prompt = (
+        "Review the old RepoBrief and rLens naming history, but do not execute "
+        "any compatibility command."
+    )
+    _write_process(proc, 123, "claude", "--prompt", prompt)
+
+    assert scan_processes(proc) == []
+
+
+def test_process_audit_ignores_prompt_flag_with_uri_only_value(tmp_path: Path) -> None:
+    proc = tmp_path / "proc"
+    _write_process(proc, 123, "claude", "--prompt", _former_resource_uri())
+
+    assert scan_processes(proc) == []
+
+
+def test_non_agent_text_argument_with_alias_is_still_scanned(tmp_path: Path) -> None:
+    proc = tmp_path / "proc"
+    _write_process(
+        proc,
+        123,
+        "custom-tool",
+        "--script",
+        "load " + _former_resource_uri(),
+    )
+
+    finding = scan_processes(proc)[0]
+
+    assert finding["matched_aliases"] == ["former-resource-scheme"]
+
+
+def test_non_agent_short_p_does_not_hide_an_alias_value(tmp_path: Path) -> None:
+    proc = tmp_path / "proc"
+    _write_process(proc, 123, "custom-tool", "-p", _former_resource_uri())
+
+    finding = scan_processes(proc)[0]
+
+    assert finding["matched_aliases"] == ["former-resource-scheme"]
+    assert finding["matched_names"] == [_former_product()]
+
+
+def test_python_wrapped_agent_prompt_is_ignored(tmp_path: Path) -> None:
+    proc = tmp_path / "proc"
+    _write_process(
+        proc,
+        123,
+        "python3",
+        "/opt/agents/claude.py",
+        "--prompt",
+        _former_resource_uri(),
+    )
+
+    assert scan_processes(proc) == []
+
+
+def test_process_audit_detects_standalone_uri_env_and_storage_tokens(tmp_path: Path) -> None:
+    proc = tmp_path / "proc"
+    old_env = ("r" + "lens_token").upper() + "=redacted"
+    old_store = "/home/alex/repos/merges/." + "r" + "lens-service"
+    _write_process(
+        proc,
+        123,
+        "python3",
+        _former_resource_uri(),
+        old_env,
+        old_store,
+    )
+
+    findings = scan_processes(proc)
+
+    assert findings[0]["matched_aliases"] == [
+        "former-environment",
+        "former-resource-scheme",
+        "former-runtime-storage",
+    ]
+
+
+def test_config_audit_is_hash_only_for_concrete_aliases(tmp_path: Path) -> None:
     config = tmp_path / "config.json"
-    config.write_text(json.dumps({"command": _former_product()}), encoding="utf-8")
+    config.write_text(
+        json.dumps({"uri": _former_resource_uri()}),
+        encoding="utf-8",
+    )
 
     finding = scan_configs([config])[0]
 
     assert finding["status"] == "scanned"
-    assert _former_product() in finding["matched_names"]
+    assert finding["matched_aliases"] == ["former-resource-scheme"]
+    assert finding["matched_names"] == [_former_product()]
     assert "sha256" in finding
-    assert "command" not in finding
+    assert "uri" not in finding
+
+
+def test_config_audit_detects_exact_command_and_args_fields(tmp_path: Path) -> None:
+    config = tmp_path / "config.json"
+    old_store = "/home/alex/repos/merges/." + "r" + "lens-service"
+    config.write_text(
+        json.dumps({"command": _former_product(), "args": [old_store]}),
+        encoding="utf-8",
+    )
+
+    finding = scan_configs([config])[0]
+
+    assert finding["matched_aliases"] == [
+        "former-command-alias",
+        "former-runtime-storage",
+    ]
+    assert finding["matched_names"] == [_former_product(), "rlens"]
+
+
+def test_config_audit_ignores_aliases_in_nonsemantic_lists(tmp_path: Path) -> None:
+    config = tmp_path / "notes.json"
+    config.write_text(
+        json.dumps({"notes": [_former_resource_uri(), _former_mcp_script()]}),
+        encoding="utf-8",
+    )
+
+    finding = scan_configs([config])[0]
+
+    assert finding["matched_aliases"] == []
+    assert finding["matched_names"] == []
+
+
+def test_config_audit_ignores_explanatory_name_mentions(tmp_path: Path) -> None:
+    config = tmp_path / "notes.json"
+    config.write_text(
+        json.dumps(
+            {
+                "description": (
+                    "Migration history mentions RepoBrief, rLens, "
+                    + _former_resource_uri()
+                    + " and "
+                    + _former_mcp_script()
+                )
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    finding = scan_configs([config])[0]
+
+    assert finding["status"] == "scanned"
+    assert finding["matched_aliases"] == []
+    assert finding["matched_names"] == []
 
 
 def test_repository_audit_detects_runtime_alias_but_not_versioned_kind(tmp_path: Path) -> None:


### PR DESCRIPTION
## Ziel

Verhindert Fehlalarme im Live-Namensaudit, wenn alte Produktnamen lediglich in Agentenprompts, Beschreibungen oder historischen Notizen vorkommen.

## Umsetzung

- Prozesse werden argumentweise statt als zusammengefügte Befehlszeile geprüft.
- Promptwerte werden nur bei erkannten Agentenprogrammen und bekannten Prompt-Schaltern ignoriert.
- `-p` bleibt bei normalen Programmen prüfbar.
- Aktive alte Befehle, URIs, Umgebungsvariablen, Speicherpfade, Dienstnamen, Module und UI-Schlüssel bleiben blockierend.
- JSON-Konfigurationen werden nach semantischen Feldern wie `command`, `args`, `uri`, `path`, `env` und `unit` ausgewertet.
- Beschreibungsfelder und nichtsemantische Listen erzeugen keine Aliasbefunde.
- Die veröffentlichte v1-Ausgabe bleibt additiv kompatibel: `matched_names` bleibt erhalten; `matched_aliases` liefert die präzise Mechanismenkategorie.
- Rohargumente und Konfigurationsinhalte bleiben redigiert.

## Reale Ursache

Ein fremder Claude-Prozess erwähnte `RepoBrief` und `rLens` ausschließlich in seinem Arbeitsauftrag. Der alte Audit wertete diese Wörter als aktive Aliasnutzung. Der Prozess wurde nicht beendet oder verändert.

## Prüfung

- 4.402 Pytests bestanden, 2 erwartete Skips, 13 ausgeschlossene Browser-/Livefälle
- 26 fokussierte Audit-, Hard-Cut- und Diensttests bestanden
- Ruff: PASS
- Graph-Wartbarkeit: PASS
- realer Host-Audit: `active_aliases_zero=true`, keine Prozess-, Konfigurations- oder Repositorybefunde
- Diff-SHA-256: `069434016c6a64849e4d12b1ebf228b1a3b5125d5cb04217174e7ede93f4513c`
- Volltest-Task: `d54f196863054ea29e1157bc`
- Lifecycle-Receipt: `d26e3ca1b0b54e1711766c541f01173154a681169fc868bfa6826974bbeb0e06`

## Nicht behauptet

- Der produktive Dienst enthält diesen Fix bereits.
- Bureau #703 ist organisationsweit abgeschlossen.

Der Dienst wird erst nach grünem GitHub-Readback und Merge commitgebunden aktualisiert.