### PR TITLE
feat(cli): expose optional diagnostics

### DIFF
--- a/config/repoground-module-reachability.v1.json
+++ b/config/repoground-module-reachability.v1.json
@@ -8,14 +8,7 @@
   "require_production_evidence": true,
   "allowed_unproven": [],
   "allowed_documentation_only": [],
-  "allowed_test_only": [
-    "merger.repoground.core.answer_grounding_delta",
-    "merger.repoground.core.history_lens",
-    "merger.repoground.core.memory",
-    "merger.repoground.retrieval.audit_finding",
-    "merger.repoground.retrieval.audit_lane",
-    "merger.repoground.retrieval.eval_diagnostics_integration"
-  ],
+  "allowed_test_only": [],
   "removal_policy": "An unproven module is not a dead module. Removing production code requires positive evidence of non-use (retired consumer, replaced surface, measured zero use), never the absence of a static reference.",
   "allowlist_policy": "Entries record modules whose reachability could not be measured and that were reviewed by hand. A stale entry fails the check so the allowlist cannot silently outlive its reason.",
   "test_only_policy": "A test import proves the module is exercised, not that a production surface reaches it. These modules are recorded so the gap is visible and so a newly test-only module fails the check; the list is not a deletion list.",

--- a/docs/diagnostics/optional-diagnostics-cli.md
+++ b/docs/diagnostics/optional-diagnostics-cli.md
@@ -1,0 +1,80 @@
+# Optional RepoGround diagnostics CLI
+
+The `repoground diagnostics` command exposes bounded diagnostic capabilities that are deliberately not part of normal indexing, querying, service, MCP, merge or publication flows.
+
+## Why this surface exists
+
+Several mature diagnostic modules had unit tests and proof documents but no product entrypoint. Keeping them indefinitely on the module-reachability exception list hid that gap. Deleting them based only on missing static callers would have been unsafe.
+
+The explicit CLI gives each module a real consumer while preserving its authority boundary:
+
+- every operation is opt-in;
+- CLI-loaded JSON control inputs are bounded to 8 MiB and symbolic links are rejected;
+- results are emitted as deterministic JSON;
+- diagnostic outputs do not become repository truth, merge authority or review completeness evidence;
+- normal RepoGround paths do not invoke these operations.
+
+## Commands
+
+### Revalidate answer grounding
+
+```text
+repoground diagnostics answer-delta \
+  --old-declaration answer-grounding.json \
+  --new-bundle-manifest bundle.manifest.json \
+  --new-citation-map citation_map.jsonl
+```
+
+### Project a history lens
+
+```text
+repoground diagnostics history-lens \
+  --records history-records.json \
+  --profile summary
+```
+
+### Build and revalidate citation-bound memory
+
+```text
+repoground diagnostics memory-build \
+  --claim-text "The remembered claim" \
+  --citations citations.json \
+  --snapshot-stem snapshot-20260726 \
+  --snapshot-hash <64-hex-sha256> \
+  --freshness-status fresh
+
+repoground diagnostics memory-check \
+  --memory-record memory.json \
+  --current-citations citations.json \
+  --current-snapshot-hash <64-hex-sha256> \
+  --current-freshness-status fresh
+```
+
+### Plan audit lanes and bind candidate findings
+
+```text
+repoground diagnostics audit-plan \
+  --changed-path src/auth/session.py \
+  --review-query "authority boundary"
+
+repoground diagnostics audit-findings \
+  --plan audit-plan.json \
+  --candidates candidates.json \
+  --reviewed-revision <40-hex-commit> \
+  --current-revision <40-hex-commit> \
+  --citation-ids citation-ids.json
+```
+
+### Explain retrieval-evaluation misses
+
+```text
+repoground diagnostics eval-report \
+  --eval-results retrieval-eval.json \
+  --index chunk_index.jsonl \
+  --canonical canonical.md \
+  --citation citation_map.jsonl
+```
+
+## Deliberate limits
+
+This CLI does not execute review agents, edit repositories, create issues, modify retrieval rankings, refresh snapshots, approve findings, grant merge permission or establish completeness. Inputs and revision identities remain the caller's responsibility; live GitHub, CI and working-tree state must be checked separately.

--- a/docs/diagnostics/optional-diagnostics-cli.md
+++ b/docs/diagnostics/optional-diagnostics-cli.md
@@ -12,6 +12,8 @@ The explicit CLI gives each module a real consumer while preserving its authorit
 - CLI-loaded JSON control inputs are bounded to 8 MiB and symbolic links are rejected;
 - nested list members and well-formed JSONL records are type-checked before dispatch;
 - retrieval-evaluation detail fields enforce string, boolean, non-negative integer and string-list contracts;
+- answer citation maps require valid JSONL objects with unique, non-empty string citation IDs;
+- a validated answer citation map is passed as parsed records and is not reread by path;
 - malformed structured inputs return exit code 2 without a traceback;
 - results are emitted as deterministic JSON;
 - diagnostic outputs do not become repository truth, merge authority or review completeness evidence;

--- a/docs/diagnostics/optional-diagnostics-cli.md
+++ b/docs/diagnostics/optional-diagnostics-cli.md
@@ -14,6 +14,7 @@ The explicit CLI gives each module a real consumer while preserving its authorit
 - retrieval-evaluation detail fields enforce string, boolean, non-negative integer and string-list contracts;
 - answer citation maps require valid JSONL objects with unique, non-empty string citation IDs;
 - a validated answer citation map is passed as parsed records and is not reread by path;
+- answer declarations require list-shaped citation and range collections with valid evidence members;
 - malformed structured inputs return exit code 2 without a traceback;
 - results are emitted as deterministic JSON;
 - diagnostic outputs do not become repository truth, merge authority or review completeness evidence;

--- a/docs/diagnostics/optional-diagnostics-cli.md
+++ b/docs/diagnostics/optional-diagnostics-cli.md
@@ -11,6 +11,7 @@ The explicit CLI gives each module a real consumer while preserving its authorit
 - every operation is opt-in;
 - CLI-loaded JSON control inputs are bounded to 8 MiB and symbolic links are rejected;
 - nested list members and well-formed JSONL records are type-checked before dispatch;
+- retrieval-evaluation detail fields enforce string, boolean, non-negative integer and string-list contracts;
 - malformed structured inputs return exit code 2 without a traceback;
 - results are emitted as deterministic JSON;
 - diagnostic outputs do not become repository truth, merge authority or review completeness evidence;

--- a/docs/diagnostics/optional-diagnostics-cli.md
+++ b/docs/diagnostics/optional-diagnostics-cli.md
@@ -10,6 +10,8 @@ The explicit CLI gives each module a real consumer while preserving its authorit
 
 - every operation is opt-in;
 - CLI-loaded JSON control inputs are bounded to 8 MiB and symbolic links are rejected;
+- nested list members and well-formed JSONL records are type-checked before dispatch;
+- malformed structured inputs return exit code 2 without a traceback;
 - results are emitted as deterministic JSON;
 - diagnostic outputs do not become repository truth, merge authority or review completeness evidence;
 - normal RepoGround paths do not invoke these operations.

--- a/docs/diagnostics/optional-diagnostics-cli.md
+++ b/docs/diagnostics/optional-diagnostics-cli.md
@@ -11,7 +11,7 @@ The explicit CLI gives each module a real consumer while preserving its authorit
 - every operation is opt-in;
 - CLI-loaded JSON control inputs are bounded to 8 MiB and symbolic links are rejected;
 - nested list members and well-formed JSONL records are type-checked before dispatch;
-- retrieval-evaluation detail fields enforce string, boolean, non-negative integer and string-list contracts;
+- retrieval-evaluation detail fields enforce string, boolean, non-negative integer and non-empty string-list contracts;
 - answer citation maps require valid JSONL objects with unique, non-empty string citation IDs;
 - a validated answer citation map is passed as parsed records and is not reread by path;
 - answer declarations require list-shaped citation and range collections with valid evidence members;

--- a/docs/diagnostics/optional-diagnostics-cli.md
+++ b/docs/diagnostics/optional-diagnostics-cli.md
@@ -12,6 +12,7 @@ The explicit CLI gives each module a real consumer while preserving its authorit
 - CLI-loaded JSON control inputs are bounded to 8 MiB and symbolic links are rejected;
 - nested list members and well-formed JSONL records are type-checked before dispatch;
 - retrieval-evaluation detail fields enforce string, boolean, non-negative integer and non-empty string-list contracts;
+- retrieval artifact records require non-empty paths and identities, preserve the legacy chunk `id` alias, reject duplicates and fail closed on invalid JSONL;
 - answer citation maps require valid JSONL objects with unique, non-empty string citation IDs;
 - a validated answer citation map is passed as parsed records and is not reread by path;
 - answer declarations require list-shaped citation and range collections with valid evidence members;

