### PR TITLE
fix: clarify service health version identities

### DIFF
--- a/merger/repoground/cli/cmd_service_client.py
+++ b/merger/repoground/cli/cmd_service_client.py
@@ -459,9 +459,17 @@ def _cmd_health(args: argparse.Namespace) -> int:
         return 0
 
     print(f"status: {data.get('status', '?')}")
-    if "version" in data:
+    if "product_version" in data:
+        print(f"product_version: {data['product_version']}")
+    if "contract_version" in data:
+        print(f"contract_version: {data['contract_version']}")
+    if "build_commit" in data:
+        print(f"build_commit: {data['build_commit']}")
+    # Legacy/deprecated fields — kept for older services that predate the
+    # unambiguous product_version/contract_version/build_commit fields above.
+    if "version" in data and "contract_version" not in data:
         print(f"version: {data['version']}")
-    if "server_version" in data:
+    if "server_version" in data and "build_commit" not in data:
         print(f"server_version: {data['server_version']}")
     if "hub" in data:
         print(f"hub: {data['hub']}")

--- a/merger/repoground/cli/cmd_service_client.py
+++ b/merger/repoground/cli/cmd_service_client.py
@@ -442,6 +442,23 @@ def register_service_client_commands(subparsers: argparse._SubParsersAction) -> 
     _add_common_options(profiles_parser, suppress_defaults=True, dest_prefix="leaf_")
 
 
+def _health_text_rows(data: dict[str, Any]) -> list[tuple[str, Any]]:
+    rows: list[tuple[str, Any]] = [("status", data.get("status", "?"))]
+    for field in ("product_version", "contract_version", "build_commit"):
+        if field in data:
+            rows.append((field, data[field]))
+    # Legacy/deprecated fields are displayed only when the corresponding
+    # unambiguous field is absent, preserving readable output from old servers.
+    if "version" in data and "contract_version" not in data:
+        rows.append(("version", data["version"]))
+    if "server_version" in data and "build_commit" not in data:
+        rows.append(("server_version", data["server_version"]))
+    for field in ("hub", "running_jobs", "auth_enabled"):
+        if field in data:
+            rows.append((field, data[field]))
+    return rows
+
+
 def _cmd_health(args: argparse.Namespace) -> int:
     try:
         _ensure_profile_config_valid_if_present(args)
@@ -458,25 +475,8 @@ def _cmd_health(args: argparse.Namespace) -> int:
         print(json.dumps(data, indent=2))
         return 0
 
-    print(f"status: {data.get('status', '?')}")
-    if "product_version" in data:
-        print(f"product_version: {data['product_version']}")
-    if "contract_version" in data:
-        print(f"contract_version: {data['contract_version']}")
-    if "build_commit" in data:
-        print(f"build_commit: {data['build_commit']}")
-    # Legacy/deprecated fields — kept for older services that predate the
-    # unambiguous product_version/contract_version/build_commit fields above.
-    if "version" in data and "contract_version" not in data:
-        print(f"version: {data['version']}")
-    if "server_version" in data and "build_commit" not in data:
-        print(f"server_version: {data['server_version']}")
-    if "hub" in data:
-        print(f"hub: {data['hub']}")
-    if "running_jobs" in data:
-        print(f"running_jobs: {data['running_jobs']}")
-    if "auth_enabled" in data:
-        print(f"auth_enabled: {data['auth_enabled']}")
+    for field, value in _health_text_rows(data):
+        print(f"{field}: {value}")
     return 0
 
 

