### PR TITLE
Safely classify and quarantine managed build residues

### DIFF
--- a/merger/repoground/tests/test_fleet_runtime.py
+++ b/merger/repoground/tests/test_fleet_runtime.py
@@ -6,8 +6,10 @@ import importlib.util
 import json
 import os
 import shutil
+import sqlite3
 import subprocess
 import sys
+import time
 from pathlib import Path
 from types import ModuleType
 
@@ -42,6 +44,25 @@ def load_publisher() -> ModuleType:
     return module
 
 
+def allow_no_active_managed_build_leases(
+    module: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def evidence(worktree: Path, build: Path) -> dict[str, object]:
+        return {
+            "authority": "test-exact-path-lease-evidence",
+            "database": "test",
+            "checked_at_unix": 1,
+            "resource_keys": [
+                f"path:{worktree.resolve()}",
+                f"path:{build.resolve(strict=False)}",
+            ],
+            "active_leases": [],
+            "does_not_establish": ["non-exact resource keys"],
+        }
+
+    monkeypatch.setattr(module, "managed_build_lease_evidence", evidence)
+
+
 def git(repo: Path, *args: str) -> str:
     completed = subprocess.run(
         ["git", "-C", str(repo), *args],
@@ -73,7 +94,7 @@ def initialize_repository(tmp_path: Path, name: str = "repo") -> tuple[Path, str
     git(repo, "config", "user.name", "RepoBrief Test")
     git(repo, "config", "user.email", "repobrief-test@example.invalid")
     (repo / ".gitignore").write_text(
-        "ignored.txt\n__pycache__/\n.pytest_cache/\n*.pyc\n*.pyo\n*.egg-info/\nbuild/\n",
+        "ignored.txt\n__pycache__/\n.pytest_cache/\n.ruff_cache/\n*.pyc\n*.pyo\n*.egg-info/\nbuild/\n",
         encoding="utf-8",
     )
     (repo / "tracked.txt").write_text("clean\n", encoding="utf-8")
@@ -506,6 +527,9 @@ def test_managed_worktree_cleanup_removes_only_bounded_disposable_artifacts(
     pytest_cache = worktree / ".pytest_cache"
     pytest_cache.mkdir()
     (pytest_cache / "README.md").write_text("pytest cache\n", encoding="utf-8")
+    ruff_cache = worktree / ".ruff_cache"
+    ruff_cache.mkdir()
+    (ruff_cache / "CACHEDIR.TAG").write_text("ruff cache\n", encoding="utf-8")
     egg_info = worktree / "src" / "demo.egg-info"
     egg_info.mkdir(parents=True)
     (egg_info / "PKG-INFO").write_text("Metadata-Version: 2.4\n", encoding="utf-8")
@@ -517,14 +541,16 @@ def test_managed_worktree_cleanup_removes_only_bounded_disposable_artifacts(
     removed = module.cleanup_managed_disposable_artifacts(worktree, repo)
 
     assert removed == [
-        ".pytest_cache",
         "build",
+        ".pytest_cache",
+        ".ruff_cache",
         "loose.pyc",
         "pkg/__pycache__",
         "src/demo.egg-info",
     ]
     assert not pycache.exists()
     assert not pytest_cache.exists()
+    assert not ruff_cache.exists()
     assert not egg_info.exists()
     assert not loose.exists()
     assert not build.exists()
@@ -532,7 +558,7 @@ def test_managed_worktree_cleanup_removes_only_bounded_disposable_artifacts(
 
 
 def test_managed_worktree_cleanup_rejects_unrelated_and_nonempty_build(
-    tmp_path: Path,
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     module = load_publisher()
     repo, sha = initialize_repository(tmp_path)
@@ -550,9 +576,520 @@ def test_managed_worktree_cleanup_rejects_unrelated_and_nonempty_build(
     build.mkdir()
     payload = build / "artifact.bin"
     payload.write_bytes(b"preserve")
-    with pytest.raises(RuntimeError, match="build residue is not empty"):
+    ruff_cache = worktree / ".ruff_cache"
+    ruff_cache.mkdir()
+    (ruff_cache / "CACHEDIR.TAG").write_text("preserve", encoding="utf-8")
+    monkeypatch.setattr(module, "STATE_ROOT", tmp_path / "state")
+    with pytest.raises(RuntimeError, match="managed build residue blocked") as excinfo:
+        module.cleanup_managed_disposable_artifacts(worktree, repo)
+    blocker = json.loads(str(excinfo.value).split(": ", 1)[1])
+    assert blocker["classification"] == "unknown"
+    assert blocker["automatic_mutation_authorized"] is False
+    assert payload.read_bytes() == b"preserve"
+    assert (ruff_cache / "CACHEDIR.TAG").read_text(encoding="utf-8") == "preserve"
+
+
+def test_managed_build_residue_with_exact_stale_provenance_is_quarantined(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    repo, sha = initialize_repository(tmp_path, "repo")
+    source_root = tmp_path / "sources"
+    source_root.mkdir()
+    worktree = source_root / "managed"
+    git(repo, "worktree", "add", "--detach", str(worktree), sha)
+    state_root = tmp_path / "state"
+    monkeypatch.setattr(module, "SOURCE_ROOT", source_root)
+    monkeypatch.setattr(module, "STATE_ROOT", state_root)
+    monkeypatch.setattr(module, "MANAGED_BUILD_RESIDUE_STALE_SECONDS", 0)
+    allow_no_active_managed_build_leases(module, monkeypatch)
+
+    armed = module.arm_managed_build_residue_provenance(worktree, repo)
+    assert armed is not None
+    build = worktree / "build"
+    build.mkdir()
+    payload = build / "artifact.bin"
+    payload.write_bytes(b"publisher-owned")
+    module.finalize_managed_build_residue_provenance(armed, worktree, repo)
+
+    removed = module.cleanup_managed_disposable_artifacts(worktree, repo)
+
+    assert len(removed) == 1
+    assert removed[0].startswith("build->quarantine:")
+    quarantine = Path(removed[0].split(":", 1)[1])
+    assert not build.exists()
+    assert (quarantine / "artifact.bin").read_bytes() == b"publisher-owned"
+    assert not module.managed_build_residue_record_path(worktree).exists()
+    receipts = list((state_root / "managed-build-quarantines").glob("*.json"))
+    assert len(receipts) == 1
+    receipt = json.loads(receipts[0].read_text(encoding="utf-8"))
+    assert receipt["automatic_deletion_authorized"] is False
+    assert receipt["classification"] == "managed-stale"
+    module.assert_managed_worktree_clean(worktree, repo)
+
+
+def test_managed_build_residue_fresh_or_changed_stays_fail_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    repo, sha = initialize_repository(tmp_path, "repo")
+    source_root = tmp_path / "sources"
+    source_root.mkdir()
+    worktree = source_root / "managed"
+    git(repo, "worktree", "add", "--detach", str(worktree), sha)
+    monkeypatch.setattr(module, "SOURCE_ROOT", source_root)
+    monkeypatch.setattr(module, "STATE_ROOT", tmp_path / "state")
+    monkeypatch.setattr(module, "MANAGED_BUILD_RESIDUE_STALE_SECONDS", 3600)
+    allow_no_active_managed_build_leases(module, monkeypatch)
+
+    armed = module.arm_managed_build_residue_provenance(worktree, repo)
+    assert armed is not None
+    build = worktree / "build"
+    build.mkdir()
+    payload = build / "artifact.bin"
+    payload.write_bytes(b"first")
+    module.finalize_managed_build_residue_provenance(armed, worktree, repo)
+
+    with pytest.raises(RuntimeError, match="publisher-owned but not stale"):
+        module.cleanup_managed_disposable_artifacts(worktree, repo)
+    assert payload.read_bytes() == b"first"
+
+    monkeypatch.setattr(module, "MANAGED_BUILD_RESIDUE_STALE_SECONDS", 0)
+    allow_no_active_managed_build_leases(module, monkeypatch)
+    payload.write_bytes(b"changed")
+    with pytest.raises(RuntimeError, match="changed after publisher observation"):
+        module.cleanup_managed_disposable_artifacts(worktree, repo)
+    assert payload.read_bytes() == b"changed"
+
+
+@pytest.mark.parametrize("lease_target", ["worktree", "build"])
+def test_exact_active_managed_build_lease_blocks_quarantine(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, lease_target: str
+) -> None:
+    module = load_publisher()
+    repo, sha = initialize_repository(tmp_path, "repo")
+    source_root = tmp_path / "sources"
+    source_root.mkdir()
+    worktree = source_root / "managed"
+    git(repo, "worktree", "add", "--detach", str(worktree), sha)
+    state_root = tmp_path / "state"
+    monkeypatch.setattr(module, "SOURCE_ROOT", source_root)
+    monkeypatch.setattr(module, "STATE_ROOT", state_root)
+    monkeypatch.setattr(module, "MANAGED_BUILD_RESIDUE_STALE_SECONDS", 0)
+    build = worktree / "build"
+    armed = module.arm_managed_build_residue_provenance(worktree, repo)
+    assert armed is not None
+    build.mkdir()
+    payload = build / "artifact.bin"
+    payload.write_bytes(b"leased")
+    module.finalize_managed_build_residue_provenance(armed, worktree, repo)
+
+    database = tmp_path / "resources.sqlite3"
+    with sqlite3.connect(database) as connection:
+        connection.executescript(
+            """
+            CREATE TABLE metadata(key TEXT PRIMARY KEY, value TEXT NOT NULL);
+            CREATE TABLE leases(
+                resource_key TEXT PRIMARY KEY,
+                owner_id TEXT NOT NULL,
+                purpose TEXT NOT NULL,
+                acquired_at_unix INTEGER NOT NULL,
+                updated_at_unix INTEGER NOT NULL,
+                expires_at_unix INTEGER NOT NULL,
+                metadata_sha256 TEXT NOT NULL,
+                metadata_json TEXT NOT NULL,
+                reclaimed_from_owner TEXT
+            );
+            """
+        )
+        connection.execute(
+            "INSERT INTO metadata(key, value) VALUES('schema_version', '2')"
+        )
+        target = worktree if lease_target == "worktree" else build
+        now = int(time.time())
+        connection.execute(
+            "INSERT INTO leases VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                f"path:{target.resolve()}",
+                "operator:foreign-active-work",
+                "test active lease",
+                now,
+                now,
+                now + 3600,
+                "0" * 64,
+                "{}",
+                None,
+            ),
+        )
+    monkeypatch.setattr(module, "GRABOWSKI_RESOURCE_DB", database)
+
+    with pytest.raises(RuntimeError, match="managed build residue blocked") as excinfo:
+        module.cleanup_managed_disposable_artifacts(worktree, repo)
+
+    blocker = module.parse_managed_build_blocker(excinfo.value)
+    assert blocker is not None
+    assert blocker["classification"] == "active-legitimate"
+    assert blocker["reason"] == "exact active Grabowski path lease"
+    leases = blocker["lease_evidence"]["active_leases"]
+    assert leases == [
+        {
+            "resource_key": f"path:{target.resolve()}",
+            "owner_id": "operator:foreign-active-work",
+            "expires_at_unix": now + 3600,
+            "updated_at_unix": now,
+        }
+    ]
+    assert payload.read_bytes() == b"leased"
+    assert not (source_root / module.MANAGED_BUILD_QUARANTINE_DIR_NAME).exists()
+
+
+def test_managed_build_quarantine_rolls_back_when_receipt_write_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    repo, sha = initialize_repository(tmp_path, "repo")
+    source_root = tmp_path / "sources"
+    source_root.mkdir()
+    worktree = source_root / "managed"
+    git(repo, "worktree", "add", "--detach", str(worktree), sha)
+    monkeypatch.setattr(module, "SOURCE_ROOT", source_root)
+    monkeypatch.setattr(module, "STATE_ROOT", tmp_path / "state")
+    monkeypatch.setattr(module, "MANAGED_BUILD_RESIDUE_STALE_SECONDS", 0)
+    allow_no_active_managed_build_leases(module, monkeypatch)
+    armed = module.arm_managed_build_residue_provenance(worktree, repo)
+    assert armed is not None
+    build = worktree / "build"
+    build.mkdir()
+    payload = build / "artifact.bin"
+    payload.write_bytes(b"rollback")
+    module.finalize_managed_build_residue_provenance(armed, worktree, repo)
+
+    real_atomic_write = module.atomic_write_json
+
+    def fail_receipt(path: Path, value: dict[str, object]) -> None:
+        if path.parent.name == "managed-build-quarantines":
+            raise OSError("simulated receipt failure")
+        real_atomic_write(path, value)
+
+    monkeypatch.setattr(module, "atomic_write_json", fail_receipt)
+    with pytest.raises(OSError, match="simulated receipt failure"):
+        module.cleanup_managed_disposable_artifacts(worktree, repo)
+    assert payload.read_bytes() == b"rollback"
+    restored = json.loads(
+        module.managed_build_residue_record_path(worktree).read_text(encoding="utf-8")
+    )
+    assert restored["status"] == "observed"
+
+
+def test_interrupted_managed_build_quarantine_is_reconciled_next_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    repo, sha = initialize_repository(tmp_path, "repo")
+    source_root = tmp_path / "sources"
+    source_root.mkdir()
+    worktree = source_root / "managed"
+    git(repo, "worktree", "add", "--detach", str(worktree), sha)
+    state_root = tmp_path / "state"
+    monkeypatch.setattr(module, "SOURCE_ROOT", source_root)
+    monkeypatch.setattr(module, "STATE_ROOT", state_root)
+    monkeypatch.setattr(module, "MANAGED_BUILD_RESIDUE_STALE_SECONDS", 0)
+    allow_no_active_managed_build_leases(module, monkeypatch)
+    armed = module.arm_managed_build_residue_provenance(worktree, repo)
+    assert armed is not None
+    build = worktree / "build"
+    build.mkdir()
+    (build / "artifact.bin").write_bytes(b"interrupted")
+    module.finalize_managed_build_residue_provenance(armed, worktree, repo)
+    classification = module.classify_managed_build_residue(build, worktree, repo)
+    transaction_id = "a" * 32
+    quarantine_root = module.managed_build_residue_quarantine_root(worktree)
+    transaction_root = quarantine_root / transaction_id
+    transaction_root.mkdir(mode=0o700)
+    worktree_quarantine = transaction_root / worktree.name
+    worktree_quarantine.mkdir(mode=0o700)
+    quarantine = worktree_quarantine / "build"
+    record_path = classification["record_path"]
+    planned = dict(classification["record"])
+    planned.update(
+        {
+            "status": "quarantine-planned",
+            "transaction_id": transaction_id,
+            "quarantine": str(quarantine),
+            "quarantine_planned_at_unix": 1,
+            "lease_evidence": classification["lease_evidence"],
+        }
+    )
+    module.atomic_write_json(record_path, planned)
+    planned_receipt = module.managed_build_quarantine_receipt(
+        transaction_id=transaction_id,
+        status="planned",
+        build=build,
+        quarantine=quarantine,
+        record_path=record_path,
+        snapshot=classification["snapshot"],
+        classification="managed-stale",
+        lease_evidence=classification["lease_evidence"],
+    )
+    receipt_path = module.managed_build_quarantine_receipt_path(transaction_id)
+    module.atomic_write_json(receipt_path, planned_receipt)
+    os.replace(build, quarantine)
+
+    removed = module.cleanup_managed_disposable_artifacts(worktree, repo)
+
+    assert removed == [f"build->quarantine:{quarantine}"]
+    assert not build.exists()
+    assert (quarantine / "artifact.bin").read_bytes() == b"interrupted"
+    assert not record_path.exists()
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert receipt["status"] == "quarantined"
+    assert receipt["reconciled_after_interruption"] is True
+
+
+def test_planned_quarantine_without_move_resumes_safely(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    repo, sha = initialize_repository(tmp_path, "repo")
+    source_root = tmp_path / "sources"
+    source_root.mkdir()
+    worktree = source_root / "managed"
+    git(repo, "worktree", "add", "--detach", str(worktree), sha)
+    state_root = tmp_path / "state"
+    monkeypatch.setattr(module, "SOURCE_ROOT", source_root)
+    monkeypatch.setattr(module, "STATE_ROOT", state_root)
+    monkeypatch.setattr(module, "MANAGED_BUILD_RESIDUE_STALE_SECONDS", 0)
+    allow_no_active_managed_build_leases(module, monkeypatch)
+    armed = module.arm_managed_build_residue_provenance(worktree, repo)
+    assert armed is not None
+    build = worktree / "build"
+    build.mkdir()
+    (build / "artifact.bin").write_bytes(b"not-moved")
+    module.finalize_managed_build_residue_provenance(armed, worktree, repo)
+    classification = module.classify_managed_build_residue(build, worktree, repo)
+    transaction_id = "b" * 32
+    quarantine_root = module.managed_build_residue_quarantine_root(worktree)
+    transaction_root = quarantine_root / transaction_id
+    transaction_root.mkdir(mode=0o700)
+    worktree_quarantine = transaction_root / worktree.name
+    worktree_quarantine.mkdir(mode=0o700)
+    quarantine = worktree_quarantine / "build"
+    record_path = classification["record_path"]
+    planned = dict(classification["record"])
+    planned.update(
+        {
+            "status": "quarantine-planned",
+            "transaction_id": transaction_id,
+            "quarantine": str(quarantine),
+            "quarantine_planned_at_unix": 1,
+            "lease_evidence": classification["lease_evidence"],
+        }
+    )
+    module.atomic_write_json(record_path, planned)
+
+    removed = module.cleanup_managed_disposable_artifacts(worktree, repo)
+
+    assert len(removed) == 1
+    assert removed[0].startswith("build->quarantine:")
+    assert not build.exists()
+    first_receipt = json.loads(
+        module.managed_build_quarantine_receipt_path(transaction_id).read_text(
+            encoding="utf-8"
+        )
+    )
+    assert first_receipt["status"] == "not-moved"
+    completed = [
+        json.loads(path.read_text(encoding="utf-8"))
+        for path in (state_root / "managed-build-quarantines").glob("*.json")
+    ]
+    assert sorted(receipt["status"] for receipt in completed) == [
+        "not-moved",
+        "quarantined",
+    ]
+
+
+def test_managed_build_provenance_record_symlink_is_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    repo, sha = initialize_repository(tmp_path, "repo")
+    source_root = tmp_path / "sources"
+    source_root.mkdir()
+    worktree = source_root / "managed"
+    git(repo, "worktree", "add", "--detach", str(worktree), sha)
+    monkeypatch.setattr(module, "SOURCE_ROOT", source_root)
+    monkeypatch.setattr(module, "STATE_ROOT", tmp_path / "state")
+    build = worktree / "build"
+    build.mkdir()
+    (build / "artifact.bin").write_bytes(b"preserve")
+    record = module.managed_build_residue_record_path(worktree)
+    record.parent.mkdir(parents=True)
+    outside = tmp_path / "outside.json"
+    outside.write_text("{}", encoding="utf-8")
+    record.symlink_to(outside)
+
+    with pytest.raises(RuntimeError, match="managed build residue blocked"):
+        module.cleanup_managed_disposable_artifacts(worktree, repo)
+    assert (build / "artifact.bin").read_bytes() == b"preserve"
+
+
+def test_managed_build_quarantine_root_symlink_is_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    repo, sha = initialize_repository(tmp_path, "repo")
+    source_root = tmp_path / "sources"
+    source_root.mkdir()
+    worktree = source_root / "managed"
+    git(repo, "worktree", "add", "--detach", str(worktree), sha)
+    monkeypatch.setattr(module, "SOURCE_ROOT", source_root)
+    monkeypatch.setattr(module, "STATE_ROOT", tmp_path / "state")
+    monkeypatch.setattr(module, "MANAGED_BUILD_RESIDUE_STALE_SECONDS", 0)
+    allow_no_active_managed_build_leases(module, monkeypatch)
+    armed = module.arm_managed_build_residue_provenance(worktree, repo)
+    assert armed is not None
+    build = worktree / "build"
+    build.mkdir()
+    payload = build / "artifact.bin"
+    payload.write_bytes(b"preserve")
+    module.finalize_managed_build_residue_provenance(armed, worktree, repo)
+    outside = tmp_path / "outside-quarantine"
+    outside.mkdir()
+    (source_root / module.MANAGED_BUILD_QUARANTINE_DIR_NAME).symlink_to(
+        outside, target_is_directory=True
+    )
+
+    with pytest.raises(RuntimeError, match="quarantine root is not"):
         module.cleanup_managed_disposable_artifacts(worktree, repo)
     assert payload.read_bytes() == b"preserve"
+    assert list(outside.iterdir()) == []
+
+
+def test_managed_build_residue_armed_record_is_not_remediated(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    repo, sha = initialize_repository(tmp_path, "repo")
+    source_root = tmp_path / "sources"
+    source_root.mkdir()
+    worktree = source_root / "managed"
+    git(repo, "worktree", "add", "--detach", str(worktree), sha)
+    monkeypatch.setattr(module, "SOURCE_ROOT", source_root)
+    monkeypatch.setattr(module, "STATE_ROOT", tmp_path / "state")
+    monkeypatch.setattr(module, "MANAGED_BUILD_RESIDUE_STALE_SECONDS", 0)
+    allow_no_active_managed_build_leases(module, monkeypatch)
+
+    armed = module.arm_managed_build_residue_provenance(worktree, repo)
+    assert armed is not None
+    build = worktree / "build"
+    build.mkdir()
+    payload = build / "artifact.bin"
+    payload.write_bytes(b"unfinished-generator")
+
+    with pytest.raises(RuntimeError, match="managed build residue blocked") as excinfo:
+        module.cleanup_managed_disposable_artifacts(worktree, repo)
+    blocker = json.loads(str(excinfo.value).split(": ", 1)[1])
+    assert blocker["classification"] == "unknown"
+    assert "does not match worktree identity" in blocker["reason"]
+    assert payload.read_bytes() == b"unfinished-generator"
+
+
+def test_managed_build_tree_symlink_is_quarantined_without_following_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    repo, sha = initialize_repository(tmp_path, "repo")
+    source_root = tmp_path / "sources"
+    source_root.mkdir()
+    worktree = source_root / "managed"
+    git(repo, "worktree", "add", "--detach", str(worktree), sha)
+    monkeypatch.setattr(module, "SOURCE_ROOT", source_root)
+    monkeypatch.setattr(module, "STATE_ROOT", tmp_path / "state")
+    monkeypatch.setattr(module, "MANAGED_BUILD_RESIDUE_STALE_SECONDS", 0)
+    allow_no_active_managed_build_leases(module, monkeypatch)
+
+    armed = module.arm_managed_build_residue_provenance(worktree, repo)
+    assert armed is not None
+    outside = tmp_path / "outside.txt"
+    outside.write_text("preserve", encoding="utf-8")
+    build = worktree / "build"
+    build.mkdir()
+    (build / "outside-link").symlink_to(outside)
+    module.finalize_managed_build_residue_provenance(armed, worktree, repo)
+
+    removed = module.cleanup_managed_disposable_artifacts(worktree, repo)
+
+    quarantine = Path(removed[0].split(":", 1)[1])
+    link = quarantine / "outside-link"
+    assert link.is_symlink()
+    assert link.readlink() == outside
+    assert outside.read_text(encoding="utf-8") == "preserve"
+
+
+def test_managed_worktree_idle_detects_open_file_descriptor(
+    tmp_path: Path
+) -> None:
+    module = load_publisher()
+    repo, sha = initialize_repository(tmp_path, "repo")
+    worktree = tmp_path / "managed"
+    git(repo, "worktree", "add", "--detach", str(worktree), sha)
+    pycache = worktree / "pkg" / "__pycache__"
+    pycache.mkdir(parents=True)
+    payload = pycache / "module.pyc"
+    payload.write_bytes(b"cache")
+    environment = dict(os.environ)
+    environment["REPOGROUND_TEST_OPEN_PATH"] = str(payload)
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            "import os,time; handle=open(os.environ['REPOGROUND_TEST_OPEN_PATH'],'rb'); time.sleep(30)",
+        ],
+        cwd=tmp_path,
+        env=environment,
+    )
+    try:
+        import time
+
+        for _ in range(100):
+            references = module.active_process_cwds(worktree)
+            if any(pid == process.pid and "fd=" in evidence for pid, evidence in references):
+                break
+            time.sleep(0.01)
+        with pytest.raises(RuntimeError, match="active use"):
+            module.cleanup_managed_disposable_artifacts(worktree, repo)
+        assert payload.read_bytes() == b"cache"
+    finally:
+        process.terminate()
+        process.wait(timeout=5)
+
+
+def test_managed_worktree_idle_detects_source_path_in_argv(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    repo, sha = initialize_repository(tmp_path, "repo")
+    worktree = tmp_path / "managed"
+    git(repo, "worktree", "add", "--detach", str(worktree), sha)
+    pycache = worktree / "pkg" / "__pycache__"
+    pycache.mkdir(parents=True)
+    (pycache / "module.pyc").write_bytes(b"cache")
+    process = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(30)", str(worktree)],
+        cwd=tmp_path,
+    )
+    try:
+        for _ in range(100):
+            if any(pid == process.pid for pid, _ in module.active_process_cwds(worktree)):
+                break
+            import time
+            time.sleep(0.01)
+        with pytest.raises(RuntimeError, match="active use"):
+            module.cleanup_managed_disposable_artifacts(worktree, repo)
+        assert pycache.is_dir()
+    finally:
+        process.terminate()
+        process.wait(timeout=5)
 
 
 def test_managed_worktree_cleanup_rejects_symlink_inside_disposable_tree(
@@ -1824,6 +2361,63 @@ def test_regression_canonical_unit_names_and_installer_cutover_order() -> None:
         "systemctl --user enable --now repoground-publish-fleet-watch.timer"
     )
     assert install_position < reload_position < enable_position
+
+
+def test_managed_build_blocker_is_structured_in_fleet_receipt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    roots = isolate_retention_roots(module, tmp_path, monkeypatch)
+    monkeypatch.setattr(module, "LOCK_PATH", tmp_path / "fleet.lock")
+    monkeypatch.setattr(module, "FLEET_LOG", roots["log"] / "fleet.log")
+    entry = module.RepoEntry(
+        key="heimgewebe/demo",
+        owner="heimgewebe",
+        repo="demo",
+        path=tmp_path / "demo",
+        remote="git@github.com:heimgewebe/demo.git",
+    )
+    monkeypatch.setattr(module, "discover", lambda: [entry])
+    monkeypatch.setattr(
+        module,
+        "prioritize_fleet_publication",
+        lambda entries: (entries, {"policy": "test"}),
+    )
+    monkeypatch.setattr(
+        module,
+        "reconcile_prune_transactions",
+        lambda *, protected, apply: {"status": "ok"},
+    )
+    monkeypatch.setattr(module, "ensure_tool_worktree", lambda: ("b" * 40, "c" * 64))
+    monkeypatch.setattr(
+        module, "remote_head", lambda path: ("origin/main", "main", "a" * 40)
+    )
+    monkeypatch.setattr(
+        module,
+        "publication_config",
+        lambda entry: module.PublicationConfig(profile="full-max"),
+    )
+
+    def block(entry: object, ref_segment: str) -> list[str]:
+        raise module.managed_build_blocker(
+            tmp_path / "sources" / "demo" / "build",
+            classification="unknown",
+            reason="no exact publisher provenance",
+        )
+
+    monkeypatch.setattr(module, "preflight_existing_source_worktree", block)
+
+    assert module.main(["--repo", "heimgewebe/demo"]) == 1
+    receipt = json.loads((roots["log"] / "fleet-last.json").read_text(encoding="utf-8"))
+    detail = receipt["details"][0]
+    assert detail["status"] == "failed"
+    assert detail["managed_build_residue"] == {
+        "schema": module.MANAGED_BUILD_RESIDUE_SCHEMA,
+        "classification": "unknown",
+        "path": str(tmp_path / "sources" / "demo" / "build"),
+        "reason": "no exact publisher provenance",
+        "automatic_mutation_authorized": False,
+    }
 
 
 def test_missing_generator_inputs_fail_before_publication_and_write_receipt(

--- a/scripts/ops/repoground-publish-fleet
+++ b/scripts/ops/repoground-publish-fleet
@@ -16,6 +16,7 @@ import json
 import os
 import re
 import shutil
+import sqlite3
 import stat
 import subprocess
 import sys
@@ -69,6 +70,18 @@ STATE_SCHEMA = "repobrief.fleet-publication-state.v1"
 SCHEDULING_POLICY = "oldest-successful-publication-first.v1"
 ACTIVE_LEASE_SCHEMA = "repobrief.active-publication-lease.v1"
 PRUNE_TRANSACTION_SCHEMA = "repobrief.retention-transaction.v1"
+MANAGED_BUILD_RESIDUE_SCHEMA = "repoground.managed-build-residue.v1"
+MANAGED_BUILD_QUARANTINE_SCHEMA = "repoground.managed-build-quarantine.v1"
+MANAGED_BUILD_RESIDUE_STALE_SECONDS = int(
+    os.environ.get("REPOGROUND_MANAGED_BUILD_RESIDUE_STALE_SECONDS") or "3600"
+)
+if MANAGED_BUILD_RESIDUE_STALE_SECONDS < 60:
+    raise RuntimeError("managed build residue stale threshold must be at least 60 seconds")
+MANAGED_BUILD_QUARANTINE_DIR_NAME = ".repoground-residue-quarantine"
+GRABOWSKI_RESOURCE_DB = Path(
+    os.environ.get("REPOGROUND_GRABOWSKI_RESOURCE_DB")
+    or "/home/alex/.local/state/grabowski/resources.sqlite3"
+).expanduser()
 QUARANTINE_DIR_NAME = ".repoground-prune-quarantine"
 PERSISTED_V1_QUARANTINE_DIR_NAME = "." + "r" + "b-prune-quarantine"
 READABLE_QUARANTINE_DIR_NAMES = (
@@ -473,11 +486,19 @@ def managed_worktree_status(path: Path) -> list[tuple[str, str]]:
 
 
 def active_process_cwds(path: Path) -> list[tuple[int, str]]:
+    """Return observable current-user process references to a managed worktree.
+
+    The generator uses the tool worktree as cwd and carries the source path in
+    argv, so both surfaces are checked. Inaccessible unrelated process details are
+    not treated as path evidence; complete absence of hidden references is not
+    established by this bounded positive-reference check.
+    """
     proc = Path("/proc")
     if not proc.is_dir():
-        return []
+        raise RuntimeError("process observation is unavailable; refusing cleanup")
     root = path.resolve()
     current_pid = os.getpid()
+    current_uid = os.getuid()
     active: list[tuple[int, str]] = []
     for entry in proc.iterdir():
         if not entry.name.isdigit():
@@ -486,18 +507,67 @@ def active_process_cwds(path: Path) -> list[tuple[int, str]]:
         if pid == current_pid:
             continue
         try:
-            cwd = (entry / "cwd").resolve(strict=True)
+            status = (entry / "status").read_text(encoding="utf-8", errors="replace")
         except (FileNotFoundError, OSError, PermissionError):
             continue
-        if cwd == root or root in cwd.parents:
-            active.append((pid, str(cwd)))
+        uid_line = next(
+            (line for line in status.splitlines() if line.startswith("Uid:")), None
+        )
+        if uid_line is None:
+            continue
+        try:
+            real_uid = int(uid_line.split()[1])
+        except (IndexError, ValueError):
+            continue
+        if real_uid != current_uid:
+            continue
+        evidence: set[str] = set()
+        try:
+            cwd = (entry / "cwd").resolve(strict=True)
+        except (FileNotFoundError, OSError, PermissionError):
+            cwd = None
+        if cwd is not None and (cwd == root or root in cwd.parents):
+            evidence.add(f"cwd={cwd}")
+        try:
+            argv = (entry / "cmdline").read_bytes().split(b"\0")
+        except (FileNotFoundError, OSError, PermissionError):
+            argv = []
+        for raw in argv:
+            if not raw:
+                continue
+            value = raw.decode("utf-8", errors="surrogateescape")
+            candidate_value = (
+                value.split("=", 1)[1]
+                if value.startswith("-") and "=" in value
+                else value
+            )
+            if candidate_value == str(root) or candidate_value.startswith(
+                str(root) + os.sep
+            ):
+                evidence.add(f"argv={value}")
+        try:
+            descriptors = list((entry / "fd").iterdir())[:512]
+        except (FileNotFoundError, OSError, PermissionError):
+            descriptors = []
+        for descriptor in descriptors:
+            try:
+                target = descriptor.resolve(strict=True)
+            except (FileNotFoundError, OSError, PermissionError):
+                continue
+            if target == root or root in target.parents:
+                evidence.add(f"fd={descriptor.name}:{target}")
+                break
+        if evidence:
+            active.append((pid, ",".join(sorted(evidence))))
     return sorted(active)
 
 
 def assert_managed_worktree_idle(path: Path) -> None:
     active = active_process_cwds(path)
     if active:
-        sample = ", ".join(f"pid={pid} cwd={cwd}" for pid, cwd in active[:10])
+        sample = ", ".join(
+            f"pid={pid} reference={reference}" for pid, reference in active[:10]
+        )
         raise RuntimeError(
             f"managed worktree is in active use; refusing cleanup or reset: {path}: {sample}"
         )
@@ -510,7 +580,9 @@ def managed_disposable_artifact_root(relative: str) -> Path | None:
     if candidate == Path("build"):
         return candidate
     for index, part in enumerate(candidate.parts):
-        if part in {"__pycache__", ".pytest_cache"} or part.endswith(".egg-info"):
+        if part in {"__pycache__", ".pytest_cache", ".ruff_cache"} or part.endswith(
+            ".egg-info"
+        ):
             return Path(*candidate.parts[: index + 1])
     if candidate.suffix in {".pyc", ".pyo"}:
         return candidate
@@ -547,11 +619,10 @@ def validate_managed_disposable_artifact(path: Path, worktree: Path) -> None:
     if path.relative_to(worktree) == Path("build"):
         if not stat.S_ISDIR(metadata.st_mode):
             raise RuntimeError(f"managed build residue is not a directory: {path}")
-        try:
-            next(path.iterdir())
-        except StopIteration:
-            return
-        raise RuntimeError(f"managed build residue is not empty; refusing cleanup: {path}")
+        # The build root is moved atomically as one opaque tree. Internal symlinks
+        # are never followed or deleted by this path; their exact identity is
+        # captured by managed_build_snapshot and revalidated before and after the move.
+        return
     if stat.S_ISREG(metadata.st_mode):
         if path.suffix not in {".pyc", ".pyo"} and not path.name.endswith(".egg-info"):
             raise RuntimeError(f"managed disposable artifact is not removable: {path}")
@@ -559,6 +630,711 @@ def validate_managed_disposable_artifact(path: Path, worktree: Path) -> None:
     if not stat.S_ISDIR(metadata.st_mode):
         raise RuntimeError(f"managed disposable artifact is not regular: {path}")
     validate_removable_tree(path)
+
+
+def managed_build_file_sha256(
+    path: Path, expected: os.stat_result
+) -> str:
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if not nofollow:
+        raise RuntimeError("managed build snapshot requires O_NOFOLLOW")
+    try:
+        descriptor = os.open(path, os.O_RDONLY | os.O_CLOEXEC | nofollow)
+    except OSError as exc:
+        raise RuntimeError(
+            f"managed build file cannot be opened without following links: {path}"
+        ) from exc
+    digest = hashlib.sha256()
+    with os.fdopen(descriptor, "rb") as handle:
+        opened = os.fstat(handle.fileno())
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or opened.st_dev != expected.st_dev
+            or opened.st_ino != expected.st_ino
+        ):
+            raise RuntimeError(f"managed build file identity changed: {path}")
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+        final = os.fstat(handle.fileno())
+    if (
+        final.st_dev != opened.st_dev
+        or final.st_ino != opened.st_ino
+        or final.st_size != opened.st_size
+        or final.st_mtime_ns != opened.st_mtime_ns
+    ):
+        raise RuntimeError(f"managed build file changed while hashing: {path}")
+    return digest.hexdigest()
+
+
+def managed_build_snapshot(path: Path) -> dict[str, object]:
+    if path.is_symlink() or not path.is_dir():
+        raise RuntimeError(f"managed build residue is not a real directory: {path}")
+    root_stat = path.lstat()
+    rows: list[list[object]] = []
+    for root, directories, files in os.walk(path, topdown=True, followlinks=False):
+        root_path = Path(root)
+        relative_root = root_path.relative_to(path).as_posix()
+        root_metadata = root_path.lstat()
+        rows.append(
+            [
+                "d",
+                relative_root,
+                stat.S_IMODE(root_metadata.st_mode),
+                root_metadata.st_mtime_ns,
+            ]
+        )
+        traversable: list[str] = []
+        for name in sorted(directories):
+            candidate = root_path / name
+            metadata = candidate.lstat()
+            relative = candidate.relative_to(path).as_posix()
+            if stat.S_ISLNK(metadata.st_mode):
+                rows.append(
+                    [
+                        "l",
+                        relative,
+                        stat.S_IMODE(metadata.st_mode),
+                        os.readlink(candidate),
+                    ]
+                )
+            elif stat.S_ISDIR(metadata.st_mode):
+                traversable.append(name)
+            else:
+                raise RuntimeError(
+                    f"managed build residue contains unsafe directory entry: {candidate}"
+                )
+        directories[:] = traversable
+        for name in sorted(files):
+            candidate = root_path / name
+            metadata = candidate.lstat()
+            relative = candidate.relative_to(path).as_posix()
+            if stat.S_ISLNK(metadata.st_mode):
+                rows.append(
+                    [
+                        "l",
+                        relative,
+                        stat.S_IMODE(metadata.st_mode),
+                        os.readlink(candidate),
+                    ]
+                )
+            elif stat.S_ISREG(metadata.st_mode):
+                rows.append(
+                    [
+                        "f",
+                        relative,
+                        stat.S_IMODE(metadata.st_mode),
+                        metadata.st_size,
+                        metadata.st_mtime_ns,
+                        managed_build_file_sha256(candidate, metadata),
+                    ]
+                )
+            else:
+                raise RuntimeError(
+                    f"managed build residue contains unsafe file entry: {candidate}"
+                )
+    digest = hashlib.sha256(
+        json.dumps(rows, sort_keys=False, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return {
+        "device": root_stat.st_dev,
+        "inode": root_stat.st_ino,
+        "tree_sha256": digest,
+    }
+
+
+def managed_build_residue_record_path(worktree: Path) -> Path:
+    identity = hashlib.sha256(str(worktree.resolve()).encode("utf-8")).hexdigest()
+    return STATE_ROOT / "managed-build-residues" / f"{identity}.json"
+
+
+def managed_build_residue_quarantine_root(worktree: Path) -> Path:
+    source_root_path = SOURCE_ROOT.expanduser()
+    try:
+        source_metadata = source_root_path.lstat()
+    except FileNotFoundError as exc:
+        raise RuntimeError("managed source root does not exist") from exc
+    if (
+        stat.S_ISLNK(source_metadata.st_mode)
+        or not stat.S_ISDIR(source_metadata.st_mode)
+        or source_metadata.st_uid != os.getuid()
+    ):
+        raise RuntimeError("managed source root is not an owner-controlled real directory")
+    source_root = source_root_path.resolve(strict=True)
+    resolved = worktree.resolve(strict=True)
+    if resolved.parent != source_root:
+        raise RuntimeError(f"managed source worktree is outside source root: {worktree}")
+    quarantine_root = source_root / MANAGED_BUILD_QUARANTINE_DIR_NAME
+    try:
+        quarantine_root.mkdir(mode=0o700)
+    except FileExistsError:
+        pass
+    metadata = quarantine_root.lstat()
+    if (
+        stat.S_ISLNK(metadata.st_mode)
+        or not stat.S_ISDIR(metadata.st_mode)
+        or metadata.st_uid != os.getuid()
+    ):
+        raise RuntimeError(
+            "managed build residue quarantine root is not an owner-controlled real directory"
+        )
+    return quarantine_root
+
+
+def managed_build_identity(worktree: Path, expected_repo: Path) -> dict[str, object]:
+    return {
+        "worktree": str(worktree.resolve()),
+        "git_common_dir": str(git_common_dir(expected_repo)),
+        "head": run(["git", "-C", str(worktree), "rev-parse", "HEAD"]).stdout.strip(),
+        "artifact": "build",
+    }
+
+
+def load_owner_json_object(path: Path, *, label: str) -> dict[str, object]:
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if not nofollow:
+        raise RuntimeError(f"{label} requires O_NOFOLLOW")
+    flags = os.O_RDONLY | os.O_CLOEXEC | nofollow
+    try:
+        descriptor = os.open(path, flags)
+    except FileNotFoundError as exc:
+        raise RuntimeError(f"{label} does not exist") from exc
+    except OSError as exc:
+        raise RuntimeError(f"{label} cannot be opened without following links") from exc
+    with os.fdopen(descriptor, "rb") as handle:
+        metadata = os.fstat(handle.fileno())
+        if not stat.S_ISREG(metadata.st_mode):
+            raise RuntimeError(f"{label} is not a regular file")
+        if metadata.st_uid != os.getuid():
+            raise RuntimeError(f"{label} ownership is invalid")
+        raw = handle.read(65537)
+    if len(raw) > 65536:
+        raise RuntimeError(f"{label} is oversized")
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"{label} is invalid") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"{label} is not an object")
+    return payload
+
+
+def load_managed_build_residue_record(path: Path) -> dict[str, object]:
+    try:
+        return load_owner_json_object(
+            path, label="managed build residue provenance record"
+        )
+    except RuntimeError as exc:
+        if str(exc) == "managed build residue provenance record does not exist":
+            raise RuntimeError(
+                "managed build residue has no publisher provenance record"
+            ) from exc
+        raise
+
+
+def managed_build_quarantine_receipt_path(transaction_id: str) -> Path:
+    if not TRANSACTION_ID_RE.fullmatch(transaction_id):
+        raise RuntimeError("managed build quarantine transaction id is invalid")
+    return STATE_ROOT / "managed-build-quarantines" / f"{transaction_id}.json"
+
+
+def managed_build_quarantine_receipt(
+    *,
+    transaction_id: str,
+    status: str,
+    build: Path,
+    quarantine: Path,
+    record_path: Path,
+    snapshot: dict[str, object],
+    classification: str,
+    lease_evidence: dict[str, object] | None = None,
+) -> dict[str, object]:
+    receipt: dict[str, object] = {
+        "schema": MANAGED_BUILD_QUARANTINE_SCHEMA,
+        "transaction_id": transaction_id,
+        "status": status,
+        "classification": classification,
+        "source": str(build),
+        "quarantine": str(quarantine),
+        "provenance_record": str(record_path),
+        "snapshot": snapshot,
+        "updated_at_unix": int(time.time()),
+        "automatic_deletion_authorized": False,
+    }
+    if lease_evidence is not None:
+        receipt["lease_evidence"] = lease_evidence
+    return receipt
+
+
+def arm_managed_build_residue_provenance(
+    worktree: Path, expected_repo: Path
+) -> tuple[Path, str] | None:
+    build = worktree / "build"
+    if build.exists() or build.is_symlink():
+        return None
+    assert_managed_worktree_identity(worktree, expected_repo)
+    assert_managed_worktree_idle(worktree)
+    record_path = managed_build_residue_record_path(worktree)
+    token = uuid.uuid4().hex
+    atomic_write_json(
+        record_path,
+        {
+            "schema": MANAGED_BUILD_RESIDUE_SCHEMA,
+            "status": "armed",
+            "token": token,
+            "armed_at_unix": int(time.time()),
+            **managed_build_identity(worktree, expected_repo),
+        },
+    )
+    return record_path, token
+
+
+def finalize_managed_build_residue_provenance(
+    armed: tuple[Path, str] | None, worktree: Path, expected_repo: Path
+) -> None:
+    if armed is None:
+        return
+    record_path, token = armed
+    payload = load_managed_build_residue_record(record_path)
+    expected_identity = managed_build_identity(worktree, expected_repo)
+    if (
+        payload.get("schema") != MANAGED_BUILD_RESIDUE_SCHEMA
+        or payload.get("status") != "armed"
+        or payload.get("token") != token
+        or any(payload.get(key) != value for key, value in expected_identity.items())
+    ):
+        raise RuntimeError("managed build residue provenance changed during generation")
+    build = worktree / "build"
+    if not build.exists() and not build.is_symlink():
+        record_path.unlink()
+        return
+    validate_managed_disposable_artifact(build, worktree)
+    payload.update(
+        {
+            "status": "observed",
+            "observed_at_unix": int(time.time()),
+            "snapshot": managed_build_snapshot(build),
+        }
+    )
+    atomic_write_json(record_path, payload)
+
+
+def managed_build_lease_evidence(
+    worktree: Path, build: Path
+) -> dict[str, object]:
+    database = GRABOWSKI_RESOURCE_DB.expanduser()
+    try:
+        metadata = database.lstat()
+    except FileNotFoundError as exc:
+        raise RuntimeError("canonical Grabowski lease database is unavailable") from exc
+    if (
+        stat.S_ISLNK(metadata.st_mode)
+        or not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_uid != os.getuid()
+    ):
+        raise RuntimeError(
+            "canonical Grabowski lease database is not an owner-controlled regular file"
+        )
+    resource_keys = [
+        f"path:{worktree.resolve()}",
+        f"path:{build.resolve(strict=False)}",
+    ]
+    uri = f"file:{database}?mode=ro"
+    try:
+        with sqlite3.connect(uri, uri=True, timeout=2.0) as connection:
+            connection.execute("PRAGMA query_only=ON")
+            schema_row = connection.execute(
+                "SELECT value FROM metadata WHERE key = 'schema_version'"
+            ).fetchone()
+            columns = {
+                row[1] for row in connection.execute("PRAGMA table_info(leases)")
+            }
+            required = {
+                "resource_key",
+                "owner_id",
+                "expires_at_unix",
+                "updated_at_unix",
+            }
+            if schema_row != ("2",) or not required.issubset(columns):
+                raise RuntimeError("canonical Grabowski lease schema is incompatible")
+            placeholders = ",".join("?" for _ in resource_keys)
+            now = int(time.time())
+            rows = connection.execute(
+                "SELECT resource_key, owner_id, expires_at_unix, updated_at_unix "
+                f"FROM leases WHERE resource_key IN ({placeholders}) "
+                "AND expires_at_unix > ? ORDER BY resource_key, owner_id",
+                (*resource_keys, now),
+            ).fetchall()
+    except (sqlite3.Error, RuntimeError) as exc:
+        if isinstance(exc, RuntimeError):
+            raise
+        raise RuntimeError("canonical Grabowski lease read failed") from exc
+    return {
+        "authority": "grabowski-resources-sqlite-v2",
+        "database": str(database),
+        "checked_at_unix": now,
+        "resource_keys": resource_keys,
+        "active_leases": [
+            {
+                "resource_key": row[0],
+                "owner_id": row[1],
+                "expires_at_unix": row[2],
+                "updated_at_unix": row[3],
+            }
+            for row in rows
+        ],
+        "does_not_establish": [
+            "leases on non-exact resource keys",
+            "process inactivity",
+            "publisher ownership",
+        ],
+    }
+
+
+def managed_build_blocker(
+    build: Path, *, classification: str, reason: str, **evidence: object
+) -> RuntimeError:
+    payload: dict[str, object] = {
+        "schema": MANAGED_BUILD_RESIDUE_SCHEMA,
+        "classification": classification,
+        "path": str(build),
+        "reason": reason,
+        "automatic_mutation_authorized": False,
+    }
+    payload.update(evidence)
+    return RuntimeError(
+        "managed build residue blocked: "
+        + json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    )
+
+
+def require_no_active_managed_build_leases(
+    build: Path, worktree: Path
+) -> dict[str, object]:
+    try:
+        evidence = managed_build_lease_evidence(worktree, build)
+    except RuntimeError as exc:
+        raise managed_build_blocker(
+            build,
+            classification="unknown",
+            reason=f"lease evidence unavailable: {exc}",
+        ) from exc
+    active = evidence.get("active_leases")
+    if not isinstance(active, list):
+        raise managed_build_blocker(
+            build,
+            classification="unknown",
+            reason="lease evidence envelope is invalid",
+        )
+    if active:
+        raise managed_build_blocker(
+            build,
+            classification="active-legitimate",
+            reason="exact active Grabowski path lease",
+            lease_evidence=evidence,
+        )
+    return evidence
+
+
+def parse_managed_build_blocker(exc: Exception) -> dict[str, object] | None:
+    prefix = "managed build residue blocked: "
+    rendered = str(exc)
+    if not rendered.startswith(prefix):
+        return None
+    try:
+        payload = json.loads(rendered[len(prefix) :])
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def classify_managed_build_residue(
+    build: Path, worktree: Path, expected_repo: Path
+) -> dict[str, object]:
+    lease_evidence = require_no_active_managed_build_leases(build, worktree)
+    record_path = managed_build_residue_record_path(worktree)
+    try:
+        payload = load_managed_build_residue_record(record_path)
+    except RuntimeError as exc:
+        raise managed_build_blocker(
+            build,
+            classification="unknown",
+            reason=str(exc),
+            lease_evidence=lease_evidence,
+        ) from exc
+    expected_identity = managed_build_identity(worktree, expected_repo)
+    if (
+        payload.get("schema") != MANAGED_BUILD_RESIDUE_SCHEMA
+        or payload.get("status") != "observed"
+        or any(payload.get(key) != value for key, value in expected_identity.items())
+    ):
+        raise managed_build_blocker(
+            build,
+            classification="unknown",
+            reason="publisher provenance does not match worktree identity",
+            lease_evidence=lease_evidence,
+        )
+    observed_at = payload.get("observed_at_unix")
+    if not isinstance(observed_at, int):
+        raise managed_build_blocker(
+            build,
+            classification="unknown",
+            reason="provenance lacks observed timestamp",
+            lease_evidence=lease_evidence,
+        )
+    age = int(time.time()) - observed_at
+    if age < MANAGED_BUILD_RESIDUE_STALE_SECONDS:
+        raise managed_build_blocker(
+            build,
+            classification="active-legitimate",
+            reason="publisher-owned but not stale",
+            age_seconds=age,
+            required_age_seconds=MANAGED_BUILD_RESIDUE_STALE_SECONDS,
+            lease_evidence=lease_evidence,
+        )
+    snapshot = payload.get("snapshot")
+    if not isinstance(snapshot, dict) or managed_build_snapshot(build) != snapshot:
+        raise managed_build_blocker(
+            build,
+            classification="unknown",
+            reason="changed after publisher observation",
+            lease_evidence=lease_evidence,
+        )
+    return {
+        "record_path": record_path,
+        "record": payload,
+        "snapshot": snapshot,
+        "age_seconds": age,
+        "classification": "managed-stale",
+        "lease_evidence": lease_evidence,
+    }
+
+
+def reconcile_managed_build_quarantine(
+    worktree: Path, expected_repo: Path
+) -> str | None:
+    record_path = managed_build_residue_record_path(worktree)
+    try:
+        record_path.lstat()
+    except FileNotFoundError:
+        return None
+    try:
+        record = load_managed_build_residue_record(record_path)
+    except RuntimeError as exc:
+        raise managed_build_blocker(
+            worktree / "build", classification="unknown", reason=str(exc)
+        ) from exc
+    if record.get("status") != "quarantine-planned":
+        return None
+    identity = managed_build_identity(worktree, expected_repo)
+    if (
+        record.get("schema") != MANAGED_BUILD_RESIDUE_SCHEMA
+        or any(record.get(key) != value for key, value in identity.items())
+    ):
+        raise managed_build_blocker(
+            worktree / "build",
+            classification="unknown",
+            reason="pending quarantine provenance does not match worktree identity",
+        )
+    transaction_id = record.get("transaction_id")
+    snapshot = record.get("snapshot")
+    raw_quarantine = record.get("quarantine")
+    lease_evidence = record.get("lease_evidence")
+    if (
+        not isinstance(transaction_id, str)
+        or not TRANSACTION_ID_RE.fullmatch(transaction_id)
+        or not isinstance(snapshot, dict)
+        or not isinstance(raw_quarantine, str)
+        or not isinstance(lease_evidence, dict)
+    ):
+        raise managed_build_blocker(
+            worktree / "build",
+            classification="unknown",
+            reason="pending quarantine record is incomplete",
+        )
+    quarantine_root = managed_build_residue_quarantine_root(worktree)
+    quarantine = quarantine_root / transaction_id / worktree.name / "build"
+    if Path(raw_quarantine) != quarantine:
+        raise managed_build_blocker(
+            worktree / "build",
+            classification="unknown",
+            reason="pending quarantine path is not canonically bound",
+        )
+    build = worktree / "build"
+    source_present = build.exists() or build.is_symlink()
+    quarantine_present = quarantine.exists() or quarantine.is_symlink()
+    receipt_path = managed_build_quarantine_receipt_path(transaction_id)
+    if source_present and not quarantine_present:
+        if managed_build_snapshot(build) != snapshot:
+            raise managed_build_blocker(
+                build,
+                classification="unknown",
+                reason="retained build changed during quarantine recovery",
+            )
+        restored = dict(record)
+        restored["status"] = "observed"
+        restored.pop("transaction_id", None)
+        restored.pop("quarantine", None)
+        restored.pop("quarantine_planned_at_unix", None)
+        atomic_write_json(record_path, restored)
+        receipt = managed_build_quarantine_receipt(
+            transaction_id=transaction_id,
+            status="not-moved",
+            build=build,
+            quarantine=quarantine,
+            record_path=record_path,
+            snapshot=snapshot,
+            classification="managed-stale",
+            lease_evidence=lease_evidence,
+        )
+        atomic_write_json(receipt_path, receipt)
+        for parent in (quarantine.parent, quarantine.parent.parent):
+            try:
+                parent.rmdir()
+            except OSError:
+                break
+        return None
+    if not source_present and quarantine_present:
+        if quarantine.is_symlink() or managed_build_snapshot(quarantine) != snapshot:
+            raise managed_build_blocker(
+                build,
+                classification="unknown",
+                reason="quarantined build changed during recovery",
+            )
+        receipt = managed_build_quarantine_receipt(
+            transaction_id=transaction_id,
+            status="quarantined",
+            build=build,
+            quarantine=quarantine,
+            record_path=record_path,
+            snapshot=snapshot,
+            classification="managed-stale",
+            lease_evidence=lease_evidence,
+        )
+        receipt["reconciled_after_interruption"] = True
+        atomic_write_json(receipt_path, receipt)
+        record_path.unlink()
+        return f"build->quarantine:{quarantine}"
+    raise managed_build_blocker(
+        build,
+        classification="unknown",
+        reason="pending quarantine has contradictory source and destination state",
+        source_present=source_present,
+        quarantine_present=quarantine_present,
+    )
+
+
+def quarantine_managed_build_residue(
+    build: Path, worktree: Path, expected_repo: Path
+) -> str:
+    classification = classify_managed_build_residue(build, worktree, expected_repo)
+    assert_managed_worktree_idle(worktree)
+    expected_snapshot = classification["snapshot"]
+    if managed_build_snapshot(build) != expected_snapshot:
+        raise managed_build_blocker(
+            build,
+            classification="unknown",
+            reason="changed before quarantine",
+        )
+    lease_evidence = require_no_active_managed_build_leases(build, worktree)
+    transaction_id = uuid.uuid4().hex
+    quarantine_root = managed_build_residue_quarantine_root(worktree)
+    transaction_root = quarantine_root / transaction_id
+    transaction_root.mkdir(mode=0o700)
+    worktree_quarantine = transaction_root / worktree.name
+    worktree_quarantine.mkdir(mode=0o700)
+    quarantine = worktree_quarantine / "build"
+    if quarantine.exists() or quarantine.is_symlink():
+        raise RuntimeError(f"managed build residue quarantine already exists: {quarantine}")
+    record_path = classification["record_path"]
+    original_record = classification["record"]
+    planned_record = dict(original_record)
+    planned_record.update(
+        {
+            "status": "quarantine-planned",
+            "transaction_id": transaction_id,
+            "quarantine": str(quarantine),
+            "quarantine_planned_at_unix": int(time.time()),
+            "lease_evidence": lease_evidence,
+        }
+    )
+    receipt_path = managed_build_quarantine_receipt_path(transaction_id)
+    planned_receipt = managed_build_quarantine_receipt(
+        transaction_id=transaction_id,
+        status="planned",
+        build=build,
+        quarantine=quarantine,
+        record_path=record_path,
+        snapshot=expected_snapshot,
+        classification="managed-stale",
+        lease_evidence=lease_evidence,
+    )
+    atomic_write_json(record_path, planned_record)
+    try:
+        atomic_write_json(receipt_path, planned_receipt)
+    except Exception:
+        atomic_write_json(record_path, original_record)
+        for parent in (quarantine.parent, quarantine.parent.parent):
+            try:
+                parent.rmdir()
+            except OSError:
+                break
+        raise
+    moved = False
+    try:
+        os.replace(build, quarantine)
+        moved = True
+        if managed_build_snapshot(quarantine) != expected_snapshot:
+            raise RuntimeError("managed build residue identity changed during quarantine")
+        completed_receipt = managed_build_quarantine_receipt(
+            transaction_id=transaction_id,
+            status="quarantined",
+            build=build,
+            quarantine=quarantine,
+            record_path=record_path,
+            snapshot=expected_snapshot,
+            classification="managed-stale",
+            lease_evidence=lease_evidence,
+        )
+        atomic_write_json(receipt_path, completed_receipt)
+        record_path.unlink()
+    except Exception as exc:
+        rollback_error: Exception | None = None
+        try:
+            if moved and not build.exists() and quarantine.exists():
+                os.replace(quarantine, build)
+            atomic_write_json(record_path, original_record)
+            rolled_back = managed_build_quarantine_receipt(
+                transaction_id=transaction_id,
+                status="rolled-back",
+                build=build,
+                quarantine=quarantine,
+                record_path=record_path,
+                snapshot=expected_snapshot,
+                classification="managed-stale",
+                lease_evidence=lease_evidence,
+            )
+            try:
+                atomic_write_json(receipt_path, rolled_back)
+            except Exception:
+                # Data and provenance are already restored. Remove the stale
+                # planned journal rather than leaving contradictory authority.
+                try:
+                    receipt_path.unlink()
+                except FileNotFoundError:
+                    pass
+            for parent in (quarantine.parent, quarantine.parent.parent):
+                try:
+                    parent.rmdir()
+                except OSError:
+                    break
+        except Exception as rollback_exc:
+            rollback_error = rollback_exc
+        if rollback_error is not None:
+            raise RuntimeError(
+                f"managed build quarantine failed and rollback was incomplete: {rollback_error}"
+            ) from exc
+        raise
+    return str(quarantine)
 
 
 def remove_managed_disposable_artifact(path: Path, worktree: Path) -> None:
@@ -573,11 +1349,13 @@ def remove_managed_disposable_artifact(path: Path, worktree: Path) -> None:
         return
     shutil.rmtree(path)
 
+
 def cleanup_managed_disposable_artifacts(path: Path, expected_repo: Path) -> list[str]:
     assert_managed_worktree_identity(path, expected_repo)
+    reconciled = reconcile_managed_build_quarantine(path, expected_repo)
     status = managed_worktree_status(path)
     if not status:
-        return []
+        return [reconciled] if reconciled is not None else []
     roots: set[Path] = set()
     for code, relative in status:
         artifact = managed_disposable_artifact_root(relative)
@@ -595,11 +1373,27 @@ def cleanup_managed_disposable_artifacts(path: Path, expected_repo: Path) -> lis
         if any(parent == candidate or parent in candidate.parents for parent in retained):
             continue
         retained.append(candidate)
+    nonempty_build = False
     for relative in retained:
-        validate_managed_disposable_artifact(path / relative, path)
-    for relative in retained:
-        remove_managed_disposable_artifact(path / relative, path)
-    return [item.as_posix() for item in retained]
+        candidate = path / relative
+        validate_managed_disposable_artifact(candidate, path)
+        if relative == Path("build") and any(candidate.iterdir()):
+            classify_managed_build_residue(candidate, path, expected_repo)
+            nonempty_build = True
+    effect_order = sorted(
+        retained,
+        key=lambda relative: (0 if relative == Path("build") else 1, relative.as_posix()),
+    )
+    removed: list[str] = [reconciled] if reconciled is not None else []
+    for relative in effect_order:
+        candidate = path / relative
+        if relative == Path("build") and nonempty_build:
+            quarantine = quarantine_managed_build_residue(candidate, path, expected_repo)
+            removed.append(f"build->quarantine:{quarantine}")
+            continue
+        remove_managed_disposable_artifact(candidate, path)
+        removed.append(relative.as_posix())
+    return removed
 
 
 def assert_managed_worktree_clean(path: Path, expected_repo: Path) -> None:
@@ -2018,15 +2812,23 @@ def publish(
         command.append("--redact-secrets")
     try:
         STATE_ROOT.mkdir(parents=True, exist_ok=True)
+        residue_provenance = arm_managed_build_residue_provenance(
+            source_wt, entry.path
+        )
         with tempfile.TemporaryDirectory(
             prefix=".generation-runtime-", dir=str(STATE_ROOT)
         ) as raw_runtime:
-            cp = run(
-                command,
-                cwd=TOOL_WT,
-                check=False,
-                env=generation_environment(Path(raw_runtime)),
-            )
+            try:
+                cp = run(
+                    command,
+                    cwd=TOOL_WT,
+                    check=False,
+                    env=generation_environment(Path(raw_runtime)),
+                )
+            finally:
+                finalize_managed_build_residue_provenance(
+                    residue_provenance, source_wt, entry.path
+                )
         try:
             assert_managed_worktree_clean(source_wt, entry.path)
             assert_managed_worktree_clean(TOOL_WT, REPOGROUND_REPO)
@@ -2409,9 +3211,15 @@ def main(argv: list[str]) -> int:
                 details.append(published_detail)
             except Exception as exc:
                 failed += 1
-                details.append(
-                    {"repo": entry.key, "status": "failed", "error": str(exc)[:2000]}
-                )
+                failed_detail: dict[str, object] = {
+                    "repo": entry.key,
+                    "status": "failed",
+                    "error": str(exc)[:2000],
+                }
+                residue_blocker = parse_managed_build_blocker(exc)
+                if residue_blocker is not None:
+                    failed_detail["managed_build_residue"] = residue_blocker
+                details.append(failed_detail)
                 log(f"FAILED {entry.key}: {exc}")
         summary: dict[str, object] = {
             "status": "ok" if failed == 0 else "warn",


### PR DESCRIPTION
## Summary
- classify managed build residues as managed-stale, active-legitimate, or unknown using bound repository, ref, process, exact path-lease, provenance, and snapshot evidence
- keep unknown, active, changed, foreign, or lease-bound state fail-closed before any cleanup effect
- quarantine only exact publisher-owned stale residues through a journaled atomic move with deterministic interruption recovery and no automatic deletion
- expose structured blockers in Fleet receipts and include `.ruff_cache` in bounded generated-cache cleanup

## Verification
- 80 focused Fleet runtime tests passed
- full suite: 4665 passed, 2 skipped, 13 deselected
- Ruff and syntax checks passed
- self-review PASS on diff SHA-256 af8ace13304ba7226ed5b353bb8a7cb6cdd85ef3774ec8172f37e654295e8929

## Live boundary
The historical `heimgewebe/grabowski` build residue remains untouched and classifies as `unknown` because it has no publisher provenance record. Exact Grabowski worktree/build path leases are currently absent; this does not authorize mutation.

Bureau task: `REPOGROUND-AGENT-UTILITY-V1-T009`