### PR TITLE
fix: preserve bounded impact relation source diversity

### DIFF
--- a/merger/repoground/core/agent_impact_context.py
+++ b/merger/repoground/core/agent_impact_context.py
@@ -1534,6 +1534,30 @@ def _result_status(
     return "available"
 
 
+def _select_impact_relations(
+    architecture_relations: list[dict[str, Any]],
+    call_relations: list[dict[str, Any]],
+    *,
+    max_items: int,
+) -> tuple[list[dict[str, Any]], bool]:
+    combined = architecture_relations + call_relations
+    if max_items <= 0:
+        return [], bool(combined)
+    if not architecture_relations or not call_relations or max_items == 1:
+        selected = combined[:max_items]
+        return selected, len(combined) > len(selected)
+
+    selected = [architecture_relations[0], call_relations[0]]
+    remaining = max_items - len(selected)
+    if remaining > 0:
+        selected.extend(architecture_relations[1 : 1 + remaining])
+        remaining = max_items - len(selected)
+    if remaining > 0:
+        selected.extend(call_relations[1 : 1 + remaining])
+    return selected, len(combined) > len(selected)
+
+
+
 def build_agent_impact_context(
     *,
     target_path: Any = None,
@@ -1657,9 +1681,11 @@ def build_agent_impact_context(
 
     if request.mode == "impact":
         impact_call_relations = direct_callers + direct_callees
-        combined_relations = all_relations + impact_call_relations
-        relations = combined_relations[: request.max_items]
-        relations_truncated = len(combined_relations) > request.max_items
+        relations, relations_truncated = _select_impact_relations(
+            all_relations,
+            impact_call_relations,
+            max_items=request.max_items,
+        )
 
     if request.mode == "edit":
         gaps.extend(call_graph_coverage_gaps)

--- a/merger/repoground/tests/test_agent_impact_context.py
+++ b/merger/repoground/tests/test_agent_impact_context.py
@@ -474,6 +474,39 @@ def test_impact_context_projects_coherent_call_graph_relations_without_edit_sema
     )
 
 
+def test_impact_context_preserves_source_diversity_when_relations_are_bounded() -> None:
+    result = _context(mode="impact", max_items=2)
+
+    call_relations = [
+        item
+        for item in result["relations"]
+        if isinstance(item.get("freshness"), dict)
+        and item["freshness"].get("source") == "python_call_graph_json"
+    ]
+    architecture_relations = [
+        item for item in result["relations"] if item not in call_relations
+    ]
+
+    assert len(result["relations"]) == 2
+    assert len(architecture_relations) == 1
+    assert len(call_relations) == 1
+    assert call_relations[0]["freshness"]["status"] == "coherent"
+    assert result["truncation"]["relations"] is True
+
+
+def test_impact_context_keeps_single_relation_budget_backward_compatible() -> None:
+    result = _context(mode="impact", max_items=1)
+
+    assert len(result["relations"]) == 1
+    assert not (
+        isinstance(result["relations"][0].get("freshness"), dict)
+        and result["relations"][0]["freshness"].get("source")
+        == "python_call_graph_json"
+    )
+    assert result["truncation"]["relations"] is True
+
+
+
 def test_impact_context_does_not_project_untrusted_call_graph_relations() -> None:
     call_graph = _fixture_call_graph()
     call_graph["run_id"] = "other-run"


### PR DESCRIPTION
## Zweck

Schließt die zweite T007-Integrationslücke nach #1071: Der große Call-Graph war zwar wieder lesbar und kohärent, wurde im begrenzten `agent_impact_context` aber von vorangestellten Architekturrelationen aus dem `max_items`-Fenster verdrängt. Dadurch konnte Grabowskis T006-Composer korrekt keinen `call_graph`-Lane-Claim setzen.

## Änderung

- Bei Impact-Modus und vorhandenen Architektur- **und** Call-Graph-Relationen erhält ein Budget von mindestens 2 deterministisch je eine Relation aus beiden Quellen.
- Der Rest des Budgets wird stabil in bisheriger Priorität aufgefüllt: zuerst weitere Architekturrelationen, dann weitere Call-Graph-Relationen.
- Budget 1 bleibt rückwärtskompatibel architektur-priorisiert.
- Keine Erhöhung von `max_items`, keine Änderung der Evidenzsemantik, keine Änderung der T006-Claim-Regel.

## Exakte Bindung

- Base: `4474f46b44f1b6fcd3e974f7f74b5b52b4d61c2e`
- Head: `5eed98ed360ce41c3970d73fa00e40399d134ee9`
- Diff SHA-256: `fecbc964dc012ee19cd4dd2671571f04660339735c43b44ee92db2924c64afbe`
- Diff: 3.585 Bytes

## Validierung

- 155 relevante RepoGround-Tests grün
- fokussierte Impact-/Adapter-/Large-Call-Graph-Suite grün
- Ruff grün
- Maintainability-Ratchet grün
- `git diff --check` grün

## Frischer T003/T007-Pilot

Gebunden an:
- frisches Weltgewebe-Bundle `heimgewebe__weltgewebe__main-max-260721-1911`
- Bundle-Commit `3113f5a48df3286d231563ebe589e2c5e836f103`
- Manifest SHA-256 `1287e5041e1523fed9e33056d33abca0e00fdcda9564015662e2db8d10963d86`
- Basis des großen Call-Graph-Lesers: gemergter #1071-Commit `4474f46b44f1b6fcd3e974f7f74b5b52b4d61c2e`

Vier Fälle bestehen den strikten Pilotcheck:
- DB/Auth PR #1295: 83,512 % Kontextreduktion, keine unbelegte Call-Graph-Lane.
- Web/Karte PR #1514: 58,991 % Reduktion, keine unbelegte Call-Graph-Lane.
- Deployment/Kubernetes PR #1458: 65,410 % Reduktion, 8 Zielsymbole, 3 verwandte Tests, 7 kausale Relationen; mindestens 1 kohärente Call-Graph-Relation liegt tatsächlich in der Capsule und `call_graph` wird deshalb belegt geclaimt.
- kontrollierter Livefall PR #1523: 82,888 % Reduktion, keine unbelegte Call-Graph-Lane.

Alle vier Fälle: `quality_pass=true`; Promotion-Gate bestanden; kein `artifact_too_large`, kein `impact_context_blocked`.

## Evidenzgrenzen

Der Kubernetes-Fall bleibt bei 12 KiB Kontextbudget wegen `budget_exhausted` als `degraded` markiert. Das ist eine transparente Budgetgrenze, kein Impact- oder Freshness-Blocker. DB/Auth und Web/Karte zeigen weiterhin `target_path_not_present_as_graph_node` für die Architekturgraph-Abdeckung; diese separate Abdeckungslücke wird nicht durch diesen PR behoben.

Dieser PR autorisiert keine Default-Promotion und beweist keine semantische Vollständigkeit, Test-Suffizienz oder Runtime-Reachability.