### PR TITLE
fix(ci): guard current test stub namespace

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -35,6 +35,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Reject test stub shadow packages
+        run: python scripts/check_no_test_stubs.py
+
       - name: Install dependencies
         run: |
           python -m pip install --disable-pip-version-check --require-hashes -r requirements/repoground-dev.lock.txt

--- a/merger/repoground/tests/test_no_test_stubs_guard.py
+++ b/merger/repoground/tests/test_no_test_stubs_guard.py
@@ -1,0 +1,74 @@
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+GUARD_SOURCE = REPO_ROOT / "scripts" / "check_no_test_stubs.py"
+STUBS_RELATIVE = Path("merger/repoground/tests/stubs")
+
+
+def install_guard(tmp_path: Path) -> tuple[Path, Path]:
+    repo = tmp_path / "repository"
+    script = repo / "scripts" / "check_no_test_stubs.py"
+    script.parent.mkdir(parents=True)
+    shutil.copyfile(GUARD_SOURCE, script)
+    return repo, script
+
+
+def run_guard(script: Path, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(script)],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_rejects_stubs_in_current_repoground_namespace(tmp_path: Path) -> None:
+    repo, script = install_guard(tmp_path)
+    stub = repo / STUBS_RELATIVE / "fastapi" / "__init__.py"
+    stub.parent.mkdir(parents=True)
+    stub.write_text("# forbidden shadow package\n", encoding="utf-8")
+
+    result = run_guard(script, repo)
+
+    assert result.returncode == 1
+    assert f"ERROR: Forbidden path found: {repo / STUBS_RELATIVE}" in result.stdout
+
+
+def test_accepts_repository_without_test_stubs(tmp_path: Path) -> None:
+    repo, script = install_guard(tmp_path)
+
+    result = run_guard(script, repo)
+
+    assert result.returncode == 0
+    assert result.stdout == "OK: No forbidden 'tests/stubs' directory found.\n"
+
+
+def test_resolves_repository_from_script_location_not_working_directory(
+    tmp_path: Path,
+) -> None:
+    repo, script = install_guard(tmp_path)
+    (repo / STUBS_RELATIVE).mkdir(parents=True)
+    unrelated_cwd = tmp_path / "unrelated"
+    unrelated_cwd.mkdir()
+
+    result = run_guard(script, unrelated_cwd)
+
+    assert result.returncode == 1
+    assert str(repo / STUBS_RELATIVE) in result.stdout
+
+
+def test_rejects_dangling_symlink_at_forbidden_path(tmp_path: Path) -> None:
+    repo, script = install_guard(tmp_path)
+    stubs = repo / STUBS_RELATIVE
+    stubs.parent.mkdir(parents=True)
+    stubs.symlink_to(repo / "missing-stub-target", target_is_directory=True)
+
+    result = run_guard(script, repo)
+
+    assert result.returncode == 1
+    assert f"ERROR: Forbidden path found: {stubs}" in result.stdout

--- a/scripts/check_no_test_stubs.py
+++ b/scripts/check_no_test_stubs.py
@@ -2,23 +2,26 @@
 import sys
 from pathlib import Path
 
-def check_no_test_stubs():
-    """
-    Guards against the re-introduction of 'tests/stubs' directory which
-    caused shadowing of real packages (fastapi, pydantic, starlette).
-    """
-    repo_root = Path(__file__).parent.parent
 
-    # Check specifically for tests/stubs
-    stubs_dir = repo_root / "merger" / "lenskit" / "tests" / "stubs"
-    if stubs_dir.exists():
-        print(f"ERROR: Forbidden directory found: {stubs_dir}")
-        print("FAIL: We have decided to abolish extensive stubs in favor of real dependencies.")
-        print("Please remove this directory to prevent import shadowing.")
+FORBIDDEN_STUBS_PATH = Path("merger/repoground/tests/stubs")
+
+
+def check_no_test_stubs() -> None:
+    """Reject the test-stub path that can shadow installed dependencies."""
+    repo_root = Path(__file__).resolve().parent.parent
+    stubs_path = repo_root / FORBIDDEN_STUBS_PATH
+
+    # Path.exists() is false for a dangling symlink. The symlink itself is still
+    # forbidden because replacing its target could silently reactivate shadowing.
+    if stubs_path.exists() or stubs_path.is_symlink():
+        print(f"ERROR: Forbidden path found: {stubs_path}")
+        print("FAIL: Test stubs can shadow installed dependencies.")
+        print("Please remove this path and use the real dependencies instead.")
         sys.exit(1)
 
     print("OK: No forbidden 'tests/stubs' directory found.")
     sys.exit(0)
+
 
 if __name__ == "__main__":
     check_no_test_stubs()


### PR DESCRIPTION
## Summary

- update `scripts/check_no_test_stubs.py` to guard the current `merger/repoground/tests/stubs` namespace instead of the removed Lenskit implementation path
- fail closed for dangling symlinks at the forbidden path
- run the guard explicitly in the full test workflow before dependency installation
- add subprocess-based regression tests against temporary repositories

## Bureau binding

- primary finding: candidate `candidate-c928622467069a4301eb6495`, event `1277`
- duplicate evidence only: candidate `candidate-2b7c47503dec27dfaaea8244`, event `1270`

These two observations describe the same defect and must not become separate canonical tasks.

## Verification

- `python3 scripts/check_no_test_stubs.py` — PASS
- focused pytest — `4 passed`
- Ruff check — PASS
- Ruff format check — PASS
- `git diff --check` — PASS
- broad suite excluding only the two Bubblewrap-dependent host files — `4849 passed, 2 skipped, 13 deselected`
- unfiltered broad suite reached `4859 passed, 2 skipped, 13 deselected`; its 33 failures were all confined to `tests/test_patch_evaluation_sidecar.py` and `tests/test_patch_evaluation_sidecar_host_readback.py` because the host returned `bwrap: Creating new namespace failed: Resource temporarily unavailable`

Base: `40dd1088a642370c5a7cc0dfd19dbd59e6395a35`
Head: `3e04e0276c4c126262cf99d77b21531da5d2224a`
