### PR TITLE
Harden Agent Consumption declarations

### DIFF
--- a/docs/architecture/agent-consumption-contract.md
+++ b/docs/architecture/agent-consumption-contract.md
@@ -7,8 +7,9 @@ Answer Compliance Contract v1 implemented.
 Agent Consumption Trace v1 implemented.
 The Agent Entry Manifest core is implemented with a contract, producer and
 focused tests.
-A dedicated CLI command, automatic bundle emission, bundle-manifest
-registration and stable consumer integration are not yet implemented.
+The dedicated Agent Consumption CLI is implemented. Automatic bundle emission,
+bundle-manifest registration and stable external consumer adoption are not yet
+implemented.
 Export Safety Report, Lens Cards, and Relation Cards exist as scoped contract/core surfaces. Agent Reading Pack v2 card indexes and any promoted Retrieval v2 default remain unimplemented.
 
 ---
@@ -155,10 +156,23 @@ It may report:
 
 - pass: required artifacts are declared and no warning/failure condition was found.
 - warn: required artifacts are declared, but recommended artifacts are missing/unread or unknown declared artifacts were observed.
-- fail: required artifacts are missing/unread, task profiles mismatch, or required negative semantics are missing or invalid.
-- not_applicable: no applicable task profile could be resolved and no failing contract invariant was detected.
+- fail: required artifacts are missing/unread, task profiles mismatch, input fields cannot be safely normalised, declarations contradict themselves, unread roles are assigned to the wrong expectation class, or required negative semantics are missing or invalid.
+- not_applicable: no applicable task profile could be resolved and no failing input or declaration invariant was detected.
 
 The trace is a declaration-comparison artifact only. It does not prove actual reading, answer correctness, complete context use, runtime behavior, test sufficiency, regression absence, forensic readiness, or repo understanding.
+
+### Consistency boundary
+
+The validator is not a replacement for full JSON Schema validation of Required Reading or Answer Compliance. It does enforce the minimum boundary needed for a deterministic, schema-shaped trace:
+
+- missing or malformed comparison fields (`task_profile`, Required Reading `status`, `required`, `recommended`, and Answer Compliance `declared_artifacts`) become `invalid_input_field` failures instead of being silently treated as empty;
+- a scalar string remains a compatibility shorthand for one role, while other scalar role values and mappings fail closed instead of being coerced;
+- one artifact cannot consistently be declared both read and unread;
+- one artifact cannot consistently be classified as both required-unread and recommended-unread;
+- unread declarations must match the required or recommended class of the resolved profile;
+- citation, range and epistemic-gap objects are deep-copied so later consumer mutation cannot rewrite the original declaration.
+
+These checks establish formal self-consistency only. They do not turn declarations into observed evidence.
 
 ### Files
 
@@ -166,13 +180,17 @@ The trace is a declaration-comparison artifact only. It does not prove actual re
 |------|------|
 | `merger/repoground/contracts/agent-consumption-trace.v1.schema.json` | JSON Schema (Draft-07) for the trace contract |
 | `merger/repoground/core/agent_consumption_validate.py` | Pure validator: `validate_agent_consumption(required_reading_result, answer_compliance, *, available_roles=None)` |
-| `merger/repoground/tests/test_agent_consumption_trace.py` | Schema validation and validator behaviour tests |
+| `merger/repoground/tests/test_agent_consumption_trace.py` | Base schema validation and validator behaviour tests |
+| `merger/repoground/tests/test_agent_consumption_consistency.py` | Contradiction, malformed-input and mutable-identity regression tests |
 
 ### Scope
 
 Implemented:
 - Agent Consumption Trace Contract
-- Core validator
+- Core validator split into bounded comparison helpers
+- fail-closed declaration consistency checks
+- schema-shaped malformed-input handling
+- deep-copy isolation for pass-through declaration objects
 - strict-mode validation
 - deterministic exit-code policy
 - CLI commands for Required Reading resolution, preflight, and trace validation
@@ -184,6 +202,8 @@ Deferred:
 - Output Health or Post-Emit Health integration
 - export-safety wiring
 - mandatory adoption by external agent wrappers
+- source-bound tool-read receipts that compare declarations with observed access events
+- cryptographic binding of those future receipts to task, commit and consumed artifact identities
 
 The validator performs no I/O, holds no global state, and reuses the existing Required Reading resolution rather than re-deriving it.
 

