### PR TITLE
feat: add Python call graph goldset and promotion gate

### DIFF
--- a/.github/workflows/python-call-graph-goldset.yml
+++ b/.github/workflows/python-call-graph-goldset.yml
@@ -75,6 +75,17 @@ jobs:
       - name: Structural checks
         run: git diff --check
 
+      - name: Generate exact pull-request diff
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          git fetch --no-tags --depth=1 origin "$BASE_SHA"
+          git fetch --no-tags --depth=1 origin "$HEAD_SHA"
+          git diff --binary --full-index "$BASE_SHA" "$HEAD_SHA" > repoground-pr.diff
+          test -s repoground-pr.diff
+
       - name: Upload benchmark evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
@@ -83,5 +94,6 @@ jobs:
           path: |
             python-call-graph-quality-report.json
             python-call-graph-goldset-tests.log
+            repoground-pr.diff
           if-no-files-found: warn
           retention-days: 7

--- a/.github/workflows/python-call-graph-goldset.yml
+++ b/.github/workflows/python-call-graph-goldset.yml
@@ -1,0 +1,87 @@
+---
+name: Python Call Graph Goldset
+
+"on":
+  push:
+    branches: ["main", "master"]
+    paths:
+      - "docs/retrieval/python_call_graph_goldset.v1.json"
+      - "docs/proofs/python-call-graph-goldset-v1-proof.md"
+      - "merger/repoground/architecture/call_graph.py"
+      - "merger/repoground/architecture/call_graph_quality_eval.py"
+      - "merger/repoground/core/agent_impact_eval.py"
+      - "merger/repoground/tests/fixtures/python_call_graph_goldset/**"
+      - "merger/repoground/tests/test_python_call_graph.py"
+      - "merger/repoground/tests/test_python_call_graph_goldset.py"
+      - ".github/workflows/python-call-graph-goldset.yml"
+      - "requirements/repoground-dev.lock.txt"
+  pull_request:
+    branches: ["main", "master"]
+    paths:
+      - "docs/retrieval/python_call_graph_goldset.v1.json"
+      - "docs/proofs/python-call-graph-goldset-v1-proof.md"
+      - "merger/repoground/architecture/call_graph.py"
+      - "merger/repoground/architecture/call_graph_quality_eval.py"
+      - "merger/repoground/core/agent_impact_eval.py"
+      - "merger/repoground/tests/fixtures/python_call_graph_goldset/**"
+      - "merger/repoground/tests/test_python_call_graph.py"
+      - "merger/repoground/tests/test_python_call_graph_goldset.py"
+      - ".github/workflows/python-call-graph-goldset.yml"
+      - "requirements/repoground-dev.lock.txt"
+
+permissions:
+  contents: read
+
+jobs:
+  python-call-graph-goldset:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --disable-pip-version-check --require-hashes -r requirements/repoground-dev.lock.txt
+
+      - name: Validate goldset JSON
+        run: python -m json.tool docs/retrieval/python_call_graph_goldset.v1.json >/dev/null
+
+      - name: Generate reviewable benchmark report
+        run: |
+          python -m merger.repoground.architecture.call_graph_quality_eval \
+            --goldset docs/retrieval/python_call_graph_goldset.v1.json \
+            --out python-call-graph-quality-report.json
+          python -m json.tool python-call-graph-quality-report.json >/dev/null
+
+      - name: Run focused tests
+        run: |
+          set -o pipefail
+          python -m pytest -q \
+            merger/repoground/tests/test_python_call_graph_goldset.py \
+            merger/repoground/tests/test_python_call_graph.py \
+            merger/repoground/tests/test_agent_impact_refinement.py \
+            2>&1 | tee python-call-graph-goldset-tests.log
+
+      - name: Ruff
+        run: |
+          ruff check \
+            merger/repoground/architecture/call_graph_quality_eval.py \
+            merger/repoground/tests/test_python_call_graph_goldset.py
+
+      - name: Structural checks
+        run: git diff --check
+
+      - name: Upload benchmark evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: python-call-graph-goldset-evidence
+          path: |
+            python-call-graph-quality-report.json
+            python-call-graph-goldset-tests.log
+          if-no-files-found: warn
+          retention-days: 7

--- a/docs/proofs/python-call-graph-goldset-v1-proof.md
+++ b/docs/proofs/python-call-graph-goldset-v1-proof.md
@@ -53,10 +53,10 @@ deterministic fixed navigation tasks, not an LLM quality experiment. The report
 therefore records task outcomes and compression while explicitly refusing to
 claim general agent-quality improvement or answer correctness.
 
-The fixed path surface is expected to reduce aggregate context paths from `11`
-to `5` and tool calls from `9` to `3`, with unchanged target recall. CI generates
-the full JSON report so byte count and wall-clock build time remain observable
-without turning machine-dependent timing into a committed exact baseline.
+The fixed path surface reduces aggregate context paths from `11` to `5` and tool
+calls from `9` to `3`, with unchanged target recall. CI generates the full JSON
+report so byte count and wall-clock build time remain observable without turning
+machine-dependent timing into a committed exact baseline.
 
 ## Promotion semantics
 
@@ -65,6 +65,36 @@ Passing thresholds yields only `eligible_for_review=true`.
 Bureau. The report also preserves the nonclaims for completeness, runtime
 reachability, dynamic dispatch, test sufficiency, review completeness and merge
 readiness.
+
+## Commit-bound CI evidence
+
+The canonical pull-request run is bound to:
+
+- head SHA: `a91aacf22e86bb4bdfb1afbbabd14f5788f4bbdb`;
+- workflow run: `29733013149`;
+- Actions artifact: `8457081289`;
+- artifact digest: `sha256:d53ceda0c82691ed4ac40f7d5af92a2916c85684126eb4064157b17ca7a392f4`;
+- goldset SHA-256: `beab71b88895dd173d2622a9ad5bf3aae36b5cf37b2a430a8b26348e9533c681`;
+- fixture SHA-256: `5b123139486b03b2f188c58f5b78dce8ee857abeb82947833e520894808459ac`;
+- call-record SHA-256: `6a26b3a4f0e2ba55d0e1a59c53b7980cc9204e9e7d6718103eab80b4100220e2`.
+
+Observed report values on the GitHub-hosted Python 3.12 runner:
+
+- `13` scored cases across `13` categories and `16` call records;
+- S1 precision `1.0`, target recall `1.0`;
+- `0` false positives and `0` false negatives;
+- unresolved share `0.307692` (`4/13`);
+- serialized call records: `9305` bytes;
+- measured build time: `2.854 ms`;
+- aggregate context-path reduction: `0.5454545454545454` (`11` to `5`);
+- tool-call reduction: `0.666667` (`9` to `3`);
+- all three deterministic navigation tasks passed;
+- `40` focused tests passed in `2.14 s`;
+- all four registered threshold checks passed;
+- `default_promoted=false`.
+
+The timing value is evidence for this exact runner and commit, not a portable
+performance guarantee.
 
 ## Reproduction
 

--- a/docs/proofs/python-call-graph-goldset-v1-proof.md
+++ b/docs/proofs/python-call-graph-goldset-v1-proof.md
@@ -1,0 +1,83 @@
+# Python Call Graph Goldset and Promotion Gate v1
+
+Bureau task: `RPU-V1-T024`
+
+## Scope
+
+This slice evaluates the existing conservative Python call graph. It does not
+change producer resolution rules or promote call-graph context into the default
+agent route.
+
+The fixed goldset covers 13 scored categories:
+
+- direct calls;
+- imported-name aliases and module aliases;
+- direct recursion;
+- same-class methods;
+- lexical shadowing and callback parameters;
+- decorator and default-argument calls;
+- higher-order dynamic dispatch;
+- an ambiguous negative control;
+- a German Unicode identifier and UTF-8 literal;
+- local constructor relations.
+
+Python is the scored producer. The Unicode case checks encoding and identifier
+handling; it is not evidence for a multilingual call-graph implementation.
+
+## Metrics and gate
+
+The evaluator reports these dimensions separately:
+
+- S1 precision and target recall;
+- false-positive classes, false negatives and unresolved share;
+- serialized call-record bytes and measured build time;
+- baseline versus graph context paths;
+- baseline versus graph tool calls;
+- deterministic fixed navigation-task outcomes.
+
+The registered promotion checks are:
+
+- S1 precision at least `0.97`;
+- target recall `1.0` on the fixed goldset;
+- at least `0.40` aggregate context-path reduction at equal or better recall;
+- no scored case or navigation-task regression.
+
+A wrong S1 target counts as both a false positive and a false negative. This
+prevents a confidently resolved but incorrect edge from preserving either
+precision or recall.
+
+## Navigation-usefulness boundary
+
+The navigation cases reuse the existing `agent_impact_eval` contract. They are
+deterministic fixed navigation tasks, not an LLM quality experiment. The report
+therefore records task outcomes and compression while explicitly refusing to
+claim general agent-quality improvement or answer correctness.
+
+The fixed path surface is expected to reduce aggregate context paths from `11`
+to `5` and tool calls from `9` to `3`, with unchanged target recall. CI generates
+the full JSON report so byte count and wall-clock build time remain observable
+without turning machine-dependent timing into a committed exact baseline.
+
+## Promotion semantics
+
+Passing thresholds yields only `eligible_for_review=true`.
+`default_promoted` remains `false` and the separate decision authority is the
+Bureau. The report also preserves the nonclaims for completeness, runtime
+reachability, dynamic dispatch, test sufficiency, review completeness and merge
+readiness.
+
+## Reproduction
+
+```bash
+python -m merger.repoground.architecture.call_graph_quality_eval \
+  --goldset docs/retrieval/python_call_graph_goldset.v1.json \
+  --out python-call-graph-quality-report.json
+python -m pytest -q \
+  merger/repoground/tests/test_python_call_graph_goldset.py \
+  merger/repoground/tests/test_python_call_graph.py \
+  merger/repoground/tests/test_agent_impact_refinement.py
+```
+
+The dedicated `Python Call Graph Goldset` workflow validates JSON, emits the
+reviewable report, runs focused producer and impact-evaluator regressions,
+checks Ruff and rejects structural diff errors.

