### PR TITLE
Harden scalar agent-consumption regression coverage

### DIFF
--- a/merger/repoground/core/agent_consumption_validate.py
+++ b/merger/repoground/core/agent_consumption_validate.py
@@ -42,6 +42,7 @@ DOES_NOT_ESTABLISH: tuple[str, ...] = (
     "runtime_behavior",
     "forensic_ready",
 )
+_DOES_NOT_ESTABLISH_SET = frozenset(DOES_NOT_ESTABLISH)
 
 _FAIL = "fail"
 _WARN = "warn"
@@ -346,7 +347,7 @@ def _has_exact_negative_semantics(answer_compliance: dict) -> bool:
         isinstance(item, str) for item in value
     ):
         return False
-    return set(value) == set(DOES_NOT_ESTABLISH) and len(value) == len(
+    return set(value) == _DOES_NOT_ESTABLISH_SET and len(value) == len(
         DOES_NOT_ESTABLISH
     )
 

--- a/merger/repoground/tests/test_agent_consumption_consistency.py
+++ b/merger/repoground/tests/test_agent_consumption_consistency.py
@@ -186,22 +186,36 @@ def test_scalar_string_role_shorthand_remains_compatible():
     _assert_schema_valid(trace)
 
 
-def test_invalid_passthrough_container_is_normalized_fail_closed():
+@pytest.mark.parametrize(
+    "field",
+    ["declared_citations", "declared_ranges", "epistemic_gaps"],
+)
+@pytest.mark.parametrize(
+    "invalid_value",
+    [123, True, "not-an-array", {"not": "an-array"}],
+)
+def test_invalid_passthrough_container_is_normalized_fail_closed(
+    field, invalid_value
+):
     trace = validate_agent_consumption(
         _required(),
-        _answer(declared_citations="not-an-array"),
+        _answer(**{field: invalid_value}),
     )
 
-    assert trace["declared_citations"] == []
+    assert trace[field] == []
     assert trace["status"] == "fail"
     assert "invalid_input_field" in _codes(trace)
     _assert_schema_valid(trace)
 
 
-def test_negative_semantics_scalar_does_not_crash():
+@pytest.mark.parametrize(
+    "invalid_value",
+    [1, True, "actual_reading_proven", {"boundary": "actual_reading_proven"}],
+)
+def test_negative_semantics_scalar_does_not_crash(invalid_value):
     trace = validate_agent_consumption(
         _required(),
-        _answer(does_not_establish=1),
+        _answer(does_not_establish=invalid_value),
     )
 
     assert trace["status"] == "fail"


### PR DESCRIPTION
## Summary

- precompute the immutable negative-semantics set instead of rebuilding it per validation call
- cover all LLM-facing object-list fields against truthy scalar and mapping inputs
- expand scalar negative-semantics regression coverage

## Review triage

The reported runtime crash is already fixed on current `main`: malformed containers are normalized fail-closed and emit `invalid_input_field`; malformed negative semantics emit `missing_negative_semantics`.

The suggested task-profile simplification and redundant-sort cleanup are also already present.

Set subtraction is not O(1) for the whole collection and would not improve the current ordered diagnostic path, which already uses set membership. Returning `DOES_NOT_ESTABLISH` as a tuple is intentionally rejected because the trace schema requires a JSON array and `jsonschema` rejects tuples.

## Validation

- 78 focused tests passed
- Ruff passed for both changed files
- maintainability ratchet passed with no findings
- `git diff --check` passed
