### PR TITLE
feat: add fail-closed security alert readback

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,3 +43,19 @@ jobs:
         run: >-
           python3 scripts/ci/assert_codeql_sarif_clean.py
           "${{ steps.analyze.outputs.sarif-output }}"
+
+      - name: Emit security-alert readback summary
+        if: always() && steps.analyze.outputs.sarif-output != ''
+        run: >-
+          python3 scripts/ci/emit_security_alert_summary.py
+          --sarif-dir "${{ steps.analyze.outputs.sarif-output }}"
+          --output "${{ runner.temp }}/security-alert-summary.json"
+
+      - name: Upload security-alert readback summary
+        if: always() && steps.analyze.outputs.sarif-output != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: security-alert-summary
+          path: ${{ runner.temp }}/security-alert-summary.json
+          if-no-files-found: error
+          retention-days: 90

--- a/docs/architecture/security-alert-readback-v1.md
+++ b/docs/architecture/security-alert-readback-v1.md
@@ -1,0 +1,98 @@
+---
+doc_type: architecture_decision
+status: implemented
+finding: candidate-52e48525291654cff4605a47
+---
+
+# Security-alert readback contract v1
+
+## Problem
+
+An audit that reads GitHub's live code-scanning alerts endpoint cannot tell "zero
+alerts" apart from "the read failed": GitHub returns `404` both when code scanning
+is disabled for the repository and when the caller lacks `security-events: read`
+access, and any transport failure looks like silence, not a clean bill of health. A
+prior audit observed exactly this: a live endpoint read returned `404` while the
+required CodeQL check on the same commit was green. Nothing in the repository
+distinguished "clean" from "unavailable/unauthorized," so the ambiguity could only
+be resolved by guessing -- and guessing "clean" on missing evidence is a fail-open
+bug.
+
+## Decision
+
+Classify readback evidence into one explicit, closed-vocabulary state instead of
+inferring "clean" from absence:
+
+`clean` | `alerts_present` | `unavailable` | `unauthorized` | `unknown`
+
+Implementation:
+
+- [`merger/repoground/retrieval/security_alert_summary.py`](../../merger/repoground/retrieval/security_alert_summary.py)
+  -- pure, deterministic classifier (`classify_security_alert_state`).
+- [`merger/repoground/contracts/security-alert-summary.v1.schema.json`](../../merger/repoground/contracts/security-alert-summary.v1.schema.json)
+  -- the machine-readable contract for the summary object.
+- [`scripts/ci/emit_security_alert_summary.py`](../../scripts/ci/emit_security_alert_summary.py)
+  -- CLI that reads local evidence and writes the summary; exit code `0` only for
+  `clean`.
+- [`.github/workflows/codeql.yml`](../../.github/workflows/codeql.yml) -- emits and
+  uploads `security-alert-summary.json` as a workflow artifact on every run of the
+  `analyze` job, using `if: always()` so the artifact still reflects reality when an
+  earlier step fails.
+
+## Evidence sources and priority
+
+1. **Repository-local SARIF (authoritative for the current CodeQL analysis boundary).** The `analyze` step's raw CodeQL SARIF
+   output is read directly from disk in the same job that already produces it. This
+   needs no additional permission beyond the job's existing `contents: read` and no
+   network call, so it is the preferred, least-privilege evidence source. When it
+   resolves to a definitive state (`clean` or `alerts_present`), it decides the
+   summary even if a concurrent live-API read is unavailable or unauthorized -- a
+   live `404` must never override a deterministic, CI-produced clean result.
+2. **Live GitHub alerts API (optional, supplementary).** If a caller has separately
+   captured a `GET /repos/{owner}/{repo}/code-scanning/alerts` response (status code
+   and, for `200`, an open-alert count), it can be passed to the classifier as a
+   small JSON file. A zero API count is `clean` only when exhaustive pagination is
+   explicitly proven (`paginated=true`); an unpaginated zero fails closed to `unknown`.
+   Any positive count is already sufficient for `alerts_present`. The script never performs this HTTP call itself and never
+   handles a token; the caller owns the request and its credentials.
+3. **Disagreement fails closed.** If both sources resolve to a definitive state and
+   they disagree (e.g. SARIF says clean, the API says alerts are open), the result is
+   `unknown`, not a silent pick of either side.
+4. **No evidence at all resolves to `unknown`, never `clean`.**
+
+## Required permissions
+
+| Evidence path | Required permission |
+| --- | --- |
+| Repository-local SARIF | None beyond the analysis job's existing `contents: read`. No network call, no additional scope. |
+| Live alerts API (optional) | `security-events: read` -- least privilege, read-only. Never request `security-events: write` for a readback; `write` is only needed to *upload* SARIF (already granted to the `analyze` step for that reason), not to read alert state. |
+
+An external auditor with no repository write access can satisfy the entire
+contract by reading the `security-alert-summary` workflow artifact produced by
+`codeql.yml` on the commit under review -- no token beyond `actions: read` is
+needed, and the live alerts API does not have to be called at all.
+
+## States
+
+| State | Meaning | Does not mean |
+| --- | --- | --- |
+| `clean` | current CodeQL SARIF reports zero findings for its analysis boundary, or an API read proves zero open alerts with exhaustive pagination; no other definitive source disagrees | absence of coverage gaps outside analyzed languages/paths |
+| `alerts_present` | a definitive evidence source reports one or more alerts | severity, exploitability, or which specific alerts |
+| `unavailable` | evidence was attempted but unreachable (missing/unreadable SARIF, API `404`, non-2xx/401/403 API response) | zero alerts |
+| `unauthorized` | the live API responded `401`/`403` | zero alerts |
+| `unknown` | no evidence was supplied, or two definitive sources disagree | zero alerts |
+
+Only `clean` is a pass. `emit_security_alert_summary.py` exits `0` for `clean` and
+non-zero for every other state, including `unknown` -- fail closed, not fail open.
+
+## Non-goals
+
+- Calling the GitHub REST API. This repository's tooling only classifies evidence
+  handed to it; it never fetches credentials or makes the live request itself.
+- Replacing `scripts/ci/assert_codeql_sarif_clean.py`, which already fails the
+  `codeql.yml` job when raw SARIF contains results. This contract adds an
+  explicit, exportable state for consumers *outside* that job (audits, other CI
+  systems) who cannot see its pass/fail alone and need to know *why*.
+- Determining severity, exploitability, or remediation priority of any alert.
+- Registering as a required branch-protection status check; that decision belongs
+  to repository governance, not this contract.

--- a/docs/proofs/security-alert-readback-v1-proof.md
+++ b/docs/proofs/security-alert-readback-v1-proof.md
@@ -1,0 +1,102 @@
+# Security-alert readback contract v1 -- proof
+
+Finding: `candidate-52e48525291654cff4605a47`
+
+## Scope
+
+Complete audits could not distinguish "zero GitHub code-scanning alerts" from
+"alerts API unavailable/unauthorized": a live endpoint read returned `404` while
+the required CodeQL check on the same commit was green, and nothing in the
+repository captured that ambiguity explicitly. This proof covers a deterministic
+classifier, its machine-readable contract, a CI-produced summary artifact, and a
+fail-closed exit contract for consumers. It does not prove that CodeQL's own
+analysis is complete, that the live GitHub alerts API behaves as documented in
+every case, or that every possible transport failure is enumerated.
+
+## Implemented surface
+
+- `merger/repoground/retrieval/security_alert_summary.py` -- deterministic
+  classifier (`classify_security_alert_state`), no filesystem, network, or
+  subprocess access.
+- `merger/repoground/contracts/security-alert-summary.v1.schema.json` -- the
+  closed-vocabulary contract for the summary object.
+- `scripts/ci/emit_security_alert_summary.py` -- CLI wrapper: reads local raw
+  CodeQL SARIF (reusing `scripts/ci/assert_codeql_sarif_clean.collect_results`)
+  and an optional captured API-response file, classifies, prints and optionally
+  writes the summary, and exits `0` only for `clean`.
+- `.github/workflows/codeql.yml` -- emits and uploads
+  `security-alert-summary.json` as a workflow artifact from the existing
+  `analyze` job, using `if: always()` (guarded on the analyze step having
+  produced SARIF output) so the artifact reflects reality even when the job
+  fails.
+- `docs/architecture/security-alert-readback-v1.md` -- contract documentation,
+  including required permissions per evidence path.
+- `merger/repoground/tests/test_security_alert_summary.py` -- classifier and
+  schema-validation tests.
+- `merger/repoground/tests/test_security_alert_summary_cli.py` -- CLI
+  behavior and exit-code tests.
+
+## Invariants
+
+1. Repository-local SARIF evidence is authoritative for the current CodeQL analysis
+   boundary when it resolves to a definitive state (`clean`/`alerts_present`); it
+   needs no additional readback permission or network call.
+2. A live API `404` is never classified as `clean` -- GitHub returns `404` for
+   both "code scanning disabled" and "caller unauthorized," so it always
+   resolves to `unavailable`.
+3. Live API `401`/`403` resolves to `unauthorized`.
+4. A live API `200` with zero reported open alerts is `clean` only when exhaustive
+   pagination is explicitly proven; an unpaginated zero resolves to `unknown`. A
+   positive count remains `alerts_present` even when pagination is incomplete.
+5. Two definitive evidence sources that disagree resolve to `unknown`, not a
+   silent pick of either side.
+6. No evidence supplied resolves to `unknown`, never `clean`.
+7. Only `clean` is a pass; `alerts_present`, `unavailable`, `unauthorized`, and
+   `unknown` all exit non-zero from the CLI -- fail closed on unknown rather
+   than treating missing endpoint data as clean.
+8. Malformed evidence (wrong types, out-of-range counts, unsupported fields,
+   inconsistent `available`/`alert_count` or `status_code`/`open_alert_count`
+   pairing) is rejected with `SecurityAlertSummaryError` rather than silently
+   coerced.
+9. The CLI never performs the live HTTP call itself and never handles a
+   credential; API evidence is supplied as a pre-captured JSON file, keeping the
+   contract's own permission footprint at `contents: read` only.
+10. The emitted summary validates against `security-alert-summary.v1.schema.json`
+   for every tested state.
+
+## Verification
+
+Focused command:
+
+```text
+pytest -q \
+  merger/repoground/tests/test_security_alert_summary.py \
+  merger/repoground/tests/test_security_alert_summary_cli.py \
+  merger/repoground/tests/test_codeql_sarif_gate.py \
+  merger/repoground/tests/test_codeql_suppression_ratchet.py \
+  merger/repoground/tests/test_github_main_ruleset.py \
+  merger/repoground/tests/test_github_actions_node_runtime.py
+```
+
+Result: 69 passed, 0 failed.
+
+Also run and green:
+
+```text
+python3 scripts/ci/check_codeql_suppressions.py
+python3 scripts/ci/check_github_actions_pins.py
+python3 scripts/ci/check_reusable_workflow_contracts.py
+git diff --check
+```
+
+Repository-wide GitHub CI (including `codeql.yml` itself, `contracts-validate.yml`,
+and the full test suite) is authoritative for the published change.
+
+## What this does not establish
+
+- That GitHub's live code-scanning alerts API will continue to return exactly
+  these status codes for these conditions in the future.
+- Severity, exploitability, or remediation priority of any alert reported by
+  either evidence source.
+- That CodeQL's Python analysis itself has no coverage gaps.
+- Permission to create issues, patches, commits, pushes, or merges.

