### PR TITLE
ci(retrieval): harden semantic real-model follow-up

### DIFF
--- a/.github/workflows/semantic-lock.yml
+++ b/.github/workflows/semantic-lock.yml
@@ -70,6 +70,7 @@ jobs:
           target=""
           cleanup() {
             if [[ -n "$target" ]]; then
+              chmod -R u+rwX -- "$target" 2>/dev/null || true
               rm -rf -- "$target"
             fi
           }

--- a/merger/repoground/tests/test_semantic_real_model.py
+++ b/merger/repoground/tests/test_semantic_real_model.py
@@ -1,19 +1,27 @@
 from __future__ import annotations
 
+import hashlib
+import json
 import re
+import socket
 from pathlib import Path
 
 import pytest
 
+from merger.repoground.retrieval import query_core
 from scripts.ci.run_semantic_real_model_integration import (
+    EXPECTED_FIXTURE_VOCAB_SHA256,
     EXPECTED_MODEL_TREE_SHA256,
     EXPECTED_SENTENCE_TRANSFORMERS_VERSION,
     EXPECTED_TORCH_VERSION,
     FIXTURE_DIMENSIONS,
     FIXTURE_VOCAB,
+    SEMANTIC_TARGET_ID,
+    _compiler_image,
     _require_dependency_target,
     _require_loopback_only_network,
     canonical_tree_sha256,
+    deny_python_network,
 )
 
 ROOT = Path(__file__).resolve().parents[3]
@@ -25,9 +33,16 @@ RUNNER = ROOT / "scripts/ci/run_semantic_real_model_integration.py"
 def test_real_model_fixture_identity_is_explicit() -> None:
     assert EXPECTED_SENTENCE_TRANSFORMERS_VERSION == "5.6.0"
     assert EXPECTED_TORCH_VERSION == "2.13.0+cpu"
+    assert SEMANTIC_TARGET_ID == "cpython-312-linux-x86_64"
     assert FIXTURE_DIMENSIONS == 8
     assert len(FIXTURE_VOCAB) == len(set(FIXTURE_VOCAB))
