### PR TITLE
Hard-cut RepoGround publisher storage aliases

### DIFF
--- a/docs/contracts/repoground-naming-hard-cut.v1.json
+++ b/docs/contracts/repoground-naming-hard-cut.v1.json
@@ -22,7 +22,10 @@
     "source_snapshot_directory": ".repoground-source-snapshots",
     "pythonista_state_file": ".repoground-state.json",
     "pr_workspace_directory": ".repoground/pr-schau",
-    "generator_name": "repoground"
+    "generator_name": "repoground",
+    "fleet_state_directory": "~/.local/state/repoground-publish/fleet",
+    "fleet_log_directory": "~/logs/repoground-publish",
+    "retention_quarantine_directory": ".repoground-prune-quarantine"
   },
   "versioned_data_contracts": {
     "policy": "retained_exactly_until_a_new_versioned_producer_schema_reader_migration_exists",
@@ -43,7 +46,17 @@
       "docs/reviews/"
     ],
     "must_be_non_executable": true,
-    "not_runtime_authority": true
+    "not_runtime_authority": true,
+    "runtime_archives_not_default_storage": true,
+    "read_only_state_and_log_archives": [
+      "/home/alex/.local/state/repobrief-publish",
+      "/home/alex/logs/repobrief-publish"
+    ],
+    "explicit_prune_only_publication_archives": [
+      "/home/alex/repos/merges/repobrief-auto",
+      "/home/alex/repos/manifest-publications/repobrief-auto"
+    ],
+    "publication_archive_mutation_requires_explicit_prune": true
   },
   "audit": {
     "command": "scripts/ops/repoground-naming-audit --repo-root . --fail-on-active-alias",

--- a/merger/repoground/core/naming_audit.py
+++ b/merger/repoground/core/naming_audit.py
@@ -128,6 +128,7 @@ def _external_alias_patterns() -> dict[str, tuple[str, ...]]:
             old_profile_var,
             ("r" + "lens_").upper(),
             ("repo" + "lens_").upper(),
+            ("r" + "b_").upper(),
         ),
         "former-runtime-storage": (
             "." + "r" + "lens-service",
@@ -135,6 +136,9 @@ def _external_alias_patterns() -> dict[str, tuple[str, ...]]:
             "r" + "lens-job-",
             ".repo" + "Lens-state.json",
             ".repo" + "lens/pr-schau",
+            "/.local/state/" + "repobrief-publish/",
+            "/logs/" + "repobrief-publish",
+            "." + "rb-prune-quarantine",
         ),
         "former-service-unit": (FORMER_SERVICE_UNIT,),
         "former-python-module": ("merger." + "lens" + "kit",),

--- a/merger/repoground/tests/test_fleet_runtime.py
+++ b/merger/repoground/tests/test_fleet_runtime.py
@@ -103,11 +103,29 @@ def isolate_retention_roots(
         "log": tmp_path / "log",
     }
     monkeypatch.setattr(module, "PUB_ROOT", roots["publication"])
-    monkeypatch.setattr(module, "LEGACY_OUT_ROOT", roots["legacy"])
-    monkeypatch.setattr(module, "SPECIAL_OUT_ROOT", roots["special"])
+    monkeypatch.setattr(module, "ARCHIVED_LEGACY_OUT_ROOT", roots["legacy"])
+    monkeypatch.setattr(module, "ARCHIVED_SPECIAL_OUT_ROOT", roots["special"])
     monkeypatch.setattr(module, "STATE_ROOT", roots["state"])
     monkeypatch.setattr(module, "LOG_ROOT", roots["log"])
     return roots
+
+
+def test_publisher_uses_only_canonical_active_environment_and_storage() -> None:
+    text = PUBLISHER.read_text(encoding="utf-8")
+    former_env_prefix = "R" + "B_"
+    former_state = "/home/alex/.local/state/" + "repobrief-publish/fleet"
+    former_log = "/home/alex/logs/" + "repobrief-publish"
+    former_quarantine = "." + "rb-prune-quarantine"
+
+    assert former_env_prefix not in text
+    assert former_state not in text
+    assert former_log not in text
+    assert former_quarantine not in text
+    assert "/home/alex/.local/state/repoground-publish/fleet" in text
+    assert "/home/alex/logs/repoground-publish" in text
+    assert ".repoground-prune-quarantine" in text
+    assert "ARCHIVED_LEGACY_OUT_ROOT" in text
+    assert "ARCHIVED_SPECIAL_OUT_ROOT" in text
 
 
 def test_fingerprint_is_stable_and_covers_all_output_inputs() -> None:
@@ -562,6 +580,71 @@ def test_runtime_has_one_hourly_changed_only_timer_and_no_force_fallback() -> No
         "repoground-publish-fleet-watch.service",
         "repoground-publish-fleet-watch.timer",
     ]
+
+
+def _run_installer(tmp_path: Path) -> subprocess.CompletedProcess[str]:
+    home = tmp_path / "home"
+    fake_bin = tmp_path / "bin"
+    home.mkdir(exist_ok=True)
+    fake_bin.mkdir(exist_ok=True)
+    systemctl = fake_bin / "systemctl"
+    systemctl.write_text(
+        "#!/bin/sh\nprintf '%s\n' \"$*\" >> \"$HOME/systemctl.log\"\n",
+        encoding="utf-8",
+    )
+    systemctl.chmod(0o755)
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["PATH"] = str(fake_bin) + os.pathsep + env["PATH"]
+    return subprocess.run(
+        [str(INSTALLER)],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        check=False,
+    )
+
+
+def test_installer_atomically_migrates_state_and_starts_canonical_logs(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    old_state = home / ".local/state/repobrief-publish/fleet"
+    old_log = home / "logs/repobrief-publish"
+    old_state.mkdir(parents=True)
+    old_log.mkdir(parents=True)
+    (old_state / "marker.json").write_text("{}\n", encoding="utf-8")
+    (old_log / "historical.log").write_text("old\n", encoding="utf-8")
+
+    completed = _run_installer(tmp_path)
+
+    new_state = home / ".local/state/repoground-publish/fleet"
+    new_log = home / "logs/repoground-publish"
+    assert completed.returncode == 0, completed.stderr
+    assert not old_state.exists()
+    assert (new_state / "marker.json").read_text(encoding="utf-8") == "{}\n"
+    assert new_log.is_dir()
+    assert (old_log / "historical.log").read_text(encoding="utf-8") == "old\n"
+    assert (home / ".local/bin/repoground-publish-fleet").is_file()
+    assert "PASS paused" in completed.stdout
+
+
+def test_installer_refuses_dual_state_truth(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    old_state = home / ".local/state/repobrief-publish/fleet"
+    new_state = home / ".local/state/repoground-publish/fleet"
+    old_state.mkdir(parents=True)
+    new_state.mkdir(parents=True)
+    (old_state / "old").write_text("old", encoding="utf-8")
+    (new_state / "new").write_text("new", encoding="utf-8")
+
+    completed = _run_installer(tmp_path)
+
+    assert completed.returncode == 1
+    assert "refusing dual truth" in completed.stderr
+    assert (old_state / "old").is_file()
+    assert (new_state / "new").is_file()
 
 
 def test_installer_defaults_to_paused_and_removes_duplicate_generators() -> None:

--- a/merger/repoground/tests/test_naming_audit.py
+++ b/merger/repoground/tests/test_naming_audit.py
@@ -145,6 +145,30 @@ def test_process_audit_detects_standalone_uri_env_and_storage_tokens(tmp_path: P
     ]
 
 
+def test_process_audit_detects_former_fleet_env_and_storage(tmp_path: Path) -> None:
+    proc = tmp_path / "proc"
+    old_env = ("r" + "b_state_root").upper() + "=/tmp/state"
+    old_state = "/home/alex/.local/state/" + "repobrief-publish/fleet"
+    old_log = "/home/alex/logs/" + "repobrief-publish"
+    old_quarantine = "." + "rb-prune-quarantine"
+    _write_process(
+        proc,
+        123,
+        "python3",
+        old_env,
+        old_state,
+        old_log,
+        old_quarantine,
+    )
+
+    finding = scan_processes(proc)[0]
+
+    assert finding["matched_aliases"] == [
+        "former-environment",
+        "former-runtime-storage",
+    ]
+
+
 def test_config_audit_is_hash_only_for_concrete_aliases(tmp_path: Path) -> None:
     config = tmp_path / "config.json"
     config.write_text(

--- a/scripts/ops/install_repoground_publish_fleet_runtime.sh
+++ b/scripts/ops/install_repoground_publish_fleet_runtime.sh
@@ -5,6 +5,10 @@ ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
 BIN_DIR=${HOME}/.local/bin
 UNIT_DIR=${HOME}/.config/systemd/user
 ENABLE=0
+OLD_STATE_ROOT=${HOME}/.local/state/repobrief-publish/fleet
+STATE_ROOT=${HOME}/.local/state/repoground-publish/fleet
+LOG_ROOT=${HOME}/logs/repoground-publish
+
 if [[ ${1:-} == "--enable" ]]; then
   ENABLE=1
 elif [[ $# -gt 0 ]]; then
@@ -31,9 +35,33 @@ OLD_UNITS=(
 )
 
 install -d -m 0755 "$BIN_DIR" "$UNIT_DIR"
+systemctl --user disable --now repoground-publish-fleet-watch.timer 2>/dev/null || true
+systemctl --user stop repoground-publish-fleet-watch.service 2>/dev/null || true
 for unit in "${OLD_TIMERS[@]}"; do
   systemctl --user disable --now "$unit" 2>/dev/null || true
 done
+
+if [[ -L $OLD_STATE_ROOT || -L $STATE_ROOT ]]; then
+  echo "publisher state roots must not be symlinks" >&2
+  exit 1
+fi
+if [[ -e $OLD_STATE_ROOT && ! -d $OLD_STATE_ROOT ]]; then
+  echo "old publisher state root is not a directory: $OLD_STATE_ROOT" >&2
+  exit 1
+fi
+if [[ -e $STATE_ROOT && ! -d $STATE_ROOT ]]; then
+  echo "RepoGround publisher state root is not a directory: $STATE_ROOT" >&2
+  exit 1
+fi
+if [[ -d $OLD_STATE_ROOT && -d $STATE_ROOT ]]; then
+  echo "both old and RepoGround publisher state roots exist; refusing dual truth" >&2
+  exit 1
+fi
+if [[ -d $OLD_STATE_ROOT ]]; then
+  install -d -m 0755 "$(dirname "$STATE_ROOT")"
+  mv -- "$OLD_STATE_ROOT" "$STATE_ROOT"
+fi
+install -d -m 0755 "$STATE_ROOT" "$LOG_ROOT"
 
 install -m 0755 "$ROOT/scripts/ops/repoground-publish-fleet" "$BIN_DIR/repoground-publish-fleet"
 install -m 0755 "$ROOT/scripts/ops/repoground-publication-policy" "$BIN_DIR/repoground-publication-policy"

--- a/scripts/ops/repoground-publish-fleet
+++ b/scripts/ops/repoground-publish-fleet
@@ -27,54 +27,47 @@ from pathlib import Path
 from typing import Any, Iterable
 
 
-def _env_value(primary: str, legacy: str, default: str) -> str:
-    return os.environ.get(primary) or os.environ.get(legacy) or default
-
-
 REPOS_ROOT = Path(
-    _env_value("REPOGROUND_REPOS_ROOT", "RB_REPOS_ROOT", "/home/alex/repos")
+    os.environ.get("REPOGROUND_REPOS_ROOT") or "/home/alex/repos"
 ).expanduser()
 REPOGROUND_REPO = Path(
-    os.environ.get("REPOGROUND_REPOSITORY_PATH")
-    or os.environ.get("RB_REPOSITORY_PATH")
-    or (REPOS_ROOT / "repoground")
+    os.environ.get("REPOGROUND_REPOSITORY_PATH") or (REPOS_ROOT / "repoground")
 )
 TOOL_WT = Path(
     os.environ.get("REPOGROUND_TOOL_WORKTREE")
-    or os.environ.get("RB_TOOL_WORKTREE")
     or (REPOS_ROOT / ".repoground-tools" / "repoground-main")
 )
 SOURCE_ROOT = Path(
     os.environ.get("REPOGROUND_SOURCE_ROOT")
-    or os.environ.get("RB_SOURCE_ROOT")
     or (REPOS_ROOT / ".repoground-sources")
 )
-LEGACY_OUT_ROOT = REPOS_ROOT / "merges" / "repobrief-auto"
 PUB_ROOT = REPOS_ROOT / "manifest-publications"
-SPECIAL_OUT_ROOT = PUB_ROOT / "repobrief-auto"
+
+# Historical publication trees are archive-only retention roots. New
+# publications are written only below PUB_ROOT / "bundles". Archive mutation is
+# available only through explicit prune flags; moving old manifests would
+# invalidate recorded paths and evidence.
+ARCHIVED_LEGACY_OUT_ROOT = REPOS_ROOT / "merges" / "repobrief-auto"
+ARCHIVED_SPECIAL_OUT_ROOT = PUB_ROOT / "repobrief-auto"
+
 STATE_ROOT = Path(
-    _env_value(
-        "REPOGROUND_FLEET_STATE_ROOT",
-        "RB_STATE_ROOT",
-        "/home/alex/.local/state/repobrief-publish/fleet",
-    )
+    os.environ.get("REPOGROUND_FLEET_STATE_ROOT")
+    or "/home/alex/.local/state/repoground-publish/fleet"
 ).expanduser()
 LOG_ROOT = Path(
-    _env_value(
-        "REPOGROUND_FLEET_LOG_ROOT",
-        "RB_LOG_ROOT",
-        "/home/alex/logs/repobrief-publish",
-    )
+    os.environ.get("REPOGROUND_FLEET_LOG_ROOT")
+    or "/home/alex/logs/repoground-publish"
 ).expanduser()
 FLEET_LOG = LOG_ROOT / "fleet.log"
 LOCK_PATH = STATE_ROOT.parent / "fleet.lock"
+
 DEFAULT_RETENTION = 3
 MAX_RETENTION = 10
 FINGERPRINT_SCHEMA = "repobrief.fleet-publication-fingerprint.v3"
 STATE_SCHEMA = "repobrief.fleet-publication-state.v1"
 ACTIVE_LEASE_SCHEMA = "repobrief.active-publication-lease.v1"
 PRUNE_TRANSACTION_SCHEMA = "repobrief.retention-transaction.v1"
-QUARANTINE_DIR_NAME = ".rb-prune-quarantine"
+QUARANTINE_DIR_NAME = ".repoground-prune-quarantine"
 GENERATOR_INPUT_PATHS = (
     "merger/repoground/__init__.py",
     "merger/repoground/cli/__init__.py",
@@ -650,7 +643,7 @@ def prune_transaction_root() -> Path:
 
 
 def retention_roots() -> tuple[Path, ...]:
-    return (PUB_ROOT, LEGACY_OUT_ROOT, SPECIAL_OUT_ROOT)
+    return (PUB_ROOT, ARCHIVED_LEGACY_OUT_ROOT, ARCHIVED_SPECIAL_OUT_ROOT)
 
 
 def _path_under(path: Path, root: Path) -> bool:
@@ -1467,7 +1460,7 @@ def prune_all_current(
 def legacy_version_groups() -> list[Path]:
     groups: list[Path] = []
     for repository_group in managed_directories(
-        LEGACY_OUT_ROOT, label="legacy publication"
+        ARCHIVED_LEGACY_OUT_ROOT, label="legacy publication"
     ):
         children = managed_directories(
             repository_group, label=f"legacy repository {repository_group.name}"
@@ -1506,7 +1499,7 @@ def prune_all_special(
 ) -> list[dict[str, object]]:
     return [
         prune_group(group, keep=keep, apply=apply, protected=protected)
-        for group in managed_directories(SPECIAL_OUT_ROOT, label="special publication")
+        for group in managed_directories(ARCHIVED_SPECIAL_OUT_ROOT, label="special publication")
     ]
 
 

--- a/tests/test_naming_hard_cut.py
+++ b/tests/test_naming_hard_cut.py
@@ -48,7 +48,23 @@ def test_runtime_identity_is_canonical() -> None:
         "pythonista_state_file": ".repoground-state.json",
         "pr_workspace_directory": ".repoground/pr-schau",
         "generator_name": "repoground",
+        "fleet_state_directory": "~/.local/state/repoground-publish/fleet",
+        "fleet_log_directory": "~/logs/repoground-publish",
+        "retention_quarantine_directory": ".repoground-prune-quarantine",
     }
+
+
+def test_historical_runtime_archives_are_bounded_and_not_defaults() -> None:
+    data = json.loads(CONTRACT.read_text(encoding="utf-8"))
+    evidence = data["historical_evidence"]
+    read_only = evidence["read_only_state_and_log_archives"]
+    prune_only = evidence["explicit_prune_only_publication_archives"]
+
+    assert evidence["runtime_archives_not_default_storage"] is True
+    assert evidence["publication_archive_mutation_requires_explicit_prune"] is True
+    assert "/home/alex/logs/repobrief-publish" in read_only
+    assert "/home/alex/repos/merges/repobrief-auto" in prune_only
+    assert "/home/alex/repos/manifest-publications/repobrief-auto" in prune_only
 
 
 def test_versioned_data_ids_are_not_reinterpreted_as_aliases() -> None:


### PR DESCRIPTION
## Ziel

Schließt die noch aktive RepoBrief/rb-Namensschicht im RepoGround Fleet-Publisher, ohne historische Publikationsbelege umzudeuten oder den 1,2-GB-Archivbaum zu duplizieren.

## Umsetzung

- alle aktiven `RB_*`-Umgebungsfallbacks aus dem Publisher entfernt
- Fleet-State auf `~/.local/state/repoground-publish/fleet` umgestellt
- Fleet-Logs auf `~/logs/repoground-publish` umgestellt
- Retention-Quarantäne auf `.repoground-prune-quarantine` umgestellt
- Installer stoppt Timer und Service vor der Migration
- alter Fleet-State wird bei eindeutigem Ziel atomar verschoben
- gleichzeitig alter und neuer State führt fail-closed zum Abbruch
- alte Logs bleiben unverändert als read-only Archiv; neue Läufe schreiben kanonisch
- alte Publikationsbäume bleiben archive-only Retentionquellen und sind nur über explizite Prune-Flags veränderbar
- Hard-Cut-Vertrag um Publisher-State, Logs, Quarantäne und Archivgrenzen ergänzt
- Live-Audit erkennt ehemalige Fleet-Umgebungs- und Speichermechanismen

## Nicht verändert

- versionierte `repobrief.*`-Schema- und Zustandskennungen
- historische Manifest- und Evidenzpfade
- fremder dirty Worktree `fleet-publisher-hygiene-v1`
- bestehende Altarchive unter `repobrief-auto`

## Prüfung

- 4.407 Pytests bestanden, 2 erwartete Skips, 13 ausgeschlossene Browser-/Livefälle
- 72 fokussierte Fleet-, Installer-, Audit- und Hard-Cut-Tests bestanden
- Installer-Shellsyntax: PASS
- Ruff: PASS
- Graph-Wartbarkeit: PASS
- Release-Vertrag: PASS
- GitHub-Actions-Pins: PASS
- Doc-Freshness: 36 PASS
- Repository-Namensaudit: `active_aliases_zero=true`
- Diff-SHA-256: `3be40a3a77441f3510ded781aaa53f775aa216fd8300f120dc7f652e004b847a`
- Volltest-Task: `8bfa7ebca0374e5197cf7a4a`
- Test-Receipt: `1339758f5770c5649f0b616b05f03a838ac6409730c50c1da9b5da45ad8e8e49`

## Deployment-Grenze

Der aktive Timer und installierte Publisher bleiben bis zum grünen GitHub-Readback unverändert. Nach Merge erfolgt ein kontrollierter Stop, State-Digest, atomarer Move, Installer-Cutover, gezielte RepoGround-Publikation und `fresh_exact`-Readback.