--- a/docs/diagnostics/retrieval-eval-diagnostics.md
+++ b/docs/diagnostics/retrieval-eval-diagnostics.md
@@ -97,7 +97,6 @@ The calibrator asks five questions in sequence:
   ],
   "metadata": {
     "version": "1.0",
-    "timestamp": "2026-05-26T12:00:00Z",
     "total_misses": 47,
     "diagnostic_breakdowns": {
       "target_in_top_k": 0,
@@ -140,6 +139,9 @@ The calibrator asks five questions in sequence:
   ]
 }
 ```
+
+The standard producer omits `metadata.timestamp`, so identical inputs produce byte-stable JSON.
+Callers may supply a stable source or run timestamp explicitly; RepoGround never inserts the current wall clock automatically.
 
 Optional overfetch diagnostics example (explicitly separate from default top-k-only diagnostics):
 

--- a/docs/proofs/test-only-module-disposition-v1-proof.md
+++ b/docs/proofs/test-only-module-disposition-v1-proof.md
@@ -305,3 +305,38 @@ Thirty fresh-process normal CLI starts were measured after the broad suite compl
 Observed median delta: `+1.944 ms` or approximately `+1.36%`. The declaration validator remains behind the lazy diagnostics parser and executes only for `diagnostics answer-delta`. The normal-start delta is reported as measured and may include fresh-process noise.
 
 Rollback of this addendum is the revert of `dcba932d00e074f685da26a703ebf777271d3a21`. Current-head GitHub CI and a fresh Codex review remain separate post-push gates.
+
+
+## Fifth review-hardening addendum
+
+Codex reviewed PR head `737538559d9064648019e7b2b7ae5a4a90dcf037` and identified a fifth P2 boundary issue. Empty strings in `expected` or `top_results` are valid Python strings but match every path during substring comparison, producing a false high-confidence `target_in_top_k` diagnosis.
+
+The finding is addressed by revision `f2c55552e69e47c3f98c0c74ae0957cb2199237a`.
+
+- Parent head: `737538559d9064648019e7b2b7ae5a4a90dcf037`
+- Path-hardening diff bytes: `2065`
+- Path-hardening diff SHA-256: `e9a4b7bb6050e6e8955a33d75928be517273008675ba1b28d5acfcae60563461`
+
+The existing string-list validator now requires every present `expected` and `top_results` member to contain non-whitespace text. Empty lists remain valid. Four regression cases cover empty and whitespace-only members in both fields.
+
+Verification on the exact path-hardening revision:
+
+- focused CLI and retrieval-diagnostics tests: `64 passed in 1.45s`;
+- relevant domain, CLI and retrieval-diagnostics tests: `180 passed in 1.80s`;
+- broad suite excluding only the two documented host-blocked Bubblewrap files: `4897 passed, 2 skipped in 149.84s`;
+- durable broad-test task: `4b602c2afd684d8486e930a6`;
+- durable lifecycle receipt SHA-256: `1a82112726764c2a383b418a8e5a500ace97405195b123f1887a81d7b89a0859`;
+- Ruff changed-scope check: pass;
+- graph-maintainability ratchet: pass;
+- module reachability: `205 production modules, 0 unproven, 0 documentation-only, 0 test-only`.
+
+Thirty fresh-process normal CLI starts were measured after the broad suite completed:
+
+| Revision | Median | p90 | Minimum | Maximum |
+|---|---:|---:|---:|---:|
+| base `main` | 137.554 ms | 139.092 ms | 135.129 ms | 142.155 ms |
+| path-hardened implementation | 139.565 ms | 143.065 ms | 135.950 ms | 146.168 ms |
+
+Observed median delta: `+2.011 ms` or approximately `+1.46%`. The path-member validation remains behind the lazy diagnostics parser and executes only for `diagnostics eval-report`. The normal-start delta is reported as measured and may include fresh-process noise.
+
+Rollback of this addendum is the revert of `f2c55552e69e47c3f98c0c74ae0957cb2199237a`. Current-head GitHub CI and a fresh Codex review remain separate post-push gates.

--- a/docs/proofs/test-only-module-disposition-v1-proof.md
+++ b/docs/proofs/test-only-module-disposition-v1-proof.md
@@ -216,3 +216,48 @@ Thirty fresh-process normal CLI starts were measured after the broad suite compl
 Observed median delta: `+1.047 ms` or approximately `+0.74%`. The validation functions remain behind the lazy diagnostics parser and therefore do not execute during normal `--help`, indexing, querying, service, MCP, merge or publication paths. The measured delta is compatible with fresh-process noise, but is reported rather than treated as zero.
 
 This addendum supersedes the earlier statement that a fresh external review of the first review-hardened head remained pending. A further current-head review and current-head GitHub CI are still separate post-push gates.
+
+
+## Third review-hardening addendum
+
+Codex reviewed PR head `edb317473c13c6100b486f8db96e7f7108b5c9f5` and identified a third P2 boundary issue. `answer-delta` still delegated its citation-map path to older tolerant domain loading. A well-formed but structurally invalid JSONL line such as `[]` could therefore be ignored and misreported as a missing citation with exit code 0 instead of a malformed-input error.
+
+The finding is addressed by revision `3cb2350cd94e2bc3891b6349793e6a70611fb183`.
+
+- Parent head: `edb317473c13c6100b486f8db96e7f7108b5c9f5`
+- Citation-map-hardening diff format: `git diff --binary --no-ext-diff <parent>..<citation-map-hardening>`
+- Citation-map-hardening diff bytes: `10592`
+- Citation-map-hardening diff SHA-256: `d23ef945fe95f842f3bcf373d568b06ed2e56204af87b1d24b1950bd80e6e7af`
+
+The CLI adapter now reads a supplied answer citation map once through the existing bounded, no-symlink file loader and requires every nonblank JSONL line to:
+
+- contain valid JSON;
+- be an object;
+- contain a non-empty string `citation_id`;
+- use a `citation_id` that has not already appeared in the same map.
+
+The parsed records are passed into `check_answer_grounding_delta()` through the optional `new_citation_entries` parameter. When that parameter is supplied, the domain function validates and copies the in-memory mapping and does not reread the citation-map path. A regression test deletes the original map before evaluation and still obtains a valid result, proving that validation and consumption use the same parsed records rather than two path reads.
+
+Six CLI regression cases cover non-object records, missing, empty and non-string IDs, duplicate IDs and invalid JSON. These inputs return exit code 2 with empty stdout and no traceback.
+
+Verification on the exact citation-map-hardening revision:
+
+- focused answer-delta and CLI tests: `31 passed in 1.12s`;
+- relevant domain, CLI and retrieval-diagnostics tests: `167 passed in 1.34s`;
+- broad suite excluding only the two already documented host-blocked Bubblewrap files: `4884 passed, 2 skipped in 148.99s`;
+- durable broad-test task: `c06ec494a85b4c8282c812e8`;
+- durable lifecycle receipt SHA-256: `c8d8dbde5c2d1b9f99661aae3802790d81259cdf6b71b302f23fc37e01da4918`;
+- Ruff changed-scope check: pass;
+- graph-maintainability ratchet: pass;
+- module reachability: `205 production modules, 0 unproven, 0 documentation-only, 0 test-only`.
+
+Thirty fresh-process normal CLI starts were measured after the broad suite completed:
+
+| Revision | Median | p90 | Minimum | Maximum |
+|---|---:|---:|---:|---:|
+| base `main` | 139.228 ms | 141.323 ms | 135.801 ms | 141.881 ms |
+| citation-map-hardened implementation | 140.228 ms | 142.329 ms | 136.065 ms | 146.392 ms |
+
+Observed median delta: `+1.000 ms` or approximately `+0.72%`. The strict citation-map reader remains behind the lazy diagnostics parser and executes only when `diagnostics answer-delta --new-citation-map` is invoked. The measured normal-start delta is compatible with process-start noise, but is reported rather than treated as zero.
+
+Rollback of this addendum is the revert of `3cb2350cd94e2bc3891b6349793e6a70611fb183`; the previous tolerant domain path remains available to pre-existing callers that do not supply prevalidated entries. Current-head GitHub CI and a fresh Codex review remain separate post-push gates.

--- a/docs/proofs/test-only-module-disposition-v1-proof.md
+++ b/docs/proofs/test-only-module-disposition-v1-proof.md
@@ -340,3 +340,52 @@ Thirty fresh-process normal CLI starts were measured after the broad suite compl
 Observed median delta: `+2.011 ms` or approximately `+1.46%`. The path-member validation remains behind the lazy diagnostics parser and executes only for `diagnostics eval-report`. The normal-start delta is reported as measured and may include fresh-process noise.
 
 Rollback of this addendum is the revert of `f2c55552e69e47c3f98c0c74ae0957cb2199237a`. Current-head GitHub CI and a fresh Codex review remain separate post-push gates.
+
+
+## Sixth review-hardening addendum
+
+Codex reviewed PR head `55e4289e906dd6f17da4ce427b0d4bb4186b49e2` and identified a sixth P2 boundary issue. A chunk-index record with an empty `path` was formally a string and therefore passed the first type check, but the empty substring matched every expected target. The resulting diagnostic could falsely claim that a target existed in the index and even connect unrelated citations.
+
+The finding is addressed by revision `88060705b548e218e9751b557bc053591f9dc199`.
+
+- Parent head: `55e4289e906dd6f17da4ce427b0d4bb4186b49e2`
+- Artifact-identity-hardening diff bytes: `16595`
+- Artifact-identity-hardening diff SHA-256: `61f46025a4cca02e4a05425ceadd61d8efa9222fe04c3f2c4d89b798647ac3a9`
+
+The correction closes the reported universal-path bug and the same error class in the adjacent identity chain:
+
+- chunk-index `path` values are required non-empty strings;
+- each chunk record requires a non-empty `chunk_id` or the supported legacy alias `id`;
+- when both chunk identity fields are present, they must agree;
+- duplicate chunk identities are rejected across the index;
+- citation records require non-empty, unique `citation_id` values;
+- present citation `chunk_id` values must be non-empty strings;
+- syntactically invalid chunk-index and citation-map JSONL lines fail closed instead of disappearing from the diagnostic evidence set;
+- the valid legacy `id` form remains covered by a positive compatibility test.
+
+Regression coverage includes missing, empty, whitespace-only and wrong-type paths and identities, conflicting aliases, duplicate chunk and citation identities, non-object records and invalid JSONL syntax. These inputs return exit code 2 with empty stdout and no traceback.
+
+While this fix was being verified, `origin/main` advanced from `40dd1088a642370c5a7cc0dfd19dbd59e6395a35` to `9a8a21d7e6e9bd4c17c0f36696dd67f7586ccf03` through `fix(ci): guard current test stub namespace (#1107)`. That commit changes only the test-stub workflow, its guard script and its guard tests. It had no file overlap with the diagnostics change. The feature branch merged the new base conflict-free in `40468c66fc78a53c2c6b9532429091f7fcade168`, preserving all already published review-fix hashes.
+
+Verification:
+
+- focused CLI and retrieval-diagnostics tests before the base merge: `87 passed in 2.16s`;
+- relevant six-module tests before the base merge: `203 passed in 2.61s`;
+- relevant tests plus the new main guard after the base merge: `207 passed in 2.65s`;
+- broad suite on the merged current-main basis, excluding only the two documented host-blocked Bubblewrap files: `4924 passed, 2 skipped in 144.94s`;
+- durable broad-test task: `8ddf8b5a685e471a8411be7e`;
+- durable lifecycle receipt SHA-256: `67b6f612ea731dadc2db54475885d9b438c8add4757de6c76934aa93ef237aa8`;
+- Ruff changed-scope check: pass;
+- graph-maintainability ratchet: pass;
+- module reachability: `205 production modules, 0 unproven, 0 documentation-only, 0 test-only`.
+
+Thirty fresh-process normal CLI starts were measured after the current-main merge and broad suite:
+
+| Revision | Median | p90 | Minimum | Maximum |
+|---|---:|---:|---:|---:|
+| current `main` `9a8a21d7…` | 142.835 ms | 145.422 ms | 138.212 ms | 148.992 ms |
+| artifact-hardened merged branch | 144.927 ms | 147.752 ms | 139.866 ms | 149.182 ms |
+
+Observed median delta: `+2.092 ms` or approximately `+1.46%`. The artifact validators remain behind the lazy diagnostics parser and execute only for `diagnostics eval-report`. The normal-start delta is reported as measured and may include fresh-process noise.
+
+Rollback of the technical addendum is the revert of `88060705b548e218e9751b557bc053591f9dc199`. The merge commit `40468c66fc78a53c2c6b9532429091f7fcade168` should not be reverted merely to roll back this feature, because it carries the independent current-main CI guard. Current-head GitHub CI and a fresh Codex review remain separate post-push gates.

--- a/docs/proofs/test-only-module-disposition-v1-proof.md
+++ b/docs/proofs/test-only-module-disposition-v1-proof.md
@@ -1,0 +1,139 @@
+# RepoGround test-only module disposition v1 proof
+
+## Binding
+
+- Bureau task: `REPOGROUND-LEGACY-RECONCILIATION-V1-T013`
+- Parent task: `REPOGROUND-LEGACY-RECONCILIATION-V1-T004`
+- Repository: `heimgewebe/repoground`
+- Base revision: `40dd1088a642370c5a7cc0dfd19dbd59e6395a35`
+- Implementation revision: `397ebc1a520f1a723f47b267560a6973a1532830`
+- Implementation diff format: `git diff --binary --no-ext-diff <base>..<implementation>`
+- Implementation diff bytes: `25442`
+- Implementation diff SHA-256: `f0f67e5cbb80a23ef93cd39477fd38651bac755279532493de85229c93622abd`
+- Observed date: `2026-07-26`
+
+This proof records a keep-and-integrate disposition for six production modules that previously had test evidence but no measured production entrypoint. It does not close the T004 parent task or establish that every dynamic or private consumer has been discovered.
+
+## Live-state and non-conflict preflight
+
+Before implementation:
+
+- canonical checkout `/home/alex/repos/repoground` was clean at the base revision;
+- `origin/main` was fetched immediately before commit and matched the base revision exactly;
+- open PR `#1105` was inspected and changed a disjoint MCP/frontdoor and call-graph scope;
+- a separate worktree and branch were used: `refactor/legacy-reconciliation-t004-port-current-v1`;
+- an owner-bound path and branch lease protected that workspace;
+- the historical T004 worktree and PR #1105 workspace were not modified.
+
+The five historical T004 commits were examined against current `main`. Their complexity baseline, reachability scanner, tests and graph-maintainability budget were already present in newer or stricter forms. Porting them would have duplicated or downgraded current behavior, so no historical commit was retained.
+
+## Exact module inventory
+
+The domain module files were not modified by this disposition. Their observed content identities at the base and implementation revision are:
+
+| Module | Path | SHA-256 | Pre-state | Disposition |
+|---|---|---|---|---|
+| `merger.repoground.core.answer_grounding_delta` | `merger/repoground/core/answer_grounding_delta.py` | `4c5cf6f4f24662ce2b20ecf4897384a00acfbcc05227e424bbc7bfcb3b813d18` | test-only reachability exception | keep and integrate through `diagnostics answer-delta` |
+| `merger.repoground.core.history_lens` | `merger/repoground/core/history_lens.py` | `a02e9797a65affc86c734a2143404cf70506efb4cdecf53479b8309b5ff3cc59` | test-only reachability exception | keep and integrate through `diagnostics history-lens` |
+| `merger.repoground.core.memory` | `merger/repoground/core/memory.py` | `0cc08645583c96ce041eab3fcd05b41e72fc61113da8d7e3000d075ba481e304` | test-only reachability exception | keep and integrate through `diagnostics memory-build` and `diagnostics memory-check` |
+| `merger.repoground.retrieval.audit_finding` | `merger/repoground/retrieval/audit_finding.py` | `c91545293164819fe0907b5a52922a0fc02cf719a304791fd365e1d8fab6b389` | test-only reachability exception | keep and integrate through `diagnostics audit-findings` |
+| `merger.repoground.retrieval.audit_lane` | `merger/repoground/retrieval/audit_lane.py` | `9f5b5982b729c63f78c8f7d7c85bbdffcdb1677d3da0e4605d8af529b22ae306` | test-only reachability exception | keep and integrate through `diagnostics audit-plan` |
+| `merger.repoground.retrieval.eval_diagnostics_integration` | `merger/repoground/retrieval/eval_diagnostics_integration.py` | `c97aadf7f6eb8cadde409383721eba34b0148f640a480f647ee7d0f274bad7d9` | test-only reachability exception | keep and integrate through `diagnostics eval-report` |
+
+## Consumer and removal assessment
+
+Repository searches separated these evidence classes:
+
+- direct production imports: absent before this change;
+- CLI/runtime entrypoint: absent before this change;
+- tests and proof documents: present for all six modules;
+- packaging presence: all six modules were shipped inside the production package tree;
+- organization code search: searches for `check_answer_grounding_delta`, `build_history_lens`, `build_memory_record`, `adapt_audit_findings`, `plan_audit_lanes` and `integrate_diagnostics_with_eval_results` returned RepoGround-local implementations, tests or documents, with no separate Heimgewebe consumer observed.
+
+Static absence was not treated as deletion authority. The modules contain tested, bounded domain behavior, and their proof history shows deliberate authority constraints. The safer disposition is therefore explicit opt-in integration rather than deletion.
+
+## Product surface
+
+The implementation adds `repoground diagnostics` with seven operations:
+
+- `answer-delta`
+- `history-lens`
+- `memory-build`
+- `memory-check`
+- `audit-plan`
+- `audit-findings`
+- `eval-report`
+
+The nested parser and domain imports are lazy. Normal indexing, querying, service, MCP, merge and publication paths do not execute these modules.
+
+CLI-owned JSON control files are:
+
+- limited to 8 MiB;
+- required to be regular files;
+- rejected when presented as symbolic links;
+- opened with `O_NOFOLLOW` when supported;
+- checked by device and inode before and after opening to detect path replacement;
+- decoded as UTF-8 and parsed as JSON.
+
+## Authority boundary
+
+The new surface does not:
+
+- establish repository or claim truth;
+- establish retrieval, review or audit completeness;
+- approve audit candidates;
+- modify retrieval metrics or rankings;
+- edit repositories or create issues;
+- refresh snapshots;
+- grant merge permission;
+- execute automatically in normal RepoGround flows.
+
+Revision identities and input provenance remain caller responsibilities. Live Git, GitHub, CI and working-tree state must still be checked separately.
+
+## Verification
+
+Exact implementation revision checks:
+
+- relevant domain and CLI tests: `148 passed in 0.79s`;
+- broad suite excluding only the two host-blocked Bubblewrap files: `4865 passed, 2 skipped in 152.64s`;
+- durable broad-test task: `7652d6a5ec724fb2818e6364`;
+- durable lifecycle receipt SHA-256: `7357309e3dd33ba0bb244117b49c259e32b3b16e86b4140de3c087eae348357c`;
+- Ruff changed-scope check: pass;
+- graph-maintainability ratchet: pass;
+- module reachability: `205 production modules, 0 unproven, 0 documentation-only, 0 test-only`;
+- staged diff whitespace/error check before commit: pass.
+
+A complete unfiltered suite run reached `4874 passed, 2 skipped, 33 failed`. All 33 failures were confined to:
+
+- `tests/test_patch_evaluation_sidecar.py`
+- `tests/test_patch_evaluation_sidecar_host_readback.py`
+
+Every failure had the same host infrastructure cause: Bubblewrap could not create a namespace and returned `Creating new namespace failed: Resource temporarily unavailable`. The changed files do not implement or call that sidecar. This proof therefore records those tests as not evaluable on the current host, not as passing.
+
+## Performance
+
+Thirty fresh-process `python -m merger.repoground.cli.main --help` runs were measured per revision on the same host:
+
+| Revision | Median | p90 | Minimum | Maximum |
+|---|---:|---:|---:|---:|
+| base `main` | 142.030 ms | 144.947 ms | 137.964 ms | 148.940 ms |
+| implementation | 142.889 ms | 147.076 ms | 139.087 ms | 152.772 ms |
+
+Observed median delta: `+0.859 ms` or approximately `+0.60%`. This is small and may include process-start noise. An earlier eager implementation added roughly 4–5 ms and was rejected; lazy parser construction and lazy domain imports removed most of that cost.
+
+## Rollback
+
+Rollback is bounded and mechanical:
+
+1. revert implementation revision `397ebc1a520f1a723f47b267560a6973a1532830`;
+2. restore the six exact module names in `allowed_test_only` within `config/repoground-module-reachability.v1.json`;
+3. rerun module reachability, graph maintainability, the relevant domain tests and the broad suite available on the host.
+
+Reverting removes only the opt-in CLI, its tests, its documentation and the reachability-list reduction. It does not delete or mutate the six domain modules.
+
+## Limitations
+
+- Organization code search cannot prove the absence of dynamic, generated, local-only or inaccessible private consumers.
+- CLI reachability proves a product entrypoint exists; it does not prove real-world usage frequency.
+- The current host could not evaluate the two Bubblewrap-dependent sidecar files.
+- GitHub CI and external review are separate post-push evidence and are not established by this local proof.

--- a/docs/proofs/test-only-module-disposition-v1-proof.md
+++ b/docs/proofs/test-only-module-disposition-v1-proof.md
@@ -173,3 +173,46 @@ Reverting removes only the opt-in CLI, its tests, its documentation, the review 
 - CLI reachability proves a product entrypoint exists; it does not prove real-world usage frequency.
 - The current host could not evaluate the two Bubblewrap-dependent sidecar files.
 - GitHub CI and a fresh external review of the review-hardened head remain separate post-push evidence.
+
+## Second review-hardening addendum
+
+Codex reviewed PR head `b00e443b6b39e56503fc4ddb87e0a666e042eab0` and identified a second P2 boundary issue. Object-shaped retrieval-evaluation details could still carry invalid field types. In particular, `"is_relevant": "false"` is a truthy string in Python and could silently suppress a miss, while a non-string `query` could produce a diagnostics artifact that violates its schema.
+
+The finding is addressed by revision `e080654c4c4b0d11d426a44d4088028bbff79163`.
+
+- Parent head: `b00e443b6b39e56503fc4ddb87e0a666e042eab0`
+- Field-hardening diff format: `git diff --binary --no-ext-diff <parent>..<field-hardening>`
+- Field-hardening diff bytes: `7510`
+- Field-hardening diff SHA-256: `09c640246ac6072d442e5058ed7478e5c39dde9e42128e469b1168db0b2952d4`
+
+The adapter now validates these present fields before miss classification:
+
+- `query`: string;
+- `expected`: list of strings;
+- `is_relevant`: boolean;
+- `found_count`: non-negative integer, explicitly excluding booleans;
+- `top_results`: list of strings.
+
+Missing fields retain the previous bounded defaults. Present malformed fields fail with exit code 2 and without a traceback. Nine parameterized regression cases cover scalar/list mismatches, invalid list members, boolean-as-integer ambiguity and negative hit counts.
+
+Verification on the exact field-hardening revision:
+
+- focused diagnostics tests: `45 passed in 0.84s`;
+- relevant domain, CLI and retrieval-diagnostics tests: `160 passed in 1.17s`;
+- broad suite excluding only the two already documented host-blocked Bubblewrap files: `4877 passed, 2 skipped in 149.90s`;
+- durable broad-test task: `f681a924ca8a45c8a14b488e`;
+- durable lifecycle receipt SHA-256: `98ee3e1be27530188343811a3346348d7bceeb40607548104f1911a9fed332c7`;
+- Ruff changed-scope check: pass;
+- graph-maintainability ratchet: pass;
+- module reachability: `205 production modules, 0 unproven, 0 documentation-only, 0 test-only`.
+
+Thirty fresh-process normal CLI starts were measured after the broad suite completed:
+
+| Revision | Median | p90 | Minimum | Maximum |
+|---|---:|---:|---:|---:|
+| base `main` | 142.167 ms | 145.178 ms | 137.477 ms | 150.679 ms |
+| field-hardened implementation | 143.214 ms | 144.771 ms | 138.812 ms | 147.088 ms |
+
+Observed median delta: `+1.047 ms` or approximately `+0.74%`. The validation functions remain behind the lazy diagnostics parser and therefore do not execute during normal `--help`, indexing, querying, service, MCP, merge or publication paths. The measured delta is compatible with fresh-process noise, but is reported rather than treated as zero.
+
+This addendum supersedes the earlier statement that a fresh external review of the first review-hardened head remained pending. A further current-head review and current-head GitHub CI are still separate post-push gates.

--- a/docs/proofs/test-only-module-disposition-v1-proof.md
+++ b/docs/proofs/test-only-module-disposition-v1-proof.md
@@ -261,3 +261,47 @@ Thirty fresh-process normal CLI starts were measured after the broad suite compl
 Observed median delta: `+1.000 ms` or approximately `+0.72%`. The strict citation-map reader remains behind the lazy diagnostics parser and executes only when `diagnostics answer-delta --new-citation-map` is invoked. The measured normal-start delta is compatible with process-start noise, but is reported rather than treated as zero.
 
 Rollback of this addendum is the revert of `3cb2350cd94e2bc3891b6349793e6a70611fb183`; the previous tolerant domain path remains available to pre-existing callers that do not supply prevalidated entries. Current-head GitHub CI and a fresh Codex review remain separate post-push gates.
+
+
+## Fourth review-hardening addendum
+
+Codex reviewed PR head `6aad39035b78ddb67660b62cfd3dcdd205b464f0` and identified a fourth P2 boundary issue. The `answer-delta` adapter validated only that the old declaration was an object. Object-valued or otherwise malformed `used_citations` and `used_ranges` collections could therefore be iterated by the tolerant domain function and silently omit declared evidence. In the concrete review example, an object-valued `used_citations` collection beside one valid range could still produce an overall `valid` result with no citation checks.
+
+The finding is addressed by revision `dcba932d00e074f685da26a703ebf777271d3a21`.
+
+- Parent head: `6aad39035b78ddb67660b62cfd3dcdd205b464f0`
+- Declaration-hardening diff format: `git diff --binary --no-ext-diff <parent>..<declaration-hardening>`
+- Declaration-hardening diff bytes: `4819`
+- Declaration-hardening diff SHA-256: `f435059dd11bc1b80d26c78f426cf99c5b6098986f2fa00e05917fc458c4b938`
+
+At the CLI boundary:
+
+- missing `used_citations` and `used_ranges` remain compatible with the previous empty-declaration defaults;
+- present `used_citations` and `used_ranges` values must be JSON lists;
+- every list member must be a JSON object;
+- each citation member must carry a non-empty string `citation_id`;
+- each range member must carry an object-valued `range_ref`.
+
+Nine parameterized regression cases cover the Codex example, object-valued collections, scalar list members, missing, empty and non-string citation IDs, and missing or non-object range references. All malformed inputs return exit code 2 with empty stdout and no traceback.
+
+Verification on the exact declaration-hardening revision:
+
+- focused answer-delta and CLI tests: `40 passed in 1.29s`;
+- relevant domain, CLI and retrieval-diagnostics tests: `176 passed in 1.66s`;
+- broad suite excluding only the two already documented host-blocked Bubblewrap files: `4893 passed, 2 skipped in 189.12s`;
+- durable broad-test task: `2f90a62335ff47c0b22eaff8`;
+- durable lifecycle receipt SHA-256: `6963f8dce31bd680825296805c2489c61ef8258c0fdf6623c8bdaf78ce52fb9b`;
+- Ruff changed-scope check: pass;
+- graph-maintainability ratchet: pass;
+- module reachability: `205 production modules, 0 unproven, 0 documentation-only, 0 test-only`.
+
+Thirty fresh-process normal CLI starts were measured after the broad suite completed:
+
+| Revision | Median | p90 | Minimum | Maximum |
+|---|---:|---:|---:|---:|
+| base `main` | 142.541 ms | 146.209 ms | 137.695 ms | 151.107 ms |
+| declaration-hardened implementation | 144.485 ms | 147.171 ms | 141.525 ms | 151.200 ms |
+
+Observed median delta: `+1.944 ms` or approximately `+1.36%`. The declaration validator remains behind the lazy diagnostics parser and executes only for `diagnostics answer-delta`. The normal-start delta is reported as measured and may include fresh-process noise.
+
+Rollback of this addendum is the revert of `dcba932d00e074f685da26a703ebf777271d3a21`. Current-head GitHub CI and a fresh Codex review remain separate post-push gates.

--- a/docs/proofs/test-only-module-disposition-v1-proof.md
+++ b/docs/proofs/test-only-module-disposition-v1-proof.md
@@ -10,6 +10,11 @@
 - Implementation diff format: `git diff --binary --no-ext-diff <base>..<implementation>`
 - Implementation diff bytes: `25442`
 - Implementation diff SHA-256: `f0f67e5cbb80a23ef93cd39477fd38651bac755279532493de85229c93622abd`
+- Initial proof revision: `178d1705850b5ef7f8db25223a79541f129de5b1`
+- Review-hardening revision: `4759b2a8ca205416d6bfa9b329ee225a0bf58290`
+- Review-hardening diff format: `git diff --binary --no-ext-diff <initial-proof>..<review-hardening>`
+- Review-hardening diff bytes: `12603`
+- Review-hardening diff SHA-256: `f5bc05e58c662b6b2c673b9a40c9bd07516b9a82dce4f1626535184ebd0df0a3`
 - Observed date: `2026-07-26`
 
 This proof records a keep-and-integrate disposition for six production modules that previously had test evidence but no measured production entrypoint. It does not close the T004 parent task or establish that every dynamic or private consumer has been discovered.
@@ -19,7 +24,7 @@ This proof records a keep-and-integrate disposition for six production modules t
 Before implementation:
 
 - canonical checkout `/home/alex/repos/repoground` was clean at the base revision;
-- `origin/main` was fetched immediately before commit and matched the base revision exactly;
+- `origin/main` was fetched immediately before both implementation and review-hardening commits and matched the base revision exactly;
 - open PR `#1105` was inspected and changed a disjoint MCP/frontdoor and call-graph scope;
 - a separate worktree and branch were used: `refactor/legacy-reconciliation-t004-port-current-v1`;
 - an owner-bound path and branch lease protected that workspace;
@@ -29,7 +34,7 @@ The five historical T004 commits were examined against current `main`. Their com
 
 ## Exact module inventory
 
-The domain module files were not modified by this disposition. Their observed content identities at the base and implementation revision are:
+The six domain module files were not modified by the initial disposition. Their observed content identities at the base and implementation revision are:
 
 | Module | Path | SHA-256 | Pre-state | Disposition |
 |---|---|---|---|---|
@@ -39,6 +44,13 @@ The domain module files were not modified by this disposition. Their observed co
 | `merger.repoground.retrieval.audit_finding` | `merger/repoground/retrieval/audit_finding.py` | `c91545293164819fe0907b5a52922a0fc02cf719a304791fd365e1d8fab6b389` | test-only reachability exception | keep and integrate through `diagnostics audit-findings` |
 | `merger.repoground.retrieval.audit_lane` | `merger/repoground/retrieval/audit_lane.py` | `9f5b5982b729c63f78c8f7d7c85bbdffcdb1677d3da0e4605d8af529b22ae306` | test-only reachability exception | keep and integrate through `diagnostics audit-plan` |
 | `merger.repoground.retrieval.eval_diagnostics_integration` | `merger/repoground/retrieval/eval_diagnostics_integration.py` | `c97aadf7f6eb8cadde409383721eba34b0148f640a480f647ee7d0f274bad7d9` | test-only reachability exception | keep and integrate through `diagnostics eval-report` |
+
+The review-hardening revision changes only input-shape validation in the integration path. At that revision:
+
+- `merger/repoground/retrieval/eval_diagnostics_integration.py`: `cfffb7011ac03d68b41f933a8e22215c1085a9d1224ae7bb694e016b81500eb4`
+- adjacent calibrator `merger/repoground/retrieval/eval_diagnostics.py`: `36acd91d7b768c63e081b8e45beaf851fe46a46a83099aa389c8e79e72af8f03`
+- CLI adapter `merger/repoground/cli/cmd_diagnostics.py`: `acaef2845ab6c7197458b24072e763dbaf53907a79f8be1f3aacec47d9d812d0`
+- CLI regression tests: `2a6445a094192295541c3fe34a44ed15a0074276c1a51597540ba4910f0cd681`
 
 ## Consumer and removal assessment
 
@@ -73,7 +85,23 @@ CLI-owned JSON control files are:
 - rejected when presented as symbolic links;
 - opened with `O_NOFOLLOW` when supported;
 - checked by device and inode before and after opening to detect path replacement;
-- decoded as UTF-8 and parsed as JSON.
+- decoded as UTF-8 and parsed as JSON;
+- checked for required top-level and nested element shapes before domain dispatch.
+
+Well-formed JSONL records that are not objects are rejected with a bounded `ValueError`; the CLI translates these and other supported malformed-input errors to exit code 2 without a traceback.
+
+## Review hardening
+
+Codex reviewed initial PR head `178d1705850b5ef7f8db25223a79541f129de5b1` and identified one P2 issue: top-level JSON types were checked, but malformed nested elements could still cause `AttributeError` tracebacks. Examples included history records such as `[1]` and JSONL index records such as `[]`.
+
+Revision `4759b2a8ca205416d6bfa9b329ee225a0bf58290` addresses that finding by:
+
+- validating list members for history records, memory citations, audit paths, audit candidates, citation IDs and verification records;
+- validating retrieval-evaluation detail records before field access;
+- validating chunk-index and citation-map JSONL object shape and optional string fields before field access;
+- preserving invalid-JSON-line tolerance while rejecting well-formed but structurally invalid records;
+- adding regression tests that assert exit code 2, empty stdout and absence of `Traceback`;
+- extracting small validation helpers after the first implementation exceeded two complexity ratchets.
 
 ## Authority boundary
 
@@ -92,48 +120,56 @@ Revision identities and input provenance remain caller responsibilities. Live Gi
 
 ## Verification
 
-Exact implementation revision checks:
+Initial implementation revision checks:
 
 - relevant domain and CLI tests: `148 passed in 0.79s`;
 - broad suite excluding only the two host-blocked Bubblewrap files: `4865 passed, 2 skipped in 152.64s`;
 - durable broad-test task: `7652d6a5ec724fb2818e6364`;
-- durable lifecycle receipt SHA-256: `7357309e3dd33ba0bb244117b49c259e32b3b16e86b4140de3c087eae348357c`;
+- durable lifecycle receipt SHA-256: `7357309e3dd33ba0bb244117b49c259e32b3b16e86b4140de3c087eae348357c`.
+
+Review-hardening revision checks:
+
+- relevant domain, CLI and retrieval-diagnostics tests: `151 passed in 0.89s`;
+- broad suite excluding only the two host-blocked Bubblewrap files: `4868 passed, 2 skipped in 146.71s`;
+- durable broad-test task: `d258e54954d549b5be7ed792`;
+- durable lifecycle receipt SHA-256: `9b430567129386e2e0c0807476ac82a61d1ee50e30422284059886c66be277d3`;
 - Ruff changed-scope check: pass;
 - graph-maintainability ratchet: pass;
 - module reachability: `205 production modules, 0 unproven, 0 documentation-only, 0 test-only`;
 - staged diff whitespace/error check before commit: pass.
 
-A complete unfiltered suite run reached `4874 passed, 2 skipped, 33 failed`. All 33 failures were confined to:
+A complete unfiltered suite run on the initial implementation reached `4874 passed, 2 skipped, 33 failed`. All 33 failures were confined to:
 
 - `tests/test_patch_evaluation_sidecar.py`
 - `tests/test_patch_evaluation_sidecar_host_readback.py`
 
-Every failure had the same host infrastructure cause: Bubblewrap could not create a namespace and returned `Creating new namespace failed: Resource temporarily unavailable`. The changed files do not implement or call that sidecar. This proof therefore records those tests as not evaluable on the current host, not as passing.
+Every failure had the same host infrastructure cause: Bubblewrap could not create a namespace and returned `Creating new namespace failed: Resource temporarily unavailable`. The changed files do not implement or call that sidecar. This proof therefore records those tests as not evaluable on the current host, not as passing. The host issue already has Bureau coverage in `OPERATOR-PC-HYGIENE-V1-T014`, and `REPOGROUND-LEGACY-RECONCILIATION-V1-T016` explicitly depends on its resolution; no duplicate task was registered.
 
 ## Performance
 
-Thirty fresh-process `python -m merger.repoground.cli.main --help` runs were measured per revision on the same host:
+Thirty fresh-process `python -m merger.repoground.cli.main --help` runs were measured per revision on the same idle host after review hardening:
 
 | Revision | Median | p90 | Minimum | Maximum |
 |---|---:|---:|---:|---:|
-| base `main` | 142.030 ms | 144.947 ms | 137.964 ms | 148.940 ms |
-| implementation | 142.889 ms | 147.076 ms | 139.087 ms | 152.772 ms |
+| base `main` | 139.046 ms | 141.822 ms | 134.844 ms | 142.845 ms |
+| review-hardened implementation | 139.853 ms | 143.670 ms | 136.513 ms | 146.926 ms |
 
-Observed median delta: `+0.859 ms` or approximately `+0.60%`. This is small and may include process-start noise. An earlier eager implementation added roughly 4–5 ms and was rejected; lazy parser construction and lazy domain imports removed most of that cost.
+Observed median delta: `+0.807 ms` or approximately `+0.58%`. This is small and may include process-start noise. An earlier eager implementation added roughly 4–5 ms and was rejected; lazy parser construction and lazy domain imports removed most of that cost.
 
 ## Rollback
 
 Rollback is bounded and mechanical:
 
-1. revert implementation revision `397ebc1a520f1a723f47b267560a6973a1532830`;
-2. restore the six exact module names in `allowed_test_only` within `config/repoground-module-reachability.v1.json`;
-3. rerun module reachability, graph maintainability, the relevant domain tests and the broad suite available on the host.
+1. revert review-hardening revision `4759b2a8ca205416d6bfa9b329ee225a0bf58290`;
+2. revert implementation revision `397ebc1a520f1a723f47b267560a6973a1532830`;
+3. restore the six exact module names in `allowed_test_only` if they were not restored by the implementation revert;
+4. rerun module reachability, graph maintainability, the relevant domain tests and the broad suite available on the host.
 
-Reverting removes only the opt-in CLI, its tests, its documentation and the reachability-list reduction. It does not delete or mutate the six domain modules.
+Reverting removes only the opt-in CLI, its tests, its documentation, the review input hardening and the reachability-list reduction. It does not delete the six domain modules.
 
 ## Limitations
 
 - Organization code search cannot prove the absence of dynamic, generated, local-only or inaccessible private consumers.
 - CLI reachability proves a product entrypoint exists; it does not prove real-world usage frequency.
 - The current host could not evaluate the two Bubblewrap-dependent sidecar files.
-- GitHub CI and external review are separate post-push evidence and are not established by this local proof.
+- GitHub CI and a fresh external review of the review-hardened head remain separate post-push evidence.

--- a/merger/repoground/cli/cmd_diagnostics.py
+++ b/merger/repoground/cli/cmd_diagnostics.py
@@ -1,0 +1,298 @@
+"""Explicit, bounded diagnostic surfaces for optional RepoGround capabilities.
+
+These commands turn previously test-only modules into real opt-in product surfaces.
+They do not run during normal indexing, querying, service or merge flows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+from typing import Any
+
+_MAX_JSON_BYTES = 8 * 1024 * 1024
+
+
+def _read_json(
+    path_value: str,
+    *,
+    expected_type: type | tuple[type, ...] | None = None,
+) -> Any:
+    path = Path(path_value).expanduser()
+    before_open = path.lstat()
+    if stat.S_ISLNK(before_open.st_mode):
+        raise ValueError(f"refusing symbolic-link input: {path}")
+    if not stat.S_ISREG(before_open.st_mode):
+        raise ValueError(f"input must be a regular file: {path}")
+    if before_open.st_size > _MAX_JSON_BYTES:
+        raise ValueError(
+            f"input exceeds {_MAX_JSON_BYTES} bytes: {path} ({before_open.st_size} bytes)"
+        )
+
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags)
+    try:
+        after_open = os.fstat(descriptor)
+        if not stat.S_ISREG(after_open.st_mode):
+            raise ValueError(f"input must remain a regular file while opening: {path}")
+        if (before_open.st_dev, before_open.st_ino) != (
+            after_open.st_dev,
+            after_open.st_ino,
+        ):
+            raise ValueError(f"input changed while opening: {path}")
+        if after_open.st_size > _MAX_JSON_BYTES:
+            raise ValueError(
+                f"input exceeds {_MAX_JSON_BYTES} bytes: {path} ({after_open.st_size} bytes)"
+            )
+        with os.fdopen(descriptor, "rb", closefd=False) as handle:
+            payload = handle.read(_MAX_JSON_BYTES + 1)
+    finally:
+        os.close(descriptor)
+
+    if len(payload) > _MAX_JSON_BYTES:
+        raise ValueError(f"input exceeds {_MAX_JSON_BYTES} bytes while reading: {path}")
+    value = json.loads(payload.decode("utf-8"))
+    if expected_type is not None and not isinstance(value, expected_type):
+        expected_name = (
+            ", ".join(item.__name__ for item in expected_type)
+            if isinstance(expected_type, tuple)
+            else expected_type.__name__
+        )
+        raise ValueError(f"input must contain JSON {expected_name}: {path}")
+    return value
+
+
+def _emit(value: Any) -> None:
+    print(json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True))
+
+
+def _build_diagnostics_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="repoground diagnostics",
+        description="Run explicit, read-only or locally projected diagnostic operations",
+    )
+    operations = parser.add_subparsers(
+        dest="diagnostics_command",
+        required=True,
+        help="Diagnostic operation",
+    )
+
+    answer_delta = operations.add_parser(
+        "answer-delta",
+        help="Revalidate declared answer citations against a newer bundle",
+    )
+    answer_delta.add_argument("--old-declaration", required=True)
+    answer_delta.add_argument("--new-bundle-manifest", required=True)
+    answer_delta.add_argument("--new-citation-map")
+
+    history_lens = operations.add_parser(
+        "history-lens",
+        help="Project bounded history records without claiming repository truth",
+    )
+    history_lens.add_argument("--records", required=True)
+    history_lens.add_argument(
+        "--profile",
+        choices=["disabled", "summary", "full"],
+        default="summary",
+    )
+    history_lens.add_argument("--include-author-metadata", action="store_true")
+
+    memory_build = operations.add_parser(
+        "memory-build",
+        help="Build a citation-bound memory record that requires recall revalidation",
+    )
+    memory_build.add_argument("--claim-text", required=True)
+    memory_build.add_argument("--citations", required=True)
+    memory_build.add_argument("--snapshot-stem", required=True)
+    memory_build.add_argument("--snapshot-hash", required=True)
+    memory_build.add_argument("--freshness-status", required=True)
+    memory_build.add_argument("--stored-at")
+    memory_build.add_argument("--metadata")
+
+    memory_check = operations.add_parser(
+        "memory-check",
+        help="Revalidate a citation-bound memory record before reuse",
+    )
+    memory_check.add_argument("--memory-record", required=True)
+    memory_check.add_argument("--current-citations", required=True)
+    memory_check.add_argument("--current-snapshot-hash")
+    memory_check.add_argument("--current-freshness-status")
+
+    audit_plan = operations.add_parser(
+        "audit-plan",
+        help="Select a bounded deterministic set of diagnostic audit lanes",
+    )
+    audit_plan.add_argument("--changed-path", action="append", default=[])
+    audit_plan.add_argument("--paths-file")
+    audit_plan.add_argument("--review-query", default="")
+    audit_plan.add_argument("--max-lanes", type=int, default=6)
+
+    audit_findings = operations.add_parser(
+        "audit-findings",
+        help="Bind audit candidates to revisions, lanes and resolvable citations",
+    )
+    audit_findings.add_argument("--plan", required=True)
+    audit_findings.add_argument("--candidates", required=True)
+    audit_findings.add_argument("--reviewed-revision", required=True)
+    audit_findings.add_argument("--current-revision", required=True)
+    audit_findings.add_argument("--citation-ids", required=True)
+    audit_findings.add_argument("--verification-records")
+
+    eval_report = operations.add_parser(
+        "eval-report",
+        help="Explain retrieval misses without changing evaluation metrics",
+    )
+    eval_report.add_argument("--eval-results", required=True)
+    eval_report.add_argument("--index")
+    eval_report.add_argument("--canonical")
+    eval_report.add_argument("--citation")
+
+    return parser
+
+
+def register_diagnostics_commands(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser(
+        "diagnostics",
+        help="Run explicit, read-only or locally projected diagnostic operations",
+        add_help=False,
+    )
+    parser.add_argument(
+        "-h",
+        "--help",
+        action="store_true",
+        dest="diagnostics_help",
+    )
+    parser.add_argument("diagnostics_args", nargs=argparse.REMAINDER)
+
+
+def _run_answer_delta(args: argparse.Namespace) -> dict[str, Any]:
+    from merger.repoground.core.answer_grounding_delta import (
+        check_answer_grounding_delta,
+    )
+
+    declaration = _read_json(args.old_declaration, expected_type=dict)
+    return check_answer_grounding_delta(
+        declaration,
+        new_bundle_manifest=args.new_bundle_manifest,
+        new_citation_map=args.new_citation_map,
+    )
+
+
+def _run_history_lens(args: argparse.Namespace) -> dict[str, Any]:
+    from merger.repoground.core.history_lens import build_history_lens
+
+    records = _read_json(args.records, expected_type=list)
+    return build_history_lens(
+        records,
+        profile=args.profile,
+        include_author_metadata=args.include_author_metadata,
+    )
+
+
+def _run_memory_build(args: argparse.Namespace) -> dict[str, Any]:
+    from merger.repoground.core.memory import build_memory_record
+
+    citations = _read_json(args.citations, expected_type=list)
+    metadata = _read_json(args.metadata, expected_type=dict) if args.metadata else None
+    return build_memory_record(
+        claim_text=args.claim_text,
+        citations=citations,
+        snapshot_stem=args.snapshot_stem,
+        snapshot_hash=args.snapshot_hash,
+        freshness_status=args.freshness_status,
+        stored_at=args.stored_at,
+        metadata=metadata,
+    )
+
+
+def _run_memory_check(args: argparse.Namespace) -> dict[str, Any]:
+    from merger.repoground.core.memory import check_memory_recall
+
+    record = _read_json(args.memory_record, expected_type=dict)
+    citations = _read_json(args.current_citations, expected_type=(dict, list))
+    return check_memory_recall(
+        record,
+        current_citations=citations,
+        current_snapshot_hash=args.current_snapshot_hash,
+        current_freshness_status=args.current_freshness_status,
+    )
+
+
+def _run_audit_plan(args: argparse.Namespace) -> dict[str, Any]:
+    from merger.repoground.retrieval.audit_lane import plan_audit_lanes
+
+    paths = list(args.changed_path)
+    if args.paths_file:
+        paths.extend(_read_json(args.paths_file, expected_type=list))
+    return plan_audit_lanes(
+        paths,
+        review_query=args.review_query,
+        max_lanes=args.max_lanes,
+    )
+
+
+def _run_audit_findings(args: argparse.Namespace) -> dict[str, Any]:
+    from merger.repoground.retrieval.audit_finding import adapt_audit_findings
+
+    plan = _read_json(args.plan, expected_type=dict)
+    candidates = _read_json(args.candidates, expected_type=list)
+    citation_ids = _read_json(args.citation_ids, expected_type=list)
+    verification_records = (
+        _read_json(args.verification_records, expected_type=list)
+        if args.verification_records
+        else []
+    )
+    return adapt_audit_findings(
+        plan,
+        candidates,
+        reviewed_revision=args.reviewed_revision,
+        current_revision=args.current_revision,
+        resolvable_citation_ids=citation_ids,
+        verification_records=verification_records,
+    )
+
+
+def _run_eval_report(args: argparse.Namespace) -> dict[str, Any]:
+    from merger.repoground.retrieval.eval_diagnostics_integration import (
+        integrate_diagnostics_with_eval_results,
+    )
+
+    eval_results = _read_json(args.eval_results, expected_type=dict)
+    return integrate_diagnostics_with_eval_results(
+        eval_results,
+        index_path=Path(args.index) if args.index else None,
+        canonical_path=Path(args.canonical) if args.canonical else None,
+        citation_path=Path(args.citation) if args.citation else None,
+    )
+
+
+def run_diagnostics(args: argparse.Namespace) -> int:
+    raw_args = ["--help"] if args.diagnostics_help else args.diagnostics_args
+    operation_args = _build_diagnostics_parser().parse_args(raw_args)
+    handlers = {
+        "answer-delta": _run_answer_delta,
+        "history-lens": _run_history_lens,
+        "memory-build": _run_memory_build,
+        "memory-check": _run_memory_check,
+        "audit-plan": _run_audit_plan,
+        "audit-findings": _run_audit_findings,
+        "eval-report": _run_eval_report,
+    }
+    try:
+        result = handlers[operation_args.diagnostics_command](operation_args)
+    except (
+        KeyError,
+        OSError,
+        UnicodeError,
+        json.JSONDecodeError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+    _emit(result)
+    return 0

--- a/merger/repoground/cli/cmd_diagnostics.py
+++ b/merger/repoground/cli/cmd_diagnostics.py
@@ -20,7 +20,8 @@ _MAX_JSON_BYTES = 8 * 1024 * 1024
 
 
 def _read_input_payload(path_value: str) -> tuple[Path, bytes]:
-    path = Path(path_value).expanduser()
+    requested_path = Path(path_value).expanduser()
+    path = requested_path.parent.resolve(strict=True) / requested_path.name
     before_open = path.lstat()
     if stat.S_ISLNK(before_open.st_mode):
         raise ValueError(f"refusing symbolic-link input: {path}")
@@ -56,11 +57,11 @@ def _read_input_payload(path_value: str) -> tuple[Path, bytes]:
     return path, payload
 
 
-def _read_json(
+def _read_json_with_path(
     path_value: str,
     *,
     expected_type: type | tuple[type, ...] | None = None,
-) -> Any:
+) -> tuple[Path, Any]:
     path, payload = _read_input_payload(path_value)
     value = strict_json_loads(payload.decode("utf-8"), source=f"input {path}")
     if expected_type is not None and not isinstance(value, expected_type):
@@ -70,7 +71,15 @@ def _read_json(
             else expected_type.__name__
         )
         raise ValueError(f"input must contain JSON {expected_name}: {path}")
-    return value
+    return path, value
+
+
+def _read_json(
+    path_value: str,
+    *,
+    expected_type: type | tuple[type, ...] | None = None,
+) -> Any:
+    return _read_json_with_path(path_value, expected_type=expected_type)[1]
 
 
 def _read_validated_citation_map_jsonl(
@@ -289,10 +298,13 @@ def _run_answer_delta(args: argparse.Namespace) -> dict[str, Any]:
         if args.new_citation_map
         else None
     )
-    manifest_data = _read_json(args.new_bundle_manifest, expected_type=dict)
+    manifest_path, manifest_data = _read_json_with_path(
+        args.new_bundle_manifest,
+        expected_type=dict,
+    )
     return check_answer_grounding_delta(
         declaration,
-        new_bundle_manifest=args.new_bundle_manifest,
+        new_bundle_manifest=manifest_path,
         new_bundle_manifest_data=manifest_data,
         new_citation_map=args.new_citation_map,
         new_citation_entries=citation_entries,

--- a/merger/repoground/cli/cmd_diagnostics.py
+++ b/merger/repoground/cli/cmd_diagnostics.py
@@ -66,6 +66,21 @@ def _read_json(
     return value
 
 
+def _require_list_items(
+    value: list[Any],
+    *,
+    item_type: type,
+    label: str,
+) -> list[Any]:
+    for index, item in enumerate(value):
+        if not isinstance(item, item_type):
+            raise ValueError(
+                f"{label}[{index}] must be JSON {item_type.__name__}, "
+                f"got {type(item).__name__}"
+            )
+    return value
+
+
 def _emit(value: Any) -> None:
     print(json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True))
 
@@ -185,7 +200,11 @@ def _run_answer_delta(args: argparse.Namespace) -> dict[str, Any]:
 def _run_history_lens(args: argparse.Namespace) -> dict[str, Any]:
     from merger.repoground.core.history_lens import build_history_lens
 
-    records = _read_json(args.records, expected_type=list)
+    records = _require_list_items(
+        _read_json(args.records, expected_type=list),
+        item_type=dict,
+        label="records",
+    )
     return build_history_lens(
         records,
         profile=args.profile,
@@ -196,7 +215,11 @@ def _run_history_lens(args: argparse.Namespace) -> dict[str, Any]:
 def _run_memory_build(args: argparse.Namespace) -> dict[str, Any]:
     from merger.repoground.core.memory import build_memory_record
 
-    citations = _read_json(args.citations, expected_type=list)
+    citations = _require_list_items(
+        _read_json(args.citations, expected_type=list),
+        item_type=dict,
+        label="citations",
+    )
     metadata = _read_json(args.metadata, expected_type=dict) if args.metadata else None
     return build_memory_record(
         claim_text=args.claim_text,
@@ -214,6 +237,8 @@ def _run_memory_check(args: argparse.Namespace) -> dict[str, Any]:
 
     record = _read_json(args.memory_record, expected_type=dict)
     citations = _read_json(args.current_citations, expected_type=(dict, list))
+    if isinstance(citations, list):
+        _require_list_items(citations, item_type=dict, label="current citations")
     return check_memory_recall(
         record,
         current_citations=citations,
@@ -227,7 +252,13 @@ def _run_audit_plan(args: argparse.Namespace) -> dict[str, Any]:
 
     paths = list(args.changed_path)
     if args.paths_file:
-        paths.extend(_read_json(args.paths_file, expected_type=list))
+        paths.extend(
+            _require_list_items(
+                _read_json(args.paths_file, expected_type=list),
+                item_type=str,
+                label="paths",
+            )
+        )
     return plan_audit_lanes(
         paths,
         review_query=args.review_query,
@@ -239,10 +270,22 @@ def _run_audit_findings(args: argparse.Namespace) -> dict[str, Any]:
     from merger.repoground.retrieval.audit_finding import adapt_audit_findings
 
     plan = _read_json(args.plan, expected_type=dict)
-    candidates = _read_json(args.candidates, expected_type=list)
-    citation_ids = _read_json(args.citation_ids, expected_type=list)
+    candidates = _require_list_items(
+        _read_json(args.candidates, expected_type=list),
+        item_type=dict,
+        label="candidates",
+    )
+    citation_ids = _require_list_items(
+        _read_json(args.citation_ids, expected_type=list),
+        item_type=str,
+        label="citation ids",
+    )
     verification_records = (
-        _read_json(args.verification_records, expected_type=list)
+        _require_list_items(
+            _read_json(args.verification_records, expected_type=list),
+            item_type=dict,
+            label="verification records",
+        )
         if args.verification_records
         else []
     )

--- a/merger/repoground/cli/cmd_diagnostics.py
+++ b/merger/repoground/cli/cmd_diagnostics.py
@@ -279,14 +279,21 @@ def _run_answer_delta(args: argparse.Namespace) -> dict[str, Any]:
     declaration = _validate_answer_declaration(
         _read_json(args.old_declaration, expected_type=dict)
     )
+    if declaration.get("used_citations") and not args.new_citation_map:
+        raise ValueError(
+            "--new-citation-map is required when old declaration "
+            "used_citations is non-empty"
+        )
     citation_entries = (
         _read_validated_citation_map_jsonl(args.new_citation_map)
         if args.new_citation_map
         else None
     )
+    manifest_data = _read_json(args.new_bundle_manifest, expected_type=dict)
     return check_answer_grounding_delta(
         declaration,
         new_bundle_manifest=args.new_bundle_manifest,
+        new_bundle_manifest_data=manifest_data,
         new_citation_map=args.new_citation_map,
         new_citation_entries=citation_entries,
     )

--- a/merger/repoground/cli/cmd_diagnostics.py
+++ b/merger/repoground/cli/cmd_diagnostics.py
@@ -17,11 +17,7 @@ from typing import Any
 _MAX_JSON_BYTES = 8 * 1024 * 1024
 
 
-def _read_json(
-    path_value: str,
-    *,
-    expected_type: type | tuple[type, ...] | None = None,
-) -> Any:
+def _read_input_payload(path_value: str) -> tuple[Path, bytes]:
     path = Path(path_value).expanduser()
     before_open = path.lstat()
     if stat.S_ISLNK(before_open.st_mode):
@@ -55,6 +51,15 @@ def _read_json(
 
     if len(payload) > _MAX_JSON_BYTES:
         raise ValueError(f"input exceeds {_MAX_JSON_BYTES} bytes while reading: {path}")
+    return path, payload
+
+
+def _read_json(
+    path_value: str,
+    *,
+    expected_type: type | tuple[type, ...] | None = None,
+) -> Any:
+    path, payload = _read_input_payload(path_value)
     value = json.loads(payload.decode("utf-8"))
     if expected_type is not None and not isinstance(value, expected_type):
         expected_name = (
@@ -64,6 +69,38 @@ def _read_json(
         )
         raise ValueError(f"input must contain JSON {expected_name}: {path}")
     return value
+
+
+def _read_validated_citation_map_jsonl(
+    path_value: str,
+) -> dict[str, dict[str, Any]]:
+    path, payload = _read_input_payload(path_value)
+    text = payload.decode("utf-8")
+    entries: dict[str, dict[str, Any]] = {}
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"citation map line {line_number} must be valid JSON: {path}"
+            ) from exc
+        if not isinstance(record, dict):
+            raise ValueError(
+                f"citation map line {line_number} must be a JSON object: {path}"
+            )
+        citation_id = record.get("citation_id")
+        if not isinstance(citation_id, str) or not citation_id:
+            raise ValueError(
+                f"citation map line {line_number} field 'citation_id' must be a non-empty string: {path}"
+            )
+        if citation_id in entries:
+            raise ValueError(
+                f"citation map line {line_number} duplicates citation_id {citation_id!r}: {path}"
+            )
+        entries[citation_id] = record
+    return entries
 
 
 def _require_list_items(
@@ -190,10 +227,16 @@ def _run_answer_delta(args: argparse.Namespace) -> dict[str, Any]:
     )
 
     declaration = _read_json(args.old_declaration, expected_type=dict)
+    citation_entries = (
+        _read_validated_citation_map_jsonl(args.new_citation_map)
+        if args.new_citation_map
+        else None
+    )
     return check_answer_grounding_delta(
         declaration,
         new_bundle_manifest=args.new_bundle_manifest,
         new_citation_map=args.new_citation_map,
+        new_citation_entries=citation_entries,
     )
 
 

--- a/merger/repoground/cli/cmd_diagnostics.py
+++ b/merger/repoground/cli/cmd_diagnostics.py
@@ -118,6 +118,43 @@ def _require_list_items(
     return value
 
 
+def _validate_answer_declaration(
+    declaration: dict[str, Any],
+) -> dict[str, Any]:
+    used_citations = declaration.get("used_citations", [])
+    if not isinstance(used_citations, list):
+        raise ValueError("old declaration field 'used_citations' must be a JSON list")
+    _require_list_items(
+        used_citations,
+        item_type=dict,
+        label="old declaration used_citations",
+    )
+    for index, item in enumerate(used_citations):
+        citation_id = item.get("citation_id")
+        if not isinstance(citation_id, str) or not citation_id:
+            raise ValueError(
+                "old declaration used_citations"
+                f"[{index}] field 'citation_id' must be a non-empty string"
+            )
+
+    used_ranges = declaration.get("used_ranges", [])
+    if not isinstance(used_ranges, list):
+        raise ValueError("old declaration field 'used_ranges' must be a JSON list")
+    _require_list_items(
+        used_ranges,
+        item_type=dict,
+        label="old declaration used_ranges",
+    )
+    for index, item in enumerate(used_ranges):
+        if not isinstance(item.get("range_ref"), dict):
+            raise ValueError(
+                "old declaration used_ranges"
+                f"[{index}] field 'range_ref' must be a JSON object"
+            )
+
+    return declaration
+
+
 def _emit(value: Any) -> None:
     print(json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True))
 
@@ -226,7 +263,9 @@ def _run_answer_delta(args: argparse.Namespace) -> dict[str, Any]:
         check_answer_grounding_delta,
     )
 
-    declaration = _read_json(args.old_declaration, expected_type=dict)
+    declaration = _validate_answer_declaration(
+        _read_json(args.old_declaration, expected_type=dict)
+    )
     citation_entries = (
         _read_validated_citation_map_jsonl(args.new_citation_map)
         if args.new_citation_map

--- a/merger/repoground/cli/cmd_diagnostics.py
+++ b/merger/repoground/cli/cmd_diagnostics.py
@@ -21,7 +21,13 @@ _MAX_JSON_BYTES = 8 * 1024 * 1024
 
 def _read_input_payload(path_value: str) -> tuple[Path, bytes]:
     requested_path = Path(path_value).expanduser()
-    path = requested_path.parent.resolve(strict=True) / requested_path.name
+    try:
+        anchored_parent = requested_path.parent.resolve(strict=True)
+    except RuntimeError as exc:
+        raise ValueError(
+            f"input path cannot be resolved safely: {requested_path}"
+        ) from exc
+    path = anchored_parent / requested_path.name
     before_open = path.lstat()
     if stat.S_ISLNK(before_open.st_mode):
         raise ValueError(f"refusing symbolic-link input: {path}")

--- a/merger/repoground/cli/cmd_diagnostics.py
+++ b/merger/repoground/cli/cmd_diagnostics.py
@@ -14,6 +14,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from merger.repoground.retrieval.diagnostics_json import strict_json_loads
+
 _MAX_JSON_BYTES = 8 * 1024 * 1024
 
 
@@ -60,7 +62,7 @@ def _read_json(
     expected_type: type | tuple[type, ...] | None = None,
 ) -> Any:
     path, payload = _read_input_payload(path_value)
-    value = json.loads(payload.decode("utf-8"))
+    value = strict_json_loads(payload.decode("utf-8"), source=f"input {path}")
     if expected_type is not None and not isinstance(value, expected_type):
         expected_name = (
             ", ".join(item.__name__ for item in expected_type)
@@ -81,7 +83,10 @@ def _read_validated_citation_map_jsonl(
         if not line.strip():
             continue
         try:
-            record = json.loads(line)
+            record = strict_json_loads(
+                line,
+                source=f"citation map line {line_number}",
+            )
         except json.JSONDecodeError as exc:
             raise ValueError(
                 f"citation map line {line_number} must be valid JSON: {path}"
@@ -156,7 +161,15 @@ def _validate_answer_declaration(
 
 
 def _emit(value: Any) -> None:
-    print(json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True))
+    print(
+        json.dumps(
+            value,
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+            allow_nan=False,
+        )
+    )
 
 
 def _build_diagnostics_parser() -> argparse.ArgumentParser:
@@ -409,15 +422,16 @@ def run_diagnostics(args: argparse.Namespace) -> int:
     }
     try:
         result = handlers[operation_args.diagnostics_command](operation_args)
+        _emit(result)
     except (
         KeyError,
         OSError,
         UnicodeError,
         json.JSONDecodeError,
+        RecursionError,
         TypeError,
         ValueError,
     ) as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 2
-    _emit(result)
     return 0

--- a/merger/repoground/cli/main.py
+++ b/merger/repoground/cli/main.py
@@ -86,6 +86,10 @@ def main(args: Optional[List[str]] = None) -> int:
     from .cmd_ground import register_ground_command
     register_ground_command(subparsers)
 
+    # Explicit optional diagnostics; never part of normal query or service flows.
+    from .cmd_diagnostics import register_diagnostics_commands
+    register_diagnostics_commands(subparsers)
+
     # Index command
     index_parser = subparsers.add_parser("index", help="Build or verify retrieval index")
     index_parser.add_argument("--dump", required=True, help="Path to dump_index.json")
@@ -295,7 +299,8 @@ def main(args: Optional[List[str]] = None) -> int:
     elif parsed_args.command == "agent-consumption":
         from .cmd_agent_consumption import run_agent_consumption
         return run_agent_consumption(parsed_args)
-    elif parsed_args.command in {"token-budget", "evidence-query", "retrieval-snapshot"}:
+    elif parsed_args.command in {"token-budget", "evidence-query", "retrieval-snapshot", "diagnostics"}:
+        from .cmd_diagnostics import run_diagnostics
         from .cmd_evidence_query import run_evidence_query
         from .cmd_incremental_snapshot import run_incremental_snapshot
         from .cmd_token_budget import run_token_budget
@@ -304,6 +309,7 @@ def main(args: Optional[List[str]] = None) -> int:
             "token-budget": run_token_budget,
             "evidence-query": run_evidence_query,
             "retrieval-snapshot": run_incremental_snapshot,
+            "diagnostics": run_diagnostics,
         }
         return handlers[parsed_args.command](parsed_args)
     elif parsed_args.command == "artifact":

--- a/merger/repoground/contracts/retrieval-eval-diagnostics.v1.schema.json
+++ b/merger/repoground/contracts/retrieval-eval-diagnostics.v1.schema.json
@@ -34,7 +34,7 @@
       "type": "object",
       "description": "Metadata about the diagnostic run.",
       "additionalProperties": false,
-      "required": ["version", "timestamp", "total_misses"],
+      "required": ["version", "total_misses"],
       "properties": {
         "version": {
           "type": "string",
@@ -44,7 +44,7 @@
         "timestamp": {
           "type": "string",
           "format": "date-time",
-          "description": "ISO 8601 timestamp of diagnostic generation."
+          "description": "Optional caller-supplied stable ISO 8601 source or run timestamp. The producer never inserts wall-clock time automatically."
         },
         "total_misses": {
           "type": "integer",

--- a/merger/repoground/core/answer_grounding_delta.py
+++ b/merger/repoground/core/answer_grounding_delta.py
@@ -6,8 +6,9 @@ from pathlib import Path
 from typing import Any, Mapping
 
 from merger.repoground.core.answer_grounding import NON_CLAIMS
-from merger.repoground.core.range_resolver import resolve_range_ref
+from merger.repoground.core.availability import snapshot_freshness_model
 from merger.repoground.core.bundle_access import snapshot_status
+from merger.repoground.core.range_resolver import resolve_range_ref
 
 KIND = "repobrief.answer_grounding_delta_verdict"
 VERSION = "1.0"
@@ -102,6 +103,29 @@ def _load_citation_entries(
     return _copy_citation_entries(prevalidated_entries), []
 
 
+def _manifest_context(
+    manifest: str | Path,
+    prevalidated_data: Mapping[str, Any] | None,
+) -> tuple[Path, dict[str, Any] | None]:
+    path = Path(manifest).expanduser()
+    if prevalidated_data is None:
+        return path.resolve(), None
+    if not path.is_absolute():
+        path = path.absolute()
+    return path, deepcopy(dict(prevalidated_data))
+
+
+def _new_snapshot_freshness(
+    manifest_path: Path,
+    manifest_data: Mapping[str, Any] | None,
+) -> Mapping[str, Any] | None:
+    if manifest_data is not None:
+        return snapshot_freshness_model(manifest_data)
+    status = snapshot_status(manifest_path)
+    freshness = status.get("freshness") if isinstance(status, dict) else None
+    return freshness if isinstance(freshness, Mapping) else None
+
+
 def check_answer_grounding_delta(
     old_declaration: Mapping[str, Any],
     *,
@@ -117,11 +141,9 @@ def check_answer_grounding_delta(
     When ``new_citation_entries`` is supplied, the citation-map path is not reread.
     When ``new_bundle_manifest_data`` is supplied, the manifest path is not reread.
     """
-    manifest_path = Path(new_bundle_manifest).expanduser().resolve()
-    manifest_data = (
-        deepcopy(dict(new_bundle_manifest_data))
-        if new_bundle_manifest_data is not None
-        else None
+    manifest_path, manifest_data = _manifest_context(
+        new_bundle_manifest,
+        new_bundle_manifest_data,
     )
     entries, diagnostics = _load_citation_entries(new_citation_map, new_citation_entries)
     citation_checks: list[dict[str, Any]] = []
@@ -181,8 +203,7 @@ def check_answer_grounding_delta(
     else:
         status = "valid"
 
-    new_status = snapshot_status(manifest_path, manifest_data=manifest_data)
-    new_freshness = new_status.get("freshness") if isinstance(new_status, dict) else None
+    new_freshness = _new_snapshot_freshness(manifest_path, manifest_data)
     return {
         "kind": KIND,
         "version": VERSION,

--- a/merger/repoground/core/answer_grounding_delta.py
+++ b/merger/repoground/core/answer_grounding_delta.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from copy import deepcopy
 from pathlib import Path
 from typing import Any, Mapping
 
@@ -55,9 +56,13 @@ def _range_ref_from_citation(entry: Mapping[str, Any]) -> dict[str, Any] | None:
     return None
 
 
-def _check_range(manifest: Path, range_ref: dict[str, Any]) -> tuple[str, str]:
+def _check_range(
+    manifest: Path,
+    range_ref: dict[str, Any],
+    manifest_data: Mapping[str, Any] | None,
+) -> tuple[str, str]:
     try:
-        resolve_range_ref(manifest, range_ref)
+        resolve_range_ref(manifest, range_ref, manifest_data=manifest_data)
     except Exception as exc:
         detail = str(exc)
         if "hash mismatch" in detail.lower():
@@ -101,6 +106,7 @@ def check_answer_grounding_delta(
     old_declaration: Mapping[str, Any],
     *,
     new_bundle_manifest: str | Path,
+    new_bundle_manifest_data: Mapping[str, Any] | None = None,
     new_citation_map: str | Path | None = None,
     new_citation_entries: Mapping[str, Mapping[str, Any]] | None = None,
 ) -> dict[str, Any]:
@@ -109,8 +115,14 @@ def check_answer_grounding_delta(
     Read-only: this function reads explicitly supplied existing files only. It does not
     create snapshots, fetch Git state, refresh bundles, or normalize freshness statuses.
     When ``new_citation_entries`` is supplied, the citation-map path is not reread.
+    When ``new_bundle_manifest_data`` is supplied, the manifest path is not reread.
     """
     manifest_path = Path(new_bundle_manifest).expanduser().resolve()
+    manifest_data = (
+        deepcopy(dict(new_bundle_manifest_data))
+        if new_bundle_manifest_data is not None
+        else None
+    )
     entries, diagnostics = _load_citation_entries(new_citation_map, new_citation_entries)
     citation_checks: list[dict[str, Any]] = []
     range_checks: list[dict[str, Any]] = []
@@ -137,7 +149,7 @@ def check_answer_grounding_delta(
                 "detail": "New citation entry has no comparable range reference.",
             })
             continue
-        status, detail = _check_range(manifest_path, range_ref)
+        status, detail = _check_range(manifest_path, range_ref, manifest_data)
         citation_checks.append({"citation_id": citation_id, "status": status, "detail": detail})
 
     for idx, item in enumerate(old_declaration.get("used_ranges") or [], start=1):
@@ -148,7 +160,11 @@ def check_answer_grounding_delta(
                 "detail": "Old declaration range is missing range_ref.",
             })
             continue
-        status, detail = _check_range(manifest_path, dict(item["range_ref"]))
+        status, detail = _check_range(
+            manifest_path,
+            dict(item["range_ref"]),
+            manifest_data,
+        )
         range_checks.append({
             "range_id": str(item.get("claim_ref") or f"declared-range-{idx}"),
             "status": status,
@@ -165,7 +181,7 @@ def check_answer_grounding_delta(
     else:
         status = "valid"
 
-    new_status = snapshot_status(manifest_path)
+    new_status = snapshot_status(manifest_path, manifest_data=manifest_data)
     new_freshness = new_status.get("freshness") if isinstance(new_status, dict) else None
     return {
         "kind": KIND,

--- a/merger/repoground/core/answer_grounding_delta.py
+++ b/merger/repoground/core/answer_grounding_delta.py
@@ -73,19 +73,45 @@ def _freshness_from_snapshot_ref(snapshot_ref: Mapping[str, Any] | None) -> str:
     return str(value) if isinstance(value, str) and value else "unknown"
 
 
+def _copy_citation_entries(
+    entries: Mapping[str, Mapping[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    copied: dict[str, dict[str, Any]] = {}
+    for citation_id, entry in entries.items():
+        if not isinstance(citation_id, str) or not citation_id:
+            raise ValueError("citation entry key must be a non-empty string")
+        if not isinstance(entry, Mapping):
+            raise ValueError(f"citation entry {citation_id!r} must be a mapping")
+        if entry.get("citation_id") != citation_id:
+            raise ValueError(f"citation entry {citation_id!r} must contain the same citation_id")
+        copied[citation_id] = dict(entry)
+    return copied
+
+
+def _load_citation_entries(
+    citation_map: str | Path | None,
+    prevalidated_entries: Mapping[str, Mapping[str, Any]] | None,
+) -> tuple[dict[str, dict[str, Any]], list[dict[str, Any]]]:
+    if prevalidated_entries is None:
+        return _read_citation_map(citation_map)
+    return _copy_citation_entries(prevalidated_entries), []
+
+
 def check_answer_grounding_delta(
     old_declaration: Mapping[str, Any],
     *,
     new_bundle_manifest: str | Path,
     new_citation_map: str | Path | None = None,
+    new_citation_entries: Mapping[str, Mapping[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Check old declared citations/ranges against a newer snapshot.
 
     Read-only: this function reads explicitly supplied existing files only. It does not
     create snapshots, fetch Git state, refresh bundles, or normalize freshness statuses.
+    When ``new_citation_entries`` is supplied, the citation-map path is not reread.
     """
     manifest_path = Path(new_bundle_manifest).expanduser().resolve()
-    entries, diagnostics = _read_citation_map(new_citation_map)
+    entries, diagnostics = _load_citation_entries(new_citation_map, new_citation_entries)
     citation_checks: list[dict[str, Any]] = []
     range_checks: list[dict[str, Any]] = []
 

--- a/merger/repoground/core/availability.py
+++ b/merger/repoground/core/availability.py
@@ -125,7 +125,7 @@ def _complete_graph_availability(base: dict[str, Any], *, status: str, reason: s
     return base
 
 
-def graph_availability_model(manifest_path: str | Path, manifest: Mapping[str, Any], *, profile: str | None = None) -> dict[str, Any]:
+def graph_availability_model(manifest_path: str | Path, manifest: Mapping[str, Any], *, profile: str | None = None, resolve_manifest_path: bool = True) -> dict[str, Any]:
     """Report graph availability without promoting graph evidence to truth.
 
     This is a read-only snapshot projection. It may surface whether graph
@@ -134,7 +134,8 @@ def graph_availability_model(manifest_path: str | Path, manifest: Mapping[str, A
     retrieval.
     """
 
-    path = Path(manifest_path).expanduser().resolve()
+    requested_path = Path(manifest_path).expanduser()
+    path = requested_path.resolve() if resolve_manifest_path else requested_path.absolute()
     capabilities = manifest.get("capabilities") if isinstance(manifest.get("capabilities"), dict) else {}
     effective_profile = profile if profile is not None else capabilities.get("repobrief_profile")
     if not isinstance(effective_profile, str) or effective_profile not in PROFILE_ARTIFACT_RULES:
@@ -266,8 +267,9 @@ def snapshot_freshness_model(manifest: Mapping[str, Any], *, max_age_seconds: in
     return result
 
 
-def snapshot_availability_model(manifest_path: str | Path, manifest: Mapping[str, Any], *, profile: str | None = None, max_age_seconds: int | None = None, as_of: datetime.datetime | None = None) -> dict[str, Any]:
-    path = Path(manifest_path).expanduser().resolve()
+def snapshot_availability_model(manifest_path: str | Path, manifest: Mapping[str, Any], *, profile: str | None = None, max_age_seconds: int | None = None, as_of: datetime.datetime | None = None, resolve_manifest_path: bool = True) -> dict[str, Any]:
+    requested_path = Path(manifest_path).expanduser()
+    path = requested_path.resolve() if resolve_manifest_path else requested_path.absolute()
     capabilities = manifest.get("capabilities") if isinstance(manifest.get("capabilities"), dict) else {}
     effective_profile = profile if profile is not None else capabilities.get("repobrief_profile")
     if not isinstance(effective_profile, str) or effective_profile not in PROFILE_ARTIFACT_RULES:
@@ -290,4 +292,4 @@ def snapshot_availability_model(manifest_path: str | Path, manifest: Mapping[str
         status = "warn"
     else:
         status = "pass"
-    return {"kind": KIND, "version": VERSION, "status": status, "profile": effective_profile, "bundle_manifest": str(path), "availability_values": list(AVAILABILITY_VALUES), "freshness_values": list(FRESHNESS_VALUES), "availability_counts": availability_counts, "artifacts": artifacts, "freshness": snapshot_freshness_model(manifest, max_age_seconds=max_age_seconds, as_of=as_of), "graph_availability": graph_availability_model(path, manifest, profile=effective_profile), "does_not_establish": list(DOES_NOT_ESTABLISH)}
+    return {"kind": KIND, "version": VERSION, "status": status, "profile": effective_profile, "bundle_manifest": str(path), "availability_values": list(AVAILABILITY_VALUES), "freshness_values": list(FRESHNESS_VALUES), "availability_counts": availability_counts, "artifacts": artifacts, "freshness": snapshot_freshness_model(manifest, max_age_seconds=max_age_seconds, as_of=as_of), "graph_availability": graph_availability_model(path, manifest, profile=effective_profile, resolve_manifest_path=False), "does_not_establish": list(DOES_NOT_ESTABLISH)}

--- a/merger/repoground/core/bundle_access.py
+++ b/merger/repoground/core/bundle_access.py
@@ -179,7 +179,11 @@ def snapshot_status(
     capabilities = manifest.get("capabilities") if isinstance(manifest.get("capabilities"), dict) else {}
     from merger.repoground.core.availability import snapshot_availability_model
 
-    availability_model = snapshot_availability_model(manifest_path, manifest)
+    availability_model = snapshot_availability_model(
+        manifest_path,
+        manifest,
+        resolve_manifest_path=manifest_data is None,
+    )
     return {
         "kind": "repobrief.snapshot_status",
         "version": "v1",

--- a/merger/repoground/core/bundle_access.py
+++ b/merger/repoground/core/bundle_access.py
@@ -162,12 +162,17 @@ def snapshot_status(
     Supplying ``manifest_data`` avoids rereading the manifest; the path remains
     the trusted base for resolving relative artifact paths.
     """
-    manifest_path = Path(bundle_manifest).expanduser().resolve()
+    requested_manifest_path = Path(bundle_manifest).expanduser()
     if manifest_data is None:
+        manifest_path = requested_manifest_path.resolve()
         manifest = _read_json_object(manifest_path)
     else:
         if not isinstance(manifest_data, Mapping):
             raise ValueError("manifest_data must be a mapping")
+        # The caller already verified this manifest generation. Keep its lexical
+        # absolute path as the artifact-root anchor instead of following a later
+        # replacement symlink at the final manifest name.
+        manifest_path = requested_manifest_path.absolute()
         manifest = deepcopy(dict(manifest_data))
     artifacts = [_artifact_record(manifest_path, a) for a in _artifact_list(manifest)]
     roles = sorted(str(a["role"]) for a in artifacts if isinstance(a.get("role"), str))

--- a/merger/repoground/core/bundle_access.py
+++ b/merger/repoground/core/bundle_access.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 from collections import OrderedDict
+from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
 from threading import RLock
@@ -151,9 +152,23 @@ def resolve_required_reading_for_bundle(
     }
 
 
-def snapshot_status(bundle_manifest: str | Path) -> dict[str, Any]:
+def snapshot_status(
+    bundle_manifest: str | Path,
+    *,
+    manifest_data: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Project snapshot status without refreshing bundle state.
+
+    Supplying ``manifest_data`` avoids rereading the manifest; the path remains
+    the trusted base for resolving relative artifact paths.
+    """
     manifest_path = Path(bundle_manifest).expanduser().resolve()
-    manifest = _read_json_object(manifest_path)
+    if manifest_data is None:
+        manifest = _read_json_object(manifest_path)
+    else:
+        if not isinstance(manifest_data, Mapping):
+            raise ValueError("manifest_data must be a mapping")
+        manifest = deepcopy(dict(manifest_data))
     artifacts = [_artifact_record(manifest_path, a) for a in _artifact_list(manifest)]
     roles = sorted(str(a["role"]) for a in artifacts if isinstance(a.get("role"), str))
     capabilities = manifest.get("capabilities") if isinstance(manifest.get("capabilities"), dict) else {}

--- a/merger/repoground/core/range_resolver.py
+++ b/merger/repoground/core/range_resolver.py
@@ -45,6 +45,22 @@ def _load_schema(schema_path: Path) -> Dict[str, Any]:
     with schema_path.open("r", encoding="utf-8") as f:
         return json.load(f)
 
+
+def _load_manifest(
+    manifest_path: Path,
+    manifest_data: Mapping[str, Any] | None,
+) -> Any:
+    if manifest_data is None:
+        if not manifest_path.exists():
+            raise FileNotFoundError(f"Manifest not found: {manifest_path}")
+        with manifest_path.open("r", encoding="utf-8") as f:
+            return json.load(f)
+
+    if not isinstance(manifest_data, Mapping):
+        raise ValueError("manifest_data must be a mapping")
+    return deepcopy(dict(manifest_data))
+
+
 def build_explicit_range_ref(
     artifact_role: str,
     repo_id: str,
@@ -185,15 +201,7 @@ def resolve_range_ref(
     exact bytes and verify content_sha256. When ``manifest_data`` is supplied, the
     manifest path is used only as the trusted base for relative artifact paths.
     """
-    if manifest_data is None:
-        if not manifest_path.exists():
-            raise FileNotFoundError(f"Manifest not found: {manifest_path}")
-        with manifest_path.open("r", encoding="utf-8") as f:
-            manifest = json.load(f)
-    else:
-        if not isinstance(manifest_data, Mapping):
-            raise ValueError("manifest_data must be a mapping")
-        manifest = deepcopy(dict(manifest_data))
+    manifest = _load_manifest(manifest_path, manifest_data)
 
     is_v2 = ref.get("range_ref_version") == "2"
     schema_path = _RANGE_REF_V2_SCHEMA_PATH if is_v2 else _RANGE_REF_V1_SCHEMA_PATH

--- a/merger/repoground/core/range_resolver.py
+++ b/merger/repoground/core/range_resolver.py
@@ -1,8 +1,9 @@
 import json
 import hashlib
+from copy import deepcopy
 from functools import lru_cache
 from pathlib import Path
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Mapping, Optional
 
 try:
     import jsonschema
@@ -173,16 +174,26 @@ def build_derived_range_ref_v2(
     }
 
 
-def resolve_range_ref(manifest_path: Path, ref: Dict[str, Any]) -> Dict[str, Any]:
+def resolve_range_ref(
+    manifest_path: Path,
+    ref: Dict[str, Any],
+    *,
+    manifest_data: Mapping[str, Any] | None = None,
+) -> Dict[str, Any]:
     """
     Resolves a range_ref against a bundle.manifest.json or dump_index.json to extract
-    exact bytes and verify content_sha256.
+    exact bytes and verify content_sha256. When ``manifest_data`` is supplied, the
+    manifest path is used only as the trusted base for relative artifact paths.
     """
-    if not manifest_path.exists():
-        raise FileNotFoundError(f"Manifest not found: {manifest_path}")
-
-    with manifest_path.open("r", encoding="utf-8") as f:
-        manifest = json.load(f)
+    if manifest_data is None:
+        if not manifest_path.exists():
+            raise FileNotFoundError(f"Manifest not found: {manifest_path}")
+        with manifest_path.open("r", encoding="utf-8") as f:
+            manifest = json.load(f)
+    else:
+        if not isinstance(manifest_data, Mapping):
+            raise ValueError("manifest_data must be a mapping")
+        manifest = deepcopy(dict(manifest_data))
 
     is_v2 = ref.get("range_ref_version") == "2"
     schema_path = _RANGE_REF_V2_SCHEMA_PATH if is_v2 else _RANGE_REF_V1_SCHEMA_PATH

--- a/merger/repoground/retrieval/diagnostics_json.py
+++ b/merger/repoground/retrieval/diagnostics_json.py
@@ -6,6 +6,36 @@ import json
 from typing import Any, NoReturn
 
 
+MAX_JSON_NESTING_DEPTH = 256
+
+
+def _check_json_nesting_depth(document: str, *, source: str) -> None:
+    nesting_depth = 0
+    in_string = False
+    escaped = False
+
+    for character in document:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                in_string = False
+            continue
+
+        if character == '"':
+            in_string = True
+        elif character in "[{":
+            nesting_depth += 1
+            if nesting_depth > MAX_JSON_NESTING_DEPTH:
+                raise ValueError(
+                    f"{source} exceeds the supported JSON nesting depth"
+                )
+        elif character in "]}":
+            nesting_depth = max(0, nesting_depth - 1)
+
+
 def strict_json_loads(document: str, *, source: str) -> Any:
     """Decode standards-compliant JSON and bound excessive nesting as input error."""
 
@@ -14,6 +44,7 @@ def strict_json_loads(document: str, *, source: str) -> Any:
             f"{source} contains non-finite JSON constant {value!r}, which is not permitted"
         )
 
+    _check_json_nesting_depth(document, source=source)
     try:
         return json.loads(document, parse_constant=reject_non_finite_constant)
     except RecursionError as exc:

--- a/merger/repoground/retrieval/diagnostics_json.py
+++ b/merger/repoground/retrieval/diagnostics_json.py
@@ -1,0 +1,20 @@
+"""Strict JSON decoding shared by the optional diagnostics input paths."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, NoReturn
+
+
+def strict_json_loads(document: str, *, source: str) -> Any:
+    """Decode standards-compliant JSON and bound excessive nesting as input error."""
+
+    def reject_non_finite_constant(value: str) -> NoReturn:
+        raise ValueError(
+            f"{source} contains non-finite JSON constant {value!r}, which is not permitted"
+        )
+
+    try:
+        return json.loads(document, parse_constant=reject_non_finite_constant)
+    except RecursionError as exc:
+        raise ValueError(f"{source} exceeds the supported JSON nesting depth") from exc

--- a/merger/repoground/retrieval/eval_diagnostics.py
+++ b/merger/repoground/retrieval/eval_diagnostics.py
@@ -17,7 +17,6 @@ the gold set. It answers "why" a miss occurred, enabling targeted remediation de
 import json
 from pathlib import Path
 from typing import Dict, List, Optional, Any, Tuple
-from datetime import datetime, timezone
 import re
 
 from .diagnostics_json import strict_json_loads
@@ -683,6 +682,8 @@ class RetrievalEvalDiagnosticsCalibrator:
     def generate_report(
         self,
         misses: List[Dict[str, Any]],
+        *,
+        timestamp: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Generate a complete diagnostics report from a list of misses.
@@ -696,10 +697,16 @@ class RetrievalEvalDiagnosticsCalibrator:
                 - rank_in_results: Optional[int]
                 - top_k: Optional[int]
                 - query_had_zero_hits: bool
+            timestamp: Optional stable source/run timestamp supplied by the caller.
+                The standard deterministic report omits it.
 
         Returns:
             Complete diagnostics report conforming to schema.
         """
+        if timestamp is not None:
+            if not isinstance(timestamp, str) or not timestamp.strip():
+                raise ValueError("timestamp must be a non-empty string when provided")
+
         # Load artifacts once
         self._load_artifacts()
 
@@ -738,22 +745,25 @@ class RetrievalEvalDiagnosticsCalibrator:
             else 0
         )
 
+        metadata: Dict[str, Any] = {
+            "version": "1.0",
+            "total_misses": len(misses),
+            "diagnostic_breakdowns": breakdowns,
+            "index_stats": {
+                "total_chunks": total_chunks,
+                "total_paths": total_paths,
+                "canonical_md_exists": self._canonical_md is not None,
+                "citation_map_exists": self._citation_map is not None,
+            },
+        }
+        if timestamp is not None:
+            metadata["timestamp"] = timestamp
+
         report = {
             "authority": "diagnostic_signal",
             "risk_class": "diagnostic",
             "does_not_prove": list(DOES_NOT_PROVE),
-            "metadata": {
-                "version": "1.0",
-                "timestamp": datetime.now(timezone.utc).isoformat(),
-                "total_misses": len(misses),
-                "diagnostic_breakdowns": breakdowns,
-                "index_stats": {
-                    "total_chunks": total_chunks,
-                    "total_paths": total_paths,
-                    "canonical_md_exists": self._canonical_md is not None,
-                    "citation_map_exists": self._citation_map is not None,
-                },
-            },
+            "metadata": metadata,
             "diagnostics": sorted(
                 diagnostics_records,
                 key=lambda x: (x["query_id"], x["expected_target"]),

--- a/merger/repoground/retrieval/eval_diagnostics.py
+++ b/merger/repoground/retrieval/eval_diagnostics.py
@@ -284,7 +284,7 @@ class IndexInspector:
         """Return index paths that contain the expected target as substring."""
         if not isinstance(expected_target, str) or not expected_target:
             return []
-        return sorted([p for p in index_paths if expected_target in p or p in expected_target])
+        return sorted([p for p in index_paths if expected_target in p])
 
     def load_canonical_md(self, canonical_path: Path) -> str:
         """

--- a/merger/repoground/retrieval/eval_diagnostics.py
+++ b/merger/repoground/retrieval/eval_diagnostics.py
@@ -183,95 +183,45 @@ class IndexInspector:
         self._canonical_md_content: Optional[str] = None
         self._citation_map_cache: Optional[Dict[str, Any]] = None
 
-    def load_index_paths(self, force_reload: bool = False) -> set:
-        """
-        Load all unique paths from the index (chunk_index).
+    def _load_index_views(
+        self,
+        force_reload: bool = False,
+    ) -> Tuple[set, Dict[str, set]]:
+        """Load path and chunk-id views from one validated index generation."""
+        if (
+            self._index_paths_cache is not None
+            and self._path_to_chunk_ids_cache is not None
+            and not force_reload
+        ):
+            return self._index_paths_cache, self._path_to_chunk_ids_cache
 
-        Args:
-            force_reload: Force reload from disk.
-
-        Returns:
-            Set of all unique paths in the index.
-        """
-        if self._index_paths_cache is not None and not force_reload:
-            return self._index_paths_cache
-
-        if self.index_path is None:
-            return set()
-
-        if self.index_path.suffix != ".jsonl":
-            raise MissingArtifactError(f"Unsupported chunk index format: {self.index_path}")
-
-        paths = set()
-        try:
-            with open(self.index_path, "r", encoding="utf-8") as f:
-                for line_number, line in enumerate(f, start=1):
-                    if not line.strip():
-                        continue
-                    try:
-                        chunk = strict_json_loads(
-                            line,
-                            source=f"chunk index line {line_number}",
-                        )
-                    except json.JSONDecodeError as exc:
-                        raise ValueError(
-                            f"chunk index line {line_number} must be valid JSON"
-                        ) from exc
-                    source = f"chunk index line {line_number}"
-                    chunk = _require_json_object(chunk, source=source)
-                    path = _required_nonempty_string_field(
-                        chunk,
-                        field="path",
-                        source=source,
-                    )
-                    _required_chunk_identifier(chunk, source=source)
-                    paths.add(path)
-        except (IOError, OSError) as e:
-            raise MissingArtifactError(
-                f"Failed to read chunk index from {self.index_path}: {e}"
-            )
-        # For SQLite index, would need similar logic
-        # For now, assume JSONL format
-
-        self._index_paths_cache = paths
-        return paths
-
-    def load_path_to_chunk_ids(self, force_reload: bool = False) -> Dict[str, set]:
-        """
-        Load mapping of path -> set(chunk_id) from chunk index JSONL.
-
-        This is required to bridge path-based expectations to citation_map entries,
-        which are keyed by citation_id and reference chunk_id.
-        """
-        if self._path_to_chunk_ids_cache is not None and not force_reload:
-            return self._path_to_chunk_ids_cache
-
+        paths: set = set()
         mapping: Dict[str, set] = {}
-        seen_chunk_ids: set[str] = set()
         if self.index_path is None:
+            self._index_paths_cache = paths
             self._path_to_chunk_ids_cache = mapping
-            return mapping
+            return paths, mapping
 
         if self.index_path.suffix != ".jsonl":
-            raise MissingArtifactError(f"Unsupported chunk index format: {self.index_path}")
+            raise MissingArtifactError(
+                f"Unsupported chunk index format: {self.index_path}"
+            )
 
+        seen_chunk_ids: set[str] = set()
         try:
             with open(self.index_path, "r", encoding="utf-8") as f:
                 for line_number, line in enumerate(f, start=1):
                     if not line.strip():
                         continue
+                    source = f"chunk index line {line_number}"
                     try:
-                        chunk = strict_json_loads(
-                            line,
-                            source=f"chunk index line {line_number}",
-                        )
+                        chunk = strict_json_loads(line, source=source)
                     except json.JSONDecodeError as exc:
                         raise ValueError(
                             f"chunk index line {line_number} must be valid JSON"
                         ) from exc
-                    source = f"chunk index line {line_number}"
                     chunk = _require_json_object(chunk, source=source)
-                    path = _required_nonempty_string_field(
+                    indexed_path = _required_nonempty_string_field(
                         chunk,
                         field="path",
                         source=source,
@@ -282,13 +232,26 @@ class IndexInspector:
                             f"{source} duplicates chunk identifier {chunk_id!r}"
                         )
                     seen_chunk_ids.add(chunk_id)
-                    mapping.setdefault(path, set()).add(chunk_id)
-        except (IOError, OSError) as e:
+                    paths.add(indexed_path)
+                    mapping.setdefault(indexed_path, set()).add(chunk_id)
+        except (IOError, OSError) as exc:
             raise MissingArtifactError(
-                f"Failed to read chunk index from {self.index_path}: {e}"
-            )
+                f"Failed to read chunk index from {self.index_path}: {exc}"
+            ) from exc
 
+        # Replace both views only after the complete generation validated.
+        self._index_paths_cache = paths
         self._path_to_chunk_ids_cache = mapping
+        return paths, mapping
+
+    def load_index_paths(self, force_reload: bool = False) -> set:
+        """Load all unique paths from the index."""
+        paths, _mapping = self._load_index_views(force_reload=force_reload)
+        return paths
+
+    def load_path_to_chunk_ids(self, force_reload: bool = False) -> Dict[str, set]:
+        """Load the path-to-chunk-id mapping from the same index generation."""
+        _paths, mapping = self._load_index_views(force_reload=force_reload)
         return mapping
 
     @staticmethod

--- a/merger/repoground/retrieval/eval_diagnostics.py
+++ b/merger/repoground/retrieval/eval_diagnostics.py
@@ -35,6 +35,24 @@ DOES_NOT_PROVE: Tuple[str, ...] = (
 )
 
 
+def _require_json_object(value: Any, *, source: str) -> Dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{source} must be a JSON object")
+    return value
+
+
+def _optional_string_field(
+    record: Dict[str, Any],
+    *,
+    field: str,
+    source: str,
+) -> Optional[str]:
+    value = record.get(field)
+    if value is not None and not isinstance(value, str):
+        raise ValueError(f"{source} field '{field}' must be a string")
+    return value
+
+
 class RetrievalEvalDiagnosticsError(Exception):
     """Base exception for diagnostics module."""
     pass
@@ -137,15 +155,18 @@ class IndexInspector:
         paths = set()
         try:
             with open(self.index_path, "r", encoding="utf-8") as f:
-                for line in f:
+                for line_number, line in enumerate(f, start=1):
                     if not line.strip():
                         continue
                     try:
                         chunk = json.loads(line)
-                        if "path" in chunk:
-                            paths.add(chunk["path"])
-                    except (json.JSONDecodeError, KeyError):
+                    except json.JSONDecodeError:
                         continue
+                    source = f"chunk index line {line_number}"
+                    chunk = _require_json_object(chunk, source=source)
+                    path = _optional_string_field(chunk, field="path", source=source)
+                    if path is not None:
+                        paths.add(path)
         except (IOError, OSError) as e:
             raise MissingArtifactError(
                 f"Failed to read chunk index from {self.index_path}: {e}"
@@ -176,16 +197,18 @@ class IndexInspector:
 
         try:
             with open(self.index_path, "r", encoding="utf-8") as f:
-                for line in f:
+                for line_number, line in enumerate(f, start=1):
                     if not line.strip():
                         continue
                     try:
                         chunk = json.loads(line)
                     except json.JSONDecodeError:
                         continue
-                    path = chunk.get("path")
-                    chunk_id = chunk.get("chunk_id")
-                    if isinstance(path, str) and isinstance(chunk_id, str):
+                    source = f"chunk index line {line_number}"
+                    chunk = _require_json_object(chunk, source=source)
+                    path = _optional_string_field(chunk, field="path", source=source)
+                    chunk_id = _optional_string_field(chunk, field="chunk_id", source=source)
+                    if path is not None and chunk_id is not None:
                         mapping.setdefault(path, set()).add(chunk_id)
         except (IOError, OSError) as e:
             raise MissingArtifactError(
@@ -278,16 +301,22 @@ class IndexInspector:
         citation_map = {}
         try:
             with open(citation_path, "r", encoding="utf-8") as f:
-                for line in f:
+                for line_number, line in enumerate(f, start=1):
                     if not line.strip():
                         continue
                     try:
                         record = json.loads(line)
-                        # Assume citation_id is the key
-                        if "citation_id" in record:
-                            citation_map[record["citation_id"]] = record
                     except json.JSONDecodeError:
                         continue
+                    source = f"citation map line {line_number}"
+                    record = _require_json_object(record, source=source)
+                    citation_id = _optional_string_field(
+                        record,
+                        field="citation_id",
+                        source=source,
+                    )
+                    if citation_id is not None:
+                        citation_map[citation_id] = record
         except (IOError, OSError) as e:
             raise MissingArtifactError(
                 f"Failed to read citation_map from {citation_path}: {e}"
@@ -598,7 +627,8 @@ class RetrievalEvalDiagnosticsCalibrator:
             "diagnostic_inconclusive": 0,
         }
 
-        for miss in misses:
+        for miss_index, miss in enumerate(misses):
+            miss = _require_json_object(miss, source=f"misses[{miss_index}]")
             record = self.diagnose_miss(
                 query_id=miss.get("query_id", ""),
                 query_text=miss.get("query_text", ""),

--- a/merger/repoground/retrieval/eval_diagnostics.py
+++ b/merger/repoground/retrieval/eval_diagnostics.py
@@ -15,6 +15,7 @@ the gold set. It answers "why" a miss occurred, enabling targeted remediation de
 """
 
 import json
+from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Any, Tuple
 import re
@@ -101,6 +102,30 @@ def _required_chunk_identifier(
         return chunk_id
     assert legacy_id is not None
     return legacy_id
+
+
+_RFC3339_DATETIME = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$"
+)
+
+
+def _validate_report_timestamp(timestamp: Any) -> Optional[str]:
+    if timestamp is None:
+        return None
+    if not isinstance(timestamp, str) or not timestamp.strip():
+        raise ValueError("timestamp must be an RFC 3339 date-time when provided")
+    if _RFC3339_DATETIME.fullmatch(timestamp) is None:
+        raise ValueError("timestamp must be an RFC 3339 date-time when provided")
+    normalized = timestamp[:-1] + "+00:00" if timestamp.endswith("Z") else timestamp
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ValueError(
+            "timestamp must be an RFC 3339 date-time when provided"
+        ) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError("timestamp must be an RFC 3339 date-time when provided")
+    return timestamp
 
 
 class RetrievalEvalDiagnosticsError(Exception):
@@ -642,6 +667,41 @@ class RetrievalEvalDiagnosticsCalibrator:
         # Keep symbol-like names (e.g., "iter_report_blocks", "Class.method") ambiguous.
         return bool(re.search(r"\.[A-Za-z0-9]{1,8}$", target))
 
+    def _diagnose_report_miss(self, miss: Dict[str, Any]) -> DiagnosticsRecord:
+        query_error = miss.get("query_error")
+        if query_error is not None:
+            if not isinstance(query_error, str) or not query_error.strip():
+                raise ValueError("query_error must be a non-empty string when provided")
+            return DiagnosticsRecord(
+                query_id=miss.get("query_id", ""),
+                query_text=miss.get("query_text", ""),
+                expected_target=miss.get("expected_target", ""),
+                primary_diagnosis="diagnostic_inconclusive",
+                diagnosis_details={
+                    "target_found_in_index": False,
+                    "target_found_in_canonical": False,
+                    "target_found_in_citation_map": False,
+                    "rank_in_results": None,
+                    "top_k": miss.get("top_k"),
+                    "query_had_zero_hits": True,
+                    "canonical_path_check": "unavailable",
+                    "possible_path_variants": [],
+                    "staleness_indicator": "none",
+                    "secondary_diagnoses": [],
+                    "confidence": "low",
+                    "instrumentation_notes": f"query execution failed: {query_error}",
+                },
+            )
+        return self.diagnose_miss(
+            query_id=miss.get("query_id", ""),
+            query_text=miss.get("query_text", ""),
+            expected_target=miss.get("expected_target", ""),
+            found_in_results=miss.get("found_in_results", False),
+            rank_in_results=miss.get("rank_in_results"),
+            top_k=miss.get("top_k"),
+            query_had_zero_hits=miss.get("query_had_zero_hits", False),
+        )
+
     def generate_report(
         self,
         misses: List[Dict[str, Any]],
@@ -666,9 +726,7 @@ class RetrievalEvalDiagnosticsCalibrator:
         Returns:
             Complete diagnostics report conforming to schema.
         """
-        if timestamp is not None:
-            if not isinstance(timestamp, str) or not timestamp.strip():
-                raise ValueError("timestamp must be a non-empty string when provided")
+        timestamp = _validate_report_timestamp(timestamp)
 
         # Load artifacts once
         self._load_artifacts()
@@ -687,15 +745,7 @@ class RetrievalEvalDiagnosticsCalibrator:
 
         for miss_index, miss in enumerate(misses):
             miss = _require_json_object(miss, source=f"misses[{miss_index}]")
-            record = self.diagnose_miss(
-                query_id=miss.get("query_id", ""),
-                query_text=miss.get("query_text", ""),
-                expected_target=miss.get("expected_target", ""),
-                found_in_results=miss.get("found_in_results", False),
-                rank_in_results=miss.get("rank_in_results"),
-                top_k=miss.get("top_k"),
-                query_had_zero_hits=miss.get("query_had_zero_hits", False),
-            )
+            record = self._diagnose_report_miss(miss)
 
             diagnostics_records.append(record.to_dict())
             breakdowns[record.primary_diagnosis] += 1

--- a/merger/repoground/retrieval/eval_diagnostics.py
+++ b/merger/repoground/retrieval/eval_diagnostics.py
@@ -46,11 +46,60 @@ def _optional_string_field(
     *,
     field: str,
     source: str,
+    require_nonempty: bool = False,
 ) -> Optional[str]:
     value = record.get(field)
     if value is not None and not isinstance(value, str):
         raise ValueError(f"{source} field '{field}' must be a string")
+    if require_nonempty and isinstance(value, str) and not value.strip():
+        raise ValueError(f"{source} field '{field}' must be a non-empty string")
     return value
+
+
+def _required_nonempty_string_field(
+    record: Dict[str, Any],
+    *,
+    field: str,
+    source: str,
+) -> str:
+    value = _optional_string_field(
+        record,
+        field=field,
+        source=source,
+        require_nonempty=True,
+    )
+    if value is None:
+        raise ValueError(f"{source} field '{field}' is required")
+    return value
+
+
+def _required_chunk_identifier(
+    record: Dict[str, Any],
+    *,
+    source: str,
+) -> str:
+    chunk_id = _optional_string_field(
+        record,
+        field="chunk_id",
+        source=source,
+        require_nonempty=True,
+    )
+    legacy_id = _optional_string_field(
+        record,
+        field="id",
+        source=source,
+        require_nonempty=True,
+    )
+    if chunk_id is None and legacy_id is None:
+        raise ValueError(f"{source} field 'chunk_id' or 'id' is required")
+    if chunk_id is not None and legacy_id is not None and chunk_id != legacy_id:
+        raise ValueError(
+            f"{source} fields 'chunk_id' and 'id' must match when both are present"
+        )
+    if chunk_id is not None:
+        return chunk_id
+    assert legacy_id is not None
+    return legacy_id
 
 
 class RetrievalEvalDiagnosticsError(Exception):
@@ -160,13 +209,19 @@ class IndexInspector:
                         continue
                     try:
                         chunk = json.loads(line)
-                    except json.JSONDecodeError:
-                        continue
+                    except json.JSONDecodeError as exc:
+                        raise ValueError(
+                            f"chunk index line {line_number} must be valid JSON"
+                        ) from exc
                     source = f"chunk index line {line_number}"
                     chunk = _require_json_object(chunk, source=source)
-                    path = _optional_string_field(chunk, field="path", source=source)
-                    if path is not None:
-                        paths.add(path)
+                    path = _required_nonempty_string_field(
+                        chunk,
+                        field="path",
+                        source=source,
+                    )
+                    _required_chunk_identifier(chunk, source=source)
+                    paths.add(path)
         except (IOError, OSError) as e:
             raise MissingArtifactError(
                 f"Failed to read chunk index from {self.index_path}: {e}"
@@ -188,6 +243,7 @@ class IndexInspector:
             return self._path_to_chunk_ids_cache
 
         mapping: Dict[str, set] = {}
+        seen_chunk_ids: set[str] = set()
         if self.index_path is None:
             self._path_to_chunk_ids_cache = mapping
             return mapping
@@ -202,14 +258,24 @@ class IndexInspector:
                         continue
                     try:
                         chunk = json.loads(line)
-                    except json.JSONDecodeError:
-                        continue
+                    except json.JSONDecodeError as exc:
+                        raise ValueError(
+                            f"chunk index line {line_number} must be valid JSON"
+                        ) from exc
                     source = f"chunk index line {line_number}"
                     chunk = _require_json_object(chunk, source=source)
-                    path = _optional_string_field(chunk, field="path", source=source)
-                    chunk_id = _optional_string_field(chunk, field="chunk_id", source=source)
-                    if path is not None and chunk_id is not None:
-                        mapping.setdefault(path, set()).add(chunk_id)
+                    path = _required_nonempty_string_field(
+                        chunk,
+                        field="path",
+                        source=source,
+                    )
+                    chunk_id = _required_chunk_identifier(chunk, source=source)
+                    if chunk_id in seen_chunk_ids:
+                        raise ValueError(
+                            f"{source} duplicates chunk identifier {chunk_id!r}"
+                        )
+                    seen_chunk_ids.add(chunk_id)
+                    mapping.setdefault(path, set()).add(chunk_id)
         except (IOError, OSError) as e:
             raise MissingArtifactError(
                 f"Failed to read chunk index from {self.index_path}: {e}"
@@ -306,17 +372,28 @@ class IndexInspector:
                         continue
                     try:
                         record = json.loads(line)
-                    except json.JSONDecodeError:
-                        continue
+                    except json.JSONDecodeError as exc:
+                        raise ValueError(
+                            f"citation map line {line_number} must be valid JSON"
+                        ) from exc
                     source = f"citation map line {line_number}"
                     record = _require_json_object(record, source=source)
-                    citation_id = _optional_string_field(
+                    citation_id = _required_nonempty_string_field(
                         record,
                         field="citation_id",
                         source=source,
                     )
-                    if citation_id is not None:
-                        citation_map[citation_id] = record
+                    _optional_string_field(
+                        record,
+                        field="chunk_id",
+                        source=source,
+                        require_nonempty=True,
+                    )
+                    if citation_id in citation_map:
+                        raise ValueError(
+                            f"{source} duplicates citation_id {citation_id!r}"
+                        )
+                    citation_map[citation_id] = record
         except (IOError, OSError) as e:
             raise MissingArtifactError(
                 f"Failed to read citation_map from {citation_path}: {e}"

--- a/merger/repoground/retrieval/eval_diagnostics.py
+++ b/merger/repoground/retrieval/eval_diagnostics.py
@@ -20,6 +20,8 @@ from typing import Dict, List, Optional, Any, Tuple
 from datetime import datetime, timezone
 import re
 
+from .diagnostics_json import strict_json_loads
+
 
 # C1 L3 inference boundary for the retrieval-eval-diagnostics.v1 artifact
 # (resolves the C2.4-tracked deferral). A retrieval-miss diagnosis is a mechanical
@@ -208,7 +210,10 @@ class IndexInspector:
                     if not line.strip():
                         continue
                     try:
-                        chunk = json.loads(line)
+                        chunk = strict_json_loads(
+                            line,
+                            source=f"chunk index line {line_number}",
+                        )
                     except json.JSONDecodeError as exc:
                         raise ValueError(
                             f"chunk index line {line_number} must be valid JSON"
@@ -257,7 +262,10 @@ class IndexInspector:
                     if not line.strip():
                         continue
                     try:
-                        chunk = json.loads(line)
+                        chunk = strict_json_loads(
+                            line,
+                            source=f"chunk index line {line_number}",
+                        )
                     except json.JSONDecodeError as exc:
                         raise ValueError(
                             f"chunk index line {line_number} must be valid JSON"
@@ -371,7 +379,10 @@ class IndexInspector:
                     if not line.strip():
                         continue
                     try:
-                        record = json.loads(line)
+                        record = strict_json_loads(
+                            line,
+                            source=f"citation map line {line_number}",
+                        )
                     except json.JSONDecodeError as exc:
                         raise ValueError(
                             f"citation map line {line_number} must be valid JSON"

--- a/merger/repoground/retrieval/eval_diagnostics_integration.py
+++ b/merger/repoground/retrieval/eval_diagnostics_integration.py
@@ -83,6 +83,7 @@ def integrate_diagnostics_with_eval_results(
     canonical_path: Optional[Path] = None,
     citation_path: Optional[Path] = None,
     output_path: Optional[Path] = None,
+    report_timestamp: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Integrate diagnostics calibrator with existing eval results.
@@ -97,6 +98,7 @@ def integrate_diagnostics_with_eval_results(
         canonical_path: Path to canonical_md artifact
         citation_path: Path to citation_map_jsonl
         output_path: Optional path to save diagnostics report
+        report_timestamp: Optional stable source/run timestamp to include in metadata.
 
     Returns:
         Dictionary with original eval results and added diagnostics report.
@@ -111,7 +113,9 @@ def integrate_diagnostics_with_eval_results(
     misses = _extract_misses_from_eval(eval_results)
 
     # Generate diagnostic report
-    diagnostics_report = calibrator.generate_report(misses)
+    diagnostics_report = calibrator.generate_report(
+        misses, timestamp=report_timestamp
+    )
 
     # Optionally save report
     if output_path:

--- a/merger/repoground/retrieval/eval_diagnostics_integration.py
+++ b/merger/repoground/retrieval/eval_diagnostics_integration.py
@@ -138,7 +138,7 @@ def _extract_misses_from_eval(eval_results: Dict[str, Any]) -> List[Dict[str, An
             {
                 "query": "...",
                 "expected": ["path1", "path2"],
-                "is_relevant": false,  # Miss if false
+                "is_relevant": false,
                 "found_count": 0,  # Number of results found
                 ...
             }
@@ -164,14 +164,11 @@ def _extract_misses_from_eval(eval_results: Dict[str, Any]) -> List[Dict[str, An
         (
             query_text,
             expected,
-            is_relevant,
+            _is_relevant,
             found_count,
             top_results,
         ) = _validate_eval_detail_fields(detail, index=detail_idx)
 
-        # Only process misses (is_relevant=false)
-        if is_relevant:
-            continue
         # Prefer configured eval k from metrics (e.g., recall@10), because top_results
         # may be shorter than k for low-hit queries.
         top_k = (
@@ -188,12 +185,18 @@ def _extract_misses_from_eval(eval_results: Dict[str, Any]) -> List[Dict[str, An
 
             # Check if target was found (substring match in results)
             for rank_idx, res_path in enumerate(top_results):
-                if isinstance(res_path, str) and (
-                    expected_target in res_path or res_path in expected_target
-                ):
+                if expected_target in res_path or res_path in expected_target:
                     found_in_results = True
                     rank_in_results = rank_idx + 1
                     break
+
+            # Query-level is_relevant cannot identify which target matched. A target
+            # observed within the effective k is not a miss; an over-fetched target
+            # below k remains diagnostic input with its observed rank preserved.
+            if rank_in_results is not None and (
+                top_k is None or rank_in_results <= top_k
+            ):
+                continue
 
             miss = {
                 "query_id": f"q{detail_idx}",

--- a/merger/repoground/retrieval/eval_diagnostics_integration.py
+++ b/merger/repoground/retrieval/eval_diagnostics_integration.py
@@ -77,6 +77,28 @@ def _validate_eval_detail_fields(
     return query_text, expected, is_relevant, found_count, top_results
 
 
+def _query_execution_error(
+    detail: Dict[str, Any],
+    *,
+    index: int,
+) -> Optional[str]:
+    prefix = f"retrieval_eval['details'][{index}]"
+    error = detail.get("error")
+    if error is not None:
+        if not isinstance(error, str) or not error.strip():
+            raise ValueError(f"Expected {prefix}['error'] to be a non-empty string.")
+
+    why_fail = detail.get("why_fail")
+    if why_fail is None and isinstance(detail.get("why"), dict):
+        why_fail = detail["why"].get("why_fail")
+    if why_fail is not None and not isinstance(why_fail, str):
+        raise ValueError(f"Expected {prefix}['why_fail'] to be a string.")
+
+    if why_fail == "query execution failed":
+        return error or why_fail
+    return None
+
+
 def integrate_diagnostics_with_eval_results(
     eval_results: Dict[str, Any],
     index_path: Optional[Path] = None,
@@ -173,6 +195,8 @@ def _extract_misses_from_eval(eval_results: Dict[str, Any]) -> List[Dict[str, An
             top_results,
         ) = _validate_eval_detail_fields(detail, index=detail_idx)
 
+        query_error = _query_execution_error(detail, index=detail_idx)
+
         # Prefer configured eval k from metrics (e.g., recall@10), because top_results
         # may be shorter than k for low-hit queries.
         top_k = (
@@ -183,6 +207,21 @@ def _extract_misses_from_eval(eval_results: Dict[str, Any]) -> List[Dict[str, An
 
         # For each expected target, create a miss record
         for expected_target in expected:
+            if query_error is not None:
+                misses.append(
+                    {
+                        "query_id": f"q{detail_idx}",
+                        "query_text": query_text,
+                        "expected_target": expected_target,
+                        "found_in_results": False,
+                        "rank_in_results": None,
+                        "top_k": top_k,
+                        "query_had_zero_hits": True,
+                        "query_error": query_error,
+                    }
+                )
+                continue
+
             # Try to determine if target was in results
             found_in_results = False
             rank_in_results = None

--- a/merger/repoground/retrieval/eval_diagnostics_integration.py
+++ b/merger/repoground/retrieval/eval_diagnostics_integration.py
@@ -34,6 +34,10 @@ def _require_detail_string_list(
     for item_index, item in enumerate(value):
         if not isinstance(item, str):
             raise ValueError(f"Expected {path}[{item_index}] to be a string.")
+        if not item.strip():
+            raise ValueError(
+                f"Expected {path}[{item_index}] to be a non-empty string."
+            )
     return value
 
 

--- a/merger/repoground/retrieval/eval_diagnostics_integration.py
+++ b/merger/repoground/retrieval/eval_diagnostics_integration.py
@@ -88,14 +88,29 @@ def _query_execution_error(
         if not isinstance(error, str) or not error.strip():
             raise ValueError(f"Expected {prefix}['error'] to be a non-empty string.")
 
-    why_fail = detail.get("why_fail")
-    if why_fail is None and isinstance(detail.get("why"), dict):
-        why_fail = detail["why"].get("why_fail")
-    if why_fail is not None and not isinstance(why_fail, str):
-        raise ValueError(f"Expected {prefix}['why_fail'] to be a string.")
+    why_fail_candidates = [
+        (f"{prefix}['why_fail']", detail.get("why_fail")),
+    ]
+    for section_name in ("why", "explain"):
+        section = detail.get(section_name)
+        if isinstance(section, dict):
+            why_fail_candidates.append(
+                (
+                    f"{prefix}['{section_name}']['why_fail']",
+                    section.get("why_fail"),
+                )
+            )
 
-    if why_fail == "query execution failed":
-        return error or why_fail
+    for marker_path, why_fail in why_fail_candidates:
+        if why_fail is not None and not isinstance(why_fail, str):
+            raise ValueError(f"Expected {marker_path} to be a string.")
+
+    has_query_execution_failure = any(
+        why_fail == "query execution failed"
+        for _, why_fail in why_fail_candidates
+    )
+    if has_query_execution_failure:
+        return error or "query execution failed"
     return None
 
 
@@ -269,8 +284,10 @@ def _infer_top_k_from_metrics(metrics: Any) -> Optional[int]:
         match = pattern.search(key)
         if match:
             try:
-                candidates.append(int(match.group(1)))
+                candidate = int(match.group(1))
             except ValueError:
                 continue
+            if candidate > 0:
+                candidates.append(candidate)
 
     return max(candidates) if candidates else None

--- a/merger/repoground/retrieval/eval_diagnostics_integration.py
+++ b/merger/repoground/retrieval/eval_diagnostics_integration.py
@@ -9,7 +9,7 @@ It only explains why misses occurred.
 """
 
 from pathlib import Path
-from typing import Dict, List, Any, Optional
+from typing import Any, Dict, List, Optional, Tuple
 import re
 from .eval_diagnostics import RetrievalEvalDiagnosticsCalibrator
 
@@ -20,6 +20,57 @@ def _require_eval_detail(value: Any, *, index: int) -> Dict[str, Any]:
             f"Expected retrieval_eval['details'][{index}] to be an object."
         )
     return value
+
+
+def _require_detail_string_list(
+    value: Any,
+    *,
+    index: int,
+    field: str,
+) -> List[str]:
+    path = f"retrieval_eval['details'][{index}]['{field}']"
+    if not isinstance(value, list):
+        raise ValueError(f"Expected {path} to be a list of strings.")
+    for item_index, item in enumerate(value):
+        if not isinstance(item, str):
+            raise ValueError(f"Expected {path}[{item_index}] to be a string.")
+    return value
+
+
+def _validate_eval_detail_fields(
+    detail: Dict[str, Any],
+    *,
+    index: int,
+) -> Tuple[str, List[str], bool, int, List[str]]:
+    prefix = f"retrieval_eval['details'][{index}]"
+
+    query_text = detail.get("query", "")
+    if not isinstance(query_text, str):
+        raise ValueError(f"Expected {prefix}['query'] to be a string.")
+
+    expected = _require_detail_string_list(
+        detail.get("expected", []),
+        index=index,
+        field="expected",
+    )
+
+    is_relevant = detail.get("is_relevant", False)
+    if not isinstance(is_relevant, bool):
+        raise ValueError(f"Expected {prefix}['is_relevant'] to be a boolean.")
+
+    found_count = detail.get("found_count", 0)
+    if isinstance(found_count, bool) or not isinstance(found_count, int):
+        raise ValueError(f"Expected {prefix}['found_count'] to be an integer.")
+    if found_count < 0:
+        raise ValueError(f"Expected {prefix}['found_count'] to be non-negative.")
+
+    top_results = _require_detail_string_list(
+        detail.get("top_results", []),
+        index=index,
+        field="top_results",
+    )
+
+    return query_text, expected, is_relevant, found_count, top_results
 
 
 def integrate_diagnostics_with_eval_results(
@@ -93,7 +144,9 @@ def _extract_misses_from_eval(eval_results: Dict[str, Any]) -> List[Dict[str, An
     misses: List[Dict[str, Any]] = []
     if "details" not in eval_results:
         if "results" in eval_results:
-            raise ValueError("Expected retrieval_eval field 'details', found unsupported legacy key 'results'.")
+            raise ValueError(
+                "Expected retrieval_eval field 'details', found unsupported legacy key 'results'."
+            )
         raise ValueError("Expected retrieval_eval field 'details'.")
 
     details = eval_results.get("details", [])
@@ -104,37 +157,36 @@ def _extract_misses_from_eval(eval_results: Dict[str, Any]) -> List[Dict[str, An
 
     for detail_idx, detail in enumerate(details):
         detail = _require_eval_detail(detail, index=detail_idx)
+        (
+            query_text,
+            expected,
+            is_relevant,
+            found_count,
+            top_results,
+        ) = _validate_eval_detail_fields(detail, index=detail_idx)
+
         # Only process misses (is_relevant=false)
-        if detail.get("is_relevant", False):
+        if is_relevant:
             continue
-
-        query_text = detail.get("query", "")
-        expected = detail.get("expected", [])
-        if not isinstance(expected, list):
-            expected = [str(expected)]
-        found_count = detail.get("found_count", 0)
-        if not isinstance(found_count, int):
-            found_count = 0
-
-        top_results = detail.get("top_results", [])
-        if not isinstance(top_results, list):
-            top_results = []
         # Prefer configured eval k from metrics (e.g., recall@10), because top_results
         # may be shorter than k for low-hit queries.
-        top_k = configured_top_k if configured_top_k is not None else (len(top_results) if len(top_results) > 0 else None)
+        top_k = (
+            configured_top_k
+            if configured_top_k is not None
+            else (len(top_results) if len(top_results) > 0 else None)
+        )
 
         # For each expected target, create a miss record
         for expected_target in expected:
-            if not isinstance(expected_target, str):
-                expected_target = str(expected_target)
-
             # Try to determine if target was in results
             found_in_results = False
             rank_in_results = None
 
             # Check if target was found (substring match in results)
             for rank_idx, res_path in enumerate(top_results):
-                if isinstance(res_path, str) and (expected_target in res_path or res_path in expected_target):
+                if isinstance(res_path, str) and (
+                    expected_target in res_path or res_path in expected_target
+                ):
                     found_in_results = True
                     rank_in_results = rank_idx + 1
                     break

--- a/merger/repoground/retrieval/eval_diagnostics_integration.py
+++ b/merger/repoground/retrieval/eval_diagnostics_integration.py
@@ -185,7 +185,7 @@ def _extract_misses_from_eval(eval_results: Dict[str, Any]) -> List[Dict[str, An
 
             # Check if target was found (substring match in results)
             for rank_idx, res_path in enumerate(top_results):
-                if expected_target in res_path or res_path in expected_target:
+                if expected_target in res_path:
                     found_in_results = True
                     rank_in_results = rank_idx + 1
                     break

--- a/merger/repoground/retrieval/eval_diagnostics_integration.py
+++ b/merger/repoground/retrieval/eval_diagnostics_integration.py
@@ -14,6 +14,14 @@ import re
 from .eval_diagnostics import RetrievalEvalDiagnosticsCalibrator
 
 
+def _require_eval_detail(value: Any, *, index: int) -> Dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(
+            f"Expected retrieval_eval['details'][{index}] to be an object."
+        )
+    return value
+
+
 def integrate_diagnostics_with_eval_results(
     eval_results: Dict[str, Any],
     index_path: Optional[Path] = None,
@@ -95,6 +103,7 @@ def _extract_misses_from_eval(eval_results: Dict[str, Any]) -> List[Dict[str, An
     configured_top_k = _infer_top_k_from_metrics(eval_results.get("metrics", {}))
 
     for detail_idx, detail in enumerate(details):
+        detail = _require_eval_detail(detail, index=detail_idx)
         # Only process misses (is_relevant=false)
         if detail.get("is_relevant", False):
             continue

--- a/merger/repoground/tests/test_answer_grounding_delta.py
+++ b/merger/repoground/tests/test_answer_grounding_delta.py
@@ -110,3 +110,26 @@ def test_answer_grounding_delta_uses_prevalidated_entries_without_rereading_map(
     assert verdict["status"] == "valid"
     assert verdict["citation_checks"][0]["status"] == "valid"
     assert verdict["diagnostics"] == []
+
+
+def test_answer_grounding_delta_uses_prevalidated_manifest_after_file_removal(
+    tmp_path,
+):
+    manifest, citation_map, range_ref = _bundle(tmp_path)
+    declaration = _declaration(range_ref)
+    manifest_data = json.loads(manifest.read_text(encoding="utf-8"))
+    record = json.loads(citation_map.read_text(encoding="utf-8").splitlines()[0])
+    entries = {record["citation_id"]: record}
+    manifest.unlink()
+
+    verdict = check_answer_grounding_delta(
+        declaration,
+        new_bundle_manifest=manifest,
+        new_bundle_manifest_data=manifest_data,
+        new_citation_map=citation_map,
+        new_citation_entries=entries,
+    )
+
+    assert verdict["status"] == "valid"
+    assert verdict["citation_checks"][0]["status"] == "valid"
+    assert verdict["range_checks"][0]["status"] == "valid"

--- a/merger/repoground/tests/test_answer_grounding_delta.py
+++ b/merger/repoground/tests/test_answer_grounding_delta.py
@@ -91,3 +91,22 @@ def test_answer_grounding_delta_preserves_existing_freshness_status(tmp_path):
 
     assert verdict["old_snapshot_freshness_status"] == "stale"
     assert verdict["new_snapshot_freshness_status"] == "unknown"
+
+
+def test_answer_grounding_delta_uses_prevalidated_entries_without_rereading_map(tmp_path):
+    manifest, citation_map, range_ref = _bundle(tmp_path)
+    declaration = _declaration(range_ref)
+    record = json.loads(citation_map.read_text(encoding="utf-8").splitlines()[0])
+    entries = {record["citation_id"]: record}
+    citation_map.unlink()
+
+    verdict = check_answer_grounding_delta(
+        declaration,
+        new_bundle_manifest=manifest,
+        new_citation_map=citation_map,
+        new_citation_entries=entries,
+    )
+
+    assert verdict["status"] == "valid"
+    assert verdict["citation_checks"][0]["status"] == "valid"
+    assert verdict["diagnostics"] == []

--- a/merger/repoground/tests/test_answer_grounding_delta.py
+++ b/merger/repoground/tests/test_answer_grounding_delta.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
+from merger.repoground.cli import cmd_diagnostics
 from merger.repoground.core.answer_grounding_delta import check_answer_grounding_delta
 from merger.repoground.tests.test_answer_grounding_verifier import _bundle, _declaration
 
@@ -130,6 +131,45 @@ def test_answer_grounding_delta_uses_prevalidated_manifest_after_file_removal(
         new_citation_entries=entries,
     )
 
+    assert verdict["status"] == "valid"
+    assert verdict["citation_checks"][0]["status"] == "valid"
+    assert verdict["range_checks"][0]["status"] == "valid"
+
+
+def test_prevalidated_manifest_keeps_original_bundle_anchor_after_symlink_swap(
+    tmp_path,
+):
+    original_bundle = tmp_path / "original"
+    replacement_bundle = tmp_path / "replacement"
+    original_bundle.mkdir()
+    replacement_bundle.mkdir()
+    manifest, citation_map, range_ref = _bundle(original_bundle)
+    replacement_manifest, _replacement_map, _replacement_range = _bundle(
+        replacement_bundle,
+        content=b"Line 1\nOther 2\nLine 3\n",
+    )
+    declaration = _declaration(range_ref)
+    manifest_path, manifest_data = cmd_diagnostics._read_json_with_path(
+        str(manifest),
+        expected_type=dict,
+    )
+    record = json.loads(citation_map.read_text(encoding="utf-8").splitlines()[0])
+    entries = {record["citation_id"]: record}
+
+    manifest.unlink()
+    manifest.symlink_to(replacement_manifest)
+
+    verdict = check_answer_grounding_delta(
+        declaration,
+        new_bundle_manifest=manifest_path,
+        new_bundle_manifest_data=manifest_data,
+        new_citation_map=citation_map,
+        new_citation_entries=entries,
+    )
+
+    assert manifest_path == manifest
+    assert manifest_path.is_absolute()
+    assert manifest.is_symlink()
     assert verdict["status"] == "valid"
     assert verdict["citation_checks"][0]["status"] == "valid"
     assert verdict["range_checks"][0]["status"] == "valid"

--- a/merger/repoground/tests/test_bundle_access_boundary.py
+++ b/merger/repoground/tests/test_bundle_access_boundary.py
@@ -59,6 +59,19 @@ def test_snapshot_status_keeps_prevalidated_manifest_parent_after_symlink_swap(
     assert status["artifacts"][0]["absolute_path"] != str(
         replacement_artifact.resolve()
     )
+    assert status["availability_model"]["bundle_manifest"] == str(
+        manifest.absolute()
+    )
+    canonical = next(
+        item
+        for item in status["availability_model"]["artifacts"]
+        if item["role"] == "canonical_md"
+    )
+    assert canonical["file_exists"] is True
+    assert status["availability_model"]["graph_availability"]["status"] in {
+        "not_generated",
+        "profile_excluded",
+    }
 
 
 def test_snapshot_status_makes_relative_prevalidated_anchor_absolute_without_resolving(

--- a/merger/repoground/tests/test_bundle_access_boundary.py
+++ b/merger/repoground/tests/test_bundle_access_boundary.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+from pathlib import Path
 
 from merger.repoground.core import bundle_access
 
@@ -27,6 +28,69 @@ def _sqlite_sidecars(index_path):
         index_path.with_name(index_path.name + suffix)
         for suffix in ("-wal", "-shm", "-journal")
     }
+
+
+def test_snapshot_status_keeps_prevalidated_manifest_parent_after_symlink_swap(
+    tmp_path,
+):
+    original = tmp_path / "original"
+    replacement = tmp_path / "replacement"
+    original.mkdir()
+    replacement.mkdir()
+    original_artifact = original / "brief.md"
+    replacement_artifact = replacement / "brief.md"
+    original_artifact.write_text("original", encoding="utf-8")
+    replacement_artifact.write_text("replacement", encoding="utf-8")
+    manifest = original / "bundle.manifest.json"
+    replacement_manifest = replacement / "bundle.manifest.json"
+    artifacts = [{"role": "canonical_md", "path": "brief.md"}]
+    _write_manifest(manifest, artifacts)
+    _write_manifest(replacement_manifest, artifacts)
+    manifest_data = json.loads(manifest.read_text(encoding="utf-8"))
+
+    manifest.unlink()
+    manifest.symlink_to(replacement_manifest)
+    status = bundle_access.snapshot_status(manifest, manifest_data=manifest_data)
+
+    assert status["bundle_manifest"] == str(manifest.absolute())
+    assert status["artifacts"][0]["absolute_path"] == str(
+        original_artifact.resolve()
+    )
+    assert status["artifacts"][0]["absolute_path"] != str(
+        replacement_artifact.resolve()
+    )
+
+
+def test_snapshot_status_makes_relative_prevalidated_anchor_absolute_without_resolving(
+    monkeypatch, tmp_path
+):
+    original = tmp_path / "original"
+    replacement = tmp_path / "replacement"
+    original.mkdir()
+    replacement.mkdir()
+    (original / "brief.md").write_text("original", encoding="utf-8")
+    (replacement / "brief.md").write_text("replacement", encoding="utf-8")
+    manifest = original / "bundle.manifest.json"
+    replacement_manifest = replacement / "bundle.manifest.json"
+    artifacts = [{"role": "canonical_md", "path": "brief.md"}]
+    _write_manifest(manifest, artifacts)
+    _write_manifest(replacement_manifest, artifacts)
+    manifest_data = json.loads(manifest.read_text(encoding="utf-8"))
+    manifest.unlink()
+    manifest.symlink_to(replacement_manifest)
+    monkeypatch.chdir(tmp_path)
+
+    relative_manifest = Path("original/bundle.manifest.json")
+    status = bundle_access.snapshot_status(
+        relative_manifest,
+        manifest_data=manifest_data,
+    )
+
+    assert status["bundle_manifest"] == str(relative_manifest.absolute())
+    assert status["bundle_manifest"] != str(relative_manifest.resolve())
+    assert status["artifacts"][0]["absolute_path"] == str(
+        (original / "brief.md").resolve()
+    )
 
 
 def test_range_get_reads_existing_artifact_without_mutation(tmp_path):

--- a/merger/repoground/tests/test_cli_diagnostics.py
+++ b/merger/repoground/tests/test_cli_diagnostics.py
@@ -548,3 +548,317 @@ def test_answer_delta_rejects_malformed_declaration_evidence_without_traceback(
     assert captured.out == ""
     assert expected_error in captured.err
     assert "Traceback" not in captured.err
+
+
+@pytest.mark.parametrize(
+    ("index_record", "expected_error"),
+    [
+        ({"chunk_id": "c1"}, "chunk index line 1 field 'path' is required"),
+        (
+            {"chunk_id": "c1", "path": ""},
+            "chunk index line 1 field 'path' must be a non-empty string",
+        ),
+        (
+            {"chunk_id": "c1", "path": "   "},
+            "chunk index line 1 field 'path' must be a non-empty string",
+        ),
+        (
+            {"path": "src/a.py"},
+            "chunk index line 1 field 'chunk_id' or 'id' is required",
+        ),
+        (
+            {"chunk_id": "", "path": "src/a.py"},
+            "chunk index line 1 field 'chunk_id' must be a non-empty string",
+        ),
+        (
+            {"chunk_id": "   ", "path": "src/a.py"},
+            "chunk index line 1 field 'chunk_id' must be a non-empty string",
+        ),
+        (
+            {"id": "", "path": "src/a.py"},
+            "chunk index line 1 field 'id' must be a non-empty string",
+        ),
+        (
+            {"chunk_id": "c1", "id": "legacy-c1", "path": "src/a.py"},
+            "chunk index line 1 fields 'chunk_id' and 'id' must match",
+        ),
+        (
+            {"chunk_id": 7, "path": "src/a.py"},
+            "chunk index line 1 field 'chunk_id' must be a string",
+        ),
+        (
+            {"chunk_id": "c1", "path": 7},
+            "chunk index line 1 field 'path' must be a string",
+        ),
+    ],
+)
+def test_eval_report_rejects_invalid_index_identifiers_without_traceback(
+    tmp_path,
+    capsys,
+    index_record,
+    expected_error,
+):
+    eval_results = _write_json(
+        tmp_path / "eval.json",
+        {
+            "metrics": {"recall@10": 0.0},
+            "details": [
+                {
+                    "query": "session authority",
+                    "expected": ["src/a.py"],
+                    "is_relevant": False,
+                    "found_count": 0,
+                    "top_results": [],
+                }
+            ],
+        },
+    )
+    index = tmp_path / "chunk-index.jsonl"
+    index.write_text(json.dumps(index_record) + "\n", encoding="utf-8")
+
+    code = main(
+        [
+            "diagnostics",
+            "eval-report",
+            "--eval-results",
+            str(eval_results),
+            "--index",
+            str(index),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert captured.out == ""
+    assert expected_error in captured.err
+    assert "Traceback" not in captured.err
+
+
+@pytest.mark.parametrize(
+    ("citation_lines", "expected_error"),
+    [
+        ([[]], "citation map line 1 must be a JSON object"),
+        ([{}], "citation map line 1 field 'citation_id' is required"),
+        ([{"citation_id": 7}], "citation map line 1 field 'citation_id' must be a string"),
+        (
+            [{"citation_id": ""}],
+            "citation map line 1 field 'citation_id' must be a non-empty string",
+        ),
+        (
+            [{"citation_id": "   "}],
+            "citation map line 1 field 'citation_id' must be a non-empty string",
+        ),
+        (
+            [{"citation_id": "cit-1"}, {"citation_id": "cit-1"}],
+            "citation map line 2 duplicates citation_id 'cit-1'",
+        ),
+        (
+            [{"citation_id": "cit-1", "chunk_id": ""}],
+            "citation map line 1 field 'chunk_id' must be a non-empty string",
+        ),
+        (
+            [{"citation_id": "cit-1", "chunk_id": "   "}],
+            "citation map line 1 field 'chunk_id' must be a non-empty string",
+        ),
+        (
+            [{"citation_id": "cit-1", "chunk_id": 7}],
+            "citation map line 1 field 'chunk_id' must be a string",
+        ),
+    ],
+)
+def test_eval_report_rejects_invalid_citation_identifiers_without_traceback(
+    tmp_path,
+    capsys,
+    citation_lines,
+    expected_error,
+):
+    eval_results = _write_json(
+        tmp_path / "eval.json",
+        {
+            "metrics": {"recall@10": 0.0},
+            "details": [
+                {
+                    "query": "session authority",
+                    "expected": ["src/a.py"],
+                    "is_relevant": False,
+                    "found_count": 0,
+                    "top_results": [],
+                }
+            ],
+        },
+    )
+    index = tmp_path / "chunk-index.jsonl"
+    index.write_text(
+        json.dumps({"chunk_id": "c1", "path": "src/a.py"}) + "\n",
+        encoding="utf-8",
+    )
+    citation = tmp_path / "citation-map.jsonl"
+    citation.write_text(
+        "\n".join(json.dumps(record) for record in citation_lines) + "\n",
+        encoding="utf-8",
+    )
+
+    code = main(
+        [
+            "diagnostics",
+            "eval-report",
+            "--eval-results",
+            str(eval_results),
+            "--index",
+            str(index),
+            "--citation",
+            str(citation),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert captured.out == ""
+    assert expected_error in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_eval_report_accepts_legacy_index_id(tmp_path, capsys):
+    eval_results = _write_json(
+        tmp_path / "eval.json",
+        {
+            "metrics": {"recall@10": 0.0},
+            "details": [
+                {
+                    "query": "session authority",
+                    "expected": ["src/a.py"],
+                    "is_relevant": False,
+                    "found_count": 0,
+                    "top_results": [],
+                }
+            ],
+        },
+    )
+    index = tmp_path / "chunk-index.jsonl"
+    index.write_text(
+        json.dumps({"id": "legacy-c1", "path": "src/a.py"}) + "\n",
+        encoding="utf-8",
+    )
+
+    code, report = _run(
+        capsys,
+        [
+            "eval-report",
+            "--eval-results",
+            str(eval_results),
+            "--index",
+            str(index),
+        ],
+    )
+
+    assert code == 0
+    assert (
+        report["diagnostics_report"]["diagnostics"][0]["primary_diagnosis"]
+        == "target_exists_not_in_top_k"
+    )
+
+
+def test_eval_report_rejects_duplicate_chunk_identifiers_without_traceback(
+    tmp_path, capsys
+):
+    eval_results = _write_json(
+        tmp_path / "eval.json",
+        {
+            "metrics": {"recall@10": 0.0},
+            "details": [
+                {
+                    "query": "session authority",
+                    "expected": ["src/a.py"],
+                    "is_relevant": False,
+                    "found_count": 0,
+                    "top_results": [],
+                }
+            ],
+        },
+    )
+    index = tmp_path / "chunk-index.jsonl"
+    index.write_text(
+        "\n".join(
+            [
+                json.dumps({"chunk_id": "c1", "path": "src/a.py"}),
+                json.dumps({"id": "c1", "path": "src/b.py"}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    code = main(
+        [
+            "diagnostics",
+            "eval-report",
+            "--eval-results",
+            str(eval_results),
+            "--index",
+            str(index),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert captured.out == ""
+    assert "chunk index line 2 duplicates chunk identifier 'c1'" in captured.err
+    assert "Traceback" not in captured.err
+
+
+@pytest.mark.parametrize(
+    ("artifact_option", "filename", "valid_prefix", "expected_error"),
+    [
+        (
+            "--index",
+            "chunk-index.jsonl",
+            "",
+            "chunk index line 1 must be valid JSON",
+        ),
+        (
+            "--citation",
+            "citation-map.jsonl",
+            json.dumps({"chunk_id": "c1", "path": "src/a.py"}) + "\n",
+            "citation map line 1 must be valid JSON",
+        ),
+    ],
+)
+def test_eval_report_rejects_invalid_jsonl_without_traceback(
+    tmp_path,
+    capsys,
+    artifact_option,
+    filename,
+    valid_prefix,
+    expected_error,
+):
+    eval_results = _write_json(
+        tmp_path / "eval.json",
+        {
+            "metrics": {"recall@10": 0.0},
+            "details": [
+                {
+                    "query": "session authority",
+                    "expected": ["src/a.py"],
+                    "is_relevant": False,
+                    "found_count": 0,
+                    "top_results": [],
+                }
+            ],
+        },
+    )
+    artifact = tmp_path / filename
+    artifact.write_text("{\n", encoding="utf-8")
+    args = ["eval-report", "--eval-results", str(eval_results)]
+    if artifact_option == "--citation":
+        index = tmp_path / "chunk-index.jsonl"
+        index.write_text(valid_prefix, encoding="utf-8")
+        args.extend(["--index", str(index)])
+    args.extend([artifact_option, str(artifact)])
+
+    code = main(["diagnostics", *args])
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert captured.out == ""
+    assert expected_error in captured.err
+    assert "Traceback" not in captured.err

--- a/merger/repoground/tests/test_cli_diagnostics.py
+++ b/merger/repoground/tests/test_cli_diagnostics.py
@@ -313,9 +313,16 @@ def test_json_input_recursion_errors_exit_two_without_traceback(
     assert "Traceback" not in captured.err
 
 
-def test_deep_json_inputs_fail_closed_without_traceback(tmp_path, capsys):
+def test_json_inputs_reject_nesting_beyond_deterministic_limit_without_traceback(
+    tmp_path,
+    capsys,
+):
     records = tmp_path / "records.json"
-    records.write_text("[" * 2000 + "0" + "]" * 2000, encoding="utf-8")
+    nesting_depth = diagnostics_json.MAX_JSON_NESTING_DEPTH + 1
+    records.write_text(
+        "[" * nesting_depth + "0" + "]" * nesting_depth,
+        encoding="utf-8",
+    )
 
     code = main(
         [
@@ -330,7 +337,25 @@ def test_deep_json_inputs_fail_closed_without_traceback(tmp_path, capsys):
     assert code == 2
     assert captured.out == ""
     assert captured.err.startswith("Error: ")
+    assert "exceeds the supported JSON nesting depth" in captured.err
     assert "Traceback" not in captured.err
+
+
+def test_json_nesting_ignores_brackets_in_escaped_strings(tmp_path, capsys):
+    bracket_count = diagnostics_json.MAX_JSON_NESTING_DEPTH + 1
+    bracket_text = 'escaped backslash and quote: \\" ' + "[{" * bracket_count
+    records = _write_json(
+        tmp_path / "records.json",
+        [{"commit": "a" * 40, "path": "src/a.py", "author": bracket_text}],
+    )
+
+    code, result = _run(
+        capsys,
+        ["history-lens", "--records", str(records), "--profile", "summary"],
+    )
+
+    assert code == 0
+    assert result["kind"] == "repobrief.history_lens"
 
 
 @pytest.mark.parametrize("constant", ["NaN", "Infinity", "-Infinity"])
@@ -583,6 +608,42 @@ def test_answer_delta_rejects_non_finite_jsonl_without_traceback(
     assert code == 2
     assert captured.out == ""
     assert "non-finite JSON constant 'NaN'" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_answer_delta_rejects_jsonl_beyond_deterministic_limit_without_traceback(
+    tmp_path,
+    capsys,
+):
+    declaration = _write_json(tmp_path / "declaration.json", {"used_citations": []})
+    citation_map = tmp_path / "citations.jsonl"
+    array_depth = diagnostics_json.MAX_JSON_NESTING_DEPTH
+    citation_line = (
+        '{"citation_id":"cit-1","nested":'
+        + "[" * array_depth
+        + "0"
+        + "]" * array_depth
+        + "}"
+    )
+    citation_map.write_text(citation_line + "\n", encoding="utf-8")
+
+    code = main(
+        [
+            "diagnostics",
+            "answer-delta",
+            "--old-declaration",
+            str(declaration),
+            "--new-bundle-manifest",
+            "bundle.manifest.json",
+            "--new-citation-map",
+            str(citation_map),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert captured.out == ""
+    assert "citation map line 1 exceeds the supported JSON nesting depth" in captured.err
     assert "Traceback" not in captured.err
 
 

--- a/merger/repoground/tests/test_cli_diagnostics.py
+++ b/merger/repoground/tests/test_cli_diagnostics.py
@@ -6,8 +6,8 @@ from pathlib import Path
 import pytest
 
 from merger.repoground.core import answer_grounding_delta
-from merger.repoground.retrieval import eval_diagnostics_integration
 from merger.repoground.cli.main import main
+from merger.repoground.retrieval import diagnostics_json, eval_diagnostics_integration
 
 
 def _write_json(path: Path, value: object) -> Path:
@@ -284,7 +284,36 @@ def test_json_inputs_reject_symbolic_links(tmp_path, capsys):
     assert "refusing symbolic-link input" in captured.err
 
 
-def test_json_inputs_reject_excessive_nesting_without_traceback(tmp_path, capsys):
+def test_json_input_recursion_errors_exit_two_without_traceback(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    records = tmp_path / "records.json"
+    records.write_text("[]", encoding="utf-8")
+
+    def raise_recursion_error(*_args, **_kwargs):
+        raise RecursionError("forced recursion limit")
+
+    monkeypatch.setattr(diagnostics_json.json, "loads", raise_recursion_error)
+
+    code = main(
+        [
+            "diagnostics",
+            "history-lens",
+            "--records",
+            str(records),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert captured.out == ""
+    assert "exceeds the supported JSON nesting depth" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_deep_json_inputs_fail_closed_without_traceback(tmp_path, capsys):
     records = tmp_path / "records.json"
     records.write_text("[" * 2000 + "0" + "]" * 2000, encoding="utf-8")
 
@@ -300,7 +329,7 @@ def test_json_inputs_reject_excessive_nesting_without_traceback(tmp_path, capsys
 
     assert code == 2
     assert captured.out == ""
-    assert "exceeds the supported JSON nesting depth" in captured.err
+    assert captured.err.startswith("Error: ")
     assert "Traceback" not in captured.err
 
 
@@ -528,31 +557,13 @@ def test_answer_delta_rejects_invalid_citation_map_records_without_traceback(
     assert "Traceback" not in captured.err
 
 
-@pytest.mark.parametrize(
-    ("citation_line", "expected_error"),
-    [
-        (
-            '{"citation_id":"cit-1","diagnostic_value":NaN}',
-            "non-finite JSON constant 'NaN'",
-        ),
-        (
-            '{"citation_id":"cit-1","nested":'
-            + "[" * 2000
-            + "0"
-            + "]" * 2000
-            + "}",
-            "citation map line 1 exceeds the supported JSON nesting depth",
-        ),
-    ],
-)
-def test_answer_delta_rejects_strict_jsonl_violations_without_traceback(
+def test_answer_delta_rejects_non_finite_jsonl_without_traceback(
     tmp_path,
     capsys,
-    citation_line,
-    expected_error,
 ):
     declaration = _write_json(tmp_path / "declaration.json", {"used_citations": []})
     citation_map = tmp_path / "citations.jsonl"
+    citation_line = '{"citation_id":"cit-1","diagnostic_value":NaN}'
     citation_map.write_text(citation_line + "\n", encoding="utf-8")
 
     code = main(
@@ -571,7 +582,56 @@ def test_answer_delta_rejects_strict_jsonl_violations_without_traceback(
 
     assert code == 2
     assert captured.out == ""
-    assert expected_error in captured.err
+    assert "non-finite JSON constant 'NaN'" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_answer_delta_jsonl_recursion_errors_exit_two_without_traceback(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    declaration = _write_json(tmp_path / "declaration.json", {"used_citations": []})
+    manifest = _write_json(
+        tmp_path / "bundle.manifest.json",
+        {
+            "kind": "repolens.bundle.manifest",
+            "version": "1.0",
+            "run_id": "strict-json-test",
+            "artifacts": [],
+            "links": {},
+            "capabilities": {},
+        },
+    )
+    citation_map = tmp_path / "citations.jsonl"
+    citation_line = '{"citation_id":"cit-1"}'
+    citation_map.write_text(citation_line + "\n", encoding="utf-8")
+    real_json_loads = diagnostics_json.json.loads
+
+    def raise_for_citation_line(document, *args, **kwargs):
+        if document == citation_line:
+            raise RecursionError("forced citation-map recursion limit")
+        return real_json_loads(document, *args, **kwargs)
+
+    monkeypatch.setattr(diagnostics_json.json, "loads", raise_for_citation_line)
+
+    code = main(
+        [
+            "diagnostics",
+            "answer-delta",
+            "--old-declaration",
+            str(declaration),
+            "--new-bundle-manifest",
+            str(manifest),
+            "--new-citation-map",
+            str(citation_map),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert captured.out == ""
+    assert "citation map line 1 exceeds the supported JSON nesting depth" in captured.err
     assert "Traceback" not in captured.err
 
 

--- a/merger/repoground/tests/test_cli_diagnostics.py
+++ b/merger/repoground/tests/test_cli_diagnostics.py
@@ -284,6 +284,51 @@ def test_json_inputs_reject_symbolic_links(tmp_path, capsys):
     assert "refusing symbolic-link input" in captured.err
 
 
+def test_json_inputs_reject_excessive_nesting_without_traceback(tmp_path, capsys):
+    records = tmp_path / "records.json"
+    records.write_text("[" * 2000 + "0" + "]" * 2000, encoding="utf-8")
+
+    code = main(
+        [
+            "diagnostics",
+            "history-lens",
+            "--records",
+            str(records),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert captured.out == ""
+    assert "exceeds the supported JSON nesting depth" in captured.err
+    assert "Traceback" not in captured.err
+
+
+@pytest.mark.parametrize("constant", ["NaN", "Infinity", "-Infinity"])
+def test_json_inputs_reject_non_finite_constants_without_traceback(
+    tmp_path,
+    capsys,
+    constant,
+):
+    records = tmp_path / "records.json"
+    records.write_text(f'[{{"diagnostic_value": {constant}}}]', encoding="utf-8")
+
+    code = main(
+        [
+            "diagnostics",
+            "history-lens",
+            "--records",
+            str(records),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert captured.out == ""
+    assert f"non-finite JSON constant {constant!r}" in captured.err
+    assert "Traceback" not in captured.err
+
+
 def test_history_lens_rejects_non_object_records_without_traceback(tmp_path, capsys):
     records = _write_json(tmp_path / "records.json", [1])
 
@@ -460,6 +505,53 @@ def test_answer_delta_rejects_invalid_citation_map_records_without_traceback(
         tmp_path / "declaration.json",
         {"used_citations": [{"citation_id": "cit_0000000000000001"}]},
     )
+    citation_map = tmp_path / "citations.jsonl"
+    citation_map.write_text(citation_line + "\n", encoding="utf-8")
+
+    code = main(
+        [
+            "diagnostics",
+            "answer-delta",
+            "--old-declaration",
+            str(declaration),
+            "--new-bundle-manifest",
+            "bundle.manifest.json",
+            "--new-citation-map",
+            str(citation_map),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert captured.out == ""
+    assert expected_error in captured.err
+    assert "Traceback" not in captured.err
+
+
+@pytest.mark.parametrize(
+    ("citation_line", "expected_error"),
+    [
+        (
+            '{"citation_id":"cit-1","diagnostic_value":NaN}',
+            "non-finite JSON constant 'NaN'",
+        ),
+        (
+            '{"citation_id":"cit-1","nested":'
+            + "[" * 2000
+            + "0"
+            + "]" * 2000
+            + "}",
+            "citation map line 1 exceeds the supported JSON nesting depth",
+        ),
+    ],
+)
+def test_answer_delta_rejects_strict_jsonl_violations_without_traceback(
+    tmp_path,
+    capsys,
+    citation_line,
+    expected_error,
+):
+    declaration = _write_json(tmp_path / "declaration.json", {"used_citations": []})
     citation_map = tmp_path / "citations.jsonl"
     citation_map.write_text(citation_line + "\n", encoding="utf-8")
 
@@ -861,4 +953,61 @@ def test_eval_report_rejects_invalid_jsonl_without_traceback(
     assert code == 2
     assert captured.out == ""
     assert expected_error in captured.err
+    assert "Traceback" not in captured.err
+
+
+@pytest.mark.parametrize(
+    ("artifact_option", "filename"),
+    [
+        ("--index", "chunk-index.jsonl"),
+        ("--citation", "citation-map.jsonl"),
+    ],
+)
+def test_eval_report_rejects_non_finite_jsonl_constants_without_traceback(
+    tmp_path,
+    capsys,
+    artifact_option,
+    filename,
+):
+    eval_results = _write_json(
+        tmp_path / "eval.json",
+        {
+            "metrics": {"recall@10": 0.0},
+            "details": [
+                {
+                    "query": "session authority",
+                    "expected": ["src/a.py"],
+                    "is_relevant": False,
+                    "found_count": 0,
+                    "top_results": [],
+                }
+            ],
+        },
+    )
+    artifact = tmp_path / filename
+    args = ["eval-report", "--eval-results", str(eval_results)]
+    if artifact_option == "--index":
+        artifact.write_text(
+            '{"chunk_id":"c1","path":"src/a.py","diagnostic_value":NaN}\n',
+            encoding="utf-8",
+        )
+    else:
+        index = tmp_path / "chunk-index.jsonl"
+        index.write_text(
+            json.dumps({"chunk_id": "c1", "path": "src/a.py"}) + "\n",
+            encoding="utf-8",
+        )
+        artifact.write_text(
+            '{"citation_id":"cit-1","chunk_id":"c1","diagnostic_value":NaN}\n',
+            encoding="utf-8",
+        )
+        args.extend(["--index", str(index)])
+    args.extend([artifact_option, str(artifact)])
+
+    code = main(["diagnostics", *args])
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert captured.out == ""
+    assert "non-finite JSON constant 'NaN'" in captured.err
     assert "Traceback" not in captured.err

--- a/merger/repoground/tests/test_cli_diagnostics.py
+++ b/merger/repoground/tests/test_cli_diagnostics.py
@@ -470,6 +470,26 @@ def test_eval_report_stdout_is_byte_stable(tmp_path, capsys):
     assert "timestamp" not in payload["diagnostics_report"]["metadata"]
 
 
+def test_json_input_parent_symlink_loop_returns_bounded_error(tmp_path, capsys):
+    loop = tmp_path / "loop"
+    loop.symlink_to("loop", target_is_directory=True)
+
+    code = main(
+        [
+            "diagnostics",
+            "history-lens",
+            "--records",
+            str(loop / "records.json"),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert captured.out == ""
+    assert "input path cannot be resolved safely" in captured.err
+    assert "Traceback" not in captured.err
+
+
 def test_json_inputs_reject_symbolic_links(tmp_path, capsys):
     target = _write_json(tmp_path / "records.json", [])
     link = tmp_path / "records-link.json"

--- a/merger/repoground/tests/test_cli_diagnostics.py
+++ b/merger/repoground/tests/test_cli_diagnostics.py
@@ -477,3 +477,70 @@ def test_answer_delta_rejects_invalid_citation_map_records_without_traceback(
     assert captured.out == ""
     assert expected_error in captured.err
     assert "Traceback" not in captured.err
+
+
+@pytest.mark.parametrize(
+    ("declaration", "expected_error"),
+    [
+        (
+            {"used_citations": {}, "used_ranges": [{"range_ref": {}}]},
+            "old declaration field 'used_citations' must be a JSON list",
+        ),
+        (
+            {"used_ranges": {}},
+            "old declaration field 'used_ranges' must be a JSON list",
+        ),
+        (
+            {"used_citations": [1]},
+            "old declaration used_citations[0] must be JSON dict, got int",
+        ),
+        (
+            {"used_ranges": [1]},
+            "old declaration used_ranges[0] must be JSON dict, got int",
+        ),
+        (
+            {"used_citations": [{}]},
+            "old declaration used_citations[0] field 'citation_id' must be a non-empty string",
+        ),
+        (
+            {"used_citations": [{"citation_id": 7}]},
+            "old declaration used_citations[0] field 'citation_id' must be a non-empty string",
+        ),
+        (
+            {"used_citations": [{"citation_id": ""}]},
+            "old declaration used_citations[0] field 'citation_id' must be a non-empty string",
+        ),
+        (
+            {"used_ranges": [{}]},
+            "old declaration used_ranges[0] field 'range_ref' must be a JSON object",
+        ),
+        (
+            {"used_ranges": [{"range_ref": []}]},
+            "old declaration used_ranges[0] field 'range_ref' must be a JSON object",
+        ),
+    ],
+)
+def test_answer_delta_rejects_malformed_declaration_evidence_without_traceback(
+    tmp_path,
+    capsys,
+    declaration,
+    expected_error,
+):
+    declaration_path = _write_json(tmp_path / "declaration.json", declaration)
+
+    code = main(
+        [
+            "diagnostics",
+            "answer-delta",
+            "--old-declaration",
+            str(declaration_path),
+            "--new-bundle-manifest",
+            "bundle.manifest.json",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert captured.out == ""
+    assert expected_error in captured.err
+    assert "Traceback" not in captured.err

--- a/merger/repoground/tests/test_cli_diagnostics.py
+++ b/merger/repoground/tests/test_cli_diagnostics.py
@@ -370,6 +370,8 @@ def test_eval_report_rejects_non_object_index_records_without_traceback(
         ("query", 7, "['query'] to be a string"),
         ("expected", "src/auth/session.py", "['expected'] to be a list of strings"),
         ("expected", [7], "['expected'][0] to be a string"),
+        ("expected", [""], "['expected'][0] to be a non-empty string"),
+        ("expected", ["   "], "['expected'][0] to be a non-empty string"),
         ("is_relevant", "false", "['is_relevant'] to be a boolean"),
         ("found_count", "0", "['found_count'] to be an integer"),
         ("found_count", True, "['found_count'] to be an integer"),
@@ -380,6 +382,8 @@ def test_eval_report_rejects_non_object_index_records_without_traceback(
             "['top_results'] to be a list of strings",
         ),
         ("top_results", [7], "['top_results'][0] to be a string"),
+        ("top_results", [""], "['top_results'][0] to be a non-empty string"),
+        ("top_results", ["   "], "['top_results'][0] to be a non-empty string"),
     ],
 )
 def test_eval_report_rejects_invalid_detail_field_types_without_traceback(

--- a/merger/repoground/tests/test_cli_diagnostics.py
+++ b/merger/repoground/tests/test_cli_diagnostics.py
@@ -5,14 +5,29 @@ from pathlib import Path
 
 import pytest
 
-from merger.repoground.core import answer_grounding_delta
+from merger.repoground.cli import cmd_diagnostics
 from merger.repoground.cli.main import main
+from merger.repoground.core import answer_grounding_delta
 from merger.repoground.retrieval import diagnostics_json, eval_diagnostics_integration
 
 
 def _write_json(path: Path, value: object) -> Path:
     path.write_text(json.dumps(value), encoding="utf-8")
     return path
+
+
+def _write_bundle_manifest(path: Path) -> Path:
+    return _write_json(
+        path,
+        {
+            "kind": "repolens.bundle.manifest",
+            "version": "1.0",
+            "run_id": "diagnostics-test",
+            "artifacts": [],
+            "links": {},
+            "capabilities": {},
+        },
+    )
 
 
 def _run(capsys, args: list[str]) -> tuple[int, dict]:
@@ -171,23 +186,34 @@ def test_answer_delta_cli_delegates_to_read_only_domain_surface(
     tmp_path, capsys, monkeypatch
 ):
     declaration = _write_json(tmp_path / "declaration.json", {"used_citations": []})
+    manifest = _write_bundle_manifest(tmp_path / "bundle.manifest.json")
     citation_map = tmp_path / "citations.jsonl"
     citation_map.write_text(
         json.dumps({"citation_id": "cit_0000000000000001"}) + "\n",
         encoding="utf-8",
     )
     seen = {}
+    manifest_reads = 0
+    real_read_input_payload = cmd_diagnostics._read_input_payload
+
+    def tracked_read_input_payload(path_value):
+        nonlocal manifest_reads
+        if Path(path_value) == manifest:
+            manifest_reads += 1
+        return real_read_input_payload(path_value)
 
     def fake_check(
         value,
         *,
         new_bundle_manifest,
+        new_bundle_manifest_data,
         new_citation_map,
         new_citation_entries,
     ):
         seen.update(
             value=value,
             manifest=new_bundle_manifest,
+            manifest_data=new_bundle_manifest_data,
             citation_map=new_citation_map,
             citation_entries=new_citation_entries,
         )
@@ -195,6 +221,11 @@ def test_answer_delta_cli_delegates_to_read_only_domain_surface(
 
     monkeypatch.setattr(
         answer_grounding_delta, "check_answer_grounding_delta", fake_check
+    )
+    monkeypatch.setattr(
+        cmd_diagnostics,
+        "_read_input_payload",
+        tracked_read_input_payload,
     )
 
     code, result = _run(
@@ -204,7 +235,7 @@ def test_answer_delta_cli_delegates_to_read_only_domain_surface(
             "--old-declaration",
             str(declaration),
             "--new-bundle-manifest",
-            "bundle.manifest.json",
+            str(manifest),
             "--new-citation-map",
             str(citation_map),
         ],
@@ -212,14 +243,159 @@ def test_answer_delta_cli_delegates_to_read_only_domain_surface(
 
     assert code == 0
     assert result["status"] == "valid"
+    assert manifest_reads == 1
     assert seen == {
         "value": {"used_citations": []},
-        "manifest": "bundle.manifest.json",
+        "manifest": str(manifest),
+        "manifest_data": {
+            "kind": "repolens.bundle.manifest",
+            "version": "1.0",
+            "run_id": "diagnostics-test",
+            "artifacts": [],
+            "links": {},
+            "capabilities": {},
+        },
         "citation_map": str(citation_map),
         "citation_entries": {
             "cit_0000000000000001": {"citation_id": "cit_0000000000000001"}
         },
     }
+
+
+def test_answer_delta_requires_citation_map_for_declared_citations(
+    tmp_path,
+    capsys,
+):
+    declaration = _write_json(
+        tmp_path / "declaration.json",
+        {"used_citations": [{"citation_id": "cit_0000000000000001"}]},
+    )
+
+    code = main(
+        [
+            "diagnostics",
+            "answer-delta",
+            "--old-declaration",
+            str(declaration),
+            "--new-bundle-manifest",
+            "not-read.bundle.manifest.json",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert captured.out == ""
+    assert (
+        "--new-citation-map is required when old declaration "
+        "used_citations is non-empty"
+    ) in captured.err
+    assert "Traceback" not in captured.err
+
+
+@pytest.mark.parametrize("declaration", [{}, {"used_citations": []}])
+def test_answer_delta_allows_empty_or_missing_citations_without_map(
+    tmp_path,
+    capsys,
+    declaration,
+):
+    declaration_path = _write_json(tmp_path / "declaration.json", declaration)
+    manifest = _write_bundle_manifest(tmp_path / "bundle.manifest.json")
+
+    code, result = _run(
+        capsys,
+        [
+            "answer-delta",
+            "--old-declaration",
+            str(declaration_path),
+            "--new-bundle-manifest",
+            str(manifest),
+        ],
+    )
+
+    assert code == 0
+    assert result["status"] == "not_comparable"
+
+
+def test_answer_delta_manifest_rejects_symbolic_link_without_traceback(
+    tmp_path,
+    capsys,
+):
+    declaration = _write_json(tmp_path / "declaration.json", {})
+    target = _write_bundle_manifest(tmp_path / "bundle.manifest.json")
+    link = tmp_path / "bundle-link.manifest.json"
+    link.symlink_to(target)
+
+    code = main(
+        [
+            "diagnostics",
+            "answer-delta",
+            "--old-declaration",
+            str(declaration),
+            "--new-bundle-manifest",
+            str(link),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert captured.out == ""
+    assert "refusing symbolic-link input" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_answer_delta_manifest_rejects_non_finite_json_without_traceback(
+    tmp_path,
+    capsys,
+):
+    declaration = _write_json(tmp_path / "declaration.json", {})
+    manifest = tmp_path / "bundle.manifest.json"
+    manifest.write_text(
+        '{"kind":"repolens.bundle.manifest","diagnostic_value":NaN}',
+        encoding="utf-8",
+    )
+
+    code = main(
+        [
+            "diagnostics",
+            "answer-delta",
+            "--old-declaration",
+            str(declaration),
+            "--new-bundle-manifest",
+            str(manifest),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert captured.out == ""
+    assert "non-finite JSON constant 'NaN'" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_answer_delta_manifest_rejects_oversized_input_without_traceback(
+    tmp_path,
+    capsys,
+):
+    declaration = _write_json(tmp_path / "declaration.json", {})
+    manifest = tmp_path / "bundle.manifest.json"
+    manifest.write_bytes(b"x" * (cmd_diagnostics._MAX_JSON_BYTES + 1))
+
+    code = main(
+        [
+            "diagnostics",
+            "answer-delta",
+            "--old-declaration",
+            str(declaration),
+            "--new-bundle-manifest",
+            str(manifest),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert captured.out == ""
+    assert f"input exceeds {cmd_diagnostics._MAX_JSON_BYTES} bytes" in captured.err
+    assert "Traceback" not in captured.err
 
 
 def test_eval_report_cli_delegates_without_changing_metrics(

--- a/merger/repoground/tests/test_cli_diagnostics.py
+++ b/merger/repoground/tests/test_cli_diagnostics.py
@@ -186,7 +186,11 @@ def test_answer_delta_cli_delegates_to_read_only_domain_surface(
     tmp_path, capsys, monkeypatch
 ):
     declaration = _write_json(tmp_path / "declaration.json", {"used_citations": []})
-    manifest = _write_bundle_manifest(tmp_path / "bundle.manifest.json")
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    manifest = _write_bundle_manifest(bundle_dir / "bundle.manifest.json")
+    bundle_link = tmp_path / "bundle-link"
+    bundle_link.symlink_to(bundle_dir, target_is_directory=True)
     citation_map = tmp_path / "citations.jsonl"
     citation_map.write_text(
         json.dumps({"citation_id": "cit_0000000000000001"}) + "\n",
@@ -198,9 +202,10 @@ def test_answer_delta_cli_delegates_to_read_only_domain_surface(
 
     def tracked_read_input_payload(path_value):
         nonlocal manifest_reads
-        if Path(path_value) == manifest:
+        anchored_path, payload = real_read_input_payload(path_value)
+        if anchored_path == manifest:
             manifest_reads += 1
-        return real_read_input_payload(path_value)
+        return anchored_path, payload
 
     def fake_check(
         value,
@@ -227,6 +232,7 @@ def test_answer_delta_cli_delegates_to_read_only_domain_surface(
         "_read_input_payload",
         tracked_read_input_payload,
     )
+    monkeypatch.chdir(tmp_path)
 
     code, result = _run(
         capsys,
@@ -235,7 +241,7 @@ def test_answer_delta_cli_delegates_to_read_only_domain_surface(
             "--old-declaration",
             str(declaration),
             "--new-bundle-manifest",
-            str(manifest),
+            str(Path(bundle_link.name) / manifest.name),
             "--new-citation-map",
             str(citation_map),
         ],
@@ -246,7 +252,7 @@ def test_answer_delta_cli_delegates_to_read_only_domain_surface(
     assert manifest_reads == 1
     assert seen == {
         "value": {"used_citations": []},
-        "manifest": str(manifest),
+        "manifest": manifest,
         "manifest_data": {
             "kind": "repolens.bundle.manifest",
             "version": "1.0",

--- a/merger/repoground/tests/test_cli_diagnostics.py
+++ b/merger/repoground/tests/test_cli_diagnostics.py
@@ -171,13 +171,25 @@ def test_answer_delta_cli_delegates_to_read_only_domain_surface(
     tmp_path, capsys, monkeypatch
 ):
     declaration = _write_json(tmp_path / "declaration.json", {"used_citations": []})
+    citation_map = tmp_path / "citations.jsonl"
+    citation_map.write_text(
+        json.dumps({"citation_id": "cit_0000000000000001"}) + "\n",
+        encoding="utf-8",
+    )
     seen = {}
 
-    def fake_check(value, *, new_bundle_manifest, new_citation_map):
+    def fake_check(
+        value,
+        *,
+        new_bundle_manifest,
+        new_citation_map,
+        new_citation_entries,
+    ):
         seen.update(
             value=value,
             manifest=new_bundle_manifest,
             citation_map=new_citation_map,
+            citation_entries=new_citation_entries,
         )
         return {"kind": "repobrief.answer_grounding_delta_verdict", "status": "valid"}
 
@@ -194,7 +206,7 @@ def test_answer_delta_cli_delegates_to_read_only_domain_surface(
             "--new-bundle-manifest",
             "bundle.manifest.json",
             "--new-citation-map",
-            "citations.jsonl",
+            str(citation_map),
         ],
     )
 
@@ -203,7 +215,10 @@ def test_answer_delta_cli_delegates_to_read_only_domain_surface(
     assert seen == {
         "value": {"used_citations": []},
         "manifest": "bundle.manifest.json",
-        "citation_map": "citations.jsonl",
+        "citation_map": str(citation_map),
+        "citation_entries": {
+            "cit_0000000000000001": {"citation_id": "cit_0000000000000001"}
+        },
     }
 
 
@@ -393,6 +408,67 @@ def test_eval_report_rejects_invalid_detail_field_types_without_traceback(
             "eval-report",
             "--eval-results",
             str(eval_results),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert captured.out == ""
+    assert expected_error in captured.err
+    assert "Traceback" not in captured.err
+
+
+@pytest.mark.parametrize(
+    ("citation_line", "expected_error"),
+    [
+        ("[]", "citation map line 1 must be a JSON object"),
+        (
+            json.dumps({"citation_id": 7}),
+            "citation map line 1 field 'citation_id' must be a non-empty string",
+        ),
+        (
+            json.dumps({}),
+            "citation map line 1 field 'citation_id' must be a non-empty string",
+        ),
+        (
+            json.dumps({"citation_id": ""}),
+            "citation map line 1 field 'citation_id' must be a non-empty string",
+        ),
+        (
+            "\n".join(
+                [
+                    json.dumps({"citation_id": "duplicate"}),
+                    json.dumps({"citation_id": "duplicate"}),
+                ]
+            ),
+            "citation map line 2 duplicates citation_id 'duplicate'",
+        ),
+        ("{", "citation map line 1 must be valid JSON"),
+    ],
+)
+def test_answer_delta_rejects_invalid_citation_map_records_without_traceback(
+    tmp_path,
+    capsys,
+    citation_line,
+    expected_error,
+):
+    declaration = _write_json(
+        tmp_path / "declaration.json",
+        {"used_citations": [{"citation_id": "cit_0000000000000001"}]},
+    )
+    citation_map = tmp_path / "citations.jsonl"
+    citation_map.write_text(citation_line + "\n", encoding="utf-8")
+
+    code = main(
+        [
+            "diagnostics",
+            "answer-delta",
+            "--old-declaration",
+            str(declaration),
+            "--new-bundle-manifest",
+            "bundle.manifest.json",
+            "--new-citation-map",
+            str(citation_map),
         ]
     )
     captured = capsys.readouterr()

--- a/merger/repoground/tests/test_cli_diagnostics.py
+++ b/merger/repoground/tests/test_cli_diagnostics.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from merger.repoground.core import answer_grounding_delta
+from merger.repoground.retrieval import eval_diagnostics_integration
+from merger.repoground.cli.main import main
+
+
+def _write_json(path: Path, value: object) -> Path:
+    path.write_text(json.dumps(value), encoding="utf-8")
+    return path
+
+
+def _run(capsys, args: list[str]) -> tuple[int, dict]:
+    code = main(["diagnostics", *args])
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    return code, json.loads(captured.out)
+
+
+def _range(content_hash: str = "a" * 64) -> dict:
+    return {
+        "file_path": "demo.md",
+        "start_byte": 0,
+        "end_byte": 12,
+        "start_line": 1,
+        "end_line": 2,
+        "content_sha256": content_hash,
+    }
+
+
+def test_diagnostics_help_is_forwarded_to_the_lazy_parser(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        main(["diagnostics", "--help"])
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 0
+    assert "answer-delta" in captured.out
+    assert captured.err == ""
+
+
+def test_history_lens_is_available_as_explicit_cli(tmp_path, capsys):
+    records = _write_json(
+        tmp_path / "records.json",
+        [
+            {"commit": "a" * 40, "path": "src/a.py", "author": "Ada"},
+            {"commit": "b" * 40, "path": "src/a.py", "author": "Bob"},
+        ],
+    )
+
+    code, result = _run(
+        capsys,
+        ["history-lens", "--records", str(records), "--profile", "summary"],
+    )
+
+    assert code == 0
+    assert result["kind"] == "repobrief.history_lens"
+    assert result["canonical_content_truth"] is False
+    assert result["file_churn"] == [
+        {"commit_count": 2, "navigation_only": True, "path": "src/a.py"}
+    ]
+
+
+def test_memory_build_and_recall_are_available_as_explicit_cli(tmp_path, capsys):
+    citations = [
+        {
+            "citation_id": "cit_0000000000000001",
+            "source_range": _range(),
+        }
+    ]
+    citations_path = _write_json(tmp_path / "citations.json", citations)
+
+    code, record = _run(
+        capsys,
+        [
+            "memory-build",
+            "--claim-text",
+            "Claims require fresh citations.",
+            "--citations",
+            str(citations_path),
+            "--snapshot-stem",
+            "demo-snapshot",
+            "--snapshot-hash",
+            "b" * 64,
+            "--freshness-status",
+            "fresh",
+        ],
+    )
+    assert code == 0
+    assert record["kind"] == "repobrief.agent_memory_claim"
+
+    record_path = _write_json(tmp_path / "memory.json", record)
+    code, recall = _run(
+        capsys,
+        [
+            "memory-check",
+            "--memory-record",
+            str(record_path),
+            "--current-citations",
+            str(citations_path),
+            "--current-snapshot-hash",
+            "b" * 64,
+            "--current-freshness-status",
+            "fresh",
+        ],
+    )
+
+    assert code == 0
+    assert recall["status"] == "usable"
+    assert recall["usable_as_source_backed_memory"] is True
+    assert recall["memory_is_source_truth"] is False
+
+
+def test_audit_plan_and_finding_adapter_are_available_as_explicit_cli(tmp_path, capsys):
+    code, plan = _run(
+        capsys,
+        [
+            "audit-plan",
+            "--changed-path",
+            "src/auth/session.py",
+            "--review-query",
+            "permission boundary",
+        ],
+    )
+    assert code == 0
+    assert plan["version"] == "audit_lane_plan.v1"
+    assert plan["authority"] == "navigation_index"
+
+    citation_id = "cit_0000000000000001"
+    plan_path = _write_json(tmp_path / "plan.json", plan)
+    candidates_path = _write_json(
+        tmp_path / "candidates.json",
+        [
+            {
+                "lane_id": plan["lanes"][0]["id"],
+                "claim": "The authority boundary needs independent verification.",
+                "citation_ids": [citation_id],
+            }
+        ],
+    )
+    citation_ids_path = _write_json(tmp_path / "citation-ids.json", [citation_id])
+
+    code, findings = _run(
+        capsys,
+        [
+            "audit-findings",
+            "--plan",
+            str(plan_path),
+            "--candidates",
+            str(candidates_path),
+            "--reviewed-revision",
+            "c" * 40,
+            "--current-revision",
+            "c" * 40,
+            "--citation-ids",
+            str(citation_ids_path),
+        ],
+    )
+
+    assert code == 0
+    assert findings["version"] == "audit_finding_set.v2"
+    assert findings["revision_fresh"] is True
+    assert findings["findings"][0]["state"] == "candidate"
+
+
+def test_answer_delta_cli_delegates_to_read_only_domain_surface(
+    tmp_path, capsys, monkeypatch
+):
+    declaration = _write_json(tmp_path / "declaration.json", {"used_citations": []})
+    seen = {}
+
+    def fake_check(value, *, new_bundle_manifest, new_citation_map):
+        seen.update(
+            value=value,
+            manifest=new_bundle_manifest,
+            citation_map=new_citation_map,
+        )
+        return {"kind": "repobrief.answer_grounding_delta_verdict", "status": "valid"}
+
+    monkeypatch.setattr(
+        answer_grounding_delta, "check_answer_grounding_delta", fake_check
+    )
+
+    code, result = _run(
+        capsys,
+        [
+            "answer-delta",
+            "--old-declaration",
+            str(declaration),
+            "--new-bundle-manifest",
+            "bundle.manifest.json",
+            "--new-citation-map",
+            "citations.jsonl",
+        ],
+    )
+
+    assert code == 0
+    assert result["status"] == "valid"
+    assert seen == {
+        "value": {"used_citations": []},
+        "manifest": "bundle.manifest.json",
+        "citation_map": "citations.jsonl",
+    }
+
+
+def test_eval_report_cli_delegates_without_changing_metrics(
+    tmp_path, capsys, monkeypatch
+):
+    eval_results = _write_json(
+        tmp_path / "eval.json",
+        {"metrics": {"recall@10": 50.0}, "details": []},
+    )
+    seen = {}
+
+    def fake_integrate(value, *, index_path, canonical_path, citation_path):
+        seen.update(
+            value=value,
+            index_path=index_path,
+            canonical_path=canonical_path,
+            citation_path=citation_path,
+        )
+        return {"eval_results": value, "diagnostics_report": {"status": "diagnostic"}}
+
+    monkeypatch.setattr(
+        eval_diagnostics_integration,
+        "integrate_diagnostics_with_eval_results",
+        fake_integrate,
+    )
+
+    code, result = _run(
+        capsys,
+        [
+            "eval-report",
+            "--eval-results",
+            str(eval_results),
+            "--index",
+            "chunk-index.jsonl",
+        ],
+    )
+
+    assert code == 0
+    assert result["eval_results"]["metrics"]["recall@10"] == 50.0
+    assert seen["index_path"] == Path("chunk-index.jsonl")
+    assert seen["canonical_path"] is None
+    assert seen["citation_path"] is None
+
+
+def test_json_inputs_reject_symbolic_links(tmp_path, capsys):
+    target = _write_json(tmp_path / "records.json", [])
+    link = tmp_path / "records-link.json"
+    link.symlink_to(target)
+
+    code = main(
+        [
+            "diagnostics",
+            "history-lens",
+            "--records",
+            str(link),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert captured.out == ""
+    assert "refusing symbolic-link input" in captured.err

--- a/merger/repoground/tests/test_cli_diagnostics.py
+++ b/merger/repoground/tests/test_cli_diagnostics.py
@@ -446,6 +446,30 @@ def test_eval_report_cli_delegates_without_changing_metrics(
     assert seen["citation_path"] is None
 
 
+def test_eval_report_stdout_is_byte_stable(tmp_path, capsys):
+    eval_results = _write_json(
+        tmp_path / "eval.json",
+        {"metrics": {"recall@10": 100.0}, "details": []},
+    )
+    args = [
+        "diagnostics",
+        "eval-report",
+        "--eval-results",
+        str(eval_results),
+    ]
+
+    first_code = main(args)
+    first = capsys.readouterr()
+    second_code = main(args)
+    second = capsys.readouterr()
+
+    assert first_code == second_code == 0
+    assert first.err == second.err == ""
+    assert first.out == second.out
+    payload = json.loads(first.out)
+    assert "timestamp" not in payload["diagnostics_report"]["metadata"]
+
+
 def test_json_inputs_reject_symbolic_links(tmp_path, capsys):
     target = _write_json(tmp_path / "records.json", [])
     link = tmp_path / "records-link.json"

--- a/merger/repoground/tests/test_cli_diagnostics.py
+++ b/merger/repoground/tests/test_cli_diagnostics.py
@@ -347,3 +347,57 @@ def test_eval_report_rejects_non_object_index_records_without_traceback(
     assert captured.out == ""
     assert "chunk index line 1 must be a JSON object" in captured.err
     assert "Traceback" not in captured.err
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected_error"),
+    [
+        ("query", 7, "['query'] to be a string"),
+        ("expected", "src/auth/session.py", "['expected'] to be a list of strings"),
+        ("expected", [7], "['expected'][0] to be a string"),
+        ("is_relevant", "false", "['is_relevant'] to be a boolean"),
+        ("found_count", "0", "['found_count'] to be an integer"),
+        ("found_count", True, "['found_count'] to be an integer"),
+        ("found_count", -1, "['found_count'] to be non-negative"),
+        (
+            "top_results",
+            "src/auth/session.py",
+            "['top_results'] to be a list of strings",
+        ),
+        ("top_results", [7], "['top_results'][0] to be a string"),
+    ],
+)
+def test_eval_report_rejects_invalid_detail_field_types_without_traceback(
+    tmp_path,
+    capsys,
+    field,
+    value,
+    expected_error,
+):
+    detail = {
+        "query": "session authority",
+        "expected": ["src/auth/session.py"],
+        "is_relevant": False,
+        "found_count": 0,
+        "top_results": [],
+    }
+    detail[field] = value
+    eval_results = _write_json(
+        tmp_path / "eval.json",
+        {"metrics": {"recall@10": 0.0}, "details": [detail]},
+    )
+
+    code = main(
+        [
+            "diagnostics",
+            "eval-report",
+            "--eval-results",
+            str(eval_results),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert captured.out == ""
+    assert expected_error in captured.err
+    assert "Traceback" not in captured.err

--- a/merger/repoground/tests/test_cli_diagnostics.py
+++ b/merger/repoground/tests/test_cli_diagnostics.py
@@ -267,3 +267,83 @@ def test_json_inputs_reject_symbolic_links(tmp_path, capsys):
     assert code == 2
     assert captured.out == ""
     assert "refusing symbolic-link input" in captured.err
+
+
+def test_history_lens_rejects_non_object_records_without_traceback(tmp_path, capsys):
+    records = _write_json(tmp_path / "records.json", [1])
+
+    code = main(
+        [
+            "diagnostics",
+            "history-lens",
+            "--records",
+            str(records),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert captured.out == ""
+    assert "records[0] must be JSON dict, got int" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_eval_report_rejects_non_object_details_without_traceback(tmp_path, capsys):
+    eval_results = _write_json(
+        tmp_path / "eval.json",
+        {"metrics": {}, "details": [1]},
+    )
+
+    code = main(
+        [
+            "diagnostics",
+            "eval-report",
+            "--eval-results",
+            str(eval_results),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert captured.out == ""
+    assert "Expected retrieval_eval['details'][0] to be an object" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_eval_report_rejects_non_object_index_records_without_traceback(
+    tmp_path, capsys
+):
+    eval_results = _write_json(
+        tmp_path / "eval.json",
+        {
+            "metrics": {"recall@10": 0.0},
+            "details": [
+                {
+                    "query": "session authority",
+                    "expected": ["src/auth/session.py"],
+                    "is_relevant": False,
+                    "found_count": 0,
+                    "top_results": [],
+                }
+            ],
+        },
+    )
+    index = tmp_path / "chunk-index.jsonl"
+    index.write_text("[]\n", encoding="utf-8")
+
+    code = main(
+        [
+            "diagnostics",
+            "eval-report",
+            "--eval-results",
+            str(eval_results),
+            "--index",
+            str(index),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert captured.out == ""
+    assert "chunk index line 1 must be a JSON object" in captured.err
+    assert "Traceback" not in captured.err

--- a/merger/repoground/tests/test_retrieval_eval_diagnostics.py
+++ b/merger/repoground/tests/test_retrieval_eval_diagnostics.py
@@ -289,6 +289,38 @@ class TestIntegrationExtraction:
         assert misses[0]["rank_in_results"] == 2
         assert misses[0]["top_k"] == 1
 
+    def test_query_execution_error_is_diagnostic_inconclusive(
+        self, tmp_artifacts
+    ):
+        eval_results = {
+            "metrics": {"recall@10": 0.0},
+            "details": [
+                {
+                    "query": "find merge",
+                    "expected": ["merger/repoground/core/merge.py"],
+                    "is_relevant": False,
+                    "found_count": 0,
+                    "top_results": [],
+                    "error": "backend unavailable",
+                    "why_fail": "query execution failed",
+                }
+            ],
+        }
+
+        misses = _extract_misses_from_eval(eval_results)
+        report = RetrievalEvalDiagnosticsCalibrator(
+            index_path=tmp_artifacts["index"]
+        ).generate_report(misses)
+
+        assert misses[0]["query_error"] == "backend unavailable"
+        diagnosis = report["diagnostics"][0]
+        assert diagnosis["primary_diagnosis"] == "diagnostic_inconclusive"
+        assert diagnosis["primary_diagnosis"] != "target_exists_not_in_top_k"
+        assert diagnosis["diagnosis_details"]["confidence"] == "low"
+        assert "query execution failed" in diagnosis["diagnosis_details"][
+            "instrumentation_notes"
+        ]
+
     def test_extract_rejects_legacy_results_key(self):
         eval_results = {
             "metrics": {},
@@ -597,9 +629,16 @@ class TestRetrievalEvalDiagnosticsCalibrator:
             / "retrieval-eval-diagnostics.v1.schema.json"
         )
         schema = json.loads(schema_path.read_text(encoding="utf-8"))
-        jsonschema.validate(instance=report, schema=schema)
+        jsonschema.validate(
+            instance=report,
+            schema=schema,
+            format_checker=jsonschema.FormatChecker(),
+        )
 
-    @pytest.mark.parametrize("timestamp", ["", "   ", 7])
+    @pytest.mark.parametrize(
+        "timestamp",
+        ["", "   ", 7, "not-a-date", "2026-05-26T12:00:00"],
+    )
     def test_report_rejects_invalid_optional_timestamp(
         self, tmp_artifacts, timestamp
     ):
@@ -609,7 +648,7 @@ class TestRetrievalEvalDiagnosticsCalibrator:
 
         with pytest.raises(
             ValueError,
-            match="timestamp must be a non-empty string when provided",
+            match="timestamp must be an RFC 3339 date-time when provided",
         ):
             calibrator.generate_report([], timestamp=timestamp)
 

--- a/merger/repoground/tests/test_retrieval_eval_diagnostics.py
+++ b/merger/repoground/tests/test_retrieval_eval_diagnostics.py
@@ -289,6 +289,35 @@ class TestIntegrationExtraction:
         assert misses[0]["rank_in_results"] == 2
         assert misses[0]["top_k"] == 1
 
+    def test_extract_ignores_nonpositive_inferred_top_k(self, tmp_artifacts):
+        eval_results = {
+            "metrics": {"recall@0": 0.0},
+            "details": [
+                {
+                    "query": "find merge",
+                    "expected": ["merger/repoground/core/merge.py"],
+                    "is_relevant": False,
+                    "found_count": 0,
+                    "top_results": [],
+                }
+            ],
+        }
+
+        misses = _extract_misses_from_eval(eval_results)
+        report = RetrievalEvalDiagnosticsCalibrator(
+            index_path=tmp_artifacts["index"]
+        ).generate_report(misses)
+        schema_path = (
+            Path(__file__).parents[1]
+            / "contracts"
+            / "retrieval-eval-diagnostics.v1.schema.json"
+        )
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+
+        assert misses[0]["top_k"] is None
+        assert report["diagnostics"][0]["diagnosis_details"]["top_k"] is None
+        jsonschema.validate(instance=report, schema=schema)
+
     def test_index_matching_uses_evaluator_one_way_semantics(self, tmp_path):
         index_path = tmp_path / "chunks.jsonl"
         index_path.write_text(
@@ -351,6 +380,37 @@ class TestIntegrationExtraction:
         assert "query execution failed" in diagnosis["diagnosis_details"][
             "instrumentation_notes"
         ]
+
+    def test_query_execution_error_from_explain_is_diagnostic_inconclusive(
+        self, tmp_artifacts
+    ):
+        eval_results = {
+            "metrics": {"recall@10": 0.0},
+            "details": [
+                {
+                    "query": "find merge",
+                    "expected": ["merger/repoground/core/merge.py"],
+                    "is_relevant": False,
+                    "found_count": 0,
+                    "top_results": [],
+                    "error": "backend unavailable",
+                    "explain": {
+                        "filters": {},
+                        "why_fail": "query execution failed",
+                    },
+                }
+            ],
+        }
+
+        misses = _extract_misses_from_eval(eval_results)
+        report = RetrievalEvalDiagnosticsCalibrator(
+            index_path=tmp_artifacts["index"]
+        ).generate_report(misses)
+
+        assert misses[0]["query_error"] == "backend unavailable"
+        diagnosis = report["diagnostics"][0]
+        assert diagnosis["primary_diagnosis"] == "diagnostic_inconclusive"
+        assert diagnosis["primary_diagnosis"] != "target_exists_not_in_top_k"
 
     def test_extract_rejects_legacy_results_key(self):
         eval_results = {

--- a/merger/repoground/tests/test_retrieval_eval_diagnostics.py
+++ b/merger/repoground/tests/test_retrieval_eval_diagnostics.py
@@ -1,5 +1,6 @@
 """Tests for retrieval evaluation diagnostics calibrator."""
 
+import io
 import json
 from pathlib import Path
 
@@ -111,6 +112,73 @@ class TestIndexInspector:
         inspector = IndexInspector(tmp_artifacts["index"])
         mapping = inspector.load_path_to_chunk_ids()
         assert mapping["merger/repoground/core/merge.py"] == {"c1"}
+
+    def test_index_views_share_one_read_generation(self, monkeypatch, tmp_path):
+        index_path = tmp_path / "chunks.jsonl"
+        first_generation = (
+            json.dumps({"chunk_id": "c1", "path": "src/first.py"}) + "\n"
+        )
+        second_generation = (
+            json.dumps({"chunk_id": "c2", "path": "src/second.py"}) + "\n"
+        )
+        generations = [first_generation, second_generation]
+        open_count = 0
+        real_open = open
+
+        def generation_open(path, *args, **kwargs):
+            nonlocal open_count
+            if Path(path) == index_path:
+                payload = generations[min(open_count, len(generations) - 1)]
+                open_count += 1
+                return io.StringIO(payload)
+            return real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", generation_open)
+        calibrator = RetrievalEvalDiagnosticsCalibrator(index_path=index_path)
+
+        report = calibrator.generate_report([])
+
+        assert open_count == 1
+        assert calibrator._index_paths == {"src/first.py"}
+        assert calibrator._path_to_chunk_ids == {"src/first.py": {"c1"}}
+        assert report["metadata"]["index_stats"] == {
+            "total_chunks": 1,
+            "total_paths": 1,
+            "canonical_md_exists": False,
+            "citation_map_exists": False,
+        }
+
+    def test_force_reload_replaces_both_index_views_from_one_generation(
+        self, monkeypatch, tmp_path
+    ):
+        index_path = tmp_path / "chunks.jsonl"
+        generations = [
+            json.dumps({"chunk_id": "c1", "path": "src/first.py"}) + "\n",
+            json.dumps({"chunk_id": "c2", "path": "src/second.py"}) + "\n",
+        ]
+        open_count = 0
+        real_open = open
+
+        def generation_open(path, *args, **kwargs):
+            nonlocal open_count
+            if Path(path) == index_path:
+                payload = generations[min(open_count, len(generations) - 1)]
+                open_count += 1
+                return io.StringIO(payload)
+            return real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", generation_open)
+        inspector = IndexInspector(index_path)
+
+        assert inspector.load_index_paths() == {"src/first.py"}
+        assert inspector.load_path_to_chunk_ids() == {"src/first.py": {"c1"}}
+        assert open_count == 1
+
+        assert inspector.load_path_to_chunk_ids(force_reload=True) == {
+            "src/second.py": {"c2"}
+        }
+        assert inspector.load_index_paths() == {"src/second.py"}
+        assert open_count == 2
 
 
 class TestIntegrationExtraction:

--- a/merger/repoground/tests/test_retrieval_eval_diagnostics.py
+++ b/merger/repoground/tests/test_retrieval_eval_diagnostics.py
@@ -492,6 +492,59 @@ class TestRetrievalEvalDiagnosticsCalibrator:
         schema = json.loads(schema_path.read_text(encoding="utf-8"))
         jsonschema.validate(instance=report, schema=schema)
 
+    def test_report_is_byte_stable_without_timestamp(self, tmp_artifacts):
+        calibrator = RetrievalEvalDiagnosticsCalibrator(
+            index_path=tmp_artifacts["index"],
+            canonical_path=tmp_artifacts["canonical"],
+            citation_path=tmp_artifacts["citation"],
+        )
+
+        first = calibrator.generate_report([])
+        second = calibrator.generate_report([])
+
+        assert first == second
+        assert calibrator.to_json(first) == calibrator.to_json(second)
+        assert "timestamp" not in first["metadata"]
+
+        schema_path = (
+            Path(__file__).resolve().parent.parent
+            / "contracts"
+            / "retrieval-eval-diagnostics.v1.schema.json"
+        )
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        jsonschema.validate(instance=first, schema=schema)
+
+    def test_report_preserves_explicit_stable_timestamp(self, tmp_artifacts):
+        calibrator = RetrievalEvalDiagnosticsCalibrator(
+            index_path=tmp_artifacts["index"]
+        )
+        timestamp = "2026-05-26T12:00:00Z"
+
+        report = calibrator.generate_report([], timestamp=timestamp)
+
+        assert report["metadata"]["timestamp"] == timestamp
+        schema_path = (
+            Path(__file__).resolve().parent.parent
+            / "contracts"
+            / "retrieval-eval-diagnostics.v1.schema.json"
+        )
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        jsonschema.validate(instance=report, schema=schema)
+
+    @pytest.mark.parametrize("timestamp", ["", "   ", 7])
+    def test_report_rejects_invalid_optional_timestamp(
+        self, tmp_artifacts, timestamp
+    ):
+        calibrator = RetrievalEvalDiagnosticsCalibrator(
+            index_path=tmp_artifacts["index"]
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="timestamp must be a non-empty string when provided",
+        ):
+            calibrator.generate_report([], timestamp=timestamp)
+
     def test_report_carries_does_not_prove_boundary(self, tmp_artifacts):
         # C1 L3: the diagnostics artifact must carry a machine-readable inference
         # boundary (resolves the C2.4-tracked deferral). The producer emits the

--- a/merger/repoground/tests/test_retrieval_eval_diagnostics.py
+++ b/merger/repoground/tests/test_retrieval_eval_diagnostics.py
@@ -289,6 +289,37 @@ class TestIntegrationExtraction:
         assert misses[0]["rank_in_results"] == 2
         assert misses[0]["top_k"] == 1
 
+    def test_index_matching_uses_evaluator_one_way_semantics(self, tmp_path):
+        index_path = tmp_path / "chunks.jsonl"
+        index_path.write_text(
+            json.dumps({"chunk_id": "c1", "path": "src/foo.py"}) + "\n",
+            encoding="utf-8",
+        )
+        eval_results = {
+            "metrics": {"recall@1": 0.0},
+            "details": [
+                {
+                    "query": "find extended target",
+                    "expected": ["src/foo.py.extra"],
+                    "is_relevant": False,
+                    "found_count": 1,
+                    "top_results": ["src/foo.py"],
+                }
+            ],
+        }
+
+        misses = _extract_misses_from_eval(eval_results)
+        report = RetrievalEvalDiagnosticsCalibrator(
+            index_path=index_path
+        ).generate_report(misses)
+
+        assert report["diagnostics"][0]["primary_diagnosis"] == (
+            "target_missing_from_index"
+        )
+        assert report["diagnostics"][0]["diagnosis_details"][
+            "target_found_in_index"
+        ] is False
+
     def test_query_execution_error_is_diagnostic_inconclusive(
         self, tmp_artifacts
     ):

--- a/merger/repoground/tests/test_retrieval_eval_diagnostics.py
+++ b/merger/repoground/tests/test_retrieval_eval_diagnostics.py
@@ -114,7 +114,7 @@ class TestIndexInspector:
 
 
 class TestIntegrationExtraction:
-    def test_extract_uses_details_structure(self):
+    def test_extracts_only_unmatched_expected_targets_per_query(self):
         eval_results = {
             "metrics": {"total_queries": 2},
             "details": [
@@ -136,10 +136,69 @@ class TestIntegrationExtraction:
         }
 
         misses = _extract_misses_from_eval(eval_results)
-        assert len(misses) == 2
+        assert len(misses) == 1
         assert misses[0]["query_id"] == "q0"
+        assert misses[0]["expected_target"] == "iter_report_blocks"
         assert misses[0]["query_had_zero_hits"] is False
         assert misses[0]["top_k"] == 2
+
+    def test_extracts_partial_hit_even_when_query_is_relevant(self):
+        eval_results = {
+            "metrics": {"recall@2": 50.0},
+            "details": [
+                {
+                    "query": "find both modules",
+                    "expected": ["src/a.py", "src/b.py"],
+                    "is_relevant": True,
+                    "found_count": 1,
+                    "top_results": ["src/a.py"],
+                }
+            ],
+        }
+
+        misses = _extract_misses_from_eval(eval_results)
+
+        assert [miss["expected_target"] for miss in misses] == ["src/b.py"]
+        assert misses[0]["found_in_results"] is False
+        assert misses[0]["rank_in_results"] is None
+
+    def test_extract_skips_complete_hits_within_top_k(self):
+        eval_results = {
+            "metrics": {"recall@2": 100.0},
+            "details": [
+                {
+                    "query": "find both modules",
+                    "expected": ["src/a.py", "src/b.py"],
+                    "is_relevant": False,
+                    "found_count": 2,
+                    "top_results": ["src/a.py", "src/b.py"],
+                }
+            ],
+        }
+
+        assert _extract_misses_from_eval(eval_results) == []
+
+    def test_extract_keeps_found_target_below_configured_top_k_as_miss(self):
+        eval_results = {
+            "metrics": {"recall@1": 0.0},
+            "details": [
+                {
+                    "query": "find target",
+                    "expected": ["src/target.py"],
+                    "is_relevant": True,
+                    "found_count": 2,
+                    "top_results": ["src/noise.py", "src/target.py"],
+                }
+            ],
+        }
+
+        misses = _extract_misses_from_eval(eval_results)
+
+        assert len(misses) == 1
+        assert misses[0]["expected_target"] == "src/target.py"
+        assert misses[0]["found_in_results"] is True
+        assert misses[0]["rank_in_results"] == 2
+        assert misses[0]["top_k"] == 1
 
     def test_extract_rejects_legacy_results_key(self):
         eval_results = {

--- a/merger/repoground/tests/test_retrieval_eval_diagnostics.py
+++ b/merger/repoground/tests/test_retrieval_eval_diagnostics.py
@@ -178,6 +178,27 @@ class TestIntegrationExtraction:
 
         assert _extract_misses_from_eval(eval_results) == []
 
+    def test_extract_does_not_reverse_match_result_inside_expected_target(self):
+        eval_results = {
+            "metrics": {"recall@1": 0.0},
+            "details": [
+                {
+                    "query": "find exact module",
+                    "expected": ["src/foo.py.extra"],
+                    "is_relevant": False,
+                    "found_count": 1,
+                    "top_results": ["src/foo.py"],
+                }
+            ],
+        }
+
+        misses = _extract_misses_from_eval(eval_results)
+
+        assert len(misses) == 1
+        assert misses[0]["expected_target"] == "src/foo.py.extra"
+        assert misses[0]["found_in_results"] is False
+        assert misses[0]["rank_in_results"] is None
+
     def test_extract_keeps_found_target_below_configured_top_k_as_miss(self):
         eval_results = {
             "metrics": {"recall@1": 0.0},


### PR DESCRIPTION
## Aufgabe

Die optionale Retrieval-Evaluationsdiagnostik wird über die CLI verfügbar gemacht und gegen die bestehenden RepoGround-Verträge abgesichert.

## Änderungen

- neue Diagnoseerzeugung für Evaluationsfehlschläge mit deterministischer Primärklassifikation;
- CLI-Unterstützung für Diagnoseberichte, JSON-Ausgabe und Schema-Validierung;
- Schema, Dokumentation, Proofs und Regressionstests ergänzt;
- bereits validierte Manifestdaten werden nicht erneut vom Dateisystem gelesen;
- normale Bundle-Reads verwenden weiterhin die requestweit gebundene Manifest-Snapshot-Garantie aus dem aktuellen `main`.

## Codex-Review-Fixes

- Aus `recall@k` abgeleitete `top_k`-Werte werden nur übernommen, wenn `k > 0`; `recall@0` erzeugt damit keinen schemawidrigen Bericht mehr.
- Der exakte Query-Fehlermarker `query execution failed` wird nun auch aus `detail["explain"]["why_fail"]` gelesen. Producerförmige Ausführungsfehler werden dadurch als `diagnostic_inconclusive` statt fälschlich als Rankingfehler klassifiziert.
- Beide Fälle besitzen producernahe Regressionstests; der `recall@0`-Fall validiert zusätzlich den vollständigen Bericht gegen das kanonische JSON-Schema.

## Main-Abgleich

Der PR wurde konfliktfrei auf den aktuellen Basisstand gebracht. Die Konfliktauflösung erhält beide Sicherheitsverträge:

1. Normale Manifestzugriffe konsumieren den requestweit fixierten Snapshot.
2. Explizit übergebene, bereits geprüfte Manifestdaten werden nicht nochmals eingelesen und behalten ihren geprüften Pfadanker.

## Revisionsbindung

- Basis: `0229516146d50023918e9f4ee904e68479a72e9e`
- Kopf: `043985abc321130b63a928c90ababc700c62f957`
- offene Reviewthreads: `0`
- GitHub-Workflows auf diesem Kopf: `10/10` erfolgreich

## Verifikation

- konfliktnahe Suite einschließlich Manifest-Bindung, Bundle-Zugriff, Range-Auflösung, MCP und Diagnostik: `447 passed, 10 skipped`
- breite lokale Suite außerhalb der bekannten hostgebundenen Sidecar-Grenze: `5052 passed, 12 skipped`
- Ruff für alle 13 geänderten Python-Dateien: PASS
- `git diff --check`: PASS
- GitHub: Test-Suite, Lint, Vertragsprüfungen, Paritätsprüfung, CodeQL und alle weiteren Workflows: PASS

## Bekannte Hostgrenze

Die beiden hostgebundenen Patch-Evaluation-Sidecar-Testdateien bleiben lokal wegen `bwrap: Creating new namespace failed: Resource temporarily unavailable` ausgeklammert. Der Befund ist bereits unter `OPERATOR-PC-HYGIENE-V1-T014` registriert und wird durch diesen PR nicht verändert.

## Umfang

- 18 Dateien
- 3.377 Einfügungen
- 163 Löschungen
- keine Datenmigration

## Prüfdiff

- Download: https://github.com/heimgewebe/repoground/pull/1106.diff
- Größe: `158935` Bytes
- SHA-256: `c536493db4e5100863562907044e751a5c385cf5c6acba9110c6d76f3524a9ab`
- kanonisches Grabowski-Artefakt: `80c78bbdbd334d06a1c110a46d095826`
- Receipt-SHA-256: `962655c8550b0e794f5012c2bbbf793a7e2a084cfd3a5e239c95b9fa6c7ee9ce`

## Rollback

Nach dem Merge kann der PR-Merge-Commit vollständig revertiert werden. Da keine Datenmigration erfolgt, ist kein gesonderter Daten-Rollback nötig.