+    observed_vocab_sha256 = hashlib.sha256(
+        json.dumps(FIXTURE_VOCAB, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    assert EXPECTED_FIXTURE_VOCAB_SHA256 == observed_vocab_sha256
+    assert re.fullmatch(r"[0-9a-f]{64}", EXPECTED_FIXTURE_VOCAB_SHA256)
     assert re.fullmatch(r"[0-9a-f]{64}", EXPECTED_MODEL_TREE_SHA256)
+    assert "@sha256:" in _compiler_image()
 
 
 def test_canonical_model_tree_hash_is_path_and_content_bound(tmp_path: Path) -> None:
@@ -73,6 +88,10 @@ def test_canonical_model_tree_hash_is_path_and_content_bound(tmp_path: Path) -> 
 
 
 def test_dependency_target_rejects_relative_links_and_files(tmp_path: Path) -> None:
+    # macOS commonly exposes pytest's temp root through /var -> /private/var.
+    # Resolve only the host-provided base so the test still creates and rejects
+    # the symlinks that belong to the fixture itself.
+    tmp_path = tmp_path.resolve(strict=True)
     target = tmp_path / "target"
     target.mkdir()
     assert _require_dependency_target(target) == target.resolve()
@@ -115,6 +134,52 @@ def test_network_observation_requires_only_loopback(tmp_path: Path) -> None:
         _require_loopback_only_network(link_root)
 
 
+
+
+def test_direct_dimension_validation_diagnostics_are_exact() -> None:
+    class FixtureModel:
+        def encode(self, value: object) -> object:
+            vector = [1.0] * FIXTURE_DIMENSIONS
+            if isinstance(value, str):
+                return vector
+            assert isinstance(value, list)
+            return [vector[:] for _ in value]
+
+    diagnostics: dict[str, object] = {
+        "enabled": True,
+        "dimension_validation": "pending",
+    }
+    query_embedding, document_embeddings = query_core._validated_semantic_embeddings(
+        semantic_model=FixtureModel(),
+        query_text="query",
+        candidate_texts=["first", "second"],
+        expected_dimensions=FIXTURE_DIMENSIONS,
+        semantic_diagnostics=diagnostics,
+    )
+
+    assert query_embedding is not None
+    assert document_embeddings is not None
+    assert diagnostics == {
+        "enabled": True,
+        "dimension_validation": "pass",
+        "actual_query_dimensions": FIXTURE_DIMENSIONS,
+        "actual_document_dimensions": FIXTURE_DIMENSIONS,
+    }
+    assert "expected_dimensions" not in diagnostics
+
+
+def test_python_network_guard_blocks_socket_calls() -> None:
+    with deny_python_network():
+        with pytest.raises(RuntimeError, match="network access is forbidden"):
+            socket.create_connection(("example.invalid", 443))
+
+        client = socket.socket()
+        try:
+            with pytest.raises(RuntimeError, match="network access is forbidden"):
+                client.connect(("127.0.0.1", 9))
+        finally:
+            client.close()
+
 def test_semantic_workflow_wires_unique_cleanup_target() -> None:
     workflow = WORKFLOW.read_text(encoding="utf-8")
 
@@ -134,6 +199,10 @@ def test_semantic_workflow_wires_unique_cleanup_target() -> None:
     assert "GITHUB_WORKSPACE" not in workflow
     assert "trap cleanup EXIT" in workflow
     assert 'chmod -R a+rX -- "$target"' in workflow
+    cleanup_chmod = 'chmod -R u+rwX -- "$target" 2>/dev/null || true'
+    cleanup_rm = 'rm -rf -- "$target"'
+    assert cleanup_chmod in workflow
+    assert workflow.index(cleanup_chmod) < workflow.index(cleanup_rm)
     assert '--verify-install "$target"' in workflow
 
 
@@ -144,12 +213,16 @@ def test_semantic_wrapper_hardens_container_and_import_roots() -> None:
     assert "--read-only" in wrapper
     assert "--cap-drop ALL" in wrapper
     assert "--security-opt no-new-privileges" in wrapper
+    assert "--pids-limit 256" in wrapper
+    assert "--memory 2g" in wrapper
+    assert "--memory-swap 2g" in wrapper
     assert 'sandbox_uid=65532' in wrapper
     assert 'sandbox_gid=65532' in wrapper
     assert '--user "$sandbox_uid:$sandbox_gid"' in wrapper
     assert '$(id -u):$(id -g)' not in wrapper
     assert "PYTHONPATH=/semantic-target:/work" in wrapper
     assert "PYTHONSAFEPATH=1" in wrapper
+    assert "PYTHONNOUSERSITE=1" in wrapper
     assert wrapper.count("python3 -I -S") == 3
     assert "python3 -P" not in wrapper
     assert "python -P -S scripts/ci/run_semantic_real_model_integration.py" in wrapper
@@ -157,8 +230,9 @@ def test_semantic_wrapper_hardens_container_and_import_roots() -> None:
     assert "TRANSFORMERS_OFFLINE=1" in wrapper
     assert ":/work:ro" in wrapper
     assert ":/semantic-target:ro" in wrapper
-    assert "docs/release/repoground-semantic-platforms.v1.json" in wrapper
-    assert "@sha256:" in wrapper
+    assert "--compiler-image" in wrapper
+    assert "docs/release/repoground-semantic-platforms.v1.json" not in wrapper
+    assert "@sha256:" not in wrapper
     assert "mcr.microsoft.com/playwright/python:v1.61.0-noble" not in wrapper
     assert '--volume "$runtime_work:/work:ro"' in wrapper
     assert '--volume "$repo_root:/work:ro"' not in wrapper
@@ -168,6 +242,11 @@ def test_semantic_wrapper_classifies_archive_entries_and_cleans_up() -> None:
     wrapper = WRAPPER.read_text(encoding="utf-8")
 
     assert '"archive", "--format=tar", "HEAD"' in wrapper
+    assert "tempfile.TemporaryFile()" in wrapper
+    assert "stdout=archive" in wrapper
+    assert "archive.seek(0)" in wrapper
+    assert "io.BytesIO" not in wrapper
+    assert "stdout=subprocess.PIPE" not in wrapper
     assert "def _archive_member_kind" in wrapper
     assert "member.issym()" in wrapper
     assert "member.islnk()" in wrapper
@@ -178,6 +257,10 @@ def test_semantic_wrapper_classifies_archive_entries_and_cleans_up() -> None:
     assert 'destination.chmod(0o444)' in wrapper
     assert 'directory.chmod(0o555)' in wrapper
     assert 'status=$?' in wrapper
+    assert 'trap - EXIT HUP INT TERM' in wrapper
+    assert "trap 'handle_signal 129' HUP" in wrapper
+    assert "trap 'handle_signal 130' INT" in wrapper
+    assert "trap 'handle_signal 143' TERM" in wrapper
     assert 'chmod -R u+rwX -- "$runtime_root"' in wrapper
     assert 'exit "$status"' in wrapper
 
@@ -190,6 +273,9 @@ def test_semantic_runner_hardens_offline_execution() -> None:
     assert "_require_loopback_only_network" in runner
     assert "_require_explicit_import_roots" in runner
     assert "os.umask(0o077)" in runner
+    assert '"PYTHONNOUSERSITE": "1"' in runner
+    assert "_load_semantic_platform_contract" in runner
+    assert "_locked_root_versions" in runner
     assert "sys.path.insert" not in runner
     assert "ignore_cleanup_errors=True" not in runner
     assert '"downloaded": False' in runner

--- a/scripts/ci/run_semantic_real_model_integration.py
+++ b/scripts/ci/run_semantic_real_model_integration.py
@@ -16,8 +16,66 @@ from typing import Any, Iterator
 from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parents[2]
-EXPECTED_SENTENCE_TRANSFORMERS_VERSION = "5.6.0"
-EXPECTED_TORCH_VERSION = "2.13.0+cpu"
+SEMANTIC_PLATFORM_CONTRACT = (
+    ROOT / "docs/release/repoground-semantic-platforms.v1.json"
+)
+SEMANTIC_TARGET_ID = "cpython-312-linux-x86_64"
+
+
+def _load_semantic_platform_contract(
+    path: Path = SEMANTIC_PLATFORM_CONTRACT,
+) -> dict[str, Any]:
+    contract = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(contract, dict):
+        raise RuntimeError("semantic platform contract must be a JSON object")
+    return contract
+
+
+def _locked_root_versions(
+    contract: dict[str, Any],
+    *,
+    target_id: str = SEMANTIC_TARGET_ID,
+) -> tuple[str, str]:
+    supported_targets = contract.get("supported_targets")
+    if not isinstance(supported_targets, list):
+        raise RuntimeError("semantic platform contract has no supported_targets list")
+    matches = [
+        target
+        for target in supported_targets
+        if isinstance(target, dict) and target.get("id") == target_id
+    ]
+    if len(matches) != 1:
+        raise RuntimeError(
+            f"semantic platform contract must define target {target_id!r} exactly once"
+        )
+    target = matches[0]
+    root_pins = target.get("root_pins")
+    if not isinstance(root_pins, dict):
+        raise RuntimeError("semantic platform target has no root_pins object")
+    sentence_transformers = root_pins.get("sentence-transformers")
+    torch = root_pins.get("torch")
+    if not isinstance(sentence_transformers, str) or not sentence_transformers:
+        raise RuntimeError("semantic platform contract has no sentence-transformers pin")
+    if not isinstance(torch, str) or not torch:
+        raise RuntimeError("semantic platform contract has no torch pin")
+    return sentence_transformers, torch
+
+
+def _compiler_image(contract: dict[str, Any] | None = None) -> str:
+    if contract is None:
+        contract = _load_semantic_platform_contract()
+    compiler = contract.get("compiler")
+    if not isinstance(compiler, dict):
+        raise RuntimeError("semantic platform contract has no compiler object")
+    image = compiler.get("image")
+    if not isinstance(image, str) or "@sha256:" not in image:
+        raise RuntimeError("semantic platform contract has no digest-pinned compiler image")
+    return image
+
+
+EXPECTED_SENTENCE_TRANSFORMERS_VERSION, EXPECTED_TORCH_VERSION = _locked_root_versions(
+    _load_semantic_platform_contract()
+)
 FIXTURE_VOCAB = (
     "commons",
     "community",
@@ -29,6 +87,9 @@ FIXTURE_VOCAB = (
     "knowledge",
 )
 FIXTURE_DIMENSIONS = len(FIXTURE_VOCAB)
+EXPECTED_FIXTURE_VOCAB_SHA256 = (
+    "f65f5462143c8530bd6ba6dec59e000970f3ba60070886f0cbd1956c576ef445"
+)
 EXPECTED_MODEL_TREE_SHA256 = (
     "913b82d98b28add74e605bde8a807826ce1b995b783ddac158e7f0fdf5bcfc75"
 )
@@ -338,9 +399,7 @@ def _integration_report(
             "source": "generated_local_fixture",
             "modules": ["BoW", "Normalize"],
             "dimensions": FIXTURE_DIMENSIONS,
-            "vocab_sha256": hashlib.sha256(
-                json.dumps(FIXTURE_VOCAB, separators=(",", ":")).encode("utf-8")
-            ).hexdigest(),
+            "vocab_sha256": EXPECTED_FIXTURE_VOCAB_SHA256,
             "tree_sha256": model["tree_sha256"],
             "repeat_tree_sha256": model["repeat_tree_sha256"],
             "files": model["files"],
@@ -390,6 +449,7 @@ def run_integration(dependency_target: Path) -> dict[str, Any]:
             "HF_HUB_OFFLINE": "1",
             "TRANSFORMERS_OFFLINE": "1",
             "HF_HUB_DISABLE_TELEMETRY": "1",
+            "PYTHONNOUSERSITE": "1",
             "SENTENCE_TRANSFORMERS_HOME": "/tmp/repoground-semantic-model-cache",
         }
     )
@@ -429,7 +489,15 @@ def main() -> int:
     mode = parser.add_mutually_exclusive_group(required=True)
     mode.add_argument("--dependency-target", type=Path)
     mode.add_argument("--validate-dependency-target", type=Path)
+    mode.add_argument("--compiler-image", action="store_true")
     args = parser.parse_args()
+
+    if args.compiler_image:
+        try:
+            print(_compiler_image())
+        except Exception as exc:
+            parser.error(str(exc))
+        return 0
 
     if args.validate_dependency_target is not None:
         try:

--- a/scripts/ci/run_semantic_real_model_integration.sh
+++ b/scripts/ci/run_semantic_real_model_integration.sh
@@ -12,32 +12,33 @@ runtime_root="$(
 )"
 cleanup() {
   status=$?
-  trap - EXIT
+  trap - EXIT HUP INT TERM
   chmod -R u+rwX -- "$runtime_root" 2>/dev/null || true
   rm -rf -- "$runtime_root" || true
   exit "$status"
 }
+handle_signal() {
+  exit "$1"
+}
 trap cleanup EXIT
+trap 'handle_signal 129' HUP
+trap 'handle_signal 130' INT
+trap 'handle_signal 143' TERM
 runtime_work="$runtime_root/work"
 mkdir -- "$runtime_work"
 
 python3 -I -S - "$repo_root" "$runtime_work" <<'PY'
 from __future__ import annotations
 
-import io
 import shutil
 import subprocess
 import sys
 import tarfile
+import tempfile
 from pathlib import Path, PurePosixPath
 
 repo_root = Path(sys.argv[1])
 target = Path(sys.argv[2])
-archive = subprocess.run(
-    ["git", "-C", str(repo_root), "archive", "--format=tar", "HEAD"],
-    check=True,
-    stdout=subprocess.PIPE,
-).stdout
 
 
 def _archive_member_kind(member: tarfile.TarInfo) -> str:
@@ -58,59 +59,55 @@ def _archive_member_kind(member: tarfile.TarInfo) -> str:
     return f"unknown type {member.type!r}"
 
 
-with tarfile.open(fileobj=io.BytesIO(archive), mode="r:") as handle:
-    members = handle.getmembers()
-    for member in members:
-        relative = PurePosixPath(member.name)
-        if relative.is_absolute() or ".." in relative.parts:
-            raise RuntimeError(f"unsafe archive path: {member.name!r}")
-        member_kind = _archive_member_kind(member)
-        if member_kind not in {"directory", "regular file"}:
-            raise RuntimeError(
-                "runtime archive contains unsafe "
-                f"{member_kind}: {member.name!r}"
-            )
+with tempfile.TemporaryFile() as archive:
+    subprocess.run(
+        ["git", "-C", str(repo_root), "archive", "--format=tar", "HEAD"],
+        check=True,
+        stdout=archive,
+    )
+    archive.seek(0)
+    with tarfile.open(fileobj=archive, mode="r:") as handle:
+        members = handle.getmembers()
+        for member in members:
+            relative = PurePosixPath(member.name)
+            if relative.is_absolute() or ".." in relative.parts:
+                raise RuntimeError(f"unsafe archive path: {member.name!r}")
+            member_kind = _archive_member_kind(member)
+            if member_kind not in {"directory", "regular file"}:
+                raise RuntimeError(
+                    "runtime archive contains unsafe "
+                    f"{member_kind}: {member.name!r}"
+                )
 
-    directories: set[Path] = {target}
-    for member in members:
-        relative = PurePosixPath(member.name)
-        destination = target.joinpath(*relative.parts)
-        if member.isdir():
-            destination.mkdir(parents=True, exist_ok=True)
-            directories.add(destination)
-            continue
+        directories: set[Path] = {target}
+        for member in members:
+            relative = PurePosixPath(member.name)
+            destination = target.joinpath(*relative.parts)
+            if member.isdir():
+                destination.mkdir(parents=True, exist_ok=True)
+                directories.add(destination)
+                continue
 
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        directories.add(destination.parent)
-        source = handle.extractfile(member)
-        if source is None:
-            raise RuntimeError(f"archive file has no payload: {member.name!r}")
-        with source, destination.open("xb") as output:
-            shutil.copyfileobj(source, output)
-        destination.chmod(0o444)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            directories.add(destination.parent)
+            source = handle.extractfile(member)
+            if source is None:
+                raise RuntimeError(f"archive file has no payload: {member.name!r}")
+            with source, destination.open("xb") as output:
+                shutil.copyfileobj(source, output)
+            destination.chmod(0o444)
 
 for directory in sorted(directories, key=lambda path: len(path.parts), reverse=True):
     directory.chmod(0o555)
 PY
 
 runner="$runtime_work/scripts/ci/run_semantic_real_model_integration.py"
-platform_contract="$runtime_work/docs/release/repoground-semantic-platforms.v1.json"
 dependency_target="$(
   python3 -I -S "$runner" \
     --validate-dependency-target "$1"
 )"
 image="$(