--- a/merger/repoground/contracts/agent-consumption-trace.v1.schema.json
+++ b/merger/repoground/contracts/agent-consumption-trace.v1.schema.json
@@ -41,7 +41,7 @@
     "status": {
       "type": "string",
       "enum": ["pass", "warn", "fail", "not_applicable"],
-      "description": "pass: required artifacts declared and no warn/fail condition. warn: recommended missing/unread or unknown declared artifacts. fail: required missing/unread, task profile mismatch, or required negative semantics missing or invalid. not_applicable: no applicable task profile could be resolved and no failing contract invariant was detected."
+      "description": "pass: required artifacts declared and no warn/fail condition. warn: recommended missing/unread or unknown declared artifacts. fail: required missing/unread, task profile mismatch, malformed comparison input, contradictory declarations, unexpected unread classifications, or required negative semantics missing or invalid. not_applicable: no applicable task profile could be resolved and no failing contract invariant was detected."
     },
     "required_artifacts": {
       "$ref": "#/definitions/role_array",
@@ -69,26 +69,26 @@
     },
     "unread_required_artifacts": {
       "$ref": "#/definitions/role_array",
-      "description": "Required roles the Answer Compliance declaration reports as unread or unavailable. Adopted from the declaration."
+      "description": "Required roles the Answer Compliance declaration reports as unread or unavailable."
     },
     "unread_recommended_artifacts": {
       "$ref": "#/definitions/role_array",
-      "description": "Recommended roles the Answer Compliance declaration reports as unread or unavailable. Adopted from the declaration."
+      "description": "Recommended roles the Answer Compliance declaration reports as unread or unavailable."
     },
     "declared_citations": {
       "type": "array",
       "items": { "type": "object" },
-      "description": "Citation declarations adopted verbatim from the Answer Compliance declaration. Not re-validated here."
+      "description": "Citation declarations copied from Answer Compliance without semantic revalidation and without shared mutable identity."
     },
     "declared_ranges": {
       "type": "array",
       "items": { "type": "object" },
-      "description": "Range declarations adopted verbatim from the Answer Compliance declaration. Not re-validated here."
+      "description": "Range declarations copied from Answer Compliance without semantic revalidation and without shared mutable identity."
     },
     "epistemic_gaps": {
       "type": "array",
       "items": { "type": "object" },
-      "description": "Epistemic gaps adopted verbatim from the Answer Compliance declaration. Not re-validated here."
+      "description": "Epistemic gaps copied from Answer Compliance without semantic revalidation and without shared mutable identity."
     },
     "diagnostics": {
       "type": "array",
@@ -116,6 +116,7 @@
         "code": {
           "type": "string",
           "enum": [
+            "invalid_input_field",
             "task_profile_mismatch",
             "task_profile_not_applicable",
             "missing_required_artifact",
@@ -123,6 +124,8 @@
             "missing_recommended_artifact",
             "unread_recommended_artifact",
             "unknown_declared_artifact",
+            "contradictory_artifact_declaration",
+            "unexpected_unread_artifact",
             "missing_negative_semantics"
           ],
           "description": "Machine-readable diagnostic code."

--- a/merger/repoground/core/agent_consumption_validate.py
+++ b/merger/repoground/core/agent_consumption_validate.py
@@ -2,7 +2,7 @@
 
 Pure, deterministic comparison of Required Reading Protocol expectations (the
 "should") against an Answer Compliance declaration (what the answer claims to
-have used).  The result is a machine-readable Agent Consumption Trace.
+have used). The result is a machine-readable Agent Consumption Trace.
 
 Strict separation of layers:
 
@@ -14,13 +14,16 @@ Strict separation of layers:
   with the expectation?
 
 This module performs no I/O, holds no global state, and imports nothing from the
-service / CLI layers.  It makes no truth claim.  It does not prove actual
-reading, answer correctness, repo understanding, complete context use, runtime
-behavior, test sufficiency, regression absence, forensic readiness, or claim
-truth.  It only reports whether a declared self-report formally matches the
-required-reading expectation.
+service / CLI layers. It makes no truth claim. It does not prove actual reading,
+answer correctness, repo understanding, complete context use, runtime behavior,
+test sufficiency, regression absence, forensic readiness, or claim truth. It
+only reports whether a declared self-report formally matches the required-
+reading expectation.
 """
 from __future__ import annotations
+
+from collections.abc import Mapping
+from copy import deepcopy
 
 
 KIND = "lenskit.agent_consumption_trace"
@@ -43,6 +46,8 @@ DOES_NOT_ESTABLISH: tuple[str, ...] = (
 _FAIL = "fail"
 _WARN = "warn"
 _INFO = "info"
+_RESOLVED_STATUSES = frozenset({"pass", "warn", "fail", "not_applicable"})
+_ROLE_CONTAINERS = (list, tuple, set, frozenset)
 
 
 def validate_agent_consumption(
@@ -51,58 +56,48 @@ def validate_agent_consumption(
     *,
     available_roles: set[str] | None = None,
 ) -> dict:
-    """Compare a resolved Required Reading result against an Answer Compliance
-    declaration and return a deterministic Agent Consumption Trace dict.
+    """Compare Required Reading expectations with an Answer Compliance claim.
 
-    Parameters
-    ----------
-    required_reading_result:
-        Output of ``resolve_required_reading`` (or an equivalent dict carrying
-        ``task_profile``, ``required``, ``recommended`` and ``status``).  The
-        existing Required Reading resolution is reused as-is; this validator does
-        not re-derive it.
-    answer_compliance:
-        An ``answer-compliance.v1`` declaration dict.
-    available_roles:
-        Optional set of roles known to exist in the bundle context.  When
-        provided, declared artifacts in this set are not flagged as unknown.
-        When ``None``, only required + recommended roles are treated as known and
-        any other declared role is conservatively warned.
-
-    Returns
-    -------
-    dict
-        A trace that validates against
-        ``contracts/agent-consumption-trace.v1.schema.json``.
+    The function remains a comparison layer rather than a second full JSON
+    Schema validator. It does, however, normalise its narrow input boundary so
+    malformed fields cannot crash the comparison or make its own output violate
+    the trace schema's basic types.
     """
-    rr = required_reading_result or {}
-    ac = answer_compliance or {}
-
-    rr_profile = rr.get("task_profile")
-    ac_profile = ac.get("task_profile")
-    task_profile = rr_profile if rr_profile not in (None, "") else ac_profile
-    if task_profile in (None, ""):
-        task_profile = "unknown"
-
-    required_artifacts = _norm_roles(rr.get("required"))
-    recommended_artifacts = _norm_roles(rr.get("recommended"))
-    declared_artifacts = _norm_roles(ac.get("declared_artifacts"))
-    unread_required = _norm_roles(ac.get("unread_required_artifacts"))
-    unread_recommended = _norm_roles(ac.get("unread_recommended_artifacts"))
-
-    # Pass-through declarations.  The trace is a comparison artifact, not a second
-    # Answer Compliance validator, so these are adopted verbatim.
-    declared_citations = list(ac.get("declared_citations") or [])
-    declared_ranges = list(ac.get("declared_ranges") or [])
-    epistemic_gaps = list(ac.get("epistemic_gaps") or [])
-
     diagnostics: list[dict] = []
+    rr = _input_mapping(required_reading_result, "required_reading_result", diagnostics)
+    ac = _input_mapping(answer_compliance, "answer_compliance", diagnostics)
 
-    # ── Negative semantics (contract invariant) ─────────────────────────────
-    # A broken Answer Compliance artifact stays broken even when the task
-    # profile is not applicable: the nine does_not_establish boundaries are a
-    # contract invariant, not a profile question.  Evaluated before the
-    # not_applicable short-circuit so invalid boundaries are never swallowed.
+    rr_profile = _task_profile(rr.get("task_profile"), "required reading", diagnostics)
+    ac_profile = _task_profile(ac.get("task_profile"), "answer compliance", diagnostics)
+    task_profile = rr_profile or ac_profile or "unknown"
+    resolved_status = _resolved_status(rr.get("status"), diagnostics)
+
+    required_artifacts = _required_role_list(rr, "required", diagnostics)
+    recommended_artifacts = _required_role_list(rr, "recommended", diagnostics)
+    declared_artifacts = _required_role_list(ac, "declared_artifacts", diagnostics)
+    unread_required = _role_list(
+        ac.get("unread_required_artifacts"),
+        "unread_required_artifacts",
+        diagnostics,
+    )
+    unread_recommended = _role_list(
+        ac.get("unread_recommended_artifacts"),
+        "unread_recommended_artifacts",
+        diagnostics,
+    )
+
+    # These declarations are comparison payload, not evidence. Deep copies
+    # prevent later mutation of either input or trace from rewriting the other.
+    declared_citations = _object_list(
+        ac.get("declared_citations"), "declared_citations", diagnostics
+    )
+    declared_ranges = _object_list(
+        ac.get("declared_ranges"), "declared_ranges", diagnostics
+    )
+    epistemic_gaps = _object_list(
+        ac.get("epistemic_gaps"), "epistemic_gaps", diagnostics
+    )
+
     if not _has_exact_negative_semantics(ac):
         diagnostics.append(
             _diag(
@@ -113,11 +108,17 @@ def validate_agent_consumption(
             )
         )
 
-    # ── Rule 1: task profile resolution ─────────────────────────────────────
-    # not_applicable stops the Soll/Ist comparison (there is no meaningful
-    # expectation to compare against), but a failing contract invariant such as
-    # invalid negative semantics still wins.
-    if rr.get("status") == "not_applicable":
+    diagnostics.extend(
+        _declaration_consistency_diagnostics(
+            declared_artifacts,
+            unread_required,
+            unread_recommended,
+        )
+    )
+
+    # No Soll/Ist comparison is meaningful without an applicable profile.
+    # Input and declaration invariants above still remain fail-closed.
+    if resolved_status == "not_applicable":
         diagnostics.append(
             _diag(
                 "task_profile_not_applicable",
@@ -147,7 +148,7 @@ def validate_agent_consumption(
             diagnostics=diagnostics,
         )
 
-    if ac_profile is not None and ac_profile != rr_profile:
+    if rr_profile is not None and ac_profile is not None and ac_profile != rr_profile:
         diagnostics.append(
             _diag(
                 "task_profile_mismatch",
@@ -160,92 +161,57 @@ def validate_agent_consumption(
     declared_set = set(declared_artifacts)
     unread_required_set = set(unread_required)
     unread_recommended_set = set(unread_recommended)
+    required_set = set(required_artifacts)
+    recommended_set = set(recommended_artifacts)
 
-    # ── Rule 2: required artifacts ──────────────────────────────────────────
-    # Honestly declaring a required artifact as unread is good practice, but it
-    # is still a formal deviation from the expectation.
-    missing_required_artifacts: list[str] = []
-    for role in required_artifacts:
-        if role in unread_required_set:
-            diagnostics.append(
-                _diag(
-                    "unread_required_artifact",
-                    _FAIL,
-                    f"Required artifact '{role}' was declared unread.",
-                    artifact=role,
-                )
-            )
-        elif role not in declared_set:
-            missing_required_artifacts.append(role)
-            diagnostics.append(
-                _diag(
-                    "missing_required_artifact",
-                    _FAIL,
-                    f"Required artifact '{role}' was not declared.",
-                    artifact=role,
-                )
-            )
+    diagnostics.extend(
+        _unexpected_unread_diagnostics(
+            unread_required_set,
+            unread_recommended_set,
+            required_set,
+            recommended_set,
+        )
+    )
 
-    # ── Rule 3: recommended artifacts ───────────────────────────────────────
-    missing_recommended_artifacts: list[str] = []
-    for role in recommended_artifacts:
-        if role in unread_recommended_set:
-            diagnostics.append(
-                _diag(
-                    "unread_recommended_artifact",
-                    _WARN,
-                    f"Recommended artifact '{role}' was declared unread.",
-                    artifact=role,
-                )
-            )
-        elif role not in declared_set:
-            missing_recommended_artifacts.append(role)
-            diagnostics.append(
-                _diag(
-                    "missing_recommended_artifact",
-                    _WARN,
-                    f"Recommended artifact '{role}' was not declared.",
-                    artifact=role,
-                )
-            )
+    missing_required_artifacts, required_diagnostics = _expected_artifact_result(
+        required_artifacts,
+        declared_set,
+        unread_required_set,
+        severity=_FAIL,
+        missing_code="missing_required_artifact",
+        unread_code="unread_required_artifact",
+        expectation="Required",
+    )
+    diagnostics.extend(required_diagnostics)
 
-    # ── Rule 4: unknown declared artifacts ──────────────────────────────────
-    known_roles = set(required_artifacts) | set(recommended_artifacts)
+    missing_recommended_artifacts, recommended_diagnostics = _expected_artifact_result(
+        recommended_artifacts,
+        declared_set,
+        unread_recommended_set,
+        severity=_WARN,
+        missing_code="missing_recommended_artifact",
+        unread_code="unread_recommended_artifact",
+        expectation="Recommended",
+    )
+    diagnostics.extend(recommended_diagnostics)
+
+    known_roles = required_set | recommended_set
     if available_roles is not None:
-        known_roles |= {str(x) for x in available_roles}
-    unknown_declared_artifacts: list[str] = []
-    for role in declared_artifacts:
-        if role not in known_roles:
-            unknown_declared_artifacts.append(role)
-            diagnostics.append(
-                _diag(
-                    "unknown_declared_artifact",
-                    _WARN,
-                    f"Declared artifact '{role}' is not a known required, "
-                    f"recommended, or available role.",
-                    artifact=role,
-                )
-            )
-
-    # ── Status priority ─────────────────────────────────────────────────────
-    # Negative semantics were already evaluated above, before the
-    # not_applicable short-circuit.
-    if any(d["severity"] == _FAIL for d in diagnostics):
-        status = "fail"
-    elif any(d["severity"] == _WARN for d in diagnostics):
-        status = "warn"
-    else:
-        status = "pass"
+        known_roles |= {x for x in available_roles if isinstance(x, str) and x}
+    unknown_declared_artifacts, unknown_diagnostics = _unknown_declared_result(
+        declared_artifacts, known_roles
+    )
+    diagnostics.extend(unknown_diagnostics)
 
     return _trace(
         task_profile=task_profile,
-        status=status,
+        status=_status_from_diagnostics(diagnostics),
         required_artifacts=required_artifacts,
         recommended_artifacts=recommended_artifacts,
         declared_artifacts=declared_artifacts,
-        missing_required_artifacts=sorted(missing_required_artifacts),
-        missing_recommended_artifacts=sorted(missing_recommended_artifacts),
-        unknown_declared_artifacts=sorted(unknown_declared_artifacts),
+        missing_required_artifacts=missing_required_artifacts,
+        missing_recommended_artifacts=missing_recommended_artifacts,
+        unknown_declared_artifacts=unknown_declared_artifacts,
         unread_required_artifacts=unread_required,
         unread_recommended_artifacts=unread_recommended,
         declared_citations=declared_citations,
@@ -255,33 +221,257 @@ def validate_agent_consumption(
     )
 
 
-def _norm_roles(value) -> list[str]:
-    """Normalise a role list deterministically: stringify, dedupe, sort.
+def _input_mapping(value, label: str, diagnostics: list[dict]) -> dict:
+    if isinstance(value, Mapping):
+        return dict(value)
+    diagnostics.append(
+        _diag(
+            "invalid_input_field",
+            _FAIL,
+            f"{label} must be a JSON object.",
+        )
+    )
+    return {}
 
-    Defensive only: a scalar string is treated as a single role rather than
-    being decomposed into characters.  No schema validation, no exceptions.
+
+def _task_profile(value, label: str, diagnostics: list[dict]) -> str | None:
+    if isinstance(value, str) and value:
+        return value
+    diagnostics.append(
+        _diag(
+            "invalid_input_field",
+            _FAIL,
+            f"{label} task_profile must be a non-empty string.",
+        )
+    )
+    return None
+
+
+def _resolved_status(value, diagnostics: list[dict]) -> str | None:
+    if isinstance(value, str) and value in _RESOLVED_STATUSES:
+        return value
+    diagnostics.append(
+        _diag(
+            "invalid_input_field",
+            _FAIL,
+            "Required reading status must be one of pass, warn, fail, or "
+            "not_applicable.",
+        )
+    )
+    return None
+
+
+def _required_role_list(
+    source: Mapping,
+    field: str,
+    diagnostics: list[dict],
+) -> list[str]:
+    if field not in source:
+        diagnostics.append(
+            _diag(
+                "invalid_input_field",
+                _FAIL,
+                f"Required comparison field '{field}' is missing.",
+            )
+        )
+        return []
+    if source[field] is None:
+        return _invalid_role_list(field, diagnostics)
+    return _role_list(source[field], field, diagnostics)
+
+
+def _role_list(value, field: str, diagnostics: list[dict]) -> list[str]:
+    """Return sorted unique non-empty role strings without raising.
+
+    A scalar string remains a compatibility shorthand for one role. Other
+    scalar values and mappings are rejected instead of string-coerced.
     """
     if value is None:
         return []
     if isinstance(value, str):
-        return [value]
-    if not value:
+        return [value] if value else _invalid_role_list(field, diagnostics)
+    if not isinstance(value, _ROLE_CONTAINERS):
+        return _invalid_role_list(field, diagnostics)
+
+    valid_roles = [x for x in value if isinstance(x, str) and x]
+    if len(valid_roles) != len(value):
+        diagnostics.append(
+            _diag(
+                "invalid_input_field",
+                _FAIL,
+                f"{field} must contain only non-empty strings; invalid entries were ignored.",
+            )
+        )
+    return sorted(set(valid_roles))
+
+
+def _invalid_role_list(field: str, diagnostics: list[dict]) -> list[str]:
+    diagnostics.append(
+        _diag(
+            "invalid_input_field",
+            _FAIL,
+            f"{field} must be an array of non-empty strings.",
+        )
+    )
+    return []
+
+
+def _object_list(value, field: str, diagnostics: list[dict]) -> list[dict]:
+    if value is None:
         return []
-    return sorted({str(x) for x in value})
+    if not isinstance(value, (list, tuple)):
+        diagnostics.append(
+            _diag(
+                "invalid_input_field",
+                _FAIL,
+                f"{field} must be an array of objects.",
+            )
+        )
+        return []
+    valid = [item for item in value if isinstance(item, dict)]
+    if len(valid) != len(value):
+        diagnostics.append(
+            _diag(
+                "invalid_input_field",
+                _FAIL,
+                f"{field} must contain only objects; invalid entries were ignored.",
+            )
+        )
+    return deepcopy(valid)
 
 
 def _has_exact_negative_semantics(answer_compliance: dict) -> bool:
-    """True iff Answer Compliance declares exactly the nine required boundaries.
-
-    Rejects missing, extra, unknown, and duplicate values alike.
-    """
-    ac_negatives = [
-        str(x) for x in (answer_compliance.get("does_not_establish") or [])
-    ]
-    return (
-        set(ac_negatives) == set(DOES_NOT_ESTABLISH)
-        and len(ac_negatives) == len(DOES_NOT_ESTABLISH)
+    value = answer_compliance.get("does_not_establish")
+    if not isinstance(value, (list, tuple)) or not all(
+        isinstance(item, str) for item in value
+    ):
+        return False
+    return set(value) == set(DOES_NOT_ESTABLISH) and len(value) == len(
+        DOES_NOT_ESTABLISH
     )
+
+
+def _declaration_consistency_diagnostics(
+    declared_artifacts: list[str],
+    unread_required: list[str],
+    unread_recommended: list[str],
+) -> list[dict]:
+    declared = set(declared_artifacts)
+    unread_required_set = set(unread_required)
+    unread_recommended_set = set(unread_recommended)
+    diagnostics = []
+
+    for role in sorted(declared & (unread_required_set | unread_recommended_set)):
+        diagnostics.append(
+            _diag(
+                "contradictory_artifact_declaration",
+                _FAIL,
+                f"Artifact '{role}' was declared both read and unread.",
+                artifact=role,
+            )
+        )
+    for role in sorted(unread_required_set & unread_recommended_set):
+        diagnostics.append(
+            _diag(
+                "contradictory_artifact_declaration",
+                _FAIL,
+                f"Artifact '{role}' was classified as both required-unread and "
+                "recommended-unread.",
+                artifact=role,
+            )
+        )
+    return diagnostics
+
+
+def _unexpected_unread_diagnostics(
+    unread_required: set[str],
+    unread_recommended: set[str],
+    required: set[str],
+    recommended: set[str],
+) -> list[dict]:
+    diagnostics = []
+    for role in sorted(unread_required - required):
+        diagnostics.append(
+            _diag(
+                "unexpected_unread_artifact",
+                _FAIL,
+                f"Artifact '{role}' was declared required-unread but is not "
+                "required by the resolved profile.",
+                artifact=role,
+            )
+        )
+    for role in sorted(unread_recommended - recommended):
+        diagnostics.append(
+            _diag(
+                "unexpected_unread_artifact",
+                _FAIL,
+                f"Artifact '{role}' was declared recommended-unread but is not "
+                "recommended by the resolved profile.",
+                artifact=role,
+            )
+        )
+    return diagnostics
+
+
+def _expected_artifact_result(
+    expected: list[str],
+    declared: set[str],
+    unread: set[str],
+    *,
+    severity: str,
+    missing_code: str,
+    unread_code: str,
+    expectation: str,
+) -> tuple[list[str], list[dict]]:
+    missing = []
+    diagnostics = []
+    for role in expected:
+        if role in unread:
+            diagnostics.append(
+                _diag(
+                    unread_code,
+                    severity,
+                    f"{expectation} artifact '{role}' was declared unread.",
+                    artifact=role,
+                )
+            )
+        elif role not in declared:
+            missing.append(role)
+            diagnostics.append(
+                _diag(
+                    missing_code,
+                    severity,
+                    f"{expectation} artifact '{role}' was not declared.",
+                    artifact=role,
+                )
+            )
+    return missing, diagnostics
+
+
+def _unknown_declared_result(
+    declared_artifacts: list[str], known_roles: set[str]
+) -> tuple[list[str], list[dict]]:
+    unknown = [role for role in declared_artifacts if role not in known_roles]
+    diagnostics = [
+        _diag(
+            "unknown_declared_artifact",
+            _WARN,
+            f"Declared artifact '{role}' is not a known required, recommended, "
+            "or available role.",
+            artifact=role,
+        )
+        for role in unknown
+    ]
+    return unknown, diagnostics
+
+
+def _status_from_diagnostics(diagnostics: list[dict]) -> str:
+    severities = {item["severity"] for item in diagnostics}
+    if _FAIL in severities:
+        return "fail"
+    if _WARN in severities:
+        return "warn"
+    return "pass"
 
 
 def _diag(code: str, severity: str, detail: str, *, artifact: str | None = None) -> dict:
@@ -315,6 +505,7 @@ def _trace(
             severity_weight.get(d.get("severity"), 3),
             d["code"],
             d.get("artifact", ""),
+            d["detail"],
         ),
     )
     return {

--- a/merger/repoground/tests/test_agent_consumption_consistency.py
+++ b/merger/repoground/tests/test_agent_consumption_consistency.py
@@ -1,0 +1,242 @@
+import json
+from pathlib import Path
+
+import pytest
+
+jsonschema = pytest.importorskip("jsonschema")
+
+from merger.repoground.core.agent_consumption_validate import (
+    DOES_NOT_ESTABLISH,
+    validate_agent_consumption,
+)
+
+_SCHEMA_PATH = (
+    Path(__file__).parent.parent
+    / "contracts"
+    / "agent-consumption-trace.v1.schema.json"
+)
+
+
+def _schema() -> dict:
+    return json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def _required(**overrides) -> dict:
+    result = {
+        "task_profile": "pr_review",
+        "required": ["canonical_md"],
+        "recommended": ["citation_map_jsonl"],
+        "status": "pass",
+    }
+    result.update(overrides)
+    return result
+
+
+def _answer(**overrides) -> dict:
+    result = {
+        "task_profile": "pr_review",
+        "declared_artifacts": ["canonical_md", "citation_map_jsonl"],
+        "declared_citations": [],
+        "declared_ranges": [],
+        "unread_required_artifacts": [],
+        "unread_recommended_artifacts": [],
+        "epistemic_gaps": [],
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }
+    result.update(overrides)
+    return result
+
+
+def _without(source: dict, field: str) -> dict:
+    result = dict(source)
+    result.pop(field)
+    return result
+
+
+def _codes(trace: dict) -> list[str]:
+    return [diagnostic["code"] for diagnostic in trace["diagnostics"]]
+
+
+def _assert_schema_valid(trace: dict) -> None:
+    jsonschema.validate(instance=trace, schema=_schema())
+
+
+def test_read_and_unread_declaration_is_fail_closed():
+    trace = validate_agent_consumption(
+        _required(),
+        _answer(unread_required_artifacts=["canonical_md"]),
+    )
+
+    assert trace["status"] == "fail"
+    assert "contradictory_artifact_declaration" in _codes(trace)
+    assert "unread_required_artifact" in _codes(trace)
+    assert trace["missing_required_artifacts"] == []
+    _assert_schema_valid(trace)
+
+
+def test_both_unread_classifications_are_contradictory():
+    trace = validate_agent_consumption(
+        _required(),
+        _answer(
+            declared_artifacts=[],
+            unread_required_artifacts=["canonical_md"],
+            unread_recommended_artifacts=["canonical_md"],
+        ),
+    )
+
+    assert trace["status"] == "fail"
+    assert "contradictory_artifact_declaration" in _codes(trace)
+    assert "unexpected_unread_artifact" in _codes(trace)
+    _assert_schema_valid(trace)
+
+
+def test_unread_role_must_match_resolved_expectation_class():
+    trace = validate_agent_consumption(
+        _required(),
+        _answer(
+            declared_artifacts=["canonical_md"],
+            unread_required_artifacts=["citation_map_jsonl"],
+        ),
+    )
+
+    assert trace["status"] == "fail"
+    assert "unexpected_unread_artifact" in _codes(trace)
+    assert "missing_recommended_artifact" in _codes(trace)
+    _assert_schema_valid(trace)
+
+
+@pytest.mark.parametrize("field", ["required", "recommended"])
+def test_missing_required_reading_comparison_field_is_fail_closed(field):
+    trace = validate_agent_consumption(
+        _without(_required(), field),
+        _answer(),
+    )
+
+    assert trace["status"] == "fail"
+    assert "invalid_input_field" in _codes(trace)
+    _assert_schema_valid(trace)
+
+
+def test_missing_declared_artifacts_is_fail_closed():
+    trace = validate_agent_consumption(
+        _required(),
+        _without(_answer(), "declared_artifacts"),
+    )
+
+    assert trace["status"] == "fail"
+    assert "invalid_input_field" in _codes(trace)
+    _assert_schema_valid(trace)
+
+
+def test_null_required_comparison_field_is_fail_closed():
+    trace = validate_agent_consumption(
+        _required(required=None),
+        _answer(),
+    )
+
+    assert trace["status"] == "fail"
+    assert "invalid_input_field" in _codes(trace)
+    _assert_schema_valid(trace)
+
+
+def test_unknown_required_reading_status_is_fail_closed():
+    trace = validate_agent_consumption(
+        _required(status="invented"),
+        _answer(),
+    )
+
+    assert trace["status"] == "fail"
+    assert "invalid_input_field" in _codes(trace)
+    _assert_schema_valid(trace)
+
+
+def test_invalid_profile_type_becomes_schema_valid_failure():
+    trace = validate_agent_consumption(
+        _required(task_profile=7),
+        _answer(),
+    )
+
+    assert trace["task_profile"] == "pr_review"
+    assert trace["status"] == "fail"
+    assert "invalid_input_field" in _codes(trace)
+    _assert_schema_valid(trace)
+
+
+def test_invalid_role_container_does_not_crash_or_escape_schema():
+    trace = validate_agent_consumption(
+        _required(),
+        _answer(declared_artifacts=42),
+    )
+
+    assert trace["declared_artifacts"] == []
+    assert trace["status"] == "fail"
+    assert "invalid_input_field" in _codes(trace)
+    _assert_schema_valid(trace)
+
+
+def test_scalar_string_role_shorthand_remains_compatible():
+    trace = validate_agent_consumption(
+        _required(required="canonical_md", recommended=[]),
+        _answer(declared_artifacts="canonical_md"),
+    )
+
+    assert trace["required_artifacts"] == ["canonical_md"]
+    assert trace["declared_artifacts"] == ["canonical_md"]
+    assert trace["status"] == "pass"
+    _assert_schema_valid(trace)
+
+
+def test_invalid_passthrough_container_is_normalized_fail_closed():
+    trace = validate_agent_consumption(
+        _required(),
+        _answer(declared_citations="not-an-array"),
+    )
+
+    assert trace["declared_citations"] == []
+    assert trace["status"] == "fail"
+    assert "invalid_input_field" in _codes(trace)
+    _assert_schema_valid(trace)
+
+
+def test_negative_semantics_scalar_does_not_crash():
+    trace = validate_agent_consumption(
+        _required(),
+        _answer(does_not_establish=1),
+    )
+
+    assert trace["status"] == "fail"
+    assert "missing_negative_semantics" in _codes(trace)
+    _assert_schema_valid(trace)
+
+
+def test_passthrough_objects_do_not_share_mutable_identity():
+    citations = [{"citation_id": "c-1", "meta": {"line": 7}}]
+    trace = validate_agent_consumption(
+        _required(),
+        _answer(declared_citations=citations),
+    )
+
+    trace["declared_citations"][0]["meta"]["line"] = 99
+    assert citations[0]["meta"]["line"] == 7
+
+
+def test_not_applicable_does_not_hide_self_contradiction():
+    trace = validate_agent_consumption(
+        _required(
+            task_profile="does_not_exist",
+            required=[],
+            recommended=[],
+            status="not_applicable",
+        ),
+        _answer(
+            task_profile="does_not_exist",
+            declared_artifacts=["canonical_md"],
+            unread_required_artifacts=["canonical_md"],
+        ),
+    )
+
+    assert trace["status"] == "fail"
+    assert "task_profile_not_applicable" in _codes(trace)
+    assert "contradictory_artifact_declaration" in _codes(trace)
+    assert "unexpected_unread_artifact" not in _codes(trace)
+    _assert_schema_valid(trace)


### PR DESCRIPTION
## Zweck

Härtet den Agent Consumption Trace gegen widersprüchliche oder strukturell unbrauchbare Selbstauskünfte, ohne aus Deklarationen beobachtete Leseevidenz zu machen.

## Änderungen

- fehlende oder ungültige Vergleichspflichtfelder führen deterministisch zu `invalid_input_field`
- widersprüchliche read/unread-Angaben und falsch klassifizierte unread-Rollen führen fail-closed zu eigenen Diagnosecodes
- Rollenprüfung ist in begrenzte Hilfsfunktionen aufgeteilt; C901 liegt unter der Schwelle 10
- Citation-, Range- und Gap-Objekte werden tief kopiert
- Schema, Architekturtext und fokussierte Regressionstests sind ergänzt

## Verifikation

- 86 fokussierte Tests bestanden
- 430 breitere Agent-/Vertragstests bestanden
- vollständige Repository-Suite: 4.468 bestanden, 2 übersprungen
- Ruff inklusive C901/F401/F811: grün
- `git diff --check`: grün

## Grenzen

Der Trace beweist weiterhin weder tatsächliches Lesen noch Verständnis, Relevanz, Korrektheit, Laufzeitverhalten oder forensische Bereitschaft.

Diff-SHA-256: `9889146b8bb85ac97c7499ec4dbdcd11db863a636e608ead5b3f87fd79662aac`
Commit: `4d6e675c4cc47a3b6411c32c43bf160eba0afea1`