### PR TITLE
harden(rpu-v1-t024): fail-closed call-graph promotion benchmark

### DIFF
--- a/docs/proofs/python-call-graph-goldset-v1-proof.md
+++ b/docs/proofs/python-call-graph-goldset-v1-proof.md
@@ -66,6 +66,18 @@ Bureau. The report also preserves the nonclaims for completeness, runtime
 reachability, dynamic dispatch, test sufficiency, review completeness and merge
 readiness.
 
+## Fail-closed promotion inputs
+
+The promotion decision is computed only from measured inputs. The gate lists
+any absent, non-numeric or empty required input under
+`decision.insufficient_evidence` and, when that list is non-empty, forces
+`thresholds_met=false` and `eligible_for_review=false` instead of inheriting a
+vacuous `all([])` pass. Missing scored cases, missing agent-task outcomes, a
+missing navigation signal, or any missing quality metric therefore block
+promotion rather than self-attesting one. This hardening changes no measured
+value: the goldset, fixture and call-record digests above are unchanged and the
+happy-path decision simply reports `insufficient_evidence: []`.
+
 ## Commit-bound CI evidence
 
 The canonical pull-request run is bound to:

--- a/docs/proofs/python-call-graph-goldset-v1-proof.md
+++ b/docs/proofs/python-call-graph-goldset-v1-proof.md
@@ -75,8 +75,21 @@ any absent, non-numeric or empty required input under
 vacuous `all([])` pass. Missing scored cases, missing agent-task outcomes, a
 missing navigation signal, or any missing quality metric therefore block
 promotion rather than self-attesting one. This hardening changes no measured
-value: the goldset, fixture and call-record digests above are unchanged and the
+value: the goldset, fixture and call-record digests below are unchanged and the
 happy-path decision simply reports `insufficient_evidence: []`.
+
+The gate additionally fails closed on inputs that are present but not usable as
+measured evidence. A non-finite metric or navigation ratio (`NaN`, `+inf` or
+`-inf`) is classified as `insufficient_evidence` rather than being allowed to
+pass or fail a threshold by chance. A missing or non-numeric promotion
+threshold is surfaced under `insufficient_evidence` (as `thresholds.<field>`)
+instead of raising, so a malformed `decide_promotion` call fails closed rather
+than crashing. Threshold comparisons are inclusive at the exact boundary and a
+malformed, non-empty case or navigation-outcome record can never self-attest a
+`no_case_regression` pass. This robustness is exercised by focused tests for
+non-finite metrics, non-finite navigation ratios, absent and invalid
+thresholds, malformed case records, and the inclusive/just-below boundary of
+each numeric premise.
 
 ## Commit-bound CI evidence
 
@@ -107,6 +120,16 @@ Observed report values on the GitHub-hosted Python 3.12 runner:
 
 The timing value is evidence for this exact runner and commit, not a portable
 performance guarantee.
+
+The bound run above predates the non-finite, threshold-validation and
+malformed-record hardening. Its digests and observed values remain valid
+evidence for the unchanged happy-path fixture — the goldset, fixture and
+call-record digests and the serialized byte count are byte-identical after the
+hardening, and the happy-path decision is unchanged. It does not, however,
+exercise the fail-closed paths added here; those are covered by the focused
+tests listed above and must be re-confirmed by this pull request's CI run,
+whose head SHA, workflow run and artifact digest are not yet minted. This proof
+deliberately does not restate the bound run as covering the new code.
 
 ## Reproduction
 

--- a/merger/repoground/architecture/call_graph_quality_eval.py
+++ b/merger/repoground/architecture/call_graph_quality_eval.py
@@ -580,33 +580,111 @@ def _benchmark_metrics(
     }
 
 