-  python3 -I -S -c '
-import json
-import sys
-from pathlib import Path
-
-contract = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
-image = contract.get("compiler", {}).get("image")
-if not isinstance(image, str) or "@sha256:" not in image:
-    raise SystemExit("semantic platform contract has no digest-pinned compiler image")
-print(image)
-' "$platform_contract"
+  python3 -I -S "$runner" --compiler-image
 )"
 sandbox_uid=65532
 sandbox_gid=65532
@@ -120,11 +117,15 @@ docker run --rm \
   --read-only \
   --cap-drop ALL \
   --security-opt no-new-privileges \
+  --pids-limit 256 \
+  --memory 2g \
+  --memory-swap 2g \
   --tmpfs /tmp:rw,nosuid,nodev,noexec,size=256m,mode=1777 \
   --user "$sandbox_uid:$sandbox_gid" \
   --env HOME=/tmp \
   --env PYTHONPATH=/semantic-target:/work \
   --env PYTHONSAFEPATH=1 \
+  --env PYTHONNOUSERSITE=1 \
   --env HF_HOME=/tmp/hf-home \
   --env HF_HUB_OFFLINE=1 \
   --env TRANSFORMERS_OFFLINE=1 \


### PR DESCRIPTION
## Summary

Follow-up hardening for the merged semantic real-model integration after a second independent review.