--- a/merger/repoground/contracts/security-alert-summary.v1.schema.json
+++ b/merger/repoground/contracts/security-alert-summary.v1.schema.json
@@ -1,0 +1,350 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://lenskit.merger/schemas/security-alert-summary.v1.json",
+  "title": "Lenskit Security Alert Summary v1",
+  "description": "Fail-closed classification of GitHub code-scanning security-alert readback evidence. Distinguishes zero alerts from an unavailable, unauthorized, or unknown readback instead of treating missing evidence as clean.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "authority",
+    "risk_class",
+    "state",
+    "state_reason",
+    "evidence_source",
+    "alert_count",
+    "fail_closed",
+    "repository",
+    "commit_sha",
+    "sarif_evidence",
+    "api_evidence",
+    "required_permissions",
+    "does_not_prove"
+  ],
+  "properties": {
+    "version": {
+      "const": "security_alert_summary.v1"
+    },
+    "authority": {
+      "const": "diagnostic_signal"
+    },
+    "risk_class": {
+      "const": "diagnostic"
+    },
+    "state": {
+      "type": "string",
+      "enum": [
+        "clean",
+        "alerts_present",
+        "unavailable",
+        "unauthorized",
+        "unknown"
+      ]
+    },
+    "state_reason": {
+      "type": "string",
+      "enum": [
+        "sarif_result_count",
+        "sarif_unavailable",
+        "api_result_count",
+        "api_unauthorized",
+        "api_unavailable",
+        "sarif_api_state_disagreement",
+        "no_evidence_supplied",
+        "api_zero_count_pagination_unproven"
+      ]
+    },
+    "evidence_source": {
+      "type": "string",
+      "enum": [
+        "sarif",
+        "api",
+        "sarif+api",
+        "none"
+      ]
+    },
+    "alert_count": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "fail_closed": {
+      "type": "boolean"
+    },
+    "repository": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "commit_sha": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "sarif_evidence": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "available",
+            "alert_count"
+          ],
+          "properties": {
+            "available": {
+              "type": "boolean"
+            },
+            "alert_count": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "minimum": 0
+            },
+            "repository": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "commit_sha": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "stale": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          },
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "available": {
+                    "const": true
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "alert_count": {
+                    "type": "integer"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "available": {
+                    "const": false
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "alert_count": {
+                    "type": "null"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "api_evidence": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "status_code",
+            "open_alert_count"
+          ],
+          "properties": {
+            "status_code": {
+              "type": "integer",
+              "minimum": 100,
+              "maximum": 599
+            },
+            "open_alert_count": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "minimum": 0
+            },
+            "repository": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "commit_sha": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "paginated": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "page_count": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "minimum": 0
+            },
+            "stale": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          },
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "status_code": {
+                    "const": 200
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "open_alert_count": {
+                    "type": "integer"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "not": {
+                  "properties": {
+                    "status_code": {
+                      "const": 200
+                    }
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "open_alert_count": {
+                    "type": "null"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "required_permissions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sarif",
+        "api"
+      ],
+      "properties": {
+        "sarif": {
+          "type": "string",
+          "minLength": 1
+        },
+        "api": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "does_not_prove": {
+      "type": "array",
+      "minItems": 5,
+      "maxItems": 5,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": [
+          "the absence of code-scanning coverage gaps outside analyzed languages or paths",
+          "severity, exploitability, or business impact of any reported alert",
+          "that no alert existed before or appears after the evidence was captured",
+          "runtime correctness or merge readiness",
+          "permission to create issues, patches, commits, pushes, or merges"
+        ]
+      },
+      "allOf": [
+        {
+          "contains": {
+            "const": "the absence of code-scanning coverage gaps outside analyzed languages or paths"
+          }
+        },
+        {
+          "contains": {
+            "const": "severity, exploitability, or business impact of any reported alert"
+          }
+        },
+        {
+          "contains": {
+            "const": "that no alert existed before or appears after the evidence was captured"
+          }
+        },
+        {
+          "contains": {
+            "const": "runtime correctness or merge readiness"
+          }
+        },
+        {
+          "contains": {
+            "const": "permission to create issues, patches, commits, pushes, or merges"
+          }
+        }
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "const": "clean"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "fail_closed": {
+            "const": false
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "fail_closed": {
+            "const": true
+          }
+        }
+      }
+    }
+  ]
+}

--- a/merger/repoground/retrieval/security_alert_summary.py
+++ b/merger/repoground/retrieval/security_alert_summary.py
@@ -21,8 +21,8 @@ from collections.abc import Mapping
 from typing import Any
 
 _STATES = ("clean", "alerts_present", "unavailable", "unauthorized", "unknown")
-_DEFINITIVE_STATES = ("clean", "alerts_present")
-_UNAUTHORIZED_STATUS_CODES = (401, 403)
+_DEFINITIVE_STATES = frozenset({"clean", "alerts_present"})
+_UNAUTHORIZED_STATUS_CODES = frozenset({401, 403})
 _OK_STATUS_CODE = 200
 
 _REQUIRED_PERMISSIONS = {
@@ -39,6 +39,9 @@ _REQUIRED_PERMISSIONS = {
     ),
 }
 
+_SARIF_ALLOWED_FIELDS = frozenset({"available", "alert_count", "repository", "commit_sha", "stale"})
+_API_ALLOWED_FIELDS = frozenset({"status_code", "open_alert_count", "repository", "commit_sha", "paginated", "page_count", "stale"})
+
 _DOES_NOT_PROVE = (
     "the absence of code-scanning coverage gaps outside analyzed languages or paths",
     "severity, exploitability, or business impact of any reported alert",
@@ -53,7 +56,7 @@ class SecurityAlertSummaryError(ValueError):
 
 
 def _require_evidence_mapping(
-    value: Any, *, name: str, allowed_fields: set[str]
+    value: Any, *, name: str, allowed_fields: set[str] | frozenset[str]
 ) -> Mapping[str, Any]:
     if not isinstance(value, Mapping):
         raise SecurityAlertSummaryError(f"{name} must be an object")
@@ -62,8 +65,6 @@ def _require_evidence_mapping(
         raise SecurityAlertSummaryError(
             f"{name} has unsupported fields: {sorted(extra)}"
         )
-    if value.get("stale") is True:
-        raise SecurityAlertSummaryError(f"{name} is marked stale")
     return value
 
 
@@ -102,12 +103,15 @@ def _parse_sarif_evidence(value: Any) -> dict[str, Any] | None:
     evidence = _require_evidence_mapping(
         value,
         name="sarif_evidence",
-        allowed_fields={"available", "alert_count", "repository", "commit_sha", "stale"},
+        allowed_fields=_SARIF_ALLOWED_FIELDS,
     )
     available = evidence.get("available")
     if not isinstance(available, bool):
         raise SecurityAlertSummaryError("sarif_evidence.available must be a boolean")
     repo, sha = _evidence_identity(evidence, name="sarif_evidence")
+    stale = _optional_bool(evidence.get("stale"), field="stale", name="sarif_evidence")
+    if stale is True:
+        raise SecurityAlertSummaryError("sarif_evidence is marked stale (evidence may be from previous commit)")
     count = evidence.get("alert_count")
     if available:
         count = _non_negative_int(
@@ -122,7 +126,7 @@ def _parse_sarif_evidence(value: Any) -> dict[str, Any] | None:
         "alert_count": count,
         "repository": repo,
         "commit_sha": sha,
-        "stale": evidence.get("stale"),
+        "stale": stale,
     }
 
 
@@ -140,13 +144,13 @@ def _parse_api_evidence(value: Any) -> dict[str, Any] | None:
     evidence = _require_evidence_mapping(
         value,
         name="api_evidence",
-        allowed_fields={
-            "status_code", "open_alert_count", "repository", "commit_sha",
-            "paginated", "page_count", "stale",
-        },
+        allowed_fields=_API_ALLOWED_FIELDS,
     )
     status = _valid_http_status(evidence.get("status_code"))
     repo, sha = _evidence_identity(evidence, name="api_evidence")
+    stale = _optional_bool(evidence.get("stale"), field="stale", name="api_evidence")
+    if stale is True:
+        raise SecurityAlertSummaryError("api_evidence is marked stale (evidence may be from previous commit)")
     paginated = _optional_bool(
         evidence.get("paginated"), field="paginated", name="api_evidence"
     )
@@ -171,7 +175,7 @@ def _parse_api_evidence(value: Any) -> dict[str, Any] | None:
         "commit_sha": sha,
         "paginated": paginated,
         "page_count": page_count,
-        "stale": evidence.get("stale"),
+        "stale": stale,
     }
 
 
@@ -276,7 +280,13 @@ def _effective_binding(
     api: dict[str, Any] | None,
     field: str,
 ) -> str | None:
-    return requested or (sarif.get(field) if sarif else None) or (api.get(field) if api else None)
+    if requested is not None:
+        return requested
+    if sarif is not None and sarif.get(field) is not None:
+        return sarif.get(field)
+    if api is not None and api.get(field) is not None:
+        return api.get(field)
+    return None
 
 
 def _resolve_verdict(
@@ -294,7 +304,8 @@ def _resolve_verdict(
             if disagreement
             else sarif_verdict
         )
-        return state, reason, count, "sarif+api" if api_verdict is not None else "sarif"
+        source = "sarif+api" if disagreement or (api_verdict is not None and api_verdict[0] in _DEFINITIVE_STATES) else "sarif"
+        return state, reason, count, source
     if api_verdict is not None:
         state, reason, count = api_verdict
         return state, reason, count, "sarif+api" if sarif_verdict is not None else "api"

--- a/merger/repoground/retrieval/security_alert_summary.py
+++ b/merger/repoground/retrieval/security_alert_summary.py
@@ -1,0 +1,340 @@
+"""Classify GitHub code-scanning security-alert readback evidence.
+
+An external audit that reads a live `GET .../code-scanning/alerts` response
+cannot tell "zero alerts" apart from "endpoint unavailable" or "caller
+unauthorized" from the HTTP status alone: GitHub returns 404 both when code
+scanning is not enabled and when the caller lacks `security-events: read`
+access, and a transport failure looks like silence, not a clean bill of
+health. Treating any of those as "clean" is a fail-open bug.
+
+This module classifies deterministic, repository-local evidence (the raw
+CodeQL SARIF this repository's own CI job already produces) together with
+optional live-API evidence into one explicit state. It never invents
+"clean" from missing or unreachable evidence; when nothing is supplied, or
+independently classified sources disagree, the result fails closed to
+"unknown".
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+_STATES = ("clean", "alerts_present", "unavailable", "unauthorized", "unknown")
+_DEFINITIVE_STATES = ("clean", "alerts_present")
+_UNAUTHORIZED_STATUS_CODES = (401, 403)
+_OK_STATUS_CODE = 200
+
+_REQUIRED_PERMISSIONS = {
+    "sarif": (
+        "none beyond the analysis job's existing 'contents: read'. Reads "
+        "job-local CodeQL SARIF output already produced by "
+        "github/codeql-action/analyze in the same job; no network call, no "
+        "additional token scope."
+    ),
+    "api": (
+        "security-events: read (least privilege, read-only). Never request "
+        "security-events: write for a readback; write scope is only needed "
+        "to upload SARIF, not to read alert state."
+    ),
+}
+
+_DOES_NOT_PROVE = (
+    "the absence of code-scanning coverage gaps outside analyzed languages or paths",
+    "severity, exploitability, or business impact of any reported alert",
+    "that no alert existed before or appears after the evidence was captured",
+    "runtime correctness or merge readiness",
+    "permission to create issues, patches, commits, pushes, or merges",
+)
+
+
+class SecurityAlertSummaryError(ValueError):
+    """Raised when readback evidence cannot be classified safely."""
+
+
+def _parse_sarif_evidence(value: Any) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise SecurityAlertSummaryError("sarif_evidence must be an object")
+    extra = set(value) - {"available", "alert_count", "repository", "commit_sha", "stale"}
+    if extra:
+        raise SecurityAlertSummaryError(
+            f"sarif_evidence has unsupported fields: {sorted(extra)}"
+        )
+    if value.get("stale") is True:
+        raise SecurityAlertSummaryError("sarif_evidence is marked stale")
+    available = value.get("available")
+    if not isinstance(available, bool):
+        raise SecurityAlertSummaryError("sarif_evidence.available must be a boolean")
+
+    repo = value.get("repository")
+    if repo is not None and not isinstance(repo, str):
+        raise SecurityAlertSummaryError("sarif_evidence.repository must be a string")
+
+    sha = value.get("commit_sha")
+    if sha is not None and not isinstance(sha, str):
+        raise SecurityAlertSummaryError("sarif_evidence.commit_sha must be a string")
+
+    if available:
+        count = value.get("alert_count")
+        if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+            raise SecurityAlertSummaryError(
+                "sarif_evidence.alert_count must be a non-negative integer when available"
+            )
+        return {
+            "available": True,
+            "alert_count": count,
+            "repository": repo,
+            "commit_sha": sha,
+            "stale": value.get("stale"),
+        }
+    if value.get("alert_count") is not None:
+        raise SecurityAlertSummaryError(
+            "sarif_evidence.alert_count must be omitted or null when unavailable"
+        )
+    return {
+        "available": False,
+        "alert_count": None,
+        "repository": repo,
+        "commit_sha": sha,
+        "stale": value.get("stale"),
+    }
+
+
+def _parse_api_evidence(value: Any) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise SecurityAlertSummaryError("api_evidence must be an object")
+    extra = set(value) - {
+        "status_code",
+        "open_alert_count",
+        "repository",
+        "commit_sha",
+        "paginated",
+        "page_count",
+        "stale",
+    }
+    if extra:
+        raise SecurityAlertSummaryError(
+            f"api_evidence has unsupported fields: {sorted(extra)}"
+        )
+    if value.get("stale") is True:
+        raise SecurityAlertSummaryError("api_evidence is marked stale")
+
+    status = value.get("status_code")
+    if isinstance(status, bool) or not isinstance(status, int) or not 100 <= status <= 599:
+        raise SecurityAlertSummaryError(
+            "api_evidence.status_code must be a valid HTTP status integer"
+        )
+
+    repo = value.get("repository")
+    if repo is not None and not isinstance(repo, str):
+        raise SecurityAlertSummaryError("api_evidence.repository must be a string")
+
+    sha = value.get("commit_sha")
+    if sha is not None and not isinstance(sha, str):
+        raise SecurityAlertSummaryError("api_evidence.commit_sha must be a string")
+
+    paginated = value.get("paginated")
+    if paginated is not None and not isinstance(paginated, bool):
+        raise SecurityAlertSummaryError("api_evidence.paginated must be a boolean")
+
+    page_count = value.get("page_count")
+    if page_count is not None and (
+        isinstance(page_count, bool) or not isinstance(page_count, int) or page_count < 0
+    ):
+        raise SecurityAlertSummaryError(
+            "api_evidence.page_count must be a non-negative integer"
+        )
+
+    if status == _OK_STATUS_CODE:
+        count = value.get("open_alert_count")
+        if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+            raise SecurityAlertSummaryError(
+                "api_evidence.open_alert_count must be a non-negative integer "
+                "when status_code is 200"
+            )
+        return {
+            "status_code": status,
+            "open_alert_count": count,
+            "repository": repo,
+            "commit_sha": sha,
+            "paginated": paginated,
+            "page_count": page_count,
+            "stale": value.get("stale"),
+        }
+    if value.get("open_alert_count") is not None:
+        raise SecurityAlertSummaryError(
+            "api_evidence.open_alert_count must be omitted or null unless status_code is 200"
+        )
+    return {
+        "status_code": status,
+        "open_alert_count": None,
+        "repository": repo,
+        "commit_sha": sha,
+        "paginated": paginated,
+        "page_count": page_count,
+        "stale": value.get("stale"),
+    }
+
+
+def _sarif_verdict(sarif: dict[str, Any] | None) -> tuple[str, str, int | None] | None:
+    if sarif is None:
+        return None
+    if not sarif["available"]:
+        return ("unavailable", "sarif_unavailable", None)
+    count = sarif["alert_count"]
+    state = "clean" if count == 0 else "alerts_present"
+    return (state, "sarif_result_count", count)
+
+
+def _api_verdict(api: dict[str, Any] | None) -> tuple[str, str, int | None] | None:
+    if api is None:
+        return None
+    status = api["status_code"]
+    if status == _OK_STATUS_CODE:
+        count = api["open_alert_count"]
+        if count > 0:
+            # One observed open alert is already definitive; incomplete pagination
+            # can only mean the true count is larger, never zero.
+            return ("alerts_present", "api_result_count", count)
+        if api.get("paginated") is True:
+            return ("clean", "api_result_count", 0)
+        # A zero-length page without proof that pagination was exhausted cannot
+        # establish absence of open alerts. Fail closed instead of treating it as clean.
+        return ("unknown", "api_zero_count_pagination_unproven", None)
+    if status in _UNAUTHORIZED_STATUS_CODES:
+        return ("unauthorized", "api_unauthorized", None)
+    # Covers 404 (GitHub returns 404 both for "code scanning disabled" and
+    # "caller lacks security-events:read"; the two are indistinguishable
+    # from the status code alone) and any other non-200/401/403 response,
+    # including transport-level failures a caller may map to a status.
+    return ("unavailable", "api_unavailable", None)
+
+
+def _assemble(
+    state: str,
+    reason: str,
+    source: str,
+    alert_count: int | None,
+    sarif: dict[str, Any] | None,
+    api: dict[str, Any] | None,
+    repository: str | None = None,
+    commit_sha: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "version": "security_alert_summary.v1",
+        "authority": "diagnostic_signal",
+        "risk_class": "diagnostic",
+        "state": state,
+        "state_reason": reason,
+        "evidence_source": source,
+        "alert_count": alert_count,
+        "fail_closed": state != "clean",
+        "repository": repository,
+        "commit_sha": commit_sha,
+        "sarif_evidence": sarif,
+        "api_evidence": api,
+        "required_permissions": dict(_REQUIRED_PERMISSIONS),
+        "does_not_prove": list(_DOES_NOT_PROVE),
+    }
+
+
+def classify_security_alert_state(
+    *,
+    sarif_evidence: Mapping[str, Any] | None = None,
+    api_evidence: Mapping[str, Any] | None = None,
+    repository: str | None = None,
+    commit_sha: str | None = None,
+) -> dict[str, Any]:
+    """Classify security-alert readback evidence into one explicit state.
+
+    Repository-local SARIF evidence is authoritative whenever it resolves to
+    a definitive state (clean or alerts_present): it is deterministic,
+    CI-produced, and needs no additional permission or network call. Live
+    API evidence is used to fill gaps when SARIF evidence is absent or
+    unavailable, and to positively confirm agreement; a disagreement between
+    two definitive sources fails closed to "unknown" rather than picking
+    one silently. Supplying neither source fails closed to "unknown" rather
+    than "clean".
+    """
+
+    if repository is not None and not isinstance(repository, str):
+        raise SecurityAlertSummaryError("repository must be a string")
+    if commit_sha is not None and not isinstance(commit_sha, str):
+        raise SecurityAlertSummaryError("commit_sha must be a string")
+
+    sarif = _parse_sarif_evidence(sarif_evidence)
+    api = _parse_api_evidence(api_evidence)
+
+    # Validate binding consistency across evidence sources
+    sarif_repo = sarif.get("repository") if sarif else None
+    api_repo = api.get("repository") if api else None
+    if sarif_repo is not None and api_repo is not None and sarif_repo != api_repo:
+        raise SecurityAlertSummaryError(
+            f"Evidence repository mismatch: sarif repository '{sarif_repo}' does not match api repository '{api_repo}'"
+        )
+
+    sarif_sha = sarif.get("commit_sha") if sarif else None
+    api_sha = api.get("commit_sha") if api else None
+    if sarif_sha is not None and api_sha is not None and sarif_sha != api_sha:
+        raise SecurityAlertSummaryError(
+            f"Evidence commit_sha mismatch: sarif commit_sha '{sarif_sha}' does not match api commit_sha '{api_sha}'"
+        )
+
+    effective_repo = repository or sarif_repo or api_repo
+    if repository is not None:
+        if sarif_repo is not None and sarif_repo != repository:
+            raise SecurityAlertSummaryError(
+                f"sarif_evidence repository '{sarif_repo}' does not match requested repository '{repository}'"
+            )
+        if api_repo is not None and api_repo != repository:
+            raise SecurityAlertSummaryError(
+                f"api_evidence repository '{api_repo}' does not match requested repository '{repository}'"
+            )
+
+    effective_sha = commit_sha or sarif_sha or api_sha
+    if commit_sha is not None:
+        if sarif_sha is not None and sarif_sha != commit_sha:
+            raise SecurityAlertSummaryError(
+                f"sarif_evidence commit_sha '{sarif_sha}' does not match requested commit_sha '{commit_sha}'"
+            )
+        if api_sha is not None and api_sha != commit_sha:
+            raise SecurityAlertSummaryError(
+                f"api_evidence commit_sha '{api_sha}' does not match requested commit_sha '{commit_sha}'"
+            )
+
+    sarif_verdict = _sarif_verdict(sarif)
+    api_verdict = _api_verdict(api)
+
+    if sarif_verdict is not None and sarif_verdict[0] in _DEFINITIVE_STATES:
+        if (
+            api_verdict is not None
+            and api_verdict[0] in _DEFINITIVE_STATES
+            and api_verdict[0] != sarif_verdict[0]
+        ):
+            state, reason, count = "unknown", "sarif_api_state_disagreement", None
+        else:
+            state, reason, count = sarif_verdict
+        source = "sarif+api" if api_verdict is not None else "sarif"
+        return _assemble(state, reason, source, count, sarif, api, effective_repo, effective_sha)
+
+    if api_verdict is not None:
+        state, reason, count = api_verdict
+        source = "sarif+api" if sarif_verdict is not None else "api"
+        return _assemble(state, reason, source, count, sarif, api, effective_repo, effective_sha)
+
+    if sarif_verdict is not None:
+        state, reason, count = sarif_verdict
+        return _assemble(state, reason, "sarif", count, sarif, api, effective_repo, effective_sha)
+
+    return _assemble("unknown", "no_evidence_supplied", "none", None, sarif, api, effective_repo, effective_sha)
+
+
+def known_states() -> tuple[str, ...]:
+    """Return the closed vocabulary of readback states, in fail-closed order."""
+
+    return _STATES
+

--- a/merger/repoground/retrieval/security_alert_summary.py
+++ b/merger/repoground/retrieval/security_alert_summary.py
@@ -52,131 +52,126 @@ class SecurityAlertSummaryError(ValueError):
     """Raised when readback evidence cannot be classified safely."""
 
 
+def _require_evidence_mapping(
+    value: Any, *, name: str, allowed_fields: set[str]
+) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise SecurityAlertSummaryError(f"{name} must be an object")
+    extra = set(value) - allowed_fields
+    if extra:
+        raise SecurityAlertSummaryError(
+            f"{name} has unsupported fields: {sorted(extra)}"
+        )
+    if value.get("stale") is True:
+        raise SecurityAlertSummaryError(f"{name} is marked stale")
+    return value
+
+
+def _optional_string(value: Any, *, field: str, name: str) -> str | None:
+    if value is not None and not isinstance(value, str):
+        raise SecurityAlertSummaryError(f"{name}.{field} must be a string")
+    return value
+
+
+def _optional_bool(value: Any, *, field: str, name: str) -> bool | None:
+    if value is not None and not isinstance(value, bool):
+        raise SecurityAlertSummaryError(f"{name}.{field} must be a boolean")
+    return value
+
+
+def _non_negative_int(value: Any, *, field: str, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise SecurityAlertSummaryError(
+            f"{name}.{field} must be a non-negative integer"
+        )
+    return value
+
+
+def _evidence_identity(
+    value: Mapping[str, Any], *, name: str
+) -> tuple[str | None, str | None]:
+    return (
+        _optional_string(value.get("repository"), field="repository", name=name),
+        _optional_string(value.get("commit_sha"), field="commit_sha", name=name),
+    )
+
+
 def _parse_sarif_evidence(value: Any) -> dict[str, Any] | None:
     if value is None:
         return None
-    if not isinstance(value, Mapping):
-        raise SecurityAlertSummaryError("sarif_evidence must be an object")
-    extra = set(value) - {"available", "alert_count", "repository", "commit_sha", "stale"}
-    if extra:
-        raise SecurityAlertSummaryError(
-            f"sarif_evidence has unsupported fields: {sorted(extra)}"
-        )
-    if value.get("stale") is True:
-        raise SecurityAlertSummaryError("sarif_evidence is marked stale")
-    available = value.get("available")
+    evidence = _require_evidence_mapping(
+        value,
+        name="sarif_evidence",
+        allowed_fields={"available", "alert_count", "repository", "commit_sha", "stale"},
+    )
+    available = evidence.get("available")
     if not isinstance(available, bool):
         raise SecurityAlertSummaryError("sarif_evidence.available must be a boolean")
-
-    repo = value.get("repository")
-    if repo is not None and not isinstance(repo, str):
-        raise SecurityAlertSummaryError("sarif_evidence.repository must be a string")
-
-    sha = value.get("commit_sha")
-    if sha is not None and not isinstance(sha, str):
-        raise SecurityAlertSummaryError("sarif_evidence.commit_sha must be a string")
-
+    repo, sha = _evidence_identity(evidence, name="sarif_evidence")
+    count = evidence.get("alert_count")
     if available:
-        count = value.get("alert_count")
-        if isinstance(count, bool) or not isinstance(count, int) or count < 0:
-            raise SecurityAlertSummaryError(
-                "sarif_evidence.alert_count must be a non-negative integer when available"
-            )
-        return {
-            "available": True,
-            "alert_count": count,
-            "repository": repo,
-            "commit_sha": sha,
-            "stale": value.get("stale"),
-        }
-    if value.get("alert_count") is not None:
+        count = _non_negative_int(
+            count, field="alert_count", name="sarif_evidence"
+        )
+    elif count is not None:
         raise SecurityAlertSummaryError(
             "sarif_evidence.alert_count must be omitted or null when unavailable"
         )
     return {
-        "available": False,
-        "alert_count": None,
+        "available": available,
+        "alert_count": count,
         "repository": repo,
         "commit_sha": sha,
-        "stale": value.get("stale"),
+        "stale": evidence.get("stale"),
     }
+
+
+def _valid_http_status(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or not 100 <= value <= 599:
+        raise SecurityAlertSummaryError(
+            "api_evidence.status_code must be a valid HTTP status integer"
+        )
+    return value
 
 
 def _parse_api_evidence(value: Any) -> dict[str, Any] | None:
     if value is None:
         return None
-    if not isinstance(value, Mapping):
-        raise SecurityAlertSummaryError("api_evidence must be an object")
-    extra = set(value) - {
-        "status_code",
-        "open_alert_count",
-        "repository",
-        "commit_sha",
-        "paginated",
-        "page_count",
-        "stale",
-    }
-    if extra:
-        raise SecurityAlertSummaryError(
-            f"api_evidence has unsupported fields: {sorted(extra)}"
+    evidence = _require_evidence_mapping(
+        value,
+        name="api_evidence",
+        allowed_fields={
+            "status_code", "open_alert_count", "repository", "commit_sha",
+            "paginated", "page_count", "stale",
+        },
+    )
+    status = _valid_http_status(evidence.get("status_code"))
+    repo, sha = _evidence_identity(evidence, name="api_evidence")
+    paginated = _optional_bool(
+        evidence.get("paginated"), field="paginated", name="api_evidence"
+    )
+    page_count = evidence.get("page_count")
+    if page_count is not None:
+        page_count = _non_negative_int(
+            page_count, field="page_count", name="api_evidence"
         )
-    if value.get("stale") is True:
-        raise SecurityAlertSummaryError("api_evidence is marked stale")
-
-    status = value.get("status_code")
-    if isinstance(status, bool) or not isinstance(status, int) or not 100 <= status <= 599:
-        raise SecurityAlertSummaryError(
-            "api_evidence.status_code must be a valid HTTP status integer"
-        )
-
-    repo = value.get("repository")
-    if repo is not None and not isinstance(repo, str):
-        raise SecurityAlertSummaryError("api_evidence.repository must be a string")
-
-    sha = value.get("commit_sha")
-    if sha is not None and not isinstance(sha, str):
-        raise SecurityAlertSummaryError("api_evidence.commit_sha must be a string")
-
-    paginated = value.get("paginated")
-    if paginated is not None and not isinstance(paginated, bool):
-        raise SecurityAlertSummaryError("api_evidence.paginated must be a boolean")
-
-    page_count = value.get("page_count")
-    if page_count is not None and (
-        isinstance(page_count, bool) or not isinstance(page_count, int) or page_count < 0
-    ):
-        raise SecurityAlertSummaryError(
-            "api_evidence.page_count must be a non-negative integer"
-        )
-
+    count = evidence.get("open_alert_count")
     if status == _OK_STATUS_CODE:
-        count = value.get("open_alert_count")
-        if isinstance(count, bool) or not isinstance(count, int) or count < 0:
-            raise SecurityAlertSummaryError(
-                "api_evidence.open_alert_count must be a non-negative integer "
-                "when status_code is 200"
-            )
-        return {
-            "status_code": status,
-            "open_alert_count": count,
-            "repository": repo,
-            "commit_sha": sha,
-            "paginated": paginated,
-            "page_count": page_count,
-            "stale": value.get("stale"),
-        }
-    if value.get("open_alert_count") is not None:
+        count = _non_negative_int(
+            count, field="open_alert_count", name="api_evidence"
+        )
+    elif count is not None:
         raise SecurityAlertSummaryError(
             "api_evidence.open_alert_count must be omitted or null unless status_code is 200"
         )
     return {
         "status_code": status,
-        "open_alert_count": None,
+        "open_alert_count": count,
         "repository": repo,
         "commit_sha": sha,
         "paginated": paginated,
         "page_count": page_count,
-        "stale": value.get("stale"),
+        "stale": evidence.get("stale"),
     }
 
 
@@ -242,6 +237,73 @@ def _assemble(
     }
 
 
+def _validate_cross_source_binding(
+    sarif: dict[str, Any] | None, api: dict[str, Any] | None
+) -> None:
+    if sarif is None or api is None:
+        return
+    for field in ("repository", "commit_sha"):
+        left = sarif.get(field)
+        right = api.get(field)
+        if left is not None and right is not None and left != right:
+            raise SecurityAlertSummaryError(
+                f"Evidence {field} mismatch: sarif {field} '{left}' does not match "
+                f"api {field} '{right}'"
+            )
+
+
+def _validate_requested_binding(
+    evidence: dict[str, Any] | None,
+    *,
+    source: str,
+    repository: str | None,
+    commit_sha: str | None,
+) -> None:
+    if evidence is None:
+        return
+    for field, expected in (("repository", repository), ("commit_sha", commit_sha)):
+        actual = evidence.get(field)
+        if expected is not None and actual is not None and actual != expected:
+            raise SecurityAlertSummaryError(
+                f"{source}_evidence {field} '{actual}' does not match requested "
+                f"{field} '{expected}'"
+            )
+
+
+def _effective_binding(
+    requested: str | None,
+    sarif: dict[str, Any] | None,
+    api: dict[str, Any] | None,
+    field: str,
+) -> str | None:
+    return requested or (sarif.get(field) if sarif else None) or (api.get(field) if api else None)
+
+
+def _resolve_verdict(
+    sarif_verdict: tuple[str, str, int | None] | None,
+    api_verdict: tuple[str, str, int | None] | None,
+) -> tuple[str, str, int | None, str]:
+    if sarif_verdict is not None and sarif_verdict[0] in _DEFINITIVE_STATES:
+        disagreement = (
+            api_verdict is not None
+            and api_verdict[0] in _DEFINITIVE_STATES
+            and api_verdict[0] != sarif_verdict[0]
+        )
+        state, reason, count = (
+            ("unknown", "sarif_api_state_disagreement", None)
+            if disagreement
+            else sarif_verdict
+        )
+        return state, reason, count, "sarif+api" if api_verdict is not None else "sarif"
+    if api_verdict is not None:
+        state, reason, count = api_verdict
+        return state, reason, count, "sarif+api" if sarif_verdict is not None else "api"
+    if sarif_verdict is not None:
+        state, reason, count = sarif_verdict
+        return state, reason, count, "sarif"
+    return "unknown", "no_evidence_supplied", None, "none"
+
+
 def classify_security_alert_state(
     *,
     sarif_evidence: Mapping[str, Any] | None = None,
@@ -261,76 +323,25 @@ def classify_security_alert_state(
     than "clean".
     """
 
-    if repository is not None and not isinstance(repository, str):
-        raise SecurityAlertSummaryError("repository must be a string")
-    if commit_sha is not None and not isinstance(commit_sha, str):
-        raise SecurityAlertSummaryError("commit_sha must be a string")
-
+    repository = _optional_string(repository, field="repository", name="request")
+    commit_sha = _optional_string(commit_sha, field="commit_sha", name="request")
     sarif = _parse_sarif_evidence(sarif_evidence)
     api = _parse_api_evidence(api_evidence)
-
-    # Validate binding consistency across evidence sources
-    sarif_repo = sarif.get("repository") if sarif else None
-    api_repo = api.get("repository") if api else None
-    if sarif_repo is not None and api_repo is not None and sarif_repo != api_repo:
-        raise SecurityAlertSummaryError(
-            f"Evidence repository mismatch: sarif repository '{sarif_repo}' does not match api repository '{api_repo}'"
-        )
-
-    sarif_sha = sarif.get("commit_sha") if sarif else None
-    api_sha = api.get("commit_sha") if api else None
-    if sarif_sha is not None and api_sha is not None and sarif_sha != api_sha:
-        raise SecurityAlertSummaryError(
-            f"Evidence commit_sha mismatch: sarif commit_sha '{sarif_sha}' does not match api commit_sha '{api_sha}'"
-        )
-
-    effective_repo = repository or sarif_repo or api_repo
-    if repository is not None:
-        if sarif_repo is not None and sarif_repo != repository:
-            raise SecurityAlertSummaryError(
-                f"sarif_evidence repository '{sarif_repo}' does not match requested repository '{repository}'"
-            )
-        if api_repo is not None and api_repo != repository:
-            raise SecurityAlertSummaryError(
-                f"api_evidence repository '{api_repo}' does not match requested repository '{repository}'"
-            )
-
-    effective_sha = commit_sha or sarif_sha or api_sha
-    if commit_sha is not None:
-        if sarif_sha is not None and sarif_sha != commit_sha:
-            raise SecurityAlertSummaryError(
-                f"sarif_evidence commit_sha '{sarif_sha}' does not match requested commit_sha '{commit_sha}'"
-            )
-        if api_sha is not None and api_sha != commit_sha:
-            raise SecurityAlertSummaryError(
-                f"api_evidence commit_sha '{api_sha}' does not match requested commit_sha '{commit_sha}'"
-            )
-
-    sarif_verdict = _sarif_verdict(sarif)
-    api_verdict = _api_verdict(api)
-
-    if sarif_verdict is not None and sarif_verdict[0] in _DEFINITIVE_STATES:
-        if (
-            api_verdict is not None
-            and api_verdict[0] in _DEFINITIVE_STATES
-            and api_verdict[0] != sarif_verdict[0]
-        ):
-            state, reason, count = "unknown", "sarif_api_state_disagreement", None
-        else:
-            state, reason, count = sarif_verdict
-        source = "sarif+api" if api_verdict is not None else "sarif"
-        return _assemble(state, reason, source, count, sarif, api, effective_repo, effective_sha)
-
-    if api_verdict is not None:
-        state, reason, count = api_verdict
-        source = "sarif+api" if sarif_verdict is not None else "api"
-        return _assemble(state, reason, source, count, sarif, api, effective_repo, effective_sha)
-
-    if sarif_verdict is not None:
-        state, reason, count = sarif_verdict
-        return _assemble(state, reason, "sarif", count, sarif, api, effective_repo, effective_sha)
-
-    return _assemble("unknown", "no_evidence_supplied", "none", None, sarif, api, effective_repo, effective_sha)
+    _validate_cross_source_binding(sarif, api)
+    _validate_requested_binding(
+        sarif, source="sarif", repository=repository, commit_sha=commit_sha
+    )
+    _validate_requested_binding(
+        api, source="api", repository=repository, commit_sha=commit_sha
+    )
+    effective_repo = _effective_binding(repository, sarif, api, "repository")
+    effective_sha = _effective_binding(commit_sha, sarif, api, "commit_sha")
+    state, reason, count, source = _resolve_verdict(
+        _sarif_verdict(sarif), _api_verdict(api)
+    )
+    return _assemble(
+        state, reason, source, count, sarif, api, effective_repo, effective_sha
+    )
 
 
 def known_states() -> tuple[str, ...]:

--- a/merger/repoground/tests/test_security_alert_summary.py
+++ b/merger/repoground/tests/test_security_alert_summary.py
@@ -112,7 +112,7 @@ def test_sarif_clean_dominates_a_concurrent_api_404():
     )
     assert summary["state"] == "clean"
     assert summary["state_reason"] == "sarif_result_count"
-    assert summary["evidence_source"] == "sarif+api"
+    assert summary["evidence_source"] == "sarif"
 
 
 def test_sarif_unavailable_falls_back_to_api_403_unauthorized():
@@ -278,3 +278,21 @@ def test_paginated_api_evidence_is_supported_and_validated():
             api_evidence={"status_code": 200, "open_alert_count": 0, "page_count": -1}
         )
 
+
+
+def test_sarif_unavailable_api_clean_with_pagination_is_clean():
+    summary = _validate(classify_security_alert_state(
+        sarif_evidence={"available": False, "alert_count": None},
+        api_evidence={"status_code": 200, "open_alert_count": 0, "paginated": True, "page_count": 1},
+    ))
+    assert summary["state"] == "clean"
+    assert summary["state_reason"] == "api_result_count"
+    assert summary["evidence_source"] == "sarif+api"
+
+
+@pytest.mark.parametrize("source", ["sarif", "api"])
+@pytest.mark.parametrize("stale", ["yes", 1, "false", 0])
+def test_non_boolean_stale_is_rejected(source, stale):
+    evidence = ({"available": True, "alert_count": 0, "stale": stale} if source == "sarif" else {"status_code": 200, "open_alert_count": 0, "paginated": True, "stale": stale})
+    with pytest.raises(SecurityAlertSummaryError, match="stale must be a boolean"):
+        classify_security_alert_state(**{f"{source}_evidence": evidence})

--- a/merger/repoground/tests/test_security_alert_summary.py
+++ b/merger/repoground/tests/test_security_alert_summary.py
@@ -1,0 +1,280 @@
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft7Validator
+
+from merger.repoground.retrieval.security_alert_summary import (
+    SecurityAlertSummaryError,
+    classify_security_alert_state,
+    known_states,
+)
+
+
+def _schema():
+    path = Path(__file__).parents[1] / "contracts" / "security-alert-summary.v1.schema.json"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _validate(summary):
+    Draft7Validator(_schema()).validate(summary)
+    return summary
+
+
+def test_known_states_are_the_closed_fail_closed_vocabulary():
+    assert known_states() == (
+        "clean",
+        "alerts_present",
+        "unavailable",
+        "unauthorized",
+        "unknown",
+    )
+
+
+def test_zero_alerts_from_sarif_alone_is_clean():
+    summary = _validate(
+        classify_security_alert_state(
+            sarif_evidence={"available": True, "alert_count": 0},
+        )
+    )
+    assert summary["state"] == "clean"
+    assert summary["state_reason"] == "sarif_result_count"
+    assert summary["evidence_source"] == "sarif"
+    assert summary["alert_count"] == 0
+    assert summary["fail_closed"] is False
+
+
+def test_zero_alerts_from_api_alone_is_clean():
+    summary = _validate(
+        classify_security_alert_state(
+            api_evidence={"status_code": 200, "open_alert_count": 0, "paginated": True, "page_count": 1},
+        )
+    )
+    assert summary["state"] == "clean"
+    assert summary["state_reason"] == "api_result_count"
+    assert summary["evidence_source"] == "api"
+    assert summary["fail_closed"] is False
+
+
+def test_zero_alerts_from_api_without_pagination_proof_is_unknown():
+    summary = _validate(
+        classify_security_alert_state(
+            api_evidence={"status_code": 200, "open_alert_count": 0},
+        )
+    )
+    assert summary["state"] == "unknown"
+    assert summary["state_reason"] == "api_zero_count_pagination_unproven"
+    assert summary["fail_closed"] is True
+
+
+def test_sarif_alerts_present():
+    summary = _validate(
+        classify_security_alert_state(
+            sarif_evidence={"available": True, "alert_count": 3},
+        )
+    )
+    assert summary["state"] == "alerts_present"
+    assert summary["alert_count"] == 3
+    assert summary["fail_closed"] is True
+
+
+def test_api_alerts_present():
+    summary = _validate(
+        classify_security_alert_state(
+            api_evidence={"status_code": 200, "open_alert_count": 5},
+        )
+    )
+    assert summary["state"] == "alerts_present"
+    assert summary["alert_count"] == 5
+    assert summary["fail_closed"] is True
+
+
+def test_api_404_alone_is_unavailable_not_clean():
+    """The motivating bug: a live 404 must never be read as zero alerts."""
+    summary = _validate(
+        classify_security_alert_state(
+            api_evidence={"status_code": 404, "open_alert_count": None},
+        )
+    )
+    assert summary["state"] == "unavailable"
+    assert summary["state_reason"] == "api_unavailable"
+    assert summary["alert_count"] is None
+    assert summary["fail_closed"] is True
+
+
+def test_sarif_clean_dominates_a_concurrent_api_404():
+    """Deterministic CI-local SARIF evidence outranks an unreachable live API."""
+    summary = _validate(
+        classify_security_alert_state(
+            sarif_evidence={"available": True, "alert_count": 0},
+            api_evidence={"status_code": 404, "open_alert_count": None},
+        )
+    )
+    assert summary["state"] == "clean"
+    assert summary["state_reason"] == "sarif_result_count"
+    assert summary["evidence_source"] == "sarif+api"
+
+
+def test_sarif_unavailable_falls_back_to_api_403_unauthorized():
+    summary = _validate(
+        classify_security_alert_state(
+            sarif_evidence={"available": False, "alert_count": None},
+            api_evidence={"status_code": 403, "open_alert_count": None},
+        )
+    )
+    assert summary["state"] == "unauthorized"
+    assert summary["state_reason"] == "api_unauthorized"
+
+
+@pytest.mark.parametrize("status_code", [401, 403])
+def test_api_unauthorized_status_codes(status_code):
+    summary = _validate(
+        classify_security_alert_state(
+            api_evidence={"status_code": status_code, "open_alert_count": None},
+        )
+    )
+    assert summary["state"] == "unauthorized"
+    assert summary["fail_closed"] is True
+
+
+def test_sarif_unavailable_and_no_api_is_unavailable():
+    summary = _validate(
+        classify_security_alert_state(
+            sarif_evidence={"available": False, "alert_count": None},
+        )
+    )
+    assert summary["state"] == "unavailable"
+    assert summary["state_reason"] == "sarif_unavailable"
+    assert summary["evidence_source"] == "sarif"
+
+
+def test_no_evidence_supplied_fails_closed_to_unknown_not_clean():
+    summary = _validate(classify_security_alert_state())
+    assert summary["state"] == "unknown"
+    assert summary["state_reason"] == "no_evidence_supplied"
+    assert summary["evidence_source"] == "none"
+    assert summary["fail_closed"] is True
+
+
+def test_disagreeing_definitive_sources_fail_closed_to_unknown():
+    summary = _validate(
+        classify_security_alert_state(
+            sarif_evidence={"available": True, "alert_count": 0},
+            api_evidence={"status_code": 200, "open_alert_count": 2},
+        )
+    )
+    assert summary["state"] == "unknown"
+    assert summary["state_reason"] == "sarif_api_state_disagreement"
+    assert summary["fail_closed"] is True
+
+
+def test_documents_least_privilege_required_permissions():
+    summary = _validate(classify_security_alert_state(sarif_evidence={"available": True, "alert_count": 0}))
+    assert "security-events: read" in summary["required_permissions"]["api"]
+    assert "write" not in summary["required_permissions"]["api"].split("security-events: read")[0]
+
+
+@pytest.mark.parametrize(
+    "sarif_evidence",
+    [
+        {"available": "yes", "alert_count": 0},
+        {"available": True, "alert_count": -1},
+        {"available": True, "alert_count": None},
+        {"available": False, "alert_count": 0},
+        {"available": True, "alert_count": 0, "extra": 1},
+    ],
+)
+def test_invalid_sarif_evidence_is_rejected(sarif_evidence):
+    with pytest.raises(SecurityAlertSummaryError):
+        classify_security_alert_state(sarif_evidence=sarif_evidence)
+
+
+@pytest.mark.parametrize(
+    "api_evidence",
+    [
+        {"status_code": 200, "open_alert_count": None},
+        {"status_code": 200, "open_alert_count": -1},
+        {"status_code": 404, "open_alert_count": 0},
+        {"status_code": 999, "open_alert_count": None},
+        {"status_code": 200},
+    ],
+)
+def test_invalid_api_evidence_is_rejected(api_evidence):
+    with pytest.raises(SecurityAlertSummaryError):
+        classify_security_alert_state(api_evidence=api_evidence)
+
+
+def test_repository_and_commit_sha_binding_and_validation():
+    summary = _validate(
+        classify_security_alert_state(
+            sarif_evidence={
+                "available": True,
+                "alert_count": 0,
+                "repository": "owner/repo",
+                "commit_sha": "abc123def456",
+            },
+            repository="owner/repo",
+            commit_sha="abc123def456",
+        )
+    )
+    assert summary["repository"] == "owner/repo"
+    assert summary["commit_sha"] == "abc123def456"
+
+
+def test_mismatched_repository_or_commit_sha_is_rejected():
+    with pytest.raises(SecurityAlertSummaryError, match="repository mismatch"):
+        classify_security_alert_state(
+            sarif_evidence={"available": True, "alert_count": 0, "repository": "owner/repo-a"},
+            api_evidence={"status_code": 200, "open_alert_count": 0, "repository": "owner/repo-b"},
+        )
+
+    with pytest.raises(SecurityAlertSummaryError, match="commit_sha mismatch"):
+        classify_security_alert_state(
+            sarif_evidence={"available": True, "alert_count": 0, "commit_sha": "sha1"},
+            api_evidence={"status_code": 200, "open_alert_count": 0, "commit_sha": "sha2"},
+        )
+
+    with pytest.raises(SecurityAlertSummaryError, match="does not match requested repository"):
+        classify_security_alert_state(
+            sarif_evidence={"available": True, "alert_count": 0, "repository": "owner/repo-a"},
+            repository="owner/repo-b",
+        )
+
+
+def test_stale_evidence_is_rejected():
+    with pytest.raises(SecurityAlertSummaryError, match="sarif_evidence is marked stale"):
+        classify_security_alert_state(
+            sarif_evidence={"available": True, "alert_count": 0, "stale": True}
+        )
+
+    with pytest.raises(SecurityAlertSummaryError, match="api_evidence is marked stale"):
+        classify_security_alert_state(
+            api_evidence={"status_code": 200, "open_alert_count": 0, "stale": True}
+        )
+
+
+def test_paginated_api_evidence_is_supported_and_validated():
+    summary = _validate(
+        classify_security_alert_state(
+            api_evidence={
+                "status_code": 200,
+                "open_alert_count": 45,
+                "paginated": True,
+                "page_count": 2,
+            }
+        )
+    )
+    assert summary["state"] == "alerts_present"
+    assert summary["api_evidence"]["paginated"] is True
+    assert summary["api_evidence"]["page_count"] == 2
+
+    with pytest.raises(SecurityAlertSummaryError, match="paginated must be a boolean"):
+        classify_security_alert_state(
+            api_evidence={"status_code": 200, "open_alert_count": 0, "paginated": "yes"}
+        )
+
+    with pytest.raises(SecurityAlertSummaryError, match="page_count must be a non-negative integer"):
+        classify_security_alert_state(
+            api_evidence={"status_code": 200, "open_alert_count": 0, "page_count": -1}
+        )
+

--- a/merger/repoground/tests/test_security_alert_summary_cli.py
+++ b/merger/repoground/tests/test_security_alert_summary_cli.py
@@ -1,0 +1,154 @@
+import json
+from pathlib import Path
+
+from scripts.ci.emit_security_alert_summary import main
+
+
+def _write_sarif(path: Path, results: list[dict]) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "python.sarif").write_text(
+        json.dumps({"version": "2.1.0", "runs": [{"results": results}]}),
+        encoding="utf-8",
+    )
+
+
+def _run(monkeypatch, args, capsys):
+    monkeypatch.setattr("sys.argv", ["emit_security_alert_summary.py", *args])
+    exit_code = main()
+    return exit_code, capsys.readouterr().out
+
+
+def test_zero_findings_sarif_dir_is_clean_and_exits_zero(tmp_path, monkeypatch, capsys):
+    sarif_dir = tmp_path / "codeql-results"
+    _write_sarif(sarif_dir, [])
+
+    exit_code, out = _run(monkeypatch, ["--sarif-dir", str(sarif_dir)], capsys)
+
+    assert exit_code == 0
+    assert '"state": "clean"' in out
+
+
+def test_findings_present_in_sarif_dir_exits_nonzero(tmp_path, monkeypatch, capsys):
+    sarif_dir = tmp_path / "codeql-results"
+    _write_sarif(
+        sarif_dir,
+        [
+            {
+                "ruleId": "py/path-injection",
+                "locations": [
+                    {
+                        "physicalLocation": {
+                            "artifactLocation": {"uri": "example.py"},
+                            "region": {"startLine": 3},
+                        }
+                    }
+                ],
+            }
+        ],
+    )
+
+    exit_code, out = _run(monkeypatch, ["--sarif-dir", str(sarif_dir)], capsys)
+
+    assert exit_code == 1
+    assert '"state": "alerts_present"' in out
+    assert '"alert_count": 1' in out
+
+
+def test_missing_sarif_dir_is_unavailable_not_clean_and_exits_nonzero(tmp_path, monkeypatch, capsys):
+    missing_dir = tmp_path / "does-not-exist"
+
+    exit_code, out = _run(monkeypatch, ["--sarif-dir", str(missing_dir)], capsys)
+
+    assert exit_code == 1
+    assert '"state": "unavailable"' in out
+    assert '"state": "clean"' not in out
+
+
+def test_api_401_response_is_unauthorized_and_exits_nonzero(tmp_path, monkeypatch, capsys):
+    api_response = tmp_path / "api-response.json"
+    api_response.write_text(json.dumps({"status_code": 401, "open_alert_count": None}), encoding="utf-8")
+
+    exit_code, out = _run(monkeypatch, ["--api-response", str(api_response)], capsys)
+
+    assert exit_code == 1
+    assert '"state": "unauthorized"' in out
+
+
+def test_api_404_response_alone_is_unavailable_not_clean(tmp_path, monkeypatch, capsys):
+    api_response = tmp_path / "api-response.json"
+    api_response.write_text(json.dumps({"status_code": 404, "open_alert_count": None}), encoding="utf-8")
+
+    exit_code, out = _run(monkeypatch, ["--api-response", str(api_response)], capsys)
+
+    assert exit_code == 1
+    assert '"state": "unavailable"' in out
+    assert '"state": "clean"' not in out
+
+
+def test_no_evidence_at_all_fails_closed_to_unknown(monkeypatch, capsys):
+    exit_code, out = _run(monkeypatch, [], capsys)
+
+    assert exit_code == 1
+    assert '"state": "unknown"' in out
+
+
+def test_writes_summary_to_output_path(tmp_path, monkeypatch, capsys):
+    sarif_dir = tmp_path / "codeql-results"
+    _write_sarif(sarif_dir, [])
+    output_path = tmp_path / "security-alert-summary.json"
+
+    exit_code, _out = _run(
+        monkeypatch,
+        ["--sarif-dir", str(sarif_dir), "--output", str(output_path)],
+        capsys,
+    )
+
+    assert exit_code == 0
+    written = json.loads(output_path.read_text(encoding="utf-8"))
+    assert written["state"] == "clean"
+
+
+def test_cli_raw_empty_api_page_without_pagination_proof_fails_closed(tmp_path, monkeypatch, capsys):
+    api_response = tmp_path / "raw-alerts.json"
+    api_response.write_text(json.dumps([]), encoding="utf-8")
+
+    exit_code, out = _run(monkeypatch, ["--api-response", str(api_response)], capsys)
+
+    assert exit_code == 1
+    assert '"state": "unknown"' in out
+    assert 'api_zero_count_pagination_unproven' in out
+
+
+def test_cli_supports_repository_and_commit_sha_arguments(tmp_path, monkeypatch, capsys):
+    sarif_dir = tmp_path / "codeql-results"
+    _write_sarif(sarif_dir, [])
+
+    exit_code, out = _run(
+        monkeypatch,
+        [
+            "--sarif-dir",
+            str(sarif_dir),
+            "--repository",
+            "heimgewebe/repoground",
+            "--commit-sha",
+            "1234567890abcdef1234567890abcdef12345678",
+        ],
+        capsys,
+    )
+
+    assert exit_code == 0
+    assert '"repository": "heimgewebe/repoground"' in out
+    assert '"commit_sha": "1234567890abcdef1234567890abcdef12345678"' in out
+
+
+def test_cli_returns_exit_code_2_on_classification_error(tmp_path, monkeypatch, capsys):
+    api_response = tmp_path / "api-invalid.json"
+    api_response.write_text(
+        json.dumps({"status_code": 200, "open_alert_count": -5}), encoding="utf-8"
+    )
+
+    exit_code, out = _run(monkeypatch, ["--api-response", str(api_response)], capsys)
+
+    assert exit_code == 2
+    assert "security-alert readback error:" in out
+

--- a/scripts/ci/emit_security_alert_summary.py
+++ b/scripts/ci/emit_security_alert_summary.py
@@ -60,7 +60,7 @@ def _load_api_evidence(api_response_path: Path | None) -> dict[str, Any] | None:
         return {
             "status_code": 200,
             "open_alert_count": len(payload),
-            "paginated": False,
+            "paginated": None,
             "page_count": 1,
         }
 
@@ -100,9 +100,10 @@ def main() -> int:
         type=Path,
         default=None,
         help=(
-            "Optional JSON file with a captured "
-            "'GET /repos/{owner}/{repo}/code-scanning/alerts' response, as "
-            '{"status_code": <int>, "open_alert_count": <int|null>}. '
+            "Optional JSON file with captured code-scanning alert evidence. "
+            "A raw GitHub API array is treated as one non-exhaustive page; zero items "
+            "therefore cannot prove clean. To prove exhaustive zero, pass a structured "
+            "object with status_code=200, open_alert_count=0, and paginated=true. "
             "Never fetched by this script; the caller owns any token."
         ),
     )

