### PR TITLE
test(retrieval): clarify semantic integration invariants

### DIFF
--- a/merger/repoground/tests/test_semantic_real_model.py
+++ b/merger/repoground/tests/test_semantic_real_model.py
@@ -85,6 +85,16 @@ def test_semantic_platform_contract_is_lazy_and_cached(monkeypatch: pytest.Monke
         assert calls == ["load"]
         assert semantic_runner._locked_runtime_versions() == ("5.6.0", "2.13.0+cpu")
         assert calls == ["load"]
+
+        def fail_if_versions_are_recomputed(_contract: dict[str, object]) -> tuple[str, str]:
+            raise AssertionError("locked runtime versions cache was bypassed")
+
+        monkeypatch.setattr(
+            semantic_runner,
+            "_locked_root_versions",
+            fail_if_versions_are_recomputed,
+        )
+        assert semantic_runner._locked_runtime_versions() == ("5.6.0", "2.13.0+cpu")
     finally:
         semantic_runner._semantic_platform_contract.cache_clear()
         semantic_runner._locked_runtime_versions.cache_clear()
@@ -99,6 +109,11 @@ def test_semantic_platform_contract_errors_include_path(tmp_path: Path) -> None:
     invalid.write_text("{not-json", encoding="utf-8")
     with pytest.raises(RuntimeError, match=re.escape(str(invalid))):
         semantic_runner._load_semantic_platform_contract(invalid)
+
+    wrong_type = tmp_path / "wrong-type.json"
+    wrong_type.write_text("[]", encoding="utf-8")
+    with pytest.raises(RuntimeError, match=r"must be a JSON object, got list"):
+        semantic_runner._load_semantic_platform_contract(wrong_type)
 
 
 def test_compiler_image_can_be_validated_without_contract_io() -> None:
@@ -236,6 +251,7 @@ def test_integration_report_hashes_actual_fixture_vocab(
 ) -> None:
     changed_vocab = ("changed", "fixture")
     monkeypatch.setattr(semantic_runner, "FIXTURE_VOCAB", changed_vocab)
+    monkeypatch.setattr(semantic_runner, "FIXTURE_DIMENSIONS", len(changed_vocab))
     expected_actual_hash = hashlib.sha256(
         json.dumps(changed_vocab, separators=(",", ":")).encode("utf-8")
     ).hexdigest()
@@ -257,6 +273,7 @@ def test_integration_report_hashes_actual_fixture_vocab(
         network_interfaces=["lo"],
     )
 
+    assert report["model"]["dimensions"] == len(changed_vocab)
     assert report["model"]["vocab_sha256"] == expected_actual_hash
     assert report["model"]["vocab_sha256"] != EXPECTED_FIXTURE_VOCAB_SHA256
 
@@ -308,6 +325,7 @@ def test_semantic_wrapper_hardens_container_and_import_roots() -> None:
     assert "--read-only" in wrapper
     assert "--cap-drop ALL" in wrapper
     assert "--security-opt no-new-privileges" in wrapper
+    # Regression guard: do not silently disable the host's LSM/seccomp sandboxing.
     assert "apparmor=unconfined" not in wrapper
     assert "seccomp=unconfined" not in wrapper
     assert "--pids-limit 256" in wrapper

--- a/scripts/ci/run_semantic_real_model_integration.py
+++ b/scripts/ci/run_semantic_real_model_integration.py
@@ -40,7 +40,10 @@ def _load_semantic_platform_contract(
             f"at {path}:{exc.lineno}:{exc.colno}: {exc.msg}"
         ) from exc
     if not isinstance(contract, dict):
-        raise RuntimeError(f"semantic platform contract {path} must be a JSON object")
+        raise RuntimeError(
+            f"semantic platform contract {path} must be a JSON object, "
+            f"got {type(contract).__name__}"
+        )
     return contract
 
 

--- a/scripts/ci/run_semantic_real_model_integration.sh
+++ b/scripts/ci/run_semantic_real_model_integration.sh
@@ -12,6 +12,8 @@ runtime_root="$(
 )"
 cleanup() {
   status=$?
+  # Signal handlers pass an explicit 128+signal status; it intentionally wins
+  # over the command status captured for the ordinary EXIT-trap path.
   if [[ "$#" -gt 0 ]]; then
     status="$1"
   fi


### PR DESCRIPTION
## Summary

Small follow-up after another independent review of the semantic real-model integration.

### Implemented

- improve non-object platform-contract diagnostics with the observed JSON/Python type
- strengthen the locked-runtime-version cache regression test so a second lookup must come from `_locked_runtime_versions()` itself
- keep the mocked vocabulary/dimension pair internally consistent in the dynamic-report regression test
- document why explicit signal statuses override the ordinary EXIT-trap status
- document the AppArmor/seccomp assertions as security regression guards

### Review findings checked and rejected

- The claimed signal-exit-code loss is not present. `cleanup()` captures `$?` first and then explicitly overwrites it with `$1` whenever a signal handler supplies an argument. A live TERM probe against the current implementation recorded `143` inside cleanup.
- `handle_signal` is defined before all signal trap registrations in the current script.
- `_locked_root_versions()` cannot simply be decorated with `lru_cache`: its contract argument is a mutable dict and therefore unhashable. The current no-argument `_locked_runtime_versions()` cache is the correct boundary.
- The `runpy` import probe is intentionally retained because it proves the specific property under review: importing an isolated copy of the runner does not require the platform-contract file. The ordinary cache test does not establish that import-time property.
- `_fixture_vocab_sha256()` is intentionally not cached. The integration report is emitted once per run, hashing eight words is negligible, and recomputing preserves the stronger invariant that the report reflects the vocabulary actually present at report time.
- Direct module import in the cache tests is intentional because the tests need `cache_clear()` and monkeypatchable module globals.
- Hard-coded version assertions remain deliberate regression expectations against the canonical contract; moving them into new constants would reintroduce duplicated sources of truth.

## Local evidence

- base: `5981e92c7bc38a9a758cb4055a2d3c15d3da51a4`
- commit: `cd958431ecb564e47ed2b076fed3d8466b9aba7e`
- tree: `18b4422456c465e2d4148389db56a6d1a7e54d75`
- live TERM cleanup probe on pre-change main: recorded status `143`
- focused semantic real-model tests: `15 passed`
- focused semantic/retrieval suite: `78 passed`
- complete RepoGround Python suite: `4421 passed, 2 skipped in 190.39s`
- semantic lock reproduction: pass
- Ruff: pass
- ShellCheck `--severity=style`: pass
- `git diff --check`: pass

No model/container execution semantics changed in this follow-up, so the expensive real-model install/run was not repeated; it was already proven on the immediately preceding merged tree and this patch changes only diagnostics, tests, and comments.