### Accepted findings

- handle `HUP`, `INT`, and `TERM` explicitly so graceful cancellation reaches the existing `EXIT` cleanup; `SIGKILL` remains inherently untrappable
- make workflow cleanup restore owner write permissions before removing the dependency target
- keep the hardened `git archive HEAD` runtime copy, but spool the archive through `tempfile.TemporaryFile()` instead of retaining the complete tar in RAM
- centralize digest-pinned compiler-image and root-version reads in the Python runner from `repoground-semantic-platforms.v1.json`
- select the locked semantic target by explicit target ID rather than assuming the contract will forever contain exactly one target
- add `--pids-limit 256`, `--memory 2g`, `--memory-swap 2g`, and `PYTHONNOUSERSITE=1` to the isolated container
- make the dependency-target symlink test robust to macOS host temp aliases by resolving only pytest's host-provided temp base
- add direct regression tests for the Python socket guard and fixture-vocabulary identity

### Review finding rejected as incorrect

The proposed missing `expected_dimensions` diagnostics key is not a bug. `_validated_semantic_embeddings()` does not add that field; it is injected by the higher-level query flow. A new direct regression test now locks the exact inner diagnostics contract and asserts that `expected_dimensions` is absent there.

### Security decision retained

The runtime copy is deliberately **not** replaced with `rsync`, `cp -a`, or a direct host-worktree mount. `git archive HEAD` keeps execution bound to committed source, rejects symlinks/hardlinks/devices/FIFOs before extraction, and avoids exposing the mutable host worktree to the container.