--- a/scripts/ci/emit_security_alert_summary.py
+++ b/scripts/ci/emit_security_alert_summary.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Emit a fail-closed, machine-readable GitHub security-alert readback summary.
+
+Primary evidence is the raw CodeQL SARIF this repository's own `codeql.yml`
+job already produces (no extra permission, no network call). Optional
+secondary evidence is a captured GitHub code-scanning alerts API response,
+supplied as a small JSON file so this script never makes network calls or
+handles credentials itself.
+
+Exit code is 0 only for the "clean" state. Every other state --
+alerts_present, unavailable, unauthorized, unknown -- exits non-zero, so a
+missing or unreachable readback can never be silently treated as "zero
+alerts".
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.ci.assert_codeql_sarif_clean import collect_results  # noqa: E402
+
+from merger.repoground.retrieval.security_alert_summary import (  # noqa: E402
+    SecurityAlertSummaryError,
+    classify_security_alert_state,
+)
+
+
+def _load_sarif_evidence(sarif_dir: Path | None) -> dict[str, Any] | None:
+    if sarif_dir is None:
+        return None
+    try:
+        _files, findings = collect_results(sarif_dir)
+    except ValueError as exc:
+        print(f"security-alert readback: raw SARIF unavailable ({exc})")
+        return {"available": False, "alert_count": None}
+    return {"available": True, "alert_count": len(findings)}
+
+
+def _load_api_evidence(api_response_path: Path | None) -> dict[str, Any] | None:
+    if api_response_path is None:
+        return None
+    try:
+        payload = json.loads(api_response_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SystemExit(
+            f"security-alert readback: cannot read API evidence file {api_response_path}: {exc}"
+        ) from exc
+
+    if isinstance(payload, list):
+        # Raw GitHub REST API GET /repos/{owner}/{repo}/code-scanning/alerts response array
+        return {
+            "status_code": 200,
+            "open_alert_count": len(payload),
+            "paginated": False,
+            "page_count": 1,
+        }
+
+    if not isinstance(payload, dict):
+        raise SystemExit(
+            "security-alert readback: API evidence file must contain a JSON object or list"
+        )
+
+    if "alerts" in payload and "open_alert_count" not in payload:
+        status_code = payload.get("status_code", 200)
+        alerts = payload["alerts"]
+        if not isinstance(alerts, list):
+            raise SystemExit("security-alert readback: 'alerts' in API evidence must be a list")
+        return {
+            "status_code": status_code,
+            "open_alert_count": len(alerts) if status_code == 200 else None,
+            "repository": payload.get("repository"),
+            "commit_sha": payload.get("commit_sha"),
+            "paginated": payload.get("paginated"),
+            "page_count": payload.get("page_count"),
+            "stale": payload.get("stale"),
+        }
+
+    return payload
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--sarif-dir",
+        type=Path,
+        default=None,
+        help="Directory containing raw CodeQL SARIF output from this job's analyze step.",
+    )
+    parser.add_argument(
+        "--api-response",
+        type=Path,
+        default=None,
+        help=(
+            "Optional JSON file with a captured "
+            "'GET /repos/{owner}/{repo}/code-scanning/alerts' response, as "
+            '{"status_code": <int>, "open_alert_count": <int|null>}. '
+            "Never fetched by this script; the caller owns any token."
+        ),
+    )
+    parser.add_argument(
+        "--repository",
+        type=str,
+        default=os.environ.get("GITHUB_REPOSITORY"),
+        help="Target repository (owner/repo). Defaults to GITHUB_REPOSITORY if set.",
+    )
+    parser.add_argument(
+        "--commit-sha",
+        type=str,
+        default=os.environ.get("GITHUB_SHA"),
+        help="Target commit SHA. Defaults to GITHUB_SHA if set.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Path to write the summary JSON. Always printed to stdout as well.",
+    )
+    args = parser.parse_args()
+
+    sarif_evidence = _load_sarif_evidence(args.sarif_dir)
+    api_evidence = _load_api_evidence(args.api_response)
+
+    try:
+        summary = classify_security_alert_state(
+            sarif_evidence=sarif_evidence,
+            api_evidence=api_evidence,
+            repository=args.repository,
+            commit_sha=args.commit_sha,
+        )
+    except SecurityAlertSummaryError as exc:
+        print(f"security-alert readback error: {exc}")
+        return 2
+
+    rendered = json.dumps(summary, indent=2, sort_keys=True)
+    print(rendered)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered + "\n", encoding="utf-8")
+
+    state = summary["state"]
+    if state == "clean":
+        print("security-alert readback: state=clean (0 alerts, evidence confirmed)")
+        return 0
+
+    print(
+        f"security-alert readback: state={state} ({summary['state_reason']}); "
+        "failing closed -- missing or non-clean evidence is never treated as clean"
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
## Summary
- emit a machine-readable security-alert summary from the existing CodeQL analysis job
- distinguish `clean`, `alerts_present`, `unavailable`, `unauthorized`, and `unknown`
- bind summaries to repository/commit identity when supplied by CI
- treat API failures and unproven zero-count pagination fail-closed
- keep the live API optional; no new secrets or broad readback permissions are introduced

## Independent review corrections
- a `200` API response with zero alerts is not `clean` unless exhaustive pagination is proven
- documentation now limits SARIF authority to the current CodeQL analysis boundary rather than claiming universal vulnerability absence

## Verification
- focused security/CodeQL/workflow tests → 77 passed
- CodeQL suppression ratchet → pass
- GitHub Actions pin check → pass
- reusable workflow contract check → pass
- changed Python files pass Ruff
- `git diff --check` clean

Audit finding: `candidate-52e48525291654cff4605a47`