### PR TITLE
Preserve RepoGround user-site runtime dependencies

### DIFF
--- a/merger/repoground/tests/test_fleet_runtime.py
+++ b/merger/repoground/tests/test_fleet_runtime.py
@@ -634,7 +634,7 @@ def test_generation_environment_redirects_runtime_artifacts(tmp_path: Path) -> N
     env = module.generation_environment(runtime)
 
     assert env["PYTHONDONTWRITEBYTECODE"] == "1"
-    assert env["PYTHONNOUSERSITE"] == "1"
+    assert env.get("PYTHONNOUSERSITE") == os.environ.get("PYTHONNOUSERSITE")
     assert Path(env["PYTHONPYCACHEPREFIX"]) == runtime / "pycache"
     assert Path(env["XDG_CACHE_HOME"]) == runtime / "xdg-cache"
     assert Path(env["PIP_CACHE_DIR"]) == runtime / "pip-cache"

--- a/scripts/ops/repoground-publish-fleet
+++ b/scripts/ops/repoground-publish-fleet
@@ -504,7 +504,6 @@ def generation_environment(cache_root: Path) -> dict[str, str]:
         {
             "PYTHONDONTWRITEBYTECODE": "1",
             "PYTHONPYCACHEPREFIX": str(pycache),
-            "PYTHONNOUSERSITE": "1",
             "XDG_CACHE_HOME": str(xdg_cache),
             "PIP_CACHE_DIR": str(pip_cache),
             "TMPDIR": str(temporary),


### PR DESCRIPTION
## Summary
- remove only `PYTHONNOUSERSITE=1` from the fleet publisher's isolated generation environment
- preserve bytecode, pycache, XDG cache, pip cache and TMPDIR redirection outside managed worktrees
- keep the existing environment regression test aligned with ambient Python user-site policy

## Live regression evidence
After merged PR #1067 was deployed, a controlled fleet run cleaned the original Chronik/Grabowski source-worktree residue successfully, but all 7 changed repositories failed finalization. The new generator output omitted `architecture_graph_json` and therefore `relation_cards_jsonl`; `post_emit_health` became `warn`, then `agent_export_gate` and `export_safety_report` failed.

`jsonschema` resolves from `/home/alex/.local/lib/python3.10/site-packages`; `python3 -s` cannot import it. The `PYTHONNOUSERSITE=1` added by #1067 therefore made graph-index validation unavailable and caused graph artifacts to be discarded.

## Verification
- `merger/repoground/tests/test_fleet_runtime.py`: 63 passed
- Ruff: passed
- `git diff --check`: passed
- Source/tool managed worktrees stayed clean after the failed live run

## Safety
No warning gate is weakened. The fix restores the runtime dependency path required to produce the previously available graph/relation artifacts while retaining all filesystem hygiene controls from #1067.