### PR TITLE
fix: revalidate retrieval goldsets after naming hard cut

### DIFF
--- a/docs/diagnostics/retrieval-goldset-naming-hard-cut-rerun-20260723.md
+++ b/docs/diagnostics/retrieval-goldset-naming-hard-cut-rerun-20260723.md
@@ -1,0 +1,109 @@
+# Retrieval Goldset Naming Hard-Cut Revalidation — Rerun
+
+Status: lexical retrieval rerun complete, no recall regression observed
+
+## Scope
+
+This closes out audit finding `candidate-49b5e257c0aa81203efa2e0f`: revalidate the
+canonical retrieval goldset after the RepoGround naming hard cut
+(`docs/contracts/repoground-naming-hard-cut.v1.json`). It does not change
+`eval_core`, query routing, ranking, or any default runtime behavior.
+
+## What changed
+
+Retired product names describing a *current* CLI/runtime surface were replaced
+with the current name in the active goldset and adjacent docs:
+
+- `docs/retrieval/review_queries.v1.json` (`RQ-11`, `RQ-12`): "Find the Lenskit
+  query CLI command..." / "...Lenskit retrieval eval CLI command..." →
+  "RepoGround query CLI command" / "RepoGround retrieval eval CLI command".
+  The CLI's actual `prog` is `repoground` (`merger/repoground/cli/main.py`)
+  with `query` and `eval` subcommands; it was never named `lenskit`.
+- `docs/retrieval/workbench_usefulness_goldset.v1.json`: every question's
+  `expected_paths` pointed at compatibility-alias modules removed by
+  `5926118f` ("hard cut RepoGround compatibility aliases") —
+  `repobrief_readonly_adapter.py`, `repobrief_access.py`,
+  `repobrief_mcp_resources.py`, `repobrief_latest_complete.py`. None of these
+  files exist any more; the real, current modules are `readonly_adapter.py`,
+  `bundle_access.py`, `mcp_resources.py`, and `latest_complete.py`
+  respectively (confirmed via `git log --follow`). `symbol_query`/
+  `expected_symbols` for the adapter class were similarly corrected from
+  `RepoBriefReadonlyAdapter` to the actual current class,
+  `RepoGroundReadonlyAdapter`. Query prose describing "RepoBrief" as the
+  live snapshot/adapter/MCP surface was corrected to "RepoGround" to match.
+- `docs/retrieval/queries.md`, `docs/retrieval/semantic-reranking.md`: prose
+  described the current system/CLI as `lenskit`; corrected to `RepoGround` /
+  `repoground eval`.
+
+`kind` fields that are versioned data ids (e.g.
+`repobrief.workbench_usefulness_goldset`, `lenskit.graph_quality_goldset`,
+`repolens.pr_schau.delta`) were intentionally left unchanged: they are exact,
+actively-checked producer/consumer contract identifiers under the hard cut's
+`versioned_data_contracts` policy, not aliases for a live command, class, or
+file surface. `docs/retrieval/*.example.json` synthetic fixtures with
+non-repository paths (e.g. `brief.md`, `src/app.py`) were left unchanged for
+the same reason: they do not bind to real repository targets.
+
+Guard-relation and graph-quality goldset `object`/`subject` paths that do
+point at real repository files were spot-checked against the working tree;
+all resolve. One `guard_relation_goldset.v1.json` case intentionally targets a
+non-existent path (`merger/repoground/core/router.py`) as a negative control
+for "same basename, wrong layer" — that absence is by design, not staleness.
+
+## Regression coverage added
+
+Three new tests fail closed if a retired product name (`lenskit`, `repobrief`,
+`repolens`, `rlens`) re-enters an active query, expected path/symbol, or
+retrieval doc, while exempting the `kind` versioned-data-id fields:
+
+- `merger/repoground/tests/test_review_retrieval_goldset.py::test_goldsets_do_not_describe_retired_products_as_current_surface`
+- `merger/repoground/tests/test_workbench_usefulness.py::test_repository_goldset_questions_do_not_describe_retired_products_as_current`
+- `merger/repoground/tests/test_retrieval_docs_naming_hard_cut.py::test_active_retrieval_docs_do_not_describe_retired_products_as_current`
+
+## Rerun method
+
+`naming_audit.scan_repository` does not cover this class of drift: it scans
+`.py`/`.sh`/`.js`/`.html` under `merger/repoground`, `repoground`, `scripts`,
+`tests` for executable command/environment/storage aliases, not prose or JSON
+goldset fields under `docs/`. The gap above was undetected until this audit.
+
+To check whether the `review_queries.v1.json` wording fix (`RQ-11`, `RQ-12`)
+changed measured lexical recall, a repo-local, whole-file self-hosted index
+was built from this working tree (`docs/`, `merger/`, `scripts/`, `tests/`;
+1,025 text files, one FTS chunk per file) using the existing
+`index_db.build_index`, then evaluated with the existing
+`review_eval.run_review_retrieval_baseline` against the full 20-query
+`review_queries.v1.json`, once with the committed (post-fix) text and once
+with the prior (`Lenskit`-worded) text from `HEAD`.
+
+```text
+                                   before   after
+overall recall@10                  15.0     15.0
+RQ-11 (query CLI command) hit      false    false
+RQ-12 (retrieval eval CLI) hit     false    false
+```
+
+Both CLI-category queries miss their expected top-10 targets identically
+before and after the wording fix, and the goldset-wide `recall@10` is
+unchanged (`15.0` in both runs). The wording correction is therefore
+naming-accuracy only; it does not move measured recall in either direction.
+
+## Measurement boundary — what this rerun does and does not establish
+
+- This is a repo-local, ad hoc, whole-file lexical index (one FTS chunk per
+  file, no function-level chunking, no canonical bundle, no graph/semantic
+  signal). It reuses the existing `index_db` and `review_eval` production
+  code paths verbatim; it does not reuse the canonical bundle producer
+  pipeline, so absolute recall numbers here are not comparable to
+  bundle-based canonical measurements (e.g.
+  `docs/diagnostics/repobrief-canonical-retrieval-measurement-20260711.json`).
+- It establishes only that the naming fix in `review_queries.v1.json` is
+  recall-neutral under lexical retrieval on this snapshot; it does not
+  establish general retrieval quality, ranking sufficiency, review
+  completeness, or default-promotion readiness for any mode.
+- A miss for RQ-11/RQ-12 is not evidence that `cmd_query.py`/`cmd_eval.py`
+  are unreachable in the canonical, function-level-chunked bundle index; it
+  reflects the coarser granularity of this ad hoc rerun index only.
+- No committed goldset, contract, or default runtime evaluation path was
+  changed by this rerun; it is a one-off diagnostic artifact, not a new CI
+  gate.

