### PR TITLE
fix(retrieval): enforce semantic embedding dimensions

### DIFF
--- a/docs/proofs/repoground-semantic-dimension-validation-v1-proof.md
+++ b/docs/proofs/repoground-semantic-dimension-validation-v1-proof.md
@@ -1,6 +1,6 @@
 # RepoGround Semantic Dimension Validation v1 — Proof
 
-Status: implemented and locally verified on branch `feat/semantic-dimension-validation-v1` from base commit `572e9d5dd818e57b5e4b8d3a43660eca525be3a6`.
+Status: implemented and locally verified on branch `feat/semantic-dimension-validation-v1` from original base commit `572e9d5dd818e57b5e4b8d3a43660eca525be3a6`.
 
 ## Problem
 
@@ -56,12 +56,29 @@ Policy, schema, evaluation, API, context and review consumers:
 102 passed in 2.61s
 ```
 
-Full RepoGround Python suite:
+Full RepoGround Python suite before the main-branch reconciliation:
 
 ```text
 python3 -m pytest merger/repoground/tests -q
 
 4358 passed, 2 skipped in 123.37s
+```
+
+The branch was then merged without conflict with current main commit `9b4b643c448e018049d03ab1ec945af99018e2b1`. That main change touched only fleet-publisher symlink I/O and its tests. The complete suite was repeated with output persisted to a file rather than inferred from transient journal output:
+
+```text
+python3 -m pytest merger/repoground/tests -q
+
+4361 passed, 2 skipped in 119.52s
+```
+
+Durable post-main test task:
+
+```text
+task_id: d2057f00694e49f59f677061
+terminalization_sha256: 2b80d603448e404d599edb5ba51804b9fef892da423080465d9815637232a32d
+lifecycle_receipt_sha256: 428699fdc383adea252beb3b81fa85545b2c6fc8f2aa6a68b050c22e318c6764
+persisted_output_sha256: 4451f9c0d7549e18ea51ca8d8e8a75aaa0fe72164c8175c8699c27ec6edbf039
 ```
 
 Static, maintainability and diff checks:

--- a/docs/proofs/repoground-semantic-dimension-validation-v1-proof.md
+++ b/docs/proofs/repoground-semantic-dimension-validation-v1-proof.md
@@ -20,8 +20,12 @@ Status: implemented and locally verified on branch `feat/semantic-dimension-vali
 - marks general semantic encoding fallbacks explicitly in query traces;
 - separates semantic conversion, validation, scoring and failure handling from `execute_query` so the repository maintainability ratchet remains satisfied;
 - normalizes a one-dimensional document vector for exactly one candidate into a one-row batch before scoring;
-- normalizes `(1, dimensions)` query lists and tuples without requiring NumPy;
+- normalizes `(1, dimensions)` query lists, tuples and array-like rows without requiring NumPy;
+- preserves lists of array- or tensor-like document rows as real batches instead of collapsing them to one document;
+- distinguishes zero-dimensional array scalars from one-dimensional vector rows;
+- centralizes positive runtime-dimension validation at both the public query boundary and the private embedding boundary;
 - uses `numpy.asarray` only inside the NumPy scoring path, avoiding unconditional array creation and redundant copies;
+- uses the measured faster `map(operator.mul, ...)` form in the optional pure-Python cosine hot path;
 - validates rectangular Python batches without allocating a second dimensions list and set;
 - centralizes semantic validation states, trace states and fallback markers as module constants.
 
@@ -32,6 +36,8 @@ The implementation does not change lexical retrieval, graph scoring, model selec
 1. `test_eval_semantic_delta` declared 384 dimensions while its deterministic mock model emitted two-dimensional vectors. The fixture was corrected to declare 2; the production check was not weakened.
 2. A model returning a one-dimensional document vector for one candidate passed dimension validation but failed both the pure-Python and NumPy-style scoring assumptions. The vector is now normalized to a one-row batch before validation and scoring.
 3. A `(1, dimensions)` tuple query was dimension-counted correctly but remained nested. Query normalization now returns the actual single vector.
+4. A list of array- or tensor-like document rows was mistaken for one flat vector because the old discriminator recognized only nested lists and tuples. Row-shape detection now preserves the batch count and validates every row dimension.
+5. Array scalar objects can expose `shape=()`. They are now treated as ordinary vector components rather than batch rows, avoiding a regression while broadening array-like support.
 
 ## Verification
 
@@ -39,15 +45,15 @@ Review-specific semantic cases:
 
 ```text
 python3 -m pytest merger/repoground/tests/test_retrieval_query.py \
-  -k "semantic or cosine_scores_accepts or query_only_normalizes" -q
+  -k "semantic or cosine_scores" -q
 
-17 passed, 33 deselected in 0.30s
+22 passed, 33 deselected in 0.28s
 ```
 
 Complete retrieval-query module:
 
 ```text
-50 passed in 0.62s
+55 passed in 0.61s
 ```
 
 Policy, schema, evaluation, API, context and review consumers:
@@ -81,6 +87,25 @@ lifecycle_receipt_sha256: 428699fdc383adea252beb3b81fa85545b2c6fc8f2aa6a68b050c2
 persisted_output_sha256: 4451f9c0d7549e18ea51ca8d8e8a75aaa0fe72164c8175c8699c27ec6edbf039
 ```
 
+Second review follow-up on the same current-main base:
+
+```text
+python3 -m pytest merger/repoground/tests -q
+
+4366 passed, 2 skipped in 120.27s
+```
+
+Durable second-review test task:
+
+```text
+task_id: 224e5839872a44a2853037d1
+terminalization_sha256: c8598ec055b8be1477c4cf00dc80c9154add4642b93e768ae65cf53c364243c9
+lifecycle_receipt_sha256: 423e90b92ebd197353b5b1a26a885f557fb9f72c76e1e4012f72f36ec592e077
+persisted_output_sha256: 1cf9109d28ac9efb26c3a49d3156a99278f2adb98289b7098024fc62c9ef4d76
+```
+
+A local 384-component microbenchmark compared 20,000 dot products over five repeats. The best observed times were 0.294337 seconds for the generator expression and 0.114604 seconds for `sum(map(operator.mul, ...))`. This establishes a local hot-path improvement, not a universal production latency claim.
+
 Static, maintainability and diff checks:
 
 ```text
@@ -112,7 +137,12 @@ Targeted cases cover:
 - document embedding count mismatch with bounded fallback and trace marker;
 - a single candidate whose model returns a one-dimensional document vector;
 - pure-Python cosine scoring for a one-dimensional single-document input;
-- query-only validation with a `(1, dimensions)` tuple and no document encoding.
+- query-only validation with a `(1, dimensions)` tuple and no document encoding;
+- query-only dimension mismatch without document encoding;
+- a query returned as a one-row list containing an array-like vector;
+- a document batch returned as a list of array-like vectors;
+- a one-dimensional array-like single-document vector in the pure-Python scorer;
+- zero-dimensional array scalar components inside an ordinary vector.
 
 ## Review decisions
 
@@ -125,14 +155,23 @@ Accepted because they had direct correctness or measurable allocation value:
 - explicit diagnostic constants;
 - a separate result-scoring helper;
 - a clearer document-count-mismatch test name and comment;
-- explicit documentation that missing runtime `dimensions` is rejected.
+- explicit documentation that missing runtime `dimensions` is rejected;
+- array-like row detection for query and document batches;
+- zero-dimensional scalar discrimination;
+- centralized positive-dimension validation;
+- the locally measured faster `operator.mul` pure-Python hot path.
 
 Not adopted in this pull request:
 
 - a new public exception hierarchy, because the exceptions remain private implementation details and existing bounded runtime errors are contract-compatible;
 - immutable retrieval result objects, because mutation is an established internal query-core pattern and changing it would expand the pull request beyond semantic validation;
 - requiring or warning for NumPy above an arbitrary candidate threshold, because semantic dependencies remain optional and no benchmark establishes 500 as a defensible boundary;
-- an enum for diagnostics, because internal string constants remove duplication without changing serialized contracts or adding conversion overhead.
+- an enum for diagnostics, because internal string constants remove duplication without changing serialized contracts or adding conversion overhead;
+- removal of defensive normalization in the scoring helpers, because those private helpers are directly tested and intentionally remain safe when called independently of `_validated_semantic_embeddings`;
+- removal of the NumPy shape guards as "dead code", for the same standalone-helper reason;
+- a real `sentence-transformers` model test in the default suite, because the dependency is optional, absent in the verification environment, and model acquisition would make the test network- and artifact-dependent;
+- arbitrary 1536/3072/4096-dimension tests, because vector-size bookkeeping is dimension-agnostic and such cases do not exercise a distinct branch;
+- a nested diagnostics-schema migration or new logging contract, because both would change serialized observability surfaces beyond this correctness slice.
 
 ## Boundaries
 

--- a/docs/proofs/repoground-semantic-dimension-validation-v1-proof.md
+++ b/docs/proofs/repoground-semantic-dimension-validation-v1-proof.md
@@ -1,0 +1,70 @@
+# RepoGround Semantic Dimension Validation v1 — Proof
+
+Status: implemented and locally verified on branch `feat/semantic-dimension-validation-v1` from base commit `572e9d5dd818e57b5e4b8d3a43660eca525be3a6`.
+
+## Problem
+
+`embedding-policy.v1` defines `dimensions` as the vector size produced by the configured model. The query runtime previously loaded the field but did not compare it with the actual query or document embeddings. A misconfigured model could therefore participate in semantic reranking without satisfying its declared policy.
+
+## Change
+
+`merger/repoground/retrieval/query_core.py` now:
+
+- rejects non-positive or non-integer runtime `dimensions` values;
+- reads vector shapes without requiring NumPy;
+- validates the query vector and document-vector batch before similarity calculation;
+- records expected and observed dimensions plus `dimension_validation` in semantic diagnostics;
+- preserves pre-semantic candidate scores and ordering when `fallback_behavior=ignore`;
+- raises a bounded dimension-mismatch error when `fallback_behavior=fail`;
+- checks that the document embedding count matches the candidate count;
+- marks general semantic encoding fallbacks explicitly in query traces.
+
+The implementation does not change lexical retrieval, graph scoring, model selection, provider support, similarity metrics or default semantic activation.
+
+## Regression discovered
+
+`test_eval_semantic_delta` declared 384 dimensions while its deterministic mock model emitted two-dimensional vectors. The fixture was corrected to declare 2; the production check was not weakened.
+
+## Verification
+
+Targeted new and adjacent cases:
+
+```text
+10 passed, 37 deselected
+```
+
+Full RepoGround Python suite:
+
+```text
+python3 -m pytest merger/repoground/tests -q
+
+4355 passed, 2 skipped in 127.86s
+```
+
+Static and diff checks:
+
+```text
+python3 -m ruff check \
+  merger/repoground/retrieval/query_core.py \
+  merger/repoground/tests/test_retrieval_query.py \
+  merger/repoground/tests/test_eval_semantic.py
+
+All checks passed!
+
+git diff --check
+
+passed
+```
+
+Targeted cases cover:
+
+- matching dimensions with successful semantic reranking diagnostics;
+- query-dimension mismatch with pre-semantic fallback;
+- query-dimension mismatch with strict failure;
+- document-dimension mismatch with pre-semantic fallback;
+- invalid direct policy dimensions, including booleans and non-integers;
+- document embedding count mismatch with bounded fallback and trace marker.
+
+## Boundaries
+
+A passing dimension check proves shape compatibility only. It does not prove model identity, semantic quality, ranking improvement, retrieval completeness, claim truth or production readiness. The optional semantic dependency and model approval boundaries remain unchanged.

