### PR TITLE
fix(read): avoid max-bound allocation for small artifacts

### DIFF
--- a/docs/proofs/repoground-legacy-t011-bundle-access-v1-proof.md
+++ b/docs/proofs/repoground-legacy-t011-bundle-access-v1-proof.md
@@ -80,7 +80,7 @@ path, size, hash or metadata failure invalidates the citation-map source.
 production modules are 181–580 lines each.
 
 This is a decomposition and hardening slice, not an aggregate-LOC reduction:
-the six production files together contain 4,282 lines. The measurement records
+the six production files together contain 4,287 lines. The measurement records
 that explicitly rather than treating moved or expanded validation code as
 deleted code.
 
@@ -121,11 +121,38 @@ reading, and preserves weak-filesystem identity handling through content-hash
 verification. Existing atomic-replacement and weak-identity tests and the new
 symlink test all pass.
 
+## Same-host performance and allocation closeout
+
+The first acceptance benchmark found a real peak-allocation regression after the
+initial merge: a small manifest read requested `MAX_MANIFEST_BYTES + 1` from the
+buffered stream and transiently allocated about 4.2 MiB instead of about 34 KiB.
+Corrective implementation `38ec6fe335a7c4b1b291f332f599abd7e82a205a` sizes the read from the already
+validated descriptor file size plus one byte, while preserving the hard cap and
+growth detection. A regression test binds the requested read size to the observed
+file rather than the maximum allowance.
+
+The same immutable benchmark script (`SHA-256
+7157a27fcb3203f5921fbe9558b36c7ccf1369968d9a81553fba2b1009c1a51e`) ran on
+`heim-pc`, Python 3.10.12, with nine timing samples and a separate `tracemalloc`
+run. Relative to base `a029bbcd2779e7bed1ac41e936bdf720249f0538`:
+
+| Path | Median delta |
+| --- | ---: |
+| `available_roles` | -26.380% |
+| `list_artifacts` | +5.421% |
+| `get_artifact` | +7.358% |
+| combined sequence | -4.727% |
+| peak traced memory | -0.032% |
+
+All measured final regressions remain below the predeclared 10% threshold; the
+combined path improves and peak allocation returns to base level. The benchmark
+does not claim SQLite-query or large-call-graph performance.
+
 ## Verification
 
 - focused bundle/catalog/freshness/evidence/symbol/call/MCP/adapter/
   maintainability regression: **332 passed, 10 skipped**;
-- new adversarial suite: **20 passed**;
+- new adversarial suite after allocation regression coverage: **21 passed**;
 - changed-file Ruff: **pass**;
 - C901 on all changed production modules: **pass**;
 - graph-maintainability gate: **pass** at 193 findings, max 138, excess 2,348,

--- a/docs/proofs/repoground-legacy-t011-bundle-access.measurement.json
+++ b/docs/proofs/repoground-legacy-t011-bundle-access.measurement.json
@@ -27,7 +27,7 @@
     "extracted_modules": [
       {
         "path": "merger/repoground/core/bounded_artifact_read.py",
-        "lines": 181
+        "lines": 186
       },
       {
         "path": "merger/repoground/core/bundle_roles.py",
@@ -47,7 +47,7 @@
       }
     ],
     "aggregate_product_lines_before": 3676,