--- a/docs/retrieval/python_call_graph_goldset.v1.json
+++ b/docs/retrieval/python_call_graph_goldset.v1.json
@@ -1,0 +1,250 @@
+{
+  "agent_tasks": [
+    {
+      "baseline_paths": [
+        "callkit/__init__.py",
+        "callkit/ambiguous.py",
+        "callkit/consumer.py",
+        "callkit/targets.py"
+      ],
+      "baseline_tool_calls": 3,
+      "case_ids": [
+        "imported-normalize-alias",
+        "module-normalize-alias"
+      ],
+      "id": "cross-module-normalization"
+    },
+    {
+      "baseline_paths": [
+        "callkit/ambiguous.py",
+        "callkit/consumer.py",
+        "callkit/targets.py"
+      ],
+      "baseline_tool_calls": 3,
+      "case_ids": [
+        "direct-local-helper",
+        "direct-recursion-loop",
+        "same-class-method",
+        "local-constructor"
+      ],
+      "id": "local-caller-callee-edit"
+    },
+    {
+      "baseline_paths": [
+        "callkit/__init__.py",
+        "callkit/ambiguous.py",
+        "callkit/consumer.py",
+        "callkit/targets.py"
+      ],
+      "baseline_tool_calls": 3,
+      "case_ids": [
+        "decorator-header-call",
+        "default-header-call",
+        "unicode-imported-identifier"
+      ],
+      "id": "definition-header-and-unicode"
+    }
+  ],
+  "cases": [
+    {
+      "callee_expression": "helper",
+      "caller_qualified_name": "direct",
+      "category": "direct_call",
+      "expected_evidence_level": "S1",
+      "expected_reason": "local_module_function",
+      "expected_relation_type": "calls",
+      "expected_status": "resolved",
+      "expected_target_id": "py:callkit:consumer.py:function:helper",
+      "id": "direct-local-helper",
+      "path": "callkit/consumer.py"
+    },
+    {
+      "callee_expression": "norm",
+      "caller_qualified_name": "imported_alias",
+      "category": "import_alias",
+      "expected_evidence_level": "S1",
+      "expected_reason": "imported_internal_name",
+      "expected_relation_type": "calls",
+      "expected_status": "resolved",
+      "expected_target_id": "py:callkit:targets.py:function:normalize",
+      "id": "imported-normalize-alias",
+      "path": "callkit/consumer.py"
+    },
+    {
+      "callee_expression": "target_mod.normalize",
+      "caller_qualified_name": "module_alias",
+      "category": "module_alias",
+      "expected_evidence_level": "S1",
+      "expected_reason": "module_alias_call",
+      "expected_relation_type": "calls",
+      "expected_status": "resolved",
+      "expected_target_id": "py:callkit:targets.py:function:normalize",
+      "id": "module-normalize-alias",
+      "path": "callkit/consumer.py"
+    },
+    {
+      "callee_expression": "loop",
+      "caller_qualified_name": "loop",
+      "category": "recursion",
+      "expected_evidence_level": "S1",
+      "expected_reason": "direct_recursion",
+      "expected_relation_type": "calls",
+      "expected_status": "resolved",
+      "expected_target_id": "py:callkit:consumer.py:function:loop",
+      "id": "direct-recursion-loop",
+      "path": "callkit/consumer.py"
+    },
+    {
+      "callee_expression": "self.indent",
+      "caller_qualified_name": "Formatter.format",
+      "category": "method",
+      "expected_evidence_level": "S1",
+      "expected_reason": "self_method_same_class",
+      "expected_relation_type": "calls",
+      "expected_status": "resolved",
+      "expected_target_id": "py:callkit:consumer.py:function:Formatter.indent",
+      "id": "same-class-method",
+      "path": "callkit/consumer.py"
+    },
+    {
+      "callee_expression": "normalize",
+      "caller_qualified_name": "shadowed",
+      "category": "shadowing",
+      "expected_evidence_level": "S0",
+      "expected_reason": "lexically_shadowed_name",
+      "expected_relation_type": "calls",
+      "expected_status": "unresolved",
+      "expected_target_id": null,
+      "id": "shadowed-parameter",
+      "path": "callkit/consumer.py"
+    },
+    {
+      "callee_expression": "callback",
+      "caller_qualified_name": "invoke",
+      "category": "callback",
+      "expected_evidence_level": "S0",
+      "expected_reason": "lexically_shadowed_name",
+      "expected_relation_type": "calls",
+      "expected_status": "unresolved",
+      "expected_target_id": null,
+      "id": "callback-parameter",
+      "path": "callkit/consumer.py"
+    },
+    {
+      "callee_expression": "decorate",
+      "caller_qualified_name": null,
+      "category": "decorator",
+      "expected_evidence_level": "S1",
+      "expected_reason": "imported_internal_name",
+      "expected_relation_type": "calls",
+      "expected_status": "resolved",
+      "expected_target_id": "py:callkit:targets.py:function:decorate",
+      "id": "decorator-header-call",
+      "path": "callkit/consumer.py"
+    },
+    {
+      "callee_expression": "default_factory",
+      "caller_qualified_name": null,
+      "category": "default_argument",
+      "expected_evidence_level": "S1",
+      "expected_reason": "imported_internal_name",
+      "expected_relation_type": "calls",
+      "expected_status": "resolved",
+      "expected_target_id": "py:callkit:targets.py:function:default_factory",
+      "id": "default-header-call",
+      "path": "callkit/consumer.py"
+    },
+    {
+      "callee_expression": "registry.handle",
+      "caller_qualified_name": "dynamic",
+      "category": "dynamic_dispatch",
+      "expected_evidence_level": "S0",
+      "expected_reason": "dynamic_attribute_call",
+      "expected_relation_type": "calls",
+      "expected_status": "unresolved",
+      "expected_target_id": null,
+      "id": "dynamic-registry-call",
+      "path": "callkit/consumer.py"
+    },
+    {
+      "callee_expression": "choose",
+      "caller_qualified_name": "use",
+      "category": "negative_control",
+      "expected_evidence_level": "S0",
+      "expected_reason": "local_module_function_multiple_definitions",
+      "expected_relation_type": "calls",
+      "expected_status": "ambiguous",
+      "expected_target_id": null,
+      "id": "ambiguous-conditional-definition",
+      "path": "callkit/ambiguous.py"
+    },
+    {
+      "callee_expression": "grüßen",
+      "caller_qualified_name": "unicode_case",
+      "category": "unicode_identifier",
+      "expected_evidence_level": "S1",
+      "expected_reason": "imported_internal_name",
+      "expected_relation_type": "calls",
+      "expected_status": "resolved",
+      "expected_target_id": "py:callkit:targets.py:function:grüßen",
+      "id": "unicode-imported-identifier",
+      "path": "callkit/consumer.py"
+    },
+    {
+      "callee_expression": "Formatter",
+      "caller_qualified_name": "build_formatter",
+      "category": "constructor",
+      "expected_evidence_level": "S1",
+      "expected_reason": "local_class_constructor",
+      "expected_relation_type": "constructs",
+      "expected_status": "resolved",
+      "expected_target_id": "py:callkit:consumer.py:class:Formatter",
+      "id": "local-constructor",
+      "path": "callkit/consumer.py"
+    }
+  ],
+  "does_not_establish": [
+    "complete_call_graph",
+    "runtime_reachability",
+    "dynamic_dispatch_resolution",
+    "multilanguage_call_graph_quality",
+    "general_agent_quality_improvement",
+    "answer_correctness",
+    "test_sufficiency",
+    "review_completeness",
+    "merge_readiness",
+    "default_promotion"
+  ],
+  "fixture_root": "merger/repoground/tests/fixtures/python_call_graph_goldset",
+  "kind": "lenskit.python_call_graph_quality_goldset",
+  "language_scope": [
+    "python"
+  ],
+  "measurement_scope": "fixed_python_fixture_and_deterministic_navigation_tasks",
+  "required_categories": [
+    "direct_call",
+    "import_alias",
+    "module_alias",
+    "recursion",
+    "method",
+    "shadowing",
+    "callback",
+    "decorator",
+    "default_argument",
+    "dynamic_dispatch",
+    "negative_control",
+    "unicode_identifier",
+    "constructor"
+  ],
+  "task_id": "RPU-V1-T024",
+  "thresholds": {
+    "minimum_context_path_reduction": 0.4,
+    "minimum_s1_precision": 0.97,
+    "minimum_target_recall": 1.0,
+    "no_case_regression": true
+  },
+  "unicode_scope": [
+    "German identifier and UTF-8 literal"
+  ],
+  "version": "1.0"
+}

