### PR TITLE
Read persisted v1 prune quarantine paths

### DIFF
--- a/merger/repoground/tests/test_fleet_runtime.py
+++ b/merger/repoground/tests/test_fleet_runtime.py
@@ -842,6 +842,9 @@ def test_transactional_delete_is_journaled_and_confined(
     payload = json.loads(transaction.read_text())
     assert payload["state"] == "deleted"
     assert payload["source"] == str(candidate.resolve(strict=False))
+    quarantine_path = Path(payload["quarantine"])
+    assert quarantine_path.parent.parent.name == module.QUARANTINE_DIR_NAME
+    assert module.PERSISTED_V1_QUARANTINE_DIR_NAME not in quarantine_path.parts
 
     outside = tmp_path / "outside"
     outside.mkdir()
@@ -853,6 +856,87 @@ def test_transactional_delete_is_journaled_and_confined(
             removed_bytes=0,
             protected=set(),
         )
+
+
+def test_reconciliation_accepts_terminal_persisted_v1_quarantine_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    roots = isolate_retention_roots(module, tmp_path, monkeypatch)
+    group = roots["publication"] / "bundles" / "demo" / "main"
+    group.mkdir(parents=True)
+    source = group / "20260714T100000Z"
+    transaction_id = "a" * 32
+    quarantine = (
+        group
+        / module.PERSISTED_V1_QUARANTINE_DIR_NAME
+        / transaction_id
+        / source.name
+    )
+    transaction = module.prune_transaction_root() / f"{transaction_id}.json"
+    module.atomic_write_json(
+        transaction,
+        {
+            "schema": module.PRUNE_TRANSACTION_SCHEMA,
+            "transaction_id": transaction_id,
+            "state": "deleted",
+            "source": str(source.resolve(strict=False)),
+            "quarantine": str(quarantine.resolve(strict=False)),
+            "root": str(group.resolve()),
+            "snapshot": {"device": 1, "inode": 2, "tree_sha256": "a" * 64},
+            "removed_bytes": 1,
+        },
+    )
+
+    reports = module.reconcile_prune_transactions(protected=set(), apply=True)
+
+    assert reports == [{"transaction": str(transaction), "state": "deleted"}]
+    assert json.loads(transaction.read_text(encoding="utf-8"))["quarantine"] == str(
+        quarantine.resolve(strict=False)
+    )
+
+
+def test_reconciliation_finishes_persisted_v1_quarantine_after_crash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    roots = isolate_retention_roots(module, tmp_path, monkeypatch)
+    group = roots["publication"] / "bundles" / "demo" / "main"
+    source, _ = write_version(group, "20260714T100000Z", b"payload", 1)
+    snapshot = module.tree_snapshot(source)
+    removed_bytes = module.tree_bytes(source)
+    transaction_id = "9" * 32
+    quarantine = (
+        group
+        / module.PERSISTED_V1_QUARANTINE_DIR_NAME
+        / transaction_id
+        / source.name
+    )
+    quarantine.parent.mkdir(parents=True)
+    os.replace(source, quarantine)
+    transaction = module.prune_transaction_root() / f"{transaction_id}.json"
+    module.atomic_write_json(
+        transaction,
+        {
+            "schema": module.PRUNE_TRANSACTION_SCHEMA,
+            "transaction_id": transaction_id,
+            "state": "quarantined",
+            "source": str(source.resolve(strict=False)),
+            "quarantine": str(quarantine.resolve(strict=False)),
+            "root": str(group.resolve()),
+            "snapshot": snapshot,
+            "removed_bytes": removed_bytes,
+        },
+    )
+
+    assert module.version_dirs(group) == []
+    reports = module.reconcile_prune_transactions(protected=set(), apply=True)
+
+    assert reports[0]["applied"] == "delete"
+    assert not source.exists()
+    assert not quarantine.exists()
+    assert not (group / module.PERSISTED_V1_QUARANTINE_DIR_NAME).exists()
+    assert json.loads(transaction.read_text(encoding="utf-8"))["state"] == "deleted"
 
 
 def test_reconciliation_restores_planned_move_that_became_protected(
@@ -986,14 +1070,21 @@ def test_reconciliation_rejects_forged_quarantine_path(
     assert forged.is_dir()
 
 
+@pytest.mark.parametrize(
+    "directory_name_attribute",
+    ["QUARANTINE_DIR_NAME", "PERSISTED_V1_QUARANTINE_DIR_NAME"],
+)
 def test_unjournaled_quarantine_entry_fails_closed(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    directory_name_attribute: str,
 ) -> None:
     module = load_publisher()
     roots = isolate_retention_roots(module, tmp_path, monkeypatch)
     group = roots["publication"] / "bundles" / "demo" / "main"
     write_version(group, "20260714T100000Z", b"payload", 1)
-    orphan = group / module.QUARANTINE_DIR_NAME / ("e" * 32) / "20260714T090000Z"
+    directory_name = getattr(module, directory_name_attribute)
+    orphan = group / directory_name / ("e" * 32) / "20260714T090000Z"
     orphan.mkdir(parents=True)
 
     with pytest.raises(RuntimeError, match="unexpected retention quarantine entries"):

--- a/scripts/ops/repoground-publish-fleet
+++ b/scripts/ops/repoground-publish-fleet
@@ -68,6 +68,11 @@ STATE_SCHEMA = "repobrief.fleet-publication-state.v1"
 ACTIVE_LEASE_SCHEMA = "repobrief.active-publication-lease.v1"
 PRUNE_TRANSACTION_SCHEMA = "repobrief.retention-transaction.v1"
 QUARANTINE_DIR_NAME = ".repoground-prune-quarantine"
+PERSISTED_V1_QUARANTINE_DIR_NAME = "." + "r" + "b-prune-quarantine"
+READABLE_QUARANTINE_DIR_NAMES = (
+    QUARANTINE_DIR_NAME,
+    PERSISTED_V1_QUARANTINE_DIR_NAME,
+)
 GENERATOR_INPUT_PATHS = (
     "merger/repoground/__init__.py",
     "merger/repoground/cli/__init__.py",
@@ -696,31 +701,32 @@ def prune_transaction_files() -> list[Path]:
 
 
 def validate_quarantine_directory(group: Path) -> None:
-    quarantine_root = group / QUARANTINE_DIR_NAME
-    if not quarantine_root.exists():
-        return
-    if quarantine_root.is_symlink() or not quarantine_root.is_dir():
-        raise RuntimeError(
-            f"retention quarantine is not a directory: {quarantine_root}"
-        )
     unexpected: list[Path] = []
-    for transaction_dir in quarantine_root.iterdir():
-        transaction_file = prune_transaction_root() / f"{transaction_dir.name}.json"
-        valid_transaction_dir = (
-            transaction_dir.is_dir()
-            and not transaction_dir.is_symlink()
-            and TRANSACTION_ID_RE.fullmatch(transaction_dir.name)
-            and transaction_file.is_file()
-            and not transaction_file.is_symlink()
-        )
-        if not valid_transaction_dir:
-            unexpected.append(transaction_dir)
+    for directory_name in READABLE_QUARANTINE_DIR_NAMES:
+        quarantine_root = group / directory_name
+        if not quarantine_root.exists():
             continue
-        children = list(transaction_dir.iterdir())
-        if len(children) > 1 or any(
-            child.is_symlink() or not child.is_dir() for child in children
-        ):
-            unexpected.extend(children or [transaction_dir])
+        if quarantine_root.is_symlink() or not quarantine_root.is_dir():
+            raise RuntimeError(
+                f"retention quarantine is not a directory: {quarantine_root}"
+            )
+        for transaction_dir in quarantine_root.iterdir():
+            transaction_file = prune_transaction_root() / f"{transaction_dir.name}.json"
+            valid_transaction_dir = (
+                transaction_dir.is_dir()
+                and not transaction_dir.is_symlink()
+                and TRANSACTION_ID_RE.fullmatch(transaction_dir.name)
+                and transaction_file.is_file()
+                and not transaction_file.is_symlink()
+            )
+            if not valid_transaction_dir:
+                unexpected.append(transaction_dir)
+                continue
+            children = list(transaction_dir.iterdir())
+            if len(children) > 1 or any(
+                child.is_symlink() or not child.is_dir() for child in children
+            ):
+                unexpected.extend(children or [transaction_dir])
     if unexpected:
         rendered = ", ".join(str(path) for path in sorted(unexpected))
         raise RuntimeError(f"unexpected retention quarantine entries: {rendered}")
@@ -767,10 +773,13 @@ def _validated_transaction_paths(
         raise RuntimeError(
             f"prune transaction source is not a direct group child: {transaction_file}"
         )
-    expected_quarantine = (
-        managed_root / QUARANTINE_DIR_NAME / transaction_id / source.name
-    ).resolve(strict=False)
-    if quarantine != expected_quarantine:
+    expected_quarantines = {
+        (managed_root / directory_name / transaction_id / source.name).resolve(
+            strict=False
+        )
+        for directory_name in READABLE_QUARANTINE_DIR_NAMES
+    }
+    if quarantine not in expected_quarantines:
         raise RuntimeError(
             f"prune transaction quarantine path mismatch: {transaction_file}"
         )
@@ -851,7 +860,11 @@ def version_dirs(group: Path) -> list[Path]:
     rows: list[Path] = []
     unexpected: list[Path] = []
     for path in group.iterdir():
-        if path.name == QUARANTINE_DIR_NAME and path.is_dir() and not path.is_symlink():
+        if (
+            path.name in READABLE_QUARANTINE_DIR_NAMES
+            and path.is_dir()
+            and not path.is_symlink()
+        ):
             continue
         if (
             path.is_dir()
@@ -876,7 +889,11 @@ def localized_hash_dirs(group: Path) -> list[Path]:
     rows: list[Path] = []
     unexpected: list[Path] = []
     for path in group.iterdir():
-        if path.name == QUARANTINE_DIR_NAME and path.is_dir() and not path.is_symlink():
+        if (
+            path.name in READABLE_QUARANTINE_DIR_NAMES
+            and path.is_dir()
+            and not path.is_symlink()
+        ):
             continue
         if (
             path.is_dir()
@@ -1024,8 +1041,15 @@ def _cleanup_quarantine_parents(quarantine: Path, managed_root: Path) -> None:
         quarantine.parent.rmdir()
     except OSError:
         pass
+    quarantine_root = quarantine.parent.parent.resolve(strict=False)
+    readable_roots = {
+        managed_root.joinpath(directory_name).resolve(strict=False)
+        for directory_name in READABLE_QUARANTINE_DIR_NAMES
+    }
+    if quarantine_root not in readable_roots:
+        return
     try:
-        managed_root.joinpath(QUARANTINE_DIR_NAME).rmdir()
+        quarantine_root.rmdir()
     except OSError:
         pass
 


### PR DESCRIPTION
## Problem

Nach dem Publisher-State-Cutover verweigerte RepoGround die 630 bereits terminalen `repobrief.retention-transaction.v1`-Belege, weil deren gespeicherter Quarantänepfad noch den damals gültigen Namen trägt.

## Lösung

- der v1-Leser akzeptiert exakt den kanonischen und den historisch gespeicherten Quarantänepfad
- beide Pfade müssen weiterhin unter derselben verwalteten Wurzel, Transaktions-ID und demselben Quellnamen liegen
- Pfadflucht, Symlinks, falsche IDs, falsche Quellnamen und unjournalisierte Ordner bleiben fail-closed
- neue Transaktionen schreiben weiterhin ausschließlich `.repoground-prune-quarantine`
- alte Belege werden nicht umgeschrieben
- unterbrochene alte v1-Transaktionen können sicher abgeschlossen und ihre leeren Quarantäneverzeichnisse bereinigt werden

## Prüfung

- realer Read-only-Check: 630/630 gespeicherte Transaktionen lesbar, alle `deleted`
- 70 fokussierte Tests bestanden
- 4.410 Volltests bestanden, 2 erwartete Skips, 13 ausgeschlossene Browser-/Livefälle
- Ruff: PASS
- Graph-Wartbarkeit: PASS
- Release-Vertrag: PASS
- Namensaudit: `active_aliases_zero=true`
- Diff-SHA-256: `32843d9edd54ee8df2a31afc0fdaa51bce095a66832e717c65d95ac150966116`
- Volltest-Task: `5b653c44fa4049e8aaf5a161`
- Test-Receipt: `0c37a04a2b798c0377c2c8dc8657a82aec05e224037415b90bb47370e0ed32eb`

## Betriebsgrenze

Der Publisher-Timer bleibt bis zum grünen GitHub-Readback deaktiviert. Nach Merge wird der installierte Publisher aktualisiert, die gezielte RepoGround-Publikation wiederholt und `fresh_exact` belegt.