### PR TITLE
fix: harden cross-language graph evidence

### DIFF
--- a/docs/architecture/graph-runtime-contract.md
+++ b/docs/architecture/graph-runtime-contract.md
@@ -17,11 +17,13 @@ Der RepoGround-Architekturgraph (`graph_index.json`) dient nicht nur der Visuali
 * **Bedeutung:** Ein Knoten repräsentiert eine strukturelle Code-Einheit. Im Standardfall entspricht dies einer Datei (File-Node). Die Granularität kann später auf Module oder Klassen erweitert werden.
 * **Identität (`node_id`):** Eindeutiger Identifier. Für Dateien wird üblicherweise `file:<path>` oder der reine `<path>` verwendet.
 * **Erreichbarkeit:** Ein Knoten gilt als erreichbar, wenn ein Pfad von mindestens einem Entrypoint zu ihm existiert.
+* **Inventarknoten:** Datei-Knoten für nicht-Pythonische Quellen können reine Inventar- und Navigationsknoten sein. Ihre Existenz belegt die Datei im gebundenen Retrieval-Snapshot, aber keine Abhängigkeit, Laufzeitkausalität oder Erreichbarkeit.
 
 ### 2.2 Edge (Kante)
 * **Bedeutung:** Eine gerichtete Kante (`src` → `dst`) repräsentiert eine Abhängigkeit.
 * **Beispiel:** `src` importiert oder ruft `dst` auf. Wenn `A` von `B` abhängt (z.B. `A` importiert `B`), zeigt die Kante von `A` nach `B`.
 * **Traversierung:** Die Traversierung für die Distanzberechnung erfolgt entlang dieser gerichteten Kanten (von den Entrypoints in die Tiefe der Abhängigkeiten).
+* **Producer-Grenze:** Der aktuelle `architecture.graph.v1`-Producer erzeugt statische Importkanten ausschließlich aus geparstem Python-AST. Cross-Language-Dateiknoten werden nicht still zu Kanten hochgestuft. Das Fehlen einer Kante für Rust, TypeScript, Svelte, SQL, YAML oder andere Inventarsprachen ist daher kein Beleg für das Fehlen einer fachlichen Abhängigkeit.
 
 ### 2.3 Entrypoint
 * **Bedeutung:** Entrypoints sind definierte Einstiegspunkte in das System (z.B. `main.py`, API-Routen, CLI-Befehle).
@@ -68,6 +70,7 @@ final_score = score_pre * current_penalty
   * `entrypoint_boost = 0.0`
 
 ### 3.3 Caps und Begrenzungen
+* Der Producer begrenzt den verarbeiteten Repository-Snapshot deterministisch auf maximal 50.000 Quelldateien und 512 MiB Quellmaterial. `coverage.repository_truncated` zeigt eine gekappte Auswahl explizit an; `repository_files_*` und `repository_bytes_*` machen Umfang und Grenze sichtbar.
 * Der Graph-Bonus ist durch die Gewichtungsfaktoren (`w_graph`, `w_entry`) strikt nach oben begrenzt.
 * Ein lexikalischer "perfect match" ohne Graph-Verbindung wird typischerweise immer noch höher gerankt als ein schwacher lexikalischer Treffer mit perfekter Graph-Verbindung, abhängig von der exakten Parameterisierung der Gewichte.
 

--- a/merger/repoground/architecture/bundle_sources.py
+++ b/merger/repoground/architecture/bundle_sources.py
@@ -12,6 +12,14 @@ from .entrypoints import generate_entrypoints_document
 from .import_graph import generate_import_graph_document
 
 
+_GRAPH_SOURCE_SUFFIXES = frozenset(
+    {
+        ".js", ".json", ".jsx", ".md", ".py", ".rs", ".sql",
+        ".svelte", ".toml", ".ts", ".tsx", ".yaml", ".yml",
+    }
+)
+
+
 class BundleGraphSourceError(RuntimeError):
     """Graph source production failed before a coherent pair was published."""
 
@@ -51,8 +59,13 @@ def _write_json_atomic(path: Path, payload: Mapping[str, Any]) -> None:
             tmp_path.unlink(missing_ok=True)
 
 
-def _eligible_python_paths(chunk_index_path: Path, repo_name: str) -> tuple[str, ...]:
-    """Return full-contact Python paths from the retrieval source surface."""
+def _eligible_source_paths(
+    chunk_index_path: Path,
+    repo_name: str,
+    *,
+    suffixes: frozenset[str],
+) -> tuple[str, ...]:
+    """Return full-contact source paths for the requested bounded suffix set."""
 
     eligibility: dict[str, bool] = {}
     try:
@@ -75,10 +88,15 @@ def _eligible_python_paths(chunk_index_path: Path, repo_name: str) -> tuple[str,
                 if item_repo != repo_name:
                     continue
                 raw_path = item.get("path") or item.get("source_file")
-                if not isinstance(raw_path, str) or not raw_path.endswith(".py"):
+                if not isinstance(raw_path, str):
                     continue
 
                 rel_path = Path(raw_path)
+                if (
+                    rel_path.suffix.lower() not in suffixes
+                    or rel_path.name.lower().endswith(".graph.json")
+                ):
+                    continue
                 if rel_path.is_absolute() or ".." in rel_path.parts:
                     raise BundleGraphSourceError(
                         f"unsafe chunk source path: {raw_path!r}"
@@ -103,7 +121,27 @@ def _eligible_python_paths(chunk_index_path: Path, repo_name: str) -> tuple[str,
     return tuple(sorted(path for path, allowed in eligibility.items() if allowed))
 
 
-def _materialize_selected_python_tree(
+def _eligible_python_paths(chunk_index_path: Path, repo_name: str) -> tuple[str, ...]:
+    """Return full-contact Python paths from the retrieval source surface."""
+
+    return _eligible_source_paths(
+        chunk_index_path,
+        repo_name,
+        suffixes=frozenset({".py"}),
+    )
+
+
+def _eligible_graph_paths(chunk_index_path: Path, repo_name: str) -> tuple[str, ...]:
+    """Return full-contact paths supported by the architecture inventory."""
+
+    return _eligible_source_paths(
+        chunk_index_path,
+        repo_name,
+        suffixes=_GRAPH_SOURCE_SUFFIXES,
+    )
+
+
+def _materialize_selected_source_tree(
     repo_root: Path,
     selected_paths: Sequence[str],
     destination_root: Path,
@@ -185,10 +223,10 @@ def ensure_bundle_graph_sources(
             if source_roots is not None
             else summary.get("source_roots", ())
         )
-        selected_paths = _eligible_python_paths(chunk_index_path, repo_name)
+        selected_paths = _eligible_graph_paths(chunk_index_path, repo_name)
         with tempfile.TemporaryDirectory(prefix="lenskit-graph-sources-") as tmp:
             selected_root = Path(tmp)
-            _materialize_selected_python_tree(
+            _materialize_selected_source_tree(
                 repo_root,
                 selected_paths,
                 selected_root,
@@ -223,5 +261,5 @@ def ensure_bundle_graph_sources(
             f"failed to produce bundle-bound graph sources: {exc}"
         ) from exc
 
-    reason = None if selected_paths else "no eligible full-contact Python sources"
+    reason = None if selected_paths else "no eligible full-contact graph sources"
     return BundleGraphSources(graph_path, entrypoints_path, "produced", reason)

--- a/merger/repoground/architecture/import_graph.py
+++ b/merger/repoground/architecture/import_graph.py
@@ -33,6 +33,11 @@ logger = logging.getLogger(__name__)
 
 _SKIP_DIRECTORIES = {"__pycache__", "env", "node_modules", "venv"}
 _GRAPH_SKIP_DIRECTORIES = _SKIP_DIRECTORIES | {"build", "dist", "target"}
+_HARD_MAX_GRAPH_FILES = 50_000
+_HARD_MAX_GRAPH_SOURCE_BYTES = 512 * 1024 * 1024
+_DEFAULT_MAX_GRAPH_FILES = _HARD_MAX_GRAPH_FILES
+_DEFAULT_MAX_GRAPH_SOURCE_BYTES = _HARD_MAX_GRAPH_SOURCE_BYTES
+
 _GRAPH_FILE_LANGUAGES = {
     ".js": "javascript",
     ".json": "json",
@@ -85,6 +90,14 @@ class Coverage(TypedDict):
     files_parsed: int
     edge_counts_by_type: dict[str, int]
     unknown_layer_share: float
+    repository_file_unknown_layer_share: float
+    repository_files_seen: int
+    repository_files_included: int
+    repository_bytes_seen: int
+    repository_bytes_included: int
+    repository_truncated: bool
+    max_repository_files: int
+    max_repository_source_bytes: int
 
 
 class GraphDocument(TypedDict, total=False):
@@ -107,31 +120,94 @@ def _infer_layer(path: str) -> str:
     return infer_architecture_layer(path)
 
 
-def _iter_graph_files(repo_root: Path) -> list[Path]:
-    paths: list[Path] = []
+def _scan_graph_source_files(repo_root: Path) -> tuple[list[Path], list[Path]]:
+    """Scan once while preserving legacy Python and bounded inventory scope."""
+
+    python_files: list[Path] = []
+    inventory_files: list[Path] = []
     for root, dirs, files in os.walk(repo_root):
         dirs[:] = sorted(
             directory
             for directory in dirs
             if (not directory.startswith(".") or directory == ".github")
-            and directory not in _GRAPH_SKIP_DIRECTORIES
+            and directory not in _SKIP_DIRECTORIES
         )
+        root_path = Path(root)
+        relative_root = root_path.relative_to(repo_root)
+        root_parts = set(relative_root.parts)
         for filename in sorted(files):
-            file_path = Path(root) / filename
-            if file_path.suffix.lower() not in _GRAPH_FILE_LANGUAGES:
+            file_path = root_path / filename
+            suffix = file_path.suffix.lower()
+            if suffix == ".py":
+                if ".github" not in root_parts:
+                    python_files.append(file_path)
                 continue
-            if filename.endswith(".graph.json"):
+            if suffix not in _GRAPH_FILE_LANGUAGES:
                 continue
-            paths.append(file_path)
-    return paths
+            if filename.lower().endswith(".graph.json"):
+                continue
+            if root_parts.intersection(_GRAPH_SKIP_DIRECTORIES - _SKIP_DIRECTORIES):
+                continue
+            inventory_files.append(file_path)
+    return python_files, inventory_files
 
 
-def _iter_inventory_files(repo_root: Path) -> list[Path]:
-    return [
-        path
-        for path in _iter_graph_files(repo_root)
-        if path.suffix.lower() != ".py"
-    ]
+def _bounded_graph_source_files(
+    repo_root: Path,
+    python_files: list[Path],
+    inventory_files: list[Path],
+    *,
+    max_files: int,
+    max_source_bytes: int,
+) -> tuple[list[Path], list[Path], dict[str, int | bool]]:
+    if not 0 < max_files <= _HARD_MAX_GRAPH_FILES:
+        raise ValueError(
+            f"max_graph_files must be between 1 and {_HARD_MAX_GRAPH_FILES}"
+        )
+    if not 0 < max_source_bytes <= _HARD_MAX_GRAPH_SOURCE_BYTES:
+        raise ValueError(
+            "max_graph_source_bytes must be between 1 and "
+            f"{_HARD_MAX_GRAPH_SOURCE_BYTES}"
+        )
+
+    python_set = set(python_files)
+    candidates = sorted(
+        [*python_files, *inventory_files],
+        key=lambda path: path.relative_to(repo_root).as_posix(),
+    )
+    sized: list[tuple[Path, int]] = []
+    total_bytes = 0
+    for file_path in candidates:
+        relative_path = file_path.relative_to(repo_root).as_posix()
+        try:
+            size_bytes = file_path.stat().st_size
+        except OSError as exc:
+            logger.warning("Could not stat graph source %s: %s", relative_path, exc)
+            continue
+        sized.append((file_path, size_bytes))
+        total_bytes += size_bytes
+
+    selected: list[Path] = []
+    selected_bytes = 0
+    truncated = False
+    for file_path, size_bytes in sized:
+        if len(selected) >= max_files or selected_bytes + size_bytes > max_source_bytes:
+            truncated = True
+            continue
+        selected.append(file_path)
+        selected_bytes += size_bytes
+
+    selected_python = [path for path in selected if path in python_set]
+    selected_inventory = [path for path in selected if path not in python_set]
+    return selected_python, selected_inventory, {
+        "repository_files_seen": len(sized),
+        "repository_files_included": len(selected),
+        "repository_bytes_seen": total_bytes,
+        "repository_bytes_included": selected_bytes,
+        "repository_truncated": truncated,
+        "max_repository_files": max_files,
+        "max_repository_source_bytes": max_source_bytes,
+    }
 
 
 def _iter_parsed_python_files(
@@ -178,20 +254,6 @@ def _add_inventory_file_nodes(
         node = _inventory_file_node(repo_root, file_path)
         if node is not None:
             nodes[node["node_id"]] = node
-
-
-def _iter_python_files(repo_root: Path) -> list[Path]:
-    paths: list[Path] = []
-    for root, dirs, files in os.walk(repo_root):
-        dirs[:] = sorted(
-            directory
-            for directory in dirs
-            if not directory.startswith(".") and directory not in _SKIP_DIRECTORIES
-        )
-        for filename in sorted(files):
-            if filename.endswith(".py"):
-                paths.append(Path(root) / filename)
-    return paths
 
 
 def _normalize_source_roots(
@@ -404,6 +466,8 @@ def generate_import_graph_document(
     canonical_dump_index_sha256: str,
     *,
     source_roots: Sequence[str] = (),
+    max_graph_files: int = _DEFAULT_MAX_GRAPH_FILES,
+    max_graph_source_bytes: int = _DEFAULT_MAX_GRAPH_SOURCE_BYTES,
 ) -> GraphDocument:
     """Build a deterministic repository file graph with static Python import edges."""
 
@@ -411,8 +475,14 @@ def generate_import_graph_document(
     edges: list[Edge] = []
     files_parsed = 0
     normalized_source_roots = _normalize_source_roots(repo_root, source_roots)
-    python_files = _iter_python_files(repo_root)
-    inventory_files = _iter_inventory_files(repo_root)
+    scanned_python_files, scanned_inventory_files = _scan_graph_source_files(repo_root)
+    python_files, inventory_files, source_coverage = _bounded_graph_source_files(
+        repo_root,
+        scanned_python_files,
+        scanned_inventory_files,
+        max_files=max_graph_files,
+        max_source_bytes=max_graph_source_bytes,
+    )
     module_index = _build_local_module_index(
         repo_root,
         python_files,
@@ -487,6 +557,17 @@ def generate_import_graph_document(
     unknown_layer_share = (
         unknown_layer_count / len(sorted_nodes) if sorted_nodes else 0.0
     )
+    repository_file_nodes = [
+        node for node in sorted_nodes if node.get("kind") == "file"
+    ]
+    repository_file_unknown_layer_count = sum(
+        1 for node in repository_file_nodes if node.get("layer") == "unknown"
+    )
+    repository_file_unknown_layer_share = (
+        repository_file_unknown_layer_count / len(repository_file_nodes)
+        if repository_file_nodes
+        else 0.0
+    )
     edge_counts_by_type: dict[str, int] = {}
     for edge in sorted_edges:
         edge_type = edge["edge_type"]
@@ -518,5 +599,7 @@ def generate_import_graph_document(
             "files_parsed": files_parsed,
             "edge_counts_by_type": edge_counts_by_type,
             "unknown_layer_share": unknown_layer_share,
+            "repository_file_unknown_layer_share": repository_file_unknown_layer_share,
+            **source_coverage,
         },
     }

--- a/merger/repoground/architecture/path_classification.py
+++ b/merger/repoground/architecture/path_classification.py
@@ -19,7 +19,7 @@ _PRODUCT_LAYER_BY_SEGMENT = {
     "service": "service",
 }
 _SCRIPT_SEGMENTS = {"scripts", "tools"}
-_TEST_SEGMENTS = {"test", "tests"}
+_TEST_SEGMENTS = {"__tests__", "test", "tests"}
 _TEST_NAME_SUFFIXES = {".js", ".jsx", ".py", ".rs", ".svelte", ".ts", ".tsx"}
 
 
@@ -35,7 +35,7 @@ def is_test_path(path: str) -> bool:
         ".test." in name or ".spec." in name or "_test." in name
     )
     return (
-        name.startswith("test_")
+        (suffix in _TEST_NAME_SUFFIXES and name.startswith("test_"))
         or marked_test_name
         or bool(set(parsed.parts).intersection(_TEST_SEGMENTS))
     )

--- a/merger/repoground/contracts/architecture.graph.v1.schema.json
+++ b/merger/repoground/contracts/architecture.graph.v1.schema.json
@@ -63,7 +63,15 @@
         "files_seen": { "type": "integer", "minimum": 0 },
         "files_parsed": { "type": "integer", "minimum": 0 },
         "edge_counts_by_type": { "type": "object" },
-        "unknown_layer_share": { "type": "number", "minimum": 0, "maximum": 1 }
+        "unknown_layer_share": { "type": "number", "minimum": 0, "maximum": 1 },
+        "repository_file_unknown_layer_share": { "type": "number", "minimum": 0, "maximum": 1 },
+        "repository_files_seen": { "type": "integer", "minimum": 0 },
+        "repository_files_included": { "type": "integer", "minimum": 0 },
+        "repository_bytes_seen": { "type": "integer", "minimum": 0 },
+        "repository_bytes_included": { "type": "integer", "minimum": 0 },
+        "repository_truncated": { "type": "boolean" },
+        "max_repository_files": { "type": "integer", "minimum": 1 },
+        "max_repository_source_bytes": { "type": "integer", "minimum": 1 }
       }
     }
   }

--- a/merger/repoground/core/agent_impact_context.py
+++ b/merger/repoground/core/agent_impact_context.py
@@ -1123,14 +1123,126 @@ def _unique_ranked(
     return ordered[:max_items], len(ordered) > max_items
 
 
+def _related_test_key(item: Mapping[str, Any]) -> tuple[str, str]:
+    return str(item.get("path")), str(item.get("evidence_type"))
+
+
+def _seed_related_test_diversity(
+    ordered: list[dict[str, Any]],
+    *,
+    max_items: int,
+) -> tuple[list[dict[str, Any]], set[tuple[str, str]], set[str]]:
+    selected: list[dict[str, Any]] = []
+    selected_keys: set[tuple[str, str]] = set()
+    selected_paths: set[str] = set()
+    for evidence_type in (
+        "graph_edge",
+        "changed_test_path",
+        "symbol_index_path_match",
+    ):
+        candidate = next(
+            (
+                item
+                for item in ordered
+                if item.get("evidence_type") == evidence_type
+                and str(item.get("path")) not in selected_paths
+            ),
+            None,
+        )
+        if candidate is None:
+            continue
+        path, _ = _related_test_key(candidate)
+        selected.append(candidate)
+        selected_keys.add((path, evidence_type))
+        selected_paths.add(path)
+        if len(selected) >= max_items:
+            break
+    return selected, selected_keys, selected_paths
+
+
+def _fill_related_test_budget(
+    ordered: list[dict[str, Any]],
+    selected: list[dict[str, Any]],
+    selected_keys: set[tuple[str, str]],
+    selected_paths: set[str],
+    *,
+    max_items: int,
+    prefer_distinct_path: bool,
+) -> None:
+    for item in ordered:
+        if len(selected) >= max_items:
+            return
+        key = _related_test_key(item)
+        path = key[0]
+        if key in selected_keys or (path in selected_paths) == prefer_distinct_path:
+            continue
+        selected.append(item)
+        selected_keys.add(key)
+        selected_paths.add(path)
+
+
+def _select_related_tests(
+    candidates: list[dict[str, Any]],
+    *,
+    max_items: int,
+) -> tuple[list[dict[str, Any]], bool]:
+    """Bound related-test evidence without letting one evidence class starve others."""
+
+    rank = {
+        "graph_edge": 0,
+        "symbol_index_path_match": 1,
+        "changed_test_path": 2,
+    }
+    unique: dict[tuple[str, str], dict[str, Any]] = {}
+    for item in candidates:
+        path = item.get("path")
+        evidence_type = item.get("evidence_type")
+        if isinstance(path, str) and isinstance(evidence_type, str):
+            unique.setdefault((path, evidence_type), item)
+    ordered = sorted(
+        unique.values(),
+        key=lambda item: (
+            rank.get(str(item.get("evidence_type")), 99),
+            str(item.get("path", "")),
+        ),
+    )
+    selected, selected_keys, selected_paths = _seed_related_test_diversity(
+        ordered,
+        max_items=max_items,
+    )
+    _fill_related_test_budget(
+        ordered,
+        selected,
+        selected_keys,
+        selected_paths,
+        max_items=max_items,
+        prefer_distinct_path=True,
+    )
+    _fill_related_test_budget(
+        ordered,
+        selected,
+        selected_keys,
+        selected_paths,
+        max_items=max_items,
+        prefer_distinct_path=False,
+    )
+    return selected, len(ordered) > len(selected)
+
+
 def _changed_test_candidates(
     target_paths: set[str],
+    current_paths: set[str],
 ) -> list[dict[str, Any]]:
     return [
         {
             "path": path,
             "evidence_type": "changed_test_path",
             "reason": "changed_path_is_test",
+            "provenance_strength": "direct_diff",
+            "relationship_strength": "co_changed",
+            "current_read_evidence": (
+                "available" if path in current_paths else "unverified"
+            ),
         }
         for path in sorted(target_paths)
         if _is_test_path(path)
@@ -1140,6 +1252,7 @@ def _changed_test_candidates(
 def _related_tests(
     *,
     target_paths: set[str],
+    current_paths: set[str],
     all_relations: list[dict[str, Any]],
     symbol_index: Mapping[str, Any],
     max_items: int,
@@ -1149,18 +1262,10 @@ def _related_tests(
         for item in _items(symbol_index.get("symbols"))
         if isinstance(item, Mapping) and isinstance(item.get("path"), str)
     }
-    candidates = _changed_test_candidates(target_paths)
-    candidates.extend(_graph_test_candidates(all_relations))
+    candidates = _graph_test_candidates(all_relations)
+    candidates.extend(_changed_test_candidates(target_paths, current_paths))
     candidates.extend(_conventional_test_candidates(target_paths, known_paths))
-    return _unique_ranked(
-        candidates,
-        rank={
-            "changed_test_path": 0,
-            "graph_edge": 1,
-            "symbol_index_path_match": 2,
-        },
-        max_items=max_items,
-    )
+    return _select_related_tests(candidates, max_items=max_items)
 
 
 def _query_items(query_context: Any) -> list[dict[str, Any]]:
@@ -1715,6 +1820,13 @@ def build_agent_impact_context(
         max_items=request.max_items,
     )
     paths.update(derived_paths)
+    _nodes_by_id, id_by_path = _node_index(graph)
+    current_paths = set(id_by_path)
+    current_paths.update(
+        str(item["path"])
+        for item in _items(symbols.get("symbols"))
+        if isinstance(item, Mapping) and isinstance(item.get("path"), str)
+    )
     relations, all_relations, peers, relations_truncated = _relations(
         graph,
         target_paths=paths,
@@ -1722,6 +1834,7 @@ def build_agent_impact_context(
     )
     related_tests, tests_truncated = _related_tests(
         target_paths=paths,
+        current_paths=current_paths,
         all_relations=all_relations,
         symbol_index=symbols,
         max_items=request.max_items,
@@ -1787,7 +1900,6 @@ def build_agent_impact_context(
             max_items=request.max_items,
         )
 
-    _nodes_by_id, id_by_path = _node_index(graph)
     gaps.extend(
         _target_gaps(
             paths=paths,
@@ -1841,6 +1953,10 @@ def build_agent_impact_context(
             "composition": {
                 "delta_context_input": "changed_paths_only",
                 "does_not_parse_or_apply_diff": True,
+                "changed_test_paths_are_cochange_only": True,
+                "changed_test_paths_establish_relationship": False,
+                "changed_test_paths_establish_coverage": False,
+                "current_read_evidence_from_graph_or_symbols_only": True,
                 "query_context_used": bool(_query_items(query_context)),
             },
         }
@@ -1852,11 +1968,15 @@ def build_agent_impact_context(
         )
         result["edit_context"] = {
             "recommended_first_reads": _first_reads(
-                target_paths=paths,
+                target_paths=paths & current_paths,
                 target_symbols=target_symbols,
                 call_relations=selected_call_relations,
                 relations=relations,
-                related_tests=related_tests,
+                related_tests=[
+                    item
+                    for item in related_tests
+                    if item.get("current_read_evidence") != "unverified"
+                ],
                 supporting=supporting,
                 max_items=request.max_items,
             ),

--- a/merger/repoground/core/agent_impact_refinement.py
+++ b/merger/repoground/core/agent_impact_refinement.py
@@ -14,9 +14,9 @@ from typing import Any
 from merger.repoground.architecture.path_classification import is_test_path as _is_test_path
 
 _EVIDENCE_RANK = {
-    "changed_test_path": 0,
-    "graph_edge": 1,
-    "symbol_index_path_match": 2,
+    "graph_edge": 0,
+    "symbol_index_path_match": 1,
+    "changed_test_path": 2,
     "resolved_query": 3,
     "heuristic": 4,
 }
@@ -152,11 +152,11 @@ def _read_priority(reason: Any) -> int:
         return 1
     if text.endswith("_graph_relation"):
         return 2
-    if text == "related_test:changed_test_path":
-        return 3
     if text == "related_test:graph_edge":
-        return 4
+        return 3
     if text == "related_test:symbol_index_path_match":
+        return 4
+    if text == "related_test:changed_test_path":
         return 5
     if text == "related_test:resolved_query":
         return 6

--- a/merger/repoground/tests/fixtures/architecture_import_graph/expected.graph.json
+++ b/merger/repoground/tests/fixtures/architecture_import_graph/expected.graph.json
@@ -383,6 +383,14 @@
     "edge_counts_by_type": {
       "import": 18
     },
-    "unknown_layer_share": 0.9411764705882353
+    "unknown_layer_share": 0.9411764705882353,
+    "repository_file_unknown_layer_share": 0.9,
+    "repository_files_seen": 10,
+    "repository_files_included": 10,
+    "repository_bytes_seen": 362,
+    "repository_bytes_included": 362,
+    "repository_truncated": false,
+    "max_repository_files": 50000,
+    "max_repository_source_bytes": 536870912
   }
 }

--- a/merger/repoground/tests/test_agent_impact_context.py
+++ b/merger/repoground/tests/test_agent_impact_context.py
@@ -606,6 +606,64 @@ def test_changed_cross_language_test_paths_are_related_test_evidence() -> None:
         item["path"].endswith("searchIndex.ts")
         for item in result["related_tests"]
     )
+    changed = [
+        item
+        for item in result["related_tests"]
+        if item["evidence_type"] == "changed_test_path"
+    ]
+    assert all(item["provenance_strength"] == "direct_diff" for item in changed)
+    assert all(item["relationship_strength"] == "co_changed" for item in changed)
+    assert all(item["current_read_evidence"] == "unverified" for item in changed)
+
+
+def test_related_test_budget_preserves_graph_and_co_changed_evidence() -> None:
+    result = _context(
+        target_symbol=None,
+        changed_paths=["src/app.py", "tests/changed_only.test.ts"],
+        max_items=2,
+    )
+
+    assert [item["evidence_type"] for item in result["related_tests"]] == [
+        "graph_edge",
+        "changed_test_path",
+    ]
+    assert result["truncation"]["related_tests"] is True
+
+
+def test_related_test_budget_prefers_distinct_paths_over_duplicate_evidence() -> None:
+    result = _context(
+        target_symbol=None,
+        changed_paths=[
+            "src/app.py",
+            "tests/test_app.py",
+            "tests/z_changed_only.test.ts",
+        ],
+        max_items=2,
+    )
+
+    assert [(item["path"], item["evidence_type"]) for item in result["related_tests"]] == [
+        ("tests/test_app.py", "graph_edge"),
+        ("tests/z_changed_only.test.ts", "changed_test_path"),
+    ]
+
+
+def test_unverified_changed_test_is_not_recommended_as_current_first_read() -> None:
+    result = _context(
+        target_symbol=None,
+        changed_paths=["src/app.py", "tests/deleted.test.ts"],
+        max_items=10,
+    )
+
+    unverified = next(
+        item
+        for item in result["related_tests"]
+        if item["path"] == "tests/deleted.test.ts"
+    )
+    assert unverified["current_read_evidence"] == "unverified"
+    assert not any(
+        item["path"] == "tests/deleted.test.ts"
+        for item in result["edit_context"]["recommended_first_reads"]
+    )
 
 
 def test_edit_context_bundles_target_support_and_entrypoint_reads() -> None:
@@ -629,6 +687,10 @@ def test_edit_context_bundles_target_support_and_entrypoint_reads() -> None:
     assert ("src/app.py", "target_symbol") in reads
     assert ("tests/test_app.py", "incoming_graph_relation") in reads
     assert result["composition"]["does_not_parse_or_apply_diff"] is True
+    assert result["composition"]["changed_test_paths_are_cochange_only"] is True
+    assert result["composition"]["changed_test_paths_establish_relationship"] is False
+    assert result["composition"]["changed_test_paths_establish_coverage"] is False
+    assert result["composition"]["current_read_evidence_from_graph_or_symbols_only"] is True
 
 
 

--- a/merger/repoground/tests/test_agent_impact_refinement.py
+++ b/merger/repoground/tests/test_agent_impact_refinement.py
@@ -75,7 +75,7 @@ def test_resolved_query_candidates_recognize_cross_language_test_names() -> None
     ]
 
 
-def test_refinement_prioritizes_changed_test_path_evidence() -> None:
+def test_refinement_prioritizes_relationship_evidence_over_co_changed_tests() -> None:
     base = {
         "status": "available",
         "related_tests": [
@@ -105,6 +105,12 @@ def test_refinement_prioritizes_changed_test_path_evidence() -> None:
                     "qualified_name": None,
                     "reason": "related_test:changed_test_path",
                 },
+                {
+                    "path": "tests/test_graph.py",
+                    "range_ref": None,
+                    "qualified_name": None,
+                    "reason": "related_test:graph_edge",
+                },
             ],
             "related_test_count": 2,
         },
@@ -113,14 +119,15 @@ def test_refinement_prioritizes_changed_test_path_evidence() -> None:
     refined = refine_agent_impact_context(base, _query_context(), max_items=20)
 
     assert [item["evidence_type"] for item in refined["related_tests"]] == [
-        "changed_test_path",
         "graph_edge",
+        "changed_test_path",
     ]
     assert [
         item["reason"]
         for item in refined["edit_context"]["recommended_first_reads"]
     ] == [
         "target_path",
+        "related_test:graph_edge",
         "related_test:changed_test_path",
     ]
 

--- a/merger/repoground/tests/test_architecture_import_graph.py
+++ b/merger/repoground/tests/test_architecture_import_graph.py
@@ -210,6 +210,59 @@ def test_graph_includes_bounded_cross_language_file_inventory(tmp_path):
     )
 
 
+def test_graph_source_limits_are_deterministic_and_report_truncation(tmp_path):
+    for relative, content in {
+        "a.py": "value = 1\n",
+        "b.rs": "pub fn b() {}\n",
+        "c.ts": "export const c = 1\n",
+    }.items():
+        target = tmp_path / relative
+        target.write_text(content, encoding="utf-8")
+
+    file_limited = generate_import_graph_document(
+        tmp_path,
+        "run",
+        "0" * 64,
+        max_graph_files=2,
+        max_graph_source_bytes=10_000,
+    )
+    file_nodes = [
+        node for node in file_limited["nodes"] if node["kind"] == "file"
+    ]
+    assert [node["path"] for node in file_nodes] == ["a.py", "b.rs"]
+    assert file_limited["coverage"]["repository_files_seen"] == 3
+    assert file_limited["coverage"]["repository_files_included"] == 2
+    assert file_limited["coverage"]["repository_truncated"] is True
+
+    byte_limited = generate_import_graph_document(
+        tmp_path,
+        "run",
+        "0" * 64,
+        max_graph_files=10,
+        max_graph_source_bytes=1,
+    )
+    assert not any(node["kind"] == "file" for node in byte_limited["nodes"])
+    assert byte_limited["coverage"]["repository_files_included"] == 0
+    assert byte_limited["coverage"]["repository_truncated"] is True
+
+
+def test_graph_source_limits_cannot_exceed_hard_bounds(tmp_path):
+    with pytest.raises(ValueError, match="max_graph_files"):
+        generate_import_graph_document(
+            tmp_path,
+            "run",
+            "0" * 64,
+            max_graph_files=50_001,
+        )
+    with pytest.raises(ValueError, match="max_graph_source_bytes"):
+        generate_import_graph_document(
+            tmp_path,
+            "run",
+            "0" * 64,
+            max_graph_source_bytes=(512 * 1024 * 1024) + 1,
+        )
+
+
 def test_test_directory_layer_precedes_nested_core_segment(tmp_path):
     target = tmp_path / "tests" / "core" / "service.py"
     target.parent.mkdir(parents=True)

--- a/merger/repoground/tests/test_graph_bundle_sources.py
+++ b/merger/repoground/tests/test_graph_bundle_sources.py
@@ -73,6 +73,68 @@ def test_produces_sources_from_full_contact_retrieval_paths(tmp_path):
     assert [item["path"] for item in entrypoints["entrypoints"]] == ["main.py"]
 
 
+def test_produces_cross_language_inventory_from_full_contact_retrieval_paths(tmp_path):
+    repo = _repo(tmp_path)
+    root = repo["root"]
+    sources = {
+        "apps/web/Component.svelte": "<div />\n",
+        "apps/web/Component.test.ts": "test('x', () => {})\n",
+        "apps/api/migrations/001.sql": "select 1;\n",
+        ".github/workflows/ci.yml": "name: ci\n",
+        "derived.graph.json": "{}\n",
+    }
+    for relative, content in sources.items():
+        target = root / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+
+    records = [
+        {
+            "repo": "repo1",
+            "path": path,
+            "source_status": "full",
+            "truncated": False,
+            "source_range": {"status": "declared"},
+        }
+        for path in ["main.py", *sources]
+    ]
+    result = _ensure(
+        tmp_path,
+        summaries=[repo],
+        chunk_index=_chunk_index(tmp_path, records=records),
+    )
+
+    graph = json.loads(result.graph_path.read_text(encoding="utf-8"))
+    entrypoints = json.loads(result.entrypoints_path.read_text(encoding="utf-8"))
+    file_nodes = {
+        node["path"]: node
+        for node in graph["nodes"]
+        if node["kind"] == "file"
+    }
+
+    assert set(file_nodes) == {
+        ".github/workflows/ci.yml",
+        "apps/api/migrations/001.sql",
+        "apps/web/Component.svelte",
+        "apps/web/Component.test.ts",
+        "main.py",
+    }
+    assert file_nodes["apps/web/Component.test.ts"]["is_test"] is True
+    assert file_nodes["apps/web/Component.svelte"]["language"] == "svelte"
+    assert file_nodes["apps/api/migrations/001.sql"]["language"] == "sql"
+    assert file_nodes[".github/workflows/ci.yml"]["language"] == "yaml"
+    non_python_ids = {
+        node["node_id"]
+        for node in file_nodes.values()
+        if node["language"] != "python"
+    }
+    assert not any(
+        edge["src"] in non_python_ids or edge["dst"] in non_python_ids
+        for edge in graph["edges"]
+    )
+    assert [item["path"] for item in entrypoints["entrypoints"]] == ["main.py"]
+
+
 def test_excludes_truncated_or_unverifiable_chunk_sources(tmp_path):
     repo = _repo(tmp_path)
     chunk_index = _chunk_index(
@@ -96,11 +158,39 @@ def test_excludes_truncated_or_unverifiable_chunk_sources(tmp_path):
 
     result = _ensure(tmp_path, summaries=[repo], chunk_index=chunk_index)
 
-    assert result.reason == "no eligible full-contact Python sources"
+    assert result.reason == "no eligible full-contact graph sources"
     graph = json.loads(result.graph_path.read_text(encoding="utf-8"))
     entrypoints = json.loads(result.entrypoints_path.read_text(encoding="utf-8"))
     assert graph["nodes"] == []
     assert entrypoints["entrypoints"] == []
+
+
+def test_redacted_cross_language_sources_do_not_bypass_source_range_boundary(tmp_path):
+    repo = _repo(tmp_path)
+    workflow = repo["root"] / ".github/workflows/ci.yml"
+    workflow.parent.mkdir(parents=True, exist_ok=True)
+    workflow.write_text("name: ci\n", encoding="utf-8")
+    chunk_index = _chunk_index(
+        tmp_path,
+        records=[
+            {
+                "repo": "repo1",
+                "path": ".github/workflows/ci.yml",
+                "source_status": "full",
+                "truncated": False,
+                "source_range": {"status": "unavailable"},
+            }
+        ],
+    )
+
+    result = _ensure(tmp_path, summaries=[repo], chunk_index=chunk_index)
+
+    graph = json.loads(result.graph_path.read_text(encoding="utf-8"))
+    assert result.reason == "no eligible full-contact graph sources"
+    assert not any(
+        node.get("path") == ".github/workflows/ci.yml"
+        for node in graph["nodes"]
+    )
 
 
 def test_skips_automatic_production_for_multi_repo(tmp_path):

--- a/merger/repoground/tests/test_path_classification.py
+++ b/merger/repoground/tests/test_path_classification.py
@@ -34,6 +34,9 @@ def test_generic_unmatched_product_path_remains_unknown() -> None:
 def test_cross_language_test_filenames_are_recognized() -> None:
     assert is_test_path("apps/web/src/lib/map/nodes.test.ts")
     assert is_test_path("apps/web/src/lib/map/nodes.spec.ts")
+    assert is_test_path("apps/web/src/lib/map/__tests__/nodes.ts")
     assert is_test_path("apps/api/src/store_test.rs")
     assert is_test_path("apps/api/tests/store.rs")
     assert not is_test_path("apps/web/src/lib/map/nodes.ts")
+    assert not is_test_path("config/test_config.json")
+    assert not is_test_path("docs/test_report.md")


### PR DESCRIPTION
## Summary
- materialize full-contact cross-language retrieval sources into bundle-bound architecture inventory
- preserve redaction/source-range boundaries and avoid inventing non-Python causal edges
- separate co-changed test evidence from relationship evidence, prioritize distinct strongly-related tests, and suppress unverified paths from first-read recommendations
- add deterministic hard graph caps, single-scan source discovery, clearer coverage fields, and stricter cross-language test classification

## Validation
- targeted regression: 107 passed
- full pytest: 4558 passed, 2 skipped
- Ruff: pass
- graph maintainability ratchets: pass
- git diff --check: pass

Full-suite receipt SHA-256: 8f241efa57ca32e81fb854dca5eee79d16c01c3aa5cbe84631a8387c5f604b0d