+REQUIRED_METRIC_FIELDS = (
+    "s1_precision",
+    "target_recall",
+    "unresolved_share",
+    "serialized_call_bytes",
+    "build_time_ms",
+    "baseline_tool_calls",
+    "graph_tool_calls",
+)
+REQUIRED_NAVIGATION_FIELDS = (
+    "context_path_reduction_ratio",
+    "no_case_regression",
+)
+
+
+def _is_number(value: Any) -> bool:
+    return not isinstance(value, bool) and isinstance(value, (int, float))
+
+
+def _meets(value: Any, threshold: float) -> bool:
+    """Fail closed: a missing or non-numeric metric never satisfies a gate."""
+
+    return _is_number(value) and float(value) >= float(threshold)
+
+
+def _missing_promotion_inputs(
+    metrics: Mapping[str, Any],
+    case_results: Sequence[Mapping[str, Any]],
+    agent_outcomes: Sequence[Mapping[str, Any]],
+) -> list[str]:
+    """List required promotion inputs that are absent, non-numeric or empty.
+
+    Promotion must be computed from measured inputs. Any missing metric,
+    missing navigation signal, or absent scored evidence blocks promotion
+    rather than letting an empty ``all(...)`` silently attest a pass.
+    """
+
+    missing: list[str] = []
+    for field in REQUIRED_METRIC_FIELDS:
+        if not _is_number(metrics.get(field)):
+            missing.append(field)
+    navigation = metrics.get("navigation_utility")
+    if not isinstance(navigation, Mapping):
+        missing.append("navigation_utility")
+    else:
+        for field in REQUIRED_NAVIGATION_FIELDS:
+            if field not in navigation:
+                missing.append(f"navigation_utility.{field}")
+    if not case_results:
+        missing.append("scored_cases")
+    if not agent_outcomes:
+        missing.append("agent_task_outcomes")
+    return sorted(missing)
+
+
 def _threshold_checks(
     metrics: Mapping[str, Any],
     thresholds: Mapping[str, Any],
     case_results: Sequence[Mapping[str, Any]],
     agent_outcomes: Sequence[Mapping[str, Any]],
 ) -> dict[str, bool]:
-    navigation_metrics = metrics["navigation_utility"]
+    navigation = metrics.get("navigation_utility")
+    navigation = navigation if isinstance(navigation, Mapping) else {}
     return {
-        "minimum_s1_precision": (
-            metrics["s1_precision"] >= thresholds["minimum_s1_precision"]
+        "minimum_s1_precision": _meets(
+            metrics.get("s1_precision"),
+            thresholds["minimum_s1_precision"],
         ),
-        "minimum_target_recall": (
-            metrics["target_recall"] >= thresholds["minimum_target_recall"]
+        "minimum_target_recall": _meets(
+            metrics.get("target_recall"),
+            thresholds["minimum_target_recall"],
         ),
-        "minimum_context_path_reduction": (
-            navigation_metrics["context_path_reduction_ratio"]
-            >= thresholds["minimum_context_path_reduction"]
+        "minimum_context_path_reduction": _meets(
+            navigation.get("context_path_reduction_ratio"),
+            thresholds["minimum_context_path_reduction"],
         ),
         "no_case_regression": (
-            all(case["passed"] for case in case_results)
+            bool(case_results)
+            and bool(agent_outcomes)
+            and all(case["passed"] for case in case_results)
             and all(item["outcome"] == "pass" for item in agent_outcomes)
-            and navigation_metrics["no_case_regression"]
+            and navigation.get("no_case_regression") is True
         ),
     }
 
 
-def _decision(checks: Mapping[str, bool]) -> dict[str, Any]:
+def _decision(
+    checks: Mapping[str, bool],
+    missing_inputs: Sequence[str],
+) -> dict[str, Any]:
+    missing = list(missing_inputs)
+    if missing:
+        return {
+            "threshold_checks": {name: False for name in checks},
+            "thresholds_met": False,
+            "eligible_for_review": False,
+            "default_promoted": False,
+            "decision_authority": "Bureau",
+            "insufficient_evidence": missing,
+            "reason": (
+                "required promotion inputs missing ("
+                + ", ".join(missing)
+                + "); default promotion remains prohibited"
+            ),
+        }
     eligible = all(checks.values())
     reason = (
         "quality thresholds met; a separate reviewed Bureau decision is required"
@@ -619,8 +697,22 @@ def _decision(checks: Mapping[str, bool]) -> dict[str, Any]:
         "eligible_for_review": eligible,
         "default_promoted": False,
         "decision_authority": "Bureau",
+        "insufficient_evidence": [],
         "reason": reason,
     }
+
+
+def decide_promotion(
+    metrics: Mapping[str, Any],
+    thresholds: Mapping[str, Any],
+    case_results: Sequence[Mapping[str, Any]],
+    agent_outcomes: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Compute the fail-closed promotion decision from measured inputs."""
+
+    missing = _missing_promotion_inputs(metrics, case_results, agent_outcomes)
+    checks = _threshold_checks(metrics, thresholds, case_results, agent_outcomes)
+    return _decision(checks, missing)
 
 
 def evaluate_python_call_graph_fixture(
@@ -644,7 +736,7 @@ def evaluate_python_call_graph_fixture(
         navigation,
         tool_counts,
     )
-    checks = _threshold_checks(
+    decision = decide_promotion(
         metrics,
         goldset["thresholds"],
         case_results,
@@ -670,7 +762,7 @@ def evaluate_python_call_graph_fixture(
         "metrics": metrics,
         "cases": case_results,
         "agent_task_outcomes": agent_outcomes,
-        "decision": _decision(checks),
+        "decision": decision,
         "does_not_establish": list(goldset["does_not_establish"]),
     }
 

--- a/merger/repoground/architecture/call_graph_quality_eval.py
+++ b/merger/repoground/architecture/call_graph_quality_eval.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import math
 import time
 from collections import Counter
 from pathlib import Path
@@ -589,45 +590,65 @@ REQUIRED_METRIC_FIELDS = (
     "baseline_tool_calls",
     "graph_tool_calls",
 )
-REQUIRED_NAVIGATION_FIELDS = (
-    "context_path_reduction_ratio",
-    "no_case_regression",
+REQUIRED_THRESHOLD_FIELDS = (
+    "minimum_s1_precision",
+    "minimum_target_recall",
+    "minimum_context_path_reduction",
 )
 
 
-def _is_number(value: Any) -> bool:
-    return not isinstance(value, bool) and isinstance(value, (int, float))
+def _is_finite_number(value: Any) -> bool:
+    """True only for a real, finite measured number (never bool, NaN or inf)."""
+
+    return (
+        not isinstance(value, bool)
+        and isinstance(value, (int, float))
+        and math.isfinite(value)
+    )
 
 
-def _meets(value: Any, threshold: float) -> bool:
-    """Fail closed: a missing or non-numeric metric never satisfies a gate."""
+def _meets(value: Any, threshold: Any) -> bool:
+    """Fail closed: a missing, non-finite or non-numeric side never satisfies a gate."""
 
-    return _is_number(value) and float(value) >= float(threshold)
+    return (
+        _is_finite_number(value)
+        and _is_finite_number(threshold)
+        and float(value) >= float(threshold)
+    )
 
 
 def _missing_promotion_inputs(
     metrics: Mapping[str, Any],
+    thresholds: Mapping[str, Any],
     case_results: Sequence[Mapping[str, Any]],
     agent_outcomes: Sequence[Mapping[str, Any]],
 ) -> list[str]:
-    """List required promotion inputs that are absent, non-numeric or empty.
+    """List required promotion inputs that are absent, non-finite or empty.
 
-    Promotion must be computed from measured inputs. Any missing metric,
-    missing navigation signal, or absent scored evidence blocks promotion
-    rather than letting an empty ``all(...)`` silently attest a pass.
+    Promotion must be computed from measured inputs. Any missing or non-finite
+    metric or threshold, missing navigation signal, or absent scored evidence
+    blocks promotion rather than letting an empty ``all(...)`` silently attest a
+    pass. A non-finite value (``NaN``/``inf``) is treated as absent evidence,
+    not as a value that happens to miss a threshold.
     """
 
     missing: list[str] = []
     for field in REQUIRED_METRIC_FIELDS:
-        if not _is_number(metrics.get(field)):
+        if not _is_finite_number(metrics.get(field)):
             missing.append(field)
     navigation = metrics.get("navigation_utility")
     if not isinstance(navigation, Mapping):
         missing.append("navigation_utility")
     else:
-        for field in REQUIRED_NAVIGATION_FIELDS:
-            if field not in navigation:
-                missing.append(f"navigation_utility.{field}")
+        if not _is_finite_number(navigation.get("context_path_reduction_ratio")):
+            missing.append("navigation_utility.context_path_reduction_ratio")
+        # ``no_case_regression`` is a measured boolean; a present ``False`` is a
+        # real regression signal, not missing evidence, so only absence blocks.
+        if "no_case_regression" not in navigation:
+            missing.append("navigation_utility.no_case_regression")
+    for field in REQUIRED_THRESHOLD_FIELDS:
+        if not _is_finite_number(thresholds.get(field)):
+            missing.append(f"thresholds.{field}")
     if not case_results:
         missing.append("scored_cases")
     if not agent_outcomes:
@@ -646,21 +667,21 @@ def _threshold_checks(
     return {
         "minimum_s1_precision": _meets(
             metrics.get("s1_precision"),
-            thresholds["minimum_s1_precision"],
+            thresholds.get("minimum_s1_precision"),
         ),
         "minimum_target_recall": _meets(
             metrics.get("target_recall"),
-            thresholds["minimum_target_recall"],
+            thresholds.get("minimum_target_recall"),
         ),
         "minimum_context_path_reduction": _meets(
             navigation.get("context_path_reduction_ratio"),
-            thresholds["minimum_context_path_reduction"],
+            thresholds.get("minimum_context_path_reduction"),
         ),
         "no_case_regression": (
             bool(case_results)
             and bool(agent_outcomes)
-            and all(case["passed"] for case in case_results)
-            and all(item["outcome"] == "pass" for item in agent_outcomes)
+            and all(case.get("passed") is True for case in case_results)
+            and all(item.get("outcome") == "pass" for item in agent_outcomes)
             and navigation.get("no_case_regression") is True
         ),
     }
@@ -708,9 +729,19 @@ def decide_promotion(
     case_results: Sequence[Mapping[str, Any]],
     agent_outcomes: Sequence[Mapping[str, Any]],
 ) -> dict[str, Any]:
-    """Compute the fail-closed promotion decision from measured inputs."""
+    """Compute the fail-closed promotion decision from measured inputs.
 
-    missing = _missing_promotion_inputs(metrics, case_results, agent_outcomes)
+    Missing or non-finite thresholds, metrics or evidence are surfaced under
+    ``insufficient_evidence`` instead of raising, so a malformed call fails
+    closed rather than crashing or producing a vacuous pass.
+    """
+
+    missing = _missing_promotion_inputs(
+        metrics,
+        thresholds,
+        case_results,
+        agent_outcomes,
+    )
     checks = _threshold_checks(metrics, thresholds, case_results, agent_outcomes)
     return _decision(checks, missing)
 

--- a/merger/repoground/tests/test_python_call_graph_goldset.py
+++ b/merger/repoground/tests/test_python_call_graph_goldset.py
@@ -5,6 +5,7 @@ import pytest
 
 from merger.repoground.architecture.call_graph_quality_eval import (
     PythonCallGraphGoldsetError,
+    decide_promotion,
     evaluate_python_call_graph_fixture,
     evaluate_python_call_graph_goldset,
     load_python_call_graph_goldset,
@@ -152,3 +153,71 @@ def test_cli_writes_reviewable_report(tmp_path):
     assert report["kind"] == "lenskit.python_call_graph_quality_benchmark"
     assert report["decision"]["thresholds_met"] is True
     assert report["decision"]["default_promoted"] is False
+    assert report["decision"]["insufficient_evidence"] == []
+
+
+def _measured_inputs() -> tuple[dict, dict, list, list]:
+    report = evaluate_python_call_graph_goldset(GOLDSET_PATH)
+    return (
+        report["metrics"],
+        report["thresholds"],
+        report["cases"],
+        report["agent_task_outcomes"],
+    )
+
+
+def test_promotion_fails_closed_when_a_required_metric_is_missing():
+    metrics, thresholds, cases, outcomes = _measured_inputs()
+    del metrics["s1_precision"]
+
+    decision = decide_promotion(metrics, thresholds, cases, outcomes)
+
+    assert decision["thresholds_met"] is False
+    assert decision["eligible_for_review"] is False
+    assert decision["default_promoted"] is False
+    assert "s1_precision" in decision["insufficient_evidence"]
+    assert all(value is False for value in decision["threshold_checks"].values())
+
+
+def test_promotion_fails_closed_when_a_required_metric_is_non_numeric():
+    metrics, thresholds, cases, outcomes = _measured_inputs()
+    metrics["s1_precision"] = None
+
+    decision = decide_promotion(metrics, thresholds, cases, outcomes)
+
+    assert decision["thresholds_met"] is False
+    assert "s1_precision" in decision["insufficient_evidence"]
+
+
+def test_promotion_fails_closed_without_scored_cases_or_agent_outcomes():
+    metrics, thresholds, _cases, _outcomes = _measured_inputs()
+
+    decision = decide_promotion(metrics, thresholds, [], [])
+
+    assert decision["thresholds_met"] is False
+    assert decision["threshold_checks"]["no_case_regression"] is False
+    assert "scored_cases" in decision["insufficient_evidence"]
+    assert "agent_task_outcomes" in decision["insufficient_evidence"]
+
+
+def test_promotion_fails_closed_when_navigation_signal_is_absent():
+    metrics, thresholds, cases, outcomes = _measured_inputs()
+    metrics["navigation_utility"] = {}
+
+    decision = decide_promotion(metrics, thresholds, cases, outcomes)
+
+    assert decision["thresholds_met"] is False
+    assert (
+        "navigation_utility.context_path_reduction_ratio"
+        in decision["insufficient_evidence"]
+    )
+    assert decision["threshold_checks"]["no_case_regression"] is False
+
+
+def test_empty_case_set_does_not_self_attest_a_pass():
+    metrics, thresholds, _cases, _outcomes = _measured_inputs()
+
+    checks = decide_promotion(metrics, thresholds, [], [])["threshold_checks"]
+
+    # ``all([])`` is True; the gate must not inherit that for missing evidence.
+    assert checks["no_case_regression"] is False

--- a/merger/repoground/tests/test_python_call_graph_goldset.py
+++ b/merger/repoground/tests/test_python_call_graph_goldset.py
@@ -1,4 +1,5 @@
 import json
+import math
 from pathlib import Path
 
 import pytest
@@ -221,3 +222,112 @@ def test_empty_case_set_does_not_self_attest_a_pass():
 
     # ``all([])`` is True; the gate must not inherit that for missing evidence.
     assert checks["no_case_regression"] is False
+
+
+@pytest.mark.parametrize(
+    "value",
+    [math.nan, math.inf, -math.inf],
+    ids=["nan", "inf", "-inf"],
+)
+def test_promotion_treats_non_finite_metric_as_insufficient_evidence(value):
+    metrics, thresholds, cases, outcomes = _measured_inputs()
+    metrics["s1_precision"] = value
+
+    decision = decide_promotion(metrics, thresholds, cases, outcomes)
+
+    assert decision["thresholds_met"] is False
+    assert decision["eligible_for_review"] is False
+    assert decision["default_promoted"] is False
+    assert "s1_precision" in decision["insufficient_evidence"]
+    assert all(value is False for value in decision["threshold_checks"].values())
+
+
+@pytest.mark.parametrize(
+    "value",
+    [math.nan, math.inf, -math.inf],
+    ids=["nan", "inf", "-inf"],
+)
+def test_non_finite_navigation_ratio_is_insufficient_evidence(value):
+    metrics, thresholds, cases, outcomes = _measured_inputs()
+    metrics["navigation_utility"]["context_path_reduction_ratio"] = value
+
+    decision = decide_promotion(metrics, thresholds, cases, outcomes)
+
+    assert decision["thresholds_met"] is False
+    assert (
+        "navigation_utility.context_path_reduction_ratio"
+        in decision["insufficient_evidence"]
+    )
+    assert decision["threshold_checks"]["minimum_context_path_reduction"] is False
+
+
+def test_promotion_fails_closed_when_a_threshold_field_is_missing():
+    metrics, thresholds, cases, outcomes = _measured_inputs()
+    del thresholds["minimum_s1_precision"]
+
+    decision = decide_promotion(metrics, thresholds, cases, outcomes)
+
+    assert decision["thresholds_met"] is False
+    assert "thresholds.minimum_s1_precision" in decision["insufficient_evidence"]
+
+
+@pytest.mark.parametrize("value", [None, "0.97", math.nan])
+def test_promotion_fails_closed_when_a_threshold_field_is_invalid(value):
+    metrics, thresholds, cases, outcomes = _measured_inputs()
+    thresholds["minimum_target_recall"] = value
+
+    decision = decide_promotion(metrics, thresholds, cases, outcomes)
+
+    assert decision["thresholds_met"] is False
+    assert "thresholds.minimum_target_recall" in decision["insufficient_evidence"]
+
+
+def test_malformed_case_record_cannot_self_attest_a_pass():
+    metrics, thresholds, cases, outcomes = _measured_inputs()
+    # A non-empty but malformed record (no ``passed`` field) must not crash the
+    # gate nor be counted as a pass.
+    malformed = {k: v for k, v in cases[0].items() if k != "passed"}
+
+    decision = decide_promotion(metrics, thresholds, [malformed], outcomes)
+
+    assert decision["threshold_checks"]["no_case_regression"] is False
+    assert decision["thresholds_met"] is False
+
+
+@pytest.mark.parametrize(
+    ("threshold_key", "check_key", "metric_getter"),
+    [
+        (
+            "minimum_s1_precision",
+            "minimum_s1_precision",
+            lambda metrics: ("s1_precision", metrics),
+        ),
+        (
+            "minimum_target_recall",
+            "minimum_target_recall",
+            lambda metrics: ("target_recall", metrics),
+        ),
+        (
+            "minimum_context_path_reduction",
+            "minimum_context_path_reduction",
+            lambda metrics: (
+                "context_path_reduction_ratio",
+                metrics["navigation_utility"],
+            ),
+        ),
+    ],
+)
+def test_numeric_threshold_boundary_is_inclusive(
+    threshold_key, check_key, metric_getter
+):
+    metrics, thresholds, cases, outcomes = _measured_inputs()
+    field, container = metric_getter(metrics)
+    threshold = float(thresholds[threshold_key])
+
+    container[field] = threshold
+    at_boundary = decide_promotion(metrics, thresholds, cases, outcomes)
+    assert at_boundary["threshold_checks"][check_key] is True
+
+    container[field] = math.nextafter(threshold, -math.inf)
+    below_boundary = decide_promotion(metrics, thresholds, cases, outcomes)
+    assert below_boundary["threshold_checks"][check_key] is False


### PR DESCRIPTION
## Summary

Completes the remaining hardening for Bureau task `RPU-V1-T024` on top of the existing Python call-graph goldset and promotion benchmark.

- makes promotion decisions fail closed when required measured inputs are missing, empty, malformed, non-numeric, NaN, or infinite;
- prevents empty/malformed case and navigation-task evidence from self-attesting `no_case_regression` via vacuous `all([])` semantics;
- validates required promotion thresholds fail closed and adds explicit inclusive boundary tests;
- keeps `default_promoted=false` unconditionally; passing measurements only produce `eligible_for_review=true` with Bureau as decision authority;
- documents that the historical commit-bound CI evidence predates this hardening and does not falsely claim to cover the new code paths.

The call-graph producer and the fixed goldset measurements are unchanged.

## Measured happy path

- S1 precision: `1.0`
- target recall: `1.0`
- unresolved share: `0.307692`
- context-path reduction: `0.5454545454545454`
- `default_promoted`: `false`

## Validation

- `python -m pytest -q merger/repoground/tests/test_python_call_graph_goldset.py merger/repoground/tests/test_python_call_graph.py merger/repoground/tests/test_agent_impact_refinement.py` → `61 passed`
- `python -m ruff check merger/repoground/architecture/call_graph_quality_eval.py merger/repoground/tests/test_python_call_graph_goldset.py` → passed
- `git diff --check origin/main...HEAD` → clean
- two independent read-only reviews → PASS, no merge blockers

## Task

Bureau: `RPU-V1-T024 — Symbol call graph goldset and promotion benchmark`
