### PR TITLE
fix: require evidence for related tests

### DIFF
--- a/docs/diagnostics/repobrief-agent-impact-context-fixture-eval-v1.json
+++ b/docs/diagnostics/repobrief-agent-impact-context-fixture-eval-v1.json
@@ -7,7 +7,7 @@
         "src/db.py"
       ],
       "baseline_recall": 0.25,
-      "context_path_reduction_ratio": -6.0,
+      "context_path_reduction_ratio": -4.0,
       "expected_paths": [
         "src/db.py",
         "tests/test_app.py",
@@ -15,12 +15,10 @@
         "contracts/app.schema.json"
       ],
       "id": "app-structural-impact",
-      "impact_context_path_count": 7,
+      "impact_context_path_count": 5,
       "impact_paths": [
         "src/app.py",
         "tests/test_app.py",
-        "merger/lenskit/tests/test_app.py",
-        "src/tests/test_app.py",
         "contracts/app.schema.json",
         "docs/app.md",
         "src/db.py"
@@ -35,19 +33,17 @@
         "src/app.py"
       ],
       "baseline_recall": 0.3333333333333333,
-      "context_path_reduction_ratio": -6.0,
+      "context_path_reduction_ratio": -4.0,
       "expected_paths": [
         "src/app.py",
         "tests/test_app.py",
         "docs/app.md"
       ],
       "id": "app-edit-reading-set",