--- a/docs/retrieval/python_call_graph_goldset.v1.json
+++ b/docs/retrieval/python_call_graph_goldset.v1.json
@@ -155,15 +155,15 @@
       "path": "callkit/consumer.py"
     },
     {
-      "callee_expression": "registry.handle",
+      "callee_expression": "factory()",
       "caller_qualified_name": "dynamic",
       "category": "dynamic_dispatch",
       "expected_evidence_level": "S0",
-      "expected_reason": "dynamic_attribute_call",
+      "expected_reason": "dynamic_callee_expression",
       "expected_relation_type": "calls",
       "expected_status": "unresolved",
       "expected_target_id": null,
-      "id": "dynamic-registry-call",
+      "id": "dynamic-higher-order-call",
       "path": "callkit/consumer.py"
     },
     {

--- a/merger/repoground/architecture/call_graph_quality_eval.py
+++ b/merger/repoground/architecture/call_graph_quality_eval.py
@@ -1,0 +1,589 @@
+"""Evaluate the fixed Python call-graph quality and navigation goldset."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import time
+from collections import Counter
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from merger.repoground.core.agent_impact_eval import evaluate_agent_impact_goldset
+
+from .call_graph import extract_python_calls
+
+
+GOLDSET_KIND = "lenskit.python_call_graph_quality_goldset"
+GOLDSET_VERSION = "1.0"
+VALID_STATUSES = frozenset({"resolved", "candidate", "ambiguous", "unresolved"})
+VALID_EVIDENCE_LEVELS = frozenset({"S0", "S1"})
+VALID_RELATION_TYPES = frozenset({"calls", "constructs"})
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+class PythonCallGraphGoldsetError(ValueError):
+    """The Python call-graph quality goldset is structurally invalid."""
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _sha256(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _ratio(numerator: int, denominator: int) -> float:
+    return round(numerator / denominator, 6) if denominator else 0.0
+
+
+def _require_non_empty_string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise PythonCallGraphGoldsetError(f"{label} must be a non-empty string")
+    return value
+
+
+def _validate_thresholds(raw: Any) -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        raise PythonCallGraphGoldsetError("thresholds must be an object")
+    required = {
+        "minimum_s1_precision",
+        "minimum_target_recall",
+        "minimum_context_path_reduction",
+        "no_case_regression",
+    }
+    missing = required - set(raw)
+    if missing:
+        raise PythonCallGraphGoldsetError(
+            f"thresholds missing {', '.join(sorted(missing))}"
+        )
+    thresholds = dict(raw)
+    for key in (
+        "minimum_s1_precision",
+        "minimum_target_recall",
+        "minimum_context_path_reduction",
+    ):
+        value = thresholds[key]
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise PythonCallGraphGoldsetError(f"{key} must be numeric")
+        if not 0.0 <= float(value) <= 1.0:
+            raise PythonCallGraphGoldsetError(f"{key} must be between 0 and 1")
+        thresholds[key] = float(value)
+    if thresholds["no_case_regression"] is not True:
+        raise PythonCallGraphGoldsetError("no_case_regression must be true")
+    return thresholds
+
+
+def _validate_categories(payload: Mapping[str, Any]) -> set[str]:
+    categories = payload.get("required_categories")
+    if not isinstance(categories, list) or not categories:
+        raise PythonCallGraphGoldsetError(
+            "required_categories must be a non-empty list"
+        )
+    if any(not isinstance(category, str) or not category for category in categories):
+        raise PythonCallGraphGoldsetError(
+            "required_categories must contain non-empty strings"
+        )
+    if len(set(categories)) != len(categories):
+        raise PythonCallGraphGoldsetError("required_categories must be unique")
+    return set(categories)
+
+
+def _validate_cases(payload: Mapping[str, Any]) -> set[str]:
+    cases = payload.get("cases")
+    if not isinstance(cases, list) or not cases:
+        raise PythonCallGraphGoldsetError("cases must be a non-empty list")
+    case_ids: set[str] = set()
+    observed_categories: set[str] = set()
+    for case in cases:
+        if not isinstance(case, Mapping):
+            raise PythonCallGraphGoldsetError("case must be an object")
+        case_id = _require_non_empty_string(case.get("id"), "case id")
+        if case_id in case_ids:
+            raise PythonCallGraphGoldsetError(f"duplicate case id: {case_id}")
+        case_ids.add(case_id)
+        category = _require_non_empty_string(
+            case.get("category"), f"{case_id}.category"
+        )
+        observed_categories.add(category)
+        _require_non_empty_string(case.get("path"), f"{case_id}.path")
+        _require_non_empty_string(
+            case.get("callee_expression"), f"{case_id}.callee_expression"
+        )
+        if "caller_qualified_name" not in case:
+            raise PythonCallGraphGoldsetError(
+                f"{case_id}.caller_qualified_name must be explicit"
+            )
+        caller = case["caller_qualified_name"]
+        if caller is not None and (not isinstance(caller, str) or not caller):
+            raise PythonCallGraphGoldsetError(
+                f"{case_id}.caller_qualified_name must be null or non-empty"
+            )
+        status = case.get("expected_status")
+        if status not in VALID_STATUSES:
+            raise PythonCallGraphGoldsetError(
+                f"{case_id}.expected_status is invalid"
+            )
+        evidence = case.get("expected_evidence_level")
+        if evidence not in VALID_EVIDENCE_LEVELS:
+            raise PythonCallGraphGoldsetError(
+                f"{case_id}.expected_evidence_level is invalid"
+            )
+        relation = case.get("expected_relation_type")
+        if relation not in VALID_RELATION_TYPES:
+            raise PythonCallGraphGoldsetError(
+                f"{case_id}.expected_relation_type is invalid"
+            )
+        _require_non_empty_string(
+            case.get("expected_reason"), f"{case_id}.expected_reason"
+        )
+        target_id = case.get("expected_target_id")
+        if status == "resolved":
+            _require_non_empty_string(target_id, f"{case_id}.expected_target_id")
+            if evidence != "S1":
+                raise PythonCallGraphGoldsetError(
+                    f"{case_id}: resolved cases must expect S1"
+                )
+        elif target_id is not None:
+            raise PythonCallGraphGoldsetError(
+                f"{case_id}: non-resolved cases must not expect a target"
+            )
+    missing = _validate_categories(payload) - observed_categories
+    if missing:
+        raise PythonCallGraphGoldsetError(
+            "goldset missing required categories: "
+            + ", ".join(sorted(missing))
+        )
+    return case_ids
+
+
+def _validate_agent_tasks(payload: Mapping[str, Any], case_ids: set[str]) -> None:
+    tasks = payload.get("agent_tasks")
+    if not isinstance(tasks, list) or not tasks:
+        raise PythonCallGraphGoldsetError("agent_tasks must be a non-empty list")
+    task_ids: set[str] = set()
+    for task in tasks:
+        if not isinstance(task, Mapping):
+            raise PythonCallGraphGoldsetError("agent task must be an object")
+        task_id = _require_non_empty_string(task.get("id"), "agent task id")
+        if task_id in task_ids:
+            raise PythonCallGraphGoldsetError(
+                f"duplicate agent task id: {task_id}"
+            )
+        task_ids.add(task_id)
+        selected = task.get("case_ids")
+        if not isinstance(selected, list) or not selected:
+            raise PythonCallGraphGoldsetError(
+                f"{task_id}.case_ids must be a non-empty list"
+            )
+        if any(not isinstance(case_id, str) or not case_id for case_id in selected):
+            raise PythonCallGraphGoldsetError(
+                f"{task_id}.case_ids must contain non-empty strings"
+            )
+        if len(set(selected)) != len(selected):
+            raise PythonCallGraphGoldsetError(
+                f"{task_id}.case_ids must be unique"
+            )
+        unknown = set(selected) - case_ids
+        if unknown:
+            raise PythonCallGraphGoldsetError(
+                f"{task_id} references unknown cases: "
+                + ", ".join(sorted(unknown))
+            )
+        paths = task.get("baseline_paths")
+        if not isinstance(paths, list) or not paths:
+            raise PythonCallGraphGoldsetError(
+                f"{task_id}.baseline_paths must be a non-empty list"
+            )
+        if any(not isinstance(path, str) or not path for path in paths):
+            raise PythonCallGraphGoldsetError(
+                f"{task_id}.baseline_paths must contain non-empty strings"
+            )
+        if len(set(paths)) != len(paths):
+            raise PythonCallGraphGoldsetError(
+                f"{task_id}.baseline_paths must be unique"
+            )
+        tool_calls = task.get("baseline_tool_calls")
+        if (
+            isinstance(tool_calls, bool)
+            or not isinstance(tool_calls, int)
+            or tool_calls < 1
+        ):
+            raise PythonCallGraphGoldsetError(
+                f"{task_id}.baseline_tool_calls must be a positive integer"
+            )
+
+
+def load_python_call_graph_goldset(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PythonCallGraphGoldsetError(
+            f"cannot load Python call-graph goldset: {path}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise PythonCallGraphGoldsetError("goldset must be a JSON object")
+    if payload.get("kind") != GOLDSET_KIND:
+        raise PythonCallGraphGoldsetError("unexpected goldset kind")
+    if payload.get("version") != GOLDSET_VERSION:
+        raise PythonCallGraphGoldsetError("unsupported goldset version")
+    _require_non_empty_string(payload.get("fixture_root"), "fixture_root")
+    thresholds = _validate_thresholds(payload.get("thresholds"))
+    case_ids = _validate_cases(payload)
+    _validate_agent_tasks(payload, case_ids)
+    boundaries = payload.get("does_not_establish")
+    if not isinstance(boundaries, list) or not boundaries:
+        raise PythonCallGraphGoldsetError(
+            "does_not_establish must be a non-empty list"
+        )
+    if any(not isinstance(item, str) or not item for item in boundaries):
+        raise PythonCallGraphGoldsetError(
+            "does_not_establish must contain non-empty strings"
+        )
+    result = dict(payload)
+    result["thresholds"] = thresholds
+    return result
+
+
+def _target_path(target_id: str | None) -> str | None:
+    if not target_id or not target_id.startswith("py:"):
+        return None
+    for marker in (":async_function:", ":function:", ":class:"):
+        prefix, separator, _ = target_id.partition(marker)
+        if separator:
+            return prefix.removeprefix("py:").replace(":", "/")
+    return None
+
+
+def _fixture_sha256(root: Path) -> str:
+    digest = hashlib.sha256()
+    files = (candidate for candidate in root.rglob("*") if candidate.is_file())
+    for path in sorted(files):
+        relative = path.relative_to(root).as_posix().encode("utf-8")
+        payload = path.read_bytes()
+        digest.update(len(relative).to_bytes(8, "big"))
+        digest.update(relative)
+        digest.update(len(payload).to_bytes(8, "big"))
+        digest.update(payload)
+    return digest.hexdigest()
+
+
+def _case_match(call: Mapping[str, Any], case: Mapping[str, Any]) -> bool:
+    return (
+        call.get("path") == case["path"]
+        and call.get("callee_expression") == case["callee_expression"]
+        and call.get("caller_qualified_name") == case["caller_qualified_name"]
+    )
+
+
+def _evaluate_case(
+    calls: Sequence[Mapping[str, Any]], case: Mapping[str, Any]
+) -> dict[str, Any]:
+    matches = [call for call in calls if _case_match(call, case)]
+    if len(matches) != 1:
+        return {
+            "id": case["id"],
+            "category": case["category"],
+            "path": case["path"],
+            "callee_expression": case["callee_expression"],
+            "caller_qualified_name": case["caller_qualified_name"],
+            "selector_match_count": len(matches),
+            "expected_status": case["expected_status"],
+            "actual_status": None,
+            "expected_target_id": case.get("expected_target_id"),
+            "actual_target_ids": [],
+            "counts_as_true_positive": False,
+            "counts_as_false_positive": False,
+            "counts_as_false_negative": case["expected_status"] == "resolved",
+            "outcome": "selector_error",
+            "passed": False,
+        }
+
+    call = matches[0]
+    expected_target = case.get("expected_target_id")
+    target_ids = list(call.get("resolved_target_ids", []))
+    target_match = (
+        target_ids == [expected_target]
+        if expected_target is not None
+        else target_ids == []
+    )
+    fields_match = (
+        call.get("resolution_status") == case["expected_status"]
+        and call.get("resolution_reason") == case["expected_reason"]
+        and call.get("evidence_level") == case["expected_evidence_level"]
+        and call.get("relation_type") == case["expected_relation_type"]
+    )
+    expected_s1 = case["expected_status"] == "resolved"
+    actual_s1 = (
+        call.get("resolution_status") == "resolved"
+        and call.get("evidence_level") == "S1"
+    )
+    correct_s1 = expected_s1 and actual_s1 and target_match
+    false_positive = actual_s1 and not correct_s1
+    false_negative = expected_s1 and not correct_s1
+    if correct_s1:
+        outcome = "true_positive"
+    elif expected_s1 and actual_s1:
+        outcome = "wrong_target"
+    elif false_positive:
+        outcome = "false_positive"
+    elif false_negative:
+        outcome = "false_negative"
+    else:
+        outcome = "non_s1_expected"
+
+    return {
+        "id": case["id"],
+        "category": case["category"],
+        "path": case["path"],
+        "callee_expression": case["callee_expression"],
+        "caller_qualified_name": case["caller_qualified_name"],
+        "selector_match_count": 1,
+        "expected_status": case["expected_status"],
+        "actual_status": call.get("resolution_status"),
+        "expected_reason": case["expected_reason"],
+        "actual_reason": call.get("resolution_reason"),
+        "expected_evidence_level": case["expected_evidence_level"],
+        "actual_evidence_level": call.get("evidence_level"),
+        "expected_relation_type": case["expected_relation_type"],
+        "actual_relation_type": call.get("relation_type"),
+        "expected_target_id": expected_target,
+        "actual_target_ids": target_ids,
+        "source_range_ref": call.get("range_ref"),
+        "counts_as_true_positive": correct_s1,
+        "counts_as_false_positive": false_positive,
+        "counts_as_false_negative": false_negative,
+        "outcome": outcome,
+        "passed": fields_match and target_match,
+    }
+
+
+def _impact_paths(
+    task: Mapping[str, Any],
+    case_results: Mapping[str, Mapping[str, Any]],
+) -> list[str]:
+    paths: set[str] = set()
+    for case_id in task["case_ids"]:
+        case = case_results[case_id]
+        paths.add(str(case["path"]))
+        target_path = _target_path(case.get("expected_target_id"))
+        if target_path:
+            paths.add(target_path)
+    return sorted(paths)
+
+
+def _evaluate_navigation_tasks(
+    goldset: Mapping[str, Any],
+    case_results: Sequence[Mapping[str, Any]],
+) -> tuple[dict[str, Any], list[dict[str, Any]], dict[str, int]]:
+    by_id = {case["id"]: case for case in case_results}
+    tasks = list(goldset["agent_tasks"])
+    navigation_goldset = {
+        "id": "python-call-graph-navigation-tasks-v1",
+        "minimum_target_recall_advantage": 1.0,
+        "minimum_context_path_reduction_at_equal_or_better_recall": goldset[
+            "thresholds"
+        ]["minimum_context_path_reduction"],
+        "cases": [
+            {
+                "id": task["id"],
+                "expected_paths": _impact_paths(task, by_id),
+            }
+            for task in tasks
+        ],
+    }
+    observations = {
+        task["id"]: {
+            "baseline_paths": list(task["baseline_paths"]),
+            "impact_context": {
+                "target": {"paths": _impact_paths(task, by_id)},
+                "gaps": [],
+                "source_statuses": [],
+            },
+        }
+        for task in tasks
+    }
+    utility = evaluate_agent_impact_goldset(navigation_goldset, observations)
+    utility_by_id = {item["id"]: item for item in utility["cases"]}
+    outcomes: list[dict[str, Any]] = []
+    for task in tasks:
+        item = utility_by_id[task["id"]]
+        selected_cases_pass = all(
+            by_id[case_id]["passed"] for case_id in task["case_ids"]
+        )
+        passed = (
+            selected_cases_pass
+            and item["impact_recall"] >= item["baseline_recall"]
+            and item["context_path_reduction_ratio"]
+            >= goldset["thresholds"]["minimum_context_path_reduction"]
+        )
+        outcomes.append(
+            {
+                **item,
+                "execution_mode": "deterministic_fixed_navigation_task",
+                "case_ids": list(task["case_ids"]),
+                "baseline_tool_calls": int(task["baseline_tool_calls"]),
+                "graph_tool_calls": 1,
+                "outcome": "pass" if passed else "fail",
+            }
+        )
+    tool_counts = {
+        "baseline": sum(item["baseline_tool_calls"] for item in outcomes),
+        "graph": sum(item["graph_tool_calls"] for item in outcomes),
+    }
+    return utility, outcomes, tool_counts
+
+
+def evaluate_python_call_graph_fixture(
+    fixture_root: Path,
+    goldset: Mapping[str, Any],
+) -> dict[str, Any]:
+    fixture_root = fixture_root.resolve()
+    started = time.perf_counter_ns()
+    calls, skipped_files_count, skipped_errors = extract_python_calls(fixture_root)
+    build_time_ms = round((time.perf_counter_ns() - started) / 1_000_000, 3)
+
+    case_results = [_evaluate_case(calls, case) for case in goldset["cases"]]
+    true_positives = sum(case["counts_as_true_positive"] for case in case_results)
+    false_positives = sum(case["counts_as_false_positive"] for case in case_results)
+    false_negatives = sum(case["counts_as_false_negative"] for case in case_results)
+    unresolved_count = sum(case["actual_status"] != "resolved" for case in case_results)
+    false_positive_classes = Counter(
+        str(case.get("actual_reason") or "unknown")
+        for case in case_results
+        if case["counts_as_false_positive"]
+    )
+    call_bytes = _canonical_bytes(calls)
+    navigation, agent_outcomes, tool_counts = _evaluate_navigation_tasks(
+        goldset, case_results
+    )
+    all_cases_passed = all(case["passed"] for case in case_results)
+    all_tasks_passed = all(item["outcome"] == "pass" for item in agent_outcomes)
+    metrics = {
+        "s1_precision": _ratio(
+            true_positives, true_positives + false_positives
+        ),
+        "target_recall": _ratio(
+            true_positives, true_positives + false_negatives
+        ),
+        "true_positive_count": true_positives,
+        "false_positive_count": false_positives,
+        "false_negative_count": false_negatives,
+        "false_positive_classes": dict(sorted(false_positive_classes.items())),
+        "unresolved_count": unresolved_count,
+        "unresolved_share": _ratio(unresolved_count, len(case_results)),
+        "serialized_call_bytes": len(call_bytes),
+        "build_time_ms": build_time_ms,
+        "baseline_tool_calls": tool_counts["baseline"],
+        "graph_tool_calls": tool_counts["graph"],
+        "tool_call_reduction": _ratio(
+            tool_counts["baseline"] - tool_counts["graph"],
+            tool_counts["baseline"],
+        ),
+        "navigation_utility": navigation["metrics"],
+    }
+    thresholds = goldset["thresholds"]
+    threshold_checks = {
+        "minimum_s1_precision": (
+            metrics["s1_precision"] >= thresholds["minimum_s1_precision"]
+        ),
+        "minimum_target_recall": (
+            metrics["target_recall"] >= thresholds["minimum_target_recall"]
+        ),
+        "minimum_context_path_reduction": (
+            navigation["metrics"]["context_path_reduction_ratio"]
+            >= thresholds["minimum_context_path_reduction"]
+        ),
+        "no_case_regression": (
+            all_cases_passed
+            and all_tasks_passed
+            and navigation["metrics"]["no_case_regression"]
+        ),
+    }
+    eligible = all(threshold_checks.values())
+    return {
+        "kind": "lenskit.python_call_graph_quality_benchmark",
+        "version": "1.0",
+        "scope": "fixed_python_goldset_and_deterministic_navigation_tasks",
+        "evidence": {
+            "goldset_sha256": _sha256(_canonical_bytes(goldset)),
+            "fixture_sha256": _fixture_sha256(fixture_root),
+            "call_records_sha256": _sha256(call_bytes),
+        },
+        "coverage": {
+            "case_count": len(case_results),
+            "category_count": len({case["category"] for case in case_results}),
+            "call_record_count": len(calls),
+            "skipped_files_count": skipped_files_count,
+            "skipped_errors": skipped_errors,
+        },
+        "thresholds": dict(thresholds),
+        "metrics": metrics,
+        "cases": case_results,
+        "agent_task_outcomes": agent_outcomes,
+        "decision": {
+            "threshold_checks": threshold_checks,
+            "thresholds_met": eligible,
+            "eligible_for_review": eligible,
+            "default_promoted": False,
+            "decision_authority": "Bureau",
+            "reason": (
+                "quality thresholds met; a separate reviewed Bureau decision "
+                "is required"
+                if eligible
+                else "quality thresholds failed; default promotion remains prohibited"
+            ),
+        },
+        "does_not_establish": list(goldset["does_not_establish"]),
+    }
+
+
+def evaluate_python_call_graph_goldset(
+    goldset_path: Path,
+    *,
+    repository_root: Path = REPO_ROOT,
+) -> dict[str, Any]:
+    goldset = load_python_call_graph_goldset(goldset_path)
+    fixture_root = Path(goldset["fixture_root"])
+    if not fixture_root.is_absolute():
+        fixture_root = repository_root / fixture_root
+    return evaluate_python_call_graph_fixture(fixture_root, goldset)
+
+
+def stable_report_projection(report: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the deterministic report surface, excluding measured wall time."""
+
+    projection = json.loads(json.dumps(report))
+    projection["metrics"].pop("build_time_ms", None)
+    return projection
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--goldset",
+        type=Path,
+        default=REPO_ROOT / "docs/retrieval/python_call_graph_goldset.v1.json",
+    )
+    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    parser.add_argument("--out", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    report = evaluate_python_call_graph_goldset(
+        args.goldset, repository_root=args.repo_root
+    )
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.out:
+        args.out.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0 if report["decision"]["thresholds_met"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/merger/repoground/architecture/call_graph_quality_eval.py
+++ b/merger/repoground/architecture/call_graph_quality_eval.py
@@ -39,212 +39,235 @@ def _ratio(numerator: int, denominator: int) -> float:
     return round(numerator / denominator, 6) if denominator else 0.0
 
 
-def _require_non_empty_string(value: Any, label: str) -> str:
-    if not isinstance(value, str) or not value:
-        raise PythonCallGraphGoldsetError(f"{label} must be a non-empty string")
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise PythonCallGraphGoldsetError(message)
+
+
+def _non_empty_string(value: Any, label: str) -> str:
+    _expect(
+        isinstance(value, str) and bool(value),
+        f"{label} must be a non-empty string",
+    )
+    return str(value)
+
+
+def _mapping(value: Any, label: str) -> Mapping[str, Any]:
+    _expect(isinstance(value, Mapping), f"{label} must be an object")
     return value
 
 
-def _validate_thresholds(raw: Any) -> dict[str, Any]:
-    if not isinstance(raw, Mapping):
-        raise PythonCallGraphGoldsetError("thresholds must be an object")
-    required = {
-        "minimum_s1_precision",
-        "minimum_target_recall",
-        "minimum_context_path_reduction",
-        "no_case_regression",
-    }
-    missing = required - set(raw)
-    if missing:
-        raise PythonCallGraphGoldsetError(
-            f"thresholds missing {', '.join(sorted(missing))}"
-        )
-    thresholds = dict(raw)
-    for key in (
-        "minimum_s1_precision",
-        "minimum_target_recall",
-        "minimum_context_path_reduction",
-    ):
-        value = thresholds[key]
-        if isinstance(value, bool) or not isinstance(value, (int, float)):
-            raise PythonCallGraphGoldsetError(f"{key} must be numeric")
-        if not 0.0 <= float(value) <= 1.0:
-            raise PythonCallGraphGoldsetError(f"{key} must be between 0 and 1")
-        thresholds[key] = float(value)
-    if thresholds["no_case_regression"] is not True:
-        raise PythonCallGraphGoldsetError("no_case_regression must be true")
-    return thresholds
+def _non_empty_list(value: Any, label: str) -> list[Any]:
+    _expect(
+        isinstance(value, list) and bool(value),
+        f"{label} must be a non-empty list",
+    )
+    return list(value)
 
 
-def _validate_categories(payload: Mapping[str, Any]) -> set[str]:
-    categories = payload.get("required_categories")
-    if not isinstance(categories, list) or not categories:
-        raise PythonCallGraphGoldsetError(
-            "required_categories must be a non-empty list"
-        )
-    if any(not isinstance(category, str) or not category for category in categories):
-        raise PythonCallGraphGoldsetError(
-            "required_categories must contain non-empty strings"
-        )
-    if len(set(categories)) != len(categories):
-        raise PythonCallGraphGoldsetError("required_categories must be unique")
-    return set(categories)
+def _unique_strings(value: Any, label: str) -> list[str]:
+    values = _non_empty_list(value, label)
+    _expect(
+        all(isinstance(item, str) and item for item in values),
+        f"{label} must contain non-empty strings",
+    )
+    _expect(len(set(values)) == len(values), f"{label} must be unique")
+    return [str(item) for item in values]
 
 
-def _validate_cases(payload: Mapping[str, Any]) -> set[str]:
-    cases = payload.get("cases")
-    if not isinstance(cases, list) or not cases:
-        raise PythonCallGraphGoldsetError("cases must be a non-empty list")
-    case_ids: set[str] = set()
-    observed_categories: set[str] = set()
-    for case in cases:
-        if not isinstance(case, Mapping):
-            raise PythonCallGraphGoldsetError("case must be an object")
-        case_id = _require_non_empty_string(case.get("id"), "case id")
-        if case_id in case_ids:
-            raise PythonCallGraphGoldsetError(f"duplicate case id: {case_id}")
-        case_ids.add(case_id)
-        category = _require_non_empty_string(
-            case.get("category"), f"{case_id}.category"
-        )
-        observed_categories.add(category)
-        _require_non_empty_string(case.get("path"), f"{case_id}.path")
-        _require_non_empty_string(
-            case.get("callee_expression"), f"{case_id}.callee_expression"
-        )
-        if "caller_qualified_name" not in case:
-            raise PythonCallGraphGoldsetError(
-                f"{case_id}.caller_qualified_name must be explicit"
-            )
-        caller = case["caller_qualified_name"]
-        if caller is not None and (not isinstance(caller, str) or not caller):
-            raise PythonCallGraphGoldsetError(
-                f"{case_id}.caller_qualified_name must be null or non-empty"
-            )
-        status = case.get("expected_status")
-        if status not in VALID_STATUSES:
-            raise PythonCallGraphGoldsetError(
-                f"{case_id}.expected_status is invalid"
-            )
-        evidence = case.get("expected_evidence_level")
-        if evidence not in VALID_EVIDENCE_LEVELS:
-            raise PythonCallGraphGoldsetError(
-                f"{case_id}.expected_evidence_level is invalid"
-            )
-        relation = case.get("expected_relation_type")
-        if relation not in VALID_RELATION_TYPES:
-            raise PythonCallGraphGoldsetError(
-                f"{case_id}.expected_relation_type is invalid"
-            )
-        _require_non_empty_string(
-            case.get("expected_reason"), f"{case_id}.expected_reason"
-        )
-        target_id = case.get("expected_target_id")
-        if status == "resolved":
-            _require_non_empty_string(target_id, f"{case_id}.expected_target_id")
-            if evidence != "S1":
-                raise PythonCallGraphGoldsetError(
-                    f"{case_id}: resolved cases must expect S1"
-                )
-        elif target_id is not None:
-            raise PythonCallGraphGoldsetError(
-                f"{case_id}: non-resolved cases must not expect a target"
-            )
-    missing = _validate_categories(payload) - observed_categories
-    if missing:
-        raise PythonCallGraphGoldsetError(
-            "goldset missing required categories: "
-            + ", ".join(sorted(missing))
-        )
-    return case_ids
+def _positive_integer(value: Any, label: str) -> int:
+    _expect(
+        not isinstance(value, bool) and isinstance(value, int) and value >= 1,
+        f"{label} must be a positive integer",
+    )
+    return int(value)
 
 
-def _validate_agent_tasks(payload: Mapping[str, Any], case_ids: set[str]) -> None:
-    tasks = payload.get("agent_tasks")
-    if not isinstance(tasks, list) or not tasks:
-        raise PythonCallGraphGoldsetError("agent_tasks must be a non-empty list")
-    task_ids: set[str] = set()
-    for task in tasks:
-        if not isinstance(task, Mapping):
-            raise PythonCallGraphGoldsetError("agent task must be an object")
-        task_id = _require_non_empty_string(task.get("id"), "agent task id")
-        if task_id in task_ids:
-            raise PythonCallGraphGoldsetError(
-                f"duplicate agent task id: {task_id}"
-            )
-        task_ids.add(task_id)
-        selected = task.get("case_ids")
-        if not isinstance(selected, list) or not selected:
-            raise PythonCallGraphGoldsetError(
-                f"{task_id}.case_ids must be a non-empty list"
-            )
-        if any(not isinstance(case_id, str) or not case_id for case_id in selected):
-            raise PythonCallGraphGoldsetError(
-                f"{task_id}.case_ids must contain non-empty strings"
-            )
-        if len(set(selected)) != len(selected):
-            raise PythonCallGraphGoldsetError(
-                f"{task_id}.case_ids must be unique"
-            )
-        unknown = set(selected) - case_ids
-        if unknown:
-            raise PythonCallGraphGoldsetError(
-                f"{task_id} references unknown cases: "
-                + ", ".join(sorted(unknown))
-            )
-        paths = task.get("baseline_paths")
-        if not isinstance(paths, list) or not paths:
-            raise PythonCallGraphGoldsetError(
-                f"{task_id}.baseline_paths must be a non-empty list"
-            )
-        if any(not isinstance(path, str) or not path for path in paths):
-            raise PythonCallGraphGoldsetError(
-                f"{task_id}.baseline_paths must contain non-empty strings"
-            )
-        if len(set(paths)) != len(paths):
-            raise PythonCallGraphGoldsetError(
-                f"{task_id}.baseline_paths must be unique"
-            )
-        tool_calls = task.get("baseline_tool_calls")
-        if (
-            isinstance(tool_calls, bool)
-            or not isinstance(tool_calls, int)
-            or tool_calls < 1
-        ):
-            raise PythonCallGraphGoldsetError(
-                f"{task_id}.baseline_tool_calls must be a positive integer"
-            )
+def _number_between_zero_and_one(value: Any, label: str) -> float:
+    _expect(
+        not isinstance(value, bool) and isinstance(value, (int, float)),
+        f"{label} must be numeric",
+    )
+    number = float(value)
+    _expect(0.0 <= number <= 1.0, f"{label} must be between 0 and 1")
+    return number
 
 
-def load_python_call_graph_goldset(path: Path) -> dict[str, Any]:
+def _read_json_object(path: Path) -> dict[str, Any]:
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         raise PythonCallGraphGoldsetError(
             f"cannot load Python call-graph goldset: {path}"
         ) from exc
-    if not isinstance(payload, dict):
-        raise PythonCallGraphGoldsetError("goldset must be a JSON object")
-    if payload.get("kind") != GOLDSET_KIND:
-        raise PythonCallGraphGoldsetError("unexpected goldset kind")
-    if payload.get("version") != GOLDSET_VERSION:
-        raise PythonCallGraphGoldsetError("unsupported goldset version")
-    _require_non_empty_string(payload.get("fixture_root"), "fixture_root")
+    _expect(isinstance(payload, dict), "goldset must be a JSON object")
+    return dict(payload)
+
+
+def _validate_thresholds(raw: Any) -> dict[str, Any]:
+    thresholds = dict(_mapping(raw, "thresholds"))
+    required = {
+        "minimum_s1_precision",
+        "minimum_target_recall",
+        "minimum_context_path_reduction",
+        "no_case_regression",
+    }
+    missing = required - set(thresholds)
+    _expect(
+        not missing,
+        f"thresholds missing {', '.join(sorted(missing))}",
+    )
+    for key in (
+        "minimum_s1_precision",
+        "minimum_target_recall",
+        "minimum_context_path_reduction",
+    ):
+        thresholds[key] = _number_between_zero_and_one(thresholds[key], key)
+    _expect(
+        thresholds["no_case_regression"] is True,
+        "no_case_regression must be true",
+    )
+    return thresholds
+
+
+def _validate_caller(case: Mapping[str, Any], case_id: str) -> None:
+    _expect(
+        "caller_qualified_name" in case,
+        f"{case_id}.caller_qualified_name must be explicit",
+    )
+    caller = case["caller_qualified_name"]
+    _expect(
+        caller is None or (isinstance(caller, str) and bool(caller)),
+        f"{case_id}.caller_qualified_name must be null or non-empty",
+    )
+
+
+def _validate_expected_target(
+    case_id: str,
+    status: str,
+    evidence: str,
+    target_id: Any,
+) -> None:
+    if status == "resolved":
+        _non_empty_string(target_id, f"{case_id}.expected_target_id")
+        _expect(evidence == "S1", f"{case_id}: resolved cases must expect S1")
+    else:
+        _expect(
+            target_id is None,
+            f"{case_id}: non-resolved cases must not expect a target",
+        )
+
+
+def _validated_case(
+    raw_case: Any,
+    known_ids: set[str],
+) -> tuple[str, str]:
+    case = _mapping(raw_case, "case")
+    case_id = _non_empty_string(case.get("id"), "case id")
+    _expect(case_id not in known_ids, f"duplicate case id: {case_id}")
+    category = _non_empty_string(case.get("category"), f"{case_id}.category")
+    _non_empty_string(case.get("path"), f"{case_id}.path")
+    _non_empty_string(
+        case.get("callee_expression"),
+        f"{case_id}.callee_expression",
+    )
+    _validate_caller(case, case_id)
+    status = str(case.get("expected_status"))
+    evidence = str(case.get("expected_evidence_level"))
+    relation = str(case.get("expected_relation_type"))
+    _expect(status in VALID_STATUSES, f"{case_id}.expected_status is invalid")
+    _expect(
+        evidence in VALID_EVIDENCE_LEVELS,
+        f"{case_id}.expected_evidence_level is invalid",
+    )
+    _expect(
+        relation in VALID_RELATION_TYPES,
+        f"{case_id}.expected_relation_type is invalid",
+    )
+    _non_empty_string(case.get("expected_reason"), f"{case_id}.expected_reason")
+    _validate_expected_target(
+        case_id,
+        status,
+        evidence,
+        case.get("expected_target_id"),
+    )
+    return case_id, category
+
+
+def _validate_cases(payload: Mapping[str, Any]) -> set[str]:
+    cases = _non_empty_list(payload.get("cases"), "cases")
+    case_ids: set[str] = set()
+    observed_categories: set[str] = set()
+    for raw_case in cases:
+        case_id, category = _validated_case(raw_case, case_ids)
+        case_ids.add(case_id)
+        observed_categories.add(category)
+    required_categories = set(
+        _unique_strings(payload.get("required_categories"), "required_categories")
+    )
+    missing = required_categories - observed_categories
+    _expect(
+        not missing,
+        "goldset missing required categories: " + ", ".join(sorted(missing)),
+    )
+    return case_ids
+
+
+def _validated_agent_task(
+    raw_task: Any,
+    known_task_ids: set[str],
+    case_ids: set[str],
+) -> str:
+    task = _mapping(raw_task, "agent task")
+    task_id = _non_empty_string(task.get("id"), "agent task id")
+    _expect(
+        task_id not in known_task_ids,
+        f"duplicate agent task id: {task_id}",
+    )
+    selected = _unique_strings(task.get("case_ids"), f"{task_id}.case_ids")
+    unknown = set(selected) - case_ids
+    _expect(
+        not unknown,
+        f"{task_id} references unknown cases: "
+        + ", ".join(sorted(unknown)),
+    )
+    _unique_strings(task.get("baseline_paths"), f"{task_id}.baseline_paths")
+    _positive_integer(
+        task.get("baseline_tool_calls"),
+        f"{task_id}.baseline_tool_calls",
+    )
+    return task_id
+
+
+def _validate_agent_tasks(
+    payload: Mapping[str, Any],
+    case_ids: set[str],
+) -> None:
+    tasks = _non_empty_list(payload.get("agent_tasks"), "agent_tasks")
+    task_ids: set[str] = set()
+    for raw_task in tasks:
+        task_id = _validated_agent_task(raw_task, task_ids, case_ids)
+        task_ids.add(task_id)
+
+
+def _validate_boundaries(payload: Mapping[str, Any]) -> None:
+    _unique_strings(payload.get("does_not_establish"), "does_not_establish")
+
+
+def load_python_call_graph_goldset(path: Path) -> dict[str, Any]:
+    payload = _read_json_object(path)
+    _expect(payload.get("kind") == GOLDSET_KIND, "unexpected goldset kind")
+    _expect(
+        payload.get("version") == GOLDSET_VERSION,
+        "unsupported goldset version",
+    )
+    _non_empty_string(payload.get("fixture_root"), "fixture_root")
     thresholds = _validate_thresholds(payload.get("thresholds"))
     case_ids = _validate_cases(payload)
     _validate_agent_tasks(payload, case_ids)
-    boundaries = payload.get("does_not_establish")
-    if not isinstance(boundaries, list) or not boundaries:
-        raise PythonCallGraphGoldsetError(
-            "does_not_establish must be a non-empty list"
-        )
-    if any(not isinstance(item, str) or not item for item in boundaries):
-        raise PythonCallGraphGoldsetError(
-            "does_not_establish must contain non-empty strings"
-        )
-    result = dict(payload)
-    result["thresholds"] = thresholds
-    return result
+    _validate_boundaries(payload)
+    payload["thresholds"] = thresholds
+    return payload
 
 
 def _target_path(target_id: str | None) -> str | None:
@@ -278,48 +301,40 @@ def _case_match(call: Mapping[str, Any], case: Mapping[str, Any]) -> bool:
     )
 
 
-def _evaluate_case(
-    calls: Sequence[Mapping[str, Any]], case: Mapping[str, Any]
-) -> dict[str, Any]:
-    matches = [call for call in calls if _case_match(call, case)]
-    if len(matches) != 1:
-        return {
-            "id": case["id"],
-            "category": case["category"],
-            "path": case["path"],
-            "callee_expression": case["callee_expression"],
-            "caller_qualified_name": case["caller_qualified_name"],
-            "selector_match_count": len(matches),
-            "expected_status": case["expected_status"],
-            "actual_status": None,
-            "expected_target_id": case.get("expected_target_id"),
-            "actual_target_ids": [],
-            "counts_as_true_positive": False,
-            "counts_as_false_positive": False,
-            "counts_as_false_negative": case["expected_status"] == "resolved",
-            "outcome": "selector_error",
-            "passed": False,
-        }
+def _selector_error(case: Mapping[str, Any], match_count: int) -> dict[str, Any]:
+    return {
+        "id": case["id"],
+        "category": case["category"],
+        "path": case["path"],
+        "callee_expression": case["callee_expression"],
+        "caller_qualified_name": case["caller_qualified_name"],
+        "selector_match_count": match_count,
+        "expected_status": case["expected_status"],
+        "actual_status": None,
+        "expected_target_id": case.get("expected_target_id"),
+        "actual_target_ids": [],
+        "counts_as_true_positive": False,
+        "counts_as_false_positive": False,
+        "counts_as_false_negative": case["expected_status"] == "resolved",
+        "outcome": "selector_error",
+        "passed": False,
+    }
 
-    call = matches[0]
-    expected_target = case.get("expected_target_id")
-    target_ids = list(call.get("resolved_target_ids", []))
-    target_match = (
-        target_ids == [expected_target]
-        if expected_target is not None
-        else target_ids == []
-    )
-    fields_match = (
-        call.get("resolution_status") == case["expected_status"]
-        and call.get("resolution_reason") == case["expected_reason"]
-        and call.get("evidence_level") == case["expected_evidence_level"]
-        and call.get("relation_type") == case["expected_relation_type"]
-    )
-    expected_s1 = case["expected_status"] == "resolved"
-    actual_s1 = (
-        call.get("resolution_status") == "resolved"
-        and call.get("evidence_level") == "S1"
-    )
+
+def _target_ids_match(
+    target_ids: list[str],
+    expected_target: str | None,
+) -> bool:
+    if expected_target is None:
+        return target_ids == []
+    return target_ids == [expected_target]
+
+
+def _classification(
+    expected_s1: bool,
+    actual_s1: bool,
+    target_match: bool,
+) -> tuple[str, bool, bool, bool]:
     correct_s1 = expected_s1 and actual_s1 and target_match
     false_positive = actual_s1 and not correct_s1
     false_negative = expected_s1 and not correct_s1
@@ -333,7 +348,32 @@ def _evaluate_case(
         outcome = "false_negative"
     else:
         outcome = "non_s1_expected"
+    return outcome, correct_s1, false_positive, false_negative
 
+
+def _matched_case_result(
+    call: Mapping[str, Any],
+    case: Mapping[str, Any],
+) -> dict[str, Any]:
+    expected_target = case.get("expected_target_id")
+    target_ids = list(call.get("resolved_target_ids", []))
+    target_match = _target_ids_match(target_ids, expected_target)
+    fields_match = (
+        call.get("resolution_status") == case["expected_status"]
+        and call.get("resolution_reason") == case["expected_reason"]
+        and call.get("evidence_level") == case["expected_evidence_level"]
+        and call.get("relation_type") == case["expected_relation_type"]
+    )
+    expected_s1 = case["expected_status"] == "resolved"
+    actual_s1 = (
+        call.get("resolution_status") == "resolved"
+        and call.get("evidence_level") == "S1"
+    )
+    outcome, true_positive, false_positive, false_negative = _classification(
+        expected_s1,
+        actual_s1,
+        target_match,
+    )
     return {
         "id": case["id"],
         "category": case["category"],
@@ -352,12 +392,22 @@ def _evaluate_case(
         "expected_target_id": expected_target,
         "actual_target_ids": target_ids,
         "source_range_ref": call.get("range_ref"),
-        "counts_as_true_positive": correct_s1,
+        "counts_as_true_positive": true_positive,
         "counts_as_false_positive": false_positive,
         "counts_as_false_negative": false_negative,
         "outcome": outcome,
         "passed": fields_match and target_match,
     }
+
+
+def _evaluate_case(
+    calls: Sequence[Mapping[str, Any]],
+    case: Mapping[str, Any],
+) -> dict[str, Any]:
+    matches = [call for call in calls if _case_match(call, case)]
+    if len(matches) != 1:
+        return _selector_error(case, len(matches))
+    return _matched_case_result(matches[0], case)
 
 
 def _impact_paths(
@@ -374,18 +424,17 @@ def _impact_paths(
     return sorted(paths)
 
 
-def _evaluate_navigation_tasks(
-    goldset: Mapping[str, Any],
-    case_results: Sequence[Mapping[str, Any]],
-) -> tuple[dict[str, Any], list[dict[str, Any]], dict[str, int]]:
-    by_id = {case["id"]: case for case in case_results}
-    tasks = list(goldset["agent_tasks"])
-    navigation_goldset = {
+def _navigation_goldset(
+    tasks: Sequence[Mapping[str, Any]],
+    by_id: Mapping[str, Mapping[str, Any]],
+    minimum_reduction: float,
+) -> dict[str, Any]:
+    return {
         "id": "python-call-graph-navigation-tasks-v1",
         "minimum_target_recall_advantage": 1.0,
-        "minimum_context_path_reduction_at_equal_or_better_recall": goldset[
-            "thresholds"
-        ]["minimum_context_path_reduction"],
+        "minimum_context_path_reduction_at_equal_or_better_recall": (
+            minimum_reduction
+        ),
         "cases": [
             {
                 "id": task["id"],
@@ -394,8 +443,14 @@ def _evaluate_navigation_tasks(
             for task in tasks
         ],
     }
-    observations = {
-        task["id"]: {
+
+
+def _navigation_observations(
+    tasks: Sequence[Mapping[str, Any]],
+    by_id: Mapping[str, Mapping[str, Any]],
+) -> dict[str, Any]:
+    return {
+        str(task["id"]): {
             "baseline_paths": list(task["baseline_paths"]),
             "impact_context": {
                 "target": {"paths": _impact_paths(task, by_id)},
@@ -405,30 +460,53 @@ def _evaluate_navigation_tasks(
         }
         for task in tasks
     }
-    utility = evaluate_agent_impact_goldset(navigation_goldset, observations)
+
+
+def _navigation_outcome(
+    task: Mapping[str, Any],
+    utility_case: Mapping[str, Any],
+    by_id: Mapping[str, Mapping[str, Any]],
+    minimum_reduction: float,
+) -> dict[str, Any]:
+    selected_cases_pass = all(
+        by_id[case_id]["passed"] for case_id in task["case_ids"]
+    )
+    passed = (
+        selected_cases_pass
+        and utility_case["impact_recall"] >= utility_case["baseline_recall"]
+        and utility_case["context_path_reduction_ratio"] >= minimum_reduction
+    )
+    return {
+        **utility_case,
+        "execution_mode": "deterministic_fixed_navigation_task",
+        "case_ids": list(task["case_ids"]),
+        "baseline_tool_calls": int(task["baseline_tool_calls"]),
+        "graph_tool_calls": 1,
+        "outcome": "pass" if passed else "fail",
+    }
+
+
+def _evaluate_navigation_tasks(
+    goldset: Mapping[str, Any],
+    case_results: Sequence[Mapping[str, Any]],
+) -> tuple[dict[str, Any], list[dict[str, Any]], dict[str, int]]:
+    by_id = {case["id"]: case for case in case_results}
+    tasks = list(goldset["agent_tasks"])
+    minimum_reduction = goldset["thresholds"]["minimum_context_path_reduction"]
+    utility = evaluate_agent_impact_goldset(
+        _navigation_goldset(tasks, by_id, minimum_reduction),
+        _navigation_observations(tasks, by_id),
+    )
     utility_by_id = {item["id"]: item for item in utility["cases"]}
-    outcomes: list[dict[str, Any]] = []
-    for task in tasks:
-        item = utility_by_id[task["id"]]
-        selected_cases_pass = all(
-            by_id[case_id]["passed"] for case_id in task["case_ids"]
+    outcomes = [
+        _navigation_outcome(
+            task,
+            utility_by_id[task["id"]],
+            by_id,
+            minimum_reduction,
         )
-        passed = (
-            selected_cases_pass
-            and item["impact_recall"] >= item["baseline_recall"]
-            and item["context_path_reduction_ratio"]
-            >= goldset["thresholds"]["minimum_context_path_reduction"]
-        )
-        outcomes.append(
-            {
-                **item,
-                "execution_mode": "deterministic_fixed_navigation_task",
-                "case_ids": list(task["case_ids"]),
-                "baseline_tool_calls": int(task["baseline_tool_calls"]),
-                "graph_tool_calls": 1,
-                "outcome": "pass" if passed else "fail",
-            }
-        )
+        for task in tasks
+    ]
     tool_counts = {
         "baseline": sum(item["baseline_tool_calls"] for item in outcomes),
         "graph": sum(item["graph_tool_calls"] for item in outcomes),
@@ -436,44 +514,60 @@ def _evaluate_navigation_tasks(
     return utility, outcomes, tool_counts
 
 
-def evaluate_python_call_graph_fixture(
-    fixture_root: Path,
-    goldset: Mapping[str, Any],
-) -> dict[str, Any]:
-    fixture_root = fixture_root.resolve()
-    started = time.perf_counter_ns()
-    calls, skipped_files_count, skipped_errors = extract_python_calls(fixture_root)
-    build_time_ms = round((time.perf_counter_ns() - started) / 1_000_000, 3)
+def _quality_counts(case_results: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    return {
+        "true_positives": sum(
+            case["counts_as_true_positive"] for case in case_results
+        ),
+        "false_positives": sum(
+            case["counts_as_false_positive"] for case in case_results
+        ),
+        "false_negatives": sum(
+            case["counts_as_false_negative"] for case in case_results
+        ),
+        "unresolved": sum(
+            case["actual_status"] != "resolved" for case in case_results
+        ),
+    }
 
-    case_results = [_evaluate_case(calls, case) for case in goldset["cases"]]
-    true_positives = sum(case["counts_as_true_positive"] for case in case_results)
-    false_positives = sum(case["counts_as_false_positive"] for case in case_results)
-    false_negatives = sum(case["counts_as_false_negative"] for case in case_results)
-    unresolved_count = sum(case["actual_status"] != "resolved" for case in case_results)
-    false_positive_classes = Counter(
+
+def _false_positive_classes(
+    case_results: Sequence[Mapping[str, Any]],
+) -> dict[str, int]:
+    counts = Counter(
         str(case.get("actual_reason") or "unknown")
         for case in case_results
         if case["counts_as_false_positive"]
     )
-    call_bytes = _canonical_bytes(calls)
-    navigation, agent_outcomes, tool_counts = _evaluate_navigation_tasks(
-        goldset, case_results
-    )
-    all_cases_passed = all(case["passed"] for case in case_results)
-    all_tasks_passed = all(item["outcome"] == "pass" for item in agent_outcomes)
-    metrics = {
+    return dict(sorted(counts.items()))
+
+
+def _benchmark_metrics(
+    case_results: Sequence[Mapping[str, Any]],
+    call_bytes: bytes,
+    build_time_ms: float,
+    navigation: Mapping[str, Any],
+    tool_counts: Mapping[str, int],
+) -> dict[str, Any]:
+    counts = _quality_counts(case_results)
+    true_positives = counts["true_positives"]
+    false_positives = counts["false_positives"]
+    false_negatives = counts["false_negatives"]
+    return {
         "s1_precision": _ratio(
-            true_positives, true_positives + false_positives
+            true_positives,
+            true_positives + false_positives,
         ),
         "target_recall": _ratio(
-            true_positives, true_positives + false_negatives
+            true_positives,
+            true_positives + false_negatives,
         ),
         "true_positive_count": true_positives,
         "false_positive_count": false_positives,
         "false_negative_count": false_negatives,
-        "false_positive_classes": dict(sorted(false_positive_classes.items())),
-        "unresolved_count": unresolved_count,
-        "unresolved_share": _ratio(unresolved_count, len(case_results)),
+        "false_positive_classes": _false_positive_classes(case_results),
+        "unresolved_count": counts["unresolved"],
+        "unresolved_share": _ratio(counts["unresolved"], len(case_results)),
         "serialized_call_bytes": len(call_bytes),
         "build_time_ms": build_time_ms,
         "baseline_tool_calls": tool_counts["baseline"],
@@ -484,8 +578,16 @@ def evaluate_python_call_graph_fixture(
         ),
         "navigation_utility": navigation["metrics"],
     }
-    thresholds = goldset["thresholds"]
-    threshold_checks = {
+
+
+def _threshold_checks(
+    metrics: Mapping[str, Any],
+    thresholds: Mapping[str, Any],
+    case_results: Sequence[Mapping[str, Any]],
+    agent_outcomes: Sequence[Mapping[str, Any]],
+) -> dict[str, bool]:
+    navigation_metrics = metrics["navigation_utility"]
+    return {
         "minimum_s1_precision": (
             metrics["s1_precision"] >= thresholds["minimum_s1_precision"]
         ),
@@ -493,16 +595,61 @@ def evaluate_python_call_graph_fixture(
             metrics["target_recall"] >= thresholds["minimum_target_recall"]
         ),
         "minimum_context_path_reduction": (
-            navigation["metrics"]["context_path_reduction_ratio"]
+            navigation_metrics["context_path_reduction_ratio"]
             >= thresholds["minimum_context_path_reduction"]
         ),
         "no_case_regression": (
-            all_cases_passed
-            and all_tasks_passed
-            and navigation["metrics"]["no_case_regression"]
+            all(case["passed"] for case in case_results)
+            and all(item["outcome"] == "pass" for item in agent_outcomes)
+            and navigation_metrics["no_case_regression"]
         ),
     }
-    eligible = all(threshold_checks.values())
+
+
+def _decision(checks: Mapping[str, bool]) -> dict[str, Any]:
+    eligible = all(checks.values())
+    reason = (
+        "quality thresholds met; a separate reviewed Bureau decision is required"
+        if eligible
+        else "quality thresholds failed; default promotion remains prohibited"
+    )
+    return {
+        "threshold_checks": dict(checks),
+        "thresholds_met": eligible,
+        "eligible_for_review": eligible,
+        "default_promoted": False,
+        "decision_authority": "Bureau",
+        "reason": reason,
+    }
+
+
+def evaluate_python_call_graph_fixture(
+    fixture_root: Path,
+    goldset: Mapping[str, Any],
+) -> dict[str, Any]:
+    fixture_root = fixture_root.resolve()
+    started = time.perf_counter_ns()
+    calls, skipped_files_count, skipped_errors = extract_python_calls(fixture_root)
+    build_time_ms = round((time.perf_counter_ns() - started) / 1_000_000, 3)
+    case_results = [_evaluate_case(calls, case) for case in goldset["cases"]]
+    call_bytes = _canonical_bytes(calls)
+    navigation, agent_outcomes, tool_counts = _evaluate_navigation_tasks(
+        goldset,
+        case_results,
+    )
+    metrics = _benchmark_metrics(
+        case_results,
+        call_bytes,
+        build_time_ms,
+        navigation,
+        tool_counts,
+    )
+    checks = _threshold_checks(
+        metrics,
+        goldset["thresholds"],
+        case_results,
+        agent_outcomes,
+    )
     return {
         "kind": "lenskit.python_call_graph_quality_benchmark",
         "version": "1.0",
@@ -519,23 +666,11 @@ def evaluate_python_call_graph_fixture(
             "skipped_files_count": skipped_files_count,
             "skipped_errors": skipped_errors,
         },
-        "thresholds": dict(thresholds),
+        "thresholds": dict(goldset["thresholds"]),
         "metrics": metrics,
         "cases": case_results,
         "agent_task_outcomes": agent_outcomes,
-        "decision": {
-            "threshold_checks": threshold_checks,
-            "thresholds_met": eligible,
-            "eligible_for_review": eligible,
-            "default_promoted": False,
-            "decision_authority": "Bureau",
-            "reason": (
-                "quality thresholds met; a separate reviewed Bureau decision "
-                "is required"
-                if eligible
-                else "quality thresholds failed; default promotion remains prohibited"
-            ),
-        },
+        "decision": _decision(checks),
         "does_not_establish": list(goldset["does_not_establish"]),
     }
 
@@ -575,7 +710,8 @@ def _parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parser().parse_args(argv)
     report = evaluate_python_call_graph_goldset(
-        args.goldset, repository_root=args.repo_root
+        args.goldset,
+        repository_root=args.repo_root,
     )
     rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
     if args.out:

--- a/merger/repoground/tests/fixtures/python_call_graph_goldset/callkit/ambiguous.py
+++ b/merger/repoground/tests/fixtures/python_call_graph_goldset/callkit/ambiguous.py
@@ -1,0 +1,10 @@
+if True:
+    def choose(value):
+        return value
+else:
+    def choose(value):
+        return -value
+
+
+def use(value):
+    return choose(value)

--- a/merger/repoground/tests/fixtures/python_call_graph_goldset/callkit/consumer.py
+++ b/merger/repoground/tests/fixtures/python_call_graph_goldset/callkit/consumer.py
@@ -45,8 +45,8 @@ def shadowed(normalize, value):
     return normalize(value)
 
 
-def dynamic(value):
-    return registry.handle(value)
+def dynamic(factory, value):
+    return factory()(value)
 
 
 def unicode_case(name):

--- a/merger/repoground/tests/fixtures/python_call_graph_goldset/callkit/consumer.py
+++ b/merger/repoground/tests/fixtures/python_call_graph_goldset/callkit/consumer.py
@@ -1,0 +1,57 @@
+import callkit.targets as target_mod
+from callkit.targets import decorate, default_factory, grüßen, normalize as norm
+
+
+def helper(value):
+    return value
+
+
+def direct(value):
+    return helper(value)
+
+
+def imported_alias(value):
+    return norm(value)
+
+
+def module_alias(value):
+    return target_mod.normalize(value)
+
+
+def loop(value):
+    if value:
+        return loop(value - 1)
+    return 0
+
+
+class Formatter:
+    def format(self, value):
+        return self.indent(value)
+
+    def indent(self, value):
+        return value
+
+
+def invoke(callback, value):
+    return callback(value)
+
+
+@decorate(norm("präzise"))
+def decorated(value=default_factory()):
+    return value
+
+
+def shadowed(normalize, value):
+    return normalize(value)
+
+
+def dynamic(value):
+    return registry.handle(value)
+
+
+def unicode_case(name):
+    return grüßen(name)
+
+
+def build_formatter():
+    return Formatter()

--- a/merger/repoground/tests/fixtures/python_call_graph_goldset/callkit/targets.py
+++ b/merger/repoground/tests/fixtures/python_call_graph_goldset/callkit/targets.py
@@ -1,0 +1,17 @@
+def normalize(value):
+    return value.strip()
+
+
+def decorate(label):
+    def apply(function):
+        return function
+
+    return apply
+
+
+def default_factory():
+    return "Standard"
+
+
+def grüßen(name):
+    return f"Hallo, {name}"

--- a/merger/repoground/tests/test_python_call_graph_goldset.py
+++ b/merger/repoground/tests/test_python_call_graph_goldset.py
@@ -1,0 +1,154 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from merger.repoground.architecture.call_graph_quality_eval import (
+    PythonCallGraphGoldsetError,
+    evaluate_python_call_graph_fixture,
+    evaluate_python_call_graph_goldset,
+    load_python_call_graph_goldset,
+    main,
+    stable_report_projection,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+GOLDSET_PATH = REPO_ROOT / "docs/retrieval/python_call_graph_goldset.v1.json"
+FIXTURE_ROOT = (
+    REPO_ROOT / "merger/repoground/tests/fixtures/python_call_graph_goldset"
+)
+
+
+def _load() -> dict:
+    return load_python_call_graph_goldset(GOLDSET_PATH)
+
+
+def test_goldset_covers_registered_categories_and_existing_fixture_paths():
+    goldset = _load()
+    categories = {case["category"] for case in goldset["cases"]}
+
+    assert categories == set(goldset["required_categories"])
+    assert len(goldset["cases"]) == 13
+    assert len(goldset["agent_tasks"]) == 3
+    assert goldset["language_scope"] == ["python"]
+    assert "German identifier and UTF-8 literal" in goldset["unicode_scope"]
+
+    referenced_paths = {case["path"] for case in goldset["cases"]}
+    referenced_paths.update(
+        path
+        for task in goldset["agent_tasks"]
+        for path in task["baseline_paths"]
+    )
+    for relative_path in sorted(referenced_paths):
+        assert (FIXTURE_ROOT / relative_path).is_file(), relative_path
+
+
+def test_quality_benchmark_meets_gate_without_promoting_default():
+    report = evaluate_python_call_graph_goldset(GOLDSET_PATH)
+    metrics = report["metrics"]
+    navigation = metrics["navigation_utility"]
+
+    assert report["coverage"] == {
+        "case_count": 13,
+        "category_count": 13,
+        "call_record_count": 15,
+        "skipped_files_count": 0,
+        "skipped_errors": [],
+    }
+    assert metrics["s1_precision"] == 1.0
+    assert metrics["target_recall"] == 1.0
+    assert metrics["true_positive_count"] == 9
+    assert metrics["false_positive_count"] == 0
+    assert metrics["false_negative_count"] == 0
+    assert metrics["false_positive_classes"] == {}
+    assert metrics["unresolved_count"] == 4
+    assert metrics["unresolved_share"] == 0.307692
+    assert metrics["serialized_call_bytes"] > 0
+    assert metrics["build_time_ms"] >= 0
+    assert metrics["baseline_tool_calls"] == 9
+    assert metrics["graph_tool_calls"] == 3
+    assert metrics["tool_call_reduction"] == 0.666667
+
+    assert navigation["baseline_target_recall"] == 1.0
+    assert navigation["impact_target_recall"] == 1.0
+    assert navigation["no_case_regression"] is True
+    assert navigation["baseline_mean_context_path_count"] == pytest.approx(11 / 3)
+    assert navigation["impact_mean_context_path_count"] == pytest.approx(5 / 3)
+    assert navigation["context_path_reduction_ratio"] == pytest.approx(6 / 11)
+    assert all(item["outcome"] == "pass" for item in report["agent_task_outcomes"])
+
+    assert report["decision"]["thresholds_met"] is True
+    assert report["decision"]["eligible_for_review"] is True
+    assert report["decision"]["default_promoted"] is False
+    assert report["decision"]["decision_authority"] == "Bureau"
+    assert "default_promotion" in report["does_not_establish"]
+
+
+def test_report_is_deterministic_except_measured_wall_time():
+    first = evaluate_python_call_graph_goldset(GOLDSET_PATH)
+    second = evaluate_python_call_graph_goldset(GOLDSET_PATH)
+
+    assert stable_report_projection(first) == stable_report_projection(second)
+    assert first["evidence"] == second["evidence"]
+
+
+def test_wrong_s1_target_counts_as_false_positive_and_false_negative():
+    goldset = json.loads(json.dumps(_load()))
+    goldset["cases"][0]["expected_target_id"] = (
+        "py:callkit:consumer.py:function:not_helper"
+    )
+
+    report = evaluate_python_call_graph_fixture(FIXTURE_ROOT, goldset)
+    case = next(item for item in report["cases"] if item["id"] == "direct-local-helper")
+
+    assert case["outcome"] == "wrong_target"
+    assert case["counts_as_false_positive"] is True
+    assert case["counts_as_false_negative"] is True
+    assert report["metrics"]["false_positive_count"] == 1
+    assert report["metrics"]["false_negative_count"] == 1
+    assert report["metrics"]["s1_precision"] == 0.888889
+    assert report["metrics"]["target_recall"] == 0.888889
+    assert report["decision"]["thresholds_met"] is False
+    assert report["decision"]["default_promoted"] is False
+
+
+def test_goldset_rejects_duplicate_case_ids(tmp_path):
+    payload = json.loads(GOLDSET_PATH.read_text(encoding="utf-8"))
+    payload["cases"][1]["id"] = payload["cases"][0]["id"]
+    path = tmp_path / "duplicate.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(PythonCallGraphGoldsetError, match="duplicate case id"):
+        load_python_call_graph_goldset(path)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("minimum_s1_precision", True, "must be numeric"),
+        ("minimum_target_recall", 1.1, "between 0 and 1"),
+        ("minimum_context_path_reduction", -0.1, "between 0 and 1"),
+        ("no_case_regression", False, "must be true"),
+    ],
+)
+def test_goldset_rejects_invalid_promotion_thresholds(
+    tmp_path, field, value, message
+):
+    payload = json.loads(GOLDSET_PATH.read_text(encoding="utf-8"))
+    payload["thresholds"][field] = value
+    path = tmp_path / "invalid-threshold.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(PythonCallGraphGoldsetError, match=message):
+        load_python_call_graph_goldset(path)
+
+
+def test_cli_writes_reviewable_report(tmp_path):
+    output = tmp_path / "report.json"
+
+    assert main(["--goldset", str(GOLDSET_PATH), "--out", str(output)]) == 0
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["kind"] == "lenskit.python_call_graph_quality_benchmark"
+    assert report["decision"]["thresholds_met"] is True
+    assert report["decision"]["default_promoted"] is False

--- a/merger/repoground/tests/test_python_call_graph_goldset.py
+++ b/merger/repoground/tests/test_python_call_graph_goldset.py
@@ -52,7 +52,7 @@ def test_quality_benchmark_meets_gate_without_promoting_default():
     assert report["coverage"] == {
         "case_count": 13,
         "category_count": 13,
-        "call_record_count": 15,
+        "call_record_count": 16,
         "skipped_files_count": 0,
         "skipped_errors": [],
     }


### PR DESCRIPTION
## Summary

Implements Bureau task `RPU-V1-T024` on an isolated branch.

- adds a fixed Python call-graph goldset covering direct calls, aliases, recursion, methods, shadowing, callbacks, definition headers, dynamic higher-order calls, negative controls, Unicode identifiers and constructors;
- reports S1 precision, target recall, false-positive classes, unresolved share, serialized bytes and build time;
- reuses the existing agent-impact evaluator for deterministic navigation tasks, context-path compression and tool-call counts;
- treats a wrong S1 target as both false positive and false negative;
- keeps `default_promoted=false` even when the review thresholds pass;
- adds focused tests, a dedicated Actions gate and a proof document.

## Registered thresholds

- S1 precision >= 0.97
- target recall = 1.0
- context-path reduction >= 0.40 at equal or better recall
- no case or navigation-task regression

## Boundaries

The navigation tasks are deterministic fixed tasks, not an LLM-quality experiment. The report does not establish general agent improvement, answer correctness, call-graph completeness, test sufficiency, review completeness, merge readiness or default promotion.

## Test plan

- `Python Call Graph Goldset` workflow
- focused producer, evaluator and mutation tests
- Ruff and `git diff --check`
