### PR TITLE
fix: prioritize causal evidence under byte budgets

### DIFF
--- a/merger/repoground/core/agent_impact_context.py
+++ b/merger/repoground/core/agent_impact_context.py
@@ -1596,7 +1596,10 @@ def _select_impact_relations(
         selected = combined[:max_items]
         return selected, len(combined) > len(selected)
 
-    selected = [architecture_relations[0], call_relations[0]]
+    # Put coherent call evidence first so downstream byte-bounded consumers
+    # retain the more specific causal relation when only one relation fits.
+    # The max_items == 1 branch above intentionally preserves legacy behavior.
+    selected = [call_relations[0], architecture_relations[0]]
     remaining = max_items - len(selected)
     if remaining > 0:
         selected.extend(architecture_relations[1 : 1 + remaining])

--- a/merger/repoground/tests/test_agent_impact_context.py
+++ b/merger/repoground/tests/test_agent_impact_context.py
@@ -618,6 +618,7 @@ def test_impact_context_preserves_source_diversity_when_relations_are_bounded() 
     assert len(result["relations"]) == 2
     assert len(architecture_relations) == 1
     assert len(call_relations) == 1
+    assert result["relations"][0] == call_relations[0]
     assert call_relations[0]["freshness"]["status"] == "coherent"
     assert result["truncation"]["relations"] is True
 


### PR DESCRIPTION
## Summary
- keep the legacy architecture-first behavior when the producer itself is limited to exactly one relation
- when both architecture and coherent call-graph evidence are available with max_items >= 2, order the call relation first and architecture second
- preserve source diversity while allowing downstream byte-budget minimum coverage to retain the more specific causal evidence

## Validation
- focused impact suites: 61 passed
- full RepoGround suite: 4457 passed, 2 skipped
- Ruff: passed
- git diff --check: passed
- real PR-1458 adapter probe: target symbols start with test load_module and scripts/platform/kind_reference.py::ProofError; relations now start with coherent python_call_graph_json then architecture import

## Compatibility
The max_items=1 producer contract remains architecture-first exactly as before. This does not establish complete call-graph coverage, runtime reachability, test sufficiency, or language-agnostic graph coverage.