-      "impact_context_path_count": 7,
+      "impact_context_path_count": 5,
       "impact_paths": [
         "src/app.py",
         "tests/test_app.py",
-        "merger/lenskit/tests/test_app.py",
-        "src/tests/test_app.py",
         "contracts/app.schema.json",
         "docs/app.md",
         "src/db.py"
@@ -80,8 +76,8 @@
   "metrics": {
     "baseline_mean_context_path_count": 1.0,
     "baseline_target_recall": 0.29166666666666663,
-    "context_path_reduction_ratio": -6.0,
-    "impact_mean_context_path_count": 7.0,
+    "context_path_reduction_ratio": -4.0,
+    "impact_mean_context_path_count": 5.0,
     "impact_target_recall": 1.0,
     "minimum_context_path_reduction_at_equal_or_better_recall": 0.2,
     "minimum_target_recall_advantage": 0.2,

--- a/docs/proofs/repobrief-agent-impact-context-v1-proof.md
+++ b/docs/proofs/repobrief-agent-impact-context-v1-proof.md
@@ -32,7 +32,7 @@ integritätsgeprüften RepoBrief-Adapter. Sie erzeugt keinen zweiten Index und
 - Kernartefakte mit abweichendem `run_id` oder Digest blockieren.
 - Integritätsseitig blockierte Kernartefakte blockieren die Gesamtausgabe.
 - Graphkanten behalten Richtung, Typ, Evidenzniveau und Ursprungsbeleg.
-- Heuristische Testpfade sind als `heuristic` gekennzeichnet.
+- Unbelegte heuristische Testpfade werden nicht als `related_tests` ausgegeben; Graph- und Symbolindexpfade behalten ihre Evidenztypen.
 - Keine Git-, Patch-, Shell-, Test-, PR-, Snapshot- oder Memory-Mutation.
 - Kein Reviewverdikt, Risikoscore, Coverageversprechen oder Mergefreigabe.
 
@@ -42,7 +42,7 @@ Die Tests decken ab:
 
 - Schema- und Determinismusprüfung;
 - Richtung und Evidenz der Graphkanten;
-- Trennung von Graph-, Symbolpfad- und Heuristik-Testkandidaten;
+- Beschränkung verwandter Tests auf Graph- und Symbolindex-Evidenz;
 - Edit-Context-Erstleseliste;
 - Verträge, Dokumentation und Einstiegspunkte;
 - inkohärente Bundle-Identitäten;

--- a/merger/repoground/core/agent_impact_context.py
+++ b/merger/repoground/core/agent_impact_context.py
@@ -1019,18 +1019,13 @@ def _conventional_test_candidates(
     ]
     for target_path in python_targets:
         for guess in sorted(_test_path_guesses(target_path)):
-            present = guess in known_paths
+            if guess not in known_paths:
+                continue
             candidates.append(
                 {
                     "path": guess,
-                    "evidence_type": (
-                        "symbol_index_path_match" if present else "heuristic"
-                    ),
-                    "reason": (
-                        "conventional_test_path_present_in_symbol_index"
-                        if present
-                        else "python_test_naming_convention"
-                    ),
+                    "evidence_type": "symbol_index_path_match",
+                    "reason": "conventional_test_path_present_in_symbol_index",
                 }
             )
     return candidates
@@ -1074,7 +1069,7 @@ def _related_tests(
     candidates.extend(_conventional_test_candidates(target_paths, known_paths))
     return _unique_ranked(
         candidates,
-        rank={"graph_edge": 0, "symbol_index_path_match": 1, "heuristic": 2},
+        rank={"graph_edge": 0, "symbol_index_path_match": 1},
         max_items=max_items,
     )
 

--- a/merger/repoground/core/agent_impact_refinement.py
+++ b/merger/repoground/core/agent_impact_refinement.py
@@ -120,11 +120,7 @@ def _valid_test_candidates(current: Any) -> list[dict[str, Any]]:
 
 def _suppress_heuristics(
     candidates: list[dict[str, Any]],
-    *,
-    resolved_available: bool,
 ) -> tuple[list[dict[str, Any]], int]:
-    if not resolved_available:
-        return candidates, 0
     retained = [
         item
         for item in candidates
@@ -139,10 +135,7 @@ def _ordered_related_tests(
     *,
     max_items: int,
 ) -> tuple[list[dict[str, Any]], bool, int]:
-    candidates, suppressed = _suppress_heuristics(
-        _valid_test_candidates(current),
-        resolved_available=bool(resolved),
-    )
+    candidates, suppressed = _suppress_heuristics(_valid_test_candidates(current))
     candidates.extend(resolved)
     unique: dict[tuple[str, str], dict[str, Any]] = {}
     for item in candidates:
@@ -181,18 +174,13 @@ def _read_priority(reason: Any) -> int:
 
 def _valid_first_reads(
     edit_context: Mapping[str, Any],
-    *,
-    resolved_available: bool,
 ) -> list[dict[str, Any]]:
     return [
         dict(item)
         for item in _items(edit_context.get("recommended_first_reads"))
         if isinstance(item, Mapping)
         and is_repository_relative_path(item.get("path"))
-        and not (
-            resolved_available
-            and item.get("reason") == "related_test:heuristic"
-        )
+        and item.get("reason") != "related_test:heuristic"
     ]
 
 
@@ -205,10 +193,7 @@ def _refine_first_reads(
     if not isinstance(edit_context, Mapping):
         return None
     refined = dict(edit_context)
-    reads = _valid_first_reads(
-        edit_context,
-        resolved_available=bool(resolved),
-    )
+    reads = _valid_first_reads(edit_context)
     reads.extend(
         {
             "path": item["path"],
@@ -274,7 +259,8 @@ def refine_agent_impact_context(
         {
             "resolved_query_test_candidates_added": len(resolved),
             "heuristic_test_candidates_suppressed": suppressed,
-            "heuristics_suppressed_only_with_resolved_query_tests": True,
+            "heuristics_suppressed_only_with_resolved_query_tests": False,
+            "heuristic_test_candidates_always_suppressed": True,
             "resolved_query_tests_are_graph_edges": False,
             "resolved_query_tests_establish_coverage": False,
         }

--- a/merger/repoground/tests/test_agent_impact_context.py
+++ b/merger/repoground/tests/test_agent_impact_context.py
@@ -411,7 +411,7 @@ def test_agent_impact_context_preserves_relation_direction_and_evidence() -> Non
     )
 
 
-def test_related_tests_keep_graph_symbol_and_heuristic_evidence_separate() -> None:
+def test_related_tests_require_graph_or_symbol_index_evidence() -> None:
     result = _context()
     observed = {
         (item["path"], item["evidence_type"])
@@ -420,10 +420,11 @@ def test_related_tests_keep_graph_symbol_and_heuristic_evidence_separate() -> No
 
     assert ("tests/test_app.py", "graph_edge") in observed
     assert ("tests/test_app.py", "symbol_index_path_match") in observed
-    assert (
-        "merger/repoground/tests/test_app.py",
-        "heuristic",
-    ) in observed
+    assert all(
+        item["evidence_type"] in {"graph_edge", "symbol_index_path_match"}
+        for item in result["related_tests"]
+    )
+    assert not any(item["evidence_type"] == "heuristic" for item in result["related_tests"])
     assert "test_sufficiency" in result["does_not_establish"]
     assert "test_coverage" in result["does_not_establish"]
 

--- a/merger/repoground/tests/test_agent_impact_refinement.py
+++ b/merger/repoground/tests/test_agent_impact_refinement.py
@@ -120,8 +120,9 @@ def test_refinement_keeps_strong_evidence_and_suppresses_guesses() -> None:
         refined["composition"][
             "heuristics_suppressed_only_with_resolved_query_tests"
         ]
-        is True
+        is False
     )
+    assert refined["composition"]["heuristic_test_candidates_always_suppressed"] is True
     assert refined["composition"]["resolved_query_tests_are_graph_edges"] is False
     assert refined["composition"]["resolved_query_tests_establish_coverage"] is False
     reads = refined["edit_context"]["recommended_first_reads"]
@@ -131,7 +132,7 @@ def test_refinement_keeps_strong_evidence_and_suppresses_guesses() -> None:
     ]
 
 
-def test_refinement_keeps_heuristics_without_resolved_test() -> None:
+def test_refinement_suppresses_heuristics_without_resolved_test() -> None:
     base = {
         "status": "available",
         "related_tests": [
@@ -160,11 +161,10 @@ def test_refinement_keeps_heuristics_without_resolved_test() -> None:
         max_items=20,
     )
 
-    assert refined["related_tests"] == base["related_tests"]
-    assert refined["composition"]["heuristic_test_candidates_suppressed"] == 0
-    assert refined["edit_context"]["recommended_first_reads"] == base[
-        "edit_context"
-    ]["recommended_first_reads"]
+    assert refined["related_tests"] == []
+    assert refined["composition"]["heuristic_test_candidates_suppressed"] == 1
+    assert refined["composition"]["heuristic_test_candidates_always_suppressed"] is True
+    assert refined["edit_context"]["recommended_first_reads"] == []
 
 
 def test_adapter_emits_resolved_query_test_candidate(
@@ -213,7 +213,8 @@ def test_adapter_emits_resolved_query_test_candidate(
         item for item in matches if item["evidence_type"] == "resolved_query"
     )
     assert resolved["citation_id"] == "resolved-test"
-    assert result["composition"]["heuristic_test_candidates_suppressed"] >= 1
+    assert result["composition"]["heuristic_test_candidates_suppressed"] == 0
+    assert result["composition"]["heuristic_test_candidates_always_suppressed"] is True
     assert result["mutation_boundary"]["writes"] == []
 
 


### PR DESCRIPTION
## Zweck

Härtet T007 so, dass `related_tests` nur tatsächlich belegte Kandidaten ausgibt. Reine Python-Namensheuristiken werden nicht mehr als verwandte Tests dargestellt.

## Befund

Im revisionsgebundenen Weltgewebe-Kubernetes-Pilot wurden drei `heuristic`-Testpfade ausgegeben, die im gebundenen Commit nicht existieren. Das widerspricht der T007-Akzeptanz `related_tests ... nur bei tatsächlich belegter Evidenz`.

## Änderung

- konventionelle Testkandidaten nur bei vorhandenem Symbolindex-Pfad
- Refinement unterdrückt eingehende Legacy-Heuristiken unabhängig von Query-Evidenz
- Graph-, Symbolindex- und `resolved_query`-Evidenz bleiben getrennt
- synthetische Goldset-Diagnose aktualisiert: Impact-Kontextpfade 7 → 5, Target Recall bleibt 1.0
- Proof-Wahrheitsgrenze aktualisiert

## Lokale Evidenz

- `47 passed` für Impact Context, Refinement, Adapter und Large-Call-Graph-Index
- Ruff auf geänderten Python-Dateien: grün
- RepoGround `main` war beim Branchstart exakt aktuell

Kein Default-Routing und keine Vollständigkeitsbehauptung werden dadurch autorisiert.