### PR TITLE
fix: cover cross-language impact paths and changed tests

### DIFF
--- a/merger/repoground/architecture/graph_maintainability.py
+++ b/merger/repoground/architecture/graph_maintainability.py
@@ -26,7 +26,11 @@ def measure_graph_maintainability(repo_root: Path) -> dict[str, Any]:
         "maintainability",
         "0" * 64,
     )
-    file_nodes = [node for node in graph["nodes"] if node["kind"] == "file"]
+    file_nodes = [
+        node
+        for node in graph["nodes"]
+        if node["kind"] == "file" and node.get("language") == "python"
+    ]
     external_nodes = [node for node in graph["nodes"] if node["kind"] == "external"]
     projected: dict[str, list[dict[str, Any]]] = defaultdict(list)
     for node in file_nodes:

--- a/merger/repoground/architecture/import_graph.py
+++ b/merger/repoground/architecture/import_graph.py
@@ -1,5 +1,6 @@
 """
-Extracts a Python import graph via static AST analysis.
+Extracts a bounded repository file graph with Python import edges via static
+AST analysis.
 
 Resolver boundaries (S1 heuristic):
 - This artifact is static evidence and does not represent runtime causality.
@@ -31,6 +32,22 @@ from merger.repoground.architecture.path_classification import (
 logger = logging.getLogger(__name__)
 
 _SKIP_DIRECTORIES = {"__pycache__", "env", "node_modules", "venv"}
+_GRAPH_SKIP_DIRECTORIES = _SKIP_DIRECTORIES | {"build", "dist", "target"}
+_GRAPH_FILE_LANGUAGES = {
+    ".js": "javascript",
+    ".json": "json",
+    ".jsx": "javascript",
+    ".md": "markdown",
+    ".py": "python",
+    ".rs": "rust",
+    ".sql": "sql",
+    ".svelte": "svelte",
+    ".toml": "toml",
+    ".ts": "typescript",
+    ".tsx": "typescript",
+    ".yaml": "yaml",
+    ".yml": "yaml",
+}
 
 
 class SourceRootError(ValueError):
@@ -88,6 +105,25 @@ def _is_test_file(path: str) -> bool:
 
 def _infer_layer(path: str) -> str:
     return infer_architecture_layer(path)
+
+
+def _iter_graph_files(repo_root: Path) -> list[Path]:
+    paths: list[Path] = []
+    for root, dirs, files in os.walk(repo_root):
+        dirs[:] = sorted(
+            directory
+            for directory in dirs
+            if (not directory.startswith(".") or directory == ".github")
+            and directory not in _GRAPH_SKIP_DIRECTORIES
+        )
+        for filename in sorted(files):
+            file_path = Path(root) / filename
+            if file_path.suffix.lower() not in _GRAPH_FILE_LANGUAGES:
+                continue
+            if filename.endswith(".graph.json"):
+                continue
+            paths.append(file_path)
+    return paths
 
 
 def _iter_python_files(repo_root: Path) -> list[Path]:
@@ -315,18 +351,46 @@ def generate_import_graph_document(
     *,
     source_roots: Sequence[str] = (),
 ) -> GraphDocument:
-    """Build a deterministic static Python import graph for ``repo_root``."""
+    """Build a deterministic repository file graph with static Python import edges."""
 
     nodes: dict[str, Node] = {}
     edges: list[Edge] = []
     files_parsed = 0
     normalized_source_roots = _normalize_source_roots(repo_root, source_roots)
+    graph_files = _iter_graph_files(repo_root)
     python_files = _iter_python_files(repo_root)
+    inventory_files = [
+        path
+        for path in graph_files
+        if path.suffix.lower() != ".py"
+    ]
     module_index = _build_local_module_index(
         repo_root,
         python_files,
         normalized_source_roots,
     )
+
+    for file_path in inventory_files:
+        relative_path = file_path.relative_to(repo_root).as_posix()
+        try:
+            size_bytes = file_path.stat().st_size
+        except OSError as exc:
+            logger.warning("Could not stat graph file %s: %s", relative_path, exc)
+            continue
+        node_id = f"file:{relative_path}"
+        nodes[node_id] = {
+            "node_id": node_id,
+            "kind": "file",
+            "path": relative_path,
+            "repo": "",
+            "language": _GRAPH_FILE_LANGUAGES.get(
+                file_path.suffix.lower(),
+                "python",
+            ),
+            "layer": _infer_layer(relative_path),
+            "is_test": _is_test_file(relative_path),
+            "size_bytes": size_bytes,
+        }
 
     for file_path in python_files:
         relative_path = file_path.relative_to(repo_root).as_posix()
@@ -339,7 +403,7 @@ def generate_import_graph_document(
             continue
 
         node_id = f"file:{relative_path}"
-        file_node: Node = {
+        nodes[node_id] = {
             "node_id": node_id,
             "kind": "file",
             "path": relative_path,
@@ -349,7 +413,6 @@ def generate_import_graph_document(
             "is_test": _is_test_file(relative_path),
             "size_bytes": file_path.stat().st_size,
         }
-        nodes[node_id] = file_node
 
         for syntax_node in ast.walk(tree):
             if isinstance(syntax_node, ast.Import):

--- a/merger/repoground/architecture/import_graph.py
+++ b/merger/repoground/architecture/import_graph.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import ast
 import logging
 import os
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal, TypedDict
@@ -124,6 +124,60 @@ def _iter_graph_files(repo_root: Path) -> list[Path]:
                 continue
             paths.append(file_path)
     return paths
+
+
+def _iter_inventory_files(repo_root: Path) -> list[Path]:
+    return [
+        path
+        for path in _iter_graph_files(repo_root)
+        if path.suffix.lower() != ".py"
+    ]
+
+
+def _iter_parsed_python_files(
+    repo_root: Path,
+    python_files: list[Path],
+) -> Iterator[tuple[Path, str, ast.AST]]:
+    for file_path in python_files:
+        relative_path = file_path.relative_to(repo_root).as_posix()
+        try:
+            content = file_path.read_text(encoding="utf-8")
+            tree = ast.parse(content, filename=relative_path)
+        except Exception as exc:
+            logger.warning("Could not parse AST for %s: %s", relative_path, exc)
+            continue
+        yield file_path, relative_path, tree
+
+
+def _inventory_file_node(repo_root: Path, file_path: Path) -> Node | None:
+    relative_path = file_path.relative_to(repo_root).as_posix()
+    try:
+        size_bytes = file_path.stat().st_size
+    except OSError as exc:
+        logger.warning("Could not stat graph file %s: %s", relative_path, exc)
+        return None
+    node_id = f"file:{relative_path}"
+    return {
+        "node_id": node_id,
+        "kind": "file",
+        "path": relative_path,
+        "repo": "",
+        "language": _GRAPH_FILE_LANGUAGES[file_path.suffix.lower()],
+        "layer": _infer_layer(relative_path),
+        "is_test": _is_test_file(relative_path),
+        "size_bytes": size_bytes,
+    }
+
+
+def _add_inventory_file_nodes(
+    nodes: dict[str, Node],
+    repo_root: Path,
+    inventory_files: list[Path],
+) -> None:
+    for file_path in inventory_files:
+        node = _inventory_file_node(repo_root, file_path)
+        if node is not None:
+            nodes[node["node_id"]] = node
 
 
 def _iter_python_files(repo_root: Path) -> list[Path]:
@@ -357,51 +411,21 @@ def generate_import_graph_document(
     edges: list[Edge] = []
     files_parsed = 0
     normalized_source_roots = _normalize_source_roots(repo_root, source_roots)
-    graph_files = _iter_graph_files(repo_root)
     python_files = _iter_python_files(repo_root)
-    inventory_files = [
-        path
-        for path in graph_files
-        if path.suffix.lower() != ".py"
-    ]
+    inventory_files = _iter_inventory_files(repo_root)
     module_index = _build_local_module_index(
         repo_root,
         python_files,
         normalized_source_roots,
     )
 
-    for file_path in inventory_files:
-        relative_path = file_path.relative_to(repo_root).as_posix()
-        try:
-            size_bytes = file_path.stat().st_size
-        except OSError as exc:
-            logger.warning("Could not stat graph file %s: %s", relative_path, exc)
-            continue
-        node_id = f"file:{relative_path}"
-        nodes[node_id] = {
-            "node_id": node_id,
-            "kind": "file",
-            "path": relative_path,
-            "repo": "",
-            "language": _GRAPH_FILE_LANGUAGES.get(
-                file_path.suffix.lower(),
-                "python",
-            ),
-            "layer": _infer_layer(relative_path),
-            "is_test": _is_test_file(relative_path),
-            "size_bytes": size_bytes,
-        }
+    _add_inventory_file_nodes(nodes, repo_root, inventory_files)
 
-    for file_path in python_files:
-        relative_path = file_path.relative_to(repo_root).as_posix()
-        try:
-            content = file_path.read_text(encoding="utf-8")
-            tree = ast.parse(content, filename=relative_path)
-            files_parsed += 1
-        except Exception as exc:
-            logger.warning("Could not parse AST for %s: %s", relative_path, exc)
-            continue
-
+    for file_path, relative_path, tree in _iter_parsed_python_files(
+        repo_root,
+        python_files,
+    ):
+        files_parsed += 1
         node_id = f"file:{relative_path}"
         nodes[node_id] = {
             "node_id": node_id,

--- a/merger/repoground/architecture/path_classification.py
+++ b/merger/repoground/architecture/path_classification.py
@@ -20,6 +20,7 @@ _PRODUCT_LAYER_BY_SEGMENT = {
 }
 _SCRIPT_SEGMENTS = {"scripts", "tools"}
 _TEST_SEGMENTS = {"test", "tests"}
+_TEST_NAME_SUFFIXES = {".js", ".jsx", ".py", ".rs", ".svelte", ".ts", ".tsx"}
 
 
 def _path(path: str) -> PurePosixPath:
@@ -28,9 +29,14 @@ def _path(path: str) -> PurePosixPath:
 
 def is_test_path(path: str) -> bool:
     parsed = _path(path)
+    name = parsed.name.lower()
+    suffix = parsed.suffix.lower()
+    marked_test_name = suffix in _TEST_NAME_SUFFIXES and (
+        ".test." in name or ".spec." in name or "_test." in name
+    )
     return (
-        parsed.name.startswith("test_")
-        or parsed.name.endswith("_test.py")
+        name.startswith("test_")
+        or marked_test_name
         or bool(set(parsed.parts).intersection(_TEST_SEGMENTS))
     )
 

--- a/merger/repoground/core/agent_impact_context.py
+++ b/merger/repoground/core/agent_impact_context.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass
 from pathlib import PurePosixPath
 from typing import Any
 
+from merger.repoground.architecture.path_classification import is_test_path as _is_test_path
+
 KIND = "repobrief.agent_impact_context"
 VERSION = "1.0"
 MODES = ("impact", "edit")
@@ -297,16 +299,6 @@ def _coherence(
         }
     )
     return "unknown", None, None, gaps
-
-
-def _is_test_path(path: str) -> bool:
-    name = PurePosixPath(path).name
-    return (
-        "/tests/" in f"/{path}"
-        or path.startswith("tests/")
-        or name.startswith("test_")
-        or name.endswith("_test.py")
-    )
 
 
 def _path_class(path: str) -> str:
@@ -1131,6 +1123,20 @@ def _unique_ranked(
     return ordered[:max_items], len(ordered) > max_items
 
 
+def _changed_test_candidates(
+    target_paths: set[str],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "path": path,
+            "evidence_type": "changed_test_path",
+            "reason": "changed_path_is_test",
+        }
+        for path in sorted(target_paths)
+        if _is_test_path(path)
+    ]
+
+
 def _related_tests(
     *,
     target_paths: set[str],
@@ -1143,11 +1149,16 @@ def _related_tests(
         for item in _items(symbol_index.get("symbols"))
         if isinstance(item, Mapping) and isinstance(item.get("path"), str)
     }
-    candidates = _graph_test_candidates(all_relations)
+    candidates = _changed_test_candidates(target_paths)
+    candidates.extend(_graph_test_candidates(all_relations))
     candidates.extend(_conventional_test_candidates(target_paths, known_paths))
     return _unique_ranked(
         candidates,
-        rank={"graph_edge": 0, "symbol_index_path_match": 1},
+        rank={
+            "changed_test_path": 0,
+            "graph_edge": 1,
+            "symbol_index_path_match": 2,
+        },
         max_items=max_items,
     )
 

--- a/merger/repoground/core/agent_impact_refinement.py
+++ b/merger/repoground/core/agent_impact_refinement.py
@@ -11,11 +11,14 @@ from copy import deepcopy
 from pathlib import PurePosixPath
 from typing import Any
 
+from merger.repoground.architecture.path_classification import is_test_path as _is_test_path
+
 _EVIDENCE_RANK = {
-    "graph_edge": 0,
-    "symbol_index_path_match": 1,
-    "resolved_query": 2,
-    "heuristic": 3,
+    "changed_test_path": 0,
+    "graph_edge": 1,
+    "symbol_index_path_match": 2,
+    "resolved_query": 3,
+    "heuristic": 4,
 }
 
 
@@ -46,16 +49,6 @@ def is_repository_relative_path(value: Any) -> bool:
         return False
     path = PurePosixPath(text)
     return bool(path.parts)
-
-
-def _is_test_path(path: str) -> bool:
-    name = PurePosixPath(path).name
-    return (
-        "/tests/" in f"/{path}"
-        or path.startswith("tests/")
-        or name.startswith("test_")
-        or name.endswith("_test.py")
-    )
 
 
 def _query_items(query_context: Any) -> list[dict[str, Any]]:
@@ -159,17 +152,19 @@ def _read_priority(reason: Any) -> int:
         return 1
     if text.endswith("_graph_relation"):
         return 2
-    if text == "related_test:graph_edge":
+    if text == "related_test:changed_test_path":
         return 3
-    if text == "related_test:symbol_index_path_match":
+    if text == "related_test:graph_edge":
         return 4
-    if text == "related_test:resolved_query":
+    if text == "related_test:symbol_index_path_match":
         return 5
-    if text == "related_test:heuristic":
+    if text == "related_test:resolved_query":
         return 6
-    if text.startswith("supporting_"):
+    if text == "related_test:heuristic":
         return 7
-    return 8
+    if text.startswith("supporting_"):
+        return 8
+    return 9
 
 
 def _valid_first_reads(

--- a/merger/repoground/tests/test_agent_impact_context.py
+++ b/merger/repoground/tests/test_agent_impact_context.py
@@ -577,6 +577,37 @@ def test_related_tests_require_graph_or_symbol_index_evidence() -> None:
     assert "test_coverage" in result["does_not_establish"]
 
 
+def test_changed_cross_language_test_paths_are_related_test_evidence() -> None:
+    result = _selection_context(
+        [],
+        changed_paths=[
+            "apps/web/src/lib/map/searchIndex.ts",
+            "apps/web/src/lib/map/searchIndex.test.ts",
+            "apps/api/tests/db_passkey_store_persistence.rs",
+        ],
+        max_items=10,
+    )
+
+    observed = {
+        (item["path"], item["evidence_type"], item.get("reason"))
+        for item in result["related_tests"]
+    }
+    assert (
+        "apps/web/src/lib/map/searchIndex.test.ts",
+        "changed_test_path",
+        "changed_path_is_test",
+    ) in observed
+    assert (
+        "apps/api/tests/db_passkey_store_persistence.rs",
+        "changed_test_path",
+        "changed_path_is_test",
+    ) in observed
+    assert not any(
+        item["path"].endswith("searchIndex.ts")
+        for item in result["related_tests"]
+    )
+
+
 def test_edit_context_bundles_target_support_and_entrypoint_reads() -> None:
     result = _context()
     support = {

--- a/merger/repoground/tests/test_agent_impact_refinement.py
+++ b/merger/repoground/tests/test_agent_impact_refinement.py
@@ -55,6 +55,76 @@ def test_resolved_query_candidates_keep_navigation_authority() -> None:
     ]
 
 
+def test_resolved_query_candidates_recognize_cross_language_test_names() -> None:
+    candidates = resolved_query_test_candidates(
+        _query_context(
+            {
+                "path": "apps/web/src/lib/map/nodes.test.ts",
+                "citation_id": "citation-ts-test",
+                "range_status": "resolved",
+            },
+            {
+                "path": "apps/web/src/lib/map/nodes.ts",
+                "citation_id": "citation-ts-source",
+            },
+        )
+    )
+
+    assert [item["path"] for item in candidates] == [
+        "apps/web/src/lib/map/nodes.test.ts"
+    ]
+
+
+def test_refinement_prioritizes_changed_test_path_evidence() -> None:
+    base = {
+        "status": "available",
+        "related_tests": [
+            {
+                "path": "apps/web/src/lib/map/nodes.test.ts",
+                "evidence_type": "changed_test_path",
+                "reason": "changed_path_is_test",
+            },
+            {
+                "path": "tests/test_graph.py",
+                "evidence_type": "graph_edge",
+            },
+        ],
+        "truncation": {"related_tests": False},
+        "composition": {},
+        "edit_context": {
+            "recommended_first_reads": [
+                {
+                    "path": "src/target.py",
+                    "range_ref": None,
+                    "qualified_name": None,
+                    "reason": "target_path",
+                },
+                {
+                    "path": "apps/web/src/lib/map/nodes.test.ts",
+                    "range_ref": None,
+                    "qualified_name": None,
+                    "reason": "related_test:changed_test_path",
+                },
+            ],
+            "related_test_count": 2,
+        },
+    }
+
+    refined = refine_agent_impact_context(base, _query_context(), max_items=20)
+
+    assert [item["evidence_type"] for item in refined["related_tests"]] == [
+        "changed_test_path",
+        "graph_edge",
+    ]
+    assert [
+        item["reason"]
+        for item in refined["edit_context"]["recommended_first_reads"]
+    ] == [
+        "target_path",
+        "related_test:changed_test_path",
+    ]
+
+
 def test_refinement_keeps_strong_evidence_and_suppresses_guesses() -> None:
     base = {
         "status": "available",

--- a/merger/repoground/tests/test_architecture_import_graph.py
+++ b/merger/repoground/tests/test_architecture_import_graph.py
@@ -167,6 +167,49 @@ def test_ambiguous_local_module_name_remains_external(tmp_path):
     assert ("file:consumer.py", "file:foo/__init__.py") not in edges
 
 
+def test_graph_includes_bounded_cross_language_file_inventory(tmp_path):
+    files = {
+        ".github/workflows/ci.yml": "name: ci\n",
+        "apps/api/migrations/001.sql": "select 1;\n",
+        "apps/api/src/lib.rs": "pub fn run() {}\n",
+        "apps/web/src/Component.svelte": "<div />\n",
+        "apps/web/src/Component.test.ts": "test('x', () => {})\n",
+        "docs/guide.md": "# Guide\n",
+        "config/settings.toml": "enabled = true\n",
+        "build/legacy.py": "import os\n",
+        ".cache/ignored.ts": "export const ignored = true\n",
+        "vendor.bin": "ignored\n",
+    }
+    for relative, content in files.items():
+        target = tmp_path / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+
+    doc = generate_import_graph_document(tmp_path, "run", "0" * 64)
+    nodes = {item["path"]: item for item in doc["nodes"] if item["kind"] == "file"}
+
+    assert nodes[".github/workflows/ci.yml"]["language"] == "yaml"
+    assert nodes["apps/api/migrations/001.sql"]["language"] == "sql"
+    assert nodes["apps/api/src/lib.rs"]["language"] == "rust"
+    assert nodes["apps/web/src/Component.svelte"]["language"] == "svelte"
+    assert nodes["apps/web/src/Component.test.ts"]["language"] == "typescript"
+    assert nodes["apps/web/src/Component.test.ts"]["is_test"] is True
+    assert nodes["docs/guide.md"]["language"] == "markdown"
+    assert nodes["config/settings.toml"]["language"] == "toml"
+    assert nodes["build/legacy.py"]["language"] == "python"
+    assert ".cache/ignored.ts" not in nodes
+    assert "vendor.bin" not in nodes
+    non_python_ids = {
+        f"file:{path}"
+        for path, node in nodes.items()
+        if node.get("language") != "python"
+    }
+    assert not any(
+        edge["src"] in non_python_ids or edge["dst"] in non_python_ids
+        for edge in doc["edges"]
+    )
+
+
 def test_test_directory_layer_precedes_nested_core_segment(tmp_path):
     target = tmp_path / "tests" / "core" / "service.py"
     target.parent.mkdir(parents=True)

--- a/merger/repoground/tests/test_path_classification.py
+++ b/merger/repoground/tests/test_path_classification.py
@@ -1,5 +1,6 @@
 from merger.repoground.architecture.path_classification import (
     infer_architecture_layer,
+    is_test_path,
     path_projection,
 )
 
@@ -28,3 +29,11 @@ def test_architecture_layers_identify_lenskit_product_areas() -> None:
 
 def test_generic_unmatched_product_path_remains_unknown() -> None:
     assert infer_architecture_layer("src/domain.py") == "unknown"
+
+
+def test_cross_language_test_filenames_are_recognized() -> None:
+    assert is_test_path("apps/web/src/lib/map/nodes.test.ts")
+    assert is_test_path("apps/web/src/lib/map/nodes.spec.ts")
+    assert is_test_path("apps/api/src/store_test.rs")
+    assert is_test_path("apps/api/tests/store.rs")
+    assert not is_test_path("apps/web/src/lib/map/nodes.ts")


### PR DESCRIPTION
## Summary
- add bounded cross-language file inventory nodes for common source, test, config, contract and documentation formats while keeping causal import edges Python-only
- preserve existing Python parse-failure semantics and Python graph maintainability ratchets
- unify test-path classification across architecture, impact context and refinement for .test.*, .spec.* and _test.* code files
- treat changed test files as direct, explicit related-test evidence without claiming test coverage or runtime causality

## Validation
- focused current-main overlap suite: 86 passed
- full RepoGround suite on current base 056f9ae8: 4464 passed, 2 skipped
- Ruff: passed
- git diff --check: passed
- production-like Weltgewebe four-case probe: database/auth, web/map, deployment/kubernetes and controlled live case all receive changed-test evidence and no longer report target_path_not_present_as_graph_node for supported file types
- Weltgewebe graph prototype: about 1016 nodes / 1636 Python import edges, generation under one second; no cross-language causal edges invented

## Boundaries
This improves navigation and direct changed-test evidence only. It does not establish cross-language causal relations, symbol coverage for non-Python languages, executed test sufficiency, runtime correctness, contract proof or rollback safety.