--- a/docs/proofs/repoground-semantic-dimension-validation-v1-proof.md
+++ b/docs/proofs/repoground-semantic-dimension-validation-v1-proof.md
@@ -18,20 +18,42 @@ Status: implemented and locally verified on branch `feat/semantic-dimension-vali
 - raises a bounded dimension-mismatch error when `fallback_behavior=fail`;
 - checks that the document embedding count matches the candidate count;
 - marks general semantic encoding fallbacks explicitly in query traces;
-- separates semantic conversion, validation, scoring and failure handling from `execute_query` so the repository maintainability ratchet remains satisfied.
+- separates semantic conversion, validation, scoring and failure handling from `execute_query` so the repository maintainability ratchet remains satisfied;
+- normalizes a one-dimensional document vector for exactly one candidate into a one-row batch before scoring;
+- normalizes `(1, dimensions)` query lists and tuples without requiring NumPy;
+- uses `numpy.asarray` only inside the NumPy scoring path, avoiding unconditional array creation and redundant copies;
+- validates rectangular Python batches without allocating a second dimensions list and set;
+- centralizes semantic validation states, trace states and fallback markers as module constants.
 
 The implementation does not change lexical retrieval, graph scoring, model selection, provider support, similarity metrics or default semantic activation.
 
-## Regression discovered
+## Regressions discovered
 
-`test_eval_semantic_delta` declared 384 dimensions while its deterministic mock model emitted two-dimensional vectors. The fixture was corrected to declare 2; the production check was not weakened.
+1. `test_eval_semantic_delta` declared 384 dimensions while its deterministic mock model emitted two-dimensional vectors. The fixture was corrected to declare 2; the production check was not weakened.
+2. A model returning a one-dimensional document vector for one candidate passed dimension validation but failed both the pure-Python and NumPy-style scoring assumptions. The vector is now normalized to a one-row batch before validation and scoring.
+3. A `(1, dimensions)` tuple query was dimension-counted correctly but remained nested. Query normalization now returns the actual single vector.
 
 ## Verification
 
-Targeted new and adjacent cases:
+Review-specific semantic cases:
 
 ```text
-10 passed, 37 deselected in 0.28s
+python3 -m pytest merger/repoground/tests/test_retrieval_query.py \
+  -k "semantic or cosine_scores_accepts or query_only_normalizes" -q
+
+17 passed, 33 deselected in 0.30s
+```
+
+Complete retrieval-query module:
+
+```text
+50 passed in 0.62s
+```
+
+Policy, schema, evaluation, API, context and review consumers:
+
+```text
+102 passed in 2.61s
 ```
 
 Full RepoGround Python suite:
@@ -39,7 +61,7 @@ Full RepoGround Python suite:
 ```text
 python3 -m pytest merger/repoground/tests -q
 
-4355 passed, 2 skipped in 180.39s
+4358 passed, 2 skipped in 123.37s
 ```
 
 Static, maintainability and diff checks:
@@ -47,8 +69,7 @@ Static, maintainability and diff checks:
 ```text
 python3 -m ruff check \
   merger/repoground/retrieval/query_core.py \
-  merger/repoground/tests/test_retrieval_query.py \
-  merger/repoground/tests/test_eval_semantic.py
+  merger/repoground/tests/test_retrieval_query.py
 
 All checks passed!
 
@@ -71,7 +92,30 @@ Targeted cases cover:
 - query-dimension mismatch with strict failure;
 - document-dimension mismatch with pre-semantic fallback;
 - invalid direct policy dimensions, including booleans and non-integers;
-- document embedding count mismatch with bounded fallback and trace marker.
+- document embedding count mismatch with bounded fallback and trace marker;
+- a single candidate whose model returns a one-dimensional document vector;
+- pure-Python cosine scoring for a one-dimensional single-document input;
+- query-only validation with a `(1, dimensions)` tuple and no document encoding.
+
+## Review decisions
+
+Accepted because they had direct correctness or measurable allocation value:
+
+- single-candidate batch normalization;
+- tuple/list query normalization;
+- `numpy.asarray` instead of unconditional `numpy.array` copies;
+- allocation-free rectangular-batch validation;
+- explicit diagnostic constants;
+- a separate result-scoring helper;
+- a clearer document-count-mismatch test name and comment;
+- explicit documentation that missing runtime `dimensions` is rejected.
+
+Not adopted in this pull request:
+
+- a new public exception hierarchy, because the exceptions remain private implementation details and existing bounded runtime errors are contract-compatible;
+- immutable retrieval result objects, because mutation is an established internal query-core pattern and changing it would expand the pull request beyond semantic validation;
+- requiring or warning for NumPy above an arbitrary candidate threshold, because semantic dependencies remain optional and no benchmark establishes 500 as a defensible boundary;
+- an enum for diagnostics, because internal string constants remove duplication without changing serialized contracts or adding conversion overhead.
 
 ## Boundaries
 

--- a/docs/proofs/repoground-semantic-dimension-validation-v1-proof.md
+++ b/docs/proofs/repoground-semantic-dimension-validation-v1-proof.md
@@ -17,7 +17,8 @@ Status: implemented and locally verified on branch `feat/semantic-dimension-vali
 - preserves pre-semantic candidate scores and ordering when `fallback_behavior=ignore`;
 - raises a bounded dimension-mismatch error when `fallback_behavior=fail`;
 - checks that the document embedding count matches the candidate count;
-- marks general semantic encoding fallbacks explicitly in query traces.
+- marks general semantic encoding fallbacks explicitly in query traces;
+- separates semantic conversion, validation, scoring and failure handling from `execute_query` so the repository maintainability ratchet remains satisfied.
 
 The implementation does not change lexical retrieval, graph scoring, model selection, provider support, similarity metrics or default semantic activation.
 
@@ -30,7 +31,7 @@ The implementation does not change lexical retrieval, graph scoring, model selec
 Targeted new and adjacent cases:
 
 ```text
-10 passed, 37 deselected
+10 passed, 37 deselected in 0.28s
 ```
 
 Full RepoGround Python suite:
@@ -38,10 +39,10 @@ Full RepoGround Python suite:
 ```text
 python3 -m pytest merger/repoground/tests -q
 
-4355 passed, 2 skipped in 127.86s
+4355 passed, 2 skipped in 180.39s
 ```
 
-Static and diff checks:
+Static, maintainability and diff checks:
 
 ```text
 python3 -m ruff check \
@@ -50,6 +51,13 @@ python3 -m ruff check \
   merger/repoground/tests/test_eval_semantic.py
 
 All checks passed!
+
+python3 scripts/ci/check_graph_maintainability.py --root . --format json
+
+status: pass
+new_count: 0
+resolved_count: 2
+findings: []
 
 git diff --check
 

--- a/docs/retrieval/semantic-reranking.md
+++ b/docs/retrieval/semantic-reranking.md
@@ -30,6 +30,10 @@ For the local provider, RepoGround validates the actual query-vector and documen
 
 A direct runtime caller must provide a positive integer `dimensions` value. Omitting it, passing a boolean, or passing a non-positive or non-integer value is rejected instead of preserving the historical silent-ignore behavior. A one-dimensional document vector returned for exactly one candidate is normalized to a one-row batch before validation and scoring; this does not relax the declared dimension or candidate-count checks.
 
+Python lists and tuples may contain ordinary component scalars or vector rows supplied as array-like objects with a one-dimensional `.shape`, such as NumPy arrays or tensors. RepoGround distinguishes zero-dimensional array scalars from vector rows, validates every row dimension, and preserves the original batch count. This keeps the optional pure-Python path consistent with array-backed providers without importing NumPy merely for shape validation.
+
+RepoGround does not infer model identity from vector size. Different models can emit vectors with the same dimension, and runtime fingerprinting would require a separately versioned provenance contract covering model artifacts, revisions, tokenizer state, provider configuration, and reproducible loading. Phase F1 therefore proves shape compatibility only; model identity and semantic quality require independent evidence.
+
 ## Evaluation Strategy
 
 We employ a strict **improvement delta vs non-semantic** strategy.

--- a/docs/retrieval/semantic-reranking.md
+++ b/docs/retrieval/semantic-reranking.md
@@ -22,7 +22,11 @@ The parameters for this re-ranking step are defined by the `embedding-policy.v1.
 - **`dimensions`**: Specifies the expected vector size.
 - **`provider`**: Delineates `api` vs `local` model execution.
 - **`similarity_metric`**: Distance metric to compute similarity (e.g., `cosine`).
-- **`fallback_behavior`**: Crucially, if the semantic service fails (e.g., API timeout), the policy determines whether to `fail` the request or `ignore` the error and yield the raw BM25 candidates.
+- **`fallback_behavior`**: Crucially, if the semantic service fails (e.g., API timeout), the policy determines whether to `fail` the request or `ignore` the error and yield the pre-semantic candidates.
+
+### Runtime dimension invariant
+
+For the local provider, RepoGround validates the actual query-vector and document-vector dimensions before calculating similarity. Both must equal the policy's positive `dimensions` value. A mismatch is reported as `dimension_validation: mismatch`; `fallback_behavior: ignore` keeps the unchanged pre-semantic candidate scores and ordering, while `fallback_behavior: fail` raises a bounded error without exposing model internals. A matching size proves only shape compatibility, not semantic quality or model identity.
 
 ## Evaluation Strategy
 

--- a/docs/retrieval/semantic-reranking.md
+++ b/docs/retrieval/semantic-reranking.md
@@ -28,6 +28,8 @@ The parameters for this re-ranking step are defined by the `embedding-policy.v1.
 
 For the local provider, RepoGround validates the actual query-vector and document-vector dimensions before calculating similarity. Both must equal the policy's positive `dimensions` value. A mismatch is reported as `dimension_validation: mismatch`; `fallback_behavior: ignore` keeps the unchanged pre-semantic candidate scores and ordering, while `fallback_behavior: fail` raises a bounded error without exposing model internals. A matching size proves only shape compatibility, not semantic quality or model identity.
 
