### PR TITLE
fix: expose coherent call graph relations in impact context

### DIFF
--- a/merger/repoground/core/agent_impact_context.py
+++ b/merger/repoground/core/agent_impact_context.py
@@ -1635,7 +1635,11 @@ def build_agent_impact_context(
     unresolved_risks: list[dict[str, Any]] = []
     call_graph_coverage_gaps: list[dict[str, Any]] = []
     edit_selection: dict[str, Any] = {}
-    if request.mode == "edit":
+    # Impact consumers need trusted call relations as evidence, but edit-only
+    # selection, unresolved-risk projection and coverage-gap semantics stay
+    # confined to edit mode. Missing optional call graphs therefore do not
+    # degrade ordinary impact requests.
+    if request.mode == "edit" or bool(call_graph):
         (
             direct_callers,
             direct_callees,
@@ -1650,6 +1654,14 @@ def build_agent_impact_context(
             expected_run_id=run_id,
             expected_digest=digest,
         )
+
+    if request.mode == "impact":
+        impact_call_relations = direct_callers + direct_callees
+        combined_relations = all_relations + impact_call_relations
+        relations = combined_relations[: request.max_items]
+        relations_truncated = len(combined_relations) > request.max_items
+
+    if request.mode == "edit":
         gaps.extend(call_graph_coverage_gaps)
         edit_selection = _edit_selection(
             target_symbols=all_target_symbols,

--- a/merger/repoground/tests/test_agent_impact_adapter.py
+++ b/merger/repoground/tests/test_agent_impact_adapter.py
@@ -308,6 +308,34 @@ def test_agent_impact_adapter_composes_integrity_checked_reads_without_writes(
     )
 
 
+def test_agent_impact_adapter_projects_coherent_call_graph_relations_in_impact_mode(
+    tmp_path: Path,
+) -> None:
+    adapter, _bundle, _config = _impact_adapter(tmp_path)
+
+    result = adapter.agent_impact_context(
+        "demo",
+        target_symbol="hello_adapter",
+        mode="impact",
+        include_query_context=False,
+    )
+
+    call_relations = [
+        item
+        for item in result["relations"]
+        if isinstance(item.get("freshness"), dict)
+        and item["freshness"].get("source") == "python_call_graph_json"
+    ]
+    assert result["status"] == "available"
+    assert "edit_context" not in result
+    assert call_relations
+    assert {item["relation_kind"] for item in call_relations} == {
+        "direct_caller",
+        "direct_callee",
+    }
+    assert all(item["freshness"]["status"] == "coherent" for item in call_relations)
+
+
 def test_agent_impact_adapter_dispatches_and_validates_arguments(
     tmp_path: Path,
 ) -> None:

--- a/merger/repoground/tests/test_agent_impact_context.py
+++ b/merger/repoground/tests/test_agent_impact_context.py
@@ -452,6 +452,55 @@ def test_edit_context_bundles_target_support_and_entrypoint_reads() -> None:
 
 
 
+def test_impact_context_projects_coherent_call_graph_relations_without_edit_semantics() -> None:
+    result = _context(mode="impact")
+
+    call_relations = [
+        item
+        for item in result["relations"]
+        if isinstance(item.get("freshness"), dict)
+        and item["freshness"].get("source") == "python_call_graph_json"
+    ]
+
+    assert "edit_context" not in result
+    assert {item["relation_kind"] for item in call_relations} == {
+        "direct_caller",
+        "direct_callee",
+    }
+    assert all(item["freshness"]["status"] == "coherent" for item in call_relations)
+    assert all(
+        item["provenance"]["relation"]["source"] == "python_call_graph_json"
+        for item in call_relations
+    )
+
+
+def test_impact_context_does_not_project_untrusted_call_graph_relations() -> None:
+    call_graph = _fixture_call_graph()
+    call_graph["run_id"] = "other-run"
+
+    result = _context(mode="impact", python_call_graph=call_graph)
+
+    assert result["status"] == "available"
+    assert "edit_context" not in result
+    assert not any(
+        isinstance(item.get("freshness"), dict)
+        and item["freshness"].get("source") == "python_call_graph_json"
+        for item in result["relations"]
+    )
+
+
+def test_impact_context_keeps_optional_missing_call_graph_non_degrading() -> None:
+    result = _context(mode="impact", python_call_graph=None)
+
+    assert result["status"] == "available"
+    assert "edit_context" not in result
+    assert not any(
+        isinstance(item.get("freshness"), dict)
+        and item["freshness"].get("source") == "python_call_graph_json"
+        for item in result["relations"]
+    )
+
+
 def test_edit_context_separately_budgets_proven_call_graph_relations() -> None:
     result = _context(max_items=1)
     selection = result["edit_context"]["selection"]


### PR DESCRIPTION
## Summary
- expose provenance-coherent direct caller/callee relations in `agent_impact_context` impact mode
- keep edit-only selection, unresolved-risk projection, and coverage-gap semantics confined to edit mode
- preserve non-degrading behavior for missing or untrusted optional call-graph artifacts
- add producer and real adapter regression coverage

## Validation
- `python3 -m pytest -q merger/repoground/tests/test_agent_impact_context.py merger/repoground/tests/test_agent_impact_adapter.py` → 31 passed
- `python3 -m pytest -q` → 4530 passed, 2 skipped

This closes the positive-path gap found while hardening REPOGROUND-AGENT-UTILITY-V1-T006: Grabowski composes impact context, so trusted call-graph evidence must be available in impact mode without importing edit-only semantics.