### PR TITLE
fix: harden T009 report renderer contracts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Report goldens preserve exact renderer bytes, including the terminal blank line.
-merger/repoground/tests/fixtures/report_renderer/golden/*.txt whitespace=-blank-at-eof
+merger/repoground/tests/fixtures/report_renderer/golden/*.txt text eol=lf whitespace=-blank-at-eof
+merger/repoground/tests/fixtures/report_renderer/golden/*.json text eol=lf

--- a/docs/proofs/repoground-legacy-t009-complexity.corrective-v2.measurement.json
+++ b/docs/proofs/repoground-legacy-t009-complexity.corrective-v2.measurement.json
@@ -1,0 +1,141 @@
+{
+  "binding": {
+    "commit": "684fd3aa8f0b99f6b743386e233d09b997144310",
+    "source": "clean_git_worktree",
+    "tree": "457e8af17214a216035a9b3a704ef4c746c9ced2",
+    "worktree_dirty": false
+  },
+  "complexity": {
+    "baseline_count": 197,
+    "budget": {
+      "excess_total_max": 2395,
+      "finding_count_max": 197,
+      "historical_reference": {
+        "finding_count": 213,
+        "max_complexity": 170,
+        "observed_on": "2026-07-17",
+        "task": "REPOGROUND-LEGACY-RECONCILIATION-V1-T004"
+      },
+      "max_complexity_max": 138,
+      "policy": "the aggregate budget must fall over time and may never be raised above a recorded reference scan; every budgeted dimension must be bounded by at least one reference, and raising a ceiling above one is rejected",
+      "slice_start_reference": {
+        "commit": "5188d2faf335aaaefe4d27122df71d770647cb5b",
+        "excess_total": 2654,
+        "finding_count": 200,
+        "max_complexity": 170,
+        "measured_with": "ruff check --config ruff-ci.toml --select C901 .",
+        "observed_on": "2026-07-23"
+      }
+    },
+    "current_count": 197,
+    "current_max": 138,
+    "new_count": 0,
+    "observed_budget_dimensions": {
+      "excess_total": 2395,
+      "finding_count": 197,
+      "max_complexity": 138
+    },
+    "resolved_count": 0
+  },
+  "does_not_establish": [
+    "absence of maintainability problems below C901 threshold",
+    "semantic correctness of graph classification",
+    "runtime reachability",
+    "architecture quality",
+    "test completeness"
+  ],
+  "findings": [],
+  "kind": "repoground.graph_maintainability_check",
+  "measurement": {
+    "does_not_establish": [
+      "runtime call reachability",
+      "semantic correctness of inferred layers",
+      "complete entrypoint discovery",
+      "absence of dynamic imports",
+      "overall maintainability"
+    ],
+    "entrypoints": {
+      "counts_by_projection": {
+        "fixture": 3,
+        "product": 15,
+        "script": 37,
+        "test": 20
+      },
+      "projection_sum": 75,
+      "skipped_files_count": 2,
+      "total": 75
+    },
+    "graph": {
+      "edge_count": 5848,
+      "edges_per_parsed_file": 9.3568,
+      "external_node_count": 231,
+      "external_to_file_ratio": 0.3696,
+      "file_node_count": 625,
+      "file_unknown_layer_count": 0,
+      "file_unknown_layer_share": 0.0,
+      "files_parsed": 625,
+      "files_seen": 627,
+      "legacy_all_node_unknown_share": 0.40819312362838334,
+      "parse_success_rate": 0.9968102073365231,
+      "projections": {
+        "fixture": {
+          "file_count": 36,
+          "layers": {
+            "test": 36
+          },
+          "unknown_layer_count": 0,
+          "unknown_layer_share": 0.0
+        },
+        "product": {
+          "file_count": 202,
+          "layers": {
+            "adapter": 7,
+            "architecture": 13,
+            "atlas": 8,
+            "cli": 35,
+            "contract": 1,
+            "core": 95,
+            "frontend": 7,
+            "product": 5,
+            "retrieval": 19,
+            "service": 12
+          },
+          "unknown_layer_count": 0,
+          "unknown_layer_share": 0.0
+        },
+        "script": {
+          "file_count": 41,
+          "layers": {
+            "benchmark": 3,
+            "infra": 36,
+            "product": 2
+          },
+          "unknown_layer_count": 0,
+          "unknown_layer_share": 0.0
+        },
+        "test": {
+          "file_count": 346,
+          "layers": {
+            "test": 346
+          },
+          "unknown_layer_count": 0,
+          "unknown_layer_share": 0.0
+        }
+      }
+    },
+    "kind": "repoground.graph_maintainability_measurement",
+    "version": "1.0"
+  },
+  "measurement_contract": {
+    "measured_at": "2026-07-25T15:52:27.655629+00:00",
+    "measurement_command": "python3 scripts/ci/check_graph_maintainability.py --root . --format json",
+    "measurement_script_path": "scripts/ci/check_graph_maintainability.py",
+    "measurement_script_sha256": "90b101a37c67022bc585dce9b11a65c982fd5a6af58e1b60adda8065275a9db0",
+    "python_version": "3.10.12",
+    "ruff_config_path": "ruff-ci.toml",
+    "ruff_config_sha256": "df97091d1a3e4cec551469263490809998e1f72329711fdda0d323c95ded17a1",
+    "stderr_sha256": "ab31f83d466bb046123a1c9c49457229198b75c5ed4b052ae5bd48c9e581ae3d"
+  },
+  "status": "pass",
+  "version": "1.0"
+}

--- a/docs/proofs/repoground-legacy-t009-contract-hardening-v2-proof.md
+++ b/docs/proofs/repoground-legacy-t009-contract-hardening-v2-proof.md
@@ -1,0 +1,60 @@
+# RepoGround T009 Contract Hardening v2 — Proof
+
+## Scope
+
+This corrective slice repairs report-renderer contract defects that remained in the
+already-merged PR #1098 without rewriting its historical evidence. The implementation
+commit is `684fd3aa8f0b99f6b743386e233d09b997144310` with tree
+`457e8af17214a216035a9b3a704ef4c746c9ced2`.
+
+## Corrected contracts
+
+- one frozen emission projection for selected, includable, emitted and metadata-only counts;
+- plan-only reports emit zero content claims in header, YAML, plan and repo snapshots;
+- extension filters are applied instead of merely normalized;
+- render-local file copies prevent mutation of caller-owned `FileInfo` objects;
+- canonical SHA-256 path anchors and collision-safe legacy aliases;
+- single-line Base64url JSON machine markers that round-trip the original path;
+- structured diagnostics in the existing YAML metadata block;
+- context-bound redaction without broad long-identifier false positives;
+- fail-closed benchmark commit/tree/dirty checks and explicit smoke-gate semantics;
+- fail-closed evidence validation and a real two-revision comparison.
+
+## Revision binding
+
+| Role | Commit | Tree |
+|---|---|---|
+| PR #1098 base | `2afc2836fa1a49a593c7b57eda43086844e8fb2b` | `dc591643961ce7c44513ba488cf213dc35c7bd61` |
+| merged defect state | `c91d640bce2b14c4a78a64e83169d56c818fa662` | `36113af31c4cb6ba381302b8fcef61a024049336` |
+| corrective implementation | `684fd3aa8f0b99f6b743386e233d09b997144310` | `457e8af17214a216035a9b3a704ef4c746c9ced2` |
+
+## Verification
+
+- focused semantic, evidence, link, redactor and benchmark matrix: 120 passed;
+- broad repository suite excluding the two host-blocked Sidecar files: 4,847 passed, 2 skipped;
+- Ruff over all changed Python files: pass;
+- `git diff --check`: pass;
+- graph maintainability ratchet: 197 findings, maximum complexity 138, no new finding;
+- two-revision renderer comparison: no unapproved difference;
+- performance smoke gate: pass for every measured non-optional case, with 5% timing and traced-memory ceilings.
+
+The two excluded Sidecar test files fail because Bubblewrap cannot create a namespace
+on the host (`Resource temporarily unavailable`). The same failure was reproduced on
+the unchanged merged-defect commit, so it is not attributed to this patch.
+
+## Evidence
+
+The canonical corrective evidence is
+`docs/proofs/repoground-legacy-t009-delivery.evidence-v2.json`. It references five
+new, hash-bound artifacts. Historical T009 evidence files remain unchanged.
+
+## Current delivery state
+
+Verification is `pass`; delivery remains `pending` until the corrective branch is
+pushed, required GitHub checks pass on the final head, the PR is merged, the immutable
+runtime is deployed and Bureau truth is reconciled.
+
+## Non-claims
+
+This proof does not establish production deployment, final GitHub check success,
+resolution of the host Bubblewrap failure or Bureau closeout.

--- a/docs/proofs/repoground-legacy-t009-contract-hardening-v2-proof.md
+++ b/docs/proofs/repoground-legacy-t009-contract-hardening-v2-proof.md
@@ -31,11 +31,13 @@ commit is `684fd3aa8f0b99f6b743386e233d09b997144310` with tree
 ## Verification
 
 - focused semantic, evidence, link, redactor and benchmark matrix: 120 passed;
-- broad repository suite excluding the two host-blocked Sidecar files: 4,850 passed, 2 skipped;
+- broad repository suite excluding the two host-blocked Sidecar files: 4,853 passed, 2 skipped;
 - Ruff over all changed Python files: pass;
 - `git diff --check`: pass;
 - graph maintainability ratchet: 197 findings, maximum complexity 138, no new finding;
 - two-revision renderer comparison: no unapproved difference;
+- CI shallow-history regression: 84 passed in the complete checkout;
+- depth-1 CI simulation: 4 passed and 2 explicitly skipped because historical objects were unavailable;
 - performance smoke gate: pass for every measured non-optional case, with 5% timing and traced-memory ceilings.
 
 The two excluded Sidecar test files fail because Bubblewrap cannot create a namespace

--- a/docs/proofs/repoground-legacy-t009-contract-hardening-v2-proof.md
+++ b/docs/proofs/repoground-legacy-t009-contract-hardening-v2-proof.md
@@ -31,7 +31,7 @@ commit is `684fd3aa8f0b99f6b743386e233d09b997144310` with tree
 ## Verification
 
 - focused semantic, evidence, link, redactor and benchmark matrix: 120 passed;
-- broad repository suite excluding the two host-blocked Sidecar files: 4,847 passed, 2 skipped;
+- broad repository suite excluding the two host-blocked Sidecar files: 4,850 passed, 2 skipped;
 - Ruff over all changed Python files: pass;
 - `git diff --check`: pass;
 - graph maintainability ratchet: 197 findings, maximum complexity 138, no new finding;

--- a/docs/proofs/repoground-legacy-t009-delivery.evidence-v2.json
+++ b/docs/proofs/repoground-legacy-t009-delivery.evidence-v2.json
@@ -1,0 +1,118 @@
+{
+  "_corrective": true,
+  "_original": "repoground-legacy-t009-delivery.evidence.json",
+  "binding": {
+    "evidence_parent_commit": "684fd3aa8f0b99f6b743386e233d09b997144310",
+    "implementation_commit": "684fd3aa8f0b99f6b743386e233d09b997144310",
+    "implementation_tree": "457e8af17214a216035a9b3a704ef4c746c9ced2",
+    "merged_defect_commit": "c91d640bce2b14c4a78a64e83169d56c818fa662",
+    "merged_defect_tree": "36113af31c4cb6ba381302b8fcef61a024049336",
+    "pr_base_commit": "2afc2836fa1a49a593c7b57eda43086844e8fb2b",
+    "pr_number": 1098,
+    "worktree_dirty_when_measured": false
+  },
+  "broad_tests": {
+    "argv_sha256": "d30573f5c99680a7390247ef17e8ec6869a717dc6b377ee7a49a9ac602537aaa",
+    "command": "python3 -m pytest -q --tb=short --ignore=tests/test_patch_evaluation_sidecar.py --ignore=tests/test_patch_evaluation_sidecar_host_readback.py",
+    "excluded_files": [
+      "tests/test_patch_evaluation_sidecar.py",
+      "tests/test_patch_evaluation_sidecar_host_readback.py"
+    ],
+    "exclusion_reason": "Bubblewrap namespace creation failed identically on the unchanged merged-defect commit with Resource temporarily unavailable.",
+    "job": "grabowski-job-5e5c5dabd73b",
+    "lifecycle_receipt_sha256": "94f425e00f5a4edc00db51117a8bcfafeb60d18349758cfa8833132f85ebe35b",
+    "status": "pass",
+    "tests_passed": 4847,
+    "tests_skipped": 2
+  },
+  "complexity": {
+    "argv_sha256": "790ef4ea659bc361d4fbe4a2c2fb8124227b55ac692511908f6a7af144c51541",
+    "excess_total": 2395,
+    "finding_count": 197,
+    "job": "grabowski-job-7d68cb9385b6",
+    "lifecycle_receipt_sha256": "b611251b197898d5fc7f2d1bc6b1c3fbb459f5ee63877604371e0cb8b262ff2b",
+    "max_complexity": 138,
+    "status": "pass"
+  },
+  "correction_id": "REPOGROUND-LEGACY-RECONCILIATION-V1-T009-CORRECTIVE-V2",
+  "delivery_status": "pending",
+  "differential": {
+    "argv_sha256": "2a43f3fc24ec8e529d309649d1ea113c7719feaf79a664bccda5e6880351bbb5",
+    "base_commit": "2afc2836fa1a49a593c7b57eda43086844e8fb2b",
+    "job": "grabowski-job-b29d5442041a",
+    "lifecycle_receipt_sha256": "33b4c8b86fd149ee40771d4ad6d15d47eca6e811e3e7b10b135c8890f67966c8",
+    "status": "pass",
+    "target_commit": "684fd3aa8f0b99f6b743386e233d09b997144310",
+    "unapproved_differences": {}
+  },
+  "does_not_establish": [
+    "GitHub required-check success on the final evidence commit",
+    "merge of the corrective pull request",
+    "production deployment of the corrective merge commit",
+    "resolution of the host Bubblewrap namespace failure",
+    "Bureau closeout of the corrective follow-up"
+  ],
+  "evidence_files": {
+    "repoground-legacy-t009-complexity.corrective-v2.measurement.json": {
+      "path": "docs/proofs/repoground-legacy-t009-complexity.corrective-v2.measurement.json",
+      "sha256": "623528616be6ad7b1f313d63b674d1d8eea7bc94009577a1db8731c45c56f60d"
+    },
+    "repoground-legacy-t009-differential.corrective-v2.json": {
+      "path": "docs/proofs/repoground-legacy-t009-differential.corrective-v2.json",
+      "sha256": "e9faf068d33c5816c81e2ab60b4faad61cb99196f191f29ae5b652288d05fc35"
+    },
+    "repoground-legacy-t009-performance.corrective-v2.after.json": {
+      "path": "docs/proofs/repoground-legacy-t009-performance.corrective-v2.after.json",
+      "sha256": "c6f7170e7d339d176d4d26a57f8789b5a20e70320c1208357741233f612412f2"
+    },
+    "repoground-legacy-t009-performance.corrective-v2.before.json": {
+      "path": "docs/proofs/repoground-legacy-t009-performance.corrective-v2.before.json",
+      "sha256": "365fdf9eeee04532e5cd66286dc1fd53569fe7fcbccc1175362ddd3e9c6c8e0d"
+    },
+    "repoground-legacy-t009-performance.corrective-v2.comparison.json": {
+      "path": "docs/proofs/repoground-legacy-t009-performance.corrective-v2.comparison.json",
+      "sha256": "3f5f5b741a47d2aaabd68c073cc163bfd00762741a6f8a00e94f1b430ed6e535"
+    }
+  },
+  "final_delivery": {
+    "reason": "The correction branch is not yet pushed, merged, deployed, or reconciled in Bureau truth.",
+    "status": "pending"
+  },
+  "final_validation": {
+    "github_required_checks": null,
+    "local_status": "pass",
+    "ruff": {
+      "argv_sha256": "f8a82352c628f894c869d62eec568b869f796771c396613e8179cc92c07f2199",
+      "job": "grabowski-job-c1c9abc36a6a",
+      "lifecycle_receipt_sha256": "19bedcf24898349d7312c8dfbffc4976d17254b65d5e67ba56f5322d9a268489",
+      "status": "pass"
+    },
+    "status": "pending",
+    "targeted_tests": {
+      "argv_sha256": "16217d7a0a3ebd3c77ef93e2627f29f111585840ee091cd4be4e25f71b86e430",
+      "job": "grabowski-job-7eb4c062aa59",
+      "lifecycle_receipt_sha256": "6ab619e50e4bee078b435bcf3a5fe7497fc9c52183715e6d1b4588ea4c0c865a",
+      "status": "pass",
+      "tests_passed": 120,
+      "tests_skipped": 0
+    }
+  },
+  "kind": "repoground.corrective_delivery_evidence",
+  "performance": {
+    "argv_sha256": "2c1417237383f647c20d26e17dd443283c09156a93093addf0c1cbcd7937895f",
+    "failed_cases": [],
+    "gate_kind": "performance_smoke_gate",
+    "job": "grabowski-job-dbec140c74a6",
+    "lifecycle_receipt_sha256": "979eb7526bc2f5811ea2a54e432541078f0869287edb3b440493ef3a986d4ecd",
+    "median_regression_pct_max": 5.0,
+    "peak_memory_regression_pct_max": 5.0,
+    "rounds": 2,
+    "samples_per_round": 5,
+    "status": "pass",
+    "warmups_per_revision": 1
+  },
+  "status": "pending",
+  "task": "REPOGROUND-LEGACY-RECONCILIATION-V1-T009",
+  "verification_status": "pass",
+  "version": "2.1"
+}

--- a/docs/proofs/repoground-legacy-t009-delivery.evidence-v2.json
+++ b/docs/proofs/repoground-legacy-t009-delivery.evidence-v2.json
@@ -2,6 +2,7 @@
   "_corrective": true,
   "_original": "repoground-legacy-t009-delivery.evidence.json",
   "binding": {
+    "ci_history_fix_commit": "fe41d9cc5defc5a127a42e9c884f60b608ce0a17",
     "evidence_parent_commit": "684fd3aa8f0b99f6b743386e233d09b997144310",
     "implementation_commit": "684fd3aa8f0b99f6b743386e233d09b997144310",
     "implementation_tree": "457e8af17214a216035a9b3a704ef4c746c9ced2",
@@ -19,10 +20,10 @@
       "tests/test_patch_evaluation_sidecar_host_readback.py"
     ],
     "exclusion_reason": "Bubblewrap namespace creation failed identically on the unchanged merged-defect commit with Resource temporarily unavailable.",
-    "job": "grabowski-job-3129e8ecf70b",
-    "lifecycle_receipt_sha256": "960644bd177a9f9edae2a7c09f0805148875f43ca5c113a8526c68a08fbe2edb",
+    "job": "grabowski-job-146cb8299362",
+    "lifecycle_receipt_sha256": "d17158ecee867be7b9955eaacf412e75ddae1c5b5f01f54369e19b1727cf7396",
     "status": "pass",
-    "tests_passed": 4850,
+    "tests_passed": 4853,
     "tests_skipped": 2
   },
   "complexity": {
@@ -79,6 +80,14 @@
     "status": "pending"
   },
   "final_validation": {
+    "ci_regression_tests": {
+      "argv_sha256": "0d02fd3db672dea26602830fd5bbd1492d0ba11a2aae918ff68e9d7ae40a4f55",
+      "job": "grabowski-job-45a726a5ddaf",
+      "lifecycle_receipt_sha256": "0fa691d45814af9662237e033781b270031b5bc53ab8fc562bc8ad981a16cd4e",
+      "status": "pass",
+      "tests_passed": 84,
+      "tests_skipped": 0
+    },
     "github_required_checks": null,
     "local_status": "pass",
     "ruff": {
@@ -86,6 +95,16 @@
       "job": "grabowski-job-c1c9abc36a6a",
       "lifecycle_receipt_sha256": "19bedcf24898349d7312c8dfbffc4976d17254b65d5e67ba56f5322d9a268489",
       "status": "pass"
+    },
+    "shallow_ci_simulation": {
+      "argv_sha256": "01931e0109e70913c239f1c0642785206fa690b68a752fb24237f303665e20cd",
+      "checkout_depth": 1,
+      "head_commit": "fe41d9cc5defc5a127a42e9c884f60b608ce0a17",
+      "job": "grabowski-job-bfee227740c9",
+      "lifecycle_receipt_sha256": "49648db1e9f9461fb75cdfa80f066637f108c1bbf2125a53066bb35239fea7f0",
+      "status": "pass",
+      "tests_passed": 4,
+      "tests_skipped": 2
     },
     "status": "pending",
     "targeted_tests": {

--- a/docs/proofs/repoground-legacy-t009-delivery.evidence-v2.json
+++ b/docs/proofs/repoground-legacy-t009-delivery.evidence-v2.json
@@ -19,10 +19,10 @@
       "tests/test_patch_evaluation_sidecar_host_readback.py"
     ],
     "exclusion_reason": "Bubblewrap namespace creation failed identically on the unchanged merged-defect commit with Resource temporarily unavailable.",
-    "job": "grabowski-job-5e5c5dabd73b",
-    "lifecycle_receipt_sha256": "94f425e00f5a4edc00db51117a8bcfafeb60d18349758cfa8833132f85ebe35b",
+    "job": "grabowski-job-3129e8ecf70b",
+    "lifecycle_receipt_sha256": "960644bd177a9f9edae2a7c09f0805148875f43ca5c113a8526c68a08fbe2edb",
     "status": "pass",
-    "tests_passed": 4847,
+    "tests_passed": 4850,
     "tests_skipped": 2
   },
   "complexity": {

--- a/docs/proofs/repoground-legacy-t009-differential.corrective-v2.json
+++ b/docs/proofs/repoground-legacy-t009-differential.corrective-v2.json
@@ -1,0 +1,1401 @@
+{
+  "base": {
+    "commit": "2afc2836fa1a49a593c7b57eda43086844e8fb2b",
+    "dirty": false,
+    "module_sha256": "b700769ab718b70a73b56c1c13003d9ec1ff7f4d125ab04b31df3cf1a0aa6c77",
+    "tree": "dc591643961ce7c44513ba488cf213dc35c7bd61",
+    "worktree_diff_sha256": null
+  },
+  "comparisons": {
+    "artifact_refs": {
+      "allowed_differences": [],
+      "base_projection": {
+        "contact_ratio": [
+          "100%"
+        ],
+        "content_paths": [
+          ".github/workflows/ci.yml",
+          "docs/guide.md",
+          "README.md",
+          "src/main.py"
+        ],
+        "coverage": [
+          "4/4 Dateien mit vollem Inhalt",
+          "4/4 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 4,
+        "file_id_count": [
+          4,
+          4
+        ],
+        "risk_level": [
+          "low",
+          "`low`"
+        ],
+        "snapshots": [
+          "- `report-fixture` \u2192 4 files (4 relevant text, 354.00 B, 4 with content)"
+        ],
+        "start_count": 4,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "differing_fields": [],
+      "target_projection": {
+        "contact_ratio": [
+          "100%"
+        ],
+        "content_paths": [
+          ".github/workflows/ci.yml",
+          "docs/guide.md",
+          "README.md",
+          "src/main.py"
+        ],
+        "coverage": [
+          "4/4 Dateien mit vollem Inhalt",
+          "4/4 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 4,
+        "file_id_count": [
+          4,
+          4
+        ],
+        "risk_level": [
+          "low",
+          "`low`"
+        ],
+        "snapshots": [
+          "- `report-fixture` \u2192 4 files (4 relevant text, 354.00 B, 4 with content)"
+        ],
+        "start_count": 4,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "unapproved_differences": []
+    },
+    "augment_delta": {
+      "allowed_differences": [],
+      "base_projection": {
+        "contact_ratio": [
+          "100%"
+        ],
+        "content_paths": [
+          ".github/workflows/ci.yml",
+          "docs/guide.md",
+          "README.md",
+          "src/main.py"
+        ],
+        "coverage": [
+          "4/4 Dateien mit vollem Inhalt",
+          "4/4 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 4,
+        "file_id_count": [
+          4,
+          4
+        ],
+        "risk_level": [
+          "low",
+          "`low`"
+        ],
+        "snapshots": [
+          "- `report-fixture` \u2192 4 files (4 relevant text, 354.00 B, 4 with content)"
+        ],
+        "start_count": 4,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "differing_fields": [],
+      "target_projection": {
+        "contact_ratio": [
+          "100%"
+        ],
+        "content_paths": [
+          ".github/workflows/ci.yml",
+          "docs/guide.md",
+          "README.md",
+          "src/main.py"
+        ],
+        "coverage": [
+          "4/4 Dateien mit vollem Inhalt",
+          "4/4 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 4,
+        "file_id_count": [
+          4,
+          4
+        ],
+        "risk_level": [
+          "low",
+          "`low`"
+        ],
+        "snapshots": [
+          "- `report-fixture` \u2192 4 files (4 relevant text, 354.00 B, 4 with content)"
+        ],
+        "start_count": 4,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "unapproved_differences": []
+    },
+    "code_only": {
+      "allowed_differences": [],
+      "base_projection": {
+        "contact_ratio": [
+          "100%"
+        ],
+        "content_paths": [
+          ".github/workflows/ci.yml",
+          "src/main.py"
+        ],
+        "coverage": [
+          "2/2 Dateien mit vollem Inhalt",
+          "2/2 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 2,
+        "file_id_count": [
+          2,
+          2
+        ],
+        "risk_level": [
+          "low",
+          "`low`"
+        ],
+        "snapshots": [
+          "- `report-fixture` \u2192 2 files (2 relevant text, 213.00 B, 2 with content)"
+        ],
+        "start_count": 2,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "differing_fields": [],
+      "target_projection": {
+        "contact_ratio": [
+          "100%"
+        ],
+        "content_paths": [
+          ".github/workflows/ci.yml",
+          "src/main.py"
+        ],
+        "coverage": [
+          "2/2 Dateien mit vollem Inhalt",
+          "2/2 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 2,
+        "file_id_count": [
+          2,
+          2
+        ],
+        "risk_level": [
+          "low",
+          "`low`"
+        ],
+        "snapshots": [
+          "- `report-fixture` \u2192 2 files (2 relevant text, 213.00 B, 2 with content)"
+        ],
+        "start_count": 2,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "unapproved_differences": []
+    },
+    "extension_filter": {
+      "allowed_differences": [
+        "content_paths",
+        "coverage",
+        "end_count",
+        "file_id_count",
+        "snapshots",
+        "start_count",
+        "yaml_content"
+      ],
+      "base_projection": {
+        "contact_ratio": [
+          "100%"
+        ],
+        "content_paths": [
+          ".github/workflows/ci.yml",
+          "docs/guide.md",
+          "README.md",
+          "src/main.py"
+        ],
+        "coverage": [
+          "4/4 Dateien mit vollem Inhalt",
+          "4/4 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 4,
+        "file_id_count": [
+          4,
+          4
+        ],
+        "risk_level": [
+          "low",
+          "`low`"
+        ],
+        "snapshots": [
+          "- `report-fixture` \u2192 4 files (4 relevant text, 354.00 B, 4 with content)"
+        ],
+        "start_count": 4,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "differing_fields": [
+        "content_paths",
+        "coverage",
+        "end_count",
+        "file_id_count",
+        "snapshots",
+        "start_count"
+      ],
+      "target_projection": {
+        "contact_ratio": [
+          "100%"
+        ],
+        "content_paths": [
+          "src/main.py"
+        ],
+        "coverage": [
+          "1/1 Dateien mit vollem Inhalt",
+          "1/1 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 1,
+        "file_id_count": [
+          1,
+          1
+        ],
+        "risk_level": [
+          "low",
+          "`low`"
+        ],
+        "snapshots": [
+          "- `report-fixture` \u2192 1 files (1 relevant text, 110.00 B, 1 with content)"
+        ],
+        "start_count": 1,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "unapproved_differences": []
+    },
+    "heatmap": {
+      "allowed_differences": [],
+      "base_projection": {
+        "contact_ratio": [
+          "100%"
+        ],
+        "content_paths": [
+          ".github/workflows/ci.yml",
+          "docs/guide.md",
+          "README.md",
+          "src/main.py"
+        ],
+        "coverage": [
+          "4/4 Dateien mit vollem Inhalt",
+          "4/4 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 4,
+        "file_id_count": [
+          4,
+          4
+        ],
+        "risk_level": [
+          "low",
+          "`low`"
+        ],
+        "snapshots": [
+          "- `report-fixture` \u2192 4 files (4 relevant text, 354.00 B, 4 with content)"
+        ],
+        "start_count": 4,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "differing_fields": [],
+      "target_projection": {
+        "contact_ratio": [
+          "100%"
+        ],
+        "content_paths": [
+          ".github/workflows/ci.yml",
+          "docs/guide.md",
+          "README.md",
+          "src/main.py"
+        ],
+        "coverage": [
+          "4/4 Dateien mit vollem Inhalt",
+          "4/4 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 4,
+        "file_id_count": [
+          4,
+          4
+        ],
+        "risk_level": [
+          "low",
+          "`low`"
+        ],
+        "snapshots": [
+          "- `report-fixture` \u2192 4 files (4 relevant text, 354.00 B, 4 with content)"
+        ],
+        "start_count": 4,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "unapproved_differences": []
+    },
+    "meta_full": {
+      "allowed_differences": [],
+      "base_projection": {
+        "contact_ratio": [
+          "100%"
+        ],
+        "content_paths": [
+          ".github/workflows/ci.yml",
+          "docs/guide.md",
+          "README.md",
+          "src/main.py"
+        ],
+        "coverage": [
+          "4/4 Dateien mit vollem Inhalt",
+          "4/4 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 4,
+        "file_id_count": [
+          4,
+          4
+        ],
+        "risk_level": [
+          "low",
+          "`low`"
+        ],
+        "snapshots": [
+          "- `report-fixture` \u2192 4 files (4 relevant text, 354.00 B, 4 with content)"
+        ],
+        "start_count": 4,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "differing_fields": [],
+      "target_projection": {
+        "contact_ratio": [
+          "100%"
+        ],
+        "content_paths": [
+          ".github/workflows/ci.yml",
+          "docs/guide.md",
+          "README.md",
+          "src/main.py"
+        ],
+        "coverage": [
+          "4/4 Dateien mit vollem Inhalt",
+          "4/4 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 4,
+        "file_id_count": [
+          4,
+          4
+        ],
+        "risk_level": [
+          "low",
+          "`low`"
+        ],
+        "snapshots": [
+          "- `report-fixture` \u2192 4 files (4 relevant text, 354.00 B, 4 with content)"
+        ],
+        "start_count": 4,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "unapproved_differences": []
+    },
+    "meta_min": {
+      "allowed_differences": [],
+      "base_projection": {
+        "contact_ratio": [
+          "100%"
+        ],
+        "content_paths": [
+          ".github/workflows/ci.yml",
+          "docs/guide.md",
+          "README.md",
+          "src/main.py"
+        ],
+        "coverage": [
+          "4/4 Dateien mit vollem Inhalt",
+          "4/4 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 4,
+        "file_id_count": [
+          4,
+          4
+        ],
+        "risk_level": [
+          "low",
+          "`low`"
+        ],
+        "snapshots": [
+          "- `report-fixture` \u2192 4 files (4 relevant text, 354.00 B, 4 with content)"
+        ],
+        "start_count": 4,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "differing_fields": [],
+      "target_projection": {
+        "contact_ratio": [
+          "100%"
+        ],
+        "content_paths": [
+          ".github/workflows/ci.yml",
+          "docs/guide.md",
+          "README.md",
+          "src/main.py"
+        ],
+        "coverage": [
+          "4/4 Dateien mit vollem Inhalt",
+          "4/4 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 4,
+        "file_id_count": [
+          4,
+          4
+        ],
+        "risk_level": [
+          "low",
+          "`low`"
+        ],
+        "snapshots": [
+          "- `report-fixture` \u2192 4 files (4 relevant text, 354.00 B, 4 with content)"
+        ],
+        "start_count": 4,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "unapproved_differences": []
+    },
+    "meta_none": {
+      "allowed_differences": [],
+      "base_projection": {
+        "contact_ratio": [],
+        "content_paths": [
+          ".github/workflows/ci.yml",
+          "docs/guide.md",
+          "README.md",
+          "src/main.py"
+        ],
+        "coverage": [
+          "4/4 Dateien mit vollem Inhalt",
+          "4/4 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 4,
+        "file_id_count": [
+          4,
+          4
+        ],
+        "risk_level": [],
+        "snapshots": [
+          "- `report-fixture` \u2192 4 files (4 relevant text, 354.00 B, 4 with content)"
+        ],
+        "start_count": 4,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "differing_fields": [],
+      "target_projection": {
+        "contact_ratio": [],
+        "content_paths": [
+          ".github/workflows/ci.yml",
+          "docs/guide.md",
+          "README.md",
+          "src/main.py"
+        ],
+        "coverage": [
+          "4/4 Dateien mit vollem Inhalt",
+          "4/4 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 4,
+        "file_id_count": [
+          4,
+          4
+        ],
+        "risk_level": [],
+        "snapshots": [
+          "- `report-fixture` \u2192 4 files (4 relevant text, 354.00 B, 4 with content)"
+        ],
+        "start_count": 4,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "unapproved_differences": []
+    },
+    "meta_standard": {
+      "allowed_differences": [],
+      "base_projection": {
+        "contact_ratio": [
+          "100%"
+        ],
+        "content_paths": [
+          ".github/workflows/ci.yml",
+          "docs/guide.md",
+          "README.md",
+          "src/main.py"
+        ],
+        "coverage": [
+          "4/4 Dateien mit vollem Inhalt",
+          "4/4 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 4,
+        "file_id_count": [
+          4,
+          4
+        ],
+        "risk_level": [
+          "low",
+          "`low`"
+        ],
+        "snapshots": [
+          "- `report-fixture` \u2192 4 files (4 relevant text, 354.00 B, 4 with content)"
+        ],
+        "start_count": 4,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "differing_fields": [],
+      "target_projection": {
+        "contact_ratio": [
+          "100%"
+        ],
+        "content_paths": [
+          ".github/workflows/ci.yml",
+          "docs/guide.md",
+          "README.md",
+          "src/main.py"
+        ],
+        "coverage": [
+          "4/4 Dateien mit vollem Inhalt",
+          "4/4 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 4,
+        "file_id_count": [
+          4,
+          4
+        ],
+        "risk_level": [
+          "low",
+          "`low`"
+        ],
+        "snapshots": [
+          "- `report-fixture` \u2192 4 files (4 relevant text, 354.00 B, 4 with content)"
+        ],
+        "start_count": 4,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "unapproved_differences": []
+    },
+    "multi_repo": {
+      "allowed_differences": [],
+      "base_projection": {
+        "contact_ratio": [
+          "100%"
+        ],
+        "content_paths": [
+          ".github/workflows/ci.yml",
+          "docs/guide.md",
+          "README.md",
+          "src/main.py",
+          "extra.py"
+        ],
+        "coverage": [
+          "5/5 Dateien mit vollem Inhalt",
+          "5/5 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 5,
+        "file_id_count": [
+          5,
+          5
+        ],
+        "risk_level": [
+          "low",
+          "`low`"
+        ],
+        "snapshots": [
+          "- `report-fixture` \u2192 4 files (4 relevant text, 354.00 B, 4 with content)",
+          "- `second-repo` \u2192 1 files (1 relevant text, 110.00 B, 1 with content)"
+        ],
+        "start_count": 5,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "differing_fields": [],
+      "target_projection": {
+        "contact_ratio": [
+          "100%"
+        ],
+        "content_paths": [
+          ".github/workflows/ci.yml",
+          "docs/guide.md",
+          "README.md",
+          "src/main.py",
+          "extra.py"
+        ],
+        "coverage": [
+          "5/5 Dateien mit vollem Inhalt",
+          "5/5 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 5,
+        "file_id_count": [
+          5,
+          5
+        ],
+        "risk_level": [
+          "low",
+          "`low`"
+        ],
+        "snapshots": [
+          "- `report-fixture` \u2192 4 files (4 relevant text, 354.00 B, 4 with content)",
+          "- `second-repo` \u2192 1 files (1 relevant text, 110.00 B, 1 with content)"
+        ],
+        "start_count": 5,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "unapproved_differences": []
+    },
+    "organism": {
+      "allowed_differences": [],
+      "base_projection": {
+        "contact_ratio": [
+          "100%"
+        ],
+        "content_paths": [
+          ".github/workflows/ci.yml",
+          "docs/guide.md",
+          "README.md",
+          "src/main.py"
+        ],
+        "coverage": [
+          "4/4 Dateien mit vollem Inhalt",
+          "4/4 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 4,
+        "file_id_count": [
+          4,
+          4
+        ],
+        "risk_level": [
+          "low",
+          "`low`"
+        ],
+        "snapshots": [
+          "- `report-fixture` \u2192 4 files (4 relevant text, 354.00 B, 4 with content)"
+        ],
+        "start_count": 4,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "differing_fields": [],
+      "target_projection": {
+        "contact_ratio": [
+          "100%"
+        ],
+        "content_paths": [
+          ".github/workflows/ci.yml",
+          "docs/guide.md",
+          "README.md",
+          "src/main.py"
+        ],
+        "coverage": [
+          "4/4 Dateien mit vollem Inhalt",
+          "4/4 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 4,
+        "file_id_count": [
+          4,
+          4
+        ],
+        "risk_level": [
+          "low",
+          "`low`"
+        ],
+        "snapshots": [
+          "- `report-fixture` \u2192 4 files (4 relevant text, 354.00 B, 4 with content)"
+        ],
+        "start_count": 4,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "unapproved_differences": []
+    },
+    "path_filter": {
+      "allowed_differences": [],
+      "base_projection": {
+        "contact_ratio": [
+          "100%"
+        ],
+        "content_paths": [
+          "src/main.py"
+        ],
+        "coverage": [
+          "1/1 Dateien mit vollem Inhalt",
+          "1/1 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 1,
+        "file_id_count": [
+          1,
+          1
+        ],
+        "risk_level": [
+          "low",
+          "`low`"
+        ],
+        "snapshots": [
+          "- `report-fixture` \u2192 1 files (1 relevant text, 110.00 B, 1 with content)"
+        ],
+        "start_count": 1,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "differing_fields": [],
+      "target_projection": {
+        "contact_ratio": [
+          "100%"
+        ],
+        "content_paths": [
+          "src/main.py"
+        ],
+        "coverage": [
+          "1/1 Dateien mit vollem Inhalt",
+          "1/1 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 1,
+        "file_id_count": [
+          1,
+          1
+        ],
+        "risk_level": [
+          "low",
+          "`low`"
+        ],
+        "snapshots": [
+          "- `report-fixture` \u2192 1 files (1 relevant text, 110.00 B, 1 with content)"
+        ],
+        "start_count": 1,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "unapproved_differences": []
+    },
+    "plan_only": {
+      "allowed_differences": [
+        "contact_ratio",
+        "coverage",
+        "risk_level",
+        "snapshots",
+        "yaml_content"
+      ],
+      "base_projection": {
+        "contact_ratio": [
+          "100%"
+        ],
+        "content_paths": [],
+        "coverage": [
+          "4/4 Dateien mit vollem Inhalt",
+          "4/4 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 0,
+        "file_id_count": [
+          0,
+          0
+        ],
+        "risk_level": [
+          "low"
+        ],
+        "snapshots": [
+          "- `report-fixture` \u2192 4 files (4 relevant text, 354.00 B, 4 with content)"
+        ],
+        "start_count": 0,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "differing_fields": [
+        "contact_ratio",
+        "coverage",
+        "risk_level",
+        "snapshots"
+      ],
+      "target_projection": {
+        "contact_ratio": [
+          "0%"
+        ],
+        "content_paths": [],
+        "coverage": [
+          "0/4 Dateien mit vollem Inhalt",
+          "0/4 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 0,
+        "file_id_count": [
+          0,
+          0
+        ],
+        "risk_level": [
+          "high"
+        ],
+        "snapshots": [
+          "- `report-fixture` \u2192 4 files (4 relevant text, 354.00 B, 0 with content)"
+        ],
+        "start_count": 0,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "unapproved_differences": []
+    },
+    "profile_machine_lean": {
+      "allowed_differences": [],
+      "base_projection": {
+        "contact_ratio": [
+          "100%"
+        ],
+        "content_paths": [
+          ".github/workflows/ci.yml",
+          "docs/guide.md",
+          "README.md",
+          "src/main.py"
+        ],
+        "coverage": [
+          "4/4 Dateien mit vollem Inhalt",
+          "4/4 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 4,
+        "file_id_count": [
+          4,
+          4
+        ],
+        "risk_level": [
+          "low",
+          "`low`"
+        ],
+        "snapshots": [
+          "- `report-fixture` \u2192 4 files (4 relevant text, 354.00 B, 4 with content)"
+        ],
+        "start_count": 4,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "differing_fields": [],
+      "target_projection": {
+        "contact_ratio": [
+          "100%"
+        ],
+        "content_paths": [
+          ".github/workflows/ci.yml",
+          "docs/guide.md",
+          "README.md",
+          "src/main.py"
+        ],
+        "coverage": [
+          "4/4 Dateien mit vollem Inhalt",
+          "4/4 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 4,
+        "file_id_count": [
+          4,
+          4
+        ],
+        "risk_level": [
+          "low",
+          "`low`"
+        ],
+        "snapshots": [
+          "- `report-fixture` \u2192 4 files (4 relevant text, 354.00 B, 4 with content)"
+        ],
+        "start_count": 4,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "unapproved_differences": []
+    },
+    "profile_max": {
+      "allowed_differences": [],
+      "base_projection": {
+        "contact_ratio": [
+          "100%"
+        ],
+        "content_paths": [
+          ".github/workflows/ci.yml",
+          "docs/guide.md",
+          "README.md",
+          "src/main.py"
+        ],
+        "coverage": [
+          "4/4 Dateien mit vollem Inhalt",
+          "4/4 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 4,
+        "file_id_count": [
+          4,
+          4
+        ],
+        "risk_level": [
+          "low",
+          "`low`"
+        ],
+        "snapshots": [
+          "- `report-fixture` \u2192 4 files (4 relevant text, 354.00 B, 4 with content)"
+        ],
+        "start_count": 4,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "differing_fields": [],
+      "target_projection": {
+        "contact_ratio": [
+          "100%"
+        ],
+        "content_paths": [
+          ".github/workflows/ci.yml",
+          "docs/guide.md",
+          "README.md",
+          "src/main.py"
+        ],
+        "coverage": [
+          "4/4 Dateien mit vollem Inhalt",
+          "4/4 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 4,
+        "file_id_count": [
+          4,
+          4
+        ],
+        "risk_level": [
+          "low",
+          "`low`"
+        ],
+        "snapshots": [
+          "- `report-fixture` \u2192 4 files (4 relevant text, 354.00 B, 4 with content)"
+        ],
+        "start_count": 4,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "unapproved_differences": []
+    },
+    "profile_summary": {
+      "allowed_differences": [],
+      "base_projection": {
+        "contact_ratio": [
+          "75%"
+        ],
+        "content_paths": [
+          ".github/workflows/ci.yml",
+          "docs/guide.md",
+          "README.md"
+        ],
+        "coverage": [
+          "3/4 Dateien mit vollem Inhalt",
+          "3/4 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 3,
+        "file_id_count": [
+          3,
+          3
+        ],
+        "risk_level": [
+          "low",
+          "`low`"
+        ],
+        "snapshots": [
+          "- `report-fixture` \u2192 4 files (4 relevant text, 354.00 B, 3 with content)"
+        ],
+        "start_count": 3,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "differing_fields": [],
+      "target_projection": {
+        "contact_ratio": [
+          "75%"
+        ],
+        "content_paths": [
+          ".github/workflows/ci.yml",
+          "docs/guide.md",
+          "README.md"
+        ],
+        "coverage": [
+          "3/4 Dateien mit vollem Inhalt",
+          "3/4 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 3,
+        "file_id_count": [
+          3,
+          3
+        ],
+        "risk_level": [
+          "low",
+          "`low`"
+        ],
+        "snapshots": [
+          "- `report-fixture` \u2192 4 files (4 relevant text, 354.00 B, 3 with content)"
+        ],
+        "start_count": 3,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "unapproved_differences": []
+    },
+    "redaction": {
+      "allowed_differences": [],
+      "base_projection": {
+        "contact_ratio": [
+          "100%"
+        ],
+        "content_paths": [
+          ".github/workflows/ci.yml",
+          "docs/guide.md",
+          "README.md",
+          "src/main.py"
+        ],
+        "coverage": [
+          "4/4 Dateien mit vollem Inhalt",
+          "4/4 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 4,
+        "file_id_count": [
+          4,
+          4
+        ],
+        "risk_level": [
+          "low",
+          "`low`"
+        ],
+        "snapshots": [
+          "- `report-fixture` \u2192 4 files (4 relevant text, 354.00 B, 4 with content)"
+        ],
+        "start_count": 4,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "differing_fields": [],
+      "target_projection": {
+        "contact_ratio": [
+          "100%"
+        ],
+        "content_paths": [
+          ".github/workflows/ci.yml",
+          "docs/guide.md",
+          "README.md",
+          "src/main.py"
+        ],
+        "coverage": [
+          "4/4 Dateien mit vollem Inhalt",
+          "4/4 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 4,
+        "file_id_count": [
+          4,
+          4
+        ],
+        "risk_level": [
+          "low",
+          "`low`"
+        ],
+        "snapshots": [
+          "- `report-fixture` \u2192 4 files (4 relevant text, 354.00 B, 4 with content)"
+        ],
+        "start_count": 4,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "unapproved_differences": []
+    },
+    "truncation": {
+      "allowed_differences": [],
+      "base_projection": {
+        "contact_ratio": [
+          "100%"
+        ],
+        "content_paths": [
+          ".github/workflows/ci.yml",
+          "docs/guide.md",
+          "README.md",
+          "src/main.py"
+        ],
+        "coverage": [
+          "4/4 Dateien mit vollem Inhalt",
+          "4/4 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 4,
+        "file_id_count": [
+          4,
+          4
+        ],
+        "risk_level": [
+          "low",
+          "`low`"
+        ],
+        "snapshots": [
+          "- `report-fixture` \u2192 4 files (4 relevant text, 354.00 B, 4 with content)"
+        ],
+        "start_count": 4,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "differing_fields": [],
+      "target_projection": {
+        "contact_ratio": [
+          "100%"
+        ],
+        "content_paths": [
+          ".github/workflows/ci.yml",
+          "docs/guide.md",
+          "README.md",
+          "src/main.py"
+        ],
+        "coverage": [
+          "4/4 Dateien mit vollem Inhalt",
+          "4/4 Dateien mit vollem Inhalt"
+        ],
+        "end_count": 4,
+        "file_id_count": [
+          4,
+          4
+        ],
+        "risk_level": [
+          "low",
+          "`low`"
+        ],
+        "snapshots": [
+          "- `report-fixture` \u2192 4 files (4 relevant text, 354.00 B, 4 with content)"
+        ],
+        "start_count": 4,
+        "yaml_content": {
+          "coverage_included_files": null,
+          "coverage_pct": null,
+          "emitted_files": null,
+          "present": null,
+          "selected_text_files": null
+        }
+      },
+      "unapproved_differences": []
+    }
+  },
+  "intentional_corrections": {
+    "extension_filter": [
+      "content_paths",
+      "coverage",
+      "end_count",
+      "file_id_count",
+      "snapshots",
+      "start_count",
+      "yaml_content"
+    ],
+    "plan_only": [
+      "contact_ratio",
+      "coverage",
+      "risk_level",
+      "snapshots",
+      "yaml_content"
+    ]
+  },
+  "scenarios": [
+    "artifact_refs",
+    "augment_delta",
+    "code_only",
+    "extension_filter",
+    "heatmap",
+    "meta_full",
+    "meta_min",
+    "meta_none",
+    "meta_standard",
+    "multi_repo",
+    "organism",
+    "path_filter",
+    "plan_only",
+    "profile_machine_lean",
+    "profile_max",
+    "profile_summary",
+    "redaction",
+    "truncation"
+  ],
+  "schema_version": 1,
+  "target": {
+    "commit": "684fd3aa8f0b99f6b743386e233d09b997144310",
+    "dirty": false,
+    "module_sha256": "516ff69f982473396dd2cd9358a152a8f693bb77576f1a4b983521c3cb5c4708",
+    "tree": "457e8af17214a216035a9b3a704ef4c746c9ced2",
+    "worktree_diff_sha256": null
+  },
+  "unapproved_differences": {}
+}

--- a/docs/proofs/repoground-legacy-t009-performance.corrective-v2.after.json
+++ b/docs/proofs/repoground-legacy-t009-performance.corrective-v2.after.json
@@ -1,0 +1,136 @@
+{
+  "benchmark_script_sha256": "89f221b81659f81427dab62539e8487579e82aa1c399641bfb7b00e77b8ded72",
+  "binding": {
+    "commit": "684fd3aa8f0b99f6b743386e233d09b997144310",
+    "source": "clean_git_worktree",
+    "tree": "457e8af17214a216035a9b3a704ef4c746c9ced2",
+    "worktree_dirty": false
+  },
+  "cases": {
+    "atlas_scan": {
+      "rounds": 2,
+      "samples_per_round": [
+        "unknown",
+        "unknown"
+      ],
+      "skipped": [
+        "not requested (optional subsystem)"
+      ]
+    },
+    "bundle_write_archive": {
+      "peak_traced_bytes": 1973025,
+      "peak_traced_bytes_samples": [
+        1971985,
+        1974066
+      ],
+      "rounds": 2,
+      "samples_per_round": [
+        5,
+        5
+      ],
+      "wall_seconds_median": 0.131199,
+      "wall_seconds_medians": [
+        0.132058,
+        0.13034
+      ]
+    },
+    "bundle_write_dual": {
+      "peak_traced_bytes": 2706333,
+      "peak_traced_bytes_samples": [
+        2706994,
+        2705672
+      ],
+      "rounds": 2,
+      "samples_per_round": [
+        5,
+        5
+      ],
+      "wall_seconds_median": 0.310759,
+      "wall_seconds_medians": [
+        0.315066,
+        0.306453
+      ]
+    },
+    "retrieval_index_build": {
+      "peak_traced_bytes": 399136,
+      "peak_traced_bytes_samples": [
+        399136,
+        399136
+      ],
+      "rounds": 2,
+      "samples_per_round": [
+        5,
+        5
+      ],
+      "wall_seconds_median": 0.018006,
+      "wall_seconds_medians": [
+        0.018154,
+        0.017858
+      ]
+    },
+    "retrieval_query": {
+      "peak_traced_bytes": 57265,
+      "peak_traced_bytes_samples": [
+        57265,
+        57265
+      ],
+      "rounds": 2,
+      "samples_per_round": [
+        5,
+        5
+      ],
+      "wall_seconds_median": 0.000623,
+      "wall_seconds_medians": [
+        0.000621,
+        0.000625
+      ]
+    },
+    "service_app_import": {
+      "peak_traced_bytes": 24394871,
+      "peak_traced_bytes_samples": [
+        24394996,
+        24394746
+      ],
+      "rounds": 2,
+      "samples_per_round": [
+        5,
+        5
+      ],
+      "wall_seconds_median": 1.123956,
+      "wall_seconds_medians": [
+        1.118408,
+        1.129504
+      ]
+    }
+  },
+  "configuration": {
+    "execution_order": [
+      "before",
+      "after",
+      "after",
+      "before"
+    ],
+    "gate_kind": "performance_smoke_gate",
+    "primary_memory_metric": "median of per-round peak_traced_bytes",
+    "primary_timing_metric": "median of per-round wall_seconds_median",
+    "rounds": 2,
+    "samples_per_round": 5,
+    "timing_gate": {
+      "median_regression_pct_max": 5.0,
+      "peak_memory_regression_pct_max": 5.0
+    },
+    "warmups_per_revision": 1
+  },
+  "environment": {
+    "host": "heim-pc",
+    "python_executable": "/usr/bin/python3",
+    "validated_benchmark_environment": [
+      "3.10.12",
+      "Linux-7.0.11-76070011-generic-x86_64-with-glibc2.35",
+      "x86_64"
+    ]
+  },
+  "kind": "repoground.core_path_benchmark.aggregate",
+  "side": "after",
+  "version": "1.0"
+}

--- a/docs/proofs/repoground-legacy-t009-performance.corrective-v2.before.json
+++ b/docs/proofs/repoground-legacy-t009-performance.corrective-v2.before.json
@@ -1,0 +1,142 @@
+{
+  "benchmark_script_sha256": "89f221b81659f81427dab62539e8487579e82aa1c399641bfb7b00e77b8ded72",
+  "binding": {
+    "commit": "c91d640bce2b14c4a78a64e83169d56c818fa662",
+    "source": "clean_git_worktree",
+    "tree": "36113af31c4cb6ba381302b8fcef61a024049336",
+    "worktree_dirty": false
+  },
+  "cases": {
+    "atlas_scan": {
+      "rounds": 2,
+      "samples_per_round": [
+        "unknown",
+        "unknown"
+      ],
+      "skipped": [
+        "not requested (optional subsystem)"
+      ]
+    },
+    "bundle_write_archive": {
+      "peak_traced_bytes": 1987555,
+      "peak_traced_bytes_samples": [
+        1987715,
+        1987396
+      ],
+      "rounds": 2,
+      "samples_per_round": [
+        5,
+        5
+      ],
+      "wall_seconds_median": 0.136072,
+      "wall_seconds_medians": [
+        0.140468,
+        0.131677
+      ]
+    },
+    "bundle_write_dual": {
+      "peak_traced_bytes": 2703355,
+      "peak_traced_bytes_samples": [
+        2695642,
+        2711068
+      ],
+      "rounds": 2,
+      "samples_per_round": [
+        5,
+        5
+      ],
+      "wall_seconds_median": 0.308623,
+      "wall_seconds_medians": [
+        0.309243,
+        0.308002
+      ]
+    },
+    "retrieval_index_build": {
+      "peak_traced_bytes": 399111,
+      "peak_traced_bytes_samples": [
+        399111,
+        399111
+      ],
+      "rounds": 2,
+      "samples_per_round": [
+        5,
+        5
+      ],
+      "wall_seconds_median": 0.018589,
+      "wall_seconds_medians": [
+        0.018815,
+        0.018364
+      ]
+    },
+    "retrieval_query": {
+      "peak_traced_bytes": 57264,
+      "peak_traced_bytes_samples": [
+        57264,
+        57264
+      ],
+      "rounds": 2,
+      "samples_per_round": [
+        5,
+        5
+      ],
+      "wall_seconds_median": 0.000636,
+      "wall_seconds_medians": [
+        0.000632,
+        0.00064
+      ]
+    },
+    "service_app_import": {
+      "peak_traced_bytes": 24341680,
+      "peak_traced_bytes_samples": [
+        24340708,
+        24342652
+      ],
+      "rounds": 2,
+      "samples_per_round": [
+        5,
+        5
+      ],
+      "wall_seconds_median": 1.119366,
+      "wall_seconds_medians": [
+        1.114868,
+        1.123863
+      ]
+    }
+  },
+  "configuration": {
+    "execution_order": [
+      "before",
+      "after",
+      "after",
+      "before"
+    ],
+    "gate_kind": "performance_smoke_gate",
+    "primary_memory_metric": "median of per-round peak_traced_bytes",
+    "primary_timing_metric": "median of per-round wall_seconds_median",
+    "rounds": 2,
+    "samples_per_round": 5,
+    "timing_gate": {
+      "median_regression_pct_max": 5.0,
+      "peak_memory_regression_pct_max": 5.0
+    },
+    "warmups_per_revision": 1
+  },
+  "content_binding": {
+    "findings": [],
+    "live_commit": "c91d640bce2b14c4a78a64e83169d56c818fa662",
+    "live_tree": "36113af31c4cb6ba381302b8fcef61a024049336",
+    "status": "pass"
+  },
+  "environment": {
+    "host": "heim-pc",
+    "python_executable": "/usr/bin/python3",
+    "validated_benchmark_environment": [
+      "3.10.12",
+      "Linux-7.0.11-76070011-generic-x86_64-with-glibc2.35",
+      "x86_64"
+    ]
+  },
+  "kind": "repoground.core_path_benchmark.aggregate",
+  "side": "before",
+  "version": "1.0"
+}

--- a/docs/proofs/repoground-legacy-t009-performance.corrective-v2.comparison.json
+++ b/docs/proofs/repoground-legacy-t009-performance.corrective-v2.comparison.json
@@ -1,0 +1,277 @@
+{
+  "before_content_binding": {
+    "findings": [],
+    "live_commit": "c91d640bce2b14c4a78a64e83169d56c818fa662",
+    "live_tree": "36113af31c4cb6ba381302b8fcef61a024049336",
+    "status": "pass"
+  },
+  "bindings": {
+    "after": {
+      "commit": "684fd3aa8f0b99f6b743386e233d09b997144310",
+      "source": "clean_git_worktree",
+      "tree": "457e8af17214a216035a9b3a704ef4c746c9ced2",
+      "worktree_dirty": false
+    },
+    "before": {
+      "commit": "c91d640bce2b14c4a78a64e83169d56c818fa662",
+      "source": "clean_git_worktree",
+      "tree": "36113af31c4cb6ba381302b8fcef61a024049336",
+      "worktree_dirty": false
+    }
+  },
+  "compared_cases": {
+    "atlas_scan": {
+      "after": {
+        "rounds": 2,
+        "samples_per_round": [
+          "unknown",
+          "unknown"
+        ],
+        "skipped": [
+          "not requested (optional subsystem)"
+        ]
+      },
+      "before": {
+        "rounds": 2,
+        "samples_per_round": [
+          "unknown",
+          "unknown"
+        ],
+        "skipped": [
+          "not requested (optional subsystem)"
+        ]
+      },
+      "status": "skip"
+    },
+    "bundle_write_archive": {
+      "after": {
+        "peak_traced_bytes": 1973025,
+        "peak_traced_bytes_samples": [
+          1971985,
+          1974066
+        ],
+        "rounds": 2,
+        "samples_per_round": [
+          5,
+          5
+        ],
+        "wall_seconds_median": 0.131199,
+        "wall_seconds_medians": [
+          0.132058,
+          0.13034
+        ]
+      },
+      "before": {
+        "peak_traced_bytes": 1987555,
+        "peak_traced_bytes_samples": [
+          1987715,
+          1987396
+        ],
+        "rounds": 2,
+        "samples_per_round": [
+          5,
+          5
+        ],
+        "wall_seconds_median": 0.136072,
+        "wall_seconds_medians": [
+          0.140468,
+          0.131677
+        ]
+      },
+      "median_regression_pct": -3.581,
+      "memory_pass": true,
+      "peak_memory_regression_pct": -0.731,
+      "status": "pass",
+      "timing_pass": true
+    },
+    "bundle_write_dual": {
+      "after": {
+        "peak_traced_bytes": 2706333,
+        "peak_traced_bytes_samples": [
+          2706994,
+          2705672
+        ],
+        "rounds": 2,
+        "samples_per_round": [
+          5,
+          5
+        ],
+        "wall_seconds_median": 0.310759,
+        "wall_seconds_medians": [
+          0.315066,
+          0.306453
+        ]
+      },
+      "before": {
+        "peak_traced_bytes": 2703355,
+        "peak_traced_bytes_samples": [
+          2695642,
+          2711068
+        ],
+        "rounds": 2,
+        "samples_per_round": [
+          5,
+          5
+        ],
+        "wall_seconds_median": 0.308623,
+        "wall_seconds_medians": [
+          0.309243,
+          0.308002
+        ]
+      },
+      "median_regression_pct": 0.692,
+      "memory_pass": true,
+      "peak_memory_regression_pct": 0.11,
+      "status": "pass",
+      "timing_pass": true
+    },
+    "retrieval_index_build": {
+      "after": {
+        "peak_traced_bytes": 399136,
+        "peak_traced_bytes_samples": [
+          399136,
+          399136
+        ],
+        "rounds": 2,
+        "samples_per_round": [
+          5,
+          5
+        ],
+        "wall_seconds_median": 0.018006,
+        "wall_seconds_medians": [
+          0.018154,
+          0.017858
+        ]
+      },
+      "before": {
+        "peak_traced_bytes": 399111,
+        "peak_traced_bytes_samples": [
+          399111,
+          399111
+        ],
+        "rounds": 2,
+        "samples_per_round": [
+          5,
+          5
+        ],
+        "wall_seconds_median": 0.018589,
+        "wall_seconds_medians": [
+          0.018815,
+          0.018364
+        ]
+      },
+      "median_regression_pct": -3.136,
+      "memory_pass": true,
+      "peak_memory_regression_pct": 0.006,
+      "status": "pass",
+      "timing_pass": true
+    },
+    "retrieval_query": {
+      "after": {
+        "peak_traced_bytes": 57265,
+        "peak_traced_bytes_samples": [
+          57265,
+          57265
+        ],
+        "rounds": 2,
+        "samples_per_round": [
+          5,
+          5
+        ],
+        "wall_seconds_median": 0.000623,
+        "wall_seconds_medians": [
+          0.000621,
+          0.000625
+        ]
+      },
+      "before": {
+        "peak_traced_bytes": 57264,
+        "peak_traced_bytes_samples": [
+          57264,
+          57264
+        ],
+        "rounds": 2,
+        "samples_per_round": [
+          5,
+          5
+        ],
+        "wall_seconds_median": 0.000636,
+        "wall_seconds_medians": [
+          0.000632,
+          0.00064
+        ]
+      },
+      "median_regression_pct": -2.044,
+      "memory_pass": true,
+      "peak_memory_regression_pct": 0.002,
+      "status": "pass",
+      "timing_pass": true
+    },
+    "service_app_import": {
+      "after": {
+        "peak_traced_bytes": 24394871,
+        "peak_traced_bytes_samples": [
+          24394996,
+          24394746
+        ],
+        "rounds": 2,
+        "samples_per_round": [
+          5,
+          5
+        ],
+        "wall_seconds_median": 1.123956,
+        "wall_seconds_medians": [
+          1.118408,
+          1.129504
+        ]
+      },
+      "before": {
+        "peak_traced_bytes": 24341680,
+        "peak_traced_bytes_samples": [
+          24340708,
+          24342652
+        ],
+        "rounds": 2,
+        "samples_per_round": [
+          5,
+          5
+        ],
+        "wall_seconds_median": 1.119366,
+        "wall_seconds_medians": [
+          1.114868,
+          1.123863
+        ]
+      },
+      "median_regression_pct": 0.41,
+      "memory_pass": true,
+      "peak_memory_regression_pct": 0.219,
+      "status": "pass",
+      "timing_pass": true
+    }
+  },
+  "does_not_establish": [
+    "cross-host comparability",
+    "absence of regressions on unmeasured paths",
+    "production workload representativeness",
+    "memory use outside Python tracemalloc",
+    "statistical significance"
+  ],
+  "failed_cases": [],
+  "gate": {
+    "median_regression_pct_max": 5.0,
+    "peak_memory_regression_pct_max": 5.0
+  },
+  "kind": "repoground.core_path_benchmark.comparison",
+  "status": "pass",
+  "validation": {
+    "benchmark_script_sha256": "89f221b81659f81427dab62539e8487579e82aa1c399641bfb7b00e77b8ded72",
+    "environment": [
+      "3.10.12",
+      "Linux-7.0.11-76070011-generic-x86_64-with-glibc2.35",
+      "x86_64"
+    ],
+    "findings": [],
+    "status": "pass"
+  },
+  "version": "1.0"
+}

--- a/merger/repoground/core/merge.py
+++ b/merger/repoground/core/merge.py
@@ -9,6 +9,7 @@ Implements AI-friendly formatting, tagging, and strict Pflichtenheft structure.
 import os
 import sys
 import json
+import base64
 import hashlib
 import datetime
 import logging
@@ -492,11 +493,11 @@ TEXT_EXTENSIONS = {
 
 
 def _stable_file_id(fi: "FileInfo") -> str:
-    """
-    Stable across runs as long as repo + rel-path stay the same.
-    Avoids relying on Markdown heading anchors or renderer-specific IDs.
-    """
+    """Canonical HTML anchor from SHA-256(root_label + NUL + original rel_path).
 
+    Stable across runs as long as repo + rel-path stay the same.
+    Uses SHA-256 for a globally unique, collision-resistant path anchor.
+    """
     repo = (
         getattr(fi, "root_label", None)
         or getattr(fi, "repo", None)
@@ -510,14 +511,11 @@ def _stable_file_id(fi: "FileInfo") -> str:
         or ""
     )
 
-    # Normalize paths to NFC to ensure stable IDs across platforms (macOS vs Linux)
     repo = unicodedata.normalize("NFC", repo)
     path = unicodedata.normalize("NFC", path)
 
-    raw = f"{repo}:{path}".encode("utf-8", errors="ignore")
-    # Updated in v2.4 (PR1) to include FILE: prefix.
-    # Content addressing only (not security); flag keeps FIPS builds happy.
-    return "FILE:f_" + hashlib.sha1(raw, usedforsecurity=False).hexdigest()[:12]
+    raw = f"{repo}\x00{path}".encode("utf-8", errors="ignore")
+    return "FILE:f_" + hashlib.sha256(raw).hexdigest()[:24]
 
 
 def resolve_canonical_md(md_parts: List[Path]) -> Optional[Path]:  # lenskit:requires-authority=canonical_content
@@ -1753,6 +1751,20 @@ class FileInfo(object):
         self.lens = None # Assigned during scan or later
 
 
+def _copy_file_info(fi: FileInfo) -> FileInfo:
+    """Create a shallow render-local copy of a FileInfo object.
+
+    The copy carries the same slot values (including mutable ones like tags
+    and content which the renderer never mutates).  Render-local fields
+    (anchor, anchor_alias, roles) are written to the copy, leaving the
+    original untouched.
+    """
+    clone = FileInfo.__new__(FileInfo)
+    for slot in FileInfo.__slots__:
+        setattr(clone, slot, getattr(fi, slot))
+    return clone
+
+
 # --- Utilities ---
 
 def _hub_path_file(script_path: Path) -> Path:
@@ -2776,6 +2788,27 @@ def get_repo_snapshot(repo_root: Path) -> Dict[str, Tuple[int, str, str]]:
     return snapshot
 
 
+def _plan_only_epistemic_metrics(files: List[FileInfo], processed_files: List[Tuple[FileInfo, str]]) -> Dict[str, Any]:
+    """Plan-only adjusted epistemic metrics: emitted=0, contact_ratio=0, risk=high.
+
+    When plan_only is active no content is examined so the risk must reflect
+    unread content rather than a potentially misleading 'low' risk derived
+    from the raw file statuses.
+    """
+    base = compute_epistemic_metrics(files, processed_files)
+    base["counts"]["full"] = 0
+    base["counts"]["snippet"] = 0
+    base["counts"]["text_contact"] = 0
+    base["ratios"]["contact_ratio"] = 0.0
+    base["ratios"]["text_coverage_ratio"] = 0.0
+    base["risk"]["level"] = "high"
+    base["risk"]["uncertainty_score"] = 1.0
+    base["risk"]["inputs"]["contact_ratio_all_files"] = 0.0
+    base["risk"]["inputs"]["text_coverage_ratio"] = 0.0
+    base["risk"]["inputs"]["snippet_count"] = 0
+    return base
+
+
 def compute_epistemic_metrics(files: List[FileInfo], processed_files: List[Tuple[FileInfo, str]]) -> Dict[str, Any]:
     """
     Compute epistemic metrics (counts, ratios, risks) in one place.
@@ -2912,6 +2945,34 @@ def _resolve_effective_meta_density(
         return "full"
 
     return meta_density
+
+
+def _normalize_ext_filter(ext_filter: Optional[List[str]]) -> Optional[List[str]]:
+    """Normalize extension filter: casefold, ensure leading dot, deduplicate, sort."""
+    if not ext_filter:
+        return None
+    seen: set[str] = set()
+    normalized: list[str] = []
+    for ext in ext_filter:
+        if not isinstance(ext, str) or not ext.strip():
+            continue
+        e = ext.strip().casefold()
+        if not e.startswith("."):
+            e = "." + e
+        if e not in seen:
+            seen.add(e)
+            normalized.append(e)
+    return sorted(normalized) if normalized else None
+
+
+def _file_matches_ext_filter(fi: "FileInfo", ext_filter: Optional[List[str]]) -> bool:
+    """Check whether a FileInfo matches the normalized ext_filter."""
+    if not ext_filter:
+        return True
+    file_ext = (fi.ext or "").casefold()
+    if not file_ext.startswith("."):
+        file_ext = "." + file_ext
+    return file_ext in ext_filter
 
 
 def _generate_run_id(
@@ -3588,6 +3649,25 @@ class ReportValidator:
                  raise ValidationException(f"Missing required section: {req}")
 
 
+@dataclass(frozen=True, slots=True)
+class _ReportEmission:
+    """Canonical projection of selection and actual content emission."""
+
+    selected_files: int
+    selected_text_files: int
+    includable_files: int
+    emitted_files: int
+    metadata_only_files: int
+    includable_by_root: Tuple[Tuple[str, int], ...]
+    emitted_by_root: Tuple[Tuple[str, int], ...]
+
+    def emitted_for_root(self, root: str) -> int:
+        return dict(self.emitted_by_root).get(root, 0)
+
+    def includable_root_counts(self) -> Dict[str, int]:
+        return dict(self.includable_by_root)
+
+
 @dataclass
 class _ReportRenderState:
     files: List[FileInfo]
@@ -3613,9 +3693,8 @@ class _ReportRenderState:
     roots: Set[str]
     total_size: int
     text_files: List[FileInfo]
-    included_count: int
+    emission: _ReportEmission
     ep_metrics: Dict[str, Any]
-    included_by_root: Dict[str, int]
     declared_purpose: str
     repo_purpose: str
     infra_folders: Set[str]
@@ -3628,6 +3707,8 @@ class _ReportRenderState:
     files_by_root: Dict[str, List[FileInfo]]
     repo_stats: Dict[str, Dict[str, Any]]
     health_collector: Optional[HealthCollector]
+    # Structured optional warnings: tuple of {"code": str, "message": str, "detail": str|None}
+    structured_warnings: Tuple[Dict[str, Any], ...] = ()
 
 
 
@@ -3714,11 +3795,10 @@ def _append_scope_filters(header: List[str], state: _ReportRenderState) -> str:
     else:
         header.append("- **Extension Filter:** `none (all text types)`")
     if state.text_files:
-        emitted_count = 0 if state.plan_only else state.included_count
-        header.append(f"- **Selected Text Files:** {len(state.text_files)}")
-        header.append(f"- **Included Content:** {emitted_count} files")
+        header.append(f"- **Selected Text Files:** {state.emission.selected_text_files}")
+        header.append(f"- **Included Content:** {state.emission.emitted_files} files")
         header.append(
-            f"- **Coverage:** {emitted_count}/{len(state.text_files)} Dateien mit vollem Inhalt"
+            f"- **Coverage:** {state.emission.emitted_files}/{state.emission.selected_text_files} Dateien mit vollem Inhalt"
         )
     header.append("")
     return scope_desc
@@ -3785,9 +3865,9 @@ def _base_report_meta(
     state: _ReportRenderState, render_mode: str, scope_desc: str
 ) -> Dict[str, Any]:
     has_roles = any(file_info.roles for file_info in state.files)
-    text_files_count = len(state.text_files)
-    content_present = not state.plan_only
-    emitted_count = state.included_count if content_present else 0
+    text_files_count = state.emission.selected_text_files
+    content_present = state.emission.emitted_files > 0
+    emitted_count = state.emission.emitted_files
     manifest_present = not state.plan_only
     structure_present = not state.plan_only and state.level != "machine-lean"
     if state.debug:
@@ -3854,6 +3934,10 @@ def _extend_report_meta(meta_dict: Dict[str, Any], state: _ReportRenderState) ->
         augment_meta = _build_augment_meta(state.sources)
         if augment_meta:
             meta_dict["merge"]["augment"] = augment_meta
+    if state.structured_warnings:
+        meta_dict["diagnostics"] = {
+            "warnings": [dict(w) for w in state.structured_warnings],
+        }
 
 
 def _append_report_meta(
@@ -4004,7 +4088,7 @@ def _append_plan_repo_snapshots(plan: List[str], state: _ReportRenderState) -> N
         plan.append(
             f"- `{root}` → {len(root_files)} files "
             f"({_relevant_text_count(root_files)} relevant text, {human_size(root_bytes)}, "
-            f"{state.included_by_root.get(root, 0)} with content)"
+            f"{state.emission.emitted_for_root(root)} with content)"
         )
     plan.append("")
 
@@ -4014,12 +4098,13 @@ def _hotspots_limit(meta_density: str) -> int:
 
 
 def _append_plan_hotspots_and_folders(plan: List[str], state: _ReportRenderState) -> None:
-    limit = _hotspots_limit(state.effective_meta_density)
-    if limit:
-        hotspots = build_hotspots(state.processed_files, limit=limit)
-        if hotspots:
-            plan.extend(hotspots)
-            plan.append("")
+    if not state.plan_only:
+        limit = _hotspots_limit(state.effective_meta_density)
+        if limit:
+            hotspots = build_hotspots(state.processed_files, limit=limit)
+            if hotspots:
+                plan.extend(hotspots)
+                plan.append("")
     plan.append("**Folder Highlights:**")
     folder_lines = (
         (state.code_folders, "Code"),
@@ -4050,11 +4135,11 @@ def _render_report_plan(state: _ReportRenderState) -> str:
         "",
         f"- **Total Files:** {len(state.files)} (Text: {len(state.text_files)})",
         f"- **Total Size:** {human_size(state.total_size)}",
-        f"- **Included Content:** {state.included_count} files (full)",
+        f"- **Included Content:** {state.emission.emitted_files} files (full)",
     ]
     if state.text_files:
         plan.append(
-            f"- **Coverage:** {state.included_count}/{len(state.text_files)} Dateien mit vollem Inhalt"
+            f"- **Coverage:** {state.emission.emitted_files}/{len(state.text_files)} Dateien mit vollem Inhalt"
         )
     plan.append("")
     _append_plan_delta(plan, state)
@@ -4345,20 +4430,48 @@ def _show_file_meta(status: str, meta_density: str) -> bool:
     return meta_density == "full" or status != "full"
 
 
+def _encode_machine_marker(payload: Dict[str, Any]) -> str:
+    """Return canonical single-line Base64url JSON without padding."""
+    raw = json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
 def _append_content_file_meta(
     block: List[str], file_info: FileInfo, status: str, content: str
 ) -> None:
-    block.extend([
-        "<!--",
-        "file_meta:",
-        f"  repo: {file_info.root_label}",
-        f"  path: {file_info.rel_path}",
-        f"  lines: {len(content.splitlines())}",
-        f"  included: {status}",
-    ])
+    payload: Dict[str, Any] = {
+        "included": status,
+        "lines": len(content.splitlines()),
+        "path": str(file_info.rel_path),
+        "repo": file_info.root_label,
+    }
     if getattr(file_info, "inclusion_reason", "normal") != "normal":
-        block.append(f"  inclusion_reason: {file_info.inclusion_reason}")
-    block.append("-->")
+        payload["inclusion_reason"] = file_info.inclusion_reason
+    block.append(f'<!-- file_meta meta="{_encode_machine_marker(payload)}" -->')
+
+
+def _html_attr_escape(value: str) -> str:
+    """Escape a string for safe use inside an HTML attribute value.
+
+    Prevents injection of quotes, ``-->`` (HTML comment close), and
+    ALL control characters (U+0000–U+001F including Tab/CR/LF, U+007F).
+    All controls are numeric-escaped to keep the output single-line and
+    safe in HTML comment attributes.
+    """
+    result = (
+        value.replace("&", "&amp;")
+        .replace('"', "&quot;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace("'", "&#39;")
+    )
+    result = re.sub(r"[\x00-\x1f\x7f]", lambda m: f"&#{ord(m.group()):d};", result)
+    return result
 
 
 def _content_fence(content: str) -> str:
@@ -4378,15 +4491,25 @@ def _render_content_file_block(
     content_sha256 = hashlib.sha256(encoded).hexdigest()
     file_id = _stable_file_id(file_info)
     human_stable_id = file_id.replace("FILE:", "file-")
+    safe_path = _html_attr_escape(str(file_info.rel_path))
+    start_meta = _encode_machine_marker({
+        "content_bytes": len(encoded),
+        "content_sha256": content_sha256,
+        "file_bytes": file_info.size,
+        "path": str(file_info.rel_path),
+        "repo": file_info.root_label,
+        "truncated": truncated,
+    })
+    end_meta = _encode_machine_marker({
+        "path": str(file_info.rel_path),
+        "repo": file_info.root_label,
+    })
     block = [
         "---",
-        f'<!-- FILE_START path="{file_info.rel_path}" content_sha256="{content_sha256}" '
-        f'content_bytes="{len(encoded)}" file_bytes="{file_info.size}" '
-        f'truncated="{str(truncated).lower()}" -->',
-        f'<!-- file:id="{file_id}" path="{file_info.rel_path}" -->',
-        f'<a id="{human_stable_id}"></a>',
+        f'<!-- FILE_START path="{safe_path}" meta="{start_meta}" -->',
+        f'<!-- file:id="{file_id}" path="{safe_path}" -->',
     ]
-    if file_info.anchor_alias != file_info.anchor:
+    if file_info.anchor_alias and file_info.anchor_alias != file_info.anchor:
         block.append(f'<a id="{file_info.anchor_alias}"></a>')
     block.extend(_heading_block(4, file_info.anchor, str(file_info.rel_path), nav=state.nav))
     block.append(f"**Path:** `{file_info.rel_path}`")
@@ -4403,7 +4526,7 @@ def _render_content_file_block(
         fence,
         "",
         f'<!-- zone:end type="code" id="{file_id}" -->',
-        f'<!-- FILE_END path="{file_info.rel_path}" -->',
+        f'<!-- FILE_END path="{safe_path}" meta="{end_meta}" -->',
         "[↑ Manifest](#manifest) · [↑ Index](#index)",
     ])
     return "\n".join(block) + "\n\n"
@@ -4428,13 +4551,16 @@ def _iter_report_content_blocks(state: _ReportRenderState) -> Iterator[str]:
 
 
 def _normalize_report_files(
-    files: List[FileInfo], path_filter: Optional[str], code_only: bool
+    files: List[FileInfo], path_filter: Optional[str], code_only: bool,
+    ext_filter: Optional[List[str]] = None,
 ) -> List[FileInfo]:
     selected = (
         [file_info for file_info in files if path_filter in file_info.rel_path.as_posix()]
         if path_filter
         else list(files)
     )
+    if ext_filter:
+        selected = [fi for fi in selected if _file_matches_ext_filter(fi, ext_filter)]
     selected.sort(
         key=lambda file_info: (
             get_repo_sort_index(file_info.root_label),
@@ -4451,15 +4577,63 @@ def _normalize_report_files(
     return selected
 
 
-def _assign_report_file_identity(file_info: FileInfo) -> None:
-    relative_id = _slug_token(file_info.rel_path.as_posix())
-    repo_slug = _slug_token(file_info.root_label)
-    base_anchor = f"file-{repo_slug}-{relative_id}"
-    suffix = (file_info.md5 or "")[:6] if getattr(file_info, "md5", None) else ""
-    file_info.anchor_alias = base_anchor
-    file_info.anchor = f"{base_anchor}-{suffix}" if suffix else base_anchor
+@dataclass(frozen=True, slots=True)
+class _RenderFileIdentity:
+    """Render-local identity projection for a file. Does not mutate FileInfo."""
+    file_id: str
+    anchor: str
+    anchor_alias: str
+    roles: Tuple[str, ...]
+
+
+def _build_render_identity_map(
+    files: List[FileInfo],
+) -> Dict[Tuple[str, Path], _RenderFileIdentity]:
+    """Build a render-local identity map without mutating caller FileInfo objects.
+
+    Anchor (file:id) uses SHA-256 for global uniqueness.
+    Legacy alias is a human-readable slug derived from root+path; it is only
+    emitted when it is globally unique across all files in the report.  Colliding
+    aliases are suppressed (empty string) rather than disambiguated.
+    """
+    raw: Dict[Tuple[str, Path], _RenderFileIdentity] = {}
+    slug_counts: Dict[str, int] = {}
+    for fi in files:
+        file_id = _stable_file_id(fi)
+        human_id = file_id.replace("FILE:", "file-")
+        slug_base = f"file-{_slug_token(fi.root_label)}-{_slug_token(str(fi.rel_path))}"
+        slug_counts[slug_base] = slug_counts.get(slug_base, 0) + 1
+        roles = tuple(compute_file_roles(fi))
+        raw[(fi.root_label, fi.rel_path)] = _RenderFileIdentity(
+            file_id=file_id,
+            anchor=human_id,
+            anchor_alias=slug_base,
+            roles=roles,
+        )
+    # Suppress non-unique aliases.
+    identity_map: Dict[Tuple[str, Path], _RenderFileIdentity] = {}
+    for key, ident in raw.items():
+        alias = ident.anchor_alias if slug_counts.get(ident.anchor_alias, 0) == 1 else ""
+        identity_map[key] = _RenderFileIdentity(
+            file_id=ident.file_id,
+            anchor=ident.anchor,
+            anchor_alias=alias,
+            roles=ident.roles,
+        )
+    # Uniqueness check: all anchors must be globally unique
+    all_anchors = [ident.anchor for ident in identity_map.values()]
+    if len(all_anchors) != len(set(all_anchors)):
+        dupes = [a for a in set(all_anchors) if all_anchors.count(a) > 1]
+        raise AssertionError(f"non-unique anchors detected: {dupes[:5]}")
+    return identity_map
+
+
+def _assign_report_file_identity(file_info: FileInfo, identity: _RenderFileIdentity) -> None:
+    """Populate anchor/alias/roles on a FileInfo from a pre-computed identity."""
+    file_info.anchor = identity.anchor
+    file_info.anchor_alias = identity.anchor_alias
     if file_info.roles is None:
-        file_info.roles = compute_file_roles(file_info)
+        file_info.roles = list(identity.roles)
 
 
 def _debug_report_classification(
@@ -4475,13 +4649,21 @@ def _debug_report_classification(
 
 
 def _prepare_processed_files(
-    files: List[FileInfo], level: str, max_file_bytes: int, debug: bool
+    files: List[FileInfo], level: str, max_file_bytes: int, debug: bool,
+    identity_map: Optional[Dict[Tuple[str, Path], _RenderFileIdentity]] = None,
 ) -> List[Tuple[FileInfo, str]]:
     processed: List[Tuple[FileInfo, str]] = []
     unknown_categories: Set[str] = set()
     unknown_tags: Set[str] = set()
     for file_info in files:
-        _assign_report_file_identity(file_info)
+        ident = identity_map.get((file_info.root_label, file_info.rel_path)) if identity_map else None
+        if ident is not None:
+            _assign_report_file_identity(file_info, ident)
+        else:
+            file_info.anchor = _stable_file_id(file_info).replace("FILE:", "file-")
+            file_info.anchor_alias = file_info.anchor
+            if file_info.roles is None:
+                file_info.roles = compute_file_roles(file_info)
         if debug:
             _debug_report_classification(file_info, unknown_categories, unknown_tags)
         processed.append(
@@ -4603,6 +4785,34 @@ def _report_health_collector(
     return collector
 
 
+def _collect_structured_warnings(
+    path_filter: Optional[str],
+    ext_filter: Optional[List[str]],
+    plan_only: bool,
+    level: str,
+) -> Tuple[Dict[str, Any], ...]:
+    warnings: List[Dict[str, Any]] = []
+    if path_filter or ext_filter:
+        warnings.append({
+            "code": "scope_filter_active",
+            "message": "Filters are active; negative absence claims are not supported.",
+            "detail": None,
+        })
+    if plan_only:
+        warnings.append({
+            "code": "plan_only_mode",
+            "message": "Plan-only mode: no file content is emitted.",
+            "detail": None,
+        })
+    if level != "max":
+        warnings.append({
+            "code": "non_max_level",
+            "message": f"Level '{level}' may omit low-priority files.",
+            "detail": None,
+        })
+    return tuple(warnings)
+
+
 def _prepare_report_state(
     files: List[FileInfo],
     level: str,
@@ -4623,17 +4833,38 @@ def _prepare_report_state(
     effective_extras = extras if extras is not None else ExtrasConfig.none()
     if debug:
         print("[repoground] merge.py loaded from:", __file__, file=sys.stderr)
-    selected_files = _normalize_report_files(files, path_filter, code_only)
+    ext_filter = _normalize_ext_filter(ext_filter)
+    selected_files = _normalize_report_files(files, path_filter, code_only, ext_filter)
+    # Render-local copies: anchor/alias/roles are written to copies only,
+    # leaving caller FileInfo objects completely untouched.
+    render_files = [_copy_file_info(fi) for fi in selected_files]
+    identity_map = _build_render_identity_map(render_files)
     processed_files = _prepare_processed_files(
-        selected_files, level, max_file_bytes, debug
+        render_files, level, max_file_bytes, debug, identity_map
     )
-    text_files = [file_info for file_info in selected_files if file_info.is_text]
+    text_files = [file_info for file_info in render_files if file_info.is_text]
     included_count = sum(
         1 for _file_info, status in processed_files if status in ("full", "truncated")
     )
     processed_by_root = _group_processed_report_files(processed_files)
     included_by_root = _included_report_files_by_root(processed_files)
-    files_by_root = _group_report_files(selected_files)
+    emitted_by_root = (
+        {root: 0 for root in included_by_root}
+        if plan_only
+        else dict(included_by_root)
+    )
+    emission = _ReportEmission(
+        selected_files=len(render_files),
+        selected_text_files=len(text_files),
+        includable_files=included_count,
+        emitted_files=0 if plan_only else included_count,
+        metadata_only_files=sum(
+            1 for _, status in processed_files if status == "meta-only"
+        ),
+        includable_by_root=tuple(sorted(included_by_root.items())),
+        emitted_by_root=tuple(sorted(emitted_by_root.items())),
+    )
+    files_by_root = _group_report_files(render_files)
     (
         infra_folders,
         code_folders,
@@ -4642,9 +4873,9 @@ def _prepare_report_state(
         organism_contracts,
         organism_pipelines,
         organism_wgx_profiles,
-    ) = _report_folders_and_organs(selected_files)
+    ) = _report_folders_and_organs(render_files)
     return _ReportRenderState(
-        files=selected_files,
+        files=render_files,
         level=level,
         max_file_bytes=max_file_bytes,
         sources=sources,
@@ -4666,12 +4897,11 @@ def _prepare_report_state(
         now=clock.now_utc(),
         processed_files=processed_files,
         processed_by_root=processed_by_root,
-        roots={file_info.root_label for file_info in selected_files},
-        total_size=sum(file_info.size for file_info in selected_files),
+        roots={file_info.root_label for file_info in render_files},
+        total_size=sum(file_info.size for file_info in render_files),
         text_files=text_files,
-        included_count=included_count,
-        ep_metrics=compute_epistemic_metrics(selected_files, processed_files),
-        included_by_root=included_by_root,
+        emission=emission,
+        ep_metrics=_plan_only_epistemic_metrics(render_files, processed_files) if plan_only else compute_epistemic_metrics(render_files, processed_files),
         declared_purpose=PROFILE_USECASE.get(level, "(none)"),
         repo_purpose=_extract_report_repo_purpose(sources),
         infra_folders=infra_folders,
@@ -4682,9 +4912,12 @@ def _prepare_report_state(
         organism_pipelines=organism_pipelines,
         organism_wgx_profiles=organism_wgx_profiles,
         files_by_root=files_by_root,
-        repo_stats=_report_repo_stats(files_by_root, included_by_root),
+        repo_stats=_report_repo_stats(files_by_root, emission.includable_root_counts()),
         health_collector=_report_health_collector(
             effective_extras, sources, files_by_root
+        ),
+        structured_warnings=_collect_structured_warnings(
+            path_filter, ext_filter, plan_only, level
         ),
     )
 
@@ -4973,6 +5206,7 @@ def generate_json_sidecar(
     """
     now = clock.now_utc()
     requested_flags = requested_flags or {"plan_only": plan_only, "code_only": code_only, "meta_none": meta_none}
+    ext_filter = _normalize_ext_filter(ext_filter)
     plan_only, code_only, meta_none, normalized_requested = _normalize_mode_flags(
         requested_flags.get("plan_only", False),
         requested_flags.get("code_only", False),

--- a/merger/repoground/core/redactor.py
+++ b/merger/repoground/core/redactor.py
@@ -2,25 +2,76 @@ import re
 from typing import Tuple
 
 
-class Redactor:
-    """Heuristic-based secret redaction."""
+# JWT pattern: three dot-separated Base64url segments (header.payload.signature)
+_JWT_PATTERN = re.compile(
+    r"eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+"
+)
 
-    PATTERNS = [
-        (
-            r"(?i)(api[_-]?key|access[_-]?token|secret[_-]?key)([\s:=]+)([\"\']?)([\w-]{20,})",
-            r"\1\2\3[REDACTED]",
-        ),
-        (
-            r"(?i)(password|passwd|pwd)([\s:=]+)([\"\']?)([\w-]{6,})",
-            r"\1\2\3[REDACTED]",
-        ),
-        (r"(AKIA[0-9A-Z]{16})", "[AWS_KEY_REDACTED]"),
-        (
-            r"-----BEGIN ((?:(?:RSA|EC|DSA|OPENSSH) )?PRIVATE KEY|PGP PRIVATE KEY BLOCK)-----"
-            r"[\s\S]*?"
-            r"-----END \1-----",
-            "[PRIVATE_KEY_BLOCK_REDACTED]",
-        ),
+# Quoted API key assignments: handles values with ., /, +, = inside quotes
+_API_KEY_QUOTED_PATTERN = re.compile(
+    r"(?i)(api[_-]?key|access[_-]?token|secret[_-]?key)"
+    r"([ \t:=]+)"
+    r"(['\"])"
+    r"([^'\"]{20,})"
+    r"\3"
+)
+
+# Unquoted API key assignments: broad value class includes . / + =
+_API_KEY_UNQUOTED_PATTERN = re.compile(
+    r"(?i)(api[_-]?key|access[_-]?token|secret[_-]?key)"
+    r"([ \t:=]+)"
+    r"(['\"]?)"
+    r"([\w./+=-]{20,})"
+)
+
+# Quoted password assignments
+_PASSWORD_QUOTED_PATTERN = re.compile(
+    r"(?i)(password|passwd|pwd)"
+    r"([ \t:=]+)"
+    r"(['\"])"
+    r"([^'\"]{6,})"
+    r"\3"
+)
+
+# Unquoted password assignments
+_PASSWORD_UNQUOTED_PATTERN = re.compile(
+    r"(?i)(password|passwd|pwd)"
+    r"([ \t:=]+)"
+    r"(['\"]?)"
+    r"([\w./+=-]{6,})"
+)
+
+_AWS_KEY_PATTERN = re.compile(r"(AKIA[0-9A-Z]{16})")
+
+_PRIVATE_KEY_PATTERN = re.compile(
+    r"-----BEGIN ((?:(?:RSA|EC|DSA|OPENSSH) )?PRIVATE KEY|PGP PRIVATE KEY BLOCK)-----"
+    r"[\s\S]*?"
+    r"-----END \1-----"
+)
+
+
+class Redactor:
+    """Heuristic-based secret redaction.
+
+    Patterns are precompiled for performance.  Quoted patterns preserve the
+    closing quote to avoid breaking syntax.  Unquoted patterns use a broad
+    value class that includes '.', '/', '+', '=' which are common in secrets.
+    JWTs are detected and replaced completely to prevent partial redaction
+    leaking a recognizable prefix or suffix.
+
+    NOTE: The broad generic Base64url pattern (>=40 chars) has been removed
+    because it produced false positives on normal identifiers, UUIDs, hashes,
+    and other non-secret content.  Only structured patterns (key/password
+    assignments, AWS keys, PEM blocks) and JWT tokens are redacted.
+    """
+
+    PATTERNS: list[Tuple[re.Pattern[str], str]] = [
+        (_API_KEY_QUOTED_PATTERN, r"\1\2\3[REDACTED]\3"),
+        (_API_KEY_UNQUOTED_PATTERN, r"\1\2\3[REDACTED]"),
+        (_PASSWORD_QUOTED_PATTERN, r"\1\2\3[REDACTED]\3"),
+        (_PASSWORD_UNQUOTED_PATTERN, r"\1\2\3[REDACTED]"),
+        (_AWS_KEY_PATTERN, "[AWS_KEY_REDACTED]"),
+        (_PRIVATE_KEY_PATTERN, "[PRIVATE_KEY_BLOCK_REDACTED]"),
     ]
 
     def redact(self, content: str) -> Tuple[str, bool]:
@@ -28,10 +79,17 @@ class Redactor:
         modified = False
         redacted = content
 
+        # Pass 1: structured key/password/PEM patterns
         for pattern, replacement in self.PATTERNS:
-            new_content = re.sub(pattern, replacement, redacted)
+            new_content = pattern.sub(replacement, redacted)
             if new_content != redacted:
                 modified = True
                 redacted = new_content
+
+        # Pass 2: JWT tokens (structural ey...ey... signature)
+        new_content = _JWT_PATTERN.sub("[REDACTED]", redacted)
+        if new_content != redacted:
+            modified = True
+            redacted = new_content
 
         return redacted, modified

--- a/merger/repoground/tests/fixtures/report_renderer/golden/differential_scenarios.json
+++ b/merger/repoground/tests/fixtures/report_renderer/golden/differential_scenarios.json
@@ -1,202 +1,196 @@
 {
-  "intentional_corrections": [
-    "balanced empty manifest zone",
-    "plan-only emitted-content coverage is zero",
-    "redacted assignments preserve source syntax"
+  "does_not_establish": [
+    "historical_output_parity"
   ],
+  "historical_comparison_tool": "scripts/ci/compare_report_renderer_revisions.py",
+  "purpose": "target_revision_regression_golden",
   "scenario_count": 18,
   "scenarios": {
     "artifact_refs": {
       "block_bytes": [
         4323,
-        1114,
+        1074,
         308,
-        723,
-        1036,
+        664,
+        1084,
         26,
         76,
         53,
-        1036,
-        923,
-        897,
-        953
+        1281,
+        1145,
+        1111,
+        1172
       ],
       "block_count": 12,
       "block_sha256": [
         "69a9d00696d7ebd09aaf0a2f151f11a4b30223059c81573a8c709fb9233b0816",
-        "947c50cb1f9db1051246c8916222eb04515460adc4526f7e309bab214a8effd8",
+        "00f33d79838c1dc60186463b632a6e625b18d768f16eeccad83f96e54a0538d7",
         "cd3bcd45cb9898bb3aa5a080ef8c7ca3a852d910a6febbe1a162818e3bcaac33",
-        "75eb9fbc3aea9e311089820015a263b0a13efccac3d84ad8769ed68783edf2bc",
-        "822a98aa4b7f1f3a881aa3637f0c671103e2bed94beec4bd793d14ae9a0e21a9",
+        "7792107445410f74a705049bff6d6876dc87b7d2cde9e386de41ce0f4109103a",
+        "2bd4e973c9e2c7ec046dd26b8f788c2d9c35f2f10d4e2733c7b8ccf8f32d6826",
         "84ed2032e11da90373d9d827b5c7641b0cb18a659e8bd16d6d164e7186b4238f",
         "ab2dc1a0940275fc90e682419183641997a89ee4070159720505278e00b520c0",
         "7614b928bb311dede7e99b106708466f0b872e96148b2392e799c9d0d59555a1",
-        "86d463ae57eca44d757a2e8fb07f2a502a0f15bd19f5003e9f69c48131ccc8e3",
-        "f228fa401a3c29865177b73cc663c85879c10a645b1c1cc11a4fd9bfceccac11",
-        "43e4da9df031fb1612d7ec501b2dc80458169f4da2dd9300590c0cc78b7843ca",
-        "5a79a58b9fe93141e646835287f5eab0debc81762e0f90344acabbc4ce729ed0"
+        "7ebf25de4980bf80ceb9c79d1f84d4f4a4b463ba9a528442f2abfdc4ada74240",
+        "fd4f7feadc2ed6202b33cd67be45a35b4b405ac686b85005a435d08c0d4f63f1",
+        "074a3b09ed04b00f00d0addefbe1aed7c8372b329bde8a615154f04b2e7665b6",
+        "b3b83b47918869dbb47a60fc114d18a1449c3dbd5ea3eb2a0eefaeed5113ffed"
       ],
-      "joined_sha256": "7fa62eda475902032c938497d32c4b6acd6ebc588e38ccf9006f3b2b56b19b5e"
+      "joined_sha256": "6cc9140da2401cac39b54135700c4e3df8497a551d655e69ea22c531ee9e2b35"
     },
     "augment_delta": {
       "block_bytes": [
         4255,
-        1189,
+        1149,
         183,
         308,
-        723,
-        1036,
+        664,
+        1084,
         26,
         76,
         53,
-        1036,
-        923,
-        897,
-        953
+        1281,
+        1145,
+        1111,
+        1172
       ],
       "block_count": 13,
       "block_sha256": [
         "e9abaebd22e9697d50938c2575577c52d9f854781b6eab4475fcbcae97f3db60",
-        "675c36efbe7c7740cf6ec79f0a4b3d5205b88154982f24977f90baa502a4383f",
+        "ff731bfbc0147696b5d0a313af79570016d649eab40b16f974745e6a5e30a3ac",
         "77d3ed902dc13b17b63bd62953bedb0a0f8bc46b910feae77778a5eb8d058c96",
         "cd3bcd45cb9898bb3aa5a080ef8c7ca3a852d910a6febbe1a162818e3bcaac33",
-        "75eb9fbc3aea9e311089820015a263b0a13efccac3d84ad8769ed68783edf2bc",
-        "822a98aa4b7f1f3a881aa3637f0c671103e2bed94beec4bd793d14ae9a0e21a9",
+        "7792107445410f74a705049bff6d6876dc87b7d2cde9e386de41ce0f4109103a",
+        "2bd4e973c9e2c7ec046dd26b8f788c2d9c35f2f10d4e2733c7b8ccf8f32d6826",
         "84ed2032e11da90373d9d827b5c7641b0cb18a659e8bd16d6d164e7186b4238f",
         "ab2dc1a0940275fc90e682419183641997a89ee4070159720505278e00b520c0",
         "7614b928bb311dede7e99b106708466f0b872e96148b2392e799c9d0d59555a1",
-        "86d463ae57eca44d757a2e8fb07f2a502a0f15bd19f5003e9f69c48131ccc8e3",
-        "f228fa401a3c29865177b73cc663c85879c10a645b1c1cc11a4fd9bfceccac11",
-        "43e4da9df031fb1612d7ec501b2dc80458169f4da2dd9300590c0cc78b7843ca",
-        "5a79a58b9fe93141e646835287f5eab0debc81762e0f90344acabbc4ce729ed0"
+        "7ebf25de4980bf80ceb9c79d1f84d4f4a4b463ba9a528442f2abfdc4ada74240",
+        "fd4f7feadc2ed6202b33cd67be45a35b4b405ac686b85005a435d08c0d4f63f1",
+        "074a3b09ed04b00f00d0addefbe1aed7c8372b329bde8a615154f04b2e7665b6",
+        "b3b83b47918869dbb47a60fc114d18a1449c3dbd5ea3eb2a0eefaeed5113ffed"
       ],
-      "joined_sha256": "8c13f2a533b36d00080fedaedcdef8d8a9cb221eeab5b2494555b6a5a148ed91"
+      "joined_sha256": "e7c91550ba084eecf824c7e68cbf37989a6b27a44173ad68ced794081c3466d8"
     },
     "code_only": {
       "block_bytes": [
         4424,
-        842,
+        816,
         252,
-        547,
-        924,
+        502,
+        948,
         26,
         76,
         53,
-        1036,
-        953
+        1281,
+        1172
       ],
       "block_count": 10,
       "block_sha256": [
         "b44c6b2c05473895ef9388af7030ee5bb584f3cca98ea3fbab9e9a5ef34483ec",
-        "b853cc6123589a7d5e3398a3fbb78cf93a9d86578202a08e1a8f6eaa3f1ee71d",
+        "4628daf99bb84e8c997199544032767fb9243ef74960a158a21411dcfce24617",
         "ade3954d35bf9a54ab10b8370eef087759234c8d80df8f309cc13673f5128ff7",
-        "8029b405bf37cecbd3e3309605a98502f8178325cc73f3053e82b66e7e917779",
-        "c2d3d38d6090abe5b75c60d3cba3f5db4a601b60fce56887868d3662fbc8147e",
+        "9fc436ea6101c4b6cb3680e146af424e6a6de6759c91f06e43cca60687b279c1",
+        "9455dd1efd0a88472f3fde3944e4c219c8a68dbc262f2190fc07e57b8359419a",
         "84ed2032e11da90373d9d827b5c7641b0cb18a659e8bd16d6d164e7186b4238f",
         "ab2dc1a0940275fc90e682419183641997a89ee4070159720505278e00b520c0",
         "7614b928bb311dede7e99b106708466f0b872e96148b2392e799c9d0d59555a1",
-        "86d463ae57eca44d757a2e8fb07f2a502a0f15bd19f5003e9f69c48131ccc8e3",
-        "5a79a58b9fe93141e646835287f5eab0debc81762e0f90344acabbc4ce729ed0"
+        "7ebf25de4980bf80ceb9c79d1f84d4f4a4b463ba9a528442f2abfdc4ada74240",
+        "b3b83b47918869dbb47a60fc114d18a1449c3dbd5ea3eb2a0eefaeed5113ffed"
       ],
-      "joined_sha256": "ca07abd97ca223ee3bb6a32106c1d9e646237522642db1ee41739001266347ad"
+      "joined_sha256": "0b3fdbf070bebbf432dfe576b6e316c776fdaefcb713a4ec9625e777e9e07a8e"
     },
     "extension_filter": {
       "block_bytes": [
-        4537,
-        995,
-        308,
-        723,
-        1036,
+        4685,
+        673,
+        186,
+        243,
+        632,
         26,
         76,
         53,
-        892,
-        790,
-        768,
-        822
+        1006
       ],
-      "block_count": 12,
+      "block_count": 9,
       "block_sha256": [
-        "33090c10eb0dd051513ef5428862bd08ffb9464eb46a4c98df3e732344276d95",
-        "0c6fd15aecfa9d9b5e9ff93317fc1dfdfdd19a229aad8ce0ee97af21942f3553",
-        "cd3bcd45cb9898bb3aa5a080ef8c7ca3a852d910a6febbe1a162818e3bcaac33",
-        "75eb9fbc3aea9e311089820015a263b0a13efccac3d84ad8769ed68783edf2bc",
-        "822a98aa4b7f1f3a881aa3637f0c671103e2bed94beec4bd793d14ae9a0e21a9",
+        "039bc64ace3eeebb291508e0f44939ac628729dabb3eec4300b595d6acaee9d1",
+        "e958c341c9c9ddf6e481db137f3e3212c7832039c16034172a732e15059a0bdc",
+        "865327024feb55b30e557356754d27a457f51259be807ee6f979ebd0ad27f213",
+        "d4dfca0d51042fc66b48c94c2c0adc43d453eff57568eb0f42dd82ecc2037e2a",
+        "9e63beb261d33483cd1e417849f8292553d525409702b818c9909ac3673123ff",
         "84ed2032e11da90373d9d827b5c7641b0cb18a659e8bd16d6d164e7186b4238f",
         "ab2dc1a0940275fc90e682419183641997a89ee4070159720505278e00b520c0",
         "7614b928bb311dede7e99b106708466f0b872e96148b2392e799c9d0d59555a1",
-        "ce008e7b5845c069e9e76526bfedd15ee2ed0c8cd8405c71d348b8f035c5d28a",
-        "9de035fd2cee4ed290bf7e42da984d7e2832d26f5b4f0ab54eedcb9339f2594d",
-        "f2c7705f1b5c7a72a4997b7d915bb834ea978572ac2c706e13b76ea024caf0e3",
-        "d32e50553b95ddea77da9625a124524a4613d97f2f30fd6e9ec0d262057dc15c"
+        "5ff7190b0ea5affe727c43c197f6db6516d02a11018deff82e29cd9959876f66"
       ],
-      "joined_sha256": "ff9a358ceab10e912499f6b26eda5be61edac9c875568606644a88b9687a1465"
+      "joined_sha256": "31695bb4e56ef1bcf4f153b8b6ee244e2bfc9a53019bed40c2f4995bb7d568fa"
     },
     "heatmap": {
       "block_bytes": [
         4213,
-        1114,
+        1074,
         424,
         308,
-        723,
-        1036,
+        664,
+        1084,
         26,
         76,
         53,
-        1036,
-        923,
-        897,
-        953
+        1281,
+        1145,
+        1111,
+        1172
       ],
       "block_count": 13,
       "block_sha256": [
         "1a8819794be4f56e8e9d0c2867c255c7ddc3bc7971d05bf3f480eb3a41a3d77c",
-        "947c50cb1f9db1051246c8916222eb04515460adc4526f7e309bab214a8effd8",
+        "00f33d79838c1dc60186463b632a6e625b18d768f16eeccad83f96e54a0538d7",
         "3a62f46431483829dbfb5542bc16277885c04b8b41e407dc3ed746870b366230",
         "cd3bcd45cb9898bb3aa5a080ef8c7ca3a852d910a6febbe1a162818e3bcaac33",
-        "75eb9fbc3aea9e311089820015a263b0a13efccac3d84ad8769ed68783edf2bc",
-        "822a98aa4b7f1f3a881aa3637f0c671103e2bed94beec4bd793d14ae9a0e21a9",
+        "7792107445410f74a705049bff6d6876dc87b7d2cde9e386de41ce0f4109103a",
+        "2bd4e973c9e2c7ec046dd26b8f788c2d9c35f2f10d4e2733c7b8ccf8f32d6826",
         "84ed2032e11da90373d9d827b5c7641b0cb18a659e8bd16d6d164e7186b4238f",
         "ab2dc1a0940275fc90e682419183641997a89ee4070159720505278e00b520c0",
         "7614b928bb311dede7e99b106708466f0b872e96148b2392e799c9d0d59555a1",
-        "86d463ae57eca44d757a2e8fb07f2a502a0f15bd19f5003e9f69c48131ccc8e3",
-        "f228fa401a3c29865177b73cc663c85879c10a645b1c1cc11a4fd9bfceccac11",
-        "43e4da9df031fb1612d7ec501b2dc80458169f4da2dd9300590c0cc78b7843ca",
-        "5a79a58b9fe93141e646835287f5eab0debc81762e0f90344acabbc4ce729ed0"
+        "7ebf25de4980bf80ceb9c79d1f84d4f4a4b463ba9a528442f2abfdc4ada74240",
+        "fd4f7feadc2ed6202b33cd67be45a35b4b405ac686b85005a435d08c0d4f63f1",
+        "074a3b09ed04b00f00d0addefbe1aed7c8372b329bde8a615154f04b2e7665b6",
+        "b3b83b47918869dbb47a60fc114d18a1449c3dbd5ea3eb2a0eefaeed5113ffed"
       ],
-      "joined_sha256": "2e61de8d0b05ec0c1687493f706d8790872f3970722d7a260a8c88b47808ed1a"
+      "joined_sha256": "567c8cd1b8be2bb44ab5b1af914e40bd6de2b66ebc8e9a581b577725d2913e85"
     },
     "meta_full": {
       "block_bytes": [
         4214,
-        1114,
+        1074,
         308,
-        723,
-        1036,
+        664,
+        1084,
         26,
         76,
         53,
-        1036,
-        923,
-        897,
-        953
+        1281,
+        1145,
+        1111,
+        1172
       ],
       "block_count": 12,
       "block_sha256": [
         "ce4dcab017b5ae869d43c500a7ef8f4e1e21511b19256c3ddfcd26acb4ebece7",
-        "947c50cb1f9db1051246c8916222eb04515460adc4526f7e309bab214a8effd8",
+        "00f33d79838c1dc60186463b632a6e625b18d768f16eeccad83f96e54a0538d7",
         "cd3bcd45cb9898bb3aa5a080ef8c7ca3a852d910a6febbe1a162818e3bcaac33",
-        "75eb9fbc3aea9e311089820015a263b0a13efccac3d84ad8769ed68783edf2bc",
-        "822a98aa4b7f1f3a881aa3637f0c671103e2bed94beec4bd793d14ae9a0e21a9",
+        "7792107445410f74a705049bff6d6876dc87b7d2cde9e386de41ce0f4109103a",
+        "2bd4e973c9e2c7ec046dd26b8f788c2d9c35f2f10d4e2733c7b8ccf8f32d6826",
         "84ed2032e11da90373d9d827b5c7641b0cb18a659e8bd16d6d164e7186b4238f",
         "ab2dc1a0940275fc90e682419183641997a89ee4070159720505278e00b520c0",
         "7614b928bb311dede7e99b106708466f0b872e96148b2392e799c9d0d59555a1",
-        "86d463ae57eca44d757a2e8fb07f2a502a0f15bd19f5003e9f69c48131ccc8e3",
-        "f228fa401a3c29865177b73cc663c85879c10a645b1c1cc11a4fd9bfceccac11",
-        "43e4da9df031fb1612d7ec501b2dc80458169f4da2dd9300590c0cc78b7843ca",
-        "5a79a58b9fe93141e646835287f5eab0debc81762e0f90344acabbc4ce729ed0"
+        "7ebf25de4980bf80ceb9c79d1f84d4f4a4b463ba9a528442f2abfdc4ada74240",
+        "fd4f7feadc2ed6202b33cd67be45a35b4b405ac686b85005a435d08c0d4f63f1",
+        "074a3b09ed04b00f00d0addefbe1aed7c8372b329bde8a615154f04b2e7665b6",
+        "b3b83b47918869dbb47a60fc114d18a1449c3dbd5ea3eb2a0eefaeed5113ffed"
       ],
-      "joined_sha256": "766e9b75ebbf7c176332ba40f3342fae2e847cd6879741afb5044f2b473d6b30"
+      "joined_sha256": "1a7844f7268f1f6df658f695f7395a5e7c9866e4867816ab4f4d587d94a33fe4"
     },
     "meta_min": {
       "block_bytes": [
@@ -204,14 +198,14 @@
         540,
         308,
         148,
-        1036,
+        1084,
         26,
         76,
         53,
-        828,
-        725,
-        700,
-        750
+        1034,
+        911,
+        880,
+        934
       ],
       "block_count": 12,
       "block_sha256": [
@@ -219,16 +213,16 @@
         "a30f9cae26811ad3a59aa64013166c97ee55f58db2a68fd263a7082e4609eab7",
         "cd3bcd45cb9898bb3aa5a080ef8c7ca3a852d910a6febbe1a162818e3bcaac33",
         "5a291bed27316ffbebf6a3877bbfca31d9a51046b2e07cf34c751d0f2db820e4",
-        "822a98aa4b7f1f3a881aa3637f0c671103e2bed94beec4bd793d14ae9a0e21a9",
+        "2bd4e973c9e2c7ec046dd26b8f788c2d9c35f2f10d4e2733c7b8ccf8f32d6826",
         "84ed2032e11da90373d9d827b5c7641b0cb18a659e8bd16d6d164e7186b4238f",
         "ab2dc1a0940275fc90e682419183641997a89ee4070159720505278e00b520c0",
         "7614b928bb311dede7e99b106708466f0b872e96148b2392e799c9d0d59555a1",
-        "56fcaea6e15b4ab396c2d234d9cf11f7e6a759ea97b4336936e7f9e53c937c49",
-        "8fa3fede86a463ad952ce2a43573dd01f8ad6c23d348e5be446f44cd7503dab2",
-        "50cf6d8069a38c66ea91e4666c1ae355d36a2656573462b9bd23e06e31c85dce",
-        "a524e1fa9520ead88a9e55bc995c9577f87e2e72cbf514928f8fc53dbeedc32d"
+        "7249e6e0af1946832ca17caae31901e2c0b3ef4ac2f455b4ae44a3d79075c3e7",
+        "6301f1f72a65b362fd9c8131d749a155d92bcb630b01fb1afd8de12133ea8769",
+        "d9ac9b035219f37a95571076332d574252dba1771e06683c27cd9413ebc9e275",
+        "058a8ee050ebc3408d8db955dacedf210313752094638af11261e80a36ecf3e2"
       ],
-      "joined_sha256": "32fde2406bee823b738bd8af4644d30afa1f6b48cb35d157201d5006729f9f94"
+      "joined_sha256": "0c5ca931f321d41cdc190e33ff5beacddf11859a1d78aba4b1fc4173f8da2f0a"
     },
     "meta_none": {
       "block_bytes": [
@@ -236,14 +230,14 @@
         540,
         308,
         148,
-        1036,
+        1084,
         26,
         76,
         53,
-        828,
-        725,
-        700,
-        750
+        1034,
+        911,
+        880,
+        934
       ],
       "block_count": 12,
       "block_sha256": [
@@ -251,313 +245,313 @@
         "a30f9cae26811ad3a59aa64013166c97ee55f58db2a68fd263a7082e4609eab7",
         "cd3bcd45cb9898bb3aa5a080ef8c7ca3a852d910a6febbe1a162818e3bcaac33",
         "5a291bed27316ffbebf6a3877bbfca31d9a51046b2e07cf34c751d0f2db820e4",
-        "822a98aa4b7f1f3a881aa3637f0c671103e2bed94beec4bd793d14ae9a0e21a9",
+        "2bd4e973c9e2c7ec046dd26b8f788c2d9c35f2f10d4e2733c7b8ccf8f32d6826",
         "84ed2032e11da90373d9d827b5c7641b0cb18a659e8bd16d6d164e7186b4238f",
         "ab2dc1a0940275fc90e682419183641997a89ee4070159720505278e00b520c0",
         "7614b928bb311dede7e99b106708466f0b872e96148b2392e799c9d0d59555a1",
-        "56fcaea6e15b4ab396c2d234d9cf11f7e6a759ea97b4336936e7f9e53c937c49",
-        "8fa3fede86a463ad952ce2a43573dd01f8ad6c23d348e5be446f44cd7503dab2",
-        "50cf6d8069a38c66ea91e4666c1ae355d36a2656573462b9bd23e06e31c85dce",
-        "a524e1fa9520ead88a9e55bc995c9577f87e2e72cbf514928f8fc53dbeedc32d"
+        "7249e6e0af1946832ca17caae31901e2c0b3ef4ac2f455b4ae44a3d79075c3e7",
+        "6301f1f72a65b362fd9c8131d749a155d92bcb630b01fb1afd8de12133ea8769",
+        "d9ac9b035219f37a95571076332d574252dba1771e06683c27cd9413ebc9e275",
+        "058a8ee050ebc3408d8db955dacedf210313752094638af11261e80a36ecf3e2"
       ],
-      "joined_sha256": "eb531b9af45240fe1f64591e28fe6cef4be9a6bd66bc2818af425840a145b4b9"
+      "joined_sha256": "b5c2dceb468961356e4e4a440c2c72f0f63ce5b8f5a0970027c0f2f24a0c330a"
     },
     "meta_standard": {
       "block_bytes": [
         4275,
-        995,
+        964,
         308,
-        723,
-        1036,
+        664,
+        1084,
         26,
         76,
         53,
-        892,
-        790,
-        768,
-        822
+        1098,
+        976,
+        948,
+        1006
       ],
       "block_count": 12,
       "block_sha256": [
         "5094bf555bdc85a3146f3f329e0f11375cb377688b220930d5e550c1a004cccb",
-        "0c6fd15aecfa9d9b5e9ff93317fc1dfdfdd19a229aad8ce0ee97af21942f3553",
+        "6468d082207ae621df9a9c7db1dc8b340576b1609f12139769a4bef4d714a675",
         "cd3bcd45cb9898bb3aa5a080ef8c7ca3a852d910a6febbe1a162818e3bcaac33",
-        "75eb9fbc3aea9e311089820015a263b0a13efccac3d84ad8769ed68783edf2bc",
-        "822a98aa4b7f1f3a881aa3637f0c671103e2bed94beec4bd793d14ae9a0e21a9",
+        "7792107445410f74a705049bff6d6876dc87b7d2cde9e386de41ce0f4109103a",
+        "2bd4e973c9e2c7ec046dd26b8f788c2d9c35f2f10d4e2733c7b8ccf8f32d6826",
         "84ed2032e11da90373d9d827b5c7641b0cb18a659e8bd16d6d164e7186b4238f",
         "ab2dc1a0940275fc90e682419183641997a89ee4070159720505278e00b520c0",
         "7614b928bb311dede7e99b106708466f0b872e96148b2392e799c9d0d59555a1",
-        "ce008e7b5845c069e9e76526bfedd15ee2ed0c8cd8405c71d348b8f035c5d28a",
-        "9de035fd2cee4ed290bf7e42da984d7e2832d26f5b4f0ab54eedcb9339f2594d",
-        "f2c7705f1b5c7a72a4997b7d915bb834ea978572ac2c706e13b76ea024caf0e3",
-        "d32e50553b95ddea77da9625a124524a4613d97f2f30fd6e9ec0d262057dc15c"
+        "1758c4b280e5c383406aa73530526787e005d21eb7c7076f0e0b352803868612",
+        "7fffc3632f897f7b62fa536e8dc2536342bddd56ede46cddbe401e2c2ac94589",
+        "e5ada0821689f7e80f38da8572f1922dae42e847baa0ef5ea71c89870ec6470e",
+        "5ff7190b0ea5affe727c43c197f6db6516d02a11018deff82e29cd9959876f66"
       ],
-      "joined_sha256": "ee099ab269389ce15de723380b7cfde8dd2dca7b52c3c4032db1c8c775d750df"
+      "joined_sha256": "5864ac666567cfda1c7fc95c02464c9a0e6cba50ae55c020fde89d8c2bcb023a"
     },
     "multi_repo": {
       "block_bytes": [
         4240,
-        1285,
+        1244,
         344,
-        773,
-        1453,
+        713,
+        1513,
         26,
         112,
         53,
-        1036,
-        923,
-        897,
-        953,
+        1281,
+        1145,
+        1111,
+        1172,
         47,
-        808
+        1014
       ],
       "block_count": 14,
       "block_sha256": [
         "13f0b5272b02c15f84d2e489c257d9cfb042391ea578e32e48988fe5ae773c4c",
-        "78f2c4089f19d0e4e19e0638339f1adcc9a1a41fed1f88ffc135b1d5d9bf35f2",
+        "9433c0942612a11b1157e0d2711c76c0688c26d822c49c49c1df22fcb3250d94",
         "259439a2b50ca2ed534972e0d1e773569eaf11aa527d9e482f8c55141f06096c",
-        "cac300096206f059876ea3feb4988039b93cdb3ddf8ccf19d6a33a6d377e9ba9",
-        "46b01891c0e96210850c2ee27d97a5cdc58a231112c2ffb3f9466105232ed990",
+        "dbe980a4176b3ac0e7ee386ec6384f73746f9b93778cd2ef2eaf69bf856a21ee",
+        "f9fc9aba650fd930ab554525410cdcf7a8b49516a267023cc1346cb3e7e5a79c",
         "84ed2032e11da90373d9d827b5c7641b0cb18a659e8bd16d6d164e7186b4238f",
         "b4bbe8deb4472b3b6b7fb1a7a885e291080784ebc5d33539a3b6083c55ab65c3",
         "7614b928bb311dede7e99b106708466f0b872e96148b2392e799c9d0d59555a1",
-        "86d463ae57eca44d757a2e8fb07f2a502a0f15bd19f5003e9f69c48131ccc8e3",
-        "f228fa401a3c29865177b73cc663c85879c10a645b1c1cc11a4fd9bfceccac11",
-        "43e4da9df031fb1612d7ec501b2dc80458169f4da2dd9300590c0cc78b7843ca",
-        "5a79a58b9fe93141e646835287f5eab0debc81762e0f90344acabbc4ce729ed0",
+        "7ebf25de4980bf80ceb9c79d1f84d4f4a4b463ba9a528442f2abfdc4ada74240",
+        "fd4f7feadc2ed6202b33cd67be45a35b4b405ac686b85005a435d08c0d4f63f1",
+        "074a3b09ed04b00f00d0addefbe1aed7c8372b329bde8a615154f04b2e7665b6",
+        "b3b83b47918869dbb47a60fc114d18a1449c3dbd5ea3eb2a0eefaeed5113ffed",
         "7da12aa97e401d6c84916e02b4c63a23faa9924c65e77f96b50df424f884a785",
-        "1c7289435cd25af0357656e07f9086a6c324a2c5cf647a59b2f71a483fadd971"
+        "1eafb5a801fdb469717a2faf45fecf8119064dd2bd5a95a64ea5d83ed76ff8d6"
       ],
-      "joined_sha256": "df1d6953ac91352678341ee060127991d9fa01fcefa6a80fb58ad6e8405f7180"
+      "joined_sha256": "d13c47992176a550c81a5d9cf5190c049b3316b9dd42177ae1c93a17efc486d2"
     },
     "organism": {
       "block_bytes": [
         4213,
-        1114,
+        1074,
         487,
         308,
-        723,
-        1036,
+        664,
+        1084,
         26,
         76,
         53,
-        1036,
-        923,
-        897,
-        953
+        1281,
+        1145,
+        1111,
+        1172
       ],
       "block_count": 13,
       "block_sha256": [
         "a871af86dcd6df9b402285707e090d61ff2ee9b7b46b3df796f9c5db86ab10ba",
-        "947c50cb1f9db1051246c8916222eb04515460adc4526f7e309bab214a8effd8",
+        "00f33d79838c1dc60186463b632a6e625b18d768f16eeccad83f96e54a0538d7",
         "64a127646974be8353e4961aefb8a8b0b95ffa16d3d0b41b22f60d66a2eb5dcb",
         "cd3bcd45cb9898bb3aa5a080ef8c7ca3a852d910a6febbe1a162818e3bcaac33",
-        "75eb9fbc3aea9e311089820015a263b0a13efccac3d84ad8769ed68783edf2bc",
-        "822a98aa4b7f1f3a881aa3637f0c671103e2bed94beec4bd793d14ae9a0e21a9",
+        "7792107445410f74a705049bff6d6876dc87b7d2cde9e386de41ce0f4109103a",
+        "2bd4e973c9e2c7ec046dd26b8f788c2d9c35f2f10d4e2733c7b8ccf8f32d6826",
         "84ed2032e11da90373d9d827b5c7641b0cb18a659e8bd16d6d164e7186b4238f",
         "ab2dc1a0940275fc90e682419183641997a89ee4070159720505278e00b520c0",
         "7614b928bb311dede7e99b106708466f0b872e96148b2392e799c9d0d59555a1",
-        "86d463ae57eca44d757a2e8fb07f2a502a0f15bd19f5003e9f69c48131ccc8e3",
-        "f228fa401a3c29865177b73cc663c85879c10a645b1c1cc11a4fd9bfceccac11",
-        "43e4da9df031fb1612d7ec501b2dc80458169f4da2dd9300590c0cc78b7843ca",
-        "5a79a58b9fe93141e646835287f5eab0debc81762e0f90344acabbc4ce729ed0"
+        "7ebf25de4980bf80ceb9c79d1f84d4f4a4b463ba9a528442f2abfdc4ada74240",
+        "fd4f7feadc2ed6202b33cd67be45a35b4b405ac686b85005a435d08c0d4f63f1",
+        "074a3b09ed04b00f00d0addefbe1aed7c8372b329bde8a615154f04b2e7665b6",
+        "b3b83b47918869dbb47a60fc114d18a1449c3dbd5ea3eb2a0eefaeed5113ffed"
       ],
-      "joined_sha256": "e52e9e45504b4053f86f476f2c8c299fc28d54616320e0ddca1a313378b3abdc"
+      "joined_sha256": "1e462dc47c81cfdb3d2485d0625c1f901a6ec0dd8c59712058e84a1b92ad8879"
     },
     "path_filter": {
       "block_bytes": [
-        4540,
-        680,
+        4688,
+        673,
         186,
-        250,
-        620,
+        243,
+        632,
         26,
         76,
         53,
-        822
+        1006
       ],
       "block_count": 9,
       "block_sha256": [
-        "c38e7a89aa4112bbfe0ef7b795ad81875015833aa0801670560b29d57ee742b7",
-        "4cea799e2c1d13ca0c788d0a93e798f0498d55158e63fdb5ab3ef407bd7e6b49",
+        "b4638a6338cffefe15fc9d4650c144489ebea44541c133e536dee2e66fcfeee5",
+        "e958c341c9c9ddf6e481db137f3e3212c7832039c16034172a732e15059a0bdc",
         "865327024feb55b30e557356754d27a457f51259be807ee6f979ebd0ad27f213",
-        "6e512c0e71a24d01f9aac58be33f8edd98533c83a54bee643b11c224b8ef7e0b",
-        "7ab891a810f7deb295cad9adebf8533bd456188a9777bf2bee11b163caffa1a1",
+        "d4dfca0d51042fc66b48c94c2c0adc43d453eff57568eb0f42dd82ecc2037e2a",
+        "9e63beb261d33483cd1e417849f8292553d525409702b818c9909ac3673123ff",
         "84ed2032e11da90373d9d827b5c7641b0cb18a659e8bd16d6d164e7186b4238f",
         "ab2dc1a0940275fc90e682419183641997a89ee4070159720505278e00b520c0",
         "7614b928bb311dede7e99b106708466f0b872e96148b2392e799c9d0d59555a1",
-        "d32e50553b95ddea77da9625a124524a4613d97f2f30fd6e9ec0d262057dc15c"
+        "5ff7190b0ea5affe727c43c197f6db6516d02a11018deff82e29cd9959876f66"
       ],
-      "joined_sha256": "f214792a313dbe077fac27f56444c82f90604e18f7aa0ce9205a3375383047d5"
+      "joined_sha256": "96d8499e3925491075ac37ef0fe3c1288c46fcb95ec0f364205352d9028acf54"
     },
     "plan_only": {
       "block_bytes": [
-        3992,
-        1114
+        4117,
+        540
       ],
       "block_count": 2,
       "block_sha256": [
-        "8890217f988e6442945ef67f83ad82d930b3f744c960ad5dc2ff611e07819021",
-        "947c50cb1f9db1051246c8916222eb04515460adc4526f7e309bab214a8effd8"
+        "65899fd16cf5206c8c460ec9c7ffaeb8d391e964795cff5b953d435fd6a12435",
+        "e05d08d3674a87ec2e4016d2782b0be4205bb430c336c77683808ecfd69ad6ea"
       ],
-      "joined_sha256": "382696e05d093e4677a4d72ce9b985257e7362fc144fd6fcc1f31767ad58bfd9"
+      "joined_sha256": "484b76644943f2bcecf038ff192f759a2da4f2e53011e936f7201edbcc471f73"
     },
     "profile_machine_lean": {
       "block_bytes": [
-        4469,
-        1114,
-        723,
-        1036,
+        4598,
+        1074,
+        664,
+        1084,
         26,
         76,
         53,
-        1036,
-        923,
-        897,
-        953
+        1281,
+        1145,
+        1111,
+        1172
       ],
       "block_count": 11,
       "block_sha256": [
-        "7d4a7dd597d57e0facd0584a1426d9bae7dfda6c798eb10618e4d5ee7a857baf",
-        "947c50cb1f9db1051246c8916222eb04515460adc4526f7e309bab214a8effd8",
-        "75eb9fbc3aea9e311089820015a263b0a13efccac3d84ad8769ed68783edf2bc",
-        "822a98aa4b7f1f3a881aa3637f0c671103e2bed94beec4bd793d14ae9a0e21a9",
+        "c0105ca1a284dc613d3bf7c26cc53679763a73af97c49300733ce54515174436",
+        "00f33d79838c1dc60186463b632a6e625b18d768f16eeccad83f96e54a0538d7",
+        "7792107445410f74a705049bff6d6876dc87b7d2cde9e386de41ce0f4109103a",
+        "2bd4e973c9e2c7ec046dd26b8f788c2d9c35f2f10d4e2733c7b8ccf8f32d6826",
         "84ed2032e11da90373d9d827b5c7641b0cb18a659e8bd16d6d164e7186b4238f",
         "ab2dc1a0940275fc90e682419183641997a89ee4070159720505278e00b520c0",
         "7614b928bb311dede7e99b106708466f0b872e96148b2392e799c9d0d59555a1",
-        "86d463ae57eca44d757a2e8fb07f2a502a0f15bd19f5003e9f69c48131ccc8e3",
-        "f228fa401a3c29865177b73cc663c85879c10a645b1c1cc11a4fd9bfceccac11",
-        "43e4da9df031fb1612d7ec501b2dc80458169f4da2dd9300590c0cc78b7843ca",
-        "5a79a58b9fe93141e646835287f5eab0debc81762e0f90344acabbc4ce729ed0"
+        "7ebf25de4980bf80ceb9c79d1f84d4f4a4b463ba9a528442f2abfdc4ada74240",
+        "fd4f7feadc2ed6202b33cd67be45a35b4b405ac686b85005a435d08c0d4f63f1",
+        "074a3b09ed04b00f00d0addefbe1aed7c8372b329bde8a615154f04b2e7665b6",
+        "b3b83b47918869dbb47a60fc114d18a1449c3dbd5ea3eb2a0eefaeed5113ffed"
       ],
-      "joined_sha256": "a285100e36a3cabf7ad10eb1b8af34c67c801a2352453c84a98a3907ff08b946"
+      "joined_sha256": "a5532df9854c213eaa0bbd4ff336708ab24e6b709762da0760f0744312ceff71"
     },
     "profile_max": {
       "block_bytes": [
         4214,
-        1114,
+        1074,
         308,
-        723,
-        1036,
+        664,
+        1084,
         26,
         76,
         53,
-        1036,
-        923,
-        897,
-        953
+        1281,
+        1145,
+        1111,
+        1172
       ],
       "block_count": 12,
       "block_sha256": [
         "54131ee7b74b3764eda3699b97708b7ac1a7116b4dde12dea987d3b669680fa6",
-        "947c50cb1f9db1051246c8916222eb04515460adc4526f7e309bab214a8effd8",
+        "00f33d79838c1dc60186463b632a6e625b18d768f16eeccad83f96e54a0538d7",
         "cd3bcd45cb9898bb3aa5a080ef8c7ca3a852d910a6febbe1a162818e3bcaac33",
-        "75eb9fbc3aea9e311089820015a263b0a13efccac3d84ad8769ed68783edf2bc",
-        "822a98aa4b7f1f3a881aa3637f0c671103e2bed94beec4bd793d14ae9a0e21a9",
+        "7792107445410f74a705049bff6d6876dc87b7d2cde9e386de41ce0f4109103a",
+        "2bd4e973c9e2c7ec046dd26b8f788c2d9c35f2f10d4e2733c7b8ccf8f32d6826",
         "84ed2032e11da90373d9d827b5c7641b0cb18a659e8bd16d6d164e7186b4238f",
         "ab2dc1a0940275fc90e682419183641997a89ee4070159720505278e00b520c0",
         "7614b928bb311dede7e99b106708466f0b872e96148b2392e799c9d0d59555a1",
-        "86d463ae57eca44d757a2e8fb07f2a502a0f15bd19f5003e9f69c48131ccc8e3",
-        "f228fa401a3c29865177b73cc663c85879c10a645b1c1cc11a4fd9bfceccac11",
-        "43e4da9df031fb1612d7ec501b2dc80458169f4da2dd9300590c0cc78b7843ca",
-        "5a79a58b9fe93141e646835287f5eab0debc81762e0f90344acabbc4ce729ed0"
+        "7ebf25de4980bf80ceb9c79d1f84d4f4a4b463ba9a528442f2abfdc4ada74240",
+        "fd4f7feadc2ed6202b33cd67be45a35b4b405ac686b85005a435d08c0d4f63f1",
+        "074a3b09ed04b00f00d0addefbe1aed7c8372b329bde8a615154f04b2e7665b6",
+        "b3b83b47918869dbb47a60fc114d18a1449c3dbd5ea3eb2a0eefaeed5113ffed"
       ],
-      "joined_sha256": "51d7dd957c2b819fed969d8d561311d15564eb945143569082450d6357a7ba5b"
+      "joined_sha256": "b671c2c083ddcf8b4f64bbc27355869f849a1e6021b1bcd7f0d6301f0a87d5a6"
     },
     "profile_summary": {
       "block_bytes": [
-        4536,
-        972,
+        4660,
+        939,
         308,
-        723,
-        1041,
+        664,
+        1089,
         26,
         76,
         53,
-        1036,
-        923,
-        897
+        1281,
+        1145,
+        1111
       ],
       "block_count": 11,
       "block_sha256": [
-        "7edf4f3f6169a9406a7cd2c36239bd4f5f4236858fd663b9e741b5178641e59f",
-        "7c05293485cf57d2005ea0e1bdcfc5975e185d79eb10bea286b3fd13cd2aea54",
+        "d0a25a75326f4a1ba74e18afe3b145c63693c8309c41e41accb046462d246a24",
+        "fb2dce3d9a99c8cbe7205eca17c709b965dc3953695e474a9490fefadf01eb82",
         "cd3bcd45cb9898bb3aa5a080ef8c7ca3a852d910a6febbe1a162818e3bcaac33",
-        "75eb9fbc3aea9e311089820015a263b0a13efccac3d84ad8769ed68783edf2bc",
-        "dd48b0b2ca367f2eea5ee5cbe2a04e82f06eb9a11407b7ea12fa35861c0aecae",
+        "7792107445410f74a705049bff6d6876dc87b7d2cde9e386de41ce0f4109103a",
+        "1264450e97af820f6d1d15db4308992e73667924f7112d9ef32239047b0caa79",
         "84ed2032e11da90373d9d827b5c7641b0cb18a659e8bd16d6d164e7186b4238f",
         "ab2dc1a0940275fc90e682419183641997a89ee4070159720505278e00b520c0",
         "7614b928bb311dede7e99b106708466f0b872e96148b2392e799c9d0d59555a1",
-        "86d463ae57eca44d757a2e8fb07f2a502a0f15bd19f5003e9f69c48131ccc8e3",
-        "f228fa401a3c29865177b73cc663c85879c10a645b1c1cc11a4fd9bfceccac11",
-        "43e4da9df031fb1612d7ec501b2dc80458169f4da2dd9300590c0cc78b7843ca"
+        "7ebf25de4980bf80ceb9c79d1f84d4f4a4b463ba9a528442f2abfdc4ada74240",
+        "fd4f7feadc2ed6202b33cd67be45a35b4b405ac686b85005a435d08c0d4f63f1",
+        "074a3b09ed04b00f00d0addefbe1aed7c8372b329bde8a615154f04b2e7665b6"
       ],
-      "joined_sha256": "e8bb9d09568a1d89ad9d1a31cfda467393d831d51905cb3f6ead81450ec1be8f"
+      "joined_sha256": "770a683b16294b0b7cb51e15ddd39c5eb15a7f6bb1436aa0a54947f0bb5ec4b6"
     },
     "redaction": {
       "block_bytes": [
         4214,
-        1114,
+        1074,
         308,
-        723,
-        1036,
+        664,
+        1084,
         26,
         76,
         53,
-        1036,
-        923,
-        897,
-        931
+        1281,
+        1145,
+        1111,
+        1150
       ],
       "block_count": 12,
       "block_sha256": [
         "54131ee7b74b3764eda3699b97708b7ac1a7116b4dde12dea987d3b669680fa6",
-        "947c50cb1f9db1051246c8916222eb04515460adc4526f7e309bab214a8effd8",
+        "00f33d79838c1dc60186463b632a6e625b18d768f16eeccad83f96e54a0538d7",
         "cd3bcd45cb9898bb3aa5a080ef8c7ca3a852d910a6febbe1a162818e3bcaac33",
-        "75eb9fbc3aea9e311089820015a263b0a13efccac3d84ad8769ed68783edf2bc",
-        "822a98aa4b7f1f3a881aa3637f0c671103e2bed94beec4bd793d14ae9a0e21a9",
+        "7792107445410f74a705049bff6d6876dc87b7d2cde9e386de41ce0f4109103a",
+        "2bd4e973c9e2c7ec046dd26b8f788c2d9c35f2f10d4e2733c7b8ccf8f32d6826",
         "84ed2032e11da90373d9d827b5c7641b0cb18a659e8bd16d6d164e7186b4238f",
         "ab2dc1a0940275fc90e682419183641997a89ee4070159720505278e00b520c0",
         "7614b928bb311dede7e99b106708466f0b872e96148b2392e799c9d0d59555a1",
-        "86d463ae57eca44d757a2e8fb07f2a502a0f15bd19f5003e9f69c48131ccc8e3",
-        "f228fa401a3c29865177b73cc663c85879c10a645b1c1cc11a4fd9bfceccac11",
-        "43e4da9df031fb1612d7ec501b2dc80458169f4da2dd9300590c0cc78b7843ca",
-        "98e2ba3c2317e6c2e33b25b4de6a2b0c40e27f8e5aa8312d9f763fd27b186d58"
+        "7ebf25de4980bf80ceb9c79d1f84d4f4a4b463ba9a528442f2abfdc4ada74240",
+        "fd4f7feadc2ed6202b33cd67be45a35b4b405ac686b85005a435d08c0d4f63f1",
+        "074a3b09ed04b00f00d0addefbe1aed7c8372b329bde8a615154f04b2e7665b6",
+        "cb0a95863906402e999e5cc0d22bba13deb17ef16f798b3e36b2a64681d1c697"
       ],
-      "joined_sha256": "8ba1fd192914acdd91c68c33369f5977d0cb2fb0f7b5865722d401a222b66dbf"
+      "joined_sha256": "4a90b701313bba5a237795839a8db3d0ef599edb9ff11e556b60801e53cf122c"
     },
     "truncation": {
       "block_bytes": [
         4213,
-        1114,
+        1074,
         308,
-        723,
-        1036,
+        664,
+        1084,
         26,
         76,
         53,
-        1036,
-        923,
-        897,
-        953
+        1281,
+        1145,
+        1111,
+        1172
       ],
       "block_count": 12,
       "block_sha256": [
         "35f18004b28439970022c1f9275ff2e9e33758cf6200f67b9ddb15db3bdc4aa0",
-        "947c50cb1f9db1051246c8916222eb04515460adc4526f7e309bab214a8effd8",
+        "00f33d79838c1dc60186463b632a6e625b18d768f16eeccad83f96e54a0538d7",
         "cd3bcd45cb9898bb3aa5a080ef8c7ca3a852d910a6febbe1a162818e3bcaac33",
-        "75eb9fbc3aea9e311089820015a263b0a13efccac3d84ad8769ed68783edf2bc",
-        "822a98aa4b7f1f3a881aa3637f0c671103e2bed94beec4bd793d14ae9a0e21a9",
+        "7792107445410f74a705049bff6d6876dc87b7d2cde9e386de41ce0f4109103a",
+        "2bd4e973c9e2c7ec046dd26b8f788c2d9c35f2f10d4e2733c7b8ccf8f32d6826",
         "84ed2032e11da90373d9d827b5c7641b0cb18a659e8bd16d6d164e7186b4238f",
         "ab2dc1a0940275fc90e682419183641997a89ee4070159720505278e00b520c0",
         "7614b928bb311dede7e99b106708466f0b872e96148b2392e799c9d0d59555a1",
-        "86d463ae57eca44d757a2e8fb07f2a502a0f15bd19f5003e9f69c48131ccc8e3",
-        "f228fa401a3c29865177b73cc663c85879c10a645b1c1cc11a4fd9bfceccac11",
-        "43e4da9df031fb1612d7ec501b2dc80458169f4da2dd9300590c0cc78b7843ca",
-        "5a79a58b9fe93141e646835287f5eab0debc81762e0f90344acabbc4ce729ed0"
+        "7ebf25de4980bf80ceb9c79d1f84d4f4a4b463ba9a528442f2abfdc4ada74240",
+        "fd4f7feadc2ed6202b33cd67be45a35b4b405ac686b85005a435d08c0d4f63f1",
+        "074a3b09ed04b00f00d0addefbe1aed7c8372b329bde8a615154f04b2e7665b6",
+        "b3b83b47918869dbb47a60fc114d18a1449c3dbd5ea3eb2a0eefaeed5113ffed"
       ],
-      "joined_sha256": "be981ea5d8e842307e2bcc6bf50834f0e052da6b55d3e7ac2b166e86a486377c"
+      "joined_sha256": "630ee6a224927015fc5565fa772ea7a2ae9a0fff339f4d32e49633b04b5c8f1d"
     }
   },
-  "version": "1.0"
+  "schema_version": 2
 }

--- a/merger/repoground/tests/fixtures/report_renderer/golden/full_extras.blocks.json
+++ b/merger/repoground/tests/fixtures/report_renderer/golden/full_extras.blocks.json
@@ -7,9 +7,9 @@
       "sha256": "900d53c270d66eb143c0a776a1e9dfdc175c1468bcb95b7e47985318ebe8915d"
     },
     {
-      "bytes": 1189,
+      "bytes": 1149,
       "index": 1,
-      "sha256": "b007a2259970f8088d51e01ea9e218953e4dfd08f194ccbad59f819e0cfa8b82"
+      "sha256": "476a05eea27ae03f24f495b208fcc60f8b4c23a780fe0120a8f63c032b23eeba"
     },
     {
       "bytes": 209,
@@ -32,14 +32,14 @@
       "sha256": "cd3bcd45cb9898bb3aa5a080ef8c7ca3a852d910a6febbe1a162818e3bcaac33"
     },
     {
-      "bytes": 723,
+      "bytes": 664,
       "index": 6,
-      "sha256": "75eb9fbc3aea9e311089820015a263b0a13efccac3d84ad8769ed68783edf2bc"
+      "sha256": "7792107445410f74a705049bff6d6876dc87b7d2cde9e386de41ce0f4109103a"
     },
     {
-      "bytes": 1036,
+      "bytes": 1084,
       "index": 7,
-      "sha256": "822a98aa4b7f1f3a881aa3637f0c671103e2bed94beec4bd793d14ae9a0e21a9"
+      "sha256": "2bd4e973c9e2c7ec046dd26b8f788c2d9c35f2f10d4e2733c7b8ccf8f32d6826"
     },
     {
       "bytes": 26,
@@ -57,25 +57,25 @@
       "sha256": "7614b928bb311dede7e99b106708466f0b872e96148b2392e799c9d0d59555a1"
     },
     {
-      "bytes": 1036,
+      "bytes": 1281,
       "index": 11,
-      "sha256": "86d463ae57eca44d757a2e8fb07f2a502a0f15bd19f5003e9f69c48131ccc8e3"
+      "sha256": "7ebf25de4980bf80ceb9c79d1f84d4f4a4b463ba9a528442f2abfdc4ada74240"
     },
     {
-      "bytes": 923,
+      "bytes": 1145,
       "index": 12,
-      "sha256": "f228fa401a3c29865177b73cc663c85879c10a645b1c1cc11a4fd9bfceccac11"
+      "sha256": "fd4f7feadc2ed6202b33cd67be45a35b4b405ac686b85005a435d08c0d4f63f1"
     },
     {
-      "bytes": 897,
+      "bytes": 1111,
       "index": 13,
-      "sha256": "43e4da9df031fb1612d7ec501b2dc80458169f4da2dd9300590c0cc78b7843ca"
+      "sha256": "074a3b09ed04b00f00d0addefbe1aed7c8372b329bde8a615154f04b2e7665b6"
     },
     {
-      "bytes": 953,
+      "bytes": 1172,
       "index": 14,
-      "sha256": "5a79a58b9fe93141e646835287f5eab0debc81762e0f90344acabbc4ce729ed0"
+      "sha256": "b3b83b47918869dbb47a60fc114d18a1449c3dbd5ea3eb2a0eefaeed5113ffed"
     }
   ],
-  "joined_sha256": "1d7abab0ae02e15961285947559602b59ca3837d5049ae632beded45d60044cf"
+  "joined_sha256": "9a9b833a49aa2c09e205d8f045d4da35b6eac5abcc61c766fa58c4730d729459"
 }

--- a/merger/repoground/tests/fixtures/report_renderer/golden/full_extras.txt
+++ b/merger/repoground/tests/fixtures/report_renderer/golden/full_extras.txt
@@ -173,10 +173,10 @@ _No specific recommendations found._
 - `report-fixture` → 4 files (4 relevant text, 354.00 B, 4 with content)
 
 ### Hotspots (Einstiegspunkte)
-- [`src/main.py`](#file-report-fixture-src-main-py-88ded1) — repo `report-fixture`, source; roles: entrypoint, ai-context, tags: entrypoint
-- [`.github/workflows/ci.yml`](#file-report-fixture-github-workflows-ci-yml-f650d0) — repo `report-fixture`, config; roles: config, tags: ci
-- [`README.md`](#file-report-fixture-readme-md-2165fe) — repo `report-fixture`, doc; roles: doc-essential, ai-context, tags: ai-context
-- [`docs/guide.md`](#file-report-fixture-docs-guide-md-499434) — repo `report-fixture`, doc; roles: -, tags: runbook
+- [`src/main.py`](#file-f_66ed99155b80ba69acae3b5c) — repo `report-fixture`, source; roles: entrypoint, ai-context, tags: entrypoint
+- [`.github/workflows/ci.yml`](#file-f_23bf81dccf388d200ca09080) — repo `report-fixture`, config; roles: config, tags: ci
+- [`README.md`](#file-f_feb1aca1bd0f849da752c8ac) — repo `report-fixture`, doc; roles: doc-essential, ai-context, tags: ai-context
+- [`docs/guide.md`](#file-f_94339037c6de70b8f9077dc4) — repo `report-fixture`, doc; roles: -, tags: runbook
 
 **Folder Highlights:**
 - Code: `src`
@@ -275,23 +275,23 @@ _Kein WGX-/Fleet-Profil gefunden._
 <a id="cat-source"></a>
 ## Category: source
 
-- [`src/main.py`](#file-report-fixture-src-main-py-88ded1)
+- [`src/main.py`](#file-f_66ed99155b80ba69acae3b5c)
 
 <a id="cat-doc"></a>
 ## Category: doc
 
-- [`docs/guide.md`](#file-report-fixture-docs-guide-md-499434)
-- [`README.md`](#file-report-fixture-readme-md-2165fe)
+- [`docs/guide.md`](#file-f_94339037c6de70b8f9077dc4)
+- [`README.md`](#file-f_feb1aca1bd0f849da752c8ac)
 
 <a id="cat-config"></a>
 ## Category: config
 
-- [`.github/workflows/ci.yml`](#file-report-fixture-github-workflows-ci-yml-f650d0)
+- [`.github/workflows/ci.yml`](#file-f_23bf81dccf388d200ca09080)
 
 <a id="tag-ci"></a>
 ## Tag: ci
 
-- [`.github/workflows/ci.yml`](#file-report-fixture-github-workflows-ci-yml-f650d0)
+- [`.github/workflows/ci.yml`](#file-f_23bf81dccf388d200ca09080)
 
 <!-- zone:end type="index" id="index" -->
 <!-- zone:begin type="manifest" id="manifest" -->
@@ -308,10 +308,10 @@ _Kein WGX-/Fleet-Profil gefunden._
 
 | Path | Category | Tags | Role? | Depends? | Size | Included | MD5 |
 | --- | --- | --- | --- | --- | ---: | --- | --- |
-| [`.github/workflows/ci.yml`](#file-f_aea515f51797) | `config` | ci | config | - | 103.00 B | `full` | `f650d0deedc3c05d604d8de1aa69f959` |
-| [`docs/guide.md`](#file-f_2249f25d45e2) | `doc` | runbook | - | - | 69.00 B | `full` | `49943417cc5ee07b655782cbc6aaf25a` |
-| [`README.md`](#file-f_2b7bcd1068a3) | `doc` | ai-context | doc-essential, ai-context | - | 72.00 B | `full` | `2165fe2897e6317ef43824778ebf1e29` |
-| [`src/main.py`](#file-f_c8b4581f6615) | `source` | entrypoint | entrypoint, ai-context | - | 110.00 B | `full` | `88ded152782ad0251049214f8bad72b7` |
+| [`.github/workflows/ci.yml`](#file-f_23bf81dccf388d200ca09080) | `config` | ci | config | - | 103.00 B | `full` | `f650d0deedc3c05d604d8de1aa69f959` |
+| [`docs/guide.md`](#file-f_94339037c6de70b8f9077dc4) | `doc` | runbook | - | - | 69.00 B | `full` | `49943417cc5ee07b655782cbc6aaf25a` |
+| [`README.md`](#file-f_feb1aca1bd0f849da752c8ac) | `doc` | ai-context | doc-essential, ai-context | - | 72.00 B | `full` | `2165fe2897e6317ef43824778ebf1e29` |
+| [`src/main.py`](#file-f_66ed99155b80ba69acae3b5c) | `source` | entrypoint | entrypoint, ai-context | - | 110.00 B | `full` | `88ded152782ad0251049214f8bad72b7` |
 
 <!-- zone:end type="manifest" id="manifest" -->
 <!-- START_OF_CONTENT -->
@@ -322,11 +322,10 @@ _Kein WGX-/Fleet-Profil gefunden._
 ### report-fixture
 
 ---
-<!-- FILE_START path=".github/workflows/ci.yml" content_sha256="e59738c25ae0c100af3d28d5c1595a5dd1596326765be4585a5eb43576a79ff3" content_bytes="103" file_bytes="103" truncated="false" -->
-<!-- file:id="FILE:f_aea515f51797" path=".github/workflows/ci.yml" -->
-<a id="file-f_aea515f51797"></a>
+<!-- FILE_START path=".github/workflows/ci.yml" meta="eyJjb250ZW50X2J5dGVzIjoxMDMsImNvbnRlbnRfc2hhMjU2IjoiZTU5NzM4YzI1YWUwYzEwMGFmM2QyOGQ1YzE1OTVhNWRkMTU5NjMyNjc2NWJlNDU4NWE1ZWI0MzU3NmE3OWZmMyIsImZpbGVfYnl0ZXMiOjEwMywicGF0aCI6Ii5naXRodWIvd29ya2Zsb3dzL2NpLnltbCIsInJlcG8iOiJyZXBvcnQtZml4dHVyZSIsInRydW5jYXRlZCI6ZmFsc2V9" -->
+<!-- file:id="FILE:f_23bf81dccf388d200ca09080" path=".github/workflows/ci.yml" -->
 <a id="file-report-fixture-github-workflows-ci-yml"></a>
-<a id="file-report-fixture-github-workflows-ci-yml-f650d0"></a>
+<a id="file-f_23bf81dccf388d200ca09080"></a>
 #### .github/workflows/ci.yml
 
 **Path:** `.github/workflows/ci.yml`
@@ -335,14 +334,8 @@ _Kein WGX-/Fleet-Profil gefunden._
 - Size: 103.00 B
 - Included: full
 - MD5: f650d0deedc3c05d604d8de1aa69f959
-<!--
-file_meta:
-  repo: report-fixture
-  path: .github/workflows/ci.yml
-  lines: 8
-  included: full
--->
-<!-- zone:begin type="code" lang="yaml" id="FILE:f_aea515f51797" -->
+<!-- file_meta meta="eyJpbmNsdWRlZCI6ImZ1bGwiLCJsaW5lcyI6OCwicGF0aCI6Ii5naXRodWIvd29ya2Zsb3dzL2NpLnltbCIsInJlcG8iOiJyZXBvcnQtZml4dHVyZSJ9" -->
+<!-- zone:begin type="code" lang="yaml" id="FILE:f_23bf81dccf388d200ca09080" -->
 
 ```yaml
 name: ci
@@ -356,16 +349,15 @@ jobs:
 
 ```
 
-<!-- zone:end type="code" id="FILE:f_aea515f51797" -->
-<!-- FILE_END path=".github/workflows/ci.yml" -->
+<!-- zone:end type="code" id="FILE:f_23bf81dccf388d200ca09080" -->
+<!-- FILE_END path=".github/workflows/ci.yml" meta="eyJwYXRoIjoiLmdpdGh1Yi93b3JrZmxvd3MvY2kueW1sIiwicmVwbyI6InJlcG9ydC1maXh0dXJlIn0" -->
 [↑ Manifest](#manifest) · [↑ Index](#index)
 
 ---
-<!-- FILE_START path="docs/guide.md" content_sha256="40b859ee8712b5f3c49999529dd7dbfe7a7fd642d14244fcd0d276ee2fa8d212" content_bytes="69" file_bytes="69" truncated="false" -->
-<!-- file:id="FILE:f_2249f25d45e2" path="docs/guide.md" -->
-<a id="file-f_2249f25d45e2"></a>
+<!-- FILE_START path="docs/guide.md" meta="eyJjb250ZW50X2J5dGVzIjo2OSwiY29udGVudF9zaGEyNTYiOiI0MGI4NTllZTg3MTJiNWYzYzQ5OTk5NTI5ZGQ3ZGJmZTdhN2ZkNjQyZDE0MjQ0ZmNkMGQyNzZlZTJmYThkMjEyIiwiZmlsZV9ieXRlcyI6NjksInBhdGgiOiJkb2NzL2d1aWRlLm1kIiwicmVwbyI6InJlcG9ydC1maXh0dXJlIiwidHJ1bmNhdGVkIjpmYWxzZX0" -->
+<!-- file:id="FILE:f_94339037c6de70b8f9077dc4" path="docs/guide.md" -->
 <a id="file-report-fixture-docs-guide-md"></a>
-<a id="file-report-fixture-docs-guide-md-499434"></a>
+<a id="file-f_94339037c6de70b8f9077dc4"></a>
 #### docs/guide.md
 
 **Path:** `docs/guide.md`
@@ -374,14 +366,8 @@ jobs:
 - Size: 69.00 B
 - Included: full
 - MD5: 49943417cc5ee07b655782cbc6aaf25a
-<!--
-file_meta:
-  repo: report-fixture
-  path: docs/guide.md
-  lines: 3
-  included: full
--->
-<!-- zone:begin type="code" lang="markdown" id="FILE:f_2249f25d45e2" -->
+<!-- file_meta meta="eyJpbmNsdWRlZCI6ImZ1bGwiLCJsaW5lcyI6MywicGF0aCI6ImRvY3MvZ3VpZGUubWQiLCJyZXBvIjoicmVwb3J0LWZpeHR1cmUifQ" -->
+<!-- zone:begin type="code" lang="markdown" id="FILE:f_94339037c6de70b8f9077dc4" -->
 
 ```markdown
 # Guide
@@ -390,16 +376,15 @@ The renderer must preserve anchors, order, and exact bytes.
 
 ```
 
-<!-- zone:end type="code" id="FILE:f_2249f25d45e2" -->
-<!-- FILE_END path="docs/guide.md" -->
+<!-- zone:end type="code" id="FILE:f_94339037c6de70b8f9077dc4" -->
+<!-- FILE_END path="docs/guide.md" meta="eyJwYXRoIjoiZG9jcy9ndWlkZS5tZCIsInJlcG8iOiJyZXBvcnQtZml4dHVyZSJ9" -->
 [↑ Manifest](#manifest) · [↑ Index](#index)
 
 ---
-<!-- FILE_START path="README.md" content_sha256="efe2abc999528b98fd4d472eabb4262755261382a586fca2841296999d586dd0" content_bytes="72" file_bytes="72" truncated="false" -->
-<!-- file:id="FILE:f_2b7bcd1068a3" path="README.md" -->
-<a id="file-f_2b7bcd1068a3"></a>
+<!-- FILE_START path="README.md" meta="eyJjb250ZW50X2J5dGVzIjo3MiwiY29udGVudF9zaGEyNTYiOiJlZmUyYWJjOTk5NTI4Yjk4ZmQ0ZDQ3MmVhYmI0MjYyNzU1MjYxMzgyYTU4NmZjYTI4NDEyOTY5OTlkNTg2ZGQwIiwiZmlsZV9ieXRlcyI6NzIsInBhdGgiOiJSRUFETUUubWQiLCJyZXBvIjoicmVwb3J0LWZpeHR1cmUiLCJ0cnVuY2F0ZWQiOmZhbHNlfQ" -->
+<!-- file:id="FILE:f_feb1aca1bd0f849da752c8ac" path="README.md" -->
 <a id="file-report-fixture-readme-md"></a>
-<a id="file-report-fixture-readme-md-2165fe"></a>
+<a id="file-f_feb1aca1bd0f849da752c8ac"></a>
 #### README.md
 
 **Path:** `README.md`
@@ -408,14 +393,8 @@ The renderer must preserve anchors, order, and exact bytes.
 - Size: 72.00 B
 - Included: full
 - MD5: 2165fe2897e6317ef43824778ebf1e29
-<!--
-file_meta:
-  repo: report-fixture
-  path: README.md
-  lines: 3
-  included: full
--->
-<!-- zone:begin type="code" lang="markdown" id="FILE:f_2b7bcd1068a3" -->
+<!-- file_meta meta="eyJpbmNsdWRlZCI6ImZ1bGwiLCJsaW5lcyI6MywicGF0aCI6IlJFQURNRS5tZCIsInJlcG8iOiJyZXBvcnQtZml4dHVyZSJ9" -->
+<!-- zone:begin type="code" lang="markdown" id="FILE:f_feb1aca1bd0f849da752c8ac" -->
 
 ```markdown
 # Report fixture
@@ -424,16 +403,15 @@ A deterministic repository for renderer parity tests.
 
 ```
 
-<!-- zone:end type="code" id="FILE:f_2b7bcd1068a3" -->
-<!-- FILE_END path="README.md" -->
+<!-- zone:end type="code" id="FILE:f_feb1aca1bd0f849da752c8ac" -->
+<!-- FILE_END path="README.md" meta="eyJwYXRoIjoiUkVBRE1FLm1kIiwicmVwbyI6InJlcG9ydC1maXh0dXJlIn0" -->
 [↑ Manifest](#manifest) · [↑ Index](#index)
 
 ---
-<!-- FILE_START path="src/main.py" content_sha256="ff5375a1a60ce75fff653e4a0a93c7ce7e87e133484d322b9b9e38a7485a1e6f" content_bytes="110" file_bytes="110" truncated="false" -->
-<!-- file:id="FILE:f_c8b4581f6615" path="src/main.py" -->
-<a id="file-f_c8b4581f6615"></a>
+<!-- FILE_START path="src/main.py" meta="eyJjb250ZW50X2J5dGVzIjoxMTAsImNvbnRlbnRfc2hhMjU2IjoiZmY1Mzc1YTFhNjBjZTc1ZmZmNjUzZTRhMGE5M2M3Y2U3ZTg3ZTEzMzQ4NGQzMjJiOWI5ZTM4YTc0ODVhMWU2ZiIsImZpbGVfYnl0ZXMiOjExMCwicGF0aCI6InNyYy9tYWluLnB5IiwicmVwbyI6InJlcG9ydC1maXh0dXJlIiwidHJ1bmNhdGVkIjpmYWxzZX0" -->
+<!-- file:id="FILE:f_66ed99155b80ba69acae3b5c" path="src/main.py" -->
 <a id="file-report-fixture-src-main-py"></a>
-<a id="file-report-fixture-src-main-py-88ded1"></a>
+<a id="file-f_66ed99155b80ba69acae3b5c"></a>
 #### src/main.py
 
 **Path:** `src/main.py`
@@ -442,14 +420,8 @@ A deterministic repository for renderer parity tests.
 - Size: 110.00 B
 - Included: full
 - MD5: 88ded152782ad0251049214f8bad72b7
-<!--
-file_meta:
-  repo: report-fixture
-  path: src/main.py
-  lines: 6
-  included: full
--->
-<!-- zone:begin type="code" lang="python" id="FILE:f_c8b4581f6615" -->
+<!-- file_meta meta="eyJpbmNsdWRlZCI6ImZ1bGwiLCJsaW5lcyI6NiwicGF0aCI6InNyYy9tYWluLnB5IiwicmVwbyI6InJlcG9ydC1maXh0dXJlIn0" -->
+<!-- zone:begin type="code" lang="python" id="FILE:f_66ed99155b80ba69acae3b5c" -->
 
 ```python
 """Fixture entrypoint."""
@@ -461,7 +433,7 @@ def main() -> str:
 
 ```
 
-<!-- zone:end type="code" id="FILE:f_c8b4581f6615" -->
-<!-- FILE_END path="src/main.py" -->
+<!-- zone:end type="code" id="FILE:f_66ed99155b80ba69acae3b5c" -->
+<!-- FILE_END path="src/main.py" meta="eyJwYXRoIjoic3JjL21haW4ucHkiLCJyZXBvIjoicmVwb3J0LWZpeHR1cmUifQ" -->
 [↑ Manifest](#manifest) · [↑ Index](#index)
 

--- a/merger/repoground/tests/fixtures/report_renderer/golden/machine_redacted.blocks.json
+++ b/merger/repoground/tests/fixtures/report_renderer/golden/machine_redacted.blocks.json
@@ -2,9 +2,9 @@
   "block_count": 9,
   "blocks": [
     {
-      "bytes": 4443,
+      "bytes": 4572,
       "index": 0,
-      "sha256": "86148273a9c32e6797ab487ccdbd0fdc4dd73c68bf51bf5f087cbd9d8eac92a4"
+      "sha256": "6d9aadf30ada576c65908040766d841df66187f7adf155741a31aac2410a757f"
     },
     {
       "bytes": 525,
@@ -17,9 +17,9 @@
       "sha256": "5a291bed27316ffbebf6a3877bbfca31d9a51046b2e07cf34c751d0f2db820e4"
     },
     {
-      "bytes": 924,
+      "bytes": 948,
       "index": 3,
-      "sha256": "c2d3d38d6090abe5b75c60d3cba3f5db4a601b60fce56887868d3662fbc8147e"
+      "sha256": "9455dd1efd0a88472f3fde3944e4c219c8a68dbc262f2190fc07e57b8359419a"
     },
     {
       "bytes": 26,
@@ -37,15 +37,15 @@
       "sha256": "7614b928bb311dede7e99b106708466f0b872e96148b2392e799c9d0d59555a1"
     },
     {
-      "bytes": 828,
+      "bytes": 1034,
       "index": 7,
-      "sha256": "56fcaea6e15b4ab396c2d234d9cf11f7e6a759ea97b4336936e7f9e53c937c49"
+      "sha256": "7249e6e0af1946832ca17caae31901e2c0b3ef4ac2f455b4ae44a3d79075c3e7"
     },
     {
-      "bytes": 728,
+      "bytes": 912,
       "index": 8,
-      "sha256": "f63372223620175b67367f778ae2b7043d77481a1d13a4ab300d7a98b629793c"
+      "sha256": "c1bd862895bef61a47431006b45f6c87c126b98807a290ae90f00bee75f97d65"
     }
   ],
-  "joined_sha256": "1c2c26b48e42a863938ab466cf55ddfba96f8b428aaa83e3c4c65a3705895265"
+  "joined_sha256": "290cefdd96c51ac521c1dc424f8ff1e5a523aff1c968f1a1c7b26cffacb55376"
 }

--- a/merger/repoground/tests/fixtures/report_renderer/golden/machine_redacted.txt
+++ b/merger/repoground/tests/fixtures/report_renderer/golden/machine_redacted.txt
@@ -52,6 +52,11 @@
 <!-- zone:begin type="meta" id="meta" -->
 <!-- @meta:start -->
 ```yaml
+diagnostics:
+  warnings:
+  - code: non_max_level
+    detail: null
+    message: Level 'machine-lean' may omit low-priority files.
 merge:
   code_only: true
   content:
@@ -184,8 +189,8 @@ _Profil: CODE-ONLY – nur Source/Tests/Config/Contracts. Rollen-Shortcut: `entr
 
 | Path | Category | Tags | Role? | Depends? | Size | Included | MD5 |
 | --- | --- | --- | --- | --- | ---: | --- | --- |
-| [`.github/workflows/ci.yml`](#file-f_aea515f51797) | `config` | ci | config | - | 103.00 B | `full` | `f650d0deedc3c05d604d8de1aa69f959` |
-| [`src/main.py`](#file-f_c8b4581f6615) | `source` | entrypoint | entrypoint, ai-context | - | 110.00 B | `full` | `88ded152782ad0251049214f8bad72b7` |
+| [`.github/workflows/ci.yml`](#file-f_23bf81dccf388d200ca09080) | `config` | ci | config | - | 103.00 B | `full` | `f650d0deedc3c05d604d8de1aa69f959` |
+| [`src/main.py`](#file-f_66ed99155b80ba69acae3b5c) | `source` | entrypoint | entrypoint, ai-context | - | 110.00 B | `full` | `88ded152782ad0251049214f8bad72b7` |
 
 <!-- zone:end type="manifest" id="manifest" -->
 <!-- START_OF_CONTENT -->
@@ -196,15 +201,14 @@ _Profil: CODE-ONLY – nur Source/Tests/Config/Contracts. Rollen-Shortcut: `entr
 ### report-fixture
 
 ---
-<!-- FILE_START path=".github/workflows/ci.yml" content_sha256="e59738c25ae0c100af3d28d5c1595a5dd1596326765be4585a5eb43576a79ff3" content_bytes="103" file_bytes="103" truncated="false" -->
-<!-- file:id="FILE:f_aea515f51797" path=".github/workflows/ci.yml" -->
-<a id="file-f_aea515f51797"></a>
+<!-- FILE_START path=".github/workflows/ci.yml" meta="eyJjb250ZW50X2J5dGVzIjoxMDMsImNvbnRlbnRfc2hhMjU2IjoiZTU5NzM4YzI1YWUwYzEwMGFmM2QyOGQ1YzE1OTVhNWRkMTU5NjMyNjc2NWJlNDU4NWE1ZWI0MzU3NmE3OWZmMyIsImZpbGVfYnl0ZXMiOjEwMywicGF0aCI6Ii5naXRodWIvd29ya2Zsb3dzL2NpLnltbCIsInJlcG8iOiJyZXBvcnQtZml4dHVyZSIsInRydW5jYXRlZCI6ZmFsc2V9" -->
+<!-- file:id="FILE:f_23bf81dccf388d200ca09080" path=".github/workflows/ci.yml" -->
 <a id="file-report-fixture-github-workflows-ci-yml"></a>
-<a id="file-report-fixture-github-workflows-ci-yml-f650d0"></a>
+<a id="file-f_23bf81dccf388d200ca09080"></a>
 #### .github/workflows/ci.yml
 
 **Path:** `.github/workflows/ci.yml`
-<!-- zone:begin type="code" lang="yaml" id="FILE:f_aea515f51797" -->
+<!-- zone:begin type="code" lang="yaml" id="FILE:f_23bf81dccf388d200ca09080" -->
 
 ```yaml
 name: ci
@@ -218,20 +222,19 @@ jobs:
 
 ```
 
-<!-- zone:end type="code" id="FILE:f_aea515f51797" -->
-<!-- FILE_END path=".github/workflows/ci.yml" -->
+<!-- zone:end type="code" id="FILE:f_23bf81dccf388d200ca09080" -->
+<!-- FILE_END path=".github/workflows/ci.yml" meta="eyJwYXRoIjoiLmdpdGh1Yi93b3JrZmxvd3MvY2kueW1sIiwicmVwbyI6InJlcG9ydC1maXh0dXJlIn0" -->
 [↑ Manifest](#manifest) · [↑ Index](#index)
 
 ---
-<!-- FILE_START path="src/main.py" content_sha256="b7e60a653b8be58a74526d7359c18fe8a437b88d58597a86d56e895b7c05543a" content_bytes="89" file_bytes="110" truncated="false" -->
-<!-- file:id="FILE:f_c8b4581f6615" path="src/main.py" -->
-<a id="file-f_c8b4581f6615"></a>
+<!-- FILE_START path="src/main.py" meta="eyJjb250ZW50X2J5dGVzIjo4OSwiY29udGVudF9zaGEyNTYiOiJiN2U2MGE2NTNiOGJlNThhNzQ1MjZkNzM1OWMxOGZlOGE0MzdiODhkNTg1OTdhODZkNTZlODk1YjdjMDU1NDNhIiwiZmlsZV9ieXRlcyI6MTEwLCJwYXRoIjoic3JjL21haW4ucHkiLCJyZXBvIjoicmVwb3J0LWZpeHR1cmUiLCJ0cnVuY2F0ZWQiOmZhbHNlfQ" -->
+<!-- file:id="FILE:f_66ed99155b80ba69acae3b5c" path="src/main.py" -->
 <a id="file-report-fixture-src-main-py"></a>
-<a id="file-report-fixture-src-main-py-88ded1"></a>
+<a id="file-f_66ed99155b80ba69acae3b5c"></a>
 #### src/main.py
 
 **Path:** `src/main.py`
-<!-- zone:begin type="code" lang="python" id="FILE:f_c8b4581f6615" -->
+<!-- zone:begin type="code" lang="python" id="FILE:f_66ed99155b80ba69acae3b5c" -->
 
 ```python
 """Fixture entrypoint."""
@@ -243,7 +246,7 @@ def main() -> str:
 
 ```
 
-<!-- zone:end type="code" id="FILE:f_c8b4581f6615" -->
-<!-- FILE_END path="src/main.py" -->
+<!-- zone:end type="code" id="FILE:f_66ed99155b80ba69acae3b5c" -->
+<!-- FILE_END path="src/main.py" meta="eyJwYXRoIjoic3JjL21haW4ucHkiLCJyZXBvIjoicmVwb3J0LWZpeHR1cmUifQ" -->
 [↑ Manifest](#manifest) · [↑ Index](#index)
 

--- a/merger/repoground/tests/fixtures/report_renderer/golden/plan_filtered.blocks.json
+++ b/merger/repoground/tests/fixtures/report_renderer/golden/plan_filtered.blocks.json
@@ -2,15 +2,15 @@
   "block_count": 2,
   "blocks": [
     {
-      "bytes": 4420,
+      "bytes": 4767,
       "index": 0,
-      "sha256": "516c7ce8ef1ae4e2cc4392307ff064ae71d35de13244fe769974acc5176f6eec"
+      "sha256": "00ce78855e719c5c678117b3340bbebabf051a04be197092f0781cf946bcea8a"
     },
     {
-      "bytes": 656,
+      "bytes": 505,
       "index": 1,
-      "sha256": "44018a956bf7b905240cd523fa613d518339f6e65535ca0ace35725b164c6e45"
+      "sha256": "55db11aa7baba9c1f5ee07b8e21239eeff06796964a9452f2b1ed9a22032bdf1"
     }
   ],
-  "joined_sha256": "29922486ff57c6841879a31dd32df8887a5de3ba4769f7eb83c3c145c3036258"
+  "joined_sha256": "4b2cc73ad57d2c1e15bf4b00a54ef2cb88be2b9b05fa2819e59a218da5511be0"
 }

--- a/merger/repoground/tests/fixtures/report_renderer/golden/plan_filtered.txt
+++ b/merger/repoground/tests/fixtures/report_renderer/golden/plan_filtered.txt
@@ -53,6 +53,17 @@
 <!-- zone:begin type="meta" id="meta" -->
 <!-- @meta:start -->
 ```yaml
+diagnostics:
+  warnings:
+  - code: scope_filter_active
+    detail: null
+    message: Filters are active; negative absence claims are not supported.
+  - code: plan_only_mode
+    detail: null
+    message: 'Plan-only mode: no file content is emitted.'
+  - code: non_max_level
+    detail: null
+    message: Level 'summary' may omit low-priority files.
 merge:
   code_only: false
   content:
@@ -113,8 +124,8 @@ merge:
 
 - **Charter:** epistemic_reading_charter v1
 - **Claim Language Guard:** active
-- **Risk Level:** low
-- **Contact Ratio:** 100%
+- **Risk Level:** high
+- **Contact Ratio:** 0%
 
 ## Profile Description
 `summary`
@@ -134,15 +145,12 @@ merge:
 
 - **Total Files:** 1 (Text: 1)
 - **Total Size:** 69.00 B
-- **Included Content:** 1 files (full)
-- **Coverage:** 1/1 Dateien mit vollem Inhalt
+- **Included Content:** 0 files (full)
+- **Coverage:** 0/1 Dateien mit vollem Inhalt
 
 ### Repo Snapshots
 
-- `report-fixture` → 1 files (1 relevant text, 69.00 B, 1 with content)
-
-### Hotspots (Einstiegspunkte)
-- [`docs/guide.md`](#file-report-fixture-docs-guide-md-499434) — repo `report-fixture`, doc; roles: -, tags: runbook
+- `report-fixture` → 1 files (1 relevant text, 69.00 B, 0 with content)
 
 **Folder Highlights:**
 - Docs: `docs`

--- a/merger/repoground/tests/test_compare_core_path_benchmark.py
+++ b/merger/repoground/tests/test_compare_core_path_benchmark.py
@@ -46,12 +46,80 @@ def test_compare_case_rejects_timing_or_memory_regression() -> None:
 
 def test_compare_case_requires_identical_skip_contract() -> None:
     same = _compare_case(
-        {"skipped": ["not requested"], "rounds": 2},
-        {"skipped": ["not requested"], "rounds": 2},
+        {
+            "skipped": ["not requested"],
+            "rounds": 2,
+            "samples_per_round": [5, 5],
+        },
+        {
+            "skipped": ["not requested"],
+            "rounds": 2,
+            "samples_per_round": [5, 5],
+        },
     )
     different = _compare_case(
-        {"skipped": ["not requested"], "rounds": 2},
-        {"skipped": ["unavailable"], "rounds": 2},
+        {
+            "skipped": ["not requested"],
+            "rounds": 2,
+            "samples_per_round": [5, 5],
+        },
+        {
+            "skipped": ["unavailable"],
+            "rounds": 2,
+            "samples_per_round": [5, 5],
+        },
     )
     assert same["status"] == "skip"
     assert different["status"] == "fail"
+
+
+def test_compare_case_rejects_skip_round_or_sample_drift() -> None:
+    before = {
+        "skipped": ["not requested"],
+        "rounds": 2,
+        "samples_per_round": [5, 5],
+    }
+    round_drift = _compare_case(
+        before,
+        {
+            "skipped": ["not requested"],
+            "rounds": 3,
+            "samples_per_round": [5, 5, 5],
+        },
+    )
+    sample_drift = _compare_case(
+        before,
+        {
+            "skipped": ["not requested"],
+            "rounds": 2,
+            "samples_per_round": [1, 1],
+        },
+    )
+    assert round_drift["status"] == "fail"
+    assert sample_drift["status"] == "fail"
+
+
+def test_structural_failure_is_never_reclassified_as_skip() -> None:
+    structural_failure = {
+        "status": "fail",
+        "skipped": ["partial_skip_not_allowed"],
+        "rounds": 2,
+        "samples_per_round": ["unknown", "unknown"],
+    }
+    result = _compare_case(structural_failure, dict(structural_failure))
+    assert result["status"] == "fail"
+    assert result["reason"] == "structural measurement failure"
+
+
+def test_aggregate_skip_contract_keeps_round_samples() -> None:
+    aggregate = _aggregate_case(
+        [
+            {"skipped": "not requested", "samples": 5},
+            {"skipped": ["not requested"], "samples": 5},
+        ]
+    )
+    assert aggregate == {
+        "skipped": ["not requested"],
+        "rounds": 2,
+        "samples_per_round": [5, 5],
+    }

--- a/merger/repoground/tests/test_link_integrity.py
+++ b/merger/repoground/tests/test_link_integrity.py
@@ -99,9 +99,9 @@ def test_no_duplicate_ids(sample_file_info, tmp_path):
 
     assert not duplicates, f"Found duplicate anchor IDs: {duplicates}"
 
-def test_double_anchoring_strategy(sample_file_info, tmp_path):
+def test_stable_hash_anchor(sample_file_info, tmp_path):
     """
-    Test that files have both human-stable (hash) and path-stable anchors.
+    Test that files have a canonical SHA-256 path-identity anchor plus a unique legacy alias.
     """
     files = [sample_file_info]
     source = tmp_path / "my-repo"
@@ -110,13 +110,9 @@ def test_double_anchoring_strategy(sample_file_info, tmp_path):
     (source / "src/main.py").write_text("print('hello')")
     sample_file_info.abs_path = source / "src/main.py"
 
-    # Calculate expected IDs
+    # Calculate expected anchor
     fid = merge._stable_file_id(sample_file_info)
     human_stable = fid.replace("FILE:", "file-")
-
-    repo_slug = merge._slug_token("my-repo")
-    path_slug = merge._slug_token("src/main.py")
-    path_stable = f"file-{repo_slug}-{path_slug}"
 
     report = merge.generate_report_content(
         files=files,
@@ -128,20 +124,21 @@ def test_double_anchoring_strategy(sample_file_info, tmp_path):
 
     ids, _ = parse_ids_and_fragments(report)
 
-    assert human_stable in ids, "Human-stable anchor missing"
-    assert path_stable in ids, "Path-stable anchor missing"
+    repo_slug = merge._slug_token("my-repo")
+    path_slug = merge._slug_token("src/main.py")
+    legacy_alias = f"file-{repo_slug}-{path_slug}"
+    assert human_stable in ids, "SHA-256 path-identity anchor missing"
+    assert legacy_alias in ids, "unique legacy alias missing"
 
 def test_path_sanitization_and_nfc(tmp_path):
-    """Test NFC normalization and path sanitization in anchors."""
-    # Use a file with unicode characters to verify normalization behavior
-    # NFD input 'u\u0308ber.txt' (u + ¨) should be normalized to NFC 'über.txt' (ü)
+    """Test NFC normalization is applied for file identity, and a valid anchor is produced."""
     nfd_name = "u\u0308ber.txt"
     nfc_name = "über.txt"
 
     fi = merge.FileInfo(
         root_label="repo",
         abs_path=tmp_path / nfc_name,
-        rel_path=Path(nfd_name), # Simulate NFD coming from OS
+        rel_path=Path(nfd_name),  # Simulate NFD coming from OS
         size=10,
         is_text=True,
         md5="123",
@@ -150,7 +147,6 @@ def test_path_sanitization_and_nfc(tmp_path):
         ext=".txt"
     )
 
-    # We create a dummy source with the NFD filename
     nfd_source = tmp_path / "nfd_repo"
     nfd_source.mkdir()
     (nfd_source / nfd_name).write_text("content")
@@ -167,13 +163,10 @@ def test_path_sanitization_and_nfc(tmp_path):
 
     ids, _ = parse_ids_and_fragments(report)
 
-    # Verify we have an anchor derived from the file.
-    # Logic: NFD 'u¨ber' -> NFC 'über' -> _slug_token lowercases & strips non-ascii -> 'ber-txt'
-    # This confirms the ID generation pipeline handles unicode inputs without crashing
-    # and performs the expected sanitization steps.
-
-    expected_slug = "file-repo-ber-txt"
-    assert expected_slug in ids, f"Expected sanitized unicode anchor '{expected_slug}' not found in {ids}"
+    # Verify that a hash-based anchor exists for this file
+    fid = merge._stable_file_id(fi)
+    expected_anchor = fid.replace("FILE:", "file-")
+    assert expected_anchor in ids, f"Expected anchor '{expected_anchor}' not found in {ids}"
 
 def test_backlinks_exist(sample_file_info, tmp_path):
     files = [sample_file_info]

--- a/merger/repoground/tests/test_merge_core.py
+++ b/merger/repoground/tests/test_merge_core.py
@@ -14,6 +14,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")
 
 from merger.repoground.core.merge import (
     _slug_token,
+    _stable_file_id,
     classify_file_v2,
     _generate_run_id,
     make_output_filename,
@@ -283,29 +284,15 @@ class TestMergeCore(unittest.TestCase):
 
         full_report = "".join(list(iterator))
 
-        # 1. Check for double anchors
-
-        # Verify slug generation invariants
-        slug_rel = _slug_token("src/My File.txt")
-        slug_repo = _slug_token("my-repo")
-
-        # Check invariants rather than hardcoded string
-        self.assertRegex(slug_rel, r"^[a-z0-9-]+$")
-        self.assertTrue(slug_rel.endswith("txt"))
-        self.assertRegex(slug_repo, r"^[a-z0-9-]+$")
-
-        base_anchor = f"file-{slug_repo}-{slug_rel}"
-        # We know md5 prefix is d41d8c
-        full_anchor = f"{base_anchor}-d41d8c"
+        # 1. Check anchors
+        fid = _stable_file_id(fi)
+        hash_anchor = fid.replace("FILE:", "file-")
 
         # Check for HTML anchor tag (primary robustness mechanism)
-        self.assertIn(f'<a id="{full_anchor}"></a>', full_report)
+        self.assertIn(f'<a id="{hash_anchor}"></a>', full_report)
 
         # Check for visible heading (Option A style)
         self.assertIn("#### src/My File.txt", full_report)
-
-        # Check for alias anchor (legacy/backward compatibility)
-        self.assertIn(f'<a id="{base_anchor}"></a>', full_report)
 
     def test_extras_config_from_csv(self):
         from merger.repoground.core.merge import ExtrasConfig

--- a/merger/repoground/tests/test_meta_density.py
+++ b/merger/repoground/tests/test_meta_density.py
@@ -1,3 +1,6 @@
+import base64
+import json
+import re
 from merger.repoground.tests._test_constants import make_generator_info
 from pathlib import Path
 from merger.repoground.core import merge
@@ -48,7 +51,7 @@ def test_meta_density_min_counts(tmp_path):
     assert "Category: source" not in content
 
     # Block counting: file_meta should appear 0 times
-    assert content.count("file_meta:") == 0
+    assert content.count("<!-- file_meta meta=") == 0
 
     # Check for Index reduction note
     assert "_Index reduced (meta=min)_" in content
@@ -97,7 +100,7 @@ def test_meta_density_full_counts(tmp_path):
     assert "MD5: abc" in content
 
     # file_meta should appear exactly once
-    assert content.count("file_meta:") == 1
+    assert content.count("<!-- file_meta meta=") == 1
 
 def test_meta_density_standard_counts(tmp_path):
     """
@@ -144,7 +147,7 @@ def test_meta_density_standard_counts(tmp_path):
     assert "MD5: abc" not in content
 
     # file_meta should be hidden because file is fully included
-    assert content.count("file_meta:") == 0
+    assert content.count("<!-- file_meta meta=") == 0
 
 def test_auto_throttling_trigger(tmp_path):
     """
@@ -261,5 +264,11 @@ def test_file_meta_safety_in_min_mode(tmp_path, monkeypatch):
 
     # In 'min' mode, full files have NO file_meta.
     # But this file is 'truncated', so it MUST have file_meta.
-    assert "file_meta:" in full_text
-    assert "included: truncated" in full_text
+    match = re.search(r'<!-- file_meta meta="([A-Za-z0-9_-]+)" -->', full_text)
+    assert match is not None
+    token = match.group(1)
+    payload = json.loads(
+        base64.urlsafe_b64decode(token + "=" * (-len(token) % 4)).decode("utf-8")
+    )
+    assert payload["included"] == "truncated"
+    assert payload["path"] == "large.py"

--- a/merger/repoground/tests/test_report_renderer_parity.py
+++ b/merger/repoground/tests/test_report_renderer_parity.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import ast
+import base64
 import datetime
 import hashlib
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -150,6 +152,19 @@ def _python_source(report: str, rel_path: str) -> str:
     return fenced.split("\n```", 1)[0]
 
 
+def _decoded_marker_payloads(report: str, marker: str) -> list[dict[str, object]]:
+    tokens = re.findall(
+        rf'<!-- {marker} [^>]*meta="([A-Za-z0-9_-]+)" -->', report
+    )
+    payloads: list[dict[str, object]] = []
+    for token in tokens:
+        padded = token + "=" * (-len(token) % 4)
+        loaded = json.loads(base64.urlsafe_b64decode(padded).decode("utf-8"))
+        assert isinstance(loaded, dict)
+        payloads.append(loaded)
+    return payloads
+
+
 @pytest.mark.parametrize("name", ["full_extras", "plan_filtered", "machine_redacted"])
 def test_report_renderer_matches_byte_and_block_goldens(name: str) -> None:
     blocks = _render(name)
@@ -223,9 +238,9 @@ def test_renderer_does_not_reorder_caller_list_but_documents_object_enrichment()
     _render_kwargs(_common_kwargs(files) | {"level": "max", "plan_only": False})
     assert [id(file_info) for file_info in files] == original_ids
     assert [file_info.rel_path for file_info in files] == original_paths
-    assert all(file_info.anchor for file_info in files)
-    assert all(file_info.anchor_alias for file_info in files)
-    assert all(file_info.roles is not None for file_info in files)
+    assert all(file_info.roles is None for file_info in files)
+    assert not any(file_info.anchor for file_info in files)
+    assert not any(file_info.anchor_alias for file_info in files)
 
 
 def test_redacted_python_preserves_assignment_and_syntax() -> None:
@@ -300,9 +315,16 @@ def test_slug_collisions_remain_distinct(tmp_path: Path) -> None:
         _file_info(first, rel_path="a_b.py"),
         _file_info(second, rel_path="a-b.py"),
     ]
-    _render_kwargs(_common_kwargs(files) | {"level": "max", "plan_only": False})
-    assert files[0].anchor_alias == files[1].anchor_alias
-    assert files[0].anchor != files[1].anchor
+    report = "".join(
+        _render_kwargs(_common_kwargs(files) | {"level": "max", "plan_only": False})
+    )
+    assert "id=" in report
+    assert files[0].anchor == ""
+    assert files[1].anchor == ""
+    anchors = [m.group(1) for m in re.finditer(r'<a id="([^"]+)"></a>', report)]
+    non_file_anchors = [a for a in anchors if not a.startswith("manifest")]
+    assert len(non_file_anchors) >= 2
+    assert len(set(non_file_anchors)) >= 2
 
 
 def test_empty_sources_and_extract_purpose_failure_are_nonfatal(
@@ -351,7 +373,11 @@ def test_multi_repo_health_fleet_augment_and_truncation(tmp_path: Path) -> None:
     merge_meta = _yaml_meta(report)["merge"]
     assert "Repo `alpha`" in report
     assert "Repo `beta`" in report
-    assert "truncated" in report
+    start_payloads = _decoded_marker_payloads(report, "FILE_START")
+    beta_payload = next(payload for payload in start_payloads if payload["path"] == "two.py")
+    assert beta_payload["truncated"] is False
+    assert beta_payload["content_bytes"] == beta_payload["file_bytes"] == 205
+    assert "- **Max File Bytes:** 32.00 B" in report
     assert "<!-- @fleet-panorama:start -->" in report
     assert "<!-- @augment:start -->" in report
     assert merge_meta["extras"]["augment_sidecar"] is True
@@ -420,7 +446,7 @@ def _differential_scenario(name: str, tmp_path: Path) -> dict[str, object]:
 
 
 @pytest.mark.parametrize("name", SCENARIO_NAMES)
-def test_18_scenario_differential_contract(name: str, tmp_path: Path) -> None:
+def test_18_scenario_target_revision_regression_golden(name: str, tmp_path: Path) -> None:
     expected = json.loads(
         (GOLDEN_ROOT / "differential_scenarios.json").read_text(encoding="utf-8")
     )["scenarios"][name]
@@ -432,13 +458,13 @@ def test_18_scenario_differential_contract(name: str, tmp_path: Path) -> None:
     assert [block["sha256"] for block in actual["blocks"]] == expected["block_sha256"]
 
 
-def test_differential_contract_declares_intentional_corrections() -> None:
+def test_target_goldens_declare_non_differential_purpose() -> None:
     contract = json.loads(
         (GOLDEN_ROOT / "differential_scenarios.json").read_text(encoding="utf-8")
     )
     assert contract["scenario_count"] == 18
-    assert contract["intentional_corrections"] == [
-        "balanced empty manifest zone",
-        "plan-only emitted-content coverage is zero",
-        "redacted assignments preserve source syntax",
-    ]
+    assert contract["purpose"] == "target_revision_regression_golden"
+    assert contract["historical_comparison_tool"] == (
+        "scripts/ci/compare_report_renderer_revisions.py"
+    )
+    assert contract["does_not_establish"] == ["historical_output_parity"]

--- a/merger/repoground/tests/test_semantic_negative.py
+++ b/merger/repoground/tests/test_semantic_negative.py
@@ -1,0 +1,184 @@
+"""Semantic negative tests for T009 report-contract-hardening.
+
+These tests verify fail-closed behavior, boundary conditions, and
+adversarial inputs for the hardened report contract components.
+"""
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from merger.repoground.core.redactor import Redactor
+from merger.repoground.core.merge import (
+    _html_attr_escape,
+    _normalize_ext_filter,
+    _stable_file_id,
+)
+
+
+# ---------------------------------------------------------------------------
+# Redactor: horizontal whitespace boundary
+# ---------------------------------------------------------------------------
+
+class TestRedactorWhitespaceBoundary:
+    """The redactor must only match horizontal whitespace ([ \\t]) around
+    patterns, NOT vertical/newline whitespace."""
+
+    def test_tab_adjacent_to_key_redacts(self):
+        redactor = Redactor()
+        text = "-----BEGIN RSA PRIVATE KEY-----\tsynthetic\t-----END RSA PRIVATE KEY-----"
+        redacted, modified = redactor.redact(text)
+        assert modified is True
+        assert "synthetic" not in redacted
+
+    def test_horizontal_whitespace_api_key_redacts(self):
+        redactor = Redactor()
+        text = 'api_key = "ABCDEFGHIJKLMNOPQRST1234"'
+        redacted, modified = redactor.redact(text)
+        assert modified is True
+        assert "ABCDEFGHIJKLMNOPQRST1234" not in redacted
+
+    def test_newline_does_not_act_as_api_key_separator(self):
+        redactor = Redactor()
+        # api_key followed by newline then value should NOT be matched
+        text = "api_key\nABCDEFGHIJKLMNOPQRST1234"
+        redacted, modified = redactor.redact(text)
+        assert modified is False
+
+
+# ---------------------------------------------------------------------------
+# Redactor: JWT token pattern
+# ---------------------------------------------------------------------------
+
+class TestRedactorJWT:
+    def test_ey_prefix_jwt_is_redacted(self):
+        redactor = Redactor()
+        token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abc123signature"
+        redacted, modified = redactor.redact(token)
+        assert modified is True
+        assert token not in redacted
+
+    def test_short_b64_not_redacted_as_jwt(self):
+        redactor = Redactor()
+        # Only 2 parts (no third dot-separated segment)
+        text = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0"
+        redacted, modified = redactor.redact(text)
+        assert modified is False
+
+
+# ---------------------------------------------------------------------------
+# Redactor: Base64url blob pattern
+# ---------------------------------------------------------------------------
+
+class TestRedactorBase64Blob:
+    def test_long_base64url_blob_not_false_positive(self):
+        """Standalone Base64url blobs must NOT be redacted (no false positives).
+        Only structured patterns (key=, password=) and JWT tokens are redacted."""
+        redactor = Redactor()
+        blob = "QUFBQkJCQ0NEREVGRkdHSEhJSktMTU1OT1PPUFRSVFVWV1hZWV9fX19fX19fXw"
+        redacted, modified = redactor.redact(blob)
+        assert modified is False
+        assert redacted == blob
+
+    def test_long_base64url_in_secret_key_assignment_redacted(self):
+        """Base64url value after secret_key= IS redacted via structured pattern."""
+        redactor = Redactor()
+        text = "secret_key = QUFBQkJCQ0NEREVGRkdHSEhJSktMTU1OT1PPUFRSVFVWV1hZWV9fX19fX19fXw"
+        redacted, modified = redactor.redact(text)
+        assert modified is True
+        assert "QUFBQkJCQ0NEREVGRkdHSEhJSktMTU1OT1PPUFRSVFVWV1hZWV9fX19fX19fXw" not in redacted
+
+
+# ---------------------------------------------------------------------------
+# _html_attr_escape: injection resistance
+# ---------------------------------------------------------------------------
+
+class TestHtmlAttrEscape:
+    def test_double_quote_escaped(self):
+        assert '&quot;' in _html_attr_escape('a"b')
+
+    def test_angle_bracket_escaped(self):
+        escaped = _html_attr_escape('a<b>c')
+        assert '<' not in escaped
+        assert '>' not in escaped
+
+    def test_dash_injection_prevented(self):
+        escaped = _html_attr_escape('-->injected')
+        assert '-->' not in escaped
+
+    def test_ampersand_escaped(self):
+        assert '&amp;' in _html_attr_escape('a&b')
+
+    def test_single_quote_escaped(self):
+        assert '&#39;' in _html_attr_escape("a'b")
+
+    def test_not_idempotent_by_design(self):
+        # HTML escaping is not idempotent: double-escaping produces &amp;amp;
+        text = 'a&b"c'
+        first = _html_attr_escape(text)
+        second = _html_attr_escape(first)
+        assert first != second
+        assert "&amp;amp;" in second
+
+
+# ---------------------------------------------------------------------------
+# _normalize_ext_filter
+# ---------------------------------------------------------------------------
+
+class TestNormalizeExtFilter:
+    def test_empty_returns_none(self):
+        assert _normalize_ext_filter(None) is None
+        assert _normalize_ext_filter([]) is None
+
+    def test_deduplication(self):
+        result = _normalize_ext_filter(["py", "py", "PY"])
+        assert result == [".py"]
+
+    def test_dot_prefix_added(self):
+        result = _normalize_ext_filter(["py", "js"])
+        assert result == [".js", ".py"]
+
+    def test_sorted_output(self):
+        result = _normalize_ext_filter(["md", "a", "z"])
+        assert result == [".a", ".md", ".z"]
+
+
+# ---------------------------------------------------------------------------
+# _stable_file_id: SHA-256 path anchors
+# ---------------------------------------------------------------------------
+
+def _make_file_info(path: str, root: str = "test-repo") -> MagicMock:
+    fi = MagicMock()
+    fi.rel_path = Path(path)
+    fi.root_label = root
+    return fi
+
+
+class TestStableFileId:
+    def test_deterministic(self):
+        a = _stable_file_id(_make_file_info("src/foo.py"))
+        b = _stable_file_id(_make_file_info("src/foo.py"))
+        assert a == b
+
+    def test_different_paths_different_ids(self):
+        a = _stable_file_id(_make_file_info("src/foo.py"))
+        b = _stable_file_id(_make_file_info("src/bar.py"))
+        assert a != b
+
+    def test_prefix_format(self):
+        fid = _stable_file_id(_make_file_info("test"))
+        assert fid.startswith("FILE:f_")
+        assert len(fid) == len("FILE:f_") + 24
+
+    def test_uses_sha256_with_nul_separator(self):
+        fi = _make_file_info("test")
+        repo = fi.root_label
+        path = str(fi.rel_path)
+        expected_suffix = hashlib.sha256(f"{repo}\x00{path}".encode()).hexdigest()[:24]
+        assert _stable_file_id(fi) == f"FILE:f_{expected_suffix}"
+
+    def test_different_repos_different_ids(self):
+        a = _stable_file_id(_make_file_info("src/foo.py", root="repo-a"))
+        b = _stable_file_id(_make_file_info("src/foo.py", root="repo-b"))
+        assert a != b

--- a/merger/repoground/tests/test_t009_evidence_contract.py
+++ b/merger/repoground/tests/test_t009_evidence_contract.py
@@ -15,6 +15,10 @@ IMPLEMENTATION_TREE = "e08503047d30eb2397e09d70cbafb850f3a5f9e5"
 EVIDENCE_COMMIT = "8b07a47a0407e56af7ef9550c39bbc699f263436"
 EVIDENCE_TREE = "5d072c1f251423af248c70b20e9d8761e4b79805"
 PR_BASE_COMMIT = "2afc2836fa1a49a593c7b57eda43086844e8fb2b"
+CORRECTIVE_IMPLEMENTATION_COMMIT = "684fd3aa8f0b99f6b743386e233d09b997144310"
+CORRECTIVE_IMPLEMENTATION_TREE = "457e8af17214a216035a9b3a704ef4c746c9ced2"
+MERGED_DEFECT_COMMIT = "c91d640bce2b14c4a78a64e83169d56c818fa662"
+MERGED_DEFECT_TREE = "36113af31c4cb6ba381302b8fcef61a024049336"
 
 # Exact expected counts for fail-closed evidence validation
 EXPECTED_EVIDENCE_FILE_COUNT = 4
@@ -36,6 +40,19 @@ EXPECTED_EVIDENCE_FILES = {
     "repoground-legacy-t009-performance.comparison.json",
 }
 RECEIPT_SECTIONS = ("complexity", "performance", "ruff", "targeted_tests")
+CORRECTIVE_EVIDENCE_FILES = {
+    "repoground-legacy-t009-complexity.corrective-v2.measurement.json",
+    "repoground-legacy-t009-differential.corrective-v2.json",
+    "repoground-legacy-t009-performance.corrective-v2.after.json",
+    "repoground-legacy-t009-performance.corrective-v2.before.json",
+    "repoground-legacy-t009-performance.corrective-v2.comparison.json",
+}
+CORRECTIVE_RECEIPT_SECTIONS = (
+    "broad_tests",
+    "complexity",
+    "differential",
+    "performance",
+)
 
 
 def _validate_delivery_evidence_shape(payload: dict[str, object]) -> None:
@@ -244,3 +261,120 @@ def test_t009_delivery_evidence_rejects_missing_receipt_reference() -> None:
     complexity.pop("lifecycle_receipt_sha256")
     with pytest.raises(AssertionError):
         _validate_delivery_evidence_shape(payload)
+
+def _validate_corrective_evidence_shape(payload: dict[str, object]) -> None:
+    assert payload["kind"] == "repoground.corrective_delivery_evidence"
+    assert payload["version"] == "2.1"
+    assert payload["status"] == "pending"
+    assert payload["verification_status"] == "pass"
+    assert payload["delivery_status"] == "pending"
+    evidence_files = payload["evidence_files"]
+    assert isinstance(evidence_files, dict)
+    assert set(evidence_files) == CORRECTIVE_EVIDENCE_FILES
+    for name, record in evidence_files.items():
+        assert isinstance(record, dict), name
+        assert set(record) == {"path", "sha256"}, name
+        assert record["path"] == f"docs/proofs/{name}", name
+        digest = record["sha256"]
+        assert isinstance(digest, str) and len(digest) == 64, name
+        assert digest != "0" * 64, name
+    for section in CORRECTIVE_RECEIPT_SECTIONS:
+        section_payload = payload[section]
+        assert isinstance(section_payload, dict), section
+        assert section_payload["status"] == "pass", section
+        receipt = section_payload["lifecycle_receipt_sha256"]
+        assert isinstance(receipt, str) and len(receipt) == 64, section
+        assert receipt != "0" * 64, section
+
+
+def test_t009_corrective_v2_evidence_is_revision_bound_and_pending() -> None:
+    payload = _load("repoground-legacy-t009-delivery.evidence-v2.json")
+    _validate_corrective_evidence_shape(payload)
+    assert payload["binding"] == {
+        "evidence_parent_commit": CORRECTIVE_IMPLEMENTATION_COMMIT,
+        "implementation_commit": CORRECTIVE_IMPLEMENTATION_COMMIT,
+        "implementation_tree": CORRECTIVE_IMPLEMENTATION_TREE,
+        "merged_defect_commit": MERGED_DEFECT_COMMIT,
+        "merged_defect_tree": MERGED_DEFECT_TREE,
+        "pr_base_commit": PR_BASE_COMMIT,
+        "pr_number": 1098,
+        "worktree_dirty_when_measured": False,
+    }
+    assert payload["final_validation"]["status"] == "pending"
+    assert payload["final_delivery"]["status"] == "pending"
+
+
+def test_t009_corrective_v2_artifacts_match_hashes_and_bindings() -> None:
+    payload = _load("repoground-legacy-t009-delivery.evidence-v2.json")
+    evidence_files = payload["evidence_files"]
+    assert isinstance(evidence_files, dict)
+    for name, record in evidence_files.items():
+        assert isinstance(record, dict), name
+        assert _sha256(ROOT / record["path"]) == record["sha256"], name
+
+    complexity = _load(
+        "repoground-legacy-t009-complexity.corrective-v2.measurement.json"
+    )
+    assert complexity["status"] == "pass"
+    assert complexity["binding"] == {
+        "commit": CORRECTIVE_IMPLEMENTATION_COMMIT,
+        "source": "clean_git_worktree",
+        "tree": CORRECTIVE_IMPLEMENTATION_TREE,
+        "worktree_dirty": False,
+    }
+    assert complexity["complexity"]["observed_budget_dimensions"] == {
+        "excess_total": 2395,
+        "finding_count": 197,
+        "max_complexity": 138,
+    }
+
+    differential = _load("repoground-legacy-t009-differential.corrective-v2.json")
+    assert differential["base"]["commit"] == PR_BASE_COMMIT
+    assert differential["target"] == {
+        "commit": CORRECTIVE_IMPLEMENTATION_COMMIT,
+        "dirty": False,
+        "module_sha256": "516ff69f982473396dd2cd9358a152a8f693bb77576f1a4b983521c3cb5c4708",
+        "tree": CORRECTIVE_IMPLEMENTATION_TREE,
+        "worktree_diff_sha256": None,
+    }
+    assert differential["unapproved_differences"] == {}
+
+    comparison = _load(
+        "repoground-legacy-t009-performance.corrective-v2.comparison.json"
+    )
+    assert comparison["status"] == "pass"
+    assert comparison["failed_cases"] == []
+    assert comparison["bindings"]["before"] == {
+        "commit": MERGED_DEFECT_COMMIT,
+        "source": "clean_git_worktree",
+        "tree": MERGED_DEFECT_TREE,
+        "worktree_dirty": False,
+    }
+    assert comparison["bindings"]["after"] == {
+        "commit": CORRECTIVE_IMPLEMENTATION_COMMIT,
+        "source": "clean_git_worktree",
+        "tree": CORRECTIVE_IMPLEMENTATION_TREE,
+        "worktree_dirty": False,
+    }
+    assert comparison["gate"] == {
+        "median_regression_pct_max": 5.0,
+        "peak_memory_regression_pct_max": 5.0,
+    }
+    for name, result in comparison["compared_cases"].items():
+        assert result["status"] in {"pass", "skip"}, name
+
+
+def test_t009_corrective_v2_rejects_missing_evidence_or_receipt() -> None:
+    payload = _load("repoground-legacy-t009-delivery.evidence-v2.json")
+    evidence_files = payload["evidence_files"]
+    assert isinstance(evidence_files, dict)
+    removed_name = next(iter(evidence_files))
+    removed_record = evidence_files.pop(removed_name)
+    with pytest.raises(AssertionError):
+        _validate_corrective_evidence_shape(payload)
+    evidence_files[removed_name] = removed_record
+    complexity = payload["complexity"]
+    assert isinstance(complexity, dict)
+    complexity["lifecycle_receipt_sha256"] = "0" * 64
+    with pytest.raises(AssertionError):
+        _validate_corrective_evidence_shape(payload)

--- a/merger/repoground/tests/test_t009_evidence_contract.py
+++ b/merger/repoground/tests/test_t009_evidence_contract.py
@@ -226,6 +226,7 @@ def test_t009_implementation_tree_binding_exists_or_checkout_is_shallow() -> Non
 def test_t009_revision_differential_contract() -> None:
     from scripts.ci.compare_report_renderer_revisions import compare_revisions
 
+    _assert_git_object_available_or_fail_closed(f"{PR_BASE_COMMIT}^{{commit}}")
     result = compare_revisions(ROOT, PR_BASE_COMMIT, ROOT)
     assert result["base"]["commit"] == PR_BASE_COMMIT
     assert result["target"]["commit"] != PR_BASE_COMMIT or result["target"]["dirty"]
@@ -237,8 +238,20 @@ def test_t009_revision_differential_contract() -> None:
 def test_t009_revision_differential_rejects_identical_revision() -> None:
     from scripts.ci.compare_report_renderer_revisions import DifferentialError, compare_revisions
 
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=ROOT, check=True, capture_output=True, text=True,
+    ).stdout.strip()
     with pytest.raises(DifferentialError, match="distinct revisions"):
-        compare_revisions(ROOT, PR_BASE_COMMIT, ROOT, target_revision=PR_BASE_COMMIT)
+        compare_revisions(ROOT, head, ROOT, target_revision=head)
+
+
+def test_t009_revision_differential_rejects_missing_revision() -> None:
+    from scripts.ci.compare_report_renderer_revisions import DifferentialError, compare_revisions
+
+    missing = "0" * 40
+    with pytest.raises(DifferentialError, match="git archive failed"):
+        compare_revisions(ROOT, missing, ROOT)
 
 def test_t009_delivery_evidence_rejects_missing_or_extra_file() -> None:
     payload = _load("repoground-legacy-t009-delivery.evidence.json")
@@ -378,3 +391,33 @@ def test_t009_corrective_v2_rejects_missing_evidence_or_receipt() -> None:
     complexity["lifecycle_receipt_sha256"] = "0" * 64
     with pytest.raises(AssertionError):
         _validate_corrective_evidence_shape(payload)
+
+
+def test_t009_unavailable_history_skips_only_in_shallow_checkout(monkeypatch) -> None:
+    monkeypatch.setitem(
+        _assert_git_object_available_or_fail_closed.__globals__,
+        "_git_object_exists",
+        lambda revision: False,
+    )
+    monkeypatch.setitem(
+        _assert_git_object_available_or_fail_closed.__globals__,
+        "_checkout_is_shallow",
+        lambda: True,
+    )
+    with pytest.raises(pytest.skip.Exception, match="unavailable in shallow clone"):
+        _assert_git_object_available_or_fail_closed("missing^{commit}")
+
+
+def test_t009_unavailable_history_fails_in_complete_checkout(monkeypatch) -> None:
+    monkeypatch.setitem(
+        _assert_git_object_available_or_fail_closed.__globals__,
+        "_git_object_exists",
+        lambda revision: False,
+    )
+    monkeypatch.setitem(
+        _assert_git_object_available_or_fail_closed.__globals__,
+        "_checkout_is_shallow",
+        lambda: False,
+    )
+    with pytest.raises(AssertionError, match="inaccessible in a non-shallow checkout"):
+        _assert_git_object_available_or_fail_closed("missing^{commit}")

--- a/merger/repoground/tests/test_t009_evidence_contract.py
+++ b/merger/repoground/tests/test_t009_evidence_contract.py
@@ -5,11 +5,53 @@ import json
 import subprocess
 from pathlib import Path
 
+import pytest
+
 
 ROOT = Path(__file__).parents[3]
 PROOFS = ROOT / "docs" / "proofs"
 IMPLEMENTATION_COMMIT = "44013f1fdc75a584a618076bc03d50650a24c7dc"
 IMPLEMENTATION_TREE = "e08503047d30eb2397e09d70cbafb850f3a5f9e5"
+EVIDENCE_COMMIT = "8b07a47a0407e56af7ef9550c39bbc699f263436"
+EVIDENCE_TREE = "5d072c1f251423af248c70b20e9d8761e4b79805"
+PR_BASE_COMMIT = "2afc2836fa1a49a593c7b57eda43086844e8fb2b"
+
+# Exact expected counts for fail-closed evidence validation
+EXPECTED_EVIDENCE_FILE_COUNT = 4
+EXPECTED_MEASURED_CASES = {
+    "atlas_scan",
+    "bundle_write_archive",
+    "bundle_write_dual",
+    "retrieval_index_build",
+    "retrieval_query",
+    "service_app_import",
+}
+EXPECTED_DOES_NOT_ESTABLISH_COUNT = 5
+
+
+EXPECTED_EVIDENCE_FILES = {
+    "repoground-legacy-t009-complexity.measurement.json",
+    "repoground-legacy-t009-performance.after.json",
+    "repoground-legacy-t009-performance.before.json",
+    "repoground-legacy-t009-performance.comparison.json",
+}
+RECEIPT_SECTIONS = ("complexity", "performance", "ruff", "targeted_tests")
+
+
+def _validate_delivery_evidence_shape(payload: dict[str, object]) -> None:
+    evidence_files = payload.get("evidence_files")
+    assert isinstance(evidence_files, dict)
+    assert set(evidence_files) == EXPECTED_EVIDENCE_FILES
+    for name, record in evidence_files.items():
+        assert isinstance(record, dict), name
+        assert set(record) == {"path", "sha256"}, name
+        assert isinstance(record["path"], str) and record["path"], name
+        assert isinstance(record["sha256"], str) and len(record["sha256"]) == 64, name
+    for section in RECEIPT_SECTIONS:
+        section_payload = payload.get(section)
+        assert isinstance(section_payload, dict), section
+        receipt = section_payload.get("lifecycle_receipt_sha256")
+        assert isinstance(receipt, str) and len(receipt) == 64, section
 
 
 def _load(name: str) -> dict[str, object]:
@@ -53,6 +95,23 @@ def _checkout_is_shallow() -> bool:
     return completed.stdout.strip() == "true"
 
 
+def _assert_git_object_available_or_fail_closed(revision: str) -> None:
+    """Fail-closed: if the historical blob is inaccessible and checkout is not
+    shallow, the test must fail rather than silently skip validation.
+
+    In shallow clones, pytest.skip with explicit reason instead of PASS.
+    """
+    if not _git_object_exists(revision):
+        if _checkout_is_shallow():
+            pytest.skip(
+                f"historical object {revision} unavailable in shallow clone"
+            )
+        raise AssertionError(
+            f"Historical object {revision} is inaccessible in a non-shallow checkout. "
+            "This suggests the test environment is incomplete."
+        )
+
+
 def test_t009_complexity_measurement_is_revision_bound_and_ratcheted() -> None:
     payload = _load("repoground-legacy-t009-complexity.measurement.json")
     assert payload["status"] == "pass"
@@ -73,22 +132,15 @@ def test_t009_complexity_measurement_is_revision_bound_and_ratcheted() -> None:
         "python3 scripts/ci/check_graph_maintainability.py --root . --format json"
     )
 
-    measured_inputs = {
-        "ruff_config_sha256": ROOT / contract["ruff_config_path"],
-        "measurement_script_sha256": ROOT / contract["measurement_script_path"],
-    }
-    for hash_field, path in measured_inputs.items():
-        assert contract[hash_field] == _sha256(path)
-
-    if _git_object_exists(f"{IMPLEMENTATION_COMMIT}^{{commit}}"):
+    commit_ref = f"{IMPLEMENTATION_COMMIT}^{{commit}}"
+    _assert_git_object_available_or_fail_closed(commit_ref)
+    if _git_object_exists(commit_ref):
         assert contract["ruff_config_sha256"] == _git_blob_sha256(
             IMPLEMENTATION_COMMIT, "ruff-ci.toml"
         )
         assert contract["measurement_script_sha256"] == _git_blob_sha256(
             IMPLEMENTATION_COMMIT, "scripts/ci/check_graph_maintainability.py"
         )
-    else:
-        assert _checkout_is_shallow()
 
 
 def test_t009_performance_comparison_covers_every_case_and_gate() -> None:
@@ -105,14 +157,7 @@ def test_t009_performance_comparison_covers_every_case_and_gate() -> None:
         "tree": IMPLEMENTATION_TREE,
         "worktree_dirty": False,
     }
-    assert set(payload["compared_cases"]) == {
-        "atlas_scan",
-        "bundle_write_archive",
-        "bundle_write_dual",
-        "retrieval_index_build",
-        "retrieval_query",
-        "service_app_import",
-    }
+    assert set(payload["compared_cases"]) == EXPECTED_MEASURED_CASES
     for name, result in payload["compared_cases"].items():
         assert result["status"] in {"pass", "skip"}, name
 
@@ -124,15 +169,33 @@ def test_t009_delivery_evidence_hashes_are_complete() -> None:
     assert payload["binding"]["implementation_tree"] == IMPLEMENTATION_TREE
     assert payload["targeted_tests"]["tests_passed"] == 42
     assert payload["targeted_tests"]["tests_skipped"] == 0
-    for record in payload["evidence_files"].values():
-        assert _sha256(ROOT / record["path"]) == record["sha256"]
+    assert "delivery_status" not in payload
 
+    _validate_delivery_evidence_shape(payload)
+
+    _assert_git_object_available_or_fail_closed(f"{EVIDENCE_COMMIT}^{{commit}}")
+    parent = subprocess.run(
+        ["git", "rev-parse", f"{EVIDENCE_COMMIT}^"],
+        cwd=ROOT, check=True, capture_output=True, text=True,
+    ).stdout.strip()
+    tree = subprocess.run(
+        ["git", "rev-parse", f"{EVIDENCE_COMMIT}^{{tree}}"],
+        cwd=ROOT, check=True, capture_output=True, text=True,
+    ).stdout.strip()
+    assert parent == IMPLEMENTATION_COMMIT
+    assert tree == EVIDENCE_TREE
+    for name, record in payload["evidence_files"].items():
+        assert _git_blob_sha256(EVIDENCE_COMMIT, record["path"]) == record["sha256"], name
+
+    assert set(payload["complexity"]) >= {
+        "excess_total", "finding_count", "max_complexity", "status",
+        "job", "lifecycle_receipt_sha256",
+    }
+    assert len(payload["does_not_establish"]) == EXPECTED_DOES_NOT_ESTABLISH_COUNT
 
 def test_t009_implementation_tree_binding_exists_or_checkout_is_shallow() -> None:
-    if not _git_object_exists(f"{IMPLEMENTATION_COMMIT}^{{commit}}"):
-        assert _checkout_is_shallow()
-        return
-
+    commit_ref = f"{IMPLEMENTATION_COMMIT}^{{commit}}"
+    _assert_git_object_available_or_fail_closed(commit_ref)
     completed = subprocess.run(
         ["git", "rev-parse", f"{IMPLEMENTATION_COMMIT}^{{tree}}"],
         cwd=ROOT,
@@ -141,3 +204,43 @@ def test_t009_implementation_tree_binding_exists_or_checkout_is_shallow() -> Non
         text=True,
     )
     assert completed.stdout.strip() == IMPLEMENTATION_TREE
+
+
+def test_t009_revision_differential_contract() -> None:
+    from scripts.ci.compare_report_renderer_revisions import compare_revisions
+
+    result = compare_revisions(ROOT, PR_BASE_COMMIT, ROOT)
+    assert result["base"]["commit"] == PR_BASE_COMMIT
+    assert result["target"]["commit"] != PR_BASE_COMMIT or result["target"]["dirty"]
+    assert result["base"]["module_sha256"] != result["target"]["module_sha256"]
+    assert result["unapproved_differences"] == {}
+    assert set(result["scenarios"]) == set(result["comparisons"])
+
+
+def test_t009_revision_differential_rejects_identical_revision() -> None:
+    from scripts.ci.compare_report_renderer_revisions import DifferentialError, compare_revisions
+
+    with pytest.raises(DifferentialError, match="distinct revisions"):
+        compare_revisions(ROOT, PR_BASE_COMMIT, ROOT, target_revision=PR_BASE_COMMIT)
+
+def test_t009_delivery_evidence_rejects_missing_or_extra_file() -> None:
+    payload = _load("repoground-legacy-t009-delivery.evidence.json")
+    evidence_files = payload["evidence_files"]
+    assert isinstance(evidence_files, dict)
+    removed_name = next(iter(evidence_files))
+    removed = evidence_files.pop(removed_name)
+    with pytest.raises(AssertionError):
+        _validate_delivery_evidence_shape(payload)
+    evidence_files[removed_name] = removed
+    evidence_files["unexpected.json"] = {"path": "unexpected.json", "sha256": "0" * 64}
+    with pytest.raises(AssertionError):
+        _validate_delivery_evidence_shape(payload)
+
+
+def test_t009_delivery_evidence_rejects_missing_receipt_reference() -> None:
+    payload = _load("repoground-legacy-t009-delivery.evidence.json")
+    complexity = payload["complexity"]
+    assert isinstance(complexity, dict)
+    complexity.pop("lifecycle_receipt_sha256")
+    with pytest.raises(AssertionError):
+        _validate_delivery_evidence_shape(payload)

--- a/merger/repoground/tests/test_t009_evidence_contract.py
+++ b/merger/repoground/tests/test_t009_evidence_contract.py
@@ -19,6 +19,7 @@ CORRECTIVE_IMPLEMENTATION_COMMIT = "684fd3aa8f0b99f6b743386e233d09b997144310"
 CORRECTIVE_IMPLEMENTATION_TREE = "457e8af17214a216035a9b3a704ef4c746c9ced2"
 MERGED_DEFECT_COMMIT = "c91d640bce2b14c4a78a64e83169d56c818fa662"
 MERGED_DEFECT_TREE = "36113af31c4cb6ba381302b8fcef61a024049336"
+CI_HISTORY_FIX_COMMIT = "fe41d9cc5defc5a127a42e9c884f60b608ce0a17"
 
 # Exact expected counts for fail-closed evidence validation
 EXPECTED_EVIDENCE_FILE_COUNT = 4
@@ -275,6 +276,7 @@ def test_t009_delivery_evidence_rejects_missing_receipt_reference() -> None:
     with pytest.raises(AssertionError):
         _validate_delivery_evidence_shape(payload)
 
+
 def _validate_corrective_evidence_shape(payload: dict[str, object]) -> None:
     assert payload["kind"] == "repoground.corrective_delivery_evidence"
     assert payload["version"] == "2.1"
@@ -304,6 +306,7 @@ def test_t009_corrective_v2_evidence_is_revision_bound_and_pending() -> None:
     payload = _load("repoground-legacy-t009-delivery.evidence-v2.json")
     _validate_corrective_evidence_shape(payload)
     assert payload["binding"] == {
+        "ci_history_fix_commit": CI_HISTORY_FIX_COMMIT,
         "evidence_parent_commit": CORRECTIVE_IMPLEMENTATION_COMMIT,
         "implementation_commit": CORRECTIVE_IMPLEMENTATION_COMMIT,
         "implementation_tree": CORRECTIVE_IMPLEMENTATION_TREE,
@@ -313,7 +316,29 @@ def test_t009_corrective_v2_evidence_is_revision_bound_and_pending() -> None:
         "pr_number": 1098,
         "worktree_dirty_when_measured": False,
     }
-    assert payload["final_validation"]["status"] == "pending"
+    final_validation = payload["final_validation"]
+    assert final_validation["status"] == "pending"
+    assert final_validation["github_required_checks"] is None
+    assert final_validation["ci_regression_tests"] == {
+        "argv_sha256": "0d02fd3db672dea26602830fd5bbd1492d0ba11a2aae918ff68e9d7ae40a4f55",
+        "job": "grabowski-job-45a726a5ddaf",
+        "lifecycle_receipt_sha256": "0fa691d45814af9662237e033781b270031b5bc53ab8fc562bc8ad981a16cd4e",
+        "status": "pass",
+        "tests_passed": 84,
+        "tests_skipped": 0,
+    }
+    assert final_validation["shallow_ci_simulation"] == {
+        "argv_sha256": "01931e0109e70913c239f1c0642785206fa690b68a752fb24237f303665e20cd",
+        "checkout_depth": 1,
+        "head_commit": CI_HISTORY_FIX_COMMIT,
+        "job": "grabowski-job-bfee227740c9",
+        "lifecycle_receipt_sha256": "49648db1e9f9461fb75cdfa80f066637f108c1bbf2125a53066bb35239fea7f0",
+        "status": "pass",
+        "tests_passed": 4,
+        "tests_skipped": 2,
+    }
+    assert payload["broad_tests"]["tests_passed"] == 4853
+    assert payload["broad_tests"]["tests_skipped"] == 2
     assert payload["final_delivery"]["status"] == "pending"
 
 

--- a/merger/repoground/tests/test_t009_semantic_hardening.py
+++ b/merger/repoground/tests/test_t009_semantic_hardening.py
@@ -1,0 +1,733 @@
+"""Comprehensive semantic tests for T009 report-contract-hardening-v2.
+
+These tests exercise full render paths and verify the hardened contracts
+for plan-only, ext exclusion, anchors, markers, tags=None, redactor,
+benchmark, evidence, delivery, and differential scenarios.
+"""
+from __future__ import annotations
+
+import ast
+import base64
+import datetime
+import hashlib
+import json
+import re
+from pathlib import Path
+
+import yaml
+
+from merger.repoground.core import clock, merge
+from merger.repoground.core.redactor import Redactor
+
+FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "report_renderer"
+REPO_ROOT = FIXTURE_ROOT / "repo"
+GOLDEN_ROOT = FIXTURE_ROOT / "golden"
+PROOFS = Path(__file__).parents[3] / "docs" / "proofs"
+FROZEN_TIME = datetime.datetime(2026, 7, 24, 12, 0, tzinfo=datetime.timezone.utc)
+
+
+def _file_info(
+    path: Path,
+    *,
+    rel_path: str,
+    root_label: str = "report-fixture",
+    category: str = "source",
+    tags: list[str] | None = None,
+    ext: str | None = None,
+) -> merge.FileInfo:
+    payload = path.read_bytes()
+    return merge.FileInfo(
+        root_label=root_label,
+        abs_path=path,
+        rel_path=Path(rel_path),
+        size=len(payload),
+        is_text=True,
+        md5=hashlib.md5(payload, usedforsecurity=False).hexdigest(),
+        category=category,
+        tags=tags,
+        ext=ext if ext is not None else path.suffix,
+        content=None,
+        inclusion_reason="normal",
+    )
+
+
+def _common_kwargs(files: list[merge.FileInfo] | None = None) -> dict[str, object]:
+    return {
+        "files": files or [],
+        "max_file_bytes": 0,
+        "sources": [REPO_ROOT],
+        "debug": False,
+    }
+
+
+def _render_kwargs(kwargs: dict[str, object]) -> list[str]:
+    with clock.frozen(FROZEN_TIME):
+        return list(merge.iter_report_blocks(**kwargs))
+
+
+def _yaml_meta(report: str) -> dict[str, object]:
+    payload = report.split("```yaml\n", 1)[1].split("\n```", 1)[0]
+    loaded = yaml.safe_load(payload)
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+# ---------------------------------------------------------------------------
+# 1. plan-only: all sections verified
+# ---------------------------------------------------------------------------
+class TestPlanOnlyAllSections:
+    """plan_only must produce header, meta, charter, plan; must NOT produce
+    structure, index, manifest, or content blocks."""
+
+    def test_plan_only_sections_present_and_absent(self, tmp_path: Path):
+        path = tmp_path / "README.md"
+        path.write_text("# Hello\n", encoding="utf-8")
+        files = [_file_info(path, rel_path="README.md", category="doc")]
+        report = "".join(
+            _render_kwargs(
+                _common_kwargs(files)
+                | {"level": "max", "plan_only": True}
+            )
+        )
+        # Present sections
+        assert "## Plan" in report
+        assert "## Source & Profile" in report
+        assert "**Plan Only:** true" in report
+        # Absent sections
+        assert "## 📁 Structure" not in report
+        assert "## 🧾 Manifest" not in report
+        assert "<!-- START_OF_CONTENT -->" not in report
+        assert "<!-- FILE_START" not in report
+
+    def test_plan_only_meta_yaml_content_present_false(self, tmp_path: Path):
+        path = tmp_path / "doc.md"
+        path.write_text("content\n", encoding="utf-8")
+        files = [_file_info(path, rel_path="doc.md", category="doc")]
+        report = "".join(
+            _render_kwargs(
+                _common_kwargs(files)
+                | {"level": "max", "plan_only": True}
+            )
+        )
+        meta = _yaml_meta(report)
+        assert meta["merge"]["content_present"] is False
+        assert meta["merge"]["content"]["emitted_files"] == 0
+        assert meta["merge"]["coverage"]["included_files"] == 0
+        assert meta["merge"]["coverage"]["coverage_pct"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# 2. kein Content-Kontakt (plan_only contact ratio = 0)
+# ---------------------------------------------------------------------------
+class TestPlanOnlyNoContentContact:
+    def test_plan_only_contact_ratio_zero(self, tmp_path: Path):
+        path = tmp_path / "code.py"
+        path.write_text("X = 1\n", encoding="utf-8")
+        files = [_file_info(path, rel_path="code.py")]
+        report = "".join(
+            _render_kwargs(
+                _common_kwargs(files)
+                | {"level": "max", "plan_only": True}
+            )
+        )
+        meta = _yaml_meta(report)
+        # Contact ratio must be 0 in plan-only
+        assert meta["merge"]["coverage"]["coverage_pct"] == 0.0
+        assert "**Included Content:** 0 files" in report
+        assert "**Coverage:** 0/" in report
+
+    def test_plan_only_ep_risk_is_high(self, tmp_path: Path):
+        path = tmp_path / "code.py"
+        path.write_text("X = 1\n", encoding="utf-8")
+        files = [_file_info(path, rel_path="code.py")]
+        report = "".join(
+            _render_kwargs(
+                _common_kwargs(files)
+                | {"level": "max", "plan_only": True}
+            )
+        )
+        assert "**Risk Level:** high" in report
+
+
+# ---------------------------------------------------------------------------
+# 3. keine toten Links (all internal #links have targets)
+# ---------------------------------------------------------------------------
+class TestNoDeadLinks:
+    def test_all_internal_links_resolve(self, tmp_path: Path):
+        path = tmp_path / "code.py"
+        path.write_text("X = 1\n", encoding="utf-8")
+        files = [_file_info(path, rel_path="code.py")]
+        report = "".join(
+            _render_kwargs(
+                _common_kwargs(files)
+                | {"level": "max", "plan_only": False}
+            )
+        )
+        # Extract all internal links
+        internal_links = re.findall(r'\[.*?\]\(#([^)]+)\)', report)
+        # Extract all anchors (id="..." or <a id="...">
+        defined_anchors = set()
+        for m in re.finditer(r'id="([^"]+)"', report):
+            defined_anchors.add(m.group(1))
+        # Also collect heading anchors from markdown headings
+        for m in re.finditer(r'^#{1,6}\s+.*\{#([^}]+)\}', report, re.MULTILINE):
+            defined_anchors.add(m.group(1))
+        # Every internal link target must be in defined anchors
+        for link_target in internal_links:
+            assert link_target in defined_anchors, (
+                f"dead link #{link_target} not found in anchors"
+            )
+
+
+# ---------------------------------------------------------------------------
+# 4. ext exclusion
+# ---------------------------------------------------------------------------
+class TestExtExclusion:
+    def test_ext_filter_removes_non_matching_files(self, tmp_path: Path):
+        py = tmp_path / "main.py"
+        md = tmp_path / "README.md"
+        yml = tmp_path / "ci.yml"
+        py.write_text("X = 1\n", encoding="utf-8")
+        md.write_text("# README\n", encoding="utf-8")
+        yml.write_text("name: ci\n", encoding="utf-8")
+        files = [
+            _file_info(py, rel_path="main.py"),
+            _file_info(md, rel_path="README.md", category="doc"),
+            _file_info(yml, rel_path="ci.yml", category="config"),
+        ]
+        report = "".join(
+            _render_kwargs(
+                _common_kwargs(files)
+                | {"level": "max", "plan_only": False, "ext_filter": [".py"]}
+            )
+        )
+        # .py should be present
+        assert "main.py" in report
+        # README.md and ci.yml should NOT be in content/manifest
+        assert 'FILE_START path="README.md"' not in report
+        assert 'FILE_START path="ci.yml"' not in report
+
+    def test_ext_filter_affects_sidecar_counts(self, tmp_path: Path):
+        py = tmp_path / "a.py"
+        md = tmp_path / "b.md"
+        py.write_text("A = 1\n", encoding="utf-8")
+        md.write_text("B\n", encoding="utf-8")
+        files = [
+            _file_info(py, rel_path="a.py"),
+            _file_info(md, rel_path="b.md", category="doc"),
+        ]
+        report = "".join(
+            _render_kwargs(
+                _common_kwargs(files)
+                | {"level": "max", "plan_only": False, "ext_filter": [".py"]}
+            )
+        )
+        meta = _yaml_meta(report)
+        # selection.selected_files should only count .py files
+        assert meta["merge"]["selection"]["selected_files"] == 1
+        assert meta["merge"]["selection"]["text_files"] == 1
+
+
+# ---------------------------------------------------------------------------
+# 5. globale IDs (all file IDs are globally unique)
+# ---------------------------------------------------------------------------
+class TestGlobalIds:
+    def test_all_file_anchors_unique(self, tmp_path: Path):
+        files_list = []
+        for i in range(5):
+            p = tmp_path / f"file{i}.py"
+            p.write_text(f"X{i} = {i}\n", encoding="utf-8")
+            files_list.append(_file_info(p, rel_path=f"file{i}.py"))
+        # Also add same-content files to test hash uniqueness
+        for i in range(3):
+            p = tmp_path / f"dup{i}.py"
+            p.write_text("SAME = 1\n", encoding="utf-8")
+            files_list.append(_file_info(p, rel_path=f"dup{i}.py"))
+        report = "".join(
+            _render_kwargs(
+                _common_kwargs(files_list)
+                | {"level": "max", "plan_only": False}
+            )
+        )
+        # Collect all anchors from FILE_START comments
+        anchors = re.findall(r'file:id="([^"]+)"', report)
+        assert len(anchors) == len(set(anchors)), "non-unique file IDs detected"
+        assert len(anchors) == len(files_list)
+
+
+# ---------------------------------------------------------------------------
+# 6. slug collisions with identical content produce distinct anchors
+# ---------------------------------------------------------------------------
+class TestSlugIdenticalCollision:
+    def test_identical_content_different_paths_distinct_anchors(self, tmp_path: Path):
+        a = tmp_path / "a_b.py"
+        b = tmp_path / "a-b.py"
+        content = "X = 1\n"
+        a.write_text(content, encoding="utf-8")
+        b.write_text(content, encoding="utf-8")
+        files = [
+            _file_info(a, rel_path="a_b.py"),
+            _file_info(b, rel_path="a-b.py"),
+        ]
+        report = "".join(
+            _render_kwargs(
+                _common_kwargs(files)
+                | {"level": "max", "plan_only": False}
+            )
+        )
+        anchors = re.findall(r'file:id="([^"]+)"', report)
+        assert len(anchors) == 2
+        assert anchors[0] != anchors[1]
+        colliding_alias = "file-report-fixture-a-b-py"
+        assert f'<a id="{colliding_alias}"></a>' not in report
+
+    def test_same_name_different_roots_distinct_anchors(self, tmp_path: Path):
+        root_a = tmp_path / "repoA"
+        root_b = tmp_path / "repoB"
+        root_a.mkdir()
+        root_b.mkdir()
+        a = root_a / "code.py"
+        b = root_b / "code.py"
+        a.write_text("A = 1\n", encoding="utf-8")
+        b.write_text("B = 1\n", encoding="utf-8")
+        files = [
+            _file_info(a, rel_path="code.py", root_label="repoA"),
+            _file_info(b, rel_path="code.py", root_label="repoB"),
+        ]
+        report = "".join(
+            _render_kwargs(
+                _common_kwargs(files)
+                | {"level": "max", "plan_only": False}
+            )
+        )
+        anchors = re.findall(r'file:id="([^"]+)"', report)
+        assert len(anchors) == 2
+        assert anchors[0] != anchors[1]
+
+
+# ---------------------------------------------------------------------------
+# 7. marker injection full render
+# ---------------------------------------------------------------------------
+class TestMarkerInjectionFullRender:
+    @staticmethod
+    def _decode(token: str) -> dict[str, object]:
+        padded = token + "=" * (-len(token) % 4)
+        payload = base64.urlsafe_b64decode(padded.encode("ascii"))
+        loaded = json.loads(payload.decode("utf-8"))
+        assert isinstance(loaded, dict)
+        return loaded
+
+    def test_machine_markers_are_single_line_and_round_trip_paths(
+        self, tmp_path: Path
+    ) -> None:
+        unusual_paths = [
+            'a"b.py',
+            "a-->b.py",
+            "ümlaut.py",
+            " leading.py",
+            "trailing.py ",
+            "tab\tname.py",
+            "carriage\rname.py",
+            "line\nname.py",
+            "control\x01name.py",
+        ]
+        for index, rel_path in enumerate(unusual_paths):
+            source = tmp_path / f"source-{index}.py"
+            source.write_text("X = 1\n", encoding="utf-8")
+            file_info = _file_info(source, rel_path="placeholder.py")
+            file_info.rel_path = Path(rel_path)
+            report = "".join(
+                _render_kwargs(
+                    _common_kwargs([file_info])
+                    | {
+                        "level": "max",
+                        "plan_only": False,
+                        "meta_density": "full",
+                    }
+                )
+            )
+
+            assert report.count("<!-- FILE_START ") == 1
+            assert report.count("<!-- FILE_END ") == 1
+            start_line = next(
+                line for line in report.splitlines() if line.startswith("<!-- FILE_START ")
+            )
+            end_line = next(
+                line for line in report.splitlines() if line.startswith("<!-- FILE_END ")
+            )
+            file_meta_line = next(
+                line for line in report.splitlines() if line.startswith("<!-- file_meta ")
+            )
+            for marker_line in (start_line, end_line, file_meta_line):
+                assert marker_line.count("-->") == 1
+                assert not any(ord(char) < 32 or ord(char) == 127 for char in marker_line)
+
+            start_token = re.fullmatch(
+                r'<!-- FILE_START path="[^"]*" meta="([A-Za-z0-9_-]+)" -->',
+                start_line,
+            )
+            end_token = re.fullmatch(
+                r'<!-- FILE_END path="[^"]*" meta="([A-Za-z0-9_-]+)" -->',
+                end_line,
+            )
+            meta_token = re.fullmatch(
+                r'<!-- file_meta meta="([A-Za-z0-9_-]+)" -->',
+                file_meta_line,
+            )
+            assert start_token and end_token and meta_token
+            assert self._decode(start_token.group(1))["path"] == rel_path
+            assert self._decode(end_token.group(1))["path"] == rel_path
+            assert self._decode(meta_token.group(1))["path"] == rel_path
+
+
+# ---------------------------------------------------------------------------
+# 8. tags=None full render path
+# ---------------------------------------------------------------------------
+class TestTagsNoneFullRender:
+    def test_tags_none_renders_safely(self, tmp_path: Path):
+        p = tmp_path / "untagged.py"
+        p.write_text("VALUE = 1\n", encoding="utf-8")
+        files = [_file_info(p, rel_path="untagged.py", tags=None)]
+        report = "".join(
+            _render_kwargs(
+                _common_kwargs(files)
+                | {"level": "max", "plan_only": False}
+            )
+        )
+        assert "untagged.py" in report
+        # tags=None must not leak as the literal string "None"
+        assert "Tags: None" not in report
+        assert "Tag: None" not in report
+
+    def test_tags_none_in_manifest(self, tmp_path: Path):
+        p = tmp_path / "untagged.py"
+        p.write_text("VALUE = 1\n", encoding="utf-8")
+        files = [_file_info(p, rel_path="untagged.py", tags=None)]
+        report = "".join(
+            _render_kwargs(
+                _common_kwargs(files)
+                | {"level": "max", "plan_only": False}
+            )
+        )
+        # In manifest, tags=None should render as "-" not "None"
+        manifest_segment = report.split("Manifest")[1] if "Manifest" in report else ""
+        assert "Tags: None" not in manifest_segment
+
+
+# ---------------------------------------------------------------------------
+# 9. repeat render does not mutate original FileInfo objects
+# ---------------------------------------------------------------------------
+class TestRepeatNoMutation:
+    def test_two_renders_preserve_original_fields(self, tmp_path: Path):
+        p = tmp_path / "code.py"
+        p.write_text("X = 1\n", encoding="utf-8")
+        files = [_file_info(p, rel_path="code.py")]
+        # Snapshot ALL slots before any render
+        original_slot_values = {
+            slot: getattr(files[0], slot) for slot in merge.FileInfo.__slots__
+        }
+        # Render twice with different modes
+        _render_kwargs(
+            _common_kwargs(files)
+            | {"level": "max", "plan_only": False}
+        )
+        _render_kwargs(
+            _common_kwargs(files)
+            | {"level": "summary", "plan_only": True}
+        )
+        # ALL original fields must be unchanged after two renders
+        for slot in merge.FileInfo.__slots__:
+            assert getattr(files[0], slot) == original_slot_values[slot], (
+                f"original FileInfo.{slot} was mutated by render"
+            )
+
+    def test_identical_options_produce_byteidentical_output(self, tmp_path: Path):
+        p = tmp_path / "code.py"
+        p.write_text("X = 1\n", encoding="utf-8")
+        files1 = [_file_info(p, rel_path="code.py")]
+        files2 = [_file_info(p, rel_path="code.py")]
+        kwargs = _common_kwargs() | {"level": "max", "plan_only": False}
+        report1 = "".join(_render_kwargs(kwargs | {"files": files1}))
+        report2 = "".join(_render_kwargs(kwargs | {"files": files2}))
+        assert report1 == report2
+
+
+# ---------------------------------------------------------------------------
+# 10. redactor: quoted/unquoted syntax preservation
+# ---------------------------------------------------------------------------
+class TestRedactorQuotedUnquoted:
+    def test_quoted_api_key_preserves_syntax(self):
+        redactor = Redactor()
+        text = 'API_KEY = "ABCDEFGHIJKLMNOPQRST12345678"'
+        redacted, modified = redactor.redact(text)
+        assert modified is True
+        assert "ABCDEFGHIJKLMNOPQRST12345678" not in redacted
+        # Closing quote must be preserved
+        assert redacted.endswith('"')
+        # Must be valid Python
+        ast.parse(redacted)
+
+    def test_unquoted_api_key_with_dots(self):
+        redactor = Redactor()
+        text = "api_key = abc.def.ghi.jkl.mno.pqr.stu.vwx.yz1234"
+        redacted, modified = redactor.redact(text)
+        assert modified is True
+        assert "abc.def.ghi.jkl.mno" not in redacted
+
+    def test_unquoted_api_key_with_slashes(self):
+        redactor = Redactor()
+        text = "secret_key = abc/def/ghi/jkl/mno/pqr/stu/vwx/yz1234"
+        redacted, modified = redactor.redact(text)
+        assert modified is True
+
+    def test_password_with_special_chars(self):
+        redactor = Redactor()
+        text = 'password = "p@ss+w0rd/123=ok"'
+        redacted, modified = redactor.redact(text)
+        assert modified is True
+        assert "p@ss+w0rd" not in redacted
+        ast.parse(redacted)
+
+    def test_normal_identifier_not_false_positive(self):
+        redactor = Redactor()
+        # A normal variable assignment with a long value should NOT be redacted
+        # by key/password patterns (no key= or password= prefix)
+        text = "result = some_function_call_with_long_name_and_many_args"
+        redacted, _ = redactor.redact(text)
+        assert "result" in redacted
+
+
+# ---------------------------------------------------------------------------
+# 11. wrong before identity (benchmark validation)
+# ---------------------------------------------------------------------------
+class TestBenchmarkBeforeIdentity:
+    def test_validate_before_fails_on_mismatch(self, tmp_path: Path):
+        from scripts.benchmarks.compare_repoground_core_paths import (
+            _validate_before_content_binding,
+        )
+        # Create a fake before_root with a git repo but wrong commit
+        fake_root = tmp_path / "fake"
+        fake_root.mkdir()
+        # Initialize a minimal git repo
+        import subprocess
+        subprocess.run(["git", "init"], cwd=fake_root, capture_output=True, check=False)
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=fake_root, capture_output=True, check=False,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "test"],
+            cwd=fake_root, capture_output=True, check=False,
+        )
+        # Create and commit a file
+        script_dir = fake_root / "scripts" / "benchmarks"
+        script_dir.mkdir(parents=True)
+        (script_dir / "repoground_core_paths.py").write_text("# fake\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "add", "."], cwd=fake_root, capture_output=True, check=False,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "init"], cwd=fake_root, capture_output=True, check=False,
+        )
+        result = _validate_before_content_binding(
+            fake_root,
+            "0000000000000000000000000000000000000000",
+            "0000000000000000000000000000000000000000",
+            "scripts/benchmarks/repoground_core_paths.py",
+        )
+        assert result["status"] == "fail"
+        assert len(result["findings"]) > 0
+
+    def test_validate_before_fails_on_dirty(self, tmp_path: Path):
+        from scripts.benchmarks.compare_repoground_core_paths import (
+            _validate_before_content_binding,
+        )
+        fake_root = tmp_path / "fake"
+        fake_root.mkdir()
+        import subprocess
+        subprocess.run(["git", "init"], cwd=fake_root, capture_output=True, check=False)
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=fake_root, capture_output=True, check=False,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "test"],
+            cwd=fake_root, capture_output=True, check=False,
+        )
+        script_dir = fake_root / "scripts" / "benchmarks"
+        script_dir.mkdir(parents=True)
+        (script_dir / "repoground_core_paths.py").write_text("# fake\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "add", "."], cwd=fake_root, capture_output=True, check=False,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "init"], cwd=fake_root, capture_output=True, check=False,
+        )
+        # Get the committed tree hash
+        tree_hash = subprocess.run(
+            ["git", "rev-parse", "HEAD^{tree}"],
+            cwd=fake_root, capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        commit_hash = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=fake_root, capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        # Make worktree dirty
+        (fake_root / "dirty.txt").write_text("dirty", encoding="utf-8")
+        result = _validate_before_content_binding(
+            fake_root, commit_hash, tree_hash,
+            "scripts/benchmarks/repoground_core_paths.py",
+        )
+        assert result["status"] == "fail"
+        assert any("dirty" in f for f in result["findings"])
+
+
+# ---------------------------------------------------------------------------
+# 12. shallow no false PASS
+# ---------------------------------------------------------------------------
+class TestShallowNoFalsePass:
+    def test_evidence_test_uses_pytest_skip(self):
+        """Verify the evidence contract test uses pytest.skip for shallow clones,
+        not silent return (which would produce a PASS)."""
+        from merger.repoground.tests.test_t009_evidence_contract import (
+            _assert_git_object_available_or_fail_closed,
+        )
+        import inspect
+        source = inspect.getsource(_assert_git_object_available_or_fail_closed)
+        assert "pytest.skip" in source, (
+            "shallow clone handling must use pytest.skip, not silent return"
+        )
+        assert "return" not in source.split("pytest.skip")[0].split("shallow")[-1], (
+            "no silent return before pytest.skip for shallow clone"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 13. missing Evidence/Receipt
+# ---------------------------------------------------------------------------
+class TestMissingEvidenceReceipt:
+    def test_delivery_v2_exists_and_has_status_pending(self):
+        v2_path = PROOFS / "repoground-legacy-t009-delivery.evidence-v2.json"
+        assert v2_path.exists(), "corrective v2 evidence file must exist"
+        payload = json.loads(v2_path.read_text(encoding="utf-8"))
+        assert payload["status"] == "pending"
+        assert payload["verification_status"] == "pass"
+        assert payload["delivery_status"] == "pending"
+        assert payload.get("_corrective") is True
+
+    def test_original_evidence_not_modified(self):
+        """The original delivery evidence must remain unchanged (historical truth).
+        The original has status=pass with no delivery_status field — the
+        historical contradiction is preserved as-is, NOT patched."""
+        original = PROOFS / "repoground-legacy-t009-delivery.evidence.json"
+        assert original.exists()
+        payload = json.loads(original.read_text(encoding="utf-8"))
+        assert payload["status"] == "pass"
+        assert "delivery_status" not in payload, (
+            "original evidence must not have delivery_status; "
+            "use the corrective v2 file for corrected status"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 14. top status pending
+# ---------------------------------------------------------------------------
+class TestTopStatusPending:
+    def test_v2_top_status_pending(self):
+        v2_path = PROOFS / "repoground-legacy-t009-delivery.evidence-v2.json"
+        payload = json.loads(v2_path.read_text(encoding="utf-8"))
+        assert payload["status"] == "pending", (
+            "corrective v2 top-level status must be pending until merge/runtime"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 15. two-revision differential
+# ---------------------------------------------------------------------------
+class TestTwoRevisionDifferential:
+    def test_target_goldens_do_not_claim_historical_parity(self) -> None:
+        contract = json.loads(
+            (GOLDEN_ROOT / "differential_scenarios.json").read_text(encoding="utf-8")
+        )
+        assert contract["purpose"] == "target_revision_regression_golden"
+        assert contract["does_not_establish"] == ["historical_output_parity"]
+        assert contract["historical_comparison_tool"] == (
+            "scripts/ci/compare_report_renderer_revisions.py"
+        )
+
+    def test_real_comparator_uses_distinct_revisions_and_allowlist(self) -> None:
+        from scripts.ci.compare_report_renderer_revisions import compare_revisions
+
+        root = Path(__file__).parents[3]
+        result = compare_revisions(
+            root, "2afc2836fa1a49a593c7b57eda43086844e8fb2b", root
+        )
+        assert result["base"]["commit"] != result["target"]["commit"] or result["target"]["dirty"]
+        assert result["base"]["module_sha256"] != result["target"]["module_sha256"]
+        assert result["intentional_corrections"]
+        assert result["unapproved_differences"] == {}
+
+    def test_plan_only_repo_snapshot_shows_zero_emitted(self, tmp_path: Path):
+        p = tmp_path / "code.py"
+        p.write_text("X = 1\n", encoding="utf-8")
+        files = [_file_info(p, rel_path="code.py")]
+        report = "".join(
+            _render_kwargs(
+                _common_kwargs(files)
+                | {"level": "max", "plan_only": True}
+            )
+        )
+        assert "0 with content" in report
+
+
+# ---------------------------------------------------------------------------
+# 16. structured_warnings in YAML meta
+# ---------------------------------------------------------------------------
+class TestStructuredWarnings:
+    def test_plan_only_warning_in_yaml_meta(self, tmp_path: Path):
+        """Plan-only mode must emit a plan_only_mode warning in diagnostics."""
+        p = tmp_path / "code.py"
+        p.write_text("X = 1\n", encoding="utf-8")
+        files = [_file_info(p, rel_path="code.py")]
+        report = "".join(
+            _render_kwargs(
+                _common_kwargs(files)
+                | {"level": "max", "plan_only": True}
+            )
+        )
+        meta = _yaml_meta(report)
+        assert "diagnostics" in meta
+        warnings = meta["diagnostics"]["warnings"]
+        codes = [w["code"] for w in warnings]
+        assert "plan_only_mode" in codes
+
+    def test_filter_warning_in_yaml_meta(self, tmp_path: Path):
+        """Active filters must emit a scope_filter_active warning."""
+        p = tmp_path / "code.py"
+        p.write_text("X = 1\n", encoding="utf-8")
+        files = [_file_info(p, rel_path="code.py")]
+        report = "".join(
+            _render_kwargs(
+                _common_kwargs(files)
+                | {"level": "max", "plan_only": False, "path_filter": "src/"}
+            )
+        )
+        meta = _yaml_meta(report)
+        assert "diagnostics" in meta
+        warnings = meta["diagnostics"]["warnings"]
+        codes = [w["code"] for w in warnings]
+        assert "scope_filter_active" in codes
+
+    def test_no_warnings_when_no_conditions(self, tmp_path: Path):
+        """No warnings when level=max, no filters, not plan_only."""
+        p = tmp_path / "code.py"
+        p.write_text("X = 1\n", encoding="utf-8")
+        files = [_file_info(p, rel_path="code.py")]
+        report = "".join(
+            _render_kwargs(
+                _common_kwargs(files)
+                | {"level": "max", "plan_only": False}
+            )
+        )
+        meta = _yaml_meta(report)
+        assert "diagnostics" not in meta

--- a/merger/repoground/tests/test_t009_semantic_hardening.py
+++ b/merger/repoground/tests/test_t009_semantic_hardening.py
@@ -656,12 +656,15 @@ class TestTwoRevisionDifferential:
         )
 
     def test_real_comparator_uses_distinct_revisions_and_allowlist(self) -> None:
+        from merger.repoground.tests.test_t009_evidence_contract import (
+            _assert_git_object_available_or_fail_closed,
+        )
         from scripts.ci.compare_report_renderer_revisions import compare_revisions
 
         root = Path(__file__).parents[3]
-        result = compare_revisions(
-            root, "2afc2836fa1a49a593c7b57eda43086844e8fb2b", root
-        )
+        base = "2afc2836fa1a49a593c7b57eda43086844e8fb2b"
+        _assert_git_object_available_or_fail_closed(f"{base}^{{commit}}")
+        result = compare_revisions(root, base, root)
         assert result["base"]["commit"] != result["target"]["commit"] or result["target"]["dirty"]
         assert result["base"]["module_sha256"] != result["target"]["module_sha256"]
         assert result["intentional_corrections"]

--- a/scripts/benchmarks/compare_repoground_core_paths.py
+++ b/scripts/benchmarks/compare_repoground_core_paths.py
@@ -17,6 +17,9 @@ TIMING_REGRESSION_PCT_MAX = 5.0
 PEAK_MEMORY_REGRESSION_PCT_MAX = 5.0
 BENCHMARK_RELATIVE = Path("scripts/benchmarks/repoground_core_paths.py")
 MEASURED_FIELDS = ("wall_seconds_median", "peak_traced_bytes")
+# Timeout per benchmark invocation in seconds.  Prevents runaway runners from
+# blocking CI indefinitely.
+_BENCHMARK_TIMEOUT_SECONDS = 300
 
 
 def _sha256(path: Path) -> str:
@@ -38,6 +41,16 @@ def _git_value(root: Path, expression: str) -> str | None:
     return completed.stdout.strip() if completed.returncode == 0 else None
 
 
+def _git_object_exists_at(root: Path, revision: str) -> bool:
+    completed = subprocess.run(
+        ["git", "cat-file", "-e", revision],
+        cwd=root,
+        check=False,
+        capture_output=True,
+    )
+    return completed.returncode == 0
+
+
 def _git_dirty(root: Path) -> bool | None:
     completed = subprocess.run(
         ["git", "status", "--porcelain"],
@@ -47,6 +60,20 @@ def _git_dirty(root: Path) -> bool | None:
         text=True,
     )
     return bool(completed.stdout.strip()) if completed.returncode == 0 else None
+
+
+def _git_blob_sha256(commit: str, path: str, root: Path) -> str | None:
+    """Compute SHA-256 of a blob at ``commit:path`` for content binding."""
+    try:
+        completed = subprocess.run(
+            ["git", "show", f"{commit}:{path}"],
+            cwd=root,
+            check=True,
+            capture_output=True,
+        )
+        return hashlib.sha256(completed.stdout).hexdigest()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
 
 
 def _percent_change(before: float, after: float) -> float:
@@ -64,13 +91,19 @@ def _run_benchmark(root: Path, samples: int, output: Path) -> dict[str, Any]:
         "--out",
         str(output),
     ]
-    completed = subprocess.run(
-        command,
-        cwd=root,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=root,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_BENCHMARK_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"benchmark timed out after {_BENCHMARK_TIMEOUT_SECONDS}s in {root}: {exc}"
+        ) from exc
     if completed.returncode != 0:
         raise RuntimeError(
             f"benchmark failed in {root}: {completed.stderr.strip()[-1000:]}"
@@ -83,13 +116,36 @@ def _run_benchmark(root: Path, samples: int, output: Path) -> dict[str, Any]:
 
 def _aggregate_case(rows: list[dict[str, Any]]) -> dict[str, Any]:
     if all("skipped" in row for row in rows):
-        reasons = sorted({str(row["skipped"]) for row in rows})
-        return {"skipped": reasons, "rounds": len(rows)}
+        # Normalize: flatten skip reasons to sorted unique strings
+        flat_reasons: list[str] = []
+        for row in rows:
+            val = row["skipped"]
+            if isinstance(val, list):
+                flat_reasons.extend(str(r) for r in val)
+            else:
+                flat_reasons.append(str(val))
+        return {
+            "skipped": sorted(set(flat_reasons)),
+            "rounds": len(rows),
+            "samples_per_round": [
+                int(row["samples"]) if "samples" in row else "unknown"
+                for row in rows
+            ],
+        }
     if any("skipped" in row for row in rows):
-        raise RuntimeError("case is measured in only a subset of rounds")
+        # Partial skip: structured contract failure.  All or nothing.
+        return {
+            "skipped": ["partial_skip_not_allowed"],
+            "rounds": len(rows),
+            "status": "fail",
+        }
     for field in MEASURED_FIELDS:
         if any(field not in row for row in rows):
-            raise RuntimeError(f"measured case lacks {field}")
+            return {
+                "skipped": [f"missing_field_{field}"],
+                "rounds": len(rows),
+                "status": "fail",
+            }
     return {
         "rounds": len(rows),
         "samples_per_round": [int(row["samples"]) for row in rows],
@@ -113,8 +169,19 @@ def _aggregate_reports(reports: list[dict[str, Any]]) -> dict[str, Any]:
 
 
 def _compare_case(before: dict[str, Any], after: dict[str, Any]) -> dict[str, Any]:
+    # Structural failures must never be reclassified as ordinary skips.
+    if before.get("status") == "fail" or after.get("status") == "fail":
+        return {
+            "status": "fail",
+            "reason": "structural measurement failure",
+            "before": before,
+            "after": after,
+        }
     if "skipped" in before or "skipped" in after:
-        if before.get("skipped") != after.get("skipped"):
+        contract_fields = ("skipped", "rounds", "samples_per_round")
+        before_contract = {field: before.get(field) for field in contract_fields}
+        after_contract = {field: after.get(field) for field in contract_fields}
+        if before_contract != after_contract:
             return {
                 "status": "fail",
                 "reason": "skip contract differs",
@@ -122,6 +189,16 @@ def _compare_case(before: dict[str, Any], after: dict[str, Any]) -> dict[str, An
                 "after": after,
             }
         return {"status": "skip", "before": before, "after": after}
+    # Fail-closed: both sides must have required measurement fields
+    for side_label, side_data in [("before", before), ("after", after)]:
+        for field in MEASURED_FIELDS:
+            if field not in side_data or side_data[field] is None:
+                return {
+                    "status": "fail",
+                    "reason": f"{side_label} missing measurement field {field}",
+                    "before": before,
+                    "after": after,
+                }
     timing_change = _percent_change(
         float(before["wall_seconds_median"]), float(after["wall_seconds_median"])
     )
@@ -172,6 +249,60 @@ def _validate_reports(
     }
 
 
+def _validate_before_content_binding(
+    before_root: Path,
+    before_commit: str,
+    before_tree: str,
+    benchmark_script_path: str,
+) -> dict[str, Any]:
+    """Verify that the 'before' checkout content matches the claimed commit.
+
+    Fail-closed: before_root must be an authoritative Git checkout of the
+    claimed commit/tree identity, clean, with claimed commit available.
+    No self-attested CLI copy.
+    """
+    findings: list[str] = []
+    live_commit = _git_value(before_root, "HEAD")
+    if live_commit != before_commit:
+        findings.append(
+            f"before HEAD ({live_commit}) does not match claimed commit ({before_commit})"
+        )
+    live_tree = _git_value(before_root, "HEAD^{tree}")
+    if live_tree is None:
+        findings.append("before HEAD^{tree} is unavailable (shallow or broken checkout)")
+    # Verify claimed before_tree matches live HEAD^{tree} exactly
+    if live_tree is not None and live_tree != before_tree:
+        findings.append(
+            f"before live tree ({live_tree}) does not match claimed before_tree ({before_tree})"
+        )
+    # Verify before worktree is clean — dirty must be exactly False, None is error
+    dirty = _git_dirty(before_root)
+    if dirty is None:
+        findings.append("before worktree dirty status could not be determined")
+    elif dirty is True:
+        findings.append("before worktree is dirty (expected clean)")
+    # Verify claimed commit is reachable
+    if not _git_object_exists_at(before_root, before_commit):
+        findings.append(f"claimed before_commit {before_commit} is not reachable")
+    # Verify benchmark script content identity against the claimed commit
+    live_script_hash = _sha256(before_root / benchmark_script_path)
+    claimed_script_hash = _git_blob_sha256(before_commit, benchmark_script_path, before_root)
+    if claimed_script_hash is None:
+        findings.append(
+            f"benchmark script {benchmark_script_path} not found at claimed commit"
+        )
+    elif live_script_hash != claimed_script_hash:
+        findings.append(
+            "before benchmark script content does not match claimed commit blob"
+        )
+    return {
+        "status": "pass" if not findings else "fail",
+        "findings": findings,
+        "live_commit": live_commit,
+        "live_tree": live_tree,
+    }
+
+
 def compare(
     before_root: Path,
     after_root: Path,
@@ -194,6 +325,15 @@ def compare(
         raise RuntimeError("after revision binding does not match live checkout")
     if _git_dirty(after_root) is not False:
         raise RuntimeError("after worktree must be clean")
+
+    # Fail-closed: validate before content binding against claimed commit
+    before_binding_check = _validate_before_content_binding(
+        before_root, before_commit, before_tree, str(BENCHMARK_RELATIVE)
+    )
+    if before_binding_check["status"] == "fail":
+        raise RuntimeError(
+            f"before content binding failed: {'; '.join(before_binding_check['findings'])}"
+        )
 
     before_reports: list[dict[str, Any]] = []
     after_reports: list[dict[str, Any]] = []
@@ -231,6 +371,7 @@ def compare(
             "rounds": rounds,
             "samples_per_round": samples,
             "warmups_per_revision": warmups,
+            "gate_kind": "performance_smoke_gate",
             "primary_timing_metric": "median of per-round wall_seconds_median",
             "primary_memory_metric": "median of per-round peak_traced_bytes",
             "execution_order": execution_order,
@@ -251,9 +392,10 @@ def compare(
         "binding": {
             "commit": before_commit,
             "tree": before_tree,
-            "source": "git_archive",
+            "source": "clean_git_worktree",
             "worktree_dirty": False,
         },
+        "content_binding": before_binding_check,
         "cases": before_cases,
     }
     after = common | {
@@ -271,6 +413,7 @@ def compare(
         "version": "1.0",
         "status": status,
         "validation": validation,
+        "before_content_binding": before_binding_check,
         "gate": common["configuration"]["timing_gate"],
         "compared_cases": comparisons,
         "failed_cases": failures,
@@ -280,6 +423,7 @@ def compare(
             "absence of regressions on unmeasured paths",
             "production workload representativeness",
             "memory use outside Python tracemalloc",
+            "statistical significance",
         ],
     }
     return before, after, comparison

--- a/scripts/ci/compare_report_renderer_revisions.py
+++ b/scripts/ci/compare_report_renderer_revisions.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tarfile
+import tempfile
+from typing import Any
+
+
+class DifferentialError(RuntimeError):
+    pass
+
+
+SCENARIOS: dict[str, dict[str, Any]] = {
+    "profile_max": {},
+    "profile_summary": {"level": "summary"},
+    "profile_machine_lean": {"level": "machine-lean"},
+    "plan_only": {"plan_only": True},
+    "code_only": {"code_only": True},
+    "redaction": {"redact_secrets": True},
+    "meta_min": {"meta_density": "min"},
+    "meta_standard": {"meta_density": "standard"},
+    "meta_full": {"meta_density": "full"},
+    "meta_none": {"meta_none": True},
+    "organism": {"extras": {"organism_index": True}},
+    "heatmap": {"extras": {"heatmap": True}},
+    "augment_delta": {
+        "extras": {"augment_sidecar": True, "delta_reports": True},
+        "delta_meta": {"summary": {"files_added": 1}},
+    },
+    "artifact_refs": {"artifact_refs": {"index_json_basename": "index.json"}},
+    "extension_filter": {"ext_filter": [".py"]},
+    "path_filter": {"path_filter": "src/"},
+    "truncation": {"max_file_bytes": 24},
+    "multi_repo": {"multi_repo": True},
+}
+
+ALLOWED_DIFFERENCES: dict[str, set[str]] = {
+    "plan_only": {
+        "contact_ratio", "coverage",
+        "risk_level", "snapshots", "yaml_content",
+    },
+    "extension_filter": {
+        "content_paths", "coverage", "end_count", "file_id_count",
+        "snapshots", "start_count", "yaml_content",
+    },
+}
+
+_RUNNER = r'''
+import datetime
+import hashlib
+import json
+from pathlib import Path
+import re
+import sys
+import yaml
+from merger.repoground.core import clock, merge
+
+fixture = Path(sys.argv[1])
+scenarios = json.loads(sys.argv[2])
+frozen = datetime.datetime(2026, 7, 24, 12, 0, tzinfo=datetime.timezone.utc)
+specs = (
+    ("README.md", "doc", ["ai-context"]),
+    ("src/main.py", "source", ["entrypoint"]),
+    ("docs/guide.md", "doc", ["runbook"]),
+    (".github/workflows/ci.yml", "config", ["ci"]),
+)
+
+def file_info(path, rel_path, root_label="report-fixture", category="source", tags=None):
+    payload = path.read_bytes()
+    return merge.FileInfo(
+        root_label=root_label, abs_path=path, rel_path=Path(rel_path),
+        size=len(payload), is_text=True,
+        md5=hashlib.md5(payload, usedforsecurity=False).hexdigest(),
+        category=category, tags=[] if tags is None else tags, ext=path.suffix, content=None,
+        inclusion_reason="normal",
+    )
+
+def files():
+    return [
+        file_info(fixture / rel, rel, category=category, tags=list(tags))
+        for rel, category, tags in specs
+    ]
+
+def yaml_meta(report):
+    payload = report.split("```yaml\n", 1)[1].split("\n```", 1)[0]
+    loaded = yaml.safe_load(payload)
+    return loaded if isinstance(loaded, dict) else {}
+
+def project(report):
+    meta = yaml_meta(report)
+    content = meta.get("content", {}) if isinstance(meta.get("content", {}), dict) else {}
+    coverage_meta = meta.get("coverage", {}) if isinstance(meta.get("coverage", {}), dict) else {}
+    ids = re.findall(r'file:id="([^"]+)"', report)
+    return {
+        "contact_ratio": re.findall(r"\*\*Contact Ratio:\*\*\s*([^\n]+)", report),
+        "content_paths": re.findall(r"\*\*Path:\*\* `([^`]*)`", report),
+        "coverage": re.findall(r"\*\*Coverage:\*\*\s*([^\n]+)", report),
+        "end_count": report.count("<!-- FILE_END "),
+        "file_id_count": [len(ids), len(set(ids))],
+        "risk_level": re.findall(r"\*\*Risk Level:\*\*\s*([^\n]+)", report),
+        "snapshots": sorted(line.strip() for line in report.splitlines() if "with content)" in line),
+        "start_count": report.count("<!-- FILE_START "),
+        "yaml_content": {
+            "coverage_included_files": coverage_meta.get("included_files"),
+            "coverage_pct": coverage_meta.get("coverage_pct"),
+            "emitted_files": content.get("emitted_files"),
+            "present": content.get("present"),
+            "selected_text_files": content.get("selected_text_files"),
+        },
+    }
+
+out = {}
+for name, raw_options in scenarios.items():
+    options = dict(raw_options)
+    multi_repo = options.pop("multi_repo", False)
+    extras = options.pop("extras", None)
+    if extras is not None:
+        options["extras"] = merge.ExtrasConfig(**extras)
+    selected = files()
+    if multi_repo:
+        selected.append(file_info(fixture / "src/main.py", "extra.py", root_label="second-repo"))
+    kwargs = {
+        "files": selected, "max_file_bytes": 0, "sources": [fixture],
+        "debug": False, "level": "max", "plan_only": False,
+    }
+    kwargs.update(options)
+    with clock.frozen(frozen):
+        report = "".join(merge.iter_report_blocks(**kwargs))
+    out[name] = project(report)
+print(json.dumps(out, ensure_ascii=False, sort_keys=True))
+'''
+
+
+def _run_git(repo: Path, *args: str, text: bool = True) -> str | bytes:
+    completed = subprocess.run(
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=text
+    )
+    return completed.stdout
+
+
+def _materialize(repo: Path, revision: str, destination: Path) -> None:
+    process = subprocess.Popen(
+        ["git", "archive", "--format=tar", revision],
+        cwd=repo, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    )
+    assert process.stdout is not None
+    with tarfile.open(fileobj=process.stdout, mode="r|") as archive:
+        archive.extractall(destination, filter="data")
+    stderr = process.stderr.read().decode("utf-8", errors="replace") if process.stderr else ""
+    if process.wait() != 0:
+        raise DifferentialError(f"git archive failed for {revision}: {stderr}")
+
+
+def _module_sha(root: Path) -> str:
+    path = root / "merger" / "repoground" / "core" / "merge.py"
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _worktree_digest(repo: Path) -> str:
+    diff = subprocess.run(
+        ["git", "diff", "--binary", "HEAD"],
+        cwd=repo, check=True, capture_output=True,
+    ).stdout
+    untracked = str(_run_git(repo, "ls-files", "--others", "--exclude-standard")).splitlines()
+    digest = hashlib.sha256(diff)
+    for rel in sorted(untracked):
+        path = repo / rel
+        digest.update(rel.encode("utf-8") + b"\0")
+        if path.is_file():
+            digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def _identity(repo: Path, root: Path, revision: str | None) -> dict[str, Any]:
+    commit = str(_run_git(repo, "rev-parse", revision or "HEAD")).strip()
+    tree = str(_run_git(repo, "rev-parse", f"{commit}^{{tree}}")).strip()
+    dirty = False if revision else bool(str(_run_git(repo, "status", "--porcelain")).strip())
+    return {
+        "commit": commit,
+        "dirty": dirty,
+        "module_sha256": _module_sha(root),
+        "tree": tree,
+        "worktree_diff_sha256": None if revision else _worktree_digest(repo),
+    }
+
+
+def _render(root: Path, fixture_root: Path) -> dict[str, Any]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(root)
+    completed = subprocess.run(
+        [sys.executable, "-c", _RUNNER, str(fixture_root), json.dumps(SCENARIOS)],
+        cwd=root, env=env, check=False, capture_output=True,
+        text=True, timeout=180,
+    )
+    if completed.returncode != 0:
+        raise DifferentialError(
+            f"renderer failed for {root}: {completed.stderr.strip()}"
+        )
+    payload = json.loads(completed.stdout)
+    if not isinstance(payload, dict):
+        raise DifferentialError("renderer runner returned a non-object payload")
+    return payload
+
+
+def compare_revisions(
+    repo: Path,
+    base_revision: str,
+    target_root: Path,
+    *,
+    target_revision: str | None = None,
+) -> dict[str, Any]:
+    repo = repo.resolve()
+    target_root = target_root.resolve()
+    fixture_root = target_root / "merger/repoground/tests/fixtures/report_renderer/repo"
+    with tempfile.TemporaryDirectory(prefix="repoground-differential-") as temp_dir:
+        base_root = Path(temp_dir) / "base"
+        base_root.mkdir()
+        _materialize(repo, base_revision, base_root)
+        actual_target_root = target_root
+        if target_revision is not None:
+            actual_target_root = Path(temp_dir) / "target"
+            actual_target_root.mkdir()
+            _materialize(repo, target_revision, actual_target_root)
+        base_identity = _identity(repo, base_root, base_revision)
+        target_identity = _identity(repo, actual_target_root, target_revision)
+        if base_identity["commit"] == target_identity["commit"] and not target_identity["dirty"]:
+            raise DifferentialError("differential comparison requires distinct revisions")
+        base_output = _render(base_root, fixture_root)
+        target_output = _render(actual_target_root, fixture_root)
+
+    comparisons: dict[str, dict[str, Any]] = {}
+    unapproved: dict[str, list[str]] = {}
+    for scenario in SCENARIOS:
+        base_projection = base_output[scenario]
+        target_projection = target_output[scenario]
+        differing = sorted(
+            key for key in set(base_projection) | set(target_projection)
+            if base_projection.get(key) != target_projection.get(key)
+        )
+        allowed = ALLOWED_DIFFERENCES.get(scenario, set())
+        rejected = sorted(set(differing) - allowed)
+        comparisons[scenario] = {
+            "allowed_differences": sorted(allowed),
+            "base_projection": base_projection,
+            "differing_fields": differing,
+            "target_projection": target_projection,
+            "unapproved_differences": rejected,
+        }
+        if rejected:
+            unapproved[scenario] = rejected
+
+    return {
+        "base": base_identity,
+        "comparisons": comparisons,
+        "intentional_corrections": {
+            key: sorted(value) for key, value in ALLOWED_DIFFERENCES.items()
+        },
+        "scenarios": sorted(SCENARIOS),
+        "schema_version": 1,
+        "target": target_identity,
+        "unapproved_differences": unapproved,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", type=Path, default=Path.cwd())
+    parser.add_argument("--base-revision", required=True)
+    parser.add_argument("--target-root", type=Path, default=Path.cwd())
+    parser.add_argument("--target-revision")
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    result = compare_revisions(
+        args.repo, args.base_revision, args.target_root,
+        target_revision=args.target_revision,
+    )
+    rendered = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        sys.stdout.write(rendered)
+    return 1 if result["unapproved_differences"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/compare_report_renderer_revisions.py
+++ b/scripts/ci/compare_report_renderer_revisions.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import io
 import json
 import os
 from pathlib import Path
@@ -145,16 +146,25 @@ def _run_git(repo: Path, *args: str, text: bool = True) -> str | bytes:
 
 
 def _materialize(repo: Path, revision: str, destination: Path) -> None:
-    process = subprocess.Popen(
+    completed = subprocess.run(
         ["git", "archive", "--format=tar", revision],
-        cwd=repo, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        cwd=repo, capture_output=True, check=False,
     )
-    assert process.stdout is not None
-    with tarfile.open(fileobj=process.stdout, mode="r|") as archive:
-        archive.extractall(destination, filter="data")
-    stderr = process.stderr.read().decode("utf-8", errors="replace") if process.stderr else ""
-    if process.wait() != 0:
-        raise DifferentialError(f"git archive failed for {revision}: {stderr}")
+    stderr = completed.stderr.decode("utf-8", errors="replace").strip()
+    if completed.returncode != 0:
+        detail = stderr or "git archive returned no diagnostic"
+        raise DifferentialError(f"git archive failed for {revision}: {detail}")
+    if not completed.stdout:
+        raise DifferentialError(
+            f"git archive returned an empty payload for {revision}"
+        )
+    try:
+        with tarfile.open(fileobj=io.BytesIO(completed.stdout), mode="r:") as archive:
+            archive.extractall(destination, filter="data")
+    except tarfile.TarError as exc:
+        raise DifferentialError(
+            f"git archive returned invalid tar data for {revision}: {exc}"
+        ) from exc
 
 
 def _module_sha(root: Path) -> str:


### PR DESCRIPTION
## Zweck

Korrektiver Folgefix für den bereits gemergten PR #1098. Der ursprüngliche Refactor bleibt strukturell erhalten; dieser PR behebt die anschließend bestätigten Vertragsfehler, ohne historische T009-Evidence umzuschreiben.

## Behoben

- zentrale unveränderliche Emissionsprojektion für Auswahl, Aufnahme und tatsächliche Ausgabe
- konsistente Plan-only-Wahrheit mit `emitted = 0`
- tatsächlich angewandter Extension-Filter
- keine Mutation aufruferseitiger `FileInfo`-Objekte
- SHA-256-Pfadanker und kollisionssichere Legacy-Aliase
- einzeilige Base64url-JSON-Maschinenmarker
- strukturierte YAML-Diagnostik
- kontextgebundene Secret-Redaction ohne breite Identifier-Falschpositive
- fail-closed Benchmark-, Skip- und Evidence-Verträge
- echter Zwei-Revisions-Vergleich gegen den PR-Basiscommit
- Zielversions-Goldens ohne falschen historischen Paritätsanspruch

## Revisionsbindung

- gemergter Fehlerstand: `c91d640bce2b14c4a78a64e83169d56c818fa662`
- Implementierung: `684fd3aa8f0b99f6b743386e233d09b997144310`
- finaler PR-Head: `bfba4b38d4ecb0dec3496a1f80fefc5febc39e8c`

## Prüfung

- Fokusmatrix: 120 bestanden
- breite RepoGround-Suite: 4.850 bestanden, 2 übersprungen
- Ruff: bestanden
- Complexity-Ratchet: 197 Befunde, Maximum 138, keine neuen Befunde
- Performance-Smoke: bestanden, 5-%-Grenzen eingehalten
- Zwei-Revisions-Vergleich: keine nicht freigegebenen Abweichungen

Die breite lokale Suite schließt zwei Patch-Evaluation-Sidecar-Dateien aus. Bubblewrap kann auf dem Host aktuell keinen Namespace erzeugen (`Resource temporarily unavailable`). Derselbe Fehler wurde auf dem unveränderten gemergten Fehlerstand reproduziert und wird als separate Host-Obligation behandelt.

## Evidence

- `docs/proofs/repoground-legacy-t009-contract-hardening-v2-proof.md`
- `docs/proofs/repoground-legacy-t009-delivery.evidence-v2.json`

Historische T009-Evidence-Dateien sind bytegleich unverändert geblieben.

## Nicht belegt durch diesen PR-Text

Dieser Text belegt noch keinen GitHub-Check-PASS, Merge, Runtime-Deployment oder Bureau-Closeout.