+A direct runtime caller must provide a positive integer `dimensions` value. Omitting it, passing a boolean, or passing a non-positive or non-integer value is rejected instead of preserving the historical silent-ignore behavior. A one-dimensional document vector returned for exactly one candidate is normalized to a one-row batch before validation and scoring; this does not relax the declared dimension or candidate-count checks.
+
 ## Evaluation Strategy
 
 We employ a strict **improvement delta vs non-semantic** strategy.

--- a/merger/repoground/retrieval/README.md
+++ b/merger/repoground/retrieval/README.md
@@ -36,4 +36,4 @@ scripts/release/compile_semantic_lock.sh --check
 - `similarity_metric` is fixed to `cosine`.
 - Without the optional packages, semantic reranking is unavailable and behavior follows the configured fallback policy.
 - Installing the packages does not download or approve a model and does not prove semantic quality.
-- `dimensions` configurations are not yet actively validated.
+- `dimensions` is enforced against both query and document vectors at runtime; mismatches follow `fallback_behavior` (`ignore` keeps the pre-semantic result ordering, `fail` aborts with a bounded diagnostic).

--- a/merger/repoground/retrieval/query_core.py
+++ b/merger/repoground/retrieval/query_core.py
@@ -101,11 +101,48 @@ class _SemanticDimensionMismatch(RuntimeError):
         )
 
 
