### PR TITLE
feat: prototype external patch evaluation sidecar

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -39,6 +39,11 @@ jobs:
         run: |
           python -m pip install --disable-pip-version-check --require-hashes -r requirements/repoground-dev.lock.txt
 
+      - name: Install Patch Evaluation sandbox runtime
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends --yes bubblewrap
+
       - name: Run full pytest suite
         run: pytest -q -m "not browser and not doc_freshness_live"
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -39,10 +39,20 @@ jobs:
         run: |
           python -m pip install --disable-pip-version-check --require-hashes -r requirements/repoground-dev.lock.txt
 
-      - name: Install Patch Evaluation sandbox runtime
+      - name: Install and verify Patch Evaluation sandbox runtime
         run: |
           sudo apt-get update
           sudo apt-get install --no-install-recommends --yes bubblewrap
+          if sysctl kernel.unprivileged_userns_clone >/dev/null 2>&1; then
+            sudo sysctl -w kernel.unprivileged_userns_clone=1
+          fi
+          if sysctl kernel.apparmor_restrict_unprivileged_userns >/dev/null 2>&1; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
+          bwrap --die-with-parent --new-session --unshare-pid \
+            --ro-bind /usr /usr --ro-bind-try /bin /bin \
+            --ro-bind-try /lib /lib --ro-bind-try /lib64 /lib64 \
+            --proc /proc --dev /dev /usr/bin/true
 
       - name: Run full pytest suite
         run: pytest -q -m "not browser and not doc_freshness_live"

--- a/docs/architecture/repobrief-agent-workbench-boundary.md
+++ b/docs/architecture/repobrief-agent-workbench-boundary.md
@@ -283,5 +283,27 @@ The decision is not “tooling or no tooling.” The decision is “deterministi
 
 - RBAW-V1-T002: defined by [Patch Evaluation Artifact v1](../contracts/patch-evaluation-v1.md).
 - RBAW-V1-T003: implemented by the read-only Patch Evaluation consumer described in [Patch Evaluation Artifact v1](../contracts/patch-evaluation-v1.md).
-- RBAW-V1-T004: prototype an external Patch Evaluation Sidecar harness later, after provenance/freshness and agent-evidence hygiene remain stable.
+- RBAW-V1-T004: prototype an external Patch Evaluation Sidecar harness after provenance/freshness and agent-evidence hygiene stabilized.
 - RBAW-V1-T005: triaged by [RepoGround Agent Optimization Triage v1](repobrief-agent-optimization-triage.md).
+
+## RBAW-V1-T004 prototype realization
+
+The first Patch Evaluation Sidecar prototype lives at
+`tools/patch_evaluation_sidecar.py`, outside `merger/repoground/core`. This
+placement is architectural: RepoBrief remains the read-only consumer, while the
+prototype alone owns disposable worktree creation, patch application, and
+argv-only command execution.
+
+The prototype has deliberately narrow authority. It accepts local repositories,
+local patch files, exact commits, relative command working directories, bounded
+command counts, and explicit timeouts. It does not expose hidden RepoGround MCP
+side effects, inherit arbitrary environment variables, authorize a merge,
+create a pull request, or claim that a passing command set proves the patch
+correct. Filesystem isolation, credential isolation, and network isolation are
+not implemented in this prototype and are therefore reported as `unknown`; only
+trusted configured commands may be run. `PATH` is inherited for tool discovery,
+while Git global/system configuration and hooks are suppressed for the
+Sidecar-owned Git operations. The source drift fingerprint covers checkout and staged-index content, not
+unrelated refs or repository configuration. Stronger sandbox and
+credential policies remain separate deployment work rather than implied
+guarantees.

--- a/docs/architecture/repobrief-agent-workbench-boundary.md
+++ b/docs/architecture/repobrief-agent-workbench-boundary.md
@@ -291,19 +291,39 @@ The decision is not “tooling or no tooling.” The decision is “deterministi
 The first Patch Evaluation Sidecar prototype lives at
 `tools/patch_evaluation_sidecar.py`, outside `merger/repoground/core`. This
 placement is architectural: RepoBrief remains the read-only consumer, while the
-prototype alone owns disposable worktree creation, patch application, and
-argv-only command execution.
+prototype alone owns independent repository materialization, patch application,
+and argv-only command execution.
 
-The prototype has deliberately narrow authority. It accepts local repositories,
-local patch files, exact commits, relative command working directories, bounded
-command counts, and explicit timeouts. It does not expose hidden RepoGround MCP
-side effects, inherit arbitrary environment variables, authorize a merge,
-create a pull request, or claim that a passing command set proves the patch
-correct. Filesystem isolation, credential isolation, and network isolation are
-not implemented in this prototype and are therefore reported as `unknown`; only
-trusted configured commands may be run. `PATH` is inherited for tool discovery,
-while Git global/system configuration and hooks are suppressed for the
-Sidecar-owned Git operations. The source drift fingerprint covers checkout and staged-index content, not
-unrelated refs or repository configuration. Stronger sandbox and
-credential policies remain separate deployment work rather than implied
-guarantees.
+The prototype accepts local repositories, local patch files, exact commits,
+relative command working directories, bounded command counts, explicit timeouts,
+and an optional `fail_fast` policy. It snapshots the patch once and materializes
+only the exact commit and its tree into a newly initialized Git repository. The
+repository has its own Git directory, configuration, refs, and object database;
+no alternates or multiply linked object files are accepted. Source-local Git
+hooks and configured clean, smudge, and process filters are neutralized for
+Sidecar-owned Git operations.
+
+Declared commands run with `shell=False` inside a Linux Bubblewrap filesystem
+and PID namespace. The source checkout is not mounted. The independent repository,
+a private home directory, and a private temporary directory are the only writable
+mounts; required system directories are read-only. The fixed system `PATH` is not
+inherited from the caller. Background descendants are contained by the PID
+namespace, while timed-out host process groups receive TERM followed by an
+unconditional KILL sweep. Bubblewrap and Linux are therefore runtime requirements
+for this prototype.
+
+Network isolation is not asserted and remains `unknown`. Secret handling also
+remains `unknown`: the environment is allowlisted, explicit argv indexes can be
+redacted from artifact command strings and bounded logs, and common secret-shaped
+options are display-redacted, but arbitrary command output cannot be proven free
+of credentials. A passing result remains evidence only and does not authorize a
+merge, create a pull request, or establish correctness.
+
+The source drift fingerprint covers HEAD, Git status, tracked worktree diff,
+staged-index diff, and the content of non-ignored untracked files. Ignored files,
+unrelated refs, repository configuration, and the object database are outside
+that fingerprint; commands cannot reach them through the Bubblewrap mount
+namespace. Fingerprinting, repository materialization, request data, patch data,
+argv, context data, changed-file counts, logs, and command execution have explicit
+limits. Stronger network and credential policies remain deployment work rather
+than implied guarantees.

--- a/docs/contracts/patch-evaluation-v1.md
+++ b/docs/contracts/patch-evaluation-v1.md
@@ -93,5 +93,35 @@ when it cannot be read.
 
 ## Deferred
 
-- The external Patch Evaluation Sidecar itself (RBAW-V1-T004).
 - Linking consumed artifacts into bundle-manifest surfaces / MCP resources.
+
+## External prototype harness (RBAW-V1-T004)
+
+`tools/patch_evaluation_sidecar.py` is a deliberately external prototype producer.
+It is not imported by RepoBrief core or exposed through RepoGround MCP. The CLI
+accepts a strict JSON request, resolves an exact local base commit, creates a
+disposable detached Git worktree, applies one declared diff, runs only explicit
+argv arrays with `shell=False`, and emits this contract atomically outside the
+source repository.
+
+The prototype fails closed on unsupported request fields, unprovable worktree
+isolation, path traversal, patch-apply failure, source-checkout drift, or
+unproven cleanup. Command environment variables are allowlisted except for `PATH`, which is
+inherited so declared argv entries can resolve the installed toolchain. The
+prototype does not provide a filesystem or network sandbox, so `network` and
+`secrets_policy` remain `unknown`; configured commands must be trusted. The `global_timeout_seconds` field is a budget that starts immediately before
+the declared command loop; validation, Git setup, cleanup, and source
+fingerprinting are outside it. Logs are bounded and marked when truncated. A
+`passed` artifact means only that the declared commands returned success in that
+isolated workspace. It is not correctness, test sufficiency,
+security evidence, merge readiness, or merge authorization.
+
+
+Request validation and read-only provenance preflight occur before artifact
+production is guaranteed. An invalid request, unresolved base commit, unreadable
+source checkout, output collision, or unwritable destination therefore fails
+without an artifact and without running a declared command. Once mutable
+evaluation begins, operational failures produce a `status: error` artifact when
+the destination remains writable. The source drift fingerprint covers checked
+out HEAD, worktree and staged-index changes, and untracked contents; other refs
+and Git config are outside that fingerprint.

--- a/docs/contracts/patch-evaluation-v1.md
+++ b/docs/contracts/patch-evaluation-v1.md
@@ -99,29 +99,47 @@ when it cannot be read.
 
 `tools/patch_evaluation_sidecar.py` is a deliberately external prototype producer.
 It is not imported by RepoBrief core or exposed through RepoGround MCP. The CLI
-accepts a strict JSON request, resolves an exact local base commit, creates a
-disposable detached Git worktree, applies one declared diff, runs only explicit
-argv arrays with `shell=False`, and emits this contract atomically outside the
-source repository.
+accepts a strict, size-bounded JSON request, resolves an exact local base commit,
+snapshots one declared diff, materializes the commit and its tree into an
+independent Git repository, runs only explicit argv arrays with `shell=False`,
+and emits this contract atomically outside the source repository.
 
-The prototype fails closed on unsupported request fields, unprovable worktree
-isolation, path traversal, patch-apply failure, source-checkout drift, or
-unproven cleanup. Command environment variables are allowlisted except for `PATH`, which is
-inherited so declared argv entries can resolve the installed toolchain. The
-prototype does not provide a filesystem or network sandbox, so `network` and
-`secrets_policy` remain `unknown`; configured commands must be trusted. The `global_timeout_seconds` field is a budget that starts immediately before
-the declared command loop; validation, Git setup, cleanup, and source
-fingerprinting are outside it. Logs are bounded and marked when truncated. A
-`passed` artifact means only that the declared commands returned success in that
-isolated workspace. It is not correctness, test sufficiency,
-security evidence, merge readiness, or merge authorization.
+The materialized repository has its own Git directory, configuration, refs, and
+object database. Its objects are imported from a newly generated pack; alternates,
+shared common directories, and multiply linked object files fail isolation
+verification. Source-local hooks and configured clean, smudge, and process filters
+are neutralized for Sidecar-owned Git operations. The source checkout itself is
+not mounted into the command sandbox.
 
+Declared commands require Linux and Bubblewrap. They run in a filesystem and PID
+namespace with a private writable repository, home, and temporary directory;
+required system directories are read-only. The caller's `PATH` and arbitrary
+environment variables are not inherited. Background descendants are contained by
+the PID namespace, and timeout cleanup sends TERM followed by an unconditional
+KILL sweep. Network isolation is not asserted, so `network` remains `unknown`.
+Credential safety also remains `unknown`: explicit `redact_argv_indexes` are
+removed from command displays and bounded logs, and common secret-shaped options
+are display-redacted, but arbitrary command output is not proven secret-free.
+
+The optional `fail_fast` request field defaults to `false`. When enabled, commands
+after the first non-passing result are recorded as `skipped`, which makes the
+artifact `incomplete`. The `global_timeout_seconds` budget starts immediately
+before the declared command loop. Validation, bounded source fingerprinting,
+independent-repository materialization, cleanup, and artifact writing are outside
+that command budget and have their own fixed limits or operation timeouts.
 
 Request validation and read-only provenance preflight occur before artifact
-production is guaranteed. An invalid request, unresolved base commit, unreadable
-source checkout, output collision, or unwritable destination therefore fails
-without an artifact and without running a declared command. Once mutable
-evaluation begins, operational failures produce a `status: error` artifact when
-the destination remains writable. The source drift fingerprint covers checked
-out HEAD, worktree and staged-index changes, and untracked contents; other refs
-and Git config are outside that fingerprint.
+production is guaranteed. An invalid request, unresolved base commit, unavailable
+Bubblewrap runtime, unreadable source checkout, output collision, or unwritable
+destination therefore fails without an artifact and without running a declared
+command. Once mutable evaluation begins, operational failures produce
+`status: error` when the destination remains writable.
+
+The source drift fingerprint covers checked-out HEAD, Git status, tracked
+worktree changes, staged-index changes, and the content of non-ignored untracked
+files. Ignored files, unrelated refs, repository configuration, and the Git object
+database are outside that fingerprint; declared commands cannot reach the source
+checkout through the Bubblewrap mount namespace. A `passed` artifact establishes
+only that every declared command returned success under these bounded conditions.
+It does not establish correctness, test sufficiency, security correctness, merge
+readiness, or merge authorization.

--- a/docs/proofs/rbaw-v1-t004-patch-evaluation-sidecar-v1-proof.md
+++ b/docs/proofs/rbaw-v1-t004-patch-evaluation-sidecar-v1-proof.md
@@ -37,10 +37,16 @@ python -m pytest -q tests/test_patch_evaluation_sidecar.py merger/repoground/tes
 # 30 passed in 2.19s
 
 python -m pytest -q
-# 4679 passed, 2 skipped in 116.93s
+# 4679 passed, 2 skipped in 118.64s
 
 python -m ruff check tools/patch_evaluation_sidecar.py tests/test_patch_evaluation_sidecar.py
 # All checks passed!
+
+python -m ruff format --check tools/patch_evaluation_sidecar.py tests/test_patch_evaluation_sidecar.py
+# 2 files already formatted
+
+python scripts/ci/check_graph_maintainability.py --root . --format json
+# status pass; new_count 0; resolved_count 3
 
 python -m py_compile tools/patch_evaluation_sidecar.py tests/test_patch_evaluation_sidecar.py
 # exit 0
@@ -52,7 +58,7 @@ git diff --check
 The durable full-suite receipt is bound to argv SHA-256
 `c3f2578d3a465d10ae97391fe2a54f1c10832286381277ce1355ccfb0bbac529`
 and receipt SHA-256
-`7301747b260194f73ed0bfb6e8565f0e1ab2192d6d333dab68ded8727d8da5b6`.
+`d497d295bceec49f5008b546630333da7b62f1410bdef263cfe33c71640cb57c`.
 
 ## Does not establish
 
@@ -60,8 +66,8 @@ This proof and a passing prototype run do not establish correctness, test
 sufficiency, security correctness, runtime behavior outside evaluated commands,
 merge authorization, merge readiness, regression absence, repository
 understanding, or truth of producer claims. Filesystem, credential, network, and
-container sandboxing are not implemented by this prototype; configured commands must be
-trusted.
+container sandboxing are not implemented by this prototype; configured
+commands must be trusted.
 
 Invalid requests and read-only provenance-preflight failures can terminate
 without an artifact; they do not create a worktree or run declared commands.

--- a/docs/proofs/rbaw-v1-t004-patch-evaluation-sidecar-v1-proof.md
+++ b/docs/proofs/rbaw-v1-t004-patch-evaluation-sidecar-v1-proof.md
@@ -1,0 +1,69 @@
+# RBAW-V1-T004 External Patch Evaluation Sidecar v1 proof
+
+## Scope
+
+This slice prototypes the mutable evaluation layer outside RepoBrief core. The
+producer is `tools/patch_evaluation_sidecar.py`; the existing schema and
+read-only consumer remain unchanged.
+
+## Boundary checks
+
+- Source checkout worktree, staged-index, and untracked content is fingerprinted
+  before evaluation and compared after cleanup; unrelated refs and Git
+  configuration are outside this fingerprint.
+- Evaluation runs in a detached disposable Git worktree at an exact commit.
+- The patch is copied once into a private snapshot; its digest and applied bytes
+  are therefore identical. Patch application fails before any configured command
+  may run.
+- Commands are argv arrays executed with `shell=False` and a confined relative
+  working directory.
+- Environment variables are allowlisted except for inherited `PATH`; Git
+  global/system configuration and hooks are suppressed. Filesystem, credential,
+  and network isolation remain unknown.
+- Per-command timeouts and a global declared-command budget are enforced; timed-out
+  process groups are terminated. The command budget begins immediately before the
+  command loop. Validation, Git setup, cleanup, and source fingerprinting are not
+  covered by it; large Python-side file hashing is not separately time-bounded.
+- Logs are bounded, stored outside the source repository, and carry truncation
+  metadata.
+- The artifact is written atomically and declares all nine mandatory non-claims.
+- Cleanup is fail-closed: an unremoved worktree or source drift forces artifact
+  status `error`.
+
+## Verification commands
+
+```text
+python -m pytest -q tests/test_patch_evaluation_sidecar.py merger/repoground/tests/test_patch_evaluation.py
+# 30 passed in 2.19s
+
+python -m pytest -q
+# 4679 passed, 2 skipped in 116.93s
+
+python -m ruff check tools/patch_evaluation_sidecar.py tests/test_patch_evaluation_sidecar.py
+# All checks passed!
+
+python -m py_compile tools/patch_evaluation_sidecar.py tests/test_patch_evaluation_sidecar.py
+# exit 0
+
+git diff --check
+# exit 0
+```
+
+The durable full-suite receipt is bound to argv SHA-256
+`c3f2578d3a465d10ae97391fe2a54f1c10832286381277ce1355ccfb0bbac529`
+and receipt SHA-256
+`7301747b260194f73ed0bfb6e8565f0e1ab2192d6d333dab68ded8727d8da5b6`.
+
+## Does not establish
+
+This proof and a passing prototype run do not establish correctness, test
+sufficiency, security correctness, runtime behavior outside evaluated commands,
+merge authorization, merge readiness, regression absence, repository
+understanding, or truth of producer claims. Filesystem, credential, network, and
+container sandboxing are not implemented by this prototype; configured commands must be
+trusted.
+
+Invalid requests and read-only provenance-preflight failures can terminate
+without an artifact; they do not create a worktree or run declared commands.
+Operational failures after mutable evaluation begins emit `status: error` when
+the artifact destination remains writable.

--- a/docs/proofs/rbaw-v1-t004-patch-evaluation-sidecar-v1-proof.md
+++ b/docs/proofs/rbaw-v1-t004-patch-evaluation-sidecar-v1-proof.md
@@ -70,10 +70,10 @@ The focused suite proves regressions for:
 
 ```text
 python -m pytest -q tests/test_patch_evaluation_sidecar.py merger/repoground/tests/test_patch_evaluation.py
-# 47 passed in 5.39s
+# 47 passed in 5.60s
 
 python -m pytest -q
-# 4696 passed, 2 skipped in 125.94s
+# 4696 passed, 2 skipped
 
 python -m ruff check tools/patch_evaluation_sidecar.py tests/test_patch_evaluation_sidecar.py
 # All checks passed!
@@ -94,9 +94,9 @@ git diff --check
 The durable full-suite task is bound to argv SHA-256
 `c3f2578d3a465d10ae97391fe2a54f1c10832286381277ce1355ccfb0bbac529`,
 lifecycle receipt SHA-256
-`c7e717172364f39f8798613324d8cb4e95e3d4813f5405fa71eb69f03032648d`,
+`d26feb16ef5ba99dc5f78f98320a47d775fb0b9024f12706d8693bb40c0c759f`,
 and terminalization SHA-256
-`9847340e7630771e814e431fff464dd3f0eeac9a9e953d56b08ff3a789216fbd`.
+`31755fc3eeca8ca8de8372e75bf4eaa920e29f9c633433e84e2de83f90e26d71`.
 
 ## Does not establish
 

--- a/docs/proofs/rbaw-v1-t004-patch-evaluation-sidecar-v1-proof.md
+++ b/docs/proofs/rbaw-v1-t004-patch-evaluation-sidecar-v1-proof.md
@@ -3,41 +3,77 @@
 ## Scope
 
 This slice prototypes the mutable evaluation layer outside RepoBrief core. The
-producer is `tools/patch_evaluation_sidecar.py`; the existing schema and
-read-only consumer remain unchanged.
+producer is `tools/patch_evaluation_sidecar.py`; the existing Patch Evaluation
+Artifact schema and read-only RepoBrief consumer remain unchanged.
 
 ## Boundary checks
 
-- Source checkout worktree, staged-index, and untracked content is fingerprinted
-  before evaluation and compared after cleanup; unrelated refs and Git
-  configuration are outside this fingerprint.
-- Evaluation runs in a detached disposable Git worktree at an exact commit.
+- The exact base commit and its tree are copied through a newly generated Git
+  pack into a newly initialized repository. The evaluation repository has its
+  own Git directory, configuration, refs, and object database; shared common
+  directories, alternates, or multiply linked object files fail isolation
+  verification.
+- Source-local Git hooks and configured clean, smudge, and process filters are
+  neutralized for every Sidecar-owned Git operation. Internal Git and Bubblewrap
+  binaries are resolved from a fixed system path rather than the caller's
+  `PATH`.
+- The source checkout is not mounted into declared command execution. Commands
+  run with `shell=False` inside Linux Bubblewrap filesystem and PID namespaces;
+  the independent repository, private home, and private temporary directory are
+  the only writable mounts, while required system directories are read-only and only an explicit `/etc` subset is exposed.
+- Background descendants are contained by the PID namespace. Timed-out host
+  process groups receive SIGTERM followed by an unconditional SIGKILL sweep.
 - The patch is copied once into a private snapshot; its digest and applied bytes
-  are therefore identical. Patch application fails before any configured command
+  are therefore identical. Patch application fails before any declared command
   may run.
-- Commands are argv arrays executed with `shell=False` and a confined relative
-  working directory.
-- Environment variables are allowlisted except for inherited `PATH`; Git
-  global/system configuration and hooks are suppressed. Filesystem, credential,
-  and network isolation remain unknown.
-- Per-command timeouts and a global declared-command budget are enforced; timed-out
-  process groups are terminated. The command budget begins immediately before the
-  command loop. Validation, Git setup, cleanup, and source fingerprinting are not
-  covered by it; large Python-side file hashing is not separately time-bounded.
-- Logs are bounded, stored outside the source repository, and carry truncation
-  metadata.
-- The artifact is written atomically and declares all nine mandatory non-claims.
-- Cleanup is fail-closed: an unremoved worktree or source drift forces artifact
-  status `error`.
+- The source drift fingerprint covers HEAD, Git status, tracked worktree diff,
+  staged-index diff, and content of non-ignored untracked files. Ignored files,
+  unrelated refs, repository configuration, and the source object database are
+  outside the fingerprint; declared commands cannot reach the source checkout
+  through the mount namespace.
+- Request, patch, repository pack, object count, argv, context, changed-file,
+  fingerprint, command-time, and log sizes are bounded. The source fingerprint
+  also has a fixed time budget.
+- `fail_fast` is optional and defaults to `false`; when enabled, later commands
+  are recorded as `skipped`, so the artifact is `incomplete`.
+- Explicit `redact_argv_indexes` are redacted from command displays and bounded
+  logs. Arbitrary command output is not proven secret-free, so
+  `secrets_policy` remains `unknown`.
+- Network isolation is not asserted and `network` remains `unknown`.
+- Empty log directories are removed. Independent-repository, patch-snapshot,
+  and runtime cleanup are read back fail-closed; unproven cleanup or source drift
+  forces artifact status `error`.
+- The artifact is written atomically, records a SHA-256 digest of the producer
+  source, and declares all nine mandatory non-claims.
+
+## Adversarial coverage
+
+The focused suite proves regressions for:
+
+- source Git configuration and ref mutations remaining confined to the
+  independent repository;
+- clean, smudge, and process filters not executing during Sidecar-owned Git
+  operations;
+- the source checkout, including ignored files, being unavailable to declared
+  commands;
+- successful commands being unable to leave background descendants;
+- timeout process-group cleanup;
+- rename destination-path reporting;
+- patch snapshot time-of-check/time-of-use binding;
+- fake parent-`PATH` Git replacement being ignored;
+- fail-fast command skipping;
+- argv and log redaction;
+- partial repository creation and forced cleanup failure;
+- input and artifact-boundary size limits.
 
 ## Verification commands
 
 ```text
 python -m pytest -q tests/test_patch_evaluation_sidecar.py merger/repoground/tests/test_patch_evaluation.py
