### PR TITLE
fix: prioritize RepoGround self-publication

### DIFF
--- a/merger/repoground/tests/test_fleet_runtime.py
+++ b/merger/repoground/tests/test_fleet_runtime.py
@@ -643,6 +643,49 @@ def test_generation_environment_redirects_runtime_artifacts(tmp_path: Path) -> N
         assert Path(env[key]).is_dir()
 
 
+def test_generator_repository_is_prioritized_without_reordering_other_entries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = load_publisher()
+    entries = [
+        module.RepoEntry(
+            key=key,
+            owner=key.split("/", 1)[0],
+            repo=key.split("/", 1)[1],
+            path=Path("/tmp") / key.split("/", 1)[1],
+            remote=f"git@github.com:{key}.git",
+        )
+        for key in (
+            "heimgewebe/alpha",
+            "heimgewebe/beta",
+            "heimgewebe/repoground",
+            "heimgewebe/zeta",
+        )
+    ]
+    monkeypatch.setattr(
+        module, "generator_repository_key", lambda: "heimgewebe/repoground"
+    )
+
+    prioritized = module.prioritize_generator_repository(entries)
+
+    assert [entry.key for entry in prioritized] == [
+        "heimgewebe/repoground",
+        "heimgewebe/alpha",
+        "heimgewebe/beta",
+        "heimgewebe/zeta",
+    ]
+
+
+def test_generator_repository_priority_is_applied_before_publication_loop() -> None:
+    source = PUBLISHER.read_text(encoding="utf-8")
+    inventory_return = source.index("if args.inventory:")
+    priority = source.index("entries = prioritize_generator_repository(entries)")
+    lock = source.index("lock = acquire_lock()", priority)
+    loop = source.index("for entry in entries:", lock)
+
+    assert inventory_return < priority < lock < loop
+
+
 def test_changed_source_hygiene_preflight_runs_before_publication_limit() -> None:
     source = PUBLISHER.read_text(encoding="utf-8")
     changed = source.index("changed += 1")

--- a/scripts/ops/repoground-publish-fleet
+++ b/scripts/ops/repoground-publish-fleet
@@ -306,6 +306,34 @@ def git_common_dir(repo: Path) -> Path:
     return (raw if raw.is_absolute() else repo / raw).resolve()
 
 
+def generator_repository_key() -> str | None:
+    remote = run(
+        ["git", "-C", str(REPOGROUND_REPO), "remote", "get-url", "origin"],
+        check=False,
+    ).stdout.strip()
+    parsed = parse_github_remote(remote)
+    if not parsed:
+        return None
+    owner, repo = parsed
+    return f"{owner}/{repo}"
+
+
+def prioritize_generator_repository(entries: list[RepoEntry]) -> list[RepoEntry]:
+    """Keep the generator repository ahead of the bounded publication backlog.
+
+    A generator-input change can invalidate every fleet fingerprint at once. The
+    per-run publication limit remains intact, but the repository supplying the
+    generator must converge in the first bounded batch so RepoGround does not
+    keep serving a stale bundle of itself while unrelated repositories drain.
+    Python's sort is stable, so discovery order for every other repository is
+    preserved.
+    """
+    generator_key = generator_repository_key()
+    if generator_key is None:
+        return list(entries)
+    return sorted(entries, key=lambda entry: entry.key != generator_key)
+
+
 def assert_managed_worktree_identity(path: Path, expected_repo: Path) -> None:
     if path.is_symlink() or not path.is_dir():
         raise RuntimeError(f"managed worktree path is not a real directory: {path}")
@@ -2128,6 +2156,8 @@ def main(argv: list[str]) -> int:
             )
         )
         return 0
+
+    entries = prioritize_generator_repository(entries)
 
     lock = acquire_lock()
     if lock is None:


### PR DESCRIPTION
## Problem
The bounded hourly fleet publisher correctly observes a newer RepoGround main commit, but broad generator-input changes invalidate all fleet fingerprints at once. With `--limit 8`, `heimgewebe/repoground` was discovered at position 31/42 and remained queued, leaving RepoGround's own canonical bundle stale while unrelated repositories drained first.

## Fix
- derive the generator repository key from the configured RepoGround repository remote;
- stably prioritize that repository before the bounded publication loop;
- preserve discovery order for every other repository;
- keep the existing per-run publication limit unchanged.

## Evidence
- live backlog before patch: `heimgewebe/repoground` source `056f9ae8524bbab5d6477c70dda9c5c79edbaa34`, status `queued`;
- current stale bundle source: `c12e6e867c0de3315b250ce5818f4331f6dbbb63`;
- live ordering probe after patch: generator repository moved from discovered index 31 to prioritized index 0 across 42 repositories;
- `python3 -m pytest -q merger/repoground/tests/test_fleet_runtime.py` -> 65 passed;
- `python3 -m ruff check scripts/ops/repoground-publish-fleet merger/repoground/tests/test_fleet_runtime.py` -> passed.

## Boundary
This fixes self-publication convergence. It intentionally does not remove the fleet publication cap or solve general fairness/latency for all queued repositories; that residual concern will be tracked separately.