+def _require_positive_embedding_dimensions(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError("embedding_policy dimensions must be a positive integer")
+    return value
+
+
+def _embedding_shape(value: Any) -> Optional[tuple[int, ...]]:
+    shape = getattr(value, "shape", None)
+    if shape is None:
+        return None
+    return tuple(int(part) for part in shape)
+
+
+def _is_embedding_row(value: Any) -> bool:
+    if isinstance(value, (list, tuple)):
+        return True
+    dimensions = _embedding_shape(value)
+    return dimensions is not None and len(dimensions) > 0
+
+
+def _embedding_row_dimension(value: Any, *, label: str) -> int:
+    """Return one row dimension for list-, tuple-, or array-like vectors."""
+    dimensions = _embedding_shape(value)
+    if dimensions is not None:
+        if len(dimensions) == 1 and dimensions[0] > 0:
+            return dimensions[0]
+        raise RuntimeError(
+            f"Semantic {label} embedding row has invalid shape {dimensions!r}."
+        )
+
+    if isinstance(value, (list, tuple)) and value:
+        return len(value)
+
+    raise RuntimeError(
+        f"Semantic {label} embedding row does not expose a supported vector shape."
+    )
+
+
 def _embedding_vector_dimension(value: Any, *, label: str) -> int:
     """Return one vector's dimension without requiring NumPy at runtime."""
-    shape = getattr(value, "shape", None)
-    if shape is not None:
-        dimensions = tuple(int(part) for part in shape)
+    dimensions = _embedding_shape(value)
+    if dimensions is not None:
         if len(dimensions) == 1 and dimensions[0] > 0:
             return dimensions[0]
         if len(dimensions) == 2 and dimensions[0] == 1 and dimensions[1] > 0:
@@ -118,12 +155,12 @@ def _embedding_vector_dimension(value: Any, *, label: str) -> int:
         if not value:
             raise RuntimeError(f"Semantic {label} embedding is empty.")
         first = value[0]
-        if isinstance(first, (list, tuple)):
-            if len(value) != 1 or not first:
+        if _is_embedding_row(first):
+            if len(value) != 1:
                 raise RuntimeError(
                     f"Semantic {label} embedding must contain exactly one non-empty vector."
                 )
-            return len(first)
+            return _embedding_row_dimension(first, label=label)
         return len(value)
 
     raise RuntimeError(
@@ -133,9 +170,8 @@ def _embedding_vector_dimension(value: Any, *, label: str) -> int:
 
 def _embedding_batch_dimensions(value: Any) -> tuple[int, int]:
     """Return (vector_count, vector_dimension) for document embeddings."""
-    shape = getattr(value, "shape", None)
-    if shape is not None:
-        dimensions = tuple(int(part) for part in shape)
+    dimensions = _embedding_shape(value)
+    if dimensions is not None:
         if len(dimensions) == 2 and dimensions[0] > 0 and dimensions[1] > 0:
             return dimensions[0], dimensions[1]
         if len(dimensions) == 1 and dimensions[0] > 0:
@@ -148,15 +184,13 @@ def _embedding_batch_dimensions(value: Any) -> tuple[int, int]:
         if not value:
             raise RuntimeError("Semantic document embeddings are empty.")
         first = value[0]
-        if not isinstance(first, (list, tuple)):
+        if not _is_embedding_row(first):
             return 1, len(value)
-        first_dimension = len(first)
+
+        first_dimension = _embedding_row_dimension(first, label="document")
         for row in value:
-            if not isinstance(row, (list, tuple)) or not row:
-                raise RuntimeError(
-                    "Semantic document embeddings must be a non-empty rectangular batch."
-                )
-            if len(row) != first_dimension:
+            row_dimension = _embedding_row_dimension(row, label="document")
+            if row_dimension != first_dimension:
                 raise RuntimeError(
                     "Semantic document embeddings must be a rectangular batch."
                 )
@@ -169,56 +203,48 @@ def _embedding_batch_dimensions(value: Any) -> tuple[int, int]:
 
 def _normalize_query_embedding(value: Any) -> Any:
     """Normalize one query embedding without importing optional dependencies."""
-    shape = getattr(value, "shape", None)
-    if shape is not None:
-        dimensions = tuple(int(part) for part in shape)
+    dimensions = _embedding_shape(value)
+    if dimensions is not None:
         if len(dimensions) == 2 and dimensions[0] == 1:
             return value.reshape(-1)
         return value
 
-    if (
-        isinstance(value, (list, tuple))
-        and len(value) == 1
-        and isinstance(value[0], (list, tuple))
-    ):
-        return value[0]
+    if isinstance(value, (list, tuple)) and len(value) == 1:
+        first = value[0]
+        if _is_embedding_row(first):
+            return _normalize_query_embedding(first)
     return value
 
 
 def _normalize_document_embedding_batch(value: Any) -> Any:
     """Normalize a single document vector to a one-row embedding batch."""
-    shape = getattr(value, "shape", None)
-    if shape is not None:
-        dimensions = tuple(int(part) for part in shape)
+    dimensions = _embedding_shape(value)
+    if dimensions is not None:
         if len(dimensions) == 1:
             return value.reshape(1, -1)
         return value
 
-    if (
-        isinstance(value, (list, tuple))
-        and value
-        and not isinstance(value[0], (list, tuple))
-    ):
-        return (value,)
+    if isinstance(value, (list, tuple)) and value:
+        first = value[0]
+        if not _is_embedding_row(first):
+            return (value,)
     return value
 
 
 def _python_cosine_scores(query_emb: Any, doc_embs: Any) -> List[float]:
     import math
+    import operator
 
     document_batch = _normalize_document_embedding_batch(doc_embs)
     query_norm = float(
-        math.sqrt(sum(component * component for component in query_emb))
+        math.sqrt(sum(map(operator.mul, query_emb, query_emb)))
     ) or 1.0
     scores = []
     for document_emb in document_batch:
         document_norm = float(
-            math.sqrt(sum(component * component for component in document_emb))
+            math.sqrt(sum(map(operator.mul, document_emb, document_emb)))
         ) or 1.0
-        dot_product = sum(
-            query_component * document_component
-            for query_component, document_component in zip(query_emb, document_emb)
-        )
+        dot_product = sum(map(operator.mul, query_emb, document_emb))
         scores.append(float(dot_product / (query_norm * document_norm)))
     return scores
 
@@ -256,6 +282,7 @@ def _validated_semantic_embeddings(
     expected_dimensions: int,
     semantic_diagnostics: Dict[str, Any],
 ) -> tuple[Any, Optional[Any]]:
+    expected_dimensions = _require_positive_embedding_dimensions(expected_dimensions)
     query_emb = _normalize_query_embedding(semantic_model.encode(query_text))
     actual_query_dimensions = _embedding_vector_dimension(
         query_emb,
@@ -638,15 +665,9 @@ def execute_query(
         if semantic_enabled:
             # F1b implements only provider=local and similarity_metric=cosine.
             # The embedding-policy dimension is a runtime invariant, not metadata.
-            expected_dimensions = embedding_policy.get("dimensions")
-            if (
-                isinstance(expected_dimensions, bool)
-                or not isinstance(expected_dimensions, int)
-                or expected_dimensions < 1
-            ):
-                raise ValueError(
-                    "embedding_policy dimensions must be a positive integer"
-                )
+            expected_dimensions = _require_positive_embedding_dimensions(
+                embedding_policy.get("dimensions")
+            )
             engine_type += "+semantic_requested"
             provider = embedding_policy.get("provider", "local")
             metric = embedding_policy.get("similarity_metric", "cosine")

--- a/merger/repoground/retrieval/query_core.py
+++ b/merger/repoground/retrieval/query_core.py
@@ -17,6 +17,25 @@ WHY_ZERO_NONE = "no results"
 _REQUIRED_READ_ONLY_SQLITE_INDEX_SUFFIX = ".index.sqlite"
 _ALLOWED_SQLITE_INDEX_SUFFIXES = (_REQUIRED_READ_ONLY_SQLITE_INDEX_SUFFIX, ".sqlite", ".sqlite3", ".db")
 _MODEL_CACHE = {}
+
+_DIMENSION_VALIDATION_PENDING = "pending"
+_DIMENSION_VALIDATION_PASS = "pass"
+_DIMENSION_VALIDATION_MISMATCH = "mismatch"
+_DIMENSION_VALIDATION_ERROR = "error"
+_DIMENSION_VALIDATION_QUERY_ONLY_PASS = "query_only_pass"
+
+_SEMANTIC_STATUS_UNKNOWN = "unknown"
+_SEMANTIC_STATUS_OK = "ok"
+_SEMANTIC_STATUS_UNSUPPORTED_PROVIDER = "unsupported_provider"
+_SEMANTIC_STATUS_UNSUPPORTED_METRIC = "unsupported_metric"
+_SEMANTIC_STATUS_DIMENSION_MISMATCH = "dimension_mismatch"
+_SEMANTIC_STATUS_ENCODING_ERROR = "encoding_error"
+
+_SEMANTIC_FALLBACK_UNSUPPORTED_PROVIDER = "semantic_fallback_unsupported_provider"
+_SEMANTIC_FALLBACK_UNSUPPORTED_METRIC = "semantic_fallback_unsupported_metric"
+_SEMANTIC_FALLBACK_DIMENSION_MISMATCH = "semantic_fallback_dimension_mismatch"
+_SEMANTIC_FALLBACK_ENCODING_ERROR = "semantic_fallback_encoding_error"
+
 logger = logging.getLogger(__name__)
 
 
@@ -131,72 +150,97 @@ def _embedding_batch_dimensions(value: Any) -> tuple[int, int]:
         first = value[0]
         if not isinstance(first, (list, tuple)):
             return 1, len(value)
-        row_dimensions = []
+        first_dimension = len(first)
         for row in value:
             if not isinstance(row, (list, tuple)) or not row:
                 raise RuntimeError(
                     "Semantic document embeddings must be a non-empty rectangular batch."
                 )
-            row_dimensions.append(len(row))
-        if len(set(row_dimensions)) != 1:
-            raise RuntimeError(
-                "Semantic document embeddings must be a rectangular batch."
-            )
-        return len(value), row_dimensions[0]
+            if len(row) != first_dimension:
+                raise RuntimeError(
+                    "Semantic document embeddings must be a rectangular batch."
+                )
+        return len(value), first_dimension
 
     raise RuntimeError(
         "Semantic document embeddings do not expose a supported batch shape."
     )
 
 
-def _as_optional_numpy_array(value: Any) -> Any:
-    """Convert list embeddings when NumPy is available without requiring it."""
-    if not isinstance(value, list):
-        return value
-    try:
-        import numpy as np
-    except ImportError:
-        return value
-    return np.array(value)
-
-
-def _flatten_single_embedding(value: Any) -> Any:
+def _normalize_query_embedding(value: Any) -> Any:
+    """Normalize one query embedding without importing optional dependencies."""
     shape = getattr(value, "shape", None)
-    if shape is not None and len(shape) == 2 and shape[0] == 1:
-        return value.flatten()
+    if shape is not None:
+        dimensions = tuple(int(part) for part in shape)
+        if len(dimensions) == 2 and dimensions[0] == 1:
+            return value.reshape(-1)
+        return value
+
+    if (
+        isinstance(value, (list, tuple))
+        and len(value) == 1
+        and isinstance(value[0], (list, tuple))
+    ):
+        return value[0]
+    return value
+
+
+def _normalize_document_embedding_batch(value: Any) -> Any:
+    """Normalize a single document vector to a one-row embedding batch."""
+    shape = getattr(value, "shape", None)
+    if shape is not None:
+        dimensions = tuple(int(part) for part in shape)
+        if len(dimensions) == 1:
+            return value.reshape(1, -1)
+        return value
+
+    if (
+        isinstance(value, (list, tuple))
+        and value
+        and not isinstance(value[0], (list, tuple))
+    ):
+        return (value,)
     return value
 
 
 def _python_cosine_scores(query_emb: Any, doc_embs: Any) -> List[float]:
     import math
 
-    query_norm = math.sqrt(sum(component * component for component in query_emb)) or 1.0
+    document_batch = _normalize_document_embedding_batch(doc_embs)
+    query_norm = float(
+        math.sqrt(sum(component * component for component in query_emb))
+    ) or 1.0
     scores = []
-    for document_emb in doc_embs:
-        document_norm = (
-            math.sqrt(sum(component * component for component in document_emb)) or 1.0
-        )
+    for document_emb in document_batch:
+        document_norm = float(
+            math.sqrt(sum(component * component for component in document_emb))
+        ) or 1.0
         dot_product = sum(
             query_component * document_component
             for query_component, document_component in zip(query_emb, document_emb)
         )
-        scores.append(dot_product / (query_norm * document_norm))
+        scores.append(float(dot_product / (query_norm * document_norm)))
     return scores
 
 
 def _semantic_cosine_scores(query_emb: Any, doc_embs: Any) -> Any:
+    document_batch = _normalize_document_embedding_batch(doc_embs)
     try:
         from sentence_transformers import util
 
-        return util.cos_sim(query_emb, doc_embs)[0]
+        return util.cos_sim(query_emb, document_batch)[0]
     except ImportError:
         try:
             import numpy as np
         except ImportError:
-            return _python_cosine_scores(query_emb, doc_embs)
+            return _python_cosine_scores(query_emb, document_batch)
 
-    query_array = np.array(query_emb)
-    document_array = np.array(doc_embs)
+    query_array = np.asarray(query_emb)
+    document_array = np.asarray(document_batch)
+    if query_array.ndim == 2 and query_array.shape[0] == 1:
+        query_array = query_array.reshape(-1)
+    if document_array.ndim == 1:
+        document_array = document_array.reshape(1, -1)
     query_norm = np.linalg.norm(query_array)
     document_norms = np.linalg.norm(document_array, axis=1)
     query_norm = query_norm if query_norm > 0 else 1.0
@@ -212,9 +256,7 @@ def _validated_semantic_embeddings(
     expected_dimensions: int,
     semantic_diagnostics: Dict[str, Any],
 ) -> tuple[Any, Optional[Any]]:
-    query_emb = _flatten_single_embedding(
-        _as_optional_numpy_array(semantic_model.encode(query_text))
-    )
+    query_emb = _normalize_query_embedding(semantic_model.encode(query_text))
     actual_query_dimensions = _embedding_vector_dimension(
         query_emb,
         label="query",
@@ -228,10 +270,12 @@ def _validated_semantic_embeddings(
         )
 
     if not candidate_texts:
-        semantic_diagnostics["dimension_validation"] = "query_only_pass"
+        semantic_diagnostics["dimension_validation"] = _DIMENSION_VALIDATION_QUERY_ONLY_PASS
         return query_emb, None
 
-    doc_embs = _as_optional_numpy_array(semantic_model.encode(candidate_texts))
+    doc_embs = _normalize_document_embedding_batch(
+        semantic_model.encode(candidate_texts)
+    )
     document_count, actual_document_dimensions = _embedding_batch_dimensions(doc_embs)
     semantic_diagnostics["actual_document_dimensions"] = actual_document_dimensions
     if document_count != len(candidate_texts):
@@ -245,7 +289,7 @@ def _validated_semantic_embeddings(
             expected_dimensions,
             actual_document_dimensions,
         )
-    semantic_diagnostics["dimension_validation"] = "pass"
+    semantic_diagnostics["dimension_validation"] = _DIMENSION_VALIDATION_PASS
     return query_emb, doc_embs
 
 
@@ -258,11 +302,11 @@ def _handle_semantic_dimension_mismatch(
 ) -> None:
     semantic_diagnostics["error"] = str(exc)
     semantic_diagnostics["enabled"] = False
-    semantic_diagnostics["dimension_validation"] = "mismatch"
+    semantic_diagnostics["dimension_validation"] = _DIMENSION_VALIDATION_MISMATCH
     if trace_data:
-        trace_data["semantic_status"] = "dimension_mismatch"
+        trace_data["semantic_status"] = _SEMANTIC_STATUS_DIMENSION_MISMATCH
         trace_data["fallback_markers"].append(
-            "semantic_fallback_dimension_mismatch"
+            _SEMANTIC_FALLBACK_DIMENSION_MISMATCH
         )
     if fallback == "fail":
         raise RuntimeError(
@@ -283,9 +327,9 @@ def _handle_semantic_encoding_failure(
         exc_info=True,
     )
     if trace_data:
-        trace_data["semantic_status"] = "encoding_error"
+        trace_data["semantic_status"] = _SEMANTIC_STATUS_ENCODING_ERROR
         trace_data["fallback_markers"].append(
-            "semantic_fallback_encoding_error"
+            _SEMANTIC_FALLBACK_ENCODING_ERROR
         )
     if fallback == "fail":
         raise RuntimeError(
@@ -294,7 +338,27 @@ def _handle_semantic_encoding_failure(
         ) from exc
     semantic_diagnostics["error"] = "semantic encoding unavailable"
     semantic_diagnostics["enabled"] = False
-    semantic_diagnostics["dimension_validation"] = "error"
+    semantic_diagnostics["dimension_validation"] = _DIMENSION_VALIDATION_ERROR
+
+
+def _score_results_with_cosine(
+    results: List[Dict[str, Any]],
+    cosine_scores: Any,
+) -> None:
+    """Apply validated semantic scores to the mutable retrieval result records."""
+    if len(cosine_scores) != len(results):
+        raise RuntimeError(
+            "Semantic score count mismatch: "
+            f"expected {len(results)}, got {len(cosine_scores)}."
+        )
+    for index, hit in enumerate(results):
+        old_score = hit.get("score", 0)
+        semantic_score = float(cosine_scores[index])
+        hit["score"] = semantic_score
+        hit["final_score"] = semantic_score
+        rank_features = hit["why"].setdefault("rank_features", {})
+        rank_features["semantic_score"] = semantic_score
+        rank_features["original_bm25"] = old_score
 
 
 def _apply_semantic_reranking(
@@ -322,14 +386,7 @@ def _apply_semantic_reranking(
             return
 
         cosine_scores = _semantic_cosine_scores(query_emb, doc_embs)
-        for index, hit in enumerate(results):
-            old_score = hit.get("score", 0)
-            semantic_score = float(cosine_scores[index])
-            hit["score"] = semantic_score
-            hit["final_score"] = semantic_score
-            hit["why"]["rank_features"] = hit["why"].get("rank_features", {})
-            hit["why"]["rank_features"]["semantic_score"] = semantic_score
-            hit["why"]["rank_features"]["original_bm25"] = old_score
+        _score_results_with_cosine(results, cosine_scores)
     except _SemanticDimensionMismatch as exc:
         _handle_semantic_dimension_mismatch(
             exc=exc,
@@ -599,8 +656,8 @@ def execute_query(
                     raise RuntimeError(f"Semantic re-ranking provider '{provider}' is not yet implemented (fallback_behavior=fail).")
                 else:
                     if trace_data:
-                        trace_data["semantic_status"] = "unsupported_provider"
-                        trace_data["fallback_markers"].append("semantic_fallback_unsupported_provider")
+                        trace_data["semantic_status"] = _SEMANTIC_STATUS_UNSUPPORTED_PROVIDER
+                        trace_data["fallback_markers"].append(_SEMANTIC_FALLBACK_UNSUPPORTED_PROVIDER)
                     base_diagnostics["semantic"] = {
                         "enabled": False,
                         "error": f"Provider '{provider}' not implemented",
@@ -614,8 +671,8 @@ def execute_query(
                     raise RuntimeError(f"Semantic re-ranking metric '{metric}' is not supported (fallback_behavior=fail).")
                 else:
                     if trace_data:
-                        trace_data["semantic_status"] = "unsupported_metric"
-                        trace_data["fallback_markers"].append("semantic_fallback_unsupported_metric")
+                        trace_data["semantic_status"] = _SEMANTIC_STATUS_UNSUPPORTED_METRIC
+                        trace_data["fallback_markers"].append(_SEMANTIC_FALLBACK_UNSUPPORTED_METRIC)
                     base_diagnostics["semantic"] = {
                         "enabled": False,
                         "error": f"Metric '{metric}' not supported",
@@ -629,7 +686,7 @@ def execute_query(
                     model_name = embedding_policy.get("model_name", "all-MiniLM-L6-v2")
                     semantic_model = _get_semantic_model(model_name)
                     if trace_data:
-                        trace_data["semantic_status"] = "ok"
+                        trace_data["semantic_status"] = _SEMANTIC_STATUS_OK
                     base_diagnostics["semantic"] = {
                         "enabled": True,
                         "fallback_behavior": fallback,
@@ -637,7 +694,7 @@ def execute_query(
                         "provider": provider,
                         "model_name": model_name,
                         "expected_dimensions": expected_dimensions,
-                        "dimension_validation": "pending",
+                        "dimension_validation": _DIMENSION_VALIDATION_PENDING,
                     }
                 except ImportError as e:
                     if fallback == "fail":
@@ -1129,7 +1186,7 @@ def build_context_bundle(query_text: str, results: List[Dict[str, Any]], raw_con
                 "bundle_origin": hit.get("repo_id", "local"),
                 "resolver_status": "resolved_explicit" if prov_type == "explicit" else ("resolved_derived" if derived_ref else "unresolved"),
                 "graph_status": hit.get("why", {}).get("diagnostics", {}).get("graph", {}).get("graph_status", "unknown"),
-                "semantic_status": "unknown",
+                "semantic_status": _SEMANTIC_STATUS_UNKNOWN,
                 "federation_status": "federated" if hit.get("federation_bundle") else "local",
                 "uncertainty": {
                     "explicit_provenance": prov_type == "explicit",

--- a/merger/repoground/retrieval/query_core.py
+++ b/merger/repoground/retrieval/query_core.py
@@ -149,6 +149,203 @@ def _embedding_batch_dimensions(value: Any) -> tuple[int, int]:
     )
 
 
+def _as_optional_numpy_array(value: Any) -> Any:
+    """Convert list embeddings when NumPy is available without requiring it."""
+    if not isinstance(value, list):
+        return value
+    try:
+        import numpy as np
+    except ImportError:
+        return value
+    return np.array(value)
+
+
+def _flatten_single_embedding(value: Any) -> Any:
+    shape = getattr(value, "shape", None)
+    if shape is not None and len(shape) == 2 and shape[0] == 1:
+        return value.flatten()
+    return value
+
+
+def _python_cosine_scores(query_emb: Any, doc_embs: Any) -> List[float]:
+    import math
+
+    query_norm = math.sqrt(sum(component * component for component in query_emb)) or 1.0
+    scores = []
+    for document_emb in doc_embs:
+        document_norm = (
+            math.sqrt(sum(component * component for component in document_emb)) or 1.0
+        )
+        dot_product = sum(
+            query_component * document_component
+            for query_component, document_component in zip(query_emb, document_emb)
+        )
+        scores.append(dot_product / (query_norm * document_norm))
+    return scores
+
+
+def _semantic_cosine_scores(query_emb: Any, doc_embs: Any) -> Any:
+    try:
+        from sentence_transformers import util
+
+        return util.cos_sim(query_emb, doc_embs)[0]
+    except ImportError:
+        try:
+            import numpy as np
+        except ImportError:
+            return _python_cosine_scores(query_emb, doc_embs)
+
+    query_array = np.array(query_emb)
+    document_array = np.array(doc_embs)
+    query_norm = np.linalg.norm(query_array)
+    document_norms = np.linalg.norm(document_array, axis=1)
+    query_norm = query_norm if query_norm > 0 else 1.0
+    document_norms = np.where(document_norms > 0, document_norms, 1.0)
+    return np.dot(document_array, query_array) / (document_norms * query_norm)
+
+
+def _validated_semantic_embeddings(
+    *,
+    semantic_model: Any,
+    query_text: str,
+    candidate_texts: List[str],
+    expected_dimensions: int,
+    semantic_diagnostics: Dict[str, Any],
+) -> tuple[Any, Optional[Any]]:
+    query_emb = _flatten_single_embedding(
+        _as_optional_numpy_array(semantic_model.encode(query_text))
+    )
+    actual_query_dimensions = _embedding_vector_dimension(
+        query_emb,
+        label="query",
+    )
+    semantic_diagnostics["actual_query_dimensions"] = actual_query_dimensions
+    if actual_query_dimensions != expected_dimensions:
+        raise _SemanticDimensionMismatch(
+            "query",
+            expected_dimensions,
+            actual_query_dimensions,
+        )
+
+    if not candidate_texts:
+        semantic_diagnostics["dimension_validation"] = "query_only_pass"
+        return query_emb, None
+
+    doc_embs = _as_optional_numpy_array(semantic_model.encode(candidate_texts))
+    document_count, actual_document_dimensions = _embedding_batch_dimensions(doc_embs)
+    semantic_diagnostics["actual_document_dimensions"] = actual_document_dimensions
+    if document_count != len(candidate_texts):
+        raise RuntimeError(
+            "Semantic document embedding count mismatch: "
+            f"expected {len(candidate_texts)}, got {document_count}."
+        )
+    if actual_document_dimensions != expected_dimensions:
+        raise _SemanticDimensionMismatch(
+            "document",
+            expected_dimensions,
+            actual_document_dimensions,
+        )
+    semantic_diagnostics["dimension_validation"] = "pass"
+    return query_emb, doc_embs
+
+
+def _handle_semantic_dimension_mismatch(
+    *,
+    exc: _SemanticDimensionMismatch,
+    fallback: str,
+    semantic_diagnostics: Dict[str, Any],
+    trace_data: Optional[Dict[str, Any]],
+) -> None:
+    semantic_diagnostics["error"] = str(exc)
+    semantic_diagnostics["enabled"] = False
+    semantic_diagnostics["dimension_validation"] = "mismatch"
+    if trace_data:
+        trace_data["semantic_status"] = "dimension_mismatch"
+        trace_data["fallback_markers"].append(
+            "semantic_fallback_dimension_mismatch"
+        )
+    if fallback == "fail":
+        raise RuntimeError(
+            f"{exc} (fallback_behavior=fail)."
+        ) from exc
+
+
+def _handle_semantic_encoding_failure(
+    *,
+    exc: Exception,
+    fallback: str,
+    semantic_diagnostics: Dict[str, Any],
+    trace_data: Optional[Dict[str, Any]],
+) -> None:
+    logger.warning(
+        "Semantic encoding failed: %s",
+        type(exc).__name__,
+        exc_info=True,
+    )
+    if trace_data:
+        trace_data["semantic_status"] = "encoding_error"
+        trace_data["fallback_markers"].append(
+            "semantic_fallback_encoding_error"
+        )
+    if fallback == "fail":
+        raise RuntimeError(
+            "Semantic re-ranking failed during encoding "
+            "(fallback_behavior=fail)."
+        ) from exc
+    semantic_diagnostics["error"] = "semantic encoding unavailable"
+    semantic_diagnostics["enabled"] = False
+    semantic_diagnostics["dimension_validation"] = "error"
+
+
+def _apply_semantic_reranking(
+    *,
+    results: List[Dict[str, Any]],
+    candidate_texts: List[str],
+    semantic_model: Any,
+    query_text: str,
+    expected_dimensions: int,
+    fallback: str,
+    base_diagnostics: Dict[str, Any],
+    trace_data: Optional[Dict[str, Any]],
+) -> None:
+    """Apply optional semantic scoring while preserving bounded fallback behavior."""
+    semantic_diagnostics = base_diagnostics["semantic"]
+    try:
+        query_emb, doc_embs = _validated_semantic_embeddings(
+            semantic_model=semantic_model,
+            query_text=query_text,
+            candidate_texts=candidate_texts,
+            expected_dimensions=expected_dimensions,
+            semantic_diagnostics=semantic_diagnostics,
+        )
+        if doc_embs is None:
+            return
+
+        cosine_scores = _semantic_cosine_scores(query_emb, doc_embs)
+        for index, hit in enumerate(results):
+            old_score = hit.get("score", 0)
+            semantic_score = float(cosine_scores[index])
+            hit["score"] = semantic_score
+            hit["final_score"] = semantic_score
+            hit["why"]["rank_features"] = hit["why"].get("rank_features", {})
+            hit["why"]["rank_features"]["semantic_score"] = semantic_score
+            hit["why"]["rank_features"]["original_bm25"] = old_score
+    except _SemanticDimensionMismatch as exc:
+        _handle_semantic_dimension_mismatch(
+            exc=exc,
+            fallback=fallback,
+            semantic_diagnostics=semantic_diagnostics,
+            trace_data=trace_data,
+        )
+    except Exception as exc:
+        _handle_semantic_encoding_failure(
+            exc=exc,
+            fallback=fallback,
+            semantic_diagnostics=semantic_diagnostics,
+            trace_data=trace_data,
+        )
+
+
 def execute_query(
     index_path: Path,
     query_text: str,
@@ -690,132 +887,16 @@ def execute_query(
             results.append(hit)
 
         if semantic_model:
-            # Re-rank results using semantic model.
-            semantic_diagnostics = base_diagnostics["semantic"]
-            try:
-                # Use a lightweight dot product/cosine calculation if the model is mocked for tests,
-                # or import standard util if it is the real sentence_transformers package.
-                query_emb = semantic_model.encode(query_text)
-                if isinstance(query_emb, list):
-                    try:
-                        import numpy as np
-                        query_emb = np.array(query_emb)
-                    except ImportError:
-                        pass
-                if hasattr(query_emb, "shape") and len(query_emb.shape) == 2 and query_emb.shape[0] == 1:
-                    query_emb = query_emb.flatten()
-
-                actual_query_dimensions = _embedding_vector_dimension(
-                    query_emb,
-                    label="query",
-                )
-                semantic_diagnostics["actual_query_dimensions"] = actual_query_dimensions
-                if actual_query_dimensions != expected_dimensions:
-                    raise _SemanticDimensionMismatch(
-                        "query",
-                        expected_dimensions,
-                        actual_query_dimensions,
-                    )
-
-                if candidate_texts:
-                    doc_embs = semantic_model.encode(candidate_texts)
-                    if isinstance(doc_embs, list):
-                        try:
-                            import numpy as np
-                            doc_embs = np.array(doc_embs)
-                        except ImportError:
-                            pass
-
-                    document_count, actual_document_dimensions = _embedding_batch_dimensions(
-                        doc_embs
-                    )
-                    semantic_diagnostics["actual_document_dimensions"] = (
-                        actual_document_dimensions
-                    )
-                    if document_count != len(candidate_texts):
-                        raise RuntimeError(
-                            "Semantic document embedding count mismatch: "
-                            f"expected {len(candidate_texts)}, got {document_count}."
-                        )
-                    if actual_document_dimensions != expected_dimensions:
-                        raise _SemanticDimensionMismatch(
-                            "document",
-                            expected_dimensions,
-                            actual_document_dimensions,
-                        )
-                    semantic_diagnostics["dimension_validation"] = "pass"
-
-                    try:
-                        from sentence_transformers import util
-                        cosine_scores = util.cos_sim(query_emb, doc_embs)[0]
-                    except ImportError:
-                        # Fallback for mocked models in tests.
-                        try:
-                            import numpy as np
-                            q = np.array(query_emb)
-                            d = np.array(doc_embs)
-                            q_norm = np.linalg.norm(q)
-                            d_norm = np.linalg.norm(d, axis=1)
-                            q_norm = q_norm if q_norm > 0 else 1.0
-                            d_norm = np.where(d_norm > 0, d_norm, 1.0)
-                            cosine_scores = np.dot(d, q) / (d_norm * q_norm)
-                        except ImportError:
-                            import math
-
-                            def _dot(a, b):
-                                return sum(x * y for x, y in zip(a, b))
-
-                            def _norm(a):
-                                return math.sqrt(sum(x * x for x in a))
-
-                            q = query_emb
-                            q_n = _norm(q) or 1.0
-                            cosine_scores = []
-                            for d in doc_embs:
-                                d_n = _norm(d) or 1.0
-                                cosine_scores.append(_dot(q, d) / (q_n * d_n))
-
-                    for i, hit in enumerate(results):
-                        old_score = hit.get("score", 0)
-                        hit["score"] = float(cosine_scores[i])
-                        hit["final_score"] = float(cosine_scores[i])
-                        hit["why"]["rank_features"] = hit["why"].get("rank_features", {})
-                        hit["why"]["rank_features"]["semantic_score"] = float(cosine_scores[i])
-                        hit["why"]["rank_features"]["original_bm25"] = old_score
-                else:
-                    semantic_diagnostics["dimension_validation"] = "query_only_pass"
-            except _SemanticDimensionMismatch as exc:
-                semantic_diagnostics["error"] = str(exc)
-                semantic_diagnostics["enabled"] = False
-                semantic_diagnostics["dimension_validation"] = "mismatch"
-                if trace_data:
-                    trace_data["semantic_status"] = "dimension_mismatch"
-                    trace_data["fallback_markers"].append(
-                        "semantic_fallback_dimension_mismatch"
-                    )
-                if fallback == "fail":
-                    raise RuntimeError(
-                        f"{exc} (fallback_behavior=fail)."
-                    ) from exc
-            except Exception as exc:
-                logger.warning(
-                    "Semantic encoding failed: %s",
-                    type(exc).__name__,
-                    exc_info=True,
-                )
-                if trace_data:
-                    trace_data["semantic_status"] = "encoding_error"
-                    trace_data["fallback_markers"].append(
-                        "semantic_fallback_encoding_error"
-                    )
-                if fallback == "fail":
-                    raise RuntimeError(
-                        "Semantic re-ranking failed during encoding "
-                        "(fallback_behavior=fail)."
-                    ) from exc
-                semantic_diagnostics["error"] = "semantic encoding unavailable"
-                semantic_diagnostics["enabled"] = False
-                semantic_diagnostics["dimension_validation"] = "error"
+            _apply_semantic_reranking(
+                results=results,
+                candidate_texts=candidate_texts,
+                semantic_model=semantic_model,
+                query_text=query_text,
+                expected_dimensions=expected_dimensions,
+                fallback=fallback,
+                base_diagnostics=base_diagnostics,
+                trace_data=trace_data,
+            )
 
         # Sort results deterministically to avoid random tie flips.
         results.sort(key=lambda x: (-x.get("final_score", 0), x["path"]))

--- a/merger/repoground/retrieval/query_core.py
+++ b/merger/repoground/retrieval/query_core.py
@@ -68,6 +68,87 @@ def _get_semantic_model(model_name: str):
         _MODEL_CACHE[model_name] = SentenceTransformer(model_name)
     return _MODEL_CACHE[model_name]
 
+
+class _SemanticDimensionMismatch(RuntimeError):
+    """Raised when a model output violates embedding-policy dimensions."""
+
+    def __init__(self, embedding_kind: str, expected: int, actual: int):
+        self.embedding_kind = embedding_kind
+        self.expected = expected
+        self.actual = actual
+        super().__init__(
+            f"Semantic {embedding_kind} embedding dimension mismatch: "
+            f"expected {expected}, got {actual}"
+        )
+
+
+def _embedding_vector_dimension(value: Any, *, label: str) -> int:
+    """Return one vector's dimension without requiring NumPy at runtime."""
+    shape = getattr(value, "shape", None)
+    if shape is not None:
+        dimensions = tuple(int(part) for part in shape)
+        if len(dimensions) == 1 and dimensions[0] > 0:
+            return dimensions[0]
+        if len(dimensions) == 2 and dimensions[0] == 1 and dimensions[1] > 0:
+            return dimensions[1]
+        raise RuntimeError(
+            f"Semantic {label} embedding has invalid shape {dimensions!r}."
+        )
+
+    if isinstance(value, (list, tuple)):
+        if not value:
+            raise RuntimeError(f"Semantic {label} embedding is empty.")
+        first = value[0]
+        if isinstance(first, (list, tuple)):
+            if len(value) != 1 or not first:
+                raise RuntimeError(
+                    f"Semantic {label} embedding must contain exactly one non-empty vector."
+                )
+            return len(first)
+        return len(value)
+
+    raise RuntimeError(
+        f"Semantic {label} embedding does not expose a supported vector shape."
+    )
+
+
+def _embedding_batch_dimensions(value: Any) -> tuple[int, int]:
+    """Return (vector_count, vector_dimension) for document embeddings."""
+    shape = getattr(value, "shape", None)
+    if shape is not None:
+        dimensions = tuple(int(part) for part in shape)
+        if len(dimensions) == 2 and dimensions[0] > 0 and dimensions[1] > 0:
+            return dimensions[0], dimensions[1]
+        if len(dimensions) == 1 and dimensions[0] > 0:
+            return 1, dimensions[0]
+        raise RuntimeError(
+            f"Semantic document embeddings have invalid shape {dimensions!r}."
+        )
+
+    if isinstance(value, (list, tuple)):
+        if not value:
+            raise RuntimeError("Semantic document embeddings are empty.")
+        first = value[0]
+        if not isinstance(first, (list, tuple)):
+            return 1, len(value)
+        row_dimensions = []
+        for row in value:
+            if not isinstance(row, (list, tuple)) or not row:
+                raise RuntimeError(
+                    "Semantic document embeddings must be a non-empty rectangular batch."
+                )
+            row_dimensions.append(len(row))
+        if len(set(row_dimensions)) != 1:
+            raise RuntimeError(
+                "Semantic document embeddings must be a rectangular batch."
+            )
+        return len(value), row_dimensions[0]
+
+    raise RuntimeError(
+        "Semantic document embeddings do not expose a supported batch shape."
+    )
+
+
 def execute_query(
     index_path: Path,
     query_text: str,
@@ -296,13 +377,22 @@ def execute_query(
         results = []
         semantic_enabled = embedding_policy is not None
         fallback = embedding_policy.get("fallback_behavior", "ignore") if semantic_enabled else "ignore"
+        expected_dimensions = None
 
         base_diagnostics = {}
         semantic_model = None
         if semantic_enabled:
-            # Note on F1b implementation limits:
-            # Currently only `provider=local` and `similarity_metric=cosine` are actively implemented.
-            # Other parameters like `dimensions` are structurally present but not actively validated here yet.
+            # F1b implements only provider=local and similarity_metric=cosine.
+            # The embedding-policy dimension is a runtime invariant, not metadata.
+            expected_dimensions = embedding_policy.get("dimensions")
+            if (
+                isinstance(expected_dimensions, bool)
+                or not isinstance(expected_dimensions, int)
+                or expected_dimensions < 1
+            ):
+                raise ValueError(
+                    "embedding_policy dimensions must be a positive integer"
+                )
             engine_type += "+semantic_requested"
             provider = embedding_policy.get("provider", "local")
             metric = embedding_policy.get("similarity_metric", "cosine")
@@ -348,7 +438,9 @@ def execute_query(
                         "fallback_behavior": fallback,
                         "candidate_k": fetch_k,
                         "provider": provider,
-                        "model_name": model_name
+                        "model_name": model_name,
+                        "expected_dimensions": expected_dimensions,
+                        "dimension_validation": "pending",
                     }
                 except ImportError as e:
                     if fallback == "fail":
@@ -598,10 +690,11 @@ def execute_query(
             results.append(hit)
 
         if semantic_model:
-            # Re-rank results using semantic model
+            # Re-rank results using semantic model.
+            semantic_diagnostics = base_diagnostics["semantic"]
             try:
                 # Use a lightweight dot product/cosine calculation if the model is mocked for tests,
-                # or import standard util if it's the real sentence_transformers.
+                # or import standard util if it is the real sentence_transformers package.
                 query_emb = semantic_model.encode(query_text)
                 if isinstance(query_emb, list):
                     try:
@@ -612,6 +705,18 @@ def execute_query(
                 if hasattr(query_emb, "shape") and len(query_emb.shape) == 2 and query_emb.shape[0] == 1:
                     query_emb = query_emb.flatten()
 
+                actual_query_dimensions = _embedding_vector_dimension(
+                    query_emb,
+                    label="query",
+                )
+                semantic_diagnostics["actual_query_dimensions"] = actual_query_dimensions
+                if actual_query_dimensions != expected_dimensions:
+                    raise _SemanticDimensionMismatch(
+                        "query",
+                        expected_dimensions,
+                        actual_query_dimensions,
+                    )
+
                 if candidate_texts:
                     doc_embs = semantic_model.encode(candidate_texts)
                     if isinstance(doc_embs, list):
@@ -621,11 +726,30 @@ def execute_query(
                         except ImportError:
                             pass
 
+                    document_count, actual_document_dimensions = _embedding_batch_dimensions(
+                        doc_embs
+                    )
+                    semantic_diagnostics["actual_document_dimensions"] = (
+                        actual_document_dimensions
+                    )
+                    if document_count != len(candidate_texts):
+                        raise RuntimeError(
+                            "Semantic document embedding count mismatch: "
+                            f"expected {len(candidate_texts)}, got {document_count}."
+                        )
+                    if actual_document_dimensions != expected_dimensions:
+                        raise _SemanticDimensionMismatch(
+                            "document",
+                            expected_dimensions,
+                            actual_document_dimensions,
+                        )
+                    semantic_diagnostics["dimension_validation"] = "pass"
+
                     try:
                         from sentence_transformers import util
                         cosine_scores = util.cos_sim(query_emb, doc_embs)[0]
                     except ImportError:
-                        # Fallback for mocked models in tests
+                        # Fallback for mocked models in tests.
                         try:
                             import numpy as np
                             q = np.array(query_emb)
@@ -637,8 +761,12 @@ def execute_query(
                             cosine_scores = np.dot(d, q) / (d_norm * q_norm)
                         except ImportError:
                             import math
-                            def _dot(a, b): return sum(x * y for x, y in zip(a, b))
-                            def _norm(a): return math.sqrt(sum(x * x for x in a))
+
+                            def _dot(a, b):
+                                return sum(x * y for x, y in zip(a, b))
+
+                            def _norm(a):
+                                return math.sqrt(sum(x * x for x in a))
 
                             q = query_emb
                             q_n = _norm(q) or 1.0
@@ -654,19 +782,40 @@ def execute_query(
                         hit["why"]["rank_features"] = hit["why"].get("rank_features", {})
                         hit["why"]["rank_features"]["semantic_score"] = float(cosine_scores[i])
                         hit["why"]["rank_features"]["original_bm25"] = old_score
+                else:
+                    semantic_diagnostics["dimension_validation"] = "query_only_pass"
+            except _SemanticDimensionMismatch as exc:
+                semantic_diagnostics["error"] = str(exc)
+                semantic_diagnostics["enabled"] = False
+                semantic_diagnostics["dimension_validation"] = "mismatch"
+                if trace_data:
+                    trace_data["semantic_status"] = "dimension_mismatch"
+                    trace_data["fallback_markers"].append(
+                        "semantic_fallback_dimension_mismatch"
+                    )
+                if fallback == "fail":
+                    raise RuntimeError(
+                        f"{exc} (fallback_behavior=fail)."
+                    ) from exc
             except Exception as exc:
                 logger.warning(
                     "Semantic encoding failed: %s",
                     type(exc).__name__,
                     exc_info=True,
                 )
+                if trace_data:
+                    trace_data["semantic_status"] = "encoding_error"
+                    trace_data["fallback_markers"].append(
+                        "semantic_fallback_encoding_error"
+                    )
                 if fallback == "fail":
                     raise RuntimeError(
                         "Semantic re-ranking failed during encoding "
                         "(fallback_behavior=fail)."
                     ) from exc
-                base_diagnostics["semantic"]["error"] = "semantic encoding unavailable"
-                base_diagnostics["semantic"]["enabled"] = False
+                semantic_diagnostics["error"] = "semantic encoding unavailable"
+                semantic_diagnostics["enabled"] = False
+                semantic_diagnostics["dimension_validation"] = "error"
 
         # Sort results deterministically to avoid random tie flips.
         results.sort(key=lambda x: (-x.get("final_score", 0), x["path"]))

--- a/merger/repoground/tests/test_eval_semantic.py
+++ b/merger/repoground/tests/test_eval_semantic.py
@@ -50,7 +50,7 @@ def test_eval_semantic_delta(mini_index_for_eval, tmp_path, capsys, monkeypatch)
         "provider": "local",
         "similarity_metric": "cosine",
         "model_name": "mock-model",
-        "dimensions": 384,
+        "dimensions": 2,
         "fallback_behavior": "ignore"
     }), encoding="utf-8")
 
@@ -58,7 +58,8 @@ def test_eval_semantic_delta(mini_index_for_eval, tmp_path, capsys, monkeypatch)
         def encode(self, texts):
             # If input is string, make it list-like for uniform processing
             is_single = isinstance(texts, str)
-            if is_single: texts = [texts]
+            if is_single:
+                texts = [texts]
 
             embeddings = []
             for t in texts:

--- a/merger/repoground/tests/test_retrieval_query.py
+++ b/merger/repoground/tests/test_retrieval_query.py
@@ -449,10 +449,97 @@ def test_query_semantic_reranking(mini_index, monkeypatch):
     assert semantic["actual_document_dimensions"] == 2
 
 
+class _ScalarWithShape(float):
+    shape = ()
+
+
+class _ArrayLikeVector:
+    def __init__(self, values):
+        self._values = tuple(values)
+        self.shape = (len(self._values),)
+
+    def __iter__(self):
+        return iter(self._values)
+
+    def __len__(self):
+        return len(self._values)
+
+    def __getitem__(self, index):
+        return self._values[index]
+
+    def reshape(self, *_shape):
+        return (self._values,)
+
+
 def test_python_cosine_scores_accepts_single_1d_document_vector():
     scores = query_core._python_cosine_scores([1.0, 0.0], [1.0, 0.0])
 
     assert scores == [1.0]
+
+
+def test_python_cosine_scores_accepts_single_array_like_document_vector():
+    scores = query_core._python_cosine_scores(
+        _ArrayLikeVector([1.0, 0.0]),
+        _ArrayLikeVector([1.0, 0.0]),
+    )
+
+    assert scores == [1.0]
+
+
+def test_python_cosine_scores_treats_zero_dimensional_array_scalars_as_components():
+    vector = [_ScalarWithShape(1.0), _ScalarWithShape(0.0)]
+
+    scores = query_core._python_cosine_scores(vector, vector)
+
+    assert scores == [1.0]
+
+
+def test_semantic_query_only_normalizes_single_array_like_vector_batch():
+    class QueryOnlyModel:
+        def encode(self, texts):
+            if not isinstance(texts, str):
+                raise AssertionError("document embeddings must not be requested")
+            return [_ArrayLikeVector([1.0, 0.0])]
+
+    diagnostics = {"dimension_validation": "pending"}
+    query_embedding, document_embeddings = query_core._validated_semantic_embeddings(
+        semantic_model=QueryOnlyModel(),
+        query_text="no candidates",
+        candidate_texts=[],
+        expected_dimensions=2,
+        semantic_diagnostics=diagnostics,
+    )
+
+    assert tuple(query_embedding) == (1.0, 0.0)
+    assert document_embeddings is None
+    assert diagnostics["actual_query_dimensions"] == 2
+    assert diagnostics["dimension_validation"] == "query_only_pass"
+
+
+def test_semantic_list_of_array_like_document_vectors_is_a_batch():
+    class ArrayBatchModel:
+        def encode(self, texts):
+            if isinstance(texts, str):
+                return _ArrayLikeVector([1.0, 0.0])
+            return [
+                _ArrayLikeVector([1.0, 0.0]),
+                _ArrayLikeVector([0.0, 1.0]),
+            ]
+
+    diagnostics = {"dimension_validation": "pending"}
+    query_embedding, document_embeddings = query_core._validated_semantic_embeddings(
+        semantic_model=ArrayBatchModel(),
+        query_text="two candidates",
+        candidate_texts=["first", "second"],
+        expected_dimensions=2,
+        semantic_diagnostics=diagnostics,
+    )
+
+    assert tuple(query_embedding) == (1.0, 0.0)
+    assert len(document_embeddings) == 2
+    assert diagnostics["actual_query_dimensions"] == 2
+    assert diagnostics["actual_document_dimensions"] == 2
+    assert diagnostics["dimension_validation"] == "pass"
 
 
 def test_semantic_single_candidate_1d_document_embedding_is_scored(
@@ -516,6 +603,30 @@ def test_semantic_query_only_normalizes_single_vector_batch():
     assert document_embeddings is None
     assert diagnostics["actual_query_dimensions"] == 2
     assert diagnostics["dimension_validation"] == "query_only_pass"
+
+
+def test_semantic_query_only_dimension_mismatch_is_rejected():
+    class WrongQueryDimensionModel:
+        def encode(self, texts):
+            if not isinstance(texts, str):
+                raise AssertionError("document embeddings must not be requested")
+            return [1.0, 0.0, 0.0]
+
+    diagnostics = {"dimension_validation": "pending"}
+    with pytest.raises(
+        query_core._SemanticDimensionMismatch,
+        match="Semantic query embedding dimension mismatch: expected 2, got 3",
+    ):
+        query_core._validated_semantic_embeddings(
+            semantic_model=WrongQueryDimensionModel(),
+            query_text="no candidates",
+            candidate_texts=[],
+            expected_dimensions=2,
+            semantic_diagnostics=diagnostics,
+        )
+
+    assert diagnostics["actual_query_dimensions"] == 3
+    assert diagnostics["dimension_validation"] == "pending"
 
 
 def test_semantic_dimension_mismatch_falls_back_to_lexical_results(mini_index, monkeypatch):

--- a/merger/repoground/tests/test_retrieval_query.py
+++ b/merger/repoground/tests/test_retrieval_query.py
@@ -442,6 +442,185 @@ def test_query_semantic_reranking(mini_index, monkeypatch):
 
     # Assert semantic score logic is correctly calculated by the mock fallback
     assert top_hit["why"]["rank_features"]["semantic_score"] > second_hit["why"]["rank_features"]["semantic_score"]
+    semantic = top_hit["why"]["diagnostics"]["semantic"]
+    assert semantic["dimension_validation"] == "pass"
+    assert semantic["expected_dimensions"] == 2
+    assert semantic["actual_query_dimensions"] == 2
+    assert semantic["actual_document_dimensions"] == 2
+
+
+def test_semantic_dimension_mismatch_falls_back_to_lexical_results(mini_index, monkeypatch):
+    class WrongDimensionModel:
+        def encode(self, texts):
+            if isinstance(texts, str):
+                return [1.0, 0.0, 0.0]
+            return [[1.0, 0.0, 0.0] for _ in texts]
+
+    monkeypatch.setattr(query_core, "_get_semantic_model", lambda _name: WrongDimensionModel())
+    policy = {
+        "model_name": "wrong-dimension-model",
+        "provider": "local",
+        "fallback_behavior": "ignore",
+        "similarity_metric": "cosine",
+        "dimensions": 2,
+    }
+
+    result = query_core.execute_query(
+        mini_index,
+        query_text="def",
+        k=2,
+        embedding_policy=policy,
+        trace=True,
+    )
+
+    assert result["count"] == 2
+    assert result["query_trace"]["semantic_status"] == "dimension_mismatch"
+    assert "semantic_fallback_dimension_mismatch" in result["query_trace"]["fallback_markers"]
+    for hit in result["results"]:
+        semantic = hit["why"]["diagnostics"]["semantic"]
+        assert semantic["enabled"] is False
+        assert semantic["dimension_validation"] == "mismatch"
+        assert semantic["expected_dimensions"] == 2
+        assert semantic["actual_query_dimensions"] == 3
+        assert semantic["error"] == (
+            "Semantic query embedding dimension mismatch: expected 2, got 3"
+        )
+        assert "semantic_score" not in hit["why"]["rank_features"]
+
+
+def test_semantic_dimension_mismatch_respects_fail_policy(mini_index, monkeypatch):
+    class WrongDimensionModel:
+        def encode(self, texts):
+            if isinstance(texts, str):
+                return [1.0, 0.0, 0.0]
+            return [[1.0, 0.0, 0.0] for _ in texts]
+
+    monkeypatch.setattr(query_core, "_get_semantic_model", lambda _name: WrongDimensionModel())
+    policy = {
+        "model_name": "wrong-dimension-model",
+        "provider": "local",
+        "fallback_behavior": "fail",
+        "similarity_metric": "cosine",
+        "dimensions": 2,
+    }
+
+    with pytest.raises(RuntimeError) as excinfo:
+        query_core.execute_query(
+            mini_index,
+            query_text="def",
+            k=2,
+            embedding_policy=policy,
+        )
+
+    assert str(excinfo.value) == (
+        "Semantic query embedding dimension mismatch: expected 2, got 3 "
+        "(fallback_behavior=fail)."
+    )
+
+
+def test_semantic_document_dimension_mismatch_falls_back(mini_index, monkeypatch):
+    class WrongDocumentDimensionModel:
+        def encode(self, texts):
+            if isinstance(texts, str):
+                return [1.0, 0.0]
+            return [[1.0, 0.0, 0.0] for _ in texts]
+
+    monkeypatch.setattr(
+        query_core,
+        "_get_semantic_model",
+        lambda _name: WrongDocumentDimensionModel(),
+    )
+    policy = {
+        "model_name": "wrong-document-dimension-model",
+        "provider": "local",
+        "fallback_behavior": "ignore",
+        "similarity_metric": "cosine",
+        "dimensions": 2,
+    }
+
+    result = query_core.execute_query(
+        mini_index,
+        query_text="def",
+        k=2,
+        embedding_policy=policy,
+    )
+
+    assert result["count"] == 2
+    for hit in result["results"]:
+        semantic = hit["why"]["diagnostics"]["semantic"]
+        assert semantic["enabled"] is False
+        assert semantic["dimension_validation"] == "mismatch"
+        assert semantic["expected_dimensions"] == 2
+        assert semantic["actual_query_dimensions"] == 2
+        assert semantic["actual_document_dimensions"] == 3
+        assert semantic["error"] == (
+            "Semantic document embedding dimension mismatch: expected 2, got 3"
+        )
+        assert "semantic_score" not in hit["why"]["rank_features"]
+
+
+@pytest.mark.parametrize("dimensions", [None, 0, -1, True, 1.5])
+def test_semantic_direct_policy_rejects_invalid_dimensions(mini_index, dimensions):
+    policy = {
+        "model_name": "invalid-policy-model",
+        "provider": "local",
+        "fallback_behavior": "ignore",
+        "similarity_metric": "cosine",
+        "dimensions": dimensions,
+    }
+
+    with pytest.raises(
+        ValueError,
+        match="embedding_policy dimensions must be a positive integer",
+    ):
+        query_core.execute_query(
+            mini_index,
+            query_text="def",
+            k=2,
+            embedding_policy=policy,
+        )
+
+
+def test_semantic_document_count_mismatch_falls_back(mini_index, monkeypatch):
+    class WrongDocumentCountModel:
+        def encode(self, texts):
+            if isinstance(texts, str):
+                return [1.0, 0.0]
+            return [[1.0, 0.0]]
+
+    monkeypatch.setattr(
+        query_core,
+        "_get_semantic_model",
+        lambda _name: WrongDocumentCountModel(),
+    )
+    policy = {
+        "model_name": "wrong-document-count-model",
+        "provider": "local",
+        "fallback_behavior": "ignore",
+        "similarity_metric": "cosine",
+        "dimensions": 2,
+    }
+
+    result = query_core.execute_query(
+        mini_index,
+        query_text="def",
+        k=2,
+        embedding_policy=policy,
+        trace=True,
+    )
+
+    assert result["count"] == 2
+    assert result["query_trace"]["semantic_status"] == "encoding_error"
+    assert "semantic_fallback_encoding_error" in result["query_trace"]["fallback_markers"]
+    for hit in result["results"]:
+        semantic = hit["why"]["diagnostics"]["semantic"]
+        assert semantic["enabled"] is False
+        assert semantic["dimension_validation"] == "error"
+        assert semantic["expected_dimensions"] == 2
+        assert semantic["actual_query_dimensions"] == 2
+        assert semantic["actual_document_dimensions"] == 2
+        assert semantic["error"] == "semantic encoding unavailable"
+        assert "semantic_score" not in hit["why"]["rank_features"]
 
 
 def test_query_explain_graph_fields_match_scoring(mini_index, tmp_path, monkeypatch):

--- a/merger/repoground/tests/test_retrieval_query.py
+++ b/merger/repoground/tests/test_retrieval_query.py
@@ -449,6 +449,75 @@ def test_query_semantic_reranking(mini_index, monkeypatch):
     assert semantic["actual_document_dimensions"] == 2
 
 
+def test_python_cosine_scores_accepts_single_1d_document_vector():
+    scores = query_core._python_cosine_scores([1.0, 0.0], [1.0, 0.0])
+
+    assert scores == [1.0]
+
+
+def test_semantic_single_candidate_1d_document_embedding_is_scored(
+    mini_index,
+    monkeypatch,
+):
+    class SingleCandidateModel:
+        def encode(self, texts):
+            if isinstance(texts, str):
+                return [1.0, 0.0]
+            assert len(texts) == 1
+            return [1.0, 0.0]
+
+    monkeypatch.setattr(
+        query_core,
+        "_get_semantic_model",
+        lambda _name: SingleCandidateModel(),
+    )
+    policy = {
+        "model_name": "single-candidate-model",
+        "provider": "local",
+        "fallback_behavior": "ignore",
+        "similarity_metric": "cosine",
+        "dimensions": 2,
+    }
+
+    result = query_core.execute_query(
+        mini_index,
+        query_text="hello",
+        k=1,
+        embedding_policy=policy,
+        trace=True,
+    )
+
+    assert result["count"] == 1
+    assert result["query_trace"]["semantic_status"] == "ok"
+    semantic = result["results"][0]["why"]["diagnostics"]["semantic"]
+    assert semantic["enabled"] is True
+    assert semantic["dimension_validation"] == "pass"
+    assert semantic["actual_document_dimensions"] == 2
+    assert result["results"][0]["why"]["rank_features"]["semantic_score"] == 1.0
+
+
+def test_semantic_query_only_normalizes_single_vector_batch():
+    class QueryOnlyModel:
+        def encode(self, texts):
+            if not isinstance(texts, str):
+                raise AssertionError("document embeddings must not be requested")
+            return ((1.0, 0.0),)
+
+    diagnostics = {"dimension_validation": "pending"}
+    query_embedding, document_embeddings = query_core._validated_semantic_embeddings(
+        semantic_model=QueryOnlyModel(),
+        query_text="no candidates",
+        candidate_texts=[],
+        expected_dimensions=2,
+        semantic_diagnostics=diagnostics,
+    )
+
+    assert tuple(query_embedding) == (1.0, 0.0)
+    assert document_embeddings is None
+    assert diagnostics["actual_query_dimensions"] == 2
+    assert diagnostics["dimension_validation"] == "query_only_pass"
+
+
 def test_semantic_dimension_mismatch_falls_back_to_lexical_results(mini_index, monkeypatch):
     class WrongDimensionModel:
         def encode(self, texts):
@@ -581,11 +650,15 @@ def test_semantic_direct_policy_rejects_invalid_dimensions(mini_index, dimension
         )
 
 
-def test_semantic_document_count_mismatch_falls_back(mini_index, monkeypatch):
+def test_semantic_document_count_mismatch_reports_encoding_fallback(
+    mini_index,
+    monkeypatch,
+):
     class WrongDocumentCountModel:
         def encode(self, texts):
             if isinstance(texts, str):
                 return [1.0, 0.0]
+            # Deliberately return one vector for a multi-candidate request.
             return [[1.0, 0.0]]
 
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

- enforce `embedding-policy.v1` dimensions against actual query and document vectors before semantic similarity calculation
- preserve pre-semantic scores and ordering for `fallback_behavior=ignore`; fail with bounded diagnostics for `fallback_behavior=fail`
- validate positive dimensions, rectangular batches and candidate/vector counts before scoring
- normalize one-dimensional single-document vectors into one-row batches
- normalize one-row query batches from lists, tuples and array-like values
- preserve lists of NumPy-/tensor-like document rows as actual batches instead of collapsing them into one document
- distinguish zero-dimensional array scalars from one-dimensional vector rows
- centralize positive-dimension validation at both public and private runtime boundaries
- avoid redundant NumPy copies with `numpy.asarray`
- use the locally measured faster `map(operator.mul, ...)` implementation in the optional pure-Python cosine path
- retain defensive scorer normalization because the helpers are independently callable and directly tested

## Review findings

Two review rounds found two real shape bugs:

1. a one-dimensional document embedding for one candidate passed validation but violated scorer batch assumptions;
2. `[array(d), array(d)]` was mistaken for one flat vector because only nested lists and tuples were recognized as rows.

Both were reproduced before correction and are now protected by regression tests. The first review claim that a direct one-dimensional array still broke the pure-Python path did not reproduce on the then-current head; that path was already normalized correctly.

## Verification

- semantic/cosine regression slice: `22 passed, 33 deselected in 0.28s`
- complete retrieval-query module: `55 passed in 0.61s`
- complete current-main-bound RepoGround Python suite: `4366 passed, 2 skipped in 120.27s`
- persisted full-suite output SHA-256: `1cf9109d28ac9efb26c3a49d3156a99278f2adb98289b7098024fc62c9ef4d76`
- full-suite task: `224e5839872a44a2853037d1`
- lifecycle receipt SHA-256: `423e90b92ebd197353b5b1a26a885f557fb9f72c76e1e4012f72f36ec592e077`
- Ruff: passed
- maintainability ratchet: `status=pass`, `new_count=0`, `resolved_count=2`, `findings=[]`
- `git diff --check`: passed
- GitHub CI: all 21 checks passed

## Performance evidence

A local 384-component microbenchmark over 20,000 dot products and five repeats measured best times of `0.294337s` for the generator expression and `0.114604s` for `sum(map(operator.mul, ...))`. This supports the local pure-Python hot-path change; it is not presented as a universal production-latency claim.

## Evidence binding

- base: `9b4b643c448e018049d03ab1ec945af99018e2b1`
- head: `38110fb92fa6f372762f5988d4c9ee044900ec65`
- exact base-to-head review diff SHA-256: `bed311091b0a63c013c594aaf14ef59806bf55ce941de037ade87e6de48f2e30`
- proof: `docs/proofs/repoground-semantic-dimension-validation-v1-proof.md`

## Deliberate boundaries

Not included in this correctness slice:

- public exception hierarchy or immutable retrieval-result migration
- nested diagnostics-schema or logging-contract changes
- arbitrary 1536/3072/4096-dimension tests, because size bookkeeping has no dimension-specific branch
- a default real-model integration test, because `sentence-transformers` is optional, absent in the verification environment, and model acquisition would make the default suite network- and artifact-dependent
- removal of defensive scorer normalization or NumPy shape guards, because those helpers remain independently callable

A matching dimension proves vector-shape compatibility only. It does not prove model identity, semantic quality, ranking improvement, retrieval completeness, claim truth or production readiness.