### PR TITLE
perf(mcp): defer heavy stdio handler imports

### DIFF
--- a/merger/repoground/cli/mcp_stdio.py
+++ b/merger/repoground/cli/mcp_stdio.py
@@ -8,7 +8,6 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, TextIO
 
-from merger.repoground.core import mcp_resources, mcp_tools
 from merger.repoground.core.live_freshness import (
     DOES_NOT_ESTABLISH as FRESHNESS_DOES_NOT_ESTABLISH,
 )
@@ -340,6 +339,8 @@ class RepoGroundMcpStdioServer:
             }
 
     def _resource_list(self) -> dict[str, Any]:
+        from merger.repoground.core import mcp_resources
+
         listed = mcp_resources.list_mcp_resources(self.bundle_root)
         resources = []
         for item in listed.get("resources", []):
@@ -362,6 +363,8 @@ class RepoGroundMcpStdioServer:
         return {"resources": resources}
 
     def _resource_templates(self) -> dict[str, Any]:
+        from merger.repoground.core import mcp_resources
+
         return {
             "resourceTemplates": [
                 {
@@ -380,6 +383,8 @@ class RepoGroundMcpStdioServer:
         uri = params.get("uri")
         if not isinstance(uri, str) or not uri:
             raise McpProtocolError(-32602, "resources/read requires a non-empty uri")
+        from merger.repoground.core import mcp_resources
+
         result = mcp_resources.read_mcp_resource(uri, bundle_root=self.bundle_root)
         manifest = result.get("bundle_manifest")
         live = None
@@ -408,6 +413,8 @@ class RepoGroundMcpStdioServer:
         call_args = dict(arguments)
         manifest = self._guard_manifest(call_args.get("bundle_manifest"))
         call_args["bundle_manifest"] = str(manifest)
+        from merger.repoground.core import mcp_tools
+
         payload = mcp_tools.ask_context(**call_args)
         payload["live_freshness"] = self._safe_live_freshness(manifest)
         return payload
@@ -421,6 +428,8 @@ class RepoGroundMcpStdioServer:
             manifest,
             label="citation_map",
         )
+        from merger.repoground.core import mcp_tools
+
         payload = mcp_tools.grounding_verify(**call_args)
         payload["live_freshness"] = self._safe_live_freshness(manifest)
         return payload
@@ -433,6 +442,8 @@ class RepoGroundMcpStdioServer:
         name = call_args.get("name")
         if not isinstance(name, str) or not name.strip():
             raise McpProtocolError(-32602, "find_symbol requires a non-empty name")
+        from merger.repoground.core import mcp_tools
+
         kind = call_args.get("kind")
         if kind is not None and kind not in mcp_tools.FIND_SYMBOL_KINDS:
             raise McpProtocolError(
@@ -464,6 +475,8 @@ class RepoGroundMcpStdioServer:
             )
         manifest = self._guard_manifest(call_args.get("bundle_manifest"))
         call_args["bundle_manifest"] = str(manifest)
+        from merger.repoground.core import mcp_tools
+
         handlers = {
             "find_references": mcp_tools.find_references,
             "get_callers": mcp_tools.get_callers,
@@ -489,6 +502,8 @@ class RepoGroundMcpStdioServer:
         call_args = dict(arguments)
         call_args["repo"] = str(self.repo_root)
         call_args["output_root"] = str(self.snapshot_output_root)
+        from merger.repoground.core import mcp_tools
+
         return mcp_tools.snapshot_create(**call_args)
 
     def _tool_payload(self, name: str, arguments: Mapping[str, Any]) -> dict[str, Any]:

--- a/merger/repoground/tests/test_mcp_stdio.py
+++ b/merger/repoground/tests/test_mcp_stdio.py
@@ -1,4 +1,6 @@
 import json
+import subprocess
+import sys
 from io import StringIO
 from pathlib import Path
 
@@ -46,6 +48,45 @@ def _tools(server: RepoGroundMcpStdioServer) -> list[dict]:
         {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}
     )
     return response["result"]["tools"]
+
+
+def test_mcp_stdio_handshake_defers_handler_modules():
+    root = Path(__file__).resolve().parents[3]
+    probe = """
+import json
+import sys
+import tempfile
+
+from merger.repoground.cli.mcp_stdio import PROTOCOL_VERSION, RepoGroundMcpStdioServer
+
+with tempfile.TemporaryDirectory() as bundle_root:
+    server = RepoGroundMcpStdioServer(bundle_root=bundle_root)
+    server.handle_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {"protocolVersion": PROTOCOL_VERSION},
+        }
+    )
+    server.handle_message(
+        {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}
+    )
+
+names = (
+    "merger.repoground.core.mcp_resources",
+    "merger.repoground.core.mcp_tools",
+)
+print(json.dumps([name for name in names if name in sys.modules]))
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert json.loads(completed.stdout) == []
 
 
 def test_canonical_mcp_server_identity(tmp_path):


### PR DESCRIPTION
## Summary

- defer `mcp_resources` and `mcp_tools` imports until the corresponding MCP operation is invoked
- keep cheap transport validation and authorization checks ahead of the heavy imports
- prove that `initialize` plus `tools/list` leaves both handler modules unloaded

## Measured effect

Seven fresh Python subprocesses on the same checkout:

- `merger.repoground.cli.mcp_stdio` import median: **65.995 ms -> 5.440 ms**
- loaded module count: **246 -> 97**

This changes startup cost only. Tool schemas, JSON-RPC behavior, bundle guards, freshness projection and handler results are unchanged.

## Validation

- `python3 -m pytest -q merger/repoground/tests/test_mcp_stdio.py merger/repoground/tests/test_mcp_stdio_e2e.py merger/repoground/tests/test_mcp_resources.py merger/repoground/tests/test_mcp_snapshot_create.py` — 55 passed
- `python3 -m pytest -q merger/repoground/tests -k mcp` — 73 passed, 4506 deselected
- `python3 -m ruff check merger/repoground/cli/mcp_stdio.py merger/repoground/tests/test_mcp_stdio.py` — pass
- `git diff --check` — pass

## Review binding

- base: `de1fffa98fb9ed2bbb33d5229172746d89c6b40c`
- head: `c99d5b1cbf960d1c917f81187bca2dd033cddb07`
- diff SHA-256: `ae765ea8b6327b517d75405cfb2e12999a42c73aa0cd32140fa5084623c7104e`

The review establishes the bounded import-timing change and its tests; it does not establish performance on every machine or remove the first-use cost of the deferred handlers.