### PR TITLE
fix: make fleet publication backlog fair

### DIFF
--- a/merger/repoground/tests/test_fleet_runtime.py
+++ b/merger/repoground/tests/test_fleet_runtime.py
@@ -679,11 +679,93 @@ def test_generator_repository_is_prioritized_without_reordering_other_entries(
 def test_generator_repository_priority_is_applied_before_publication_loop() -> None:
     source = PUBLISHER.read_text(encoding="utf-8")
     inventory_return = source.index("if args.inventory:")
-    priority = source.index("entries = prioritize_generator_repository(entries)")
-    lock = source.index("lock = acquire_lock()", priority)
-    loop = source.index("for entry in entries:", lock)
+    lock = source.index("lock = acquire_lock()", inventory_return)
+    priority = source.index("entries, scheduling = prioritize_fleet_publication(entries)")
+    loop = source.index("for entry in entries:", priority)
 
-    assert inventory_return < priority < lock < loop
+    assert inventory_return < lock < priority < loop
+
+
+def test_fleet_fairness_converges_42_repository_backlog_with_limit_8(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    monkeypatch.setattr(module, "STATE_ROOT", tmp_path / "state")
+    module.STATE_ROOT.mkdir(parents=True)
+    generator_key = "heimgewebe/repoground"
+    monkeypatch.setattr(module, "generator_repository_key", lambda: generator_key)
+    keys = [generator_key] + [f"heimgewebe/repo-{index:02d}" for index in range(41)]
+    entries = [
+        module.RepoEntry(
+            key=key,
+            owner=key.split("/", 1)[0],
+            repo=key.split("/", 1)[1],
+            path=tmp_path / key.split("/", 1)[1],
+            remote=f"git@github.com:{key}.git",
+        )
+        for key in keys
+    ]
+
+    def record_publication(entry: object, sequence: int) -> None:
+        repository = module.publication_repository(entry)
+        path = module.STATE_ROOT / f"{repository}__main.state.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "schema": module.STATE_SCHEMA,
+                    "repo_id": repository,
+                    "ref": "main",
+                    "created_at": f"2026-07-22T{sequence // 3600:02d}:"
+                    f"{(sequence // 60) % 60:02d}:{sequence % 60:02d}Z",
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+    for index, entry in enumerate(entries):
+        record_publication(entry, index)
+
+    changed = set(keys)
+    publication_counts = {key: 0 for key in keys}
+    newly_changed_key: str | None = None
+    completed_rounds = 0
+    for round_index in range(1, 8):
+        ordered, scheduling = module.prioritize_fleet_publication(
+            entries, now_epoch=1784773200.0
+        )
+        assert scheduling["policy"] == module.SCHEDULING_POLICY
+        assert scheduling["ordered_repositories"][0] == generator_key
+        batch = [entry for entry in ordered if entry.key in changed][:8]
+        assert len(batch) <= 8
+        for entry in batch:
+            changed.remove(entry.key)
+            if entry.key == newly_changed_key and publication_counts[entry.key] == 1:
+                assert all(count >= 1 for count in publication_counts.values())
+            publication_counts[entry.key] += 1
+            record_publication(
+                entry, 3600 + round_index * 60 + publication_counts[entry.key]
+            )
+        if round_index == 1:
+            newly_changed_key = batch[1].key
+            changed.add(newly_changed_key)
+        completed_rounds = round_index
+        if not changed:
+            break
+
+    assert completed_rounds <= 6
+    assert not changed
+    assert all(count >= 1 for count in publication_counts.values())
+    assert newly_changed_key is not None
+    assert publication_counts[newly_changed_key] == 2
+
+    _ordered, final_scheduling = module.prioritize_fleet_publication(
+        entries, now_epoch=1784773200.0
+    )
+    evidence = final_scheduling["entries"][newly_changed_key]
+    assert evidence["rank"] >= 1
+    assert evidence["debt_basis"] == "age_since_last_successful_publication"
+    assert isinstance(evidence["publication_debt_seconds"], int)
 
 
 def test_changed_source_hygiene_preflight_runs_before_publication_limit() -> None:

--- a/scripts/ops/repoground-publish-fleet
+++ b/scripts/ops/repoground-publish-fleet
@@ -23,6 +23,7 @@ import tempfile
 import time
 import uuid
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -65,6 +66,7 @@ DEFAULT_RETENTION = 3
 MAX_RETENTION = 10
 FINGERPRINT_SCHEMA = "repobrief.fleet-publication-fingerprint.v3"
 STATE_SCHEMA = "repobrief.fleet-publication-state.v1"
+SCHEDULING_POLICY = "oldest-successful-publication-first.v1"
 ACTIVE_LEASE_SCHEMA = "repobrief.active-publication-lease.v1"
 PRUNE_TRANSACTION_SCHEMA = "repobrief.retention-transaction.v1"
 QUARANTINE_DIR_NAME = ".repoground-prune-quarantine"
@@ -332,6 +334,96 @@ def prioritize_generator_repository(entries: list[RepoEntry]) -> list[RepoEntry]
     if generator_key is None:
         return list(entries)
     return sorted(entries, key=lambda entry: entry.key != generator_key)
+
+
+def _publication_timestamp_epoch(value: object) -> float | None:
+    if not isinstance(value, str) or not value:
+        return None
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed.astimezone(timezone.utc).timestamp()
+
+
+def latest_successful_publication(entry: RepoEntry) -> tuple[str | None, float | None]:
+    """Return repository-level publication age from the existing fleet state.
+
+    Scheduling derives only from the durable publication state that already
+    exists. It does not persist a second queue or cursor authority. If historical
+    state contains multiple refs, the most recent successful publication for the
+    repository defines its current service debt.
+    """
+    repository = publication_repository(entry)
+    latest_value: str | None = None
+    latest_epoch: float | None = None
+    prefix = f"{repository}__"
+    for path in sorted(STATE_ROOT.glob(f"{prefix}*.state.json")):
+        state = load_state(path)
+        if state is None or state.get("repo_id") != repository:
+            continue
+        value = state.get("created_at")
+        epoch = _publication_timestamp_epoch(value)
+        if epoch is None:
+            continue
+        if latest_epoch is None or epoch > latest_epoch:
+            latest_value = value
+            latest_epoch = epoch
+    return latest_value, latest_epoch
+
+
+def prioritize_fleet_publication(
+    entries: list[RepoEntry], *, now_epoch: float | None = None
+) -> tuple[list[RepoEntry], dict[str, object]]:
+    """Order bounded fleet work by self-priority, then oldest publication debt.
+
+    A successful publication moves a repository to the back of the debt order.
+    Repositories without usable publication history sort ahead of already-served
+    peers. This makes repeated limited runs converge without another durable queue.
+    """
+    now = time.time() if now_epoch is None else now_epoch
+    generator_key = generator_repository_key()
+    prioritized = prioritize_generator_repository(entries)
+    rows: list[tuple[RepoEntry, str | None, float | None, int]] = []
+    for discovery_rank, entry in enumerate(prioritized):
+        created_at, created_epoch = latest_successful_publication(entry)
+        rows.append((entry, created_at, created_epoch, discovery_rank))
+    rows.sort(
+        key=lambda row: (
+            row[0].key != generator_key,
+            row[2] is not None,
+            row[2] if row[2] is not None else float("-inf"),
+            row[3],
+        )
+    )
+    ordered = [row[0] for row in rows]
+    evidence: dict[str, dict[str, object]] = {}
+    for rank, (entry, created_at, created_epoch, _discovery_rank) in enumerate(
+        rows, start=1
+    ):
+        debt_seconds = (
+            max(0, int(now - created_epoch)) if created_epoch is not None else None
+        )
+        evidence[entry.key] = {
+            "rank": rank,
+            "generator_priority": entry.key == generator_key,
+            "last_successful_publication_at": created_at,
+            "publication_debt_seconds": debt_seconds,
+            "debt_basis": (
+                "publication_history_unavailable"
+                if created_epoch is None
+                else "age_since_last_successful_publication"
+            ),
+        }
+    return ordered, {
+        "policy": SCHEDULING_POLICY,
+        "generator_repository": generator_key,
+        "ordered_repositories": [entry.key for entry in ordered],
+        "entries": evidence,
+    }
 
 
 def assert_managed_worktree_identity(path: Path, expected_repo: Path) -> None:
@@ -2157,8 +2249,6 @@ def main(argv: list[str]) -> int:
         )
         return 0
 
-    entries = prioritize_generator_repository(entries)
-
     lock = acquire_lock()
     if lock is None:
         print(
@@ -2168,6 +2258,7 @@ def main(argv: list[str]) -> int:
     try:
         STATE_ROOT.mkdir(parents=True, exist_ok=True)
         LOG_ROOT.mkdir(parents=True, exist_ok=True)
+        entries, scheduling = prioritize_fleet_publication(entries)
         mode = "targeted-force" if args.force_republish else "if-changed"
         log(
             f"== fleet {mode} {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())} "
@@ -2182,6 +2273,7 @@ def main(argv: list[str]) -> int:
                 "count": len(entries),
                 "failed": len(entries),
                 "error": str(exc)[:4000],
+                "scheduling": scheduling,
                 "details": [],
             }
             atomic_write_json(LOG_ROOT / "fleet-last.json", summary)
@@ -2336,6 +2428,7 @@ def main(argv: list[str]) -> int:
             "generator_inputs_sha": generator_sha,
             "force_reason": args.reason if args.force_republish else None,
             "retention_reconciliation": reconciliation,
+            "scheduling": scheduling,
             "details": details,
         }
         atomic_write_json(LOG_ROOT / "fleet-last.json", summary)


### PR DESCRIPTION
## Summary
- order bounded fleet publications by existing successful-publication age while preserving RepoGround self-priority
- expose machine-readable scheduling debt/rank evidence in fleet receipts without introducing a second queue authority
- prove 42-repository backlog convergence with limit 8, including a new change arriving while the backlog drains

## Validation
- `git diff --check`
- `python3 -m py_compile scripts/ops/repoground-publish-fleet`
- `ruff check --config ruff-ci.toml scripts/ops/repoground-publish-fleet merger/repoground/tests/test_fleet_runtime.py`
- `python3 -m pytest -q merger/repoground/tests/test_fleet_runtime.py` (66 passed)
- live read-only scheduling projection recognized publication history for 42/42 repositories

Closes the implementation scope of Bureau task `REPOGROUND-AGENT-UTILITY-V1-T008`; Bureau lifecycle closeout follows merge/live verification.