## Local evidence

- commit: `f81377ea953b5592436e77429af860d2beed591a`
- tree: `90806513104751570d5e37abe70af4d3014236d6`
- base: `b3fd591c94aee96144a3baf531c43b89c6a3bbfe`
- focused semantic/retrieval suite: `73 passed`
- complete RepoGround Python suite: `4415 passed, 2 skipped in 180.11s`
- Ruff: pass
- Bash syntax: pass
- ShellCheck `--severity=style`: pass
- `git diff --check`: pass
- semantic lock reproduction `--check`: pass
- real locked install: pass
- real-model wrapper status: `0`
- dependency-target cleanup: no residue
- model tree SHA-256, both independent builds: `913b82d98b28add74e605bde8a807826ce1b995b783ddac158e7f0fdf5bcfc75`
- fixture vocab SHA-256: `f65f5462143c8530bd6ba6dec59e000970f3ba60070886f0cbd1956c576ef445`
- interfaces observed in container: `[lo]`
- dimensions: query `[8]`, single document `[1, 8]`, batch `[2, 8]`
- scores: `[0.866025447845459, 0.0]`

The first durable real-model harness attempt reported outer exit 1 despite a passing integration payload. A controlled rerun measured `wrapper_status=0`; a minimal probe showed the extra test-harness `EXIT` trap itself caused the outer discrepancy. The final verification removed that artificial outer trap and completed successfully with explicit cleanup readback.
