### PR TITLE
refactor: reduce core complexity and prove module reachability

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,3 +32,6 @@ jobs:
 
       - name: Check graph and complexity maintainability ratchets
         run: python scripts/ci/check_graph_maintainability.py --root . --format json
+
+      - name: Check production module reachability evidence
+        run: python scripts/ci/check_module_reachability.py --root . --format json

--- a/config/repoground-c901-baseline.v1.json
+++ b/config/repoground-c901-baseline.v1.json
@@ -1,11 +1,11 @@
 {
   "kind": "repoground.c901_baseline",
   "version": "1.0",
-  "observed_on": "2026-07-22",
+  "observed_on": "2026-07-23",
   "ruff_config": "ruff-ci.toml",
   "threshold": 10,
-  "finding_count": 203,
-  "max_complexity": 170,
+  "finding_count": 198,
+  "max_complexity": 148,
   "findings": [
     {
       "path": "merger/repoground/adapters/atlas.py",
@@ -213,11 +213,6 @@
       "max_complexity": 19
     },
     {
-      "path": "merger/repoground/core/agent_consumption_validate.py",
-      "qualified_name": "validate_agent_consumption",
-      "max_complexity": 16
-    },
-    {
       "path": "merger/repoground/core/agent_entry_manifest.py",
       "qualified_name": "build_agent_entry_manifest",
       "max_complexity": 16
@@ -310,7 +305,7 @@
     {
       "path": "merger/repoground/core/context_compiler.py",
       "qualified_name": "_relation_candidates",
-      "max_complexity": 13
+      "max_complexity": 12
     },
     {
       "path": "merger/repoground/core/context_compiler.py",
@@ -430,7 +425,7 @@
     {
       "path": "merger/repoground/core/merge.py",
       "qualified_name": "MergeArtifacts.get_all_paths",
-      "max_complexity": 23
+      "max_complexity": 22
     },
     {
       "path": "merger/repoground/core/merge.py",
@@ -510,17 +505,7 @@
     {
       "path": "merger/repoground/core/merge.py",
       "qualified_name": "write_reports_v2",
-      "max_complexity": 170
-    },
-    {
-      "path": "merger/repoground/core/merge.py",
-      "qualified_name": "write_reports_v2.generate_chunk_artifacts",
-      "max_complexity": 17
-    },
-    {
-      "path": "merger/repoground/core/merge.py",
-      "qualified_name": "write_reports_v2.process_and_write",
-      "max_complexity": 27
+      "max_complexity": 73
     },
     {
       "path": "merger/repoground/core/output_health.py",
@@ -750,7 +735,7 @@
     {
       "path": "merger/repoground/retrieval/query_core.py",
       "qualified_name": "execute_query",
-      "max_complexity": 110
+      "max_complexity": 96
     },
     {
       "path": "merger/repoground/retrieval/query_range_coverage.py",
@@ -983,11 +968,6 @@
       "max_complexity": 17
     },
     {
-      "path": "scripts/release/check_identity_distribution_decisions.py",
-      "qualified_name": "check",
-      "max_complexity": 14
-    },
-    {
       "path": "scripts/release/check_release_contract.py",
       "qualified_name": "_check_workflows",
       "max_complexity": 11
@@ -1010,12 +990,7 @@
     {
       "path": "scripts/release/verify_release_candidate.py",
       "qualified_name": "_verify_manifest_contract",
-      "max_complexity": 25
-    },
-    {
-      "path": "tools/parity_guard.py",
-      "qualified_name": "ParityChecker.check_repolens",
-      "max_complexity": 26
+      "max_complexity": 16
     },
     {
       "path": "tools/verify_ui.py",

--- a/config/repoground-graph-maintainability.v1.json
+++ b/config/repoground-graph-maintainability.v1.json
@@ -18,7 +18,19 @@
   },
   "complexity": {
     "baseline_path": "config/repoground-c901-baseline.v1.json",
-    "policy": "existing identities may disappear; new identities and higher complexity are blocked"
+    "policy": "existing identities may disappear; new identities and higher complexity are blocked",
+    "budget": {
+      "policy": "the aggregate budget must fall over time and may never be raised above the historical reference; raising any ceiling is a visible policy change and is rejected while it exceeds the reference",
+      "historical_reference": {
+        "task": "REPOGROUND-LEGACY-RECONCILIATION-V1-T004",
+        "observed_on": "2026-07-17",
+        "finding_count": 213,
+        "max_complexity": 170
+      },
+      "finding_count_max": 198,
+      "max_complexity_max": 148,
+      "excess_total_max": 2533
+    }
   },
   "does_not_establish": [
     "semantic correctness of inferred layers",

--- a/config/repoground-graph-maintainability.v1.json
+++ b/config/repoground-graph-maintainability.v1.json
@@ -20,12 +20,20 @@
     "baseline_path": "config/repoground-c901-baseline.v1.json",
     "policy": "existing identities may disappear; new identities and higher complexity are blocked",
     "budget": {
-      "policy": "the aggregate budget must fall over time and may never be raised above the historical reference; raising any ceiling is a visible policy change and is rejected while it exceeds the reference",
+      "policy": "the aggregate budget must fall over time and may never be raised above a recorded reference scan; every budgeted dimension must be bounded by at least one reference, and raising a ceiling above one is rejected",
       "historical_reference": {
         "task": "REPOGROUND-LEGACY-RECONCILIATION-V1-T004",
         "observed_on": "2026-07-17",
         "finding_count": 213,
         "max_complexity": 170
+      },
+      "slice_start_reference": {
+        "commit": "5188d2faf335aaaefe4d27122df71d770647cb5b",
+        "observed_on": "2026-07-23",
+        "measured_with": "ruff check --config ruff-ci.toml --select C901 .",
+        "finding_count": 200,
+        "max_complexity": 170,
+        "excess_total": 2654
       },
       "finding_count_max": 198,
       "max_complexity_max": 148,

--- a/config/repoground-module-reachability.v1.json
+++ b/config/repoground-module-reachability.v1.json
@@ -12,8 +12,6 @@
     "merger.repoground.core.answer_grounding_delta",
     "merger.repoground.core.history_lens",
     "merger.repoground.core.memory",
-    "merger.repoground.frontends.pythonista.build_helpers",
-    "merger.repoground.frontends.pythonista.build_utils",
     "merger.repoground.retrieval.audit_finding",
     "merger.repoground.retrieval.audit_lane",
     "merger.repoground.retrieval.eval_diagnostics_integration"

--- a/config/repoground-module-reachability.v1.json
+++ b/config/repoground-module-reachability.v1.json
@@ -1,0 +1,18 @@
+{
+  "kind": "repoground.module_reachability_policy",
+  "version": "1.0",
+  "package_roots": [
+    "merger"
+  ],
+  "require_non_documentation_evidence": true,
+  "allowed_unproven": [],
+  "allowed_documentation_only": [],
+  "removal_policy": "An unproven module is not a dead module. Removing production code requires positive evidence of non-use (retired consumer, replaced surface, measured zero use), never the absence of a static reference.",
+  "allowlist_policy": "Entries record modules whose reachability could not be measured and that were reviewed by hand. A stale entry fails the check so the allowlist cannot silently outlive its reason.",
+  "does_not_establish": [
+    "that an unproven module is dead",
+    "that a reachable module is executed at runtime",
+    "completeness of dynamic loader discovery",
+    "that evidence surfaces are themselves used"
+  ]
+}

--- a/config/repoground-module-reachability.v1.json
+++ b/config/repoground-module-reachability.v1.json
@@ -5,13 +5,26 @@
     "merger"
   ],
   "require_non_documentation_evidence": true,
+  "require_production_evidence": true,
   "allowed_unproven": [],
   "allowed_documentation_only": [],
+  "allowed_test_only": [
+    "merger.repoground.core.answer_grounding_delta",
+    "merger.repoground.core.history_lens",
+    "merger.repoground.core.memory",
+    "merger.repoground.frontends.pythonista.build_helpers",
+    "merger.repoground.frontends.pythonista.build_utils",
+    "merger.repoground.retrieval.audit_finding",
+    "merger.repoground.retrieval.audit_lane",
+    "merger.repoground.retrieval.eval_diagnostics_integration"
+  ],
   "removal_policy": "An unproven module is not a dead module. Removing production code requires positive evidence of non-use (retired consumer, replaced surface, measured zero use), never the absence of a static reference.",
   "allowlist_policy": "Entries record modules whose reachability could not be measured and that were reviewed by hand. A stale entry fails the check so the allowlist cannot silently outlive its reason.",
+  "test_only_policy": "A test import proves the module is exercised, not that a production surface reaches it. These modules are recorded so the gap is visible and so a newly test-only module fails the check; the list is not a deletion list.",
   "does_not_establish": [
     "that an unproven module is dead",
     "that a reachable module is executed at runtime",
+    "that a test-only module has a production consumer",
     "completeness of dynamic loader discovery",
     "that evidence surfaces are themselves used"
   ]

--- a/docs/proofs/repoground-core-complexity-v1-proof.md
+++ b/docs/proofs/repoground-core-complexity-v1-proof.md
@@ -29,18 +29,20 @@ individually, without conflict, onto current RepoGround base
 The port was revalidated on the current tree rather than relying on the old
 proof summary:
 
-- focused maintainability, reachability and sidecar-integrity suite: 42 passed;
-- full repository pytest task `d6f4c47f862941d8b976df9b`: terminal success,
-  exit status 0, lifecycle receipt
-  `7aaab1cc89ebade1bf74d9ed91a26ff43dc56e24f841f245cea77329aa99fbe6`;
+- focused maintainability, reachability and sidecar-integrity suite: 44 passed;
+- full repository pytest task `5cb9d09f4af6413fbcd21be6`: terminal success,
+  4,748 passed and 2 skipped, exit status 0, lifecycle receipt
+  `48d67e772ccab492509282ec99f77eb145cd2ffdf06967cfc5e6eb09ccda1cf9`;
 - graph-maintainability gate: pass at 198 C901 findings, maximum 148 and
   excess mass 2533;
 - module-reachability gate: pass, 199 production modules measured, no
   unproven or documentation-only module and no findings;
 - review hardening: plain strings no longer count as dynamic imports,
   non-equality `__name__` comparisons no longer count as entry points,
-  script-style sibling imports require a direct-execution main guard, and
-  symbol/call-graph sidecars reject every non-canonical SHA-256 digest.
+  script-style sibling imports require a direct-execution main guard,
+  symbol/call-graph sidecars reject every non-canonical SHA-256 digest, and
+  sidecar paths require the canonical `.bundle.manifest.json` base suffix so a
+  malformed base cannot be overwritten by a secondary artifact.
 
 The historical before/after performance measurements below remain bound to
 their recorded commits. Conflict-free replay and current tests do not turn them

--- a/docs/proofs/repoground-core-complexity-v1-proof.md
+++ b/docs/proofs/repoground-core-complexity-v1-proof.md
@@ -29,14 +29,18 @@ individually, without conflict, onto current RepoGround base
 The port was revalidated on the current tree rather than relying on the old
 proof summary:
 
-- focused maintainability and reachability suite: 28 passed;
-- full repository pytest task `27464ea3412e4afdbc4a2294`: terminal success,
+- focused maintainability, reachability and sidecar-integrity suite: 42 passed;
+- full repository pytest task `d6f4c47f862941d8b976df9b`: terminal success,
   exit status 0, lifecycle receipt
-  `83c3452307f3b7f06efd634cf0192ef77f4988932d4db7d849d668bebeb537cf`;
+  `7aaab1cc89ebade1bf74d9ed91a26ff43dc56e24f841f245cea77329aa99fbe6`;
 - graph-maintainability gate: pass at 198 C901 findings, maximum 148 and
   excess mass 2533;
 - module-reachability gate: pass, 199 production modules measured, no
-  unproven or documentation-only module and no findings.
+  unproven or documentation-only module and no findings;
+- review hardening: plain strings no longer count as dynamic imports,
+  non-equality `__name__` comparisons no longer count as entry points,
+  script-style sibling imports require a direct-execution main guard, and
+  symbol/call-graph sidecars reject every non-canonical SHA-256 digest.
 
 The historical before/after performance measurements below remain bound to
 their recorded commits. Conflict-free replay and current tests do not turn them
@@ -150,45 +154,55 @@ complexity out of one function, not code out of the module.
 every production module and classifies it as `reachable` or `unproven`. It never
 classifies a module as dead.
 
-199 production modules, 0 unproven, 0 documentation-only, 8 test-only. The
-`allowed_unproven` and `allowed_documentation_only` lists are empty; the eight
-test-only modules are declared individually. No code was removed by this change.
+199 production modules, 0 unproven, 0 documentation-only, 6 test-only. The
+`allowed_unproven` and `allowed_documentation_only` lists are empty; the six
+test-only modules are declared individually. Two Pythonista sibling modules that
+were previously misclassified (`build_helpers` and `build_utils`) are now
+resolved from their real script-style product imports. No code was removed by
+this change.
 
 Evidence is separated into three classes, and the classes are what the policy
 acts on:
 
 | Class | Kinds | Observed |
 | --- | --- | --- |
-| production | `static_import_product` (170), `runtime_surface_reference` (50), `static_import_script` (20), `module_main_block` (14), `dynamic_string_reference` (12), `package_of_referenced_module` (4), `package_data_reference` (1) | required |
-| test | `static_import_test` (164), `dynamic_string_reference_test` (45), `package_of_test_referenced_module` (0) | must be declared if it is all a module has |
+| production | `static_import_product` (172), `runtime_surface_reference` (50), `static_import_script` (20), `module_main_block` (14), `dynamic_string_reference` (0), `package_of_referenced_module` (4), `package_data_reference` (1) | required |
+| test | `static_import_test` (164), `dynamic_string_reference_test` (0), `package_of_test_referenced_module` (0) | must be declared if it is all a module has |
 | documentation | `documented_invocation` (83) | never sufficient |
 
-Four false-PASS risks are handled explicitly:
+Six false-PASS risks are handled explicitly:
 
 - **Documentation is not runtime.** `config/` and `docs/` are excluded from the
   runtime corpus. A module path listed in a C901 baseline or in a recorded
-  measurement is not a consumer, and counting `config/` would have made 193 of 199
-  modules look runtime-reachable instead of 50. Documentation-only evidence is a
-  separate, weaker class that must be declared in the policy; nothing currently
-  relies on it. This document is itself part of the documentation corpus and
-  therefore contributes `documented_invocation` evidence to every module it
-  names — which is exactly why that class can never carry a module on its own.
+  measurement is not a consumer. Documentation-only evidence is a separate,
+  weaker class that must be declared in the policy; nothing currently relies on
+  it. This document is itself part of the documentation corpus and therefore
+  contributes `documented_invocation` evidence to every module it names — which
+  is exactly why that class can never carry a module on its own.
 - **Tests are not production.** Test and fixture sources feed their own evidence
-  class. A production module that only its own tests import, or that only a test
-  names in a dynamic import string, is reported as `test_only` and must be
-  declared in the policy; an undeclared one fails the check, and a stale
-  declaration fails it too. Splitting this class moved 45 dynamic-string credits
-  and 8 modules out of the production class. `test_only` is not `dead`: the
-  policy states that deletion needs positive evidence of non-use.
-- **Substrings are not references.** Corpus matching is token-exact, so `merger`
-  is not credited for a mention of `merger.repoground.core`, and
-  `merger.repoground.lonely` is not credited for `merger.repoground.lonely_extra`
-  or for `merger/repoground/lonely.py.bak`. Dynamic string matching stops at a
-  dot, so `pkg.mod.attr` credits `pkg.mod` but `pkg.mod_extra` does not.
-- **Unreadable source is a failure, not an absence.** An unreadable or unparsable
-  *product or script* source is a finding, because it could hide a module or its
-  imports. Deliberately invalid test fixtures only under-claim evidence, which
-  stays on the strict side, and are recorded separately.
+  class. A production module that only its own tests import is reported as
+  `test_only` and must be declared in the policy; an undeclared one fails the
+  check, and a stale declaration fails it too. Six modules remain in that
+  class. `test_only` is not `dead`: deletion needs positive evidence of non-use.
+- **Strings are not loaders.** Plain strings and docstrings in product or test
+  code do not establish dynamic reachability. Only literal arguments passed to
+  a bound `importlib.import_module` or `__import__` call can emit dynamic-import
+  evidence. Strings that name existing packaged data files form a separate
+  `package_data_reference` class and can establish only their containing
+  package, not an arbitrary module.
+- **A comparison is not automatically an entry point.** Only the exact equality
+  guard `__name__ == "__main__"` (in either operand order) emits
+  `module_main_block`; inequalities and other comparisons do not.
+- **Script-style local imports are qualified only against real modules.** This
+  captures the Pythonista sibling imports without guessing from names. A
+  `from package import symbol` statement credits `package.symbol` only when
+  that exact production module exists, so functions and classes cannot
+  masquerade as submodules.
+- **Substrings are not references, and unreadable source is not absence.**
+  Corpus matching is token-exact, so longer names and backup paths do not credit
+  a module. An unreadable or unparsable product or script source is a finding;
+  deliberately invalid test fixtures are recorded separately and only
+  under-claim evidence.
 
 The policy itself is validated before it is used: a wrong `kind`/`version` or a
 missing, empty or non-string `package_roots` is a finding, so a malformed policy
@@ -278,6 +292,6 @@ Bureau follow-up tasks; they are deliberately not claimed here:
 3. `merge.py` itself did not shrink: the extracted report writers still call
    `merge` module functions, so moving them into their own module would create an
    import cycle. Breaking that cycle is a separate slice.
-4. The eight declared test-only modules are a recorded gap, not a resolved one.
+4. The six declared test-only modules are a recorded gap, not a resolved one.
    Each needs its own decision — production consumer, retirement with evidence of
    non-use, or an accepted test-support role.

--- a/docs/proofs/repoground-core-complexity-v1-proof.md
+++ b/docs/proofs/repoground-core-complexity-v1-proof.md
@@ -16,6 +16,33 @@ T004** — see "Open T004 acceptance gaps".
   - `docs/proofs/repoground-core-complexity-v1.after.measurement.json` (commit `b3fbeb92`, clean worktree)
   - `docs/proofs/repoground-core-complexity-v1.reachability.measurement.json`
 
+## Current-main port verification
+
+The five-commit slice was originally prepared on branch
+`refactor/legacy-reconciliation-t004-core-complexity-v1` at
+`f8dbf49f4ccbea3cce2886888f06ace96aa8dcd5`. That historical checkout was
+read only and was not taken over, reset or modified. Its commits were replayed
+individually, without conflict, onto current RepoGround base
+`dc67fdcf668942fdf4b5baef4989ce6e1e952c21` in the isolated branch
+`refactor/legacy-reconciliation-t004-core-complexity-v2`.
+
+The port was revalidated on the current tree rather than relying on the old
+proof summary:
+
+- focused maintainability and reachability suite: 28 passed;
+- full repository pytest task `27464ea3412e4afdbc4a2294`: terminal success,
+  exit status 0, lifecycle receipt
+  `83c3452307f3b7f06efd634cf0192ef77f4988932d4db7d849d668bebeb537cf`;
+- graph-maintainability gate: pass at 198 C901 findings, maximum 148 and
+  excess mass 2533;
+- module-reachability gate: pass, 199 production modules measured, no
+  unproven or documentation-only module and no findings.
+
+The historical before/after performance measurements below remain bound to
+their recorded commits. Conflict-free replay and current tests do not turn them
+into measurements of the later base. The reviewed pull-request head and its
+complete diff SHA-256 are recorded separately at delivery time.
+
 ## Task re-audit
 
 The task was registered on 2026-07-17 against a much older tree. Three of its

--- a/docs/proofs/repoground-core-complexity-v1-proof.md
+++ b/docs/proofs/repoground-core-complexity-v1-proof.md
@@ -1,0 +1,256 @@
+# RepoGround Core Complexity and Module Reachability v1 — Proof
+
+Slice of `REPOGROUND-LEGACY-RECONCILIATION-V1-T004`. **This slice does not close
+T004** — see "Open T004 acceptance gaps".
+
+## Binding
+
+- Base commit: `5188d2faf335aaaefe4d27122df71d770647cb5b`
+- Complexity policy: `config/repoground-graph-maintainability.v1.json`
+- C901 baseline: `config/repoground-c901-baseline.v1.json`
+- Reachability policy: `config/repoground-module-reachability.v1.json`
+- Gates: `scripts/ci/check_graph_maintainability.py`, `scripts/ci/check_module_reachability.py`
+- Benchmark: `scripts/benchmarks/repoground_core_paths.py`
+- Bound measurements:
+  - `docs/proofs/repoground-core-complexity-v1.before.measurement.json` (commit `bf43b2ed`, clean worktree)
+  - `docs/proofs/repoground-core-complexity-v1.after.measurement.json` (commit `b3fbeb92`, clean worktree)
+  - `docs/proofs/repoground-core-complexity-v1.reachability.measurement.json`
+
+## Task re-audit
+
+The task was registered on 2026-07-17 against a much older tree. Three of its
+premises no longer hold as written:
+
+- The historical target `repobrief_access.py` is today `merger/repoground/core/bundle_access.py`.
+- `REPOGROUND-LEGACY-RECONCILIATION-V1-T003` already decided the product boundary
+  (`docs/architecture/product-boundaries.md`): Atlas stays as an explicitly bounded
+  optional observation subsystem, OmniWandler and the standalone Repomerger were
+  removed from the active tree. No further removal is proposed here.
+- A C901 ratchet already existed, but it only blocked *new or worse* identities.
+  Total complexity could therefore stay flat forever, which is what the T004
+  acceptance criterion about a real, budgeted decrease is aimed at.
+
+## Established
+
+### Complexity fell, measured with the repository's own Ruff configuration
+
+`ruff check --config ruff-ci.toml --select C901 --output-format json .`
+
+| Dimension | T004 reference (recorded 2026-07-17) | Slice start `5188d2fa` (measured) | Now (measured) |
+| --- | --- | --- | --- |
+| Findings | 213 | 200 | 198 |
+| Single-function maximum | 170 | 170 | 148 |
+| Excess mass above threshold | not recorded | 2654 | 2533 |
+
+The 213/170 figures are the values the task recorded in July; they are quoted,
+not re-measured. The slice-start column was re-measured for this proof from a
+clean export of `5188d2fa`, and is the reference the budget is bound to.
+
+The C901 baseline file at `5188d2fa` listed 203 identities, three more than that
+commit's scan actually produced: earlier merges had resolved findings without
+re-recording the file. The ratchet permits that direction, which is why the
+baseline count alone was never a measure of complexity.
+
+The maximum moved because `merge.write_reports_v2` fell from 170 to 73 and its
+two nested hotspots — `process_and_write` (27) and `generate_chunk_artifacts` (17)
+— fell below the threshold entirely and left the baseline.
+
+No `# noqa: C901`, no threshold change, no new exclude and no reclassification
+was used: `ruff-ci.toml` is byte-identical to `5188d2fa` (it selects `F401`,
+`F811` and, for this scan, `C901` on the command line, and its only exclusion,
+`**/fixtures/**`, predates the slice).
+
+### The decrease is now budgeted, not merely recorded
+
+`config/repoground-graph-maintainability.v1.json` gains `complexity.budget` with
+three ceilings that the *current* scan must satisfy: finding count (198),
+single-function maximum (148) and excess mass (2533).
+
+The budget is fail-closed:
+
+- A missing or malformed budget is itself a finding, so deleting the budget
+  cannot disable the ratchet.
+- Every ceiling must be bounded by at least one recorded reference scan, and a
+  dimension no reference bounds is a finding. Without that rule the excess-mass
+  ceiling — the one dimension the July reference never recorded — could have been
+  raised without limit.
+- Two references are recorded: the historical T004 scan (213 findings / maximum
+  170) and the slice-start scan of `5188d2fa` (200 / 170 / 2654 excess). A
+  ceiling above either is rejected, so the slice must beat where it actually
+  started, not only the older and laxer figure.
+- Excess mass is budgeted alongside the count because splitting one hotspot
+  legitimately raises the finding count while lowering real complexity; a budget
+  on count alone would penalise the correct refactor.
+
+The C901 baseline was re-recorded from the current scan (198 identities, maximum
+148, five identities tightened, none new). That re-recording is a consequence of
+the measured reduction, not a substitute for it: a rewritten baseline still has
+to satisfy the three budget ceilings, and those cannot be raised.
+
+### Monolith decomposition
+
+`merge.write_reports_v2` carried its whole artifact pipeline in nested closures.
+It is split along responsibilities:
+
+- `merger/repoground/core/artifact_io.py` — atomic writes, file hashing,
+  deterministic JSON coercion. Dependency-free leaf.
+- `merger/repoground/core/bundle_sidecars.py` — symbol index, call graph,
+  lens/concept/relation cards, PR delta artifacts. Each writer takes the manifest
+  path and its data and returns a path or `None`. It imports `artifact_io` and the
+  card producers, never `merge`, so no import cycle exists.
+- `merger/repoground/core/merge.py` — module-level dump-index, chunk-record,
+  split-part and single-file report writers driven by an explicit
+  `_ReportRunConfig` instead of closures.
+
+Behaviour equivalence was checked directly, not only by the test suite: the same
+deterministic fixture repository was bundled from a clean export of `096ab21b^`
+(pre-refactor) and of `b3fbeb92`, and the produced artifact trees were compared
+file by file — twice, once in `dual` mode without splitting, and once with
+`split_size=40000` and `redact_secrets=True` so that the extracted split-part and
+single-file writers are both exercised (the split run produces seven parts). In
+both runs the artifact set, every path, the manifest, the dump index and all 81
+chunk records are identical; the only differences are the wall-clock generation
+timestamp and the citation identifiers derived from the canonical hash it changes.
+A control run of the *same* export against itself produces exactly the same class
+of difference, so it is run-to-run noise, not a refactor effect.
+
+`merge.py` did not shrink (7 093 → 7 138 lines); the decomposition moved
+complexity out of one function, not code out of the module.
+
+### Reachability evidence
+
+`scripts/ci/check_module_reachability.py` collects positive evidence of use for
+every production module and classifies it as `reachable` or `unproven`. It never
+classifies a module as dead.
+
+199 production modules, 0 unproven, 0 documentation-only, 8 test-only. The
+`allowed_unproven` and `allowed_documentation_only` lists are empty; the eight
+test-only modules are declared individually. No code was removed by this change.
+
+Evidence is separated into three classes, and the classes are what the policy
+acts on:
+
+| Class | Kinds | Observed |
+| --- | --- | --- |
+| production | `static_import_product` (170), `runtime_surface_reference` (50), `static_import_script` (20), `module_main_block` (14), `dynamic_string_reference` (12), `package_of_referenced_module` (4), `package_data_reference` (1) | required |
+| test | `static_import_test` (164), `dynamic_string_reference_test` (45), `package_of_test_referenced_module` (0) | must be declared if it is all a module has |
+| documentation | `documented_invocation` (83) | never sufficient |
+
+Four false-PASS risks are handled explicitly:
+
+- **Documentation is not runtime.** `config/` and `docs/` are excluded from the
+  runtime corpus. A module path listed in a C901 baseline or in a recorded
+  measurement is not a consumer, and counting `config/` would have made 193 of 199
+  modules look runtime-reachable instead of 50. Documentation-only evidence is a
+  separate, weaker class that must be declared in the policy; nothing currently
+  relies on it. This document is itself part of the documentation corpus and
+  therefore contributes `documented_invocation` evidence to every module it
+  names — which is exactly why that class can never carry a module on its own.
+- **Tests are not production.** Test and fixture sources feed their own evidence
+  class. A production module that only its own tests import, or that only a test
+  names in a dynamic import string, is reported as `test_only` and must be
+  declared in the policy; an undeclared one fails the check, and a stale
+  declaration fails it too. Splitting this class moved 45 dynamic-string credits
+  and 8 modules out of the production class. `test_only` is not `dead`: the
+  policy states that deletion needs positive evidence of non-use.
+- **Substrings are not references.** Corpus matching is token-exact, so `merger`
+  is not credited for a mention of `merger.repoground.core`, and
+  `merger.repoground.lonely` is not credited for `merger.repoground.lonely_extra`
+  or for `merger/repoground/lonely.py.bak`. Dynamic string matching stops at a
+  dot, so `pkg.mod.attr` credits `pkg.mod` but `pkg.mod_extra` does not.
+- **Unreadable source is a failure, not an absence.** An unreadable or unparsable
+  *product or script* source is a finding, because it could hide a module or its
+  imports. Deliberately invalid test fixtures only under-claim evidence, which
+  stays on the strict side, and are recorded separately.
+
+The policy itself is validated before it is used: a wrong `kind`/`version` or a
+missing, empty or non-string `package_roots` is a finding, so a malformed policy
+cannot fall back to defaults and report a pass over the wrong tree.
+
+### Runtime and memory
+
+`scripts/benchmarks/repoground_core_paths.py` drives the real production entry
+points over a deterministic synthetic repository: bundle write (archive and dual),
+retrieval index build, retrieval query, cold service-application import and the
+optional Atlas scan. Wall time is the minimum of seven samples. For the in-process
+cases, peak allocation is measured with `tracemalloc` in one separate run so
+tracing overhead never contaminates the timing samples;
+`service_app_import` is the exception — it runs in a subprocess and reports
+allocation from the timed runs themselves, which the measurement records as
+`peak_traced_measured_separately: false`. Its wall time therefore carries
+tracing overhead in both the before and the after measurement.
+
+Same host, same Python (3.10.12), same benchmark script digest, same fixture,
+seven samples, clean worktrees, before `bf43b2ed` → after `b3fbeb92`:
+
+| Case | Wall before (s) | Wall after (s) | Δ | Peak before (B) | Peak after (B) | Δ |
+| --- | --- | --- | --- | --- | --- | --- |
+| `bundle_write_archive` | 0.124117 | 0.126338 | +1.8% | 1 989 130 | 1 984 296 | −0.2% |
+| `bundle_write_dual` | 0.300833 | 0.301638 | +0.3% | 3 943 328 | 3 937 435 | −0.1% |
+| `retrieval_index_build` | 0.017941 | 0.017642 | −1.7% | 399 111 | 399 111 | 0.0% |
+| `retrieval_query` | 0.000586 | 0.000584 | −0.3% | 57 264 | 57 264 | 0.0% |
+| `service_app_import` | 1.102161 | 1.098461 | −0.3% | 24 228 716 | 24 278 421 | +0.2% |
+| `atlas_scan` (optional) | 0.004829 | 0.004897 | +1.4% | 80 024 | 80 024 | 0.0% |
+
+`bf43b2ed` is the commit before the decomposition and `b3fbeb92` the commit after
+it, so the pair brackets the refactor. The closing commit of this slice is not
+re-measured: it changes only gate code (`module_reachability.py`, the two check
+scripts, the two policies and their tests), none of which is imported by any
+measured path.
+
+Every delta is within ±2% and both signs occur, so the refactor is
+performance-neutral within this host's noise. Atlas is optional and is measured
+only when `--include-atlas` is passed; its absence is recorded as a skip, never as
+a failure.
+
+No timing gate is applied. Absolute wall time is not reproducible across hosts, so
+the script records evidence and leaves comparison to a same-host before/after pair.
+
+## Verification commands
+
+```text
+python3 -m pytest -q
+python3 -m pytest -q merger/repoground/tests/test_graph_maintainability.py merger/repoground/tests/test_module_reachability.py
+python3 scripts/ci/check_graph_maintainability.py --root . --format json
+python3 scripts/ci/check_module_reachability.py --root . --format json
+ruff check --config ruff-ci.toml .
+ruff check --config ruff-ci.toml --select C901 --output-format json .
+python3 scripts/benchmarks/repoground_core_paths.py --samples 7 --include-atlas
+python3 tools/parity_guard.py
+git diff --check
+```
+
+## Does not establish
+
+- that the remaining C901 debt is acceptable;
+- that `merge.iter_report_blocks` (148),
+  `scripts/proofs/guard_relation_validates_schema_audit.py::analyze` (138),
+  `snapshot_preflight.consumption_preflight` (116) or `atlas.AtlasScanner.scan`
+  (114) are maintainable — they are untouched;
+- that the July 2026 reference figures (213 / 170) are reproducible; they are
+  quoted from the task record, not re-measured;
+- that any module is dead, or that a reachable module is executed at runtime;
+- that a test-only module has a production consumer;
+- completeness of dynamic loader discovery;
+- cross-host comparability of the recorded timings;
+- memory use outside the Python allocator;
+- absence of regressions on paths the benchmark or the differential bundle
+  comparison does not drive.
+
+## Open T004 acceptance gaps
+
+This slice does not close T004. The following remain open and need their own
+Bureau follow-up tasks; they are deliberately not claimed here:
+
+1. `merge.iter_report_blocks` (148) is now the repository maximum and is untouched.
+   It is a 1 000-line generator over shared local state; splitting it needs its own
+   slice with block-level golden output tests.
+2. `merger/repoground/frontends/pythonista/build.py` (4 029 lines),
+   `merger/repoground/core/bundle_access.py` (3 209 lines) and
+   `merger/repoground/service/app.py` (2 394 lines) are not decomposed.
+3. `merge.py` itself did not shrink: the extracted report writers still call
+   `merge` module functions, so moving them into their own module would create an
+   import cycle. Breaking that cycle is a separate slice.
+4. The eight declared test-only modules are a recorded gap, not a resolved one.
+   Each needs its own decision — production consumer, retirement with evidence of
+   non-use, or an accepted test-support role.

--- a/docs/proofs/repoground-core-complexity-v1.after.measurement.json
+++ b/docs/proofs/repoground-core-complexity-v1.after.measurement.json
@@ -1,0 +1,82 @@
+{
+  "binding": {
+    "benchmark_script_sha256": "89f221b81659f81427dab62539e8487579e82aa1c399641bfb7b00e77b8ded72",
+    "commit": "b3fbeb923d10a602eb39f06da88a425da30aae03",
+    "worktree_dirty": false
+  },
+  "cases": {
+    "atlas_scan": {
+      "optional_subsystem": true,
+      "peak_traced_bytes": 80024,
+      "peak_traced_measured_separately": true,
+      "samples": 7,
+      "wall_seconds_max": 0.005432,
+      "wall_seconds_median": 0.004974,
+      "wall_seconds_min": 0.004897
+    },
+    "bundle_write_archive": {
+      "peak_traced_bytes": 1984296,
+      "peak_traced_measured_separately": true,
+      "samples": 7,
+      "wall_seconds_max": 0.138455,
+      "wall_seconds_median": 0.129957,
+      "wall_seconds_min": 0.126338
+    },
+    "bundle_write_dual": {
+      "peak_traced_bytes": 3937435,
+      "peak_traced_measured_separately": true,
+      "samples": 7,
+      "wall_seconds_max": 0.311005,
+      "wall_seconds_median": 0.304114,
+      "wall_seconds_min": 0.301638
+    },
+    "retrieval_index_build": {
+      "peak_traced_bytes": 399111,
+      "peak_traced_measured_separately": true,
+      "samples": 7,
+      "wall_seconds_max": 0.01869,
+      "wall_seconds_median": 0.017845,
+      "wall_seconds_min": 0.017642
+    },
+    "retrieval_query": {
+      "peak_traced_bytes": 57264,
+      "peak_traced_measured_separately": true,
+      "samples": 7,
+      "wall_seconds_max": 0.001049,
+      "wall_seconds_median": 0.00062,
+      "wall_seconds_min": 0.000584
+    },
+    "service_app_import": {
+      "isolation": "subprocess",
+      "peak_traced_bytes": 24278421,
+      "peak_traced_measured_separately": false,
+      "samples": 7,
+      "wall_seconds_max": 1.142839,
+      "wall_seconds_median": 1.108081,
+      "wall_seconds_min": 1.098461
+    }
+  },
+  "configuration": {
+    "fixture_functions_per_file": 12,
+    "fixture_markdown_files": 20,
+    "fixture_python_files": 60,
+    "reported_statistic": "wall_seconds_min is the comparison figure",
+    "samples": 7,
+    "timing_gate": "none"
+  },
+  "does_not_establish": [
+    "cross-host comparability of absolute timings",
+    "absence of regressions on unmeasured paths",
+    "production workload representativeness",
+    "memory use outside the Python allocator"
+  ],
+  "environment": {
+    "platform": "Linux-7.0.11-76070011-generic-x86_64-with-glibc2.35",
+    "processor": "x86_64",
+    "python": "3.10.12"
+  },
+  "failures": [],
+  "kind": "repoground.core_path_benchmark",
+  "status": "pass",
+  "version": "1.0"
+}

--- a/docs/proofs/repoground-core-complexity-v1.before.measurement.json
+++ b/docs/proofs/repoground-core-complexity-v1.before.measurement.json
@@ -1,0 +1,82 @@
+{
+  "binding": {
+    "benchmark_script_sha256": "89f221b81659f81427dab62539e8487579e82aa1c399641bfb7b00e77b8ded72",
+    "commit": "bf43b2edab9a723703da83bc1b34a0bd9032450f",
+    "worktree_dirty": false
+  },
+  "cases": {
+    "atlas_scan": {
+      "optional_subsystem": true,
+      "peak_traced_bytes": 80024,
+      "peak_traced_measured_separately": true,
+      "samples": 7,
+      "wall_seconds_max": 0.005492,
+      "wall_seconds_median": 0.004891,
+      "wall_seconds_min": 0.004829
+    },
+    "bundle_write_archive": {
+      "peak_traced_bytes": 1989130,
+      "peak_traced_measured_separately": true,
+      "samples": 7,
+      "wall_seconds_max": 0.139336,
+      "wall_seconds_median": 0.126368,
+      "wall_seconds_min": 0.124117
+    },
+    "bundle_write_dual": {
+      "peak_traced_bytes": 3943328,
+      "peak_traced_measured_separately": true,
+      "samples": 7,
+      "wall_seconds_max": 0.309299,
+      "wall_seconds_median": 0.305684,
+      "wall_seconds_min": 0.300833
+    },
+    "retrieval_index_build": {
+      "peak_traced_bytes": 399111,
+      "peak_traced_measured_separately": true,
+      "samples": 7,
+      "wall_seconds_max": 0.018609,
+      "wall_seconds_median": 0.018372,
+      "wall_seconds_min": 0.017941
+    },
+    "retrieval_query": {
+      "peak_traced_bytes": 57264,
+      "peak_traced_measured_separately": true,
+      "samples": 7,
+      "wall_seconds_max": 0.000709,
+      "wall_seconds_median": 0.000604,
+      "wall_seconds_min": 0.000586
+    },
+    "service_app_import": {
+      "isolation": "subprocess",
+      "peak_traced_bytes": 24228716,
+      "peak_traced_measured_separately": false,
+      "samples": 7,
+      "wall_seconds_max": 1.135862,
+      "wall_seconds_median": 1.117364,
+      "wall_seconds_min": 1.102161
+    }
+  },
+  "configuration": {
+    "fixture_functions_per_file": 12,
+    "fixture_markdown_files": 20,
+    "fixture_python_files": 60,
+    "reported_statistic": "wall_seconds_min is the comparison figure",
+    "samples": 7,
+    "timing_gate": "none"
+  },
+  "does_not_establish": [
+    "cross-host comparability of absolute timings",
+    "absence of regressions on unmeasured paths",
+    "production workload representativeness",
+    "memory use outside the Python allocator"
+  ],
+  "environment": {
+    "platform": "Linux-7.0.11-76070011-generic-x86_64-with-glibc2.35",
+    "processor": "x86_64",
+    "python": "3.10.12"
+  },
+  "failures": [],
+  "kind": "repoground.core_path_benchmark",
+  "status": "pass",
+  "version": "1.0"
+}

--- a/docs/proofs/repoground-core-complexity-v1.reachability.measurement.json
+++ b/docs/proofs/repoground-core-complexity-v1.reachability.measurement.json
@@ -24,7 +24,6 @@
         "evidence": [
           "static_import_product",
           "static_import_test",
-          "dynamic_string_reference",
           "runtime_surface_reference",
           "documented_invocation"
         ],
@@ -38,7 +37,6 @@
         "evidence": [
           "static_import_product",
           "module_main_block",
-          "dynamic_string_reference_test",
           "runtime_surface_reference"
         ],
         "has_non_documentation_evidence": true,
@@ -50,8 +48,7 @@
       {
         "evidence": [
           "static_import_product",
-          "static_import_test",
-          "dynamic_string_reference_test"
+          "static_import_test"
         ],
         "has_non_documentation_evidence": true,
         "has_production_evidence": true,
@@ -63,8 +60,7 @@
         "evidence": [
           "static_import_product",
           "static_import_test",
-          "static_import_script",
-          "dynamic_string_reference_test"
+          "static_import_script"
         ],
         "has_non_documentation_evidence": true,
         "has_production_evidence": true,
@@ -74,8 +70,7 @@
       },
       {
         "evidence": [
-          "static_import_product",
-          "dynamic_string_reference_test"
+          "static_import_product"
         ],
         "has_non_documentation_evidence": true,
         "has_production_evidence": true,
@@ -87,7 +82,6 @@
         "evidence": [
           "static_import_product",
           "static_import_test",
-          "dynamic_string_reference_test",
           "documented_invocation"
         ],
         "has_non_documentation_evidence": true,
@@ -99,8 +93,7 @@
       {
         "evidence": [
           "static_import_product",
-          "static_import_test",
-          "dynamic_string_reference_test"
+          "static_import_test"
         ],
         "has_non_documentation_evidence": true,
         "has_production_evidence": true,
@@ -112,7 +105,6 @@
         "evidence": [
           "static_import_product",
           "static_import_test",
-          "dynamic_string_reference_test",
           "documented_invocation"
         ],
         "has_non_documentation_evidence": true,
@@ -123,8 +115,7 @@
       },
       {
         "evidence": [
-          "static_import_product",
-          "dynamic_string_reference_test"
+          "static_import_product"
         ],
         "has_non_documentation_evidence": true,
         "has_production_evidence": true,
@@ -136,7 +127,6 @@
         "evidence": [
           "static_import_product",
           "static_import_test",
-          "dynamic_string_reference_test",
           "runtime_surface_reference"
         ],
         "has_non_documentation_evidence": true,
@@ -185,7 +175,6 @@
         "evidence": [
           "static_import_product",
           "static_import_test",
-          "dynamic_string_reference_test",
           "runtime_surface_reference"
         ],
         "has_non_documentation_evidence": true,
@@ -198,7 +187,6 @@
         "evidence": [
           "static_import_product",
           "static_import_test",
-          "dynamic_string_reference_test",
           "runtime_surface_reference",
           "documented_invocation"
         ],
@@ -234,7 +222,6 @@
         "evidence": [
           "static_import_product",
           "static_import_test",
-          "dynamic_string_reference_test",
           "runtime_surface_reference"
         ],
         "has_non_documentation_evidence": true,
@@ -247,7 +234,6 @@
         "evidence": [
           "static_import_product",
           "static_import_test",
-          "dynamic_string_reference_test",
           "runtime_surface_reference"
         ],
         "has_non_documentation_evidence": true,
@@ -383,7 +369,6 @@
         "evidence": [
           "static_import_product",
           "static_import_test",
-          "dynamic_string_reference_test",
           "runtime_surface_reference",
           "documented_invocation"
         ],
@@ -461,7 +446,6 @@
         "evidence": [
           "static_import_product",
           "static_import_test",
-          "dynamic_string_reference_test",
           "runtime_surface_reference"
         ],
         "has_non_documentation_evidence": true,
@@ -484,7 +468,6 @@
         "evidence": [
           "static_import_product",
           "static_import_test",
-          "dynamic_string_reference_test",
           "runtime_surface_reference",
           "documented_invocation"
         ],
@@ -551,8 +534,7 @@
       {
         "evidence": [
           "static_import_product",
-          "static_import_test",
-          "dynamic_string_reference_test"
+          "static_import_test"
         ],
         "has_non_documentation_evidence": true,
         "has_production_evidence": true,
@@ -607,7 +589,6 @@
         "evidence": [
           "static_import_product",
           "static_import_test",
-          "dynamic_string_reference_test",
           "runtime_surface_reference"
         ],
         "has_non_documentation_evidence": true,
@@ -630,8 +611,7 @@
       {
         "evidence": [
           "static_import_product",
-          "static_import_test",
-          "dynamic_string_reference_test"
+          "static_import_test"
         ],
         "has_non_documentation_evidence": true,
         "has_production_evidence": true,
@@ -689,7 +669,6 @@
           "static_import_product",
           "static_import_test",
           "module_main_block",
-          "dynamic_string_reference_test",
           "runtime_surface_reference"
         ],
         "has_non_documentation_evidence": true,
@@ -703,7 +682,6 @@
           "static_import_product",
           "static_import_test",
           "module_main_block",
-          "dynamic_string_reference_test",
           "runtime_surface_reference",
           "documented_invocation"
         ],
@@ -719,7 +697,6 @@
           "static_import_test",
           "static_import_script",
           "module_main_block",
-          "dynamic_string_reference_test",
           "documented_invocation"
         ],
         "has_non_documentation_evidence": true,
@@ -753,8 +730,7 @@
         "evidence": [
           "static_import_product",
           "static_import_test",
-          "module_main_block",
-          "dynamic_string_reference_test"
+          "module_main_block"
         ],
         "has_non_documentation_evidence": true,
         "has_production_evidence": true,
@@ -767,7 +743,6 @@
           "static_import_product",
           "static_import_test",
           "module_main_block",
-          "dynamic_string_reference_test",
           "documented_invocation"
         ],
         "has_non_documentation_evidence": true,
@@ -801,9 +776,7 @@
         "evidence": [
           "static_import_product",
           "static_import_test",
-          "static_import_script",
-          "dynamic_string_reference",
-          "documented_invocation"
+          "static_import_script"
         ],
         "has_non_documentation_evidence": true,
         "has_production_evidence": true,
@@ -921,8 +894,7 @@
       {
         "evidence": [
           "static_import_product",
-          "static_import_test",
-          "dynamic_string_reference_test"
+          "static_import_test"
         ],
         "has_non_documentation_evidence": true,
         "has_production_evidence": true,
@@ -1029,6 +1001,7 @@
       {
         "evidence": [
           "static_import_product",
+          "static_import_test",
           "documented_invocation"
         ],
         "has_non_documentation_evidence": true,
@@ -1099,7 +1072,6 @@
         "evidence": [
           "static_import_product",
           "static_import_test",
-          "dynamic_string_reference_test",
           "runtime_surface_reference"
         ],
         "has_non_documentation_evidence": true,
@@ -1123,6 +1095,7 @@
       {
         "evidence": [
           "static_import_product",
+          "static_import_test",
           "documented_invocation"
         ],
         "has_non_documentation_evidence": true,
@@ -1135,7 +1108,6 @@
         "evidence": [
           "static_import_product",
           "static_import_test",
-          "dynamic_string_reference",
           "runtime_surface_reference",
           "documented_invocation"
         ],
@@ -1184,7 +1156,6 @@
           "static_import_product",
           "static_import_test",
           "static_import_script",
-          "dynamic_string_reference_test",
           "documented_invocation"
         ],
         "has_non_documentation_evidence": true,
@@ -1209,7 +1180,6 @@
         "evidence": [
           "static_import_product",
           "static_import_test",
-          "dynamic_string_reference",
           "runtime_surface_reference",
           "documented_invocation"
         ],
@@ -1223,7 +1193,6 @@
         "evidence": [
           "static_import_product",
           "static_import_test",
-          "dynamic_string_reference",
           "runtime_surface_reference",
           "documented_invocation"
         ],
@@ -1486,7 +1455,6 @@
       {
         "evidence": [
           "static_import_test",
-          "dynamic_string_reference_test",
           "runtime_surface_reference",
           "documented_invocation"
         ],
@@ -1500,7 +1468,6 @@
         "evidence": [
           "static_import_product",
           "static_import_test",
-          "dynamic_string_reference_test",
           "runtime_surface_reference",
           "documented_invocation"
         ],
@@ -1514,7 +1481,6 @@
         "evidence": [
           "static_import_product",
           "static_import_test",
-          "dynamic_string_reference",
           "runtime_surface_reference",
           "documented_invocation"
         ],
@@ -1528,7 +1494,6 @@
         "evidence": [
           "static_import_product",
           "static_import_test",
-          "dynamic_string_reference_test",
           "runtime_surface_reference",
           "documented_invocation"
         ],
@@ -1553,7 +1518,6 @@
         "evidence": [
           "static_import_product",
           "static_import_test",
-          "dynamic_string_reference_test",
           "documented_invocation"
         ],
         "has_non_documentation_evidence": true,
@@ -1567,7 +1531,6 @@
           "static_import_product",
           "static_import_test",
           "static_import_script",
-          "dynamic_string_reference_test",
           "documented_invocation"
         ],
         "has_non_documentation_evidence": true,
@@ -1591,7 +1554,6 @@
           "static_import_product",
           "static_import_test",
           "static_import_script",
-          "dynamic_string_reference",
           "runtime_surface_reference",
           "documented_invocation"
         ],
@@ -1604,7 +1566,6 @@
       {
         "evidence": [
           "static_import_test",
-          "dynamic_string_reference",
           "runtime_surface_reference"
         ],
         "has_non_documentation_evidence": true,
@@ -1617,7 +1578,6 @@
         "evidence": [
           "static_import_product",
           "static_import_test",
-          "dynamic_string_reference_test",
           "documented_invocation"
         ],
         "has_non_documentation_evidence": true,
@@ -1740,7 +1700,6 @@
         "evidence": [
           "static_import_product",
           "static_import_test",
-          "dynamic_string_reference",
           "documented_invocation"
         ],
         "has_non_documentation_evidence": true,
@@ -1801,7 +1760,6 @@
         "evidence": [
           "static_import_product",
           "static_import_test",
-          "dynamic_string_reference",
           "documented_invocation"
         ],
         "has_non_documentation_evidence": true,
@@ -1946,7 +1904,6 @@
           "static_import_product",
           "static_import_test",
           "module_main_block",
-          "dynamic_string_reference",
           "runtime_surface_reference",
           "documented_invocation"
         ],
@@ -1958,20 +1915,22 @@
       },
       {
         "evidence": [
+          "static_import_product",
           "static_import_test"
         ],
         "has_non_documentation_evidence": true,
-        "has_production_evidence": false,
+        "has_production_evidence": true,
         "module": "merger.repoground.frontends.pythonista.build_helpers",
         "path": "merger/repoground/frontends/pythonista/build_helpers.py",
         "status": "reachable"
       },
       {
         "evidence": [
+          "static_import_product",
           "static_import_test"
         ],
         "has_non_documentation_evidence": true,
-        "has_production_evidence": false,
+        "has_production_evidence": true,
         "module": "merger.repoground.frontends.pythonista.build_utils",
         "path": "merger/repoground/frontends/pythonista/build_utils.py",
         "status": "reachable"
@@ -2003,8 +1962,7 @@
         "evidence": [
           "static_import_product",
           "static_import_test",
-          "static_import_script",
-          "dynamic_string_reference_test"
+          "static_import_script"
         ],
         "has_non_documentation_evidence": true,
         "has_production_evidence": true,
@@ -2096,7 +2054,6 @@
           "static_import_product",
           "static_import_test",
           "static_import_script",
-          "dynamic_string_reference_test",
           "documented_invocation"
         ],
         "has_non_documentation_evidence": true,
@@ -2121,7 +2078,6 @@
           "static_import_product",
           "static_import_test",
           "static_import_script",
-          "dynamic_string_reference_test",
           "runtime_surface_reference",
           "documented_invocation"
         ],
@@ -2158,7 +2114,6 @@
           "static_import_product",
           "static_import_test",
           "static_import_script",
-          "dynamic_string_reference_test",
           "documented_invocation"
         ],
         "has_non_documentation_evidence": true,
@@ -2217,7 +2172,6 @@
         "evidence": [
           "static_import_product",
           "static_import_test",
-          "dynamic_string_reference_test",
           "documented_invocation"
         ],
         "has_non_documentation_evidence": true,
@@ -2229,8 +2183,7 @@
       {
         "evidence": [
           "static_import_test",
-          "package_of_referenced_module",
-          "dynamic_string_reference_test"
+          "package_of_referenced_module"
         ],
         "has_non_documentation_evidence": true,
         "has_production_evidence": true,
@@ -2253,7 +2206,6 @@
         "evidence": [
           "static_import_product",
           "static_import_test",
-          "dynamic_string_reference_test",
           "runtime_surface_reference",
           "documented_invocation"
         ],
@@ -2267,7 +2219,6 @@
         "evidence": [
           "static_import_product",
           "static_import_test",
-          "dynamic_string_reference_test",
           "documented_invocation"
         ],
         "has_non_documentation_evidence": true,
@@ -2279,8 +2230,7 @@
       {
         "evidence": [
           "static_import_product",
-          "static_import_test",
-          "dynamic_string_reference_test"
+          "static_import_test"
         ],
         "has_non_documentation_evidence": true,
         "has_production_evidence": true,
@@ -2291,8 +2241,7 @@
       {
         "evidence": [
           "static_import_product",
-          "static_import_test",
-          "dynamic_string_reference_test"
+          "static_import_test"
         ],
         "has_non_documentation_evidence": true,
         "has_production_evidence": true,
@@ -2304,7 +2253,6 @@
         "evidence": [
           "static_import_product",
           "static_import_test",
-          "dynamic_string_reference",
           "runtime_surface_reference",
           "documented_invocation"
         ],
@@ -2340,8 +2288,7 @@
       {
         "evidence": [
           "static_import_product",
-          "static_import_test",
-          "dynamic_string_reference_test"
+          "static_import_test"
         ],
         "has_non_documentation_evidence": true,
         "has_production_evidence": true,
@@ -2365,7 +2312,6 @@
         "evidence": [
           "static_import_product",
           "static_import_test",
-          "dynamic_string_reference_test",
           "documented_invocation"
         ],
         "has_non_documentation_evidence": true,
@@ -2382,8 +2328,6 @@
       "merger.repoground.core.answer_grounding_delta",
       "merger.repoground.core.history_lens",
       "merger.repoground.core.memory",
-      "merger.repoground.frontends.pythonista.build_helpers",
-      "merger.repoground.frontends.pythonista.build_utils",
       "merger.repoground.retrieval.audit_finding",
       "merger.repoground.retrieval.audit_lane",
       "merger.repoground.retrieval.eval_diagnostics_integration"

--- a/docs/proofs/repoground-core-complexity-v1.reachability.measurement.json
+++ b/docs/proofs/repoground-core-complexity-v1.reachability.measurement.json
@@ -1,0 +1,2401 @@
+{
+  "does_not_establish": [
+    "that an unproven module is dead",
+    "that a reachable module is executed at runtime",
+    "that a test-only module has a production consumer",
+    "completeness of dynamic loader discovery",
+    "that evidence surfaces are themselves used"
+  ],
+  "findings": [],
+  "kind": "repoground.module_reachability_check",
+  "measurement": {
+    "documentation_only": [],
+    "does_not_establish": [
+      "that an unproven module is dead",
+      "that a reachable module is executed at runtime",
+      "that a test-only module has a production consumer",
+      "completeness of dynamic loader discovery",
+      "that evidence surfaces are themselves used"
+    ],
+    "kind": "repoground.module_reachability_measurement",
+    "module_count": 199,
+    "modules": [
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference",
+          "runtime_surface_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground",
+        "path": "merger/repoground/__init__.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "module_main_block",
+          "dynamic_string_reference_test",
+          "runtime_surface_reference"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.__main__",
+        "path": "merger/repoground/__main__.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.adapters",
+        "path": "merger/repoground/adapters/__init__.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "static_import_script",
+          "dynamic_string_reference_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.adapters.atlas",
+        "path": "merger/repoground/adapters/atlas.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "dynamic_string_reference_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.adapters.diagnostics",
+        "path": "merger/repoground/adapters/diagnostics.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference_test",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.adapters.filesystem",
+        "path": "merger/repoground/adapters/filesystem.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.adapters.metarepo",
+        "path": "merger/repoground/adapters/metarepo.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference_test",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.adapters.security",
+        "path": "merger/repoground/adapters/security.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "dynamic_string_reference_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.adapters.sources",
+        "path": "merger/repoground/adapters/sources.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference_test",
+          "runtime_surface_reference"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.architecture.bundle_sources",
+        "path": "merger/repoground/architecture/bundle_sources.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "static_import_script",
+          "runtime_surface_reference"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.architecture.call_graph",
+        "path": "merger/repoground/architecture/call_graph.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.architecture.call_graph_contract",
+        "path": "merger/repoground/architecture/call_graph_contract.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_test",
+          "module_main_block",
+          "runtime_surface_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.architecture.call_graph_quality_eval",
+        "path": "merger/repoground/architecture/call_graph_quality_eval.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference_test",
+          "runtime_surface_reference"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.architecture.entrypoints",
+        "path": "merger/repoground/architecture/entrypoints.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference_test",
+          "runtime_surface_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.architecture.graph_index",
+        "path": "merger/repoground/architecture/graph_index.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_test",
+          "static_import_script"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.architecture.graph_maintainability",
+        "path": "merger/repoground/architecture/graph_maintainability.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_test",
+          "runtime_surface_reference"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.architecture.graph_quality_eval",
+        "path": "merger/repoground/architecture/graph_quality_eval.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference_test",
+          "runtime_surface_reference"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.architecture.graph_source_validation",
+        "path": "merger/repoground/architecture/graph_source_validation.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference_test",
+          "runtime_surface_reference"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.architecture.import_graph",
+        "path": "merger/repoground/architecture/import_graph.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_test",
+          "static_import_script"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.architecture.module_reachability",
+        "path": "merger/repoground/architecture/module_reachability.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.architecture.path_classification",
+        "path": "merger/repoground/architecture/path_classification.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.architecture.symbol_index",
+        "path": "merger/repoground/architecture/symbol_index.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "package_of_referenced_module"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.atlas",
+        "path": "merger/repoground/atlas/__init__.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.atlas.diff",
+        "path": "merger/repoground/atlas/diff.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.atlas.index",
+        "path": "merger/repoground/atlas/index.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.atlas.lifecycle",
+        "path": "merger/repoground/atlas/lifecycle.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.atlas.paths",
+        "path": "merger/repoground/atlas/paths.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.atlas.planner",
+        "path": "merger/repoground/atlas/planner.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.atlas.registry",
+        "path": "merger/repoground/atlas/registry.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.atlas.search",
+        "path": "merger/repoground/atlas/search.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference_test",
+          "runtime_surface_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.cli",
+        "path": "merger/repoground/cli/__init__.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "module_main_block"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.cli.__main__",
+        "path": "merger/repoground/cli/__main__.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "module_main_block",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.cli.agent_benchmark",
+        "path": "merger/repoground/cli/agent_benchmark.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_test",
+          "module_main_block",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.cli.agent_impact",
+        "path": "merger/repoground/cli/agent_impact.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.cli.cmd_agent_consumption",
+        "path": "merger/repoground/cli/cmd_agent_consumption.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.cli.cmd_agent_entry",
+        "path": "merger/repoground/cli/cmd_agent_entry.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.cli.cmd_agent_pack",
+        "path": "merger/repoground/cli/cmd_agent_pack.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference_test",
+          "runtime_surface_reference"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.cli.cmd_architecture",
+        "path": "merger/repoground/cli/cmd_architecture.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.cli.cmd_artifact",
+        "path": "merger/repoground/cli/cmd_artifact.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference_test",
+          "runtime_surface_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.cli.cmd_atlas",
+        "path": "merger/repoground/cli/cmd_atlas.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.cli.cmd_bundle_health",
+        "path": "merger/repoground/cli/cmd_bundle_health.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.cli.cmd_bundle_surface",
+        "path": "merger/repoground/cli/cmd_bundle_surface.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.cli.cmd_citation",
+        "path": "merger/repoground/cli/cmd_citation.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.cli.cmd_context_quality",
+        "path": "merger/repoground/cli/cmd_context_quality.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "runtime_surface_reference"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.cli.cmd_doc_freshness",
+        "path": "merger/repoground/cli/cmd_doc_freshness.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.cli.cmd_eval",
+        "path": "merger/repoground/cli/cmd_eval.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.cli.cmd_evidence_query",
+        "path": "merger/repoground/cli/cmd_evidence_query.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.cli.cmd_export_safety",
+        "path": "merger/repoground/cli/cmd_export_safety.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.cli.cmd_federation",
+        "path": "merger/repoground/cli/cmd_federation.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "runtime_surface_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.cli.cmd_governance",
+        "path": "merger/repoground/cli/cmd_governance.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference_test",
+          "runtime_surface_reference"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.cli.cmd_ground",
+        "path": "merger/repoground/cli/cmd_ground.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.cli.cmd_incremental_snapshot",
+        "path": "merger/repoground/cli/cmd_incremental_snapshot.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.cli.cmd_index",
+        "path": "merger/repoground/cli/cmd_index.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "runtime_surface_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.cli.cmd_parity",
+        "path": "merger/repoground/cli/cmd_parity.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.cli.cmd_query",
+        "path": "merger/repoground/cli/cmd_query.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.cli.cmd_service_client",
+        "path": "merger/repoground/cli/cmd_service_client.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.cli.cmd_token_budget",
+        "path": "merger/repoground/cli/cmd_token_budget.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "module_main_block",
+          "dynamic_string_reference_test",
+          "runtime_surface_reference"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.cli.ground",
+        "path": "merger/repoground/cli/ground.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "module_main_block",
+          "dynamic_string_reference_test",
+          "runtime_surface_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.cli.main",
+        "path": "merger/repoground/cli/main.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "static_import_script",
+          "module_main_block",
+          "dynamic_string_reference_test",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.cli.mcp_stdio",
+        "path": "merger/repoground/cli/mcp_stdio.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.cli.policy_loader",
+        "path": "merger/repoground/cli/policy_loader.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.cli.pr_explain",
+        "path": "merger/repoground/cli/pr_explain.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "module_main_block",
+          "dynamic_string_reference_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.cli.pr_schau_verify",
+        "path": "merger/repoground/cli/pr_schau_verify.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "module_main_block",
+          "dynamic_string_reference_test",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.cli.serve",
+        "path": "merger/repoground/cli/serve.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.cli.stale_check",
+        "path": "merger/repoground/cli/stale_check.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "package_data_reference"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.contracts",
+        "path": "merger/repoground/contracts/__init__.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "static_import_script",
+          "dynamic_string_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core",
+        "path": "merger/repoground/core/__init__.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.agent_benchmark",
+        "path": "merger/repoground/core/agent_benchmark.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.agent_benchmark_common",
+        "path": "merger/repoground/core/agent_benchmark_common.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.agent_benchmark_evaluation",
+        "path": "merger/repoground/core/agent_benchmark_evaluation.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.agent_benchmark_integrity",
+        "path": "merger/repoground/core/agent_benchmark_integrity.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.agent_benchmark_policy",
+        "path": "merger/repoground/core/agent_benchmark_policy.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.agent_benchmark_receipts",
+        "path": "merger/repoground/core/agent_benchmark_receipts.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.agent_benchmark_requests",
+        "path": "merger/repoground/core/agent_benchmark_requests.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.agent_consumption_validate",
+        "path": "merger/repoground/core/agent_consumption_validate.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.agent_entry_manifest",
+        "path": "merger/repoground/core/agent_entry_manifest.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.agent_export_gate",
+        "path": "merger/repoground/core/agent_export_gate.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.agent_impact_adapter",
+        "path": "merger/repoground/core/agent_impact_adapter.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.agent_impact_context",
+        "path": "merger/repoground/core/agent_impact_context.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "runtime_surface_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.agent_impact_eval",
+        "path": "merger/repoground/core/agent_impact_eval.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.agent_impact_refinement",
+        "path": "merger/repoground/core/agent_impact_refinement.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "runtime_surface_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.agent_reading_pack",
+        "path": "merger/repoground/core/agent_reading_pack.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.answer_grounding",
+        "path": "merger/repoground/core/answer_grounding.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": false,
+        "module": "merger.repoground.core.answer_grounding_delta",
+        "path": "merger/repoground/core/answer_grounding_delta.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.anti_hallucination_ast_lint",
+        "path": "merger/repoground/core/anti_hallucination_ast_lint.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "runtime_surface_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.anti_hallucination_lint",
+        "path": "merger/repoground/core/anti_hallucination_lint.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.artifact_io",
+        "path": "merger/repoground/core/artifact_io.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.ask_context",
+        "path": "merger/repoground/core/ask_context.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.ask_evaluation",
+        "path": "merger/repoground/core/ask_evaluation.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.authority_upgrade_registry",
+        "path": "merger/repoground/core/authority_upgrade_registry.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.availability",
+        "path": "merger/repoground/core/availability.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "static_import_script",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.bundle_access",
+        "path": "merger/repoground/core/bundle_access.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference_test",
+          "runtime_surface_reference"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.bundle_generation",
+        "path": "merger/repoground/core/bundle_generation.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "static_import_script"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.bundle_identity",
+        "path": "merger/repoground/core/bundle_identity.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.bundle_sidecars",
+        "path": "merger/repoground/core/bundle_sidecars.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference",
+          "runtime_surface_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.bundle_surface_validate",
+        "path": "merger/repoground/core/bundle_surface_validate.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.call_graph_impact_index",
+        "path": "merger/repoground/core/call_graph_impact_index.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "static_import_script"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.call_navigation_index",
+        "path": "merger/repoground/core/call_navigation_index.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.check_view",
+        "path": "merger/repoground/core/check_view.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "static_import_script",
+          "dynamic_string_reference_test",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.chunker",
+        "path": "merger/repoground/core/chunker.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "runtime_surface_reference"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.citation_id",
+        "path": "merger/repoground/core/citation_id.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference",
+          "runtime_surface_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.citation_map",
+        "path": "merger/repoground/core/citation_map.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference",
+          "runtime_surface_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.citation_validate",
+        "path": "merger/repoground/core/citation_validate.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.claim_evidence_diagnostics",
+        "path": "merger/repoground/core/claim_evidence_diagnostics.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "runtime_surface_reference"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.claim_evidence_map",
+        "path": "merger/repoground/core/claim_evidence_map.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.clock",
+        "path": "merger/repoground/core/clock.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.compact_evidence",
+        "path": "merger/repoground/core/compact_evidence.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.concept_cards",
+        "path": "merger/repoground/core/concept_cards.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "runtime_surface_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.constants",
+        "path": "merger/repoground/core/constants.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.context_compiler",
+        "path": "merger/repoground/core/context_compiler.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.context_quality",
+        "path": "merger/repoground/core/context_quality.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.delta_context",
+        "path": "merger/repoground/core/delta_context.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.dependency_diagnostics",
+        "path": "merger/repoground/core/dependency_diagnostics.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "runtime_surface_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.doc_freshness",
+        "path": "merger/repoground/core/doc_freshness.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.export_safety_report",
+        "path": "merger/repoground/core/export_safety_report.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.external_manifest_generation",
+        "path": "merger/repoground/core/external_manifest_generation.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.external_manifest_reference",
+        "path": "merger/repoground/core/external_manifest_reference.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "module_main_block",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.extractor",
+        "path": "merger/repoground/core/extractor.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.federation",
+        "path": "merger/repoground/core/federation.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "runtime_surface_reference"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.forensic_preflight",
+        "path": "merger/repoground/core/forensic_preflight.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.graph_degradation",
+        "path": "merger/repoground/core/graph_degradation.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.health_degradation",
+        "path": "merger/repoground/core/health_degradation.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": false,
+        "module": "merger.repoground.core.history_lens",
+        "path": "merger/repoground/core/history_lens.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.latest_complete",
+        "path": "merger/repoground/core/latest_complete.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "runtime_surface_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.lens_audit",
+        "path": "merger/repoground/core/lens_audit.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_test",
+          "dynamic_string_reference_test",
+          "runtime_surface_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.lens_card_validate",
+        "path": "merger/repoground/core/lens_card_validate.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference_test",
+          "runtime_surface_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.lens_cards",
+        "path": "merger/repoground/core/lens_cards.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference",
+          "runtime_surface_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.lens_facets",
+        "path": "merger/repoground/core/lens_facets.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference_test",
+          "runtime_surface_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.lenses",
+        "path": "merger/repoground/core/lenses.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.live_freshness",
+        "path": "merger/repoground/core/live_freshness.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference_test",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.mcp_resources",
+        "path": "merger/repoground/core/mcp_resources.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "static_import_script",
+          "dynamic_string_reference_test",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.mcp_tools",
+        "path": "merger/repoground/core/mcp_tools.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": false,
+        "module": "merger.repoground.core.memory",
+        "path": "merger/repoground/core/memory.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "static_import_script",
+          "dynamic_string_reference",
+          "runtime_surface_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.merge",
+        "path": "merger/repoground/core/merge.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_test",
+          "dynamic_string_reference",
+          "runtime_surface_reference"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.naming_audit",
+        "path": "merger/repoground/core/naming_audit.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference_test",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.output_health",
+        "path": "merger/repoground/core/output_health.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "runtime_surface_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.parity_gates",
+        "path": "merger/repoground/core/parity_gates.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "runtime_surface_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.parity_state",
+        "path": "merger/repoground/core/parity_state.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.patch_evaluation",
+        "path": "merger/repoground/core/patch_evaluation.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.path_security",
+        "path": "merger/repoground/core/path_security.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "runtime_surface_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.post_emit_health",
+        "path": "merger/repoground/core/post_emit_health.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_test",
+          "runtime_surface_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.pr_delta_card_validate",
+        "path": "merger/repoground/core/pr_delta_card_validate.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "runtime_surface_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.pr_delta_cards",
+        "path": "merger/repoground/core/pr_delta_cards.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.pr_schau_bundle",
+        "path": "merger/repoground/core/pr_schau_bundle.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_test",
+          "runtime_surface_reference"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.publication_policy",
+        "path": "merger/repoground/core/publication_policy.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.range_resolver",
+        "path": "merger/repoground/core/range_resolver.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.readonly_adapter",
+        "path": "merger/repoground/core/readonly_adapter.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.redactor",
+        "path": "merger/repoground/core/redactor.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_test",
+          "runtime_surface_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.relation_card_validate",
+        "path": "merger/repoground/core/relation_card_validate.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "runtime_surface_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.relation_cards",
+        "path": "merger/repoground/core/relation_cards.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.required_reading",
+        "path": "merger/repoground/core/required_reading.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.response_projection",
+        "path": "merger/repoground/core/response_projection.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.review_coverage",
+        "path": "merger/repoground/core/review_coverage.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.rooted_filesystem",
+        "path": "merger/repoground/core/rooted_filesystem.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.runtime_provenance",
+        "path": "merger/repoground/core/runtime_provenance.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.snapshot_preflight",
+        "path": "merger/repoground/core/snapshot_preflight.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.snapshot_profiles",
+        "path": "merger/repoground/core/snapshot_profiles.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.snapshot_provenance",
+        "path": "merger/repoground/core/snapshot_provenance.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.token_budget_report",
+        "path": "merger/repoground/core/token_budget_report.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.workbench_usefulness",
+        "path": "merger/repoground/core/workbench_usefulness.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.core.yaml_compat",
+        "path": "merger/repoground/core/yaml_compat.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "package_of_referenced_module"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.frontends",
+        "path": "merger/repoground/frontends/__init__.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_test",
+          "package_of_referenced_module"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.frontends.pythonista",
+        "path": "merger/repoground/frontends/pythonista/__init__.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "module_main_block",
+          "dynamic_string_reference",
+          "runtime_surface_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.frontends.pythonista.build",
+        "path": "merger/repoground/frontends/pythonista/build.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": false,
+        "module": "merger.repoground.frontends.pythonista.build_helpers",
+        "path": "merger/repoground/frontends/pythonista/build_helpers.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": false,
+        "module": "merger.repoground.frontends.pythonista.build_utils",
+        "path": "merger/repoground/frontends/pythonista/build_utils.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_test",
+          "module_main_block"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.frontends.pythonista.ipad_fs_scan",
+        "path": "merger/repoground/frontends/pythonista/ipad_fs_scan.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_test",
+          "module_main_block",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.frontends.pythonista.pathfinder",
+        "path": "merger/repoground/frontends/pythonista/pathfinder.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "static_import_script",
+          "dynamic_string_reference_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.retrieval",
+        "path": "merger/repoground/retrieval/__init__.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": false,
+        "module": "merger.repoground.retrieval.audit_finding",
+        "path": "merger/repoground/retrieval/audit_finding.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": false,
+        "module": "merger.repoground.retrieval.audit_lane",
+        "path": "merger/repoground/retrieval/audit_lane.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "static_import_script",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.retrieval.eval_core",
+        "path": "merger/repoground/retrieval/eval_core.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.retrieval.eval_diagnostics",
+        "path": "merger/repoground/retrieval/eval_diagnostics.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": false,
+        "module": "merger.repoground.retrieval.eval_diagnostics_integration",
+        "path": "merger/repoground/retrieval/eval_diagnostics_integration.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.retrieval.federation_query",
+        "path": "merger/repoground/retrieval/federation_query.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.retrieval.incremental_snapshot",
+        "path": "merger/repoground/retrieval/incremental_snapshot.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "static_import_script",
+          "dynamic_string_reference_test",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.retrieval.index_db",
+        "path": "merger/repoground/retrieval/index_db.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.retrieval.output_projection",
+        "path": "merger/repoground/retrieval/output_projection.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "static_import_script",
+          "dynamic_string_reference_test",
+          "runtime_surface_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.retrieval.query_core",
+        "path": "merger/repoground/retrieval/query_core.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.retrieval.query_range_coverage",
+        "path": "merger/repoground/retrieval/query_range_coverage.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_test",
+          "static_import_script"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.retrieval.retrieval_promotion_gate",
+        "path": "merger/repoground/retrieval/retrieval_promotion_gate.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "static_import_script",
+          "dynamic_string_reference_test",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.retrieval.review_eval",
+        "path": "merger/repoground/retrieval/review_eval.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "static_import_script"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.retrieval.review_query",
+        "path": "merger/repoground/retrieval/review_query.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.retrieval.review_router",
+        "path": "merger/repoground/retrieval/review_router.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.retrieval.router",
+        "path": "merger/repoground/retrieval/router.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_test",
+          "static_import_script",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.retrieval.security_alert_summary",
+        "path": "merger/repoground/retrieval/security_alert_summary.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference_test",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.retrieval.session",
+        "path": "merger/repoground/retrieval/session.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_test",
+          "package_of_referenced_module",
+          "dynamic_string_reference_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.service",
+        "path": "merger/repoground/service/__init__.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.service.access_log",
+        "path": "merger/repoground/service/access_log.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference_test",
+          "runtime_surface_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.service.app",
+        "path": "merger/repoground/service/app.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference_test",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.service.auth",
+        "path": "merger/repoground/service/auth.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.service.jobstore",
+        "path": "merger/repoground/service/jobstore.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.service.logging_provider",
+        "path": "merger/repoground/service/logging_provider.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference",
+          "runtime_surface_reference",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.service.models",
+        "path": "merger/repoground/service/models.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.service.query_artifact_store",
+        "path": "merger/repoground/service/query_artifact_store.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.service.repo_sync",
+        "path": "merger/repoground/service/repo_sync.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference_test"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.service.runner",
+        "path": "merger/repoground/service/runner.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.service.runtime_artifact_retention",
+        "path": "merger/repoground/service/runtime_artifact_retention.py",
+        "status": "reachable"
+      },
+      {
+        "evidence": [
+          "static_import_product",
+          "static_import_test",
+          "dynamic_string_reference_test",
+          "documented_invocation"
+        ],
+        "has_non_documentation_evidence": true,
+        "has_production_evidence": true,
+        "module": "merger.repoground.service.source_acquisition",
+        "path": "merger/repoground/service/source_acquisition.py",
+        "status": "reachable"
+      }
+    ],
+    "package_roots": [
+      "merger"
+    ],
+    "test_only": [
+      "merger.repoground.core.answer_grounding_delta",
+      "merger.repoground.core.history_lens",
+      "merger.repoground.core.memory",
+      "merger.repoground.frontends.pythonista.build_helpers",
+      "merger.repoground.frontends.pythonista.build_utils",
+      "merger.repoground.retrieval.audit_finding",
+      "merger.repoground.retrieval.audit_lane",
+      "merger.repoground.retrieval.eval_diagnostics_integration"
+    ],
+    "unparsed_files": [],
+    "unparsed_non_product_files": [
+      "merger/repoground/tests/fixtures/entrypoints_test_project/invalid.py",
+      "merger/repoground/tests/fixtures/graph_quality_goldset/invalid_case/broken.py"
+    ],
+    "unproven": [],
+    "version": "1.0"
+  },
+  "status": "pass",
+  "version": "1.0"
+}

--- a/merger/repoground/architecture/module_reachability.py
+++ b/merger/repoground/architecture/module_reachability.py
@@ -125,31 +125,155 @@ def _resolve_relative(module_name: str, is_package: bool, node: ast.ImportFrom) 
     return ".".join(parts)
 
 
-def _imported_names(tree: ast.AST, module_name: str, is_package: bool) -> set[str]:
+def _package_name(module_name: str, is_package: bool) -> str:
+    if is_package:
+        return module_name
+    return module_name.rpartition(".")[0]
+
+
+def _resolve_local_absolute(
+    imported_name: str,
+    *,
+    module_name: str,
+    is_package: bool,
+    known_modules: set[str],
+) -> str:
+    """Resolve script-style sibling imports only when a real module exists.
+
+    Pythonista executes ``build.py`` with its own directory on ``sys.path``, so
+    imports such as ``from build_utils import ...`` reach the sibling package
+    module even though they are not written as relative imports. Guessing from
+    the name alone would over-claim reachability; the qualified candidate must
+    exist in the measured production-module inventory.
+    """
+
+    package = _package_name(module_name, is_package)
+    candidate = f"{package}.{imported_name}" if package else imported_name
+    if candidate in known_modules or any(
+        name.startswith(f"{candidate}.") for name in known_modules
+    ):
+        return candidate
+    return imported_name
+
+
+def _imported_names(
+    tree: ast.AST,
+    module_name: str,
+    is_package: bool,
+    known_modules: set[str],
+    *,
+    allow_local_siblings: bool,
+) -> set[str]:
     names: set[str] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:
-                names.add(alias.name)
+                resolved = alias.name
+                if alias.name not in known_modules and allow_local_siblings:
+                    resolved = _resolve_local_absolute(
+                        alias.name,
+                        module_name=module_name,
+                        is_package=is_package,
+                        known_modules=known_modules,
+                    )
+                names.add(resolved)
         elif isinstance(node, ast.ImportFrom):
             base = (
                 _resolve_relative(module_name, is_package, node)
                 if node.level
-                else (node.module or "")
+                else (
+                    _resolve_local_absolute(
+                        node.module or "",
+                        module_name=module_name,
+                        is_package=is_package,
+                        known_modules=known_modules,
+                    )
+                    if allow_local_siblings
+                    else (node.module or "")
+                )
             )
             if not base:
                 continue
             names.add(base)
-            # ``from pkg import module`` also binds ``pkg.module``.
-            names.update(f"{base}.{alias.name}" for alias in node.names)
+            # ``from pkg import module`` is evidence for ``pkg.module`` only
+            # when that exact production module exists. A function or class
+            # imported from a module must not masquerade as a submodule.
+            for alias in node.names:
+                candidate = f"{base}.{alias.name}"
+                if alias.name != "*" and candidate in known_modules:
+                    names.add(candidate)
     return names
 
 
-def _string_literals(tree: ast.AST) -> set[str]:
+def _resource_strings(tree: ast.AST) -> set[str]:
+    """Return literals that may name packaged data files, never modules."""
+
     return {
         node.value
         for node in ast.walk(tree)
         if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    }
+
+
+def _dynamic_import_aliases(tree: ast.AST) -> tuple[set[str], set[str]]:
+    importlib_aliases: set[str] = set()
+    import_module_names = {"__import__"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            importlib_aliases.update(
+                alias.asname or alias.name
+                for alias in node.names
+                if alias.name == "importlib"
+            )
+        elif isinstance(node, ast.ImportFrom) and node.module == "importlib":
+            import_module_names.update(
+                alias.asname or alias.name
+                for alias in node.names
+                if alias.name == "import_module"
+            )
+    return importlib_aliases, import_module_names
+
+
+def _literal_dynamic_import(
+    node: ast.AST,
+    *,
+    importlib_aliases: set[str],
+    import_module_names: set[str],
+) -> str | None:
+    if not isinstance(node, ast.Call) or not node.args:
+        return None
+    direct_call = isinstance(node.func, ast.Name) and node.func.id in import_module_names
+    module_call = (
+        isinstance(node.func, ast.Attribute)
+        and node.func.attr == "import_module"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id in importlib_aliases
+    )
+    first_argument = node.args[0]
+    if not (direct_call or module_call):
+        return None
+    if not isinstance(first_argument, ast.Constant) or not isinstance(
+        first_argument.value, str
+    ):
+        return None
+    return first_argument.value
+
+
+def _dynamic_module_strings(tree: ast.AST) -> set[str]:
+    """Return literal module names passed to actual dynamic import APIs."""
+
+    importlib_aliases, import_module_names = _dynamic_import_aliases(tree)
+    return {
+        value
+        for node in ast.walk(tree)
+        if (
+            value := _literal_dynamic_import(
+                node,
+                importlib_aliases=importlib_aliases,
+                import_module_names=import_module_names,
+            )
+        )
+        is not None
     }
 
 
@@ -166,7 +290,10 @@ def _has_main_block(tree: ast.AST) -> bool:
     for node in ast.walk(tree):
         if not isinstance(node, ast.If) or not isinstance(node.test, ast.Compare):
             continue
-        operands = [node.test.left, *node.test.comparators]
+        comparison = node.test
+        if len(comparison.ops) != 1 or not isinstance(comparison.ops[0], ast.Eq):
+            continue
+        operands = [comparison.left, comparison.comparators[0]]
         has_name = any(
             isinstance(item, ast.Name) and item.id == "__name__" for item in operands
         )
@@ -223,6 +350,41 @@ class _Corpus:
         )
 
 
+def _collect_source_evidence(
+    parsed_sources: list[tuple[str, str, bool, ast.AST]],
+    known_modules: set[str],
+) -> tuple[dict[str, set[str]], dict[str, set[str]], dict[str, set[str]]]:
+    imports_by_projection: dict[str, set[str]] = {
+        "product": set(),
+        "test": set(),
+        "script": set(),
+        "fixture": set(),
+    }
+    dynamic_strings_by_projection: dict[str, set[str]] = {}
+    resource_strings_by_projection: dict[str, set[str]] = {}
+    for projection, module_name, is_package, tree in parsed_sources:
+        imports_by_projection.setdefault(projection, set()).update(
+            _imported_names(
+                tree,
+                module_name,
+                is_package,
+                known_modules,
+                allow_local_siblings=_has_main_block(tree),
+            )
+        )
+        dynamic_strings_by_projection.setdefault(projection, set()).update(
+            _dynamic_module_strings(tree)
+        )
+        resource_strings_by_projection.setdefault(projection, set()).update(
+            _resource_strings(tree)
+        )
+    return (
+        imports_by_projection,
+        dynamic_strings_by_projection,
+        resource_strings_by_projection,
+    )
+
+
 def measure_module_reachability(
     repo_root: Path,
     package_roots: Iterable[str] = ("merger",),
@@ -237,7 +399,9 @@ def measure_module_reachability(
         "script": set(),
         "fixture": set(),
     }
-    strings_by_projection: dict[str, set[str]] = {}
+    dynamic_strings_by_projection: dict[str, set[str]] = {}
+    resource_strings_by_projection: dict[str, set[str]] = {}
+    parsed_sources: list[tuple[str, str, bool, ast.AST]] = []
     data_files: list[str] = []
     runtime_corpus = _Corpus()
     documentation_corpus = _Corpus()
@@ -261,12 +425,7 @@ def measure_module_reachability(
                 continue
             module_name = _module_name(relative)
             is_package = path.name == "__init__.py"
-            imports_by_projection.setdefault(projection, set()).update(
-                _imported_names(tree, module_name, is_package)
-            )
-            strings_by_projection.setdefault(projection, set()).update(
-                _string_literals(tree)
-            )
+            parsed_sources.append((projection, module_name, is_package, tree))
             if projection == "product" and relative.startswith(
                 tuple(f"{root}/" for root in roots)
             ):
@@ -288,6 +447,12 @@ def measure_module_reachability(
             if text is not None:
                 documentation_corpus.add(text)
 
+    (
+        imports_by_projection,
+        dynamic_strings_by_projection,
+        resource_strings_by_projection,
+    ) = _collect_source_evidence(parsed_sources, set(modules))
+
     # Production evidence may only be drawn from production and script sources.
     # Test sources form their own, weaker class so that a module the tests alone
     # reach cannot present itself as part of a shipped path.
@@ -296,8 +461,13 @@ def measure_module_reachability(
 
     production_imports = _union(imports_by_projection, "product", "script")
     all_imports = _union(imports_by_projection, *imports_by_projection)
-    production_strings = _union(strings_by_projection, "product", "script")
-    test_strings = _union(strings_by_projection, "test", "fixture")
+    production_dynamic_strings = _union(
+        dynamic_strings_by_projection, "product", "script"
+    )
+    test_dynamic_strings = _union(dynamic_strings_by_projection, "test", "fixture")
+    production_resource_strings = _union(
+        resource_strings_by_projection, "product", "script"
+    )
 
     records = [
         _module_record(
@@ -306,8 +476,9 @@ def measure_module_reachability(
             imports_by_projection=imports_by_projection,
             production_imports=production_imports,
             all_imports=all_imports,
-            production_strings=production_strings,
-            test_strings=test_strings,
+            production_dynamic_strings=production_dynamic_strings,
+            test_dynamic_strings=test_dynamic_strings,
+            production_resource_strings=production_resource_strings,
             data_files=data_files,
             runtime_corpus=runtime_corpus,
             documentation_corpus=documentation_corpus,
@@ -429,8 +600,9 @@ def _module_record(
     imports_by_projection: dict[str, set[str]],
     production_imports: set[str],
     all_imports: set[str],
-    production_strings: set[str],
-    test_strings: set[str],
+    production_dynamic_strings: set[str],
+    test_dynamic_strings: set[str],
+    production_resource_strings: set[str],
     data_files: list[str],
     runtime_corpus: _Corpus,
     documentation_corpus: _Corpus,
@@ -446,7 +618,7 @@ def _module_record(
             relative_path,
             production_imports=production_imports,
             all_imports=all_imports,
-            production_strings=production_strings,
+            production_strings=production_resource_strings,
             data_files=data_files,
         )
         if package_evidence is not None:
@@ -455,9 +627,9 @@ def _module_record(
     if details["module_main_block"]:
         evidence.append("module_main_block")
 
-    if _names_module(module_name, relative_path, production_strings):
+    if _names_module(module_name, relative_path, production_dynamic_strings):
         evidence.append("dynamic_string_reference")
-    elif _names_module(module_name, relative_path, test_strings):
+    elif _names_module(module_name, relative_path, test_dynamic_strings):
         evidence.append("dynamic_string_reference_test")
 
     if runtime_corpus.contains(module_name, relative_path):

--- a/merger/repoground/architecture/module_reachability.py
+++ b/merger/repoground/architecture/module_reachability.py
@@ -1,0 +1,434 @@
+"""Conservative reachability evidence for production Python modules.
+
+Static import analysis alone cannot decide whether a module is used: RepoGround
+reaches modules through ``python -m`` entry points, CLI dispatch, lazy imports,
+systemd units and shell wrappers. This module therefore collects *evidence of
+use* from several surfaces and classifies every production module as either
+``reachable`` (at least one piece of evidence) or ``unproven`` (none found).
+
+``unproven`` is deliberately not ``dead``. The measurement is fail-closed in the
+direction that matters for deletion: it can under-claim reachability, never
+under-claim it in a way that would license removing live code.
+"""
+
+from __future__ import annotations
+
+import ast
+import functools
+import os
+import re
+from pathlib import Path
+from typing import Any, Iterable
+
+from merger.repoground.architecture.path_classification import path_projection
+
+_SKIP_DIRECTORIES = {
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".venv",
+    "__pycache__",
+    "build",
+    "dist",
+    "node_modules",
+    "venv",
+}
+
+#: Text surfaces that can invoke a module without importing it in Python.
+_RUNTIME_SUFFIXES = {
+    ".cfg",
+    ".ini",
+    ".json",
+    ".service",
+    ".sh",
+    ".timer",
+    ".toml",
+    ".yaml",
+    ".yml",
+}
+_DOCUMENTATION_SUFFIXES = {".md", ".rst", ".txt"}
+
+#: Directories that can actually invoke code. ``config/`` and ``docs/`` are
+#: excluded on purpose: they hold policies, baselines and measurement artifacts
+#: that merely *name* modules, and counting those as evidence would let a
+#: recorded path masquerade as a live consumer.
+_RUNTIME_DIRECTORIES = (
+    ".github/",
+    ".wgx/",
+    "ops/",
+    "scripts/",
+    "tools/",
+)
+
+#: Evidence kinds that show use by code or by an operational surface.
+NON_DOCUMENTATION_EVIDENCE = (
+    "static_import_product",
+    "static_import_test",
+    "static_import_script",
+    "package_of_referenced_module",
+    "package_data_reference",
+    "module_main_block",
+    "dynamic_string_reference",
+    "runtime_surface_reference",
+)
+
+
+def _iter_files(repo_root: Path) -> list[Path]:
+    paths: list[Path] = []
+    for root, directories, filenames in os.walk(repo_root):
+        directories[:] = sorted(
+            directory for directory in directories if directory not in _SKIP_DIRECTORIES
+        )
+        for filename in sorted(filenames):
+            paths.append(Path(root) / filename)
+    return paths
+
+
+def _module_name(relative_path: str) -> str:
+    dotted = relative_path[: -len(".py")].replace("/", ".")
+    if dotted.endswith(".__init__"):
+        return dotted[: -len(".__init__")]
+    return dotted
+
+
+def _read_text(path: Path) -> str | None:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def _resolve_relative(module_name: str, is_package: bool, node: ast.ImportFrom) -> str:
+    """Resolve a relative import against the importing module's package."""
+
+    parts = module_name.split(".")
+    if not is_package:
+        parts = parts[:-1]
+    ascend = node.level - 1
+    if ascend:
+        parts = parts[: len(parts) - ascend] if ascend < len(parts) else []
+    if node.module:
+        parts = parts + node.module.split(".")
+    return ".".join(parts)
+
+
+def _imported_names(tree: ast.AST, module_name: str, is_package: bool) -> set[str]:
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            base = (
+                _resolve_relative(module_name, is_package, node)
+                if node.level
+                else (node.module or "")
+            )
+            if not base:
+                continue
+            names.add(base)
+            # ``from pkg import module`` also binds ``pkg.module``.
+            names.update(f"{base}.{alias.name}" for alias in node.names)
+    return names
+
+
+def _string_literals(tree: ast.AST) -> set[str]:
+    return {
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    }
+
+
+def _parse(text: str | None, path: Path) -> ast.AST | None:
+    if text is None:
+        return None
+    try:
+        return ast.parse(text, filename=str(path))
+    except SyntaxError:
+        return None
+
+
+def _has_main_block(tree: ast.AST) -> bool:
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If) or not isinstance(node.test, ast.Compare):
+            continue
+        operands = [node.test.left, *node.test.comparators]
+        has_name = any(
+            isinstance(item, ast.Name) and item.id == "__name__" for item in operands
+        )
+        has_literal = any(
+            isinstance(item, ast.Constant) and item.value == "__main__"
+            for item in operands
+        )
+        if has_name and has_literal:
+            return True
+    return False
+
+
+def _is_runtime_surface(relative_path: str, suffix: str) -> bool:
+    """Decide whether a non-Python file can invoke a module."""
+
+    in_runtime_directory = relative_path.startswith(_RUNTIME_DIRECTORIES)
+    at_repository_root = "/" not in relative_path
+    if not (in_runtime_directory or at_repository_root):
+        return False
+    return suffix in _RUNTIME_SUFFIXES or (not suffix and in_runtime_directory)
+
+
+@functools.lru_cache(maxsize=2048)
+def _token_pattern(needle: str) -> re.Pattern[str]:
+    """Match ``needle`` only as a whole dotted name or path."""
+
+    return re.compile(rf"(?<![\w./-]){re.escape(needle)}(?![\w./-])")
+
+
+class _Corpus:
+    """Concatenated text of one surface, searched by module name and path.
+
+    Matching is token-exact: ``merger`` must not be credited for a mention of
+    ``merger.repoground.core``. Over-claiming reachability would turn an unused
+    module into a silent pass, so partial matches are rejected.
+    """
+
+    def __init__(self) -> None:
+        self._chunks: list[str] = []
+        self._joined: str | None = None
+
+    def add(self, text: str) -> None:
+        self._chunks.append(text)
+        self._joined = None
+
+    def contains(self, *needles: str) -> bool:
+        if self._joined is None:
+            self._joined = "\n".join(self._chunks)
+        return any(
+            # The cheap substring test keeps the regex off the whole corpus for
+            # the overwhelming majority of module names.
+            needle in self._joined and _token_pattern(needle).search(self._joined)
+            for needle in needles
+        )
+
+
+def measure_module_reachability(
+    repo_root: Path,
+    package_roots: Iterable[str] = ("merger",),
+) -> dict[str, Any]:
+    """Collect reachability evidence for every production module."""
+
+    roots = tuple(package_roots)
+    modules: dict[str, dict[str, Any]] = {}
+    imports_by_projection: dict[str, set[str]] = {
+        "product": set(),
+        "test": set(),
+        "script": set(),
+        "fixture": set(),
+    }
+    dynamic_strings: set[str] = set()
+    data_files: list[str] = []
+    runtime_corpus = _Corpus()
+    documentation_corpus = _Corpus()
+    unparsed: list[str] = []
+    unparsed_non_product: list[str] = []
+
+    for path in _iter_files(repo_root):
+        relative = path.relative_to(repo_root).as_posix()
+        suffix = path.suffix.lower()
+
+        if suffix == ".py":
+            projection = path_projection(relative)
+            text = _read_text(path)
+            tree = _parse(text, path)
+            if tree is None:
+                # An unreadable product or script source could hide a module or
+                # its imports, so it fails; deliberately invalid test fixtures
+                # only under-claim evidence, which stays on the strict side.
+                target = unparsed if projection in {"product", "script"} else unparsed_non_product
+                target.append(relative)
+                continue
+            module_name = _module_name(relative)
+            is_package = path.name == "__init__.py"
+            imports_by_projection.setdefault(projection, set()).update(
+                _imported_names(tree, module_name, is_package)
+            )
+            dynamic_strings.update(_string_literals(tree))
+            if projection == "product" and relative.startswith(
+                tuple(f"{root}/" for root in roots)
+            ):
+                modules[module_name] = {
+                    "path": relative,
+                    "is_package": is_package,
+                    "module_main_block": _has_main_block(tree),
+                }
+            continue
+
+        data_files.append(relative)
+
+        if _is_runtime_surface(relative, suffix):
+            text = _read_text(path)
+            if text is not None:
+                runtime_corpus.add(text)
+        elif suffix in _DOCUMENTATION_SUFFIXES:
+            text = _read_text(path)
+            if text is not None:
+                documentation_corpus.add(text)
+
+    all_imports = set().union(*imports_by_projection.values())
+    records = [
+        _module_record(
+            module_name,
+            details,
+            imports_by_projection=imports_by_projection,
+            all_imports=all_imports,
+            dynamic_strings=dynamic_strings,
+            data_files=data_files,
+            runtime_corpus=runtime_corpus,
+            documentation_corpus=documentation_corpus,
+        )
+        for module_name, details in sorted(modules.items())
+    ]
+
+    unproven = [record["module"] for record in records if record["status"] == "unproven"]
+    documentation_only = [
+        record["module"]
+        for record in records
+        if record["status"] == "reachable" and not record["has_non_documentation_evidence"]
+    ]
+    return {
+        "kind": "repoground.module_reachability_measurement",
+        "version": "1.0",
+        "package_roots": list(roots),
+        "module_count": len(records),
+        "unproven": unproven,
+        "documentation_only": documentation_only,
+        "unparsed_files": sorted(unparsed),
+        "unparsed_non_product_files": sorted(unparsed_non_product),
+        "modules": records,
+        "does_not_establish": [
+            "that an unproven module is dead",
+            "that a reachable module is executed at runtime",
+            "completeness of dynamic loader discovery",
+            "that evidence surfaces are themselves used",
+        ],
+    }
+
+
+def _referenced_data_file(
+    data_file: str,
+    package_directory: str,
+    dynamic_strings: set[str],
+) -> bool:
+    """Report whether Python source names this packaged data file."""
+
+    relative_inside_package = data_file[len(package_directory) :]
+    return any(
+        value == data_file
+        or value == relative_inside_package
+        or value.endswith(f"/{relative_inside_package}")
+        for value in dynamic_strings
+    )
+
+
+def _module_record(
+    module_name: str,
+    details: dict[str, Any],
+    *,
+    imports_by_projection: dict[str, set[str]],
+    all_imports: set[str],
+    dynamic_strings: set[str],
+    data_files: list[str],
+    runtime_corpus: _Corpus,
+    documentation_corpus: _Corpus,
+) -> dict[str, Any]:
+    relative_path = details["path"]
+    prefix = f"{module_name}."
+    evidence: list[str] = []
+
+    for projection, kind in (
+        ("product", "static_import_product"),
+        ("test", "static_import_test"),
+        ("script", "static_import_script"),
+    ):
+        if module_name in imports_by_projection.get(projection, set()):
+            evidence.append(kind)
+
+    if details["is_package"] and not evidence:
+        # A package is reached whenever anything below it is imported.
+        if any(name.startswith(prefix) for name in all_imports):
+            evidence.append("package_of_referenced_module")
+
+    if details["is_package"] and not evidence:
+        # A package directory also ships the non-Python contract and schema
+        # files that production code loads by path.
+        package_directory = relative_path[: -len("__init__.py")]
+        if any(
+            data_file.startswith(package_directory)
+            and _referenced_data_file(data_file, package_directory, dynamic_strings)
+            for data_file in data_files
+        ):
+            evidence.append("package_data_reference")
+
+    if details["module_main_block"]:
+        evidence.append("module_main_block")
+
+    if any(
+        value == module_name or value == relative_path or value.startswith(prefix)
+        for value in dynamic_strings
+    ):
+        evidence.append("dynamic_string_reference")
+
+    if runtime_corpus.contains(module_name, relative_path):
+        evidence.append("runtime_surface_reference")
+
+    if documentation_corpus.contains(module_name, relative_path):
+        evidence.append("documented_invocation")
+
+    return {
+        "module": module_name,
+        "path": relative_path,
+        "status": "reachable" if evidence else "unproven",
+        "evidence": evidence,
+        "has_non_documentation_evidence": any(
+            kind in NON_DOCUMENTATION_EVIDENCE for kind in evidence
+        ),
+    }
+
+
+def evaluate_reachability_policy(
+    measurement: dict[str, Any],
+    policy: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Reject newly unproven modules and undeclared documentation-only modules."""
+
+    findings: list[dict[str, Any]] = []
+    allowed_unproven = set(policy.get("allowed_unproven") or [])
+    allowed_documentation_only = set(policy.get("allowed_documentation_only") or [])
+
+    for module in measurement["unproven"]:
+        if module not in allowed_unproven:
+            findings.append({"code": "module_reachability_unproven", "module": module})
+    for module in sorted(allowed_unproven - set(measurement["unproven"])):
+        findings.append({"code": "module_reachability_allowlist_stale", "module": module})
+
+    if policy.get("require_non_documentation_evidence", True):
+        for module in measurement["documentation_only"]:
+            if module not in allowed_documentation_only:
+                findings.append(
+                    {"code": "module_reachability_documentation_only", "module": module}
+                )
+        for module in sorted(
+            allowed_documentation_only - set(measurement["documentation_only"])
+        ):
+            findings.append(
+                {"code": "module_reachability_documentation_allowlist_stale", "module": module}
+            )
+
+    if measurement["unparsed_files"]:
+        findings.append(
+            {
+                "code": "module_reachability_unparsed_sources",
+                "files": measurement["unparsed_files"],
+            }
+        )
+    return findings

--- a/merger/repoground/architecture/module_reachability.py
+++ b/merger/repoground/architecture/module_reachability.py
@@ -61,10 +61,9 @@ _RUNTIME_DIRECTORIES = (
     "tools/",
 )
 
-#: Evidence kinds that show use by code or by an operational surface.
-NON_DOCUMENTATION_EVIDENCE = (
+#: Evidence kinds that show use by a production or operational surface.
+PRODUCTION_EVIDENCE = (
     "static_import_product",
-    "static_import_test",
     "static_import_script",
     "package_of_referenced_module",
     "package_data_reference",
@@ -72,6 +71,19 @@ NON_DOCUMENTATION_EVIDENCE = (
     "dynamic_string_reference",
     "runtime_surface_reference",
 )
+
+#: Evidence kinds that show use by the test suite alone. A test proves the
+#: module is exercised, not that any production surface reaches it, so the two
+#: classes are kept apart: a production module that only its own tests reach is
+#: a distinct — and weaker — situation than one a shipped path reaches.
+TEST_EVIDENCE = (
+    "static_import_test",
+    "package_of_test_referenced_module",
+    "dynamic_string_reference_test",
+)
+
+#: Evidence kinds that show use by code rather than by prose.
+NON_DOCUMENTATION_EVIDENCE = PRODUCTION_EVIDENCE + TEST_EVIDENCE
 
 
 def _iter_files(repo_root: Path) -> list[Path]:
@@ -225,7 +237,7 @@ def measure_module_reachability(
         "script": set(),
         "fixture": set(),
     }
-    dynamic_strings: set[str] = set()
+    strings_by_projection: dict[str, set[str]] = {}
     data_files: list[str] = []
     runtime_corpus = _Corpus()
     documentation_corpus = _Corpus()
@@ -252,7 +264,9 @@ def measure_module_reachability(
             imports_by_projection.setdefault(projection, set()).update(
                 _imported_names(tree, module_name, is_package)
             )
-            dynamic_strings.update(_string_literals(tree))
+            strings_by_projection.setdefault(projection, set()).update(
+                _string_literals(tree)
+            )
             if projection == "product" and relative.startswith(
                 tuple(f"{root}/" for root in roots)
             ):
@@ -274,14 +288,26 @@ def measure_module_reachability(
             if text is not None:
                 documentation_corpus.add(text)
 
-    all_imports = set().union(*imports_by_projection.values())
+    # Production evidence may only be drawn from production and script sources.
+    # Test sources form their own, weaker class so that a module the tests alone
+    # reach cannot present itself as part of a shipped path.
+    def _union(source: dict[str, set[str]], *projections: str) -> set[str]:
+        return set().union(*(source.get(name, set()) for name in projections), set())
+
+    production_imports = _union(imports_by_projection, "product", "script")
+    all_imports = _union(imports_by_projection, *imports_by_projection)
+    production_strings = _union(strings_by_projection, "product", "script")
+    test_strings = _union(strings_by_projection, "test", "fixture")
+
     records = [
         _module_record(
             module_name,
             details,
             imports_by_projection=imports_by_projection,
+            production_imports=production_imports,
             all_imports=all_imports,
-            dynamic_strings=dynamic_strings,
+            production_strings=production_strings,
+            test_strings=test_strings,
             data_files=data_files,
             runtime_corpus=runtime_corpus,
             documentation_corpus=documentation_corpus,
@@ -295,6 +321,12 @@ def measure_module_reachability(
         for record in records
         if record["status"] == "reachable" and not record["has_non_documentation_evidence"]
     ]
+    test_only = [
+        record["module"]
+        for record in records
+        if record["has_non_documentation_evidence"]
+        and not record["has_production_evidence"]
+    ]
     return {
         "kind": "repoground.module_reachability_measurement",
         "version": "1.0",
@@ -302,12 +334,14 @@ def measure_module_reachability(
         "module_count": len(records),
         "unproven": unproven,
         "documentation_only": documentation_only,
+        "test_only": test_only,
         "unparsed_files": sorted(unparsed),
         "unparsed_non_product_files": sorted(unparsed_non_product),
         "modules": records,
         "does_not_establish": [
             "that an unproven module is dead",
             "that a reachable module is executed at runtime",
+            "that a test-only module has a production consumer",
             "completeness of dynamic loader discovery",
             "that evidence surfaces are themselves used",
         ],
@@ -330,53 +364,101 @@ def _referenced_data_file(
     )
 
 
+def _package_evidence(
+    module_name: str,
+    relative_path: str,
+    *,
+    production_imports: set[str],
+    all_imports: set[str],
+    production_strings: set[str],
+    data_files: list[str],
+) -> str | None:
+    """Return package-level evidence for a package with no production import."""
+
+    prefix = f"{module_name}."
+    # A package is reached whenever anything below it is imported.
+    if any(name.startswith(prefix) for name in production_imports):
+        return "package_of_referenced_module"
+    # A package directory also ships the non-Python contract and schema files
+    # that production code loads by path.
+    package_directory = relative_path[: -len("__init__.py")]
+    if any(
+        data_file.startswith(package_directory)
+        and _referenced_data_file(data_file, package_directory, production_strings)
+        for data_file in data_files
+    ):
+        return "package_data_reference"
+    if any(name.startswith(prefix) for name in all_imports):
+        return "package_of_test_referenced_module"
+    return None
+
+
+def _names_module(module_name: str, relative_path: str, values: set[str]) -> bool:
+    """Report whether any string literal names this module or its path.
+
+    A dotted prefix match is deliberate — ``pkg.mod.attr`` references ``pkg.mod``
+    — but it stops at the dot, so ``pkg.module_extra`` never credits ``pkg.module``.
+    """
+
+    prefix = f"{module_name}."
+    return any(
+        value == module_name or value == relative_path or value.startswith(prefix)
+        for value in values
+    )
+
+
+def _import_evidence(
+    module_name: str,
+    imports_by_projection: dict[str, set[str]],
+) -> list[str]:
+    return [
+        kind
+        for projection, kind in (
+            ("product", "static_import_product"),
+            ("test", "static_import_test"),
+            ("script", "static_import_script"),
+        )
+        if module_name in imports_by_projection.get(projection, set())
+    ]
+
+
 def _module_record(
     module_name: str,
     details: dict[str, Any],
     *,
     imports_by_projection: dict[str, set[str]],
+    production_imports: set[str],
     all_imports: set[str],
-    dynamic_strings: set[str],
+    production_strings: set[str],
+    test_strings: set[str],
     data_files: list[str],
     runtime_corpus: _Corpus,
     documentation_corpus: _Corpus,
 ) -> dict[str, Any]:
     relative_path = details["path"]
-    prefix = f"{module_name}."
-    evidence: list[str] = []
+    evidence = _import_evidence(module_name, imports_by_projection)
 
-    for projection, kind in (
-        ("product", "static_import_product"),
-        ("test", "static_import_test"),
-        ("script", "static_import_script"),
+    if details["is_package"] and not any(
+        kind in PRODUCTION_EVIDENCE for kind in evidence
     ):
-        if module_name in imports_by_projection.get(projection, set()):
-            evidence.append(kind)
-
-    if details["is_package"] and not evidence:
-        # A package is reached whenever anything below it is imported.
-        if any(name.startswith(prefix) for name in all_imports):
-            evidence.append("package_of_referenced_module")
-
-    if details["is_package"] and not evidence:
-        # A package directory also ships the non-Python contract and schema
-        # files that production code loads by path.
-        package_directory = relative_path[: -len("__init__.py")]
-        if any(
-            data_file.startswith(package_directory)
-            and _referenced_data_file(data_file, package_directory, dynamic_strings)
-            for data_file in data_files
-        ):
-            evidence.append("package_data_reference")
+        package_evidence = _package_evidence(
+            module_name,
+            relative_path,
+            production_imports=production_imports,
+            all_imports=all_imports,
+            production_strings=production_strings,
+            data_files=data_files,
+        )
+        if package_evidence is not None:
+            evidence.append(package_evidence)
 
     if details["module_main_block"]:
         evidence.append("module_main_block")
 
-    if any(
-        value == module_name or value == relative_path or value.startswith(prefix)
-        for value in dynamic_strings
-    ):
+    if _names_module(module_name, relative_path, production_strings):
         evidence.append("dynamic_string_reference")
+    elif _names_module(module_name, relative_path, test_strings):
+        evidence.append("dynamic_string_reference_test")
 
     if runtime_corpus.contains(module_name, relative_path):
         evidence.append("runtime_surface_reference")
@@ -392,37 +474,65 @@ def _module_record(
         "has_non_documentation_evidence": any(
             kind in NON_DOCUMENTATION_EVIDENCE for kind in evidence
         ),
+        "has_production_evidence": any(
+            kind in PRODUCTION_EVIDENCE for kind in evidence
+        ),
     }
+
+
+def _declaration_findings(
+    observed: list[str],
+    allowed: Iterable[str],
+    *,
+    code: str,
+    stale_code: str,
+) -> list[dict[str, Any]]:
+    """Require every observed module to be declared, and every declaration used."""
+
+    declared = set(allowed)
+    findings = [
+        {"code": code, "module": module}
+        for module in observed
+        if module not in declared
+    ]
+    findings.extend(
+        {"code": stale_code, "module": module}
+        for module in sorted(declared - set(observed))
+    )
+    return findings
 
 
 def evaluate_reachability_policy(
     measurement: dict[str, Any],
     policy: dict[str, Any],
 ) -> list[dict[str, Any]]:
-    """Reject newly unproven modules and undeclared documentation-only modules."""
+    """Reject undeclared unproven, documentation-only and test-only modules."""
 
-    findings: list[dict[str, Any]] = []
-    allowed_unproven = set(policy.get("allowed_unproven") or [])
-    allowed_documentation_only = set(policy.get("allowed_documentation_only") or [])
-
-    for module in measurement["unproven"]:
-        if module not in allowed_unproven:
-            findings.append({"code": "module_reachability_unproven", "module": module})
-    for module in sorted(allowed_unproven - set(measurement["unproven"])):
-        findings.append({"code": "module_reachability_allowlist_stale", "module": module})
+    findings = _declaration_findings(
+        measurement["unproven"],
+        policy.get("allowed_unproven") or [],
+        code="module_reachability_unproven",
+        stale_code="module_reachability_allowlist_stale",
+    )
 
     if policy.get("require_non_documentation_evidence", True):
-        for module in measurement["documentation_only"]:
-            if module not in allowed_documentation_only:
-                findings.append(
-                    {"code": "module_reachability_documentation_only", "module": module}
-                )
-        for module in sorted(
-            allowed_documentation_only - set(measurement["documentation_only"])
-        ):
-            findings.append(
-                {"code": "module_reachability_documentation_allowlist_stale", "module": module}
-            )
+        findings += _declaration_findings(
+            measurement["documentation_only"],
+            policy.get("allowed_documentation_only") or [],
+            code="module_reachability_documentation_only",
+            stale_code="module_reachability_documentation_allowlist_stale",
+        )
+
+    if policy.get("require_production_evidence", True):
+        # A production module that only its own tests reach is not proven to be
+        # part of any production path. It is not dead either, so it is declared
+        # rather than removed, and the declaration must stay accurate.
+        findings += _declaration_findings(
+            measurement["test_only"],
+            policy.get("allowed_test_only") or [],
+            code="module_reachability_test_only",
+            stale_code="module_reachability_test_only_allowlist_stale",
+        )
 
     if measurement["unparsed_files"]:
         findings.append(

--- a/merger/repoground/core/artifact_io.py
+++ b/merger/repoground/core/artifact_io.py
@@ -60,6 +60,16 @@ def compute_file_sha256(path: Path) -> str:
         return "ERROR"
 
 
+def is_sha256_digest(value: object) -> bool:
+    """Return whether ``value`` is exactly one lowercase SHA-256 digest."""
+
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
 def append_unique_path(paths: List[Path], path: Optional[Path]) -> None:
     """Append ``path`` unless it is absent or already recorded."""
 

--- a/merger/repoground/core/artifact_io.py
+++ b/merger/repoground/core/artifact_io.py
@@ -1,0 +1,102 @@
+"""Deterministic artifact writing and hashing primitives.
+
+This module is a dependency-free leaf of the bundle pipeline: it must not
+import any other RepoGround core module so that artifact writers can depend on
+it without creating import cycles.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, List, Optional
+
+_SHA256_READ_CHUNK_BYTES = 65536
+
+
+def write_text_atomic(path: Path, text: str) -> None:
+    """Write ``text`` to ``path`` via a same-directory temporary file."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path: Optional[Path] = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            delete=False,
+            dir=str(path.parent),
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+        ) as tmp_file:
+            tmp_file.write(text)
+            tmp_file.flush()
+            os.fsync(tmp_file.fileno())
+            tmp_path = Path(tmp_file.name)
+        os.replace(tmp_path, path)
+    finally:
+        if tmp_path is not None and tmp_path.exists():
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
+
+
+def compute_file_sha256(path: Path) -> str:
+    """Compute SHA256 hash of a file using chunked reading for memory efficiency."""
+
+    sha256 = hashlib.sha256()
+    try:
+        with path.open("rb") as f:
+            while True:
+                chunk = f.read(_SHA256_READ_CHUNK_BYTES)
+                if not chunk:
+                    break
+                sha256.update(chunk)
+        return sha256.hexdigest()
+    except OSError:
+        return "ERROR"
+
+
+def append_unique_path(paths: List[Path], path: Optional[Path]) -> None:
+    """Append ``path`` unless it is absent or already recorded."""
+
+    if path is not None and path not in paths:
+        paths.append(path)
+
+
+def json_safe(obj: Any) -> Any:
+    """Coerce ``obj`` into deterministic JSON-serialisable data.
+
+    Unknown objects become a stable ``__type__:<module>.<qualname>`` tag rather
+    than a ``repr`` so that provenance hashes never depend on memory addresses.
+    """
+
+    if isinstance(obj, (str, int, float, bool, type(None))):
+        return obj
+    if isinstance(obj, (list, tuple)):
+        return [json_safe(x) for x in obj]
+    if isinstance(obj, set):
+        return sorted([json_safe(x) for x in obj])
+    if isinstance(obj, dict):
+        return {
+            str(k): json_safe(v)
+            for k, v in sorted(obj.items(), key=lambda i: str(i[0]))
+        }
+    if isinstance(obj, Path):
+        return str(obj)
+    if hasattr(obj, "name") and hasattr(obj, "value"):  # Enum-like
+        return obj.name
+
+    obj_type = type(obj)
+    module = getattr(obj_type, "__module__", "__builtin__")
+    qualname = getattr(obj_type, "__qualname__", obj_type.__name__)
+    return f"__type__:{module}.{qualname}"
+
+
+def write_json_lines(path: Path, rows: List[Any]) -> None:
+    """Write ``rows`` as deterministic JSONL."""
+
+    write_text_atomic(path, "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows))

--- a/merger/repoground/core/bundle_sidecars.py
+++ b/merger/repoground/core/bundle_sidecars.py
@@ -16,7 +16,12 @@ import json
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from .artifact_io import compute_file_sha256, write_json_lines, write_text_atomic
+from .artifact_io import (
+    compute_file_sha256,
+    is_sha256_digest,
+    write_json_lines,
+    write_text_atomic,
+)
 
 _MANIFEST_SUFFIX = ".bundle.manifest.json"
 
@@ -72,7 +77,7 @@ def write_python_symbol_index_json(
     if repo_root is None:
         return None
     canonical_sha = compute_file_sha256(final_dump_index)
-    if not canonical_sha:
+    if not is_sha256_digest(canonical_sha):
         return None
     from merger.repoground.architecture.symbol_index import (
         generate_symbol_index_document,
@@ -98,7 +103,7 @@ def write_python_call_graph_json(
     if repo_root is None:
         return None
     canonical_sha = compute_file_sha256(final_dump_index)
-    if not canonical_sha:
+    if not is_sha256_digest(canonical_sha):
         return None
     from merger.repoground.architecture.call_graph import generate_call_graph_document
 

--- a/merger/repoground/core/bundle_sidecars.py
+++ b/merger/repoground/core/bundle_sidecars.py
@@ -1,0 +1,194 @@
+"""Deterministic emission of bundle sidecar navigation artifacts.
+
+A sidecar is a secondary artifact written next to the bundle manifest: symbol
+index, call graph, lens/concept/relation cards and PR delta evidence. Each
+writer is pure with respect to the merge run: it receives the manifest path and
+the data it needs, writes at most one file and returns its path or ``None``.
+
+The module depends only on :mod:`merger.repoground.core.artifact_io` and on the
+individual card producers, never on :mod:`merger.repoground.core.merge`, so the
+bundle pipeline can import it without an import cycle.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .artifact_io import compute_file_sha256, write_json_lines, write_text_atomic
+
+_MANIFEST_SUFFIX = ".bundle.manifest.json"
+
+
+def sidecar_path(base_manifest_path: Path, suffix: str) -> Path:
+    """Return the sidecar path derived from the bundle manifest name."""
+
+    return base_manifest_path.with_name(
+        base_manifest_path.name.replace(_MANIFEST_SUFFIX, suffix)
+    )
+
+
+def _single_repo_root(
+    repo_summaries: List[Dict[str, Any]],
+    final_dump_index: Optional[Path],
+) -> Optional[Path]:
+    """Return the repository root for single-repo bundles with a dump index."""
+
+    if len(repo_summaries) != 1:
+        return None
+    if final_dump_index is None or not final_dump_index.exists():
+        return None
+    repo_root = repo_summaries[0].get("root")
+    if repo_root is None:
+        return None
+    return Path(repo_root)
+
+
+def _write_provenance_document(
+    *,
+    base_manifest_path: Path,
+    suffix: str,
+    document: Dict[str, Any],
+) -> Path:
+    out_path = sidecar_path(base_manifest_path, suffix)
+    write_text_atomic(
+        out_path,
+        json.dumps(document, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
+    )
+    return out_path
+
+
+def write_python_symbol_index_json(
+    *,
+    base_manifest_path: Path,
+    repo_summaries: List[Dict[str, Any]],
+    final_dump_index: Optional[Path],
+    run_id: str,
+) -> Optional[Path]:
+    """Emit Python Symbol Index v1 for single-repo bundles as navigation only."""
+
+    repo_root = _single_repo_root(repo_summaries, final_dump_index)
+    if repo_root is None:
+        return None
+    canonical_sha = compute_file_sha256(final_dump_index)
+    if not canonical_sha:
+        return None
+    from merger.repoground.architecture.symbol_index import (
+        generate_symbol_index_document,
+    )
+
+    return _write_provenance_document(
+        base_manifest_path=base_manifest_path,
+        suffix=".python_symbol_index.json",
+        document=generate_symbol_index_document(repo_root, run_id, canonical_sha),
+    )
+
+
+def write_python_call_graph_json(
+    *,
+    base_manifest_path: Path,
+    repo_summaries: List[Dict[str, Any]],
+    final_dump_index: Optional[Path],
+    run_id: str,
+) -> Optional[Path]:
+    """Emit Python Call Graph v1 for one repository as navigation only."""
+
+    repo_root = _single_repo_root(repo_summaries, final_dump_index)
+    if repo_root is None:
+        return None
+    canonical_sha = compute_file_sha256(final_dump_index)
+    if not canonical_sha:
+        return None
+    from merger.repoground.architecture.call_graph import generate_call_graph_document
+
+    return _write_provenance_document(
+        base_manifest_path=base_manifest_path,
+        suffix=".python_call_graph.json",
+        document=generate_call_graph_document(repo_root, run_id, canonical_sha),
+    )
+
+
+def write_lens_cards_jsonl(
+    *,
+    base_manifest_path: Path,
+    repo_summaries: List[Dict[str, Any]],
+) -> Optional[Path]:
+    """Emit Lens Cards v1 as deterministic JSONL navigation."""
+
+    from .lens_cards import produce_lens_cards
+
+    paths: List[str] = []
+    for summary in repo_summaries:
+        for fi in summary.get("files", []):
+            if getattr(fi, "is_text", False):
+                paths.append(fi.rel_path.as_posix())
+    if not paths:
+        return None
+    cards = produce_lens_cards(paths)
+    if not cards:
+        return None
+    out_path = sidecar_path(base_manifest_path, ".lens_cards.jsonl")
+    write_json_lines(out_path, cards)
+    return out_path
+
+
+def write_concept_cards_jsonl(*, base_manifest_path: Path) -> Optional[Path]:
+    """Emit built-in Concept Cards v1 as deterministic JSONL navigation."""
+
+    from .concept_cards import produce_default_concept_cards
+
+    cards = produce_default_concept_cards()
+    if not cards:
+        return None
+    out_path = sidecar_path(base_manifest_path, ".concept_cards.jsonl")
+    write_json_lines(out_path, cards)
+    return out_path
+
+
+def write_relation_cards_jsonl(
+    *,
+    base_manifest_path: Path,
+    graph_path: Optional[Path],
+) -> Optional[Path]:
+    """Emit Relation Cards v1 as deterministic JSONL navigation."""
+
+    if graph_path is None or not graph_path.exists():
+        return None
+    from .relation_cards import produce_relation_cards
+
+    graph_data = json.loads(graph_path.read_text(encoding="utf-8"))
+    cards = produce_relation_cards(graph_data)
+    if not cards:
+        return None
+    out_path = sidecar_path(base_manifest_path, ".relation_cards.jsonl")
+    write_json_lines(out_path, cards)
+    return out_path
+
+
+def write_delta_json(
+    *,
+    base_manifest_path: Path,
+    source_delta: Dict[str, Any],
+) -> Path:
+    """Emit the validated PR Schau delta source as bundle diagnostic JSON."""
+
+    return _write_provenance_document(
+        base_manifest_path=base_manifest_path,
+        suffix=".delta.json",
+        document=source_delta,
+    )
+
+
+def write_pr_delta_cards_jsonl(
+    *,
+    base_manifest_path: Path,
+    cards: List[Dict[str, Any]],
+) -> Optional[Path]:
+    """Emit PR Delta Cards v1 after the changed-set source was validated."""
+
+    if not cards:
+        return None
+    out_path = sidecar_path(base_manifest_path, ".pr_delta_cards.jsonl")
+    write_json_lines(out_path, cards)
+    return out_path

--- a/merger/repoground/core/bundle_sidecars.py
+++ b/merger/repoground/core/bundle_sidecars.py
@@ -27,11 +27,19 @@ _MANIFEST_SUFFIX = ".bundle.manifest.json"
 
 
 def sidecar_path(base_manifest_path: Path, suffix: str) -> Path:
-    """Return the sidecar path derived from the bundle manifest name."""
+    """Return a sidecar path derived from one canonical bundle manifest name.
 
-    return base_manifest_path.with_name(
-        base_manifest_path.name.replace(_MANIFEST_SUFFIX, suffix)
-    )
+    Refuse malformed bases instead of letting ``str.replace`` return the
+    original path and allowing a secondary artifact to overwrite its manifest.
+    """
+
+    if not base_manifest_path.name.endswith(_MANIFEST_SUFFIX):
+        raise ValueError(
+            "sidecar base must end with "
+            f"{_MANIFEST_SUFFIX!r}: {base_manifest_path.name!r}"
+        )
+    stem = base_manifest_path.name[: -len(_MANIFEST_SUFFIX)]
+    return base_manifest_path.with_name(f"{stem}{suffix}")
 
 
 def _single_repo_root(

--- a/merger/repoground/core/merge.py
+++ b/merger/repoground/core/merge.py
@@ -13,14 +13,20 @@ import hashlib
 import datetime
 import logging
 import re
-import tempfile
 import unicodedata
 import concurrent.futures
+import functools
 from pathlib import Path
 from typing import List, Dict, Optional, Tuple, Any, Iterator, NamedTuple, Set
 from dataclasses import dataclass, asdict
 
-from . import lenses
+from . import bundle_sidecars, lenses
+from .artifact_io import (
+    append_unique_path as _append_unique_path,
+    compute_file_sha256 as _compute_file_sha256,
+    json_safe as _json_safe,
+    write_text_atomic as _write_text_atomic,
+)
 from .constants import (
     ArtifactRole,
     CLAIM_EVIDENCE_MAP_ABSENCE_REASON_LINK_KEY,
@@ -45,67 +51,6 @@ EPISTEMIC_HUMILITY_WARNING = "⚠️ **Hinweis:** Dieses Profil/Filter erlaubt k
 logger = logging.getLogger(__name__)
 
 
-def _write_text_atomic(path: Path, text: str) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path: Optional[Path] = None
-    try:
-        with tempfile.NamedTemporaryFile(
-            mode="w",
-            encoding="utf-8",
-            delete=False,
-            dir=str(path.parent),
-            prefix=f".{path.name}.",
-            suffix=".tmp",
-        ) as tmp_file:
-            tmp_file.write(text)
-            tmp_file.flush()
-            os.fsync(tmp_file.fileno())
-            tmp_path = Path(tmp_file.name)
-        os.replace(tmp_path, path)
-    finally:
-        if tmp_path is not None and tmp_path.exists():
-            try:
-                tmp_path.unlink()
-            except OSError:
-                pass
-
-
-def _append_unique_path(paths: List[Path], path: Optional[Path]) -> None:
-    if path is not None and path not in paths:
-        paths.append(path)
-
-
-def _write_python_call_graph_json(
-    *,
-    base_manifest_path: Path,
-    repo_summaries: List[Dict[str, Any]],
-    final_dump_index: Optional[Path],
-    run_id: str,
-) -> Optional[Path]:
-    """Emit Python Call Graph v1 for one repository as navigation only."""
-    if len(repo_summaries) != 1 or final_dump_index is None or not final_dump_index.exists():
-        return None
-    repo_root = repo_summaries[0].get("root")
-    if repo_root is None:
-        return None
-    canonical_sha = _compute_file_sha256(final_dump_index)
-    if not canonical_sha:
-        return None
-    from merger.repoground.architecture.call_graph import generate_call_graph_document
-
-    document = generate_call_graph_document(Path(repo_root), run_id, canonical_sha)
-    out_path = base_manifest_path.with_name(
-        base_manifest_path.name.replace(
-            ".bundle.manifest.json", ".python_call_graph.json"
-        )
-    )
-    _write_text_atomic(
-        out_path,
-        json.dumps(document, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
-    )
-    return out_path
-
-
 def _register_optional_artifact(
     path: Optional[Path],
     *,
@@ -114,12 +59,14 @@ def _register_optional_artifact(
     out_paths: List[Path],
     other_paths: List[Path],
     add_artifact: Any,
-) -> None:
+) -> Optional[Path]:
+    """Record an optional artifact in both path lists; return it unchanged."""
     if path is None:
-        return
+        return None
     out_paths.append(path)
     _append_unique_path(other_paths, path)
     add_artifact(path, role, content_type)
+    return path
 
 
 def _slug_token(s: str) -> str:
@@ -2140,21 +2087,6 @@ def is_probably_text(path: Path, size: int) -> bool:
     if b"\x00" in chunk:
         return False
     return True
-
-
-def _compute_file_sha256(path: Path) -> str:
-    """Compute SHA256 hash of a file using chunked reading for memory efficiency."""
-    sha256 = hashlib.sha256()
-    try:
-        with path.open("rb") as f:
-            while True:
-                chunk = f.read(65536)
-                if not chunk:
-                    break
-                sha256.update(chunk)
-        return sha256.hexdigest()
-    except OSError:
-        return "ERROR"
 
 
 def _attach_inline_chunk_content(chunk, content_bytes: bytes) -> None:
@@ -5445,6 +5377,767 @@ def extract_file_offsets(md_paths: List[Path], debug: bool = False) -> Dict[str,
                 print(f"Error extracting offsets from {md_path}: {e}")
     return offsets
 
+
+_DUMP_INDEX_CONTENT_TYPES = (
+    (".json", "application/json"),
+    (".jsonl", "application/x-ndjson"),
+    (".md", "text/markdown"),
+)
+
+_DUMP_INDEX_CONTRACTS = {
+    ArtifactRole.CHUNK_INDEX_JSONL.value: ("chunk-index", "v2"),
+    ArtifactRole.ARCHITECTURE_SUMMARY.value: ("architecture-summary", "v1"),
+}
+
+
+def _dump_index_content_type(name: str) -> str:
+    for extension, content_type in _DUMP_INDEX_CONTENT_TYPES:
+        if name.endswith(extension):
+            return content_type
+    return "application/octet-stream"
+
+
+def _dump_index_contract(role: str) -> Optional[Tuple[str, str]]:
+    """Return (contract, version) for roles that carry a declared contract."""
+    if role == ArtifactRole.INDEX_SIDECAR_JSON.value:
+        return AGENT_CONTRACT_NAME, AGENT_CONTRACT_VERSION
+    if role == ArtifactRole.CANONICAL_MD.value:
+        return MERGE_CONTRACT_NAME, MERGE_CONTRACT_VERSION
+    return _DUMP_INDEX_CONTRACTS.get(role)
+
+
+def _dump_index_entry(role: str, path: Path) -> Dict[str, Any]:
+    entry = {
+        "path": path.name,
+        "role": role,
+        "content_type": _dump_index_content_type(path.name),
+        "bytes": path.stat().st_size,
+        "sha256": _compute_file_sha256(path),
+    }
+    contract = _dump_index_contract(role)
+    if contract is not None:
+        entry["contract"], entry["contract_version"] = contract
+    return entry
+
+
+def generate_dump_index(base_name_func, run_id, artifacts_map, generator_info, repo_names):
+    """Write the canonical dump index that lists every materialized artifact."""
+    out_path = base_name_func(part_suffix="").with_suffix(".dump_index.json")
+
+    artifacts_block = {
+        role: _dump_index_entry(role, path)
+        for role, path in artifacts_map.items()
+        if path and path.exists()
+    }
+
+    now_str = clock.now_utc().strftime('%Y-%m-%dT%H:%M:%SZ')
+    data = {
+        "contract": "dump-index",
+        "contract_version": "v1",
+        "run_id": run_id,
+        "created_at": now_str,
+        "generated_at": now_str,
+        "generator": generator_info,
+        "repos": repo_names,
+        # Sort artifacts by key for determinism
+        "artifacts": dict(sorted(artifacts_block.items())),
+    }
+
+    out_path.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+    return out_path
+
+
+@dataclass(frozen=True)
+class _ReportRunConfig:
+    """Immutable rendering configuration shared by the report writers.
+
+    ``write_reports_v2`` normalizes its arguments once and hands this object to
+    the block renderers so that they stay independently testable instead of
+    closing over the caller's locals.
+    """
+
+    detail: str
+    max_file_bytes: int
+    plan_only: bool
+    code_only: bool
+    split_size: int
+    path_filter: Optional[str]
+    ext_filter: Optional[List[str]]
+    extras: Optional["ExtrasConfig"]
+    delta_meta: Optional[Dict[str, Any]]
+    meta_density: str
+    meta_none: bool
+    output_mode: str
+    redact_secrets: bool
+    debug: bool
+
+
+def _chunk_record(
+    chunk,
+    *,
+    fi: "FileInfo",
+    lang: str,
+    status: str,
+    truncated: bool,
+    trunc_msg: Optional[str],
+    sem_meta: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Build the machine-readable chunk row, including legacy field aliases."""
+    d = asdict(chunk)
+    d["path"] = fi.rel_path.as_posix()
+    d["repo"] = fi.root_label
+    d["language"] = lang
+    d["source_status"] = status
+    d["truncated"] = truncated
+    # Semantic Extension
+    d["section"] = sem_meta["section"]
+    d["layer"] = sem_meta["layer"]
+    d["artifact_type"] = sem_meta["artifact_type"]
+    d["concepts"] = sem_meta["concepts"]
+
+    if trunc_msg:
+        d["truncation_msg"] = trunc_msg
+
+    # Legacy Aliases (Backward Compatibility for v2 transition)
+    d["byte_offset_start"] = d["start_byte"]
+    d["byte_offset_end"] = d["end_byte"]
+    d["line_start"] = d["start_line"]
+    d["line_end"] = d["end_line"]
+    d["content_sha256"] = d["sha256"]
+    d["size_bytes"] = d["size"]
+
+    # Extended machine-readable fields (v2.4)
+    d["source_file"] = fi.rel_path.as_posix()
+    d["content_artifact"] = "merge_md"
+    d["content_range"] = {
+        "start_byte": d["start_byte"],
+        "end_byte": d["end_byte"],
+        "start_line": d["start_line"],
+        "end_line": d["end_line"]
+    }
+    d["search_keys"] = {
+        "repo_id": fi.root_label,
+        "path_norm": fi.rel_path.as_posix().lower(),
+        "ext": fi.ext.lower().lstrip("."),
+        "layer": sem_meta["layer"],
+        "artifact_type": sem_meta["artifact_type"]
+    }
+    return d
+
+
+def _attach_canonical_range(
+    d: Dict[str, Any],
+    *,
+    repo_label: str,
+    md_file_name: str,
+    md_start_byte: int,
+    canonical_md_bytes: Optional[bytes],
+) -> None:
+    """Point the chunk at its canonical Markdown byte range.
+
+    V2.4 Range Ref Propagation: refs address the canonical_md bytes directly.
+    The resolver only accepts the primary canonical_md artifact defined in the
+    manifest, so full bundle-backed refs stay limited to the first part.
+    """
+    abs_start = md_start_byte + d["start_byte"]
+    abs_end = md_start_byte + d["end_byte"]
+
+    if canonical_md_bytes is not None:
+        # Compute canonical-local values once; share across both fields.
+        # can_sha256 is the exact range hash for canonical_md_bytes[abs_start:abs_end].
+        can_chunk = canonical_md_bytes[abs_start:abs_end]
+        can_sha256 = hashlib.sha256(can_chunk).hexdigest()
+        can_start_line = _line_for_byte(canonical_md_bytes, abs_start)
+        can_end_line = _line_for_byte(canonical_md_bytes, max(abs_start, abs_end - 1))
+    else:
+        # Fall back to source-local values when canonical bytes unavailable.
+        can_sha256 = d["sha256"]
+        can_start_line = d["start_line"]
+        can_end_line = d["end_line"]
+
+    d["content_range_ref"] = build_explicit_range_ref(
+        artifact_role=ArtifactRole.CANONICAL_MD.value,
+        repo_id=repo_label,
+        file_path=md_file_name,
+        start_byte=abs_start,
+        end_byte=abs_end,
+        start_line=can_start_line,
+        end_line=can_end_line,
+        content_sha256=can_sha256,
+    )
+
+    if canonical_md_bytes is not None:
+        d["canonical_range"] = {
+            "artifact_role": ArtifactRole.CANONICAL_MD.value,
+            "repo_id": repo_label,
+            "file_path": md_file_name,
+            "start_byte": abs_start,
+            "end_byte": abs_end,
+            "start_line": can_start_line,
+            "end_line": can_end_line,
+            "content_sha256": can_sha256,
+        }
+
+
+def _attach_source_range(
+    d: Dict[str, Any],
+    *,
+    fi: "FileInfo",
+    was_redacted: bool,
+    truncated: bool,
+    source_git_blob_sha1: Optional[str],
+) -> None:
+    """Attach source-space coordinates.
+
+    ``source_range`` is always present. Status taxonomy: ``declared`` (source
+    coordinates claimed, not externally verified) or ``unavailable`` (redacted
+    or truncated).
+    """
+    if was_redacted or truncated:
+        d["source_range"] = {
+            "file_path": fi.rel_path.as_posix(),
+            "repo_id": fi.root_label,
+            "status": "unavailable",
+        }
+        return
+
+    d["source_range"] = {
+        "file_path": fi.rel_path.as_posix(),
+        "repo_id": fi.root_label,
+        "start_byte": d["start_byte"],
+        "end_byte": d["end_byte"],
+        "start_line": d["start_line"],
+        "end_line": d["end_line"],
+        "content_sha256": d["sha256"],
+        "status": "declared",
+    }
+    if source_git_blob_sha1:
+        d["source_range"]["git_blob_sha1"] = source_git_blob_sha1
+        d["source_range"]["git_blob_sha1_basis"] = "source_worktree_file_content"
+
+
+def _file_chunk_records(
+    fi: "FileInfo",
+    *,
+    config: "_ReportRunConfig",
+    chunker: "Chunker",
+    redactor: Optional["Redactor"],
+    status: str,
+    md_offsets: Dict[str, Tuple[str, int]],
+    canonical_md_name: Optional[str],
+    canonical_md_bytes: Optional[bytes],
+) -> List[Dict[str, Any]]:
+    """Chunk one included text file into fully annotated chunk rows."""
+    # Read content for chunking using the same limit as report to ensure coherence
+    content, truncated, trunc_msg = read_smart_content(fi, config.max_file_bytes)
+
+    was_redacted = False
+    if redactor:
+        content, _redacted_items = redactor.redact(content)
+        was_redacted = bool(_redacted_items)
+
+    content_bytes = content.encode("utf-8")
+    source_git_blob_sha1 = (
+        _compute_git_blob_sha1(fi.abs_path)
+        if not was_redacted and not truncated
+        else None
+    )
+
+    sem_meta = get_semantic_metadata(fi.rel_path.as_posix(), content)
+    fid = _stable_file_id(fi)
+    # Pass file_path for deterministic chunk ID
+    chunks = chunker.chunk_file(fid, content, file_path=fi.rel_path.as_posix())
+    lang = lang_for(fi.ext)
+
+    records: List[Dict[str, Any]] = []
+    for c in chunks:
+        d = _chunk_record(
+            c,
+            fi=fi,
+            lang=lang,
+            status=status,
+            truncated=truncated,
+            trunc_msg=trunc_msg,
+            sem_meta=sem_meta,
+        )
+        offset = md_offsets.get(fid)
+        if offset is not None and offset[0] == canonical_md_name:
+            _attach_canonical_range(
+                d,
+                repo_label=fi.root_label,
+                md_file_name=offset[0],
+                md_start_byte=offset[1],
+                canonical_md_bytes=canonical_md_bytes,
+            )
+
+        # Retrieval-only and noncanonical split chunks must carry
+        # their exact redacted text because no canonical artifact exists.
+        _attach_inline_chunk_content(d, content_bytes)
+        _attach_source_range(
+            d,
+            fi=fi,
+            was_redacted=was_redacted,
+            truncated=truncated,
+            source_git_blob_sha1=source_git_blob_sha1,
+        )
+        records.append(d)
+    return records
+
+
+def generate_chunk_artifacts(
+    config: "_ReportRunConfig",
+    target_files,
+    output_filename_base_func,
+    md_paths: Optional[List[Path]] = None,
+):
+    """Emit the chunk index for retrieval-capable output modes."""
+    if config.output_mode not in ("retrieval", "dual"):
+        return None
+
+    chunker = Chunker()
+    redactor = Redactor() if config.redact_secrets else None
+
+    # Build offset map from all generated markdown parts
+    md_offsets = extract_file_offsets(md_paths, config.debug) if md_paths else {}
+    can_md = resolve_canonical_md(md_paths) if md_paths else None
+    canonical_md_name = can_md.name if can_md else None
+    canonical_md_bytes = can_md.read_bytes() if (can_md and can_md.exists()) else None
+
+    all_chunks: List[Dict[str, Any]] = []
+
+    # Sort files same as report
+    target_files.sort(key=lambda fi: (get_repo_sort_index(fi.root_label), fi.root_label.lower(), str(fi.rel_path).lower()))
+
+    for fi in target_files:
+        # Only process included text files
+        status = determine_inclusion_status(fi, config.detail, config.max_file_bytes)
+        if not fi.is_text or status not in ("full", "truncated"):
+            continue
+        all_chunks.extend(
+            _file_chunk_records(
+                fi,
+                config=config,
+                chunker=chunker,
+                redactor=redactor,
+                status=status,
+                md_offsets=md_offsets,
+                canonical_md_name=canonical_md_name,
+                canonical_md_bytes=canonical_md_bytes,
+            )
+        )
+
+    if not all_chunks:
+        return None
+
+    out_path = output_filename_base_func(part_suffix="").with_suffix(".chunk_index.jsonl")
+    try:
+        with out_path.open("w", encoding="utf-8") as f:
+            for c in all_chunks:
+                f.write(json.dumps(c) + "\n")
+        return out_path
+    except Exception as e:
+        if config.debug:
+            print(f"Error writing chunk index: {e}")
+        return None
+
+
+# --- Split-Mode Contract ---
+# By architectural mandate (Phase 1, Schwerpunkt D), only the FIRST part of a split
+# bundle is considered fully `bundle-backed` and canonically referenceable.
+# Subsequent parts are transient artifacts and do NOT receive `content_range_ref` provenance.
+# The chunker and the JSON sidecar exclusively refer to `md_parts[0]` as the canonical representation.
+
+
+class _SplitReportBuffer:
+    """Accumulate report blocks and flush them into temporary part files."""
+
+    def __init__(self, output_filename_base_func) -> None:
+        self._base_name = output_filename_base_func
+        self.part_paths: List[Path] = []
+        self.parts_meta: List[Dict[str, Optional[str]]] = []
+        self._part_num = 1
+        self._size = 0
+        self._lines: List[str] = []
+        self._part_block_paths: List[str] = []
+
+    @property
+    def size(self) -> int:
+        return self._size
+
+    @property
+    def buffered_blocks(self) -> int:
+        return len(self._lines)
+
+    def append(self, block: str, block_len: int, block_path: Optional[str]) -> None:
+        self._lines.append(block)
+        self._size += block_len
+        if block_path:
+            self._part_block_paths.append(block_path)
+
+    def flush(self, is_last: bool = False) -> None:
+        if not self._lines:
+            return
+
+        # Record metadata for this part
+        first = self._part_block_paths[0] if self._part_block_paths else None
+        last = self._part_block_paths[-1] if self._part_block_paths else None
+        self.parts_meta.append({"first": first, "last": last})
+        self._part_block_paths = []
+
+        # Temporärer Name während der Generierung
+        # Wir nutzen _tmp_partX, um es später sauber umzubenennen
+        out_path = self._base_name(part_suffix=f"_tmp_part{self._part_num}")
+        out_path.write_text("".join(self._lines), encoding="utf-8")
+        self.part_paths.append(out_path)
+
+        self._part_num += 1
+        self._lines = []
+        # Add continuation header for next part
+        if not is_last:
+            header = f"{CANONICAL_REPORT_HEADING} (Part {self._part_num})\n\n"
+            # Note: we don't feed continuation headers to validator as they are technical split artifacts,
+            # not part of the logical report structure.
+            self._lines.append(header)
+            self._size = len(header.encode('utf-8'))
+        else:
+            self._size = 0
+
+
+def _part_signature_block(
+    idx: int,
+    total_parts: int,
+    parts_meta: List[Dict[str, Optional[str]]],
+    output_filename_base_func,
+) -> str:
+    meta = parts_meta[idx - 1]
+    p_start = meta["first"]
+    p_end = meta["last"]
+    range_str = f"{p_start} ... {p_end}" if p_start else "Meta/Structure/Index"
+
+    prev_name = "none"
+    if idx > 1:
+        # calculate name of part idx-1
+        prev_suffix = f"_part{idx - 1}of{total_parts}"
+        prev_name = output_filename_base_func(part_suffix=prev_suffix).name
+
+    return (
+        f"<!-- part_signature:\n"
+        f"  part_index: {idx}\n"
+        f"  part_total: {total_parts}\n"
+        f"  continuation_of: \"{prev_name}\"\n"
+        f"  range: \"{range_str}\"\n"
+        f"-->\n"
+        f"**[Part {idx}/{total_parts}]** continuation_of: `{prev_name}` · range: `{range_str}`\n\n"
+    )
+
+
+def _rewrite_part_heading(
+    text: str,
+    idx: int,
+    total_parts: int,
+    parts_meta: List[Dict[str, Optional[str]]],
+    output_filename_base_func,
+) -> str:
+    """Normalize the part heading and inject the part signature."""
+    lines = text.splitlines(True)
+    prefix_part = f"{CANONICAL_REPORT_HEADING} (Part "
+    prefix_main = CANONICAL_REPORT_HEADING
+    for i, line in enumerate(lines):
+        stripped = line.lstrip("\ufeff")
+        if stripped.startswith(prefix_part) or stripped.startswith(prefix_main):
+            lines[i] = f"{CANONICAL_REPORT_HEADING} (Part {idx}/{total_parts})\n"
+            if total_parts > 1:
+                lines.insert(
+                    i + 1,
+                    _part_signature_block(idx, total_parts, parts_meta, output_filename_base_func),
+                )
+            break
+    return "".join(lines)
+
+
+def _finalize_split_parts(
+    output_filename_base_func,
+    part_paths: List[Path],
+    parts_meta: List[Dict[str, Optional[str]]],
+) -> List[Path]:
+    """Nachlauf: Header normalisieren UND Dateien umbenennen (Part X of Y)."""
+    total_parts = len(part_paths)
+    final_paths: List[Path] = []
+
+    for idx, path in enumerate(part_paths, start=1):
+        # 1. Header Rewrite
+        try:
+            text = _rewrite_part_heading(
+                path.read_text(encoding="utf-8"),
+                idx,
+                total_parts,
+                parts_meta,
+                output_filename_base_func,
+            )
+        except Exception:
+            text = None  # Skip rewrite if read fails, but still rename
+
+        # 2. Rename File
+        # If total_parts == 1, no part suffix.
+        # If total_parts > 1, _partXofY.
+        new_suffix = "" if total_parts == 1 else f"_part{idx}of{total_parts}"
+        new_path = output_filename_base_func(part_suffix=new_suffix)
+
+        if text is not None:
+            new_path.write_text(text, encoding="utf-8")
+            # Delete old tmp file
+            try:
+                path.unlink()
+            except OSError:
+                pass
+        else:
+            # Just replace/move if we couldn't read/edit content
+            try:
+                path.replace(new_path)
+            except OSError as e:
+                raise OSError(f"Failed to replace '{path}' with '{new_path}'") from e
+
+        final_paths.append(new_path)
+
+    return final_paths
+
+
+def _report_artifact_refs(
+    config: "_ReportRunConfig",
+    target_sources,
+    output_filename_base_func,
+) -> Dict[str, str]:
+    """Pre-calculate artifact basenames for linking in MD (Recommendation 1)."""
+    artifact_refs: Dict[str, str] = {}
+    if config.extras and config.extras.json_sidecar:
+        # We predict the JSON filename.
+        # Note: We rely on the fact that single-file mode uses part_suffix="".
+        # For split mode, JSON usually follows the base name.
+        artifact_refs["index_json_basename"] = (
+            output_filename_base_func(part_suffix="").with_suffix('.json').name
+        )
+
+    if config.extras and config.extras.augment_sidecar:
+        # Find augment file to get name
+        _aug = _find_augment_file_for_sources(target_sources)
+        if _aug:
+            artifact_refs["augment_sidecar_basename"] = _aug.name
+    return artifact_refs
+
+
+def _iter_configured_report_blocks(
+    config: "_ReportRunConfig",
+    target_files,
+    target_sources,
+    artifact_refs: Dict[str, str],
+) -> Iterator[str]:
+    return iter_report_blocks(
+        target_files,
+        config.detail,
+        config.max_file_bytes,
+        target_sources,
+        config.plan_only,
+        config.code_only,
+        config.debug,
+        config.path_filter,
+        config.ext_filter,
+        config.extras,
+        config.delta_meta,
+        artifact_refs=artifact_refs,
+        meta_density=config.meta_density,
+        meta_none=config.meta_none,
+        redact_secrets=config.redact_secrets,
+    )
+
+
+def _write_split_report(
+    config: "_ReportRunConfig",
+    target_files,
+    target_sources,
+    output_filename_base_func,
+    validator: "ReportValidator",
+    artifact_refs: Dict[str, str],
+) -> List[Path]:
+    """Stream the report into size-bounded parts and finalize their names."""
+    buffer = _SplitReportBuffer(output_filename_base_func)
+
+    for block in _iter_configured_report_blocks(
+        config, target_files, target_sources, artifact_refs
+    ):
+        # Validate the block before writing
+        validator.feed(block)
+        block_len = len(block.encode('utf-8'))
+
+        # Detect path in block using regex to track range for signatures
+        m = re.search(r"\*\*Path:\*\* `(.+?)`", block)
+        block_path = m.group(1) if m else None
+
+        if buffer.size + block_len > config.split_size and buffer.buffered_blocks > 1:
+            # After flush, the block belongs to the next part.
+            buffer.flush()
+
+        buffer.append(block, block_len, block_path)
+
+    buffer.flush(is_last=True)
+    validator.close()
+    return _finalize_split_parts(
+        output_filename_base_func, buffer.part_paths, buffer.parts_meta
+    )
+
+
+def _force_single_part_heading(block: str) -> str:
+    """Enforce the Part 1/1 header strictly on the first yielded block."""
+    lines = block.splitlines(True)
+    for line_idx, line in enumerate(lines):
+        stripped = line.lstrip("\ufeff")
+        if stripped.startswith(REPORT_HEADINGS):
+            lines[line_idx] = f"{CANONICAL_REPORT_HEADING} (Part 1/1)\n"
+            break
+    return "".join(lines)
+
+
+def _write_single_report(
+    config: "_ReportRunConfig",
+    target_files,
+    target_sources,
+    output_filename_base_func,
+    validator: "ReportValidator",
+    artifact_refs: Dict[str, str],
+) -> Path:
+    """Stream the whole report into one file."""
+    out_path = output_filename_base_func(part_suffix="")
+
+    with out_path.open("w", encoding="utf-8") as f:
+        if config.plan_only:
+            f.write("<!-- MODE:PLAN_ONLY -->\n")
+
+        iterator = _iter_configured_report_blocks(
+            config, target_files, target_sources, artifact_refs
+        )
+        for i, block in enumerate(iterator):
+            if i == 0:
+                block = _force_single_part_heading(block)
+            validator.feed(block)
+            f.write(block)
+
+    validator.close()
+    return out_path
+
+
+def process_and_write(
+    config: "_ReportRunConfig",
+    target_files,
+    target_sources,
+    output_filename_base_func,
+    out_paths: List[Path],
+) -> List[Path]:
+    """Render the canonical report, honouring the configured split size."""
+    artifact_refs = _report_artifact_refs(config, target_sources, output_filename_base_func)
+
+    # Instantiate stream validator
+    validator = ReportValidator(
+        plan_only=config.plan_only,
+        code_only=config.code_only,
+        machine_lean=(config.detail == "machine-lean"),
+    )
+
+    if config.split_size > 0:
+        generated_paths = _write_split_report(
+            config, target_files, target_sources, output_filename_base_func,
+            validator, artifact_refs,
+        )
+    else:
+        generated_paths = [
+            _write_single_report(
+                config, target_files, target_sources, output_filename_base_func,
+                validator, artifact_refs,
+            )
+        ]
+
+    out_paths.extend(generated_paths)
+    return generated_paths
+
+
+def _bundle_artifact_entry(
+    path: Path,
+    role: ArtifactRole,
+    content_type: str,
+    merges_dir: Path,
+) -> Optional[Dict[str, Any]]:
+    """Describe one materialized bundle artifact, or ``None`` if unreadable."""
+    sha = _compute_file_sha256(path)
+    if not sha:
+        return None
+    try:
+        rel_path = path.relative_to(merges_dir).as_posix()
+    except ValueError:
+        rel_path = path.name
+
+    entry: Dict[str, Any] = {
+        "role": role.value,
+        "path": rel_path,
+        "content_type": content_type,
+        "bytes": path.stat().st_size,
+        "sha256": sha,
+    }
+    if role in ARTIFACT_CONTRACT_REGISTRY:
+        entry["contract"] = ARTIFACT_CONTRACT_REGISTRY[role]
+        entry["interpretation"] = {"mode": "contract"}
+    else:
+        entry["interpretation"] = {"mode": "role_only"}
+    entry.update(ARTIFACT_AUTHORITY_REGISTRY.get(role, {}))
+    return entry
+
+
+def _collect_bundle_artifact(
+    artifacts_list: List[Dict[str, Any]],
+    merges_dir: Path,
+    path: Optional[Path],
+    role: ArtifactRole,
+    content_type: str,
+) -> None:
+    """Append the manifest entry for ``path`` when the artifact exists."""
+    if path is None or not path.exists():
+        return
+    entry = _bundle_artifact_entry(path, role, content_type, merges_dir)
+    if entry is not None:
+        artifacts_list.append(entry)
+
+
+def _write_architecture_summary(
+    files,
+    merges_dir,
+    repo_names,
+    detail,
+    path_filter,
+    ext_filter_str,
+    run_id,
+    plan_only,
+    code_only,
+    timestamp,
+    meta_none,
+    out_paths
+):
+    # Helper to generate and write the architecture summary.
+    arch_path = make_output_filename(
+        merges_dir,
+        repo_names,
+        detail,
+        "",
+        path_filter,
+        ext_filter_str,
+        run_id,
+        plan_only=plan_only,
+        code_only=code_only,
+        timestamp=timestamp,
+        meta_none=meta_none,
+        suffix="_architecture.md"
+    )
+    arch_path.write_text(generate_architecture_summary(files), encoding="utf-8")
+    out_paths.append(arch_path)
+    return arch_path
+
+
 def write_reports_v2(
     merges_dir: Path,
     hub: Path,
@@ -5505,27 +6198,6 @@ def write_reports_v2(
                 "version": os.getenv("REPOGROUND_VERSION", CORE_VERSION)
             }
 
-    def _json_safe(obj):
-        if isinstance(obj, (str, int, float, bool, type(None))):
-            return obj
-        if isinstance(obj, (list, tuple)):
-            return [_json_safe(x) for x in obj]
-        if isinstance(obj, set):
-            return sorted([_json_safe(x) for x in obj])
-        if isinstance(obj, dict):
-            return {str(k): _json_safe(v) for k, v in sorted(obj.items(), key=lambda i: str(i[0]))}
-        if isinstance(obj, Path):
-            return str(obj)
-        if hasattr(obj, "name") and hasattr(obj, "value"): # Enum-like
-            return obj.name
-
-        # Fallback: Deterministic Type Tagging
-        # Avoids unstable repr/str (memory addresses)
-        t = type(obj)
-        module = getattr(t, "__module__", "__builtin__")
-        qualname = getattr(t, "__qualname__", t.__name__)
-        return f"__type__:{module}.{qualname}"
-
     # Calculate config_sha256 for parity checks and bundle manifest provenance
     extras_dict = None
     if extras:
@@ -5564,513 +6236,23 @@ def write_reports_v2(
     if "config_sha256" not in generator_info:
         generator_info["config_sha256"] = config_sha256
 
-    # Helper for architecture summary writing (DRY)
-    def _write_architecture_summary(
-        files,
-        merges_dir,
-        repo_names,
-        detail,
-        path_filter,
-        ext_filter_str,
-        run_id,
-        plan_only,
-        code_only,
-        timestamp,
-        meta_none,
-        out_paths
-    ):
-        # Helper to generate and write the architecture summary.
-        arch_path = make_output_filename(
-            merges_dir,
-            repo_names,
-            detail,
-            "",
-            path_filter,
-            ext_filter_str,
-            run_id,
-            plan_only=plan_only,
-            code_only=code_only,
-            timestamp=timestamp,
-            meta_none=meta_none,
-            suffix="_architecture.md"
-        )
-        arch_path.write_text(generate_architecture_summary(files), encoding="utf-8")
-        out_paths.append(arch_path)
-        return arch_path
+    run_config = _ReportRunConfig(
+        detail=detail,
+        max_file_bytes=max_file_bytes,
+        plan_only=plan_only,
+        code_only=code_only,
+        split_size=split_size,
+        path_filter=path_filter,
+        ext_filter=ext_filter,
+        extras=extras,
+        delta_meta=delta_meta,
+        meta_density=meta_density,
+        meta_none=meta_none,
+        output_mode=output_mode,
+        redact_secrets=redact_secrets,
+        debug=debug,
+    )
 
-    # Helper for dump index (Canonical Entrypoint)
-    def generate_dump_index(base_name_func, run_id, artifacts_map, generator_info, repo_names):
-        out_path = base_name_func(part_suffix="").with_suffix(".dump_index.json")
-
-        artifacts_block = {}
-        for role, path in artifacts_map.items():
-            if path and path.exists():
-                # Infer content_type
-                name = path.name
-                if name.endswith(".json"):
-                    ctype = "application/json"
-                elif name.endswith(".jsonl"):
-                    ctype = "application/x-ndjson"
-                elif name.endswith(".md"):
-                    ctype = "text/markdown"
-                else:
-                    ctype = "application/octet-stream"
-
-                entry = {
-                    "path": name,
-                    "role": role,
-                    "content_type": ctype,
-                    "bytes": path.stat().st_size,
-                    "sha256": _compute_file_sha256(path)
-                }
-
-                # Contract annotations
-                if role == ArtifactRole.INDEX_SIDECAR_JSON.value:
-                    entry["contract"] = AGENT_CONTRACT_NAME
-                    entry["contract_version"] = AGENT_CONTRACT_VERSION
-                elif role == ArtifactRole.CANONICAL_MD.value:
-                    entry["contract"] = MERGE_CONTRACT_NAME
-                    entry["contract_version"] = MERGE_CONTRACT_VERSION
-                elif role == ArtifactRole.CHUNK_INDEX_JSONL.value:
-                    entry["contract"] = "chunk-index"
-                    entry["contract_version"] = "v2"
-                elif role == ArtifactRole.ARCHITECTURE_SUMMARY.value:
-                    entry["contract"] = "architecture-summary"
-                    entry["contract_version"] = "v1"
-
-                artifacts_block[role] = entry
-
-        # Sort artifacts by key for determinism
-        artifacts_sorted = dict(sorted(artifacts_block.items()))
-
-        now_str = clock.now_utc().strftime('%Y-%m-%dT%H:%M:%SZ')
-        data = {
-            "contract": "dump-index",
-            "contract_version": "v1",
-            "run_id": run_id,
-            "created_at": now_str,
-            "generated_at": now_str,
-            "generator": generator_info,
-            "repos": repo_names,
-            "artifacts": artifacts_sorted
-        }
-
-        out_path.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
-        return out_path
-
-
-
-    # --- Split-Mode Contract ---
-    # By architectural mandate (Phase 1, Schwerpunkt D), only the FIRST part of a split
-    # bundle is considered fully `bundle-backed` and canonically referenceable.
-    # Subsequent parts are transient artifacts and do NOT receive `content_range_ref` provenance.
-    # The chunker and the JSON sidecar exclusively refer to `md_parts[0]` as the canonical representation.
-
-    # Helper for chunking (PR-Optimierung)
-    def generate_chunk_artifacts(target_files, output_filename_base_func, md_paths: Optional[List[Path]] = None):
-        if output_mode not in ("retrieval", "dual"):
-            return None
-
-        chunker = Chunker()
-        redactor = Redactor() if redact_secrets else None
-
-        # Build offset map from all generated markdown parts
-        md_offsets = extract_file_offsets(md_paths, debug) if md_paths else {}
-        can_md = resolve_canonical_md(md_paths) if md_paths else None
-        canonical_md_name = can_md.name if can_md else None
-        canonical_md_bytes = can_md.read_bytes() if (can_md and can_md.exists()) else None
-
-        all_chunks = []
-
-        # Sort files same as report
-        target_files.sort(key=lambda fi: (get_repo_sort_index(fi.root_label), fi.root_label.lower(), str(fi.rel_path).lower()))
-
-        for fi in target_files:
-            # Only process included text files
-            status = determine_inclusion_status(fi, detail, max_file_bytes)
-            if not fi.is_text or status not in ("full", "truncated"):
-                continue
-
-            # Read content for chunking using the same limit as report to ensure coherence
-            content, truncated, trunc_msg = read_smart_content(fi, max_file_bytes)
-
-            was_redacted = False
-            if redactor:
-                content, _redacted_items = redactor.redact(content)
-                was_redacted = bool(_redacted_items)
-
-            content_bytes = content.encode("utf-8")
-            source_git_blob_sha1 = (
-                _compute_git_blob_sha1(fi.abs_path)
-                if not was_redacted and not truncated
-                else None
-            )
-
-            # Get Semantic Metadata
-            sem_meta = get_semantic_metadata(fi.rel_path.as_posix(), content)
-
-            fid = _stable_file_id(fi)
-            # Pass file_path for deterministic chunk ID
-            chunks = chunker.chunk_file(fid, content, file_path=fi.rel_path.as_posix())
-
-            lang = lang_for(fi.ext)
-
-            for c in chunks:
-                d = asdict(c)
-                d["path"] = fi.rel_path.as_posix()
-                d["repo"] = fi.root_label
-                d["language"] = lang
-                d["source_status"] = status
-                d["truncated"] = truncated
-                # Semantic Extension
-                d["section"] = sem_meta["section"]
-                d["layer"] = sem_meta["layer"]
-                d["artifact_type"] = sem_meta["artifact_type"]
-                d["concepts"] = sem_meta["concepts"]
-
-                if trunc_msg:
-                    d["truncation_msg"] = trunc_msg
-
-                # Legacy Aliases (Backward Compatibility for v2 transition)
-                d["byte_offset_start"] = d["start_byte"]
-                d["byte_offset_end"] = d["end_byte"]
-                d["line_start"] = d["start_line"]
-                d["line_end"] = d["end_line"]
-                d["content_sha256"] = d["sha256"]
-                d["size_bytes"] = d["size"]
-
-                # Extended machine-readable fields (v2.4)
-                d["source_file"] = fi.rel_path.as_posix()
-                d["content_artifact"] = "merge_md"
-                d["content_range"] = {
-                    "start_byte": d["start_byte"],
-                    "end_byte": d["end_byte"],
-                    "start_line": d["start_line"],
-                    "end_line": d["end_line"]
-                }
-
-                # V2.4 Range Ref Propagation: Point directly to the canonical_md bytes
-                # Contract Fix: The resolver only accepts the primary canonical_md artifact defined in the manifest.
-                # We strictly limit full bundle-backed refs to the first part.
-                if md_paths and fid in md_offsets:
-                    md_file_name, md_start_byte = md_offsets[fid]
-                    if md_file_name == canonical_md_name:
-                        abs_start = md_start_byte + d["start_byte"]
-                        abs_end = md_start_byte + d["end_byte"]
-
-                        if canonical_md_bytes is not None:
-                            # Compute canonical-local values once; share across both fields.
-                            # can_sha256 is the exact range hash for canonical_md_bytes[abs_start:abs_end].
-                            can_chunk = canonical_md_bytes[abs_start:abs_end]
-                            can_sha256 = hashlib.sha256(can_chunk).hexdigest()
-                            can_start_line = _line_for_byte(canonical_md_bytes, abs_start)
-                            can_end_line = _line_for_byte(canonical_md_bytes, max(abs_start, abs_end - 1))
-                        else:
-                            # Fall back to source-local values when canonical bytes unavailable.
-                            can_sha256 = d["sha256"]
-                            can_start_line = d["start_line"]
-                            can_end_line = d["end_line"]
-
-                        d["content_range_ref"] = build_explicit_range_ref(
-                            artifact_role=ArtifactRole.CANONICAL_MD.value,
-                            repo_id=fi.root_label,
-                            file_path=md_file_name,
-                            start_byte=abs_start,
-                            end_byte=abs_end,
-                            start_line=can_start_line,
-                            end_line=can_end_line,
-                            content_sha256=can_sha256,
-                        )
-
-                        if canonical_md_bytes is not None:
-                            d["canonical_range"] = {
-                                "artifact_role": ArtifactRole.CANONICAL_MD.value,
-                                "repo_id": fi.root_label,
-                                "file_path": md_file_name,
-                                "start_byte": abs_start,
-                                "end_byte": abs_end,
-                                "start_line": can_start_line,
-                                "end_line": can_end_line,
-                                "content_sha256": can_sha256,
-                            }
-
-                # Retrieval-only and noncanonical split chunks must carry
-                # their exact redacted text because no canonical artifact exists.
-                _attach_inline_chunk_content(d, content_bytes)
-
-                # source_range: always present, coordinates in source content space.
-                # Status taxonomy: "declared" (source coords claimed, not externally verified) | "unavailable" (redacted or truncated).
-                if was_redacted or truncated:
-                    d["source_range"] = {
-                        "file_path": fi.rel_path.as_posix(),
-                        "repo_id": fi.root_label,
-                        "status": "unavailable",
-                    }
-                else:
-                    d["source_range"] = {
-                        "file_path": fi.rel_path.as_posix(),
-                        "repo_id": fi.root_label,
-                        "start_byte": d["start_byte"],
-                        "end_byte": d["end_byte"],
-                        "start_line": d["start_line"],
-                        "end_line": d["end_line"],
-                        "content_sha256": d["sha256"],
-                        "status": "declared",
-                    }
-                    if source_git_blob_sha1:
-                        d["source_range"]["git_blob_sha1"] = source_git_blob_sha1
-                        d["source_range"]["git_blob_sha1_basis"] = "source_worktree_file_content"
-
-                d["search_keys"] = {
-                    "repo_id": fi.root_label,
-                    "path_norm": fi.rel_path.as_posix().lower(),
-                    "ext": fi.ext.lower().lstrip("."),
-                    "layer": sem_meta["layer"],
-                    "artifact_type": sem_meta["artifact_type"]
-                }
-
-                all_chunks.append(d)
-
-        if not all_chunks:
-            return None
-
-        out_path = output_filename_base_func(part_suffix="").with_suffix(".chunk_index.jsonl")
-        try:
-            with out_path.open("w", encoding="utf-8") as f:
-                for c in all_chunks:
-                    f.write(json.dumps(c) + "\n")
-            return out_path
-        except Exception as e:
-            if debug:
-                print(f"Error writing chunk index: {e}")
-            return None
-
-    # Helper for writing logic
-    def process_and_write(target_files, target_sources, output_filename_base_func):
-        generated_paths: List[Path] = []
-
-        # Pre-calculate artifacts basenames for linking in MD (Recommendation 1)
-        artifact_refs = {}
-        if extras and extras.json_sidecar:
-            # We predict the JSON filename
-            # Note: We rely on the fact that single-file mode uses part_suffix=""
-            # For split mode, JSON usually follows the base name.
-            # We use a dummy call to get the base path
-            _dummy_path = output_filename_base_func(part_suffix="")
-            _json_name = _dummy_path.with_suffix('.json').name
-            artifact_refs["index_json_basename"] = _json_name
-
-        if extras and extras.augment_sidecar:
-             # Find augment file to get name
-             _aug = _find_augment_file_for_sources(target_sources)
-             if _aug:
-                 artifact_refs["augment_sidecar_basename"] = _aug.name
-
-        # Instantiate stream validator
-        validator = ReportValidator(plan_only=plan_only, code_only=code_only, machine_lean=(detail=="machine-lean"))
-
-        if split_size > 0:
-            local_out_paths = []
-            part_num = 1
-            current_size = 0
-            current_lines = []
-
-            # --- Metadata tracking for parts (NEW) ---
-            parts_meta = []  # List of dicts: {first, last}
-            current_part_paths = []  # Paths in current buffer
-
-            # Helper to flush
-            def flush_part(is_last=False):
-                nonlocal part_num, current_size, current_lines, current_part_paths
-                if not current_lines:
-                    return
-
-                # Record metadata for this part
-                first = current_part_paths[0] if current_part_paths else None
-                last = current_part_paths[-1] if current_part_paths else None
-                parts_meta.append({"first": first, "last": last})
-                current_part_paths = []
-
-                # Temporärer Name während der Generierung
-                # Wir nutzen _tmp_partX, um es später sauber umzubenennen
-                out_path = output_filename_base_func(part_suffix=f"_tmp_part{part_num}")
-                out_path.write_text("".join(current_lines), encoding="utf-8")
-                local_out_paths.append(out_path)
-
-                part_num += 1
-                current_lines = []
-                # Add continuation header for next part
-                if not is_last:
-                    header = f"{CANONICAL_REPORT_HEADING} (Part {part_num})\n\n"
-                    # Note: we don't feed continuation headers to validator as they are technical split artifacts,
-                    # not part of the logical report structure.
-                    current_lines.append(header)
-                    current_size = len(header.encode('utf-8'))
-                else:
-                    current_size = 0
-
-            iterator = iter_report_blocks(
-                target_files,
-                detail,
-                max_file_bytes,
-                target_sources,
-                plan_only,
-                code_only,
-                debug,
-                path_filter,
-                ext_filter,
-                extras,
-                delta_meta,
-                artifact_refs=artifact_refs,
-                meta_density=meta_density,
-                meta_none=meta_none,
-                redact_secrets=redact_secrets,
-            )
-
-            for block in iterator:
-                # Validate the block before writing
-                validator.feed(block)
-
-                block_len = len(block.encode('utf-8'))
-
-                # --- Path detection (NEW) ---
-                # Detect path in block using regex to track range for signatures
-                m = re.search(r"\*\*Path:\*\* `(.+?)`", block)
-                block_path = m.group(1) if m else None
-
-                if current_size + block_len > split_size and len(current_lines) > 1:
-                    flush_part()
-                    # After flush, block belongs to next part.
-                    # current_part_paths was cleared in flush_part.
-
-                current_lines.append(block)
-                current_size += block_len
-                if block_path:
-                    current_part_paths.append(block_path)
-
-            flush_part(is_last=True)
-            validator.close()
-
-            # Nachlauf: Header normalisieren UND Dateien umbenennen (Part X of Y)
-            total_parts = len(local_out_paths)
-            final_paths = []
-
-            for idx, path in enumerate(local_out_paths, start=1):
-                # 1. Header Rewrite
-                try:
-                    text = path.read_text(encoding="utf-8")
-                    lines = text.splitlines(True)
-                    if lines:
-                        prefix_part = f"{CANONICAL_REPORT_HEADING} (Part "
-                        prefix_main = CANONICAL_REPORT_HEADING
-                        for i, line in enumerate(lines):
-                            stripped = line.lstrip("\ufeff")
-                            if stripped.startswith(prefix_part) or stripped.startswith(prefix_main):
-                                lines[i] = f"{CANONICAL_REPORT_HEADING} (Part {idx}/{total_parts})\n"
-
-                                # --- Inject Signature (NEW) ---
-                                if total_parts > 1:
-                                    meta = parts_meta[idx - 1]
-                                    p_start = meta["first"]
-                                    p_end = meta["last"]
-                                    range_str = f"{p_start} ... {p_end}" if p_start else "Meta/Structure/Index"
-
-                                    prev_name = "none"
-                                    if idx > 1:
-                                        # calculate name of part idx-1
-                                        prev_suffix = f"_part{idx - 1}of{total_parts}"
-                                        prev_path_obj = output_filename_base_func(part_suffix=prev_suffix)
-                                        prev_name = prev_path_obj.name
-
-                                    sig_block = (
-                                        f"<!-- part_signature:\n"
-                                        f"  part_index: {idx}\n"
-                                        f"  part_total: {total_parts}\n"
-                                        f"  continuation_of: \"{prev_name}\"\n"
-                                        f"  range: \"{range_str}\"\n"
-                                        f"-->\n"
-                                        f"**[Part {idx}/{total_parts}]** continuation_of: `{prev_name}` · range: `{range_str}`\n\n"
-                                    )
-                                    lines.insert(i + 1, sig_block)
-                                break
-                    text = "".join(lines)
-                except Exception:
-                    text = None  # Skip rewrite if read fails, but still rename
-
-                # 2. Rename File
-                # If total_parts == 1, no part suffix.
-                # If total_parts > 1, _partXofY.
-                if total_parts == 1:
-                    new_suffix = ""
-                else:
-                    new_suffix = f"_part{idx}of{total_parts}"
-
-                new_path = output_filename_base_func(part_suffix=new_suffix)
-
-                if text is not None:
-                    new_path.write_text(text, encoding="utf-8")
-                    # Delete old tmp file
-                    try:
-                        path.unlink()
-                    except OSError:
-                        pass
-                else:
-                    # Just replace/move if we couldn't read/edit content
-                    try:
-                        path.replace(new_path)
-                    except OSError as e:
-                        raise OSError(f"Failed to replace '{path}' with '{new_path}'") from e
-
-                final_paths.append(new_path)
-
-            generated_paths.extend(final_paths)
-            out_paths.extend(final_paths)
-
-        else:
-            # Standard single file (Streamed Write)
-            out_path = output_filename_base_func(part_suffix="")
-
-            with out_path.open("w", encoding="utf-8") as f:
-                if plan_only:
-                    f.write("<!-- MODE:PLAN_ONLY -->\n")
-
-                iterator = iter_report_blocks(
-                    target_files,
-                    detail,
-                    max_file_bytes,
-                    target_sources,
-                    plan_only,
-                    code_only,
-                    debug,
-                    path_filter,
-                    ext_filter,
-                    extras,
-                    delta_meta,
-                    artifact_refs=artifact_refs,
-                    meta_density=meta_density,
-                    meta_none=meta_none,
-                    redact_secrets=redact_secrets,
-                )
-
-                for i, block in enumerate(iterator):
-                    # Enforce Part 1/1 header strictly on the first yielded block (Header contract)
-                    if i == 0:
-                        lines = block.splitlines(True)
-                        for line_idx, line in enumerate(lines):
-                            stripped = line.lstrip("\ufeff")
-                            if stripped.startswith(REPORT_HEADINGS):
-                                lines[line_idx] = f"{CANONICAL_REPORT_HEADING} (Part 1/1)\n"
-                                break
-                        block = "".join(lines)
-
-                    validator.feed(block)
-                    f.write(block)
-
-            validator.close()
-            generated_paths.append(out_path)
-            out_paths.append(out_path)
-
-        return generated_paths
 
     last_chunk_index_path = None
     last_dump_index_path = None
@@ -6102,7 +6284,9 @@ def write_reports_v2(
         generated_paths = []
         arch_path = None
         if output_mode in ("archive", "dual"):
-            generated_paths = process_and_write(all_files, sources, base_name_func)
+            generated_paths = process_and_write(
+                run_config, all_files, sources, base_name_func, out_paths
+            )
 
             arch_path = _write_architecture_summary(
                 all_files,
@@ -6123,7 +6307,9 @@ def write_reports_v2(
         if output_mode in ("retrieval", "dual"):
             # Pass all generated MD parts to support split_size > 0
             md_parts = [p for p in generated_paths if p.suffix.lower() == ".md"]
-            chunk_path = generate_chunk_artifacts(all_files, base_name_func, md_paths=md_parts)
+            chunk_path = generate_chunk_artifacts(
+                run_config, all_files, base_name_func, md_paths=md_parts
+            )
             if chunk_path:
                 out_paths.append(chunk_path)
                 last_chunk_index_path = chunk_path
@@ -6228,7 +6414,9 @@ def write_reports_v2(
             generated_paths = []
             arch_path = None
             if output_mode in ("archive", "dual"):
-                generated_paths = process_and_write(s_files, [s_root], base_name_func)
+                generated_paths = process_and_write(
+                    run_config, s_files, [s_root], base_name_func, out_paths
+                )
 
                 arch_path = _write_architecture_summary(
                     s_files,
@@ -6248,7 +6436,9 @@ def write_reports_v2(
             chunk_path = None
             if output_mode in ("retrieval", "dual"):
                 md_parts = [p for p in generated_paths if p.suffix.lower() == ".md"]
-                chunk_path = generate_chunk_artifacts(s_files, base_name_func, md_paths=md_parts)
+                chunk_path = generate_chunk_artifacts(
+                    run_config, s_files, base_name_func, md_paths=md_parts
+                )
                 if chunk_path:
                     out_paths.append(chunk_path)
                     last_chunk_index_path = chunk_path
@@ -6434,38 +6624,10 @@ def write_reports_v2(
         meta_none=meta_none,
         ).with_suffix(".bundle.manifest.json")
 
-    # Aliases into module-level registries (ARTIFACT_CONTRACT_REGISTRY / ARTIFACT_AUTHORITY_REGISTRY).
-    CONTRACT_REGISTRY = ARTIFACT_CONTRACT_REGISTRY
-    AUTHORITY_REGISTRY = ARTIFACT_AUTHORITY_REGISTRY
-
-    artifacts_list = []
-    def _add_artifact(p: Optional[Path], role: ArtifactRole, content_type: str):
-        if p and p.exists():
-            sha = _compute_file_sha256(p)
-            if sha:
-                try:
-                    rel_path = p.relative_to(merges_dir).as_posix()
-                except ValueError:
-                    rel_path = p.name
-
-                entry = {
-                    "role": role.value,
-                    "path": rel_path,
-                    "content_type": content_type,
-                    "bytes": p.stat().st_size,
-                    "sha256": sha
-                }
-
-                if role in CONTRACT_REGISTRY:
-                    entry["contract"] = CONTRACT_REGISTRY[role]
-                    entry["interpretation"] = {"mode": "contract"}
-                else:
-                    entry["interpretation"] = {"mode": "role_only"}
-
-                if role in AUTHORITY_REGISTRY:
-                    entry.update(AUTHORITY_REGISTRY[role])
-
-                artifacts_list.append(entry)
+    artifacts_list: List[Dict[str, Any]] = []
+    _add_artifact = functools.partial(
+        _collect_bundle_artifact, artifacts_list, merges_dir
+    )
 
     _add_artifact(final_canonical_md, ArtifactRole.CANONICAL_MD, "text/markdown")
     if extras and extras.json_sidecar:
@@ -6493,49 +6655,27 @@ def write_reports_v2(
     if derived_manifests:
         _add_artifact(derived_manifests[-1], ArtifactRole.DERIVED_MANIFEST_JSON, "application/json")
 
-    def _write_python_symbol_index_json(base_manifest_path: Path) -> Optional[Path]:
-        """Emit Python Symbol Index v1 for single-repo bundles as navigation only."""
-        if len(repo_summaries) != 1 or not final_dump_index or not final_dump_index.exists():
-            return None
-        repo_root = repo_summaries[0].get("root")
-        if repo_root is None:
-            return None
-        from merger.repoground.architecture.symbol_index import generate_symbol_index_document
-
-        canonical_sha = _compute_file_sha256(final_dump_index)
-        if not canonical_sha:
-            return None
-        document = generate_symbol_index_document(Path(repo_root), run_id, canonical_sha)
-        out_path = base_manifest_path.with_name(
-            base_manifest_path.name.replace(
-                ".bundle.manifest.json", ".python_symbol_index.json"
-            )
-        )
-        _write_text_atomic(
-            out_path,
-            json.dumps(document, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
-        )
-        return out_path
-
-    python_symbol_index_path = _write_python_symbol_index_json(bundle_manifest_path)
-    if python_symbol_index_path is not None:
-        out_paths.append(python_symbol_index_path)
-        if python_symbol_index_path not in other_paths:
-            other_paths.append(python_symbol_index_path)
-        _add_artifact(
-            python_symbol_index_path,
-            ArtifactRole.PYTHON_SYMBOL_INDEX_JSON,
-            "application/json",
-        )
-
-    python_call_graph_path = _write_python_call_graph_json(
-        base_manifest_path=bundle_manifest_path,
-        repo_summaries=repo_summaries,
-        final_dump_index=final_dump_index,
-        run_id=run_id,
+    python_symbol_index_path = _register_optional_artifact(
+        bundle_sidecars.write_python_symbol_index_json(
+            base_manifest_path=bundle_manifest_path,
+            repo_summaries=repo_summaries,
+            final_dump_index=final_dump_index,
+            run_id=run_id,
+        ),
+        role=ArtifactRole.PYTHON_SYMBOL_INDEX_JSON,
+        content_type="application/json",
+        out_paths=out_paths,
+        other_paths=other_paths,
+        add_artifact=_add_artifact,
     )
-    _register_optional_artifact(
-        python_call_graph_path,
+
+    python_call_graph_path = _register_optional_artifact(
+        bundle_sidecars.write_python_call_graph_json(
+            base_manifest_path=bundle_manifest_path,
+            repo_summaries=repo_summaries,
+            final_dump_index=final_dump_index,
+            run_id=run_id,
+        ),
         role=ArtifactRole.PYTHON_CALL_GRAPH_JSON,
         content_type="application/json",
         out_paths=out_paths,
@@ -6543,137 +6683,40 @@ def write_reports_v2(
         add_artifact=_add_artifact,
     )
 
-
-    def _write_lens_cards_jsonl(base_manifest_path: Path) -> Optional[Path]:
-        """Emit Lens Cards v1 as deterministic JSONL navigation."""
-        from .lens_cards import produce_lens_cards
-
-        paths: List[str] = []
-        for summary in repo_summaries:
-            for fi in summary.get("files", []):
-                if getattr(fi, "is_text", False):
-                    paths.append(fi.rel_path.as_posix())
-        if not paths:
-            return None
-        cards = produce_lens_cards(paths)
-        if not cards:
-            return None
-        out_path = base_manifest_path.with_name(
-            base_manifest_path.name.replace(".bundle.manifest.json", ".lens_cards.jsonl")
-        )
-        text = "".join(json.dumps(card, sort_keys=True) + "\n" for card in cards)
-        _write_text_atomic(out_path, text)
-        return out_path
-
-    lens_cards_path = _write_lens_cards_jsonl(bundle_manifest_path)
-    if lens_cards_path is not None:
-        out_paths.append(lens_cards_path)
-        if lens_cards_path not in other_paths:
-            other_paths.append(lens_cards_path)
-        _add_artifact(
-            lens_cards_path,
-            ArtifactRole.LENS_CARDS_JSONL,
-            "application/x-ndjson",
-        )
-
-
-    def _write_concept_cards_jsonl(base_manifest_path: Path) -> Optional[Path]:
-        """Emit built-in Concept Cards v1 as deterministic JSONL navigation."""
-        from .concept_cards import produce_default_concept_cards
-
-        cards = produce_default_concept_cards()
-        if not cards:
-            return None
-        out_path = base_manifest_path.with_name(
-            base_manifest_path.name.replace(
-                ".bundle.manifest.json", ".concept_cards.jsonl"
-            )
-        )
-        text = "".join(json.dumps(card, sort_keys=True) + "\n" for card in cards)
-        _write_text_atomic(out_path, text)
-        return out_path
-
-    concept_cards_path = _write_concept_cards_jsonl(bundle_manifest_path)
-    if concept_cards_path is not None:
-        out_paths.append(concept_cards_path)
-        if concept_cards_path not in other_paths:
-            other_paths.append(concept_cards_path)
-        _add_artifact(
-            concept_cards_path,
-            ArtifactRole.CONCEPT_CARDS_JSONL,
-            "application/x-ndjson",
-        )
-
-
-
-    def _write_relation_cards_jsonl(
-        base_manifest_path: Path,
-        graph_path: Optional[Path],
-    ) -> Optional[Path]:
-        """Emit Relation Cards v1 as deterministic JSONL navigation."""
-        if graph_path is None or not graph_path.exists():
-            return None
-        from .relation_cards import produce_relation_cards
-
-        graph_data = json.loads(graph_path.read_text(encoding="utf-8"))
-        cards = produce_relation_cards(graph_data)
-        if not cards:
-            return None
-        out_path = base_manifest_path.with_name(
-            base_manifest_path.name.replace(
-                ".bundle.manifest.json", ".relation_cards.jsonl"
-            )
-        )
-        text = "".join(json.dumps(card, sort_keys=True) + "\n" for card in cards)
-        _write_text_atomic(out_path, text)
-        return out_path
-
-    relation_cards_path = _write_relation_cards_jsonl(
-        bundle_manifest_path,
-        architecture_graphs[-1] if architecture_graphs else None,
+    lens_cards_path = _register_optional_artifact(
+        bundle_sidecars.write_lens_cards_jsonl(
+            base_manifest_path=bundle_manifest_path,
+            repo_summaries=repo_summaries,
+        ),
+        role=ArtifactRole.LENS_CARDS_JSONL,
+        content_type="application/x-ndjson",
+        out_paths=out_paths,
+        other_paths=other_paths,
+        add_artifact=_add_artifact,
     )
-    if relation_cards_path is not None:
-        out_paths.append(relation_cards_path)
-        if relation_cards_path not in other_paths:
-            other_paths.append(relation_cards_path)
-        _add_artifact(
-            relation_cards_path,
-            ArtifactRole.RELATION_CARDS_JSONL,
-            "application/x-ndjson",
-        )
 
-    def _write_delta_json(
-        base_manifest_path: Path,
-        source_delta: Dict[str, Any],
-    ) -> Path:
-        """Emit the validated PR Schau delta source as bundle diagnostic JSON."""
-        out_path = base_manifest_path.with_name(
-            base_manifest_path.name.replace(".bundle.manifest.json", ".delta.json")
-        )
-        text = json.dumps(
-            source_delta,
-            indent=2,
-            sort_keys=True,
-            ensure_ascii=False,
-        ) + "\n"
-        _write_text_atomic(out_path, text)
-        return out_path
+    concept_cards_path = _register_optional_artifact(
+        bundle_sidecars.write_concept_cards_jsonl(
+            base_manifest_path=bundle_manifest_path,
+        ),
+        role=ArtifactRole.CONCEPT_CARDS_JSONL,
+        content_type="application/x-ndjson",
+        out_paths=out_paths,
+        other_paths=other_paths,
+        add_artifact=_add_artifact,
+    )
 
-    def _write_pr_delta_cards_jsonl(
-        base_manifest_path: Path,
-        cards: List[Dict[str, Any]],
-    ) -> Optional[Path]:
-        """Emit PR Delta Cards v1 after the changed-set source was validated."""
-        if not cards:
-            return None
-        out_path = base_manifest_path.with_name(
-            base_manifest_path.name.replace(
-                ".bundle.manifest.json", ".pr_delta_cards.jsonl"
-            )
-        )
-        text = "".join(json.dumps(card, sort_keys=True) + "\n" for card in cards)
-        _write_text_atomic(out_path, text)
-        return out_path
+    relation_cards_path = _register_optional_artifact(
+        bundle_sidecars.write_relation_cards_jsonl(
+            base_manifest_path=bundle_manifest_path,
+            graph_path=architecture_graphs[-1] if architecture_graphs else None,
+        ),
+        role=ArtifactRole.RELATION_CARDS_JSONL,
+        content_type="application/x-ndjson",
+        out_paths=out_paths,
+        other_paths=other_paths,
+        add_artifact=_add_artifact,
+    )
 
     delta_json_path = None
     pr_delta_cards_path = None
@@ -6681,29 +6724,31 @@ def write_reports_v2(
         from .pr_delta_cards import produce_pr_delta_cards
 
         pr_delta_cards = produce_pr_delta_cards(delta_meta)
-        delta_json_path = _write_delta_json(bundle_manifest_path, delta_meta)
-        out_paths.append(delta_json_path)
-        if delta_json_path not in other_paths:
-            other_paths.append(delta_json_path)
-        _add_artifact(
+        delta_json_path = bundle_sidecars.write_delta_json(
+            base_manifest_path=bundle_manifest_path,
+            source_delta=delta_meta,
+        )
+        _register_optional_artifact(
             delta_json_path,
-            ArtifactRole.PR_DELTA_JSON,
-            "application/json",
+            role=ArtifactRole.PR_DELTA_JSON,
+            content_type="application/json",
+            out_paths=out_paths,
+            other_paths=other_paths,
+            add_artifact=_add_artifact,
         )
 
-        pr_delta_cards_path = _write_pr_delta_cards_jsonl(
-            bundle_manifest_path,
-            pr_delta_cards,
+        pr_delta_cards_path = bundle_sidecars.write_pr_delta_cards_jsonl(
+            base_manifest_path=bundle_manifest_path,
+            cards=pr_delta_cards,
         )
-        if pr_delta_cards_path is not None:
-            out_paths.append(pr_delta_cards_path)
-            if pr_delta_cards_path not in other_paths:
-                other_paths.append(pr_delta_cards_path)
-            _add_artifact(
-                pr_delta_cards_path,
-                ArtifactRole.PR_DELTA_CARDS_JSONL,
-                "application/x-ndjson",
-            )
+        _register_optional_artifact(
+            pr_delta_cards_path,
+            role=ArtifactRole.PR_DELTA_CARDS_JSONL,
+            content_type="application/x-ndjson",
+            out_paths=out_paths,
+            other_paths=other_paths,
+            add_artifact=_add_artifact,
+        )
 
     # Write output health report BEFORE the bundle manifest is finalized.
     # In this implementation, health checks are anchored to already-materialized primary artifacts

--- a/merger/repoground/tests/test_bundle_sidecars.py
+++ b/merger/repoground/tests/test_bundle_sidecars.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from merger.repoground.core import bundle_sidecars
+from merger.repoground.core.artifact_io import is_sha256_digest
+
+
+@pytest.mark.parametrize(
+    "writer",
+    [
+        bundle_sidecars.write_python_symbol_index_json,
+        bundle_sidecars.write_python_call_graph_json,
+    ],
+)
+@pytest.mark.parametrize("invalid_digest", ["ERROR", "", "A" * 64, "g" * 64])
+def test_navigation_sidecars_reject_invalid_dump_hash(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    writer,
+    invalid_digest: str,
+) -> None:
+    dump_index = tmp_path / "demo.dump_index.json"
+    dump_index.write_text("{}\n", encoding="utf-8")
+    manifest = tmp_path / "demo.bundle.manifest.json"
+    monkeypatch.setattr(bundle_sidecars, "compute_file_sha256", lambda _path: invalid_digest)
+
+    result = writer(
+        base_manifest_path=manifest,
+        repo_summaries=[{"root": str(tmp_path)}],
+        final_dump_index=dump_index,
+        run_id="run-1",
+    )
+
+    assert result is None
+    assert not list(tmp_path.glob("demo.python_*_index.json"))
+    assert not list(tmp_path.glob("demo.python_call_graph.json"))
+
+
+def test_sha256_digest_contract_is_exact() -> None:
+    assert is_sha256_digest("0" * 64) is True
+    assert is_sha256_digest("a" * 64) is True
+    assert is_sha256_digest("A" * 64) is False
+    assert is_sha256_digest("0" * 63) is False
+    assert is_sha256_digest("g" * 64) is False
+    assert is_sha256_digest(None) is False

--- a/merger/repoground/tests/test_bundle_sidecars.py
+++ b/merger/repoground/tests/test_bundle_sidecars.py
@@ -8,6 +8,26 @@ from merger.repoground.core import bundle_sidecars
 from merger.repoground.core.artifact_io import is_sha256_digest
 
 
+def test_sidecar_path_requires_canonical_manifest_suffix(tmp_path: Path) -> None:
+    manifest = tmp_path / "demo.bundle.manifest.json"
+
+    assert bundle_sidecars.sidecar_path(
+        manifest, ".python_symbol_index.json"
+    ) == tmp_path / "demo.python_symbol_index.json"
+
+
+def test_sidecar_path_rejects_non_manifest_base_without_overwrite(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "demo.json"
+    source.write_text("original\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="sidecar base must end"):
+        bundle_sidecars.sidecar_path(source, ".delta.json")
+
+    assert source.read_text(encoding="utf-8") == "original\n"
+
+
 @pytest.mark.parametrize(
     "writer",
     [

--- a/merger/repoground/tests/test_graph_maintainability.py
+++ b/merger/repoground/tests/test_graph_maintainability.py
@@ -10,6 +10,8 @@ from merger.repoground.architecture.graph_maintainability import (
 from scripts.ci.check_graph_maintainability import (
     ComplexityFinding,
     compare_complexity_baseline,
+    evaluate_complexity_budget,
+    measure_complexity_budget,
 )
 
 ROOT = Path(__file__).resolve().parents[3]
@@ -100,6 +102,99 @@ def test_complexity_baseline_rejects_structural_drift() -> None:
         "complexity_baseline_maximum_mismatch",
         "complexity_baseline_not_sorted",
     ]
+
+
+def _budget_scan(complexities: list[int]) -> list[ComplexityFinding]:
+    return [
+        ComplexityFinding("a.py", f"f{index}", complexity, 10)
+        for index, complexity in enumerate(complexities)
+    ]
+
+
+def _budget(**overrides) -> dict:
+    budget = {
+        "historical_reference": {"finding_count": 213, "max_complexity": 170},
+        "finding_count_max": 10,
+        "max_complexity_max": 50,
+        "excess_total_max": 100,
+    }
+    budget.update(overrides)
+    return budget
+
+
+def test_complexity_budget_accepts_a_scan_inside_every_dimension() -> None:
+    assert evaluate_complexity_budget(_budget_scan([40, 30]), _budget()) == []
+
+
+def test_complexity_budget_rejects_each_exceeded_dimension() -> None:
+    findings = evaluate_complexity_budget(
+        _budget_scan([60] * 11),
+        _budget(),
+    )
+
+    assert sorted({item["dimension"] for item in findings}) == [
+        "excess_total",
+        "finding_count",
+        "max_complexity",
+    ]
+    assert {item["code"] for item in findings} == {"complexity_budget_exceeded"}
+
+
+def test_complexity_budget_rewards_splitting_a_function() -> None:
+    """Splitting one hotspot raises the count but must lower the excess mass."""
+
+    before = measure_complexity_budget(_budget_scan([48]))
+    after = measure_complexity_budget(_budget_scan([16, 14, 12]))
+
+    assert after["finding_count"] > before["finding_count"]
+    assert after["max_complexity"] < before["max_complexity"]
+    assert after["excess_total"] < before["excess_total"]
+
+
+def test_complexity_budget_rejects_ceilings_above_the_historical_reference() -> None:
+    findings = evaluate_complexity_budget(
+        _budget_scan([12]),
+        _budget(finding_count_max=214, max_complexity_max=171),
+    )
+
+    assert [item["code"] for item in findings] == [
+        "complexity_budget_raised_above_reference",
+        "complexity_budget_raised_above_reference",
+    ]
+
+
+def test_complexity_budget_is_fail_closed_when_absent_or_malformed() -> None:
+    assert [item["code"] for item in evaluate_complexity_budget([], None)] == [
+        "complexity_budget_missing"
+    ]
+    assert [
+        item["code"] for item in evaluate_complexity_budget([], {"finding_count_max": 1})
+    ] == ["complexity_budget_reference_missing"]
+    assert [
+        item["code"]
+        for item in evaluate_complexity_budget(
+            [], _budget(max_complexity_max="none")
+        )
+    ] == ["complexity_budget_invalid"]
+
+
+def test_repository_complexity_budget_binds_the_recorded_baseline() -> None:
+    budget = _policy()["complexity"]["budget"]
+    reference = budget["historical_reference"]
+    baseline = json.loads(
+        (ROOT / _policy()["complexity"]["baseline_path"]).read_text(encoding="utf-8")
+    )
+
+    assert reference["finding_count"] == 213
+    assert reference["max_complexity"] == 170
+    assert budget["finding_count_max"] < reference["finding_count"]
+    assert budget["max_complexity_max"] < reference["max_complexity"]
+    assert baseline["finding_count"] <= budget["finding_count_max"]
+    assert baseline["max_complexity"] <= budget["max_complexity_max"]
+    assert (
+        sum(max(row["max_complexity"] - baseline["threshold"], 0) for row in baseline["findings"])
+        <= budget["excess_total_max"]
+    )
 
 
 def test_lint_workflow_runs_graph_maintainability_ratchet() -> None:

--- a/merger/repoground/tests/test_graph_maintainability.py
+++ b/merger/repoground/tests/test_graph_maintainability.py
@@ -114,6 +114,11 @@ def _budget_scan(complexities: list[int]) -> list[ComplexityFinding]:
 def _budget(**overrides) -> dict:
     budget = {
         "historical_reference": {"finding_count": 213, "max_complexity": 170},
+        "slice_start_reference": {
+            "finding_count": 200,
+            "max_complexity": 170,
+            "excess_total": 2654,
+        },
         "finding_count_max": 10,
         "max_complexity_max": 50,
         "excess_total_max": 100,
@@ -151,16 +156,47 @@ def test_complexity_budget_rewards_splitting_a_function() -> None:
     assert after["excess_total"] < before["excess_total"]
 
 
-def test_complexity_budget_rejects_ceilings_above_the_historical_reference() -> None:
+def test_complexity_budget_rejects_ceilings_above_any_recorded_reference() -> None:
     findings = evaluate_complexity_budget(
         _budget_scan([12]),
         _budget(finding_count_max=214, max_complexity_max=171),
     )
 
-    assert [item["code"] for item in findings] == [
-        "complexity_budget_raised_above_reference",
-        "complexity_budget_raised_above_reference",
+    assert {item["code"] for item in findings} == {
+        "complexity_budget_raised_above_reference"
+    }
+    # 214 exceeds both recorded finding counts, 171 exceeds both maxima.
+    assert sorted((item["dimension"], item["reference"]) for item in findings) == [
+        ("finding_count", "historical_reference"),
+        ("finding_count", "slice_start_reference"),
+        ("max_complexity", "historical_reference"),
+        ("max_complexity", "slice_start_reference"),
     ]
+
+
+def test_complexity_budget_rejects_a_raised_excess_ceiling() -> None:
+    """Excess mass is the dimension a rewritten baseline cannot fake away."""
+
+    findings = evaluate_complexity_budget(
+        _budget_scan([12]),
+        _budget(excess_total_max=2655),
+    )
+
+    assert [(item["code"], item["dimension"]) for item in findings] == [
+        ("complexity_budget_raised_above_reference", "excess_total")
+    ]
+
+
+def test_complexity_budget_rejects_an_unbounded_dimension() -> None:
+    """A ceiling no recorded scan bounds could be raised without limit."""
+
+    budget = _budget()
+    del budget["slice_start_reference"]
+
+    assert [
+        (item["code"], item["dimension"])
+        for item in evaluate_complexity_budget(_budget_scan([12]), budget)
+    ] == [("complexity_budget_reference_missing", "excess_total")]
 
 
 def test_complexity_budget_is_fail_closed_when_absent_or_malformed() -> None:
@@ -181,6 +217,7 @@ def test_complexity_budget_is_fail_closed_when_absent_or_malformed() -> None:
 def test_repository_complexity_budget_binds_the_recorded_baseline() -> None:
     budget = _policy()["complexity"]["budget"]
     reference = budget["historical_reference"]
+    slice_start = budget["slice_start_reference"]
     baseline = json.loads(
         (ROOT / _policy()["complexity"]["baseline_path"]).read_text(encoding="utf-8")
     )
@@ -189,6 +226,10 @@ def test_repository_complexity_budget_binds_the_recorded_baseline() -> None:
     assert reference["max_complexity"] == 170
     assert budget["finding_count_max"] < reference["finding_count"]
     assert budget["max_complexity_max"] < reference["max_complexity"]
+    # The slice must beat where it started, not only the older reference.
+    assert budget["finding_count_max"] < slice_start["finding_count"]
+    assert budget["max_complexity_max"] < slice_start["max_complexity"]
+    assert budget["excess_total_max"] < slice_start["excess_total"]
     assert baseline["finding_count"] <= budget["finding_count_max"]
     assert baseline["max_complexity"] <= budget["max_complexity_max"]
     assert (

--- a/merger/repoground/tests/test_module_reachability.py
+++ b/merger/repoground/tests/test_module_reachability.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from merger.repoground.architecture.module_reachability import (
+    NON_DOCUMENTATION_EVIDENCE,
+    evaluate_reachability_policy,
+    measure_module_reachability,
+)
+
+ROOT = Path(__file__).resolve().parents[3]
+POLICY = ROOT / "config/repoground-module-reachability.v1.json"
+
+
+def _policy() -> dict:
+    return json.loads(POLICY.read_text(encoding="utf-8"))
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+#: The synthetic fixtures declare package markers that no fixture imports;
+#: they are not the subject of these unit tests.
+_FIXTURE_PACKAGES = {"merger", "merger.repoground", "merger.repoground.core"}
+
+
+def _project(root: Path) -> None:
+    _write(root / "merger/__init__.py", "")
+    _write(root / "merger/repoground/__init__.py", "")
+
+
+def _unproven(measurement: dict) -> list[str]:
+    return [
+        module
+        for module in measurement["unproven"]
+        if module not in _FIXTURE_PACKAGES
+    ]
+
+
+def test_real_repository_has_evidence_for_every_production_module() -> None:
+    measurement = measure_module_reachability(ROOT)
+
+    assert evaluate_reachability_policy(measurement, _policy()) == []
+    assert measurement["unproven"] == []
+    assert measurement["unparsed_files"] == []
+    assert measurement["module_count"] > 100
+
+
+def test_policy_records_no_unreviewed_exceptions() -> None:
+    policy = _policy()
+
+    assert policy["allowed_unproven"] == []
+    assert policy["allowed_documentation_only"] == []
+    assert policy["require_non_documentation_evidence"] is True
+    assert "not a dead module" in policy["removal_policy"]
+
+
+def test_static_import_and_main_block_count_as_evidence(tmp_path: Path) -> None:
+    _project(tmp_path)
+    _write(tmp_path / "merger/repoground/used.py", "VALUE = 1\n")
+    _write(
+        tmp_path / "merger/repoground/consumer.py",
+        "from merger.repoground.used import VALUE\n",
+    )
+    _write(
+        tmp_path / "merger/repoground/runnable.py",
+        "def main():\n    return 0\n\n\nif __name__ == '__main__':\n    main()\n",
+    )
+
+    by_module = {
+        record["module"]: record
+        for record in measure_module_reachability(tmp_path)["modules"]
+    }
+
+    assert by_module["merger.repoground.used"]["evidence"] == ["static_import_product"]
+    assert by_module["merger.repoground.runnable"]["evidence"] == ["module_main_block"]
+
+
+def test_relative_import_resolves_to_the_imported_module(tmp_path: Path) -> None:
+    _project(tmp_path)
+    _write(tmp_path / "merger/repoground/core/__init__.py", "")
+    _write(tmp_path / "merger/repoground/core/leaf.py", "VALUE = 1\n")
+    _write(tmp_path / "merger/repoground/core/consumer.py", "from .leaf import VALUE\n")
+
+    measurement = measure_module_reachability(tmp_path)
+
+    # The importer itself stays unproven; only the imported leaf gains evidence.
+    assert _unproven(measurement) == ["merger.repoground.core.consumer"]
+
+
+def test_dynamic_and_runtime_references_count_as_evidence(tmp_path: Path) -> None:
+    _project(tmp_path)
+    _write(tmp_path / "merger/repoground/plugin.py", "VALUE = 1\n")
+    _write(tmp_path / "merger/repoground/launched.py", "VALUE = 1\n")
+    _write(
+        tmp_path / "merger/repoground/loader.py",
+        "import importlib\n\nloaded = importlib.import_module('merger.repoground.plugin')\n",
+    )
+    _write(
+        tmp_path / "scripts/run.sh",
+        "#!/bin/sh\npython -m merger.repoground.launched\n",
+    )
+
+    by_module = {
+        record["module"]: record
+        for record in measure_module_reachability(tmp_path)["modules"]
+    }
+
+    assert by_module["merger.repoground.plugin"]["evidence"] == [
+        "dynamic_string_reference"
+    ]
+    assert by_module["merger.repoground.launched"]["evidence"] == [
+        "runtime_surface_reference"
+    ]
+
+
+def test_recorded_baselines_do_not_count_as_runtime_evidence(tmp_path: Path) -> None:
+    """A path listed in a measurement artifact is not a consumer."""
+
+    _project(tmp_path)
+    _write(tmp_path / "merger/repoground/orphan.py", "VALUE = 1\n")
+    _write(
+        tmp_path / "config/some-baseline.v1.json",
+        json.dumps({"findings": [{"path": "merger/repoground/orphan.py"}]}),
+    )
+    _write(
+        tmp_path / "docs/proofs/some-proof.measurement.json",
+        json.dumps({"module": "merger.repoground.orphan"}),
+    )
+
+    measurement = measure_module_reachability(tmp_path)
+
+    assert _unproven(measurement) == ["merger.repoground.orphan"]
+
+
+def test_documentation_alone_is_reachable_but_flagged(tmp_path: Path) -> None:
+    _project(tmp_path)
+    _write(tmp_path / "merger/repoground/documented.py", "VALUE = 1\n")
+    _write(
+        tmp_path / "docs/usage.md",
+        "Run `python -m merger.repoground.documented` manually.\n",
+    )
+
+    measurement = measure_module_reachability(tmp_path)
+
+    assert _unproven(measurement) == []
+    assert measurement["documentation_only"] == ["merger.repoground.documented"]
+    assert "module_reachability_documentation_only" in {
+        item["code"]
+        for item in evaluate_reachability_policy(
+            measurement, {"require_non_documentation_evidence": True}
+        )
+    }
+    assert "documented_invocation" not in NON_DOCUMENTATION_EVIDENCE
+
+
+def test_unparsed_product_source_fails_but_broken_fixture_does_not(tmp_path: Path) -> None:
+    _project(tmp_path)
+    _write(tmp_path / "merger/repoground/tests/fixtures/broken.py", "def (\n")
+
+    measurement = measure_module_reachability(tmp_path)
+    assert measurement["unparsed_files"] == []
+    assert measurement["unparsed_non_product_files"] == [
+        "merger/repoground/tests/fixtures/broken.py"
+    ]
+
+    _write(tmp_path / "merger/repoground/damaged.py", "def (\n")
+    measurement = measure_module_reachability(tmp_path)
+
+    assert measurement["unparsed_files"] == ["merger/repoground/damaged.py"]
+    assert "module_reachability_unparsed_sources" in {
+        item["code"] for item in evaluate_reachability_policy(measurement, {})
+    }
+
+
+def test_stale_allowlist_entries_are_rejected() -> None:
+    measurement = {
+        "unproven": [],
+        "documentation_only": [],
+        "unparsed_files": [],
+    }
+    policy = {
+        "allowed_unproven": ["merger.repoground.gone"],
+        "allowed_documentation_only": ["merger.repoground.also_gone"],
+    }
+
+    assert [item["code"] for item in evaluate_reachability_policy(measurement, policy)] == [
+        "module_reachability_allowlist_stale",
+        "module_reachability_documentation_allowlist_stale",
+    ]
+
+
+def test_lint_workflow_runs_the_reachability_check() -> None:
+    workflow = (ROOT / ".github/workflows/lint.yml").read_text(encoding="utf-8")
+
+    assert "scripts/ci/check_module_reachability.py" in workflow

--- a/merger/repoground/tests/test_module_reachability.py
+++ b/merger/repoground/tests/test_module_reachability.py
@@ -139,6 +139,88 @@ def test_dynamic_and_runtime_references_count_as_evidence(tmp_path: Path) -> Non
     ]
 
 
+def test_plain_product_string_does_not_count_as_dynamic_import(tmp_path: Path) -> None:
+    _project(tmp_path)
+    _write(tmp_path / "merger/repoground/orphan.py", "VALUE = 1\n")
+    _write(
+        tmp_path / "merger/repoground/narrator.py",
+        "MESSAGE = 'merger.repoground.orphan'\n",
+    )
+
+    assert _unproven(measure_module_reachability(tmp_path)) == [
+        "merger.repoground.narrator",
+        "merger.repoground.orphan",
+    ]
+
+
+def test_non_equal_main_comparison_does_not_count_as_entrypoint(tmp_path: Path) -> None:
+    _project(tmp_path)
+    _write(
+        tmp_path / "merger/repoground/not_runnable.py",
+        "if __name__ != '__main__':\n    VALUE = 1\n",
+    )
+
+    assert _unproven(measure_module_reachability(tmp_path)) == [
+        "merger.repoground.not_runnable"
+    ]
+
+
+def test_unbound_importlib_name_does_not_count_as_dynamic_import(
+    tmp_path: Path,
+) -> None:
+    _project(tmp_path)
+    _write(tmp_path / "merger/repoground/plugin.py", "VALUE = 1\n")
+    _write(
+        tmp_path / "merger/repoground/broken_loader.py",
+        "loaded = importlib.import_module('merger.repoground.plugin')\n",
+    )
+
+    assert "merger.repoground.plugin" in _unproven(
+        measure_module_reachability(tmp_path)
+    )
+
+
+def test_non_runnable_bare_import_does_not_claim_package_sibling(
+    tmp_path: Path,
+) -> None:
+    _project(tmp_path)
+    _write(tmp_path / "merger/repoground/core/__init__.py", "")
+    _write(tmp_path / "merger/repoground/core/utils.py", "VALUE = 1\n")
+    _write(
+        tmp_path / "merger/repoground/core/consumer.py",
+        "from utils import VALUE\n",
+    )
+
+    assert "merger.repoground.core.utils" in _unproven(
+        measure_module_reachability(tmp_path)
+    )
+
+
+def test_script_style_sibling_import_resolves_only_to_existing_module(
+    tmp_path: Path,
+) -> None:
+    _project(tmp_path)
+    _write(tmp_path / "merger/repoground/frontends/__init__.py", "")
+    _write(tmp_path / "merger/repoground/frontends/pythonista/__init__.py", "")
+    _write(
+        tmp_path / "merger/repoground/frontends/pythonista/build_utils.py",
+        "VALUE = 1\n",
+    )
+    _write(
+        tmp_path / "merger/repoground/frontends/pythonista/build.py",
+        "from build_utils import VALUE\n\nif __name__ == '__main__':\n    print(VALUE)\n",
+    )
+
+    by_module = {
+        record["module"]: record
+        for record in measure_module_reachability(tmp_path)["modules"]
+    }
+
+    assert by_module[
+        "merger.repoground.frontends.pythonista.build_utils"
+    ]["evidence"] == ["static_import_product"]
+
+
 def test_recorded_baselines_do_not_count_as_runtime_evidence(tmp_path: Path) -> None:
     """A path listed in a measurement artifact is not a consumer."""
 

--- a/merger/repoground/tests/test_module_reachability.py
+++ b/merger/repoground/tests/test_module_reachability.py
@@ -5,9 +5,11 @@ from pathlib import Path
 
 from merger.repoground.architecture.module_reachability import (
     NON_DOCUMENTATION_EVIDENCE,
+    PRODUCTION_EVIDENCE,
     evaluate_reachability_policy,
     measure_module_reachability,
 )
+from scripts.ci.check_module_reachability import validate_policy
 
 ROOT = Path(__file__).resolve().parents[3]
 POLICY = ROOT / "config/repoground-module-reachability.v1.json"
@@ -55,7 +57,27 @@ def test_policy_records_no_unreviewed_exceptions() -> None:
     assert policy["allowed_unproven"] == []
     assert policy["allowed_documentation_only"] == []
     assert policy["require_non_documentation_evidence"] is True
+    assert policy["require_production_evidence"] is True
     assert "not a dead module" in policy["removal_policy"]
+    # Test-only modules are declared, never silently counted as production use.
+    assert policy["allowed_test_only"] == sorted(policy["allowed_test_only"])
+    assert measure_module_reachability(ROOT)["test_only"] == sorted(
+        policy["allowed_test_only"]
+    )
+
+
+def test_policy_identity_and_roots_are_fail_closed() -> None:
+    assert validate_policy(_policy()) == []
+    assert [item["code"] for item in validate_policy([])] == [
+        "module_reachability_policy_invalid"
+    ]
+    assert [item["code"] for item in validate_policy({})] == [
+        "module_reachability_policy_identity_invalid",
+        "module_reachability_policy_invalid",
+    ]
+    assert [
+        item["code"] for item in validate_policy(_policy() | {"package_roots": []})
+    ] == ["module_reachability_policy_invalid"]
 
 
 def test_static_import_and_main_block_count_as_evidence(tmp_path: Path) -> None:
@@ -176,20 +198,100 @@ def test_unparsed_product_source_fails_but_broken_fixture_does_not(tmp_path: Pat
     }
 
 
+def test_a_test_import_alone_is_not_production_evidence(tmp_path: Path) -> None:
+    _project(tmp_path)
+    _write(tmp_path / "merger/repoground/exercised.py", "VALUE = 1\n")
+    _write(
+        tmp_path / "merger/repoground/tests/test_exercised.py",
+        "from merger.repoground.exercised import VALUE\n",
+    )
+
+    measurement = measure_module_reachability(tmp_path)
+    by_module = {record["module"]: record for record in measurement["modules"]}
+    record = by_module["merger.repoground.exercised"]
+
+    assert record["evidence"] == ["static_import_test"]
+    assert record["has_non_documentation_evidence"] is True
+    assert record["has_production_evidence"] is False
+    assert "static_import_test" not in PRODUCTION_EVIDENCE
+    # A package above a test-imported module inherits the test class, not the
+    # production class.
+    assert by_module["merger.repoground"]["evidence"] == [
+        "package_of_test_referenced_module"
+    ]
+    # Undeclared, it fails; it is never reported as unproven or dead.
+    assert measurement["unproven"] == []
+    assert measurement["test_only"] == [
+        "merger",
+        "merger.repoground",
+        "merger.repoground.exercised",
+    ]
+    assert [
+        item["code"]
+        for item in evaluate_reachability_policy(measurement, {"allowed_unproven": []})
+    ] == ["module_reachability_test_only"] * 3
+    assert (
+        evaluate_reachability_policy(
+            measurement, {"allowed_test_only": measurement["test_only"]}
+        )
+        == []
+    )
+
+
+def test_a_test_string_is_not_a_production_dynamic_reference(tmp_path: Path) -> None:
+    _project(tmp_path)
+    _write(tmp_path / "merger/repoground/plugin.py", "VALUE = 1\n")
+    _write(
+        tmp_path / "merger/repoground/tests/test_plugin.py",
+        "import importlib\n\n\n"
+        "def test_loads():\n"
+        "    importlib.import_module('merger.repoground.plugin')\n",
+    )
+
+    by_module = {
+        record["module"]: record
+        for record in measure_module_reachability(tmp_path)["modules"]
+    }
+
+    assert by_module["merger.repoground.plugin"]["evidence"] == [
+        "dynamic_string_reference_test"
+    ]
+    assert by_module["merger.repoground.plugin"]["has_production_evidence"] is False
+
+
+def test_a_longer_dotted_name_does_not_credit_its_prefix(tmp_path: Path) -> None:
+    """Corpus matching is token-exact, so a longer name is not a consumer."""
+
+    _project(tmp_path)
+    _write(tmp_path / "merger/repoground/lonely.py", "VALUE = 1\n")
+    _write(
+        tmp_path / "scripts/run.sh",
+        "#!/bin/sh\npython -m merger.repoground.lonely_extra\n",
+    )
+    _write(tmp_path / "docs/usage.md", "See `merger/repoground/lonely.py.bak`.\n")
+
+    assert _unproven(measure_module_reachability(tmp_path)) == [
+        "merger.repoground.lonely"
+    ]
+
+
 def test_stale_allowlist_entries_are_rejected() -> None:
     measurement = {
         "unproven": [],
         "documentation_only": [],
+        "test_only": [],
         "unparsed_files": [],
     }
     policy = {
         "allowed_unproven": ["merger.repoground.gone"],
         "allowed_documentation_only": ["merger.repoground.also_gone"],
+        "allowed_test_only": ["merger.repoground.gone_too"],
     }
 
     assert [item["code"] for item in evaluate_reachability_policy(measurement, policy)] == [
         "module_reachability_allowlist_stale",
         "module_reachability_documentation_allowlist_stale",
+        "module_reachability_test_only_allowlist_stale",
     ]
 
 

--- a/scripts/benchmarks/repoground_core_paths.py
+++ b/scripts/benchmarks/repoground_core_paths.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Measure runtime and allocation cost of central RepoGround core paths.
+
+The benchmark drives the real production entry points over a deterministic
+synthetic repository so that two runs on the same host are comparable:
+
+  * ``bundle_write_archive``   – ``write_reports_v2`` in archive output mode
+  * ``bundle_write_dual``      – ``write_reports_v2`` in dual mode (chunks, sidecars)
+  * ``retrieval_index_build``  – ``index_db.build_index`` over the produced bundle
+  * ``retrieval_query``        – ``query_core.execute_query`` against that index
+  * ``service_app_import``     – cold subprocess import of the service application
+  * ``atlas_scan``             – optional Atlas observation subsystem scan
+
+Wall time is reported as the minimum and median of repeated samples; the
+minimum is the stable figure because host noise can only add time.  Peak
+allocation is measured with ``tracemalloc`` in one separate, unsampled run so
+that the tracing overhead never contaminates the timing samples.
+
+No acceptance gate is applied.  Timing on shared hosts is not reproducible
+across machines, so this script records evidence and leaves comparison to the
+reader; only execution failures are reported as a failing status.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+import tracemalloc
+from pathlib import Path
+from typing import Any, Callable
+
+# Permit direct execution from any checkout directory without installation.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+DEFAULT_SAMPLES = 5
+FIXTURE_PYTHON_FILES = 60
+FIXTURE_MARKDOWN_FILES = 20
+FIXTURE_FUNCTIONS_PER_FILE = 12
+
+DOES_NOT_ESTABLISH = [
+    "cross-host comparability of absolute timings",
+    "absence of regressions on unmeasured paths",
+    "production workload representativeness",
+    "memory use outside the Python allocator",
+]
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(65536), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _git_commit() -> str | None:
+    completed = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        return None
+    return completed.stdout.strip() or None
+
+
+def _git_dirty() -> bool | None:
+    completed = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        return None
+    return bool(completed.stdout.strip())
+
+
+def build_fixture_repository(root: Path) -> Path:
+    """Write a deterministic source tree; identical bytes across runs and hosts."""
+
+    repo_root = root / "benchfixture"
+    (repo_root / "src").mkdir(parents=True)
+    (repo_root / "docs").mkdir(parents=True)
+    for index in range(FIXTURE_PYTHON_FILES):
+        lines = [
+            '"""Deterministic benchmark module."""',
+            "",
+            "from __future__ import annotations",
+            "",
+        ]
+        for function in range(FIXTURE_FUNCTIONS_PER_FILE):
+            lines.extend(
+                [
+                    f"def module_{index:03d}_function_{function:02d}(value: int) -> int:",
+                    '    """Return a deterministic transform of ``value``."""',
+                    f"    total = value * {function + 1}",
+                    f"    if total > {index + 1}:",
+                    f"        total -= {index + 1}",
+                    "    return total",
+                    "",
+                ]
+            )
+        (repo_root / "src" / f"module_{index:03d}.py").write_text(
+            "\n".join(lines), encoding="utf-8"
+        )
+    for index in range(FIXTURE_MARKDOWN_FILES):
+        body = [f"# Benchmark document {index:03d}", ""]
+        for paragraph in range(8):
+            body.append(
+                f"Section {paragraph} of document {index:03d} describes deterministic "
+                "benchmark content used to exercise chunking and retrieval."
+            )
+            body.append("")
+        (repo_root / "docs" / f"document_{index:03d}.md").write_text(
+            "\n".join(body), encoding="utf-8"
+        )
+    (repo_root / "README.md").write_text(
+        "# Benchmark fixture\n\nDeterministic RepoGround core-path benchmark input.\n",
+        encoding="utf-8",
+    )
+    return repo_root
+
+
+class _WorkspaceSequence:
+    """Hand out a fresh output directory per invocation.
+
+    ``write_reports_v2`` derives artifact names from a minute-resolution
+    timestamp, so repeated samples must not share an output directory.
+    """
+
+    def __init__(self, root: Path, name: str) -> None:
+        self._root = root / name
+        self._counter = 0
+
+    def next(self) -> Path:
+        self._counter += 1
+        workspace = self._root / f"run{self._counter:03d}"
+        workspace.mkdir(parents=True, exist_ok=True)
+        return workspace
+
+
+def _measure(
+    operation: Callable[[], Any],
+    *,
+    samples: int,
+    setup: Callable[[], None] | None = None,
+) -> dict[str, Any]:
+    """Time ``operation`` repeatedly, then measure peak allocation once."""
+
+    durations: list[float] = []
+    for _ in range(samples):
+        if setup is not None:
+            setup()
+        started = time.perf_counter()
+        operation()
+        durations.append(time.perf_counter() - started)
+
+    if setup is not None:
+        setup()
+    tracemalloc.start()
+    try:
+        operation()
+        _current, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    return {
+        "samples": samples,
+        "wall_seconds_min": round(min(durations), 6),
+        "wall_seconds_median": round(statistics.median(durations), 6),
+        "wall_seconds_max": round(max(durations), 6),
+        "peak_traced_bytes": int(peak),
+        "peak_traced_measured_separately": True,
+    }
+
+
+def _bundle_cases(
+    root: Path, repo_root: Path, samples: int
+) -> tuple[dict[str, Any], Path | None, Path | None]:
+    from merger.repoground.core.merge import ExtrasConfig, scan_repo, write_reports_v2
+
+    generator_info = {
+        "name": "repoground-core-path-benchmark",
+        "platform": "benchmark",
+        "version": "0",
+    }
+    summary = scan_repo(repo_root, calculate_md5=True)
+    cases: dict[str, Any] = {}
+
+    def _write(merges_dir: Path, output_mode: str, json_sidecar: bool) -> Any:
+        return write_reports_v2(
+            merges_dir=merges_dir,
+            hub=root,
+            repo_summaries=[summary],
+            detail="max",
+            mode="gesamt",
+            max_bytes=0,
+            plan_only=False,
+            output_mode=output_mode,
+            extras=ExtrasConfig(json_sidecar=json_sidecar),
+            redact_secrets=False,
+            generator_info=dict(generator_info),
+            publish_generation=False,
+        )
+
+    archive_workspaces = _WorkspaceSequence(root, "merges_archive")
+    cases["bundle_write_archive"] = _measure(
+        lambda: _write(archive_workspaces.next(), "archive", False),
+        samples=samples,
+    )
+
+    dual_workspaces = _WorkspaceSequence(root, "merges_dual")
+    produced: dict[str, Any] = {}
+
+    def _run_dual() -> None:
+        produced["value"] = _write(dual_workspaces.next(), "dual", True)
+
+    cases["bundle_write_dual"] = _measure(_run_dual, samples=samples)
+    artifacts = produced["value"]
+    return cases, artifacts.dump_index, artifacts.chunk_index
+
+
+def _retrieval_cases(
+    root: Path, dump_index: Path | None, chunk_index: Path | None, samples: int
+) -> dict[str, Any]:
+    if dump_index is None or chunk_index is None:
+        return {
+            "retrieval_index_build": {"skipped": "bundle produced no retrieval artifacts"},
+            "retrieval_query": {"skipped": "bundle produced no retrieval artifacts"},
+        }
+
+    from merger.repoground.retrieval.index_db import build_index
+    from merger.repoground.retrieval.query_core import execute_query
+
+    db_path = root / "index" / "bench.sqlite"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def _drop_index() -> None:
+        if db_path.exists():
+            db_path.unlink()
+
+    cases = {
+        "retrieval_index_build": _measure(
+            lambda: build_index(dump_index, chunk_index, db_path),
+            samples=samples,
+            setup=_drop_index,
+        )
+    }
+    build_index(dump_index, chunk_index, db_path)
+    cases["retrieval_query"] = _measure(
+        lambda: execute_query(db_path, "deterministic transform value", k=10),
+        samples=samples,
+    )
+    return cases
+
+
+def _service_case(samples: int) -> dict[str, Any]:
+    """Measure cold service-application import in a separate interpreter."""
+
+    program = (
+        "import time, tracemalloc, json, sys\n"
+        "tracemalloc.start()\n"
+        "started = time.perf_counter()\n"
+        "import merger.repoground.service.app  # noqa: F401\n"
+        "elapsed = time.perf_counter() - started\n"
+        "peak = tracemalloc.get_traced_memory()[1]\n"
+        "tracemalloc.stop()\n"
+        "print(json.dumps({'wall_seconds': elapsed, 'peak_traced_bytes': peak}))\n"
+    )
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = os.pathsep.join(
+        [str(REPO_ROOT), environment.get("PYTHONPATH", "")]
+    ).rstrip(os.pathsep)
+
+    durations: list[float] = []
+    peaks: list[int] = []
+    for _ in range(samples):
+        completed = subprocess.run(
+            [sys.executable, "-c", program],
+            cwd=REPO_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+            env=environment,
+        )
+        if completed.returncode != 0:
+            return {
+                "skipped": "service application import failed",
+                "detail": completed.stderr.strip()[-500:],
+            }
+        payload = json.loads(completed.stdout.strip().splitlines()[-1])
+        durations.append(float(payload["wall_seconds"]))
+        peaks.append(int(payload["peak_traced_bytes"]))
+
+    return {
+        "samples": samples,
+        "wall_seconds_min": round(min(durations), 6),
+        "wall_seconds_median": round(statistics.median(durations), 6),
+        "wall_seconds_max": round(max(durations), 6),
+        "peak_traced_bytes": min(peaks),
+        "peak_traced_measured_separately": False,
+        "isolation": "subprocess",
+    }
+
+
+def _atlas_case(root: Path, repo_root: Path, samples: int) -> dict[str, Any]:
+    """Atlas is an optional observation subsystem; absence is recorded, not failed."""
+
+    try:
+        from merger.repoground.adapters.atlas import AtlasScanner
+    except Exception as exc:  # pragma: no cover - optional subsystem
+        return {"skipped": "atlas adapter unavailable", "detail": str(exc)[:200]}
+
+    inventory = root / "atlas" / "inventory.jsonl"
+    inventory.parent.mkdir(parents=True, exist_ok=True)
+
+    def _scan() -> None:
+        AtlasScanner(
+            repo_root,
+            max_depth=6,
+            snapshot_id="benchmark-fixed-snapshot",
+        ).scan(inventory_file=inventory)
+
+    return _measure(_scan, samples=samples) | {"optional_subsystem": True}
+
+
+def run(samples: int, include_atlas: bool) -> dict[str, Any]:
+    cases: dict[str, Any] = {}
+    failures: list[str] = []
+    with tempfile.TemporaryDirectory(prefix="repoground-corebench-") as raw_root:
+        root = Path(raw_root)
+        repo_root = build_fixture_repository(root)
+        try:
+            bundle_cases, dump_index, chunk_index = _bundle_cases(root, repo_root, samples)
+            cases.update(bundle_cases)
+            cases.update(_retrieval_cases(root, dump_index, chunk_index, samples))
+        except Exception as exc:
+            failures.append(f"bundle_or_retrieval: {type(exc).__name__}: {exc}")
+        cases["service_app_import"] = _service_case(samples)
+        if include_atlas:
+            try:
+                cases["atlas_scan"] = _atlas_case(root, repo_root, samples)
+            except Exception as exc:
+                failures.append(f"atlas: {type(exc).__name__}: {exc}")
+        else:
+            cases["atlas_scan"] = {"skipped": "not requested (optional subsystem)"}
+
+    return {
+        "kind": "repoground.core_path_benchmark",
+        "version": "1.0",
+        "status": "fail" if failures else "pass",
+        "failures": failures,
+        "binding": {
+            "commit": _git_commit(),
+            "worktree_dirty": _git_dirty(),
+            "benchmark_script_sha256": _sha256(Path(__file__)),
+        },
+        "configuration": {
+            "samples": samples,
+            "fixture_python_files": FIXTURE_PYTHON_FILES,
+            "fixture_markdown_files": FIXTURE_MARKDOWN_FILES,
+            "fixture_functions_per_file": FIXTURE_FUNCTIONS_PER_FILE,
+            "reported_statistic": "wall_seconds_min is the comparison figure",
+            "timing_gate": "none",
+        },
+        "environment": {
+            "python": sys.version.split()[0],
+            "platform": platform.platform(),
+            "processor": platform.processor(),
+        },
+        "cases": cases,
+        "does_not_establish": DOES_NOT_ESTABLISH,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--samples", type=int, default=DEFAULT_SAMPLES)
+    parser.add_argument("--include-atlas", action="store_true")
+    parser.add_argument("--out", type=Path)
+    args = parser.parse_args(argv)
+    if args.samples < 1:
+        parser.error("--samples must be at least 1")
+    report = run(args.samples, args.include_atlas)
+    text = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(text, encoding="utf-8")
+    else:
+        sys.stdout.write(text)
+    return 1 if report["status"] == "fail" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check_graph_maintainability.py
+++ b/scripts/ci/check_graph_maintainability.py
@@ -216,6 +216,80 @@ def _complexity_regressions(
     return findings
 
 
+_BUDGET_DIMENSIONS = (
+    # (budget key, historical reference key, human label)
+    ("finding_count_max", "finding_count", "finding_count"),
+    ("max_complexity_max", "max_complexity", "max_complexity"),
+    ("excess_total_max", None, "excess_total"),
+)
+
+
+def measure_complexity_budget(current: list[ComplexityFinding]) -> dict[str, int]:
+    """Aggregate the three budgeted complexity dimensions of a scan."""
+
+    return {
+        "finding_count": len(current),
+        "max_complexity": max((item.complexity for item in current), default=0),
+        # Excess is the complexity mass above the configured threshold. It falls
+        # when a function is split even if the split creates further findings.
+        "excess_total": sum(max(item.complexity - item.limit, 0) for item in current),
+    }
+
+
+def evaluate_complexity_budget(
+    current: list[ComplexityFinding],
+    budget: Any,
+) -> list[dict[str, Any]]:
+    """Reject scans above the recorded budget, and budgets above the reference.
+
+    Fail-closed: a missing or malformed budget is itself a finding, so removing
+    the budget cannot silently disable the ratchet.
+    """
+
+    if not isinstance(budget, dict):
+        return [{"code": "complexity_budget_missing"}]
+
+    reference = budget.get("historical_reference")
+    if not isinstance(reference, dict):
+        return [{"code": "complexity_budget_reference_missing"}]
+
+    findings: list[dict[str, Any]] = []
+    observed = measure_complexity_budget(current)
+    for budget_key, reference_key, label in _BUDGET_DIMENSIONS:
+        ceiling = budget.get(budget_key)
+        if not isinstance(ceiling, int) or isinstance(ceiling, bool):
+            findings.append(
+                {"code": "complexity_budget_invalid", "dimension": budget_key}
+            )
+            continue
+        if observed[label] > ceiling:
+            findings.append(
+                {
+                    "code": "complexity_budget_exceeded",
+                    "dimension": label,
+                    "observed": observed[label],
+                    "budget": ceiling,
+                }
+            )
+        if reference_key is None:
+            continue
+        historical = reference.get(reference_key)
+        if not isinstance(historical, int) or isinstance(historical, bool):
+            findings.append(
+                {"code": "complexity_budget_reference_invalid", "dimension": label}
+            )
+        elif ceiling > historical:
+            findings.append(
+                {
+                    "code": "complexity_budget_raised_above_reference",
+                    "dimension": label,
+                    "budget": ceiling,
+                    "historical_reference": historical,
+                }
+            )
+    return findings
+
+
 def compare_complexity_baseline(
     current: list[ComplexityFinding],
     baseline: dict[str, Any],
@@ -237,7 +311,10 @@ def check(repo_root: Path, policy_path: Path) -> dict[str, Any]:
     baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
     current_complexity = collect_complexity_findings(repo_root)
     complexity_findings = compare_complexity_baseline(current_complexity, baseline)
-    findings = graph_findings + complexity_findings
+    budget_findings = evaluate_complexity_budget(
+        current_complexity, policy["complexity"].get("budget")
+    )
+    findings = graph_findings + complexity_findings + budget_findings
     baseline_identities = {
         f"{row['path']}::{row['qualified_name']}" for row in baseline["findings"]
     }
@@ -256,6 +333,8 @@ def check(repo_root: Path, policy_path: Path) -> dict[str, Any]:
                 (item.complexity for item in current_complexity),
                 default=0,
             ),
+            "budget": policy["complexity"].get("budget"),
+            "observed_budget_dimensions": measure_complexity_budget(current_complexity),
         },
         "findings": findings,
         "does_not_establish": [

--- a/scripts/ci/check_graph_maintainability.py
+++ b/scripts/ci/check_graph_maintainability.py
@@ -217,11 +217,16 @@ def _complexity_regressions(
 
 
 _BUDGET_DIMENSIONS = (
-    # (budget key, historical reference key, human label)
-    ("finding_count_max", "finding_count", "finding_count"),
-    ("max_complexity_max", "max_complexity", "max_complexity"),
-    ("excess_total_max", None, "excess_total"),
+    # (budget key, dimension label shared with the recorded references)
+    ("finding_count_max", "finding_count"),
+    ("max_complexity_max", "max_complexity"),
+    ("excess_total_max", "excess_total"),
 )
+
+#: Recorded scans a ceiling may never exceed. Every budgeted dimension must be
+#: bounded by at least one of them, otherwise a ceiling could be raised without
+#: limit and the ratchet would only appear to hold.
+_REFERENCE_KEYS = ("historical_reference", "slice_start_reference")
 
 
 def measure_complexity_budget(current: list[ComplexityFinding]) -> dict[str, int]:
@@ -236,57 +241,86 @@ def measure_complexity_budget(current: list[ComplexityFinding]) -> dict[str, int
     }
 
 
-def evaluate_complexity_budget(
-    current: list[ComplexityFinding],
-    budget: Any,
+def _recorded_references(budget: dict[str, Any], label: str) -> list[tuple[str, Any]]:
+    """Return every recorded scan that bounds one budgeted dimension."""
+
+    recorded: list[tuple[str, Any]] = []
+    for key in _REFERENCE_KEYS:
+        reference = budget.get(key)
+        if isinstance(reference, dict) and label in reference:
+            recorded.append((key, reference[label]))
+    return recorded
+
+
+def _budget_dimension_findings(
+    budget: dict[str, Any],
+    observed: dict[str, int],
+    budget_key: str,
+    label: str,
 ) -> list[dict[str, Any]]:
-    """Reject scans above the recorded budget, and budgets above the reference.
-
-    Fail-closed: a missing or malformed budget is itself a finding, so removing
-    the budget cannot silently disable the ratchet.
-    """
-
-    if not isinstance(budget, dict):
-        return [{"code": "complexity_budget_missing"}]
-
-    reference = budget.get("historical_reference")
-    if not isinstance(reference, dict):
-        return [{"code": "complexity_budget_reference_missing"}]
+    ceiling = budget.get(budget_key)
+    if not isinstance(ceiling, int) or isinstance(ceiling, bool):
+        return [{"code": "complexity_budget_invalid", "dimension": budget_key}]
 
     findings: list[dict[str, Any]] = []
-    observed = measure_complexity_budget(current)
-    for budget_key, reference_key, label in _BUDGET_DIMENSIONS:
-        ceiling = budget.get(budget_key)
-        if not isinstance(ceiling, int) or isinstance(ceiling, bool):
-            findings.append(
-                {"code": "complexity_budget_invalid", "dimension": budget_key}
-            )
-            continue
-        if observed[label] > ceiling:
+    if observed[label] > ceiling:
+        findings.append(
+            {
+                "code": "complexity_budget_exceeded",
+                "dimension": label,
+                "observed": observed[label],
+                "budget": ceiling,
+            }
+        )
+
+    recorded = _recorded_references(budget, label)
+    if not recorded:
+        # An unbounded ceiling could be raised at will, so it is a finding.
+        findings.append(
+            {"code": "complexity_budget_reference_missing", "dimension": label}
+        )
+    for reference_key, value in recorded:
+        if not isinstance(value, int) or isinstance(value, bool):
             findings.append(
                 {
-                    "code": "complexity_budget_exceeded",
+                    "code": "complexity_budget_reference_invalid",
                     "dimension": label,
-                    "observed": observed[label],
-                    "budget": ceiling,
+                    "reference": reference_key,
                 }
             )
-        if reference_key is None:
-            continue
-        historical = reference.get(reference_key)
-        if not isinstance(historical, int) or isinstance(historical, bool):
-            findings.append(
-                {"code": "complexity_budget_reference_invalid", "dimension": label}
-            )
-        elif ceiling > historical:
+        elif ceiling > value:
             findings.append(
                 {
                     "code": "complexity_budget_raised_above_reference",
                     "dimension": label,
                     "budget": ceiling,
-                    "historical_reference": historical,
+                    "reference": reference_key,
+                    "recorded": value,
                 }
             )
+    return findings
+
+
+def evaluate_complexity_budget(
+    current: list[ComplexityFinding],
+    budget: Any,
+) -> list[dict[str, Any]]:
+    """Reject scans above the recorded budget, and budgets above the references.
+
+    Fail-closed: a missing or malformed budget is itself a finding, so removing
+    the budget cannot silently disable the ratchet, and every ceiling must be
+    bounded by at least one recorded scan.
+    """
+
+    if not isinstance(budget, dict):
+        return [{"code": "complexity_budget_missing"}]
+    if not any(isinstance(budget.get(key), dict) for key in _REFERENCE_KEYS):
+        return [{"code": "complexity_budget_reference_missing"}]
+
+    observed = measure_complexity_budget(current)
+    findings: list[dict[str, Any]] = []
+    for budget_key, label in _BUDGET_DIMENSIONS:
+        findings += _budget_dimension_findings(budget, observed, budget_key, label)
     return findings
 
 

--- a/scripts/ci/check_module_reachability.py
+++ b/scripts/ci/check_module_reachability.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Fail when a production module has no recorded reachability evidence.
+
+The check answers "is there evidence that this module is used?", not "is this
+module dead?". A module without evidence is reported as ``unproven`` and blocks
+the build so the gap is reviewed; it never licenses deletion.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from merger.repoground.architecture.module_reachability import (  # noqa: E402
+    evaluate_reachability_policy,
+    measure_module_reachability,
+)
+
+DEFAULT_POLICY = Path("config/repoground-module-reachability.v1.json")
+
+
+def check(repo_root: Path, policy_path: Path) -> dict[str, Any]:
+    policy = json.loads(policy_path.read_text(encoding="utf-8"))
+    measurement = measure_module_reachability(
+        repo_root, policy.get("package_roots") or ("merger",)
+    )
+    findings = evaluate_reachability_policy(measurement, policy)
+    return {
+        "kind": "repoground.module_reachability_check",
+        "version": "1.0",
+        "status": "pass" if not findings else "fail",
+        "measurement": measurement,
+        "findings": findings,
+        "does_not_establish": measurement["does_not_establish"],
+    }
+
+
+def _summary(report: dict[str, Any]) -> str:
+    measurement = report["measurement"]
+    return (
+        f"Module reachability: {measurement['module_count']} production modules, "
+        f"{len(measurement['unproven'])} unproven, "
+        f"{len(measurement['documentation_only'])} documentation-only"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--policy", type=Path, default=DEFAULT_POLICY)
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    parser.add_argument("--out", type=Path)
+    args = parser.parse_args(argv)
+
+    root = args.root.resolve()
+    policy = args.policy if args.policy.is_absolute() else root / args.policy
+    report = check(root, policy)
+
+    if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+
+    if args.format == "json":
+        print(json.dumps(report, indent=2, sort_keys=True))
+    elif report["findings"]:
+        for finding in report["findings"]:
+            print(json.dumps(finding, sort_keys=True))
+    else:
+        print(_summary(report))
+    return 1 if report["findings"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check_module_reachability.py
+++ b/scripts/ci/check_module_reachability.py
@@ -26,12 +26,42 @@ from merger.repoground.architecture.module_reachability import (  # noqa: E402
 DEFAULT_POLICY = Path("config/repoground-module-reachability.v1.json")
 
 
+POLICY_KIND = "repoground.module_reachability_policy"
+POLICY_VERSION = "1.0"
+
+
+def validate_policy(policy: Any) -> list[dict[str, Any]]:
+    """Reject a policy that cannot be trusted to describe what is measured.
+
+    Fail-closed: a policy without an identity or without package roots would
+    otherwise fall back to defaults and report a pass over the wrong tree.
+    """
+
+    if not isinstance(policy, dict):
+        return [{"code": "module_reachability_policy_invalid", "detail": "not an object"}]
+    findings: list[dict[str, Any]] = []
+    if (
+        policy.get("kind") != POLICY_KIND
+        or policy.get("version") != POLICY_VERSION
+    ):
+        findings.append({"code": "module_reachability_policy_identity_invalid"})
+    roots = policy.get("package_roots")
+    if not isinstance(roots, list) or not roots or not all(
+        isinstance(root, str) and root for root in roots
+    ):
+        findings.append(
+            {"code": "module_reachability_policy_invalid", "detail": "package_roots"}
+        )
+    return findings
+
+
 def check(repo_root: Path, policy_path: Path) -> dict[str, Any]:
     policy = json.loads(policy_path.read_text(encoding="utf-8"))
+    policy_findings = validate_policy(policy)
     measurement = measure_module_reachability(
         repo_root, policy.get("package_roots") or ("merger",)
     )
-    findings = evaluate_reachability_policy(measurement, policy)
+    findings = policy_findings + evaluate_reachability_policy(measurement, policy)
     return {
         "kind": "repoground.module_reachability_check",
         "version": "1.0",
@@ -47,7 +77,8 @@ def _summary(report: dict[str, Any]) -> str:
     return (
         f"Module reachability: {measurement['module_count']} production modules, "
         f"{len(measurement['unproven'])} unproven, "
-        f"{len(measurement['documentation_only'])} documentation-only"
+        f"{len(measurement['documentation_only'])} documentation-only, "
+        f"{len(measurement['test_only'])} test-only"
     )
 
 


### PR DESCRIPTION
## Bureau task

Bounded implementation slice of `REPOGROUND-LEGACY-RECONCILIATION-V1-T004`.

This PR deliberately does **not** close the umbrella task.

## What changes

- decomposes the artifact-writing portion of `merge.write_reports_v2`
- adds dependency-light `artifact_io.py` and `bundle_sidecars.py`
- lowers the measured C901 maximum from 170 to 148
- lowers measured C901 findings from the slice reference 200 to 198
- adds a fail-closed aggregate complexity budget
- adds production/test/documentation-separated module reachability evidence
- adds bounded core-path benchmark tooling and revision-bound proof artifacts
- ports the existing clean five-commit slice conflict-free onto current main `dc67fdcf668942fdf4b5baef4989ce6e1e952c21`

## Review hardening

- plain strings/docstrings no longer count as dynamic imports
- only bound `importlib.import_module` / `__import__` calls count
- only exact `__name__ == "__main__"` guards count as entry points
- script-style sibling imports require a directly executable module and a real sibling module
- packaged resource references remain a separate evidence class
- symbol/call-graph sidecars reject `ERROR`, uppercase, malformed and non-hex hashes instead of emitting false provenance

## Verification

- focused maintainability/reachability/sidecar tests: 42 passed
- full repository pytest task `d6f4c47f862941d8b976df9b`: exit 0, lifecycle receipt `7aaab1cc89ebade1bf74d9ed91a26ff43dc56e24f841f245cea77329aa99fbe6`
- graph maintainability gate: pass, 198 findings, max 148, excess mass 2533
- module reachability gate: pass, 199 modules, 0 unproven, 0 documentation-only, 6 explicitly declared test-only
- Ruff: pass
- parity guard: pass
- `git diff --check`: pass

## Explicit remaining T004 gaps

- `merge.iter_report_blocks` remains at complexity 148
- Pythonista `build.py`, `bundle_access.py` and `service/app.py` remain monolithic
- `merge.py` itself remains large
- six test-only module classifications still require individual disposition

These gaps are being registered as separate dependent Bureau tasks rather than hidden inside this PR.