### PR TITLE
fix(mcp): harden the agent frontdoor

### DIFF
--- a/config/codeql-path-suppressions.v1.json
+++ b/config/codeql-path-suppressions.v1.json
@@ -273,7 +273,7 @@
       ]
     },
     "query-readonly-index": {
-      "authority": "Read-only query callers pass an absolute canonical index selected from validated artifact or bundle metadata.",
+      "authority": "Read-only query callers pass either an absolute canonical chunk-index path or a descriptor path pinned to an artifact whose bytes and SHA-256 were verified against the active bundle manifest.",
       "expected_occurrences": 1,
       "files": [
         "merger/repoground/retrieval/query_core.py"
@@ -281,8 +281,8 @@
       "sites": [
         {
           "path": "merger/repoground/retrieval/query_core.py",
-          "scope": "execute_query",
-          "statement": "conn = sqlite3.connect(db_uri, uri=True)"
+          "scope": "_open_query_connection",
+          "statement": "return sqlite3.connect(db_uri, uri=True)"
         }
       ],
       "tests": [
@@ -292,7 +292,8 @@
         "merger/repoground/tests/test_retrieval_query.py::test_query_read_only_uses_immutable_sqlite_uri"
       ],
       "validation": [
-        "Read-only mode requires the canonical chunk-index SQLite suffix and an absolute path.",
+        "Read-only mode requires an absolute path; manifest-bound callers query only a verified /proc/self/fd or /dev/fd descriptor while the pinned handle remains open.",
+        "The separately validated source path must carry the canonical chunk-index SQLite suffix.",
         "The SQLite URI uses mode=ro and immutable=1."
       ]
     },

--- a/docs/architecture/repoground-mcp-boundary.md
+++ b/docs/architecture/repoground-mcp-boundary.md
@@ -72,11 +72,26 @@ size, path, and integrity checks.
 
 ## Read-only tools
 
-The MCP tools available by default are:
+The MCP tools available by default are generated from the runtime registry:
 
-- `ask_context`
-- `grounding_verify`
-- `live_freshness`
+<!-- repoground-mcp-tools:start -->
+- `bundle_discover`: List healthy existing bundles or select one by repository identity/stem.
+- `snapshot_status`: Read health, availability and freshness for one selected existing bundle.
+- `ask_context`: Build a cited context pack from one existing RepoGround bundle.
+- `query_existing_index`: Route exact symbol-definition questions to the symbol index; otherwise use exact AND and labelled OR fallback with bounded cited ranges.
+- `range_get`: Resolve one exact bundle range reference without reading a live workspace.
+- `grounding_verify`: Verify declared citations and ranges against an existing RepoGround bundle.
+- `live_freshness`: Compare snapshot Git provenance with the configured local checkout without refreshing it.
+- `find_symbol`: Locate Python symbol definitions by name with exact path and line range.
+- `find_references`: List bounded static call sites for a callee name.
+- `get_callers`: Group uniquely resolved callers for one exact target symbol.
+- `get_callees`: Group uniquely resolved outgoing calls for one exact caller symbol.
+<!-- repoground-mcp-tools:end -->
+
+Every read tool that targets one snapshot accepts either an exact `bundle_manifest`
+inside the startup root or the agent-facing `repo`/`stem` selector. Combining an
+exact path with selectors is rejected. Selection considers only healthy bundles and
+fails closed when the newest identity is ambiguous.
 
 The underlying read-only library surface also contains:
 

--- a/docs/usage/repoground-mcp-stdio.md
+++ b/docs/usage/repoground-mcp-stdio.md
@@ -64,13 +64,32 @@ bundle root, and optional repository root are the stable RepoGround side of the 
 
 Read-only by default:
 
-- `ask_context`: builds the existing cited context pack from one registered bundle;
-- `grounding_verify`: runs the existing declaration and evidence verifier;
-- `live_freshness`: compares the snapshot commit and cleanliness with the configured checkout;
-- `find_symbol`: locates Python symbol definitions by name in the snapshot's symbol index (exact matches first), answering "where is X defined?" with a path and line range; each call also attaches the live freshness of the snapshot.
-- `find_references`: searches bounded static Python call sites by callee name and returns source ranges, relation type, S0/S1 evidence and each call site's explicit `resolved`, `candidate`, `ambiguous`, or `unresolved` verdict;
-- `get_callers`: selects one exact target symbol from a run/hash-coherent Symbol Index and returns only S1 call edges to that symbol. Equal names in other files and unresolved textual matches remain separate; use the optional `path` field to disambiguate exact names;
-- `get_callees`: selects one exact caller symbol and groups its uniquely resolved S1 targets while retaining candidate, ambiguous and unresolved S0 call sites separately.
+
+<!-- repoground-mcp-tools:start -->
+- `bundle_discover`: List healthy existing bundles or select one by repository identity/stem.
+- `snapshot_status`: Read health, availability and freshness for one selected existing bundle.
+- `ask_context`: Build a cited context pack from one existing RepoGround bundle.
+- `query_existing_index`: Route exact symbol-definition questions to the symbol index; otherwise use exact AND and labelled OR fallback with bounded cited ranges.
+- `range_get`: Resolve one exact bundle range reference without reading a live workspace.
+- `grounding_verify`: Verify declared citations and ranges against an existing RepoGround bundle.
+- `live_freshness`: Compare snapshot Git provenance with the configured local checkout without refreshing it.
+- `find_symbol`: Locate Python symbol definitions by name with exact path and line range.
+- `find_references`: List bounded static call sites for a callee name.
+- `get_callers`: Group uniquely resolved callers for one exact target symbol.
+- `get_callees`: Group uniquely resolved outgoing calls for one exact caller symbol.
+<!-- repoground-mcp-tools:end -->
+
+Snapshot-targeting read tools accept either `bundle_manifest` or the agent-facing
+`repo`/`stem` selectors. An exact manifest cannot be combined with selectors. The
+server selects only a unique healthy publication and rejects missing or ambiguous
+selection instead of falling back to an older unrelated bundle.
+
+Tool calls return the complete typed payload once in `structuredContent`. The text
+content is only a small status summary, so clients do not receive the same large
+JSON object twice. `query_existing_index` routes explicit symbol-definition
+questions through the exact symbol index first. For broader content questions it
+shares `ask_context`'s exact-AND then labelled relaxed-OR retrieval strategy.
+Context is bounded globally and per hit; empty and duplicate excerpts are omitted.
 
 The call-navigation tools read only bundle-registered `python_call_graph_json` and `python_symbol_index_json` artifacts. They validate artifact integrity and provenance coherence before returning symbol relations. `S1` means one unique local target under the producer's bounded static rules; it does not mean the target executes at runtime. `S0` preserves uncertainty instead of guessing.
 

--- a/docs/usage/repoground-mcp-stdio.md
+++ b/docs/usage/repoground-mcp-stdio.md
@@ -32,9 +32,16 @@ python3 -m merger.repoground.cli.mcp_stdio \
 
 The repository tracks `.mcp.json`, which starts `scripts/repoground-mcp-project.py`.
 For a checkout opened as an MCP-aware project, this is the canonical configuration. The launcher
-binds `--repo-root` to that checkout and uses `~/.local/share/repoground/bundles` by default.
-Set `REPOGROUND_BUNDLE_ROOT` only when an operator intentionally uses another existing bundle
-root. Snapshot creation remains disabled unless `REPOGROUND_MCP_ENABLE_SNAPSHOT_CREATE=1`.
+binds `--repo-root` to that checkout and discovers the canonical publication catalog in a nearby
+`manifest-publications/bundles` directory. It selects one uniquely healthy bundle whose repository
+identity matches the checkout; it does not fall back to the legacy
+`~/.local/share/repoground/bundles` location.
+
+`REPOGROUND_PUBLICATION_ROOT` overrides the discovered canonical publication catalog. The
+higher-priority `REPOGROUND_BUNDLE_ROOT` override may instead name another existing catalog or one
+exact bundle manifest for an intentional operator-controlled setup. `REPOGROUND_REPO_ID` can bind
+selection to an explicit qualified repository identity when Git `origin` is unavailable. Snapshot
+creation remains disabled unless `REPOGROUND_MCP_ENABLE_SNAPSHOT_CREATE=1`.
 
 ## Generic MCP client configuration
 

--- a/merger/repoground/architecture/call_graph.py
+++ b/merger/repoground/architecture/call_graph.py
@@ -270,6 +270,7 @@ class _CallGraphVisitor(ast.NodeVisitor):
     def visit_FunctionDef(self, node: ast.FunctionDef) -> Any:
         self._register_def(node.name, "function")
         self._visit_function_header(node)
+        self._invalidate_local_imports({node.name})
         frame = _function_frame(
             node,
             name=node.name,
@@ -285,6 +286,7 @@ class _CallGraphVisitor(ast.NodeVisitor):
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> Any:
         self._register_def(node.name, "async_function")
         self._visit_function_header(node)
+        self._invalidate_local_imports({node.name})
         frame = _function_frame(
             node,
             name=node.name,
@@ -307,6 +309,7 @@ class _CallGraphVisitor(ast.NodeVisitor):
             self.visit(keyword.value)
         for type_param in getattr(node, "type_params", ()):
             self.visit(type_param)
+        self._invalidate_local_imports({node.name})
         self.stack.append(_class_frame(node))
         for statement in node.body:
             self.visit(statement)
@@ -385,11 +388,23 @@ class _CallGraphVisitor(ast.NodeVisitor):
             return None
 
         aliases = dict(self.stack[-1].module_aliases)
+        imports = {
+            local: (module, original)
+            for local, module, original in self.stack[-1].from_imports
+        }
         for alias in node.names:
             local = alias.asname or alias.name.split(".")[0]
             aliases[local] = alias.name if alias.asname else local
+            imports.pop(local, None)
         self.stack[-1] = replace(
-            self.stack[-1], module_aliases=tuple(sorted(aliases.items()))
+            self.stack[-1],
+            module_aliases=tuple(sorted(aliases.items())),
+            from_imports=tuple(
+                sorted(
+                    (local, module, original)
+                    for local, (module, original) in imports.items()
+                )
+            ),
         )
         return None
 
@@ -417,13 +432,16 @@ class _CallGraphVisitor(ast.NodeVisitor):
             local: (module, original)
             for local, module, original in self.stack[-1].from_imports
         }
+        aliases = dict(self.stack[-1].module_aliases)
         for alias in node.names:
             if alias.name == "*" or not source:
                 continue
             local = alias.asname or alias.name
             imports[local] = (source, alias.name)
+            aliases.pop(local, None)
         self.stack[-1] = replace(
             self.stack[-1],
+            module_aliases=tuple(sorted(aliases.items())),
             from_imports=tuple(
                 sorted(
                     (local, module, original)
@@ -433,6 +451,36 @@ class _CallGraphVisitor(ast.NodeVisitor):
         )
         return None
 
+    def _invalidate_local_imports(self, names: set[str]) -> None:
+        if not self.stack or not names:
+            return
+        frame = self.stack[-1]
+        aliases = tuple(
+            (local, module)
+            for local, module in frame.module_aliases
+            if local not in names
+        )
+        imports = tuple(
+            (local, module, original)
+            for local, module, original in frame.from_imports
+            if local not in names
+        )
+        if aliases != frame.module_aliases or imports != frame.from_imports:
+            self.stack[-1] = replace(
+                frame,
+                module_aliases=aliases,
+                from_imports=imports,
+            )
+
+    def _bind_or_invalidate_targets(self, targets: Iterable[ast.expr]) -> None:
+        target_list = tuple(targets)
+        names = set().union(*(_target_names(target) for target in target_list))
+        if self.stack:
+            self._invalidate_local_imports(names)
+            return
+        for target in target_list:
+            self._bind_module_target(target)
+
     def _bind_module_target(self, target: ast.expr) -> None:
         if isinstance(target, ast.Name):
             self.state.add_binding(target.id, "assign")
@@ -441,22 +489,36 @@ class _CallGraphVisitor(ast.NodeVisitor):
                 self._bind_module_target(element)
 
     def visit_Assign(self, node: ast.Assign) -> Any:
-        if not self.stack:
-            for target in node.targets:
-                self._bind_module_target(target)
-        self.generic_visit(node)
+        self.visit(node.value)
+        for target in node.targets:
+            self.visit(target)
+        self._bind_or_invalidate_targets(node.targets)
         return None
 
     def visit_AnnAssign(self, node: ast.AnnAssign) -> Any:
-        if not self.stack:
-            self._bind_module_target(node.target)
-        self.generic_visit(node)
+        self.visit(node.annotation)
+        if node.value is not None:
+            self.visit(node.value)
+        self.visit(node.target)
+        self._bind_or_invalidate_targets((node.target,))
+        return None
+
+    def visit_AugAssign(self, node: ast.AugAssign) -> Any:
+        self.visit(node.target)
+        self.visit(node.value)
+        self._bind_or_invalidate_targets((node.target,))
         return None
 
     def visit_NamedExpr(self, node: ast.NamedExpr) -> Any:
-        if not self.stack:
-            self._bind_module_target(node.target)
-        self.generic_visit(node)
+        self.visit(node.value)
+        self.visit(node.target)
+        self._bind_or_invalidate_targets((node.target,))
+        return None
+
+    def visit_Delete(self, node: ast.Delete) -> Any:
+        for target in node.targets:
+            self.visit(target)
+        self._bind_or_invalidate_targets(node.targets)
         return None
 
     def visit_Call(self, node: ast.Call) -> Any:

--- a/merger/repoground/architecture/call_graph.py
+++ b/merger/repoground/architecture/call_graph.py
@@ -4,12 +4,13 @@ The producer parses source text only. It records every ``ast.Call`` and resolves
 only a deliberately small set of targets that are unique under the modelled
 lexical bindings. Everything else remains explicit S0 navigation evidence.
 """
+
 from __future__ import annotations
 
 import ast
 import os
 from operator import attrgetter
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any, Iterable, Sequence
 
@@ -42,6 +43,8 @@ class _ScopeFrame:
     local_bindings: frozenset[str] = field(default_factory=frozenset)
     global_names: frozenset[str] = field(default_factory=frozenset)
     nonlocal_names: frozenset[str] = field(default_factory=frozenset)
+    module_aliases: tuple[tuple[str, str], ...] = field(default_factory=tuple)
+    from_imports: tuple[tuple[str, str, str], ...] = field(default_factory=tuple)
     start_line: int | None = None
     end_line: int | None = None
     receiver_name: str | None = None
@@ -83,7 +86,10 @@ def _relative_import_base(module: str, is_package: bool, level: int) -> str | No
 
 
 def _argument_names(arguments: ast.arguments) -> set[str]:
-    names = {arg.arg for arg in (*arguments.posonlyargs, *arguments.args, *arguments.kwonlyargs)}
+    names = {
+        arg.arg
+        for arg in (*arguments.posonlyargs, *arguments.args, *arguments.kwonlyargs)
+    }
     if arguments.vararg is not None:
         names.add(arguments.vararg.arg)
     if arguments.kwarg is not None:
@@ -167,7 +173,9 @@ def _function_frame(
 ) -> _ScopeFrame:
     collector = _BindingCollector()
     collector.local.update(_argument_names(node.args))
-    body: Iterable[ast.AST] = (node.body,) if isinstance(node, ast.Lambda) else node.body
+    body: Iterable[ast.AST] = (
+        (node.body,) if isinstance(node, ast.Lambda) else node.body
+    )
     for statement in body:
         collector.visit(statement)
     collector.local.difference_update(collector.global_names)
@@ -220,10 +228,14 @@ class _CallGraphVisitor(ast.NodeVisitor):
         named_frames = [frame for frame in self.stack if frame.name]
         if not named_frames:
             self.state.add_binding(name, "def" if kind in _FUNCTION_KINDS else "class")
-            table = self.state.functions if kind in _FUNCTION_KINDS else self.state.classes
+            table = (
+                self.state.functions if kind in _FUNCTION_KINDS else self.state.classes
+            )
             table.setdefault(name, []).append(symbol_id)
         elif kind in _FUNCTION_KINDS and named_frames[-1].kind == "class":
-            class_qualified = ".".join(frame.name for frame in named_frames if frame.name)
+            class_qualified = ".".join(
+                frame.name for frame in named_frames if frame.name
+            )
             self.state.methods.setdefault((class_qualified, name), []).append(symbol_id)
 
     def _visit_present(self, nodes: Iterable[ast.AST | None]) -> None:
@@ -231,7 +243,9 @@ class _CallGraphVisitor(ast.NodeVisitor):
             if child is not None:
                 self.visit(child)
 
-    def _visit_function_header(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+    def _visit_function_header(
+        self, node: ast.FunctionDef | ast.AsyncFunctionDef
+    ) -> None:
         arguments = (*node.args.posonlyargs, *node.args.args, *node.args.kwonlyargs)
         optional_nodes = (
             *node.args.kw_defaults,
@@ -245,7 +259,9 @@ class _CallGraphVisitor(ast.NodeVisitor):
         self._visit_present(optional_nodes)
         self._visit_present(getattr(node, "type_params", ()))
 
-    def _direct_method_receiver(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> str | None:
+    def _direct_method_receiver(
+        self, node: ast.FunctionDef | ast.AsyncFunctionDef
+    ) -> str | None:
         if not self.stack or self.stack[-1].kind != "class":
             return None
         positional = (*node.args.posonlyargs, *node.args.args)
@@ -366,17 +382,28 @@ class _CallGraphVisitor(ast.NodeVisitor):
                 else:
                     self.state.imported_module_names.add(alias.name)
                     self.state.add_binding(alias.name.split(".")[0], "import")
+            return None
+
+        aliases = dict(self.stack[-1].module_aliases)
+        for alias in node.names:
+            local = alias.asname or alias.name.split(".")[0]
+            aliases[local] = alias.name if alias.asname else local
+        self.stack[-1] = replace(
+            self.stack[-1], module_aliases=tuple(sorted(aliases.items()))
+        )
         return None
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> Any:
+        if node.level:
+            base = _relative_import_base(self.state.module, self.is_package, node.level)
+            source = (
+                None
+                if base is None
+                else ".".join(part for part in (base, node.module or "") if part)
+            )
+        else:
+            source = node.module
         if not self.stack:
-            if node.level:
-                base = _relative_import_base(self.state.module, self.is_package, node.level)
-                source = None if base is None else ".".join(
-                    part for part in (base, node.module or "") if part
-                )
-            else:
-                source = node.module
             for alias in node.names:
                 if alias.name == "*":
                     continue
@@ -384,6 +411,26 @@ class _CallGraphVisitor(ast.NodeVisitor):
                 self.state.add_binding(local, "import")
                 if source:
                     self.state.from_imports[local] = (source, alias.name)
+            return None
+
+        imports = {
+            local: (module, original)
+            for local, module, original in self.stack[-1].from_imports
+        }
+        for alias in node.names:
+            if alias.name == "*" or not source:
+                continue
+            local = alias.asname or alias.name
+            imports[local] = (source, alias.name)
+        self.stack[-1] = replace(
+            self.stack[-1],
+            from_imports=tuple(
+                sorted(
+                    (local, module, original)
+                    for local, (module, original) in imports.items()
+                )
+            ),
+        )
         return None
 
     def _bind_module_target(self, target: ast.expr) -> None:
@@ -507,19 +554,17 @@ class _Resolver:
     def __init__(self, modules: dict[str, list[_ModuleState]]) -> None:
         self.modules = modules
 
-    def _target_in_module(self, module: str, name: str, reason_prefix: str) -> dict[str, Any]:
+    def _target_in_module(
+        self, module: str, name: str, reason_prefix: str
+    ) -> dict[str, Any]:
         states = self.modules.get(module, [])
         if not states:
             return _verdict("unresolved", f"{reason_prefix}_foreign_module")
         functions = [
-            symbol_id
-            for state in states
-            for symbol_id in state.functions.get(name, [])
+            symbol_id for state in states for symbol_id in state.functions.get(name, [])
         ]
         classes = [
-            symbol_id
-            for state in states
-            for symbol_id in state.classes.get(name, [])
+            symbol_id for state in states for symbol_id in state.classes.get(name, [])
         ]
         all_targets = sorted(set(functions) | set(classes))
         definition_count = len(functions) + len(classes)
@@ -561,7 +606,11 @@ class _Resolver:
                     return "lexically_shadowed_name", False
             elif frame.kind == "comprehension" and name in frame.local_bindings:
                 return "comprehension_binding", False
-            elif frame.kind == "class" and not inside_function and name in frame.local_bindings:
+            elif (
+                frame.kind == "class"
+                and not inside_function
+                and name in frame.local_bindings
+            ):
                 return "class_scope_binding", False
         return None, False
 
@@ -625,7 +674,9 @@ class _Resolver:
         definition_count = len(local_functions) + len(local_classes)
         if definition_count == 1:
             relation_type = "constructs" if local_classes else "calls"
-            reason = "local_class_constructor" if local_classes else "local_module_function"
+            reason = (
+                "local_class_constructor" if local_classes else "local_module_function"
+            )
             return _verdict(
                 "resolved",
                 reason,
@@ -641,9 +692,36 @@ class _Resolver:
             return _verdict("ambiguous", reason, candidates=candidates)
         return _verdict("unresolved", "unknown_name")
 
+    def _resolve_local_import_name(
+        self, name: str, stack: Sequence[_ScopeFrame]
+    ) -> dict[str, Any] | None:
+        for frame in reversed(stack):
+            if frame.kind in (*_FUNCTION_KINDS, "lambda"):
+                if name in frame.global_names or name in frame.nonlocal_names:
+                    return None
+            imported = {
+                local: (module, original)
+                for local, module, original in frame.from_imports
+            }.get(name)
+            if imported is not None:
+                source_module, original = imported
+                if source_module not in self.modules:
+                    return None
+                return self._target_in_module(
+                    source_module,
+                    original,
+                    "local_imported_internal_name",
+                )
+            if name in frame.local_bindings:
+                return None
+        return None
+
     def _resolve_name(
         self, state: _ModuleState, name: str, stack: Sequence[_ScopeFrame]
     ) -> dict[str, Any]:
+        local_import = self._resolve_local_import_name(name, stack)
+        if local_import is not None:
+            return local_import
         shadow_reason, force_module = self._shadow_reason(name, stack)
         if shadow_reason:
             return _verdict("unresolved", shadow_reason)
@@ -658,12 +736,16 @@ class _Resolver:
         candidates = sorted(set(local_functions) | set(local_classes))
         if "assign" in sources:
             status = "candidate" if candidates else "unresolved"
-            return _verdict(status, "name_rebound_at_module_level", candidates=candidates)
+            return _verdict(
+                status, "name_rebound_at_module_level", candidates=candidates
+            )
         if len(sources) > 1:
             return self._multiple_binding_verdict(state, name, candidates)
         if name in state.from_imports:
             source_module, original = state.from_imports[name]
-            return self._target_in_module(source_module, original, "imported_internal_name")
+            return self._target_in_module(
+                source_module, original, "imported_internal_name"
+            )
         if "import" in sources:
             return _verdict("unresolved", "module_object_called")
         return self._local_binding_verdict(local_functions, local_classes)
@@ -713,9 +795,57 @@ class _Resolver:
             )
         return _verdict("unresolved", "method_not_defined_in_same_class")
 
+    def _resolve_local_import_dotted(
+        self, parts: list[str], stack: Sequence[_ScopeFrame]
+    ) -> dict[str, Any] | None:
+        root = parts[0]
+        for frame in reversed(stack):
+            if frame.kind in (*_FUNCTION_KINDS, "lambda"):
+                if root in frame.global_names:
+                    return None
+                if root in frame.nonlocal_names:
+                    continue
+
+            module_alias = dict(frame.module_aliases).get(root)
+            if module_alias is not None:
+                target_module = ".".join(
+                    part for part in (module_alias, *parts[1:-1]) if part
+                )
+                if target_module not in self.modules:
+                    return None
+                return self._target_in_module(
+                    target_module,
+                    parts[-1],
+                    "local_module_alias_call",
+                )
+
+            imported = {
+                local: (module, original)
+                for local, module, original in frame.from_imports
+            }.get(root)
+            if imported is not None:
+                source, original = imported
+                imported_module = ".".join(
+                    part for part in (source, original, *parts[1:-1]) if part
+                )
+                if imported_module not in self.modules:
+                    return None
+                return self._target_in_module(
+                    imported_module,
+                    parts[-1],
+                    "local_from_import_module_call",
+                )
+
+            if root in frame.local_bindings:
+                return _verdict("unresolved", "attribute_root_lexically_shadowed_name")
+        return None
+
     def _resolve_module_dotted(
         self, state: _ModuleState, parts: list[str], stack: Sequence[_ScopeFrame]
     ) -> dict[str, Any]:
+        local_import = self._resolve_local_import_dotted(parts, stack)
+        if local_import is not None:
+            return local_import
         shadow_reason, _ = self._shadow_reason(parts[0], stack)
         if shadow_reason:
             return _verdict("unresolved", f"attribute_root_{shadow_reason}")
@@ -766,7 +896,9 @@ class _Resolver:
             "start_col": raw_call["start_col"],
             "end_line": raw_call["end_line"],
             "end_col": raw_call["end_col"],
-            "range_ref": _range_ref(state.path, raw_call["start_line"], raw_call["end_line"]),
+            "range_ref": _range_ref(
+                state.path, raw_call["start_line"], raw_call["end_line"]
+            ),
             "callee_expression": ast.unparse(func),
             "simple_name": simple_name,
         }
@@ -775,13 +907,17 @@ class _Resolver:
         return record
 
 
-def extract_python_calls(repo_root: Path) -> tuple[list[dict[str, Any]], int, list[str]]:
+def extract_python_calls(
+    repo_root: Path,
+) -> tuple[list[dict[str, Any]], int, list[str]]:
     """Return deterministic call records plus bounded parse diagnostics."""
     modules: dict[str, list[_ModuleState]] = {}
     skipped_files_count = 0
     skipped_errors: list[str] = []
     for root, dirs, files in os.walk(repo_root, topdown=True):
-        dirs[:] = sorted(directory for directory in dirs if directory not in EXCLUDED_DIRS)
+        dirs[:] = sorted(
+            directory for directory in dirs if directory not in EXCLUDED_DIRS
+        )
         for file_name in sorted(files):
             if not file_name.endswith(".py"):
                 continue

--- a/merger/repoground/architecture/call_graph.py
+++ b/merger/repoground/architecture/call_graph.py
@@ -97,6 +97,18 @@ def _argument_names(arguments: ast.arguments) -> set[str]:
     return names
 
 
+def _match_pattern_names(pattern: ast.pattern) -> set[str]:
+    names: set[str] = set()
+    for child in ast.walk(pattern):
+        if isinstance(child, ast.MatchAs) and child.name:
+            names.add(child.name)
+        elif isinstance(child, ast.MatchStar) and child.name:
+            names.add(child.name)
+        elif isinstance(child, ast.MatchMapping) and child.rest:
+            names.add(child.rest)
+    return names
+
+
 class _BindingCollector(ast.NodeVisitor):
     """Collect bindings owned by one function, lambda, class or comprehension."""
 
@@ -161,6 +173,15 @@ class _BindingCollector(ast.NodeVisitor):
             self.local.add(node.name)
         for statement in node.body:
             self.visit(statement)
+        return None
+
+    def visit_Match(self, node: ast.Match) -> Any:
+        for case in node.cases:
+            self.local.update(_match_pattern_names(case.pattern))
+            if case.guard is not None:
+                self.visit(case.guard)
+            for statement in case.body:
+                self.visit(statement)
         return None
 
 
@@ -472,14 +493,19 @@ class _CallGraphVisitor(ast.NodeVisitor):
                 from_imports=imports,
             )
 
-    def _bind_or_invalidate_targets(self, targets: Iterable[ast.expr]) -> None:
-        target_list = tuple(targets)
-        names = set().union(*(_target_names(target) for target in target_list))
+    def _bind_or_invalidate_names(self, names: set[str]) -> None:
+        if not names:
+            return
         if self.stack:
             self._invalidate_local_imports(names)
             return
-        for target in target_list:
-            self._bind_module_target(target)
+        for name in names:
+            self.state.add_binding(name, "assign")
+
+    def _bind_or_invalidate_targets(self, targets: Iterable[ast.expr]) -> None:
+        target_list = tuple(targets)
+        names = set().union(*(_target_names(target) for target in target_list))
+        self._bind_or_invalidate_names(names)
 
     def _bind_module_target(self, target: ast.expr) -> None:
         if isinstance(target, ast.Name):
@@ -519,6 +545,72 @@ class _CallGraphVisitor(ast.NodeVisitor):
         for target in node.targets:
             self.visit(target)
         self._bind_or_invalidate_targets(node.targets)
+        return None
+
+    def _visit_for_statement(self, node: ast.For | ast.AsyncFor) -> None:
+        self.visit(node.iter)
+        self.visit(node.target)
+        names = _target_names(node.target)
+        self._bind_or_invalidate_names(names)
+        for statement in node.body:
+            self.visit(statement)
+        # The loop target is rebound on every iteration. An import inside the body
+        # must not make post-loop calls look unconditionally bound to that import.
+        self._bind_or_invalidate_names(names)
+        for statement in node.orelse:
+            self.visit(statement)
+
+    def visit_For(self, node: ast.For) -> Any:
+        self._visit_for_statement(node)
+        return None
+
+    def visit_AsyncFor(self, node: ast.AsyncFor) -> Any:
+        self._visit_for_statement(node)
+        return None
+
+    def _visit_with_statement(self, node: ast.With | ast.AsyncWith) -> None:
+        for item in node.items:
+            self.visit(item.context_expr)
+            if item.optional_vars is not None:
+                self.visit(item.optional_vars)
+                self._bind_or_invalidate_targets((item.optional_vars,))
+        for statement in node.body:
+            self.visit(statement)
+
+    def visit_With(self, node: ast.With) -> Any:
+        self._visit_with_statement(node)
+        return None
+
+    def visit_AsyncWith(self, node: ast.AsyncWith) -> Any:
+        self._visit_with_statement(node)
+        return None
+
+    def visit_ExceptHandler(self, node: ast.ExceptHandler) -> Any:
+        if node.type is not None:
+            self.visit(node.type)
+        names = {node.name} if isinstance(node.name, str) else set()
+        self._bind_or_invalidate_names(names)
+        for statement in node.body:
+            self.visit(statement)
+        # Python clears an exception target after the handler suite.
+        self._bind_or_invalidate_names(names)
+        return None
+
+    def visit_Match(self, node: ast.Match) -> Any:
+        self.visit(node.subject)
+        bound_names = set().union(
+            *(_match_pattern_names(case.pattern) for case in node.cases)
+        )
+        for case in node.cases:
+            # Cases are mutually exclusive. Reset the conservative binding state so
+            # an import in one case cannot leak into a later case during AST traversal.
+            self._bind_or_invalidate_names(bound_names)
+            self.visit(case.pattern)
+            if case.guard is not None:
+                self.visit(case.guard)
+            for statement in case.body:
+                self.visit(statement)
+        self._bind_or_invalidate_names(bound_names)
         return None
 
     def visit_Call(self, node: ast.Call) -> Any:

--- a/merger/repoground/architecture/call_graph.py
+++ b/merger/repoground/architecture/call_graph.py
@@ -48,6 +48,7 @@ class _ScopeFrame:
     start_line: int | None = None
     end_line: int | None = None
     receiver_name: str | None = None
+    type_alias_name: str | None = None
 
 
 class _ModuleState:
@@ -168,6 +169,18 @@ class _BindingCollector(ast.NodeVisitor):
     def visit_GeneratorExp(self, node: ast.GeneratorExp) -> Any:
         return None
 
+    def visit_TypeAlias(self, node: Any) -> Any:
+        name = getattr(node, "name", None)
+        if isinstance(name, ast.Name):
+            self.local.add(name.id)
+        for type_param in getattr(node, "type_params", ()):  # Python 3.12+
+            if isinstance(type_param, ast.AST):
+                self.visit(type_param)
+        value = getattr(node, "value", None)
+        if isinstance(value, ast.AST):
+            self.visit(value)
+        return None
+
     def visit_ExceptHandler(self, node: ast.ExceptHandler) -> Any:
         if isinstance(node.name, str):
             self.local.add(node.name)
@@ -233,11 +246,60 @@ def _target_names(target: ast.AST) -> set[str]:
     }
 
 
+def _type_parameter_names(type_params: Iterable[ast.AST]) -> set[str]:
+    names: set[str] = set()
+    for type_param in type_params:
+        name = getattr(type_param, "name", None)
+        if isinstance(name, str):
+            names.add(name)
+        elif isinstance(name, ast.Name):
+            names.add(name.id)
+    return names
+
+
+def _statement_falls_through(statement: ast.stmt) -> bool:
+    if isinstance(statement, (ast.Return, ast.Raise, ast.Break, ast.Continue)):
+        return False
+    if isinstance(statement, ast.If):
+        return _statements_fall_through(statement.body) or _statements_fall_through(
+            statement.orelse
+        )
+    try_star_type = getattr(ast, "TryStar", None)
+    if isinstance(statement, ast.Try) or (
+        try_star_type is not None and isinstance(statement, try_star_type)
+    ):
+        if statement.finalbody and not _statements_fall_through(statement.finalbody):
+            return False
+        normal_path_falls_through = _statements_fall_through(
+            statement.body
+        ) and _statements_fall_through(statement.orelse)
+        handler_falls_through = any(
+            _statements_fall_through(handler.body) for handler in statement.handlers
+        )
+        return normal_path_falls_through or handler_falls_through
+    if isinstance(statement, (ast.With, ast.AsyncWith)):
+        return _statements_fall_through(statement.body)
+    return True
+
+
+def _statements_fall_through(statements: Sequence[ast.stmt]) -> bool:
+    return all(_statement_falls_through(statement) for statement in statements)
+
+
+def _type_alias_binding_reason(frame: _ScopeFrame, name: str) -> str:
+    if name == frame.type_alias_name:
+        return "type_alias_self_binding"
+    return "type_parameter_binding"
+
+
 class _CallGraphVisitor(ast.NodeVisitor):
     def __init__(self, path: str, is_package: bool) -> None:
         self.state = _ModuleState(path, _module_name(path))
         self.is_package = is_package
         self.stack: list[_ScopeFrame] = []
+        self._loop_break_bindings: list[list[dict[str, tuple[str, ...]]]] = []
+        self._loop_continue_bindings: list[list[dict[str, tuple[str, ...]]]] = []
+        self._suppress_loop_exits = 0
 
     def _qualified(self, name: str) -> str:
         return ".".join([*(frame.name for frame in self.stack if frame.name), name])
@@ -299,8 +361,7 @@ class _CallGraphVisitor(ast.NodeVisitor):
             receiver_name=self._direct_method_receiver(node),
         )
         self.stack.append(frame)
-        for statement in node.body:
-            self.visit(statement)
+        self._visit_statement_list(node.body)
         self.stack.pop()
         return None
 
@@ -315,8 +376,7 @@ class _CallGraphVisitor(ast.NodeVisitor):
             receiver_name=self._direct_method_receiver(node),
         )
         self.stack.append(frame)
-        for statement in node.body:
-            self.visit(statement)
+        self._visit_statement_list(node.body)
         self.stack.pop()
         return None
 
@@ -332,8 +392,7 @@ class _CallGraphVisitor(ast.NodeVisitor):
             self.visit(type_param)
         self._invalidate_local_imports({node.name})
         self.stack.append(_class_frame(node))
-        for statement in node.body:
-            self.visit(statement)
+        self._visit_statement_list(node.body)
         self.stack.pop()
         return None
 
@@ -493,6 +552,72 @@ class _CallGraphVisitor(ast.NodeVisitor):
                 from_imports=imports,
             )
 
+    def _local_import_bindings(self) -> dict[str, tuple[str, ...]]:
+        if not self.stack:
+            return {}
+        frame = self.stack[-1]
+        bindings = {local: ("module", module) for local, module in frame.module_aliases}
+        bindings.update(
+            {
+                local: ("symbol", module, original)
+                for local, module, original in frame.from_imports
+            }
+        )
+        return bindings
+
+    def _set_local_import_bindings(self, bindings: dict[str, tuple[str, ...]]) -> None:
+        if not self.stack:
+            return
+        frame = self.stack[-1]
+        self.stack[-1] = replace(
+            frame,
+            module_aliases=tuple(
+                sorted(
+                    (local, binding[1])
+                    for local, binding in bindings.items()
+                    if binding[0] == "module"
+                )
+            ),
+            from_imports=tuple(
+                sorted(
+                    (local, binding[1], binding[2])
+                    for local, binding in bindings.items()
+                    if binding[0] == "symbol"
+                )
+            ),
+        )
+
+    @staticmethod
+    def _intersect_import_bindings(
+        *states: dict[str, tuple[str, ...]],
+    ) -> dict[str, tuple[str, ...]]:
+        if not states:
+            return {}
+        first, *rest = states
+        return {
+            name: binding
+            for name, binding in first.items()
+            if all(state.get(name) == binding for state in rest)
+        }
+
+    def _visit_unreachable_statement_list(self, statements: Sequence[ast.stmt]) -> None:
+        imports_before = self._local_import_bindings()
+        self._suppress_loop_exits += 1
+        try:
+            for statement in statements:
+                self.visit(statement)
+        finally:
+            self._suppress_loop_exits -= 1
+            self._set_local_import_bindings(imports_before)
+
+    def _visit_statement_list(self, statements: Sequence[ast.stmt]) -> bool:
+        for index, statement in enumerate(statements):
+            self.visit(statement)
+            if not _statement_falls_through(statement):
+                self._visit_unreachable_statement_list(statements[index + 1 :])
+                return False
+        return True
+
     def _bind_or_invalidate_names(self, names: set[str]) -> None:
         if not names:
             return
@@ -547,18 +672,375 @@ class _CallGraphVisitor(ast.NodeVisitor):
         self._bind_or_invalidate_targets(node.targets)
         return None
 
+    def visit_TypeAlias(self, node: Any) -> Any:
+        name = getattr(node, "name", None)
+        alias_name = name.id if isinstance(name, ast.Name) else None
+        type_params = tuple(getattr(node, "type_params", ()))  # Python 3.12+
+        visible_type_parameters: set[str] = set()
+        for type_param in type_params:
+            if isinstance(type_param, ast.AST):
+                self.stack.append(
+                    _ScopeFrame(
+                        name=None,
+                        kind="type_alias",
+                        local_bindings=frozenset(visible_type_parameters),
+                    )
+                )
+                try:
+                    self.visit(type_param)
+                finally:
+                    self.stack.pop()
+                visible_type_parameters.update(_type_parameter_names((type_param,)))
+        value = getattr(node, "value", None)
+        if isinstance(value, ast.AST):
+            self.stack.append(
+                _ScopeFrame(
+                    name=None,
+                    kind="type_alias",
+                    local_bindings=frozenset(
+                        visible_type_parameters
+                        | ({alias_name} if alias_name is not None else set())
+                    ),
+                    type_alias_name=alias_name,
+                )
+            )
+            try:
+                self.visit(value)
+            finally:
+                self.stack.pop()
+        if isinstance(name, ast.Name):
+            self._bind_or_invalidate_names({name.id})
+        return None
+
+    def visit_If(self, node: ast.If) -> Any:
+        self.visit(node.test)
+        imports_before = self._local_import_bindings()
+
+        body_falls_through = self._visit_statement_list(node.body)
+        imports_after_body = self._local_import_bindings()
+
+        self._set_local_import_bindings(imports_before)
+        else_falls_through = self._visit_statement_list(node.orelse)
+        imports_after_else = self._local_import_bindings()
+
+        reachable_states = []
+        if body_falls_through:
+            reachable_states.append(imports_after_body)
+        if else_falls_through:
+            reachable_states.append(imports_after_else)
+        self._set_local_import_bindings(
+            self._intersect_import_bindings(*reachable_states)
+        )
+        return None
+
+    @staticmethod
+    def _binding_names_in_statements(statements: Iterable[ast.stmt]) -> set[str]:
+        collector = _BindingCollector()
+        for statement in statements:
+            collector.visit(statement)
+        return collector.local
+
+    @staticmethod
+    def _loop_exit_checkpoint(
+        exit_stack: list[list[dict[str, tuple[str, ...]]]],
+    ) -> tuple[list[dict[str, tuple[str, ...]]] | None, int]:
+        if not exit_stack:
+            return None, 0
+        states = exit_stack[-1]
+        return states, len(states)
+
+    @staticmethod
+    def _take_loop_exits_since(
+        checkpoint: tuple[list[dict[str, tuple[str, ...]]] | None, int],
+    ) -> list[dict[str, tuple[str, ...]]]:
+        states, start = checkpoint
+        if states is None:
+            return []
+        pending = list(states[start:])
+        del states[start:]
+        return pending
+
+    @staticmethod
+    def _bindings_without_names(
+        bindings: dict[str, tuple[str, ...]],
+        changed_names: set[str],
+    ) -> dict[str, tuple[str, ...]]:
+        return {
+            name: binding
+            for name, binding in bindings.items()
+            if name not in changed_names
+        }
+
+    def _visit_try_handler(self, handler: ast.ExceptHandler) -> bool:
+        if handler.type is not None:
+            self.visit(handler.type)
+        handler_names = {handler.name} if isinstance(handler.name, str) else set()
+        self._bind_or_invalidate_names(handler_names)
+        handler_falls_through = self._visit_statement_list(handler.body)
+        self._bind_or_invalidate_names(handler_names)
+        return handler_falls_through
+
+    def _visit_try_handlers(
+        self,
+        handlers: Sequence[ast.ExceptHandler],
+        handler_entry: dict[str, tuple[str, ...]],
+    ) -> list[dict[str, tuple[str, ...]]]:
+        normal_exit_states = []
+        for handler in handlers:
+            self._set_local_import_bindings(handler_entry)
+            if self._visit_try_handler(handler):
+                normal_exit_states.append(self._local_import_bindings())
+        return normal_exit_states
+
+    def _visit_try_else_path(
+        self,
+        statements: Sequence[ast.stmt],
+        *,
+        body_falls_through: bool,
+        imports_after_body: dict[str, tuple[str, ...]],
+    ) -> list[dict[str, tuple[str, ...]]]:
+        self._set_local_import_bindings(imports_after_body)
+        if not body_falls_through:
+            self._visit_unreachable_statement_list(statements)
+            return []
+        if self._visit_statement_list(statements):
+            return [self._local_import_bindings()]
+        return []
+
+    def _visit_try_except_else_paths(
+        self,
+        node: ast.Try | ast.TryStar,
+        imports_before_try: dict[str, tuple[str, ...]],
+    ) -> list[dict[str, tuple[str, ...]]]:
+        body_falls_through = self._visit_statement_list(node.body)
+        imports_after_body = self._local_import_bindings()
+        handler_entry = self._bindings_without_names(
+            imports_before_try,
+            self._binding_names_in_statements(node.body),
+        )
+        normal_exit_states = self._visit_try_handlers(
+            node.handlers,
+            handler_entry,
+        )
+        normal_exit_states.extend(
+            self._visit_try_else_path(
+                node.orelse,
+                body_falls_through=body_falls_through,
+                imports_after_body=imports_after_body,
+            )
+        )
+        return normal_exit_states
+
+    def _exceptional_finally_entry(
+        self,
+        node: ast.Try | ast.TryStar,
+        imports_before_try: dict[str, tuple[str, ...]],
+    ) -> dict[str, tuple[str, ...]]:
+        changed_before_finally = self._binding_names_in_statements(
+            [
+                *node.body,
+                *(statement for handler in node.handlers for statement in handler.body),
+                *node.orelse,
+            ]
+        )
+        changed_before_finally.update(
+            handler.name for handler in node.handlers if isinstance(handler.name, str)
+        )
+        return self._bindings_without_names(
+            imports_before_try,
+            changed_before_finally,
+        )
+
+    @staticmethod
+    def _apply_finally_bindings(
+        imports: dict[str, tuple[str, ...]],
+        imports_after_finally: dict[str, tuple[str, ...]],
+        changed_names: set[str],
+    ) -> dict[str, tuple[str, ...]]:
+        result = {
+            local: binding
+            for local, binding in imports.items()
+            if local not in changed_names
+        }
+        result.update(
+            {
+                local: binding
+                for local, binding in imports_after_finally.items()
+                if local in changed_names
+            }
+        )
+        return result
+
+    def _paths_after_finally(
+        self,
+        paths: Sequence[dict[str, tuple[str, ...]]],
+        *,
+        final_falls_through: bool,
+        imports_after_finally: dict[str, tuple[str, ...]],
+        changed_names: set[str],
+    ) -> list[dict[str, tuple[str, ...]]]:
+        if not final_falls_through:
+            return []
+        return [
+            self._apply_finally_bindings(
+                imports,
+                imports_after_finally,
+                changed_names,
+            )
+            for imports in paths
+        ]
+
+    @staticmethod
+    def _restore_loop_exits_after_finally(
+        checkpoint: tuple[list[dict[str, tuple[str, ...]]] | None, int],
+        resumed_exits: Sequence[dict[str, tuple[str, ...]]],
+    ) -> None:
+        states, start = checkpoint
+        if states is None:
+            return
+        exits_from_finally = list(states[start:])
+        states[start:] = [*resumed_exits, *exits_from_finally]
+
+    def _visit_try_finally_paths(
+        self,
+        node: ast.Try | ast.TryStar,
+        *,
+        imports_before_try: dict[str, tuple[str, ...]],
+        normal_exit_states: Sequence[dict[str, tuple[str, ...]]],
+        break_checkpoint: tuple[
+            list[dict[str, tuple[str, ...]]] | None,
+            int,
+        ],
+        continue_checkpoint: tuple[
+            list[dict[str, tuple[str, ...]]] | None,
+            int,
+        ],
+    ) -> None:
+        pending_breaks = self._take_loop_exits_since(break_checkpoint)
+        pending_continues = self._take_loop_exits_since(continue_checkpoint)
+        finally_entry = self._intersect_import_bindings(
+            *normal_exit_states,
+            *pending_breaks,
+            *pending_continues,
+            self._exceptional_finally_entry(node, imports_before_try),
+        )
+        self._set_local_import_bindings(finally_entry)
+        final_falls_through = self._visit_statement_list(node.finalbody)
+        imports_after_finally = self._local_import_bindings()
+        changed_names = self._binding_names_in_statements(node.finalbody)
+
+        normal_after_finally = self._paths_after_finally(
+            normal_exit_states,
+            final_falls_through=final_falls_through,
+            imports_after_finally=imports_after_finally,
+            changed_names=changed_names,
+        )
+        self._set_local_import_bindings(
+            self._intersect_import_bindings(*normal_after_finally)
+        )
+        breaks_after_finally = self._paths_after_finally(
+            pending_breaks,
+            final_falls_through=final_falls_through,
+            imports_after_finally=imports_after_finally,
+            changed_names=changed_names,
+        )
+        self._restore_loop_exits_after_finally(
+            break_checkpoint,
+            breaks_after_finally,
+        )
+        continues_after_finally = self._paths_after_finally(
+            pending_continues,
+            final_falls_through=final_falls_through,
+            imports_after_finally=imports_after_finally,
+            changed_names=changed_names,
+        )
+        self._restore_loop_exits_after_finally(
+            continue_checkpoint,
+            continues_after_finally,
+        )
+
+    def _visit_try_statement(self, node: ast.Try | ast.TryStar) -> None:
+        imports_before_try = self._local_import_bindings()
+        break_checkpoint = self._loop_exit_checkpoint(self._loop_break_bindings)
+        continue_checkpoint = self._loop_exit_checkpoint(self._loop_continue_bindings)
+        normal_exit_states = self._visit_try_except_else_paths(
+            node,
+            imports_before_try,
+        )
+        self._set_local_import_bindings(
+            self._intersect_import_bindings(*normal_exit_states)
+        )
+        if node.finalbody:
+            self._visit_try_finally_paths(
+                node,
+                imports_before_try=imports_before_try,
+                normal_exit_states=normal_exit_states,
+                break_checkpoint=break_checkpoint,
+                continue_checkpoint=continue_checkpoint,
+            )
+
+    def visit_Try(self, node: ast.Try) -> Any:
+        self._visit_try_statement(node)
+        return None
+
+    def visit_TryStar(self, node: ast.TryStar) -> Any:
+        self._visit_try_statement(node)
+        return None
+
     def _visit_for_statement(self, node: ast.For | ast.AsyncFor) -> None:
         self.visit(node.iter)
+        imports_after_iter = self._local_import_bindings()
         self.visit(node.target)
         names = _target_names(node.target)
         self._bind_or_invalidate_names(names)
-        for statement in node.body:
-            self.visit(statement)
-        # The loop target is rebound on every iteration. An import inside the body
-        # must not make post-loop calls look unconditionally bound to that import.
-        self._bind_or_invalidate_names(names)
-        for statement in node.orelse:
-            self.visit(statement)
+        self._loop_break_bindings.append([])
+        self._loop_continue_bindings.append([])
+        try:
+            body_falls_through = self._visit_statement_list(node.body)
+        finally:
+            break_bindings = self._loop_break_bindings.pop()
+            continue_bindings = self._loop_continue_bindings.pop()
+
+        def without_target_names(
+            state: dict[str, tuple[str, ...]],
+        ) -> dict[str, tuple[str, ...]]:
+            return {
+                name: binding for name, binding in state.items() if name not in names
+            }
+
+        break_bindings = [
+            without_target_names(break_state) for break_state in break_bindings
+        ]
+        continue_bindings = [
+            without_target_names(continue_state) for continue_state in continue_bindings
+        ]
+
+        # The loop may execute zero times. A target-name reimport observed while
+        # walking the body is not definite: it may be conditional, and another
+        # iteration rebinds the target first. ``else`` may establish it again.
+        # Other imports must agree before the loop and on body fallthrough.
+        imports_after_body = {
+            name: binding
+            for name, binding in self._local_import_bindings().items()
+            if name not in names
+        }
+        normal_exit_states = [imports_after_iter, *continue_bindings]
+        if body_falls_through:
+            normal_exit_states.append(imports_after_body)
+        self._set_local_import_bindings(
+            self._intersect_import_bindings(*normal_exit_states)
+        )
+        else_falls_through = self._visit_statement_list(node.orelse)
+        imports_after_else = self._local_import_bindings()
+
+        # Every possible break skips ``else``. Keep only the identical import
+        # bindings present on the else path and on every observed break path.
+        reachable_states = list(break_bindings)
+        if else_falls_through:
+            reachable_states.append(imports_after_else)
+        self._set_local_import_bindings(
+            self._intersect_import_bindings(*reachable_states)
+        )
 
     def visit_For(self, node: ast.For) -> Any:
         self._visit_for_statement(node)
@@ -566,6 +1048,41 @@ class _CallGraphVisitor(ast.NodeVisitor):
 
     def visit_AsyncFor(self, node: ast.AsyncFor) -> Any:
         self._visit_for_statement(node)
+        return None
+
+    def visit_While(self, node: ast.While) -> Any:
+        self.visit(node.test)
+        imports_after_test = self._local_import_bindings()
+        self._loop_break_bindings.append([])
+        self._loop_continue_bindings.append([])
+        try:
+            body_falls_through = self._visit_statement_list(node.body)
+        finally:
+            break_bindings = self._loop_break_bindings.pop()
+            continue_bindings = self._loop_continue_bindings.pop()
+        normal_exit_states = [imports_after_test, *continue_bindings]
+        if body_falls_through:
+            normal_exit_states.append(self._local_import_bindings())
+        self._set_local_import_bindings(
+            self._intersect_import_bindings(*normal_exit_states)
+        )
+        else_falls_through = self._visit_statement_list(node.orelse)
+        reachable_states = list(break_bindings)
+        if else_falls_through:
+            reachable_states.append(self._local_import_bindings())
+        self._set_local_import_bindings(
+            self._intersect_import_bindings(*reachable_states)
+        )
+        return None
+
+    def visit_Break(self, _node: ast.Break) -> Any:
+        if self._loop_break_bindings and not self._suppress_loop_exits:
+            self._loop_break_bindings[-1].append(self._local_import_bindings())
+        return None
+
+    def visit_Continue(self, _node: ast.Continue) -> Any:
+        if self._loop_continue_bindings and not self._suppress_loop_exits:
+            self._loop_continue_bindings[-1].append(self._local_import_bindings())
         return None
 
     def _visit_with_statement(self, node: ast.With | ast.AsyncWith) -> None:
@@ -772,6 +1289,8 @@ class _Resolver:
                     return "lexically_shadowed_name", False
             elif frame.kind == "comprehension" and name in frame.local_bindings:
                 return "comprehension_binding", False
+            elif frame.kind == "type_alias" and name in frame.local_bindings:
+                return _type_alias_binding_reason(frame, name), False
             elif (
                 frame.kind == "class"
                 and not inside_function

--- a/merger/repoground/architecture/call_graph.py
+++ b/merger/repoground/architecture/call_graph.py
@@ -257,6 +257,32 @@ def _type_parameter_names(type_params: Iterable[ast.AST]) -> set[str]:
     return names
 
 
+def _match_pattern_is_irrefutable(pattern: ast.pattern) -> bool:
+    if isinstance(pattern, ast.MatchAs):
+        return pattern.pattern is None or _match_pattern_is_irrefutable(pattern.pattern)
+    if isinstance(pattern, ast.MatchOr):
+        return any(_match_pattern_is_irrefutable(item) for item in pattern.patterns)
+    return False
+
+
+def _match_is_exhaustive(node: ast.Match) -> bool:
+    return any(
+        case.guard is None and _match_pattern_is_irrefutable(case.pattern)
+        for case in node.cases
+    )
+
+
+def _match_falls_through(node: ast.Match) -> bool:
+    if not _match_is_exhaustive(node):
+        return True
+    for case in node.cases:
+        if _statements_fall_through(case.body):
+            return True
+        if case.guard is None and _match_pattern_is_irrefutable(case.pattern):
+            return False
+    return False
+
+
 def _statement_falls_through(statement: ast.stmt) -> bool:
     if isinstance(statement, (ast.Return, ast.Raise, ast.Break, ast.Continue)):
         return False
@@ -264,6 +290,8 @@ def _statement_falls_through(statement: ast.stmt) -> bool:
         return _statements_fall_through(statement.body) or _statements_fall_through(
             statement.orelse
         )
+    if isinstance(statement, ast.Match):
+        return _match_falls_through(statement)
     try_star_type = getattr(ast, "TryStar", None)
     if isinstance(statement, ast.Try) or (
         try_star_type is not None and isinstance(statement, try_star_type)
@@ -1115,19 +1143,48 @@ class _CallGraphVisitor(ast.NodeVisitor):
 
     def visit_Match(self, node: ast.Match) -> Any:
         self.visit(node.subject)
-        bound_names = set().union(
-            *(_match_pattern_names(case.pattern) for case in node.cases)
-        )
+        if not self.stack:
+            for case in node.cases:
+                for name in _match_pattern_names(case.pattern):
+                    self.state.add_binding(name, "assign")
+        next_case_state = self._local_import_bindings()
+        fallthrough_states: list[dict[str, tuple[str, ...]]] = []
+        exhaustive = False
         for case in node.cases:
-            # Cases are mutually exclusive. Reset the conservative binding state so
-            # an import in one case cannot leak into a later case during AST traversal.
-            self._bind_or_invalidate_names(bound_names)
+            pattern_names = _match_pattern_names(case.pattern)
+            pattern_miss_state = next_case_state
+            pattern_success_state = self._bindings_without_names(
+                next_case_state,
+                pattern_names,
+            )
+            self._set_local_import_bindings(pattern_success_state)
             self.visit(case.pattern)
             if case.guard is not None:
                 self.visit(case.guard)
-            for statement in case.body:
-                self.visit(statement)
-        self._bind_or_invalidate_names(bound_names)
+                guard_state = self._local_import_bindings()
+                # A later case can be reached either because this pattern did not
+                # match or because its guard was false. Retain only imports that
+                # survive both paths.
+                next_case_state = self._intersect_import_bindings(
+                    pattern_miss_state,
+                    guard_state,
+                )
+            else:
+                guard_state = pattern_success_state
+                next_case_state = pattern_miss_state
+            self._set_local_import_bindings(guard_state)
+            if self._visit_statement_list(case.body):
+                fallthrough_states.append(self._local_import_bindings())
+            if case.guard is None and _match_pattern_is_irrefutable(case.pattern):
+                exhaustive = True
+                break
+        if not exhaustive:
+            # A refutable match may select no case. The pre-match path is therefore
+            # a reachable exit and must prevent conditional imports becoming S1.
+            fallthrough_states.append(next_case_state)
+        self._set_local_import_bindings(
+            self._intersect_import_bindings(*fallthrough_states)
+        )
         return None
 
     def visit_Call(self, node: ast.Call) -> Any:

--- a/merger/repoground/architecture/call_graph.py
+++ b/merger/repoground/architecture/call_graph.py
@@ -12,7 +12,7 @@ import os
 from operator import attrgetter
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import Any, Iterable, Sequence
+from typing import Any, Iterable, Iterator, Sequence
 
 from merger.repoground.architecture.call_graph_contract import (
     MAX_SKIPPED_ERRORS,
@@ -507,6 +507,18 @@ def _named_frames(stack: Sequence[_ScopeFrame]) -> list[_ScopeFrame]:
     return [frame for frame in stack if frame.name and frame.kind in CALLER_KINDS]
 
 
+def _visible_import_frames(
+    stack: Sequence[_ScopeFrame],
+) -> Iterator[_ScopeFrame]:
+    inside_function = False
+    for frame in reversed(stack):
+        if frame.kind in (*_FUNCTION_KINDS, "lambda"):
+            inside_function = True
+        if inside_function and frame.kind == "class":
+            continue
+        yield frame
+
+
 def _caller_fields(path: str, stack: Sequence[_ScopeFrame]) -> dict[str, Any]:
     named = _named_frames(stack)
     if not named:
@@ -695,7 +707,7 @@ class _Resolver:
     def _resolve_local_import_name(
         self, name: str, stack: Sequence[_ScopeFrame]
     ) -> dict[str, Any] | None:
-        for frame in reversed(stack):
+        for frame in _visible_import_frames(stack):
             if frame.kind in (*_FUNCTION_KINDS, "lambda"):
                 if name in frame.global_names or name in frame.nonlocal_names:
                     return None
@@ -799,7 +811,7 @@ class _Resolver:
         self, parts: list[str], stack: Sequence[_ScopeFrame]
     ) -> dict[str, Any] | None:
         root = parts[0]
-        for frame in reversed(stack):
+        for frame in _visible_import_frames(stack):
             if frame.kind in (*_FUNCTION_KINDS, "lambda"):
                 if root in frame.global_names:
                     return None

--- a/merger/repoground/cli/mcp_stdio.py
+++ b/merger/repoground/cli/mcp_stdio.py
@@ -1,4 +1,5 @@
 """Minimal newline-delimited MCP stdio transport for RepoGround."""
+
 from __future__ import annotations
 
 import argparse
@@ -38,138 +39,166 @@ def _read_annotations() -> dict[str, bool]:
     }
 
 
+def _selector_properties() -> dict[str, Any]:
+    return {
+        "bundle_manifest": {
+            "type": ["string", "null"],
+            "description": "Optional exact manifest path inside the startup bundle root.",
+        },
+        "repo": {
+            "type": ["string", "null"],
+            "description": "Repository identity such as owner/repository or repository name.",
+        },
+        "stem": {
+            "type": ["string", "null"],
+            "description": "Optional exact snapshot stem.",
+        },
+    }
+
+
 def _tool_definitions(enable_snapshot_create: bool) -> list[dict[str, Any]]:
+    selector = _selector_properties()
+
+    def schema(
+        properties: dict[str, Any], required: list[str] | None = None
+    ) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {**selector, **properties},
+            "required": required or [],
+            "additionalProperties": False,
+        }
+
     tools: list[dict[str, Any]] = [
+        {
+            "name": "bundle_discover",
+            "title": "RepoGround bundle discovery",
+            "description": "List healthy existing bundles or select one by repository identity/stem.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "repo": selector["repo"],
+                    "stem": selector["stem"],
+                },
+                "required": [],
+                "additionalProperties": False,
+            },
+            "annotations": _read_annotations(),
+        },
+        {
+            "name": "snapshot_status",
+            "title": "RepoGround snapshot status",
+            "description": "Read health, availability and freshness for one selected existing bundle.",
+            "inputSchema": schema({"verbose": {"type": "boolean", "default": False}}),
+            "annotations": _read_annotations(),
+        },
         {
             "name": "ask_context",
             "title": "RepoGround context pack",
             "description": "Build a cited context pack from one existing RepoGround bundle.",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "bundle_manifest": {"type": "string"},
+            "inputSchema": schema(
+                {
                     "query": {"type": "string"},
-                    "task_profile": {"type": "string", "default": "basic_repo_question"},
-                    "max_context_tokens": {"type": "integer", "minimum": 1, "default": 8000},
-                    "max_answer_tokens": {"type": "integer", "minimum": 1, "default": 1200},
-                    "k": {"type": "integer", "minimum": 1, "maximum": 100, "default": 5},
+                    "task_profile": {
+                        "type": "string",
+                        "default": "basic_repo_question",
+                    },
+                    "max_context_tokens": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "default": 8000,
+                    },
+                    "max_answer_tokens": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "default": 1200,
+                    },
+                    "k": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 100,
+                        "default": 5,
+                    },
+                    "verbose": {"type": "boolean", "default": False},
                 },
-                "required": ["bundle_manifest", "query"],
-                "additionalProperties": False,
-            },
+                ["query"],
+            ),
+            "annotations": _read_annotations(),
+        },
+        {
+            "name": "query_existing_index",
+            "title": "RepoGround bounded query",
+            "description": "Route exact symbol-definition questions to the symbol index; otherwise use exact AND and labelled OR fallback with bounded cited ranges.",
+            "inputSchema": schema(
+                {
+                    "query": {"type": "string"},
+                    "task_profile": {
+                        "type": "string",
+                        "default": "basic_repo_question",
+                    },
+                    "max_context_tokens": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "default": 2000,
+                    },
+                    "k": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 100,
+                        "default": 5,
+                    },
+                    "verbose": {"type": "boolean", "default": False},
+                },
+                ["query"],
+            ),
+            "annotations": _read_annotations(),
+        },
+        {
+            "name": "range_get",
+            "title": "RepoGround range reader",
+            "description": "Resolve one exact bundle range reference without reading a live workspace.",
+            "inputSchema": schema(
+                {
+                    "range_ref": {"type": "object"},
+                    "verbose": {"type": "boolean", "default": False},
+                },
+                ["range_ref"],
+            ),
             "annotations": _read_annotations(),
         },
         {
             "name": "grounding_verify",
             "title": "RepoGround grounding verifier",
             "description": "Verify declared citations and ranges against an existing RepoGround bundle.",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
+            "inputSchema": schema(
+                {
                     "declaration": {"type": "object"},
-                    "bundle_manifest": {"type": "string"},
                     "citation_map": {"type": ["string", "null"]},
                     "task_profile": {"type": ["string", "null"]},
+                    "verbose": {"type": "boolean", "default": False},
                 },
-                "required": ["declaration", "bundle_manifest"],
-                "additionalProperties": False,
-            },
+                ["declaration"],
+            ),
             "annotations": _read_annotations(),
         },
         {
             "name": "live_freshness",
             "title": "RepoGround live freshness",
-            "description": (
-                "Compare snapshot Git provenance with the configured local checkout "
-                "without refreshing it."
-            ),
-            "inputSchema": {
-                "type": "object",
-                "properties": {"bundle_manifest": {"type": "string"}},
-                "required": ["bundle_manifest"],
-                "additionalProperties": False,
-            },
+            "description": "Compare snapshot Git provenance with the configured local checkout without refreshing it.",
+            "inputSchema": schema({}),
             "annotations": _read_annotations(),
         },
         {
             "name": "find_symbol",
             "title": "RepoGround symbol locator",
-            "description": (
-                "Locate Python symbol definitions (function/class/async_function) by name "
-                "in an existing RepoGround bundle. Answers 'where is X defined?' with an "
-                "exact path and line range."
-            ),
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "bundle_manifest": {"type": "string"},
+            "description": "Locate Python symbol definitions by name with exact path and line range.",
+            "inputSchema": schema(
+                {
                     "name": {"type": "string", "minLength": 1},
                     "kind": {
                         "type": ["string", "null"],
                         "enum": [None, "class", "function", "async_function"],
                     },
-                    "path": {"type": ["string", "null"]},
-                    "k": {"type": "integer", "minimum": 1, "maximum": 200, "default": 25},
-                },
-                "required": ["bundle_manifest", "name"],
-                "additionalProperties": False,
-            },
-            "annotations": _read_annotations(),
-        },
-        {
-            "name": "find_references",
-            "title": "RepoGround call reference locator",
-            "description": (
-                "List static call sites for a callee name from an existing RepoGround "
-                "bundle's python_call_graph artifact. Exact matches first; bounded, "
-                "read-only, no refresh. Answers 'where is X called?'"
-            ),
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "bundle_manifest": {"type": "string"},
-                    "name": {"type": "string", "minLength": 1},
-                    "path": {"type": ["string", "null"]},
-                    "k": {"type": "integer", "minimum": 1, "maximum": 200, "default": 25},
-                },
-                "required": ["bundle_manifest", "name"],
-                "additionalProperties": False,
-            },
-            "annotations": _read_annotations(),
-        },
-        {
-            "name": "get_callers",
-            "title": "RepoGround caller locator",
-            "description": (
-                "Select one exact symbol and group only S1 call edges to it by unique "
-                "enclosing caller. Unresolved name similarities stay separate. "
-                "Answers 'who calls X?'"
-            ),
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "bundle_manifest": {"type": "string"},
-                    "name": {"type": "string", "minLength": 1},
-                    "path": {"type": ["string", "null"]},
-                    "k": {"type": "integer", "minimum": 1, "maximum": 200, "default": 25},
-                },
-                "required": ["bundle_manifest", "name"],
-                "additionalProperties": False,
-            },
-            "annotations": _read_annotations(),
-        },
-        {
-            "name": "get_callees",
-            "title": "RepoGround callee locator",
-            "description": (
-                "Select one exact caller symbol, group its uniquely resolved S1 targets, "
-                "and retain unresolved S0 call sites separately. Answers 'what does X call?'"
-            ),
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "bundle_manifest": {"type": "string"},
-                    "name": {"type": "string", "minLength": 1},
                     "path": {"type": ["string", "null"]},
                     "k": {
                         "type": "integer",
@@ -177,29 +206,69 @@ def _tool_definitions(enable_snapshot_create: bool) -> list[dict[str, Any]]:
                         "maximum": 200,
                         "default": 25,
                     },
+                    "verbose": {"type": "boolean", "default": False},
                 },
-                "required": ["bundle_manifest", "name"],
-                "additionalProperties": False,
-            },
+                ["name"],
+            ),
             "annotations": _read_annotations(),
         },
     ]
+    for name, title, description in (
+        (
+            "find_references",
+            "RepoGround call reference locator",
+            "List bounded static call sites for a callee name.",
+        ),
+        (
+            "get_callers",
+            "RepoGround caller locator",
+            "Group uniquely resolved callers for one exact target symbol.",
+        ),
+        (
+            "get_callees",
+            "RepoGround callee locator",
+            "Group uniquely resolved outgoing calls for one exact caller symbol.",
+        ),
+    ):
+        tools.append(
+            {
+                "name": name,
+                "title": title,
+                "description": description,
+                "inputSchema": schema(
+                    {
+                        "name": {"type": "string", "minLength": 1},
+                        "path": {"type": ["string", "null"]},
+                        "k": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 200,
+                            "default": 25,
+                        },
+                        "verbose": {"type": "boolean", "default": False},
+                    },
+                    ["name"],
+                ),
+                "annotations": _read_annotations(),
+            }
+        )
     if enable_snapshot_create:
         tools.append(
             {
                 "name": "snapshot_create",
                 "title": "RepoGround snapshot create",
-                "description": (
-                    "Create RepoGround bundle artifacts for the startup-bound repository "
-                    "inside the startup-bound bundle root."
-                ),
+                "description": "Create bundle artifacts for the startup-bound repository and output root.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
                         "profile": {"type": "string"},
                         "output_subdir": {"type": ["string", "null"]},
                         "output_mode": {"type": ["string", "null"]},
-                        "timeout_seconds": {"type": "integer", "minimum": 1, "maximum": 1800},
+                        "timeout_seconds": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 1800,
+                        },
                         "max_file_bytes": {"type": "string"},
                         "max_total_bytes": {"type": "string"},
                         "split_size": {"type": "string"},
@@ -221,6 +290,16 @@ def _tool_definitions(enable_snapshot_create: bool) -> list[dict[str, Any]]:
     return tools
 
 
+def tool_registry(enable_snapshot_create: bool = False) -> tuple[dict[str, Any], ...]:
+    """Public immutable-length registry projection for docs and drift checks."""
+    return tuple(_tool_definitions(enable_snapshot_create))
+
+
+def tool_names(enable_snapshot_create: bool = False) -> tuple[str, ...]:
+    """Public name projection used by documentation drift checks."""
+    return tuple(tool["name"] for tool in tool_registry(enable_snapshot_create))
+
+
 class RepoGroundMcpStdioServer:
     """Bind existing RepoGround handlers to the MCP JSON-RPC lifecycle."""
 
@@ -234,13 +313,21 @@ class RepoGroundMcpStdioServer:
         self.bundle_root = Path(bundle_root).expanduser().resolve()
         if not self.bundle_root.exists():
             raise ValueError(f"bundle root does not exist: {self.bundle_root}")
-        if self.bundle_root.is_file() and not self.bundle_root.name.endswith(MANIFEST_SUFFIX):
-            raise ValueError("file-valued bundle root must be a *.bundle.manifest.json file")
-        self.repo_root = Path(repo_root).expanduser().resolve() if repo_root is not None else None
+        if self.bundle_root.is_file() and not self.bundle_root.name.endswith(
+            MANIFEST_SUFFIX
+        ):
+            raise ValueError(
+                "file-valued bundle root must be a *.bundle.manifest.json file"
+            )
+        self.repo_root = (
+            Path(repo_root).expanduser().resolve() if repo_root is not None else None
+        )
         if self.repo_root is not None and not self.repo_root.is_dir():
             raise ValueError(f"repo root is not a directory: {self.repo_root}")
         if enable_snapshot_create and self.repo_root is None:
-            raise ValueError("--enable-snapshot-create requires an explicit --repo-root")
+            raise ValueError(
+                "--enable-snapshot-create requires an explicit --repo-root"
+            )
         self.enable_snapshot_create = enable_snapshot_create
         self.snapshot_output_root = (
             self.bundle_root if self.bundle_root.is_dir() else self.bundle_root.parent
@@ -249,7 +336,9 @@ class RepoGroundMcpStdioServer:
 
     def _initialize(self, params: Mapping[str, Any]) -> dict[str, Any]:
         requested = params.get("protocolVersion")
-        negotiated = requested if requested in SUPPORTED_PROTOCOL_VERSIONS else PROTOCOL_VERSION
+        negotiated = (
+            requested if requested in SUPPORTED_PROTOCOL_VERSIONS else PROTOCOL_VERSION
+        )
         self._negotiated = True
         return {
             "protocolVersion": negotiated,
@@ -257,7 +346,11 @@ class RepoGroundMcpStdioServer:
                 "resources": {"subscribe": False, "listChanged": False},
                 "tools": {"listChanged": False},
             },
-            "serverInfo": {"name": SERVER_NAME, "title": "RepoGround", "version": SERVER_VERSION},
+            "serverInfo": {
+                "name": SERVER_NAME,
+                "title": "RepoGround",
+                "version": SERVER_VERSION,
+            },
             "instructions": (
                 "RepoGround reads existing deterministic bundles, including documented legacy identities. Reads never refresh snapshots. "
                 "Use live_freshness before relying on a snapshot. snapshot_create is exposed only "
@@ -274,7 +367,9 @@ class RepoGroundMcpStdioServer:
             raise McpProtocolError(-32602, "bundle_manifest must be a non-empty string")
         manifest = Path(raw_path).expanduser().resolve()
         if not manifest.name.endswith(MANIFEST_SUFFIX):
-            raise McpProtocolError(-32602, "bundle_manifest must name a RepoGround bundle manifest")
+            raise McpProtocolError(
+                -32602, "bundle_manifest must name a RepoGround bundle manifest"
+            )
         if self.bundle_root.is_file():
             allowed = manifest == self.bundle_root
         else:
@@ -285,22 +380,74 @@ class RepoGroundMcpStdioServer:
             else:
                 allowed = True
         if not allowed:
-            raise McpProtocolError(-32602, "bundle_manifest is outside the configured bundle root")
+            raise McpProtocolError(
+                -32602, "bundle_manifest is outside the configured bundle root"
+            )
         if not manifest.is_file():
             raise McpProtocolError(-32602, "bundle_manifest does not exist")
         return manifest
+
+    def _resolve_manifest(self, arguments: Mapping[str, Any]) -> Path:
+        raw_manifest = arguments.get("bundle_manifest")
+        repo = arguments.get("repo")
+        stem = arguments.get("stem")
+        if raw_manifest is not None:
+            if repo is not None or stem is not None:
+                raise McpProtocolError(
+                    -32602,
+                    "bundle_manifest cannot be combined with repo or stem selectors",
+                )
+            return self._guard_manifest(raw_manifest)
+        from merger.repoground.core.bundle_catalog import select_bundle_manifest
+
+        selection = select_bundle_manifest(
+            self.bundle_root,
+            repo=repo,
+            stem=stem,
+            require_healthy=True,
+        )
+        selected = selection.get("selected")
+        manifest = selected.get("manifest_path") if isinstance(selected, dict) else None
+        if selection.get("status") != "available" or not isinstance(manifest, str):
+            raise McpProtocolError(
+                -32602,
+                "no unique healthy RepoGround bundle matched the selector",
+                {
+                    "status": selection.get("status"),
+                    "reason": selection.get("reason"),
+                    "requested_repo": selection.get("requested_repo"),
+                    "requested_stem": selection.get("requested_stem"),
+                },
+            )
+        return self._guard_manifest(manifest)
+
+    def _selected_call_args(
+        self, arguments: Mapping[str, Any]
+    ) -> tuple[dict[str, Any], Path]:
+        manifest = self._resolve_manifest(arguments)
+        call_args = {
+            key: value
+            for key, value in arguments.items()
+            if key not in {"bundle_manifest", "repo", "stem"}
+        }
+        call_args["bundle_manifest"] = str(manifest)
+        return call_args, manifest
 
     @staticmethod
     def _guard_bundle_path(raw_path: Any, manifest: Path, *, label: str) -> str | None:
         if raw_path is None:
             return None
         if not isinstance(raw_path, str) or not raw_path:
-            raise McpProtocolError(-32602, f"{label} must be null or a non-empty string")
+            raise McpProtocolError(
+                -32602, f"{label} must be null or a non-empty string"
+            )
         path = Path(raw_path).expanduser().resolve()
         try:
             path.relative_to(manifest.parent.resolve())
         except ValueError as exc:
-            raise McpProtocolError(-32602, f"{label} is outside the bundle directory") from exc
+            raise McpProtocolError(
+                -32602, f"{label} is outside the bundle directory"
+            ) from exc
         if not path.is_file():
             raise McpProtocolError(-32602, f"{label} does not exist")
         return str(path)
@@ -394,7 +541,9 @@ class RepoGroundMcpStdioServer:
         if not isinstance(text, str):
             text = json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True)
         content_type = result.get("content_type")
-        mime_type = content_type if isinstance(content_type, str) else "application/json"
+        mime_type = (
+            content_type if isinstance(content_type, str) else "application/json"
+        )
         resource_meta = {
             "status": result.get("status"),
             "snapshotContext": result.get("snapshot_context"),
@@ -409,20 +558,85 @@ class RepoGroundMcpStdioServer:
             },
         }
 
+    def _call_bundle_discover(self, arguments: Mapping[str, Any]) -> dict[str, Any]:
+        from merger.repoground.core.bundle_catalog import (
+            discover_bundle_catalog,
+            select_bundle_manifest,
+        )
+
+        repo = arguments.get("repo")
+        stem = arguments.get("stem")
+        if repo is not None or stem is not None:
+            return select_bundle_manifest(
+                self.bundle_root,
+                repo=repo,
+                stem=stem,
+                require_healthy=True,
+            )
+        return discover_bundle_catalog(self.bundle_root)
+
+    def _call_snapshot_status(self, arguments: Mapping[str, Any]) -> dict[str, Any]:
+        call_args, manifest = self._selected_call_args(arguments)
+        from merger.repoground.core import mcp_tools
+
+        payload = mcp_tools.snapshot_status(**call_args)
+        payload["live_freshness"] = self._safe_live_freshness(manifest)
+        return payload
+
     def _call_ask_context(self, arguments: Mapping[str, Any]) -> dict[str, Any]:
-        call_args = dict(arguments)
-        manifest = self._guard_manifest(call_args.get("bundle_manifest"))
-        call_args["bundle_manifest"] = str(manifest)
+        call_args, manifest = self._selected_call_args(arguments)
+        query = call_args.get("query")
+        if not isinstance(query, str) or not query.strip():
+            raise McpProtocolError(-32602, "ask_context requires a non-empty query")
         from merger.repoground.core import mcp_tools
 
         payload = mcp_tools.ask_context(**call_args)
         payload["live_freshness"] = self._safe_live_freshness(manifest)
         return payload
 
+    def _call_query_existing_index(
+        self, arguments: Mapping[str, Any]
+    ) -> dict[str, Any]:
+        call_args, manifest = self._selected_call_args(arguments)
+        query = call_args.get("query")
+        if not isinstance(query, str) or not query.strip():
+            raise McpProtocolError(
+                -32602, "query_existing_index requires a non-empty query"
+            )
+        k = call_args.get("k", 5)
+        if not isinstance(k, int) or isinstance(k, bool) or not 1 <= k <= 100:
+            raise McpProtocolError(
+                -32602,
+                "query_existing_index k must be an integer between 1 and 100",
+            )
+        budget = call_args.get("max_context_tokens", 2000)
+        if not isinstance(budget, int) or isinstance(budget, bool) or budget < 1:
+            raise McpProtocolError(
+                -32602,
+                "query_existing_index max_context_tokens must be a positive integer",
+            )
+        from merger.repoground.core import mcp_tools
+
+        payload = mcp_tools.query_existing_index(**call_args)
+        payload["live_freshness"] = self._safe_live_freshness(manifest)
+        return payload
+
+    def _call_range_get(self, arguments: Mapping[str, Any]) -> dict[str, Any]:
+        call_args, manifest = self._selected_call_args(arguments)
+        if not isinstance(call_args.get("range_ref"), dict):
+            raise McpProtocolError(-32602, "range_get requires an object range_ref")
+        from merger.repoground.core import mcp_tools
+
+        payload = mcp_tools.range_get(**call_args)
+        payload["live_freshness"] = self._safe_live_freshness(manifest)
+        return payload
+
     def _call_grounding_verify(self, arguments: Mapping[str, Any]) -> dict[str, Any]:
-        call_args = dict(arguments)
-        manifest = self._guard_manifest(call_args.get("bundle_manifest"))
-        call_args["bundle_manifest"] = str(manifest)
+        call_args, manifest = self._selected_call_args(arguments)
+        if not isinstance(call_args.get("declaration"), dict):
+            raise McpProtocolError(
+                -32602, "grounding_verify requires an object declaration"
+            )
         call_args["citation_map"] = self._guard_bundle_path(
             call_args.get("citation_map"),
             manifest,
@@ -435,10 +649,7 @@ class RepoGroundMcpStdioServer:
         return payload
 
     def _call_find_symbol(self, arguments: Mapping[str, Any]) -> dict[str, Any]:
-        call_args = dict(arguments)
-        # Fail closed at the transport boundary: reject an empty name (which would
-        # otherwise list the first k symbols) or an unknown kind, independent of
-        # any client-side inputSchema enforcement.
+        call_args, manifest = self._selected_call_args(arguments)
         name = call_args.get("name")
         if not isinstance(name, str) or not name.strip():
             raise McpProtocolError(-32602, "find_symbol requires a non-empty name")
@@ -451,18 +662,14 @@ class RepoGroundMcpStdioServer:
                 "find_symbol kind must be one of class, function, async_function, or null",
                 {"allowed_kinds": list(mcp_tools.FIND_SYMBOL_KINDS)},
             )
-        manifest = self._guard_manifest(call_args.get("bundle_manifest"))
-        call_args["bundle_manifest"] = str(manifest)
         payload = mcp_tools.find_symbol(**call_args)
-        # Nav results reflect the snapshot; surface freshness so the agent knows
-        # whether the index may lag the live working tree.
         payload["live_freshness"] = self._safe_live_freshness(manifest)
         return payload
 
-    def _call_call_navigation(self, tool: str, arguments: Mapping[str, Any]) -> dict[str, Any]:
-        call_args = dict(arguments)
-        # Fail closed at the transport boundary, independent of client-side
-        # inputSchema enforcement: reject an empty name and an out-of-bounds k.
+    def _call_call_navigation(
+        self, tool: str, arguments: Mapping[str, Any]
+    ) -> dict[str, Any]:
+        call_args, manifest = self._selected_call_args(arguments)
         name = call_args.get("name")
         if not isinstance(name, str) or not name.strip():
             raise McpProtocolError(-32602, f"{tool} requires a non-empty name")
@@ -473,8 +680,6 @@ class RepoGroundMcpStdioServer:
                 f"{tool} k must be an integer between 1 and 200",
                 {"k": k},
             )
-        manifest = self._guard_manifest(call_args.get("bundle_manifest"))
-        call_args["bundle_manifest"] = str(manifest)
         from merger.repoground.core import mcp_tools
 
         handlers = {
@@ -482,10 +687,7 @@ class RepoGroundMcpStdioServer:
             "get_callers": mcp_tools.get_callers,
             "get_callees": mcp_tools.get_callees,
         }
-        handler = handlers[tool]
-        payload = handler(**call_args)
-        # Call-graph results reflect the snapshot; surface freshness so the agent
-        # knows whether the artifact may lag the live working tree.
+        payload = handlers[tool](**call_args)
         payload["live_freshness"] = self._safe_live_freshness(manifest)
         return payload
 
@@ -507,13 +709,20 @@ class RepoGroundMcpStdioServer:
         return mcp_tools.snapshot_create(**call_args)
 
     def _tool_payload(self, name: str, arguments: Mapping[str, Any]) -> dict[str, Any]:
+        if name == "bundle_discover":
+            return self._call_bundle_discover(arguments)
+        if name == "snapshot_status":
+            return self._call_snapshot_status(arguments)
         if name == "ask_context":
             return self._call_ask_context(arguments)
+        if name == "query_existing_index":
+            return self._call_query_existing_index(arguments)
+        if name == "range_get":
+            return self._call_range_get(arguments)
         if name == "grounding_verify":
             return self._call_grounding_verify(arguments)
         if name == "live_freshness":
-            manifest = self._guard_manifest(arguments.get("bundle_manifest"))
-            return self._safe_live_freshness(manifest)
+            return self._safe_live_freshness(self._resolve_manifest(arguments))
         if name == "find_symbol":
             return self._call_find_symbol(arguments)
         if name in ("find_references", "get_callers", "get_callees"):
@@ -522,11 +731,34 @@ class RepoGroundMcpStdioServer:
             return self._call_snapshot_create(arguments)
         raise McpProtocolError(-32602, f"unknown or disabled tool: {name}")
 
+    @staticmethod
+    def _tool_text_summary(name: str, payload: Mapping[str, Any]) -> str:
+        summary: dict[str, Any] = {
+            "tool": name,
+            "status": payload.get("status", "unknown"),
+            "details": "Use structuredContent for the complete typed result.",
+        }
+        retrieval = payload.get("retrieval")
+        if isinstance(retrieval, Mapping):
+            summary["strategy"] = retrieval.get("strategy")
+            summary["match_count"] = retrieval.get("match_count")
+        result = payload.get("result")
+        if isinstance(result, Mapping):
+            hit_count = result.get("hit_count")
+            if isinstance(hit_count, int):
+                summary["hit_count"] = hit_count
+        selected = payload.get("selected")
+        if isinstance(selected, Mapping):
+            summary["stem"] = selected.get("stem")
+        return json.dumps(summary, ensure_ascii=False, separators=(",", ":"))
+
     def _tool_call(self, params: Mapping[str, Any]) -> dict[str, Any]:
         name = params.get("name")
         arguments = params.get("arguments", {})
         if not isinstance(name, str) or not isinstance(arguments, dict):
-            raise McpProtocolError(-32602, "tools/call requires name and object arguments")
+            raise McpProtocolError(
+                -32602, "tools/call requires name and object arguments"
+            )
         try:
             payload = self._tool_payload(name, arguments)
         except McpProtocolError:
@@ -535,17 +767,17 @@ class RepoGroundMcpStdioServer:
             error_payload = {"status": "error", "tool": name, "error": str(exc)}
             return {
                 "content": [
-                    {"type": "text", "text": json.dumps(error_payload, ensure_ascii=False)}
+                    {
+                        "type": "text",
+                        "text": self._tool_text_summary(name, error_payload),
+                    }
                 ],
                 "structuredContent": error_payload,
                 "isError": True,
             }
         return {
             "content": [
-                {
-                    "type": "text",
-                    "text": json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True),
-                }
+                {"type": "text", "text": self._tool_text_summary(name, payload)}
             ],
             "structuredContent": payload,
             "isError": False,
@@ -574,7 +806,9 @@ class RepoGroundMcpStdioServer:
             return _error_response(None, -32600, "invalid JSON-RPC request")
         method = message.get("method")
         if not isinstance(method, str):
-            return _error_response(message.get("id"), -32600, "request method is required")
+            return _error_response(
+                message.get("id"), -32600, "request method is required"
+            )
         if "id" not in message:
             return None
         request_id = message.get("id")
@@ -586,11 +820,15 @@ class RepoGroundMcpStdioServer:
         except McpProtocolError as exc:
             return _error_response(request_id, exc.code, exc.message, exc.data)
         except Exception as exc:
-            return _error_response(request_id, -32603, "internal error", {"detail": str(exc)})
+            return _error_response(
+                request_id, -32603, "internal error", {"detail": str(exc)}
+            )
         return {"jsonrpc": "2.0", "id": request_id, "result": result}
 
 
-def _error_response(request_id: Any, code: int, message: str, data: Any = None) -> dict[str, Any]:
+def _error_response(
+    request_id: Any, code: int, message: str, data: Any = None
+) -> dict[str, Any]:
     error: dict[str, Any] = {"code": code, "message": message}
     if data is not None:
         error["data"] = data

--- a/merger/repoground/cli/mcp_stdio.py
+++ b/merger/repoground/cli/mcp_stdio.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Any, TextIO
 
@@ -13,6 +13,13 @@ from merger.repoground.core.live_freshness import (
     DOES_NOT_ESTABLISH as FRESHNESS_DOES_NOT_ESTABLISH,
 )
 from merger.repoground.core.live_freshness import evaluate_live_freshness
+from merger.repoground.core.manifest_snapshot import (
+    ManifestBinding,
+    ManifestBindingError,
+    capture_manifest_snapshot,
+    manifest_path_identity,
+    use_manifest_binding,
+)
 
 PROTOCOL_VERSION = "2025-06-18"
 SUPPORTED_PROTOCOL_VERSIONS = (PROTOCOL_VERSION, "2025-03-26", "2024-11-05")
@@ -389,7 +396,9 @@ class RepoGroundMcpStdioServer:
             raise McpProtocolError(-32602, "bundle_manifest does not exist")
         return manifest
 
-    def _resolve_manifest(self, arguments: Mapping[str, Any]) -> Path:
+    def _resolve_manifest(
+        self, arguments: Mapping[str, Any]
+    ) -> tuple[Path, ManifestBinding]:
         raw_manifest = arguments.get("bundle_manifest")
         repo = arguments.get("repo")
         stem = arguments.get("stem")
@@ -399,7 +408,16 @@ class RepoGroundMcpStdioServer:
                     -32602,
                     "bundle_manifest cannot be combined with repo or stem selectors",
                 )
-            return self._guard_manifest(raw_manifest)
+            selected_path = manifest_path_identity(raw_manifest)
+            manifest = self._guard_manifest(raw_manifest)
+            try:
+                binding = capture_manifest_snapshot(
+                    manifest,
+                    selected_path=selected_path,
+                ).binding
+            except ManifestBindingError as exc:
+                raise self._manifest_binding_error(exc) from exc
+            return selected_path, binding
         from merger.repoground.core.bundle_catalog import select_bundle_manifest
 
         selection = select_bundle_manifest(
@@ -410,7 +428,17 @@ class RepoGroundMcpStdioServer:
         )
         selected = selection.get("selected")
         manifest = selected.get("manifest_path") if isinstance(selected, dict) else None
-        if selection.get("status") != "available" or not isinstance(manifest, str):
+        manifest_sha256 = (
+            selected.get("manifest_sha256") if isinstance(selected, dict) else None
+        )
+        run_id = selected.get("run_id") if isinstance(selected, dict) else None
+        if (
+            selection.get("status") != "available"
+            or not isinstance(manifest, str)
+            or not isinstance(manifest_sha256, str)
+            or not isinstance(run_id, str)
+            or not run_id
+        ):
             raise McpProtocolError(
                 -32602,
                 "no unique healthy RepoGround bundle matched the selector",
@@ -421,19 +449,52 @@ class RepoGroundMcpStdioServer:
                     "requested_stem": selection.get("requested_stem"),
                 },
             )
-        return self._guard_manifest(manifest)
+        guarded = self._guard_manifest(manifest)
+        selected_path = manifest_path_identity(manifest)
+        return selected_path, ManifestBinding(
+            selected_path=selected_path,
+            resolved_path=guarded,
+            sha256=manifest_sha256,
+            run_id=run_id,
+        )
 
     def _selected_call_args(
         self, arguments: Mapping[str, Any]
-    ) -> tuple[dict[str, Any], Path]:
-        manifest = self._resolve_manifest(arguments)
+    ) -> tuple[dict[str, Any], Path, ManifestBinding]:
+        manifest, binding = self._resolve_manifest(arguments)
         call_args = {
             key: value
             for key, value in arguments.items()
             if key not in {"bundle_manifest", "repo", "stem"}
         }
         call_args["bundle_manifest"] = str(manifest)
-        return call_args, manifest
+        return call_args, manifest, binding
+
+    @staticmethod
+    def _manifest_binding_error(exc: ManifestBindingError) -> McpProtocolError:
+        return McpProtocolError(
+            -32001,
+            "selected RepoGround bundle manifest binding failed",
+            {
+                "status": "manifest_binding_failed",
+                "reason": str(exc),
+            },
+        )
+
+    def _invoke_bound_tool(
+        self,
+        handler: Callable[..., dict[str, Any]],
+        call_args: dict[str, Any],
+        manifest: Path,
+        binding: ManifestBinding,
+    ) -> dict[str, Any]:
+        try:
+            with use_manifest_binding(binding):
+                payload = handler(**call_args)
+                payload["live_freshness"] = self._safe_live_freshness(manifest)
+                return payload
+        except ManifestBindingError as exc:
+            raise self._manifest_binding_error(exc) from exc
 
     @staticmethod
     def _guard_bundle_path(raw_path: Any, manifest: Path, *, label: str) -> str | None:
@@ -578,28 +639,34 @@ class RepoGroundMcpStdioServer:
         return discover_bundle_catalog(self.bundle_root)
 
     def _call_snapshot_status(self, arguments: Mapping[str, Any]) -> dict[str, Any]:
-        call_args, manifest = self._selected_call_args(arguments)
+        call_args, manifest, binding = self._selected_call_args(arguments)
         from merger.repoground.core import mcp_tools
 
-        payload = mcp_tools.snapshot_status(**call_args)
-        payload["live_freshness"] = self._safe_live_freshness(manifest)
-        return payload
+        return self._invoke_bound_tool(
+            mcp_tools.snapshot_status,
+            call_args,
+            manifest,
+            binding,
+        )
 
     def _call_ask_context(self, arguments: Mapping[str, Any]) -> dict[str, Any]:
-        call_args, manifest = self._selected_call_args(arguments)
+        call_args, manifest, binding = self._selected_call_args(arguments)
         query = call_args.get("query")
         if not isinstance(query, str) or not query.strip():
             raise McpProtocolError(-32602, "ask_context requires a non-empty query")
         from merger.repoground.core import mcp_tools
 
-        payload = mcp_tools.ask_context(**call_args)
-        payload["live_freshness"] = self._safe_live_freshness(manifest)
-        return payload
+        return self._invoke_bound_tool(
+            mcp_tools.ask_context,
+            call_args,
+            manifest,
+            binding,
+        )
 
     def _call_query_existing_index(
         self, arguments: Mapping[str, Any]
     ) -> dict[str, Any]:
-        call_args, manifest = self._selected_call_args(arguments)
+        call_args, manifest, binding = self._selected_call_args(arguments)
         query = call_args.get("query")
         if not isinstance(query, str) or not query.strip():
             raise McpProtocolError(
@@ -619,39 +686,48 @@ class RepoGroundMcpStdioServer:
             )
         from merger.repoground.core import mcp_tools
 
-        payload = mcp_tools.query_existing_index(**call_args)
-        payload["live_freshness"] = self._safe_live_freshness(manifest)
-        return payload
+        return self._invoke_bound_tool(
+            mcp_tools.query_existing_index,
+            call_args,
+            manifest,
+            binding,
+        )
 
     def _call_range_get(self, arguments: Mapping[str, Any]) -> dict[str, Any]:
-        call_args, manifest = self._selected_call_args(arguments)
+        call_args, manifest, binding = self._selected_call_args(arguments)
         if not isinstance(call_args.get("range_ref"), dict):
             raise McpProtocolError(-32602, "range_get requires an object range_ref")
         from merger.repoground.core import mcp_tools
 
-        payload = mcp_tools.range_get(**call_args)
-        payload["live_freshness"] = self._safe_live_freshness(manifest)
-        return payload
+        return self._invoke_bound_tool(
+            mcp_tools.range_get,
+            call_args,
+            manifest,
+            binding,
+        )
 
     def _call_grounding_verify(self, arguments: Mapping[str, Any]) -> dict[str, Any]:
-        call_args, manifest = self._selected_call_args(arguments)
+        call_args, manifest, binding = self._selected_call_args(arguments)
         if not isinstance(call_args.get("declaration"), dict):
             raise McpProtocolError(
                 -32602, "grounding_verify requires an object declaration"
             )
         call_args["citation_map"] = self._guard_bundle_path(
             call_args.get("citation_map"),
-            manifest,
+            binding.resolved_path,
             label="citation_map",
         )
         from merger.repoground.core import mcp_tools
 
-        payload = mcp_tools.grounding_verify(**call_args)
-        payload["live_freshness"] = self._safe_live_freshness(manifest)
-        return payload
+        return self._invoke_bound_tool(
+            mcp_tools.grounding_verify,
+            call_args,
+            manifest,
+            binding,
+        )
 
     def _call_find_symbol(self, arguments: Mapping[str, Any]) -> dict[str, Any]:
-        call_args, manifest = self._selected_call_args(arguments)
+        call_args, manifest, binding = self._selected_call_args(arguments)
         name = call_args.get("name")
         if not isinstance(name, str) or not name.strip():
             raise McpProtocolError(-32602, "find_symbol requires a non-empty name")
@@ -664,14 +740,17 @@ class RepoGroundMcpStdioServer:
                 "find_symbol kind must be one of class, function, async_function, or null",
                 {"allowed_kinds": list(mcp_tools.FIND_SYMBOL_KINDS)},
             )
-        payload = mcp_tools.find_symbol(**call_args)
-        payload["live_freshness"] = self._safe_live_freshness(manifest)
-        return payload
+        return self._invoke_bound_tool(
+            mcp_tools.find_symbol,
+            call_args,
+            manifest,
+            binding,
+        )
 
     def _call_call_navigation(
         self, tool: str, arguments: Mapping[str, Any]
     ) -> dict[str, Any]:
-        call_args, manifest = self._selected_call_args(arguments)
+        call_args, manifest, binding = self._selected_call_args(arguments)
         name = call_args.get("name")
         if not isinstance(name, str) or not name.strip():
             raise McpProtocolError(-32602, f"{tool} requires a non-empty name")
@@ -689,9 +768,12 @@ class RepoGroundMcpStdioServer:
             "get_callers": mcp_tools.get_callers,
             "get_callees": mcp_tools.get_callees,
         }
-        payload = handlers[tool](**call_args)
-        payload["live_freshness"] = self._safe_live_freshness(manifest)
-        return payload
+        return self._invoke_bound_tool(
+            handlers[tool],
+            call_args,
+            manifest,
+            binding,
+        )
 
     def _call_snapshot_create(self, arguments: Mapping[str, Any]) -> dict[str, Any]:
         if not self.enable_snapshot_create or self.repo_root is None:
@@ -725,7 +807,12 @@ class RepoGroundMcpStdioServer:
         if handler is not None:
             return handler(arguments)
         if name == "live_freshness":
-            return self._safe_live_freshness(self._resolve_manifest(arguments))
+            manifest, binding = self._resolve_manifest(arguments)
+            try:
+                with use_manifest_binding(binding):
+                    return self._safe_live_freshness(manifest)
+            except ManifestBindingError as exc:
+                raise self._manifest_binding_error(exc) from exc
         if name in ("find_references", "get_callers", "get_callees"):
             return self._call_call_navigation(name, arguments)
         raise McpProtocolError(-32602, f"unknown or disabled tool: {name}")

--- a/merger/repoground/cli/mcp_stdio.py
+++ b/merger/repoground/cli/mcp_stdio.py
@@ -333,6 +333,7 @@ class RepoGroundMcpStdioServer:
             self.bundle_root if self.bundle_root.is_dir() else self.bundle_root.parent
         )
         self._negotiated = False
+        self._protocol_version: str | None = None
 
     def _initialize(self, params: Mapping[str, Any]) -> dict[str, Any]:
         requested = params.get("protocolVersion")
@@ -340,6 +341,7 @@ class RepoGroundMcpStdioServer:
             requested if requested in SUPPORTED_PROTOCOL_VERSIONS else PROTOCOL_VERSION
         )
         self._negotiated = True
+        self._protocol_version = negotiated
         return {
             "protocolVersion": negotiated,
             "capabilities": {
@@ -749,6 +751,11 @@ class RepoGroundMcpStdioServer:
             summary["stem"] = selected.get("stem")
         return json.dumps(summary, ensure_ascii=False, separators=(",", ":"))
 
+    def _tool_text(self, name: str, payload: Mapping[str, Any]) -> str:
+        if self._protocol_version == PROTOCOL_VERSION:
+            return self._tool_text_summary(name, payload)
+        return json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True)
+
     def _tool_call(self, params: Mapping[str, Any]) -> dict[str, Any]:
         name = params.get("name")
         arguments = params.get("arguments", {})
@@ -766,16 +773,14 @@ class RepoGroundMcpStdioServer:
                 "content": [
                     {
                         "type": "text",
-                        "text": self._tool_text_summary(name, error_payload),
+                        "text": self._tool_text(name, error_payload),
                     }
                 ],
                 "structuredContent": error_payload,
                 "isError": True,
             }
         return {
-            "content": [
-                {"type": "text", "text": self._tool_text_summary(name, payload)}
-            ],
+            "content": [{"type": "text", "text": self._tool_text(name, payload)}],
             "structuredContent": payload,
             "isError": False,
         }

--- a/merger/repoground/cli/mcp_stdio.py
+++ b/merger/repoground/cli/mcp_stdio.py
@@ -709,26 +709,23 @@ class RepoGroundMcpStdioServer:
         return mcp_tools.snapshot_create(**call_args)
 
     def _tool_payload(self, name: str, arguments: Mapping[str, Any]) -> dict[str, Any]:
-        if name == "bundle_discover":
-            return self._call_bundle_discover(arguments)
-        if name == "snapshot_status":
-            return self._call_snapshot_status(arguments)
-        if name == "ask_context":
-            return self._call_ask_context(arguments)
-        if name == "query_existing_index":
-            return self._call_query_existing_index(arguments)
-        if name == "range_get":
-            return self._call_range_get(arguments)
-        if name == "grounding_verify":
-            return self._call_grounding_verify(arguments)
+        handlers = {
+            "bundle_discover": self._call_bundle_discover,
+            "snapshot_status": self._call_snapshot_status,
+            "ask_context": self._call_ask_context,
+            "query_existing_index": self._call_query_existing_index,
+            "range_get": self._call_range_get,
+            "grounding_verify": self._call_grounding_verify,
+            "find_symbol": self._call_find_symbol,
+            "snapshot_create": self._call_snapshot_create,
+        }
+        handler = handlers.get(name)
+        if handler is not None:
+            return handler(arguments)
         if name == "live_freshness":
             return self._safe_live_freshness(self._resolve_manifest(arguments))
-        if name == "find_symbol":
-            return self._call_find_symbol(arguments)
         if name in ("find_references", "get_callers", "get_callees"):
             return self._call_call_navigation(name, arguments)
-        if name == "snapshot_create":
-            return self._call_snapshot_create(arguments)
         raise McpProtocolError(-32602, f"unknown or disabled tool: {name}")
 
     @staticmethod

--- a/merger/repoground/core/answer_grounding.py
+++ b/merger/repoground/core/answer_grounding.py
@@ -5,6 +5,10 @@ import json
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
+from merger.repoground.core.manifest_snapshot import (
+    manifest_path_identity,
+    resolve_manifest_path,
+)
 from merger.repoground.core.range_resolver import resolve_range_ref
 from merger.repoground.core.required_reading import default_required_reading_protocol, resolve_required_reading
 
@@ -241,7 +245,8 @@ def verify_answer_grounding(
     range extraction to the existing range resolver. It performs no Git, shell, refresh,
     snapshot creation, patch, PR, test or merge operation.
     """
-    manifest_path = Path(bundle_manifest).expanduser().resolve()
+    selected_manifest_path = manifest_path_identity(bundle_manifest)
+    manifest_path = resolve_manifest_path(bundle_manifest)
     citation_map_path = Path(citation_map).expanduser().resolve() if citation_map is not None else None
 
     citation_checks: list[dict[str, Any]] = []
@@ -384,7 +389,7 @@ def verify_answer_grounding(
         "version": VERSION,
         "status": status,
         "checked_declaration": _declaration_ref(declaration),
-        "snapshot_ref": _snapshot_ref(declaration, manifest_path),
+        "snapshot_ref": _snapshot_ref(declaration, selected_manifest_path),
         "citation_checks": citation_checks,
         "range_checks": range_checks,
         "required_reading_checks": required_checks,

--- a/merger/repoground/core/ask_context.py
+++ b/merger/repoground/core/ask_context.py
@@ -11,6 +11,10 @@ from merger.repoground.core.bundle_access import (
     resolve_required_reading_for_bundle,
     snapshot_status,
 )
+from merger.repoground.core.manifest_snapshot import (
+    active_manifest_snapshot,
+    resolve_manifest_path,
+)
 
 # Bilingual (EN/DE) function-word stoplist. These words carry no retrieval
 # signal but, because the FTS router AND-joins every term, a single one that is
@@ -258,7 +262,12 @@ def _availability_block(snapshot: dict[str, Any]) -> dict[str, Any]:
 def _snapshot_ref(
     snapshot: dict[str, Any], manifest_path: Path, freshness: dict[str, Any]
 ) -> dict[str, Any]:
-    manifest_sha = _sha256_file(manifest_path)
+    bound_snapshot = active_manifest_snapshot(manifest_path)
+    manifest_sha = (
+        bound_snapshot.binding.sha256
+        if bound_snapshot is not None
+        else _sha256_file(manifest_path)
+    )
     result: dict[str, Any] = {
         "stem": manifest_path.name.replace(".bundle.manifest.json", ""),
         "manifest_path": str(manifest_path),
@@ -464,7 +473,7 @@ def build_ask_context_pack(
     existing read-only index query and reports token budget as a constraint, not as a
     quality or correctness proof.
     """
-    manifest_path = Path(bundle_manifest).expanduser().resolve()
+    manifest_path = resolve_manifest_path(bundle_manifest)
     snapshot = snapshot_status(manifest_path)
     freshness = _freshness_block(snapshot)
     availability = _availability_block(snapshot)

--- a/merger/repoground/core/ask_context.py
+++ b/merger/repoground/core/ask_context.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import re
 from pathlib import Path
 from typing import Any
@@ -16,18 +17,80 @@ from merger.repoground.core.bundle_access import (
 # absent from a chunk zeroes an otherwise good match. Removing them for the
 # relaxed OR retry is safe: the set holds only unambiguous function words, never
 # code identifiers or content terms.
-_RETRIEVAL_STOPWORDS = frozenset({
-    # English
-    "how", "does", "do", "did", "is", "are", "was", "were", "be", "been",
-    "the", "a", "an", "of", "to", "into", "in", "on", "for", "and", "or",
-    "with", "what", "which", "where", "when", "why", "who", "that", "this",
-    "these", "those", "its", "it", "as", "at", "by",
-    # German
-    "wie", "was", "welche", "welcher", "welches", "wo", "wann", "warum", "wer",
-    "ist", "sind", "war", "den", "dem", "der", "die", "das", "ein", "eine",
-    "einen", "und", "oder", "mit", "fuer", "von", "zu", "im", "auf", "ob",
-    "des", "als",
-})
+_RETRIEVAL_STOPWORDS = frozenset(
+    {
+        # English
+        "how",
+        "does",
+        "do",
+        "did",
+        "is",
+        "are",
+        "was",
+        "were",
+        "be",
+        "been",
+        "the",
+        "a",
+        "an",
+        "of",
+        "to",
+        "into",
+        "in",
+        "on",
+        "for",
+        "and",
+        "or",
+        "with",
+        "what",
+        "which",
+        "where",
+        "when",
+        "why",
+        "who",
+        "that",
+        "this",
+        "these",
+        "those",
+        "its",
+        "it",
+        "as",
+        "at",
+        "by",
+        # German
+        "wie",
+        "was",
+        "welche",
+        "welcher",
+        "welches",
+        "wo",
+        "wann",
+        "warum",
+        "wer",
+        "ist",
+        "sind",
+        "war",
+        "den",
+        "dem",
+        "der",
+        "die",
+        "das",
+        "ein",
+        "eine",
+        "einen",
+        "und",
+        "oder",
+        "mit",
+        "fuer",
+        "von",
+        "zu",
+        "im",
+        "auf",
+        "ob",
+        "des",
+        "als",
+    }
+)
 
 
 def _content_tokens(query: str) -> list[str]:
@@ -54,7 +117,9 @@ def _or_fts_query(tokens: list[str]) -> str:
     return " OR ".join(f'"{token}"' for token in tokens)
 
 
-def _run_query(manifest_path: Path, query: str, k: int, prepared_fts_query: str | None = None) -> dict[str, Any]:
+def _run_query(
+    manifest_path: Path, query: str, k: int, prepared_fts_query: str | None = None
+) -> dict[str, Any]:
     return query_existing_index(
         manifest_path,
         query,
@@ -64,6 +129,7 @@ def _run_query(manifest_path: Path, query: str, k: int, prepared_fts_query: str 
         project_sources=True,
         prepared_fts_query=prepared_fts_query,
     )
+
 
 KIND = "repobrief.ask_context_pack"
 VERSION = "1.0"
@@ -91,7 +157,24 @@ DOES_NOT_ESTABLISH = [
 ]
 _FRESHNESS_STATUSES = {"fresh", "stale", "unknown", "not_comparable", "not_applicable"}
 _AVAILABILITY_STATUSES = {"available", "partial", "missing", "unknown"}
-_RANGE_STATUSES = {"resolved", "missing", "drifted", "invalid", "degraded", "not_applicable"}
+_RANGE_STATUSES = {
+    "resolved",
+    "missing",
+    "drifted",
+    "invalid",
+    "degraded",
+    "not_applicable",
+}
+_AVAILABILITY_STATUS_MAP = {
+    "pass": "available",
+    "warn": "partial",
+    "fail": "missing",
+    "available": "available",
+    "partial": "partial",
+    "missing": "missing",
+    "unknown": "unknown",
+}
+MAX_EXCERPT_CHARS_PER_HIT = 1600
 
 
 def _sha256_file(path: Path) -> str | None:
@@ -117,35 +200,64 @@ def _freshness_block(snapshot: dict[str, Any]) -> dict[str, Any]:
         status = _as_status(raw.get("status"), _FRESHNESS_STATUSES, "unknown")
         caveats = []
         if status in {"stale", "unknown", "not_comparable"}:
-            caveats.append({
-                "kind": "unknown_freshness" if status == "unknown" else "stale_snapshot",
-                "detail": f"Snapshot freshness status is {status}.",
-            })
+            caveats.append(
+                {
+                    "kind": "unknown_freshness"
+                    if status == "unknown"
+                    else "stale_snapshot",
+                    "detail": f"Snapshot freshness status is {status}.",
+                }
+            )
         return {"status": status, "caveats": caveats}
     return {
         "status": "unknown",
-        "caveats": [{"kind": "unknown_freshness", "detail": "Snapshot freshness metadata was unavailable."}],
+        "caveats": [
+            {
+                "kind": "unknown_freshness",
+                "detail": "Snapshot freshness metadata was unavailable.",
+            }
+        ],
     }
 
 
 def _availability_block(snapshot: dict[str, Any]) -> dict[str, Any]:
     model = snapshot.get("availability_model")
     if isinstance(model, dict):
-        status = _as_status(model.get("status"), _AVAILABILITY_STATUSES, "unknown")
+        raw_status = model.get("status")
+        status = _AVAILABILITY_STATUS_MAP.get(raw_status, "unknown")
+        status = _as_status(status, _AVAILABILITY_STATUSES, "unknown")
         caveats = []
         if status in {"partial", "missing", "unknown"}:
-            caveats.append({
-                "kind": "missing_artifact" if status in {"partial", "missing"} else "degraded_validation",
-                "detail": f"Snapshot availability status is {status}.",
-            })
+            caveats.append(
+                {
+                    "kind": "missing_artifact"
+                    if status in {"partial", "missing"}
+                    else "degraded_validation",
+                    "detail": (
+                        f"Snapshot availability status is {status}"
+                        + (
+                            f" (source status: {raw_status})."
+                            if raw_status != status
+                            else "."
+                        )
+                    ),
+                }
+            )
         return {"status": status, "caveats": caveats}
     return {
         "status": "unknown",
-        "caveats": [{"kind": "degraded_validation", "detail": "Snapshot availability metadata was unavailable."}],
+        "caveats": [
+            {
+                "kind": "degraded_validation",
+                "detail": "Snapshot availability metadata was unavailable.",
+            }
+        ],
     }
 
 
-def _snapshot_ref(snapshot: dict[str, Any], manifest_path: Path, freshness: dict[str, Any]) -> dict[str, Any]:
+def _snapshot_ref(
+    snapshot: dict[str, Any], manifest_path: Path, freshness: dict[str, Any]
+) -> dict[str, Any]:
     manifest_sha = _sha256_file(manifest_path)
     result: dict[str, Any] = {
         "stem": manifest_path.name.replace(".bundle.manifest.json", ""),
@@ -157,7 +269,11 @@ def _snapshot_ref(snapshot: dict[str, Any], manifest_path: Path, freshness: dict
         result["manifest_sha256"] = manifest_sha
     run_id = snapshot.get("bundle_run_id")
     if isinstance(run_id, str) and run_id:
-        result["git_commit"] = snapshot.get("git_commit") if isinstance(snapshot.get("git_commit"), str) else None
+        result["git_commit"] = (
+            snapshot.get("git_commit")
+            if isinstance(snapshot.get("git_commit"), str)
+            else None
+        )
     return result
 
 
@@ -170,7 +286,11 @@ def _fts_query_of(query_result: dict[str, Any]) -> str | None:
 def _retrieval_hits(query_result: dict[str, Any]) -> list[dict[str, Any]]:
     raw = query_result.get("query_result") if isinstance(query_result, dict) else None
     hits = raw.get("results") if isinstance(raw, dict) else []
-    projection = query_result.get("source_citation_projection") if isinstance(query_result, dict) else None
+    projection = (
+        query_result.get("source_citation_projection")
+        if isinstance(query_result, dict)
+        else None
+    )
     projected_items = projection.get("items") if isinstance(projection, dict) else []
     citations_by_ref = {
         str(item.get("chunk_id")): item.get("citation_id")
@@ -183,7 +303,9 @@ def _retrieval_hits(query_result: dict[str, Any]) -> list[dict[str, Any]]:
             continue
         ref = str(hit.get("chunk_id") or hit.get("id") or f"hit-{idx + 1}")
         item = {
-            "artifact_role": str(hit.get("artifact_role") or hit.get("artifact_type") or "sqlite_index"),
+            "artifact_role": str(
+                hit.get("artifact_role") or hit.get("artifact_type") or "sqlite_index"
+            ),
             "ref": ref,
             "score": float(hit.get("score") or hit.get("bm25_score") or 0.0),
             "purpose": "retrieval candidate for ask context",
@@ -219,37 +341,89 @@ def _source_address_fields(hit: dict[str, Any]) -> dict[str, Any]:
     return fields
 
 
-def _resolved_ranges(query_result: dict[str, Any], max_context_tokens: int) -> tuple[list[dict[str, Any]], int, bool]:
-    resolved = query_result.get("resolved_evidence") if isinstance(query_result, dict) else None
+def _resolved_ranges(
+    query_result: dict[str, Any], max_context_tokens: int
+) -> tuple[list[dict[str, Any]], int, bool]:
+    resolved = (
+        query_result.get("resolved_evidence")
+        if isinstance(query_result, dict)
+        else None
+    )
     hits = resolved.get("hits") if isinstance(resolved, dict) else []
     budget_chars = max_context_tokens * 4
-    used_chars = 0
+    candidates: list[tuple[int, dict[str, Any], str]] = []
+    seen: set[str] = set()
     truncated = False
-    result = []
+
     for idx, hit in enumerate(hits if isinstance(hits, list) else []):
         if not isinstance(hit, dict):
             continue
         range_value = hit.get("range") if isinstance(hit.get("range"), dict) else {}
         text = range_value.get("text") if isinstance(range_value, dict) else None
         excerpt = text if isinstance(text, str) else hit.get("text_excerpt")
-        if isinstance(excerpt, str):
-            remaining = max(0, budget_chars - used_chars)
-            if len(excerpt) > remaining:
-                excerpt = excerpt[:remaining]
-                truncated = True
-            used_chars += len(excerpt)
+        if not isinstance(excerpt, str) or not excerpt.strip():
+            truncated = True
+            continue
+        range_ref = (
+            hit.get("range_ref")
+            if isinstance(hit.get("range_ref"), dict)
+            else {"ref": str(hit.get("chunk_id") or f"range-{idx + 1}")}
+        )
+        source_path = hit.get("source_path") or hit.get("path") or ""
+        key = json.dumps(
+            {
+                "source_path": source_path,
+                "source_line_range": hit.get("source_line_range"),
+                "range_ref": range_ref,
+            },
+            sort_keys=True,
+            ensure_ascii=False,
+        )
+        if key in seen:
+            truncated = True
+            continue
+        seen.add(key)
+        diagnostic = int(
+            isinstance(source_path, str)
+            and (
+                source_path.startswith("docs/diagnostics/")
+                or source_path.startswith("docs/proofs/")
+            )
+        )
+        candidates.append((diagnostic, hit, excerpt))
+
+    candidates.sort(key=lambda item: item[0])
+    used_chars = 0
+    result: list[dict[str, Any]] = []
+    for position, (_diagnostic, hit, excerpt) in enumerate(candidates):
+        remaining = budget_chars - used_chars
+        if remaining <= 0:
+            truncated = True
+            break
+        remaining_hits = len(candidates) - position
+        fair_share = max(1, remaining // max(1, remaining_hits))
+        excerpt_limit = min(MAX_EXCERPT_CHARS_PER_HIT, fair_share, remaining)
+        bounded_excerpt = excerpt[:excerpt_limit]
+        if len(bounded_excerpt) < len(excerpt):
+            truncated = True
+        if not bounded_excerpt:
+            truncated = True
+            continue
+        used_chars += len(bounded_excerpt)
         status = _as_status(hit.get("range_status"), _RANGE_STATUSES, "degraded")
-        range_ref = hit.get("range_ref") if isinstance(hit.get("range_ref"), dict) else {"ref": str(hit.get("chunk_id") or f"range-{idx + 1}")}
+        range_ref = (
+            hit.get("range_ref")
+            if isinstance(hit.get("range_ref"), dict)
+            else {"ref": str(hit.get("chunk_id") or f"range-{position + 1}")}
+        )
         item: dict[str, Any] = {
             "artifact_role": str(hit.get("artifact_role") or "canonical_md"),
             "status": status,
             "range_ref": range_ref,
+            "text_excerpt": bounded_excerpt,
         }
-        if isinstance(excerpt, str):
-            item["text_excerpt"] = excerpt
-        content_sha = None
-        if isinstance(range_value, dict):
-            content_sha = range_value.get("content_sha256") or range_value.get("sha256")
+        range_value = hit.get("range") if isinstance(hit.get("range"), dict) else {}
+        content_sha = range_value.get("content_sha256") or range_value.get("sha256")
         if isinstance(content_sha, str) and len(content_sha) == 64:
             item["content_sha256"] = content_sha
         item.update(_source_address_fields(hit))
@@ -262,7 +436,11 @@ def _required_reading_block(resolution: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(rr, dict):
         rr = {}
     return {
-        "task_profile": str(resolution.get("task_profile") or rr.get("task_profile") or "basic_repo_question"),
+        "task_profile": str(
+            resolution.get("task_profile")
+            or rr.get("task_profile")
+            or "basic_repo_question"
+        ),
         "required": list(rr.get("required") or []),
         "recommended": list(rr.get("recommended") or []),
         "missing_required": list(rr.get("missing_required") or []),
@@ -290,10 +468,14 @@ def build_ask_context_pack(
     snapshot = snapshot_status(manifest_path)
     freshness = _freshness_block(snapshot)
     availability = _availability_block(snapshot)
-    required_reading = _required_reading_block(resolve_required_reading_for_bundle(manifest_path, task_profile))
+    required_reading = _required_reading_block(
+        resolve_required_reading_for_bundle(manifest_path, task_profile)
+    )
     query_result = _run_query(manifest_path, query, k)
     retrieval_hits = _retrieval_hits(query_result)
-    resolved_ranges, used_chars, truncated = _resolved_ranges(query_result, max_context_tokens)
+    resolved_ranges, used_chars, truncated = _resolved_ranges(
+        query_result, max_context_tokens
+    )
     executed_fts = _fts_query_of(query_result)
     strategy = "exact_and"
     relaxed = False
@@ -307,12 +489,20 @@ def build_ask_context_pack(
         tokens = _content_tokens(query)
         if len(tokens) >= 2:
             or_query = _or_fts_query(tokens)
-            relaxed_result = _run_query(manifest_path, query, k, prepared_fts_query=or_query)
-            relaxed_ranges, relaxed_chars, relaxed_truncated = _resolved_ranges(relaxed_result, max_context_tokens)
+            relaxed_result = _run_query(
+                manifest_path, query, k, prepared_fts_query=or_query
+            )
+            relaxed_ranges, relaxed_chars, relaxed_truncated = _resolved_ranges(
+                relaxed_result, max_context_tokens
+            )
             if relaxed_ranges:
                 query_result = relaxed_result
                 retrieval_hits = _retrieval_hits(relaxed_result)
-                resolved_ranges, used_chars, truncated = relaxed_ranges, relaxed_chars, relaxed_truncated
+                resolved_ranges, used_chars, truncated = (
+                    relaxed_ranges,
+                    relaxed_chars,
+                    relaxed_truncated,
+                )
                 executed_fts = or_query
                 strategy = "or_relaxed"
                 relaxed = True
@@ -324,29 +514,47 @@ def build_ask_context_pack(
         "match_count": len(resolved_ranges),
     }
 
-    caveats = list(freshness.get("caveats") or []) + list(availability.get("caveats") or [])
+    caveats = list(freshness.get("caveats") or []) + list(
+        availability.get("caveats") or []
+    )
     if query_result.get("status") != "available":
-        caveats.append({"kind": "missing_artifact", "detail": str(query_result.get("error") or "Query evidence unavailable.")})
+        caveats.append(
+            {
+                "kind": "missing_artifact",
+                "detail": str(
+                    query_result.get("error") or "Query evidence unavailable."
+                ),
+            }
+        )
     if truncated:
-        caveats.append({"kind": "other", "detail": "Context excerpts were truncated to respect max_context_tokens."})
+        caveats.append(
+            {
+                "kind": "other",
+                "detail": "Context excerpts were truncated to respect max_context_tokens.",
+            }
+        )
     if relaxed:
-        caveats.append({
-            "kind": "other",
-            "detail": (
-                "No exact (AND) retrieval match; results are relaxed OR-matches ranked by "
-                "relevance and may be less precise. Rephrase with specific code identifiers "
-                "for a tighter match."
-            ),
-        })
+        caveats.append(
+            {
+                "kind": "other",
+                "detail": (
+                    "No exact (AND) retrieval match; results are relaxed OR-matches ranked by "
+                    "relevance and may be less precise. Rephrase with specific code identifiers "
+                    "for a tighter match."
+                ),
+            }
+        )
     elif not resolved_ranges:
-        caveats.append({
-            "kind": "other",
-            "detail": (
-                "No evidence matched the query. RepoGround retrieval is keyword/identifier-based "
-                f"(executed FTS: {executed_fts or query!r}). Rephrase with concrete code "
-                "identifiers or terms."
-            ),
-        })
+        caveats.append(
+            {
+                "kind": "other",
+                "detail": (
+                    "No evidence matched the query. RepoGround retrieval is keyword/identifier-based "
+                    f"(executed FTS: {executed_fts or query!r}). Rephrase with concrete code "
+                    "identifiers or terms."
+                ),
+            }
+        )
     citation_obligations = [
         "Cite every strong repository claim with resolved RepoGround evidence where available.",
         "Surface freshness, availability and non-claim caveats in the answer.",
@@ -354,7 +562,9 @@ def build_ask_context_pack(
     return {
         "kind": KIND,
         "version": VERSION,
-        "request_id": hashlib.sha256(f"{manifest_path}\0{task_profile}\0{query}".encode("utf-8")).hexdigest()[:16],
+        "request_id": hashlib.sha256(
+            f"{manifest_path}\0{task_profile}\0{query}".encode("utf-8")
+        ).hexdigest()[:16],
         "snapshot_ref": _snapshot_ref(snapshot, manifest_path, freshness),
         "freshness": freshness,
         "availability": availability,

--- a/merger/repoground/core/bundle_access.py
+++ b/merger/repoground/core/bundle_access.py
@@ -5,11 +5,14 @@ import json
 import logging
 import os
 import re
+import stat
+import tempfile
 from collections import OrderedDict
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from threading import RLock
-from typing import Any, Mapping, Sequence
+from typing import Any, BinaryIO, Iterator, Mapping, Sequence
 
 from merger.repoground.architecture.call_graph_contract import (
     MAX_SKIPPED_ERRORS as MAX_CALL_GRAPH_SKIPPED_ERRORS,
@@ -19,6 +22,10 @@ from merger.repoground.architecture.call_graph_contract import (
 from merger.repoground.core.call_navigation_index import (
     CallNavigationIndex,
     SymbolNavigationIndex,
+)
+from merger.repoground.core.manifest_snapshot import (
+    active_manifest_snapshot,
+    resolve_manifest_path,
 )
 from merger.repoground.core.response_projection import project_read_result
 
@@ -48,6 +55,9 @@ logger = logging.getLogger(__name__)
 
 
 def _read_json_object(path: Path) -> dict[str, Any]:
+    snapshot = active_manifest_snapshot(path)
+    if snapshot is not None:
+        return snapshot.json_object()
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError as exc:
@@ -98,7 +108,7 @@ def _artifact_record(bundle_manifest: Path, artifact: dict[str, Any]) -> dict[st
 
 
 def available_roles(bundle_manifest: str | Path) -> list[str]:
-    manifest_path = Path(bundle_manifest).expanduser().resolve()
+    manifest_path = resolve_manifest_path(bundle_manifest)
     manifest = _read_json_object(manifest_path)
     roles: set[str] = {"bundle_manifest"}
     for artifact in _artifact_list(manifest):
@@ -127,7 +137,7 @@ def resolve_required_reading_for_bundle(
         resolve_required_reading,
     )
 
-    manifest_path = Path(bundle_manifest).expanduser().resolve()
+    manifest_path = resolve_manifest_path(bundle_manifest)
     roles = available_roles(manifest_path)
     required = resolve_required_reading(
         default_required_reading_protocol(),
@@ -152,7 +162,7 @@ def resolve_required_reading_for_bundle(
 
 
 def snapshot_status(bundle_manifest: str | Path) -> dict[str, Any]:
-    manifest_path = Path(bundle_manifest).expanduser().resolve()
+    manifest_path = resolve_manifest_path(bundle_manifest)
     manifest = _read_json_object(manifest_path)
     artifacts = [_artifact_record(manifest_path, a) for a in _artifact_list(manifest)]
     roles = sorted(str(a["role"]) for a in artifacts if isinstance(a.get("role"), str))
@@ -200,7 +210,7 @@ def list_artifacts(bundle_manifest: str | Path) -> dict[str, Any]:
 
 
 def get_artifact(bundle_manifest: str | Path, role: str) -> dict[str, Any]:
-    manifest_path = Path(bundle_manifest).expanduser().resolve()
+    manifest_path = resolve_manifest_path(bundle_manifest)
     manifest = _read_json_object(manifest_path)
     matches = [a for a in _artifact_list(manifest) if a.get("role") == role]
     if not matches:
@@ -235,6 +245,313 @@ def get_artifact(bundle_manifest: str | Path, role: str) -> dict[str, Any]:
 
 
 MAX_QUERY_EXISTING_INDEX_K = 100
+_SQLITE_HASH_CHUNK_BYTES = 1024 * 1024
+_FILE_DESCRIPTOR_ROOTS = (Path("/proc/self/fd"), Path("/dev/fd"))
+
+
+class _SqliteArtifactValidationError(ValueError):
+    def __init__(self, error_code: str, message: str) -> None:
+        super().__init__(message)
+        self.error_code = error_code
+
+
+def _sqlite_file_identity(value: os.stat_result) -> tuple[int, int, int, int, int]:
+    return (
+        value.st_dev,
+        value.st_ino,
+        value.st_size,
+        value.st_mtime_ns,
+        value.st_ctime_ns,
+    )
+
+
+def _query_path_for_descriptor(
+    descriptor: int,
+    expected_identity: tuple[int, int, int, int, int],
+) -> Path:
+    for root in _FILE_DESCRIPTOR_ROOTS:
+        candidate = root / str(descriptor)
+        try:
+            observed_identity = _sqlite_file_identity(candidate.stat())
+        except OSError:
+            continue
+        if observed_identity == expected_identity:
+            return candidate
+    raise _SqliteArtifactValidationError(
+        "sqlite_index_descriptor_unavailable",
+        "sqlite_index cannot be pinned to a verified file descriptor",
+    )
+
+
+def _portable_copy_flags(*, write: bool) -> int:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL if write else os.O_RDONLY
+    flags |= getattr(os, "O_BINARY", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    return flags
+
+
+def _write_portable_sqlite_copy(
+    handle: BinaryIO,
+    destination: Path,
+    *,
+    expected_bytes: int,
+    expected_sha256: str,
+    expected_identity: tuple[int, int, int, int, int],
+) -> None:
+    digest = hashlib.sha256()
+    observed_bytes = 0
+    try:
+        handle.seek(0)
+        descriptor = os.open(destination, _portable_copy_flags(write=True), 0o600)
+        with os.fdopen(descriptor, "wb") as target:
+            for chunk in iter(
+                lambda: handle.read(_SQLITE_HASH_CHUNK_BYTES),
+                b"",
+            ):
+                observed_bytes += len(chunk)
+                digest.update(chunk)
+                target.write(chunk)
+            target.flush()
+            os.fsync(target.fileno())
+    except OSError as exc:
+        raise _SqliteArtifactValidationError(
+            "sqlite_index_portable_copy_failed",
+            f"sqlite_index verified copy could not be created: {exc}",
+        ) from exc
+
+    if (
+        observed_bytes != expected_bytes
+        or digest.hexdigest() != expected_sha256
+        or _sqlite_file_identity(os.fstat(handle.fileno())) != expected_identity
+    ):
+        raise _SqliteArtifactValidationError(
+            "sqlite_index_integrity_mismatch",
+            "sqlite_index bytes changed while creating the verified copy",
+        )
+    try:
+        os.chmod(destination, stat.S_IRUSR)
+    except OSError as exc:
+        raise _SqliteArtifactValidationError(
+            "sqlite_index_portable_copy_failed",
+            f"sqlite_index verified copy could not be made read-only: {exc}",
+        ) from exc
+
+
+def _verify_portable_sqlite_copy(
+    path: Path,
+    *,
+    expected_bytes: int,
+    expected_sha256: str,
+) -> None:
+    try:
+        descriptor = os.open(path, _portable_copy_flags(write=False))
+        with os.fdopen(descriptor, "rb") as handle:
+            before = os.fstat(handle.fileno())
+            if stat.S_IMODE(before.st_mode) & 0o222:
+                raise _SqliteArtifactValidationError(
+                    "sqlite_index_integrity_mismatch",
+                    "sqlite_index verified copy is not read-only",
+                )
+            identity = _verify_sqlite_handle(
+                handle,
+                expected_bytes=expected_bytes,
+                expected_sha256=expected_sha256,
+            )
+        current = os.stat(path, follow_symlinks=False)
+    except _SqliteArtifactValidationError:
+        raise
+    except OSError as exc:
+        raise _SqliteArtifactValidationError(
+            "sqlite_index_integrity_mismatch",
+            f"sqlite_index verified copy is unavailable: {exc}",
+        ) from exc
+    if not stat.S_ISREG(current.st_mode) or _sqlite_file_identity(current) != identity:
+        raise _SqliteArtifactValidationError(
+            "sqlite_index_integrity_mismatch",
+            "sqlite_index verified copy changed while it was checked",
+        )
+
+
+@contextmanager
+def _portable_verified_sqlite_copy(
+    handle: BinaryIO,
+    *,
+    expected_bytes: int,
+    expected_sha256: str,
+    expected_identity: tuple[int, int, int, int, int],
+) -> Iterator[Path]:
+    try:
+        temporary = tempfile.TemporaryDirectory(prefix="repoground-sqlite-")
+    except OSError as exc:
+        raise _SqliteArtifactValidationError(
+            "sqlite_index_portable_copy_failed",
+            f"sqlite_index private temporary directory could not be created: {exc}",
+        ) from exc
+
+    with temporary as directory:
+        query_path = Path(directory) / "verified.index.sqlite"
+        _write_portable_sqlite_copy(
+            handle,
+            query_path,
+            expected_bytes=expected_bytes,
+            expected_sha256=expected_sha256,
+            expected_identity=expected_identity,
+        )
+        _verify_portable_sqlite_copy(
+            query_path,
+            expected_bytes=expected_bytes,
+            expected_sha256=expected_sha256,
+        )
+        yield query_path
+        _verify_portable_sqlite_copy(
+            query_path,
+            expected_bytes=expected_bytes,
+            expected_sha256=expected_sha256,
+        )
+
+
+def _sqlite_integrity_contract(artifact: dict[str, Any]) -> tuple[int, str]:
+    expected_bytes = artifact.get("bytes")
+    expected_sha256 = artifact.get("sha256")
+    if (
+        not isinstance(expected_bytes, int)
+        or isinstance(expected_bytes, bool)
+        or expected_bytes < 0
+        or not _is_sha256(expected_sha256)
+    ):
+        raise _SqliteArtifactValidationError(
+            "sqlite_index_integrity_unavailable",
+            "sqlite_index bytes/sha256 contract is missing or invalid in manifest",
+        )
+    return expected_bytes, expected_sha256
+
+
+def _open_sqlite_artifact(index_path: Path) -> BinaryIO:
+    try:
+        return index_path.open("rb")
+    except FileNotFoundError as exc:
+        raise _SqliteArtifactValidationError(
+            "sqlite_index_file_missing",
+            "sqlite_index artifact file does not exist",
+        ) from exc
+    except OSError as exc:
+        raise _SqliteArtifactValidationError(
+            "sqlite_index_unreadable",
+            f"sqlite_index artifact cannot be opened: {exc}",
+        ) from exc
+
+
+def _verify_sqlite_handle(
+    handle: BinaryIO,
+    *,
+    expected_bytes: int,
+    expected_sha256: str,
+) -> tuple[int, int, int, int, int]:
+    before = os.fstat(handle.fileno())
+    if not stat.S_ISREG(before.st_mode):
+        raise _SqliteArtifactValidationError(
+            "sqlite_index_path_invalid",
+            "sqlite_index artifact is not a regular file",
+        )
+    if before.st_size != expected_bytes:
+        raise _SqliteArtifactValidationError(
+            "sqlite_index_integrity_mismatch",
+            "sqlite_index byte size does not match active manifest",
+        )
+
+    digest = hashlib.sha256()
+    observed_bytes = 0
+    for chunk in iter(lambda: handle.read(_SQLITE_HASH_CHUNK_BYTES), b""):
+        observed_bytes += len(chunk)
+        digest.update(chunk)
+    identity = _sqlite_file_identity(before)
+    stable_identity = _sqlite_file_identity(os.fstat(handle.fileno()))
+    if (
+        observed_bytes != expected_bytes
+        or digest.hexdigest() != expected_sha256
+        or stable_identity != identity
+    ):
+        raise _SqliteArtifactValidationError(
+            "sqlite_index_integrity_mismatch",
+            "sqlite_index bytes do not match active manifest",
+        )
+    return identity
+
+
+def _require_current_sqlite_path(
+    index_path: Path,
+    expected_identity: tuple[int, int, int, int, int],
+) -> None:
+    try:
+        current_identity = _sqlite_file_identity(index_path.stat())
+    except OSError as exc:
+        raise _SqliteArtifactValidationError(
+            "sqlite_index_integrity_mismatch",
+            "sqlite_index path changed during manifest verification",
+        ) from exc
+    if current_identity != expected_identity:
+        raise _SqliteArtifactValidationError(
+            "sqlite_index_integrity_mismatch",
+            "sqlite_index path changed during manifest verification",
+        )
+
+
+@contextmanager
+def _verified_sqlite_query_path(
+    manifest_path: Path,
+    artifact: dict[str, Any],
+) -> Iterator[Path]:
+    from merger.repoground.retrieval.query_core import (
+        validate_read_only_sqlite_source_path,
+    )
+
+    index_path = _safe_artifact_path(manifest_path.parent, artifact.get("path"))
+    if index_path is None:
+        raise _SqliteArtifactValidationError(
+            "sqlite_index_path_invalid",
+            "sqlite_index artifact path is invalid",
+        )
+    try:
+        validate_read_only_sqlite_source_path(index_path)
+    except ValueError as exc:
+        raise _SqliteArtifactValidationError(
+            "sqlite_index_path_invalid",
+            str(exc),
+        ) from exc
+
+    handle = _open_sqlite_artifact(index_path)
+    with handle:
+        expected_bytes, expected_sha256 = _sqlite_integrity_contract(artifact)
+        identity = _verify_sqlite_handle(
+            handle,
+            expected_bytes=expected_bytes,
+            expected_sha256=expected_sha256,
+        )
+        _require_current_sqlite_path(index_path, identity)
+        try:
+            try:
+                descriptor_path = _query_path_for_descriptor(
+                    handle.fileno(),
+                    identity,
+                )
+            except _SqliteArtifactValidationError as exc:
+                if exc.error_code != "sqlite_index_descriptor_unavailable":
+                    raise
+                with _portable_verified_sqlite_copy(
+                    handle,
+                    expected_bytes=expected_bytes,
+                    expected_sha256=expected_sha256,
+                    expected_identity=identity,
+                ) as portable_path:
+                    yield portable_path
+            else:
+                yield descriptor_path
+        finally:
+            if _sqlite_file_identity(os.fstat(handle.fileno())) != identity:
+                raise _SqliteArtifactValidationError(
+                    "sqlite_index_integrity_mismatch",
+                    "sqlite_index changed while it was queried",
+                )
 
 
 def _read_only_mutation_boundary() -> dict[str, Any]:
@@ -298,7 +615,7 @@ def range_get(
 ) -> dict[str, Any]:
     if compact is not None:
         verbose = not compact
-    manifest_path = Path(bundle_manifest).expanduser().resolve()
+    manifest_path = resolve_manifest_path(bundle_manifest)
     if not isinstance(range_ref, dict):
         return _invalid_read_result(
             kind="repobrief.range_get",
@@ -1072,7 +1389,7 @@ def query_existing_index(
 ) -> dict[str, Any]:
     if compact is not None:
         verbose = not compact
-    manifest_path = Path(bundle_manifest).expanduser().resolve()
+    manifest_path = resolve_manifest_path(bundle_manifest)
     if not isinstance(query, str):
         return _invalid_read_result(
             kind="repobrief.query_existing_index",
@@ -1129,29 +1446,45 @@ def query_existing_index(
         )
 
     index_path = Path(str(artifact["absolute_path"]))
-    if not index_path.exists():
-        return _invalid_read_result(
-            kind="repobrief.query_existing_index",
-            bundle_manifest=manifest_path,
-            status="missing",
-            error="sqlite_index artifact file does not exist",
-            error_code="sqlite_index_file_missing",
-            extra={"query": query, "k": k, "query_result": None, "index_artifact": artifact},
-            verbose=verbose,
-        )
 
     from merger.repoground.retrieval.query_core import execute_query
 
     try:
-        query_result = execute_query(
-            index_path,
-            query,
-            k=k,
-            filters=filters or {},
-            trace=False,
-            build_context=False,
-            read_only=True,
-            _prepared_fts_query=prepared_fts_query,
+        with _verified_sqlite_query_path(manifest_path, artifact) as query_path:
+            validated_source_path = (
+                index_path
+                if query_path.parent in _FILE_DESCRIPTOR_ROOTS
+                and query_path.name.isdecimal()
+                else None
+            )
+            query_result = execute_query(
+                query_path,
+                query,
+                k=k,
+                filters=filters or {},
+                trace=False,
+                build_context=False,
+                read_only=True,
+                _prepared_fts_query=prepared_fts_query,
+                _validated_read_only_source_path=validated_source_path,
+            )
+    except _SqliteArtifactValidationError as exc:
+        status = (
+            "missing" if exc.error_code == "sqlite_index_file_missing" else "invalid"
+        )
+        return _invalid_read_result(
+            kind="repobrief.query_existing_index",
+            bundle_manifest=manifest_path,
+            status=status,
+            error=str(exc),
+            error_code=exc.error_code,
+            extra={
+                "query": query,
+                "k": k,
+                "query_result": None,
+                "index_artifact": artifact,
+            },
+            verbose=verbose,
         )
     except Exception as exc:
         return _invalid_read_result(
@@ -1331,7 +1664,7 @@ def search_symbol_index(
     """
     if compact is not None:
         verbose = not compact
-    manifest_path = Path(bundle_manifest).expanduser().resolve()
+    manifest_path = resolve_manifest_path(bundle_manifest)
     return project_read_result(
         _search_symbol_index_full(manifest_path, query, k=k, kind=kind, path=path),
         manifest_path,
@@ -1599,6 +1932,106 @@ def _artifact_stat_matches_fingerprint(
     )
 
 
+def _fingerprint_matches_active_manifest_snapshot(
+    fingerprint: _ArtifactSourceFingerprint,
+) -> bool | None:
+    snapshot = active_manifest_snapshot(fingerprint.manifest_path)
+    if snapshot is None:
+        return None
+    return fingerprint.manifest_sha256 == snapshot.binding.sha256
+
+
+def _artifact_bytes_match_fingerprint(
+    fingerprint: _ArtifactSourceFingerprint,
+    artifact_path: Path,
+) -> bool:
+    artifact_bytes, artifact_stat, failure, _detail = _read_stable_artifact_bytes(
+        artifact_path
+    )
+    if failure is not None or artifact_bytes is None or artifact_stat is None:
+        return False
+    if not _artifact_stat_matches_fingerprint(fingerprint, artifact_stat):
+        return False
+    if hashlib.sha256(artifact_bytes).hexdigest() != fingerprint.artifact_sha256:
+        return False
+    try:
+        artifact_after_stat = artifact_path.stat()
+    except OSError:
+        return False
+    return _artifact_stat_matches_fingerprint(
+        fingerprint,
+        artifact_after_stat,
+    )
+
+
+def _bound_artifact_source_is_current(
+    fingerprint: _ArtifactSourceFingerprint,
+    artifact_path: Path,
+    *,
+    requires_content: bool,
+) -> bool:
+    if not requires_content:
+        try:
+            artifact_stat = artifact_path.stat()
+        except OSError:
+            return False
+        if _stat_identity_is_strong(artifact_stat):
+            return _artifact_stat_matches_fingerprint(
+                fingerprint,
+                artifact_stat,
+            )
+    return _artifact_bytes_match_fingerprint(fingerprint, artifact_path)
+
+
+def _fast_artifact_source_validation(
+    fingerprint: _ArtifactSourceFingerprint,
+    manifest_path: Path,
+    artifact_path: Path,
+) -> bool | None:
+    try:
+        manifest_stat = manifest_path.stat()
+        artifact_stat = artifact_path.stat()
+    except OSError:
+        return False
+    if not (
+        _stat_identity_is_strong(manifest_stat)
+        and _stat_identity_is_strong(artifact_stat)
+    ):
+        return None
+    return _manifest_stat_matches_fingerprint(
+        fingerprint,
+        manifest_stat,
+    ) and _artifact_stat_matches_fingerprint(fingerprint, artifact_stat)
+
+
+def _source_bytes_match_fingerprint(
+    fingerprint: _ArtifactSourceFingerprint,
+    manifest_path: Path,
+    artifact_path: Path,
+) -> bool:
+    manifest_bytes, manifest_stat, manifest_failure, _manifest_detail = (
+        _read_stable_regular_file_bytes(manifest_path)
+    )
+    if (
+        manifest_failure is not None
+        or manifest_bytes is None
+        or manifest_stat is None
+        or not _manifest_stat_matches_fingerprint(fingerprint, manifest_stat)
+        or hashlib.sha256(manifest_bytes).hexdigest() != fingerprint.manifest_sha256
+    ):
+        return False
+    if not _artifact_bytes_match_fingerprint(fingerprint, artifact_path):
+        return False
+    try:
+        manifest_after_stat = manifest_path.stat()
+    except OSError:
+        return False
+    return _manifest_stat_matches_fingerprint(
+        fingerprint,
+        manifest_after_stat,
+    )
+
+
 def _cache_validation_mode() -> str:
     """Return the cache-validation mode while preserving legacy semantics.
 
@@ -1692,6 +2125,36 @@ def _read_stable_regular_file_bytes(
     return raw, stat_after, None, None
 
 
+def _read_artifact_manifest_source(
+    manifest_path: Path,
+) -> tuple[
+    bytes | None,
+    Any,
+    tuple[int, int, int, int, int] | None,
+    str | None,
+    str | None,
+]:
+    snapshot = active_manifest_snapshot(manifest_path)
+    if snapshot is not None:
+        identity = snapshot.file_identity
+        return (
+            snapshot.raw,
+            snapshot.json_object(),
+            (identity[0], identity[1], identity[3], identity[4], identity[5]),
+            None,
+            None,
+        )
+    raw, manifest_stat, failure, detail = _read_stable_regular_file_bytes(manifest_path)
+    if failure is not None:
+        return None, None, None, failure, detail
+    assert raw is not None and manifest_stat is not None
+    try:
+        manifest = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return None, None, None, "unreadable", str(exc)
+    return raw, manifest, _file_identity(manifest_stat), None, None
+
+
 def _read_registered_artifact_source(
     manifest_path: Path, role: str
 ) -> tuple[
@@ -1700,16 +2163,12 @@ def _read_registered_artifact_source(
     str | None,
     str | None,
 ]:
-    manifest_bytes, manifest_stat, failure, detail = _read_stable_regular_file_bytes(
-        manifest_path
+    manifest_bytes, manifest, manifest_identity, failure, detail = (
+        _read_artifact_manifest_source(manifest_path)
     )
     if failure is not None:
         return None, None, failure, detail
-    assert manifest_bytes is not None and manifest_stat is not None
-    try:
-        manifest = json.loads(manifest_bytes)
-    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-        return None, None, "unreadable", str(exc)
+    assert manifest_bytes is not None and manifest_identity is not None
     if not isinstance(manifest, dict):
         return None, None, "unreadable", "bundle manifest must be a JSON object"
     try:
@@ -1744,13 +2203,13 @@ def _read_registered_artifact_source(
     if _is_sha256(declared_sha256) and actual_sha256 != declared_sha256:
         return None, artifact, "sha256_mismatch", None
     fingerprint = _ArtifactSourceFingerprint(
-        manifest_path=str(manifest_path.resolve()),
+        manifest_path=str(resolve_manifest_path(manifest_path)),
         manifest_sha256=hashlib.sha256(manifest_bytes).hexdigest(),
-        manifest_device=manifest_stat.st_dev,
-        manifest_inode=manifest_stat.st_ino,
-        manifest_size=manifest_stat.st_size,
-        manifest_mtime_ns=manifest_stat.st_mtime_ns,
-        manifest_ctime_ns=manifest_stat.st_ctime_ns,
+        manifest_device=manifest_identity[0],
+        manifest_inode=manifest_identity[1],
+        manifest_size=manifest_identity[2],
+        manifest_mtime_ns=manifest_identity[3],
+        manifest_ctime_ns=manifest_identity[4],
         role=role,
         absolute_path=str(artifact_path),
         artifact_sha256=actual_sha256,
@@ -1781,63 +2240,43 @@ def _artifact_source_is_current(
     """Validate one cached generation without reparsing its JSON payload.
 
     Cold loads and post-build checks always hash bytes read from one pinned file
-    descriptor. Warm lookups use the manifest hash plus strong file identity
-    metadata. ``REPOGROUND_CACHE_VALIDATION=strict`` forces a full hash
-    on every lookup; the legacy strict-hash switch remains supported. Weak
-    identities such as zero device or inode values automatically use strict
-    validation.
+    descriptor. Request-bound lookups authorize the cached manifest hash only
+    from the active snapshot and never from transient path bytes. Other warm
+    lookups use the manifest hash plus strong file identity metadata.
+    ``REPOGROUND_CACHE_VALIDATION=strict`` forces a full hash on every lookup;
+    the legacy strict-hash switch remains supported. Weak identities such as
+    zero device or inode values automatically use strict validation.
     """
     manifest_path = Path(fingerprint.manifest_path)
     artifact_path = Path(fingerprint.absolute_path)
+    active_manifest_match = _fingerprint_matches_active_manifest_snapshot(fingerprint)
+    if active_manifest_match is False:
+        return False
 
     requires_content = _source_content_verification_required(
         fingerprint,
         verify_content=verify_content,
     )
-    if not requires_content:
-        try:
-            manifest_stat = manifest_path.stat()
-            artifact_stat = artifact_path.stat()
-        except OSError:
-            return False
-        if _stat_identity_is_strong(manifest_stat) and _stat_identity_is_strong(
-            artifact_stat
-        ):
-            return _manifest_stat_matches_fingerprint(
-                fingerprint,
-                manifest_stat,
-            ) and _artifact_stat_matches_fingerprint(fingerprint, artifact_stat)
-        requires_content = True
+    if active_manifest_match is True:
+        return _bound_artifact_source_is_current(
+            fingerprint,
+            artifact_path,
+            requires_content=requires_content,
+        )
 
-    manifest_bytes, manifest_stat, manifest_failure, _manifest_detail = (
-        _read_stable_regular_file_bytes(manifest_path)
-    )
-    if (
-        manifest_failure is not None
-        or manifest_bytes is None
-        or manifest_stat is None
-        or not _manifest_stat_matches_fingerprint(fingerprint, manifest_stat)
-        or hashlib.sha256(manifest_bytes).hexdigest() != fingerprint.manifest_sha256
-    ):
-        return False
-    artifact_bytes, artifact_stat, failure, _detail = (
-        _read_stable_artifact_bytes(artifact_path)
-    )
-    if failure is not None or artifact_bytes is None or artifact_stat is None:
-        return False
-    if not _artifact_stat_matches_fingerprint(fingerprint, artifact_stat):
-        return False
-    if hashlib.sha256(artifact_bytes).hexdigest() != fingerprint.artifact_sha256:
-        return False
-    try:
-        manifest_after_stat = manifest_path.stat()
-        artifact_after_stat = artifact_path.stat()
-    except OSError:
-        return False
-    return _manifest_stat_matches_fingerprint(
+    if not requires_content:
+        fast_validation = _fast_artifact_source_validation(
+            fingerprint,
+            manifest_path,
+            artifact_path,
+        )
+        if fast_validation is not None:
+            return fast_validation
+    return _source_bytes_match_fingerprint(
         fingerprint,
-        manifest_after_stat,
-    ) and _artifact_stat_matches_fingerprint(fingerprint, artifact_after_stat)
+        manifest_path,
+        artifact_path,
+    )
 
 def _cache_state(
     cache: OrderedDict[Any, Any], key: Any, state: Any
@@ -1879,7 +2318,7 @@ def _drop_symbol_navigation_state_if_current(
 def _cached_call_navigation_state(
     manifest_path: Path,
 ) -> _CallNavigationState | None:
-    resolved_manifest = str(manifest_path.resolve())
+    resolved_manifest = str(resolve_manifest_path(manifest_path))
     with _CALL_NAVIGATION_CACHE_LOCK:
         # Snapshot at most two LRU entries so validation can release the lock;
         # a live reversed iterator would become invalid under concurrent mutation.
@@ -1889,6 +2328,8 @@ def _cached_call_navigation_state(
             if fingerprint.manifest_path == resolved_manifest
     ]
     for fingerprint, state in candidates:
+        if _fingerprint_matches_active_manifest_snapshot(fingerprint) is False:
+            continue
         if not _artifact_source_is_current(fingerprint):
             with _CALL_NAVIGATION_CACHE_LOCK:
                 _drop_call_navigation_state_if_current(fingerprint, state)
@@ -1903,7 +2344,7 @@ def _cached_call_navigation_state(
 def _cached_symbol_navigation_state(
     manifest_path: Path, call_state: _CallNavigationState
 ) -> _SymbolNavigationState | None:
-    resolved_manifest = str(manifest_path.resolve())
+    resolved_manifest = str(resolve_manifest_path(manifest_path))
     with _CALL_NAVIGATION_CACHE_LOCK:
         # Keep the same bounded snapshot rule as the call-navigation cache.
         candidates = [
@@ -1913,6 +2354,8 @@ def _cached_symbol_navigation_state(
             and cache_key[1].manifest_path == resolved_manifest
     ]
     for cache_key, state in candidates:
+        if _fingerprint_matches_active_manifest_snapshot(cache_key[1]) is False:
+            continue
         if not _artifact_source_is_current(cache_key[1]):
             with _CALL_NAVIGATION_CACHE_LOCK:
                 _drop_symbol_navigation_state_if_current(cache_key, state)
@@ -2796,7 +3239,7 @@ def find_references(
     """
     if compact is not None:
         verbose = not compact
-    manifest_path = Path(bundle_manifest).expanduser().resolve()
+    manifest_path = resolve_manifest_path(bundle_manifest)
     return project_read_result(
         _find_references_full(manifest_path, name, path=path, k=k),
         manifest_path,
@@ -2878,7 +3321,7 @@ def get_callers(
     """
     if compact is not None:
         verbose = not compact
-    manifest_path = Path(bundle_manifest).expanduser().resolve()
+    manifest_path = resolve_manifest_path(bundle_manifest)
     return project_read_result(
         _get_callers_full(manifest_path, name, path=path, k=k),
         manifest_path,
@@ -3029,7 +3472,7 @@ def get_callees(
     """
     if compact is not None:
         verbose = not compact
-    manifest_path = Path(bundle_manifest).expanduser().resolve()
+    manifest_path = resolve_manifest_path(bundle_manifest)
     return project_read_result(
         _get_callees_full(manifest_path, name, path=path, k=k),
         manifest_path,

--- a/merger/repoground/core/bundle_catalog.py
+++ b/merger/repoground/core/bundle_catalog.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any, Mapping
 
 from merger.repoground.core.bundle_identity import is_bundle_manifest
+from merger.repoground.core.post_health_binding import post_health_binding_status
 
 KIND = "repoground.bundle_catalog"
 VERSION = "v1"
@@ -195,40 +196,113 @@ def manifest_repo_aliases(document: Mapping[str, Any]) -> list[str]:
     return sorted(aliases)
 
 
+def _health_metadata_issue(
+    *,
+    expected_sha256: Any,
+    expected_bytes: Any,
+    require_integrity: bool,
+) -> str | None:
+    if not require_integrity:
+        return None
+    if (
+        not isinstance(expected_bytes, int)
+        or isinstance(expected_bytes, bool)
+        or expected_bytes < 0
+    ):
+        return "health artifact byte size missing or invalid in manifest"
+    if not isinstance(expected_sha256, str) or not _SHA256_RE.fullmatch(
+        expected_sha256
+    ):
+        return "health artifact sha256 missing or invalid in manifest"
+    return None
+
+
+def _health_content_issue(
+    raw: bytes,
+    *,
+    expected_sha256: Any,
+    expected_bytes: Any,
+) -> str | None:
+    if isinstance(expected_bytes, int) and len(raw) != expected_bytes:
+        return "health artifact byte size does not match manifest"
+    if (
+        isinstance(expected_sha256, str)
+        and _SHA256_RE.fullmatch(expected_sha256)
+        and _sha256_bytes(raw) != expected_sha256
+    ):
+        return "health artifact sha256 does not match manifest"
+    return None
+
+
+def _health_binding_issue(
+    document: Mapping[str, Any],
+    *,
+    expected_manifest_path: Path | None,
+    expected_manifest_run_id: Any,
+    expected_manifest_sha256: str | None,
+    require_manifest_binding: bool,
+) -> str | None:
+    if not require_manifest_binding:
+        return None
+    if expected_manifest_path is None:
+        return "post_emit_health manifest path expectation is missing"
+    binding_status, binding_detail = post_health_binding_status(
+        document,
+        resolved_manifest=expected_manifest_path.resolve(),
+        manifest_run_id=expected_manifest_run_id,
+        manifest_sha256=expected_manifest_sha256,
+    )
+    return None if binding_status == "pass" else binding_detail
+
+
 def _health_json_status(
     path: Path,
     *,
     expected_sha256: Any = None,
     expected_bytes: Any = None,
     require_integrity: bool = False,
+    expected_manifest_path: Path | None = None,
+    expected_manifest_run_id: Any = None,
+    expected_manifest_sha256: str | None = None,
+    require_manifest_binding: bool = False,
 ) -> tuple[str, str | None]:
-    if require_integrity:
-        if (
-            not isinstance(expected_bytes, int)
-            or isinstance(expected_bytes, bool)
-            or expected_bytes < 0
-        ):
-            return "invalid", "health artifact byte size missing or invalid in manifest"
-        if not isinstance(expected_sha256, str) or not _SHA256_RE.fullmatch(
-            expected_sha256
-        ):
-            return "invalid", "health artifact sha256 missing or invalid in manifest"
+    issue = _health_metadata_issue(
+        expected_sha256=expected_sha256,
+        expected_bytes=expected_bytes,
+        require_integrity=require_integrity,
+    )
+    if issue is not None:
+        return "invalid", issue
     try:
         document, raw = _load_json_object(path, MAX_HEALTH_BYTES)
     except BundleCatalogError as exc:
         return "invalid", str(exc)
-    if isinstance(expected_bytes, int) and len(raw) != expected_bytes:
-        return "invalid", "health artifact byte size does not match manifest"
-    if isinstance(expected_sha256, str) and _SHA256_RE.fullmatch(expected_sha256):
-        if _sha256_bytes(raw) != expected_sha256:
-            return "invalid", "health artifact sha256 does not match manifest"
+    issue = _health_content_issue(
+        raw,
+        expected_sha256=expected_sha256,
+        expected_bytes=expected_bytes,
+    )
+    if issue is not None:
+        return "invalid", issue
     status = document.get("status") or document.get("verdict")
-    if status == "pass":
-        return "pass", None
-    return "invalid", f"health status is {status!r}, expected 'pass'"
+    if status != "pass":
+        return "invalid", f"health status is {status!r}, expected 'pass'"
+    issue = _health_binding_issue(
+        document,
+        expected_manifest_path=expected_manifest_path,
+        expected_manifest_run_id=expected_manifest_run_id,
+        expected_manifest_sha256=expected_manifest_sha256,
+        require_manifest_binding=require_manifest_binding,
+    )
+    return ("invalid", issue) if issue is not None else ("pass", None)
 
 
-def _candidate_health(path: Path, document: Mapping[str, Any]) -> tuple[str, list[str]]:
+def _candidate_health(
+    path: Path,
+    document: Mapping[str, Any],
+    *,
+    manifest_sha256: str,
+) -> tuple[str, list[str]]:
     reasons: list[str] = []
     links = document.get("links") if isinstance(document.get("links"), Mapping) else {}
     for key in (
@@ -271,7 +345,13 @@ def _candidate_health(path: Path, document: Mapping[str, Any]) -> tuple[str, lis
     if post_path is None:
         reasons.append("post_emit_health path missing or invalid")
     else:
-        status, reason = _health_json_status(post_path)
+        status, reason = _health_json_status(
+            post_path,
+            expected_manifest_path=path,
+            expected_manifest_run_id=document.get("run_id"),
+            expected_manifest_sha256=manifest_sha256,
+            require_manifest_binding=True,
+        )
         if status != "pass":
             reasons.append(reason or "post_emit_health invalid")
 
@@ -294,7 +374,9 @@ def inspect_bundle_health(bundle_manifest: str | Path) -> dict[str, Any]:
             "reasons": [str(exc)],
             "mutation_boundary": {"writes": [], "read_paths_do_not_refresh": True},
         }
-    health_status, reasons = _candidate_health(path, document)
+    health_status, reasons = _candidate_health(
+        path, document, manifest_sha256=_sha256_bytes(raw)
+    )
     return {
         "kind": "repoground.bundle_health",
         "version": VERSION,
@@ -345,7 +427,9 @@ def discover_bundle_catalog(bundle_root: str | Path) -> dict[str, Any]:
             created_at_utc = None
             timestamp_status = "invalid"
             timestamp_reason = str(exc)
-        health_status, health_reasons = _candidate_health(path, document)
+        health_status, health_reasons = _candidate_health(
+            path, document, manifest_sha256=_sha256_bytes(raw)
+        )
         candidates.append(
             {
                 "stem": path.name[: -len(MANIFEST_SUFFIX)],

--- a/merger/repoground/core/bundle_catalog.py
+++ b/merger/repoground/core/bundle_catalog.py
@@ -17,6 +17,10 @@ from pathlib import Path
 from typing import Any, Mapping
 
 from merger.repoground.core.bundle_identity import is_bundle_manifest
+from merger.repoground.core.manifest_snapshot import (
+    active_manifest_snapshot,
+    resolve_manifest_path,
+)
 from merger.repoground.core.post_health_binding import post_health_binding_status
 
 KIND = "repoground.bundle_catalog"
@@ -71,7 +75,11 @@ def _load_json_object(path: Path, max_bytes: int) -> tuple[dict[str, Any], bytes
 
 
 def _manifest_document(path: Path) -> tuple[dict[str, Any], bytes]:
-    document, raw = _load_json_object(path, MAX_MANIFEST_BYTES)
+    snapshot = active_manifest_snapshot(path)
+    if snapshot is None:
+        document, raw = _load_json_object(path, MAX_MANIFEST_BYTES)
+    else:
+        document, raw = snapshot.json_object(), snapshot.raw
     if (
         not is_bundle_manifest(document)
         or not isinstance(document.get("run_id"), str)
@@ -248,11 +256,58 @@ def _health_binding_issue(
         return "post_emit_health manifest path expectation is missing"
     binding_status, binding_detail = post_health_binding_status(
         document,
-        resolved_manifest=expected_manifest_path.resolve(),
+        resolved_manifest=resolve_manifest_path(expected_manifest_path),
         manifest_run_id=expected_manifest_run_id,
         manifest_sha256=expected_manifest_sha256,
     )
     return None if binding_status == "pass" else binding_detail
+
+
+def _health_document_status(
+    document: Mapping[str, Any],
+    raw: bytes,
+    *,
+    expected_sha256: Any = None,
+    expected_bytes: Any = None,
+    require_integrity: bool = False,
+    expected_manifest_path: Path | None = None,
+    expected_manifest_run_id: Any = None,
+    expected_manifest_sha256: str | None = None,
+    require_manifest_binding: bool = False,
+) -> tuple[str, str | None]:
+    issue = _health_metadata_issue(
+        expected_sha256=expected_sha256,
+        expected_bytes=expected_bytes,
+        require_integrity=require_integrity,
+    )
+    if issue is not None:
+        return "invalid", issue
+    try:
+        decoded = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return "invalid", "health artifact is not valid UTF-8 JSON"
+    if not isinstance(decoded, dict):
+        return "invalid", "health artifact must be a JSON object"
+    if decoded != document:
+        return "invalid", "health document does not match supplied artifact bytes"
+    issue = _health_content_issue(
+        raw,
+        expected_sha256=expected_sha256,
+        expected_bytes=expected_bytes,
+    )
+    if issue is not None:
+        return "invalid", issue
+    status = document.get("status") or document.get("verdict")
+    if status != "pass":
+        return "invalid", f"health status is {status!r}, expected 'pass'"
+    issue = _health_binding_issue(
+        document,
+        expected_manifest_path=expected_manifest_path,
+        expected_manifest_run_id=expected_manifest_run_id,
+        expected_manifest_sha256=expected_manifest_sha256,
+        require_manifest_binding=require_manifest_binding,
+    )
+    return ("invalid", issue) if issue is not None else ("pass", None)
 
 
 def _health_json_status(
@@ -277,24 +332,52 @@ def _health_json_status(
         document, raw = _load_json_object(path, MAX_HEALTH_BYTES)
     except BundleCatalogError as exc:
         return "invalid", str(exc)
-    issue = _health_content_issue(
+    return _health_document_status(
+        document,
         raw,
         expected_sha256=expected_sha256,
         expected_bytes=expected_bytes,
-    )
-    if issue is not None:
-        return "invalid", issue
-    status = document.get("status") or document.get("verdict")
-    if status != "pass":
-        return "invalid", f"health status is {status!r}, expected 'pass'"
-    issue = _health_binding_issue(
-        document,
+        require_integrity=require_integrity,
         expected_manifest_path=expected_manifest_path,
         expected_manifest_run_id=expected_manifest_run_id,
         expected_manifest_sha256=expected_manifest_sha256,
         require_manifest_binding=require_manifest_binding,
     )
-    return ("invalid", issue) if issue is not None else ("pass", None)
+
+
+def _post_health_issue(
+    path: Path,
+    document: Mapping[str, Any],
+    *,
+    manifest_sha256: str,
+    post_health_source: tuple[Path, Mapping[str, Any], bytes] | None,
+) -> str | None:
+    links = document.get("links") if isinstance(document.get("links"), Mapping) else {}
+    post_path = _safe_child(path.parent, links.get("post_emit_health_path"))
+    if post_path is None:
+        return "post_emit_health path missing or invalid"
+    if post_health_source is None:
+        status, reason = _health_json_status(
+            post_path,
+            expected_manifest_path=path,
+            expected_manifest_run_id=document.get("run_id"),
+            expected_manifest_sha256=manifest_sha256,
+            require_manifest_binding=True,
+        )
+        return None if status == "pass" else reason or "post_emit_health invalid"
+
+    source_path, source_document, source_raw = post_health_source
+    if source_path.resolve() != post_path:
+        return "supplied post_emit_health path does not match manifest link"
+    status, reason = _health_document_status(
+        source_document,
+        source_raw,
+        expected_manifest_path=path,
+        expected_manifest_run_id=document.get("run_id"),
+        expected_manifest_sha256=manifest_sha256,
+        require_manifest_binding=True,
+    )
+    return None if status == "pass" else reason or "post_emit_health invalid"
 
 
 def _candidate_health(
@@ -302,6 +385,7 @@ def _candidate_health(
     document: Mapping[str, Any],
     *,
     manifest_sha256: str,
+    post_health_source: tuple[Path, Mapping[str, Any], bytes] | None = None,
 ) -> tuple[str, list[str]]:
     reasons: list[str] = []
     links = document.get("links") if isinstance(document.get("links"), Mapping) else {}
@@ -341,26 +425,76 @@ def _candidate_health(
             if status != "pass":
                 reasons.append(reason or "output_health invalid")
 
-    post_path = _safe_child(path.parent, links.get("post_emit_health_path"))
-    if post_path is None:
-        reasons.append("post_emit_health path missing or invalid")
-    else:
-        status, reason = _health_json_status(
-            post_path,
-            expected_manifest_path=path,
-            expected_manifest_run_id=document.get("run_id"),
-            expected_manifest_sha256=manifest_sha256,
-            require_manifest_binding=True,
-        )
-        if status != "pass":
-            reasons.append(reason or "post_emit_health invalid")
+    post_issue = _post_health_issue(
+        path,
+        document,
+        manifest_sha256=manifest_sha256,
+        post_health_source=post_health_source,
+    )
+    if post_issue is not None:
+        reasons.append(post_issue)
 
     return ("pass", []) if not reasons else ("invalid", reasons)
 
 
+def inspect_bundle_health_documents(
+    bundle_manifest: str | Path,
+    *,
+    manifest_document: Mapping[str, Any],
+    manifest_bytes: bytes,
+    post_health_path: str | Path,
+    post_health_document: Mapping[str, Any],
+    post_health_bytes: bytes,
+) -> dict[str, Any]:
+    """Inspect whole-bundle health from one already-read manifest/health pair."""
+    path = resolve_manifest_path(bundle_manifest)
+    try:
+        decoded_manifest = json.loads(manifest_bytes.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        decoded_manifest = None
+    if (
+        not isinstance(decoded_manifest, dict)
+        or decoded_manifest != manifest_document
+        or not is_bundle_manifest(manifest_document)
+        or not isinstance(manifest_document.get("run_id"), str)
+        or not isinstance(manifest_document.get("artifacts"), list)
+    ):
+        return {
+            "kind": "repoground.bundle_health",
+            "version": VERSION,
+            "status": "invalid",
+            "health_status": "invalid",
+            "bundle_manifest": str(path),
+            "manifest_sha256": None,
+            "reasons": ["invalid RepoGround bundle manifest"],
+            "mutation_boundary": {"writes": [], "read_paths_do_not_refresh": True},
+        }
+    manifest_sha256 = _sha256_bytes(manifest_bytes)
+    health_status, reasons = _candidate_health(
+        path,
+        manifest_document,
+        manifest_sha256=manifest_sha256,
+        post_health_source=(
+            Path(post_health_path).expanduser().resolve(),
+            post_health_document,
+            post_health_bytes,
+        ),
+    )
+    return {
+        "kind": "repoground.bundle_health",
+        "version": VERSION,
+        "status": "available" if health_status == "pass" else "unhealthy",
+        "health_status": health_status,
+        "bundle_manifest": str(path),
+        "manifest_sha256": manifest_sha256,
+        "reasons": reasons,
+        "mutation_boundary": {"writes": [], "read_paths_do_not_refresh": True},
+    }
+
+
 def inspect_bundle_health(bundle_manifest: str | Path) -> dict[str, Any]:
     """Inspect manifest-bound health without selecting or refreshing a bundle."""
-    path = Path(bundle_manifest).expanduser().resolve()
+    path = resolve_manifest_path(bundle_manifest)
     try:
         document, raw = _manifest_document(path)
     except BundleCatalogError as exc:

--- a/merger/repoground/core/bundle_catalog.py
+++ b/merger/repoground/core/bundle_catalog.py
@@ -12,6 +12,7 @@ import json
 import os
 import re
 import subprocess
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping
 
@@ -122,6 +123,59 @@ def _canonical_name_aliases(name: Any) -> set[str]:
     return aliases
 
 
+def _canonical_repo_identity(value: Any) -> str | None:
+    remote = normalize_repo_remote(value)
+    if remote:
+        return remote
+    if not isinstance(value, str) or not value.strip():
+        return None
+    raw = value.strip().casefold()
+    parts = raw.split("__")
+    if len(parts) >= 2 and parts[0] and parts[1]:
+        return f"{parts[0]}/{parts[1]}"
+    return None
+
+
+def manifest_repo_identities(document: Mapping[str, Any]) -> list[str]:
+    """Return canonical owner/repository identities, preferring explicit remotes."""
+    provenance = document.get("snapshot_provenance")
+    repositories = (
+        provenance.get("repositories") if isinstance(provenance, Mapping) else None
+    )
+    identities: set[str] = set()
+    fallback: set[str] = set()
+    for record in repositories if isinstance(repositories, list) else []:
+        if not isinstance(record, Mapping):
+            continue
+        remote = normalize_repo_remote(record.get("repo_remote"))
+        if remote:
+            identities.add(remote)
+            continue
+        for key in ("name", "repo"):
+            identity = _canonical_repo_identity(record.get(key))
+            if identity:
+                fallback.add(identity)
+    return sorted(identities or fallback)
+
+
+def _normalized_created_at(value: Any) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise BundleCatalogError("bundle created_at is missing or invalid")
+    raw = value.strip()
+    candidate = f"{raw[:-1]}+00:00" if raw.endswith(("Z", "z")) else raw
+    try:
+        parsed = datetime.fromisoformat(candidate)
+    except ValueError as exc:
+        raise BundleCatalogError("bundle created_at is not valid ISO-8601") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise BundleCatalogError("bundle created_at must include a timezone")
+    return (
+        parsed.astimezone(timezone.utc)
+        .isoformat(timespec="microseconds")
+        .replace("+00:00", "Z")
+    )
+
+
 def manifest_repo_aliases(document: Mapping[str, Any]) -> list[str]:
     aliases: set[str] = set()
     provenance = document.get("snapshot_provenance")
@@ -224,6 +278,35 @@ def _candidate_health(path: Path, document: Mapping[str, Any]) -> tuple[str, lis
     return ("pass", []) if not reasons else ("invalid", reasons)
 
 
+def inspect_bundle_health(bundle_manifest: str | Path) -> dict[str, Any]:
+    """Inspect manifest-bound health without selecting or refreshing a bundle."""
+    path = Path(bundle_manifest).expanduser().resolve()
+    try:
+        document, raw = _manifest_document(path)
+    except BundleCatalogError as exc:
+        return {
+            "kind": "repoground.bundle_health",
+            "version": VERSION,
+            "status": "invalid",
+            "health_status": "invalid",
+            "bundle_manifest": str(path),
+            "manifest_sha256": None,
+            "reasons": [str(exc)],
+            "mutation_boundary": {"writes": [], "read_paths_do_not_refresh": True},
+        }
+    health_status, reasons = _candidate_health(path, document)
+    return {
+        "kind": "repoground.bundle_health",
+        "version": VERSION,
+        "status": "available" if health_status == "pass" else "unhealthy",
+        "health_status": health_status,
+        "bundle_manifest": str(path),
+        "manifest_sha256": _sha256_bytes(raw),
+        "reasons": reasons,
+        "mutation_boundary": {"writes": [], "read_paths_do_not_refresh": True},
+    }
+
+
 def _manifest_paths(root: Path) -> list[Path]:
     if root.is_file():
         return [root]
@@ -254,6 +337,14 @@ def discover_bundle_catalog(bundle_root: str | Path) -> dict[str, Any]:
         except BundleCatalogError as exc:
             rejected.append({"manifest_path": str(path), "reason": str(exc)})
             continue
+        try:
+            created_at_utc = _normalized_created_at(document.get("created_at"))
+            timestamp_status = "valid"
+            timestamp_reason = None
+        except BundleCatalogError as exc:
+            created_at_utc = None
+            timestamp_status = "invalid"
+            timestamp_reason = str(exc)
         health_status, health_reasons = _candidate_health(path, document)
         candidates.append(
             {
@@ -262,10 +353,16 @@ def discover_bundle_catalog(bundle_root: str | Path) -> dict[str, Any]:
                 "manifest_sha256": _sha256_bytes(raw),
                 "run_id": document.get("run_id"),
                 "created_at": document.get("created_at"),
+                "created_at_utc": created_at_utc,
+                "timestamp_status": timestamp_status,
+                "timestamp_reason": timestamp_reason,
                 "repo_aliases": manifest_repo_aliases(document),
+                "repo_identities": manifest_repo_identities(document),
                 "health_status": health_status,
                 "health_reasons": health_reasons,
-                "selection_eligible": health_status == "pass",
+                "selection_eligible": (
+                    health_status == "pass" and timestamp_status == "valid"
+                ),
             }
         )
     return {
@@ -282,12 +379,41 @@ def discover_bundle_catalog(bundle_root: str | Path) -> dict[str, Any]:
     }
 
 
-def _normalized_requested_repo(repo: Any) -> str | None:
+def _normalized_requested_repo(repo: Any) -> tuple[str | None, bool]:
     if repo is None:
-        return None
+        return None, False
     if not isinstance(repo, str) or not repo.strip():
         raise BundleCatalogError("repo must be null or a non-empty repository identity")
-    return normalize_repo_remote(repo) or repo.strip().casefold()
+    raw = repo.strip()
+    canonical = _canonical_repo_identity(raw)
+    if canonical:
+        return canonical, True
+    return raw.casefold(), False
+
+
+def _candidate_matches_repo(
+    candidate: Mapping[str, Any], requested_repo: str | None, qualified: bool
+) -> bool:
+    if requested_repo is None:
+        return True
+    if qualified:
+        identities = candidate.get("repo_identities")
+        return isinstance(identities, list) and requested_repo in identities
+    aliases = candidate.get("repo_aliases")
+    return isinstance(aliases, list) and requested_repo in aliases
+
+
+def _short_repo_identity_groups(
+    matches: list[dict[str, Any]], requested_repo: str
+) -> set[str]:
+    groups: set[str] = set()
+    for candidate in matches:
+        identities = candidate.get("repo_identities")
+        if isinstance(identities, list) and identities:
+            groups.update(str(identity) for identity in identities)
+        else:
+            groups.add(f"unqualified:{requested_repo}")
+    return groups
 
 
 def select_bundle_manifest(
@@ -298,22 +424,44 @@ def select_bundle_manifest(
     require_healthy: bool = True,
 ) -> dict[str, Any]:
     catalog = discover_bundle_catalog(bundle_root)
-    requested_repo = _normalized_requested_repo(repo)
+    requested_repo, requested_repo_qualified = _normalized_requested_repo(repo)
     if stem is not None and (not isinstance(stem, str) or not stem.strip()):
         raise BundleCatalogError("stem must be null or a non-empty string")
 
-    matches = []
+    identity_matches = []
     for candidate in catalog["candidates"]:
         if stem is not None and candidate["stem"] != stem:
             continue
-        if (
-            requested_repo is not None
-            and requested_repo not in candidate["repo_aliases"]
+        if not _candidate_matches_repo(
+            candidate, requested_repo, requested_repo_qualified
         ):
             continue
-        if require_healthy and not candidate["selection_eligible"]:
+        if candidate.get("timestamp_status") != "valid":
             continue
-        matches.append(candidate)
+        identity_matches.append(candidate)
+
+    if requested_repo is not None and not requested_repo_qualified:
+        identity_groups = _short_repo_identity_groups(identity_matches, requested_repo)
+        if len(identity_groups) > 1:
+            return {
+                "kind": "repoground.bundle_selection",
+                "version": VERSION,
+                "status": "ambiguous",
+                "bundle_root": catalog["bundle_root"],
+                "requested_repo": requested_repo,
+                "requested_stem": stem,
+                "selected": None,
+                "reason": "repository_identity_ambiguous",
+                "repo_identity_groups": sorted(identity_groups),
+                "matches": identity_matches,
+                "does_not_establish": list(DOES_NOT_ESTABLISH),
+            }
+
+    matches = [
+        candidate
+        for candidate in identity_matches
+        if not require_healthy or candidate["health_status"] == "pass"
+    ]
     if not matches:
         return {
             "kind": "repoground.bundle_selection",
@@ -332,20 +480,20 @@ def select_bundle_manifest(
 
     matches.sort(
         key=lambda item: (
-            str(item.get("created_at") or ""),
+            str(item.get("created_at_utc") or ""),
             str(item.get("run_id") or ""),
             str(item["manifest_path"]),
         ),
         reverse=True,
     )
     newest_key = (
-        str(matches[0].get("created_at") or ""),
+        str(matches[0].get("created_at_utc") or ""),
         str(matches[0].get("run_id") or ""),
     )
     tied = [
         item
         for item in matches
-        if (str(item.get("created_at") or ""), str(item.get("run_id") or ""))
+        if (str(item.get("created_at_utc") or ""), str(item.get("run_id") or ""))
         == newest_key
     ]
     if len(tied) != 1:
@@ -370,7 +518,7 @@ def select_bundle_manifest(
         "requested_stem": stem,
         "selected": matches[0],
         "match_count": len(matches),
-        "selection_policy": "newest_healthy_by_created_at_then_run_id",
+        "selection_policy": "newest_healthy_by_created_at_utc_then_run_id",
         "does_not_establish": list(DOES_NOT_ESTABLISH),
     }
 

--- a/merger/repoground/core/bundle_catalog.py
+++ b/merger/repoground/core/bundle_catalog.py
@@ -142,8 +142,23 @@ def manifest_repo_aliases(document: Mapping[str, Any]) -> list[str]:
 
 
 def _health_json_status(
-    path: Path, *, expected_sha256: Any = None, expected_bytes: Any = None
+    path: Path,
+    *,
+    expected_sha256: Any = None,
+    expected_bytes: Any = None,
+    require_integrity: bool = False,
 ) -> tuple[str, str | None]:
+    if require_integrity:
+        if (
+            not isinstance(expected_bytes, int)
+            or isinstance(expected_bytes, bool)
+            or expected_bytes < 0
+        ):
+            return "invalid", "health artifact byte size missing or invalid in manifest"
+        if not isinstance(expected_sha256, str) or not _SHA256_RE.fullmatch(
+            expected_sha256
+        ):
+            return "invalid", "health artifact sha256 missing or invalid in manifest"
     try:
         document, raw = _load_json_object(path, MAX_HEALTH_BYTES)
     except BundleCatalogError as exc:
@@ -193,6 +208,7 @@ def _candidate_health(path: Path, document: Mapping[str, Any]) -> tuple[str, lis
                 output_path,
                 expected_sha256=output_health.get("sha256"),
                 expected_bytes=output_health.get("bytes"),
+                require_integrity=True,
             )
             if status != "pass":
                 reasons.append(reason or "output_health invalid")

--- a/merger/repoground/core/bundle_catalog.py
+++ b/merger/repoground/core/bundle_catalog.py
@@ -11,7 +11,10 @@ import hashlib
 import json
 import os
 import re
+import stat
 import subprocess
+import sys
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping
@@ -29,6 +32,7 @@ MANIFEST_SUFFIX = ".bundle.manifest.json"
 MAX_MANIFEST_BYTES = 4 * 1024 * 1024
 MAX_HEALTH_BYTES = 4 * 1024 * 1024
 MAX_DISCOVERED_MANIFESTS = 2000
+_OPEN_TIMEOUT_SECONDS = 1.0
 _SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
 _GITHUB_SCP_RE = re.compile(r"^[^@]+@github\.com:(?P<slug>[^/]+/[^/]+?)(?:\.git)?$")
 _GITHUB_URL_RE = re.compile(
@@ -48,30 +52,443 @@ class BundleCatalogError(ValueError):
     """Raised when discovery or selection cannot remain deterministic."""
 
 
+@dataclass(frozen=True, slots=True)
+class _StableRead:
+    selected_path: Path
+    resolved_path: Path
+    raw: bytes
+    identity: tuple[int, int, int, int, int, int]
+
+
 def _sha256_bytes(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
-def _read_bounded(path: Path, max_bytes: int) -> bytes:
+def _file_identity(metadata: os.stat_result) -> tuple[int, int, int, int, int, int]:
+    return (
+        int(metadata.st_dev),
+        int(metadata.st_ino),
+        int(metadata.st_mode),
+        int(metadata.st_size),
+        int(metadata.st_mtime_ns),
+        int(metadata.st_ctime_ns),
+    )
+
+
+def _absolute_path(path: Path) -> Path:
+    return Path(os.path.abspath(os.fspath(path.expanduser())))
+
+
+def _resolve_read_path(
+    path: Path,
+    *,
+    root: Path | None,
+    label: str,
+) -> Path:
     try:
-        with path.open("rb") as handle:
-            data = handle.read(max_bytes + 1)
+        resolved = path.resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise BundleCatalogError(f"file cannot be resolved: {path}") from exc
+    if root is not None:
+        try:
+            resolved.relative_to(root)
+        except ValueError as exc:
+            raise BundleCatalogError(
+                f"{label} resolves outside catalog root: {path}"
+            ) from exc
+    return resolved
+
+
+_PORTABLE_READ_HELPER = r"""
+import json
+import os
+import stat
+import sys
+
+path = sys.argv[1]
+limit = int(sys.argv[2])
+expected = tuple(json.loads(sys.argv[3]))
+
+
+def emit(status, **fields):
+    payload = {"status": status, **fields}
+    sys.stdout.buffer.write(
+        json.dumps(payload, separators=(",", ":")).encode("utf-8") + b"\n"
+    )
+
+
+flags = (
+    os.O_RDONLY
+    | getattr(os, "O_BINARY", 0)
+    | getattr(os, "O_CLOEXEC", 0)
+    | getattr(os, "O_NOFOLLOW", 0)
+)
+try:
+    descriptor = os.open(path, flags)
+except OSError as exc:
+    emit("error", reason=f"file cannot be opened: {exc}")
+    raise SystemExit(0)
+
+try:
+    before = os.fstat(descriptor)
+    identity = (
+        int(before.st_dev),
+        int(before.st_ino),
+        int(before.st_mode),
+        int(before.st_size),
+        int(before.st_mtime_ns),
+        int(before.st_ctime_ns),
+    )
+    if not stat.S_ISREG(before.st_mode):
+        emit("error", reason="file is not regular")
+        raise SystemExit(0)
+    if identity != expected:
+        emit("error", reason="file identity changed before reading")
+        raise SystemExit(0)
+    if before.st_size > limit:
+        emit("error", reason="file exceeds bounded catalog read")
+        raise SystemExit(0)
+
+    chunks = []
+    remaining = limit + 1
+    while remaining:
+        chunk = os.read(descriptor, min(1024 * 1024, remaining))
+        if not chunk:
+            break
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    raw = b"".join(chunks)
+    after = os.fstat(descriptor)
+    after_identity = (
+        int(after.st_dev),
+        int(after.st_ino),
+        int(after.st_mode),
+        int(after.st_size),
+        int(after.st_mtime_ns),
+        int(after.st_ctime_ns),
+    )
+    if after_identity != identity or len(raw) != after.st_size:
+        emit("error", reason="file changed while reading")
+        raise SystemExit(0)
+finally:
+    os.close(descriptor)
+
+emit("ok", identity=list(identity), raw_length=len(raw))
+sys.stdout.buffer.write(raw)
+"""
+
+
+def _nonblocking_open_available() -> bool:
+    value = getattr(os, "O_NONBLOCK", 0)
+    return isinstance(value, int) and bool(value)
+
+
+def _portable_reader_output(
+    stdout: bytes,
+    *,
+    path: Path,
+    max_bytes: int,
+) -> tuple[dict[str, Any], bytes]:
+    if len(stdout) > max_bytes + 4096:
+        raise BundleCatalogError(f"portable file reader exceeded output bound: {path}")
+    header, separator, raw = stdout.partition(b"\n")
+    if not separator:
+        raise BundleCatalogError(f"portable file reader returned no header: {path}")
+    try:
+        metadata = json.loads(header.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise BundleCatalogError(
+            f"portable file reader returned an invalid header: {path}"
+        ) from exc
+    if not isinstance(metadata, dict):
+        raise BundleCatalogError(
+            f"portable file reader returned an invalid header: {path}"
+        )
+    return metadata, raw
+
+
+def _portable_reader_identity(
+    metadata: dict[str, Any],
+    raw: bytes,
+    *,
+    path: Path,
+    expected_identity: tuple[int, int, int, int, int, int],
+) -> tuple[int, int, int, int, int, int]:
+    if metadata.get("status") != "ok":
+        reason = metadata.get("reason")
+        detail = reason if isinstance(reason, str) and reason else "file cannot be read"
+        raise BundleCatalogError(f"{detail}: {path}")
+    raw_identity = metadata.get("identity")
+    valid_identity = (
+        isinstance(raw_identity, list)
+        and len(raw_identity) == 6
+        and all(isinstance(item, int) for item in raw_identity)
+    )
+    if not valid_identity:
+        raise BundleCatalogError(
+            f"portable file reader returned invalid identity: {path}"
+        )
+    identity = tuple(raw_identity)
+    if identity != expected_identity:
+        raise BundleCatalogError(f"file identity changed before reading: {path}")
+    if metadata.get("raw_length") != len(raw):
+        raise BundleCatalogError(
+            f"portable file reader returned truncated bytes: {path}"
+        )
+    return identity
+
+
+def _read_bounded_portable(
+    path: Path,
+    max_bytes: int,
+    expected_identity: tuple[int, int, int, int, int, int],
+) -> tuple[bytes, tuple[int, int, int, int, int, int]]:
+    command = [
+        sys.executable,
+        "-I",
+        "-c",
+        _PORTABLE_READ_HELPER,
+        os.fspath(path),
+        str(max_bytes),
+        json.dumps(expected_identity, separators=(",", ":")),
+    ]
+    try:
+        completed = subprocess.run(
+            command,
+            capture_output=True,
+            check=False,
+            timeout=_OPEN_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise BundleCatalogError(
+            f"file open exceeded time bound: {path}"
+        ) from exc
+    if completed.returncode != 0:
+        raise BundleCatalogError(f"portable file reader failed: {path}")
+    metadata, raw = _portable_reader_output(
+        completed.stdout,
+        path=path,
+        max_bytes=max_bytes,
+    )
+    identity = _portable_reader_identity(
+        metadata,
+        raw,
+        path=path,
+        expected_identity=expected_identity,
+    )
+    return raw, identity
+
+
+def _open_binary(path: Path) -> Any:
+    nonblocking = getattr(os, "O_NONBLOCK", 0)
+    if not isinstance(nonblocking, int) or not nonblocking:
+        raise BundleCatalogError("nonblocking descriptor open is unavailable")
+    flags = (
+        os.O_RDONLY
+        | nonblocking
+        | getattr(os, "O_BINARY", 0)
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    descriptor = os.open(path, flags)
+    try:
+        return os.fdopen(descriptor, "rb")
+    except Exception:
+        os.close(descriptor)
+        raise
+
+
+def _assert_stable_read_path(
+    *,
+    selected_path: Path,
+    resolved_path: Path,
+    identity: tuple[int, int, int, int, int, int],
+    root: Path | None,
+    label: str,
+) -> None:
+    current_resolved = _resolve_read_path(
+        selected_path,
+        root=root,
+        label=label,
+    )
+    if current_resolved != resolved_path:
+        raise BundleCatalogError(f"file target changed while reading: {selected_path}")
+    try:
+        current_identity = _file_identity(current_resolved.stat())
+    except OSError as exc:
+        raise BundleCatalogError(
+            f"file identity cannot be verified: {selected_path}"
+        ) from exc
+    if current_identity != identity:
+        raise BundleCatalogError(f"file identity changed while reading: {selected_path}")
+
+
+def _preliminary_regular_identity(
+    resolved_path: Path,
+    selected_path: Path,
+    max_bytes: int,
+) -> tuple[int, int, int, int, int, int]:
+    preliminary = resolved_path.stat()
+    if not stat.S_ISREG(preliminary.st_mode):
+        raise BundleCatalogError(f"file is not regular: {selected_path}")
+    if preliminary.st_size > max_bytes:
+        raise BundleCatalogError(
+            f"file exceeds bounded catalog read: {selected_path}"
+        )
+    return _file_identity(preliminary)
+
+
+def _read_nonblocking_stable(
+    resolved_path: Path,
+    selected_path: Path,
+    max_bytes: int,
+    preliminary_identity: tuple[int, int, int, int, int, int],
+    *,
+    root: Path | None,
+    label: str,
+) -> tuple[bytes, tuple[int, int, int, int, int, int], tuple[int, int, int, int, int, int]]:
+    with _open_binary(resolved_path) as handle:
+        descriptor = handle.fileno()
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode):
+            raise BundleCatalogError(f"file is not regular: {selected_path}")
+        identity = _file_identity(before)
+        if identity != preliminary_identity:
+            raise BundleCatalogError(
+                f"file identity changed before reading: {selected_path}"
+            )
+        if before.st_size > max_bytes:
+            raise BundleCatalogError(
+                f"file exceeds bounded catalog read: {selected_path}"
+            )
+        _assert_stable_read_path(
+            selected_path=selected_path,
+            resolved_path=resolved_path,
+            identity=identity,
+            root=root,
+            label=label,
+        )
+        raw = handle.read(max_bytes + 1)
+        after_identity = _file_identity(os.fstat(descriptor))
+    return raw, identity, after_identity
+
+
+def _read_bounded_stable(
+    path: Path,
+    max_bytes: int,
+    *,
+    root: Path | None = None,
+    label: str = "file",
+) -> _StableRead:
+    selected_path = _absolute_path(path)
+    resolved_path = _resolve_read_path(
+        selected_path,
+        root=root,
+        label=label,
+    )
+    try:
+        preliminary_identity = _preliminary_regular_identity(
+            resolved_path,
+            selected_path,
+            max_bytes,
+        )
+        _assert_stable_read_path(
+            selected_path=selected_path,
+            resolved_path=resolved_path,
+            identity=preliminary_identity,
+            root=root,
+            label=label,
+        )
+        if _nonblocking_open_available():
+            raw, identity, after_identity = _read_nonblocking_stable(
+                resolved_path,
+                selected_path,
+                max_bytes,
+                preliminary_identity,
+                root=root,
+                label=label,
+            )
+        else:
+            raw, identity = _read_bounded_portable(
+                resolved_path,
+                max_bytes,
+                preliminary_identity,
+            )
+            after_identity = identity
+    except BundleCatalogError:
+        raise
     except OSError as exc:
         raise BundleCatalogError(f"file cannot be read: {path}") from exc
-    if len(data) > max_bytes:
-        raise BundleCatalogError(f"file exceeds bounded catalog read: {path}")
-    return data
+
+    if len(raw) > max_bytes:
+        raise BundleCatalogError(
+            f"file exceeds bounded catalog read: {selected_path}"
+        )
+    if identity != after_identity or len(raw) != identity[3]:
+        raise BundleCatalogError(f"file changed while reading: {selected_path}")
+    _assert_stable_read_path(
+        selected_path=selected_path,
+        resolved_path=resolved_path,
+        identity=identity,
+        root=root,
+        label=label,
+    )
+    return _StableRead(
+        selected_path=selected_path,
+        resolved_path=resolved_path,
+        raw=raw,
+        identity=identity,
+    )
 
 
-def _load_json_object(path: Path, max_bytes: int) -> tuple[dict[str, Any], bytes]:
-    raw = _read_bounded(path, max_bytes)
+def _read_bounded(
+    path: Path,
+    max_bytes: int,
+    *,
+    root: Path | None = None,
+    label: str = "file",
+) -> bytes:
+    return _read_bounded_stable(
+        path,
+        max_bytes,
+        root=root,
+        label=label,
+    ).raw
+
+
+def _decode_json_object(path: Path, raw: bytes) -> dict[str, Any]:
     try:
         value = json.loads(raw.decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise BundleCatalogError(f"file is not valid UTF-8 JSON: {path}") from exc
     if not isinstance(value, dict):
         raise BundleCatalogError(f"JSON document must be an object: {path}")
-    return value, raw
+    return value
+
+
+def _load_json_object(
+    path: Path,
+    max_bytes: int,
+    *,
+    root: Path | None = None,
+    label: str = "file",
+) -> tuple[dict[str, Any], bytes]:
+    raw = _read_bounded(path, max_bytes, root=root, label=label)
+    return _decode_json_object(path, raw), raw
+
+
+def _validate_manifest_document(
+    path: Path,
+    document: dict[str, Any],
+    raw: bytes,
+) -> tuple[dict[str, Any], bytes]:
+    if (
+        not is_bundle_manifest(document)
+        or not isinstance(document.get("run_id"), str)
+        or not isinstance(document.get("artifacts"), list)
+    ):
+        raise BundleCatalogError(f"invalid RepoGround bundle manifest: {path}")
+    return document, raw
 
 
 def _manifest_document(path: Path) -> tuple[dict[str, Any], bytes]:
@@ -80,13 +497,7 @@ def _manifest_document(path: Path) -> tuple[dict[str, Any], bytes]:
         document, raw = _load_json_object(path, MAX_MANIFEST_BYTES)
     else:
         document, raw = snapshot.json_object(), snapshot.raw
-    if (
-        not is_bundle_manifest(document)
-        or not isinstance(document.get("run_id"), str)
-        or not isinstance(document.get("artifacts"), list)
-    ):
-        raise BundleCatalogError(f"invalid RepoGround bundle manifest: {path}")
-    return document, raw
+    return _validate_manifest_document(path, document, raw)
 
 
 def _safe_child(root: Path, raw_path: Any) -> Path | None:
@@ -256,7 +667,7 @@ def _health_binding_issue(
         return "post_emit_health manifest path expectation is missing"
     binding_status, binding_detail = post_health_binding_status(
         document,
-        resolved_manifest=resolve_manifest_path(expected_manifest_path),
+        resolved_manifest=expected_manifest_path,
         manifest_run_id=expected_manifest_run_id,
         manifest_sha256=expected_manifest_sha256,
     )
@@ -320,6 +731,7 @@ def _health_json_status(
     expected_manifest_run_id: Any = None,
     expected_manifest_sha256: str | None = None,
     require_manifest_binding: bool = False,
+    read_root: Path | None = None,
 ) -> tuple[str, str | None]:
     issue = _health_metadata_issue(
         expected_sha256=expected_sha256,
@@ -329,7 +741,12 @@ def _health_json_status(
     if issue is not None:
         return "invalid", issue
     try:
-        document, raw = _load_json_object(path, MAX_HEALTH_BYTES)
+        document, raw = _load_json_object(
+            path,
+            MAX_HEALTH_BYTES,
+            root=read_root,
+            label="bundle artifact",
+        )
     except BundleCatalogError as exc:
         return "invalid", str(exc)
     return _health_document_status(
@@ -351,6 +768,7 @@ def _post_health_issue(
     *,
     manifest_sha256: str,
     post_health_source: tuple[Path, Mapping[str, Any], bytes] | None,
+    read_root: Path | None,
 ) -> str | None:
     links = document.get("links") if isinstance(document.get("links"), Mapping) else {}
     post_path = _safe_child(path.parent, links.get("post_emit_health_path"))
@@ -363,6 +781,7 @@ def _post_health_issue(
             expected_manifest_run_id=document.get("run_id"),
             expected_manifest_sha256=manifest_sha256,
             require_manifest_binding=True,
+            read_root=read_root,
         )
         return None if status == "pass" else reason or "post_emit_health invalid"
 
@@ -386,6 +805,7 @@ def _candidate_health(
     *,
     manifest_sha256: str,
     post_health_source: tuple[Path, Mapping[str, Any], bytes] | None = None,
+    read_root: Path | None = None,
 ) -> tuple[str, list[str]]:
     reasons: list[str] = []
     links = document.get("links") if isinstance(document.get("links"), Mapping) else {}
@@ -421,6 +841,7 @@ def _candidate_health(
                 expected_sha256=output_health.get("sha256"),
                 expected_bytes=output_health.get("bytes"),
                 require_integrity=True,
+                read_root=read_root,
             )
             if status != "pass":
                 reasons.append(reason or "output_health invalid")
@@ -430,6 +851,7 @@ def _candidate_health(
         document,
         manifest_sha256=manifest_sha256,
         post_health_source=post_health_source,
+        read_root=read_root,
     )
     if post_issue is not None:
         reasons.append(post_issue)
@@ -527,31 +949,59 @@ def _manifest_paths(root: Path) -> list[Path]:
     if root.is_file():
         return [root]
     if not root.is_dir():
-        return []
+        return (
+            [root]
+            if root.name.endswith(MANIFEST_SUFFIX)
+            and (root.exists() or root.is_symlink())
+            else []
+        )
     paths: list[Path] = []
     for path in root.rglob(f"*{MANIFEST_SUFFIX}"):
-        if not path.is_file():
-            continue
         relative = path.relative_to(root)
         if any(part.startswith(".") for part in relative.parts[:-1]):
             continue
-        paths.append(path.resolve())
+        paths.append(path)
         if len(paths) > MAX_DISCOVERED_MANIFESTS:
             raise BundleCatalogError(
                 f"bundle discovery exceeded {MAX_DISCOVERED_MANIFESTS} manifests"
             )
-    return sorted(set(paths))
+    return sorted(paths)
 
 
 def discover_bundle_catalog(bundle_root: str | Path) -> dict[str, Any]:
-    root = Path(bundle_root).expanduser().resolve()
+    selected_root = _absolute_path(Path(bundle_root))
+    root = selected_root.resolve()
+    if selected_root.is_dir():
+        discovery_root = root
+        read_root = root
+    else:
+        discovery_root = selected_root
+        read_root = selected_root.parent.resolve()
     candidates: list[dict[str, Any]] = []
     rejected: list[dict[str, str]] = []
-    for path in _manifest_paths(root):
+    seen_resolved_paths: set[Path] = set()
+    for selected_path in _manifest_paths(discovery_root):
         try:
-            document, raw = _manifest_document(path)
+            stable_read = _read_bounded_stable(
+                selected_path,
+                MAX_MANIFEST_BYTES,
+                root=read_root,
+                label="bundle manifest candidate",
+            )
+            path = stable_read.resolved_path
+            if path in seen_resolved_paths:
+                continue
+            seen_resolved_paths.add(path)
+            document = _decode_json_object(path, stable_read.raw)
+            document, raw = _validate_manifest_document(
+                path,
+                document,
+                stable_read.raw,
+            )
         except BundleCatalogError as exc:
-            rejected.append({"manifest_path": str(path), "reason": str(exc)})
+            rejected.append(
+                {"manifest_path": str(selected_path), "reason": str(exc)}
+            )
             continue
         try:
             created_at_utc = _normalized_created_at(document.get("created_at"))
@@ -562,8 +1012,24 @@ def discover_bundle_catalog(bundle_root: str | Path) -> dict[str, Any]:
             timestamp_status = "invalid"
             timestamp_reason = str(exc)
         health_status, health_reasons = _candidate_health(
-            path, document, manifest_sha256=_sha256_bytes(raw)
+            path,
+            document,
+            manifest_sha256=_sha256_bytes(raw),
+            read_root=read_root,
         )
+        try:
+            _assert_stable_read_path(
+                selected_path=stable_read.selected_path,
+                resolved_path=stable_read.resolved_path,
+                identity=stable_read.identity,
+                root=read_root,
+                label="bundle manifest candidate",
+            )
+        except BundleCatalogError as exc:
+            rejected.append(
+                {"manifest_path": str(selected_path), "reason": str(exc)}
+            )
+            continue
         candidates.append(
             {
                 "stem": path.name[: -len(MANIFEST_SUFFIX)],

--- a/merger/repoground/core/bundle_catalog.py
+++ b/merger/repoground/core/bundle_catalog.py
@@ -1,0 +1,391 @@
+"""Bounded, fail-closed discovery of existing RepoGround bundle publications.
+
+The catalog is read-only. It never refreshes a snapshot or mutates a publication.
+Historical runs may coexist; selection is deterministic only when one newest,
+healthy bundle matches the requested repository identity and optional stem.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Any, Mapping
+
+from merger.repoground.core.bundle_identity import is_bundle_manifest
+
+KIND = "repoground.bundle_catalog"
+VERSION = "v1"
+MANIFEST_SUFFIX = ".bundle.manifest.json"
+MAX_MANIFEST_BYTES = 4 * 1024 * 1024
+MAX_HEALTH_BYTES = 4 * 1024 * 1024
+MAX_DISCOVERED_MANIFESTS = 2000
+_SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
+_GITHUB_SCP_RE = re.compile(r"^[^@]+@github\.com:(?P<slug>[^/]+/[^/]+?)(?:\.git)?$")
+_GITHUB_URL_RE = re.compile(
+    r"^(?:https?|ssh)://(?:[^@/]+@)?github\.com/(?P<slug>[^/]+/[^/]+?)(?:\.git)?/?$"
+)
+
+DOES_NOT_ESTABLISH = [
+    "freshness_against_remote",
+    "runtime_correctness",
+    "repo_understood",
+    "claims_true",
+    "merge_readiness",
+]
+
+
+class BundleCatalogError(ValueError):
+    """Raised when discovery or selection cannot remain deterministic."""
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _read_bounded(path: Path, max_bytes: int) -> bytes:
+    try:
+        with path.open("rb") as handle:
+            data = handle.read(max_bytes + 1)
+    except OSError as exc:
+        raise BundleCatalogError(f"file cannot be read: {path}") from exc
+    if len(data) > max_bytes:
+        raise BundleCatalogError(f"file exceeds bounded catalog read: {path}")
+    return data
+
+
+def _load_json_object(path: Path, max_bytes: int) -> tuple[dict[str, Any], bytes]:
+    raw = _read_bounded(path, max_bytes)
+    try:
+        value = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise BundleCatalogError(f"file is not valid UTF-8 JSON: {path}") from exc
+    if not isinstance(value, dict):
+        raise BundleCatalogError(f"JSON document must be an object: {path}")
+    return value, raw
+
+
+def _manifest_document(path: Path) -> tuple[dict[str, Any], bytes]:
+    document, raw = _load_json_object(path, MAX_MANIFEST_BYTES)
+    if (
+        not is_bundle_manifest(document)
+        or not isinstance(document.get("run_id"), str)
+        or not isinstance(document.get("artifacts"), list)
+    ):
+        raise BundleCatalogError(f"invalid RepoGround bundle manifest: {path}")
+    return document, raw
+
+
+def _safe_child(root: Path, raw_path: Any) -> Path | None:
+    if not isinstance(raw_path, str) or not raw_path:
+        return None
+    candidate = (root / raw_path).resolve()
+    try:
+        candidate.relative_to(root.resolve())
+    except ValueError:
+        return None
+    return candidate
+
+
+def normalize_repo_remote(value: Any) -> str | None:
+    """Return a stable owner/repository identity for common GitHub remotes."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    remote = value.strip()
+    match = _GITHUB_SCP_RE.fullmatch(remote) or _GITHUB_URL_RE.fullmatch(remote)
+    if match:
+        return match.group("slug").removesuffix(".git").strip("/").casefold()
+    trimmed = remote.removesuffix(".git").rstrip("/")
+    if "/" in trimmed:
+        parts = [part for part in trimmed.replace(":", "/").split("/") if part]
+        if len(parts) >= 2:
+            return "/".join(parts[-2:]).casefold()
+    return None
+
+
+def _canonical_name_aliases(name: Any) -> set[str]:
+    if not isinstance(name, str) or not name.strip():
+        return set()
+    raw = name.strip()
+    aliases = {raw.casefold()}
+    parts = raw.split("__")
+    if len(parts) >= 3 and parts[0] and parts[1]:
+        owner_repo = f"{parts[0]}/{parts[1]}".casefold()
+        aliases.update(
+            {owner_repo, f"{parts[0]}__{parts[1]}".casefold(), parts[1].casefold()}
+        )
+    else:
+        aliases.add(Path(raw).name.casefold())
+    return aliases
+
+
+def manifest_repo_aliases(document: Mapping[str, Any]) -> list[str]:
+    aliases: set[str] = set()
+    provenance = document.get("snapshot_provenance")
+    repositories = (
+        provenance.get("repositories") if isinstance(provenance, Mapping) else None
+    )
+    for record in repositories if isinstance(repositories, list) else []:
+        if not isinstance(record, Mapping):
+            continue
+        aliases.update(_canonical_name_aliases(record.get("name")))
+        aliases.update(_canonical_name_aliases(record.get("repo")))
+        remote = normalize_repo_remote(record.get("repo_remote"))
+        if remote:
+            aliases.add(remote)
+            owner, repo = remote.split("/", 1)
+            aliases.update({f"{owner}__{repo}", repo})
+    return sorted(aliases)
+
+
+def _health_json_status(
+    path: Path, *, expected_sha256: Any = None, expected_bytes: Any = None
+) -> tuple[str, str | None]:
+    try:
+        document, raw = _load_json_object(path, MAX_HEALTH_BYTES)
+    except BundleCatalogError as exc:
+        return "invalid", str(exc)
+    if isinstance(expected_bytes, int) and len(raw) != expected_bytes:
+        return "invalid", "health artifact byte size does not match manifest"
+    if isinstance(expected_sha256, str) and _SHA256_RE.fullmatch(expected_sha256):
+        if _sha256_bytes(raw) != expected_sha256:
+            return "invalid", "health artifact sha256 does not match manifest"
+    status = document.get("status") or document.get("verdict")
+    if status == "pass":
+        return "pass", None
+    return "invalid", f"health status is {status!r}, expected 'pass'"
+
+
+def _candidate_health(path: Path, document: Mapping[str, Any]) -> tuple[str, list[str]]:
+    reasons: list[str] = []
+    links = document.get("links") if isinstance(document.get("links"), Mapping) else {}
+    for key in (
+        "agent_export_gate_status",
+        "bundle_surface_validation_status",
+        "export_safety_report_status",
+    ):
+        value = links.get(key)
+        if value is not None and value != "pass":
+            reasons.append(f"{key}={value!r}")
+
+    artifacts = (
+        document.get("artifacts") if isinstance(document.get("artifacts"), list) else []
+    )
+    output_health = next(
+        (
+            item
+            for item in artifacts
+            if isinstance(item, Mapping) and item.get("role") == "output_health"
+        ),
+        None,
+    )
+    if not isinstance(output_health, Mapping):
+        reasons.append("output_health artifact missing")
+    else:
+        output_path = _safe_child(path.parent, output_health.get("path"))
+        if output_path is None:
+            reasons.append("output_health path invalid")
+        else:
+            status, reason = _health_json_status(
+                output_path,
+                expected_sha256=output_health.get("sha256"),
+                expected_bytes=output_health.get("bytes"),
+            )
+            if status != "pass":
+                reasons.append(reason or "output_health invalid")
+
+    post_path = _safe_child(path.parent, links.get("post_emit_health_path"))
+    if post_path is None:
+        reasons.append("post_emit_health path missing or invalid")
+    else:
+        status, reason = _health_json_status(post_path)
+        if status != "pass":
+            reasons.append(reason or "post_emit_health invalid")
+
+    return ("pass", []) if not reasons else ("invalid", reasons)
+
+
+def _manifest_paths(root: Path) -> list[Path]:
+    if root.is_file():
+        return [root]
+    if not root.is_dir():
+        return []
+    paths: list[Path] = []
+    for path in root.rglob(f"*{MANIFEST_SUFFIX}"):
+        if not path.is_file():
+            continue
+        relative = path.relative_to(root)
+        if any(part.startswith(".") for part in relative.parts[:-1]):
+            continue
+        paths.append(path.resolve())
+        if len(paths) > MAX_DISCOVERED_MANIFESTS:
+            raise BundleCatalogError(
+                f"bundle discovery exceeded {MAX_DISCOVERED_MANIFESTS} manifests"
+            )
+    return sorted(set(paths))
+
+
+def discover_bundle_catalog(bundle_root: str | Path) -> dict[str, Any]:
+    root = Path(bundle_root).expanduser().resolve()
+    candidates: list[dict[str, Any]] = []
+    rejected: list[dict[str, str]] = []
+    for path in _manifest_paths(root):
+        try:
+            document, raw = _manifest_document(path)
+        except BundleCatalogError as exc:
+            rejected.append({"manifest_path": str(path), "reason": str(exc)})
+            continue
+        health_status, health_reasons = _candidate_health(path, document)
+        candidates.append(
+            {
+                "stem": path.name[: -len(MANIFEST_SUFFIX)],
+                "manifest_path": str(path),
+                "manifest_sha256": _sha256_bytes(raw),
+                "run_id": document.get("run_id"),
+                "created_at": document.get("created_at"),
+                "repo_aliases": manifest_repo_aliases(document),
+                "health_status": health_status,
+                "health_reasons": health_reasons,
+                "selection_eligible": health_status == "pass",
+            }
+        )
+    return {
+        "kind": KIND,
+        "version": VERSION,
+        "status": "available" if candidates else "missing",
+        "bundle_root": str(root),
+        "candidate_count": len(candidates),
+        "candidates": candidates,
+        "rejected_count": len(rejected),
+        "rejected": rejected[:50],
+        "mutation_boundary": {"writes": [], "read_paths_do_not_refresh": True},
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }
+
+
+def _normalized_requested_repo(repo: Any) -> str | None:
+    if repo is None:
+        return None
+    if not isinstance(repo, str) or not repo.strip():
+        raise BundleCatalogError("repo must be null or a non-empty repository identity")
+    return normalize_repo_remote(repo) or repo.strip().casefold()
+
+
+def select_bundle_manifest(
+    bundle_root: str | Path,
+    *,
+    repo: str | None = None,
+    stem: str | None = None,
+    require_healthy: bool = True,
+) -> dict[str, Any]:
+    catalog = discover_bundle_catalog(bundle_root)
+    requested_repo = _normalized_requested_repo(repo)
+    if stem is not None and (not isinstance(stem, str) or not stem.strip()):
+        raise BundleCatalogError("stem must be null or a non-empty string")
+
+    matches = []
+    for candidate in catalog["candidates"]:
+        if stem is not None and candidate["stem"] != stem:
+            continue
+        if (
+            requested_repo is not None
+            and requested_repo not in candidate["repo_aliases"]
+        ):
+            continue
+        if require_healthy and not candidate["selection_eligible"]:
+            continue
+        matches.append(candidate)
+    if not matches:
+        return {
+            "kind": "repoground.bundle_selection",
+            "version": VERSION,
+            "status": "missing",
+            "bundle_root": catalog["bundle_root"],
+            "requested_repo": requested_repo,
+            "requested_stem": stem,
+            "selected": None,
+            "reason": "no_matching_healthy_bundle"
+            if require_healthy
+            else "no_matching_bundle",
+            "candidate_count": catalog["candidate_count"],
+            "does_not_establish": list(DOES_NOT_ESTABLISH),
+        }
+
+    matches.sort(
+        key=lambda item: (
+            str(item.get("created_at") or ""),
+            str(item.get("run_id") or ""),
+            str(item["manifest_path"]),
+        ),
+        reverse=True,
+    )
+    newest_key = (
+        str(matches[0].get("created_at") or ""),
+        str(matches[0].get("run_id") or ""),
+    )
+    tied = [
+        item
+        for item in matches
+        if (str(item.get("created_at") or ""), str(item.get("run_id") or ""))
+        == newest_key
+    ]
+    if len(tied) != 1:
+        return {
+            "kind": "repoground.bundle_selection",
+            "version": VERSION,
+            "status": "ambiguous",
+            "bundle_root": catalog["bundle_root"],
+            "requested_repo": requested_repo,
+            "requested_stem": stem,
+            "selected": None,
+            "reason": "newest_bundle_identity_ambiguous",
+            "matches": tied,
+            "does_not_establish": list(DOES_NOT_ESTABLISH),
+        }
+    return {
+        "kind": "repoground.bundle_selection",
+        "version": VERSION,
+        "status": "available",
+        "bundle_root": catalog["bundle_root"],
+        "requested_repo": requested_repo,
+        "requested_stem": stem,
+        "selected": matches[0],
+        "match_count": len(matches),
+        "selection_policy": "newest_healthy_by_created_at_then_run_id",
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }
+
+
+def checkout_repo_identity(repo_root: str | Path) -> str:
+    """Derive owner/repository from the configured origin without network access."""
+    root = Path(repo_root).expanduser().resolve()
+    env = os.environ.copy()
+    env.update(
+        {
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_OPTIONAL_LOCKS": "0",
+            "GIT_TERMINAL_PROMPT": "0",
+        }
+    )
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(root), "config", "--get", "remote.origin.url"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+            env=env,
+        )
+    except (OSError, subprocess.SubprocessError):
+        completed = None
+    if completed is not None and completed.returncode == 0:
+        identity = normalize_repo_remote(completed.stdout.strip())
+        if identity:
+            return identity
+    if root.name:
+        return root.name.casefold()
+    raise BundleCatalogError("repository identity could not be derived")

--- a/merger/repoground/core/forensic_preflight.py
+++ b/merger/repoground/core/forensic_preflight.py
@@ -15,6 +15,7 @@ from .claim_evidence_diagnostics import (
 )
 from .path_security import resolve_secure_path
 from .post_emit_health import derive_post_health_path
+from .post_health_binding import post_health_binding_status
 
 try:
     import jsonschema
@@ -121,75 +122,6 @@ def _validate_claim_map_schema(claim_map_doc: Dict[str, Any]) -> Tuple[str, str]
     except jsonschema.ValidationError as e:  # type: ignore[union-attr]
         return "fail", f"claim_evidence_map schema invalid: {e.message}"
     return "pass", "claim_evidence_map schema valid"
-
-
-def _is_lower_sha256(value: Any) -> bool:
-    return (
-        isinstance(value, str)
-        and len(value) == _SHA256_LEN
-        and all(char in "0123456789abcdef" for char in value)
-    )
-
-
-def _post_health_hash_binding_status(
-    post_doc: Dict[str, Any],
-    manifest_sha256: Optional[str],
-) -> Tuple[str, str, bool]:
-    declared_sha256 = post_doc.get("bundle_manifest_sha256")
-    if declared_sha256 is None:
-        return "pass", "post_emit_health has no manifest hash binding", False
-    if not _is_lower_sha256(declared_sha256):
-        return "fail", "post_emit_health bundle_manifest_sha256 is invalid", True
-    if manifest_sha256 is None:
-        return (
-            "blocked",
-            "requested manifest could not be hashed for post_emit_health binding",
-            True,
-        )
-    if declared_sha256 != manifest_sha256:
-        return (
-            "fail",
-            "post_emit_health bundle_manifest_sha256 does not match requested manifest",
-            True,
-        )
-    return "pass", "post_emit_health hash matches requested manifest", True
-
-
-def _post_health_binding_status(
-    post_doc: Dict[str, Any],
-    *,
-    resolved_manifest: Path,
-    manifest_run_id: Any,
-    manifest_sha256: Optional[str],
-) -> Tuple[str, str]:
-    post_manifest_path = post_doc.get("bundle_manifest_path")
-    if not isinstance(post_manifest_path, str) or not post_manifest_path:
-        return "blocked", "post_emit_health missing bundle_manifest_path binding"
-    hash_status, hash_detail, hash_bound = _post_health_hash_binding_status(
-        post_doc, manifest_sha256
-    )
-    if hash_status != "pass":
-        return hash_status, hash_detail
-    path_bound = _resolve(post_manifest_path) == resolved_manifest
-    if not path_bound and not hash_bound:
-        return (
-            "fail",
-            "post_emit_health bundle_manifest_path does not match requested manifest",
-        )
-    if isinstance(manifest_run_id, str):
-        post_bundle_run_id = post_doc.get("bundle_run_id")
-        if not isinstance(post_bundle_run_id, str) or not post_bundle_run_id:
-            return "blocked", "post_emit_health missing bundle_run_id binding"
-        if post_bundle_run_id != manifest_run_id:
-            return "fail", "post_emit_health bundle_run_id does not match manifest run_id"
-    if path_bound and hash_bound:
-        return (
-            "pass",
-            "post_emit_health path-bound and hash-verified against requested manifest",
-        )
-    if path_bound:
-        return "pass", "post_emit_health path-bound to requested manifest"
-    return "pass", "post_emit_health hash-bound to requested manifest bytes"
 
 
 def compute_forensic_preflight(
@@ -322,7 +254,7 @@ def compute_forensic_preflight(
         errors.append(f"post_emit_health missing: {post_err}")
     else:
         checks.append(_check("post_emit_health_present", "pass", "post_emit_health loaded"))
-        binding_status, binding_detail = _post_health_binding_status(
+        binding_status, binding_detail = post_health_binding_status(
             post_doc,
             resolved_manifest=resolved_manifest,
             manifest_run_id=manifest.get("run_id"),

--- a/merger/repoground/core/live_freshness.py
+++ b/merger/repoground/core/live_freshness.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from .bundle_identity import is_bundle_manifest
 from .bundle_catalog import normalize_repo_remote
+from .manifest_snapshot import active_manifest_snapshot, resolve_manifest_path
 
 import json
 import os
@@ -31,6 +32,9 @@ Probe = Callable[[str | Path], dict[str, Any]]
 
 
 def _load_manifest(path: Path) -> dict[str, Any]:
+    snapshot = active_manifest_snapshot(path)
+    if snapshot is not None:
+        return snapshot.json_object()
     try:
         with path.open("rb") as handle:
             raw = handle.read(MAX_MANIFEST_BYTES + 1)
@@ -293,7 +297,7 @@ def evaluate_live_freshness(
     probe: Probe = repository_live_provenance,
 ) -> dict[str, Any]:
     """Compare snapshot provenance with one explicitly authorized local checkout."""
-    manifest_path = Path(bundle_manifest).expanduser().resolve()
+    manifest_path = resolve_manifest_path(bundle_manifest)
     records = _repository_records(_load_manifest(manifest_path))
     if repo_root is None:
         return _base(

--- a/merger/repoground/core/live_freshness.py
+++ b/merger/repoground/core/live_freshness.py
@@ -1,7 +1,9 @@
 """Compare a RepoGround snapshot with one explicit local Git working tree."""
+
 from __future__ import annotations
 
 from .bundle_identity import is_bundle_manifest
+from .bundle_catalog import normalize_repo_remote
 
 import json
 import os
@@ -133,6 +135,7 @@ def repository_live_provenance(repo_root: str | Path) -> dict[str, Any]:
         return base
 
     branch, _branch_error = _git(root, "symbolic-ref", "--short", "-q", "HEAD")
+    remote, _remote_error = _git(root, "config", "--get", "remote.origin.url")
     status, status_error = _git(
         root,
         "status",
@@ -144,6 +147,7 @@ def repository_live_provenance(repo_root: str | Path) -> dict[str, Any]:
             "git_commit": commit,
             "git_dirty": None if status_error is not None else bool(status),
             "git_branch": branch or None,
+            "repo_remote": remote or None,
             "provenance_status": "present",
             "freshness_basis": "git_commit_and_working_tree",
         }
@@ -153,7 +157,9 @@ def repository_live_provenance(repo_root: str | Path) -> dict[str, Any]:
 
 def _repository_records(manifest: Mapping[str, Any]) -> list[dict[str, Any]]:
     provenance = manifest.get("snapshot_provenance")
-    repositories = provenance.get("repositories") if isinstance(provenance, dict) else None
+    repositories = (
+        provenance.get("repositories") if isinstance(provenance, dict) else None
+    )
     if not isinstance(repositories, list):
         return []
     return [record for record in repositories if isinstance(record, dict)]
@@ -162,11 +168,25 @@ def _repository_records(manifest: Mapping[str, Any]) -> list[dict[str, Any]]:
 def _record_for_repo(
     records: list[dict[str, Any]],
     repo_root: Path,
+    current: Mapping[str, Any],
 ) -> dict[str, Any] | None:
     resolved = str(repo_root.resolve())
     exact = [record for record in records if record.get("repo_root") == resolved]
     if len(exact) == 1:
         return exact[0]
+
+    current_remote = normalize_repo_remote(current.get("repo_remote"))
+    if current_remote:
+        remote_matches = [
+            record
+            for record in records
+            if normalize_repo_remote(record.get("repo_remote")) == current_remote
+        ]
+        if len(remote_matches) == 1:
+            return remote_matches[0]
+        if len(remote_matches) > 1:
+            return None
+
     named = [record for record in records if record.get("name") == repo_root.name]
     if len(named) == 1 and not named[0].get("repo_root"):
         return named[0]
@@ -285,9 +305,17 @@ def evaluate_live_freshness(
         )
 
     explicit_root = Path(repo_root).expanduser().resolve()
-    snapshot = _record_for_repo(records, explicit_root)
+    current: Mapping[str, Any] | None = None
+    snapshot = _record_for_repo(records, explicit_root, {})
     if snapshot is None:
-        reason = "snapshot_provenance_missing" if not records else "repository_selection_ambiguous"
+        current = probe(explicit_root)
+        snapshot = _record_for_repo(records, explicit_root, current)
+    if snapshot is None:
+        reason = (
+            "snapshot_provenance_missing"
+            if not records
+            else "repository_selection_ambiguous"
+        )
         return _base(
             status="unknown",
             reason=reason,
@@ -303,7 +331,8 @@ def evaluate_live_freshness(
     if blocked is not None:
         return blocked
 
-    current = probe(explicit_root)
+    if current is None:
+        current = probe(explicit_root)
     blocked = _current_gate(
         current,
         manifest_path=manifest_path,

--- a/merger/repoground/core/manifest_snapshot.py
+++ b/merger/repoground/core/manifest_snapshot.py
@@ -1,0 +1,265 @@
+"""Stable, request-scoped bindings for one RepoGround bundle manifest."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import stat
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterator
+
+from merger.repoground.core.bundle_identity import is_bundle_manifest
+
+MAX_MANIFEST_BYTES = 4 * 1024 * 1024
+_SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
+
+
+class ManifestBindingError(ValueError):
+    """Raised when a manifest cannot satisfy its selected byte identity."""
+
+
+@dataclass(frozen=True, slots=True)
+class ManifestBinding:
+    # This deliberately retains a final symlink instead of collapsing it into
+    # the separately stored file target.
+    selected_path: Path
+    resolved_path: Path
+    sha256: str
+    run_id: str
+
+    @property
+    def path(self) -> Path:
+        """Compatibility alias for the selected absolute path identity."""
+        return self.selected_path
+
+
+@dataclass(frozen=True, slots=True)
+class ManifestSnapshot:
+    binding: ManifestBinding
+    raw: bytes
+    file_identity: tuple[int, int, int, int, int, int]
+
+    @property
+    def path(self) -> Path:
+        return self.binding.selected_path
+
+    @property
+    def selected_path(self) -> Path:
+        return self.binding.selected_path
+
+    @property
+    def resolved_path(self) -> Path:
+        return self.binding.resolved_path
+
+    def json_object(self) -> dict[str, Any]:
+        value = json.loads(self.raw.decode("utf-8"))
+        if not isinstance(value, dict):  # pragma: no cover - capture validates this
+            raise ManifestBindingError("bundle manifest must be a JSON object")
+        return value
+
+
+_ACTIVE_MANIFEST_SNAPSHOT: ContextVar[ManifestSnapshot | None] = ContextVar(
+    "repoground_active_manifest_snapshot",
+    default=None,
+)
+
+
+def _file_identity(value: Any) -> tuple[int, int, int, int, int, int]:
+    return (
+        int(value.st_dev),
+        int(value.st_ino),
+        int(value.st_mode),
+        int(value.st_size),
+        int(value.st_mtime_ns),
+        int(value.st_ctime_ns),
+    )
+
+
+def _decode_manifest(raw: bytes) -> dict[str, Any]:
+    try:
+        value = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ManifestBindingError("bundle manifest is not valid UTF-8 JSON") from exc
+    if not isinstance(value, dict):
+        raise ManifestBindingError("bundle manifest must be a JSON object")
+    if (
+        not is_bundle_manifest(value)
+        or not isinstance(value.get("run_id"), str)
+        or not value["run_id"]
+        or not isinstance(value.get("artifacts"), list)
+    ):
+        raise ManifestBindingError(
+            "bundle manifest does not have RepoGround manifest shape"
+        )
+    return value
+
+
+def manifest_path_identity(path: str | Path) -> Path:
+    """Return an absolute lexical path identity without following symlinks."""
+    return Path(os.path.abspath(Path(path).expanduser()))
+
+
+def _validate_expected_binding(
+    expected: ManifestBinding | None,
+    selected_path: Path,
+    resolved_path: Path,
+) -> None:
+    if expected is None:
+        return
+    if expected.selected_path != selected_path:
+        raise ManifestBindingError("selected bundle manifest path changed")
+    if expected.resolved_path != resolved_path:
+        raise ManifestBindingError("selected bundle manifest file target changed")
+    if not _SHA256_RE.fullmatch(expected.sha256):
+        raise ManifestBindingError("selected bundle manifest digest is invalid")
+    if not expected.run_id:
+        raise ManifestBindingError("selected bundle manifest run_id is invalid")
+
+
+def _read_stable_manifest(
+    path: Path,
+    max_bytes: int,
+) -> tuple[bytes, tuple[int, int, int, int, int, int]]:
+    try:
+        with path.open("rb") as handle:
+            descriptor = handle.fileno()
+            stat_before = os.fstat(descriptor)
+            if not stat.S_ISREG(stat_before.st_mode):
+                raise ManifestBindingError(
+                    "selected bundle manifest is not a regular file"
+                )
+            raw = handle.read(max_bytes + 1)
+            stat_after = os.fstat(descriptor)
+    except ManifestBindingError:
+        raise
+    except OSError as exc:
+        raise ManifestBindingError("selected bundle manifest is unavailable") from exc
+    if len(raw) > max_bytes:
+        raise ManifestBindingError(
+            "selected bundle manifest exceeds the bounded read limit"
+        )
+    identity = _file_identity(stat_before)
+    if identity != _file_identity(stat_after):
+        raise ManifestBindingError(
+            "selected bundle manifest changed while it was being read"
+        )
+    try:
+        current = path.stat()
+    except OSError as exc:
+        raise ManifestBindingError(
+            "selected bundle manifest changed while it was being read"
+        ) from exc
+    if identity != _file_identity(current):
+        raise ManifestBindingError(
+            "selected bundle manifest changed while it was being read"
+        )
+    return raw, identity
+
+
+def _build_manifest_binding(
+    expected: ManifestBinding | None,
+    *,
+    selected_path: Path,
+    resolved_path: Path,
+    raw: bytes,
+    document: dict[str, Any],
+) -> ManifestBinding:
+    actual_sha256 = hashlib.sha256(raw).hexdigest()
+    actual_run_id = document["run_id"]
+    if expected is None:
+        return ManifestBinding(
+            selected_path=selected_path,
+            resolved_path=resolved_path,
+            sha256=actual_sha256,
+            run_id=actual_run_id,
+        )
+    if actual_sha256 != expected.sha256:
+        raise ManifestBindingError(
+            "selected bundle manifest bytes do not match the selected digest"
+        )
+    if actual_run_id != expected.run_id:
+        raise ManifestBindingError(
+            "selected bundle manifest run_id does not match the selection"
+        )
+    return expected
+
+
+def capture_manifest_snapshot(
+    source: str | Path | ManifestBinding,
+    *,
+    selected_path: str | Path | None = None,
+    max_bytes: int = MAX_MANIFEST_BYTES,
+) -> ManifestSnapshot:
+    """Read one stable descriptor and validate its path, digest and run identity."""
+    expected = source if isinstance(source, ManifestBinding) else None
+    if expected is None:
+        source_path = manifest_path_identity(source)
+        selected = manifest_path_identity(
+            source if selected_path is None else selected_path
+        )
+        resolved = source_path.resolve()
+    else:
+        if selected_path is not None:
+            raise ManifestBindingError(
+                "selected_path cannot override an existing manifest binding"
+            )
+        selected = manifest_path_identity(expected.selected_path)
+        # Never resolve the selected path again. A request binding owns the
+        # originally resolved file target even if its selected symlink moves.
+        resolved = manifest_path_identity(expected.resolved_path)
+    _validate_expected_binding(expected, selected, resolved)
+    raw, identity = _read_stable_manifest(resolved, max_bytes)
+    document = _decode_manifest(raw)
+    binding = _build_manifest_binding(
+        expected,
+        selected_path=selected,
+        resolved_path=resolved,
+        raw=raw,
+        document=document,
+    )
+    return ManifestSnapshot(binding=binding, raw=raw, file_identity=identity)
+
+
+def active_manifest_snapshot(
+    path: str | Path,
+) -> ManifestSnapshot | None:
+    snapshot = _ACTIVE_MANIFEST_SNAPSHOT.get()
+    if snapshot is None:
+        return None
+    selected = manifest_path_identity(path)
+    if selected in (snapshot.selected_path, snapshot.resolved_path):
+        return snapshot
+    return None
+
+
+def resolve_manifest_path(path: str | Path) -> Path:
+    """Resolve a path without re-following an active selected symlink."""
+    snapshot = active_manifest_snapshot(path)
+    if snapshot is not None:
+        return snapshot.resolved_path
+    return manifest_path_identity(path).resolve()
+
+
+def manifest_snapshot(path: str | Path) -> ManifestSnapshot:
+    return active_manifest_snapshot(path) or capture_manifest_snapshot(path)
+
+
+def manifest_document(path: str | Path) -> dict[str, Any]:
+    return manifest_snapshot(path).json_object()
+
+
+@contextmanager
+def use_manifest_binding(binding: ManifestBinding) -> Iterator[ManifestSnapshot]:
+    """Pin one selected manifest snapshot for every consumer in this context."""
+    snapshot = capture_manifest_snapshot(binding)
+    token = _ACTIVE_MANIFEST_SNAPSHOT.set(snapshot)
+    try:
+        yield snapshot
+        capture_manifest_snapshot(binding)
+    finally:
+        _ACTIVE_MANIFEST_SNAPSHOT.reset(token)

--- a/merger/repoground/core/mcp_resources.py
+++ b/merger/repoground/core/mcp_resources.py
@@ -10,6 +10,7 @@ from typing import Any
 from urllib.parse import unquote, urlparse
 
 from merger.repoground.core import bundle_access
+from merger.repoground.core.bundle_catalog import discover_bundle_catalog
 
 KIND = "repoground.mcp.resource_read"
 LIST_KIND = "repoground.mcp.resource_list"
@@ -133,7 +134,9 @@ def _decode_json_bytes(
 
 def _bundle_manifest_validation_issue(path: Path) -> dict[str, Any] | None:
     if not path.is_file() or not path.name.endswith(MANIFEST_SUFFIX):
-        return _bytes_issue("blocked", "bundle root is not a RepoLens bundle manifest file")
+        return _bytes_issue(
+            "blocked", "bundle root is not a RepoGround bundle manifest file"
+        )
     data, issue = _read_bounded_bytes(
         path,
         max_bytes=MAX_MANIFEST_BYTES,
@@ -157,7 +160,9 @@ def _bundle_manifest_validation_issue(path: Path) -> dict[str, Any] | None:
         or not isinstance(parsed.get("run_id"), str)
         or not isinstance(parsed.get("artifacts"), list)
     ):
-        return _bytes_issue("blocked", "bundle root is not a valid RepoLens bundle manifest")
+        return _bytes_issue(
+            "blocked", "bundle root is not a valid RepoGround bundle manifest"
+        )
     return None
 
 
@@ -171,17 +176,27 @@ def _manifest_candidates(bundle_root: str | Path) -> list[Path]:
         return [root] if _is_bundle_manifest_file(root) else []
     if not root.exists() or not root.is_dir():
         return []
-    return [path for path in sorted(root.glob(f"*{MANIFEST_SUFFIX}")) if _is_bundle_manifest_file(path)]
+    catalog = discover_bundle_catalog(root)
+    paths = [
+        Path(item["manifest_path"])
+        for item in catalog.get("candidates", [])
+        if isinstance(item, dict) and isinstance(item.get("manifest_path"), str)
+    ]
+    return sorted(set(paths))
 
 
 def _find_manifest(bundle_root: str | Path, stem: str) -> Path | None:
-    for path in _manifest_candidates(bundle_root):
-        if _manifest_stem(path) == stem:
-            return path
-    return None
+    matches = [
+        path
+        for path in _manifest_candidates(bundle_root)
+        if _manifest_stem(path) == stem
+    ]
+    return matches[0] if len(matches) == 1 else None
 
 
-def _bundle_root_file_issue(bundle_root: str | Path, stem: str) -> dict[str, Any] | None:
+def _bundle_root_file_issue(
+    bundle_root: str | Path, stem: str
+) -> dict[str, Any] | None:
     root = Path(bundle_root).expanduser().resolve()
     if not root.exists() or not root.is_file():
         return None
@@ -205,16 +220,22 @@ def _resource_uri(stem: str, suffix: str) -> str:
 def _parse_resource_uri(uri: str) -> tuple[str, str, str | None]:
     parsed = urlparse(uri)
     if parsed.scheme != "repoground" or parsed.netloc != "snapshot":
-        raise RepoGroundMcpResourceError("resource URI must start with repoground://snapshot/")
+        raise RepoGroundMcpResourceError(
+            "resource URI must start with repoground://snapshot/"
+        )
     parts = [unquote(part) for part in parsed.path.split("/") if part]
     if len(parts) < 2:
-        raise RepoGroundMcpResourceError("resource URI must include snapshot stem and resource name")
+        raise RepoGroundMcpResourceError(
+            "resource URI must include snapshot stem and resource name"
+        )
     stem, resource_name = parts[0], parts[1]
     if not stem or ".." in stem or "/" in stem:
         raise RepoGroundMcpResourceError("resource stem is invalid")
     if resource_name == "artifact":
         if len(parts) != 3 or not parts[2] or "/" in parts[2] or ".." in parts[2]:
-            raise RepoGroundMcpResourceError("artifact resource URI must include one artifact role")
+            raise RepoGroundMcpResourceError(
+                "artifact resource URI must include one artifact role"
+            )
         return stem, resource_name, parts[2]
     if len(parts) != 2 or resource_name not in FIXED_RESOURCE_KINDS:
         raise RepoGroundMcpResourceError("unsupported RepoGround MCP resource URI")
@@ -225,10 +246,15 @@ def _sha256_bytes(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
-def _artifact_integrity_issue(data: bytes, artifact: dict[str, Any]) -> dict[str, Any] | None:
+def _artifact_integrity_issue(
+    data: bytes, artifact: dict[str, Any]
+) -> dict[str, Any] | None:
     expected_bytes = artifact.get("bytes")
     if not isinstance(expected_bytes, int):
-        return _bytes_issue("integrity_unavailable", "artifact byte size is missing or invalid in manifest")
+        return _bytes_issue(
+            "integrity_unavailable",
+            "artifact byte size is missing or invalid in manifest",
+        )
     actual_bytes = len(data)
     if actual_bytes != expected_bytes:
         return _bytes_issue(
@@ -238,8 +264,12 @@ def _artifact_integrity_issue(data: bytes, artifact: dict[str, Any]) -> dict[str
             actual_bytes=actual_bytes,
         )
     expected_sha256 = artifact.get("sha256")
-    if not isinstance(expected_sha256, str) or not _SHA256_RE.fullmatch(expected_sha256):
-        return _bytes_issue("integrity_unavailable", "artifact sha256 is missing or invalid in manifest")
+    if not isinstance(expected_sha256, str) or not _SHA256_RE.fullmatch(
+        expected_sha256
+    ):
+        return _bytes_issue(
+            "integrity_unavailable", "artifact sha256 is missing or invalid in manifest"
+        )
     expected_sha256_normalized = expected_sha256.lower()
     actual_sha256 = _sha256_bytes(data)
     if actual_sha256 != expected_sha256_normalized:
@@ -280,12 +310,20 @@ def _read_manifest_content(result: dict[str, Any], manifest: Path) -> dict[str, 
     return _apply_artifact_bytes(result, data)
 
 
-def _context_for_manifest(manifest: Path | None, *, reason: str | None = None) -> dict[str, Any]:
+def _context_for_manifest(
+    manifest: Path | None, *, reason: str | None = None
+) -> dict[str, Any]:
     if manifest is None:
         return {
             "health": {"status": "unknown", "reason": reason or "manifest unavailable"},
-            "freshness": {"status": "unknown", "reason": reason or "manifest unavailable"},
-            "availability": {"status": "unknown", "reason": reason or "manifest unavailable"},
+            "freshness": {
+                "status": "unknown",
+                "reason": reason or "manifest unavailable",
+            },
+            "availability": {
+                "status": "unknown",
+                "reason": reason or "manifest unavailable",
+            },
         }
     status = bundle_access.snapshot_status(manifest)
     health = bundle_access.get_artifact(manifest, "post_emit_health")
@@ -296,12 +334,18 @@ def _context_for_manifest(manifest: Path | None, *, reason: str | None = None) -
             "status": health.get("status", "unknown"),
             "artifact": health.get("artifact"),
         },
-        "freshness": freshness if isinstance(freshness, dict) else {"status": "unknown"},
-        "availability": availability_model if isinstance(availability_model, dict) else {"status": "unknown"},
+        "freshness": freshness
+        if isinstance(freshness, dict)
+        else {"status": "unknown"},
+        "availability": availability_model
+        if isinstance(availability_model, dict)
+        else {"status": "unknown"},
     }
 
 
-def _base_result(uri: str, manifest: Path | None, *, status: str, reason: str | None = None) -> dict[str, Any]:
+def _base_result(
+    uri: str, manifest: Path | None, *, status: str, reason: str | None = None
+) -> dict[str, Any]:
     return {
         "kind": KIND,
         "version": VERSION,
@@ -332,17 +376,19 @@ def _safe_bundle_file(manifest: Path, artifact: dict[str, Any]) -> Path | None:
 def _read_artifact_resource(uri: str, manifest: Path, role: str) -> dict[str, Any]:
     if role == "bundle_manifest":
         result = _base_result(uri, manifest, status="available")
-        result.update({
-            "resource_role": "bundle_manifest",
-            "content_type": "application/json",
-            "artifact_ref": {
-                "role": "bundle_manifest",
-                "path": manifest.name,
-                "absolute_path": str(manifest),
-                "file_exists": manifest.is_file(),
-                "bytes": manifest.stat().st_size if manifest.is_file() else None,
-            },
-        })
+        result.update(
+            {
+                "resource_role": "bundle_manifest",
+                "content_type": "application/json",
+                "artifact_ref": {
+                    "role": "bundle_manifest",
+                    "path": manifest.name,
+                    "absolute_path": str(manifest),
+                    "file_exists": manifest.is_file(),
+                    "bytes": manifest.stat().st_size if manifest.is_file() else None,
+                },
+            }
+        )
         return _read_manifest_content(result, manifest)
 
     ref = bundle_access.get_artifact(manifest, role)
@@ -399,23 +445,37 @@ def list_mcp_resources(bundle_root: str | Path) -> dict[str, Any]:
     resources: list[dict[str, Any]] = []
     for manifest in _manifest_candidates(bundle_root):
         stem = _manifest_stem(manifest)
-        for suffix in ("manifest", "canonical", "reading-pack", "health", "availability"):
-            resources.append({"uri": _resource_uri(stem, suffix), "snapshot_stem": stem, "resource": suffix})
+        for suffix in (
+            "manifest",
+            "canonical",
+            "reading-pack",
+            "health",
+            "availability",
+        ):
+            resources.append(
+                {
+                    "uri": _resource_uri(stem, suffix),
+                    "snapshot_stem": stem,
+                    "resource": suffix,
+                }
+            )
         for role in bundle_access.available_roles(manifest):
-            resources.append({
-                "uri": _resource_uri(stem, f"artifact/{role}"),
-                "snapshot_stem": stem,
-                "resource": "artifact",
-                "role": role,
-            })
+            resources.append(
+                {
+                    "uri": _resource_uri(stem, f"artifact/{role}"),
+                    "snapshot_stem": stem,
+                    "resource": "artifact",
+                    "role": role,
+                }
+            )
     return {
         "kind": LIST_KIND,
         "version": VERSION,
         "status": "ok",
         "bundle_root": str(Path(bundle_root).expanduser().resolve()),
-            "resources": resources,
-            "templates": resource_templates()["templates"],
-            "mutation_boundary": _read_only_boundary(),
+        "resources": resources,
+        "templates": resource_templates()["templates"],
+        "mutation_boundary": _read_only_boundary(),
         "does_not_establish": list(DOES_NOT_ESTABLISH),
     }
 
@@ -426,20 +486,32 @@ def read_mcp_resource(uri: str, *, bundle_root: str | Path) -> dict[str, Any]:
     if manifest is None:
         bundle_root_issue = _bundle_root_file_issue(bundle_root, stem)
         if bundle_root_issue is not None:
-            result = _base_result(uri, None, status=bundle_root_issue["status"], reason=bundle_root_issue["reason"])
+            result = _base_result(
+                uri,
+                None,
+                status=bundle_root_issue["status"],
+                reason=bundle_root_issue["reason"],
+            )
             result.update(bundle_root_issue)
             return result
-        return _base_result(uri, None, status="missing", reason=f"snapshot stem not found: {stem}")
+        return _base_result(
+            uri, None, status="missing", reason=f"snapshot stem not found: {stem}"
+        )
     if resource_name == "manifest":
         return _read_artifact_resource(uri, manifest, "bundle_manifest")
     if resource_name == "availability":
         result = _base_result(uri, manifest, status="available")
-        result.update({
-            "resource_role": "availability_model",
-            "content_type": "application/json",
-            "content_json": result["snapshot_context"]["availability"],
-            "content_text": json.dumps(result["snapshot_context"]["availability"], indent=2, sort_keys=True) + "\n",
-        })
+        result.update(
+            {
+                "resource_role": "availability_model",
+                "content_type": "application/json",
+                "content_json": result["snapshot_context"]["availability"],
+                "content_text": json.dumps(
+                    result["snapshot_context"]["availability"], indent=2, sort_keys=True
+                )
+                + "\n",
+            }
+        )
         return result
     if resource_name == "artifact":
         assert role is not None

--- a/merger/repoground/core/mcp_resources.py
+++ b/merger/repoground/core/mcp_resources.py
@@ -11,8 +11,9 @@ from urllib.parse import unquote, urlparse
 
 from merger.repoground.core import bundle_access
 from merger.repoground.core.bundle_catalog import (
+    MAX_HEALTH_BYTES,
     discover_bundle_catalog,
-    inspect_bundle_health,
+    inspect_bundle_health_documents,
 )
 
 KIND = "repoground.mcp.resource_read"
@@ -348,43 +349,101 @@ def _read_manifest_content(result: dict[str, Any], manifest: Path) -> dict[str, 
     return _apply_artifact_bytes(result, data)
 
 
-def _linked_post_health_artifact(
-    manifest: Path,
-) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+def _decode_json_object(data: bytes, *, label: str) -> dict[str, Any]:
     try:
-        document = json.loads(manifest.read_text(encoding="utf-8"))
-    except (OSError, UnicodeError, json.JSONDecodeError):
-        return None, {"status": "invalid", "reasons": ["bundle manifest unreadable"]}
-    links = document.get("links") if isinstance(document, dict) else None
+        value = json.loads(data.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"{label} is not valid UTF-8 JSON") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be a JSON object")
+    return value
+
+
+def _linked_post_health_from_manifest_bytes(
+    manifest: Path,
+    manifest_data: bytes,
+) -> tuple[dict[str, Any] | None, dict[str, Any], bytes | None]:
+    try:
+        document = _decode_json_object(manifest_data, label="bundle manifest")
+    except ValueError as exc:
+        return (
+            None,
+            {
+                "status": "invalid",
+                "health_status": "invalid",
+                "reasons": [str(exc)],
+            },
+            None,
+        )
+    links = document.get("links")
     raw_path = links.get("post_emit_health_path") if isinstance(links, dict) else None
     if not isinstance(raw_path, str) or not raw_path:
-        return None, {"status": "missing", "reasons": ["post_emit_health link missing"]}
+        return (
+            None,
+            {
+                "status": "missing",
+                "health_status": "missing",
+                "reasons": ["post_emit_health link missing"],
+            },
+            None,
+        )
     path = (manifest.parent / raw_path).resolve()
     try:
         path.relative_to(manifest.parent.resolve())
     except ValueError:
-        return None, {
-            "status": "blocked",
-            "reasons": ["post_emit_health path escapes bundle root"],
-        }
-    health = inspect_bundle_health(manifest)
-    if health.get("status") != "available" or not path.is_file():
-        return None, health
+        return (
+            None,
+            {
+                "status": "blocked",
+                "health_status": "blocked",
+                "reasons": ["post_emit_health path escapes bundle root"],
+            },
+            None,
+        )
     data, read_issue = _read_bounded_bytes(
         path,
-        max_bytes=MAX_RESOURCE_BYTES,
+        max_bytes=MAX_HEALTH_BYTES,
         too_large_reason="post_emit_health exceeds MCP resource size limit",
         unavailable_reason="post_emit_health unavailable",
     )
     if read_issue is not None or data is None:
-        return None, {
-            "status": read_issue.get("status", "unknown") if read_issue else "unknown",
-            "reasons": [
-                read_issue.get("reason", "post_emit_health unavailable")
+        return (
+            None,
+            {
+                "status": read_issue.get("status", "unknown")
                 if read_issue
-                else "post_emit_health unavailable"
-            ],
-        }
+                else "unknown",
+                "health_status": "unknown",
+                "reasons": [
+                    read_issue.get("reason", "post_emit_health unavailable")
+                    if read_issue
+                    else "post_emit_health unavailable"
+                ],
+            },
+            None,
+        )
+    try:
+        health_document = _decode_json_object(data, label="post_emit_health")
+    except ValueError as exc:
+        return (
+            None,
+            {
+                "status": "invalid",
+                "health_status": "invalid",
+                "reasons": [str(exc)],
+            },
+            None,
+        )
+    health = inspect_bundle_health_documents(
+        manifest,
+        manifest_document=document,
+        manifest_bytes=manifest_data,
+        post_health_path=path,
+        post_health_document=health_document,
+        post_health_bytes=data,
+    )
+    if health.get("status") != "available" or health.get("health_status") != "pass":
+        return None, health, None
     return (
         {
             "role": "post_emit_health",
@@ -396,11 +455,65 @@ def _linked_post_health_artifact(
             "sha256": _sha256_bytes(data),
             "authority": "diagnostic_signal",
             "canonicality": "diagnostic",
-            "risk_class": "health",
-            "integrity_source": "manifest_binding_revalidated_at_read",
+            "risk_class": "diagnostic",
+            "integrity_source": "exact_returned_bytes_manifest_binding",
         },
         health,
+        data,
     )
+
+
+def _linked_post_health_artifact(
+    manifest: Path,
+) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+    manifest_data, manifest_issue = _read_bounded_bytes(
+        manifest,
+        max_bytes=MAX_MANIFEST_BYTES,
+        too_large_reason="bundle manifest exceeds MCP manifest size limit",
+        unavailable_reason="bundle manifest unavailable",
+    )
+    if manifest_issue is not None or manifest_data is None:
+        return None, {
+            "status": manifest_issue.get("status", "unknown")
+            if manifest_issue
+            else "unknown",
+            "health_status": "unknown",
+            "reasons": [
+                manifest_issue.get("reason", "bundle manifest unavailable")
+                if manifest_issue
+                else "bundle manifest unavailable"
+            ],
+        }
+    artifact, health, _data = _linked_post_health_from_manifest_bytes(
+        manifest,
+        manifest_data,
+    )
+    return artifact, health
+
+
+def _context_from_manifest_document(
+    manifest: Path,
+    document: dict[str, Any],
+    *,
+    health_artifact: dict[str, Any] | None,
+    health_inspection: dict[str, Any],
+) -> dict[str, Any]:
+    from merger.repoground.core.availability import snapshot_availability_model
+
+    availability = snapshot_availability_model(manifest, document)
+    freshness = availability.get("freshness")
+    return {
+        "health": {
+            "status": health_inspection.get("status", "unknown"),
+            "health_status": health_inspection.get("health_status"),
+            "reasons": health_inspection.get("reasons", []),
+            "artifact": health_artifact,
+        },
+        "freshness": freshness
+        if isinstance(freshness, dict)
+        else {"status": "unknown"},
+        "availability": availability,
+    }
 
 
 def _context_for_manifest(
@@ -439,7 +552,12 @@ def _context_for_manifest(
 
 
 def _base_result(
-    uri: str, manifest: Path | None, *, status: str, reason: str | None = None
+    uri: str,
+    manifest: Path | None,
+    *,
+    status: str,
+    reason: str | None = None,
+    snapshot_context: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     return {
         "kind": KIND,
@@ -450,7 +568,9 @@ def _base_result(
         },
         "status": status,
         "bundle_manifest": str(manifest) if manifest else None,
-        "snapshot_context": _context_for_manifest(manifest, reason=reason),
+        "snapshot_context": snapshot_context
+        if snapshot_context is not None
+        else _context_for_manifest(manifest, reason=reason),
         "mutation_boundary": _read_only_boundary(),
         "does_not_establish": list(DOES_NOT_ESTABLISH),
     }
@@ -466,6 +586,105 @@ def _safe_bundle_file(manifest: Path, artifact: dict[str, Any]) -> Path | None:
     except ValueError:
         return None
     return path
+
+
+def _read_health_resource(uri: str, manifest: Path) -> dict[str, Any]:
+    manifest_data, manifest_issue = _read_bounded_bytes(
+        manifest,
+        max_bytes=MAX_MANIFEST_BYTES,
+        too_large_reason="bundle manifest exceeds MCP manifest size limit",
+        unavailable_reason="bundle manifest unavailable",
+    )
+    if manifest_issue is not None or manifest_data is None:
+        reason = (
+            manifest_issue.get("reason", "bundle manifest unavailable")
+            if manifest_issue
+            else "bundle manifest unavailable"
+        )
+        result = _base_result(
+            uri,
+            manifest,
+            status=manifest_issue.get("status", "unknown")
+            if manifest_issue
+            else "unknown",
+            reason=reason,
+            snapshot_context=_context_for_manifest(None, reason=reason),
+        )
+        result.update({"resource_role": "post_emit_health", "artifact_ref": None})
+        result["reason"] = reason
+        return result
+    try:
+        document = _decode_json_object(manifest_data, label="bundle manifest")
+    except ValueError as exc:
+        reason = str(exc)
+        result = _base_result(
+            uri,
+            manifest,
+            status="invalid",
+            reason=reason,
+            snapshot_context=_context_for_manifest(None, reason=reason),
+        )
+        result.update(
+            {
+                "resource_role": "post_emit_health",
+                "artifact_ref": None,
+                "reason": reason,
+            }
+        )
+        return result
+    if (
+        not is_bundle_manifest(document)
+        or not isinstance(document.get("run_id"), str)
+        or not document["run_id"]
+        or not isinstance(document.get("artifacts"), list)
+    ):
+        reason = "bundle root is not a valid RepoGround bundle manifest"
+        result = _base_result(
+            uri,
+            manifest,
+            status="blocked",
+            reason=reason,
+            snapshot_context=_context_for_manifest(None, reason=reason),
+        )
+        result.update(
+            {
+                "resource_role": "post_emit_health",
+                "artifact_ref": None,
+                "reason": reason,
+            }
+        )
+        return result
+
+    artifact, health, health_data = _linked_post_health_from_manifest_bytes(
+        manifest,
+        manifest_data,
+    )
+    context = _context_from_manifest_document(
+        manifest,
+        document,
+        health_artifact=artifact,
+        health_inspection=health,
+    )
+    result = _base_result(
+        uri,
+        manifest,
+        status=health.get("status", "unknown"),
+        snapshot_context=context,
+    )
+    result.update(
+        {
+            "resource_role": "post_emit_health",
+            "artifact_ref": artifact,
+        }
+    )
+    if artifact is None or health_data is None:
+        result["reason"] = (
+            "; ".join(str(item) for item in health.get("reasons", []) if item)
+            or "post_emit_health unavailable or unbound"
+        )
+        return result
+    result["content_type"] = "application/json"
+    return _apply_artifact_bytes(result, health_data)
 
 
 def _read_artifact_resource(uri: str, manifest: Path, role: str) -> dict[str, Any]:
@@ -487,15 +706,7 @@ def _read_artifact_resource(uri: str, manifest: Path, role: str) -> dict[str, An
         return _read_manifest_content(result, manifest)
 
     if role == "post_emit_health":
-        artifact, health = _linked_post_health_artifact(manifest)
-        result = _base_result(uri, manifest, status=health.get("status", "unknown"))
-        result.update({"resource_role": role, "artifact_ref": artifact})
-        if artifact is None:
-            result["reason"] = (
-                "; ".join(str(item) for item in health.get("reasons", []) if item)
-                or "post_emit_health unavailable or unbound"
-            )
-            return result
+        return _read_health_resource(uri, manifest)
     else:
         ref = bundle_access.get_artifact(manifest, role)
         result = _base_result(uri, manifest, status=ref.get("status", "unknown"))

--- a/merger/repoground/core/mcp_resources.py
+++ b/merger/repoground/core/mcp_resources.py
@@ -10,7 +10,10 @@ from typing import Any
 from urllib.parse import unquote, urlparse
 
 from merger.repoground.core import bundle_access
-from merger.repoground.core.bundle_catalog import discover_bundle_catalog
+from merger.repoground.core.bundle_catalog import (
+    discover_bundle_catalog,
+    inspect_bundle_health,
+)
 
 KIND = "repoground.mcp.resource_read"
 LIST_KIND = "repoground.mcp.resource_list"
@@ -345,6 +348,61 @@ def _read_manifest_content(result: dict[str, Any], manifest: Path) -> dict[str, 
     return _apply_artifact_bytes(result, data)
 
 
+def _linked_post_health_artifact(
+    manifest: Path,
+) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+    try:
+        document = json.loads(manifest.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return None, {"status": "invalid", "reasons": ["bundle manifest unreadable"]}
+    links = document.get("links") if isinstance(document, dict) else None
+    raw_path = links.get("post_emit_health_path") if isinstance(links, dict) else None
+    if not isinstance(raw_path, str) or not raw_path:
+        return None, {"status": "missing", "reasons": ["post_emit_health link missing"]}
+    path = (manifest.parent / raw_path).resolve()
+    try:
+        path.relative_to(manifest.parent.resolve())
+    except ValueError:
+        return None, {
+            "status": "blocked",
+            "reasons": ["post_emit_health path escapes bundle root"],
+        }
+    health = inspect_bundle_health(manifest)
+    if health.get("status") != "available" or not path.is_file():
+        return None, health
+    data, read_issue = _read_bounded_bytes(
+        path,
+        max_bytes=MAX_RESOURCE_BYTES,
+        too_large_reason="post_emit_health exceeds MCP resource size limit",
+        unavailable_reason="post_emit_health unavailable",
+    )
+    if read_issue is not None or data is None:
+        return None, {
+            "status": read_issue.get("status", "unknown") if read_issue else "unknown",
+            "reasons": [
+                read_issue.get("reason", "post_emit_health unavailable")
+                if read_issue
+                else "post_emit_health unavailable"
+            ],
+        }
+    return (
+        {
+            "role": "post_emit_health",
+            "path": raw_path,
+            "absolute_path": str(path),
+            "file_exists": True,
+            "content_type": "application/json",
+            "bytes": len(data),
+            "sha256": _sha256_bytes(data),
+            "authority": "diagnostic_signal",
+            "canonicality": "diagnostic",
+            "risk_class": "health",
+            "integrity_source": "manifest_binding_revalidated_at_read",
+        },
+        health,
+    )
+
+
 def _context_for_manifest(
     manifest: Path | None, *, reason: str | None = None
 ) -> dict[str, Any]:
@@ -361,13 +419,15 @@ def _context_for_manifest(
             },
         }
     status = bundle_access.snapshot_status(manifest)
-    health = bundle_access.get_artifact(manifest, "post_emit_health")
+    health_artifact, health_inspection = _linked_post_health_artifact(manifest)
     availability_model = status.get("availability_model")
     freshness = status.get("freshness")
     return {
         "health": {
-            "status": health.get("status", "unknown"),
-            "artifact": health.get("artifact"),
+            "status": health_inspection.get("status", "unknown"),
+            "health_status": health_inspection.get("health_status"),
+            "reasons": health_inspection.get("reasons", []),
+            "artifact": health_artifact,
         },
         "freshness": freshness
         if isinstance(freshness, dict)
@@ -426,10 +486,21 @@ def _read_artifact_resource(uri: str, manifest: Path, role: str) -> dict[str, An
         )
         return _read_manifest_content(result, manifest)
 
-    ref = bundle_access.get_artifact(manifest, role)
-    result = _base_result(uri, manifest, status=ref.get("status", "unknown"))
-    result.update({"resource_role": role, "artifact_ref": ref.get("artifact")})
-    artifact = ref.get("artifact")
+    if role == "post_emit_health":
+        artifact, health = _linked_post_health_artifact(manifest)
+        result = _base_result(uri, manifest, status=health.get("status", "unknown"))
+        result.update({"resource_role": role, "artifact_ref": artifact})
+        if artifact is None:
+            result["reason"] = (
+                "; ".join(str(item) for item in health.get("reasons", []) if item)
+                or "post_emit_health unavailable or unbound"
+            )
+            return result
+    else:
+        ref = bundle_access.get_artifact(manifest, role)
+        result = _base_result(uri, manifest, status=ref.get("status", "unknown"))
+        result.update({"resource_role": role, "artifact_ref": ref.get("artifact")})
+        artifact = ref.get("artifact")
     if not isinstance(artifact, dict) or not artifact.get("path"):
         result["reason"] = f"artifact role not available: {role}"
         return result

--- a/merger/repoground/core/mcp_resources.py
+++ b/merger/repoground/core/mcp_resources.py
@@ -196,21 +196,21 @@ def _manifest_candidates(bundle_root: str | Path) -> list[Path]:
             continue
         pool.sort(
             key=lambda item: (
-                str(item.get("created_at") or ""),
+                str(item.get("created_at_utc") or item.get("created_at") or ""),
                 str(item.get("run_id") or ""),
                 str(item["manifest_path"]),
             ),
             reverse=True,
         )
         newest_key = (
-            str(pool[0].get("created_at") or ""),
+            str(pool[0].get("created_at_utc") or pool[0].get("created_at") or ""),
             str(pool[0].get("run_id") or ""),
         )
         tied = [
             item
             for item in pool
             if (
-                str(item.get("created_at") or ""),
+                str(item.get("created_at_utc") or item.get("created_at") or ""),
                 str(item.get("run_id") or ""),
             )
             == newest_key

--- a/merger/repoground/core/mcp_resources.py
+++ b/merger/repoground/core/mcp_resources.py
@@ -177,12 +177,47 @@ def _manifest_candidates(bundle_root: str | Path) -> list[Path]:
     if not root.exists() or not root.is_dir():
         return []
     catalog = discover_bundle_catalog(root)
-    paths = [
-        Path(item["manifest_path"])
+    candidates = [
+        item
         for item in catalog.get("candidates", [])
-        if isinstance(item, dict) and isinstance(item.get("manifest_path"), str)
+        if isinstance(item, dict)
+        and isinstance(item.get("stem"), str)
+        and isinstance(item.get("manifest_path"), str)
     ]
-    return sorted(set(paths))
+    selected: list[Path] = []
+    for stem in sorted({str(item["stem"]) for item in candidates}):
+        matches = [item for item in candidates if item["stem"] == stem]
+        healthy = [item for item in matches if item.get("selection_eligible") is True]
+        if healthy:
+            pool = healthy
+        elif len(matches) == 1:
+            pool = matches
+        else:
+            continue
+        pool.sort(
+            key=lambda item: (
+                str(item.get("created_at") or ""),
+                str(item.get("run_id") or ""),
+                str(item["manifest_path"]),
+            ),
+            reverse=True,
+        )
+        newest_key = (
+            str(pool[0].get("created_at") or ""),
+            str(pool[0].get("run_id") or ""),
+        )
+        tied = [
+            item
+            for item in pool
+            if (
+                str(item.get("created_at") or ""),
+                str(item.get("run_id") or ""),
+            )
+            == newest_key
+        ]
+        if len(tied) == 1:
+            selected.append(Path(tied[0]["manifest_path"]))
+    return sorted(set(selected))
 
 
 def _find_manifest(bundle_root: str | Path, stem: str) -> Path | None:

--- a/merger/repoground/core/mcp_tools.py
+++ b/merger/repoground/core/mcp_tools.py
@@ -354,13 +354,18 @@ def snapshot_status(
     from merger.repoground.core.bundle_access import (
         snapshot_status as access_snapshot_status,
     )
+    from merger.repoground.core.bundle_catalog import inspect_bundle_health
 
     snapshot = access_snapshot_status(bundle_manifest)
     availability = _availability_block(snapshot)
     freshness = _freshness_block(snapshot)
-    status = (
-        "available" if availability["status"] == "available" else availability["status"]
-    )
+    health = inspect_bundle_health(bundle_manifest)
+    if availability["status"] != "available":
+        status = availability["status"]
+    elif health["health_status"] != "pass":
+        status = "unhealthy"
+    else:
+        status = "available"
     return {
         "kind": READ_ONLY_KIND,
         "version": READ_ONLY_VERSION,
@@ -374,7 +379,9 @@ def snapshot_status(
             "profile": snapshot.get("profile"),
             "artifact_count": snapshot.get("artifact_count"),
             "roles": snapshot.get("roles"),
+            "health_status": health.get("health_status"),
         },
+        "health": health,
         "availability": availability,
         "freshness": freshness,
         "result_semantics": "repobrief.snapshot_status.v1",

--- a/merger/repoground/core/mcp_tools.py
+++ b/merger/repoground/core/mcp_tools.py
@@ -4,9 +4,11 @@ This module is not a protocol server. It provides deterministic tool handlers
 that a future MCP adapter can expose. Read-only RepoGround access helpers must
 not call these handlers as a fallback or side effect.
 """
+
 from __future__ import annotations
 
 import argparse
+import re
 import signal
 import threading
 from contextlib import contextmanager
@@ -107,13 +109,17 @@ def _path_is_within(child: Path, parent: Path) -> bool:
     return True
 
 
-def _resolve_output_dir(output_root: str | Path, output_subdir: str | None) -> tuple[Path, Path]:
+def _resolve_output_dir(
+    output_root: str | Path, output_subdir: str | None
+) -> tuple[Path, Path]:
     root = _guarded_path(output_root, label="output_root")
     if output_subdir is None or output_subdir == "":
         return root, root
     raw = Path(output_subdir)
     if raw.is_absolute() or ".." in raw.parts:
-        raise RepoGroundMcpToolError("output_subdir must be relative and must not contain '..'")
+        raise RepoGroundMcpToolError(
+            "output_subdir must be relative and must not contain '..'"
+        )
     out = (root / raw).resolve()
     if not _path_is_within(out, root):
         raise RepoGroundMcpToolError("output_subdir must remain inside output_root")
@@ -203,7 +209,9 @@ def snapshot_create(
         raise RepoGroundMcpToolError(f"repo is not a directory: {repo_path}")
     output_root_path, out_path = _resolve_output_dir(output_root, output_subdir)
     if out_path == repo_path or _path_is_within(out_path, repo_path):
-        raise RepoGroundMcpToolError("output directory must not be the repository or inside it")
+        raise RepoGroundMcpToolError(
+            "output directory must not be the repository or inside it"
+        )
     if profile not in profile_names():
         raise RepoGroundMcpToolError(f"unsupported profile: {profile}")
     if timeout_seconds > MAX_TIMEOUT_SECONDS:
@@ -251,6 +259,7 @@ def snapshot_create(
         "mutation_boundary": _mutation_boundary(),
         "does_not_establish": list(DOES_NOT_ESTABLISH),
     }
+
 
 READ_ONLY_KIND = "repobrief.mcp.read_only_frontdoor"
 READ_ONLY_VERSION = "v1"
@@ -335,6 +344,278 @@ def ask_context(
     }
 
 
+def snapshot_status(
+    *,
+    bundle_manifest: str | Path,
+    verbose: bool = False,
+) -> dict[str, Any]:
+    """Return one existing snapshot status with normalized availability semantics."""
+    from merger.repoground.core.ask_context import _availability_block, _freshness_block
+    from merger.repoground.core.bundle_access import (
+        snapshot_status as access_snapshot_status,
+    )
+
+    snapshot = access_snapshot_status(bundle_manifest)
+    availability = _availability_block(snapshot)
+    freshness = _freshness_block(snapshot)
+    status = (
+        "available" if availability["status"] == "available" else availability["status"]
+    )
+    return {
+        "kind": READ_ONLY_KIND,
+        "version": READ_ONLY_VERSION,
+        "tool": "snapshot_status",
+        "status": status,
+        "snapshot": snapshot
+        if verbose
+        else {
+            "bundle_manifest": snapshot.get("bundle_manifest"),
+            "bundle_run_id": snapshot.get("bundle_run_id"),
+            "profile": snapshot.get("profile"),
+            "artifact_count": snapshot.get("artifact_count"),
+            "roles": snapshot.get("roles"),
+        },
+        "availability": availability,
+        "freshness": freshness,
+        "result_semantics": "repobrief.snapshot_status.v1",
+        "mutation_boundary": _read_only_boundary(verbose=verbose),
+        "does_not_establish": _read_only_does_not_establish(verbose=verbose),
+    }
+
+
+_SYMBOL_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_SYMBOL_IN_BACKTICKS_RE = re.compile(r"`([A-Za-z_][A-Za-z0-9_]*)`")
+_SYMBOL_AFTER_KIND_RE = re.compile(
+    r"\b(?:function|class|method|funktion|klasse|methode)\s+([A-Za-z_][A-Za-z0-9_]*)",
+    re.IGNORECASE,
+)
+_SYMBOL_BEFORE_DEFINITION_RE = re.compile(
+    r"\b([A-Za-z_][A-Za-z0-9_]*)\s+(?:defined|definiert)\b",
+    re.IGNORECASE,
+)
+_DEFINITION_INTENT_RE = re.compile(
+    r"\b(?:defined|definition|function|class|method|definiert|definition|funktion|klasse|methode)\b",
+    re.IGNORECASE,
+)
+
+
+def _symbol_definition_intent(query: str) -> str | None:
+    """Extract one conservative identifier from an explicit definition question."""
+    if not isinstance(query, str) or not _DEFINITION_INTENT_RE.search(query):
+        return None
+    for pattern in (
+        _SYMBOL_IN_BACKTICKS_RE,
+        _SYMBOL_AFTER_KIND_RE,
+        _SYMBOL_BEFORE_DEFINITION_RE,
+    ):
+        match = pattern.search(query)
+        if match and _SYMBOL_NAME_RE.fullmatch(match.group(1)):
+            return match.group(1)
+    return None
+
+
+def _compact_symbol_hits(
+    symbol_result: dict[str, Any], *, name: str, k: int
+) -> tuple[list[dict[str, Any]], int]:
+    inner = symbol_result.get("result") if isinstance(symbol_result, dict) else None
+    hits = inner.get("hits") if isinstance(inner, dict) else []
+    exact = []
+    for hit in hits if isinstance(hits, list) else []:
+        if not isinstance(hit, dict):
+            continue
+        qualified = hit.get("qualified_name")
+        if (
+            hit.get("name") != name
+            and qualified != name
+            and not (isinstance(qualified, str) and qualified.endswith(f".{name}"))
+        ):
+            continue
+        path = hit.get("path")
+        if not isinstance(path, str) or not path:
+            continue
+        exact.append(
+            {
+                "id": hit.get("id"),
+                "kind": hit.get("kind"),
+                "name": hit.get("name"),
+                "qualified_name": qualified,
+                "path": path,
+                "start_line": hit.get("start_line"),
+                "end_line": hit.get("end_line"),
+                "range_ref": hit.get("range_ref"),
+                "source_range": hit.get("source_range"),
+            }
+        )
+    exact.sort(
+        key=lambda hit: (
+            "/tests/" in str(hit["path"]) or str(hit["path"]).startswith("tests/"),
+            str(hit["path"]),
+            int(hit.get("start_line") or 0),
+            str(hit.get("qualified_name") or ""),
+        )
+    )
+    return exact[:k], len(exact)
+
+
+def _symbol_query_result(
+    *,
+    bundle_manifest: str | Path,
+    query: str,
+    symbol_name: str,
+    max_context_tokens: int,
+    k: int,
+    verbose: bool,
+) -> dict[str, Any] | None:
+    symbol_result = find_symbol(
+        bundle_manifest=bundle_manifest,
+        name=symbol_name,
+        k=max(k, 10),
+        verbose=verbose,
+    )
+    navigation_hits, exact_hit_count = _compact_symbol_hits(
+        symbol_result, name=symbol_name, k=k
+    )
+    if not navigation_hits:
+        return None
+    inner = symbol_result.get("result") if isinstance(symbol_result, dict) else {}
+    from merger.repoground.core.ask_context import (
+        _availability_block,
+        _freshness_block,
+    )
+
+    availability = _availability_block(
+        {"availability_model": inner.get("availability")}
+        if isinstance(inner, dict)
+        else {}
+    )
+    freshness = _freshness_block(
+        {"freshness": inner.get("freshness")} if isinstance(inner, dict) else {}
+    )
+    return {
+        "kind": READ_ONLY_KIND,
+        "version": READ_ONLY_VERSION,
+        "tool": "query_existing_index",
+        "status": "available",
+        "route": "symbol_definition",
+        "intent": {"kind": "symbol_definition", "symbol": symbol_name},
+        "retrieval": {
+            "raw_query": query,
+            "fts_query": None,
+            "strategy": "symbol_definition",
+            "match_count": len(navigation_hits),
+        },
+        "retrieval_hits": [
+            {
+                "artifact_role": "python_symbol_index_json",
+                "ref": str(hit.get("id") or hit.get("range_ref") or "symbol"),
+                "score": 0.0,
+                "purpose": "exact symbol-definition navigation candidate",
+            }
+            for hit in navigation_hits
+        ],
+        "navigation_hits": navigation_hits,
+        "resolved_ranges": [],
+        "budget": {
+            "max_context_tokens": max_context_tokens,
+            "approx_context_chars_used": 0,
+            "truncated": exact_hit_count > len(navigation_hits),
+            "does_not_establish_quality": True,
+        },
+        "availability": availability,
+        "freshness": freshness,
+        "answer_caveats": [
+            {
+                "kind": "navigation_only",
+                "detail": (
+                    "Symbol-index hits establish a snapshot path and source line range, "
+                    "not source semantics or runtime behavior."
+                ),
+            }
+        ],
+        "result_semantics": "repobrief.query_existing_index.agent_frontdoor.v1",
+        "mutation_boundary": _read_only_boundary(verbose=verbose),
+        "does_not_establish": _read_only_does_not_establish(verbose=verbose),
+    }
+
+
+def query_existing_index(
+    *,
+    bundle_manifest: str | Path,
+    query: str,
+    task_profile: str = "basic_repo_question",
+    max_context_tokens: int = 2000,
+    k: int = 5,
+    verbose: bool = False,
+) -> dict[str, Any]:
+    """Query one existing index through the canonical ask retrieval strategy."""
+    from merger.repoground.core.ask_context import build_ask_context_pack
+
+    symbol_name = _symbol_definition_intent(query)
+    if symbol_name is not None:
+        routed = _symbol_query_result(
+            bundle_manifest=bundle_manifest,
+            query=query,
+            symbol_name=symbol_name,
+            max_context_tokens=max_context_tokens,
+            k=k,
+            verbose=verbose,
+        )
+        if routed is not None:
+            return routed
+
+    pack = build_ask_context_pack(
+        bundle_manifest,
+        query=query,
+        task_profile=task_profile,
+        max_context_tokens=max_context_tokens,
+        max_answer_tokens=1,
+        k=k,
+    )
+    result = {
+        "kind": READ_ONLY_KIND,
+        "version": READ_ONLY_VERSION,
+        "tool": "query_existing_index",
+        "status": "available",
+        "route": "text_retrieval",
+        "intent": {"kind": "text_retrieval"},
+        "retrieval": pack["retrieval"],
+        "retrieval_hits": pack["retrieval_hits"],
+        "resolved_ranges": pack["resolved_ranges"],
+        "budget": pack["budget"],
+        "availability": pack["availability"],
+        "freshness": pack["freshness"],
+        "answer_caveats": pack["answer_scaffold"]["caveats_to_surface"],
+        "result_semantics": "repobrief.query_existing_index.agent_frontdoor.v1",
+        "mutation_boundary": _read_only_boundary(verbose=verbose),
+        "does_not_establish": _read_only_does_not_establish(verbose=verbose),
+    }
+    if verbose:
+        result["context_pack"] = pack
+    return result
+
+
+def range_get(
+    *,
+    bundle_manifest: str | Path,
+    range_ref: dict[str, Any],
+    verbose: bool = False,
+) -> dict[str, Any]:
+    """Resolve one exact range from an existing bundle without live workspace reads."""
+    from merger.repoground.core.bundle_access import range_get as access_range_get
+
+    result = access_range_get(bundle_manifest, range_ref)
+    return {
+        "kind": READ_ONLY_KIND,
+        "version": READ_ONLY_VERSION,
+        "tool": "range_get",
+        "status": result.get("status", "invalid"),
+        "result": result,
+        "result_semantics": "repobrief.range_get.v1",
+        "mutation_boundary": _read_only_boundary(verbose=verbose),
+        "does_not_establish": _read_only_does_not_establish(verbose=verbose),
+    }
+
+
 def grounding_verify(
     *,
     declaration: dict[str, Any],
@@ -349,7 +630,9 @@ def grounding_verify(
     repeated mutation-boundary and non-claim envelope is projected to a
     compact reference by default.
     """
-    from merger.repoground.core.answer_grounding import verify_answer_grounding_for_task_profile
+    from merger.repoground.core.answer_grounding import (
+        verify_answer_grounding_for_task_profile,
+    )
 
     verdict = verify_answer_grounding_for_task_profile(
         declaration,
@@ -373,7 +656,9 @@ def grounding_verify(
 FIND_SYMBOL_KINDS = ("class", "function", "async_function")
 
 
-def _find_symbol_result(status: str, result: dict[str, Any], *, verbose: bool = False) -> dict[str, Any]:
+def _find_symbol_result(
+    status: str, result: dict[str, Any], *, verbose: bool = False
+) -> dict[str, Any]:
     return {
         "kind": READ_ONLY_KIND,
         "version": READ_ONLY_VERSION,
@@ -522,9 +807,7 @@ def get_callers(
         get_callers as access_get_callers,
     )
 
-    result = access_get_callers(
-        bundle_manifest, name, path=path, k=k, verbose=verbose
-    )
+    result = access_get_callers(bundle_manifest, name, path=path, k=k, verbose=verbose)
     return _call_navigation_result(
         "get_callers",
         result.get("status", "invalid"),
@@ -554,9 +837,7 @@ def get_callees(
         get_callees as access_get_callees,
     )
 
-    result = access_get_callees(
-        bundle_manifest, name, path=path, k=k, verbose=verbose
-    )
+    result = access_get_callees(bundle_manifest, name, path=path, k=k, verbose=verbose)
     return _call_navigation_result(
         "get_callees",
         result.get("status", "invalid"),

--- a/merger/repoground/core/post_health_binding.py
+++ b/merger/repoground/core/post_health_binding.py
@@ -1,0 +1,88 @@
+"""Shared validation for post-emit health records bound to one bundle manifest."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+_SHA256_LEN = 64
+
+
+def _is_lower_sha256(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == _SHA256_LEN
+        and all(char in "0123456789abcdef" for char in value)
+    )
+
+
+def _resolve(path: str) -> Path:
+    candidate = Path(path)
+    if not candidate.is_absolute():
+        candidate = Path.cwd() / candidate
+    return candidate.resolve()
+
+
+def _hash_binding_status(
+    post_doc: Mapping[str, Any],
+    manifest_sha256: str | None,
+) -> tuple[str, str, bool]:
+    declared_sha256 = post_doc.get("bundle_manifest_sha256")
+    if declared_sha256 is None:
+        return "pass", "post_emit_health has no manifest hash binding", False
+    if not _is_lower_sha256(declared_sha256):
+        return "fail", "post_emit_health bundle_manifest_sha256 is invalid", True
+    if manifest_sha256 is None:
+        return (
+            "blocked",
+            "requested manifest could not be hashed for post_emit_health binding",
+            True,
+        )
+    if declared_sha256 != manifest_sha256:
+        return (
+            "fail",
+            "post_emit_health bundle_manifest_sha256 does not match requested manifest",
+            True,
+        )
+    return "pass", "post_emit_health hash matches requested manifest", True
+
+
+def post_health_binding_status(
+    post_doc: Mapping[str, Any],
+    *,
+    resolved_manifest: Path,
+    manifest_run_id: Any,
+    manifest_sha256: str | None,
+) -> tuple[str, str]:
+    """Validate path/hash/run bindings for one post-emit health record."""
+    post_manifest_path = post_doc.get("bundle_manifest_path")
+    if not isinstance(post_manifest_path, str) or not post_manifest_path:
+        return "blocked", "post_emit_health missing bundle_manifest_path binding"
+    hash_status, hash_detail, hash_bound = _hash_binding_status(
+        post_doc, manifest_sha256
+    )
+    if hash_status != "pass":
+        return hash_status, hash_detail
+    path_bound = _resolve(post_manifest_path) == resolved_manifest.resolve()
+    if not path_bound and not hash_bound:
+        return (
+            "fail",
+            "post_emit_health bundle_manifest_path does not match requested manifest",
+        )
+    if isinstance(manifest_run_id, str):
+        post_bundle_run_id = post_doc.get("bundle_run_id")
+        if not isinstance(post_bundle_run_id, str) or not post_bundle_run_id:
+            return "blocked", "post_emit_health missing bundle_run_id binding"
+        if post_bundle_run_id != manifest_run_id:
+            return (
+                "fail",
+                "post_emit_health bundle_run_id does not match manifest run_id",
+            )
+    if path_bound and hash_bound:
+        return (
+            "pass",
+            "post_emit_health path-bound and hash-verified against requested manifest",
+        )
+    if path_bound:
+        return "pass", "post_emit_health path-bound to requested manifest"
+    return "pass", "post_emit_health hash-bound to requested manifest bytes"

--- a/merger/repoground/core/range_resolver.py
+++ b/merger/repoground/core/range_resolver.py
@@ -11,6 +11,7 @@ except ImportError:
 
 from .bundle_identity import is_bundle_manifest
 from .constants import ArtifactRole
+from .manifest_snapshot import active_manifest_snapshot
 
 
 _CONTRACTS_DIR = Path(__file__).parent.parent / "contracts"
@@ -173,6 +174,14 @@ def build_derived_range_ref_v2(
     }
 
 
+def _load_range_manifest(manifest_path: Path) -> Dict[str, Any]:
+    snapshot = active_manifest_snapshot(manifest_path)
+    if snapshot is not None:
+        return snapshot.json_object()
+    with manifest_path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
 def resolve_range_ref(manifest_path: Path, ref: Dict[str, Any]) -> Dict[str, Any]:
     """
     Resolves a range_ref against a bundle.manifest.json or dump_index.json to extract
@@ -181,8 +190,7 @@ def resolve_range_ref(manifest_path: Path, ref: Dict[str, Any]) -> Dict[str, Any
     if not manifest_path.exists():
         raise FileNotFoundError(f"Manifest not found: {manifest_path}")
 
-    with manifest_path.open("r", encoding="utf-8") as f:
-        manifest = json.load(f)
+    manifest = _load_range_manifest(manifest_path)
 
     is_v2 = ref.get("range_ref_version") == "2"
     schema_path = _RANGE_REF_V2_SCHEMA_PATH if is_v2 else _RANGE_REF_V1_SCHEMA_PATH

--- a/merger/repoground/retrieval/query_core.py
+++ b/merger/repoground/retrieval/query_core.py
@@ -368,6 +368,72 @@ def _handle_semantic_encoding_failure(
     semantic_diagnostics["dimension_validation"] = _DIMENSION_VALIDATION_ERROR
 
 
+def _read_only_policy_path(
+    index_path: Path,
+    validated_source_path: Optional[Path],
+) -> Path:
+    if validated_source_path is None:
+        return index_path
+    if not validated_source_path.is_absolute():
+        raise ValueError(
+            "Invalid index path: expected an absolute validated source path."
+        )
+    if (
+        index_path.parent not in (Path("/proc/self/fd"), Path("/dev/fd"))
+        or not index_path.name.isdecimal()
+    ):
+        raise ValueError("Invalid index path: expected a verified descriptor path.")
+    return validated_source_path
+
+
+def validate_read_only_sqlite_source_path(index_path: Path) -> Path:
+    source_path = Path(index_path)
+    raw_source_path = str(source_path)
+    if "\x00" in raw_source_path:
+        raise ValueError("Invalid index path: NUL bytes are not allowed.")
+    if not source_path.is_absolute():
+        raise ValueError(
+            "Invalid index path: expected an absolute read-only index path."
+        )
+    if not source_path.name.endswith(_REQUIRED_READ_ONLY_SQLITE_INDEX_SUFFIX):
+        raise ValueError("Invalid index path: expected canonical read-only index file.")
+    return source_path
+
+
+def _open_query_connection(
+    index_path: Path,
+    *,
+    read_only: bool,
+    validated_source_path: Optional[Path],
+) -> sqlite3.Connection:
+    raw_index_path = str(index_path)
+    if "\x00" in raw_index_path:
+        raise ValueError("Invalid index path: NUL bytes are not allowed.")
+    if validated_source_path is not None and not read_only:
+        raise ValueError(
+            "Invalid index path: a validated source requires read-only mode."
+        )
+    policy_index_path = _read_only_policy_path(index_path, validated_source_path)
+    if read_only:
+        validate_read_only_sqlite_source_path(policy_index_path)
+    if not read_only and not any(
+        index_path.name.endswith(suffix) for suffix in _ALLOWED_SQLITE_INDEX_SUFFIXES
+    ):
+        raise ValueError(
+            "Invalid index path: expected a SQLite index file "
+            f"ending with one of {_ALLOWED_SQLITE_INDEX_SUFFIXES!r}."
+        )
+    if not read_only:
+        return sqlite3.connect(str(index_path))
+    if not index_path.is_absolute():
+        raise ValueError(
+            "Invalid index path: expected an absolute read-only index path."
+        )
+    db_uri = f"{index_path.as_uri()}?mode=ro&immutable=1"
+    # Callers validate and confine the index path before read-only execution.
+    return sqlite3.connect(db_uri, uri=True)  # lgtm[py/path-injection] codeql-boundary:query-readonly-index
+
+
 def _score_results_with_cosine(
     results: List[Dict[str, Any]],
     cosine_scores: Any,
@@ -450,6 +516,7 @@ def execute_query(
     _prepared_fts_query: Optional[str] = None,
     _prepared_router_output: Optional[Dict[str, Any]] = None,
     read_only: bool = False,
+    _validated_read_only_source_path: Optional[Path] = None,
 ) -> Dict[str, Any]:
     """
     Executes a query against the SQLite index.
@@ -477,28 +544,17 @@ def execute_query(
 
     conn = None
     try:
-        raw_index_path = str(index_path)
-        if "\x00" in raw_index_path:
-            raise ValueError("Invalid index path: NUL bytes are not allowed.")
         resolved_index_path = Path(index_path)
-        if read_only and not resolved_index_path.name.endswith(_REQUIRED_READ_ONLY_SQLITE_INDEX_SUFFIX):
-            raise ValueError("Invalid index path: expected canonical read-only index file.")
-        if not read_only and not any(
-            resolved_index_path.name.endswith(suffix)
-            for suffix in _ALLOWED_SQLITE_INDEX_SUFFIXES
-        ):
-            raise ValueError(
-                "Invalid index path: expected a SQLite index file "
-                f"ending with one of {_ALLOWED_SQLITE_INDEX_SUFFIXES!r}."
-            )
-        if read_only:
-            if not resolved_index_path.is_absolute():
-                raise ValueError("Invalid index path: expected an absolute read-only index path.")
-            db_uri = f"{resolved_index_path.as_uri()}?mode=ro&immutable=1"
-            # Callers validate and confine the index path before read-only execution.
-            conn = sqlite3.connect(db_uri, uri=True)  # lgtm[py/path-injection] codeql-boundary:query-readonly-index
-        else:
-            conn = sqlite3.connect(str(resolved_index_path))
+        validated_source_path = (
+            Path(_validated_read_only_source_path)
+            if _validated_read_only_source_path is not None
+            else None
+        )
+        conn = _open_query_connection(
+            resolved_index_path,
+            read_only=read_only,
+            validated_source_path=validated_source_path,
+        )
         conn.row_factory = sqlite3.Row
 
         where_clauses = []

--- a/merger/repoground/tests/test_ask_context_cli.py
+++ b/merger/repoground/tests/test_ask_context_cli.py
@@ -8,32 +8,44 @@ from merger.repoground.cli.main import main
 from merger.repoground.core.ask_context import build_ask_context_pack
 from merger.repoground.tests.test_resolved_evidence_query import _build_resolved_bundle
 
-CONTEXT_SCHEMA = Path(__file__).parent.parent / "contracts" / "repobrief-ask-context-pack.v1.schema.json"
+CONTEXT_SCHEMA = (
+    Path(__file__).parent.parent
+    / "contracts"
+    / "repobrief-ask-context-pack.v1.schema.json"
+)
 
 
 def _sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
-def _add_artifact(bundle: dict, role: str, filename: str, content: str = "ok\n") -> None:
+def _add_artifact(
+    bundle: dict, role: str, filename: str, content: str = "ok\n"
+) -> None:
     manifest = bundle["manifest"]
     artifact_path = manifest.parent / filename
     artifact_path.write_text(content, encoding="utf-8")
     data = json.loads(manifest.read_text(encoding="utf-8"))
     artifacts = data.setdefault("artifacts", [])
-    artifacts.append({
-        "role": role,
-        "path": filename,
-        "content_type": "application/json" if filename.endswith(".json") else "text/markdown",
-        "bytes": artifact_path.stat().st_size,
-        "sha256": _sha256(artifact_path),
-    })
+    artifacts.append(
+        {
+            "role": role,
+            "path": filename,
+            "content_type": "application/json"
+            if filename.endswith(".json")
+            else "text/markdown",
+            "bytes": artifact_path.stat().st_size,
+            "sha256": _sha256(artifact_path),
+        }
+    )
     manifest.write_text(json.dumps(data), encoding="utf-8")
 
 
 def _complete_basic_bundle(tmp_path: Path) -> dict:
     bundle = _build_resolved_bundle(tmp_path)
-    _add_artifact(bundle, "agent_reading_pack", "demo.agent_reading_pack.md", "# Agent pack\n")
+    _add_artifact(
+        bundle, "agent_reading_pack", "demo.agent_reading_pack.md", "# Agent pack\n"
+    )
     _add_artifact(bundle, "snapshot_plan_json", "demo.snapshot_plan.json", "{}\n")
     return bundle
 
@@ -41,8 +53,15 @@ def _complete_basic_bundle(tmp_path: Path) -> dict:
 def _complete_pr_review_bundle(tmp_path: Path) -> dict:
     bundle = _complete_basic_bundle(tmp_path)
     _add_artifact(bundle, "post_emit_health", "demo.bundle_health.post.json", "{}\n")
-    _add_artifact(bundle, "bundle_surface_validation", "demo.bundle_surface_validation.json", "{}\n")
-    _add_artifact(bundle, "claim_evidence_map_json", "demo.claim_evidence_map.json", "{}\n")
+    _add_artifact(
+        bundle,
+        "bundle_surface_validation",
+        "demo.bundle_surface_validation.json",
+        "{}\n",
+    )
+    _add_artifact(
+        bundle, "claim_evidence_map_json", "demo.claim_evidence_map.json", "{}\n"
+    )
     return bundle
 
 
@@ -66,6 +85,7 @@ def test_build_ask_context_pack_json_for_basic_profile(tmp_path):
     _validate_context_pack(pack)
     assert pack["kind"] == "repobrief.ask_context_pack"
     assert pack["required_reading"]["status"] == "pass"
+    assert pack["availability"] == {"status": "available", "caveats": []}
     assert pack["retrieval_hits"]
     assert pack["resolved_ranges"][0]["status"] == "resolved"
     assert "hello resolved world" in pack["resolved_ranges"][0]["text_excerpt"]
@@ -85,22 +105,24 @@ def test_build_ask_context_pack_json_for_basic_profile(tmp_path):
 def test_ask_context_cli_emits_json_context_pack(tmp_path, capsys):
     bundle = _complete_basic_bundle(tmp_path)
 
-    rc = main([
-        "ground",
-        "ask",
-        "--bundle-manifest",
-        str(bundle["manifest"]),
-        "--q",
-        "hello",
-        "--task-profile",
-        "basic_repo_question",
-        "--context-budget",
-        "8000",
-        "--answer-budget",
-        "1200",
-        "--emit",
-        "json",
-    ])
+    rc = main(
+        [
+            "ground",
+            "ask",
+            "--bundle-manifest",
+            str(bundle["manifest"]),
+            "--q",
+            "hello",
+            "--task-profile",
+            "basic_repo_question",
+            "--context-budget",
+            "8000",
+            "--answer-budget",
+            "1200",
+            "--emit",
+            "json",
+        ]
+    )
 
     captured = capsys.readouterr()
     assert rc == 0
@@ -114,16 +136,18 @@ def test_ask_context_cli_emits_json_context_pack(tmp_path, capsys):
 def test_ask_context_cli_emits_human_context_pack(tmp_path, capsys):
     bundle = _complete_basic_bundle(tmp_path)
 
-    rc = main([
-        "ground",
-        "ask",
-        "--bundle-manifest",
-        str(bundle["manifest"]),
-        "--q",
-        "hello",
-        "--emit",
-        "text",
-    ])
+    rc = main(
+        [
+            "ground",
+            "ask",
+            "--bundle-manifest",
+            str(bundle["manifest"]),
+            "--q",
+            "hello",
+            "--emit",
+            "text",
+        ]
+    )
 
     captured = capsys.readouterr()
     assert rc == 0
@@ -135,18 +159,20 @@ def test_ask_context_cli_emits_human_context_pack(tmp_path, capsys):
 def test_ask_context_cli_stricter_profile_smoke(tmp_path, capsys):
     bundle = _complete_pr_review_bundle(tmp_path)
 
-    rc = main([
-        "ground",
-        "ask",
-        "--bundle-manifest",
-        str(bundle["manifest"]),
-        "--q",
-        "hello",
-        "--task-profile",
-        "pr_review",
-        "--emit",
-        "json",
-    ])
+    rc = main(
+        [
+            "ground",
+            "ask",
+            "--bundle-manifest",
+            str(bundle["manifest"]),
+            "--q",
+            "hello",
+            "--task-profile",
+            "pr_review",
+            "--emit",
+            "json",
+        ]
+    )
 
     captured = capsys.readouterr()
     assert rc == 0
@@ -171,24 +197,29 @@ def test_ask_context_budget_truncates_without_quality_claim(tmp_path):
     _validate_context_pack(pack)
     assert pack["budget"]["truncated"] is True
     assert pack["budget"]["does_not_establish_quality"] is True
-    assert any("truncated" in caveat["detail"] for caveat in pack["answer_scaffold"]["caveats_to_surface"])
+    assert any(
+        "truncated" in caveat["detail"]
+        for caveat in pack["answer_scaffold"]["caveats_to_surface"]
+    )
 
 
 def test_ask_context_missing_required_profile_returns_failure(tmp_path, capsys):
     bundle = _build_resolved_bundle(tmp_path)
 
-    rc = main([
-        "ground",
-        "ask",
-        "--bundle-manifest",
-        str(bundle["manifest"]),
-        "--q",
-        "hello",
-        "--task-profile",
-        "pr_review",
-        "--emit",
-        "json",
-    ])
+    rc = main(
+        [
+            "ground",
+            "ask",
+            "--bundle-manifest",
+            str(bundle["manifest"]),
+            "--q",
+            "hello",
+            "--task-profile",
+            "pr_review",
+            "--emit",
+            "json",
+        ]
+    )
 
     captured = capsys.readouterr()
     assert rc == 1

--- a/merger/repoground/tests/test_ask_retrieval_resilience.py
+++ b/merger/repoground/tests/test_ask_retrieval_resilience.py
@@ -8,9 +8,11 @@ Covers two guarantees added on top of the deterministic FTS retrieval:
 * resolved ranges surface the original repository source address so navigation
   tasks do not have to parse it out of the excerpt text.
 """
+
 from merger.repoground.core.ask_context import (
     _content_tokens,
     _or_fts_query,
+    _resolved_ranges,
     build_ask_context_pack,
 )
 from merger.repoground.tests.test_ask_context_cli import (
@@ -84,9 +86,71 @@ def test_content_tokens_drop_stopwords_and_dedupe():
 
 def test_content_tokens_adds_deterministic_snake_case_parts_for_or_fallback():
     assert _content_tokens("How does build_live_repo_address work?") == [
-        "build_live_repo_address", "build", "live", "repo", "address", "work"
+        "build_live_repo_address",
+        "build",
+        "live",
+        "repo",
+        "address",
+        "work",
     ]
 
 
 def test_or_fts_query_quotes_terms_to_keep_them_literal():
     assert _or_fts_query(["live", "freshness"]) == '"live" OR "freshness"'
+
+
+def test_resolved_ranges_share_budget_and_drop_empty_or_duplicate_hits():
+    base = {
+        "artifact_role": "canonical_md",
+        "range_status": "resolved",
+        "range": {"text": "x" * 5000},
+    }
+    query_result = {
+        "resolved_evidence": {
+            "hits": [
+                {
+                    **base,
+                    "source_path": "src/first.py",
+                    "source_line_range": {"start_line": 1, "end_line": 10},
+                    "range_ref": {"ref": "first"},
+                },
+                {
+                    **base,
+                    "source_path": "src/second.py",
+                    "source_line_range": {"start_line": 1, "end_line": 10},
+                    "range_ref": {"ref": "second"},
+                },
+                {
+                    **base,
+                    "source_path": "docs/diagnostics/third.json",
+                    "source_line_range": {"start_line": 1, "end_line": 10},
+                    "range_ref": {"ref": "third"},
+                },
+                {
+                    **base,
+                    "range": {"text": ""},
+                    "source_path": "src/empty.py",
+                    "range_ref": {"ref": "empty"},
+                },
+                {
+                    **base,
+                    "source_path": "src/first.py",
+                    "source_line_range": {"start_line": 1, "end_line": 10},
+                    "range_ref": {"ref": "first"},
+                },
+            ]
+        }
+    }
+
+    ranges, used_chars, truncated = _resolved_ranges(
+        query_result, max_context_tokens=1000
+    )
+
+    assert [item["source_path"] for item in ranges] == [
+        "src/first.py",
+        "src/second.py",
+        "docs/diagnostics/third.json",
+    ]
+    assert all(0 < len(item["text_excerpt"]) <= 1600 for item in ranges)
+    assert used_chars <= 4000
+    assert truncated is True

--- a/merger/repoground/tests/test_bundle_access_boundary.py
+++ b/merger/repoground/tests/test_bundle_access_boundary.py
@@ -1,5 +1,8 @@
 import hashlib
 import json
+import os
+import stat
+from pathlib import Path
 
 from merger.repoground.core import bundle_access
 
@@ -22,11 +25,53 @@ def _sha256(path):
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
+def _sealed_artifact(path, role="sqlite_index"):
+    return {
+        "role": role,
+        "path": path.name,
+        "bytes": path.stat().st_size,
+        "sha256": _sha256(path),
+    }
+
+
 def _sqlite_sidecars(index_path):
     return {
         index_path.with_name(index_path.name + suffix)
         for suffix in ("-wal", "-shm", "-journal")
     }
+
+
+def _queryable_sqlite_bundle(tmp_path):
+    from merger.repoground.retrieval import index_db
+
+    dump_path = tmp_path / "dump.json"
+    chunk_path = tmp_path / "chunks.jsonl"
+    manifest = tmp_path / "demo.bundle.manifest.json"
+    index_path = tmp_path / "index.index.sqlite"
+    chunk_path.write_text(
+        json.dumps(
+            {
+                "chunk_id": "c1",
+                "repo_id": "demo",
+                "path": "src/main.py",
+                "content": "def main(): print('portable hello')",
+                "start_line": 1,
+                "end_line": 1,
+                "layer": "core",
+                "artifact_type": "code",
+                "content_sha256": "h1",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    dump_path.write_text(
+        json.dumps({"version": "1.0", "repos": {"demo": {}}}),
+        encoding="utf-8",
+    )
+    index_db.build_index(dump_path, chunk_path, index_path)
+    _write_manifest(manifest, [_sealed_artifact(index_path)])
+    return manifest, index_path
 
 
 def test_range_get_reads_existing_artifact_without_mutation(tmp_path):
@@ -120,7 +165,7 @@ def test_range_get_reports_hash_mismatch_structurally(tmp_path):
 
 def test_query_existing_index_reports_missing_without_creating(tmp_path):
     manifest = tmp_path / "demo.bundle.manifest.json"
-    missing_index = tmp_path / "missing.sqlite"
+    missing_index = tmp_path / "missing.index.sqlite"
     _write_manifest(manifest, [{"role": "sqlite_index", "path": missing_index.name}])
 
     result = bundle_access.query_existing_index(manifest, "hello", k=1)
@@ -159,23 +204,58 @@ def test_query_existing_index_rejects_non_sqlite_artifact_path(tmp_path):
     bad_index = tmp_path / "index.txt"
     bad_index.write_text("not sqlite", encoding="utf-8")
     manifest = tmp_path / "demo.bundle.manifest.json"
-    _write_manifest(manifest, [{"role": "sqlite_index", "path": bad_index.name}])
+    _write_manifest(manifest, [_sealed_artifact(bad_index)])
 
     result = bundle_access.query_existing_index(manifest, "hello", k=1)
 
     assert result["status"] == "invalid"
-    assert result["error_code"] == "query_execution_failed"
+    assert result["error_code"] == "sqlite_index_path_invalid"
     assert "expected canonical read-only index file" in result["error"]
     assert bad_index.exists()
+
+
+def test_noncanonical_sqlite_role_is_rejected_before_open_or_hash(
+    monkeypatch,
+    tmp_path,
+):
+    bad_index = tmp_path / "large-payload.bin"
+    bad_index.write_bytes(b"x" * (2 * bundle_access._SQLITE_HASH_CHUNK_BYTES))
+    manifest = tmp_path / "demo.bundle.manifest.json"
+    _write_manifest(
+        manifest,
+        [
+            {
+                "role": "sqlite_index",
+                "path": bad_index.name,
+                "bytes": bad_index.stat().st_size,
+                "sha256": "0" * 64,
+            }
+        ],
+    )
+
+    def forbidden_open(*_args, **_kwargs):
+        raise AssertionError("noncanonical sqlite_index must not be opened")
+
+    def forbidden_hash(*_args, **_kwargs):
+        raise AssertionError("noncanonical sqlite_index must not be hashed")
+
+    monkeypatch.setattr(bundle_access, "_open_sqlite_artifact", forbidden_open)
+    monkeypatch.setattr(bundle_access, "_verify_sqlite_handle", forbidden_hash)
+
+    result = bundle_access.query_existing_index(manifest, "hello", k=1)
+
+    assert result["status"] == "invalid"
+    assert result["error_code"] == "sqlite_index_path_invalid"
+    assert "expected canonical read-only index file" in result["error"]
 
 
 def test_query_existing_index_forces_read_only_query_mode(monkeypatch, tmp_path):
     from merger.repoground.retrieval import query_core
 
-    index_path = tmp_path / "index.sqlite"
+    index_path = tmp_path / "index.index.sqlite"
     index_path.write_bytes(b"not a real sqlite database; execute_query is mocked")
     manifest = tmp_path / "demo.bundle.manifest.json"
-    _write_manifest(manifest, [{"role": "sqlite_index", "path": index_path.name}])
+    _write_manifest(manifest, [_sealed_artifact(index_path)])
     observed = {}
 
     def fake_execute_query(index_path_arg, query, **kwargs):
@@ -189,11 +269,159 @@ def test_query_existing_index_forces_read_only_query_mode(monkeypatch, tmp_path)
     result = bundle_access.query_existing_index(manifest, "hello", k=3)
 
     assert result["status"] == "available"
-    assert observed["index_path"] == index_path
+    assert observed["index_path"].parent in {
+        Path("/proc/self/fd"),
+        Path("/dev/fd"),
+    }
+    assert observed["index_path"].name.isdecimal()
     assert observed["query"] == "hello"
     assert observed["kwargs"]["read_only"] is True
+    assert observed["kwargs"]["_validated_read_only_source_path"] == index_path
     assert observed["kwargs"]["build_context"] is False
     assert observed["kwargs"]["trace"] is False
+
+
+def test_query_existing_index_uses_and_cleans_portable_verified_copy(
+    monkeypatch,
+    tmp_path,
+):
+    from merger.repoground.retrieval import query_core
+
+    manifest, index_path = _queryable_sqlite_bundle(tmp_path)
+    original_index_sha256 = _sha256(index_path)
+    original_execute_query = query_core.execute_query
+    observed = {}
+    monkeypatch.setattr(
+        bundle_access,
+        "_FILE_DESCRIPTOR_ROOTS",
+        (tmp_path / "missing-proc-fd", tmp_path / "missing-dev-fd"),
+    )
+
+    def observing_execute_query(index_path_arg, query, **kwargs):
+        portable_path = Path(index_path_arg)
+        observed["path"] = portable_path
+        observed["parent"] = portable_path.parent
+        assert portable_path != index_path
+        assert portable_path.name == "verified.index.sqlite"
+        assert stat.S_IMODE(portable_path.stat().st_mode) & 0o222 == 0
+        assert kwargs["_validated_read_only_source_path"] is None
+        return original_execute_query(index_path_arg, query, **kwargs)
+
+    monkeypatch.setattr(query_core, "execute_query", observing_execute_query)
+
+    result = bundle_access.query_existing_index(manifest, "portable", k=1)
+
+    assert result["status"] == "available"
+    assert result["query_result"]["count"] == 1
+    assert result["query_result"]["results"][0]["path"] == "src/main.py"
+    assert not observed["path"].exists()
+    assert not observed["parent"].exists()
+    assert _sha256(index_path) == original_index_sha256
+    assert not any(path.exists() for path in _sqlite_sidecars(index_path))
+
+
+def test_portable_sqlite_copy_integrity_failure_blocks_query_and_cleans_up(
+    monkeypatch,
+    tmp_path,
+):
+    from merger.repoground.retrieval import query_core
+
+    manifest, _ = _queryable_sqlite_bundle(tmp_path)
+    original_write_copy = bundle_access._write_portable_sqlite_copy
+    observed = {}
+    monkeypatch.setattr(
+        bundle_access,
+        "_FILE_DESCRIPTOR_ROOTS",
+        (tmp_path / "missing-proc-fd", tmp_path / "missing-dev-fd"),
+    )
+
+    def corrupt_copy(handle, destination, **kwargs):
+        original_write_copy(handle, destination, **kwargs)
+        observed["path"] = destination
+        observed["parent"] = destination.parent
+        os.chmod(destination, stat.S_IRUSR | stat.S_IWUSR)
+        with destination.open("ab") as copy:
+            copy.write(b"corrupt")
+        os.chmod(destination, stat.S_IRUSR)
+
+    def forbidden_query(*_args, **_kwargs):
+        raise AssertionError("SQLite must not open an invalid portable copy")
+
+    monkeypatch.setattr(
+        bundle_access,
+        "_write_portable_sqlite_copy",
+        corrupt_copy,
+    )
+    monkeypatch.setattr(query_core, "execute_query", forbidden_query)
+
+    result = bundle_access.query_existing_index(manifest, "portable", k=1)
+
+    assert result["status"] == "invalid"
+    assert result["error_code"] == "sqlite_index_integrity_mismatch"
+    assert result["query_result"] is None
+    assert not observed["path"].exists()
+    assert not observed["parent"].exists()
+
+
+def test_portable_sqlite_copy_post_query_tampering_discards_result_and_cleans_up(
+    monkeypatch,
+    tmp_path,
+):
+    from merger.repoground.retrieval import query_core
+
+    manifest, _ = _queryable_sqlite_bundle(tmp_path)
+    original_execute_query = query_core.execute_query
+    observed = {}
+    monkeypatch.setattr(
+        bundle_access,
+        "_FILE_DESCRIPTOR_ROOTS",
+        (tmp_path / "missing-proc-fd", tmp_path / "missing-dev-fd"),
+    )
+
+    def execute_then_tamper(index_path_arg, query, **kwargs):
+        result = original_execute_query(index_path_arg, query, **kwargs)
+        portable_path = Path(index_path_arg)
+        observed["path"] = portable_path
+        observed["parent"] = portable_path.parent
+        os.chmod(portable_path, stat.S_IRUSR | stat.S_IWUSR)
+        with portable_path.open("ab") as copy:
+            copy.write(b"tampered")
+        os.chmod(portable_path, stat.S_IRUSR)
+        return result
+
+    monkeypatch.setattr(query_core, "execute_query", execute_then_tamper)
+
+    result = bundle_access.query_existing_index(manifest, "portable", k=1)
+
+    assert result["status"] == "invalid"
+    assert result["error_code"] == "sqlite_index_integrity_mismatch"
+    assert result["query_result"] is None
+    assert not observed["path"].exists()
+    assert not observed["parent"].exists()
+
+
+def test_query_existing_index_rejects_manifest_integrity_drift_before_sqlite_open(
+    monkeypatch,
+    tmp_path,
+):
+    from merger.repoground.retrieval import query_core
+
+    index_path = tmp_path / "index.index.sqlite"
+    index_path.write_bytes(b"generation-a")
+    manifest = tmp_path / "demo.bundle.manifest.json"
+    _write_manifest(manifest, [_sealed_artifact(index_path)])
+    index_path.write_bytes(b"generation-b")
+
+    def forbidden_query(*_args, **_kwargs):
+        raise AssertionError("SQLite must not open after integrity drift")
+
+    monkeypatch.setattr(query_core, "execute_query", forbidden_query)
+
+    result = bundle_access.query_existing_index(manifest, "hello", k=1)
+
+    assert result["status"] == "invalid"
+    assert result["error_code"] == "sqlite_index_integrity_mismatch"
+    assert result["query_result"] is None
 
 
 def test_query_existing_index_reads_prebuilt_sqlite_index_without_mutation(tmp_path):
@@ -217,7 +445,7 @@ def test_query_existing_index_reads_prebuilt_sqlite_index_without_mutation(tmp_p
     chunk_path.write_text(json.dumps(chunk) + "\n", encoding="utf-8")
     dump_path.write_text(json.dumps({"version": "1.0", "repos": {"demo": {}}}), encoding="utf-8")
     index_db.build_index(dump_path, chunk_path, index_path)
-    _write_manifest(manifest, [{"role": "sqlite_index", "path": index_path.name}])
+    _write_manifest(manifest, [_sealed_artifact(index_path)])
 
     before_files = {path.name for path in tmp_path.iterdir()}
     before_hash = _sha256(index_path)

--- a/merger/repoground/tests/test_bundle_catalog.py
+++ b/merger/repoground/tests/test_bundle_catalog.py
@@ -35,9 +35,8 @@ def _write_bundle(
         {"verdict": output_status},
     )
     post_path = bundle_dir / f"{stem}.bundle_health.post.json"
-    _write_json(post_path, {"status": "pass"})
     manifest = bundle_dir / f"{stem}.bundle.manifest.json"
-    _write_json(
+    _, manifest_sha = _write_json(
         manifest,
         {
             "kind": "repoground.bundle.manifest",
@@ -69,6 +68,15 @@ def _write_bundle(
                 "agent_export_gate_status": "pass",
                 "export_safety_report_status": "pass",
             },
+        },
+    )
+    _write_json(
+        post_path,
+        {
+            "status": "pass",
+            "bundle_manifest_path": str(manifest.resolve()),
+            "bundle_run_id": run_id,
+            "bundle_manifest_sha256": manifest_sha,
         },
     )
     return manifest
@@ -281,6 +289,40 @@ def test_selector_rejects_output_health_without_valid_integrity_metadata(tmp_pat
     )
     assert "byte size missing or invalid" in reasons
     assert "sha256 missing or invalid" in reasons
+
+
+def test_selector_rejects_post_health_bound_to_another_publication(tmp_path):
+    manifest = _write_bundle(
+        tmp_path,
+        directory="repo/main/stale-post",
+        stem="stale-post",
+        created_at="2026-07-25T21:00:00Z",
+        run_id="stale-post-run",
+    )
+    document = json.loads(manifest.read_text(encoding="utf-8"))
+    post_path = manifest.parent / document["links"]["post_emit_health_path"]
+    stale = json.loads(post_path.read_text(encoding="utf-8"))
+    stale.update(
+        {
+            "bundle_manifest_path": str(
+                (tmp_path / "other.bundle.manifest.json").resolve()
+            ),
+            "bundle_run_id": "other-run",
+            "bundle_manifest_sha256": "0" * 64,
+        }
+    )
+    _write_json(post_path, stale)
+
+    catalog = discover_bundle_catalog(tmp_path)
+    selection = select_bundle_manifest(tmp_path, repo="repoground")
+
+    assert selection["status"] == "missing"
+    candidate = next(
+        item for item in catalog["candidates"] if item["stem"] == "stale-post"
+    )
+    assert candidate["selection_eligible"] is False
+    assert candidate["health_status"] == "invalid"
+    assert any("does not match" in reason for reason in candidate["health_reasons"])
 
 
 def test_selector_fails_closed_for_equal_newest_identity(tmp_path):

--- a/merger/repoground/tests/test_bundle_catalog.py
+++ b/merger/repoground/tests/test_bundle_catalog.py
@@ -1,0 +1,171 @@
+import hashlib
+import json
+from pathlib import Path
+
+from merger.repoground.core.bundle_catalog import (
+    discover_bundle_catalog,
+    manifest_repo_aliases,
+    normalize_repo_remote,
+    select_bundle_manifest,
+)
+
+
+def _write_json(path: Path, value: dict) -> tuple[int, str]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    raw = (json.dumps(value, sort_keys=True) + "\n").encode("utf-8")
+    path.write_bytes(raw)
+    return len(raw), hashlib.sha256(raw).hexdigest()
+
+
+def _write_bundle(
+    root: Path,
+    *,
+    directory: str,
+    stem: str,
+    created_at: str,
+    run_id: str,
+    output_status: str = "pass",
+    remote: str = "git@github.com:heimgewebe/repoground.git",
+) -> Path:
+    bundle_dir = root / directory
+    output_path = bundle_dir / f"{stem}.output_health.json"
+    output_bytes, output_sha = _write_json(
+        output_path,
+        {"verdict": output_status},
+    )
+    post_path = bundle_dir / f"{stem}.bundle_health.post.json"
+    _write_json(post_path, {"status": "pass"})
+    manifest = bundle_dir / f"{stem}.bundle.manifest.json"
+    _write_json(
+        manifest,
+        {
+            "kind": "repoground.bundle.manifest",
+            "version": "2.0",
+            "run_id": run_id,
+            "created_at": created_at,
+            "snapshot_provenance": {
+                "repositories": [
+                    {
+                        "name": "heimgewebe__repoground__main",
+                        "repo_remote": remote,
+                        "git_commit": "a" * 40,
+                        "git_dirty": False,
+                        "provenance_status": "present",
+                    }
+                ]
+            },
+            "artifacts": [
+                {
+                    "role": "output_health",
+                    "path": output_path.name,
+                    "bytes": output_bytes,
+                    "sha256": output_sha,
+                }
+            ],
+            "links": {
+                "post_emit_health_path": post_path.name,
+                "bundle_surface_validation_status": "pass",
+                "agent_export_gate_status": "pass",
+                "export_safety_report_status": "pass",
+            },
+        },
+    )
+    return manifest
+
+
+def test_normalize_repo_remote_accepts_common_github_forms():
+    assert normalize_repo_remote("git@github.com:heimgewebe/repoground.git") == (
+        "heimgewebe/repoground"
+    )
+    assert normalize_repo_remote("https://github.com/heimgewebe/repoground.git") == (
+        "heimgewebe/repoground"
+    )
+
+
+def test_manifest_repo_aliases_include_canonical_and_short_identity():
+    aliases = manifest_repo_aliases(
+        {
+            "snapshot_provenance": {
+                "repositories": [
+                    {
+                        "name": "heimgewebe__repoground__main",
+                        "repo_remote": "git@github.com:heimgewebe/repoground.git",
+                    }
+                ]
+            }
+        }
+    )
+
+    assert aliases == [
+        "heimgewebe/repoground",
+        "heimgewebe__repoground",
+        "heimgewebe__repoground__main",
+        "repoground",
+    ]
+
+
+def test_catalog_ignores_hidden_generation_copy_and_selects_publication(tmp_path):
+    public = _write_bundle(
+        tmp_path,
+        directory="heimgewebe__repoground/main/run-1",
+        stem="repoground-main",
+        created_at="2026-07-25T21:09:13Z",
+        run_id="run-1",
+    )
+    _write_bundle(
+        tmp_path,
+        directory=(
+            "heimgewebe__repoground/main/run-1/.repoground-generations/repoground-main/hash"
+        ),
+        stem="repoground-main",
+        created_at="2026-07-25T21:09:13Z",
+        run_id="run-1",
+    )
+
+    catalog = discover_bundle_catalog(tmp_path)
+    selection = select_bundle_manifest(tmp_path, repo="heimgewebe/repoground")
+
+    assert catalog["candidate_count"] == 1
+    assert selection["status"] == "available"
+    assert selection["selected"]["manifest_path"] == str(public.resolve())
+
+
+def test_selector_skips_newer_unhealthy_bundle(tmp_path):
+    healthy = _write_bundle(
+        tmp_path,
+        directory="repo/main/healthy",
+        stem="healthy",
+        created_at="2026-07-25T20:00:00Z",
+        run_id="healthy-run",
+    )
+    _write_bundle(
+        tmp_path,
+        directory="repo/main/unhealthy",
+        stem="unhealthy",
+        created_at="2026-07-25T21:00:00Z",
+        run_id="unhealthy-run",
+        output_status="fail",
+    )
+
+    selection = select_bundle_manifest(tmp_path, repo="repoground")
+
+    assert selection["status"] == "available"
+    assert selection["selected"]["manifest_path"] == str(healthy.resolve())
+    assert selection["match_count"] == 1
+
+
+def test_selector_fails_closed_for_equal_newest_identity(tmp_path):
+    for directory in ("repo/main/a", "repo/main/b"):
+        _write_bundle(
+            tmp_path,
+            directory=directory,
+            stem=Path(directory).name,
+            created_at="2026-07-25T21:00:00Z",
+            run_id="same-run",
+        )
+
+    selection = select_bundle_manifest(tmp_path, repo="heimgewebe/repoground")
+
+    assert selection["status"] == "ambiguous"
+    assert selection["reason"] == "newest_bundle_identity_ambiguous"
+    assert selection["selected"] is None

--- a/merger/repoground/tests/test_bundle_catalog.py
+++ b/merger/repoground/tests/test_bundle_catalog.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from merger.repoground.core.bundle_catalog import (
     discover_bundle_catalog,
     manifest_repo_aliases,
+    manifest_repo_identities,
     normalize_repo_remote,
     select_bundle_manifest,
 )
@@ -102,6 +103,96 @@ def test_manifest_repo_aliases_include_canonical_and_short_identity():
         "heimgewebe__repoground__main",
         "repoground",
     ]
+
+
+def test_manifest_repo_identities_prefer_explicit_remote():
+    identities = manifest_repo_identities(
+        {
+            "snapshot_provenance": {
+                "repositories": [
+                    {
+                        "name": "wrong-owner__repoground__main",
+                        "repo_remote": "git@github.com:right-owner/repoground.git",
+                    }
+                ]
+            }
+        }
+    )
+    assert identities == ["right-owner/repoground"]
+
+
+def test_short_repo_selector_fails_closed_across_owners(tmp_path):
+    first = _write_bundle(
+        tmp_path,
+        directory="owner-a/main/run",
+        stem="owner-a",
+        created_at="2026-07-25T20:00:00Z",
+        run_id="owner-a-run",
+        remote="git@github.com:owner-a/repoground.git",
+    )
+    second = _write_bundle(
+        tmp_path,
+        directory="owner-b/main/run",
+        stem="owner-b",
+        created_at="2026-07-25T21:00:00Z",
+        run_id="owner-b-run",
+        remote="git@github.com:owner-b/repoground.git",
+    )
+
+    short = select_bundle_manifest(tmp_path, repo="repoground")
+    qualified = select_bundle_manifest(tmp_path, repo="owner-a/repoground")
+    underscored = select_bundle_manifest(tmp_path, repo="owner-b__repoground")
+
+    assert short["status"] == "ambiguous"
+    assert short["reason"] == "repository_identity_ambiguous"
+    assert short["repo_identity_groups"] == [
+        "owner-a/repoground",
+        "owner-b/repoground",
+    ]
+    assert qualified["selected"]["manifest_path"] == str(first.resolve())
+    assert underscored["selected"]["manifest_path"] == str(second.resolve())
+
+
+def test_selector_orders_created_at_by_normalized_utc_and_rejects_invalid(tmp_path):
+    earlier = _write_bundle(
+        tmp_path,
+        directory="repo/main/earlier",
+        stem="earlier",
+        created_at="2026-07-25T23:30:00+02:00",
+        run_id="earlier-run",
+    )
+    later = _write_bundle(
+        tmp_path,
+        directory="repo/main/later",
+        stem="later",
+        created_at="2026-07-25T22:00:00Z",
+        run_id="later-run",
+    )
+    _write_bundle(
+        tmp_path,
+        directory="repo/main/invalid",
+        stem="invalid",
+        created_at="zzzz",
+        run_id="invalid-run",
+    )
+
+    catalog = discover_bundle_catalog(tmp_path)
+    selection = select_bundle_manifest(tmp_path, repo="heimgewebe/repoground")
+
+    assert selection["status"] == "available"
+    assert selection["selected"]["manifest_path"] == str(later.resolve())
+    assert selection["selected"]["manifest_path"] != str(earlier.resolve())
+    assert selection["selected"]["created_at_utc"] == "2026-07-25T22:00:00.000000Z"
+    invalid = next(item for item in catalog["candidates"] if item["stem"] == "invalid")
+    assert invalid["timestamp_status"] == "invalid"
+    assert invalid["selection_eligible"] is False
+    assert "created_at" in invalid["timestamp_reason"]
+    invalid_only = select_bundle_manifest(
+        invalid["manifest_path"],
+        repo="heimgewebe/repoground",
+        require_healthy=False,
+    )
+    assert invalid_only["status"] == "missing"
 
 
 def test_catalog_ignores_hidden_generation_copy_and_selects_publication(tmp_path):

--- a/merger/repoground/tests/test_bundle_catalog.py
+++ b/merger/repoground/tests/test_bundle_catalog.py
@@ -1,7 +1,14 @@
 import hashlib
 import json
+import os
 from pathlib import Path
+import subprocess
+import sys
+import threading
 
+import pytest
+
+from merger.repoground.core import bundle_catalog as bundle_catalog_module
 from merger.repoground.core.bundle_catalog import (
     discover_bundle_catalog,
     manifest_repo_aliases,
@@ -227,6 +234,378 @@ def test_catalog_ignores_hidden_generation_copy_and_selects_publication(tmp_path
     assert catalog["candidate_count"] == 1
     assert selection["status"] == "available"
     assert selection["selected"]["manifest_path"] == str(public.resolve())
+
+
+@pytest.mark.parametrize("candidate_kind", ("regular", "internal_symlink"))
+def test_catalog_accepts_regular_file_and_internal_manifest_symlink(
+    tmp_path, candidate_kind
+):
+    root = tmp_path / "catalog"
+    directory = (
+        "repo/main/run" if candidate_kind == "regular" else ".storage/repo/main/run"
+    )
+    manifest = _write_bundle(
+        root,
+        directory=directory,
+        stem="internal",
+        created_at="2026-07-25T21:00:00Z",
+        run_id=f"{candidate_kind}-run",
+    )
+    if candidate_kind == "internal_symlink":
+        publication = root / "repo" / "main" / "internal.bundle.manifest.json"
+        publication.parent.mkdir(parents=True)
+        publication.symlink_to(manifest)
+
+    catalog = discover_bundle_catalog(root)
+
+    assert catalog["candidate_count"] == 1
+    assert catalog["candidates"][0]["manifest_path"] == str(manifest.resolve())
+    assert catalog["candidates"][0]["health_status"] == "pass"
+
+
+def test_catalog_bounded_reads_use_portable_open_fallback(tmp_path, monkeypatch):
+    manifest = _write_bundle(
+        tmp_path,
+        directory="repo/main/run",
+        stem="portable",
+        created_at="2026-07-25T21:00:00Z",
+        run_id="portable-run",
+    )
+    monkeypatch.setattr(bundle_catalog_module.os, "O_NONBLOCK", 0, raising=False)
+
+    catalog = discover_bundle_catalog(tmp_path)
+
+    assert catalog["candidate_count"] == 1
+    assert catalog["candidates"][0]["manifest_path"] == str(manifest.resolve())
+    assert catalog["candidates"][0]["health_status"] == "pass"
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFO requires POSIX support")
+@pytest.mark.parametrize("via_symlink", (False, True))
+def test_catalog_fifo_candidate_without_writer_terminates_and_is_rejected(
+    tmp_path, via_symlink
+):
+    root = tmp_path / "catalog"
+    healthy = _write_bundle(
+        root,
+        directory="repo/main/healthy",
+        stem="healthy",
+        created_at="2026-07-25T20:00:00Z",
+        run_id="healthy-run",
+    )
+    if via_symlink:
+        fifo = root / ".storage" / "blocked.fifo"
+        fifo.parent.mkdir(parents=True)
+        os.mkfifo(fifo)
+        candidate = root / "blocked.bundle.manifest.json"
+        candidate.symlink_to(fifo)
+    else:
+        candidate = root / "blocked.bundle.manifest.json"
+        os.mkfifo(candidate)
+
+    script = (
+        "import json,sys;"
+        "from merger.repoground.core.bundle_catalog import discover_bundle_catalog;"
+        "print(json.dumps(discover_bundle_catalog(sys.argv[1])))"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script, str(root)],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    catalog = json.loads(completed.stdout)
+
+    assert catalog["candidate_count"] == 1
+    assert catalog["candidates"][0]["manifest_path"] == str(healthy.resolve())
+    assert catalog["rejected_count"] == 1
+    assert catalog["rejected"][0]["manifest_path"] == str(candidate)
+    assert "not regular" in catalog["rejected"][0]["reason"]
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFO requires POSIX support")
+@pytest.mark.parametrize("via_symlink", (False, True))
+def test_catalog_direct_fifo_root_is_one_rejected_candidate(tmp_path, via_symlink):
+    fifo = tmp_path / "blocked.fifo"
+    os.mkfifo(fifo)
+    if via_symlink:
+        candidate = tmp_path / "blocked.bundle.manifest.json"
+        candidate.symlink_to(fifo)
+    else:
+        candidate = tmp_path / "blocked.bundle.manifest.json"
+        fifo.rename(candidate)
+
+    script = (
+        "import json,sys;"
+        "from merger.repoground.core.bundle_catalog import discover_bundle_catalog;"
+        "print(json.dumps(discover_bundle_catalog(sys.argv[1])))"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script, str(candidate)],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    catalog = json.loads(completed.stdout)
+
+    assert catalog["candidate_count"] == 0
+    assert catalog["rejected_count"] == 1
+    assert catalog["rejected"][0]["manifest_path"] == str(candidate)
+    assert "not regular" in catalog["rejected"][0]["reason"]
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFO requires POSIX support")
+@pytest.mark.parametrize("portable_fallback", (False, True))
+def test_catalog_rejects_regular_to_fifo_open_race_as_one_candidate(
+    tmp_path, monkeypatch, portable_fallback
+):
+    root = tmp_path / "catalog"
+    healthy = _write_bundle(
+        root,
+        directory="repo/main/healthy",
+        stem="healthy",
+        created_at="2026-07-25T20:00:00Z",
+        run_id="healthy-run",
+    )
+    raced = _write_bundle(
+        root,
+        directory="repo/main/raced",
+        stem="raced",
+        created_at="2026-07-25T21:00:00Z",
+        run_id="raced-run",
+    )
+    backup = raced.with_name("raced.original")
+    exchanged = False
+
+    def exchange_target() -> None:
+        nonlocal exchanged
+        exchanged = True
+        raced.replace(backup)
+        os.mkfifo(raced)
+
+    def restore_target() -> None:
+        raced.unlink(missing_ok=True)
+        backup.replace(raced)
+
+    if portable_fallback:
+        original_portable = bundle_catalog_module._read_bounded_portable
+        monkeypatch.setattr(bundle_catalog_module.os, "O_NONBLOCK", 0)
+        monkeypatch.setattr(bundle_catalog_module, "_OPEN_TIMEOUT_SECONDS", 0.05)
+
+        def exchange_portable(path, max_bytes, expected_identity):
+            if not exchanged and Path(path) == raced:
+                exchange_target()
+                try:
+                    return original_portable(path, max_bytes, expected_identity)
+                finally:
+                    restore_target()
+            return original_portable(path, max_bytes, expected_identity)
+
+        monkeypatch.setattr(
+            bundle_catalog_module,
+            "_read_bounded_portable",
+            exchange_portable,
+        )
+    else:
+        original_open = bundle_catalog_module._open_binary
+
+        def exchange_open(path):
+            if not exchanged and Path(path) == raced:
+                exchange_target()
+                try:
+                    return original_open(path)
+                finally:
+                    restore_target()
+            return original_open(path)
+
+        monkeypatch.setattr(bundle_catalog_module, "_open_binary", exchange_open)
+
+    catalog = discover_bundle_catalog(root)
+
+    assert exchanged is True
+    assert catalog["candidate_count"] == 1
+    assert catalog["candidates"][0]["manifest_path"] == str(healthy.resolve())
+    assert catalog["rejected_count"] == 1
+    assert catalog["rejected"][0]["manifest_path"] == str(raced)
+    expected_reason = (
+        "open exceeded time bound" if portable_fallback else "not regular"
+    )
+    assert expected_reason in catalog["rejected"][0]["reason"]
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFO requires POSIX support")
+def test_portable_fifo_timeouts_leave_no_threads_or_children(tmp_path, monkeypatch):
+    candidate = _write_bundle(
+        tmp_path,
+        directory="repo/main/raced",
+        stem="raced",
+        created_at="2026-07-25T21:00:00Z",
+        run_id="raced-run",
+    )
+    original_portable = bundle_catalog_module._read_bounded_portable
+    original_popen = subprocess.Popen
+    processes = []
+
+    class RecordingPopen(original_popen):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            processes.append(self)
+
+    monkeypatch.setattr(bundle_catalog_module.os, "O_NONBLOCK", 0)
+    monkeypatch.setattr(bundle_catalog_module, "_OPEN_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(bundle_catalog_module.subprocess, "Popen", RecordingPopen)
+
+    baseline_threads = len(threading.enumerate())
+    for attempt in range(3):
+        backup = candidate.with_name(f"raced.original.{attempt}")
+        candidate.replace(backup)
+        os.mkfifo(candidate)
+        expected_identity = bundle_catalog_module._file_identity(backup.stat())
+        try:
+            with pytest.raises(
+                bundle_catalog_module.BundleCatalogError,
+                match="open exceeded time bound",
+            ):
+                original_portable(candidate, 4 * 1024 * 1024, expected_identity)
+        finally:
+            candidate.unlink(missing_ok=True)
+            backup.replace(candidate)
+
+    assert len(threading.enumerate()) == baseline_threads
+    assert len(processes) == 3
+    assert all(process.poll() is not None for process in processes)
+
+
+@pytest.mark.parametrize("nested", (False, True))
+def test_catalog_rejects_manifest_symlink_escape_without_hiding_healthy_candidates(
+    tmp_path, monkeypatch, nested
+):
+    root = tmp_path / "catalog"
+    root.mkdir()
+    healthy = _write_bundle(
+        root,
+        directory="repo/main/healthy",
+        stem="healthy",
+        created_at="2026-07-25T20:00:00Z",
+        run_id="healthy-run",
+    )
+    external = _write_bundle(
+        tmp_path / "outside",
+        directory="run",
+        stem="external",
+        created_at="2026-07-25T21:00:00Z",
+        run_id="external-run",
+    )
+    escape = (
+        root / "repo" / "main" / "nested" / "escape.bundle.manifest.json"
+        if nested
+        else root / "escape.bundle.manifest.json"
+    )
+    escape.parent.mkdir(parents=True, exist_ok=True)
+    escape.symlink_to(external)
+    opened_paths = []
+    original_open = bundle_catalog_module._open_binary
+
+    def record_open(path):
+        opened_paths.append(Path(path))
+        return original_open(path)
+
+    monkeypatch.setattr(bundle_catalog_module, "_open_binary", record_open)
+
+    catalog = discover_bundle_catalog(root)
+
+    assert catalog["candidate_count"] == 1
+    assert catalog["candidates"][0]["manifest_path"] == str(healthy.resolve())
+    assert catalog["rejected_count"] == 1
+    assert catalog["rejected"][0]["manifest_path"] == str(escape)
+    assert "outside catalog root" in catalog["rejected"][0]["reason"]
+    assert external.resolve() not in opened_paths
+    assert str(external.resolve()) not in json.dumps(catalog, sort_keys=True)
+
+
+def test_catalog_rejects_open_time_escape_exchange_and_restore_before_read(
+    tmp_path, monkeypatch
+):
+    root = tmp_path / "catalog"
+    healthy = _write_bundle(
+        root,
+        directory="repo/main/healthy",
+        stem="healthy",
+        created_at="2026-07-25T20:00:00Z",
+        run_id="healthy-run",
+    )
+    internal = _write_bundle(
+        root,
+        directory=".storage/run",
+        stem="selected",
+        created_at="2026-07-25T21:00:00Z",
+        run_id="internal-run",
+    )
+    publication = root / "repo" / "selected.bundle.manifest.json"
+    publication.parent.mkdir(parents=True, exist_ok=True)
+    publication.symlink_to(internal)
+    external = _write_bundle(
+        tmp_path / "outside",
+        directory="run",
+        stem="external",
+        created_at="2026-07-25T22:00:00Z",
+        run_id="external-run",
+    )
+    original_open = bundle_catalog_module._open_binary
+    backup = internal.with_name("selected.original")
+    exchanged = False
+    external_bytes_read = False
+
+    class TrackingHandle:
+        def __init__(self, handle):
+            self.handle = handle
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            self.handle.close()
+            return False
+
+        def fileno(self):
+            return self.handle.fileno()
+
+        def read(self, size):
+            nonlocal external_bytes_read
+            external_bytes_read = True
+            return self.handle.read(size)
+
+    def exchange_around_open(path):
+        nonlocal exchanged
+        if not exchanged and Path(path) == internal:
+            exchanged = True
+            internal.replace(backup)
+            internal.symlink_to(external)
+            try:
+                handle = original_open(path)
+            finally:
+                internal.unlink()
+                backup.replace(internal)
+            return TrackingHandle(handle)
+        return original_open(path)
+
+    monkeypatch.setattr(bundle_catalog_module, "_open_binary", exchange_around_open)
+
+    catalog = discover_bundle_catalog(root)
+
+    assert exchanged is True
+    assert external_bytes_read is False
+    assert catalog["candidate_count"] == 1
+    assert catalog["candidates"][0]["manifest_path"] == str(healthy.resolve())
+    assert catalog["rejected_count"] == 1
+    assert catalog["rejected"][0]["manifest_path"] == str(publication)
+    assert any(
+        text in catalog["rejected"][0]["reason"]
+        for text in ("cannot be read", "identity changed")
+    )
+    assert str(external.resolve()) not in json.dumps(catalog, sort_keys=True)
 
 
 def test_selector_skips_newer_unhealthy_bundle(tmp_path):

--- a/merger/repoground/tests/test_bundle_catalog.py
+++ b/merger/repoground/tests/test_bundle_catalog.py
@@ -154,6 +154,44 @@ def test_selector_skips_newer_unhealthy_bundle(tmp_path):
     assert selection["match_count"] == 1
 
 
+def test_selector_rejects_output_health_without_valid_integrity_metadata(tmp_path):
+    cases = (
+        ("missing-bytes", lambda artifact: artifact.pop("bytes")),
+        ("missing-sha", lambda artifact: artifact.pop("sha256")),
+        ("malformed-sha", lambda artifact: artifact.update({"sha256": "bad"})),
+    )
+    for label, mutate in cases:
+        manifest = _write_bundle(
+            tmp_path,
+            directory=f"repo/main/{label}",
+            stem=label,
+            created_at="2026-07-25T21:00:00Z",
+            run_id=f"{label}-run",
+        )
+        document = json.loads(manifest.read_text(encoding="utf-8"))
+        artifact = next(
+            item for item in document["artifacts"] if item["role"] == "output_health"
+        )
+        mutate(artifact)
+        _write_json(manifest, document)
+
+    catalog = discover_bundle_catalog(tmp_path)
+    selection = select_bundle_manifest(tmp_path, repo="repoground")
+
+    assert selection["status"] == "missing"
+    assert {item["stem"] for item in catalog["candidates"]} == {
+        "missing-bytes",
+        "missing-sha",
+        "malformed-sha",
+    }
+    assert all(item["selection_eligible"] is False for item in catalog["candidates"])
+    reasons = " ".join(
+        reason for item in catalog["candidates"] for reason in item["health_reasons"]
+    )
+    assert "byte size missing or invalid" in reasons
+    assert "sha256 missing or invalid" in reasons
+
+
 def test_selector_fails_closed_for_equal_newest_identity(tmp_path):
     for directory in ("repo/main/a", "repo/main/b"):
         _write_bundle(

--- a/merger/repoground/tests/test_call_navigation.py
+++ b/merger/repoground/tests/test_call_navigation.py
@@ -13,6 +13,10 @@ from merger.repoground.core.bundle_access import (
     get_callees,
     get_callers,
 )
+from merger.repoground.core.manifest_snapshot import (
+    capture_manifest_snapshot,
+    use_manifest_binding,
+)
 
 RUN_ID = "run-1"
 CANONICAL_SHA = "a" * 64
@@ -307,6 +311,59 @@ def _refresh_manifest_artifact(manifest: Path, role: str, artifact: Path) -> Non
     manifest.write_text(json.dumps(payload), encoding="utf-8")
 
 
+def _navigation_manifest_generations(
+    tmp_path: Path,
+) -> tuple[Path, bytes, bytes]:
+    publication = tmp_path / "publication"
+    generation_a = publication / "generation-a"
+    generation_b = publication / "generation-b"
+    generation_a.mkdir(parents=True)
+    generation_b.mkdir(parents=True)
+    manifest_a, _, _ = _write_bundle(generation_a)
+    manifest_b, call_graph_b, symbol_index_b = _write_bundle(generation_b)
+
+    call_payload = json.loads(call_graph_b.read_text(encoding="utf-8"))
+    call_payload["calls"][0]["simple_name"] = "generation_b_target"
+    call_payload["calls"][0]["callee_expression"] = "generation_b_target"
+    call_graph_b.write_text(json.dumps(call_payload), encoding="utf-8")
+    _refresh_manifest_artifact(
+        manifest_b,
+        "python_call_graph_json",
+        call_graph_b,
+    )
+
+    symbol_payload = json.loads(symbol_index_b.read_text(encoding="utf-8"))
+    selected_target = next(
+        item for item in symbol_payload["symbols"] if item["id"] == TARGET_ID
+    )
+    selected_target["name"] = "generation_b_target"
+    selected_target["qualified_name"] = "generation_b_target"
+    symbol_index_b.write_text(json.dumps(symbol_payload), encoding="utf-8")
+    _refresh_manifest_artifact(
+        manifest_b,
+        "python_symbol_index_json",
+        symbol_index_b,
+    )
+
+    def publication_bytes(source: Path, generation: str) -> bytes:
+        document = json.loads(source.read_text(encoding="utf-8"))
+        for artifact in document["artifacts"]:
+            artifact["path"] = f"{generation}/{artifact['path']}"
+        return json.dumps(document, sort_keys=True).encode("utf-8")
+
+    active_manifest = publication / "demo.bundle.manifest.json"
+    manifest_a_bytes = publication_bytes(manifest_a, generation_a.name)
+    manifest_b_bytes = publication_bytes(manifest_b, generation_b.name)
+    active_manifest.write_bytes(manifest_a_bytes)
+    return active_manifest, manifest_a_bytes, manifest_b_bytes
+
+
+def _replace_manifest_bytes(path: Path, raw: bytes, label: str) -> None:
+    replacement = path.with_name(f"{label}.bundle.manifest.json")
+    replacement.write_bytes(raw)
+    replacement.replace(path)
+
+
 def test_navigation_cache_reuses_validated_call_state(tmp_path, monkeypatch):
     manifest = _bundle(tmp_path)
     original = bundle_access._load_call_graph_source
@@ -325,6 +382,94 @@ def test_navigation_cache_reuses_validated_call_state(tmp_path, monkeypatch):
     assert cold == warm
     assert calls == 1
     assert len(bundle_access._CALL_NAVIGATION_CACHE) == 1
+
+
+def test_bound_manifest_excludes_warm_call_cache_from_other_generation(tmp_path):
+    manifest, manifest_a, manifest_b = _navigation_manifest_generations(tmp_path)
+    _replace_manifest_bytes(manifest, manifest_b, "warm-generation-b")
+    warmed_b = find_references(manifest, "target", k=10)
+    assert warmed_b["exact_match_count"] == 3
+
+    _replace_manifest_bytes(manifest, manifest_a, "select-generation-a")
+    binding_a = capture_manifest_snapshot(manifest).binding
+    with use_manifest_binding(binding_a):
+        _replace_manifest_bytes(manifest, manifest_b, "transient-generation-b")
+        try:
+            selected_a = find_references(manifest, "target", k=10)
+        finally:
+            _replace_manifest_bytes(manifest, manifest_a, "restore-generation-a")
+
+    assert selected_a["status"] == "available"
+    assert selected_a["exact_match_count"] == 4
+
+
+def test_bound_manifest_excludes_warm_symbol_cache_from_other_generation(tmp_path):
+    manifest, manifest_a, manifest_b = _navigation_manifest_generations(tmp_path)
+    _replace_manifest_bytes(manifest, manifest_b, "warm-generation-b")
+    warmed_b = get_callers(
+        manifest,
+        "generation_b_target",
+        path="pkg/target.py",
+        k=10,
+    )
+    assert warmed_b["status"] == "available"
+    assert warmed_b["target_symbol"]["name"] == "generation_b_target"
+
+    _replace_manifest_bytes(manifest, manifest_a, "select-generation-a")
+    binding_a = capture_manifest_snapshot(manifest).binding
+    with use_manifest_binding(binding_a):
+        _replace_manifest_bytes(manifest, manifest_b, "transient-generation-b")
+        try:
+            selected_a = get_callers(
+                manifest,
+                "target",
+                path="pkg/target.py",
+                k=10,
+            )
+        finally:
+            _replace_manifest_bytes(manifest, manifest_a, "restore-generation-a")
+
+    assert selected_a["status"] == "available"
+    assert selected_a["target_symbol"]["name"] == "target"
+
+
+def test_matching_bound_manifest_reuses_call_and_symbol_warm_caches(
+    tmp_path,
+    monkeypatch,
+):
+    manifest, manifest_a, manifest_b = _navigation_manifest_generations(tmp_path)
+    warmed_a = get_callers(
+        manifest,
+        "target",
+        path="pkg/target.py",
+        k=10,
+    )
+    assert warmed_a["status"] == "available"
+    binding_a = capture_manifest_snapshot(manifest).binding
+
+    def forbidden_reload(*_args, **_kwargs):
+        raise AssertionError(
+            "matching manifest binding must reuse warm navigation state"
+        )
+
+    monkeypatch.setattr(bundle_access, "_load_call_graph_source", forbidden_reload)
+    monkeypatch.setattr(bundle_access, "_load_symbol_index_source", forbidden_reload)
+    with use_manifest_binding(binding_a):
+        _replace_manifest_bytes(manifest, manifest_b, "transient-generation-b")
+        try:
+            references = find_references(manifest, "target", k=10)
+            callers = get_callers(
+                manifest,
+                "target",
+                path="pkg/target.py",
+                k=10,
+            )
+        finally:
+            _replace_manifest_bytes(manifest, manifest_a, "restore-generation-a")
+
+    assert references["status"] == "available"
+    assert references["exact_match_count"] == 4
+    assert callers == warmed_a
 
 
 def test_public_navigation_results_cannot_mutate_cached_state(tmp_path):

--- a/merger/repoground/tests/test_mcp_boundary_doc.py
+++ b/merger/repoground/tests/test_mcp_boundary_doc.py
@@ -1,5 +1,12 @@
 from pathlib import Path
 
+from merger.repoground.cli.mcp_stdio import tool_names
+from scripts.docmeta.sync_repoground_mcp_tools import (
+    END_MARKER,
+    START_MARKER,
+    render_tool_block,
+)
+
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 MCP_BOUNDARY_DOC = REPO_ROOT / "docs/architecture/repoground-mcp-boundary.md"
@@ -16,17 +23,12 @@ MCP_RESOURCES = (
     "repoground://snapshot/{stem}/artifact/{role}",
 )
 
-READ_ONLY_TOOLS = (
-    "snapshot_list",
-    "snapshot_status",
-    "artifact_get",
-    "required_reading_resolve",
-    "range_get",
-    "query_existing_index",
-    "ask_context",
-    "grounding_verify",
-    "live_freshness",
+READ_ONLY_TOOLS = tuple(
+    dict.fromkeys(
+        (*tool_names(), "snapshot_list", "artifact_get", "required_reading_resolve")
+    )
 )
+
 
 FORBIDDEN_OPERATIONS = (
     "git_push",
@@ -177,7 +179,9 @@ def test_mcp_boundary_doc_names_concrete_readonly_resource_adapter() -> None:
 def test_mcp_usage_doc_has_stable_start_and_client_configuration() -> None:
     text = _read(MCP_USAGE_DOC)
 
-    assert "python3 /absolute/path/to/repoground/scripts/repoground-mcp-stdio.py" in text
+    assert (
+        "python3 /absolute/path/to/repoground/scripts/repoground-mcp-stdio.py" in text
+    )
     assert "python3 -m merger.repoground.cli.mcp_stdio" in text
     assert '"mcpServers"' in text
     assert '"repoground": {' in text
@@ -187,3 +191,12 @@ def test_mcp_usage_doc_has_stable_start_and_client_configuration() -> None:
     assert "--enable-snapshot-create" in text
     assert "cannot choose another source repository or output root" in text
     assert "repo_root_not_configured" not in text
+
+
+def test_mcp_tool_blocks_are_generated_from_runtime_registry() -> None:
+    expected = render_tool_block()
+    for path in (MCP_BOUNDARY_DOC, MCP_USAGE_DOC):
+        text = _read(path)
+        start = text.index(START_MARKER)
+        end = text.index(END_MARKER, start) + len(END_MARKER)
+        assert text[start:end] == expected

--- a/merger/repoground/tests/test_mcp_project_launcher.py
+++ b/merger/repoground/tests/test_mcp_project_launcher.py
@@ -109,3 +109,14 @@ def test_selected_bundle_fails_closed_when_catalog_is_ambiguous(tmp_path, monkey
 
     with pytest.raises(BundleCatalogError, match="newest_bundle_identity_ambiguous"):
         module._selected_bundle_manifest()
+
+
+def test_project_launcher_documentation_matches_canonical_publication_roots():
+    documentation = (REPO_ROOT / "docs/usage/repoground-mcp-stdio.md").read_text(
+        encoding="utf-8"
+    )
+    assert "manifest-publications/bundles" in documentation
+    assert "REPOGROUND_PUBLICATION_ROOT" in documentation
+    assert "REPOGROUND_BUNDLE_ROOT" in documentation
+    assert "REPOGROUND_REPO_ID" in documentation
+    assert "does not fall back" in documentation

--- a/merger/repoground/tests/test_mcp_project_launcher.py
+++ b/merger/repoground/tests/test_mcp_project_launcher.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from merger.repoground.core.bundle_catalog import BundleCatalogError
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+LAUNCHER_PATH = REPO_ROOT / "scripts" / "repoground-mcp-project.py"
+
+
+def _load_launcher():
+    spec = importlib.util.spec_from_file_location(
+        "repoground_mcp_project_test_module", LAUNCHER_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_launcher_source_does_not_contain_legacy_local_bundle_default():
+    text = LAUNCHER_PATH.read_text(encoding="utf-8")
+
+    assert "~/.local/share/repoground/bundles" not in text
+    assert "manifest-publications" in text
+
+
+def test_canonical_publication_root_finds_ancestor_catalog(tmp_path, monkeypatch):
+    module = _load_launcher()
+    repo_root = tmp_path / ".repoground-worktrees" / "frontdoor"
+    repo_root.mkdir(parents=True)
+    publication_root = tmp_path / "manifest-publications" / "bundles"
+    publication_root.mkdir(parents=True)
+    monkeypatch.setattr(module, "REPO_ROOT", repo_root)
+    monkeypatch.delenv("REPOGROUND_BUNDLE_ROOT", raising=False)
+    monkeypatch.delenv("REPOGROUND_PUBLICATION_ROOT", raising=False)
+
+    assert module._canonical_publication_root() == publication_root.resolve()
+
+
+def test_explicit_bundle_root_override_has_priority(tmp_path, monkeypatch):
+    module = _load_launcher()
+    override = tmp_path / "explicit-bundles"
+    monkeypatch.setenv("REPOGROUND_BUNDLE_ROOT", str(override))
+    monkeypatch.setenv("REPOGROUND_PUBLICATION_ROOT", str(tmp_path / "lower-priority"))
+
+    assert module._canonical_publication_root() == override.resolve()
+
+
+def test_selected_bundle_uses_repo_identity_and_healthy_catalog(tmp_path, monkeypatch):
+    module = _load_launcher()
+    publication_root = tmp_path / "publications"
+    manifest = publication_root / "selected.bundle.manifest.json"
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    seen = {}
+
+    monkeypatch.setattr(module, "REPO_ROOT", repo_root)
+    monkeypatch.setattr(module, "_canonical_publication_root", lambda: publication_root)
+    monkeypatch.setattr(
+        module, "checkout_repo_identity", lambda _root: "heimgewebe/repoground"
+    )
+
+    def select(root, *, repo, require_healthy):
+        seen.update(
+            {
+                "root": root,
+                "repo": repo,
+                "require_healthy": require_healthy,
+            }
+        )
+        return {
+            "status": "available",
+            "selected": {"manifest_path": str(manifest)},
+        }
+
+    monkeypatch.setattr(module, "select_bundle_manifest", select)
+    monkeypatch.delenv("REPOGROUND_REPO_ID", raising=False)
+
+    assert module._selected_bundle_manifest() == manifest
+    assert seen == {
+        "root": publication_root,
+        "repo": "heimgewebe/repoground",
+        "require_healthy": True,
+    }
+
+
+def test_selected_bundle_fails_closed_when_catalog_is_ambiguous(tmp_path, monkeypatch):
+    module = _load_launcher()
+    publication_root = tmp_path / "publications"
+    monkeypatch.setattr(module, "_canonical_publication_root", lambda: publication_root)
+    monkeypatch.setattr(
+        module, "checkout_repo_identity", lambda _root: "heimgewebe/repoground"
+    )
+    monkeypatch.setattr(
+        module,
+        "select_bundle_manifest",
+        lambda *_args, **_kwargs: {
+            "status": "ambiguous",
+            "reason": "newest_bundle_identity_ambiguous",
+            "selected": None,
+        },
+    )
+    monkeypatch.delenv("REPOGROUND_REPO_ID", raising=False)
+
+    with pytest.raises(BundleCatalogError, match="newest_bundle_identity_ambiguous"):
+        module._selected_bundle_manifest()

--- a/merger/repoground/tests/test_mcp_query_routing.py
+++ b/merger/repoground/tests/test_mcp_query_routing.py
@@ -1,0 +1,160 @@
+from merger.repoground.core import ask_context, mcp_tools
+
+
+def test_symbol_definition_intent_is_conservative_and_bilingual():
+    assert (
+        mcp_tools._symbol_definition_intent(
+            "Wo ist die Funktion snapshot_status definiert?"
+        )
+        == "snapshot_status"
+    )
+    assert (
+        mcp_tools._symbol_definition_intent("Where is `snapshot_status` defined?")
+        == "snapshot_status"
+    )
+    assert mcp_tools._symbol_definition_intent("How does snapshot status work?") is None
+    assert (
+        mcp_tools._symbol_definition_intent("Wo wird `snapshot_status` aufgerufen?")
+        is None
+    )
+    assert (
+        mcp_tools._symbol_definition_intent("Where is `snapshot_status` called?")
+        is None
+    )
+
+
+def test_query_routes_exact_definition_question_to_symbol_index(monkeypatch):
+    monkeypatch.setattr(
+        mcp_tools,
+        "find_symbol",
+        lambda **_arguments: {
+            "status": "available",
+            "result": {
+                "status": "available",
+                "availability": {"status": "pass"},
+                "freshness": {"status": "not_comparable"},
+                "hits": [
+                    {
+                        "id": "exact",
+                        "kind": "function",
+                        "name": "snapshot_status",
+                        "qualified_name": "snapshot_status",
+                        "path": "src/snapshot.py",
+                        "start_line": 10,
+                        "end_line": 20,
+                        "range_ref": "file:src/snapshot.py#L10-L20",
+                        "source_range": {
+                            "path": "src/snapshot.py",
+                            "start_line": 10,
+                            "end_line": 20,
+                        },
+                    },
+                    {
+                        "id": "fuzzy",
+                        "kind": "function",
+                        "name": "update_snapshot_status",
+                        "qualified_name": "update_snapshot_status",
+                        "path": "src/other.py",
+                        "start_line": 1,
+                        "end_line": 2,
+                    },
+                ],
+            },
+        },
+    )
+    monkeypatch.setattr(
+        ask_context,
+        "build_ask_context_pack",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("text fallback must not run for an exact symbol hit")
+        ),
+    )
+
+    result = mcp_tools.query_existing_index(
+        bundle_manifest="demo.bundle.manifest.json",
+        query="Wo ist die Funktion snapshot_status definiert?",
+        k=5,
+    )
+
+    assert result["route"] == "symbol_definition"
+    assert result["retrieval"]["strategy"] == "symbol_definition"
+    assert result["navigation_hits"] == [
+        {
+            "id": "exact",
+            "kind": "function",
+            "name": "snapshot_status",
+            "qualified_name": "snapshot_status",
+            "path": "src/snapshot.py",
+            "start_line": 10,
+            "end_line": 20,
+            "range_ref": "file:src/snapshot.py#L10-L20",
+            "source_range": {
+                "path": "src/snapshot.py",
+                "start_line": 10,
+                "end_line": 20,
+            },
+        }
+    ]
+    assert result["resolved_ranges"] == []
+    assert result["availability"] == {"status": "available", "caveats": []}
+    assert result["freshness"]["status"] == "not_comparable"
+    assert result["budget"]["truncated"] is False
+
+
+def test_compact_symbol_hits_reports_total_before_limit():
+    result = {
+        "result": {
+            "hits": [
+                {
+                    "id": "one",
+                    "name": "run",
+                    "qualified_name": "run",
+                    "path": "src/a.py",
+                    "start_line": 1,
+                },
+                {
+                    "id": "two",
+                    "name": "run",
+                    "qualified_name": "Worker.run",
+                    "path": "src/b.py",
+                    "start_line": 2,
+                },
+            ]
+        }
+    }
+
+    hits, total = mcp_tools._compact_symbol_hits(result, name="run", k=1)
+
+    assert [hit["id"] for hit in hits] == ["one"]
+    assert total == 2
+
+
+def test_query_uses_text_retrieval_for_broad_question(monkeypatch):
+    monkeypatch.setattr(
+        ask_context,
+        "build_ask_context_pack",
+        lambda *_args, **_kwargs: {
+            "retrieval": {
+                "raw_query": "How does freshness work?",
+                "fts_query": "freshness",
+                "strategy": "exact_and",
+                "match_count": 1,
+            },
+            "retrieval_hits": [],
+            "resolved_ranges": [],
+            "budget": {"max_context_tokens": 1000},
+            "availability": {"status": "available", "caveats": []},
+            "freshness": {"status": "fresh", "caveats": []},
+            "answer_scaffold": {"caveats_to_surface": []},
+        },
+    )
+
+    result = mcp_tools.query_existing_index(
+        bundle_manifest="demo.bundle.manifest.json",
+        query="How does freshness work?",
+        max_context_tokens=1000,
+    )
+
+    assert result["route"] == "text_retrieval"
+    assert result["retrieval"]["strategy"] == "exact_and"
+    assert "navigation_hits" not in result

--- a/merger/repoground/tests/test_mcp_query_routing.py
+++ b/merger/repoground/tests/test_mcp_query_routing.py
@@ -1,3 +1,9 @@
+import json
+
+from merger.repoground.tests.test_ask_context_cli import (
+    _add_artifact,
+    _complete_basic_bundle,
+)
 from merger.repoground.core import ask_context, mcp_tools
 
 
@@ -158,3 +164,30 @@ def test_query_uses_text_retrieval_for_broad_question(monkeypatch):
     assert result["route"] == "text_retrieval"
     assert result["retrieval"]["strategy"] == "exact_and"
     assert "navigation_hits" not in result
+
+
+def test_snapshot_status_surfaces_unhealthy_exact_manifest(tmp_path):
+    bundle = _complete_basic_bundle(tmp_path)
+    _add_artifact(
+        bundle,
+        "output_health",
+        "demo.output_health.json",
+        json.dumps({"verdict": "fail"}) + "\n",
+    )
+    post_path = bundle["manifest"].parent / "demo.bundle_health.post.json"
+    post_path.write_text(json.dumps({"status": "pass"}) + "\n", encoding="utf-8")
+    document = json.loads(bundle["manifest"].read_text(encoding="utf-8"))
+    document["links"] = {
+        "post_emit_health_path": post_path.name,
+        "bundle_surface_validation_status": "pass",
+        "agent_export_gate_status": "pass",
+        "export_safety_report_status": "pass",
+    }
+    bundle["manifest"].write_text(json.dumps(document), encoding="utf-8")
+
+    result = mcp_tools.snapshot_status(bundle_manifest=bundle["manifest"])
+
+    assert result["status"] == "unhealthy"
+    assert result["health"]["health_status"] == "invalid"
+    assert any("expected 'pass'" in reason for reason in result["health"]["reasons"])
+    assert result["snapshot"]["health_status"] == "invalid"

--- a/merger/repoground/tests/test_mcp_resources.py
+++ b/merger/repoground/tests/test_mcp_resources.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 from pathlib import Path
 
@@ -14,6 +15,28 @@ from merger.repoground.tests.test_ask_context_cli import (
     _add_artifact,
     _complete_basic_bundle,
 )
+
+
+def _bind_post_health(bundle: dict) -> None:
+    manifest = bundle["manifest"].resolve()
+    document = json.loads(manifest.read_text(encoding="utf-8"))
+    post_path = manifest.parent / document["links"]["post_emit_health_path"]
+    post_path.write_text(
+        json.dumps(
+            {
+                "kind": "health",
+                "status": "pass",
+                "bundle_manifest_path": str(manifest),
+                "bundle_run_id": document["run_id"],
+                "bundle_manifest_sha256": hashlib.sha256(
+                    manifest.read_bytes()
+                ).hexdigest(),
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
 
 
 def _bundle_with_health(tmp_path: Path) -> dict:
@@ -41,6 +64,7 @@ def _bundle_with_health(tmp_path: Path) -> dict:
     bundle["manifest"].write_text(
         json.dumps(document, sort_keys=True) + "\n", encoding="utf-8"
     )
+    _bind_post_health(bundle)
     return bundle
 
 
@@ -89,6 +113,7 @@ def test_mcp_resource_list_selects_one_readable_newest_generation_per_stem(tmp_p
         bundle["manifest"].write_text(
             json.dumps(document, sort_keys=True) + "\n", encoding="utf-8"
         )
+        _bind_post_health(bundle)
 
     listed = list_mcp_resources(tmp_path)
     manifest_uri = "repoground://snapshot/demo/manifest"

--- a/merger/repoground/tests/test_mcp_resources.py
+++ b/merger/repoground/tests/test_mcp_resources.py
@@ -164,6 +164,9 @@ def test_mcp_read_canonical_reading_pack_health_and_availability_resources(tmp_p
     assert "Agent pack" in reading["content_text"]
     assert health["resource_role"] == "post_emit_health"
     assert health["content_json"]["status"] == "pass"
+    assert health["artifact_ref"]["authority"] == "diagnostic_signal"
+    assert health["artifact_ref"]["canonicality"] == "diagnostic"
+    assert health["artifact_ref"]["risk_class"] == "diagnostic"
     assert availability["resource_role"] == "availability_model"
     assert availability["content_json"]["status"] in {
         "available",
@@ -174,6 +177,219 @@ def test_mcp_read_canonical_reading_pack_health_and_availability_resources(tmp_p
         "warn",
         "fail",
     }
+
+
+def test_mcp_health_validates_and_returns_the_same_single_read_bytes(
+    tmp_path, monkeypatch
+):
+    bundle = _bundle_with_health(tmp_path)
+    manifest = bundle["manifest"].resolve()
+    document = json.loads(manifest.read_text(encoding="utf-8"))
+    health_path = (
+        manifest.parent / document["links"]["post_emit_health_path"]
+    ).resolve()
+    expected = health_path.read_bytes()
+    original_read = mcp_resources._read_bounded_bytes
+    read_counts = {"manifest": 0, "health": 0}
+
+    def counted_read(path, **kwargs):
+        resolved = path.resolve()
+        if resolved == manifest:
+            read_counts["manifest"] += 1
+        elif resolved == health_path:
+            read_counts["health"] += 1
+        return original_read(path, **kwargs)
+
+    monkeypatch.setattr(mcp_resources, "_read_bounded_bytes", counted_read)
+    result = read_mcp_resource(
+        "repoground://snapshot/demo/health",
+        bundle_root=manifest.parent,
+    )
+
+    assert result["status"] == "available"
+    assert result["content_text"].encode("utf-8") == expected
+    assert result["artifact_ref"]["bytes"] == len(expected)
+    assert result["artifact_ref"]["sha256"] == hashlib.sha256(expected).hexdigest()
+    assert read_counts == {"manifest": 1, "health": 1}
+
+
+def test_mcp_health_fails_closed_on_exchanged_health_bytes(tmp_path, monkeypatch):
+    bundle = _bundle_with_health(tmp_path)
+    manifest = bundle["manifest"].resolve()
+    document = json.loads(manifest.read_text(encoding="utf-8"))
+    health_path = (
+        manifest.parent / document["links"]["post_emit_health_path"]
+    ).resolve()
+    exchanged = (
+        json.dumps(
+            {
+                "kind": "health",
+                "status": "pass",
+                "bundle_manifest_path": str(manifest),
+                "bundle_run_id": "other-run",
+                "bundle_manifest_sha256": "0" * 64,
+            },
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8")
+    original_read = mcp_resources._read_bounded_bytes
+    health_reads = 0
+
+    def exchange_health(path, **kwargs):
+        nonlocal health_reads
+        if path.resolve() == health_path:
+            health_reads += 1
+            return exchanged, None
+        return original_read(path, **kwargs)
+
+    monkeypatch.setattr(mcp_resources, "_read_bounded_bytes", exchange_health)
+    result = read_mcp_resource(
+        "repoground://snapshot/demo/health",
+        bundle_root=manifest.parent,
+    )
+
+    assert result["status"] == "unhealthy"
+    assert "does not match" in result["reason"]
+    assert "content_text" not in result
+    assert health_reads == 1
+
+
+def test_mcp_health_blocks_valid_json_above_health_limit(tmp_path):
+    bundle = _bundle_with_health(tmp_path)
+    manifest = bundle["manifest"].resolve()
+    document = json.loads(manifest.read_text(encoding="utf-8"))
+    health_path = (
+        manifest.parent / document["links"]["post_emit_health_path"]
+    ).resolve()
+    oversized = {
+        "kind": "health",
+        "status": "pass",
+        "bundle_manifest_path": str(manifest),
+        "bundle_run_id": document["run_id"],
+        "bundle_manifest_sha256": hashlib.sha256(manifest.read_bytes()).hexdigest(),
+        "padding": "x" * mcp_resources.MAX_HEALTH_BYTES,
+    }
+    health_path.write_text(
+        json.dumps(oversized, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    health_bytes = health_path.stat().st_size
+    assert mcp_resources.MAX_HEALTH_BYTES < health_bytes
+    assert health_bytes < mcp_resources.MAX_RESOURCE_BYTES
+
+    result = read_mcp_resource(
+        "repoground://snapshot/demo/health",
+        bundle_root=manifest.parent,
+    )
+
+    assert result["status"] == "blocked"
+    assert result["artifact_ref"] is None
+    assert "post_emit_health exceeds MCP resource size limit" in result["reason"]
+    assert "content_text" not in result
+    assert "content_json" not in result
+
+
+@pytest.mark.parametrize(
+    ("failure", "reason_fragment"),
+    [
+        ("missing_output_health", "output_health artifact missing"),
+        ("output_health_hash_drift", "sha256 does not match manifest"),
+        (
+            "manifest_gate_failed",
+            "bundle_surface_validation_status='fail'",
+        ),
+    ],
+)
+def test_mcp_health_requires_complete_bundle_health_gates(
+    tmp_path,
+    failure,
+    reason_fragment,
+):
+    bundle = _bundle_with_health(tmp_path)
+    manifest = bundle["manifest"].resolve()
+    document = json.loads(manifest.read_text(encoding="utf-8"))
+    output_health = next(
+        item for item in document["artifacts"] if item["role"] == "output_health"
+    )
+
+    if failure == "missing_output_health":
+        document["artifacts"].remove(output_health)
+        manifest.write_text(
+            json.dumps(document, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        _bind_post_health(bundle)
+    elif failure == "output_health_hash_drift":
+        output_path = manifest.parent / output_health["path"]
+        original = output_path.read_bytes()
+        drifted = original.replace(b'"pass"', b'"fail"', 1)
+        assert len(drifted) == len(original)
+        output_path.write_bytes(drifted)
+    else:
+        document["links"]["bundle_surface_validation_status"] = "fail"
+        manifest.write_text(
+            json.dumps(document, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        _bind_post_health(bundle)
+
+    result = read_mcp_resource(
+        "repoground://snapshot/demo/health",
+        bundle_root=manifest.parent,
+    )
+
+    assert result["status"] == "unhealthy"
+    assert result["snapshot_context"]["health"]["health_status"] == "invalid"
+    assert reason_fragment in result["reason"]
+    assert result["artifact_ref"] is None
+    assert "content_text" not in result
+
+
+def test_mcp_health_path_exchange_after_validation_cannot_change_returned_bytes(
+    tmp_path,
+    monkeypatch,
+):
+    bundle = _bundle_with_health(tmp_path)
+    manifest = bundle["manifest"].resolve()
+    document = json.loads(manifest.read_text(encoding="utf-8"))
+    health_path = (
+        manifest.parent / document["links"]["post_emit_health_path"]
+    ).resolve()
+    expected = health_path.read_bytes()
+    exchanged = b'{"kind":"health","status":"fail"}\n'
+    original_inspection = mcp_resources.inspect_bundle_health_documents
+    original_read = mcp_resources._read_bounded_bytes
+    health_reads = 0
+
+    def counted_read(path, **kwargs):
+        nonlocal health_reads
+        if path.resolve() == health_path:
+            health_reads += 1
+        return original_read(path, **kwargs)
+
+    def inspect_then_exchange(*args, **kwargs):
+        inspection = original_inspection(*args, **kwargs)
+        health_path.write_bytes(exchanged)
+        return inspection
+
+    monkeypatch.setattr(mcp_resources, "_read_bounded_bytes", counted_read)
+    monkeypatch.setattr(
+        mcp_resources,
+        "inspect_bundle_health_documents",
+        inspect_then_exchange,
+    )
+
+    result = read_mcp_resource(
+        "repoground://snapshot/demo/health",
+        bundle_root=manifest.parent,
+    )
+
+    assert result["status"] == "available"
+    assert result["content_text"].encode("utf-8") == expected
+    assert result["artifact_ref"]["sha256"] == hashlib.sha256(expected).hexdigest()
+    assert health_path.read_bytes() == exchanged
+    assert health_reads == 1
 
 
 def test_mcp_read_arbitrary_artifact_resource(tmp_path):

--- a/merger/repoground/tests/test_mcp_resources.py
+++ b/merger/repoground/tests/test_mcp_resources.py
@@ -10,7 +10,10 @@ from merger.repoground.core.mcp_resources import (
     read_mcp_resource,
     resource_templates,
 )
-from merger.repoground.tests.test_ask_context_cli import _add_artifact, _complete_basic_bundle
+from merger.repoground.tests.test_ask_context_cli import (
+    _add_artifact,
+    _complete_basic_bundle,
+)
 
 
 def _bundle_with_health(tmp_path: Path) -> dict:
@@ -76,10 +79,18 @@ def test_mcp_read_manifest_resource_carries_context_and_content(tmp_path):
 def test_mcp_read_canonical_reading_pack_health_and_availability_resources(tmp_path):
     bundle = _bundle_with_health(tmp_path)
 
-    canonical = read_mcp_resource("repoground://snapshot/demo/canonical", bundle_root=bundle["manifest"].parent)
-    reading = read_mcp_resource("repoground://snapshot/demo/reading-pack", bundle_root=bundle["manifest"].parent)
-    health = read_mcp_resource("repoground://snapshot/demo/health", bundle_root=bundle["manifest"].parent)
-    availability = read_mcp_resource("repoground://snapshot/demo/availability", bundle_root=bundle["manifest"].parent)
+    canonical = read_mcp_resource(
+        "repoground://snapshot/demo/canonical", bundle_root=bundle["manifest"].parent
+    )
+    reading = read_mcp_resource(
+        "repoground://snapshot/demo/reading-pack", bundle_root=bundle["manifest"].parent
+    )
+    health = read_mcp_resource(
+        "repoground://snapshot/demo/health", bundle_root=bundle["manifest"].parent
+    )
+    availability = read_mcp_resource(
+        "repoground://snapshot/demo/availability", bundle_root=bundle["manifest"].parent
+    )
 
     assert canonical["resource_role"] == "canonical_md"
     assert "hello resolved world" in canonical["content_text"]
@@ -88,12 +99,20 @@ def test_mcp_read_canonical_reading_pack_health_and_availability_resources(tmp_p
     assert health["resource_role"] == "post_emit_health"
     assert health["content_json"]["status"] == "pass"
     assert availability["resource_role"] == "availability_model"
-    assert availability["content_json"]["status"] in {"available", "partial", "missing", "unknown", "pass", "warn", "fail"}
+    assert availability["content_json"]["status"] in {
+        "available",
+        "partial",
+        "missing",
+        "unknown",
+        "pass",
+        "warn",
+        "fail",
+    }
 
 
 def test_mcp_read_arbitrary_artifact_resource(tmp_path):
     bundle = _complete_basic_bundle(tmp_path)
-    _add_artifact(bundle, "extra_json", "extra.json", "{\"ok\": true}\n")
+    _add_artifact(bundle, "extra_json", "extra.json", '{"ok": true}\n')
 
     result = read_mcp_resource(
         "repoground://snapshot/demo/artifact/extra_json",
@@ -122,28 +141,37 @@ def test_mcp_read_bundle_manifest_artifact_role_is_available(tmp_path):
 def test_mcp_file_bundle_root_accepts_only_real_bundle_manifest(tmp_path):
     bundle = _complete_basic_bundle(tmp_path)
 
-    ok = read_mcp_resource("repoground://snapshot/demo/manifest", bundle_root=bundle["manifest"])
+    ok = read_mcp_resource(
+        "repoground://snapshot/demo/manifest", bundle_root=bundle["manifest"]
+    )
 
     assert ok["status"] == "available"
     assert ok["content_json"]["kind"] == "repolens.bundle.manifest"
 
     secret = tmp_path / "demo.txt"
     secret.write_text("plain secret\n", encoding="utf-8")
-    missing = read_mcp_resource("repoground://snapshot/demo/manifest", bundle_root=secret)
+    missing = read_mcp_resource(
+        "repoground://snapshot/demo/manifest", bundle_root=secret
+    )
 
     assert missing["status"] == "blocked"
-    assert missing["reason"] == "bundle root is not a RepoLens bundle manifest file"
+    assert missing["reason"] == "bundle root is not a RepoGround bundle manifest file"
     assert "content_text" not in missing
 
 
 def test_mcp_file_bundle_root_rejects_fake_manifest_shape(tmp_path):
     fake = tmp_path / "fake.bundle.manifest.json"
-    fake.write_text(json.dumps({"kind": "not-a-repolens-manifest", "run_id": "fake", "artifacts": []}), encoding="utf-8")
+    fake.write_text(
+        json.dumps(
+            {"kind": "not-a-repolens-manifest", "run_id": "fake", "artifacts": []}
+        ),
+        encoding="utf-8",
+    )
 
     result = read_mcp_resource("repoground://snapshot/fake/manifest", bundle_root=fake)
 
     assert result["status"] == "blocked"
-    assert result["reason"] == "bundle root is not a valid RepoLens bundle manifest"
+    assert result["reason"] == "bundle root is not a valid RepoGround bundle manifest"
     assert "content_text" not in result
 
 
@@ -161,10 +189,15 @@ def test_mcp_file_bundle_root_rejects_invalid_json_manifest(tmp_path):
 def test_mcp_file_bundle_root_reports_stem_mismatch(tmp_path):
     bundle = _complete_basic_bundle(tmp_path)
 
-    result = read_mcp_resource("repoground://snapshot/other/manifest", bundle_root=bundle["manifest"])
+    result = read_mcp_resource(
+        "repoground://snapshot/other/manifest", bundle_root=bundle["manifest"]
+    )
 
     assert result["status"] == "blocked"
-    assert result["reason"] == "bundle root file stem does not match requested snapshot stem"
+    assert (
+        result["reason"]
+        == "bundle root file stem does not match requested snapshot stem"
+    )
     assert result["bundle_root_stem"] == "demo"
     assert result["requested_stem"] == "other"
 
@@ -174,13 +207,15 @@ def test_mcp_artifact_resource_blocks_paths_outside_bundle_root(tmp_path):
     outside = tmp_path.parent / "secret.txt"
     outside.write_text("do not read me\n", encoding="utf-8")
     data = json.loads(bundle["manifest"].read_text(encoding="utf-8"))
-    data["artifacts"].append({
-        "role": "escape_attempt",
-        "path": str(outside),
-        "content_type": "text/plain",
-        "bytes": outside.stat().st_size,
-        "sha256": "0" * 64,
-    })
+    data["artifacts"].append(
+        {
+            "role": "escape_attempt",
+            "path": str(outside),
+            "content_type": "text/plain",
+            "bytes": outside.stat().st_size,
+            "sha256": "0" * 64,
+        }
+    )
     bundle["manifest"].write_text(json.dumps(data), encoding="utf-8")
 
     result = read_mcp_resource(
@@ -191,7 +226,9 @@ def test_mcp_artifact_resource_blocks_paths_outside_bundle_root(tmp_path):
     assert result["status"] == "blocked"
     assert "content_text" not in result
     assert "do not read me" not in json.dumps(result)
-    assert result["reason"] == "artifact path escapes bundle root for role: escape_attempt"
+    assert (
+        result["reason"] == "artifact path escapes bundle root for role: escape_attempt"
+    )
 
 
 def test_mcp_artifact_resource_blocks_relative_escape_paths(tmp_path):
@@ -199,13 +236,15 @@ def test_mcp_artifact_resource_blocks_relative_escape_paths(tmp_path):
     outside = tmp_path.parent / f"{tmp_path.name}-relative-secret.txt"
     outside.write_text("relative secret\n", encoding="utf-8")
     data = json.loads(bundle["manifest"].read_text(encoding="utf-8"))
-    data["artifacts"].append({
-        "role": "relative_escape",
-        "path": f"../{outside.name}",
-        "content_type": "text/plain",
-        "bytes": outside.stat().st_size,
-        "sha256": "0" * 64,
-    })
+    data["artifacts"].append(
+        {
+            "role": "relative_escape",
+            "path": f"../{outside.name}",
+            "content_type": "text/plain",
+            "bytes": outside.stat().st_size,
+            "sha256": "0" * 64,
+        }
+    )
     bundle["manifest"].write_text(json.dumps(data), encoding="utf-8")
 
     result = read_mcp_resource(
@@ -228,13 +267,15 @@ def test_mcp_artifact_resource_blocks_symlink_escape_paths(tmp_path):
     except OSError:
         pytest.skip("symlink creation not supported on this platform")
     data = json.loads(bundle["manifest"].read_text(encoding="utf-8"))
-    data["artifacts"].append({
-        "role": "symlink_escape",
-        "path": link.name,
-        "content_type": "text/plain",
-        "bytes": outside.stat().st_size,
-        "sha256": "0" * 64,
-    })
+    data["artifacts"].append(
+        {
+            "role": "symlink_escape",
+            "path": link.name,
+            "content_type": "text/plain",
+            "bytes": outside.stat().st_size,
+            "sha256": "0" * 64,
+        }
+    )
     bundle["manifest"].write_text(json.dumps(data), encoding="utf-8")
 
     result = read_mcp_resource(
@@ -268,12 +309,16 @@ def test_mcp_artifact_resource_blocks_integrity_mismatch(tmp_path):
 def test_mcp_artifact_resource_blocks_missing_integrity_metadata(tmp_path):
     bundle = _complete_basic_bundle(tmp_path)
     data = json.loads(bundle["manifest"].read_text(encoding="utf-8"))
-    data["artifacts"].append({
-        "role": "no_integrity",
-        "path": "no_integrity.txt",
-        "content_type": "text/plain",
-    })
-    (bundle["manifest"].parent / "no_integrity.txt").write_text("not trusted\n", encoding="utf-8")
+    data["artifacts"].append(
+        {
+            "role": "no_integrity",
+            "path": "no_integrity.txt",
+            "content_type": "text/plain",
+        }
+    )
+    (bundle["manifest"].parent / "no_integrity.txt").write_text(
+        "not trusted\n", encoding="utf-8"
+    )
     bundle["manifest"].write_text(json.dumps(data), encoding="utf-8")
 
     result = read_mcp_resource(
@@ -292,13 +337,15 @@ def test_mcp_artifact_resource_blocks_invalid_sha_metadata(tmp_path):
     content = "not trusted\n"
     artifact = bundle["manifest"].parent / "bad_sha.txt"
     artifact.write_text(content, encoding="utf-8")
-    data["artifacts"].append({
-        "role": "bad_sha",
-        "path": artifact.name,
-        "content_type": "text/plain",
-        "bytes": artifact.stat().st_size,
-        "sha256": "not-a-sha",
-    })
+    data["artifacts"].append(
+        {
+            "role": "bad_sha",
+            "path": artifact.name,
+            "content_type": "text/plain",
+            "bytes": artifact.stat().st_size,
+            "sha256": "not-a-sha",
+        }
+    )
     bundle["manifest"].write_text(json.dumps(data), encoding="utf-8")
 
     result = read_mcp_resource(
@@ -373,22 +420,30 @@ def test_each_listed_mcp_resource_read_carries_context(tmp_path):
         assert result["mutation_boundary"]["does_not_create_snapshots"] is True
 
 
-
 def test_mcp_missing_snapshot_explains_missing_context(tmp_path):
-    result = read_mcp_resource("repoground://snapshot/missing/manifest", bundle_root=tmp_path)
+    result = read_mcp_resource(
+        "repoground://snapshot/missing/manifest", bundle_root=tmp_path
+    )
 
     assert result["status"] == "missing"
     assert result["bundle_manifest"] is None
     assert result["snapshot_context"]["availability"]["status"] == "unknown"
-    assert "snapshot stem not found" in result["snapshot_context"]["availability"]["reason"]
+    assert (
+        "snapshot stem not found"
+        in result["snapshot_context"]["availability"]["reason"]
+    )
 
 
 def test_mcp_resource_reads_do_not_write_bundle_files(tmp_path):
     bundle = _bundle_with_health(tmp_path)
     before = {path.name for path in tmp_path.iterdir()}
 
-    read_mcp_resource("repoground://snapshot/demo/manifest", bundle_root=bundle["manifest"].parent)
-    read_mcp_resource("repoground://snapshot/demo/canonical", bundle_root=bundle["manifest"].parent)
+    read_mcp_resource(
+        "repoground://snapshot/demo/manifest", bundle_root=bundle["manifest"].parent
+    )
+    read_mcp_resource(
+        "repoground://snapshot/demo/canonical", bundle_root=bundle["manifest"].parent
+    )
     list_mcp_resources(bundle["manifest"].parent)
 
     after = {path.name for path in tmp_path.iterdir()}
@@ -414,4 +469,7 @@ def test_mcp_resource_rejects_retired_scheme(tmp_path):
     bundle = _bundle_with_health(tmp_path)
 
     with pytest.raises(RepoGroundMcpResourceError):
-        read_mcp_resource("repo" + "brief://snapshot/demo/manifest", bundle_root=bundle["manifest"].parent)
+        read_mcp_resource(
+            "repo" + "brief://snapshot/demo/manifest",
+            bundle_root=bundle["manifest"].parent,
+        )

--- a/merger/repoground/tests/test_mcp_resources.py
+++ b/merger/repoground/tests/test_mcp_resources.py
@@ -17,12 +17,29 @@ from merger.repoground.tests.test_ask_context_cli import (
 
 
 def _bundle_with_health(tmp_path: Path) -> dict:
+    tmp_path.mkdir(parents=True, exist_ok=True)
     bundle = _complete_basic_bundle(tmp_path)
+    _add_artifact(
+        bundle,
+        "output_health",
+        "demo.output_health.json",
+        json.dumps({"kind": "health", "verdict": "pass"}) + "\n",
+    )
     _add_artifact(
         bundle,
         "post_emit_health",
         "demo.bundle_health.post.json",
         json.dumps({"kind": "health", "status": "pass"}) + "\n",
+    )
+    document = json.loads(bundle["manifest"].read_text(encoding="utf-8"))
+    document["links"] = {
+        "post_emit_health_path": "demo.bundle_health.post.json",
+        "bundle_surface_validation_status": "pass",
+        "agent_export_gate_status": "pass",
+        "export_safety_report_status": "pass",
+    }
+    bundle["manifest"].write_text(
+        json.dumps(document, sort_keys=True) + "\n", encoding="utf-8"
     )
     return bundle
 
@@ -57,6 +74,30 @@ def test_mcp_resource_list_exposes_concrete_snapshot_resources(tmp_path):
     assert "repoground://snapshot/demo/availability" in uris
     assert "repoground://snapshot/demo/artifact/canonical_md" in uris
     assert listed["mutation_boundary"]["writes"] == []
+
+
+def test_mcp_resource_list_selects_one_readable_newest_generation_per_stem(tmp_path):
+    older = _bundle_with_health(tmp_path / "older")
+    newer = _bundle_with_health(tmp_path / "newer")
+    for bundle, run_id, created_at in (
+        (older, "old-run", "2026-07-25T20:00:00Z"),
+        (newer, "new-run", "2026-07-25T21:00:00Z"),
+    ):
+        document = json.loads(bundle["manifest"].read_text(encoding="utf-8"))
+        document["run_id"] = run_id
+        document["created_at"] = created_at
+        bundle["manifest"].write_text(
+            json.dumps(document, sort_keys=True) + "\n", encoding="utf-8"
+        )
+
+    listed = list_mcp_resources(tmp_path)
+    manifest_uri = "repoground://snapshot/demo/manifest"
+    assert [item["uri"] for item in listed["resources"]].count(manifest_uri) == 1
+
+    readback = read_mcp_resource(manifest_uri, bundle_root=tmp_path)
+    assert readback["status"] == "available"
+    assert readback["content_json"]["run_id"] == "new-run"
+    assert readback["bundle_manifest"] == str(newer["manifest"].resolve())
 
 
 def test_mcp_read_manifest_resource_carries_context_and_content(tmp_path):

--- a/merger/repoground/tests/test_mcp_stdio.py
+++ b/merger/repoground/tests/test_mcp_stdio.py
@@ -1,4 +1,6 @@
+import hashlib
 import json
+import sqlite3
 import subprocess
 import sys
 from io import StringIO
@@ -12,6 +14,14 @@ from merger.repoground.cli.mcp_stdio import (
     serve_stdio,
 )
 from merger.repoground.core import mcp_resources, mcp_tools
+from merger.repoground.core.manifest_snapshot import active_manifest_snapshot
+from merger.repoground.tests.test_answer_grounding_verifier import (
+    _bundle as _grounding_bundle,
+)
+from merger.repoground.tests.test_answer_grounding_verifier import (
+    _declaration as _grounding_declaration,
+)
+from merger.repoground.tests.test_ask_context_cli import _complete_basic_bundle
 
 
 def _manifest(tmp_path: Path) -> Path:
@@ -483,7 +493,11 @@ def test_mcp_stdio_repo_selector_resolves_manifest_without_exposing_host_path(
         "select_bundle_manifest",
         lambda *_args, **_kwargs: {
             "status": "available",
-            "selected": {"manifest_path": str(manifest)},
+            "selected": {
+                "manifest_path": str(manifest),
+                "manifest_sha256": hashlib.sha256(manifest.read_bytes()).hexdigest(),
+                "run_id": "demo",
+            },
         },
     )
 
@@ -506,6 +520,533 @@ def test_mcp_stdio_repo_selector_resolves_manifest_without_exposing_host_path(
 
     assert response["result"]["isError"] is False
     assert seen == {"bundle_manifest": str(manifest.resolve())}
+
+
+def test_mcp_stdio_fails_closed_when_selected_manifest_is_atomically_replaced(
+    tmp_path, monkeypatch
+):
+    manifest = _manifest(tmp_path)
+    selected_bytes = manifest.read_bytes()
+    selected_sha256 = hashlib.sha256(selected_bytes).hexdigest()
+    replacement = tmp_path / "replacement.bundle.manifest.json"
+    replacement.write_text(
+        json.dumps(
+            {
+                "kind": "repolens.bundle.manifest",
+                "run_id": "replacement",
+                "artifacts": [],
+                "snapshot_provenance": {"version": "v1", "repositories": []},
+            }
+        ),
+        encoding="utf-8",
+    )
+    server = RepoGroundMcpStdioServer(bundle_root=tmp_path)
+    _initialize(server)
+
+    from merger.repoground.core import bundle_catalog
+
+    def select_then_replace(*_args, **_kwargs):
+        selected = {
+            "manifest_path": str(manifest),
+            "manifest_sha256": selected_sha256,
+            "run_id": "demo",
+        }
+        replacement.replace(manifest)
+        return {"status": "available", "selected": selected}
+
+    monkeypatch.setattr(
+        bundle_catalog,
+        "select_bundle_manifest",
+        select_then_replace,
+    )
+    response = server.handle_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 14,
+            "method": "tools/call",
+            "params": {
+                "name": "snapshot_status",
+                "arguments": {"repo": "heimgewebe/repoground"},
+            },
+        }
+    )
+
+    assert response["error"]["code"] == -32001
+    assert response["error"]["data"]["status"] == "manifest_binding_failed"
+    assert "digest" in response["error"]["data"]["reason"]
+
+
+def test_mcp_stdio_fails_closed_when_manifest_remains_replaced_during_handler(
+    tmp_path, monkeypatch
+):
+    manifest = _manifest(tmp_path)
+    replacement = tmp_path / "replacement.bundle.manifest.json"
+    replacement.write_text(
+        json.dumps(
+            {
+                "kind": "repolens.bundle.manifest",
+                "run_id": "replacement",
+                "artifacts": [],
+                "snapshot_provenance": {"version": "v1", "repositories": []},
+            }
+        ),
+        encoding="utf-8",
+    )
+    server = RepoGroundMcpStdioServer(bundle_root=manifest)
+    _initialize(server)
+
+    from merger.repoground.core import bundle_access
+
+    def replace_during_handler(**arguments):
+        replacement.replace(manifest)
+        snapshot = bundle_access.snapshot_status(arguments["bundle_manifest"])
+        return {
+            "status": "available",
+            "selected_run_id": snapshot["bundle_run_id"],
+        }
+
+    monkeypatch.setattr(mcp_tools, "snapshot_status", replace_during_handler)
+    response = server.handle_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 15,
+            "method": "tools/call",
+            "params": {
+                "name": "snapshot_status",
+                "arguments": {"bundle_manifest": str(manifest)},
+            },
+        }
+    )
+
+    assert response["error"]["code"] == -32001
+    assert response["error"]["data"]["status"] == "manifest_binding_failed"
+
+
+def test_mcp_stdio_consumes_bound_bytes_across_exchange_and_restore(
+    tmp_path, monkeypatch
+):
+    manifest = _manifest(tmp_path)
+    original_document = json.loads(manifest.read_text(encoding="utf-8"))
+    original_document["artifacts"] = [
+        {"role": "selected_marker", "path": "selected.txt"}
+    ]
+    manifest.write_text(json.dumps(original_document), encoding="utf-8")
+    (tmp_path / "selected.txt").write_text("selected\n", encoding="utf-8")
+    original_bytes = manifest.read_bytes()
+    replacement_bytes = json.dumps(
+        {
+            "kind": "repolens.bundle.manifest",
+            "run_id": "replacement",
+            "artifacts": [{"role": "selected_marker", "path": "replacement.txt"}],
+            "snapshot_provenance": {"version": "v1", "repositories": []},
+        }
+    ).encode("utf-8")
+    (tmp_path / "replacement.txt").write_text("replacement\n", encoding="utf-8")
+    server = RepoGroundMcpStdioServer(bundle_root=manifest)
+    _initialize(server)
+
+    from merger.repoground.core import bundle_access
+
+    def exchange_and_restore(**arguments):
+        replacement = tmp_path / "replacement.bundle.manifest.json"
+        replacement.write_bytes(replacement_bytes)
+        replacement.replace(manifest)
+        snapshot = bundle_access.snapshot_status(arguments["bundle_manifest"])
+        artifact = bundle_access.get_artifact(
+            arguments["bundle_manifest"],
+            "selected_marker",
+        )
+        restored = tmp_path / "restored.bundle.manifest.json"
+        restored.write_bytes(original_bytes)
+        restored.replace(manifest)
+        return {
+            "status": "available",
+            "selected_run_id": snapshot["bundle_run_id"],
+            "selected_artifact_path": artifact["artifact"]["path"],
+        }
+
+    monkeypatch.setattr(mcp_tools, "snapshot_status", exchange_and_restore)
+    response = server.handle_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 16,
+            "method": "tools/call",
+            "params": {
+                "name": "snapshot_status",
+                "arguments": {"bundle_manifest": str(manifest)},
+            },
+        }
+    )
+
+    assert response["result"]["isError"] is False
+    assert response["result"]["structuredContent"]["selected_run_id"] == "demo"
+    assert (
+        response["result"]["structuredContent"]["selected_artifact_path"]
+        == "selected.txt"
+    )
+
+
+@pytest.mark.parametrize("replacement_outside_bundle_root", [False, True])
+def test_mcp_stdio_symlink_exchange_and_restore_uses_selected_manifest_bytes(
+    tmp_path,
+    monkeypatch,
+    replacement_outside_bundle_root,
+):
+    bundle_root = tmp_path / "bundles"
+    bundle_root.mkdir()
+    selected = _manifest(bundle_root)
+    selected_bytes = selected.read_bytes()
+    selected_sha256 = hashlib.sha256(selected_bytes).hexdigest()
+
+    replacement_root = (
+        tmp_path / "outside" if replacement_outside_bundle_root else bundle_root
+    )
+    replacement_root.mkdir(exist_ok=True)
+    replacement = replacement_root / "replacement.bundle.manifest.json"
+    replacement.write_text(
+        json.dumps(
+            {
+                "kind": "repolens.bundle.manifest",
+                "run_id": "replacement",
+                "artifacts": [],
+                "snapshot_provenance": {"version": "v1", "repositories": []},
+            }
+        ),
+        encoding="utf-8",
+    )
+    selected_link = bundle_root / "active.bundle.manifest.json"
+    selected_link.symlink_to(selected)
+
+    def point_link_at(target):
+        staged = bundle_root / ".active.bundle.manifest.json.next"
+        staged.symlink_to(target)
+        staged.replace(selected_link)
+
+    server = RepoGroundMcpStdioServer(bundle_root=bundle_root)
+    _initialize(server)
+
+    original_snapshot_status = mcp_tools.snapshot_status
+
+    def exchange_read_and_restore(**arguments):
+        point_link_at(replacement)
+        try:
+            bound = active_manifest_snapshot(arguments["bundle_manifest"])
+            payload = original_snapshot_status(**arguments)
+        finally:
+            point_link_at(selected)
+        assert bound is not None
+        payload.update(
+            {
+                "bound_selected_path": str(bound.selected_path),
+                "bound_resolved_path": str(bound.resolved_path),
+                "bound_sha256": hashlib.sha256(bound.raw).hexdigest(),
+                "selected_run_id": payload["snapshot"]["bundle_run_id"],
+            }
+        )
+        return payload
+
+    monkeypatch.setattr(mcp_tools, "snapshot_status", exchange_read_and_restore)
+    response = server.handle_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 19,
+            "method": "tools/call",
+            "params": {
+                "name": "snapshot_status",
+                "arguments": {"bundle_manifest": str(selected_link)},
+            },
+        }
+    )
+
+    assert response["result"]["isError"] is False
+    result = response["result"]["structuredContent"]
+    assert result["bound_selected_path"] == str(selected_link.absolute())
+    assert result["bound_resolved_path"] == str(selected.resolve())
+    assert result["bound_sha256"] == selected_sha256
+    assert result["selected_run_id"] == "demo"
+    assert selected_link.resolve() == selected.resolve()
+
+
+def test_mcp_stdio_grounding_verify_pins_selected_symlink_target_during_exchange(
+    tmp_path,
+    monkeypatch,
+):
+    selected_root = tmp_path / "selected"
+    replacement_root = tmp_path / "replacement"
+    selected_root.mkdir()
+    replacement_root.mkdir()
+    selected_manifest, citation_map, range_ref = _grounding_bundle(
+        selected_root,
+        content=b"Line 1\nselected\nLine 3\n",
+    )
+    replacement_manifest, _, _ = _grounding_bundle(
+        replacement_root,
+        content=b"Line 1\nreplaced\nLine 3\n",
+    )
+    selected_link = tmp_path / "active.bundle.manifest.json"
+    selected_link.symlink_to(selected_manifest)
+    declaration = _grounding_declaration(range_ref)
+    declaration.pop("snapshot_ref")
+    declaration["declared_artifacts"] = [
+        "agent_reading_pack",
+        "canonical_md",
+        "citation_map_jsonl",
+        "snapshot_plan_json",
+    ]
+
+    def point_link_at(target):
+        staged = tmp_path / ".active.bundle.manifest.json.next"
+        staged.symlink_to(target)
+        staged.replace(selected_link)
+
+    server = RepoGroundMcpStdioServer(bundle_root=tmp_path)
+    _initialize(server)
+    original_grounding_verify = mcp_tools.grounding_verify
+
+    def exchange_verify_and_restore(**arguments):
+        point_link_at(replacement_manifest)
+        try:
+            return original_grounding_verify(**arguments)
+        finally:
+            point_link_at(selected_manifest)
+
+    monkeypatch.setattr(
+        mcp_tools,
+        "grounding_verify",
+        exchange_verify_and_restore,
+    )
+    response = server.handle_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 20,
+            "method": "tools/call",
+            "params": {
+                "name": "grounding_verify",
+                "arguments": {
+                    "bundle_manifest": str(selected_link),
+                    "citation_map": str(citation_map),
+                    "declaration": declaration,
+                    "task_profile": "basic_repo_question",
+                },
+            },
+        }
+    )
+
+    assert response["result"]["isError"] is False
+    result = response["result"]["structuredContent"]
+    assert result["status"] == "pass"
+    assert result["verdict"]["status"] == "pass"
+    assert {check["status"] for check in result["verdict"]["citation_checks"]} == {
+        "resolved"
+    }
+    assert result["verdict"]["range_checks"][0]["status"] == "resolved"
+    assert result["verdict"]["snapshot_ref"]["manifest_path"] == str(
+        selected_link.absolute()
+    )
+    assert selected_link.resolve() == selected_manifest.resolve()
+
+
+def test_mcp_stdio_ask_context_keeps_selected_manifest_metadata_across_exchange(
+    tmp_path, monkeypatch
+):
+    bundle = _complete_basic_bundle(tmp_path)
+    manifest = bundle["manifest"].resolve()
+    selected_bytes = manifest.read_bytes()
+    selected_document = json.loads(selected_bytes)
+    selected_sha256 = hashlib.sha256(selected_bytes).hexdigest()
+    replacement_document = dict(selected_document)
+    replacement_document["run_id"] = "replacement-run"
+    replacement_bytes = json.dumps(replacement_document).encode("utf-8")
+    replacement_sha256 = hashlib.sha256(replacement_bytes).hexdigest()
+    server = RepoGroundMcpStdioServer(bundle_root=manifest)
+    _initialize(server)
+
+    from merger.repoground.core import ask_context as ask_context_module
+
+    original_snapshot_status = ask_context_module.snapshot_status
+    original_ask_context = mcp_tools.ask_context
+    observed_run_ids = []
+
+    def exchange_before_snapshot_status(bundle_manifest):
+        replacement = tmp_path / "replacement.bundle.manifest.json"
+        replacement.write_bytes(replacement_bytes)
+        replacement.replace(manifest)
+        status = original_snapshot_status(bundle_manifest)
+        observed_run_ids.append(status["bundle_run_id"])
+        return status
+
+    def ask_then_restore(**arguments):
+        try:
+            return original_ask_context(**arguments)
+        finally:
+            restored = tmp_path / "restored.bundle.manifest.json"
+            restored.write_bytes(selected_bytes)
+            restored.replace(manifest)
+
+    monkeypatch.setattr(
+        ask_context_module,
+        "snapshot_status",
+        exchange_before_snapshot_status,
+    )
+    monkeypatch.setattr(mcp_tools, "ask_context", ask_then_restore)
+
+    response = server.handle_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 17,
+            "method": "tools/call",
+            "params": {
+                "name": "ask_context",
+                "arguments": {
+                    "bundle_manifest": str(manifest),
+                    "query": "hello",
+                },
+            },
+        }
+    )
+
+    context_pack = response["result"]["structuredContent"]["context_pack"]
+    assert response["result"]["isError"] is False
+    assert context_pack["resolved_ranges"][0]["status"] == "resolved"
+    assert context_pack["snapshot_ref"]["manifest_sha256"] == selected_sha256
+    assert context_pack["snapshot_ref"]["manifest_sha256"] != replacement_sha256
+    assert observed_run_ids == [selected_document["run_id"]]
+    assert observed_run_ids != [replacement_document["run_id"]]
+
+
+def test_mcp_stdio_query_rejects_sqlite_from_exchanged_generation(
+    tmp_path,
+    monkeypatch,
+):
+    (tmp_path / "selected").mkdir()
+    (tmp_path / "replacement").mkdir()
+    selected = _complete_basic_bundle(tmp_path / "selected")
+    replacement = _complete_basic_bundle(tmp_path / "replacement")
+    selected_manifest = selected["manifest"].resolve()
+    selected_index = selected["index_path"].resolve()
+    replacement_manifest = replacement["manifest"].resolve()
+    replacement_index = replacement["index_path"].resolve()
+
+    with sqlite3.connect(replacement_index) as connection:
+        connection.execute(
+            "UPDATE chunks_fts SET content = ?",
+            ("generation_b_only",),
+        )
+    replacement_document = json.loads(replacement_manifest.read_text(encoding="utf-8"))
+    replacement_sqlite = next(
+        artifact
+        for artifact in replacement_document["artifacts"]
+        if artifact["role"] == "sqlite_index"
+    )
+    replacement_sqlite["bytes"] = replacement_index.stat().st_size
+    replacement_sqlite["sha256"] = hashlib.sha256(
+        replacement_index.read_bytes()
+    ).hexdigest()
+    replacement_document["run_id"] = "generation-b"
+    replacement_manifest.write_text(
+        json.dumps(replacement_document, sort_keys=True),
+        encoding="utf-8",
+    )
+    generation_b = mcp_tools.query_existing_index(
+        bundle_manifest=replacement_manifest,
+        query="generation_b_only",
+    )
+    assert generation_b["retrieval"]["match_count"] == 1
+
+    selected_manifest_bytes = selected_manifest.read_bytes()
+    selected_index_sha256 = hashlib.sha256(selected_index.read_bytes()).hexdigest()
+    replacement_manifest_bytes = replacement_manifest.read_bytes()
+    replacement_index_bytes = replacement_index.read_bytes()
+    replacement_index_sha256 = hashlib.sha256(replacement_index_bytes).hexdigest()
+    assert replacement_index_sha256 != selected_index_sha256
+
+    server = RepoGroundMcpStdioServer(bundle_root=selected_manifest)
+    _initialize(server)
+
+    from merger.repoground.core import ask_context as ask_context_module
+
+    original_snapshot_status = ask_context_module.snapshot_status
+    original_query = ask_context_module.query_existing_index
+    original_tool = mcp_tools.query_existing_index
+    observed_queries = []
+    exchanged = False
+
+    def exchange_before_query(bundle_manifest):
+        nonlocal exchanged
+        if not exchanged:
+            sqlite_replacement = selected_index.with_name("generation-b.index.sqlite")
+            sqlite_replacement.write_bytes(replacement_index_bytes)
+            sqlite_replacement.replace(selected_index)
+            manifest_replacement = selected_manifest.with_name(
+                "generation-b.bundle.manifest.json"
+            )
+            manifest_replacement.write_bytes(replacement_manifest_bytes)
+            manifest_replacement.replace(selected_manifest)
+            exchanged = True
+        return original_snapshot_status(bundle_manifest)
+
+    def record_query(*args, **kwargs):
+        result = original_query(*args, **kwargs)
+        observed_queries.append(result)
+        return result
+
+    def query_then_restore_manifest(**arguments):
+        try:
+            return original_tool(**arguments)
+        finally:
+            restored = selected_manifest.with_name(
+                "generation-a-restored.bundle.manifest.json"
+            )
+            restored.write_bytes(selected_manifest_bytes)
+            restored.replace(selected_manifest)
+
+    monkeypatch.setattr(
+        ask_context_module,
+        "snapshot_status",
+        exchange_before_query,
+    )
+    monkeypatch.setattr(
+        ask_context_module,
+        "query_existing_index",
+        record_query,
+    )
+    monkeypatch.setattr(
+        mcp_tools,
+        "query_existing_index",
+        query_then_restore_manifest,
+    )
+
+    response = server.handle_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 18,
+            "method": "tools/call",
+            "params": {
+                "name": "query_existing_index",
+                "arguments": {
+                    "bundle_manifest": str(selected_manifest),
+                    "query": "generation_b_only",
+                },
+            },
+        }
+    )
+
+    assert response["result"]["isError"] is False
+    assert len(observed_queries) == 1
+    assert observed_queries[0]["status"] == "invalid"
+    assert observed_queries[0]["error_code"] == "sqlite_index_integrity_mismatch"
+    assert observed_queries[0]["query_result"] is None
+    result = response["result"]["structuredContent"]
+    assert result["retrieval"]["match_count"] == 0
+    assert result["retrieval_hits"] == []
+    assert result["resolved_ranges"] == []
+    assert any(
+        "sqlite_index" in caveat["detail"] for caveat in result["answer_caveats"]
+    )
+    assert selected_manifest.read_bytes() == selected_manifest_bytes
+    assert hashlib.sha256(selected_index.read_bytes()).hexdigest() == (
+        replacement_index_sha256
+    )
 
 
 def test_mcp_stdio_exposes_bundle_discovery_as_read_only_tool(tmp_path, monkeypatch):

--- a/merger/repoground/tests/test_mcp_stdio.py
+++ b/merger/repoground/tests/test_mcp_stdio.py
@@ -639,3 +639,45 @@ def test_mcp_stdio_text_summary_does_not_duplicate_structured_payload(
     assert len(text.encode("utf-8")) < 300
     assert result["structuredContent"]["blob"] == "x" * 10000
     assert json.loads(text)["details"].startswith("Use structuredContent")
+
+
+def test_mcp_stdio_legacy_protocol_keeps_full_payload_in_text(tmp_path, monkeypatch):
+    manifest = _manifest(tmp_path)
+    server = RepoGroundMcpStdioServer(bundle_root=manifest)
+    initialized = server.handle_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {"name": "legacy-test", "version": "1"},
+            },
+        }
+    )
+    assert initialized["result"]["protocolVersion"] == "2025-03-26"
+    monkeypatch.setattr(
+        mcp_tools,
+        "ask_context",
+        lambda **_arguments: {"status": "ok", "blob": "x" * 10000},
+    )
+
+    response = server.handle_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 13,
+            "method": "tools/call",
+            "params": {
+                "name": "ask_context",
+                "arguments": {
+                    "bundle_manifest": str(manifest),
+                    "query": "hello",
+                },
+            },
+        }
+    )
+
+    result = response["result"]
+    assert json.loads(result["content"][0]["text"])["blob"] == "x" * 10000
+    assert result["structuredContent"]["blob"] == "x" * 10000

--- a/merger/repoground/tests/test_mcp_stdio.py
+++ b/merger/repoground/tests/test_mcp_stdio.py
@@ -6,7 +6,11 @@ from pathlib import Path
 
 import pytest
 
-from merger.repoground.cli.mcp_stdio import PROTOCOL_VERSION, RepoGroundMcpStdioServer, serve_stdio
+from merger.repoground.cli.mcp_stdio import (
+    PROTOCOL_VERSION,
+    RepoGroundMcpStdioServer,
+    serve_stdio,
+)
 from merger.repoground.core import mcp_resources, mcp_tools
 
 
@@ -127,7 +131,11 @@ def test_mcp_stdio_lists_read_tools_and_hides_snapshot_create_by_default(tmp_pat
     assert initialized["result"]["protocolVersion"] == PROTOCOL_VERSION
     assert initialized["result"]["capabilities"]["tools"]["listChanged"] is False
     assert {tool["name"] for tool in _tools(server)} == {
+        "bundle_discover",
+        "snapshot_status",
         "ask_context",
+        "query_existing_index",
+        "range_get",
         "grounding_verify",
         "live_freshness",
         "find_symbol",
@@ -157,7 +165,9 @@ def test_mcp_stdio_exposes_startup_bound_snapshot_create_schema(tmp_path):
     )
     _initialize(server)
 
-    definition = next(tool for tool in _tools(server) if tool["name"] == "snapshot_create")
+    definition = next(
+        tool for tool in _tools(server) if tool["name"] == "snapshot_create"
+    )
     properties = definition["inputSchema"]["properties"]
 
     assert definition["inputSchema"]["required"] == ["profile"]
@@ -165,7 +175,9 @@ def test_mcp_stdio_exposes_startup_bound_snapshot_create_schema(tmp_path):
     assert "output_root" not in properties
 
 
-def test_snapshot_create_injects_startup_roots_and_rejects_overrides(tmp_path, monkeypatch):
+def test_snapshot_create_injects_startup_roots_and_rejects_overrides(
+    tmp_path, monkeypatch
+):
     repo = tmp_path / "repo"
     bundles = tmp_path / "bundles"
     repo.mkdir()
@@ -278,7 +290,9 @@ def test_mcp_stdio_calls_existing_ask_handler_and_adds_freshness(tmp_path, monke
     assert seen["bundle_manifest"] == str(manifest.resolve())
 
 
-def test_mcp_stdio_resource_read_preserves_content_and_adds_metadata(tmp_path, monkeypatch):
+def test_mcp_stdio_resource_read_preserves_content_and_adds_metadata(
+    tmp_path, monkeypatch
+):
     manifest = _manifest(tmp_path)
     server = RepoGroundMcpStdioServer(bundle_root=tmp_path, repo_root=tmp_path)
     _initialize(server)
@@ -452,3 +466,176 @@ def test_mcp_stdio_dispatches_get_callees_and_adds_freshness(tmp_path, monkeypat
         "path": "pkg/a.py",
         "k": 7,
     }
+
+
+def test_mcp_stdio_repo_selector_resolves_manifest_without_exposing_host_path(
+    tmp_path, monkeypatch
+):
+    manifest = _manifest(tmp_path)
+    server = RepoGroundMcpStdioServer(bundle_root=tmp_path)
+    _initialize(server)
+    seen = {}
+
+    from merger.repoground.core import bundle_catalog
+
+    monkeypatch.setattr(
+        bundle_catalog,
+        "select_bundle_manifest",
+        lambda *_args, **_kwargs: {
+            "status": "available",
+            "selected": {"manifest_path": str(manifest)},
+        },
+    )
+
+    def fake_snapshot_status(**arguments):
+        seen.update(arguments)
+        return {"status": "available", "tool": "snapshot_status"}
+
+    monkeypatch.setattr(mcp_tools, "snapshot_status", fake_snapshot_status)
+    response = server.handle_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 8,
+            "method": "tools/call",
+            "params": {
+                "name": "snapshot_status",
+                "arguments": {"repo": "heimgewebe/repoground"},
+            },
+        }
+    )
+
+    assert response["result"]["isError"] is False
+    assert seen == {"bundle_manifest": str(manifest.resolve())}
+
+
+def test_mcp_stdio_exposes_bundle_discovery_as_read_only_tool(tmp_path, monkeypatch):
+    server = RepoGroundMcpStdioServer(bundle_root=tmp_path)
+    _initialize(server)
+
+    from merger.repoground.core import bundle_catalog
+
+    monkeypatch.setattr(
+        bundle_catalog,
+        "discover_bundle_catalog",
+        lambda root: {
+            "status": "available",
+            "bundle_root": str(root),
+            "candidate_count": 1,
+        },
+    )
+    response = server.handle_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 9,
+            "method": "tools/call",
+            "params": {"name": "bundle_discover", "arguments": {}},
+        }
+    )
+
+    assert response["result"]["structuredContent"]["candidate_count"] == 1
+    assert response["result"]["isError"] is False
+
+
+def test_mcp_stdio_dispatches_bounded_query_and_range_read(tmp_path, monkeypatch):
+    manifest = _manifest(tmp_path)
+    server = RepoGroundMcpStdioServer(bundle_root=manifest)
+    _initialize(server)
+    seen = []
+
+    def fake_query(**arguments):
+        seen.append(("query", arguments))
+        return {
+            "status": "available",
+            "retrieval": {"strategy": "or_relaxed", "match_count": 2},
+        }
+
+    def fake_range(**arguments):
+        seen.append(("range", arguments))
+        return {"status": "resolved", "result": {"text": "demo"}}
+
+    monkeypatch.setattr(mcp_tools, "query_existing_index", fake_query)
+    monkeypatch.setattr(mcp_tools, "range_get", fake_range)
+
+    query = server.handle_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 10,
+            "method": "tools/call",
+            "params": {
+                "name": "query_existing_index",
+                "arguments": {
+                    "bundle_manifest": str(manifest),
+                    "query": "natural language",
+                    "max_context_tokens": 500,
+                },
+            },
+        }
+    )
+    range_result = server.handle_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 11,
+            "method": "tools/call",
+            "params": {
+                "name": "range_get",
+                "arguments": {
+                    "bundle_manifest": str(manifest),
+                    "range_ref": {"ref": "demo"},
+                },
+            },
+        }
+    )
+
+    assert query["result"]["structuredContent"]["retrieval"]["strategy"] == "or_relaxed"
+    assert range_result["result"]["structuredContent"]["status"] == "resolved"
+    assert seen == [
+        (
+            "query",
+            {
+                "query": "natural language",
+                "max_context_tokens": 500,
+                "bundle_manifest": str(manifest.resolve()),
+            },
+        ),
+        (
+            "range",
+            {
+                "range_ref": {"ref": "demo"},
+                "bundle_manifest": str(manifest.resolve()),
+            },
+        ),
+    ]
+
+
+def test_mcp_stdio_text_summary_does_not_duplicate_structured_payload(
+    tmp_path, monkeypatch
+):
+    manifest = _manifest(tmp_path)
+    server = RepoGroundMcpStdioServer(bundle_root=manifest)
+    _initialize(server)
+
+    monkeypatch.setattr(
+        mcp_tools,
+        "ask_context",
+        lambda **_arguments: {"status": "ok", "blob": "x" * 10000},
+    )
+    response = server.handle_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 12,
+            "method": "tools/call",
+            "params": {
+                "name": "ask_context",
+                "arguments": {
+                    "bundle_manifest": str(manifest),
+                    "query": "hello",
+                },
+            },
+        }
+    )
+
+    result = response["result"]
+    text = result["content"][0]["text"]
+    assert len(text.encode("utf-8")) < 300
+    assert result["structuredContent"]["blob"] == "x" * 10000
+    assert json.loads(text)["details"].startswith("Use structuredContent")

--- a/merger/repoground/tests/test_mcp_stdio_e2e.py
+++ b/merger/repoground/tests/test_mcp_stdio_e2e.py
@@ -60,7 +60,9 @@ def _manifest(path: Path, *, repo: Path, commit: str) -> Path:
     return manifest
 
 
-def test_mcp_stdio_launcher_completes_handshake_outside_checkout(tmp_path: Path) -> None:
+def test_mcp_stdio_launcher_completes_handshake_outside_checkout(
+    tmp_path: Path,
+) -> None:
     client_cwd = tmp_path / "client-cwd"
     bundle_root = tmp_path / "bundles"
     client_cwd.mkdir()
@@ -108,10 +110,12 @@ def test_mcp_stdio_launcher_completes_handshake_outside_checkout(tmp_path: Path)
     responses = [json.loads(line) for line in completed.stdout.splitlines()]
     assert [response["id"] for response in responses] == [1, 2]
     assert responses[0]["result"]["protocolVersion"] == PROTOCOL_VERSION
-    assert {
-        tool["name"] for tool in responses[1]["result"]["tools"]
-    } == {
+    assert {tool["name"] for tool in responses[1]["result"]["tools"]} == {
+        "bundle_discover",
+        "snapshot_status",
         "ask_context",
+        "query_existing_index",
+        "range_get",
         "grounding_verify",
         "live_freshness",
         "find_symbol",
@@ -235,7 +239,9 @@ def _symbol_manifest(bundle_root: Path, *, repo: Path, commit: str) -> Path:
     return manifest
 
 
-def _run_launcher(bundle_root: Path, repo_root: Path | None, requests: list[dict]) -> list[dict]:
+def _run_launcher(
+    bundle_root: Path, repo_root: Path | None, requests: list[dict]
+) -> list[dict]:
     args = [sys.executable, str(MCP_LAUNCHER), "--bundle-root", str(bundle_root)]
     if repo_root is not None:
         args += ["--repo-root", str(repo_root)]
@@ -266,7 +272,9 @@ def _handshake(next_id: int, *calls: dict) -> list[dict]:
 
 
 @pytest.mark.skipif(shutil.which("git") is None, reason="git executable unavailable")
-def test_find_symbol_tools_call_returns_ranked_location_and_freshness(tmp_path: Path) -> None:
+def test_find_symbol_tools_call_returns_ranked_location_and_freshness(
+    tmp_path: Path,
+) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
     _git(repo, "init", "-q", "--initial-branch=main")
@@ -296,8 +304,12 @@ def test_find_symbol_tools_call_returns_ranked_location_and_freshness(tmp_path: 
     responses = _run_launcher(bundle_root, repo, requests)
     call_response = next(r for r in responses if r.get("id") == 2)
     assert "error" not in call_response, call_response
-    payload = json.loads(call_response["result"]["content"][0]["text"])
+    summary = json.loads(call_response["result"]["content"][0]["text"])
+    payload = call_response["result"]["structuredContent"]
 
+    assert summary["tool"] == "find_symbol"
+    assert summary["status"] == "available"
+    assert len(call_response["result"]["content"][0]["text"].encode("utf-8")) < 300
     assert payload["tool"] == "find_symbol"
     assert payload["status"] == "available"
     hits = payload["result"]["hits"]
@@ -312,12 +324,16 @@ def test_find_symbol_tools_call_returns_ranked_location_and_freshness(tmp_path: 
     assert payload["live_freshness"]["current_provenance"]["git_commit"] == commit
 
 
-def test_find_symbol_tools_call_rejects_empty_name_and_invalid_kind(tmp_path: Path) -> None:
+def test_find_symbol_tools_call_rejects_empty_name_and_invalid_kind(
+    tmp_path: Path,
+) -> None:
     bundle_root = tmp_path / "bundles"
     bundle_root.mkdir()
     manifest = bundle_root / "demo.bundle.manifest.json"
     manifest.write_text(
-        json.dumps({"kind": "repolens.bundle.manifest", "run_id": "demo", "artifacts": []}),
+        json.dumps(
+            {"kind": "repolens.bundle.manifest", "run_id": "demo", "artifacts": []}
+        ),
         encoding="utf-8",
     )
 
@@ -338,7 +354,11 @@ def test_find_symbol_tools_call_rejects_empty_name_and_invalid_kind(tmp_path: Pa
             "method": "tools/call",
             "params": {
                 "name": "find_symbol",
-                "arguments": {"bundle_manifest": str(manifest), "name": "run", "kind": "macro"},
+                "arguments": {
+                    "bundle_manifest": str(manifest),
+                    "name": "run",
+                    "kind": "macro",
+                },
             },
         },
     )
@@ -544,8 +564,12 @@ def test_get_callees_tools_call_round_trips_evidence_over_stdio(tmp_path: Path) 
     )
     response = next(item for item in responses if item.get("id") == 2)
     assert "error" not in response, response
-    payload = json.loads(response["result"]["content"][0]["text"])
+    summary = json.loads(response["result"]["content"][0]["text"])
+    payload = response["result"]["structuredContent"]
 
+    assert summary["tool"] == "get_callees"
+    assert summary["status"] == "available"
+    assert len(response["result"]["content"][0]["text"].encode("utf-8")) < 300
     assert payload["tool"] == "get_callees"
     assert payload["status"] == "available"
     result = payload["result"]

--- a/merger/repoground/tests/test_python_call_graph.py
+++ b/merger/repoground/tests/test_python_call_graph.py
@@ -285,6 +285,37 @@ def before_binding():
     assert simple_unresolved["resolved_target_ids"] == []
 
 
+def test_method_does_not_resolve_bare_class_scope_imports(tmp_path):
+    target = tmp_path / "toolkit" / "target.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def run():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "consumer.py").write_text(
+        """
+class Consumer:
+    from toolkit.target import run
+    import toolkit.target as local_target
+
+    def bare(self):
+        run()
+
+    def dotted(self):
+        local_target.run()
+""",
+        encoding="utf-8",
+    )
+
+    calls, _, _ = extract_python_calls(tmp_path)
+    bare = _single_call(calls, "run")
+    dotted = _single_call(calls, "local_target.run")
+
+    assert bare["caller_qualified_name"] == "Consumer.bare"
+    assert bare["resolution_status"] == "unresolved"
+    assert bare["resolved_target_ids"] == []
+    assert dotted["caller_qualified_name"] == "Consumer.dotted"
+    assert dotted["resolution_status"] == "unresolved"
+    assert dotted["resolved_target_ids"] == []
+
+
 def test_safe_resolution_self_and_cls_methods_same_class(tmp_path):
     write_utility_goldset(tmp_path)
     calls, _, _ = extract_python_calls(tmp_path)

--- a/merger/repoground/tests/test_python_call_graph.py
+++ b/merger/repoground/tests/test_python_call_graph.py
@@ -5,6 +5,7 @@ covers every safe resolution rule (local module function, imported internal
 name, module alias, self/cls method, direct recursion) plus the conservative
 outcomes (ambiguous, dynamic, foreign, module scope, parse errors).
 """
+
 import ast
 import json
 from pathlib import Path
@@ -21,7 +22,7 @@ from merger.repoground.architecture.call_graph import (
 )
 from merger.repoground.core.bundle_access import _call_record_is_valid
 
-GOLDSET_TEXT_PY = '''import os.path
+GOLDSET_TEXT_PY = """import os.path
 import utilkit.numbers as num
 from utilkit.numbers import double
 from external_lib import shim
@@ -58,9 +59,9 @@ class Formatter:
 
 
 TOP = slugify("Hi")
-'''
+"""
 
-GOLDSET_NUMBERS_PY = '''def double(x):
+GOLDSET_NUMBERS_PY = """def double(x):
     return x * 2
 
 
@@ -82,7 +83,7 @@ def use_cond(x):
 
 def use_double(x):
     return double(double(x))
-'''
+"""
 
 
 def write_utility_goldset(root: Path) -> Path:
@@ -114,7 +115,9 @@ def test_call_graph_document_is_deterministic_and_matches_schema(tmp_path):
 
     assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)
 
-    schema_path = Path(__file__).parent.parent / "contracts" / "python-call-graph.v1.schema.json"
+    schema_path = (
+        Path(__file__).parent.parent / "contracts" / "python-call-graph.v1.schema.json"
+    )
     schema = json.loads(schema_path.read_text(encoding="utf-8"))
     jsonschema.validate(instance=first, schema=schema)
 
@@ -126,7 +129,12 @@ def test_call_graph_document_is_deterministic_and_matches_schema(tmp_path):
     assert sum(first["resolution_counts"].values()) == first["call_count"]
     assert sum(first["evidence_counts"].values()) == first["call_count"]
     assert sum(first["relation_counts"].values()) == first["call_count"]
-    assert first["resolution_statuses"] == ["resolved", "candidate", "ambiguous", "unresolved"]
+    assert first["resolution_statuses"] == [
+        "resolved",
+        "candidate",
+        "ambiguous",
+        "unresolved",
+    ]
     assert first["relation_types"] == ["calls", "constructs"]
     # Calls are sorted by path, line, column, expression.
     keys = [
@@ -183,13 +191,98 @@ def test_safe_resolution_imported_internal_name_and_alias(tmp_path):
     assert len(imported) == 1
     assert imported[0]["resolution_status"] == "resolved"
     assert imported[0]["resolution_reason"] == "imported_internal_name"
-    assert imported[0]["resolved_target_ids"] == ["py:utilkit:numbers.py:function:double"]
+    assert imported[0]["resolved_target_ids"] == [
+        "py:utilkit:numbers.py:function:double"
+    ]
 
     alias = _single_call(calls, "num.triple")
     assert alias["resolution_status"] == "resolved"
     assert alias["resolution_reason"] == "module_alias_call"
     assert alias["resolved_target_ids"] == ["py:utilkit:numbers.py:function:triple"]
     assert alias["simple_name"] == "triple"
+
+
+def test_safe_resolution_local_module_imports_after_binding(tmp_path):
+    package = tmp_path / "toolkit"
+    package.mkdir()
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    (package / "target.py").write_text("def run():\n    return 1\n", encoding="utf-8")
+    (package / "consumer.py").write_text(
+        """
+def from_import():
+    from toolkit import target
+    return target.run()
+
+
+def alias_import():
+    import toolkit.target as local_target
+    return local_target.run()
+
+
+def simple_import():
+    from toolkit.target import run
+    return run()
+
+
+def before_simple_binding():
+    run()
+    from toolkit.target import run
+
+
+def before_binding():
+    local_target.run()
+    import toolkit.target as local_target
+""",
+        encoding="utf-8",
+    )
+
+    calls, _, _ = extract_python_calls(tmp_path)
+    target_calls = _calls_by_expression(calls, "target.run")
+    alias_calls = _calls_by_expression(calls, "local_target.run")
+    simple_calls = _calls_by_expression(calls, "run")
+
+    assert len(target_calls) == 1
+    assert target_calls[0]["resolution_status"] == "resolved"
+    assert target_calls[0]["resolution_reason"] == "local_from_import_module_call"
+    assert target_calls[0]["resolved_target_ids"] == [
+        "py:toolkit:target.py:function:run"
+    ]
+
+    assert len(alias_calls) == 2
+    resolved = next(
+        call for call in alias_calls if call["caller_qualified_name"] == "alias_import"
+    )
+    unresolved = next(
+        call
+        for call in alias_calls
+        if call["caller_qualified_name"] == "before_binding"
+    )
+    assert resolved["resolution_status"] == "resolved"
+    assert resolved["resolution_reason"] == "local_module_alias_call"
+    assert resolved["resolved_target_ids"] == ["py:toolkit:target.py:function:run"]
+    assert unresolved["resolution_status"] == "unresolved"
+    assert unresolved["resolution_reason"] == "attribute_root_lexically_shadowed_name"
+    assert unresolved["resolved_target_ids"] == []
+
+    assert len(simple_calls) == 2
+    simple_resolved = next(
+        call
+        for call in simple_calls
+        if call["caller_qualified_name"] == "simple_import"
+    )
+    simple_unresolved = next(
+        call
+        for call in simple_calls
+        if call["caller_qualified_name"] == "before_simple_binding"
+    )
+    assert simple_resolved["resolution_status"] == "resolved"
+    assert simple_resolved["resolution_reason"] == "local_imported_internal_name"
+    assert simple_resolved["resolved_target_ids"] == [
+        "py:toolkit:target.py:function:run"
+    ]
+    assert simple_unresolved["resolution_status"] == "unresolved"
+    assert simple_unresolved["resolution_reason"] == "lexically_shadowed_name"
+    assert simple_unresolved["resolved_target_ids"] == []
 
 
 def test_safe_resolution_self_and_cls_methods_same_class(tmp_path):
@@ -199,13 +292,17 @@ def test_safe_resolution_self_and_cls_methods_same_class(tmp_path):
     self_call = _single_call(calls, "self.indent")
     assert self_call["resolution_status"] == "resolved"
     assert self_call["resolution_reason"] == "self_method_same_class"
-    assert self_call["resolved_target_ids"] == ["py:utilkit:text.py:function:Formatter.indent"]
+    assert self_call["resolved_target_ids"] == [
+        "py:utilkit:text.py:function:Formatter.indent"
+    ]
     assert self_call["caller_qualified_name"] == "Formatter.format"
 
     cls_call = _single_call(calls, "cls.default")
     assert cls_call["resolution_status"] == "resolved"
     assert cls_call["resolution_reason"] == "cls_method_same_class"
-    assert cls_call["resolved_target_ids"] == ["py:utilkit:text.py:function:Formatter.default"]
+    assert cls_call["resolved_target_ids"] == [
+        "py:utilkit:text.py:function:Formatter.default"
+    ]
 
 
 def test_safe_resolution_direct_recursion(tmp_path):
@@ -346,7 +443,7 @@ def test_missing_ast_end_position_is_normalized_to_valid_range():
     assert _call_record_is_valid(record) is True
 
 
-SCOPE_GOLDSET_PY = '''
+SCOPE_GOLDSET_PY = """
 def target():
     return 1
 
@@ -430,7 +527,7 @@ class Receiver:
 
     def wrong(alias):
         return self.other()
-'''
+"""
 
 
 def _write_scope_goldset(root: Path) -> None:
@@ -582,19 +679,13 @@ def test_self_resolution_requires_actual_direct_method_receiver(tmp_path):
 
 def test_module_name_collision_preserves_all_calls_and_refuses_resolution(tmp_path):
     (tmp_path / "foo.py").write_text(
-        "def target():\n"
-        "    return 1\n\n"
-        "def file_caller():\n"
-        "    return target()\n",
+        "def target():\n    return 1\n\ndef file_caller():\n    return target()\n",
         encoding="utf-8",
     )
     package = tmp_path / "foo"
     package.mkdir()
     (package / "__init__.py").write_text(
-        "def target():\n"
-        "    return 2\n\n"
-        "def package_caller():\n"
-        "    return target()\n",
+        "def target():\n    return 2\n\ndef package_caller():\n    return target()\n",
         encoding="utf-8",
     )
     (tmp_path / "consumer.py").write_text(
@@ -631,7 +722,6 @@ def test_module_name_collision_preserves_all_calls_and_refuses_resolution(tmp_pa
         "py:foo:__init__.py:function:target",
     }
 
-
     aliased = next(
         call
         for call in calls
@@ -650,9 +740,7 @@ def test_module_name_collision_preserves_all_calls_and_refuses_resolution(tmp_pa
 
 def test_bare_method_name_is_not_treated_as_direct_recursion(tmp_path):
     (tmp_path / "sample.py").write_text(
-        "class Worker:\n"
-        "    def run(self):\n"
-        "        return run()\n",
+        "class Worker:\n    def run(self):\n        return run()\n",
         encoding="utf-8",
     )
 
@@ -668,11 +756,7 @@ def test_bare_method_name_is_not_treated_as_direct_recursion(tmp_path):
 
 def test_redefined_module_function_is_not_treated_as_direct_recursion(tmp_path):
     (tmp_path / "sample.py").write_text(
-        "def walk():\n"
-        "    return walk()\n"
-        "\n"
-        "def walk():\n"
-        "    return 0\n",
+        "def walk():\n    return walk()\n\ndef walk():\n    return 0\n",
         encoding="utf-8",
     )
 

--- a/merger/repoground/tests/test_python_call_graph.py
+++ b/merger/repoground/tests/test_python_call_graph.py
@@ -11,6 +11,7 @@ import json
 from pathlib import Path
 
 import jsonschema
+import pytest
 
 from merger.repoground.architecture.call_graph import (
     DOES_NOT_ESTABLISH,
@@ -391,6 +392,97 @@ def match_binding(value):
     )
 
 
+def test_loop_iter_and_test_rebindings_precede_the_zero_iteration_path(tmp_path):
+    target = tmp_path / "pkg" / "target.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def run():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "consumer.py").write_text(
+        """
+def sync_for_rebinding(items):
+    from pkg.target import run
+    for item in (run := items):
+        return item
+    run()
+
+
+async def async_for_rebinding(items):
+    from pkg.target import run
+    async for item in (run := items):
+        return item
+    run()
+
+
+def while_rebinding(condition):
+    from pkg.target import run
+    while (run := condition):
+        return run
+    run()
+
+
+def sync_for_unrelated_rebinding(items):
+    from pkg.target import run
+    for item in (observed := items):
+        return item
+    run()
+
+
+async def async_for_unrelated_rebinding(items):
+    from pkg.target import run
+    async for item in (observed := items):
+        return item
+    run()
+
+
+def while_unrelated_rebinding(condition):
+    from pkg.target import run
+    while (observed := condition):
+        return observed
+    run()
+
+
+def loop_target_is_not_bound_on_zero_path(items):
+    for run in (observed := items):
+        return run
+    run()
+""",
+        encoding="utf-8",
+    )
+
+    calls, _, _ = extract_python_calls(tmp_path)
+    run_calls = {
+        call["caller_qualified_name"]: call
+        for call in calls
+        if call["callee_expression"] == "run"
+    }
+
+    assert {name: call["evidence_level"] for name, call in run_calls.items()} == {
+        "sync_for_rebinding": "S0",
+        "async_for_rebinding": "S0",
+        "while_rebinding": "S0",
+        "sync_for_unrelated_rebinding": "S1",
+        "async_for_unrelated_rebinding": "S1",
+        "while_unrelated_rebinding": "S1",
+        "loop_target_is_not_bound_on_zero_path": "S0",
+    }
+    assert all(
+        run_calls[name]["resolution_reason"] == "lexically_shadowed_name"
+        for name in (
+            "sync_for_rebinding",
+            "async_for_rebinding",
+            "while_rebinding",
+            "loop_target_is_not_bound_on_zero_path",
+        )
+    )
+    assert all(
+        run_calls[name]["resolution_reason"] == "local_imported_internal_name"
+        for name in (
+            "sync_for_unrelated_rebinding",
+            "async_for_unrelated_rebinding",
+            "while_unrelated_rebinding",
+        )
+    )
+
+
 def test_local_import_can_be_reestablished_after_rebinding(tmp_path):
     target = tmp_path / "pkg" / "target.py"
     target.parent.mkdir(parents=True)
@@ -410,6 +502,1172 @@ def caller():
     call = _single_call(calls, "run")
     assert call["evidence_level"] == "S1"
     assert call["resolution_reason"] == "local_imported_internal_name"
+
+
+def test_for_else_import_binding_intersects_possible_break_paths(tmp_path):
+    target = tmp_path / "pkg" / "target.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def run():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "consumer.py").write_text(
+        """
+def break_skips_else(items):
+    for run in items:
+        if run:
+            break
+    else:
+        from pkg.target import run
+    run()
+
+
+def no_break_runs_else(items):
+    for run in items:
+        pass
+    else:
+        from pkg.target import run
+    run()
+
+
+async def async_break_skips_else(items):
+    async for run in items:
+        if run:
+            break
+    else:
+        from pkg.target import run
+    run()
+
+
+async def async_no_break_runs_else(items):
+    async for run in items:
+        pass
+    else:
+        from pkg.target import run
+    run()
+
+
+def nested_break_does_not_skip_outer_else(items):
+    for item in items:
+        for nested in items:
+            break
+    else:
+        from pkg.target import run
+    run()
+""",
+        encoding="utf-8",
+    )
+
+    calls, _, _ = extract_python_calls(tmp_path)
+    run_calls = {
+        call["caller_qualified_name"]: call
+        for call in calls
+        if call["callee_expression"] == "run"
+    }
+
+    assert run_calls["break_skips_else"]["evidence_level"] == "S0"
+    assert run_calls["async_break_skips_else"]["evidence_level"] == "S0"
+    assert run_calls["no_break_runs_else"]["evidence_level"] == "S1"
+    assert run_calls["async_no_break_runs_else"]["evidence_level"] == "S1"
+    assert run_calls["nested_break_does_not_skip_outer_else"]["evidence_level"] == "S1"
+    assert run_calls["no_break_runs_else"]["resolution_reason"] == (
+        "local_imported_internal_name"
+    )
+
+
+def test_loop_target_conditional_reimport_does_not_escape_as_s1(tmp_path):
+    target = tmp_path / "pkg" / "target.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def run():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "consumer.py").write_text(
+        """
+def sync_if_false(items):
+    from pkg.target import run
+    for run in items:
+        if False:
+            from pkg.target import run
+    run()
+
+
+def sync_if_conditional(items, restore):
+    from pkg.target import run
+    for run in items:
+        if restore:
+            from pkg.target import run
+    run()
+
+
+async def async_if_false(items):
+    from pkg.target import run
+    async for run in items:
+        if False:
+            from pkg.target import run
+    run()
+
+
+async def async_if_conditional(items, restore):
+    from pkg.target import run
+    async for run in items:
+        if restore:
+            from pkg.target import run
+    run()
+
+
+def sync_conditional_reimport_before_break(items, restore, stop):
+    from pkg.target import run
+    for run in items:
+        if restore:
+            from pkg.target import run
+        if stop:
+            break
+    else:
+        from pkg.target import run
+    run()
+
+
+async def async_if_false_before_break(items):
+    from pkg.target import run
+    async for run in items:
+        if False:
+            from pkg.target import run
+        break
+    else:
+        from pkg.target import run
+    run()
+
+
+def nested_loop_targets_remain_conservative(items, restore):
+    from pkg.target import run
+    for run in items:
+        for nested in items:
+            if restore:
+                from pkg.target import run
+    run()
+""",
+        encoding="utf-8",
+    )
+
+    calls, _, _ = extract_python_calls(tmp_path)
+    run_calls = {
+        call["caller_qualified_name"]: call
+        for call in calls
+        if call["callee_expression"] == "run"
+    }
+
+    assert set(run_calls) == {
+        "sync_if_false",
+        "sync_if_conditional",
+        "async_if_false",
+        "async_if_conditional",
+        "sync_conditional_reimport_before_break",
+        "async_if_false_before_break",
+        "nested_loop_targets_remain_conservative",
+    }
+    assert all(call["evidence_level"] == "S0" for call in run_calls.values())
+    assert all(
+        call["resolution_reason"] == "lexically_shadowed_name"
+        for call in run_calls.values()
+    )
+
+
+def test_if_import_paths_merge_before_sync_and_async_breaks(tmp_path):
+    target = tmp_path / "pkg" / "target.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def run():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "consumer.py").write_text(
+        """
+def left_call():
+    return None
+
+
+def right_call():
+    return None
+
+
+def conditional_import(items, cond):
+    for item in items:
+        if cond:
+            from pkg.target import run
+        break
+    else:
+        from pkg.target import run
+    run()
+
+
+async def async_conditional_import(items, cond):
+    async for item in items:
+        if cond:
+            from pkg.target import run
+        break
+    else:
+        from pkg.target import run
+    run()
+
+
+def both_branches_import(items, cond):
+    for item in items:
+        if cond:
+            left_call()
+            from pkg.target import run
+        else:
+            right_call()
+            from pkg.target import run
+        break
+    else:
+        from pkg.target import run
+    run()
+
+
+async def async_both_branches_import(items, cond):
+    async for item in items:
+        if cond:
+            left_call()
+            from pkg.target import run
+        else:
+            right_call()
+            from pkg.target import run
+        break
+    else:
+        from pkg.target import run
+    run()
+""",
+        encoding="utf-8",
+    )
+
+    calls, _, _ = extract_python_calls(tmp_path)
+    run_calls = {
+        call["caller_qualified_name"]: call
+        for call in calls
+        if call["callee_expression"] == "run"
+    }
+
+    assert run_calls["conditional_import"]["evidence_level"] == "S0"
+    assert run_calls["async_conditional_import"]["evidence_level"] == "S0"
+    assert run_calls["both_branches_import"]["evidence_level"] == "S1"
+    assert run_calls["async_both_branches_import"]["evidence_level"] == "S1"
+    assert len(_calls_by_expression(calls, "left_call")) == 2
+    assert len(_calls_by_expression(calls, "right_call")) == 2
+
+
+def test_if_import_merge_uses_only_reachable_fallthrough_paths(tmp_path):
+    target = tmp_path / "pkg" / "target.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def run():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "consumer.py").write_text(
+        """
+def body_return_else_import(cond):
+    if cond:
+        body_probe()
+        return
+    else:
+        else_probe()
+        from pkg.target import run
+    run()
+
+
+def body_raise_else_import(cond):
+    if cond:
+        body_probe()
+        raise RuntimeError
+    else:
+        else_probe()
+        from pkg.target import run
+    run()
+
+
+def body_import_else_return(cond):
+    if cond:
+        body_probe()
+        from pkg.target import run
+    else:
+        else_probe()
+        return
+    run()
+
+
+def conditional_return_without_import(cond, nested):
+    if cond:
+        if nested:
+            return
+    else:
+        from pkg.target import run
+    run()
+
+
+def both_reachable_branches_import(cond):
+    if cond:
+        from pkg.target import run
+    else:
+        from pkg.target import run
+    run()
+""",
+        encoding="utf-8",
+    )
+
+    calls, _, _ = extract_python_calls(tmp_path)
+    run_calls = {
+        call["caller_qualified_name"]: call
+        for call in calls
+        if call["callee_expression"] == "run"
+    }
+
+    assert {name: call["evidence_level"] for name, call in run_calls.items()} == {
+        "body_return_else_import": "S1",
+        "body_raise_else_import": "S1",
+        "body_import_else_return": "S1",
+        "conditional_return_without_import": "S0",
+        "both_reachable_branches_import": "S1",
+    }
+    assert all(
+        run_calls[name]["resolution_reason"] == "local_imported_internal_name"
+        for name in (
+            "body_return_else_import",
+            "body_raise_else_import",
+            "body_import_else_return",
+            "both_reachable_branches_import",
+        )
+    )
+    assert run_calls["conditional_return_without_import"]["resolution_reason"] == (
+        "lexically_shadowed_name"
+    )
+    assert len(_calls_by_expression(calls, "body_probe")) == 3
+    assert len(_calls_by_expression(calls, "else_probe")) == 3
+
+
+def test_try_fallthrough_keeps_only_safe_reachable_import_paths(tmp_path):
+    target = tmp_path / "pkg" / "target.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def run():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "consumer.py").write_text(
+        """
+def try_return_finally_pass(cond):
+    if cond:
+        try:
+            return
+        finally:
+            pass
+    else:
+        from pkg.target import run
+    run()
+
+
+def try_raise_finally_pass(cond):
+    if cond:
+        try:
+            raise RuntimeError
+        finally:
+            pass
+    else:
+        from pkg.target import run
+    run()
+
+
+def try_fallthrough_finally_return(cond):
+    if cond:
+        try:
+            body_probe()
+        finally:
+            return
+    else:
+        from pkg.target import run
+    run()
+
+
+def all_try_exits_terminate(cond):
+    if cond:
+        try:
+            body_probe()
+        except RuntimeError:
+            return
+        else:
+            raise ValueError
+    else:
+        from pkg.target import run
+    run()
+
+
+def handler_can_fall_through(cond):
+    if cond:
+        try:
+            return result_probe()
+        except RuntimeError:
+            handler_probe()
+        finally:
+            cleanup_probe()
+    else:
+        from pkg.target import run
+    run()
+
+
+def nonterminating_finally_falls_through(cond):
+    if cond:
+        try:
+            body_probe()
+        finally:
+            cleanup_probe()
+    else:
+        from pkg.target import run
+    run()
+
+
+def import_may_fail_before_handler_fallthrough(cond):
+    if cond:
+        try:
+            from pkg.target import run
+            return result_probe()
+        except Exception:
+            handler_probe()
+    else:
+        from pkg.target import run
+    run()
+""",
+        encoding="utf-8",
+    )
+
+    calls, _, _ = extract_python_calls(tmp_path)
+    run_calls = {
+        call["caller_qualified_name"]: call
+        for call in calls
+        if call["callee_expression"] == "run"
+    }
+
+    assert {name: call["evidence_level"] for name, call in run_calls.items()} == {
+        "try_return_finally_pass": "S1",
+        "try_raise_finally_pass": "S1",
+        "try_fallthrough_finally_return": "S1",
+        "all_try_exits_terminate": "S1",
+        "handler_can_fall_through": "S0",
+        "nonterminating_finally_falls_through": "S0",
+        "import_may_fail_before_handler_fallthrough": "S0",
+    }
+    assert all(
+        run_calls[name]["resolution_reason"] == "local_imported_internal_name"
+        for name in (
+            "try_return_finally_pass",
+            "try_raise_finally_pass",
+            "try_fallthrough_finally_return",
+            "all_try_exits_terminate",
+        )
+    )
+    assert all(
+        run_calls[name]["resolution_reason"] == "lexically_shadowed_name"
+        for name in (
+            "handler_can_fall_through",
+            "nonterminating_finally_falls_through",
+            "import_may_fail_before_handler_fallthrough",
+        )
+    )
+
+
+@pytest.mark.skipif(not hasattr(ast, "TryStar"), reason="requires Python 3.11+")
+def test_try_star_terminating_paths_do_not_dilute_else_import(tmp_path):
+    target = tmp_path / "pkg" / "target.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def run():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "consumer.py").write_text(
+        """
+def try_star_return(cond):
+    if cond:
+        try:
+            return
+        except* RuntimeError:
+            raise
+    else:
+        from pkg.target import run
+    run()
+""",
+        encoding="utf-8",
+    )
+
+    calls, _, _ = extract_python_calls(tmp_path)
+    run_call = next(call for call in calls if call["callee_expression"] == "run")
+
+    assert run_call["evidence_level"] == "S1"
+    assert run_call["resolution_reason"] == "local_imported_internal_name"
+
+
+def test_loop_break_and_continue_states_are_path_sensitive_and_nested(tmp_path):
+    package = tmp_path / "pkg"
+    package.mkdir(parents=True)
+    (package / "target.py").write_text(
+        "def run():\n    return 1\n",
+        encoding="utf-8",
+    )
+    (package / "other.py").write_text(
+        "def run():\n    return 2\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "consumer.py").write_text(
+        """
+def break_branch_does_not_reach_following_body(items, stop):
+    for item in items:
+        if stop:
+            from pkg.other import run
+            break
+        else:
+            from pkg.target import run
+        run()
+
+
+def continue_branch_does_not_reach_following_body(items, skip):
+    for item in items:
+        if skip:
+            from pkg.other import run
+            continue
+        else:
+            from pkg.target import run
+        run()
+
+
+def continue_binding_affects_loop_exit(items, skip):
+    from pkg.target import run
+    for item in items:
+        if skip:
+            from pkg.other import run
+            continue
+        from pkg.target import run
+    run()
+
+
+def nested_loop_exits_stay_with_the_inner_loop(items):
+    for outer in items:
+        from pkg.target import run
+        for inner in items:
+            if inner:
+                break
+            continue
+        run()
+""",
+        encoding="utf-8",
+    )
+
+    calls, _, _ = extract_python_calls(tmp_path)
+    run_calls = {
+        call["caller_qualified_name"]: call
+        for call in calls
+        if call["callee_expression"] == "run"
+    }
+
+    assert (
+        run_calls["break_branch_does_not_reach_following_body"]["evidence_level"]
+        == "S1"
+    )
+    assert (
+        run_calls["continue_branch_does_not_reach_following_body"]["evidence_level"]
+        == "S1"
+    )
+    assert run_calls["continue_binding_affects_loop_exit"]["evidence_level"] == "S0"
+    assert (
+        run_calls["nested_loop_exits_stay_with_the_inner_loop"]["evidence_level"]
+        == "S1"
+    )
+    assert run_calls["continue_binding_affects_loop_exit"]["resolution_reason"] == (
+        "lexically_shadowed_name"
+    )
+
+
+def test_break_paths_apply_finally_import_bindings_for_all_loop_kinds(tmp_path):
+    target = tmp_path / "pkg" / "target.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def run():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "consumer.py").write_text(
+        """
+def sync_for(items):
+    for item in items:
+        try:
+            break
+        finally:
+            from pkg.target import run
+    else:
+        from pkg.target import run
+    run()
+
+
+async def async_for(items):
+    async for item in items:
+        try:
+            break
+        finally:
+            from pkg.target import run
+    else:
+        from pkg.target import run
+    run()
+
+
+def while_loop(condition):
+    while condition:
+        try:
+            break
+        finally:
+            from pkg.target import run
+    else:
+        from pkg.target import run
+    run()
+""",
+        encoding="utf-8",
+    )
+
+    calls, _, _ = extract_python_calls(tmp_path)
+    run_calls = {
+        call["caller_qualified_name"]: call
+        for call in calls
+        if call["callee_expression"] == "run"
+    }
+
+    assert set(run_calls) == {"sync_for", "async_for", "while_loop"}
+    assert all(call["evidence_level"] == "S1" for call in run_calls.values())
+    assert all(
+        call["resolution_reason"] == "local_imported_internal_name"
+        for call in run_calls.values()
+    )
+
+
+def test_break_paths_keep_invalidating_and_divergent_finally_bindings_s0(tmp_path):
+    package = tmp_path / "pkg"
+    package.mkdir(parents=True)
+    (package / "target.py").write_text(
+        "def run():\n    return 1\n",
+        encoding="utf-8",
+    )
+    (package / "other.py").write_text(
+        "def run():\n    return 2\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "consumer.py").write_text(
+        """
+def invalidated(items):
+    for item in items:
+        try:
+            break
+        finally:
+            run = lambda: None
+    else:
+        from pkg.target import run
+    run()
+
+
+async def divergent(items):
+    async for item in items:
+        try:
+            break
+        finally:
+            from pkg.other import run
+    else:
+        from pkg.target import run
+    run()
+
+
+def conditional(condition, restore):
+    while condition:
+        try:
+            break
+        finally:
+            if restore:
+                from pkg.target import run
+    else:
+        from pkg.target import run
+    run()
+
+
+def nested_break_is_isolated(items):
+    for outer in items:
+        for inner in items:
+            try:
+                break
+            finally:
+                from pkg.other import run
+    else:
+        from pkg.target import run
+    run()
+""",
+        encoding="utf-8",
+    )
+
+    calls, _, _ = extract_python_calls(tmp_path)
+    run_calls = {
+        call["caller_qualified_name"]: call
+        for call in calls
+        if call["callee_expression"] == "run"
+    }
+
+    assert run_calls["invalidated"]["evidence_level"] == "S0"
+    assert run_calls["divergent"]["evidence_level"] == "S0"
+    assert run_calls["conditional"]["evidence_level"] == "S0"
+    assert run_calls["nested_break_is_isolated"]["evidence_level"] == "S1"
+
+
+def test_continue_paths_apply_and_override_finally_bindings(tmp_path):
+    package = tmp_path / "pkg"
+    package.mkdir(parents=True)
+    (package / "target.py").write_text(
+        "def run():\n    return 1\n",
+        encoding="utf-8",
+    )
+    (package / "other.py").write_text(
+        "def run():\n    return 2\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "consumer.py").write_text(
+        """
+def continue_finally_restores_selected_binding(items):
+    from pkg.target import run
+    for item in items:
+        try:
+            from pkg.other import run
+            continue
+        finally:
+            from pkg.target import run
+    run()
+
+
+def continue_finally_diverges_from_zero_iteration(items):
+    from pkg.target import run
+    for item in items:
+        try:
+            continue
+        finally:
+            from pkg.other import run
+    run()
+
+
+def finally_break_overrides_continue_and_skips_else(items):
+    for item in items:
+        try:
+            continue
+        finally:
+            from pkg.other import run
+            break
+    else:
+        from pkg.target import run
+    run()
+
+
+def finally_continue_overrides_break_and_reaches_else(items):
+    for item in items:
+        try:
+            break
+        finally:
+            from pkg.other import run
+            continue
+    else:
+        from pkg.target import run
+    run()
+""",
+        encoding="utf-8",
+    )
+
+    calls, _, _ = extract_python_calls(tmp_path)
+    run_calls = {
+        call["caller_qualified_name"]: call
+        for call in calls
+        if call["callee_expression"] == "run"
+    }
+
+    assert (
+        run_calls["continue_finally_restores_selected_binding"]["evidence_level"]
+        == "S1"
+    )
+    assert (
+        run_calls["continue_finally_diverges_from_zero_iteration"]["evidence_level"]
+        == "S0"
+    )
+    assert (
+        run_calls["finally_break_overrides_continue_and_skips_else"]["evidence_level"]
+        == "S0"
+    )
+    assert (
+        run_calls["finally_continue_overrides_break_and_reaches_else"]["evidence_level"]
+        == "S1"
+    )
+
+
+@pytest.mark.parametrize("expression_field", ("bound", "default_value"))
+@pytest.mark.parametrize(
+    ("parameter_names", "expected_expression_resolution"),
+    (
+        (("run", "T"), ("S0", "type_parameter_binding")),
+        (("T", "run"), ("S1", "local_imported_internal_name")),
+    ),
+)
+def test_type_alias_type_parameter_expressions_use_sequential_scope(
+    expression_field,
+    parameter_names,
+    expected_expression_resolution,
+):
+    type_alias_class = type(
+        "TypeAlias",
+        (ast.AST,),
+        {"_fields": ("name", "type_params", "value")},
+    )
+    type_parameter_class = type(
+        "TypeVar",
+        (ast.AST,),
+        {"_fields": ("name", "bound", "default_value")},
+    )
+    tree = ast.parse(
+        """
+def caller():
+    from pkg.target import run
+    marker()
+    run()
+"""
+    )
+    function = tree.body[0]
+    assert isinstance(function, ast.FunctionDef)
+    marker = function.body[1]
+    assert isinstance(marker, ast.Expr)
+    alias_value = ast.Call(
+        func=ast.Name(id="run", ctx=ast.Load()),
+        args=[],
+        keywords=[],
+    )
+    type_parameters = []
+    for parameter_name in parameter_names:
+        type_parameter = type_parameter_class()
+        type_parameter.name = parameter_name
+        type_parameter.bound = None
+        type_parameter.default_value = None
+        if parameter_name == "T":
+            setattr(
+                type_parameter,
+                expression_field,
+                ast.Call(
+                    func=ast.Name(id="run", ctx=ast.Load()),
+                    args=[],
+                    keywords=[],
+                ),
+            )
+        type_parameters.append(type_parameter)
+    alias = type_alias_class()
+    alias.name = ast.Name(id="Alias", ctx=ast.Store())
+    alias.type_params = type_parameters
+    alias.value = alias_value
+    function.body[1] = ast.copy_location(alias, marker)
+    ast.fix_missing_locations(tree)
+
+    target_tree = ast.parse("def run():\n    return 1\n")
+    target_visitor = _CallGraphVisitor("pkg/target.py", is_package=False)
+    target_visitor.visit(target_tree)
+    consumer_visitor = _CallGraphVisitor("consumer.py", is_package=False)
+    consumer_visitor.visit(tree)
+    modules = {
+        target_visitor.state.module: [target_visitor.state],
+        consumer_visitor.state.module: [consumer_visitor.state],
+    }
+    resolver = _Resolver(modules)
+    calls = [
+        resolver.resolve(consumer_visitor.state, raw)
+        for raw in consumer_visitor.state.calls
+    ]
+    run_calls = [call for call in calls if call["callee_expression"] == "run"]
+
+    expected_level, expected_reason = expected_expression_resolution
+    assert [call["evidence_level"] for call in run_calls] == [
+        expected_level,
+        "S0",
+        "S1",
+    ]
+    assert [call["resolution_reason"] for call in run_calls] == [
+        expected_reason,
+        "type_parameter_binding",
+        "local_imported_internal_name",
+    ]
+
+
+def test_synthetic_type_alias_rebinding_invalidates_all_local_import_forms():
+    type_alias_class = type(
+        "TypeAlias",
+        (ast.AST,),
+        {"_fields": ("name", "type_params", "value")},
+    )
+    tree = ast.parse(
+        """
+def caller():
+    from pkg.target import run
+    import pkg.target as target_module
+    run()
+    target_module.run()
+    marker()
+    run()
+    target_module.run()
+"""
+    )
+    function = tree.body[0]
+    assert isinstance(function, ast.FunctionDef)
+    marker = function.body[4]
+    assert isinstance(marker, ast.Expr)
+
+    aliases = []
+    for name in ("run", "target_module"):
+        alias = type_alias_class()
+        alias.name = ast.Name(id=name, ctx=ast.Store())
+        alias.type_params = []
+        alias.value = ast.Name(id="int", ctx=ast.Load())
+        aliases.append(ast.copy_location(alias, marker))
+    function.body[4:5] = aliases
+    ast.fix_missing_locations(tree)
+
+    target_visitor = _CallGraphVisitor("pkg/target.py", is_package=False)
+    target_visitor.visit(ast.parse("def run():\n    return 1\n"))
+    consumer_visitor = _CallGraphVisitor("consumer.py", is_package=False)
+    consumer_visitor.visit(tree)
+    resolver = _Resolver(
+        {
+            target_visitor.state.module: [target_visitor.state],
+            consumer_visitor.state.module: [consumer_visitor.state],
+        }
+    )
+    calls = [
+        resolver.resolve(consumer_visitor.state, raw)
+        for raw in consumer_visitor.state.calls
+    ]
+
+    run_calls = _calls_by_expression(calls, "run")
+    dotted_calls = _calls_by_expression(calls, "target_module.run")
+    assert [
+        (call["evidence_level"], call["resolution_reason"]) for call in run_calls
+    ] == [
+        ("S1", "local_imported_internal_name"),
+        ("S0", "lexically_shadowed_name"),
+    ]
+    assert [
+        (call["evidence_level"], call["resolution_reason"]) for call in dotted_calls
+    ] == [
+        ("S1", "local_module_alias_call"),
+        ("S0", "attribute_root_lexically_shadowed_name"),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("alias_statement", "expected_evidence"),
+    (
+        ("type Alias[run] = run()", ["S0", "S1"]),
+        ("type Alias[left, run, right] = run()", ["S0", "S1"]),
+        ("type Alias[T] = run()", ["S1", "S1"]),
+    ),
+)
+def test_type_alias_parameter_scope_with_python312_syntax(
+    tmp_path,
+    alias_statement,
+    expected_evidence,
+):
+    if not hasattr(ast, "TypeAlias"):
+        pytest.skip("requires the Python 3.12 type-alias AST and parser")
+
+    target = tmp_path / "pkg" / "target.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def run():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "consumer.py").write_text(
+        f"""
+def caller():
+    from pkg.target import run
+    {alias_statement}
+    run()
+""",
+        encoding="utf-8",
+    )
+
+    calls, _, _ = extract_python_calls(tmp_path)
+    run_calls = _calls_by_expression(calls, "run")
+
+    assert [call["evidence_level"] for call in run_calls] == expected_evidence
+    if expected_evidence[0] == "S0":
+        assert run_calls[0]["resolution_reason"] == "type_parameter_binding"
+    assert run_calls[1]["resolution_reason"] == "local_imported_internal_name"
+
+
+def test_type_alias_later_bound_sees_earlier_parameter_with_python312_syntax(
+    tmp_path,
+):
+    if not hasattr(ast, "TypeAlias"):
+        pytest.skip("requires the Python 3.12 type-alias AST and parser")
+
+    target = tmp_path / "pkg" / "target.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def run():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "consumer.py").write_text(
+        """
+def caller():
+    from pkg.target import run
+    type Alias[run, T: run()] = T
+    run()
+""",
+        encoding="utf-8",
+    )
+
+    calls, _, _ = extract_python_calls(tmp_path)
+    run_calls = _calls_by_expression(calls, "run")
+
+    assert [call["evidence_level"] for call in run_calls] == ["S0", "S1"]
+    assert run_calls[0]["resolution_reason"] == "type_parameter_binding"
+    assert run_calls[1]["resolution_reason"] == "local_imported_internal_name"
+
+
+@pytest.mark.parametrize(
+    "alias_statement",
+    (
+        "type Alias[run: run()] = int",
+        "type Alias[T: run(), run] = T",
+    ),
+)
+def test_type_alias_bound_does_not_see_current_or_later_parameter_with_python312_syntax(
+    tmp_path,
+    alias_statement,
+):
+    if not hasattr(ast, "TypeAlias"):
+        pytest.skip("requires the Python 3.12 type-alias AST and parser")
+
+    target = tmp_path / "pkg" / "target.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def run():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "consumer.py").write_text(
+        f"""
+def caller():
+    from pkg.target import run
+    {alias_statement}
+    run()
+""",
+        encoding="utf-8",
+    )
+
+    calls, _, _ = extract_python_calls(tmp_path)
+    run_calls = _calls_by_expression(calls, "run")
+
+    assert [call["evidence_level"] for call in run_calls] == ["S1", "S1"]
+    assert all(
+        call["resolution_reason"] == "local_imported_internal_name"
+        for call in run_calls
+    )
+
+
+def test_type_alias_value_sees_all_parameters_with_python312_syntax(tmp_path):
+    target = tmp_path / "pkg" / "target.py"
+    target.parent.mkdir(parents=True)
+    target.write_text(
+        "def left():\n    return 1\n\n\ndef run():\n    return 2\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "consumer.py").write_text(
+        """
+def caller():
+    from pkg.target import left, run
+    type Alias[left, run] = tuple[left(), run()]
+    left()
+    run()
+""",
+        encoding="utf-8",
+    )
+
+    if not hasattr(ast, "TypeAlias"):
+        pytest.skip("requires the Python 3.12 type-alias AST and parser")
+
+    calls, _, _ = extract_python_calls(tmp_path)
+    left_calls = _calls_by_expression(calls, "left")
+    run_calls = _calls_by_expression(calls, "run")
+
+    assert [call["evidence_level"] for call in left_calls] == ["S0", "S1"]
+    assert [call["evidence_level"] for call in run_calls] == ["S0", "S1"]
+    assert left_calls[0]["resolution_reason"] == "type_parameter_binding"
+    assert run_calls[0]["resolution_reason"] == "type_parameter_binding"
+    assert left_calls[1]["resolution_reason"] == "local_imported_internal_name"
+    assert run_calls[1]["resolution_reason"] == "local_imported_internal_name"
+
+
+def test_type_alias_syntax_invalidates_import_when_parser_supports_it(tmp_path):
+    if not hasattr(ast, "TypeAlias"):
+        pytest.skip("requires the Python 3.12 type-alias AST and parser")
+
+    source = """
+def caller():
+    from pkg.target import run
+    run()
+    type run = int
+    run()
+"""
+    try:
+        ast.parse(source)
+    except SyntaxError:
+        pytest.skip("type-alias syntax is unavailable in this parser")
+
+    target = tmp_path / "pkg" / "target.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def run():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "consumer.py").write_text(source, encoding="utf-8")
+
+    calls, _, _ = extract_python_calls(tmp_path)
+    run_calls = _calls_by_expression(calls, "run")
+
+    assert [call["evidence_level"] for call in run_calls] == ["S1", "S0"]
+    assert run_calls[1]["resolution_reason"] == "lexically_shadowed_name"
+
+
+def test_type_alias_lazy_value_self_binding_with_python312_syntax(tmp_path):
+    if not hasattr(ast, "TypeAlias"):
+        pytest.skip("requires the Python 3.12 type-alias AST and parser")
+
+    target = tmp_path / "pkg" / "target.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def run():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "consumer.py").write_text(
+        """
+def local_recursive():
+    from pkg.target import run
+    type run = run()
+    run()
+
+
+class ClassRecursive:
+    from pkg.target import run
+    type run = run()
+    run()
+
+
+def non_colliding():
+    from pkg.target import run
+    type Alias = run()
+    run()
+
+
+def recursive_with_type_parameters():
+    from pkg.target import run
+    type run[T: run()] = tuple[T, run()]
+    run()
+""",
+        encoding="utf-8",
+    )
+
+    calls, _, _ = extract_python_calls(tmp_path)
+    run_calls: dict[str, list[dict]] = {}
+    for call in calls:
+        if call["callee_expression"] == "run":
+            run_calls.setdefault(call["caller_qualified_name"], []).append(call)
+
+    assert [
+        (call["evidence_level"], call["resolution_reason"])
+        for call in run_calls["local_recursive"]
+    ] == [
+        ("S0", "type_alias_self_binding"),
+        ("S0", "lexically_shadowed_name"),
+    ]
+    assert [
+        (call["evidence_level"], call["resolution_reason"])
+        for call in run_calls["ClassRecursive"]
+    ] == [
+        ("S0", "type_alias_self_binding"),
+        ("S0", "class_scope_binding"),
+    ]
+    assert [
+        (call["evidence_level"], call["resolution_reason"])
+        for call in run_calls["non_colliding"]
+    ] == [
+        ("S1", "local_imported_internal_name"),
+        ("S1", "local_imported_internal_name"),
+    ]
+    assert [
+        (call["evidence_level"], call["resolution_reason"])
+        for call in run_calls["recursive_with_type_parameters"]
+    ] == [
+        ("S1", "local_imported_internal_name"),
+        ("S0", "type_alias_self_binding"),
+        ("S0", "lexically_shadowed_name"),
+    ]
 
 
 def test_method_does_not_resolve_bare_class_scope_imports(tmp_path):

--- a/merger/repoground/tests/test_python_call_graph.py
+++ b/merger/repoground/tests/test_python_call_graph.py
@@ -285,6 +285,60 @@ def before_binding():
     assert simple_unresolved["resolved_target_ids"] == []
 
 
+def test_local_import_is_invalidated_by_later_rebinding(tmp_path):
+    target = tmp_path / "pkg" / "target.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def run():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "consumer.py").write_text(
+        """
+def before():
+    from pkg.target import run
+    run()
+    run = lambda: 2
+    run()
+
+def dotted():
+    import pkg.target as local_target
+    local_target.run()
+    local_target = object()
+    local_target.run()
+""",
+        encoding="utf-8",
+    )
+
+    calls, _, _ = extract_python_calls(tmp_path)
+    simple = [call for call in calls if call["callee_expression"] == "run"]
+    dotted = [call for call in calls if call["callee_expression"] == "local_target.run"]
+
+    assert [call["evidence_level"] for call in simple] == ["S1", "S0"]
+    assert simple[0]["resolution_reason"] == "local_imported_internal_name"
+    assert simple[1]["resolution_reason"] == "lexically_shadowed_name"
+    assert [call["evidence_level"] for call in dotted] == ["S1", "S0"]
+    assert dotted[0]["resolution_reason"] == "local_module_alias_call"
+    assert dotted[1]["resolution_reason"] == "attribute_root_lexically_shadowed_name"
+
+
+def test_local_import_can_be_reestablished_after_rebinding(tmp_path):
+    target = tmp_path / "pkg" / "target.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def run():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "consumer.py").write_text(
+        """
+def caller():
+    from pkg.target import run
+    run = lambda: 2
+    from pkg.target import run
+    run()
+""",
+        encoding="utf-8",
+    )
+
+    calls, _, _ = extract_python_calls(tmp_path)
+    call = _single_call(calls, "run")
+    assert call["evidence_level"] == "S1"
+    assert call["resolution_reason"] == "local_imported_internal_name"
+
+
 def test_method_does_not_resolve_bare_class_scope_imports(tmp_path):
     target = tmp_path / "toolkit" / "target.py"
     target.parent.mkdir(parents=True)

--- a/merger/repoground/tests/test_python_call_graph.py
+++ b/merger/repoground/tests/test_python_call_graph.py
@@ -831,6 +831,314 @@ def both_reachable_branches_import(cond):
     assert len(_calls_by_expression(calls, "else_probe")) == 3
 
 
+def test_match_import_merge_is_exhaustive_guarded_and_fallthrough_aware(tmp_path):
+    target = tmp_path / "pkg" / "target.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def run():\n    return 1\n", encoding="utf-8")
+    alternative = tmp_path / "pkg" / "alternative.py"
+    alternative.write_text("def run():\n    return 2\n", encoding="utf-8")
+    (tmp_path / "consumer.py").write_text(
+        """
+def non_exhaustive(value):
+    match value:
+        case 1:
+            from pkg.target import run
+    run()
+
+
+def guarded_wildcard(value, allowed):
+    match value:
+        case _ if allowed:
+            from pkg.target import run
+    run()
+
+
+def non_exhaustive_identical_cases(value):
+    match value:
+        case 1:
+            from pkg.target import run
+        case 2:
+            from pkg.target import run
+    run()
+
+
+def unmatched_preserves_existing_import(value):
+    from pkg.target import run
+    match value:
+        case 1:
+            pass
+    run()
+
+
+def exhaustive_fallthrough(value):
+    match value:
+        case 1:
+            from pkg.target import run
+        case _:
+            from pkg.target import run
+    run()
+
+
+def irrefutable_capture(value):
+    match value:
+        case captured:
+            from pkg.target import run
+    run()
+
+
+def exhaustive_with_terminating_case(value):
+    match value:
+        case 1:
+            return
+        case _:
+            from pkg.target import run
+    run()
+
+
+def terminating_divergent_import(value):
+    match value:
+        case 1:
+            from pkg.alternative import run
+            return
+        case _:
+            from pkg.target import run
+    run()
+
+
+def guarded_terminating_then_default(value, allowed):
+    match value:
+        case 1 if allowed:
+            return
+        case _:
+            from pkg.target import run
+    run()
+
+
+def guarded_identical_fallthrough(value, allowed):
+    match value:
+        case 1 if allowed:
+            from pkg.target import run
+        case _:
+            from pkg.target import run
+    run()
+
+
+def guarded_divergent_fallthrough(value, allowed):
+    match value:
+        case 1 if allowed:
+            from pkg.alternative import run
+        case _:
+            from pkg.target import run
+    run()
+
+
+def all_match_cases_terminate(value, branch):
+    if branch:
+        match value:
+            case 1:
+                return
+            case _:
+                raise RuntimeError
+    else:
+        from pkg.target import run
+    run()
+
+
+def divergent_fallthrough(value):
+    match value:
+        case 1:
+            from pkg.target import run
+        case _:
+            from pkg.alternative import run
+    run()
+
+
+def default_without_import(value):
+    match value:
+        case 1:
+            from pkg.target import run
+        case _:
+            pass
+    run()
+
+
+def capture_invalidates_existing_import(value):
+    from pkg.target import run
+    match value:
+        case run:
+            pass
+    run()
+""",
+        encoding="utf-8",
+    )
+
+    calls, _, _ = extract_python_calls(tmp_path)
+    run_calls = {
+        call["caller_qualified_name"]: call
+        for call in calls
+        if call["callee_expression"] == "run"
+    }
+
+    assert {name: call["evidence_level"] for name, call in run_calls.items()} == {
+        "non_exhaustive": "S0",
+        "guarded_wildcard": "S0",
+        "non_exhaustive_identical_cases": "S0",
+        "unmatched_preserves_existing_import": "S1",
+        "exhaustive_fallthrough": "S1",
+        "irrefutable_capture": "S1",
+        "exhaustive_with_terminating_case": "S1",
+        "terminating_divergent_import": "S1",
+        "guarded_terminating_then_default": "S1",
+        "guarded_identical_fallthrough": "S1",
+        "guarded_divergent_fallthrough": "S0",
+        "all_match_cases_terminate": "S1",
+        "divergent_fallthrough": "S0",
+        "default_without_import": "S0",
+        "capture_invalidates_existing_import": "S0",
+    }
+    assert all(
+        run_calls[name]["resolution_reason"] == "local_imported_internal_name"
+        for name in (
+            "exhaustive_fallthrough",
+            "irrefutable_capture",
+            "exhaustive_with_terminating_case",
+            "terminating_divergent_import",
+            "guarded_terminating_then_default",
+            "guarded_identical_fallthrough",
+            "all_match_cases_terminate",
+            "unmatched_preserves_existing_import",
+        )
+    )
+    assert all(
+        run_calls[name]["resolution_reason"] == "lexically_shadowed_name"
+        for name in (
+            "non_exhaustive",
+            "guarded_wildcard",
+            "non_exhaustive_identical_cases",
+            "guarded_divergent_fallthrough",
+            "divergent_fallthrough",
+            "default_without_import",
+            "capture_invalidates_existing_import",
+        )
+    )
+
+
+def test_module_match_captures_rebind_import_definition_and_module_alias(tmp_path):
+    target = tmp_path / "pkg" / "target.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def run():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "consumer.py").write_text(
+        """
+from pkg.target import run as imported_run
+import pkg.target as target_alias
+
+
+def defined_run():
+    return 1
+
+
+match value:
+    case {"imported": imported_run}:
+        pass
+    case {"defined": defined_run}:
+        pass
+    case {"module": target_alias}:
+        pass
+
+imported_run()
+defined_run()
+target_alias.run()
+""",
+        encoding="utf-8",
+    )
+
+    calls, _, _ = extract_python_calls(tmp_path)
+    by_expression = {
+        expression: _calls_by_expression(calls, expression)[0]
+        for expression in ("imported_run", "defined_run", "target_alias.run")
+    }
+
+    assert all(call["evidence_level"] == "S0" for call in by_expression.values())
+    assert by_expression["imported_run"]["resolution_reason"] == (
+        "name_rebound_at_module_level"
+    )
+    assert by_expression["defined_run"]["resolution_reason"] == (
+        "name_rebound_at_module_level"
+    )
+    assert by_expression["target_alias.run"]["resolution_reason"] == (
+        "shadowed_attribute_root"
+    )
+
+
+def test_match_capture_miss_and_success_fallthrough_states_are_distinct(tmp_path):
+    target = tmp_path / "pkg" / "target.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def run():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "consumer.py").write_text(
+        """
+def capture_success_terminates(value):
+    from pkg.target import run
+    match value:
+        case {"x": run}:
+            return
+    run()
+
+
+def capture_success_falls_through(value):
+    from pkg.target import run
+    match value:
+        case {"x": run}:
+            pass
+    run()
+
+
+def unrelated_capture_guard_success_terminates(value, allowed):
+    from pkg.target import run
+    match value:
+        case {"x": captured} if allowed:
+            return
+    run()
+
+
+def captured_name_guard_success_terminates(value, allowed):
+    from pkg.target import run
+    match value:
+        case {"x": run} if allowed:
+            return
+    run()
+""",
+        encoding="utf-8",
+    )
+
+    calls, _, _ = extract_python_calls(tmp_path)
+    run_calls = {
+        call["caller_qualified_name"]: call
+        for call in calls
+        if call["callee_expression"] == "run"
+    }
+
+    assert {
+        name: call["evidence_level"] for name, call in run_calls.items()
+    } == {
+        "capture_success_terminates": "S1",
+        "capture_success_falls_through": "S0",
+        "unrelated_capture_guard_success_terminates": "S1",
+        "captured_name_guard_success_terminates": "S0",
+    }
+    assert run_calls["capture_success_terminates"]["resolution_reason"] == (
+        "local_imported_internal_name"
+    )
+    assert run_calls["unrelated_capture_guard_success_terminates"][
+        "resolution_reason"
+    ] == "local_imported_internal_name"
+    assert run_calls["capture_success_falls_through"]["resolution_reason"] == (
+        "lexically_shadowed_name"
+    )
+    assert run_calls["captured_name_guard_success_terminates"][
+        "resolution_reason"
+    ] == "lexically_shadowed_name"
+
+
 def test_try_fallthrough_keeps_only_safe_reachable_import_paths(tmp_path):
     target = tmp_path / "pkg" / "target.py"
     target.parent.mkdir(parents=True)

--- a/merger/repoground/tests/test_python_call_graph.py
+++ b/merger/repoground/tests/test_python_call_graph.py
@@ -318,6 +318,79 @@ def dotted():
     assert dotted[1]["resolution_reason"] == "attribute_root_lexically_shadowed_name"
 
 
+def test_local_import_is_invalidated_by_control_flow_bindings(tmp_path):
+    target = tmp_path / "pkg" / "target.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("def run():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "consumer.py").write_text(
+        """
+def for_binding(items):
+    from pkg.target import run
+    for run in items:
+        pass
+    run()
+
+async def async_for_binding(items):
+    from pkg.target import run
+    async for run in items:
+        pass
+    run()
+
+def with_binding(manager):
+    import pkg.target as local_target
+    with manager as local_target:
+        pass
+    local_target.run()
+
+async def async_with_binding(manager):
+    import pkg.target as local_target
+    async with manager as local_target:
+        pass
+    local_target.run()
+
+def except_binding():
+    from pkg.target import run
+    try:
+        raise RuntimeError()
+    except RuntimeError as run:
+        pass
+    run()
+
+def match_binding(value):
+    import pkg.target as local_target
+    match value:
+        case {"target": local_target}:
+            pass
+    local_target.run()
+""",
+        encoding="utf-8",
+    )
+
+    calls, _, _ = extract_python_calls(tmp_path)
+    simple = [call for call in calls if call["callee_expression"] == "run"]
+    dotted = [call for call in calls if call["callee_expression"] == "local_target.run"]
+
+    assert {call["caller_qualified_name"] for call in simple} == {
+        "for_binding",
+        "async_for_binding",
+        "except_binding",
+    }
+    assert {call["caller_qualified_name"] for call in dotted} == {
+        "with_binding",
+        "async_with_binding",
+        "match_binding",
+    }
+    assert all(call["evidence_level"] == "S0" for call in (*simple, *dotted))
+    assert all(call["resolved_target_ids"] == [] for call in (*simple, *dotted))
+    assert all(
+        call["resolution_reason"] == "lexically_shadowed_name" for call in simple
+    )
+    assert all(
+        call["resolution_reason"] == "attribute_root_lexically_shadowed_name"
+        for call in dotted
+    )
+
+
 def test_local_import_can_be_reestablished_after_rebinding(tmp_path):
     target = tmp_path / "pkg" / "target.py"
     target.parent.mkdir(parents=True)

--- a/merger/repoground/tests/test_resolved_evidence_query.py
+++ b/merger/repoground/tests/test_resolved_evidence_query.py
@@ -72,7 +72,12 @@ def _build_resolved_bundle(tmp_path, with_citation_map=True):
             "bytes": len(content),
             "sha256": canonical_sha,
         },
-        {"role": "sqlite_index", "path": index_path.name},
+        {
+            "role": "sqlite_index",
+            "path": index_path.name,
+            "bytes": index_path.stat().st_size,
+            "sha256": _sha256(index_path),
+        },
     ]
     if with_citation_map:
         citation_map_path = tmp_path / "demo.citation_map.jsonl"

--- a/scripts/docmeta/sync_repoground_mcp_tools.py
+++ b/scripts/docmeta/sync_repoground_mcp_tools.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Synchronize documented RepoGround MCP read tools with the live registry."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from merger.repoground.cli.mcp_stdio import tool_registry  # noqa: E402
+
+START_MARKER = "<!-- repoground-mcp-tools:start -->"
+END_MARKER = "<!-- repoground-mcp-tools:end -->"
+DOC_PATHS = (
+    REPO_ROOT / "docs/architecture/repoground-mcp-boundary.md",
+    REPO_ROOT / "docs/usage/repoground-mcp-stdio.md",
+)
+
+
+def render_tool_block() -> str:
+    lines = [START_MARKER]
+    for tool in tool_registry(False):
+        name = tool["name"]
+        description = " ".join(str(tool.get("description") or "").split())
+        lines.append(f"- `{name}`: {description}")
+    lines.append(END_MARKER)
+    return "\n".join(lines)
+
+
+def replace_tool_block(text: str) -> str:
+    start = text.find(START_MARKER)
+    end = text.find(END_MARKER)
+    if start < 0 or end < 0 or end < start:
+        raise ValueError("document is missing the RepoGround MCP tool markers")
+    end += len(END_MARKER)
+    return text[:start] + render_tool_block() + text[end:]
+
+
+def sync_document(path: Path, *, check: bool) -> bool:
+    before = path.read_text(encoding="utf-8")
+    after = replace_tool_block(before)
+    if before == after:
+        return True
+    if check:
+        return False
+    path.write_text(after, encoding="utf-8")
+    return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args(argv)
+    stale = [path for path in DOC_PATHS if not sync_document(path, check=args.check)]
+    if stale:
+        for path in stale:
+            print(
+                f"RepoGround MCP tool documentation is stale: {path}", file=sys.stderr
+            )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/repoground-mcp-project.py
+++ b/scripts/repoground-mcp-project.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Start the project-local RepoGround MCP server with canonical defaults."""
+
 from __future__ import annotations
 
 import os
@@ -11,18 +12,53 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from merger.repoground.cli.mcp_stdio import main  # noqa: E402
+from merger.repoground.core.bundle_catalog import (  # noqa: E402
+    BundleCatalogError,
+    checkout_repo_identity,
+    select_bundle_manifest,
+)
+
+
+def _canonical_publication_root() -> Path:
+    configured = os.environ.get("REPOGROUND_BUNDLE_ROOT")
+    if configured:
+        return Path(configured).expanduser().resolve()
+    search_parents = tuple(REPO_ROOT.parents[:3])
+    default_root = REPO_ROOT.parent / "manifest-publications" / "bundles"
+    for parent in search_parents:
+        candidate = parent / "manifest-publications" / "bundles"
+        if candidate.is_dir():
+            default_root = candidate
+            break
+    return (
+        Path(os.environ.get("REPOGROUND_PUBLICATION_ROOT", str(default_root)))
+        .expanduser()
+        .resolve()
+    )
+
+
+def _selected_bundle_manifest() -> Path:
+    bundle_root = _canonical_publication_root()
+    repo_identity = os.environ.get("REPOGROUND_REPO_ID") or checkout_repo_identity(
+        REPO_ROOT
+    )
+    selection = select_bundle_manifest(
+        bundle_root, repo=repo_identity, require_healthy=True
+    )
+    selected = selection.get("selected")
+    manifest = selected.get("manifest_path") if isinstance(selected, dict) else None
+    if selection.get("status") != "available" or not isinstance(manifest, str):
+        reason = selection.get("reason") or selection.get("status") or "unknown"
+        raise BundleCatalogError(
+            f"no unique healthy RepoGround bundle for {repo_identity!r} under {bundle_root}: {reason}"
+        )
+    return Path(manifest)
 
 
 def _argv() -> list[str]:
-    bundle_root = Path(
-        os.environ.get(
-            "REPOGROUND_BUNDLE_ROOT",
-            "~/.local/share/repoground/bundles",
-        )
-    ).expanduser()
     argv = [
         "--bundle-root",
-        str(bundle_root),
+        str(_selected_bundle_manifest()),
         "--repo-root",
         str(REPO_ROOT),
     ]
@@ -32,4 +68,8 @@ def _argv() -> list[str]:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(_argv()))
+    try:
+        raise SystemExit(main(_argv()))
+    except BundleCatalogError as exc:
+        print(f"repoground project MCP: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc


### PR DESCRIPTION
## Summary

- select the newest healthy canonical bundle deterministically
- expose bounded agent-facing query and range tools without duplicate full payloads
- route explicit symbol-definition questions through the symbol index
- preserve marked AND/OR retrieval strategy and enforce per-hit/context budgets
- resolve safe local import aliases in the Python call graph
- generate MCP tool documentation from the runtime registry

## Verification

- 126 targeted tests passed
- 4,879 broader tests passed; 2 skipped
- Ruff lint for the changed scope passed
- Ruff format check for the RepoGround changed scope passed
- `git diff --check` passed
- real published-bundle readback returned `fresh`, exact symbol locations, bounded non-empty snippets, and a compact text response

## Known host limitation

The two patch-evaluation-sidecar test files remain excluded because the current host reproducibly rejects Bubblewrap namespace creation with `Creating new namespace failed: Resource temporarily unavailable`. The same failure occurs on the unmodified host path and is tracked separately; no product failure from this diff was observed.