### PR TITLE
ci(retrieval): tighten semantic integration contracts

### DIFF
--- a/merger/repoground/tests/test_semantic_real_model.py
+++ b/merger/repoground/tests/test_semantic_real_model.py
@@ -3,21 +3,23 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+import runpy
 import socket
 from pathlib import Path
 
 import pytest
 
 from merger.repoground.retrieval import query_core
+from scripts.ci import run_semantic_real_model_integration as semantic_runner
 from scripts.ci.run_semantic_real_model_integration import (
     EXPECTED_FIXTURE_VOCAB_SHA256,
     EXPECTED_MODEL_TREE_SHA256,
-    EXPECTED_SENTENCE_TRANSFORMERS_VERSION,
-    EXPECTED_TORCH_VERSION,
     FIXTURE_DIMENSIONS,
     FIXTURE_VOCAB,
     SEMANTIC_TARGET_ID,
     _compiler_image,
+    _fixture_vocab_sha256,
+    _locked_runtime_versions,
     _require_dependency_target,
     _require_loopback_only_network,
     canonical_tree_sha256,
@@ -31,18 +33,79 @@ RUNNER = ROOT / "scripts/ci/run_semantic_real_model_integration.py"
 
 
 def test_real_model_fixture_identity_is_explicit() -> None:
-    assert EXPECTED_SENTENCE_TRANSFORMERS_VERSION == "5.6.0"
-    assert EXPECTED_TORCH_VERSION == "2.13.0+cpu"
+    sentence_transformers_version, torch_version = _locked_runtime_versions()
+    assert sentence_transformers_version == "5.6.0"
+    assert torch_version == "2.13.0+cpu"
     assert SEMANTIC_TARGET_ID == "cpython-312-linux-x86_64"
     assert FIXTURE_DIMENSIONS == 8
     assert len(FIXTURE_VOCAB) == len(set(FIXTURE_VOCAB))
-    observed_vocab_sha256 = hashlib.sha256(
-        json.dumps(FIXTURE_VOCAB, separators=(",", ":")).encode("utf-8")
-    ).hexdigest()
-    assert EXPECTED_FIXTURE_VOCAB_SHA256 == observed_vocab_sha256
+    assert EXPECTED_FIXTURE_VOCAB_SHA256 == _fixture_vocab_sha256()
     assert re.fullmatch(r"[0-9a-f]{64}", EXPECTED_FIXTURE_VOCAB_SHA256)
     assert re.fullmatch(r"[0-9a-f]{64}", EXPECTED_MODEL_TREE_SHA256)
     assert "@sha256:" in _compiler_image()
+
+
+def test_runner_import_does_not_require_platform_contract(tmp_path: Path) -> None:
+    probe = tmp_path / "scripts/ci/run_semantic_real_model_integration.py"
+    probe.parent.mkdir(parents=True)
+    probe.write_text(RUNNER.read_text(encoding="utf-8"), encoding="utf-8")
+
+    namespace = runpy.run_path(str(probe), run_name="repoground_semantic_lazy_probe")
+
+    assert "_semantic_platform_contract" in namespace
+    assert not (tmp_path / "docs/release/repoground-semantic-platforms.v1.json").exists()
+
+
+def test_semantic_platform_contract_is_lazy_and_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    contract = {
+        "supported_targets": [
+            {
+                "id": SEMANTIC_TARGET_ID,
+                "root_pins": {
+                    "sentence-transformers": "5.6.0",
+                    "torch": "2.13.0+cpu",
+                },
+            }
+        ],
+        "compiler": {"image": "example.invalid/compiler@sha256:" + "a" * 64},
+    }
+    calls: list[str] = []
+
+    def fake_loader() -> dict[str, object]:
+        calls.append("load")
+        return contract
+
+    semantic_runner._semantic_platform_contract.cache_clear()
+    semantic_runner._locked_runtime_versions.cache_clear()
+    monkeypatch.setattr(semantic_runner, "_load_semantic_platform_contract", fake_loader)
+    try:
+        assert calls == []
+        assert semantic_runner._semantic_platform_contract() is contract
+        assert semantic_runner._semantic_platform_contract() is contract
+        assert calls == ["load"]
+        assert semantic_runner._locked_runtime_versions() == ("5.6.0", "2.13.0+cpu")
+        assert calls == ["load"]
+    finally:
+        semantic_runner._semantic_platform_contract.cache_clear()
+        semantic_runner._locked_runtime_versions.cache_clear()
+
+
+def test_semantic_platform_contract_errors_include_path(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.json"
+    with pytest.raises(RuntimeError, match=re.escape(str(missing))):
+        semantic_runner._load_semantic_platform_contract(missing)
+
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text("{not-json", encoding="utf-8")
+    with pytest.raises(RuntimeError, match=re.escape(str(invalid))):
+        semantic_runner._load_semantic_platform_contract(invalid)
+
+
+def test_compiler_image_can_be_validated_without_contract_io() -> None:
+    image = "example.invalid/compiler@sha256:" + "b" * 64
+    assert _compiler_image({"compiler": {"image": image}}) == image
+    with pytest.raises(RuntimeError, match="digest-pinned compiler image"):
+        _compiler_image({"compiler": {"image": "example.invalid/compiler:latest"}})
 
 
 def test_canonical_model_tree_hash_is_path_and_content_bound(tmp_path: Path) -> None:
@@ -168,8 +231,40 @@ def test_direct_dimension_validation_diagnostics_are_exact() -> None:
     assert "expected_dimensions" not in diagnostics
 
 
+def test_integration_report_hashes_actual_fixture_vocab(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    changed_vocab = ("changed", "fixture")
+    monkeypatch.setattr(semantic_runner, "FIXTURE_VOCAB", changed_vocab)
+    expected_actual_hash = hashlib.sha256(
+        json.dumps(changed_vocab, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+    report = semantic_runner._integration_report(
+        runtime={
+            "sentence_transformers_version": "5.6.0",
+            "torch_version": "2.13.0+cpu",
+            "numpy_version": "2.5.1",
+        },
+        model={
+            "tree_sha256": EXPECTED_MODEL_TREE_SHA256,
+            "repeat_tree_sha256": EXPECTED_MODEL_TREE_SHA256,
+            "files": [],
+        },
+        outputs={},
+        diagnostics={},
+        scores=[],
+        network_interfaces=["lo"],
+    )
+
+    assert report["model"]["vocab_sha256"] == expected_actual_hash
+    assert report["model"]["vocab_sha256"] != EXPECTED_FIXTURE_VOCAB_SHA256
+
+
 def test_python_network_guard_blocks_socket_calls() -> None:
     with deny_python_network():
+        with pytest.raises(RuntimeError, match="network access is forbidden"):
+            socket.getaddrinfo("example.invalid", 443)
         with pytest.raises(RuntimeError, match="network access is forbidden"):
             socket.create_connection(("example.invalid", 443))
 
@@ -213,6 +308,8 @@ def test_semantic_wrapper_hardens_container_and_import_roots() -> None:
     assert "--read-only" in wrapper
     assert "--cap-drop ALL" in wrapper
     assert "--security-opt no-new-privileges" in wrapper
+    assert "apparmor=unconfined" not in wrapper
+    assert "seccomp=unconfined" not in wrapper
     assert "--pids-limit 256" in wrapper
     assert "--memory 2g" in wrapper
     assert "--memory-swap 2g" in wrapper
@@ -261,6 +358,8 @@ def test_semantic_wrapper_classifies_archive_entries_and_cleans_up() -> None:
     assert "trap 'handle_signal 129' HUP" in wrapper
     assert "trap 'handle_signal 130' INT" in wrapper
     assert "trap 'handle_signal 143' TERM" in wrapper
+    assert 'cleanup "$1"' in wrapper
+    assert 'handle_signal() {\n  exit "$1"' not in wrapper
     assert 'chmod -R u+rwX -- "$runtime_root"' in wrapper
     assert 'exit "$status"' in wrapper
 
@@ -275,7 +374,10 @@ def test_semantic_runner_hardens_offline_execution() -> None:
     assert "os.umask(0o077)" in runner
     assert '"PYTHONNOUSERSITE": "1"' in runner
     assert "_load_semantic_platform_contract" in runner
+    assert "_semantic_platform_contract" in runner
     assert "_locked_root_versions" in runner
+    assert "_locked_runtime_versions" in runner
+    assert "EXPECTED_SENTENCE_TRANSFORMERS_VERSION, EXPECTED_TORCH_VERSION =" not in runner
     assert "sys.path.insert" not in runner
     assert "ignore_cleanup_errors=True" not in runner
     assert '"downloaded": False' in runner

--- a/scripts/ci/run_semantic_real_model_integration.py
+++ b/scripts/ci/run_semantic_real_model_integration.py
@@ -11,6 +11,7 @@ import socket
 import sys
 import tempfile
 from contextlib import contextmanager
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Iterator
 from unittest.mock import patch
@@ -25,10 +26,28 @@ SEMANTIC_TARGET_ID = "cpython-312-linux-x86_64"
 def _load_semantic_platform_contract(
     path: Path = SEMANTIC_PLATFORM_CONTRACT,
 ) -> dict[str, Any]:
-    contract = json.loads(path.read_text(encoding="utf-8"))
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise RuntimeError(
+            f"cannot read semantic platform contract {path}: {exc}"
+        ) from exc
+    try:
+        contract = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            "semantic platform contract contains invalid JSON "
+            f"at {path}:{exc.lineno}:{exc.colno}: {exc.msg}"
+        ) from exc
     if not isinstance(contract, dict):
-        raise RuntimeError("semantic platform contract must be a JSON object")
+        raise RuntimeError(f"semantic platform contract {path} must be a JSON object")
     return contract
+
+
+@lru_cache(maxsize=1)
+def _semantic_platform_contract() -> dict[str, Any]:
+    """Load the immutable platform contract only when a caller needs it."""
+    return _load_semantic_platform_contract()
 
 
 def _locked_root_versions(
@@ -61,9 +80,14 @@ def _locked_root_versions(
     return sentence_transformers, torch
 
 
+@lru_cache(maxsize=1)
+def _locked_runtime_versions() -> tuple[str, str]:
+    return _locked_root_versions(_semantic_platform_contract())
+
+
 def _compiler_image(contract: dict[str, Any] | None = None) -> str:
     if contract is None:
-        contract = _load_semantic_platform_contract()
+        contract = _semantic_platform_contract()
     compiler = contract.get("compiler")
     if not isinstance(compiler, dict):
         raise RuntimeError("semantic platform contract has no compiler object")
@@ -73,9 +97,6 @@ def _compiler_image(contract: dict[str, Any] | None = None) -> str:
     return image
 
 
-EXPECTED_SENTENCE_TRANSFORMERS_VERSION, EXPECTED_TORCH_VERSION = _locked_root_versions(
-    _load_semantic_platform_contract()
-)
 FIXTURE_VOCAB = (
     "commons",
     "community",
@@ -90,6 +111,15 @@ FIXTURE_DIMENSIONS = len(FIXTURE_VOCAB)
 EXPECTED_FIXTURE_VOCAB_SHA256 = (
     "f65f5462143c8530bd6ba6dec59e000970f3ba60070886f0cbd1956c576ef445"
 )
+
+
+def _fixture_vocab_sha256() -> str:
+    """Hash the fixture vocabulary actually used by this process."""
+    return hashlib.sha256(
+        json.dumps(FIXTURE_VOCAB, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
 EXPECTED_MODEL_TREE_SHA256 = (
     "913b82d98b28add74e605bde8a807826ce1b995b783ddac158e7f0fdf5bcfc75"
 )
@@ -233,10 +263,13 @@ def _load_locked_runtime() -> dict[str, Any]:
 
     from merger.repoground.retrieval import query_core
 
-    sentence_transformers_version = _require_version(
-        "sentence-transformers", EXPECTED_SENTENCE_TRANSFORMERS_VERSION
+    expected_sentence_transformers_version, expected_torch_version = (
+        _locked_runtime_versions()
     )
-    torch_version = _require_version("torch", EXPECTED_TORCH_VERSION)
+    sentence_transformers_version = _require_version(
+        "sentence-transformers", expected_sentence_transformers_version
+    )
+    torch_version = _require_version("torch", expected_torch_version)
     if sentence_transformers.__version__ != sentence_transformers_version:
         raise RuntimeError("sentence-transformers package metadata/module mismatch")
     if torch.__version__ != torch_version:
@@ -399,7 +432,7 @@ def _integration_report(
             "source": "generated_local_fixture",
             "modules": ["BoW", "Normalize"],
             "dimensions": FIXTURE_DIMENSIONS,
-            "vocab_sha256": EXPECTED_FIXTURE_VOCAB_SHA256,
+            "vocab_sha256": _fixture_vocab_sha256(),
             "tree_sha256": model["tree_sha256"],
             "repeat_tree_sha256": model["repeat_tree_sha256"],
             "files": model["files"],

--- a/scripts/ci/run_semantic_real_model_integration.sh
+++ b/scripts/ci/run_semantic_real_model_integration.sh
@@ -12,13 +12,16 @@ runtime_root="$(
 )"
 cleanup() {
   status=$?
+  if [[ "$#" -gt 0 ]]; then
+    status="$1"
+  fi
   trap - EXIT HUP INT TERM
   chmod -R u+rwX -- "$runtime_root" 2>/dev/null || true
   rm -rf -- "$runtime_root" || true
   exit "$status"
 }
 handle_signal() {
-  exit "$1"
+  cleanup "$1"
 }
 trap cleanup EXIT
 trap 'handle_signal 129' HUP


### PR DESCRIPTION
## Summary

Second follow-up hardening for the semantic real-model integration after another independent review.

### Accepted and implemented

- remove platform-contract file I/O from module import; contract loading is now lazy and process-cached
- resolve locked runtime versions lazily from the canonical platform contract
- improve contract read/JSON error messages with the exact contract path and JSON location
- make the integration report hash the fixture vocabulary actually used at runtime instead of echoing the expected hash constant
- pass signal exit codes explicitly into cleanup so HUP/INT/TERM cleanup does not rely on status propagation through the EXIT trap
- add regression coverage proving the runner imports successfully when no platform contract exists at its derived path
- add regression coverage for lazy contract caching, contract error diagnostics, compiler-image validation without contract I/O, dynamic report hashing, and direct DNS blocking via socket.getaddrinfo
- lock out accidental `apparmor=unconfined` and `seccomp=unconfined` options in the wrapper contract tests

### Review findings checked and rejected

- Signal cleanup was already invoked: Bash `exit` from `handle_signal` triggers the registered EXIT trap. A live TERM probe confirmed cleanup execution. The implementation was still tightened to pass 129/130/143 directly to cleanup; a second probe recorded `cleanup_status=143`.
- The claimed DNS test crash was not reproducible. `deny_python_network()` already patches `socket.getaddrinfo`, `socket.create_connection`, and `socket.socket.connect`; the original focused test passed before this patch. Coverage now asserts `getaddrinfo` directly as well.
- `--network none` was already present in the Docker invocation.
- A shared cleanup helper across the GitHub workflow target and wrapper runtime root was not introduced: these are intentionally separate lifecycles and execution layers; coupling them would add machinery rather than remove meaningful duplication.
- `set.add()` is average O(1), so the archive directory set does not have the alleged O(n)-per-add behavior.
- Runtime package versions were already emitted in the integration report.
- Combining two tiny Python CLI invocations was not pursued because safe shell parsing would add more complexity than the startup cost saved.

## Local evidence

- base: `4aaaff8ca0c38f745f29d8f57d50d61f4568cdc3`
- commit: `7a15c7c06b469e70cdb215e76ffbf206123a9851`
- tree: `58f6408d7caf61ce25a539d2f881f6326a02b3e2`
- focused real-model tests: `15 passed`
- focused semantic/retrieval suite: `78 passed`
- complete RepoGround Python suite: `4421 passed, 2 skipped in 126.65s`
- Ruff: pass
- Bash syntax: pass
- ShellCheck `--severity=style`: pass
- `git diff --check`: pass
- semantic lock reproduction `--check`: pass
- real locked install: pass
- real-model wrapper status: `0`
- dependency-target cleanup: no residue
- explicit TERM cleanup probe: `cleanup_status=143`
- model tree SHA-256, both independent builds: `913b82d98b28add74e605bde8a807826ce1b995b783ddac158e7f0fdf5bcfc75`
- runtime vocabulary SHA-256: `f65f5462143c8530bd6ba6dec59e000970f3ba60070886f0cbd1956c576ef445`
- interfaces observed in container: `[lo]`
- dimensions: query `[8]`, single document `[1, 8]`, batch `[2, 8]`
- scores: `[0.866025447845459, 0.0]`
