### PR TITLE
Canonicalize RepoGround generation root

### DIFF
--- a/merger/repoground/core/bundle_generation.py
+++ b/merger/repoground/core/bundle_generation.py
@@ -41,7 +41,7 @@ class BundleGenerationError(RuntimeError):
     """Raised when a bundle generation cannot be published coherently."""
 
 
-GENERATION_ROOT_NAME = ".repobrief-generations"
+GENERATION_ROOT_NAME = ".repoground-generations"
 CURRENT_LINK_NAME = "current"
 CURRENT_POINTER_JSON_NAME = "current.json"
 PUBLISH_LOCK_NAME = ".publish.lock"

--- a/merger/repoground/tests/test_bundle_generation.py
+++ b/merger/repoground/tests/test_bundle_generation.py
@@ -212,6 +212,11 @@ def test_two_generations_switch_current_and_keep_old_generation_immutable(tmp_pa
     assert (second.generation_dir / "demo.md").read_bytes() == b"second\n"
     assert (second.generation_dir / "demo.agent_export_gate.json").is_file()
     assert second.current_manifest_path.parent.name == "current"
+    assert second.generation_dir.is_relative_to(
+        tmp_path / generation_mod.GENERATION_ROOT_NAME / "demo"
+    )
+    assert generation_mod.GENERATION_ROOT_NAME == ".repoground-generations"
+    assert not (tmp_path / ".repobrief-generations").exists()
     assert second.current_manifest_path.resolve() == second.resolved_manifest_path
     assert resolve_bundle_manifest_path(second.current_manifest_path) == second.resolved_manifest_path
 
@@ -403,6 +408,34 @@ def test_symlink_failure_on_existing_current_keeps_old_pointer(
 
     assert first.current_manifest_path.resolve() == first.resolved_manifest_path
     assert (first.current_manifest_path.parent / "demo.md").read_bytes() == b"first\n"
+
+
+def test_historical_generation_root_remains_readable(tmp_path: Path) -> None:
+    lane_root = tmp_path / ".repobrief-generations" / "demo"
+    generation_id = "a" * 64
+    generation = lane_root / generation_id
+    generation.mkdir(parents=True)
+    manifest = generation / "demo.bundle.manifest.json"
+    manifest.write_text("{}", encoding="utf-8")
+    manifest_sha256 = hashlib.sha256(manifest.read_bytes()).hexdigest()
+
+    current = lane_root / generation_mod.CURRENT_LINK_NAME
+    current.symlink_to(generation_id, target_is_directory=True)
+    assert resolve_bundle_manifest_path(current / manifest.name) == manifest
+
+    current.unlink()
+    pointer = lane_root / generation_mod.CURRENT_POINTER_JSON_NAME
+    pointer.write_text(
+        json.dumps(
+            _pointer_payload(
+                generation_id=generation_id,
+                sha256=manifest_sha256,
+                manifest_path=f"{generation_id}/{manifest.name}",
+            )
+        ),
+        encoding="utf-8",
+    )
+    assert resolve_bundle_manifest_path(pointer) == manifest
 
 
 def test_current_json_resolver_rejects_traversal_and_symlink_pointer(tmp_path: Path) -> None:

--- a/merger/repoground/tests/test_fleet_runtime.py
+++ b/merger/repoground/tests/test_fleet_runtime.py
@@ -98,9 +98,10 @@ def write_historical_generation_symlink(
     *,
     bundled: bool = False,
     target_hash: str = "a" * 64,
+    generation_root_name: str = ".repobrief-generations",
 ) -> tuple[Path, Path]:
     bundle_root = candidate / "bundle" if bundled else candidate
-    generation = bundle_root / ".repobrief-generations" / "legacy-scope"
+    generation = bundle_root / generation_root_name / "legacy-scope"
     target = generation / target_hash
     target.mkdir(parents=True)
     (target / "payload.txt").write_text("historical payload", encoding="utf-8")
@@ -1022,14 +1023,25 @@ def test_reconciliation_records_completed_delete_after_crash(
 
 
 @pytest.mark.parametrize("bundled", [False, True])
-def test_transactional_prune_accepts_only_bounded_historical_current_symlink(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, bundled: bool
+@pytest.mark.parametrize(
+    "generation_root_name",
+    [".repoground-generations", ".repobrief-generations"],
+)
+def test_transactional_prune_accepts_only_bounded_generation_current_symlink(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    bundled: bool,
+    generation_root_name: str,
 ) -> None:
     module = load_publisher()
     roots = isolate_retention_roots(module, tmp_path, monkeypatch)
     group = roots["publication"] / "bundles" / "demo" / "main"
     candidate, _ = write_version(group, "20260714T100000Z", b"payload", 1)
-    current, _ = write_historical_generation_symlink(candidate, bundled=bundled)
+    current, _ = write_historical_generation_symlink(
+        candidate,
+        bundled=bundled,
+        generation_root_name=generation_root_name,
+    )
 
     snapshot = module.tree_snapshot(candidate)
     removed_bytes = module.tree_bytes(candidate)

--- a/merger/repoground/tests/test_ground_snapshot_cli.py
+++ b/merger/repoground/tests/test_ground_snapshot_cli.py
@@ -344,7 +344,7 @@ def test_external_manifest_refresh_returns_exit_2_for_bundle_generation_resolver
     publication_root = tmp_path / "publication"
     repo.mkdir()
     publication_root.mkdir()
-    current_json = out / ".repobrief-generations" / "repo_merge" / "current.json"
+    current_json = out / ".repoground-generations" / "repo_merge" / "current.json"
 
     def fake_snapshot_create(_args):
         current_json.parent.mkdir(parents=True)
@@ -468,7 +468,8 @@ def test_snapshot_create_json_pointer_outputs_resolved_immutable_manifest(
     assert not bundle_manifest.endswith("/current.json")
     assert bundle_manifest == generation["current_manifest_path"]
     assert bundle_manifest == generation["resolved_manifest_path"]
-    assert ".repobrief-generations" in bundle_manifest
+    assert ".repoground-generations" in bundle_manifest
+    assert ".repobrief-generations" not in bundle_manifest
 
 
 def test_snapshot_create_emits_snapshot_plan_report(tmp_path, capsys):

--- a/merger/repoground/tests/test_merges_dir_drift.py
+++ b/merger/repoground/tests/test_merges_dir_drift.py
@@ -194,10 +194,16 @@ def test_artifact_relative_path_allows_nested_relative_paths(tmp_path):
     )
 
 
-def test_artifact_relative_path_allows_current_symlink_inside_generations(tmp_path):
+@pytest.mark.parametrize(
+    "generation_root_name",
+    [".repoground-generations", ".repobrief-generations"],
+)
+def test_artifact_relative_path_allows_current_symlink_inside_generations(
+    tmp_path, generation_root_name
+):
     merges_dir = tmp_path / "merges"
     generation_id = "a" * 64
-    generation = merges_dir / ".repobrief-generations" / "demo" / generation_id
+    generation = merges_dir / generation_root_name / "demo" / generation_id
     target = generation / "nested" / "bundle.json"
     target.parent.mkdir(parents=True)
     target.write_text("{}", encoding="utf-8")
@@ -209,7 +215,7 @@ def test_artifact_relative_path_allows_current_symlink_inside_generations(tmp_pa
         merges_dir=merges_dir,
     )
 
-    assert relative == ".repobrief-generations/demo/current/nested/bundle.json"
+    assert relative == f"{generation_root_name}/demo/current/nested/bundle.json"
 
 
 def test_artifact_relative_path_rejects_outside_root(tmp_path):

--- a/scripts/ops/repoground-publish-fleet
+++ b/scripts/ops/repoground-publish-fleet
@@ -919,10 +919,10 @@ def path_is_protected(path: Path, protected: set[Path]) -> bool:
     )
 
 
-def _bounded_historical_current_symlink(
+def _bounded_generation_current_symlink(
     candidate: Path, *, root: Path
 ) -> tuple[os.stat_result, str]:
-    """Validate the one historical internal symlink shape retained in bundles."""
+    """Validate canonical or historical bounded internal current symlinks."""
     metadata = candidate.lstat()
     if not stat.S_ISLNK(metadata.st_mode):
         raise RuntimeError(f"retention candidate is not a symlink: {candidate}")
@@ -934,6 +934,8 @@ def _bounded_historical_current_symlink(
         ) from exc
 
     prefixes = {
+        (".repoground-generations",),
+        ("bundle", ".repoground-generations"),
         (".repobrief-generations",),
         ("bundle", ".repobrief-generations"),
     }
@@ -956,7 +958,7 @@ def _bounded_historical_current_symlink(
         or not SHA256_DIR_RE.fullmatch(raw_target)
     ):
         raise RuntimeError(
-            f"retention candidate contains an unsafe historical symlink: {candidate}"
+            f"retention candidate contains an unsafe generation symlink: {candidate}"
         )
 
     sibling = candidate.parent / raw_target
@@ -964,11 +966,11 @@ def _bounded_historical_current_symlink(
         target_metadata = sibling.lstat()
     except FileNotFoundError as exc:
         raise RuntimeError(
-            f"retention candidate contains a dangling historical symlink: {candidate}"
+            f"retention candidate contains a dangling generation symlink: {candidate}"
         ) from exc
     if not stat.S_ISDIR(target_metadata.st_mode):
         raise RuntimeError(
-            f"retention candidate contains a chained historical symlink: {candidate}"
+            f"retention candidate contains a chained generation symlink: {candidate}"
         )
     confirmed_metadata = candidate.lstat()
     initial_identity = (
@@ -993,7 +995,7 @@ def _bounded_historical_current_symlink(
 
 
 def _snapshot_symlink_row(candidate: Path, *, root: Path) -> list[object]:
-    metadata, raw_target = _bounded_historical_current_symlink(candidate, root=root)
+    metadata, raw_target = _bounded_generation_current_symlink(candidate, root=root)
     return [
         "l",
         candidate.relative_to(root).as_posix(),
@@ -1012,7 +1014,7 @@ def tree_bytes(path: Path) -> int:
         for name in directories:
             candidate = root_path / name
             if candidate.is_symlink():
-                metadata, _ = _bounded_historical_current_symlink(
+                metadata, _ = _bounded_generation_current_symlink(
                     candidate, root=path
                 )
                 total += metadata.st_size
@@ -1020,7 +1022,7 @@ def tree_bytes(path: Path) -> int:
             candidate = root_path / name
             metadata = candidate.lstat()
             if stat.S_ISLNK(metadata.st_mode):
-                link_metadata, _ = _bounded_historical_current_symlink(
+                link_metadata, _ = _bounded_generation_current_symlink(
                     candidate, root=path
                 )
                 total += link_metadata.st_size

--- a/scripts/repoground-post-merge-surface-smoke.sh
+++ b/scripts/repoground-post-merge-surface-smoke.sh
@@ -44,7 +44,7 @@ from merger.repoground.core.bundle_generation import (
 )
 
 root = Path(sys.argv[1])
-current_root = root / ".repobrief-generations"
+current_root = root / ".repoground-generations"
 current = []
 pointer_seen = False
 if current_root.is_dir():


### PR DESCRIPTION
Schließt den bei T007 gefundenen Writer-Namensblocker.

Neue Bundle-Generationen werden ausschließlich unter `.repoground-generations` geschrieben. Historische `.repobrief-generations`-Pointer bleiben lesbar; die Retention akzeptiert beide Formen weiterhin nur als eng begrenzten internen `current`-Zeiger.

Nachweise:
- 138 gezielte Tests bestanden
- 4.433 Tests bestanden, 2 erwartete Skips
- Ruff für alle geänderten Python-Dateien bestanden
- `git diff --check` und Shell-Syntaxprüfung bestanden

Der globale Ruff-Bestand enthält 129 bereits vorhandene, nicht durch diesen Diff verursachte Fehler außerhalb der geänderten Dateien.