### PR TITLE
fix: preserve exact targets across path diversity

### DIFF
--- a/merger/repoground/core/agent_impact_context.py
+++ b/merger/repoground/core/agent_impact_context.py
@@ -373,6 +373,34 @@ def _symbol_key(symbol: Mapping[str, Any]) -> str:
     )
 
 
+def _exact_symbol_preferences(
+    ordered: list[dict[str, Any]],
+    *,
+    target_symbol: str | None,
+    target_paths: set[str],
+) -> tuple[dict[str, Any] | None, dict[str, dict[str, Any]]]:
+    folded = target_symbol.casefold() if target_symbol else None
+    if folded is None:
+        return None, {}
+
+    first_exact: dict[str, Any] | None = None
+    exact_by_path: dict[str, dict[str, Any]] = {}
+    for symbol in ordered:
+        exact, _path_match = _symbol_matches(
+            symbol,
+            folded_symbol=folded,
+            target_paths=target_paths,
+        )
+        if not exact:
+            continue
+        if first_exact is None:
+            first_exact = symbol
+        path = symbol.get("path")
+        if isinstance(path, str) and path in target_paths:
+            exact_by_path.setdefault(path, symbol)
+    return first_exact, exact_by_path
+
+
 def _select_symbols(
     ordered: list[dict[str, Any]],
     *,
@@ -394,25 +422,13 @@ def _select_symbols(
         if isinstance(path, str) and path in target_paths:
             represented_paths.add(path)
 
-    folded = target_symbol.casefold() if target_symbol else None
-    exact_by_path: dict[str, dict[str, Any]] = {}
-    first_exact: dict[str, Any] | None = None
-    if folded:
-        for symbol in ordered:
-            exact, _path_match = _symbol_matches(
-                symbol,
-                folded_symbol=folded,
-                target_paths=target_paths,
-            )
-            if not exact:
-                continue
-            if first_exact is None:
-                first_exact = symbol
-            path = symbol.get("path")
-            if isinstance(path, str) and path in target_paths:
-                exact_by_path.setdefault(path, symbol)
-        if first_exact is not None:
-            add(first_exact)
+    first_exact, exact_by_path = _exact_symbol_preferences(
+        ordered,
+        target_symbol=target_symbol,
+        target_paths=target_paths,
+    )
+    if first_exact is not None:
+        add(first_exact)
 
     for symbol in ordered:
         path = symbol.get("path")

--- a/merger/repoground/core/agent_impact_context.py
+++ b/merger/repoground/core/agent_impact_context.py
@@ -395,6 +395,8 @@ def _select_symbols(
             represented_paths.add(path)
 
     folded = target_symbol.casefold() if target_symbol else None
+    exact_by_path: dict[str, dict[str, Any]] = {}
+    first_exact: dict[str, Any] | None = None
     if folded:
         for symbol in ordered:
             exact, _path_match = _symbol_matches(
@@ -402,9 +404,15 @@ def _select_symbols(
                 folded_symbol=folded,
                 target_paths=target_paths,
             )
-            if exact:
-                add(symbol)
-                break
+            if not exact:
+                continue
+            if first_exact is None:
+                first_exact = symbol
+            path = symbol.get("path")
+            if isinstance(path, str) and path in target_paths:
+                exact_by_path.setdefault(path, symbol)
+        if first_exact is not None:
+            add(first_exact)
 
     for symbol in ordered:
         path = symbol.get("path")
@@ -413,7 +421,7 @@ def _select_symbols(
             and path in target_paths
             and path not in represented_paths
         ):
-            add(symbol)
+            add(exact_by_path.get(path, symbol))
 
     for symbol in ordered:
         add(symbol)

--- a/merger/repoground/tests/test_agent_impact_adapter.py
+++ b/merger/repoground/tests/test_agent_impact_adapter.py
@@ -394,6 +394,136 @@ def test_agent_impact_adapter_projects_coherent_call_graph_relations_in_impact_m
     assert all(item["freshness"]["status"] == "coherent" for item in call_relations)
 
 
+def test_agent_impact_adapter_keeps_later_changed_path_reachable_for_call_graph(
+    tmp_path: Path,
+) -> None:
+    adapter, bundle, _config = _impact_adapter(tmp_path)
+    root = bundle["manifest"].parent
+    symbol_path = root / "demo.python_symbol_index.json"
+    symbol_document = json.loads(symbol_path.read_text(encoding="utf-8"))
+    symbol_document["symbols"] = [
+        {
+            "id": "sym-early-1",
+            "kind": "function",
+            "name": "early_one",
+            "qualified_name": "a_many.early_one",
+            "module": "a_many",
+            "path": "src/a_many.py",
+            "start_line": 1,
+            "end_line": 2,
+            "range_ref": "file:src/a_many.py#L1-L2",
+            "decorators": [],
+        },
+        {
+            "id": "sym-early-2",
+            "kind": "function",
+            "name": "early_two",
+            "qualified_name": "a_many.early_two",
+            "module": "a_many",
+            "path": "src/a_many.py",
+            "start_line": 10,
+            "end_line": 11,
+            "range_ref": "file:src/a_many.py#L10-L11",
+            "decorators": [],
+        },
+        {
+            "id": "sym-peer",
+            "kind": "function",
+            "name": "peer",
+            "qualified_name": "peer.peer",
+            "module": "peer",
+            "path": "src/peer.py",
+            "start_line": 3,
+            "end_line": 5,
+            "range_ref": "file:src/peer.py#L3-L5",
+            "decorators": [],
+        },
+        {
+            "id": "sym-late",
+            "kind": "function",
+            "name": "late_target",
+            "qualified_name": "z_late.late_target",
+            "module": "z_late",
+            "path": "src/z_late.py",
+            "start_line": 1,
+            "end_line": 3,
+            "range_ref": "file:src/z_late.py#L1-L3",
+            "decorators": [],
+        },
+    ]
+    symbol_path.write_text(json.dumps(symbol_document) + "\n", encoding="utf-8")
+    _seal_existing_artifact(bundle, "python_symbol_index_json")
+
+    call_graph_path = root / "demo.python_call_graph.json"
+    call_graph = json.loads(call_graph_path.read_text(encoding="utf-8"))
+    call_graph.update(
+        {
+            "call_count": 1,
+            "resolution_counts": {
+                "resolved": 1,
+                "candidate": 0,
+                "ambiguous": 0,
+                "unresolved": 0,
+            },
+            "evidence_counts": {"S0": 0, "S1": 1},
+            "relation_counts": {"calls": 1, "constructs": 0},
+            "calls": [
+                {
+                    "path": "src/peer.py",
+                    "start_line": 4,
+                    "start_col": 4,
+                    "end_line": 4,
+                    "end_col": 20,
+                    "range_ref": "file:src/peer.py#L4-L4",
+                    "callee_expression": "late_target",
+                    "simple_name": "late_target",
+                    "caller_scope": "symbol",
+                    "caller_symbol_id": "sym-peer",
+                    "caller_qualified_name": "peer.peer",
+                    "caller_kind": "function",
+                    "caller_start_line": 3,
+                    "caller_end_line": 5,
+                    "relation_type": "calls",
+                    "evidence_level": "S1",
+                    "resolution_status": "resolved",
+                    "resolution_reason": "unique_symbol_resolution",
+                    "resolved_target_ids": ["sym-late"],
+                    "candidate_target_ids": [],
+                }
+            ],
+        }
+    )
+    call_graph_path.write_text(json.dumps(call_graph) + "\n", encoding="utf-8")
+    _seal_existing_artifact(bundle, "python_call_graph_json")
+
+    result = adapter.agent_impact_context(
+        "demo",
+        changed_paths=["src/a_many.py", "src/z_late.py"],
+        mode="impact",
+        max_items=2,
+        include_query_context=False,
+    )
+
+    assert [item["id"] for item in result["target_symbols"]] == [
+        "sym-early-1",
+        "sym-late",
+    ]
+    assert result["call_graph_projection"]["selected_call_count"] == 1
+    call_relations = [
+        item
+        for item in result["relations"]
+        if isinstance(item.get("freshness"), dict)
+        and item["freshness"].get("source") == "python_call_graph_json"
+    ]
+    assert len(call_relations) == 1
+    relation = call_relations[0]
+    assert relation["relation_kind"] == "direct_caller"
+    assert relation["symbol_id"] == "sym-peer"
+    assert relation["target_symbol_ids"] == ["sym-late"]
+    assert relation["evidence_level"] == "S1"
+    assert relation["resolution_status"] == "resolved"
+    assert relation["freshness"]["status"] == "coherent"
+
 
 def test_agent_impact_adapter_dispatches_and_validates_arguments(
     tmp_path: Path,

--- a/merger/repoground/tests/test_agent_impact_adapter.py
+++ b/merger/repoground/tests/test_agent_impact_adapter.py
@@ -394,7 +394,7 @@ def test_agent_impact_adapter_projects_coherent_call_graph_relations_in_impact_m
     assert all(item["freshness"]["status"] == "coherent" for item in call_relations)
 
 
-def test_agent_impact_adapter_keeps_later_changed_path_reachable_for_call_graph(
+def test_agent_impact_adapter_keeps_exact_later_path_reachable_for_call_graph(
     tmp_path: Path,
 ) -> None:
     adapter, bundle, _config = _impact_adapter(tmp_path)
@@ -403,10 +403,10 @@ def test_agent_impact_adapter_keeps_later_changed_path_reachable_for_call_graph(
     symbol_document = json.loads(symbol_path.read_text(encoding="utf-8"))
     symbol_document["symbols"] = [
         {
-            "id": "sym-early-1",
+            "id": "sym-early-exact",
             "kind": "function",
-            "name": "early_one",
-            "qualified_name": "a_many.early_one",
+            "name": "needle",
+            "qualified_name": "a_many.needle",
             "module": "a_many",
             "path": "src/a_many.py",
             "start_line": 1,
@@ -439,15 +439,27 @@ def test_agent_impact_adapter_keeps_later_changed_path_reachable_for_call_graph(
             "decorators": [],
         },
         {
-            "id": "sym-late",
+            "id": "sym-late-non-target",
             "kind": "function",
-            "name": "late_target",
-            "qualified_name": "z_late.late_target",
+            "name": "alpha",
+            "qualified_name": "z_late.alpha",
             "module": "z_late",
             "path": "src/z_late.py",
             "start_line": 1,
+            "end_line": 1,
+            "range_ref": "file:src/z_late.py#L1-L1",
+            "decorators": [],
+        },
+        {
+            "id": "sym-late",
+            "kind": "function",
+            "name": "needle",
+            "qualified_name": "z_late.needle",
+            "module": "z_late",
+            "path": "src/z_late.py",
+            "start_line": 2,
             "end_line": 3,
-            "range_ref": "file:src/z_late.py#L1-L3",
+            "range_ref": "file:src/z_late.py#L2-L3",
             "decorators": [],
         },
     ]
@@ -469,25 +481,25 @@ def test_agent_impact_adapter_keeps_later_changed_path_reachable_for_call_graph(
             "relation_counts": {"calls": 1, "constructs": 0},
             "calls": [
                 {
-                    "path": "src/peer.py",
-                    "start_line": 4,
+                    "path": "src/z_late.py",
+                    "start_line": 3,
                     "start_col": 4,
-                    "end_line": 4,
-                    "end_col": 20,
-                    "range_ref": "file:src/peer.py#L4-L4",
-                    "callee_expression": "late_target",
-                    "simple_name": "late_target",
+                    "end_line": 3,
+                    "end_col": 10,
+                    "range_ref": "file:src/z_late.py#L3-L3",
+                    "callee_expression": "peer",
+                    "simple_name": "peer",
                     "caller_scope": "symbol",
-                    "caller_symbol_id": "sym-peer",
-                    "caller_qualified_name": "peer.peer",
+                    "caller_symbol_id": "sym-late",
+                    "caller_qualified_name": "z_late.needle",
                     "caller_kind": "function",
-                    "caller_start_line": 3,
-                    "caller_end_line": 5,
+                    "caller_start_line": 2,
+                    "caller_end_line": 3,
                     "relation_type": "calls",
                     "evidence_level": "S1",
                     "resolution_status": "resolved",
                     "resolution_reason": "unique_symbol_resolution",
-                    "resolved_target_ids": ["sym-late"],
+                    "resolved_target_ids": ["sym-peer"],
                     "candidate_target_ids": [],
                 }
             ],
@@ -498,6 +510,7 @@ def test_agent_impact_adapter_keeps_later_changed_path_reachable_for_call_graph(
 
     result = adapter.agent_impact_context(
         "demo",
+        target_symbol="needle",
         changed_paths=["src/a_many.py", "src/z_late.py"],
         mode="impact",
         max_items=2,
@@ -505,7 +518,7 @@ def test_agent_impact_adapter_keeps_later_changed_path_reachable_for_call_graph(
     )
 
     assert [item["id"] for item in result["target_symbols"]] == [
-        "sym-early-1",
+        "sym-early-exact",
         "sym-late",
     ]
     assert result["call_graph_projection"]["selected_call_count"] == 1
@@ -517,7 +530,7 @@ def test_agent_impact_adapter_keeps_later_changed_path_reachable_for_call_graph(
     ]
     assert len(call_relations) == 1
     relation = call_relations[0]
-    assert relation["relation_kind"] == "direct_caller"
+    assert relation["relation_kind"] == "direct_callee"
     assert relation["symbol_id"] == "sym-peer"
     assert relation["target_symbol_ids"] == ["sym-late"]
     assert relation["evidence_level"] == "S1"

--- a/merger/repoground/tests/test_agent_impact_context.py
+++ b/merger/repoground/tests/test_agent_impact_context.py
@@ -472,6 +472,27 @@ def test_target_symbols_prioritize_an_exact_symbol_before_path_diversity() -> No
     assert result["target"]["paths"] == [test_path, source_path]
 
 
+def test_target_symbol_path_diversity_prefers_exact_match_on_each_path() -> None:
+    paths = ["src/a.py", "src/b.py"]
+    symbols = [
+        _selection_symbol("exact-a", path=paths[0], name="needle", line=1),
+        _selection_symbol("non-target-b", path=paths[1], name="alpha", line=1),
+        _selection_symbol("exact-b", path=paths[1], name="needle", line=2),
+    ]
+
+    result = _selection_context(
+        symbols,
+        changed_paths=paths,
+        target_symbol="needle",
+        max_items=2,
+    )
+
+    assert [item["id"] for item in result["target_symbols"]] == [
+        "exact-a",
+        "exact-b",
+    ]
+
+
 def test_target_symbol_path_diversity_is_deterministic_when_paths_exceed_budget() -> None:
     paths = ["src/c.py", "src/a.py", "src/b.py"]
     symbols = [


### PR DESCRIPTION
## Summary

Hardens the target-symbol path-diversity selection merged in #1075.

When an explicit target symbol has exact matches on multiple changed paths, the diversity pass now prefers that path's exact match instead of an earlier unrelated symbol from the same path. This keeps bounded call-graph projection aligned with the user's explicit symbol target while preserving deterministic per-path representation.

Also adds an adapter-level regression proving that a lexically later changed Python path remains reachable through bounded call-graph projection and can contribute coherent S1 evidence.

## Why

A read-only T003 Deployment/Kubernetes reproduction showed that bounded symbol selection could starve `scripts/platform/kind_reference.py` before call-graph projection. The exact bound 22.4 MB call graph contains coherent S1/resolved relations for that path. #1075 fixed the general path-starvation shape, but an independent review found a remaining collision case: on a represented path, an earlier non-target symbol could still displace an exact match for the explicitly requested symbol.

This PR closes that edge case without widening artifact limits or changing evidence/freshness semantics.

## Validation

- 53 focused impact/adapter/call-graph tests passed
- Ruff passed on changed Python files
- `git diff --check` passed
- independent review of the pre-publication full diff: PASS after fixing the exact-match collision blocker
- adapter integration regression distinguishes the old lexical truncation from the hardened selector

## Scope boundaries

This does not establish complete call-graph coverage, runtime reachability, dynamic dispatch resolution, test sufficiency, or T003 default-promotion readiness. T003 still separately lacks contract-chain, executed-runtime-proof, and rollback/recovery-risk evidence.