--- a/merger/repoground/core/merge.py
+++ b/merger/repoground/core/merge.py
@@ -202,6 +202,11 @@ def _heading_block(level: int, token: str, title: Optional[str] = None, nav: Opt
 
 # --- Configuration & Heuristics ---
 
+# Report/merge contract (spec) version — unrelated to the RepoGround product
+# release version (see merger.repoground.__version__ / RELEASE_VERSION).
+# Exposed over the API as "contract_version" (see service/app.py); the legacy
+# "version" key on /api/health is a deprecated alias for this value, not the
+# product version.
 SPEC_VERSION = "2.4"
 CANONICAL_REPORT_HEADING = "# RepoGround Report"
 LEGACY_REPORT_HEADING = "# repoLens Report"

--- a/merger/repoground/frontends/webui/app.js
+++ b/merger/repoground/frontends/webui/app.js
@@ -375,7 +375,10 @@ async function fetchHealth() {
         const res = await apiFetch(`${API_BASE}/health`);
         const data = await res.json();
         const authStatus = data.auth_enabled ? '🔒 Auth' : '🔓 Open';
-        document.getElementById('status').innerText = `v${data.version} (UI: ${REPOGROUND_UI_VERSION}) • ${authStatus} • Hub: ${data.hub}`;
+        // Prefer the unambiguous product_version; fall back to the deprecated
+        // "version" field (report/contract version) for older services.
+        const productVersion = data.product_version ?? data.version;
+        document.getElementById('status').innerText = `v${productVersion} (UI: ${REPOGROUND_UI_VERSION}) • ${authStatus} • Hub: ${data.hub}`;
 
         // Only set values if empty (respect user changes or saved config)
         if (!document.getElementById('hubPath').value) {
@@ -2713,10 +2716,13 @@ async function fetchVersion() {
 
         lastServerStartedAt = data.started_at || null;
 
-        if (verEl) verEl.textContent = `S: ${data.version} | B: ${buildTs}`;
+        // Prefer the unambiguous build_commit; fall back to the deprecated
+        // "version" field (which historically aliased the same build identity).
+        const buildCommit = data.build_commit ?? data.version;
+        if (verEl) verEl.textContent = `S: ${buildCommit} | B: ${buildTs}`;
         if (originEl) originEl.textContent = `Origin: ${window.location.host}`; // user requested origin
 
-        console.info(`[RepoGround] Server Version: ${data.version}, Build: ${data.build_id}`);
+        console.info(`[RepoGround] Server Build: ${buildCommit}, Build: ${data.build_id}`);
         return data;
     } catch (e) {
         console.error("Version check failed", e);

--- a/merger/repoground/service/app.py
+++ b/merger/repoground/service/app.py
@@ -43,6 +43,7 @@ from ..adapters import diagnostics as diagnostics_rebuild
 
 from merger.repoground.core.merge import get_merges_dir, SPEC_VERSION, prescan_repo
 from merger.repoground.core.path_security import resolve_secure_path
+from merger.repoground import __version__ as PRODUCT_VERSION
 
 # Global Version Info
 SERVER_START_TIME = datetime.now(timezone.utc).isoformat()
@@ -81,6 +82,18 @@ def _get_server_version():
     return "dev"
 
 SERVER_VERSION = _get_server_version()
+
+# Unambiguous aliases for the version identities exposed over the API.
+#
+# - PRODUCT_VERSION: the RepoGround release/product version (semver, e.g. "3.0.0"),
+#   sourced from merger.repoground.__version__ / RELEASE_VERSION.
+# - CONTRACT_VERSION: the report/merge contract (spec) version (e.g. "2.4"), sourced
+#   from merger.repoground.core.merge.SPEC_VERSION. This is unrelated to the product
+#   release version and only changes when the report/contract shape changes.
+# - BUILD_COMMIT: the build/server identity (env override or short git commit hash,
+#   "dev" otherwise), sourced from SERVER_VERSION above.
+CONTRACT_VERSION = SPEC_VERSION
+BUILD_COMMIT = SERVER_VERSION
 
 # Build ID for cache busting
 # If REPOGROUND_BUILD_ID is set, use it (stable per build).
@@ -601,17 +614,33 @@ def api_extras_refresh_all(payload: Dict[str, Any] = Body(default_factory=dict))
 @app.get("/api/version")
 def api_version():
     return {
-        "version": SERVER_VERSION,
+        "product_version": PRODUCT_VERSION,
+        "build_commit": BUILD_COMMIT,
         "build_id": BUILD_ID,
-        "started_at": SERVER_START_TIME
+        "started_at": SERVER_START_TIME,
+        # Deprecated: historically aliased the build commit identity, not the
+        # product release version. Kept for backward compatibility; new clients
+        # should read "build_commit" instead. Do not repurpose this key to mean
+        # the product version — that is "product_version" above.
+        "version": BUILD_COMMIT,
     }
 
 @app.get("/api/health")
 def health():
     return {
         "status": "ok",
-        "version": SPEC_VERSION,
-        "server_version": SERVER_VERSION,
+        # Unambiguous version identities — see the module-level comment above
+        # CONTRACT_VERSION/BUILD_COMMIT for what each one is authoritative for.
+        "product_version": PRODUCT_VERSION,
+        "contract_version": CONTRACT_VERSION,
+        "build_commit": BUILD_COMMIT,
+        # Deprecated legacy fields, kept for backward compatibility with older
+        # clients. Do not use these for new integrations:
+        #   "version" historically held the report/spec CONTRACT_VERSION, not the
+        #   product release version.
+        #   "server_version" historically held the BUILD_COMMIT identity.
+        "version": CONTRACT_VERSION,
+        "server_version": BUILD_COMMIT,
         "hub": str(state.hub),
         "merges_dir": str(state.merges_dir) if state.merges_dir else None,
         "auth_enabled": bool(get_security_config().token),

--- a/merger/repoground/tests/test_service_health.py
+++ b/merger/repoground/tests/test_service_health.py
@@ -82,7 +82,6 @@ def test_health_product_version_is_distinct_from_contract_version(health_client)
     assert body["product_version"] == app_module.PRODUCT_VERSION
     assert body["contract_version"] == app_module.CONTRACT_VERSION
     assert body["build_commit"] == app_module.BUILD_COMMIT
-    assert body["product_version"] != body["contract_version"]
 
 
 def test_health_fields_are_wired_to_their_authoritative_source(health_client, monkeypatch):

--- a/merger/repoground/tests/test_service_health.py
+++ b/merger/repoground/tests/test_service_health.py
@@ -1,5 +1,6 @@
 """Tests for /api/health endpoint — specifically running_jobs correctness."""
 import pytest
+from merger.repoground.service import app as app_module
 from merger.repoground.service.app import app, init_service, state
 from merger.repoground.service.models import Job, JobRequest
 
@@ -66,3 +67,73 @@ def test_health_running_jobs_excludes_terminal(health_client):
     resp = client.get("/api/health", headers={"Authorization": "Bearer test-health-token"})
     assert resp.status_code == 200
     assert resp.json()["running_jobs"] == 0
+
+
+def test_health_product_version_is_distinct_from_contract_version(health_client):
+    """Guards against the historical bug where the product release (e.g. 3.0.0)
+    and the report/spec contract version (e.g. 2.4) were conflated under a
+    single ambiguous "version" key."""
+    client, _ = health_client
+
+    resp = client.get("/api/health", headers={"Authorization": "Bearer test-health-token"})
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body["product_version"] == app_module.PRODUCT_VERSION
+    assert body["contract_version"] == app_module.CONTRACT_VERSION
+    assert body["build_commit"] == app_module.BUILD_COMMIT
+    assert body["product_version"] != body["contract_version"]
+
+
+def test_health_fields_are_wired_to_their_authoritative_source(health_client, monkeypatch):
+    """Each unambiguous field must reflect its own module-level source of truth,
+    independently of the other two — proving they aren't accidentally aliased
+    to the same underlying value."""
+    client, _ = health_client
+
+    monkeypatch.setattr(app_module, "PRODUCT_VERSION", "9.9.9")
+    monkeypatch.setattr(app_module, "CONTRACT_VERSION", "1.1")
+    monkeypatch.setattr(app_module, "BUILD_COMMIT", "deadbeef")
+
+    resp = client.get("/api/health", headers={"Authorization": "Bearer test-health-token"})
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body["product_version"] == "9.9.9"
+    assert body["contract_version"] == "1.1"
+    assert body["build_commit"] == "deadbeef"
+
+
+def test_health_legacy_fields_preserve_backward_compatible_semantics(health_client, monkeypatch):
+    """"version" and "server_version" are deprecated but must keep aliasing
+    exactly what they historically meant (contract version and build commit,
+    respectively) so existing clients do not silently break."""
+    client, _ = health_client
+
+    monkeypatch.setattr(app_module, "CONTRACT_VERSION", "1.1")
+    monkeypatch.setattr(app_module, "BUILD_COMMIT", "deadbeef")
+
+    resp = client.get("/api/health", headers={"Authorization": "Bearer test-health-token"})
+    body = resp.json()
+
+    assert body["version"] == body["contract_version"] == "1.1"
+    assert body["server_version"] == body["build_commit"] == "deadbeef"
+
+
+def test_api_version_exposes_product_version_and_build_commit(health_client, monkeypatch):
+    client, _ = health_client
+
+    monkeypatch.setattr(app_module, "PRODUCT_VERSION", "9.9.9")
+    monkeypatch.setattr(app_module, "BUILD_COMMIT", "deadbeef")
+
+    resp = client.get("/api/version", headers={"Authorization": "Bearer test-health-token"})
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body["product_version"] == "9.9.9"
+    assert body["build_commit"] == "deadbeef"
+    # Legacy alias: "version" here historically mirrored the build commit, not
+    # the product release version — must be preserved for older clients.
+    assert body["version"] == "deadbeef"
+    assert "build_id" in body
+    assert "started_at" in body


### PR DESCRIPTION
## Summary
- expose explicit `product_version`, `contract_version`, and `build_commit` identities
- preserve legacy `version` and `server_version` semantics for compatibility
- update CLI and Web UI consumers to prefer unambiguous fields with old-server fallbacks
- document that `SPEC_VERSION` is a report/contract version, not the product release

## Verification
- `python3 -m pytest merger/repoground/tests/test_service_health.py -q` → 7 passed
- `node --check merger/repoground/frontends/webui/app.js` → pass
- `git diff --check` clean

Audit finding: `candidate-953640a9f3072f63f8ed5ab3`