-    "aggregate_product_lines_after": 4282,
+    "aggregate_product_lines_after": 4287,
     "aggregate_line_reduction_claimed": false
   },
   "complexity": {
@@ -102,7 +102,7 @@
     "new_adversarial_suite": {
       "path": "merger/repoground/tests/test_bundle_access_decomposition.py",
       "result": "pass",
-      "passed": 20
+      "passed": 21
     },
     "ruff_changed_files": "pass",
     "ruff_c901_changed_modules": "pass",
@@ -149,13 +149,13 @@
   "source_sha256": {
     "config/repoground-c901-baseline.v1.json": "7a848e6b846f2dd8e85d3bf38b8fad5510571521dde580a58e0bab4a8328b7f3",
     "config/repoground-graph-maintainability.v1.json": "ca0923a57b327b74ae3a401581bc9b9415f9e90001efb4d5430dd4fa59c9e927",
-    "merger/repoground/core/bounded_artifact_read.py": "f871fb39819b5c250b678ac42e6c192113ba3ae4e6cca29adde7afb0aeb9d94a",
+    "merger/repoground/core/bounded_artifact_read.py": "ddc3ca7992ab89be8c94c7bd2ccc57c5902dd39601272e159e2959decd7037de",
     "merger/repoground/core/bundle_access.py": "2d942bc8c4a065cfa873bd3d5b2595185c407d4e45f5844b32b71a1f9784762a",
     "merger/repoground/core/bundle_roles.py": "ca07cc1982351f98631c6521f7f4bfd9f4ad123e6d1b09a5331f8ff4158238d8",
     "merger/repoground/core/call_graph_validation.py": "eab8bd3557bf2020e4bdb3b4e6218da012aec267538e30e4135644badbe92930",
     "merger/repoground/core/citation_projection.py": "8d4a9423c08ef3578f1307497dc1b531194f99558f6939dcfb91756e7672a5c2",
     "merger/repoground/core/sqlite_artifact_read.py": "81a06a8123f38de4ee9672a1d405f9c51d94c9d740807d679f63795b3489d04b",
-    "merger/repoground/tests/test_bundle_access_decomposition.py": "487b9514657567050c282da94efa788a4414860fb0520352290bbab9c5e6e32f"
+    "merger/repoground/tests/test_bundle_access_decomposition.py": "2110df07f352ee9344521864244d41431902e7e32bb4b868bd1ca752f2699b88"
   },
   "tool_versions": {
     "python": "3.10.12",
@@ -168,5 +168,70 @@
     "absence of maintainability debt below the C901 threshold",
     "aggregate production line-count reduction",
     "merge readiness"
-  ]
+  ],
+  "performance": {
+    "benchmark": {
+      "script_path": "/tmp/repoground_t011_read_benchmark.py",
+      "script_sha256": "7157a27fcb3203f5921fbe9558b36c7ccf1369968d9a81553fba2b1009c1a51e",
+      "host": "heim-pc",
+      "python": "3.10.12",
+      "loops": 150,
+      "samples": 9,
+      "fixture": {
+        "artifact_count": 12,
+        "artifact_bytes_each": 32768
+      },
+      "timing_method": "median nanoseconds per call across nine samples; import excluded; ten warmups",
+      "memory_method": "separate tracemalloc run over 150 combined sequences",
+      "acceptance_thresholds": {
+        "median_regression_percent_max": 10.0,
+        "peak_memory_regression_percent_max": 10.0
+      }
+    },
+    "base": {
+      "revision": "a029bbcd2779e7bed1ac41e936bdf720249f0538",
+      "timings_median_ns": {
+        "available_roles": 102763.96666666666,
+        "list_artifacts": 1654240.5133333334,
+        "get_artifact": 111288.62,
+        "combined": 1878055.2266666666
+      },
+      "peak_bytes": 33920
+    },
+    "merged_pre_fix": {
+      "revision": "d11f3e04c26738252755bc7332808f03589001be",
+      "timings_median_ns": {
+        "available_roles": 99086.40666666666,
+        "list_artifacts": 1632971.4466666668,
+        "get_artifact": 137310.24,
+        "combined": 1885488.94
+      },
+      "peak_bytes": 4206990,
+      "verdict": "fail",
+      "finding": "small manifests requested max_bytes+1 from the buffered reader and caused a 4 MiB transient allocation"
+    },
+    "corrected": {
+      "implementation_revision": "38ec6fe335a7c4b1b291f332f599abd7e82a205a",
+      "timings_median_ns": {
+        "available_roles": 75654.73333333334,
+        "list_artifacts": 1743917.3333333333,
+        "get_artifact": 119477.67333333334,
+        "combined": 1789284.68
+      },
+      "peak_bytes": 33909,
+      "delta_percent_vs_base": {
+        "available_roles": -26.38,
+        "list_artifacts": 5.421,
+        "get_artifact": 7.358,
+        "combined": -4.727,
+        "peak_memory": -0.032
+      },
+      "verdict": "pass"
+    },
+    "does_not_establish": [
+      "cross-host comparability",
+      "performance of SQLite queries or large call-graph navigation",
+      "absence of regressions outside the measured read facade"
+    ]
+  }
 }

