### PR TITLE
Bound historical publication symlink retention

### DIFF
--- a/merger/repoground/tests/test_fleet_runtime.py
+++ b/merger/repoground/tests/test_fleet_runtime.py
@@ -5,6 +5,7 @@ import importlib.machinery
 import importlib.util
 import json
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -1125,6 +1126,63 @@ def test_transaction_rejects_historical_current_target_swap(
 
     assert candidate.is_dir()
     assert current.readlink() == Path("b" * 64)
+    assert not module.prune_transaction_root().exists()
+
+
+def test_transaction_rejects_substituted_historical_parent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    roots = isolate_retention_roots(module, tmp_path, monkeypatch)
+    group = roots["publication"] / "bundles" / "demo" / "main"
+    candidate, _ = write_version(group, "20260714T100000Z", b"payload", 1)
+    current, _ = write_historical_generation_symlink(candidate)
+    generation = current.parent
+    snapshot = module.tree_snapshot(candidate)
+    removed_bytes = module.tree_bytes(candidate)
+    substitute = tmp_path / "substitute-generation"
+    substitute.mkdir()
+    substitute_target = substitute / ("a" * 64)
+    substitute_target.mkdir()
+    (substitute / "current").symlink_to(
+        substitute_target.name, target_is_directory=True
+    )
+
+    shutil.rmtree(generation)
+    generation.symlink_to(substitute, target_is_directory=True)
+
+    with pytest.raises(RuntimeError, match="contains a symlink"):
+        module.transactional_prune(
+            candidate,
+            root=group,
+            expected_snapshot=snapshot,
+            removed_bytes=removed_bytes,
+            protected=set(),
+        )
+
+    assert candidate.is_dir()
+    assert generation.is_symlink()
+    assert substitute.is_dir()
+    assert not module.prune_transaction_root().exists()
+
+
+def test_retention_rejects_special_file_and_leaves_candidate_untouched(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    roots = isolate_retention_roots(module, tmp_path, monkeypatch)
+    group = roots["publication"] / "bundles" / "demo" / "main"
+    candidate, _ = write_version(group, "20260714T100000Z", b"payload", 1)
+    fifo = candidate / "special.fifo"
+    os.mkfifo(fifo)
+
+    with pytest.raises(RuntimeError, match="non-regular file"):
+        module.tree_bytes(candidate)
+    with pytest.raises(RuntimeError, match="non-regular file"):
+        module.tree_snapshot(candidate)
+
+    assert candidate.is_dir()
+    assert fifo.exists()
     assert not module.prune_transaction_root().exists()
 
 

--- a/merger/repoground/tests/test_fleet_runtime.py
+++ b/merger/repoground/tests/test_fleet_runtime.py
@@ -1089,7 +1089,24 @@ def test_historical_current_symlink_rejects_unsafe_targets_and_locations(
         misplaced_target.name, target_is_directory=True
     )
 
-    for candidate in (absolute, escaping, chained, misplaced):
+    dangling, _ = write_version(group, "20260714T100005Z", b"dangling", 5)
+    dangling_generation = dangling / ".repobrief-generations" / "legacy-scope"
+    dangling_generation.mkdir(parents=True)
+    (dangling_generation / "current").symlink_to(
+        "e" * 64, target_is_directory=True
+    )
+
+    wrong_name, _ = write_version(group, "20260714T100006Z", b"wrong-name", 6)
+    wrong_name_generation = (
+        wrong_name / ".repobrief-generations" / "legacy-scope"
+    )
+    wrong_name_target = wrong_name_generation / ("f" * 64)
+    wrong_name_target.mkdir(parents=True)
+    (wrong_name_generation / "latest").symlink_to(
+        wrong_name_target.name, target_is_directory=True
+    )
+
+    for candidate in (absolute, escaping, chained, misplaced, dangling, wrong_name):
         with pytest.raises(RuntimeError, match="contains .*symlink"):
             module.tree_bytes(candidate)
         with pytest.raises(RuntimeError, match="contains .*symlink"):

--- a/merger/repoground/tests/test_fleet_runtime.py
+++ b/merger/repoground/tests/test_fleet_runtime.py
@@ -92,6 +92,22 @@ def write_version(
     return version, digest
 
 
+def write_historical_generation_symlink(
+    candidate: Path,
+    *,
+    bundled: bool = False,
+    target_hash: str = "a" * 64,
+) -> tuple[Path, Path]:
+    bundle_root = candidate / "bundle" if bundled else candidate
+    generation = bundle_root / ".repobrief-generations" / "legacy-scope"
+    target = generation / target_hash
+    target.mkdir(parents=True)
+    (target / "payload.txt").write_text("historical payload", encoding="utf-8")
+    current = generation / "current"
+    current.symlink_to(target_hash, target_is_directory=True)
+    return current, target
+
+
 def isolate_retention_roots(
     module: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> dict[str, Path]:
@@ -1002,6 +1018,114 @@ def test_reconciliation_records_completed_delete_after_crash(
     assert reports[0]["applied"] == "record_deleted"
     transaction = module.prune_transaction_root() / f"{'c' * 32}.json"
     assert json.loads(transaction.read_text())["state"] == "deleted"
+
+
+@pytest.mark.parametrize("bundled", [False, True])
+def test_transactional_prune_accepts_only_bounded_historical_current_symlink(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, bundled: bool
+) -> None:
+    module = load_publisher()
+    roots = isolate_retention_roots(module, tmp_path, monkeypatch)
+    group = roots["publication"] / "bundles" / "demo" / "main"
+    candidate, _ = write_version(group, "20260714T100000Z", b"payload", 1)
+    current, _ = write_historical_generation_symlink(candidate, bundled=bundled)
+
+    snapshot = module.tree_snapshot(candidate)
+    removed_bytes = module.tree_bytes(candidate)
+    result = module.transactional_prune(
+        candidate,
+        root=group,
+        expected_snapshot=snapshot,
+        removed_bytes=removed_bytes,
+        protected=set(),
+    )
+
+    assert result["state"] == "deleted"
+    assert result["removed_bytes"] == removed_bytes
+    assert not candidate.exists()
+    assert not current.exists()
+
+
+def test_historical_current_symlink_rejects_unsafe_targets_and_locations(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    roots = isolate_retention_roots(module, tmp_path, monkeypatch)
+    group = roots["publication"] / "bundles" / "demo" / "main"
+
+    absolute, _ = write_version(group, "20260714T100001Z", b"absolute", 1)
+    absolute_generation = absolute / ".repobrief-generations" / "legacy-scope"
+    absolute_generation.mkdir(parents=True)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (absolute_generation / "current").symlink_to(
+        outside, target_is_directory=True
+    )
+
+    escaping, _ = write_version(group, "20260714T100002Z", b"escaping", 2)
+    escaping_generation = escaping / ".repobrief-generations" / "legacy-scope"
+    escaping_generation.mkdir(parents=True)
+    (escaping_generation / "current").symlink_to(
+        f"../{'b' * 64}", target_is_directory=True
+    )
+
+    chained, _ = write_version(group, "20260714T100003Z", b"chained", 3)
+    chained_generation = chained / ".repobrief-generations" / "legacy-scope"
+    chained_generation.mkdir(parents=True)
+    real_target = chained_generation / ("c" * 64 + "-real")
+    real_target.mkdir()
+    (chained_generation / ("c" * 64)).symlink_to(
+        real_target.name, target_is_directory=True
+    )
+    (chained_generation / "current").symlink_to(
+        "c" * 64, target_is_directory=True
+    )
+
+    misplaced, _ = write_version(group, "20260714T100004Z", b"misplaced", 4)
+    misplaced_target = misplaced / ("d" * 64)
+    misplaced_target.mkdir()
+    (misplaced / "current").symlink_to(
+        misplaced_target.name, target_is_directory=True
+    )
+
+    for candidate in (absolute, escaping, chained, misplaced):
+        with pytest.raises(RuntimeError, match="contains .*symlink"):
+            module.tree_bytes(candidate)
+        with pytest.raises(RuntimeError, match="contains .*symlink"):
+            module.tree_snapshot(candidate)
+        assert candidate.is_dir()
+    assert outside.is_dir()
+
+
+def test_transaction_rejects_historical_current_target_swap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    roots = isolate_retention_roots(module, tmp_path, monkeypatch)
+    group = roots["publication"] / "bundles" / "demo" / "main"
+    candidate, _ = write_version(group, "20260714T100000Z", b"payload", 1)
+    current, _ = write_historical_generation_symlink(candidate)
+    replacement = current.parent / ("b" * 64)
+    replacement.mkdir()
+    (replacement / "payload.txt").write_text("replacement", encoding="utf-8")
+    snapshot = module.tree_snapshot(candidate)
+    removed_bytes = module.tree_bytes(candidate)
+
+    current.unlink()
+    current.symlink_to(replacement.name, target_is_directory=True)
+
+    with pytest.raises(RuntimeError, match="changed after planning"):
+        module.transactional_prune(
+            candidate,
+            root=group,
+            expected_snapshot=snapshot,
+            removed_bytes=removed_bytes,
+            protected=set(),
+        )
+
+    assert candidate.is_dir()
+    assert current.readlink() == Path("b" * 64)
+    assert not module.prune_transaction_root().exists()
 
 
 def test_tree_snapshot_and_localized_groups_reject_ambiguous_content(

--- a/scripts/ops/repoground-publish-fleet
+++ b/scripts/ops/repoground-publish-fleet
@@ -919,23 +919,117 @@ def path_is_protected(path: Path, protected: set[Path]) -> bool:
     )
 
 
+def _bounded_historical_current_symlink(
+    candidate: Path, *, root: Path
+) -> tuple[os.stat_result, str]:
+    """Validate the one historical internal symlink shape retained in bundles."""
+    metadata = candidate.lstat()
+    if not stat.S_ISLNK(metadata.st_mode):
+        raise RuntimeError(f"retention candidate is not a symlink: {candidate}")
+    try:
+        relative = candidate.relative_to(root)
+    except ValueError as exc:
+        raise RuntimeError(
+            f"retention candidate contains a symlink outside its root: {candidate}"
+        ) from exc
+
+    prefixes = {
+        (".repobrief-generations",),
+        ("bundle", ".repobrief-generations"),
+    }
+    if (
+        candidate.name != "current"
+        or len(relative.parts) not in {3, 4}
+        or relative.parts[:-2] not in prefixes
+    ):
+        raise RuntimeError(
+            f"retention candidate contains a symlink outside the bounded "
+            f"historical shape: {candidate}"
+        )
+
+    raw_target = os.readlink(candidate)
+    target = Path(raw_target)
+    if (
+        target.is_absolute()
+        or len(target.parts) != 1
+        or target.name != raw_target
+        or not SHA256_DIR_RE.fullmatch(raw_target)
+    ):
+        raise RuntimeError(
+            f"retention candidate contains an unsafe historical symlink: {candidate}"
+        )
+
+    sibling = candidate.parent / raw_target
+    try:
+        target_metadata = sibling.lstat()
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            f"retention candidate contains a dangling historical symlink: {candidate}"
+        ) from exc
+    if not stat.S_ISDIR(target_metadata.st_mode):
+        raise RuntimeError(
+            f"retention candidate contains a chained historical symlink: {candidate}"
+        )
+    confirmed_metadata = candidate.lstat()
+    initial_identity = (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+    )
+    confirmed_identity = (
+        confirmed_metadata.st_dev,
+        confirmed_metadata.st_ino,
+        confirmed_metadata.st_mode,
+        confirmed_metadata.st_size,
+        confirmed_metadata.st_mtime_ns,
+    )
+    if confirmed_identity != initial_identity:
+        raise RuntimeError(
+            f"retention candidate symlink changed during validation: {candidate}"
+        )
+    return confirmed_metadata, raw_target
+
+
+def _snapshot_symlink_row(candidate: Path, *, root: Path) -> list[object]:
+    metadata, raw_target = _bounded_historical_current_symlink(candidate, root=root)
+    return [
+        "l",
+        candidate.relative_to(root).as_posix(),
+        stat.S_IMODE(metadata.st_mode),
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        raw_target,
+    ]
+
+
 def tree_bytes(path: Path) -> int:
     total = 0
     for root, directories, files in os.walk(path, followlinks=False):
         root_path = Path(root)
         directories[:] = sorted(directories)
         for name in directories:
-            if (root_path / name).is_symlink():
-                raise RuntimeError(
-                    f"retention candidate contains a symlink: {root_path / name}"
-                )
-        for name in sorted(files):
             candidate = root_path / name
             if candidate.is_symlink():
-                raise RuntimeError(
-                    f"retention candidate contains a symlink: {candidate}"
+                metadata, _ = _bounded_historical_current_symlink(
+                    candidate, root=path
                 )
-            total += candidate.stat().st_size
+                total += metadata.st_size
+        for name in sorted(files):
+            candidate = root_path / name
+            metadata = candidate.lstat()
+            if stat.S_ISLNK(metadata.st_mode):
+                link_metadata, _ = _bounded_historical_current_symlink(
+                    candidate, root=path
+                )
+                total += link_metadata.st_size
+                continue
+            if not stat.S_ISREG(metadata.st_mode):
+                raise RuntimeError(
+                    f"retention candidate contains a non-regular file: {candidate}"
+                )
+            total += metadata.st_size
     return total
 
 
@@ -962,13 +1056,14 @@ def tree_snapshot(path: Path) -> dict[str, object]:
         for name in directories:
             candidate = root_path / name
             if candidate.is_symlink():
-                raise RuntimeError(
-                    f"retention candidate contains a symlink: {candidate}"
-                )
+                rows.append(_snapshot_symlink_row(candidate, root=path))
         for name in sorted(files):
             candidate = root_path / name
             metadata = candidate.lstat()
-            if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+            if stat.S_ISLNK(metadata.st_mode):
+                rows.append(_snapshot_symlink_row(candidate, root=path))
+                continue
+            if not stat.S_ISREG(metadata.st_mode):
                 raise RuntimeError(
                     f"retention candidate contains a non-regular file: {candidate}"
                 )


### PR DESCRIPTION
## Zweck

Schließt Bureau-Aufgabe `REPOGROUND-LEGACY-RECONCILIATION-V1-T007`: historische RepoGround-Publikationen mit dem internen `current`-Symlink können sicher durch die Retention verarbeitet werden.

## Sicherheitsgrenze

Akzeptiert wird ausschließlich ein relativer Link `current -> <64-stelliger SHA-256-Ordner>` in einer der beiden belegten historischen Positionen:

- `.repobrief-generations/<scope>/current`
- `bundle/.repobrief-generations/<scope>/current`

Absolute Ziele, `..`-Ausbrüche, Linkketten, fehlende Ziele, falsche Positionen und nachträgliche Zielwechsel bleiben fail-closed. Der Link selbst wird in den Baum-Digest aufgenommen. Neue Publikationsausgaben und gespeicherte Belege werden nicht verändert.

## Nachweise

- Publisher-Zielsuite: 49 bestanden
- Vollsuite: 4.427 bestanden, 2 erwartete Skips
- Ruff: bestanden
- `git diff --check`: bestanden
- Reale Bureau-Altstruktur nur lesend geprüft: 67.023.056 Byte, Baum-Digest `afe58c2d9322d81567634d70b8c2101356c13a95cd8105e3ceca9843b991bfd1`
- Review-Diff SHA-256: `7c7812416168335d2cbb6deaf9811726aa2d08cd6d0e4e08d0f79d1715c201a9`