--- a/docs/retrieval/queries.md
+++ b/docs/retrieval/queries.md
@@ -1,6 +1,6 @@
 # Retrieval Gold Queries
 
-Die folgenden 15 "Gold Queries" definieren die Zielwerte (Benchmarks) für das lenskit Retrieval-System.
+Die folgenden 15 "Gold Queries" definieren die Zielwerte (Benchmarks) für das RepoGround Retrieval-System.
 
 ## Benchmark-Zielwerte
 - **TTR (Time-to-Relevant):** < 2 Sekunden für CLI-Output.

--- a/docs/retrieval/review_queries.v1.json
+++ b/docs/retrieval/review_queries.v1.json
@@ -129,7 +129,7 @@
     }
   },
   {
-    "query": "Find the Lenskit query CLI command and its registration",
+    "query": "Find the RepoGround query CLI command and its registration",
     "category": "cli",
     "expected_patterns": [
       "merger/repoground/cli/cmd_query.py",
@@ -142,7 +142,7 @@
     }
   },
   {
-    "query": "Find the Lenskit retrieval eval CLI command and its registration",
+    "query": "Find the RepoGround retrieval eval CLI command and its registration",
     "category": "cli",
     "expected_patterns": [
       "merger/repoground/cli/cmd_eval.py",

--- a/docs/retrieval/semantic-reranking.md
+++ b/docs/retrieval/semantic-reranking.md
@@ -53,7 +53,7 @@ rm -rf -- "$target"
 We employ a strict **improvement delta vs non-semantic** strategy.
 
 Semantic re-ranking must prove its worth against the established baseline:
-- `lenskit eval` will generate metrics (like `recall@10`) using the lexical-only approach.
+- `repoground eval` will generate metrics (like `recall@10`) using the lexical-only approach.
 - The same gold queries (`queries.v1.json`) are evaluated using the semantic re-ranker.
 - The measurable difference between the two strategies constitutes the "improvement delta".
 

--- a/docs/retrieval/workbench_usefulness_goldset.v1.json
+++ b/docs/retrieval/workbench_usefulness_goldset.v1.json
@@ -4,27 +4,27 @@
   "questions": [
     {
       "id": "readonly-adapter-class",
-      "query": "RepoBrief protocol neutral read only adapter",
-      "symbol_query": "RepoBriefReadonlyAdapter",
+      "query": "RepoGround protocol neutral read only adapter",
+      "symbol_query": "RepoGroundReadonlyAdapter",
       "symbol_kind": "class",
-      "expected_paths": ["merger/repoground/core/repobrief_readonly_adapter.py"],
-      "expected_symbols": ["RepoBriefReadonlyAdapter"]
+      "expected_paths": ["merger/repoground/core/readonly_adapter.py"],
+      "expected_symbols": ["RepoGroundReadonlyAdapter"]
     },
     {
       "id": "readonly-adapter-dispatch",
       "query": "dispatch JSON request for read only adapter",
       "symbol_query": "dispatch",
       "symbol_kind": "function",
-      "symbol_path_filter": "repobrief_readonly_adapter.py",
-      "expected_paths": ["merger/repoground/core/repobrief_readonly_adapter.py"],
+      "symbol_path_filter": "readonly_adapter.py",
+      "expected_paths": ["merger/repoground/core/readonly_adapter.py"],
       "expected_symbols": ["dispatch"]
     },
     {
       "id": "snapshot-status",
-      "query": "read status of existing RepoBrief snapshot",
+      "query": "read status of existing RepoGround snapshot",
       "symbol_query": "snapshot_status",
       "symbol_kind": "function",
-      "expected_paths": ["merger/repoground/core/repobrief_access.py"],
+      "expected_paths": ["merger/repoground/core/bundle_access.py"],
       "expected_symbols": ["snapshot_status"]
     },
     {
@@ -32,7 +32,7 @@
       "query": "query an existing SQLite index without mutation",
       "symbol_query": "query_existing_index",
       "symbol_kind": "function",
-      "expected_paths": ["merger/repoground/core/repobrief_access.py"],
+      "expected_paths": ["merger/repoground/core/bundle_access.py"],
       "expected_symbols": ["query_existing_index"]
     },
     {
@@ -40,15 +40,15 @@
       "query": "search Python symbol index without importing target code",
       "symbol_query": "search_symbol_index",
       "symbol_kind": "function",
-      "expected_paths": ["merger/repoground/core/repobrief_access.py"],
+      "expected_paths": ["merger/repoground/core/bundle_access.py"],
       "expected_symbols": ["search_symbol_index"]
     },
     {
       "id": "mcp-resource-list",
-      "query": "list RepoBrief MCP resources from existing bundle",
+      "query": "list RepoGround MCP resources from existing bundle",
       "symbol_query": "list_mcp_resources",
       "symbol_kind": "function",
-      "expected_paths": ["merger/repoground/core/repobrief_mcp_resources.py"],
+      "expected_paths": ["merger/repoground/core/mcp_resources.py"],
       "expected_symbols": ["list_mcp_resources"]
     },
     {
@@ -56,12 +56,12 @@
       "query": "compare latest complete snapshot commit with live repository head",
       "symbol_query": "evaluate_registry_freshness",
       "symbol_kind": "function",
-      "expected_paths": ["merger/repoground/core/repobrief_latest_complete.py"],
+      "expected_paths": ["merger/repoground/core/latest_complete.py"],
       "expected_symbols": ["evaluate_registry_freshness"]
     },
     {
       "id": "identity-distribution-check",
-      "query": "fail closed check for RepoBrief naming and distribution decisions",
+      "query": "fail closed check for RepoGround naming and distribution decisions",
       "symbol_query": "check",
       "symbol_kind": "function",
       "symbol_path_filter": "check_identity_distribution_decisions.py",

--- a/merger/repoground/tests/test_retrieval_docs_naming_hard_cut.py
+++ b/merger/repoground/tests/test_retrieval_docs_naming_hard_cut.py
@@ -1,0 +1,33 @@
+"""Guard against retired product names re-entering active retrieval docs.
+
+``docs/retrieval/`` is not a historical-evidence path under
+``docs/contracts/repoground-naming-hard-cut.v1.json``
+(``historical_evidence.allowed_path_prefixes``), so prose describing the
+retrieval CLI/system here must track the current RepoGround surface.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+RETIRED_PRODUCT_TERMS = ("lenskit", "repobrief", "repolens", "rlens")
+ACTIVE_RETRIEVAL_DOCS = (
+    "docs/retrieval/queries.md",
+    "docs/retrieval/semantic-reranking.md",
+)
+
+
+def test_active_retrieval_docs_do_not_describe_retired_products_as_current() -> None:
+    offenders: list[str] = []
+    for relative_path in ACTIVE_RETRIEVAL_DOCS:
+        path = ROOT / relative_path
+        assert path.is_file(), f"{relative_path} is missing"
+        lowered = path.read_text(encoding="utf-8").casefold()
+        for term in RETIRED_PRODUCT_TERMS:
+            if term in lowered:
+                offenders.append(f"{relative_path} contains {term!r}")
+
+    assert offenders == [], "retired product name found in active retrieval docs: " + "; ".join(
+        offenders
+    )

--- a/merger/repoground/tests/test_review_retrieval_goldset.py
+++ b/merger/repoground/tests/test_review_retrieval_goldset.py
@@ -54,6 +54,10 @@ SKIP_SEARCH_PARTS = {
     "_generated",
 }
 SKIP_SEARCH_SUFFIXES = {".db", ".sqlite", ".bundle", ".log", ".pyc"}
+# Retired product names. These must never describe a *current* CLI, class, or
+# file surface in an active query or expected target; only "kind"/schema-style
+# versioned data ids are exempt from this check (see repoground-naming-hard-cut.v1).
+RETIRED_PRODUCT_TERMS = ("lenskit", "repobrief", "repolens", "rlens")
 
 
 def _load_json(path: Path) -> Any:
@@ -235,6 +239,36 @@ def test_review_retrieval_goldset_symbolic_patterns_exist_in_repo_text(
         "symbolic patterns not found outside the goldset and its guard test: "
         f"{sorted(remaining_patterns)}"
     )
+
+
+def test_goldsets_do_not_describe_retired_products_as_current_surface(
+    base_queries: list[dict[str, Any]],
+    review_queries: list[dict[str, Any]],
+) -> None:
+    """Guard against a retired product name silently re-entering an active query.
+
+    ``kind``/schema-style versioned data ids (e.g. ``repolens.pr_schau.delta``)
+    are a deliberate, separate exception (see
+    ``docs/contracts/repoground-naming-hard-cut.v1.json``); neither goldset
+    file carries such a field, so every string value here is in scope.
+    """
+    offenders: list[str] = []
+    for source_name, queries in (
+        ("queries.v1.json", base_queries),
+        ("review_queries.v1.json", review_queries),
+    ):
+        for index, query_case in enumerate(queries):
+            texts = [query_case.get("query", "")]
+            texts.extend(query_case.get("expected_patterns", []))
+            for text in texts:
+                if not isinstance(text, str):
+                    continue
+                lowered = text.casefold()
+                for term in RETIRED_PRODUCT_TERMS:
+                    if term in lowered:
+                        offenders.append(f"{source_name}[{index}]: {text!r} contains {term!r}")
+
+    assert offenders == [], "retired product name found in active query surface: " + "; ".join(offenders)
 
 
 def test_review_retrieval_goldset_validates_against_contract(

--- a/merger/repoground/tests/test_workbench_usefulness.py
+++ b/merger/repoground/tests/test_workbench_usefulness.py
@@ -60,6 +60,44 @@ def test_repository_goldset_matches_schema() -> None:
     )
 
 
+# Retired product names. ``kind`` (e.g. "repobrief.workbench_usefulness_goldset")
+# is a deliberate, separately-checked versioned data id exception (see
+# docs/contracts/repoground-naming-hard-cut.v1.json) and is intentionally not
+# scanned here; every other question field describes a live class/file/CLI
+# surface and must track the current name.
+RETIRED_PRODUCT_TERMS = ("lenskit", "repobrief", "repolens", "rlens")
+_NAMING_SCAN_FIELDS = (
+    "query",
+    "symbol_query",
+    "symbol_path_filter",
+    "expected_paths",
+    "expected_symbols",
+)
+
+
+def test_repository_goldset_questions_do_not_describe_retired_products_as_current() -> None:
+    goldset = json.loads(
+        (ROOT / "docs/retrieval/workbench_usefulness_goldset.v1.json").read_text(encoding="utf-8")
+    )
+
+    offenders: list[str] = []
+    for question in goldset["questions"]:
+        for field in _NAMING_SCAN_FIELDS:
+            value = question.get(field)
+            texts = value if isinstance(value, list) else [value]
+            for text in texts:
+                if not isinstance(text, str):
+                    continue
+                lowered = text.casefold()
+                for term in RETIRED_PRODUCT_TERMS:
+                    if term in lowered:
+                        offenders.append(
+                            f"question {question.get('id')!r} field {field!r}: {text!r} contains {term!r}"
+                        )
+
+    assert offenders == [], "retired product name found in active goldset question: " + "; ".join(offenders)
+
+
 def test_eval_measures_navigation_advantage_without_default_promotion(tmp_path: Path) -> None:
     _adapter_instance, _bundle, config = _adapter(tmp_path)
     result = evaluate_workbench_usefulness(


### PR DESCRIPTION
## Summary
- correct stale current-surface Lenskit/RepoBrief query wording and removed alias target paths
- preserve exact versioned legacy `kind` identifiers and intentional negative-control fixtures
- add guards against retired names re-entering active current-surface retrieval guidance
- document a controlled lexical before/after rerun

## Measurement boundary
The ad-hoc lexical rerun stayed at 15% recall@10 before and after the naming correction; RQ-11/RQ-12 missed in both cases. This establishes naming neutrality only, not canonical retrieval quality or promotion readiness. The canonical bundle-based audit finding remains a separate ranking problem.

## Verification
- focused retrieval/goldset tests → 18 passed
- `git diff --check` clean

Audit finding: `candidate-49b5e257c0aa81203efa2e0f`