-# 30 passed in 2.19s
+# 47 passed in 5.39s
 
 python -m pytest -q
-# 4679 passed, 2 skipped in 118.64s
+# 4696 passed, 2 skipped in 125.94s
 
 python -m ruff check tools/patch_evaluation_sidecar.py tests/test_patch_evaluation_sidecar.py
 # All checks passed!
@@ -46,7 +82,7 @@ python -m ruff format --check tools/patch_evaluation_sidecar.py tests/test_patch
 # 2 files already formatted
 
 python scripts/ci/check_graph_maintainability.py --root . --format json
-# status pass; new_count 0; resolved_count 3
+# status pass; current_count 200; baseline_count 203; new_count 0; resolved_count 3
 
 python -m py_compile tools/patch_evaluation_sidecar.py tests/test_patch_evaluation_sidecar.py
 # exit 0
@@ -55,21 +91,23 @@ git diff --check
 # exit 0
 ```
 
-The durable full-suite receipt is bound to argv SHA-256
-`c3f2578d3a465d10ae97391fe2a54f1c10832286381277ce1355ccfb0bbac529`
-and receipt SHA-256
-`d497d295bceec49f5008b546630333da7b62f1410bdef263cfe33c71640cb57c`.
+The durable full-suite task is bound to argv SHA-256
+`c3f2578d3a465d10ae97391fe2a54f1c10832286381277ce1355ccfb0bbac529`,
+lifecycle receipt SHA-256
+`c7e717172364f39f8798613324d8cb4e95e3d4813f5405fa71eb69f03032648d`,
+and terminalization SHA-256
+`9847340e7630771e814e431fff464dd3f0eeac9a9e953d56b08ff3a789216fbd`.
 
 ## Does not establish
 
 This proof and a passing prototype run do not establish correctness, test
 sufficiency, security correctness, runtime behavior outside evaluated commands,
 merge authorization, merge readiness, regression absence, repository
-understanding, or truth of producer claims. Filesystem, credential, network, and
-container sandboxing are not implemented by this prototype; configured
-commands must be trusted.
+understanding, or truth of producer claims. Network isolation and complete
+credential safety are not established. Linux and Bubblewrap are runtime
+requirements for declared command execution.
 
 Invalid requests and read-only provenance-preflight failures can terminate
-without an artifact; they do not create a worktree or run declared commands.
-Operational failures after mutable evaluation begins emit `status: error` when
-the artifact destination remains writable.
+without an artifact; they do not create an evaluation repository or run declared
+commands. Operational failures after mutable evaluation begins emit
+`status: error` when the artifact destination remains writable.

--- a/tests/test_patch_evaluation_sidecar.py
+++ b/tests/test_patch_evaluation_sidecar.py
@@ -1,0 +1,360 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from merger.repoground.core.patch_evaluation import validate_patch_evaluation
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "tools" / "patch_evaluation_sidecar.py"
+SPEC = importlib.util.spec_from_file_location("patch_evaluation_sidecar", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+sidecar = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = sidecar
+SPEC.loader.exec_module(sidecar)
+
+
+def _run(*argv: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(argv, cwd=cwd, text=True, capture_output=True, check=True)
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "source"
+    repo.mkdir()
+    _run("git", "init", "-q", cwd=repo)
+    _run("git", "config", "user.email", "test@example.invalid", cwd=repo)
+    _run("git", "config", "user.name", "Patch Evaluation Test", cwd=repo)
+    (repo / "message.txt").write_text("before\n", encoding="utf-8")
+    _run("git", "add", "message.txt", cwd=repo)
+    _run("git", "commit", "-qm", "initial", cwd=repo)
+    return repo
+
+
+def _patch(repo: Path, tmp_path: Path, content: str = "after\n") -> Path:
+    path = repo / "message.txt"
+    path.write_text(content, encoding="utf-8")
+    patch = tmp_path / "change.diff"
+    patch.write_text(_run("git", "diff", "--binary", cwd=repo).stdout, encoding="utf-8")
+    _run("git", "checkout", "--", "message.txt", cwd=repo)
+    return patch
+
+
+def _request(repo: Path, patch: Path, commands: list[dict[str, object]], *, max_log_bytes: int = 4096) -> dict[str, object]:
+    return {
+        "schema_version": 1, "repository": str(repo),
+        "base_commit": _run("git", "rev-parse", "HEAD", cwd=repo).stdout.strip(),
+        "patch_path": str(patch), "patch_format": "git-diff", "commands": commands,
+        "global_timeout_seconds": 30, "max_log_bytes": max_log_bytes,
+        "repobrief_context": {"workbench_outputs": ["symbol-index"], "citations": ["message.txt:1"]},
+    }
+
+
+def _evaluate(tmp_path: Path, request: dict[str, object]) -> tuple[dict[str, object], dict[str, object]]:
+    request_path = tmp_path / "request.json"
+    output = tmp_path / "out" / "evaluation.json"
+    workspace_root = tmp_path / "workspaces"
+    request_path.write_text(json.dumps(request), encoding="utf-8")
+    result = sidecar.evaluate(request_path, output, workspace_root=workspace_root)
+    return result, json.loads(output.read_text(encoding="utf-8"))
+
+
+def _source_state(repo: Path) -> tuple[str, str]:
+    return (
+        _run("git", "rev-parse", "HEAD", cwd=repo).stdout,
+        _run("git", "status", "--porcelain=v1", "--untracked-files=all", cwd=repo).stdout,
+    )
+
+
+def test_success_isolated_schema_valid_source_unchanged_and_cleaned(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    patch = _patch(repo, tmp_path)
+    before = _source_state(repo)
+    request = _request(repo, patch, [{
+        "argv": [sys.executable, "-c", "from pathlib import Path; assert Path('message.txt').read_text() == 'after\\n'"],
+        "cwd": ".", "timeout_seconds": 10,
+    }])
+    result, artifact = _evaluate(tmp_path, request)
+    assert artifact["status"] == "passed"
+    assert artifact["authority"] == "external_evaluation_evidence"
+    assert artifact["workspace"]["isolated"] is True
+    assert artifact["patch"]["applied"] is True
+    assert artifact["patch"]["changed_files"] == [{"change": "modified", "path": "message.txt"}]
+    assert artifact["commands_run"][0]["status"] == "passed"
+    assert result["workspace_cleaned"] is True
+    assert result["source_unchanged"] is True
+    assert _source_state(repo) == before
+    assert not any((tmp_path / "workspaces").iterdir())
+    assert validate_patch_evaluation(artifact)["status"] == "pass"
+
+
+def test_failing_command_is_evidence_not_approval(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    patch = _patch(repo, tmp_path)
+    _, artifact = _evaluate(tmp_path, _request(repo, patch, [{
+        "argv": [sys.executable, "-c", "raise SystemExit(7)"], "cwd": ".", "timeout_seconds": 10,
+    }]))
+    assert artifact["status"] == "failed"
+    assert artifact["commands_run"][0]["status"] == "failed"
+    assert artifact["commands_run"][0]["exit_code"] == 7
+    assert "merge_authorization" in artifact["does_not_establish"]
+    assert "correctness" in artifact["does_not_establish"]
+    assert validate_patch_evaluation(artifact)["status"] == "pass"
+
+
+def test_path_traversal_and_unknown_request_fields_fail_closed(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    patch = _patch(repo, tmp_path)
+    traversal = _request(repo, patch, [{
+        "argv": [sys.executable, "-c", "pass"], "cwd": "../outside", "timeout_seconds": 10,
+    }])
+    request_path = tmp_path / "traversal.json"
+    request_path.write_text(json.dumps(traversal), encoding="utf-8")
+    with pytest.raises(sidecar.RequestError, match="inside the isolated worktree"):
+        sidecar.load_request(request_path)
+    unknown = _request(repo, patch, [])
+    unknown["approve"] = True
+    request_path.write_text(json.dumps(unknown), encoding="utf-8")
+    with pytest.raises(sidecar.RequestError, match="unsupported field"):
+        sidecar.load_request(request_path)
+
+    option_shaped = _request(repo, patch, [])
+    option_shaped["base_commit"] = "--help"
+    request_path.write_text(json.dumps(option_shaped), encoding="utf-8")
+    with pytest.raises(sidecar.RequestError, match="must not begin"):
+        sidecar.load_request(request_path)
+
+
+def test_patch_apply_failure_runs_no_commands_and_cleans_workspace(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    invalid_patch = tmp_path / "invalid.diff"
+    invalid_patch.write_text("this is not a patch\n", encoding="utf-8")
+    marker = tmp_path / "must-not-exist"
+    request = _request(repo, invalid_patch, [{
+        "argv": [sys.executable, "-c", f"from pathlib import Path; Path({str(marker)!r}).touch()"],
+        "cwd": ".", "timeout_seconds": 10,
+    }])
+    result, artifact = _evaluate(tmp_path, request)
+    assert artifact["status"] == "error"
+    assert artifact["patch"]["applied"] is False
+    assert artifact["commands_run"] == []
+    assert result["workspace_cleaned"] is True
+    assert not marker.exists()
+    assert validate_patch_evaluation(artifact)["status"] == "pass"
+
+
+def test_logs_are_bounded_and_marked_truncated(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    patch = _patch(repo, tmp_path)
+    _, artifact = _evaluate(tmp_path, _request(repo, patch, [{
+        "argv": [sys.executable, "-c", "print('x' * 20000)"], "cwd": ".", "timeout_seconds": 10,
+    }], max_log_bytes=512))
+    command = artifact["commands_run"][0]
+    log_path = tmp_path / "out" / command["log_ref"]
+    assert command["truncated"] is True
+    assert log_path.stat().st_size <= 512
+
+
+def test_timeout_is_bounded_and_reported_without_leaving_worktree(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    patch = _patch(repo, tmp_path)
+    request = _request(repo, patch, [{
+        "argv": [sys.executable, "-c", "import time; time.sleep(30)"],
+        "cwd": ".",
+        "timeout_seconds": 1,
+    }])
+    result, artifact = _evaluate(tmp_path, request)
+    assert artifact["status"] == "error"
+    assert artifact["commands_run"][0]["status"] == "timeout"
+    assert result["workspace_cleaned"] is True
+    assert result["source_unchanged"] is True
+    assert validate_patch_evaluation(artifact)["status"] == "pass"
+
+
+def test_cli_emits_passed_artifact_and_machine_readable_summary(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    patch = _patch(repo, tmp_path)
+    request_path = tmp_path / "cli-request.json"
+    output = tmp_path / "cli-out" / "evaluation.json"
+    workspace_root = tmp_path / "cli-workspaces"
+    request_path.write_text(json.dumps(_request(repo, patch, [{
+        "argv": [sys.executable, "-c", "raise SystemExit(0)"],
+        "cwd": ".",
+        "timeout_seconds": 10,
+    }])), encoding="utf-8")
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(MODULE_PATH),
+            "--request",
+            str(request_path),
+            "--output",
+            str(output),
+            "--workspace-root",
+            str(workspace_root),
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    summary = json.loads(completed.stdout)
+    artifact = json.loads(output.read_text(encoding="utf-8"))
+    assert summary["status"] == "passed"
+    assert summary["workspace_cleaned"] is True
+    assert artifact["status"] == "passed"
+
+
+def test_internal_git_ignores_repository_hook_configuration(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    patch = _patch(repo, tmp_path)
+    hook_directory = tmp_path / "hooks"
+    hook_directory.mkdir()
+    marker = tmp_path / "hook-ran"
+    hook = hook_directory / "post-checkout"
+    hook.write_text(f"#!/bin/sh\ntouch {marker}\n", encoding="utf-8")
+    hook.chmod(0o755)
+    _run("git", "config", "core.hooksPath", str(hook_directory), cwd=repo)
+
+    _, artifact = _evaluate(tmp_path, _request(repo, patch, [{
+        "argv": [sys.executable, "-c", "raise SystemExit(0)"],
+        "cwd": ".",
+        "timeout_seconds": 10,
+    }]))
+
+    assert artifact["status"] == "passed"
+    assert not marker.exists()
+
+
+def test_patch_snapshot_binds_hash_and_applied_bytes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _repo(tmp_path)
+    patch = _patch(repo, tmp_path, "after\n")
+    original_bytes = patch.read_bytes()
+    replacement = _patch(repo, tmp_path, "replacement\n").read_bytes()
+    patch.write_bytes(original_bytes)
+    original_git = sidecar._git
+    mutated = False
+
+    def mutating_git(repository: Path, *args: str, **kwargs: object):
+        nonlocal mutated
+        if not mutated and args[:2] == ("worktree", "add"):
+            patch.write_bytes(replacement)
+            mutated = True
+        return original_git(repository, *args, **kwargs)
+
+    monkeypatch.setattr(sidecar, "_git", mutating_git)
+    _, artifact = _evaluate(tmp_path, _request(repo, patch, [{
+        "argv": [
+            sys.executable,
+            "-c",
+            "from pathlib import Path; assert Path('message.txt').read_text() == 'after\\n'",
+        ],
+        "cwd": ".",
+        "timeout_seconds": 10,
+    }]))
+
+    expected_sha256 = hashlib.sha256(original_bytes).hexdigest()
+    assert mutated is True
+    assert artifact["status"] == "passed"
+    assert artifact["patch"]["sha256"] == expected_sha256
+    assert artifact["patch"]["patch_id"] == expected_sha256
+
+
+def test_skipped_commands_roll_up_as_incomplete() -> None:
+    records = [
+        {"status": "passed"},
+        {"status": "skipped"},
+    ]
+    assert sidecar._rollup_status(
+        records, patch_applied=True, infrastructure_error=False
+    ) == "incomplete"
+
+
+def test_allowlisted_environment_does_not_inherit_secret_variables(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _repo(tmp_path)
+    patch = _patch(repo, tmp_path)
+    monkeypatch.setenv("PATCH_EVALUATION_TEST_SECRET", "must-not-leak")
+    _, artifact = _evaluate(tmp_path, _request(repo, patch, [{
+        "argv": [
+            sys.executable,
+            "-c",
+            "import os; print(os.environ.get('PATCH_EVALUATION_TEST_SECRET', 'absent'))",
+        ],
+        "cwd": ".",
+        "timeout_seconds": 10,
+    }]))
+    command = artifact["commands_run"][0]
+    log_path = tmp_path / "out" / command["log_ref"]
+    assert "must-not-leak" not in log_path.read_text(encoding="utf-8")
+    assert "absent" in log_path.read_text(encoding="utf-8")
+    assert artifact["command_policy"]["secrets_policy"] == "unknown"
+
+
+def test_dirty_source_content_change_is_detected_fail_closed(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    patch = _patch(repo, tmp_path)
+    (repo / "source-only.txt").write_text("before command\n", encoding="utf-8")
+    request = _request(repo, patch, [{
+        "argv": [
+            sys.executable,
+            "-c",
+            f"from pathlib import Path; Path({str(repo / 'source-only.txt')!r}).write_text('tampered\\n')",
+        ],
+        "cwd": ".",
+        "timeout_seconds": 10,
+    }])
+    result, artifact = _evaluate(tmp_path, request)
+    assert result["source_unchanged"] is False
+    assert artifact["status"] == "error"
+    assert validate_patch_evaluation(artifact)["status"] == "pass"
+
+
+def test_source_fingerprint_includes_staged_index_content(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    (repo / "message.txt").write_text("staged-one\n", encoding="utf-8")
+    _run("git", "add", "message.txt", cwd=repo)
+    before = sidecar._source_snapshot(repo)[1]
+
+    replacement = subprocess.run(
+        ["git", "hash-object", "-w", "--stdin"],
+        cwd=repo,
+        input="staged-two\n",
+        text=True,
+        capture_output=True,
+        check=True,
+    ).stdout.strip()
+    _run("git", "update-index", "--cacheinfo", f"100644,{replacement},message.txt", cwd=repo)
+
+    after = sidecar._source_snapshot(repo)[1]
+    assert after != before
+
+
+def test_non_utf8_changed_path_is_json_safe(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    encoded_path = bytes(repo) + b"/invalid-\xff.txt"
+    descriptor = __import__("os").open(encoded_path, __import__("os").O_WRONLY | __import__("os").O_CREAT, 0o600)
+    __import__("os").write(descriptor, b"content\n")
+    __import__("os").close(descriptor)
+
+    changed = sidecar._parse_changed_files(repo)
+    assert changed == [{"path": "invalid-\\xff.txt", "change": "added"}]
+    json.dumps(changed, ensure_ascii=False)
+
+
+def test_all_mandatory_non_claims_are_always_emitted(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    patch = _patch(repo, tmp_path)
+    _, artifact = _evaluate(tmp_path, _request(repo, patch, []))
+    assert set(sidecar.MANDATORY_NON_CLAIMS).issubset(artifact["does_not_establish"])
+    assert artifact["status"] == "incomplete"
+    assert validate_patch_evaluation(artifact)["status"] == "pass"

--- a/tests/test_patch_evaluation_sidecar.py
+++ b/tests/test_patch_evaluation_sidecar.py
@@ -45,17 +45,32 @@ def _patch(repo: Path, tmp_path: Path, content: str = "after\n") -> Path:
     return patch
 
 
-def _request(repo: Path, patch: Path, commands: list[dict[str, object]], *, max_log_bytes: int = 4096) -> dict[str, object]:
+def _request(
+    repo: Path,
+    patch: Path,
+    commands: list[dict[str, object]],
+    *,
+    max_log_bytes: int = 4096,
+) -> dict[str, object]:
     return {
-        "schema_version": 1, "repository": str(repo),
+        "schema_version": 1,
+        "repository": str(repo),
         "base_commit": _run("git", "rev-parse", "HEAD", cwd=repo).stdout.strip(),
-        "patch_path": str(patch), "patch_format": "git-diff", "commands": commands,
-        "global_timeout_seconds": 30, "max_log_bytes": max_log_bytes,
-        "repobrief_context": {"workbench_outputs": ["symbol-index"], "citations": ["message.txt:1"]},
+        "patch_path": str(patch),
+        "patch_format": "git-diff",
+        "commands": commands,
+        "global_timeout_seconds": 30,
+        "max_log_bytes": max_log_bytes,
+        "repobrief_context": {
+            "workbench_outputs": ["symbol-index"],
+            "citations": ["message.txt:1"],
+        },
     }
 
 
-def _evaluate(tmp_path: Path, request: dict[str, object]) -> tuple[dict[str, object], dict[str, object]]:
+def _evaluate(
+    tmp_path: Path, request: dict[str, object]
+) -> tuple[dict[str, object], dict[str, object]]:
     request_path = tmp_path / "request.json"
     output = tmp_path / "out" / "evaluation.json"
     workspace_root = tmp_path / "workspaces"
@@ -67,24 +82,41 @@ def _evaluate(tmp_path: Path, request: dict[str, object]) -> tuple[dict[str, obj
 def _source_state(repo: Path) -> tuple[str, str]:
     return (
         _run("git", "rev-parse", "HEAD", cwd=repo).stdout,
-        _run("git", "status", "--porcelain=v1", "--untracked-files=all", cwd=repo).stdout,
+        _run(
+            "git", "status", "--porcelain=v1", "--untracked-files=all", cwd=repo
+        ).stdout,
     )
 
 
-def test_success_isolated_schema_valid_source_unchanged_and_cleaned(tmp_path: Path) -> None:
+def test_success_isolated_schema_valid_source_unchanged_and_cleaned(
+    tmp_path: Path,
+) -> None:
     repo = _repo(tmp_path)
     patch = _patch(repo, tmp_path)
     before = _source_state(repo)
-    request = _request(repo, patch, [{
-        "argv": [sys.executable, "-c", "from pathlib import Path; assert Path('message.txt').read_text() == 'after\\n'"],
-        "cwd": ".", "timeout_seconds": 10,
-    }])
+    request = _request(
+        repo,
+        patch,
+        [
+            {
+                "argv": [
+                    sys.executable,
+                    "-c",
+                    "from pathlib import Path; assert Path('message.txt').read_text() == 'after\\n'",
+                ],
+                "cwd": ".",
+                "timeout_seconds": 10,
+            }
+        ],
+    )
     result, artifact = _evaluate(tmp_path, request)
     assert artifact["status"] == "passed"
     assert artifact["authority"] == "external_evaluation_evidence"
     assert artifact["workspace"]["isolated"] is True
     assert artifact["patch"]["applied"] is True
-    assert artifact["patch"]["changed_files"] == [{"change": "modified", "path": "message.txt"}]
+    assert artifact["patch"]["changed_files"] == [
+        {"change": "modified", "path": "message.txt"}
+    ]
     assert artifact["commands_run"][0]["status"] == "passed"
     assert result["workspace_cleaned"] is True
     assert result["source_unchanged"] is True
@@ -96,9 +128,20 @@ def test_success_isolated_schema_valid_source_unchanged_and_cleaned(tmp_path: Pa
 def test_failing_command_is_evidence_not_approval(tmp_path: Path) -> None:
     repo = _repo(tmp_path)
     patch = _patch(repo, tmp_path)
-    _, artifact = _evaluate(tmp_path, _request(repo, patch, [{
-        "argv": [sys.executable, "-c", "raise SystemExit(7)"], "cwd": ".", "timeout_seconds": 10,
-    }]))
+    _, artifact = _evaluate(
+        tmp_path,
+        _request(
+            repo,
+            patch,
+            [
+                {
+                    "argv": [sys.executable, "-c", "raise SystemExit(7)"],
+                    "cwd": ".",
+                    "timeout_seconds": 10,
+                }
+            ],
+        ),
+    )
     assert artifact["status"] == "failed"
     assert artifact["commands_run"][0]["status"] == "failed"
     assert artifact["commands_run"][0]["exit_code"] == 7
@@ -110,9 +153,17 @@ def test_failing_command_is_evidence_not_approval(tmp_path: Path) -> None:
 def test_path_traversal_and_unknown_request_fields_fail_closed(tmp_path: Path) -> None:
     repo = _repo(tmp_path)
     patch = _patch(repo, tmp_path)
-    traversal = _request(repo, patch, [{
-        "argv": [sys.executable, "-c", "pass"], "cwd": "../outside", "timeout_seconds": 10,
-    }])
+    traversal = _request(
+        repo,
+        patch,
+        [
+            {
+                "argv": [sys.executable, "-c", "pass"],
+                "cwd": "../outside",
+                "timeout_seconds": 10,
+            }
+        ],
+    )
     request_path = tmp_path / "traversal.json"
     request_path.write_text(json.dumps(traversal), encoding="utf-8")
     with pytest.raises(sidecar.RequestError, match="inside the isolated worktree"):
@@ -129,16 +180,35 @@ def test_path_traversal_and_unknown_request_fields_fail_closed(tmp_path: Path) -
     with pytest.raises(sidecar.RequestError, match="must not begin"):
         sidecar.load_request(request_path)
 
+    null_format = _request(repo, patch, [])
+    null_format["patch_format"] = None
+    request_path.write_text(json.dumps(null_format), encoding="utf-8")
+    with pytest.raises(sidecar.RequestError, match="patch_format must be"):
+        sidecar.load_request(request_path)
 
-def test_patch_apply_failure_runs_no_commands_and_cleans_workspace(tmp_path: Path) -> None:
+
+def test_patch_apply_failure_runs_no_commands_and_cleans_workspace(
+    tmp_path: Path,
+) -> None:
     repo = _repo(tmp_path)
     invalid_patch = tmp_path / "invalid.diff"
     invalid_patch.write_text("this is not a patch\n", encoding="utf-8")
     marker = tmp_path / "must-not-exist"
-    request = _request(repo, invalid_patch, [{
-        "argv": [sys.executable, "-c", f"from pathlib import Path; Path({str(marker)!r}).touch()"],
-        "cwd": ".", "timeout_seconds": 10,
-    }])
+    request = _request(
+        repo,
+        invalid_patch,
+        [
+            {
+                "argv": [
+                    sys.executable,
+                    "-c",
+                    f"from pathlib import Path; Path({str(marker)!r}).touch()",
+                ],
+                "cwd": ".",
+                "timeout_seconds": 10,
+            }
+        ],
+    )
     result, artifact = _evaluate(tmp_path, request)
     assert artifact["status"] == "error"
     assert artifact["patch"]["applied"] is False
@@ -151,23 +221,43 @@ def test_patch_apply_failure_runs_no_commands_and_cleans_workspace(tmp_path: Pat
 def test_logs_are_bounded_and_marked_truncated(tmp_path: Path) -> None:
     repo = _repo(tmp_path)
     patch = _patch(repo, tmp_path)
-    _, artifact = _evaluate(tmp_path, _request(repo, patch, [{
-        "argv": [sys.executable, "-c", "print('x' * 20000)"], "cwd": ".", "timeout_seconds": 10,
-    }], max_log_bytes=512))
+    _, artifact = _evaluate(
+        tmp_path,
+        _request(
+            repo,
+            patch,
+            [
+                {
+                    "argv": [sys.executable, "-c", "print('x' * 20000)"],
+                    "cwd": ".",
+                    "timeout_seconds": 10,
+                }
+            ],
+            max_log_bytes=512,
+        ),
+    )
     command = artifact["commands_run"][0]
     log_path = tmp_path / "out" / command["log_ref"]
     assert command["truncated"] is True
     assert log_path.stat().st_size <= 512
 
 
-def test_timeout_is_bounded_and_reported_without_leaving_worktree(tmp_path: Path) -> None:
+def test_timeout_is_bounded_and_reported_without_leaving_worktree(
+    tmp_path: Path,
+) -> None:
     repo = _repo(tmp_path)
     patch = _patch(repo, tmp_path)
-    request = _request(repo, patch, [{
-        "argv": [sys.executable, "-c", "import time; time.sleep(30)"],
-        "cwd": ".",
-        "timeout_seconds": 1,
-    }])
+    request = _request(
+        repo,
+        patch,
+        [
+            {
+                "argv": [sys.executable, "-c", "import time; time.sleep(30)"],
+                "cwd": ".",
+                "timeout_seconds": 1,
+            }
+        ],
+    )
     result, artifact = _evaluate(tmp_path, request)
     assert artifact["status"] == "error"
     assert artifact["commands_run"][0]["status"] == "timeout"
@@ -182,11 +272,22 @@ def test_cli_emits_passed_artifact_and_machine_readable_summary(tmp_path: Path) 
     request_path = tmp_path / "cli-request.json"
     output = tmp_path / "cli-out" / "evaluation.json"
     workspace_root = tmp_path / "cli-workspaces"
-    request_path.write_text(json.dumps(_request(repo, patch, [{
-        "argv": [sys.executable, "-c", "raise SystemExit(0)"],
-        "cwd": ".",
-        "timeout_seconds": 10,
-    }])), encoding="utf-8")
+    request_path.write_text(
+        json.dumps(
+            _request(
+                repo,
+                patch,
+                [
+                    {
+                        "argv": [sys.executable, "-c", "raise SystemExit(0)"],
+                        "cwd": ".",
+                        "timeout_seconds": 10,
+                    }
+                ],
+            )
+        ),
+        encoding="utf-8",
+    )
     completed = subprocess.run(
         [
             sys.executable,
@@ -222,11 +323,20 @@ def test_internal_git_ignores_repository_hook_configuration(tmp_path: Path) -> N
     hook.chmod(0o755)
     _run("git", "config", "core.hooksPath", str(hook_directory), cwd=repo)
 
-    _, artifact = _evaluate(tmp_path, _request(repo, patch, [{
-        "argv": [sys.executable, "-c", "raise SystemExit(0)"],
-        "cwd": ".",
-        "timeout_seconds": 10,
-    }]))
+    _, artifact = _evaluate(
+        tmp_path,
+        _request(
+            repo,
+            patch,
+            [
+                {
+                    "argv": [sys.executable, "-c", "raise SystemExit(0)"],
+                    "cwd": ".",
+                    "timeout_seconds": 10,
+                }
+            ],
+        ),
+    )
 
     assert artifact["status"] == "passed"
     assert not marker.exists()
@@ -251,15 +361,24 @@ def test_patch_snapshot_binds_hash_and_applied_bytes(
         return original_git(repository, *args, **kwargs)
 
     monkeypatch.setattr(sidecar, "_git", mutating_git)
-    _, artifact = _evaluate(tmp_path, _request(repo, patch, [{
-        "argv": [
-            sys.executable,
-            "-c",
-            "from pathlib import Path; assert Path('message.txt').read_text() == 'after\\n'",
-        ],
-        "cwd": ".",
-        "timeout_seconds": 10,
-    }]))
+    _, artifact = _evaluate(
+        tmp_path,
+        _request(
+            repo,
+            patch,
+            [
+                {
+                    "argv": [
+                        sys.executable,
+                        "-c",
+                        "from pathlib import Path; assert Path('message.txt').read_text() == 'after\\n'",
+                    ],
+                    "cwd": ".",
+                    "timeout_seconds": 10,
+                }
+            ],
+        ),
+    )
 
     expected_sha256 = hashlib.sha256(original_bytes).hexdigest()
     assert mutated is True
@@ -273,9 +392,10 @@ def test_skipped_commands_roll_up_as_incomplete() -> None:
         {"status": "passed"},
         {"status": "skipped"},
     ]
-    assert sidecar._rollup_status(
-        records, patch_applied=True, infrastructure_error=False
-    ) == "incomplete"
+    assert (
+        sidecar._rollup_status(records, patch_applied=True, infrastructure_error=False)
+        == "incomplete"
+    )
 
 
 def test_allowlisted_environment_does_not_inherit_secret_variables(
@@ -284,15 +404,24 @@ def test_allowlisted_environment_does_not_inherit_secret_variables(
     repo = _repo(tmp_path)
     patch = _patch(repo, tmp_path)
     monkeypatch.setenv("PATCH_EVALUATION_TEST_SECRET", "must-not-leak")
-    _, artifact = _evaluate(tmp_path, _request(repo, patch, [{
-        "argv": [
-            sys.executable,
-            "-c",
-            "import os; print(os.environ.get('PATCH_EVALUATION_TEST_SECRET', 'absent'))",
-        ],
-        "cwd": ".",
-        "timeout_seconds": 10,
-    }]))
+    _, artifact = _evaluate(
+        tmp_path,
+        _request(
+            repo,
+            patch,
+            [
+                {
+                    "argv": [
+                        sys.executable,
+                        "-c",
+                        "import os; print(os.environ.get('PATCH_EVALUATION_TEST_SECRET', 'absent'))",
+                    ],
+                    "cwd": ".",
+                    "timeout_seconds": 10,
+                }
+            ],
+        ),
+    )
     command = artifact["commands_run"][0]
     log_path = tmp_path / "out" / command["log_ref"]
     assert "must-not-leak" not in log_path.read_text(encoding="utf-8")
@@ -304,15 +433,21 @@ def test_dirty_source_content_change_is_detected_fail_closed(tmp_path: Path) -> 
     repo = _repo(tmp_path)
     patch = _patch(repo, tmp_path)
     (repo / "source-only.txt").write_text("before command\n", encoding="utf-8")
-    request = _request(repo, patch, [{
-        "argv": [
-            sys.executable,
-            "-c",
-            f"from pathlib import Path; Path({str(repo / 'source-only.txt')!r}).write_text('tampered\\n')",
+    request = _request(
+        repo,
+        patch,
+        [
+            {
+                "argv": [
+                    sys.executable,
+                    "-c",
+                    f"from pathlib import Path; Path({str(repo / 'source-only.txt')!r}).write_text('tampered\\n')",
+                ],
+                "cwd": ".",
+                "timeout_seconds": 10,
+            }
         ],
-        "cwd": ".",
-        "timeout_seconds": 10,
-    }])
+    )
     result, artifact = _evaluate(tmp_path, request)
     assert result["source_unchanged"] is False
     assert artifact["status"] == "error"
@@ -333,7 +468,13 @@ def test_source_fingerprint_includes_staged_index_content(tmp_path: Path) -> Non
         capture_output=True,
         check=True,
     ).stdout.strip()
-    _run("git", "update-index", "--cacheinfo", f"100644,{replacement},message.txt", cwd=repo)
+    _run(
+        "git",
+        "update-index",
+        "--cacheinfo",
+        f"100644,{replacement},message.txt",
+        cwd=repo,
+    )
 
     after = sidecar._source_snapshot(repo)[1]
     assert after != before
@@ -342,7 +483,9 @@ def test_source_fingerprint_includes_staged_index_content(tmp_path: Path) -> Non
 def test_non_utf8_changed_path_is_json_safe(tmp_path: Path) -> None:
     repo = _repo(tmp_path)
     encoded_path = bytes(repo) + b"/invalid-\xff.txt"
-    descriptor = __import__("os").open(encoded_path, __import__("os").O_WRONLY | __import__("os").O_CREAT, 0o600)
+    descriptor = __import__("os").open(
+        encoded_path, __import__("os").O_WRONLY | __import__("os").O_CREAT, 0o600
+    )
     __import__("os").write(descriptor, b"content\n")
     __import__("os").close(descriptor)
 

--- a/tests/test_patch_evaluation_sidecar.py
+++ b/tests/test_patch_evaluation_sidecar.py
@@ -771,10 +771,10 @@ def test_cleanup_failure_forces_error_artifact(
     patch = _patch(repo, tmp_path)
     original_rmtree = sidecar.shutil.rmtree
 
-    def selective_rmtree(path: Path) -> None:
+    def selective_rmtree(path: Path, *args: object, **kwargs: object) -> None:
         if str(path).endswith("-repository"):
             return
-        original_rmtree(path)
+        original_rmtree(path, *args, **kwargs)
 
     monkeypatch.setattr(sidecar.shutil, "rmtree", selective_rmtree)
     result, artifact = _evaluate(

--- a/tests/test_patch_evaluation_sidecar.py
+++ b/tests/test_patch_evaluation_sidecar.py
@@ -5,6 +5,7 @@ import importlib.util
 import json
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -166,7 +167,7 @@ def test_path_traversal_and_unknown_request_fields_fail_closed(tmp_path: Path) -
     )
     request_path = tmp_path / "traversal.json"
     request_path.write_text(json.dumps(traversal), encoding="utf-8")
-    with pytest.raises(sidecar.RequestError, match="inside the isolated worktree"):
+    with pytest.raises(sidecar.RequestError, match="inside the isolated repository"):
         sidecar.load_request(request_path)
     unknown = _request(repo, patch, [])
     unknown["approve"] = True
@@ -242,7 +243,7 @@ def test_logs_are_bounded_and_marked_truncated(tmp_path: Path) -> None:
     assert log_path.stat().st_size <= 512
 
 
-def test_timeout_is_bounded_and_reported_without_leaving_worktree(
+def test_timeout_is_bounded_and_reported_without_leaving_repository(
     tmp_path: Path,
 ) -> None:
     repo = _repo(tmp_path)
@@ -350,17 +351,16 @@ def test_patch_snapshot_binds_hash_and_applied_bytes(
     original_bytes = patch.read_bytes()
     replacement = _patch(repo, tmp_path, "replacement\n").read_bytes()
     patch.write_bytes(original_bytes)
-    original_git = sidecar._git
+    original_create = sidecar._create_isolated_repository
     mutated = False
 
-    def mutating_git(repository: Path, *args: str, **kwargs: object):
+    def mutating_create(setup: object, state: object) -> None:
         nonlocal mutated
-        if not mutated and args[:2] == ("worktree", "add"):
-            patch.write_bytes(replacement)
-            mutated = True
-        return original_git(repository, *args, **kwargs)
+        patch.write_bytes(replacement)
+        mutated = True
+        original_create(setup, state)
 
-    monkeypatch.setattr(sidecar, "_git", mutating_git)
+    monkeypatch.setattr(sidecar, "_create_isolated_repository", mutating_create)
     _, artifact = _evaluate(
         tmp_path,
         _request(
@@ -429,10 +429,14 @@ def test_allowlisted_environment_does_not_inherit_secret_variables(
     assert artifact["command_policy"]["secrets_policy"] == "unknown"
 
 
-def test_dirty_source_content_change_is_detected_fail_closed(tmp_path: Path) -> None:
+def test_source_checkout_is_not_visible_to_declared_commands(tmp_path: Path) -> None:
     repo = _repo(tmp_path)
+    (repo / ".gitignore").write_text("source-only.txt\n", encoding="utf-8")
+    _run("git", "add", ".gitignore", cwd=repo)
+    _run("git", "commit", "-qm", "ignore source-only file", cwd=repo)
     patch = _patch(repo, tmp_path)
-    (repo / "source-only.txt").write_text("before command\n", encoding="utf-8")
+    source_only = repo / "source-only.txt"
+    source_only.write_text("before command\n", encoding="utf-8")
     request = _request(
         repo,
         patch,
@@ -441,7 +445,7 @@ def test_dirty_source_content_change_is_detected_fail_closed(tmp_path: Path) -> 
                 "argv": [
                     sys.executable,
                     "-c",
-                    f"from pathlib import Path; Path({str(repo / 'source-only.txt')!r}).write_text('tampered\\n')",
+                    f"from pathlib import Path; Path({str(source_only)!r}).write_text('tampered\\n')",
                 ],
                 "cwd": ".",
                 "timeout_seconds": 10,
@@ -449,8 +453,9 @@ def test_dirty_source_content_change_is_detected_fail_closed(tmp_path: Path) -> 
         ],
     )
     result, artifact = _evaluate(tmp_path, request)
-    assert result["source_unchanged"] is False
-    assert artifact["status"] == "error"
+    assert result["source_unchanged"] is True
+    assert source_only.read_text(encoding="utf-8") == "before command\n"
+    assert artifact["status"] == "failed"
     assert validate_patch_evaluation(artifact)["status"] == "pass"
 
 
@@ -501,3 +506,417 @@ def test_all_mandatory_non_claims_are_always_emitted(tmp_path: Path) -> None:
     assert set(sidecar.MANDATORY_NON_CLAIMS).issubset(artifact["does_not_establish"])
     assert artifact["status"] == "incomplete"
     assert validate_patch_evaluation(artifact)["status"] == "pass"
+
+
+def test_declared_git_config_mutates_only_independent_repository(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    patch = _patch(repo, tmp_path)
+    _, artifact = _evaluate(
+        tmp_path,
+        _request(
+            repo,
+            patch,
+            [
+                {
+                    "argv": ["git", "config", "sidecar.pwned", "yes"],
+                    "cwd": ".",
+                    "timeout_seconds": 10,
+                }
+            ],
+        ),
+    )
+    source_value = subprocess.run(
+        ["git", "config", "--get", "sidecar.pwned"],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert artifact["status"] == "passed"
+    assert artifact["workspace"]["isolated"] is True
+    assert source_value.returncode == 1
+
+
+def test_declared_git_ref_mutation_does_not_reach_source(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    patch = _patch(repo, tmp_path)
+    _, artifact = _evaluate(
+        tmp_path,
+        _request(
+            repo,
+            patch,
+            [
+                {
+                    "argv": ["git", "tag", "sidecar-only"],
+                    "cwd": ".",
+                    "timeout_seconds": 10,
+                }
+            ],
+        ),
+    )
+    tags = _run("git", "tag", "--list", "sidecar-only", cwd=repo).stdout
+    assert artifact["status"] == "passed"
+    assert tags == ""
+
+
+def test_repository_smudge_filter_is_not_executed_by_sidecar(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    marker = tmp_path / "filter-ran"
+    filter_script = tmp_path / "filter.py"
+    filter_script.write_text(
+        "import pathlib, sys\n"
+        f"pathlib.Path({str(marker)!r}).touch()\n"
+        "sys.stdout.buffer.write(sys.stdin.buffer.read())\n",
+        encoding="utf-8",
+    )
+    _run(
+        "git",
+        "config",
+        "filter.sidecar-test.smudge",
+        f"{sys.executable} {filter_script}",
+        cwd=repo,
+    )
+    _run("git", "config", "filter.sidecar-test.clean", "cat", cwd=repo)
+    (repo / ".gitattributes").write_text(
+        "message.txt filter=sidecar-test\n", encoding="utf-8"
+    )
+    _run("git", "add", ".gitattributes", cwd=repo)
+    _run("git", "commit", "-qm", "attributes", cwd=repo)
+    patch = _patch(repo, tmp_path)
+    marker.unlink(missing_ok=True)
+
+    _, artifact = _evaluate(tmp_path, _request(repo, patch, []))
+
+    assert artifact["status"] == "incomplete"
+    assert not marker.exists()
+
+
+def test_successful_command_cannot_leave_background_process(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _repo(tmp_path)
+    patch = _patch(repo, tmp_path)
+    observed_after_delay = False
+    original_cleanup = sidecar._cleanup_workspace
+
+    def delayed_cleanup(setup: object, state: object) -> None:
+        nonlocal observed_after_delay
+        time.sleep(1.3)
+        observed_after_delay = (setup.workspace / "late-marker").exists()
+        original_cleanup(setup, state)
+
+    monkeypatch.setattr(sidecar, "_cleanup_workspace", delayed_cleanup)
+    child = (
+        "import time; from pathlib import Path; "
+        "time.sleep(0.7); Path('late-marker').write_text('survived')"
+    )
+    parent = (
+        "import subprocess, sys; "
+        f"subprocess.Popen([sys.executable, '-c', {child!r}], "
+        "stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, "
+        "stderr=subprocess.DEVNULL, start_new_session=True)"
+    )
+    _, artifact = _evaluate(
+        tmp_path,
+        _request(
+            repo,
+            patch,
+            [
+                {
+                    "argv": [sys.executable, "-c", parent],
+                    "cwd": ".",
+                    "timeout_seconds": 10,
+                }
+            ],
+        ),
+    )
+    assert artifact["status"] == "passed"
+    assert observed_after_delay is False
+
+
+def test_rename_reports_destination_path(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    _run("git", "mv", "message.txt", "renamed.txt", cwd=repo)
+    assert sidecar._parse_changed_files(repo) == [
+        {"path": "renamed.txt", "change": "renamed"}
+    ]
+
+
+def test_fail_fast_marks_remaining_commands_skipped(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    patch = _patch(repo, tmp_path)
+    request = _request(
+        repo,
+        patch,
+        [
+            {
+                "argv": [sys.executable, "-c", "raise SystemExit(3)"],
+                "cwd": ".",
+                "timeout_seconds": 10,
+            },
+            {
+                "argv": [sys.executable, "-c", "raise SystemExit(0)"],
+                "cwd": ".",
+                "timeout_seconds": 10,
+            },
+        ],
+    )
+    request["fail_fast"] = True
+    _, artifact = _evaluate(tmp_path, request)
+    assert [item["status"] for item in artifact["commands_run"]] == [
+        "failed",
+        "skipped",
+    ]
+    assert artifact["status"] == "incomplete"
+
+
+def test_sensitive_argv_is_redacted_from_artifact(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    patch = _patch(repo, tmp_path)
+    secret = "artifact-must-not-contain-this"
+    command = {
+        "argv": [sys.executable, "-c", "import sys; print(sys.argv[1])", secret],
+        "cwd": ".",
+        "timeout_seconds": 10,
+        "redact_argv_indexes": [3],
+    }
+    _, artifact = _evaluate(tmp_path, _request(repo, patch, [command]))
+    serialized = json.dumps(artifact)
+    assert artifact["status"] == "passed"
+    assert secret not in serialized
+    assert "<redacted>" in artifact["commands_run"][0]["command"]
+    log_path = tmp_path / "out" / artifact["commands_run"][0]["log_ref"]
+    assert secret not in log_path.read_text(encoding="utf-8")
+    assert "<redacted>" in log_path.read_text(encoding="utf-8")
+
+
+def test_empty_command_set_leaves_no_log_directory(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    patch = _patch(repo, tmp_path)
+    _, artifact = _evaluate(tmp_path, _request(repo, patch, []))
+    assert artifact["status"] == "incomplete"
+    assert not (tmp_path / "out" / "evaluation.logs").exists()
+
+
+def test_repository_clean_filter_is_not_executed_by_source_preflight(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    (repo / ".gitattributes").write_text(
+        "message.txt filter=sidecar-clean\n", encoding="utf-8"
+    )
+    _run("git", "add", ".gitattributes", cwd=repo)
+    _run("git", "commit", "-qm", "attributes", cwd=repo)
+    patch = _patch(repo, tmp_path)
+    marker = tmp_path / "clean-filter-ran"
+    script = tmp_path / "clean-filter.py"
+    script.write_text(
+        "import pathlib, sys\n"
+        f"pathlib.Path({str(marker)!r}).touch()\n"
+        "sys.stdout.buffer.write(sys.stdin.buffer.read())\n",
+        encoding="utf-8",
+    )
+    _run(
+        "git",
+        "config",
+        "filter.sidecar-clean.clean",
+        f"{sys.executable} {script}",
+        cwd=repo,
+    )
+    _run("git", "config", "filter.sidecar-clean.smudge", "cat", cwd=repo)
+
+    _, artifact = _evaluate(tmp_path, _request(repo, patch, []))
+
+    assert artifact["status"] == "incomplete"
+    assert not marker.exists()
+
+
+def test_repository_process_filter_is_not_executed_by_source_preflight(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    (repo / ".gitattributes").write_text(
+        "message.txt filter=sidecar-process\n", encoding="utf-8"
+    )
+    _run("git", "add", ".gitattributes", cwd=repo)
+    _run("git", "commit", "-qm", "attributes", cwd=repo)
+    patch = _patch(repo, tmp_path)
+    marker = tmp_path / "process-filter-ran"
+    script = tmp_path / "process-filter.py"
+    script.write_text(
+        f"import pathlib\npathlib.Path({str(marker)!r}).touch()\nraise SystemExit(1)\n",
+        encoding="utf-8",
+    )
+    _run(
+        "git",
+        "config",
+        "filter.sidecar-process.process",
+        f"{sys.executable} {script}",
+        cwd=repo,
+    )
+    _run("git", "config", "filter.sidecar-process.required", "true", cwd=repo)
+
+    _, artifact = _evaluate(tmp_path, _request(repo, patch, []))
+
+    assert artifact["status"] == "incomplete"
+    assert not marker.exists()
+
+
+def test_cleanup_failure_forces_error_artifact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _repo(tmp_path)
+    patch = _patch(repo, tmp_path)
+    original_rmtree = sidecar.shutil.rmtree
+
+    def selective_rmtree(path: Path) -> None:
+        if str(path).endswith("-repository"):
+            return
+        original_rmtree(path)
+
+    monkeypatch.setattr(sidecar.shutil, "rmtree", selective_rmtree)
+    result, artifact = _evaluate(
+        tmp_path,
+        _request(
+            repo,
+            patch,
+            [
+                {
+                    "argv": [sys.executable, "-c", "raise SystemExit(0)"],
+                    "cwd": ".",
+                    "timeout_seconds": 10,
+                }
+            ],
+        ),
+    )
+    assert result["workspace_cleaned"] is False
+    assert artifact["status"] == "error"
+    for candidate in (tmp_path / "workspaces").glob("*-repository"):
+        original_rmtree(candidate)
+
+
+def test_partial_repository_creation_is_cleaned(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _repo(tmp_path)
+    patch = _patch(repo, tmp_path)
+
+    def fail_import(setup: object, pack_path: Path) -> None:
+        raise sidecar.EvaluationError("forced object import failure")
+
+    monkeypatch.setattr(sidecar, "_import_pack_snapshot", fail_import)
+    result, artifact = _evaluate(tmp_path, _request(repo, patch, []))
+    assert artifact["status"] == "error"
+    assert result["workspace_cleaned"] is True
+    assert not any((tmp_path / "workspaces").iterdir())
+
+
+def test_parent_path_cannot_replace_internal_git(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _repo(tmp_path)
+    patch = _patch(repo, tmp_path)
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    marker = tmp_path / "fake-git-ran"
+    fake_git = fake_bin / "git"
+    fake_git.write_text(
+        f"#!/bin/sh\n/usr/bin/touch {marker}\nexit 91\n", encoding="utf-8"
+    )
+    fake_git.chmod(0o755)
+    request = _request(repo, patch, [])
+    monkeypatch.setenv("PATH", f"{fake_bin}:")
+
+    _, artifact = _evaluate(tmp_path, request)
+
+    assert artifact["status"] == "incomplete"
+    assert not marker.exists()
+    assert "/usr/bin/git" in artifact["environment"]["tool_versions"]["git"]
+
+
+def test_request_and_patch_size_limits_fail_before_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _repo(tmp_path)
+    patch = _patch(repo, tmp_path)
+    request_path = tmp_path / "request.json"
+    request_path.write_text(json.dumps(_request(repo, patch, [])), encoding="utf-8")
+    monkeypatch.setattr(sidecar, "_MAX_REQUEST_BYTES", 8)
+    with pytest.raises(sidecar.RequestError, match="request exceeds"):
+        sidecar.load_request(request_path)
+
+    monkeypatch.setattr(sidecar, "_MAX_REQUEST_BYTES", 1_000_000)
+    monkeypatch.setattr(sidecar, "_MAX_PATCH_BYTES", 1)
+    with pytest.raises(sidecar.RequestError, match="patch_path exceeds"):
+        sidecar.load_request(request_path)
+
+
+def test_atomic_artifact_publication_never_overwrites_existing_path(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "artifact.json"
+    output.write_text("foreign\n", encoding="utf-8")
+    with pytest.raises(FileExistsError):
+        sidecar._atomic_write_json(output, {"status": "passed"})
+    assert output.read_text(encoding="utf-8") == "foreign\n"
+    assert not list(tmp_path.glob(".artifact.json.*.tmp"))
+
+
+def test_log_directory_collision_fails_without_using_foreign_path(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    patch = _patch(repo, tmp_path)
+    request_path = tmp_path / "request.json"
+    output = tmp_path / "out" / "evaluation.json"
+    workspace_root = tmp_path / "workspaces"
+    request_path.write_text(
+        json.dumps(
+            _request(
+                repo,
+                patch,
+                [
+                    {
+                        "argv": [sys.executable, "-c", "raise SystemExit(0)"],
+                        "cwd": ".",
+                        "timeout_seconds": 10,
+                    }
+                ],
+            )
+        ),
+        encoding="utf-8",
+    )
+    foreign = output.parent / "evaluation.logs"
+    foreign.mkdir(parents=True)
+    marker = foreign / "foreign"
+    marker.write_text("retain\n", encoding="utf-8")
+    with pytest.raises(sidecar.RequestError, match="log directory already exists"):
+        sidecar.evaluate(request_path, output, workspace_root=workspace_root)
+    assert marker.read_text(encoding="utf-8") == "retain\n"
+    assert not output.exists()
+
+
+def test_command_sandbox_does_not_expose_unallowlisted_host_etc(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    patch = _patch(repo, tmp_path)
+    _, artifact = _evaluate(
+        tmp_path,
+        _request(
+            repo,
+            patch,
+            [
+                {
+                    "argv": [
+                        sys.executable,
+                        "-c",
+                        "from pathlib import Path; assert not Path('/etc/machine-id').exists()",
+                    ],
+                    "cwd": ".",
+                    "timeout_seconds": 10,
+                }
+            ],
+        ),
+    )
+    assert artifact["status"] == "passed"

--- a/tools/patch_evaluation_sidecar.py
+++ b/tools/patch_evaluation_sidecar.py
@@ -1,0 +1,716 @@
+#!/usr/bin/env python3
+"""External Patch Evaluation Sidecar prototype for RBAW-V1-T004.
+
+This executable is intentionally outside ``merger/repoground/core``. It applies
+one declared patch in a disposable detached Git worktree, runs an explicit list
+of argv-only commands, and emits bounded ``repobrief.patch_evaluation`` v1
+evidence. A passing artifact is not approval and does not establish correctness.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import shlex
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+from typing import Any, Mapping, Sequence
+
+PRODUCER_NAME = "repoground-external-patch-evaluation-sidecar"
+PRODUCER_VERSION = "0.1.0"
+MANDATORY_NON_CLAIMS = [
+    "correctness",
+    "test_sufficiency",
+    "security_correctness",
+    "runtime_behavior_outside_evaluated_commands",
+    "merge_authorization",
+    "merge_readiness",
+    "regression_absence",
+    "repo_understood",
+    "claims_true",
+]
+_REQUEST_KEYS = {
+    "schema_version", "repository", "base_commit", "patch_path", "patch_format",
+    "commands", "global_timeout_seconds", "max_log_bytes", "repobrief_context",
+}
+_COMMAND_KEYS = {"argv", "cwd", "timeout_seconds"}
+_CONTEXT_KEYS = {
+    "bundle_manifest", "snapshot_run_id", "workbench_outputs", "cited_ranges", "citations",
+}
+_MAX_COMMANDS = 32
+_MAX_TIMEOUT_SECONDS = 7200
+_MAX_LOG_BYTES = 1_000_000
+
+
+class RequestError(ValueError):
+    """The evaluation request is malformed or violates the prototype boundary."""
+
+
+class EvaluationError(RuntimeError):
+    """The isolated evaluation could not be completed with trustworthy provenance."""
+
+
+@dataclass(frozen=True)
+class CommandSpec:
+    argv: tuple[str, ...]
+    cwd: str
+    timeout_seconds: int
+
+
+@dataclass(frozen=True)
+class EvaluationRequest:
+    repository: Path
+    base_commit: str
+    patch_path: Path
+    patch_format: str
+    commands: tuple[CommandSpec, ...]
+    global_timeout_seconds: int
+    max_log_bytes: int
+    repobrief_context: dict[str, Any]
+
+
+def _strict_keys(value: Mapping[str, Any], allowed: set[str], label: str) -> None:
+    unknown = sorted(set(value) - allowed)
+    if unknown:
+        raise RequestError(f"{label} contains unsupported field(s): {', '.join(unknown)}")
+
+
+def _non_empty_string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.strip() or "\x00" in value:
+        raise RequestError(f"{label} must be a non-empty string without NUL bytes")
+    return value
+
+
+def _bounded_int(value: Any, label: str, *, minimum: int, maximum: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise RequestError(f"{label} must be an integer")
+    if value < minimum or value > maximum:
+        raise RequestError(f"{label} must be between {minimum} and {maximum}")
+    return value
+
+
+def _validate_relative_cwd(value: Any, label: str) -> str:
+    cwd = _non_empty_string(value, label)
+    pure = PurePosixPath(cwd)
+    if pure.is_absolute() or ".." in pure.parts:
+        raise RequestError(f"{label} must stay inside the isolated worktree")
+    normalized = str(pure)
+    return "." if normalized in {"", "."} else normalized
+
+
+def _validate_string_list(value: Any, label: str) -> list[str]:
+    if not isinstance(value, list):
+        raise RequestError(f"{label} must be an array")
+    return [_non_empty_string(item, f"{label}[{index}]") for index, item in enumerate(value)]
+
+
+def _validate_context(value: Any) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise RequestError("repobrief_context must be an object")
+    _strict_keys(value, _CONTEXT_KEYS, "repobrief_context")
+    result: dict[str, Any] = {}
+    for key in ("bundle_manifest", "snapshot_run_id"):
+        item = value.get(key)
+        if item is not None:
+            result[key] = _non_empty_string(item, f"repobrief_context.{key}")
+    for key in ("workbench_outputs", "cited_ranges", "citations"):
+        if key in value:
+            result[key] = _validate_string_list(value[key], f"repobrief_context.{key}")
+    return result
+
+
+def load_request(path: str | Path) -> EvaluationRequest:
+    request_path = Path(path).expanduser().resolve()
+    try:
+        data = json.loads(request_path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise RequestError(f"request could not be read: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise RequestError(f"request is not valid JSON: {exc}") from exc
+    if not isinstance(data, Mapping):
+        raise RequestError("request must be a JSON object")
+    _strict_keys(data, _REQUEST_KEYS, "request")
+    if data.get("schema_version") != 1:
+        raise RequestError("schema_version must be 1")
+
+    repository = Path(_non_empty_string(data.get("repository"), "repository")).expanduser().resolve()
+    if not repository.is_dir():
+        raise RequestError(f"repository is not a directory: {repository}")
+    patch_path = Path(_non_empty_string(data.get("patch_path"), "patch_path")).expanduser().resolve()
+    if not patch_path.is_file():
+        raise RequestError(f"patch_path is not a file: {patch_path}")
+    base_commit = _non_empty_string(data.get("base_commit"), "base_commit")
+    if base_commit.startswith("-"):
+        raise RequestError("base_commit must not begin with '-'")
+    patch_format = data.get("patch_format", "git-diff")
+    if patch_format not in {"git-diff", "unified-diff"}:
+        raise RequestError("patch_format must be git-diff or unified-diff")
+
+    raw_commands = data.get("commands")
+    if not isinstance(raw_commands, list):
+        raise RequestError("commands must be an array")
+    if len(raw_commands) > _MAX_COMMANDS:
+        raise RequestError(f"commands may contain at most {_MAX_COMMANDS} entries")
+    commands: list[CommandSpec] = []
+    for index, raw in enumerate(raw_commands):
+        if not isinstance(raw, Mapping):
+            raise RequestError(f"commands[{index}] must be an object")
+        _strict_keys(raw, _COMMAND_KEYS, f"commands[{index}]")
+        argv = raw.get("argv")
+        if not isinstance(argv, list) or not argv:
+            raise RequestError(f"commands[{index}].argv must be a non-empty array")
+        argv_items = tuple(
+            _non_empty_string(item, f"commands[{index}].argv[{position}]")
+            for position, item in enumerate(argv)
+        )
+        cwd = _validate_relative_cwd(raw.get("cwd", "."), f"commands[{index}].cwd")
+        timeout = _bounded_int(
+            raw.get("timeout_seconds", 300), f"commands[{index}].timeout_seconds",
+            minimum=1, maximum=_MAX_TIMEOUT_SECONDS,
+        )
+        commands.append(CommandSpec(argv_items, cwd, timeout))
+
+    global_timeout = _bounded_int(
+        data.get("global_timeout_seconds", 1800), "global_timeout_seconds",
+        minimum=1, maximum=_MAX_TIMEOUT_SECONDS,
+    )
+    max_log_bytes = _bounded_int(
+        data.get("max_log_bytes", 65536), "max_log_bytes", minimum=256, maximum=_MAX_LOG_BYTES,
+    )
+    return EvaluationRequest(
+        repository=repository,
+        base_commit=base_commit,
+        patch_path=patch_path,
+        patch_format=patch_format,
+        commands=tuple(commands),
+        global_timeout_seconds=global_timeout,
+        max_log_bytes=max_log_bytes,
+        repobrief_context=_validate_context(data.get("repobrief_context")),
+    )
+
+
+def _sanitized_environment(home: Path, tmpdir: Path) -> dict[str, str]:
+    home.mkdir(parents=True, exist_ok=True)
+    tmpdir.mkdir(parents=True, exist_ok=True)
+    xdg_config_home = home / ".config"
+    xdg_config_home.mkdir(parents=True, exist_ok=True)
+    return {
+        "HOME": str(home),
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+        "PATH": os.environ.get("PATH") or os.defpath,
+        "PYTHONNOUSERSITE": "1",
+        "TMPDIR": str(tmpdir),
+        "TZ": "UTC",
+        "XDG_CONFIG_HOME": str(xdg_config_home),
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_TERMINAL_PROMPT": "0",
+    }
+
+
+def _run_bytes(
+    argv: Sequence[str], *, cwd: Path, timeout: float = 60, check: bool = True,
+    env: Mapping[str, str] | None = None,
+) -> subprocess.CompletedProcess[bytes]:
+    completed = subprocess.run(
+        list(argv), cwd=cwd, env=dict(env) if env is not None else None,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=timeout,
+        check=False, shell=False,
+    )
+    if check and completed.returncode != 0:
+        detail = completed.stderr.decode("utf-8", errors="replace").strip()
+        raise EvaluationError(f"command failed ({completed.returncode}): {shlex.join(argv)}: {detail}")
+    return completed
+
+
+def _git(
+    repo: Path,
+    *args: str,
+    timeout: float = 60,
+    check: bool = True,
+) -> subprocess.CompletedProcess[bytes]:
+    with tempfile.TemporaryDirectory(prefix="repoground-patch-evaluation-git-") as temporary:
+        scratch = Path(temporary)
+        env = _sanitized_environment(scratch / "home", scratch / "tmp")
+        return _run_bytes(
+            (
+                "git",
+                "-c",
+                "core.hooksPath=/dev/null",
+                "-c",
+                "core.fsmonitor=false",
+                "-c",
+                "core.pager=cat",
+                "-C",
+                str(repo),
+                *args,
+            ),
+            cwd=repo,
+            timeout=timeout,
+            check=check,
+            env=env,
+        )
+
+
+def _git_text(repo: Path, *args: str, timeout: float = 60) -> str:
+    return _git(repo, *args, timeout=timeout).stdout.decode("utf-8", errors="strict").strip()
+
+
+def _snapshot_patch(path: Path, directory: Path) -> tuple[Path, str]:
+    """Copy one immutable patch snapshot and bind its digest to applied bytes."""
+    digest = hashlib.sha256()
+    snapshot: Path | None = None
+    try:
+        with path.open("rb") as source, tempfile.NamedTemporaryFile(
+            mode="wb",
+            dir=directory,
+            prefix=".patch-evaluation-input-",
+            suffix=".diff",
+            delete=False,
+        ) as destination:
+            snapshot = Path(destination.name)
+            for chunk in iter(lambda: source.read(1024 * 1024), b""):
+                digest.update(chunk)
+                destination.write(chunk)
+            destination.flush()
+            os.fsync(destination.fileno())
+        return snapshot, digest.hexdigest()
+    except Exception:
+        if snapshot is not None:
+            snapshot.unlink(missing_ok=True)
+        raise
+
+
+def _ensure_outside_repository(path: Path, repository: Path, label: str) -> None:
+    resolved = path.expanduser().resolve()
+    if resolved == repository or repository in resolved.parents:
+        raise RequestError(f"{label} must be outside the source repository")
+
+
+def _source_snapshot(repository: Path) -> tuple[str, str, str | None]:
+    """Fingerprint exact Git-visible source state, including dirty file contents."""
+    head = _git_text(repository, "rev-parse", "HEAD")
+    digest = hashlib.sha256()
+    digest.update(head.encode("ascii"))
+    digest.update(b"\0status\0")
+    digest.update(_git(repository, "status", "--porcelain=v1", "-z", "--untracked-files=all").stdout)
+    digest.update(b"\0tracked-worktree-diff\0")
+    digest.update(
+        _git(
+            repository,
+            "diff",
+            "--binary",
+            "--no-ext-diff",
+            "--no-textconv",
+            "HEAD",
+            "--",
+        ).stdout
+    )
+    digest.update(b"\0tracked-index-diff\0")
+    digest.update(
+        _git(
+            repository,
+            "diff",
+            "--binary",
+            "--cached",
+            "--no-ext-diff",
+            "--no-textconv",
+            "HEAD",
+            "--",
+        ).stdout
+    )
+    untracked = _git(repository, "ls-files", "--others", "--exclude-standard", "-z").stdout
+    digest.update(b"\0untracked\0")
+    for encoded_path in sorted(item for item in untracked.split(b"\0") if item):
+        relative = encoded_path.decode("utf-8", errors="surrogateescape")
+        candidate = repository / relative
+        digest.update(encoded_path)
+        digest.update(b"\0")
+        if candidate.is_symlink():
+            digest.update(b"symlink\0")
+            digest.update(os.readlink(candidate).encode("utf-8", errors="surrogateescape"))
+        elif candidate.is_file():
+            digest.update(b"file\0")
+            with candidate.open("rb") as handle:
+                for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                    digest.update(chunk)
+        else:
+            digest.update(b"other\0")
+    branch_result = _git(repository, "symbolic-ref", "--quiet", "--short", "HEAD", check=False)
+    branch = branch_result.stdout.decode("utf-8", errors="replace").strip() if branch_result.returncode == 0 else None
+    return head, digest.hexdigest(), branch or None
+
+
+def _resolve_base_commit(repository: Path, requested: str) -> str:
+    resolved = _git_text(
+        repository, "rev-parse", "--verify", "--end-of-options", f"{requested}^{{commit}}"
+    )
+    if len(resolved) not in {40, 64} or any(
+        character not in "0123456789abcdef" for character in resolved
+    ):
+        raise EvaluationError("base_commit did not resolve to an exact Git object id")
+    return resolved
+
+
+def _parse_changed_files(workspace: Path) -> list[dict[str, Any]]:
+    raw = _git(workspace, "status", "--porcelain=v1", "-z", "--untracked-files=all").stdout
+    entries = raw.split(b"\0")
+    changed: list[dict[str, Any]] = []
+    index = 0
+    mapping = {"A": "added", "M": "modified", "D": "deleted", "R": "renamed", "C": "renamed", "?": "added"}
+    while index < len(entries):
+        entry = entries[index]
+        index += 1
+        if not entry:
+            continue
+        if len(entry) < 4:
+            raise EvaluationError("git status returned an unexpected record")
+        code = entry[:2].decode("ascii", errors="strict")
+        path = entry[3:].decode("utf-8", errors="backslashreplace")
+        status = code[0] if code[0] != " " else code[1]
+        if status in {"R", "C"} and index < len(entries) and entries[index]:
+            path = entries[index].decode("utf-8", errors="backslashreplace")
+            index += 1
+        changed.append({"path": path, "change": mapping.get(status)})
+    return sorted(changed, key=lambda item: item["path"])
+
+
+def _terminate_process_group(process: subprocess.Popen[bytes]) -> None:
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    try:
+        process.wait(timeout=2)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return
+    process.wait(timeout=2)
+
+
+def _bounded_bytes(path: Path, limit: int) -> tuple[bytes, bool]:
+    size = path.stat().st_size
+    with path.open("rb") as handle:
+        return handle.read(limit), size > limit
+
+
+def _write_command_log(output_path: Path, stdout_path: Path, stderr_path: Path, limit: int) -> bool:
+    header_stdout = b"=== stdout ===\n"
+    header_stderr = b"\n=== stderr ===\n"
+    budget = max(0, limit - len(header_stdout) - len(header_stderr))
+    stdout_budget = budget // 2
+    stderr_budget = budget - stdout_budget
+    stdout, stdout_truncated = _bounded_bytes(stdout_path, stdout_budget)
+    stderr, stderr_truncated = _bounded_bytes(stderr_path, stderr_budget)
+    payload = header_stdout + stdout + header_stderr + stderr
+    output_path.write_bytes(payload[:limit])
+    return stdout_truncated or stderr_truncated or len(payload) > limit
+
+
+def _run_command(
+    spec: CommandSpec, *, workspace: Path, timeout_seconds: float,
+    env: Mapping[str, str], log_path: Path, max_log_bytes: int,
+) -> dict[str, Any]:
+    command_cwd = (workspace / spec.cwd).resolve()
+    if command_cwd != workspace and workspace not in command_cwd.parents:
+        raise EvaluationError(f"command cwd escaped isolated worktree: {spec.cwd}")
+    if not command_cwd.is_dir():
+        raise EvaluationError(f"command cwd is not a directory: {spec.cwd}")
+
+    started_at = datetime.now(timezone.utc)
+    started = time.monotonic()
+    with tempfile.TemporaryDirectory(prefix="patch-evaluation-command-") as temporary:
+        temporary_path = Path(temporary)
+        stdout_path = temporary_path / "stdout"
+        stderr_path = temporary_path / "stderr"
+        with stdout_path.open("wb") as stdout_handle, stderr_path.open("wb") as stderr_handle:
+            process = subprocess.Popen(
+                list(spec.argv), cwd=command_cwd, env=dict(env), stdin=subprocess.DEVNULL,
+                stdout=stdout_handle, stderr=stderr_handle, shell=False, start_new_session=True,
+            )
+            timed_out = False
+            try:
+                returncode = process.wait(timeout=max(0.001, timeout_seconds))
+            except subprocess.TimeoutExpired:
+                timed_out = True
+                _terminate_process_group(process)
+                returncode = None
+        truncated = _write_command_log(log_path, stdout_path, stderr_path, max_log_bytes)
+    duration_ms = max(0, round((time.monotonic() - started) * 1000))
+    status = "timeout" if timed_out else ("passed" if returncode == 0 else "failed")
+    return {
+        "command": shlex.join(spec.argv), "status": status, "exit_code": returncode,
+        "started_at": started_at.isoformat().replace("+00:00", "Z"),
+        "duration_ms": duration_ms, "log_ref": log_path.name, "truncated": truncated,
+    }
+
+
+def _rollup_status(records: list[dict[str, Any]], *, patch_applied: bool, infrastructure_error: bool) -> str:
+    if infrastructure_error or not patch_applied:
+        return "error"
+    if not records:
+        return "incomplete"
+    statuses = [record["status"] for record in records]
+    if any(status == "skipped" for status in statuses):
+        return "incomplete"
+    if all(status == "passed" for status in statuses):
+        return "passed"
+    if all(status == "failed" for status in statuses):
+        return "failed"
+    if all(status in {"error", "timeout", "skipped"} for status in statuses):
+        return "error" if any(status in {"error", "timeout"} for status in statuses) else "incomplete"
+    return "mixed"
+
+
+def _atomic_write_json(path: Path, value: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w", encoding="utf-8", dir=path.parent, prefix=f".{path.name}.",
+            suffix=".tmp", delete=False,
+        ) as handle:
+            json.dump(value, handle, indent=2, sort_keys=True, ensure_ascii=False)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+            temporary = Path(handle.name)
+        os.replace(temporary, path)
+    finally:
+        if temporary is not None and temporary.exists():
+            temporary.unlink()
+
+
+def evaluate(
+    request_path: str | Path, output_path: str | Path, *, workspace_root: str | Path | None = None,
+) -> dict[str, Any]:
+    request = load_request(request_path)
+    canonical_repository = Path(_git_text(request.repository, "rev-parse", "--show-toplevel")).resolve()
+    if canonical_repository != request.repository:
+        raise RequestError("repository must name the exact Git worktree root")
+    output = Path(output_path).expanduser().resolve()
+    _ensure_outside_repository(output, request.repository, "output")
+    if output.exists():
+        raise RequestError(f"output already exists: {output}")
+    requested_workspace_root = (
+        Path(workspace_root).expanduser().resolve()
+        if workspace_root is not None else output.parent / ".patch-evaluation-sidecar-workspaces"
+    )
+    _ensure_outside_repository(requested_workspace_root, request.repository, "workspace_root")
+
+    # Complete read-only provenance preflight before creating output or workspace paths.
+    source_head_before, source_fingerprint_before, source_branch = _source_snapshot(request.repository)
+    exact_base = _resolve_base_commit(request.repository, request.base_commit)
+    if source_head_before != exact_base:
+        source_branch = None
+    workspace_id = uuid.uuid4().hex
+    workspace = requested_workspace_root / workspace_id
+    log_directory = output.parent / f"{output.stem}.logs"
+    if log_directory.exists():
+        raise RequestError(f"log directory already exists: {log_directory}")
+    requested_workspace_root.mkdir(parents=True, exist_ok=True)
+    log_directory.mkdir(parents=True)
+    patch_snapshot: Path | None = None
+    patch_sha256: str | None = None
+    isolated = False
+    patch_applied = False
+    changed_files: list[dict[str, Any]] = []
+    command_records: list[dict[str, Any]] = []
+    infrastructure_error = False
+    error_detail: str | None = None
+    workspace_created = False
+    workspace_cleaned = False
+    source_unchanged = False
+    try:
+        patch_snapshot, patch_sha256 = _snapshot_patch(
+            request.patch_path, requested_workspace_root
+        )
+        # Mark the attempt before invoking Git so a timeout or transport failure still
+        # enters exact-path cleanup and readback.
+        workspace_created = True
+        add_result = _git(
+            request.repository,
+            "worktree",
+            "add",
+            "--detach",
+            str(workspace),
+            exact_base,
+            timeout=120,
+            check=False,
+        )
+        if add_result.returncode != 0:
+            detail = add_result.stderr.decode("utf-8", errors="replace").strip()
+            raise EvaluationError(f"disposable worktree creation failed: {detail}")
+        workspace_head = _git_text(workspace, "rev-parse", "HEAD")
+        isolated = (workspace / ".git").is_file() and workspace_head == exact_base and workspace != request.repository
+        if not isolated:
+            raise EvaluationError("disposable worktree isolation could not be proven")
+        check_result = _git(workspace, "apply", "--check", "--recount", str(patch_snapshot), check=False)
+        if check_result.returncode != 0:
+            detail = check_result.stderr.decode("utf-8", errors="replace").strip()
+            raise EvaluationError(f"patch apply check failed: {detail}")
+        apply_result = _git(workspace, "apply", "--recount", str(patch_snapshot), check=False)
+        if apply_result.returncode != 0:
+            detail = apply_result.stderr.decode("utf-8", errors="replace").strip()
+            raise EvaluationError(f"patch apply failed: {detail}")
+        patch_applied = True
+        changed_files = _parse_changed_files(workspace)
+
+        env = _sanitized_environment(workspace / ".sidecar-home", workspace / ".sidecar-tmp")
+        command_deadline = time.monotonic() + request.global_timeout_seconds
+        for index, spec in enumerate(request.commands, start=1):
+            remaining = command_deadline - time.monotonic()
+            if remaining <= 0:
+                command_records.append({
+                    "command": shlex.join(spec.argv), "status": "skipped", "exit_code": None,
+                    "started_at": None, "duration_ms": 0, "log_ref": None, "truncated": False,
+                })
+                continue
+            record = _run_command(
+                spec, workspace=workspace, timeout_seconds=min(float(spec.timeout_seconds), remaining),
+                env=env, log_path=log_directory / f"command-{index:03d}.log",
+                max_log_bytes=request.max_log_bytes,
+            )
+            record["log_ref"] = f"{log_directory.name}/{record['log_ref']}"
+            command_records.append(record)
+    except (EvaluationError, OSError, subprocess.SubprocessError) as exc:
+        infrastructure_error = True
+        error_detail = str(exc)
+    finally:
+        if workspace_created:
+            try:
+                _git(
+                    request.repository,
+                    "worktree",
+                    "remove",
+                    "--force",
+                    str(workspace),
+                    timeout=120,
+                    check=False,
+                )
+                # Never prune globally: cleanup is restricted to the exact workspace.
+                listed_result = _git(
+                    request.repository, "worktree", "list", "--porcelain", check=False
+                )
+                listed = listed_result.stdout.decode("utf-8", errors="replace")
+                workspace_cleaned = (
+                    listed_result.returncode == 0
+                    and not workspace.exists()
+                    and str(workspace) not in listed
+                )
+            except (EvaluationError, OSError, subprocess.SubprocessError) as exc:
+                workspace_cleaned = False
+                error_detail = error_detail or f"disposable worktree cleanup readback failed: {exc}"
+            if not workspace_cleaned:
+                infrastructure_error = True
+                error_detail = error_detail or "disposable worktree cleanup could not be proven"
+        else:
+            workspace_cleaned = not workspace.exists()
+        if patch_snapshot is not None:
+            try:
+                patch_snapshot.unlink(missing_ok=True)
+            except OSError as exc:
+                error_detail = error_detail or f"patch snapshot cleanup failed: {exc}"
+            if patch_snapshot.exists():
+                infrastructure_error = True
+                error_detail = error_detail or "patch snapshot cleanup could not be proven"
+        try:
+            source_head_after, source_fingerprint_after, _ = _source_snapshot(request.repository)
+            source_unchanged = (
+                source_head_after == source_head_before
+                and source_fingerprint_after == source_fingerprint_before
+            )
+        except (EvaluationError, OSError, subprocess.SubprocessError) as exc:
+            source_unchanged = False
+            error_detail = error_detail or f"source checkout readback failed: {exc}"
+        if not source_unchanged:
+            infrastructure_error = True
+            error_detail = error_detail or "source checkout changed during evaluation"
+
+    status = _rollup_status(command_records, patch_applied=patch_applied, infrastructure_error=infrastructure_error)
+    try:
+        git_version = _run_bytes(("git", "--version"), cwd=request.repository, check=False).stdout.decode(
+            "utf-8", errors="replace"
+        ).strip()
+    except OSError:
+        git_version = "unknown"
+    artifact: dict[str, Any] = {
+        "kind": "repobrief.patch_evaluation", "version": "v1",
+        "authority": "external_evaluation_evidence",
+        "producer": {"name": PRODUCER_NAME, "version": PRODUCER_VERSION, "commit": None, "url": None},
+        "created_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "input": {
+            "repo": str(request.repository), "branch": source_branch, "base_commit": exact_base,
+            "commit": exact_base, "pull_request": None, "patch_id": patch_sha256,
+        },
+        "repobrief_context": request.repobrief_context,
+        "workspace": {"isolated": isolated, "workspace_id": workspace_id, "base_commit": exact_base},
+        "patch": {
+            "applied": patch_applied, "patch_id": patch_sha256, "format": request.patch_format,
+            "sha256": patch_sha256, "changed_files": changed_files,
+        },
+        "command_policy": {
+            "allowed_commands": [shlex.join(command.argv) for command in request.commands],
+            "network": "unknown", "secrets_policy": "unknown",
+            "timeout_seconds": request.global_timeout_seconds,
+        },
+        "commands_run": command_records,
+        "environment": {
+            "os": platform.platform(), "runner": "local-disposable-git-worktree", "container": None,
+            "tool_versions": {"python": platform.python_version(), "git": git_version},
+        },
+        "status": status, "does_not_establish": list(MANDATORY_NON_CLAIMS),
+    }
+    _atomic_write_json(output, artifact)
+    if error_detail:
+        print(f"patch-evaluation-sidecar: {error_detail}", file=sys.stderr)
+    return {
+        "artifact": artifact, "output": str(output), "workspace_cleaned": workspace_cleaned,
+        "source_unchanged": source_unchanged, "error": error_detail,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--request", required=True, help="Strict patch-evaluation request JSON")
+    parser.add_argument("--output", required=True, help="Artifact path outside the source repository")
+    parser.add_argument("--workspace-root", help="Optional disposable-worktree parent outside the source repository")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        result = evaluate(args.request, args.output, workspace_root=args.workspace_root)
+    except RequestError as exc:
+        print(f"patch-evaluation-sidecar: {exc}", file=sys.stderr)
+        return 2
+    except (EvaluationError, OSError, UnicodeError, ValueError, subprocess.SubprocessError) as exc:
+        print(f"patch-evaluation-sidecar: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps({
+        "status": result["artifact"]["status"], "output": result["output"],
+        "workspace_cleaned": result["workspace_cleaned"], "source_unchanged": result["source_unchanged"],
+        "does_not_establish": list(MANDATORY_NON_CLAIMS),
+    }, indent=2, sort_keys=True))
+    return 0 if result["artifact"]["status"] == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/patch_evaluation_sidecar.py
+++ b/tools/patch_evaluation_sidecar.py
@@ -6,6 +6,7 @@ one declared patch in a disposable detached Git worktree, runs an explicit list
 of argv-only commands, and emits bounded ``repobrief.patch_evaluation`` v1
 evidence. A passing artifact is not approval and does not establish correctness.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -20,7 +21,7 @@ import sys
 import tempfile
 import time
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from typing import Any, Mapping, Sequence
@@ -39,12 +40,23 @@ MANDATORY_NON_CLAIMS = [
     "claims_true",
 ]
 _REQUEST_KEYS = {
-    "schema_version", "repository", "base_commit", "patch_path", "patch_format",
-    "commands", "global_timeout_seconds", "max_log_bytes", "repobrief_context",
+    "schema_version",
+    "repository",
+    "base_commit",
+    "patch_path",
+    "patch_format",
+    "commands",
+    "global_timeout_seconds",
+    "max_log_bytes",
+    "repobrief_context",
 }
 _COMMAND_KEYS = {"argv", "cwd", "timeout_seconds"}
 _CONTEXT_KEYS = {
-    "bundle_manifest", "snapshot_run_id", "workbench_outputs", "cited_ranges", "citations",
+    "bundle_manifest",
+    "snapshot_run_id",
+    "workbench_outputs",
+    "cited_ranges",
+    "citations",
 }
 _MAX_COMMANDS = 32
 _MAX_TIMEOUT_SECONDS = 7200
@@ -78,10 +90,41 @@ class EvaluationRequest:
     repobrief_context: dict[str, Any]
 
 
+@dataclass(frozen=True)
+class EvaluationSetup:
+    request: EvaluationRequest
+    output: Path
+    workspace_root: Path
+    workspace_id: str
+    workspace: Path
+    log_directory: Path
+    source_head_before: str
+    source_fingerprint_before: str
+    source_branch: str | None
+    exact_base: str
+
+
+@dataclass
+class EvaluationState:
+    patch_snapshot: Path | None = None
+    patch_sha256: str | None = None
+    isolated: bool = False
+    patch_applied: bool = False
+    changed_files: list[dict[str, Any]] = field(default_factory=list)
+    command_records: list[dict[str, Any]] = field(default_factory=list)
+    infrastructure_error: bool = False
+    error_detail: str | None = None
+    workspace_created: bool = False
+    workspace_cleaned: bool = False
+    source_unchanged: bool = False
+
+
 def _strict_keys(value: Mapping[str, Any], allowed: set[str], label: str) -> None:
     unknown = sorted(set(value) - allowed)
     if unknown:
-        raise RequestError(f"{label} contains unsupported field(s): {', '.join(unknown)}")
+        raise RequestError(
+            f"{label} contains unsupported field(s): {', '.join(unknown)}"
+        )
 
 
 def _non_empty_string(value: Any, label: str) -> str:
@@ -110,7 +153,9 @@ def _validate_relative_cwd(value: Any, label: str) -> str:
 def _validate_string_list(value: Any, label: str) -> list[str]:
     if not isinstance(value, list):
         raise RequestError(f"{label} must be an array")
-    return [_non_empty_string(item, f"{label}[{index}]") for index, item in enumerate(value)]
+    return [
+        _non_empty_string(item, f"{label}[{index}]") for index, item in enumerate(value)
+    ]
 
 
 def _validate_context(value: Any) -> dict[str, Any]:
@@ -130,7 +175,7 @@ def _validate_context(value: Any) -> dict[str, Any]:
     return result
 
 
-def load_request(path: str | Path) -> EvaluationRequest:
+def _read_request_object(path: str | Path) -> Mapping[str, Any]:
     request_path = Path(path).expanduser().resolve()
     try:
         data = json.loads(request_path.read_text(encoding="utf-8"))
@@ -140,62 +185,91 @@ def load_request(path: str | Path) -> EvaluationRequest:
         raise RequestError(f"request is not valid JSON: {exc}") from exc
     if not isinstance(data, Mapping):
         raise RequestError("request must be a JSON object")
+    return data
+
+
+def _validate_existing_path(value: Any, label: str, *, directory: bool) -> Path:
+    path = Path(_non_empty_string(value, label)).expanduser().resolve()
+    valid = path.is_dir() if directory else path.is_file()
+    if not valid:
+        expected = "directory" if directory else "file"
+        raise RequestError(f"{label} is not a {expected}: {path}")
+    return path
+
+
+def _validate_base_commit(value: Any) -> str:
+    base_commit = _non_empty_string(value, "base_commit")
+    if base_commit.startswith("-"):
+        raise RequestError("base_commit must not begin with '-'")
+    return base_commit
+
+
+def _validate_patch_format(value: Any) -> str:
+    if value not in {"git-diff", "unified-diff"}:
+        raise RequestError("patch_format must be git-diff or unified-diff")
+    return value
+
+
+def _validate_command(raw: Any, index: int) -> CommandSpec:
+    if not isinstance(raw, Mapping):
+        raise RequestError(f"commands[{index}] must be an object")
+    label = f"commands[{index}]"
+    _strict_keys(raw, _COMMAND_KEYS, label)
+    argv = raw.get("argv")
+    if not isinstance(argv, list) or not argv:
+        raise RequestError(f"{label}.argv must be a non-empty array")
+    argv_items = tuple(
+        _non_empty_string(item, f"{label}.argv[{position}]")
+        for position, item in enumerate(argv)
+    )
+    cwd = _validate_relative_cwd(raw.get("cwd", "."), f"{label}.cwd")
+    timeout = _bounded_int(
+        raw.get("timeout_seconds", 300),
+        f"{label}.timeout_seconds",
+        minimum=1,
+        maximum=_MAX_TIMEOUT_SECONDS,
+    )
+    return CommandSpec(argv_items, cwd, timeout)
+
+
+def _validate_commands(value: Any) -> tuple[CommandSpec, ...]:
+    if not isinstance(value, list):
+        raise RequestError("commands must be an array")
+    if len(value) > _MAX_COMMANDS:
+        raise RequestError(f"commands may contain at most {_MAX_COMMANDS} entries")
+    return tuple(_validate_command(raw, index) for index, raw in enumerate(value))
+
+
+def load_request(path: str | Path) -> EvaluationRequest:
+    data = _read_request_object(path)
     _strict_keys(data, _REQUEST_KEYS, "request")
     if data.get("schema_version") != 1:
         raise RequestError("schema_version must be 1")
-
-    repository = Path(_non_empty_string(data.get("repository"), "repository")).expanduser().resolve()
-    if not repository.is_dir():
-        raise RequestError(f"repository is not a directory: {repository}")
-    patch_path = Path(_non_empty_string(data.get("patch_path"), "patch_path")).expanduser().resolve()
-    if not patch_path.is_file():
-        raise RequestError(f"patch_path is not a file: {patch_path}")
-    base_commit = _non_empty_string(data.get("base_commit"), "base_commit")
-    if base_commit.startswith("-"):
-        raise RequestError("base_commit must not begin with '-'")
-    patch_format = data.get("patch_format", "git-diff")
-    if patch_format not in {"git-diff", "unified-diff"}:
-        raise RequestError("patch_format must be git-diff or unified-diff")
-
-    raw_commands = data.get("commands")
-    if not isinstance(raw_commands, list):
-        raise RequestError("commands must be an array")
-    if len(raw_commands) > _MAX_COMMANDS:
-        raise RequestError(f"commands may contain at most {_MAX_COMMANDS} entries")
-    commands: list[CommandSpec] = []
-    for index, raw in enumerate(raw_commands):
-        if not isinstance(raw, Mapping):
-            raise RequestError(f"commands[{index}] must be an object")
-        _strict_keys(raw, _COMMAND_KEYS, f"commands[{index}]")
-        argv = raw.get("argv")
-        if not isinstance(argv, list) or not argv:
-            raise RequestError(f"commands[{index}].argv must be a non-empty array")
-        argv_items = tuple(
-            _non_empty_string(item, f"commands[{index}].argv[{position}]")
-            for position, item in enumerate(argv)
-        )
-        cwd = _validate_relative_cwd(raw.get("cwd", "."), f"commands[{index}].cwd")
-        timeout = _bounded_int(
-            raw.get("timeout_seconds", 300), f"commands[{index}].timeout_seconds",
-            minimum=1, maximum=_MAX_TIMEOUT_SECONDS,
-        )
-        commands.append(CommandSpec(argv_items, cwd, timeout))
-
-    global_timeout = _bounded_int(
-        data.get("global_timeout_seconds", 1800), "global_timeout_seconds",
-        minimum=1, maximum=_MAX_TIMEOUT_SECONDS,
+    repository = _validate_existing_path(
+        data.get("repository"), "repository", directory=True
     )
-    max_log_bytes = _bounded_int(
-        data.get("max_log_bytes", 65536), "max_log_bytes", minimum=256, maximum=_MAX_LOG_BYTES,
+    patch_path = _validate_existing_path(
+        data.get("patch_path"), "patch_path", directory=False
     )
+    base_commit = _validate_base_commit(data.get("base_commit"))
     return EvaluationRequest(
         repository=repository,
         base_commit=base_commit,
         patch_path=patch_path,
-        patch_format=patch_format,
-        commands=tuple(commands),
-        global_timeout_seconds=global_timeout,
-        max_log_bytes=max_log_bytes,
+        patch_format=_validate_patch_format(data.get("patch_format", "git-diff")),
+        commands=_validate_commands(data.get("commands")),
+        global_timeout_seconds=_bounded_int(
+            data.get("global_timeout_seconds", 1800),
+            "global_timeout_seconds",
+            minimum=1,
+            maximum=_MAX_TIMEOUT_SECONDS,
+        ),
+        max_log_bytes=_bounded_int(
+            data.get("max_log_bytes", 65536),
+            "max_log_bytes",
+            minimum=256,
+            maximum=_MAX_LOG_BYTES,
+        ),
         repobrief_context=_validate_context(data.get("repobrief_context")),
     )
 
@@ -221,17 +295,28 @@ def _sanitized_environment(home: Path, tmpdir: Path) -> dict[str, str]:
 
 
 def _run_bytes(
-    argv: Sequence[str], *, cwd: Path, timeout: float = 60, check: bool = True,
+    argv: Sequence[str],
+    *,
+    cwd: Path,
+    timeout: float = 60,
+    check: bool = True,
     env: Mapping[str, str] | None = None,
 ) -> subprocess.CompletedProcess[bytes]:
     completed = subprocess.run(
-        list(argv), cwd=cwd, env=dict(env) if env is not None else None,
-        stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=timeout,
-        check=False, shell=False,
+        list(argv),
+        cwd=cwd,
+        env=dict(env) if env is not None else None,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout,
+        check=False,
+        shell=False,
     )
     if check and completed.returncode != 0:
         detail = completed.stderr.decode("utf-8", errors="replace").strip()
-        raise EvaluationError(f"command failed ({completed.returncode}): {shlex.join(argv)}: {detail}")
+        raise EvaluationError(
+            f"command failed ({completed.returncode}): {shlex.join(argv)}: {detail}"
+        )
     return completed
 
 
@@ -241,7 +326,9 @@ def _git(
     timeout: float = 60,
     check: bool = True,
 ) -> subprocess.CompletedProcess[bytes]:
-    with tempfile.TemporaryDirectory(prefix="repoground-patch-evaluation-git-") as temporary:
+    with tempfile.TemporaryDirectory(
+        prefix="repoground-patch-evaluation-git-"
+    ) as temporary:
         scratch = Path(temporary)
         env = _sanitized_environment(scratch / "home", scratch / "tmp")
         return _run_bytes(
@@ -265,7 +352,11 @@ def _git(
 
 
 def _git_text(repo: Path, *args: str, timeout: float = 60) -> str:
-    return _git(repo, *args, timeout=timeout).stdout.decode("utf-8", errors="strict").strip()
+    return (
+        _git(repo, *args, timeout=timeout)
+        .stdout.decode("utf-8", errors="strict")
+        .strip()
+    )
 
 
 def _snapshot_patch(path: Path, directory: Path) -> tuple[Path, str]:
@@ -273,13 +364,16 @@ def _snapshot_patch(path: Path, directory: Path) -> tuple[Path, str]:
     digest = hashlib.sha256()
     snapshot: Path | None = None
     try:
-        with path.open("rb") as source, tempfile.NamedTemporaryFile(
-            mode="wb",
-            dir=directory,
-            prefix=".patch-evaluation-input-",
-            suffix=".diff",
-            delete=False,
-        ) as destination:
+        with (
+            path.open("rb") as source,
+            tempfile.NamedTemporaryFile(
+                mode="wb",
+                dir=directory,
+                prefix=".patch-evaluation-input-",
+                suffix=".diff",
+                delete=False,
+            ) as destination,
+        ):
             snapshot = Path(destination.name)
             for chunk in iter(lambda: source.read(1024 * 1024), b""):
                 digest.update(chunk)
@@ -305,7 +399,11 @@ def _source_snapshot(repository: Path) -> tuple[str, str, str | None]:
     digest = hashlib.sha256()
     digest.update(head.encode("ascii"))
     digest.update(b"\0status\0")
-    digest.update(_git(repository, "status", "--porcelain=v1", "-z", "--untracked-files=all").stdout)
+    digest.update(
+        _git(
+            repository, "status", "--porcelain=v1", "-z", "--untracked-files=all"
+        ).stdout
+    )
     digest.update(b"\0tracked-worktree-diff\0")
     digest.update(
         _git(
@@ -331,7 +429,9 @@ def _source_snapshot(repository: Path) -> tuple[str, str, str | None]:
             "--",
         ).stdout
     )
-    untracked = _git(repository, "ls-files", "--others", "--exclude-standard", "-z").stdout
+    untracked = _git(
+        repository, "ls-files", "--others", "--exclude-standard", "-z"
+    ).stdout
     digest.update(b"\0untracked\0")
     for encoded_path in sorted(item for item in untracked.split(b"\0") if item):
         relative = encoded_path.decode("utf-8", errors="surrogateescape")
@@ -340,7 +440,9 @@ def _source_snapshot(repository: Path) -> tuple[str, str, str | None]:
         digest.update(b"\0")
         if candidate.is_symlink():
             digest.update(b"symlink\0")
-            digest.update(os.readlink(candidate).encode("utf-8", errors="surrogateescape"))
+            digest.update(
+                os.readlink(candidate).encode("utf-8", errors="surrogateescape")
+            )
         elif candidate.is_file():
             digest.update(b"file\0")
             with candidate.open("rb") as handle:
@@ -348,14 +450,24 @@ def _source_snapshot(repository: Path) -> tuple[str, str, str | None]:
                     digest.update(chunk)
         else:
             digest.update(b"other\0")
-    branch_result = _git(repository, "symbolic-ref", "--quiet", "--short", "HEAD", check=False)
-    branch = branch_result.stdout.decode("utf-8", errors="replace").strip() if branch_result.returncode == 0 else None
+    branch_result = _git(
+        repository, "symbolic-ref", "--quiet", "--short", "HEAD", check=False
+    )
+    branch = (
+        branch_result.stdout.decode("utf-8", errors="replace").strip()
+        if branch_result.returncode == 0
+        else None
+    )
     return head, digest.hexdigest(), branch or None
 
 
 def _resolve_base_commit(repository: Path, requested: str) -> str:
     resolved = _git_text(
-        repository, "rev-parse", "--verify", "--end-of-options", f"{requested}^{{commit}}"
+        repository,
+        "rev-parse",
+        "--verify",
+        "--end-of-options",
+        f"{requested}^{{commit}}",
     )
     if len(resolved) not in {40, 64} or any(
         character not in "0123456789abcdef" for character in resolved
@@ -365,11 +477,20 @@ def _resolve_base_commit(repository: Path, requested: str) -> str:
 
 
 def _parse_changed_files(workspace: Path) -> list[dict[str, Any]]:
-    raw = _git(workspace, "status", "--porcelain=v1", "-z", "--untracked-files=all").stdout
+    raw = _git(
+        workspace, "status", "--porcelain=v1", "-z", "--untracked-files=all"
+    ).stdout
     entries = raw.split(b"\0")
     changed: list[dict[str, Any]] = []
     index = 0
-    mapping = {"A": "added", "M": "modified", "D": "deleted", "R": "renamed", "C": "renamed", "?": "added"}
+    mapping = {
+        "A": "added",
+        "M": "modified",
+        "D": "deleted",
+        "R": "renamed",
+        "C": "renamed",
+        "?": "added",
+    }
     while index < len(entries):
         entry = entries[index]
         index += 1
@@ -410,7 +531,9 @@ def _bounded_bytes(path: Path, limit: int) -> tuple[bytes, bool]:
         return handle.read(limit), size > limit
 
 
-def _write_command_log(output_path: Path, stdout_path: Path, stderr_path: Path, limit: int) -> bool:
+def _write_command_log(
+    output_path: Path, stdout_path: Path, stderr_path: Path, limit: int
+) -> bool:
     header_stdout = b"=== stdout ===\n"
     header_stderr = b"\n=== stderr ===\n"
     budget = max(0, limit - len(header_stdout) - len(header_stderr))
@@ -424,8 +547,13 @@ def _write_command_log(output_path: Path, stdout_path: Path, stderr_path: Path, 
 
 
 def _run_command(
-    spec: CommandSpec, *, workspace: Path, timeout_seconds: float,
-    env: Mapping[str, str], log_path: Path, max_log_bytes: int,
+    spec: CommandSpec,
+    *,
+    workspace: Path,
+    timeout_seconds: float,
+    env: Mapping[str, str],
+    log_path: Path,
+    max_log_bytes: int,
 ) -> dict[str, Any]:
     command_cwd = (workspace / spec.cwd).resolve()
     if command_cwd != workspace and workspace not in command_cwd.parents:
@@ -439,10 +567,19 @@ def _run_command(
         temporary_path = Path(temporary)
         stdout_path = temporary_path / "stdout"
         stderr_path = temporary_path / "stderr"
-        with stdout_path.open("wb") as stdout_handle, stderr_path.open("wb") as stderr_handle:
+        with (
+            stdout_path.open("wb") as stdout_handle,
+            stderr_path.open("wb") as stderr_handle,
+        ):
             process = subprocess.Popen(
-                list(spec.argv), cwd=command_cwd, env=dict(env), stdin=subprocess.DEVNULL,
-                stdout=stdout_handle, stderr=stderr_handle, shell=False, start_new_session=True,
+                list(spec.argv),
+                cwd=command_cwd,
+                env=dict(env),
+                stdin=subprocess.DEVNULL,
+                stdout=stdout_handle,
+                stderr=stderr_handle,
+                shell=False,
+                start_new_session=True,
             )
             timed_out = False
             try:
@@ -451,17 +588,25 @@ def _run_command(
                 timed_out = True
                 _terminate_process_group(process)
                 returncode = None
-        truncated = _write_command_log(log_path, stdout_path, stderr_path, max_log_bytes)
+        truncated = _write_command_log(
+            log_path, stdout_path, stderr_path, max_log_bytes
+        )
     duration_ms = max(0, round((time.monotonic() - started) * 1000))
     status = "timeout" if timed_out else ("passed" if returncode == 0 else "failed")
     return {
-        "command": shlex.join(spec.argv), "status": status, "exit_code": returncode,
+        "command": shlex.join(spec.argv),
+        "status": status,
+        "exit_code": returncode,
         "started_at": started_at.isoformat().replace("+00:00", "Z"),
-        "duration_ms": duration_ms, "log_ref": log_path.name, "truncated": truncated,
+        "duration_ms": duration_ms,
+        "log_ref": log_path.name,
+        "truncated": truncated,
     }
 
 
-def _rollup_status(records: list[dict[str, Any]], *, patch_applied: bool, infrastructure_error: bool) -> str:
+def _rollup_status(
+    records: list[dict[str, Any]], *, patch_applied: bool, infrastructure_error: bool
+) -> str:
     if infrastructure_error or not patch_applied:
         return "error"
     if not records:
@@ -474,7 +619,11 @@ def _rollup_status(records: list[dict[str, Any]], *, patch_applied: bool, infras
     if all(status == "failed" for status in statuses):
         return "failed"
     if all(status in {"error", "timeout", "skipped"} for status in statuses):
-        return "error" if any(status in {"error", "timeout"} for status in statuses) else "incomplete"
+        return (
+            "error"
+            if any(status in {"error", "timeout"} for status in statuses)
+            else "incomplete"
+        )
     return "mixed"
 
 
@@ -483,8 +632,12 @@ def _atomic_write_json(path: Path, value: Mapping[str, Any]) -> None:
     temporary: Path | None = None
     try:
         with tempfile.NamedTemporaryFile(
-            mode="w", encoding="utf-8", dir=path.parent, prefix=f".{path.name}.",
-            suffix=".tmp", delete=False,
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
         ) as handle:
             json.dump(value, handle, indent=2, sort_keys=True, ensure_ascii=False)
             handle.write("\n")
@@ -497,11 +650,15 @@ def _atomic_write_json(path: Path, value: Mapping[str, Any]) -> None:
             temporary.unlink()
 
 
-def evaluate(
-    request_path: str | Path, output_path: str | Path, *, workspace_root: str | Path | None = None,
-) -> dict[str, Any]:
+def _prepare_evaluation(
+    request_path: str | Path,
+    output_path: str | Path,
+    workspace_root: str | Path | None,
+) -> EvaluationSetup:
     request = load_request(request_path)
-    canonical_repository = Path(_git_text(request.repository, "rev-parse", "--show-toplevel")).resolve()
+    canonical_repository = Path(
+        _git_text(request.repository, "rev-parse", "--show-toplevel")
+    ).resolve()
     if canonical_repository != request.repository:
         raise RequestError("repository must name the exact Git worktree root")
     output = Path(output_path).expanduser().resolve()
@@ -510,187 +667,321 @@ def evaluate(
         raise RequestError(f"output already exists: {output}")
     requested_workspace_root = (
         Path(workspace_root).expanduser().resolve()
-        if workspace_root is not None else output.parent / ".patch-evaluation-sidecar-workspaces"
+        if workspace_root is not None
+        else output.parent / ".patch-evaluation-sidecar-workspaces"
     )
-    _ensure_outside_repository(requested_workspace_root, request.repository, "workspace_root")
-
+    _ensure_outside_repository(
+        requested_workspace_root, request.repository, "workspace_root"
+    )
     # Complete read-only provenance preflight before creating output or workspace paths.
-    source_head_before, source_fingerprint_before, source_branch = _source_snapshot(request.repository)
+    source_head, source_fingerprint, source_branch = _source_snapshot(
+        request.repository
+    )
     exact_base = _resolve_base_commit(request.repository, request.base_commit)
-    if source_head_before != exact_base:
+    if source_head != exact_base:
         source_branch = None
     workspace_id = uuid.uuid4().hex
-    workspace = requested_workspace_root / workspace_id
     log_directory = output.parent / f"{output.stem}.logs"
     if log_directory.exists():
         raise RequestError(f"log directory already exists: {log_directory}")
     requested_workspace_root.mkdir(parents=True, exist_ok=True)
     log_directory.mkdir(parents=True)
-    patch_snapshot: Path | None = None
-    patch_sha256: str | None = None
-    isolated = False
-    patch_applied = False
-    changed_files: list[dict[str, Any]] = []
-    command_records: list[dict[str, Any]] = []
-    infrastructure_error = False
-    error_detail: str | None = None
-    workspace_created = False
-    workspace_cleaned = False
-    source_unchanged = False
-    try:
-        patch_snapshot, patch_sha256 = _snapshot_patch(
-            request.patch_path, requested_workspace_root
+    return EvaluationSetup(
+        request=request,
+        output=output,
+        workspace_root=requested_workspace_root,
+        workspace_id=workspace_id,
+        workspace=requested_workspace_root / workspace_id,
+        log_directory=log_directory,
+        source_head_before=source_head,
+        source_fingerprint_before=source_fingerprint,
+        source_branch=source_branch,
+        exact_base=exact_base,
+    )
+
+
+def _mark_infrastructure_error(state: EvaluationState, detail: str) -> None:
+    state.infrastructure_error = True
+    state.error_detail = state.error_detail or detail
+
+
+def _create_isolated_worktree(setup: EvaluationSetup, state: EvaluationState) -> None:
+    # Mark the attempt before Git so transport failure still enters exact-path cleanup.
+    state.workspace_created = True
+    result = _git(
+        setup.request.repository,
+        "worktree",
+        "add",
+        "--detach",
+        str(setup.workspace),
+        setup.exact_base,
+        timeout=120,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", errors="replace").strip()
+        raise EvaluationError(f"disposable worktree creation failed: {detail}")
+    workspace_head = _git_text(setup.workspace, "rev-parse", "HEAD")
+    state.isolated = (
+        (setup.workspace / ".git").is_file()
+        and workspace_head == setup.exact_base
+        and setup.workspace != setup.request.repository
+    )
+    if not state.isolated:
+        raise EvaluationError("disposable worktree isolation could not be proven")
+
+
+def _apply_patch(setup: EvaluationSetup, state: EvaluationState) -> None:
+    assert state.patch_snapshot is not None
+    check_result = _git(
+        setup.workspace,
+        "apply",
+        "--check",
+        "--recount",
+        str(state.patch_snapshot),
+        check=False,
+    )
+    if check_result.returncode != 0:
+        detail = check_result.stderr.decode("utf-8", errors="replace").strip()
+        raise EvaluationError(f"patch apply check failed: {detail}")
+    apply_result = _git(
+        setup.workspace,
+        "apply",
+        "--recount",
+        str(state.patch_snapshot),
+        check=False,
+    )
+    if apply_result.returncode != 0:
+        detail = apply_result.stderr.decode("utf-8", errors="replace").strip()
+        raise EvaluationError(f"patch apply failed: {detail}")
+    state.patch_applied = True
+    state.changed_files = _parse_changed_files(setup.workspace)
+
+
+def _skipped_command_record(spec: CommandSpec) -> dict[str, Any]:
+    return {
+        "command": shlex.join(spec.argv),
+        "status": "skipped",
+        "exit_code": None,
+        "started_at": None,
+        "duration_ms": 0,
+        "log_ref": None,
+        "truncated": False,
+    }
+
+
+def _run_declared_commands(setup: EvaluationSetup, state: EvaluationState) -> None:
+    env = _sanitized_environment(
+        setup.workspace / ".sidecar-home", setup.workspace / ".sidecar-tmp"
+    )
+    deadline = time.monotonic() + setup.request.global_timeout_seconds
+    for index, spec in enumerate(setup.request.commands, start=1):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            state.command_records.append(_skipped_command_record(spec))
+            continue
+        record = _run_command(
+            spec,
+            workspace=setup.workspace,
+            timeout_seconds=min(float(spec.timeout_seconds), remaining),
+            env=env,
+            log_path=setup.log_directory / f"command-{index:03d}.log",
+            max_log_bytes=setup.request.max_log_bytes,
         )
-        # Mark the attempt before invoking Git so a timeout or transport failure still
-        # enters exact-path cleanup and readback.
-        workspace_created = True
-        add_result = _git(
-            request.repository,
+        record["log_ref"] = f"{setup.log_directory.name}/{record['log_ref']}"
+        state.command_records.append(record)
+
+
+def _perform_evaluation(setup: EvaluationSetup, state: EvaluationState) -> None:
+    state.patch_snapshot, state.patch_sha256 = _snapshot_patch(
+        setup.request.patch_path, setup.workspace_root
+    )
+    _create_isolated_worktree(setup, state)
+    _apply_patch(setup, state)
+    _run_declared_commands(setup, state)
+
+
+def _cleanup_workspace(setup: EvaluationSetup, state: EvaluationState) -> None:
+    if not state.workspace_created:
+        state.workspace_cleaned = not setup.workspace.exists()
+        return
+    try:
+        _git(
+            setup.request.repository,
             "worktree",
-            "add",
-            "--detach",
-            str(workspace),
-            exact_base,
+            "remove",
+            "--force",
+            str(setup.workspace),
             timeout=120,
             check=False,
         )
-        if add_result.returncode != 0:
-            detail = add_result.stderr.decode("utf-8", errors="replace").strip()
-            raise EvaluationError(f"disposable worktree creation failed: {detail}")
-        workspace_head = _git_text(workspace, "rev-parse", "HEAD")
-        isolated = (workspace / ".git").is_file() and workspace_head == exact_base and workspace != request.repository
-        if not isolated:
-            raise EvaluationError("disposable worktree isolation could not be proven")
-        check_result = _git(workspace, "apply", "--check", "--recount", str(patch_snapshot), check=False)
-        if check_result.returncode != 0:
-            detail = check_result.stderr.decode("utf-8", errors="replace").strip()
-            raise EvaluationError(f"patch apply check failed: {detail}")
-        apply_result = _git(workspace, "apply", "--recount", str(patch_snapshot), check=False)
-        if apply_result.returncode != 0:
-            detail = apply_result.stderr.decode("utf-8", errors="replace").strip()
-            raise EvaluationError(f"patch apply failed: {detail}")
-        patch_applied = True
-        changed_files = _parse_changed_files(workspace)
-
-        env = _sanitized_environment(workspace / ".sidecar-home", workspace / ".sidecar-tmp")
-        command_deadline = time.monotonic() + request.global_timeout_seconds
-        for index, spec in enumerate(request.commands, start=1):
-            remaining = command_deadline - time.monotonic()
-            if remaining <= 0:
-                command_records.append({
-                    "command": shlex.join(spec.argv), "status": "skipped", "exit_code": None,
-                    "started_at": None, "duration_ms": 0, "log_ref": None, "truncated": False,
-                })
-                continue
-            record = _run_command(
-                spec, workspace=workspace, timeout_seconds=min(float(spec.timeout_seconds), remaining),
-                env=env, log_path=log_directory / f"command-{index:03d}.log",
-                max_log_bytes=request.max_log_bytes,
-            )
-            record["log_ref"] = f"{log_directory.name}/{record['log_ref']}"
-            command_records.append(record)
+        # Never prune globally: cleanup and readback are restricted to this workspace.
+        listed_result = _git(
+            setup.request.repository, "worktree", "list", "--porcelain", check=False
+        )
+        listed = listed_result.stdout.decode("utf-8", errors="replace")
+        state.workspace_cleaned = (
+            listed_result.returncode == 0
+            and not setup.workspace.exists()
+            and str(setup.workspace) not in listed
+        )
     except (EvaluationError, OSError, subprocess.SubprocessError) as exc:
-        infrastructure_error = True
-        error_detail = str(exc)
-    finally:
-        if workspace_created:
-            try:
-                _git(
-                    request.repository,
-                    "worktree",
-                    "remove",
-                    "--force",
-                    str(workspace),
-                    timeout=120,
-                    check=False,
-                )
-                # Never prune globally: cleanup is restricted to the exact workspace.
-                listed_result = _git(
-                    request.repository, "worktree", "list", "--porcelain", check=False
-                )
-                listed = listed_result.stdout.decode("utf-8", errors="replace")
-                workspace_cleaned = (
-                    listed_result.returncode == 0
-                    and not workspace.exists()
-                    and str(workspace) not in listed
-                )
-            except (EvaluationError, OSError, subprocess.SubprocessError) as exc:
-                workspace_cleaned = False
-                error_detail = error_detail or f"disposable worktree cleanup readback failed: {exc}"
-            if not workspace_cleaned:
-                infrastructure_error = True
-                error_detail = error_detail or "disposable worktree cleanup could not be proven"
-        else:
-            workspace_cleaned = not workspace.exists()
-        if patch_snapshot is not None:
-            try:
-                patch_snapshot.unlink(missing_ok=True)
-            except OSError as exc:
-                error_detail = error_detail or f"patch snapshot cleanup failed: {exc}"
-            if patch_snapshot.exists():
-                infrastructure_error = True
-                error_detail = error_detail or "patch snapshot cleanup could not be proven"
-        try:
-            source_head_after, source_fingerprint_after, _ = _source_snapshot(request.repository)
-            source_unchanged = (
-                source_head_after == source_head_before
-                and source_fingerprint_after == source_fingerprint_before
-            )
-        except (EvaluationError, OSError, subprocess.SubprocessError) as exc:
-            source_unchanged = False
-            error_detail = error_detail or f"source checkout readback failed: {exc}"
-        if not source_unchanged:
-            infrastructure_error = True
-            error_detail = error_detail or "source checkout changed during evaluation"
+        state.workspace_cleaned = False
+        state.error_detail = state.error_detail or (
+            f"disposable worktree cleanup readback failed: {exc}"
+        )
+    if not state.workspace_cleaned:
+        _mark_infrastructure_error(
+            state, "disposable worktree cleanup could not be proven"
+        )
 
-    status = _rollup_status(command_records, patch_applied=patch_applied, infrastructure_error=infrastructure_error)
+
+def _cleanup_patch_snapshot(state: EvaluationState) -> None:
+    if state.patch_snapshot is None:
+        return
     try:
-        git_version = _run_bytes(("git", "--version"), cwd=request.repository, check=False).stdout.decode(
-            "utf-8", errors="replace"
-        ).strip()
+        state.patch_snapshot.unlink(missing_ok=True)
+    except OSError as exc:
+        state.error_detail = (
+            state.error_detail or f"patch snapshot cleanup failed: {exc}"
+        )
+    if state.patch_snapshot.exists():
+        _mark_infrastructure_error(state, "patch snapshot cleanup could not be proven")
+
+
+def _verify_source_unchanged(setup: EvaluationSetup, state: EvaluationState) -> None:
+    try:
+        source_head, source_fingerprint, _ = _source_snapshot(setup.request.repository)
+        state.source_unchanged = (
+            source_head == setup.source_head_before
+            and source_fingerprint == setup.source_fingerprint_before
+        )
+    except (EvaluationError, OSError, subprocess.SubprocessError) as exc:
+        state.source_unchanged = False
+        state.error_detail = (
+            state.error_detail or f"source checkout readback failed: {exc}"
+        )
+    if not state.source_unchanged:
+        _mark_infrastructure_error(state, "source checkout changed during evaluation")
+
+
+def _cleanup_evaluation(setup: EvaluationSetup, state: EvaluationState) -> None:
+    _cleanup_workspace(setup, state)
+    _cleanup_patch_snapshot(state)
+    _verify_source_unchanged(setup, state)
+
+
+def _git_version(repository: Path) -> str:
+    try:
+        return (
+            _run_bytes(("git", "--version"), cwd=repository, check=False)
+            .stdout.decode("utf-8", errors="replace")
+            .strip()
+        )
     except OSError:
-        git_version = "unknown"
-    artifact: dict[str, Any] = {
-        "kind": "repobrief.patch_evaluation", "version": "v1",
+        return "unknown"
+
+
+def _build_artifact(setup: EvaluationSetup, state: EvaluationState) -> dict[str, Any]:
+    status = _rollup_status(
+        state.command_records,
+        patch_applied=state.patch_applied,
+        infrastructure_error=state.infrastructure_error,
+    )
+    return {
+        "kind": "repobrief.patch_evaluation",
+        "version": "v1",
         "authority": "external_evaluation_evidence",
-        "producer": {"name": PRODUCER_NAME, "version": PRODUCER_VERSION, "commit": None, "url": None},
+        "producer": {
+            "name": PRODUCER_NAME,
+            "version": PRODUCER_VERSION,
+            "commit": None,
+            "url": None,
+        },
         "created_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         "input": {
-            "repo": str(request.repository), "branch": source_branch, "base_commit": exact_base,
-            "commit": exact_base, "pull_request": None, "patch_id": patch_sha256,
+            "repo": str(setup.request.repository),
+            "branch": setup.source_branch,
+            "base_commit": setup.exact_base,
+            "commit": setup.exact_base,
+            "pull_request": None,
+            "patch_id": state.patch_sha256,
         },
-        "repobrief_context": request.repobrief_context,
-        "workspace": {"isolated": isolated, "workspace_id": workspace_id, "base_commit": exact_base},
+        "repobrief_context": setup.request.repobrief_context,
+        "workspace": {
+            "isolated": state.isolated,
+            "workspace_id": setup.workspace_id,
+            "base_commit": setup.exact_base,
+        },
         "patch": {
-            "applied": patch_applied, "patch_id": patch_sha256, "format": request.patch_format,
-            "sha256": patch_sha256, "changed_files": changed_files,
+            "applied": state.patch_applied,
+            "patch_id": state.patch_sha256,
+            "format": setup.request.patch_format,
+            "sha256": state.patch_sha256,
+            "changed_files": state.changed_files,
         },
         "command_policy": {
-            "allowed_commands": [shlex.join(command.argv) for command in request.commands],
-            "network": "unknown", "secrets_policy": "unknown",
-            "timeout_seconds": request.global_timeout_seconds,
+            "allowed_commands": [
+                shlex.join(command.argv) for command in setup.request.commands
+            ],
+            "network": "unknown",
+            "secrets_policy": "unknown",
+            "timeout_seconds": setup.request.global_timeout_seconds,
         },
-        "commands_run": command_records,
+        "commands_run": state.command_records,
         "environment": {
-            "os": platform.platform(), "runner": "local-disposable-git-worktree", "container": None,
-            "tool_versions": {"python": platform.python_version(), "git": git_version},
+            "os": platform.platform(),
+            "runner": "local-disposable-git-worktree",
+            "container": None,
+            "tool_versions": {
+                "python": platform.python_version(),
+                "git": _git_version(setup.request.repository),
+            },
         },
-        "status": status, "does_not_establish": list(MANDATORY_NON_CLAIMS),
+        "status": status,
+        "does_not_establish": list(MANDATORY_NON_CLAIMS),
     }
-    _atomic_write_json(output, artifact)
-    if error_detail:
-        print(f"patch-evaluation-sidecar: {error_detail}", file=sys.stderr)
+
+
+def evaluate(
+    request_path: str | Path,
+    output_path: str | Path,
+    *,
+    workspace_root: str | Path | None = None,
+) -> dict[str, Any]:
+    setup = _prepare_evaluation(request_path, output_path, workspace_root)
+    state = EvaluationState()
+    try:
+        _perform_evaluation(setup, state)
+    except (EvaluationError, OSError, subprocess.SubprocessError) as exc:
+        _mark_infrastructure_error(state, str(exc))
+    finally:
+        _cleanup_evaluation(setup, state)
+    artifact = _build_artifact(setup, state)
+    _atomic_write_json(setup.output, artifact)
+    if state.error_detail:
+        print(f"patch-evaluation-sidecar: {state.error_detail}", file=sys.stderr)
     return {
-        "artifact": artifact, "output": str(output), "workspace_cleaned": workspace_cleaned,
-        "source_unchanged": source_unchanged, "error": error_detail,
+        "artifact": artifact,
+        "output": str(setup.output),
+        "workspace_cleaned": state.workspace_cleaned,
+        "source_unchanged": state.source_unchanged,
+        "error": state.error_detail,
     }
 
 
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--request", required=True, help="Strict patch-evaluation request JSON")
-    parser.add_argument("--output", required=True, help="Artifact path outside the source repository")
-    parser.add_argument("--workspace-root", help="Optional disposable-worktree parent outside the source repository")
+    parser.add_argument(
+        "--request", required=True, help="Strict patch-evaluation request JSON"
+    )
+    parser.add_argument(
+        "--output", required=True, help="Artifact path outside the source repository"
+    )
+    parser.add_argument(
+        "--workspace-root",
+        help="Optional disposable-worktree parent outside the source repository",
+    )
     return parser
 
 
@@ -701,14 +992,28 @@ def main(argv: Sequence[str] | None = None) -> int:
     except RequestError as exc:
         print(f"patch-evaluation-sidecar: {exc}", file=sys.stderr)
         return 2
-    except (EvaluationError, OSError, UnicodeError, ValueError, subprocess.SubprocessError) as exc:
+    except (
+        EvaluationError,
+        OSError,
+        UnicodeError,
+        ValueError,
+        subprocess.SubprocessError,
+    ) as exc:
         print(f"patch-evaluation-sidecar: {exc}", file=sys.stderr)
         return 1
-    print(json.dumps({
-        "status": result["artifact"]["status"], "output": result["output"],
-        "workspace_cleaned": result["workspace_cleaned"], "source_unchanged": result["source_unchanged"],
-        "does_not_establish": list(MANDATORY_NON_CLAIMS),
-    }, indent=2, sort_keys=True))
+    print(
+        json.dumps(
+            {
+                "status": result["artifact"]["status"],
+                "output": result["output"],
+                "workspace_cleaned": result["workspace_cleaned"],
+                "source_unchanged": result["source_unchanged"],
+                "does_not_establish": list(MANDATORY_NON_CLAIMS),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
     return 0 if result["artifact"]["status"] == "passed" else 1
 
 

--- a/tools/patch_evaluation_sidecar.py
+++ b/tools/patch_evaluation_sidecar.py
@@ -2,8 +2,8 @@
 """External Patch Evaluation Sidecar prototype for RBAW-V1-T004.
 
 This executable is intentionally outside ``merger/repoground/core``. It applies
-one declared patch in a disposable detached Git worktree, runs an explicit list
-of argv-only commands, and emits bounded ``repobrief.patch_evaluation`` v1
+one declared patch in an independent temporary Git repository, runs an explicit
+list of argv-only commands, and emits bounded ``repobrief.patch_evaluation`` v1
 evidence. A passing artifact is not approval and does not establish correctness.
 """
 
@@ -15,6 +15,7 @@ import json
 import os
 import platform
 import shlex
+import shutil
 import signal
 import subprocess
 import sys
@@ -23,6 +24,7 @@ import time
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from functools import lru_cache
 from pathlib import Path, PurePosixPath
 from typing import Any, Mapping, Sequence
 
@@ -49,8 +51,9 @@ _REQUEST_KEYS = {
     "global_timeout_seconds",
     "max_log_bytes",
     "repobrief_context",
+    "fail_fast",
 }
-_COMMAND_KEYS = {"argv", "cwd", "timeout_seconds"}
+_COMMAND_KEYS = {"argv", "cwd", "timeout_seconds", "redact_argv_indexes"}
 _CONTEXT_KEYS = {
     "bundle_manifest",
     "snapshot_run_id",
@@ -61,6 +64,20 @@ _CONTEXT_KEYS = {
 _MAX_COMMANDS = 32
 _MAX_TIMEOUT_SECONDS = 7200
 _MAX_LOG_BYTES = 1_000_000
+_MAX_REQUEST_BYTES = 1_000_000
+_MAX_PATCH_BYTES = 100_000_000
+_MAX_REPOSITORY_PACK_BYTES = 1_000_000_000
+_MAX_REPOSITORY_OBJECTS = 1_000_000
+_MAX_FILTER_DRIVERS = 256
+_MAX_ARG_BYTES = 32_768
+_MAX_ARGV_BYTES = 131_072
+_MAX_CONTEXT_ITEMS = 256
+_MAX_CONTEXT_ITEM_BYTES = 4_096
+_MAX_CHANGED_FILES = 10_000
+_FINGERPRINT_MAX_FILES = 100_000
+_FINGERPRINT_MAX_BYTES = 512_000_000
+_FINGERPRINT_TIMEOUT_SECONDS = 120
+_TRUSTED_SYSTEM_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 
 class RequestError(ValueError):
@@ -76,6 +93,7 @@ class CommandSpec:
     argv: tuple[str, ...]
     cwd: str
     timeout_seconds: int
+    redact_argv_indexes: tuple[int, ...]
 
 
 @dataclass(frozen=True)
@@ -88,6 +106,7 @@ class EvaluationRequest:
     global_timeout_seconds: int
     max_log_bytes: int
     repobrief_context: dict[str, Any]
+    fail_fast: bool
 
 
 @dataclass(frozen=True)
@@ -102,6 +121,11 @@ class EvaluationSetup:
     source_fingerprint_before: str
     source_branch: str | None
     exact_base: str
+    sandbox_binary: Path
+    runtime_root: Path
+    sandbox_home: Path
+    sandbox_tmp: Path
+    git_scratch: Path
 
 
 @dataclass
@@ -127,9 +151,17 @@ def _strict_keys(value: Mapping[str, Any], allowed: set[str], label: str) -> Non
         )
 
 
-def _non_empty_string(value: Any, label: str) -> str:
+def _non_empty_string(value: Any, label: str, *, max_bytes: int | None = None) -> str:
     if not isinstance(value, str) or not value.strip() or "\x00" in value:
         raise RequestError(f"{label} must be a non-empty string without NUL bytes")
+    if max_bytes is not None and len(value.encode("utf-8")) > max_bytes:
+        raise RequestError(f"{label} exceeds the {max_bytes}-byte limit")
+    return value
+
+
+def _strict_bool(value: Any, label: str) -> bool:
+    if not isinstance(value, bool):
+        raise RequestError(f"{label} must be a boolean")
     return value
 
 
@@ -145,7 +177,7 @@ def _validate_relative_cwd(value: Any, label: str) -> str:
     cwd = _non_empty_string(value, label)
     pure = PurePosixPath(cwd)
     if pure.is_absolute() or ".." in pure.parts:
-        raise RequestError(f"{label} must stay inside the isolated worktree")
+        raise RequestError(f"{label} must stay inside the isolated repository")
     normalized = str(pure)
     return "." if normalized in {"", "."} else normalized
 
@@ -153,8 +185,11 @@ def _validate_relative_cwd(value: Any, label: str) -> str:
 def _validate_string_list(value: Any, label: str) -> list[str]:
     if not isinstance(value, list):
         raise RequestError(f"{label} must be an array")
+    if len(value) > _MAX_CONTEXT_ITEMS:
+        raise RequestError(f"{label} may contain at most {_MAX_CONTEXT_ITEMS} entries")
     return [
-        _non_empty_string(item, f"{label}[{index}]") for index, item in enumerate(value)
+        _non_empty_string(item, f"{label}[{index}]", max_bytes=_MAX_CONTEXT_ITEM_BYTES)
+        for index, item in enumerate(value)
     ]
 
 
@@ -178,6 +213,8 @@ def _validate_context(value: Any) -> dict[str, Any]:
 def _read_request_object(path: str | Path) -> Mapping[str, Any]:
     request_path = Path(path).expanduser().resolve()
     try:
+        if request_path.stat().st_size > _MAX_REQUEST_BYTES:
+            raise RequestError(f"request exceeds the {_MAX_REQUEST_BYTES}-byte limit")
         data = json.loads(request_path.read_text(encoding="utf-8"))
     except OSError as exc:
         raise RequestError(f"request could not be read: {exc}") from exc
@@ -219,9 +256,19 @@ def _validate_command(raw: Any, index: int) -> CommandSpec:
     if not isinstance(argv, list) or not argv:
         raise RequestError(f"{label}.argv must be a non-empty array")
     argv_items = tuple(
-        _non_empty_string(item, f"{label}.argv[{position}]")
+        _non_empty_string(item, f"{label}.argv[{position}]", max_bytes=_MAX_ARG_BYTES)
         for position, item in enumerate(argv)
     )
+    if sum(len(item.encode("utf-8")) for item in argv_items) > _MAX_ARGV_BYTES:
+        raise RequestError(f"{label}.argv exceeds the {_MAX_ARGV_BYTES}-byte limit")
+    raw_redactions = raw.get("redact_argv_indexes", [])
+    if not isinstance(raw_redactions, list) or any(
+        isinstance(item, bool) or not isinstance(item, int) for item in raw_redactions
+    ):
+        raise RequestError(f"{label}.redact_argv_indexes must be an integer array")
+    redactions = tuple(sorted(set(raw_redactions)))
+    if any(item < 0 or item >= len(argv_items) for item in redactions):
+        raise RequestError(f"{label}.redact_argv_indexes contains an invalid index")
     cwd = _validate_relative_cwd(raw.get("cwd", "."), f"{label}.cwd")
     timeout = _bounded_int(
         raw.get("timeout_seconds", 300),
@@ -229,7 +276,7 @@ def _validate_command(raw: Any, index: int) -> CommandSpec:
         minimum=1,
         maximum=_MAX_TIMEOUT_SECONDS,
     )
-    return CommandSpec(argv_items, cwd, timeout)
+    return CommandSpec(argv_items, cwd, timeout, redactions)
 
 
 def _validate_commands(value: Any) -> tuple[CommandSpec, ...]:
@@ -251,6 +298,8 @@ def load_request(path: str | Path) -> EvaluationRequest:
     patch_path = _validate_existing_path(
         data.get("patch_path"), "patch_path", directory=False
     )
+    if patch_path.stat().st_size > _MAX_PATCH_BYTES:
+        raise RequestError(f"patch_path exceeds the {_MAX_PATCH_BYTES}-byte limit")
     base_commit = _validate_base_commit(data.get("base_commit"))
     return EvaluationRequest(
         repository=repository,
@@ -271,7 +320,62 @@ def load_request(path: str | Path) -> EvaluationRequest:
             maximum=_MAX_LOG_BYTES,
         ),
         repobrief_context=_validate_context(data.get("repobrief_context")),
+        fail_fast=_strict_bool(data.get("fail_fast", False), "fail_fast"),
     )
+
+
+def _resolve_system_tool(name: str) -> Path:
+    resolved = shutil.which(name, path=_TRUSTED_SYSTEM_PATH)
+    if resolved is None:
+        raise EvaluationError(f"required system tool is unavailable: {name}")
+    path = Path(resolved).resolve()
+    if not path.is_absolute() or not path.is_file():
+        raise EvaluationError(f"required system tool is not a regular file: {name}")
+    return path
+
+
+def _git_binary() -> Path:
+    return _resolve_system_tool("git")
+
+
+def _sandbox_binary() -> Path:
+    if platform.system() != "Linux":
+        raise RequestError("the prototype requires Linux bubblewrap isolation")
+    try:
+        return _resolve_system_tool("bwrap")
+    except EvaluationError as exc:
+        raise RequestError(str(exc)) from exc
+
+
+def _display_command(spec: CommandSpec) -> str:
+    redacted = list(spec.argv)
+    sensitive_next = False
+    markers = (
+        "password",
+        "passwd",
+        "token",
+        "secret",
+        "api-key",
+        "api_key",
+        "credential",
+        "authorization",
+    )
+    for index, value in enumerate(redacted):
+        lowered = value.lower()
+        explicit = index in spec.redact_argv_indexes
+        assigned = "=" in value and any(
+            marker in lowered.split("=", 1)[0] for marker in markers
+        )
+        if explicit or sensitive_next:
+            redacted[index] = "<redacted>"
+        elif assigned:
+            redacted[index] = value.split("=", 1)[0] + "=<redacted>"
+        sensitive_next = (
+            value.startswith("-")
+            and any(marker in lowered for marker in markers)
+            and "=" not in value
+        )
+    return shlex.join(redacted)
 
 
 def _sanitized_environment(home: Path, tmpdir: Path) -> dict[str, str]:
@@ -283,7 +387,7 @@ def _sanitized_environment(home: Path, tmpdir: Path) -> dict[str, str]:
         "HOME": str(home),
         "LANG": "C.UTF-8",
         "LC_ALL": "C.UTF-8",
-        "PATH": os.environ.get("PATH") or os.defpath,
+        "PATH": _TRUSTED_SYSTEM_PATH,
         "PYTHONNOUSERSITE": "1",
         "TMPDIR": str(tmpdir),
         "TZ": "UTC",
@@ -291,6 +395,8 @@ def _sanitized_environment(home: Path, tmpdir: Path) -> dict[str, str]:
         "GIT_CONFIG_GLOBAL": os.devnull,
         "GIT_CONFIG_NOSYSTEM": "1",
         "GIT_TERMINAL_PROMPT": "0",
+        "GIT_OPTIONAL_LOCKS": "0",
+        "GIT_NO_REPLACE_OBJECTS": "1",
     }
 
 
@@ -320,6 +426,79 @@ def _run_bytes(
     return completed
 
 
+def _base_git_argv(repo: Path, *args: str) -> tuple[str, ...]:
+    return (
+        str(_git_binary()),
+        "-c",
+        "core.hooksPath=/dev/null",
+        "-c",
+        "core.fsmonitor=false",
+        "-c",
+        "core.pager=cat",
+        "-c",
+        "diff.external=",
+        "-C",
+        str(repo),
+        *args,
+    )
+
+
+@lru_cache(maxsize=256)
+def _configured_filter_drivers(repository: str) -> tuple[str, ...]:
+    repo = Path(repository)
+    with tempfile.TemporaryDirectory(
+        prefix="repoground-patch-evaluation-filter-config-"
+    ) as temporary:
+        scratch = Path(temporary)
+        completed = _run_bytes(
+            _base_git_argv(
+                repo,
+                "config",
+                "--name-only",
+                "--get-regexp",
+                r"^filter\..*\.(clean|smudge|process|required)$",
+            ),
+            cwd=repo,
+            check=False,
+            env=_sanitized_environment(scratch / "home", scratch / "tmp"),
+        )
+    if completed.returncode not in {0, 1}:
+        detail = completed.stderr.decode("utf-8", errors="replace").strip()
+        raise EvaluationError(f"Git filter configuration could not be read: {detail}")
+    drivers: set[str] = set()
+    for raw_key in completed.stdout.splitlines():
+        key = raw_key.decode("utf-8", errors="strict")
+        components = key.split(".")
+        if len(components) >= 3 and components[0].lower() == "filter":
+            drivers.add(".".join(components[1:-1]))
+    if len(drivers) > _MAX_FILTER_DRIVERS:
+        raise EvaluationError("repository exceeded the configured-filter limit")
+    return tuple(sorted(drivers))
+
+
+def _git_argv(repo: Path, *args: str) -> tuple[str, ...]:
+    prefix = list(_base_git_argv(repo))
+    # Insert overrides before -C so source-local filter commands cannot execute
+    # during status, diff, object materialization, checkout, or patch handling.
+    insertion = len(prefix) - 2
+    overrides: list[str] = []
+    for driver in _configured_filter_drivers(str(repo.resolve())):
+        overrides.extend(
+            (
+                "-c",
+                f"filter.{driver}.clean=cat",
+                "-c",
+                f"filter.{driver}.smudge=cat",
+                "-c",
+                f"filter.{driver}.process=",
+                "-c",
+                f"filter.{driver}.required=false",
+            )
+        )
+    prefix[insertion:insertion] = overrides
+    return (*prefix, *args)
+
+
 def _git(
     repo: Path,
     *args: str,
@@ -332,18 +511,7 @@ def _git(
         scratch = Path(temporary)
         env = _sanitized_environment(scratch / "home", scratch / "tmp")
         return _run_bytes(
-            (
-                "git",
-                "-c",
-                "core.hooksPath=/dev/null",
-                "-c",
-                "core.fsmonitor=false",
-                "-c",
-                "core.pager=cat",
-                "-C",
-                str(repo),
-                *args,
-            ),
+            _git_argv(repo, *args),
             cwd=repo,
             timeout=timeout,
             check=check,
@@ -432,21 +600,37 @@ def _source_snapshot(repository: Path) -> tuple[str, str, str | None]:
     untracked = _git(
         repository, "ls-files", "--others", "--exclude-standard", "-z"
     ).stdout
-    digest.update(b"\0untracked\0")
-    for encoded_path in sorted(item for item in untracked.split(b"\0") if item):
+    digest.update(b"\0nonignored-untracked\0")
+    encoded_paths = sorted(item for item in untracked.split(b"\0") if item)
+    if len(encoded_paths) > _FINGERPRINT_MAX_FILES:
+        raise EvaluationError("source fingerprint exceeded the untracked-file limit")
+    started = time.monotonic()
+    total_bytes = 0
+    for encoded_path in encoded_paths:
+        if time.monotonic() - started > _FINGERPRINT_TIMEOUT_SECONDS:
+            raise EvaluationError("source fingerprint exceeded its time budget")
         relative = encoded_path.decode("utf-8", errors="surrogateescape")
         candidate = repository / relative
         digest.update(encoded_path)
         digest.update(b"\0")
         if candidate.is_symlink():
+            payload = os.readlink(candidate).encode("utf-8", errors="surrogateescape")
+            total_bytes += len(payload)
             digest.update(b"symlink\0")
-            digest.update(
-                os.readlink(candidate).encode("utf-8", errors="surrogateescape")
-            )
+            digest.update(payload)
         elif candidate.is_file():
             digest.update(b"file\0")
             with candidate.open("rb") as handle:
                 for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                    total_bytes += len(chunk)
+                    if total_bytes > _FINGERPRINT_MAX_BYTES:
+                        raise EvaluationError(
+                            "source fingerprint exceeded its content-byte limit"
+                        )
+                    if time.monotonic() - started > _FINGERPRINT_TIMEOUT_SECONDS:
+                        raise EvaluationError(
+                            "source fingerprint exceeded its time budget"
+                        )
                     digest.update(chunk)
         else:
             digest.update(b"other\0")
@@ -501,10 +685,14 @@ def _parse_changed_files(workspace: Path) -> list[dict[str, Any]]:
         code = entry[:2].decode("ascii", errors="strict")
         path = entry[3:].decode("utf-8", errors="backslashreplace")
         status = code[0] if code[0] != " " else code[1]
-        if status in {"R", "C"} and index < len(entries) and entries[index]:
-            path = entries[index].decode("utf-8", errors="backslashreplace")
+        if status in {"R", "C"}:
+            if index >= len(entries) or not entries[index]:
+                raise EvaluationError("git status rename/copy record is incomplete")
+            # Porcelain v1 -z emits destination/current path first, source path second.
             index += 1
         changed.append({"path": path, "change": mapping.get(status)})
+        if len(changed) > _MAX_CHANGED_FILES:
+            raise EvaluationError("changed_files exceeded the artifact limit")
     return sorted(changed, key=lambda item: item["path"])
 
 
@@ -515,10 +703,10 @@ def _terminate_process_group(process: subprocess.Popen[bytes]) -> None:
         return
     try:
         process.wait(timeout=2)
-        return
     except subprocess.TimeoutExpired:
         pass
     try:
+        # Always sweep the process group after TERM, even if its leader exited.
         os.killpg(process.pid, signal.SIGKILL)
     except ProcessLookupError:
         return
@@ -526,38 +714,143 @@ def _terminate_process_group(process: subprocess.Popen[bytes]) -> None:
 
 
 def _bounded_bytes(path: Path, limit: int) -> tuple[bytes, bool]:
-    size = path.stat().st_size
     with path.open("rb") as handle:
-        return handle.read(limit), size > limit
+        content = handle.read(limit + 1)
+    return content[:limit], len(content) > limit
+
+
+def _redacted_bounded_bytes(
+    path: Path, limit: int, redactions: Sequence[bytes]
+) -> tuple[bytes, bool]:
+    extra = max((len(item) for item in redactions), default=0)
+    with path.open("rb") as handle:
+        content = handle.read(limit + extra + 1)
+    source_truncated = len(content) > limit
+    for value in sorted((item for item in redactions if item), key=len, reverse=True):
+        content = content.replace(value, b"<redacted>")
+    return content[:limit], source_truncated or len(content) > limit
 
 
 def _write_command_log(
-    output_path: Path, stdout_path: Path, stderr_path: Path, limit: int
+    output_path: Path,
+    stdout_path: Path,
+    stderr_path: Path,
+    limit: int,
+    *,
+    redactions: Sequence[bytes] = (),
 ) -> bool:
     header_stdout = b"=== stdout ===\n"
     header_stderr = b"\n=== stderr ===\n"
     budget = max(0, limit - len(header_stdout) - len(header_stderr))
     stdout_budget = budget // 2
     stderr_budget = budget - stdout_budget
-    stdout, stdout_truncated = _bounded_bytes(stdout_path, stdout_budget)
-    stderr, stderr_truncated = _bounded_bytes(stderr_path, stderr_budget)
+    stdout, stdout_truncated = _redacted_bounded_bytes(
+        stdout_path, stdout_budget, redactions
+    )
+    stderr, stderr_truncated = _redacted_bounded_bytes(
+        stderr_path, stderr_budget, redactions
+    )
     payload = header_stdout + stdout + header_stderr + stderr
     output_path.write_bytes(payload[:limit])
     return stdout_truncated or stderr_truncated or len(payload) > limit
 
 
+def _sandbox_command_argv(
+    spec: CommandSpec,
+    *,
+    sandbox_binary: Path,
+    workspace: Path,
+    sandbox_home: Path,
+    sandbox_tmp: Path,
+) -> list[str]:
+    sandbox_cwd = PurePosixPath("/workspace") / PurePosixPath(spec.cwd)
+    argv = [
+        str(sandbox_binary),
+        "--die-with-parent",
+        "--new-session",
+        "--unshare-pid",
+        "--unshare-ipc",
+        "--unshare-uts",
+        "--unshare-cgroup-try",
+        "--ro-bind",
+        "/usr",
+        "/usr",
+        "--ro-bind-try",
+        "/bin",
+        "/bin",
+        "--ro-bind-try",
+        "/lib",
+        "/lib",
+        "--ro-bind-try",
+        "/lib64",
+        "/lib64",
+        "--dir",
+        "/etc",
+        "--ro-bind-try",
+        "/etc/passwd",
+        "/etc/passwd",
+        "--ro-bind-try",
+        "/etc/group",
+        "/etc/group",
+        "--ro-bind-try",
+        "/etc/nsswitch.conf",
+        "/etc/nsswitch.conf",
+        "--ro-bind-try",
+        "/etc/hosts",
+        "/etc/hosts",
+        "--ro-bind-try",
+        "/etc/resolv.conf",
+        "/etc/resolv.conf",
+        "--ro-bind-try",
+        "/etc/ssl",
+        "/etc/ssl",
+        "--proc",
+        "/proc",
+        "--dev",
+        "/dev",
+        "--dir",
+        "/home",
+        "--bind",
+        str(sandbox_home),
+        "/home/sidecar",
+        "--bind",
+        str(sandbox_tmp),
+        "/tmp",
+        "--bind",
+        str(workspace),
+        "/workspace",
+        "--chdir",
+        str(sandbox_cwd),
+        "--clearenv",
+    ]
+    for key, value in _sanitized_environment(sandbox_home, sandbox_tmp).items():
+        argv.extend(
+            (
+                "--setenv",
+                key,
+                value.replace(str(sandbox_home), "/home/sidecar").replace(
+                    str(sandbox_tmp), "/tmp"
+                ),
+            )
+        )
+    argv.extend(spec.argv)
+    return argv
+
+
 def _run_command(
     spec: CommandSpec,
     *,
+    sandbox_binary: Path,
     workspace: Path,
+    sandbox_home: Path,
+    sandbox_tmp: Path,
     timeout_seconds: float,
-    env: Mapping[str, str],
     log_path: Path,
     max_log_bytes: int,
 ) -> dict[str, Any]:
     command_cwd = (workspace / spec.cwd).resolve()
     if command_cwd != workspace and workspace not in command_cwd.parents:
-        raise EvaluationError(f"command cwd escaped isolated worktree: {spec.cwd}")
+        raise EvaluationError(f"command cwd escaped isolated repository: {spec.cwd}")
     if not command_cwd.is_dir():
         raise EvaluationError(f"command cwd is not a directory: {spec.cwd}")
 
@@ -572,9 +865,15 @@ def _run_command(
             stderr_path.open("wb") as stderr_handle,
         ):
             process = subprocess.Popen(
-                list(spec.argv),
-                cwd=command_cwd,
-                env=dict(env),
+                _sandbox_command_argv(
+                    spec,
+                    sandbox_binary=sandbox_binary,
+                    workspace=workspace,
+                    sandbox_home=sandbox_home,
+                    sandbox_tmp=sandbox_tmp,
+                ),
+                cwd=workspace,
+                env=_sanitized_environment(sandbox_home, sandbox_tmp),
                 stdin=subprocess.DEVNULL,
                 stdout=stdout_handle,
                 stderr=stderr_handle,
@@ -589,12 +888,18 @@ def _run_command(
                 _terminate_process_group(process)
                 returncode = None
         truncated = _write_command_log(
-            log_path, stdout_path, stderr_path, max_log_bytes
+            log_path,
+            stdout_path,
+            stderr_path,
+            max_log_bytes,
+            redactions=tuple(
+                spec.argv[index].encode("utf-8") for index in spec.redact_argv_indexes
+            ),
         )
     duration_ms = max(0, round((time.monotonic() - started) * 1000))
     status = "timeout" if timed_out else ("passed" if returncode == 0 else "failed")
     return {
-        "command": shlex.join(spec.argv),
+        "command": _display_command(spec),
         "status": status,
         "exit_code": returncode,
         "started_at": started_at.isoformat().replace("+00:00", "Z"),
@@ -602,6 +907,51 @@ def _run_command(
         "log_ref": log_path.name,
         "truncated": truncated,
     }
+
+
+def _skipped_command_record(spec: CommandSpec) -> dict[str, Any]:
+    return {
+        "command": _display_command(spec),
+        "status": "skipped",
+        "exit_code": None,
+        "started_at": None,
+        "duration_ms": 0,
+        "log_ref": None,
+        "truncated": False,
+    }
+
+
+def _run_declared_commands(setup: EvaluationSetup, state: EvaluationState) -> None:
+    deadline = time.monotonic() + setup.request.global_timeout_seconds
+    commands = setup.request.commands
+    if commands:
+        setup.log_directory.parent.mkdir(parents=True, exist_ok=True)
+        setup.log_directory.mkdir()
+    for offset, spec in enumerate(commands):
+        index = offset + 1
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            state.command_records.extend(
+                _skipped_command_record(item) for item in commands[offset:]
+            )
+            break
+        record = _run_command(
+            spec,
+            sandbox_binary=setup.sandbox_binary,
+            workspace=setup.workspace,
+            sandbox_home=setup.sandbox_home,
+            sandbox_tmp=setup.sandbox_tmp,
+            timeout_seconds=min(float(spec.timeout_seconds), remaining),
+            log_path=setup.log_directory / f"command-{index:03d}.log",
+            max_log_bytes=setup.request.max_log_bytes,
+        )
+        record["log_ref"] = f"{setup.log_directory.name}/{record['log_ref']}"
+        state.command_records.append(record)
+        if setup.request.fail_fast and record["status"] != "passed":
+            state.command_records.extend(
+                _skipped_command_record(item) for item in commands[offset + 1 :]
+            )
+            break
 
 
 def _rollup_status(
@@ -644,7 +994,15 @@ def _atomic_write_json(path: Path, value: Mapping[str, Any]) -> None:
             handle.flush()
             os.fsync(handle.fileno())
             temporary = Path(handle.name)
-        os.replace(temporary, path)
+        # Hard-link publication is atomic and refuses an output path that appeared
+        # after preflight; unlike os.replace(), it never overwrites foreign data.
+        os.link(temporary, path)
+        temporary.unlink()
+        directory_fd = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
     finally:
         if temporary is not None and temporary.exists():
             temporary.unlink()
@@ -656,6 +1014,8 @@ def _prepare_evaluation(
     workspace_root: str | Path | None,
 ) -> EvaluationSetup:
     request = load_request(request_path)
+    _configured_filter_drivers.cache_clear()
+    sandbox_binary = _sandbox_binary()
     canonical_repository = Path(
         _git_text(request.repository, "rev-parse", "--show-toplevel")
     ).resolve()
@@ -681,22 +1041,32 @@ def _prepare_evaluation(
     if source_head != exact_base:
         source_branch = None
     workspace_id = uuid.uuid4().hex
+    workspace = requested_workspace_root / f"{workspace_id}-repository"
+    runtime_root = requested_workspace_root / f"{workspace_id}-runtime"
     log_directory = output.parent / f"{output.stem}.logs"
-    if log_directory.exists():
-        raise RequestError(f"log directory already exists: {log_directory}")
-    requested_workspace_root.mkdir(parents=True, exist_ok=True)
-    log_directory.mkdir(parents=True)
+    for candidate, label in (
+        (workspace, "workspace"),
+        (runtime_root, "runtime directory"),
+        (log_directory, "log directory"),
+    ):
+        if candidate.exists():
+            raise RequestError(f"{label} already exists: {candidate}")
     return EvaluationSetup(
         request=request,
         output=output,
         workspace_root=requested_workspace_root,
         workspace_id=workspace_id,
-        workspace=requested_workspace_root / workspace_id,
+        workspace=workspace,
         log_directory=log_directory,
         source_head_before=source_head,
         source_fingerprint_before=source_fingerprint,
         source_branch=source_branch,
         exact_base=exact_base,
+        sandbox_binary=sandbox_binary,
+        runtime_root=runtime_root,
+        sandbox_home=runtime_root / "home",
+        sandbox_tmp=runtime_root / "tmp",
+        git_scratch=runtime_root / "git-scratch",
     )
 
 
@@ -705,30 +1075,138 @@ def _mark_infrastructure_error(state: EvaluationState, detail: str) -> None:
     state.error_detail = state.error_detail or detail
 
 
-def _create_isolated_worktree(setup: EvaluationSetup, state: EvaluationState) -> None:
-    # Mark the attempt before Git so transport failure still enters exact-path cleanup.
+def _write_pack_snapshot(setup: EvaluationSetup) -> Path:
+    pack_path = setup.runtime_root / "objects.pack"
+    env = _sanitized_environment(setup.git_scratch / "home", setup.git_scratch / "tmp")
+    tree = _git_text(
+        setup.request.repository, "rev-parse", f"{setup.exact_base}^{{tree}}"
+    )
+    object_result = _run_bytes(
+        _git_argv(
+            setup.request.repository,
+            "rev-list",
+            "--objects",
+            "--no-object-names",
+            tree,
+        ),
+        cwd=setup.request.repository,
+        timeout=120,
+        env=env,
+    )
+    object_ids = [item for item in object_result.stdout.splitlines() if item]
+    if len(object_ids) > _MAX_REPOSITORY_OBJECTS:
+        raise EvaluationError("repository snapshot exceeded the object-count limit")
+    object_ids.append(setup.exact_base.encode("ascii"))
+    with pack_path.open("wb") as output:
+        completed = subprocess.run(
+            _git_argv(setup.request.repository, "pack-objects", "--stdout"),
+            cwd=setup.request.repository,
+            env=env,
+            input=b"\n".join(object_ids) + b"\n",
+            stdout=output,
+            stderr=subprocess.PIPE,
+            timeout=120,
+            check=False,
+            shell=False,
+            start_new_session=True,
+        )
+    if completed.returncode != 0:
+        detail = completed.stderr.decode("utf-8", errors="replace").strip()
+        raise EvaluationError(f"Git object snapshot failed: {detail}")
+    if not pack_path.is_file() or pack_path.stat().st_size == 0:
+        raise EvaluationError("Git object snapshot is empty")
+    if pack_path.stat().st_size > _MAX_REPOSITORY_PACK_BYTES:
+        raise EvaluationError("repository snapshot exceeded the pack-byte limit")
+    return pack_path
+
+
+def _import_pack_snapshot(setup: EvaluationSetup, pack_path: Path) -> None:
+    env = _sanitized_environment(setup.git_scratch / "home", setup.git_scratch / "tmp")
+    with pack_path.open("rb") as source:
+        completed = subprocess.run(
+            _git_argv(setup.workspace, "index-pack", "--stdin"),
+            cwd=setup.workspace,
+            env=env,
+            stdin=source,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=120,
+            check=False,
+            shell=False,
+            start_new_session=True,
+        )
+    if completed.returncode != 0:
+        detail = completed.stderr.decode("utf-8", errors="replace").strip()
+        raise EvaluationError(f"Git object import failed: {detail}")
+
+
+def _verify_independent_repository(setup: EvaluationSetup) -> bool:
+    source_common = Path(
+        _git_text(
+            setup.request.repository,
+            "rev-parse",
+            "--path-format=absolute",
+            "--git-common-dir",
+        )
+    ).resolve()
+    workspace_common = Path(
+        _git_text(
+            setup.workspace,
+            "rev-parse",
+            "--path-format=absolute",
+            "--git-common-dir",
+        )
+    ).resolve()
+    workspace_git = Path(
+        _git_text(
+            setup.workspace,
+            "rev-parse",
+            "--path-format=absolute",
+            "--git-dir",
+        )
+    ).resolve()
+    alternates = workspace_common / "objects" / "info" / "alternates"
+    object_files = [
+        candidate
+        for candidate in (workspace_common / "objects").rglob("*")
+        if candidate.is_file()
+    ]
+    return (
+        workspace_common == workspace_git
+        and workspace_common == (setup.workspace / ".git").resolve()
+        and workspace_common != source_common
+        and not alternates.exists()
+        and bool(object_files)
+        and all(candidate.stat().st_nlink == 1 for candidate in object_files)
+        and _git_text(setup.workspace, "rev-parse", "HEAD") == setup.exact_base
+    )
+
+
+def _create_isolated_repository(setup: EvaluationSetup, state: EvaluationState) -> None:
     state.workspace_created = True
-    result = _git(
-        setup.request.repository,
-        "worktree",
-        "add",
+    setup.workspace.mkdir()
+    init_result = _git(setup.workspace, "init", "--quiet", check=False)
+    if init_result.returncode != 0:
+        detail = init_result.stderr.decode("utf-8", errors="replace").strip()
+        raise EvaluationError(f"independent repository initialization failed: {detail}")
+    pack_path = _write_pack_snapshot(setup)
+    _import_pack_snapshot(setup, pack_path)
+    checkout_result = _git(
+        setup.workspace,
+        "checkout",
         "--detach",
-        str(setup.workspace),
+        "--force",
+        "--quiet",
         setup.exact_base,
         timeout=120,
         check=False,
     )
-    if result.returncode != 0:
-        detail = result.stderr.decode("utf-8", errors="replace").strip()
-        raise EvaluationError(f"disposable worktree creation failed: {detail}")
-    workspace_head = _git_text(setup.workspace, "rev-parse", "HEAD")
-    state.isolated = (
-        (setup.workspace / ".git").is_file()
-        and workspace_head == setup.exact_base
-        and setup.workspace != setup.request.repository
-    )
+    if checkout_result.returncode != 0:
+        detail = checkout_result.stderr.decode("utf-8", errors="replace").strip()
+        raise EvaluationError(f"independent repository checkout failed: {detail}")
+    state.isolated = _verify_independent_repository(setup)
     if not state.isolated:
-        raise EvaluationError("disposable worktree isolation could not be proven")
+        raise EvaluationError("independent repository isolation could not be proven")
 
 
 def _apply_patch(setup: EvaluationSetup, state: EvaluationState) -> None:
@@ -758,82 +1236,53 @@ def _apply_patch(setup: EvaluationSetup, state: EvaluationState) -> None:
     state.changed_files = _parse_changed_files(setup.workspace)
 
 
-def _skipped_command_record(spec: CommandSpec) -> dict[str, Any]:
-    return {
-        "command": shlex.join(spec.argv),
-        "status": "skipped",
-        "exit_code": None,
-        "started_at": None,
-        "duration_ms": 0,
-        "log_ref": None,
-        "truncated": False,
-    }
-
-
-def _run_declared_commands(setup: EvaluationSetup, state: EvaluationState) -> None:
-    env = _sanitized_environment(
-        setup.workspace / ".sidecar-home", setup.workspace / ".sidecar-tmp"
-    )
-    deadline = time.monotonic() + setup.request.global_timeout_seconds
-    for index, spec in enumerate(setup.request.commands, start=1):
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
-            state.command_records.append(_skipped_command_record(spec))
-            continue
-        record = _run_command(
-            spec,
-            workspace=setup.workspace,
-            timeout_seconds=min(float(spec.timeout_seconds), remaining),
-            env=env,
-            log_path=setup.log_directory / f"command-{index:03d}.log",
-            max_log_bytes=setup.request.max_log_bytes,
-        )
-        record["log_ref"] = f"{setup.log_directory.name}/{record['log_ref']}"
-        state.command_records.append(record)
-
-
 def _perform_evaluation(setup: EvaluationSetup, state: EvaluationState) -> None:
+    setup.workspace_root.mkdir(parents=True, exist_ok=True)
+    setup.runtime_root.mkdir()
+    setup.sandbox_home.mkdir()
+    setup.sandbox_tmp.mkdir()
+    setup.git_scratch.mkdir()
     state.patch_snapshot, state.patch_sha256 = _snapshot_patch(
-        setup.request.patch_path, setup.workspace_root
+        setup.request.patch_path, setup.runtime_root
     )
-    _create_isolated_worktree(setup, state)
+    _create_isolated_repository(setup, state)
     _apply_patch(setup, state)
     _run_declared_commands(setup, state)
 
 
 def _cleanup_workspace(setup: EvaluationSetup, state: EvaluationState) -> None:
-    if not state.workspace_created:
-        state.workspace_cleaned = not setup.workspace.exists()
-        return
     try:
-        _git(
-            setup.request.repository,
-            "worktree",
-            "remove",
-            "--force",
-            str(setup.workspace),
-            timeout=120,
-            check=False,
-        )
-        # Never prune globally: cleanup and readback are restricted to this workspace.
-        listed_result = _git(
-            setup.request.repository, "worktree", "list", "--porcelain", check=False
-        )
-        listed = listed_result.stdout.decode("utf-8", errors="replace")
-        state.workspace_cleaned = (
-            listed_result.returncode == 0
-            and not setup.workspace.exists()
-            and str(setup.workspace) not in listed
-        )
-    except (EvaluationError, OSError, subprocess.SubprocessError) as exc:
+        if setup.workspace.exists():
+            shutil.rmtree(setup.workspace)
+        state.workspace_cleaned = not setup.workspace.exists()
+    except OSError as exc:
         state.workspace_cleaned = False
         state.error_detail = state.error_detail or (
-            f"disposable worktree cleanup readback failed: {exc}"
+            f"independent repository cleanup readback failed: {exc}"
         )
     if not state.workspace_cleaned:
         _mark_infrastructure_error(
-            state, "disposable worktree cleanup could not be proven"
+            state, "independent repository cleanup could not be proven"
         )
+
+
+def _cleanup_runtime(setup: EvaluationSetup, state: EvaluationState) -> None:
+    try:
+        if setup.runtime_root.exists():
+            shutil.rmtree(setup.runtime_root)
+    except OSError as exc:
+        state.error_detail = state.error_detail or f"runtime cleanup failed: {exc}"
+    if setup.runtime_root.exists():
+        _mark_infrastructure_error(state, "runtime cleanup could not be proven")
+
+
+def _cleanup_empty_logs(setup: EvaluationSetup) -> None:
+    try:
+        if setup.log_directory.is_dir() and not any(setup.log_directory.iterdir()):
+            setup.log_directory.rmdir()
+    except OSError:
+        # Non-empty or unreadable diagnostic logs are retained rather than hidden.
+        return
 
 
 def _cleanup_patch_snapshot(state: EvaluationState) -> None:
@@ -851,6 +1300,7 @@ def _cleanup_patch_snapshot(state: EvaluationState) -> None:
 
 def _verify_source_unchanged(setup: EvaluationSetup, state: EvaluationState) -> None:
     try:
+        _configured_filter_drivers.cache_clear()
         source_head, source_fingerprint, _ = _source_snapshot(setup.request.repository)
         state.source_unchanged = (
             source_head == setup.source_head_before
@@ -868,18 +1318,31 @@ def _verify_source_unchanged(setup: EvaluationSetup, state: EvaluationState) -> 
 def _cleanup_evaluation(setup: EvaluationSetup, state: EvaluationState) -> None:
     _cleanup_workspace(setup, state)
     _cleanup_patch_snapshot(state)
+    _cleanup_runtime(setup, state)
+    _cleanup_empty_logs(setup)
     _verify_source_unchanged(setup, state)
 
 
 def _git_version(repository: Path) -> str:
     try:
-        return (
-            _run_bytes(("git", "--version"), cwd=repository, check=False)
-            .stdout.decode("utf-8", errors="replace")
-            .strip()
-        )
+        with tempfile.TemporaryDirectory(
+            prefix="repoground-patch-evaluation-version-"
+        ) as temporary:
+            scratch = Path(temporary)
+            completed = _run_bytes(
+                (str(_git_binary()), "--version"),
+                cwd=repository,
+                check=False,
+                env=_sanitized_environment(scratch / "home", scratch / "tmp"),
+            )
+        version = completed.stdout.decode("utf-8", errors="replace").strip()
+        return f"{version} ({_git_binary()})"
     except OSError:
         return "unknown"
+
+
+def _producer_digest() -> str:
+    return "sha256:" + hashlib.sha256(Path(__file__).read_bytes()).hexdigest()
 
 
 def _build_artifact(setup: EvaluationSetup, state: EvaluationState) -> dict[str, Any]:
@@ -895,7 +1358,7 @@ def _build_artifact(setup: EvaluationSetup, state: EvaluationState) -> dict[str,
         "producer": {
             "name": PRODUCER_NAME,
             "version": PRODUCER_VERSION,
-            "commit": None,
+            "commit": _producer_digest(),
             "url": None,
         },
         "created_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
@@ -922,7 +1385,7 @@ def _build_artifact(setup: EvaluationSetup, state: EvaluationState) -> dict[str,
         },
         "command_policy": {
             "allowed_commands": [
-                shlex.join(command.argv) for command in setup.request.commands
+                _display_command(command) for command in setup.request.commands
             ],
             "network": "unknown",
             "secrets_policy": "unknown",
@@ -931,8 +1394,8 @@ def _build_artifact(setup: EvaluationSetup, state: EvaluationState) -> dict[str,
         "commands_run": state.command_records,
         "environment": {
             "os": platform.platform(),
-            "runner": "local-disposable-git-worktree",
-            "container": None,
+            "runner": "local-independent-git-repository",
+            "container": "bubblewrap-fs-pid-sandbox",
             "tool_versions": {
                 "python": platform.python_version(),
                 "git": _git_version(setup.request.repository),
@@ -980,7 +1443,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--workspace-root",
-        help="Optional disposable-worktree parent outside the source repository",
+        help="Optional independent-repository parent outside the source repository",
     )
     return parser
 

--- a/tools/patch_evaluation_sidecar.py
+++ b/tools/patch_evaluation_sidecar.py
@@ -342,9 +342,48 @@ def _sandbox_binary() -> Path:
     if platform.system() != "Linux":
         raise RequestError("the prototype requires Linux bubblewrap isolation")
     try:
-        return _resolve_system_tool("bwrap")
+        binary = _resolve_system_tool("bwrap")
     except EvaluationError as exc:
         raise RequestError(str(exc)) from exc
+    try:
+        completed = subprocess.run(
+            [
+                str(binary),
+                "--die-with-parent",
+                "--new-session",
+                "--unshare-pid",
+                "--ro-bind",
+                "/usr",
+                "/usr",
+                "--ro-bind-try",
+                "/bin",
+                "/bin",
+                "--ro-bind-try",
+                "/lib",
+                "/lib",
+                "--ro-bind-try",
+                "/lib64",
+                "/lib64",
+                "--proc",
+                "/proc",
+                "--dev",
+                "/dev",
+                "/usr/bin/true",
+            ],
+            env={"PATH": _TRUSTED_SYSTEM_PATH},
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=10,
+            check=False,
+            shell=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise RequestError(f"bubblewrap runtime probe failed: {exc}") from exc
+    if completed.returncode != 0:
+        detail = completed.stderr.decode("utf-8", errors="replace").strip()
+        raise RequestError(f"bubblewrap runtime is not usable: {detail}")
+    return binary
 
 
 def _display_command(spec: CommandSpec) -> str:
@@ -784,6 +823,9 @@ def _sandbox_command_argv(
         "--ro-bind-try",
         "/lib64",
         "/lib64",
+        "--ro-bind-try",
+        "/opt",
+        "/opt",
         "--dir",
         "/etc",
         "--ro-bind-try",


### PR DESCRIPTION
## Bureau task

Implements `RBAW-V1-T004` — external Patch Evaluation Sidecar prototype.

## What changed

- keeps the mutable producer outside RepoBrief core and leaves the v1 artifact schema and read-only consumer unchanged
- snapshots the exact patch bytes and materializes the exact commit/tree into a newly initialized independent Git repository
- proves separate Git directory, configuration, refs and object database; rejects alternates and multiply linked objects
- neutralizes source-local hooks and configured clean/smudge/process filters for Sidecar-owned Git operations
- runs declared argv-only commands with `shell=False` inside Linux Bubblewrap filesystem and PID namespaces
- does not mount the source checkout; exposes private writable repository/home/tmp mounts, read-only system paths and an explicit `/etc` subset
- contains background descendants, hardens timeout process-group cleanup and keeps network/complete credential safety explicitly unknown
- uses fixed system tool resolution, bounded inputs/fingerprinting/logs, optional fail-fast and explicit argv/log redaction
- fixes rename destination parsing, removes empty log directories and prevents artifact overwrite races
- verifies Bubblewrap usability before mutable evaluation; CI installs Bubblewrap, enables supported user-namespace gates and runs a runtime smoke test
- emits evidence-only artifacts with producer source digest and all nine mandatory non-claims

## Verification

- focused sidecar/consumer suite: `47 passed in 5.60s`
- local full suite: `4696 passed, 2 skipped`, authoritative exit code `0`
- GitHub `pytest-full`: `SUCCESS`
- doc-freshness: `36 passed, 3 deselected`
- Ruff check: `All checks passed!`
- Ruff format check: `2 files already formatted`
- graph maintainability: `pass`; current `200`, baseline `203`, new `0`, resolved `3`
- workflow YAML parse: pass
- `git diff --check`: pass
- final diff-bound invariant review: PASS

Evidence binding:

- hardened implementation commit: `5fd5acf7bbf28f18bd359a743be4061b6961992d`
- final CI/runtime commit and PR head: `9f9deb544db48ba4504f4a5bbca78a80cc7844ca`
- principal hardening diff SHA-256: `810ceacfdf62265aecc34c6fd79587fddaf82e0640e27e62ec7e3dab5278dbdf`
- CI/runtime fix diff SHA-256: `3f9401cda451fb2b86dac0aa4e4a43ed190e11a7e8eb49ddf73f1c1f570b2605`
- full-suite argv SHA-256: `c3f2578d3a465d10ae97391fe2a54f1c10832286381277ce1355ccfb0bbac529`
- lifecycle receipt SHA-256: `d26feb16ef5ba99dc5f78f98320a47d775fb0b9024f12706d8693bb40c0c759f`
- terminalization SHA-256: `31755fc3eeca8ca8de8372e75bf4eaa920e29f9c633433e84e2de83f90e26d71`

## Authority boundary

A passing evaluation is external evidence only. It does **not** establish correctness, test sufficiency, security correctness, runtime behavior outside evaluated commands, merge authorization, merge readiness, regression absence, repository understanding, or truth of producer claims.

Filesystem and PID isolation are provided by a usable Bubblewrap runtime on Linux. Network isolation and complete credential safety are not claimed. Explicit redaction protects declared argv values, but arbitrary command output is not proven secret-free.

## Follow-up

A production sandbox hardening candidate was previously prepared, but Bureau refused publication because the runtime/registry projection was stale. No registry truth was fabricated or bypassed; the candidate must be reassessed after this implementation before publication.
