### PR TITLE
chore(deps): cut over version updates to Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 0
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
Direct cutover of regular Dependabot version updates to the central self-hosted Renovate Fleet runtime. Sets the configured ecosystem to `open-pull-requests-limit: 0`; Dependabot Security Updates remain a separate path. No automerge or merge-gate change.