--- a/merger/repoground/core/bounded_artifact_read.py
+++ b/merger/repoground/core/bounded_artifact_read.py
@@ -85,6 +85,11 @@ def declared_artifact_integrity(
     return declared_bytes, declared_sha256, None
 
 
+def _descriptor_read_size(file_size: int, max_bytes: int) -> int:
+    """Read one byte beyond the observed file, never beyond the hard cap."""
+    return min(file_size, max_bytes) + 1
+
+
 def _read_descriptor_bytes(
     path: Path,
     max_bytes: int,
@@ -133,7 +138,7 @@ def _read_descriptor_bytes(
                 return None, None, None, "source_changed", None
             if stat_before.st_size > max_bytes:
                 return None, None, None, "too_large", None
-            raw = stream.read(max_bytes + 1)
+            raw = stream.read(_descriptor_read_size(stat_before.st_size, max_bytes))
             stat_after = os.fstat(stream.fileno())
     except FileNotFoundError:
         return None, None, None, "file_missing", None

--- a/merger/repoground/tests/test_bundle_access_decomposition.py
+++ b/merger/repoground/tests/test_bundle_access_decomposition.py
@@ -10,9 +10,15 @@ import pytest
 from merger.repoground.core import bundle_access
 from merger.repoground.core.bounded_artifact_read import (
     MAX_REGISTERED_ARTIFACT_BYTES,
+    _descriptor_read_size,
     read_stable_regular_file_bytes,
 )
 from merger.repoground.core.manifest_snapshot import MAX_MANIFEST_BYTES
+
+
+def test_descriptor_read_size_tracks_observed_file_not_hard_cap() -> None:
+    assert _descriptor_read_size(128, 4 * 1024 * 1024) == 129
+    assert _descriptor_read_size(4 * 1024 * 1024, 4 * 1024 * 1024) == (4 * 1024 * 1024) + 1
 
 
 def _sha256(raw: bytes) -> str:


### PR DESCRIPTION
Bureau-Task: REPOGROUND-LEGACY-RECONCILIATION-V1-T011

## Befund

Die nach PR #1108 erforderliche gleiche-Host-Acceptance-Messung deckte eine reale Peak-Speicherregression auf: Ein kleines Manifest las mit `stream.read(MAX_MANIFEST_BYTES + 1)` und verursachte dadurch rund 4,2 MiB transienten Peak statt rund 34 KiB.

## Korrektur

- Descriptor-Readgröße wird aus der bereits per `fstat` geprüften Dateigröße plus einem Wachstumsbyte gebildet.
- Der feste Hard-Cap, Oversize-Blockierung, O_NOFOLLOW, Descriptor-/Pfadidentität und Growth-Detection bleiben erhalten.
- Ein Regressionstest bindet die Readgröße an die beobachtete Datei statt an den Maximalwert.
- Proof und maschinenlesbare Messung dokumentieren den zunächst fehlgeschlagenen Lauf und den korrigierten Endstand.

## Same-host-Messung

Basis: `a029bbcd2779e7bed1ac41e936bdf720249f0538`
Korrekturimplementierung: `38ec6fe335a7c4b1b291f332f599abd7e82a205a`
Finaler Head: `0bbb34c9f882d7f78dac17a9801b55ca2e31e6ae`
Benchmark-SHA-256: `7157a27fcb3203f5921fbe9558b36c7ccf1369968d9a81553fba2b1009c1a51e`

- `available_roles`: -26,380 %
- `list_artifacts`: +5,421 %
- `get_artifact`: +7,358 %
- kombinierter Read-Pfad: -4,727 %
- Peak-Speicher: -0,032 %

Alle finalen Regressionen liegen unter der gebundenen 10-%-Grenze; Peak-Speicher liegt wieder auf Basisniveau.

## Verifikation

- gezielte Race-/Allocation-Suite: `24 passed`
- Ruff: PASS
- `git diff --check`: PASS
- breite lokale Suite ohne die zwei separat hostblockierten Bubblewrap-Dateien: `5073 passed, 12 skipped`; GitHub-CI wird vor Merge abgewartet

## Grenze

Dieser PR erweitert keine API und schließt weder Parent T004 noch Bureau T011 allein. T011 wird erst nach grünem Merge-Readback und Registry-Closeout verifiziert.

## Finaler unabhängiger Review

- Ergebnis: PASS, keine umsetzbaren Befunde
- Receipt: `5065360b266b2054d66d1ad7b236625cdd6bb502f20ae3d94e994e2422e60a2a`
- Output-SHA-256: `74a50492dd65630e594a127a886ad85ee1969ac31f95bc59ac0c0fde8dbfc08a`
- Finaler Prüfdiff: `a3a4a481eb3fbc255a3ba2782395a4dc7535161e8735123bf9322c66cad25420` (9794 Bytes)
