### PR TITLE
Paginate contract deletion authorization evidence

### DIFF
--- a/.github/workflows/contracts-validate.yml
+++ b/.github/workflows/contracts-validate.yml
@@ -172,39 +172,18 @@ jobs:
           pr_number="${GH_PR_NUMBER:-}"
           pr_head_sha="${GH_PR_HEAD_SHA:-}"
           pr_base_sha="${GH_PR_BASE_SHA:-}"
-          temporary_files=()
-          cleanup() {
-            if (( ${#temporary_files[@]} )); then
-              rm -f -- "${temporary_files[@]}"
-            fi
-          }
-          trap cleanup EXIT
-
           if [[ "${GH_EVENT_NAME:-}" == "push" ]]; then
-            associated_prs="$(mktemp)"
-            temporary_files+=("$associated_prs")
-            if curl --fail --silent --show-error \
-              -H "Accept: application/vnd.github+json" \
-              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              "https://api.github.com/repos/${GH_REPOSITORY}/commits/${GH_COMMIT_SHA}/pulls?per_page=100" \
-              > "$associated_prs"
+            if subject="$(
+              python3 scripts/ci/check_contract_deletion_authorization.py \
+                resolve-push-pr \
+                --pull-requests-url \
+                  "https://api.github.com/repos/${GH_REPOSITORY}/commits/${GH_COMMIT_SHA}/pulls" \
+                --commit-sha "$GH_COMMIT_SHA"
+            )"
             then
-              if subject="$(
-                python3 scripts/ci/check_contract_deletion_authorization.py \
-                  resolve-push-pr \
-                  --pull-requests "$associated_prs" \
-                  --commit-sha "$GH_COMMIT_SHA"
-              )"
-              then
-                read -r pr_number pr_head_sha pr_base_sha <<< "$subject"
-              else
-                pr_number=""
-                pr_head_sha=""
-                pr_base_sha=""
-              fi
+              read -r pr_number pr_head_sha pr_base_sha <<< "$subject"
             else
-              echo "::warning::Could not resolve an associated pull request; failing closed"
+              echo "::warning::Could not resolve a complete associated pull-request set; failing closed"
               pr_number=""
               pr_head_sha=""
               pr_base_sha=""
@@ -272,24 +251,15 @@ jobs:
             authorized=0
 
             if [[ -n "$pr_number" && -n "$pr_head_sha" ]]; then
-              comments_json="$(mktemp)"
-              temporary_files+=("$comments_json")
-              if curl --fail --silent --show-error \
-                -H "Accept: application/vnd.github+json" \
-                -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-                -H "X-GitHub-Api-Version: 2022-11-28" \
-                "https://api.github.com/repos/${GH_REPOSITORY}/issues/${pr_number}/comments?per_page=100" \
-                > "$comments_json"
+              if python3 scripts/ci/check_contract_deletion_authorization.py \
+                verify-comments \
+                --comments-url \
+                  "https://api.github.com/repos/${GH_REPOSITORY}/issues/${pr_number}/comments" \
+                --marker "$marker"
               then
-                if python3 scripts/ci/check_contract_deletion_authorization.py \
-                  verify-comments \
-                  --comments "$comments_json" \
-                  --marker "$marker"
-                then
-                  authorized=1
-                fi
+                authorized=1
               else
-                echo "::warning::Could not read PR authorization comments; failing closed"
+                echo "::warning::Could not verify the complete PR authorization comment set; failing closed"
               fi
             fi
 

--- a/scripts/ci/check_contract_deletion_authorization.py
+++ b/scripts/ci/check_contract_deletion_authorization.py
@@ -116,6 +116,41 @@ def _github_page_url(url: str, *, page: int) -> str:
     )
 
 
+def _read_github_json_page(
+    request: Request,
+    *,
+    page: int,
+    opener: Callable[..., Any],
+) -> list[Any]:
+    try:
+        with opener(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            raw = response.read(MAX_PAGE_BYTES + 1)
+    except (OSError, URLError) as exc:
+        raise ValueError(f"GitHub API page {page} could not be read") from exc
+    if len(raw) > MAX_PAGE_BYTES:
+        raise ValueError(f"GitHub API page {page} exceeds the byte limit")
+    try:
+        payload = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"GitHub API page {page} is not valid JSON") from exc
+    if not isinstance(payload, list):
+        raise ValueError(f"GitHub API page {page} must be a JSON array")
+    if len(payload) > PAGE_SIZE:
+        raise ValueError(f"GitHub API page {page} exceeds the item limit")
+    return payload
+
+
+def _github_request(url: str, *, page: int, token: str) -> Request:
+    return Request(
+        _github_page_url(url, page=page),
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+
+
 def fetch_paginated_json(
     url: str,
     *,
@@ -132,37 +167,17 @@ def fetch_paginated_json(
     collected: list[Any] = []
 
     for page in range(1, max_pages + 2):
-        request = Request(
-            _github_page_url(url, page=page),
-            headers={
-                "Accept": "application/vnd.github+json",
-                "Authorization": f"Bearer {token}",
-                "X-GitHub-Api-Version": "2022-11-28",
-            },
+        payload = _read_github_json_page(
+            _github_request(url, page=page, token=token),
+            page=page,
+            opener=open_request,
         )
-        try:
-            with open_request(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
-                raw = response.read(MAX_PAGE_BYTES + 1)
-        except (OSError, URLError) as exc:
-            raise ValueError(f"GitHub API page {page} could not be read") from exc
-        if len(raw) > MAX_PAGE_BYTES:
-            raise ValueError(f"GitHub API page {page} exceeds the byte limit")
-        try:
-            payload = json.loads(raw)
-        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-            raise ValueError(f"GitHub API page {page} is not valid JSON") from exc
-        if not isinstance(payload, list):
-            raise ValueError(f"GitHub API page {page} must be a JSON array")
-        if len(payload) > PAGE_SIZE:
-            raise ValueError(f"GitHub API page {page} exceeds the item limit")
-
         if page > max_pages:
             if payload:
                 raise ValueError(
                     f"GitHub API pagination exceeds the {max_pages}-page limit"
                 )
             break
-
         collected.extend(payload)
         if len(payload) < PAGE_SIZE:
             break

--- a/scripts/ci/check_contract_deletion_authorization.py
+++ b/scripts/ci/check_contract_deletion_authorization.py
@@ -5,11 +5,20 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
+from urllib.error import URLError
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+from urllib.request import Request, urlopen
 
 TRUSTED_ASSOCIATIONS = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
+GITHUB_API_HOST = "api.github.com"
+PAGE_SIZE = 100
+DEFAULT_MAX_PAGES = 20
+MAX_PAGE_BYTES = 8 * 1024 * 1024
+HTTP_TIMEOUT_SECONDS = 20
 
 
 def authorization_present(comments: Any, *, marker: str) -> bool:
@@ -92,8 +101,106 @@ def resolve_associated_pr(
     return next(iter(candidates))
 
 
+def _github_page_url(url: str, *, page: int) -> str:
+    parsed = urlsplit(url)
+    if parsed.scheme != "https" or parsed.netloc != GITHUB_API_HOST:
+        raise ValueError("GitHub API URL must use https://api.github.com")
+    query = [
+        (key, value)
+        for key, value in parse_qsl(parsed.query, keep_blank_values=True)
+        if key not in {"page", "per_page"}
+    ]
+    query.extend((("per_page", str(PAGE_SIZE)), ("page", str(page))))
+    return urlunsplit(
+        (parsed.scheme, parsed.netloc, parsed.path, urlencode(query), parsed.fragment)
+    )
+
+
+def fetch_paginated_json(
+    url: str,
+    *,
+    token: str,
+    max_pages: int = DEFAULT_MAX_PAGES,
+    opener: Callable[..., Any] | None = None,
+) -> list[Any]:
+    """Fetch every GitHub API page, failing closed at explicit bounds."""
+    if not token:
+        raise ValueError("GitHub token is missing")
+    if not 1 <= max_pages <= 100:
+        raise ValueError("max_pages must be between 1 and 100")
+    open_request = opener or urlopen
+    collected: list[Any] = []
+
+    for page in range(1, max_pages + 2):
+        request = Request(
+            _github_page_url(url, page=page),
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {token}",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        try:
+            with open_request(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+                raw = response.read(MAX_PAGE_BYTES + 1)
+        except (OSError, URLError) as exc:
+            raise ValueError(f"GitHub API page {page} could not be read") from exc
+        if len(raw) > MAX_PAGE_BYTES:
+            raise ValueError(f"GitHub API page {page} exceeds the byte limit")
+        try:
+            payload = json.loads(raw)
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise ValueError(f"GitHub API page {page} is not valid JSON") from exc
+        if not isinstance(payload, list):
+            raise ValueError(f"GitHub API page {page} must be a JSON array")
+        if len(payload) > PAGE_SIZE:
+            raise ValueError(f"GitHub API page {page} exceeds the item limit")
+
+        if page > max_pages:
+            if payload:
+                raise ValueError(
+                    f"GitHub API pagination exceeds the {max_pages}-page limit"
+                )
+            break
+
+        collected.extend(payload)
+        if len(payload) < PAGE_SIZE:
+            break
+
+    return collected
+
+
 def _load_json(path: Path) -> Any:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _load_evidence(
+    *,
+    path: Path | None,
+    url: str | None,
+    max_pages: int,
+) -> Any:
+    if path is not None:
+        return _load_json(path)
+    if url is None:
+        raise ValueError("evidence source is missing")
+    return fetch_paginated_json(
+        url,
+        token=os.environ.get("GITHUB_TOKEN", ""),
+        max_pages=max_pages,
+    )
+
+
+def _add_evidence_source(
+    parser: argparse.ArgumentParser,
+    *,
+    path_option: str,
+    url_option: str,
+) -> None:
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument(path_option, type=Path)
+    source.add_argument(url_option)
+    parser.add_argument("--max-pages", type=int, default=DEFAULT_MAX_PAGES)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -101,11 +208,19 @@ def build_parser() -> argparse.ArgumentParser:
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     verify = subparsers.add_parser("verify-comments")
-    verify.add_argument("--comments", type=Path, required=True)
+    _add_evidence_source(
+        verify,
+        path_option="--comments",
+        url_option="--comments-url",
+    )
     verify.add_argument("--marker", required=True)
 
     resolve = subparsers.add_parser("resolve-push-pr")
-    resolve.add_argument("--pull-requests", type=Path, required=True)
+    _add_evidence_source(
+        resolve,
+        path_option="--pull-requests",
+        url_option="--pull-requests-url",
+    )
     resolve.add_argument("--commit-sha", required=True)
     return parser
 
@@ -114,7 +229,12 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     try:
         if args.command == "verify-comments":
-            if not authorization_present(_load_json(args.comments), marker=args.marker):
+            comments = _load_evidence(
+                path=args.comments,
+                url=args.comments_url,
+                max_pages=args.max_pages,
+            )
+            if not authorization_present(comments, marker=args.marker):
                 print(
                     "no exact trusted-human authorization comment found",
                     file=sys.stderr,
@@ -123,8 +243,13 @@ def main(argv: list[str] | None = None) -> int:
             print("exact trusted-human authorization comment verified")
             return 0
 
+        pull_requests = _load_evidence(
+            path=args.pull_requests,
+            url=args.pull_requests_url,
+            max_pages=args.max_pages,
+        )
         number, head_sha, base_sha = resolve_associated_pr(
-            _load_json(args.pull_requests),
+            pull_requests,
             commit_sha=args.commit_sha,
         )
         print(number, head_sha, base_sha)

--- a/tests/test_contract_deletion_authorization.py
+++ b/tests/test_contract_deletion_authorization.py
@@ -3,11 +3,15 @@ from __future__ import annotations
 import json
 import subprocess
 from pathlib import Path
+from urllib.error import URLError
+from urllib.parse import parse_qs, urlsplit
 
 import pytest
 
+import scripts.ci.check_contract_deletion_authorization as authorization
 from scripts.ci.check_contract_deletion_authorization import (
     authorization_present,
+    fetch_paginated_json,
     main,
     resolve_associated_pr,
 )
@@ -161,3 +165,169 @@ def test_cli_accepts_exact_comment(tmp_path) -> None:
         )
         == 0
     )
+
+
+class _FakeResponse:
+    def __init__(self, payload: object) -> None:
+        self.raw = json.dumps(payload).encode("utf-8")
+
+    def read(self, limit: int = -1) -> bytes:
+        return self.raw if limit < 0 else self.raw[:limit]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> bool:
+        return False
+
+
+def _paginated_opener(pages: dict[int, object]):
+    def opener(request, *, timeout: int):
+        assert timeout == authorization.HTTP_TIMEOUT_SECONDS
+        query = parse_qs(urlsplit(request.full_url).query)
+        assert query["per_page"] == [str(authorization.PAGE_SIZE)]
+        page = int(query["page"][0])
+        return _FakeResponse(pages.get(page, []))
+
+    return opener
+
+
+def test_paginated_fetch_reads_authorization_on_second_page() -> None:
+    first_page = [{"body": f"discussion-{index}"} for index in range(100)]
+    comments = fetch_paginated_json(
+        "https://api.github.com/repos/heimgewebe/repoground/issues/1110/comments",
+        token="secret",
+        opener=_paginated_opener({1: first_page, 2: [trusted_comment()]}),
+    )
+    assert len(comments) == 101
+    assert authorization_present(comments, marker=MARKER)
+
+
+def test_paginated_fetch_accepts_exact_cap_only_after_empty_sentinel() -> None:
+    comments = fetch_paginated_json(
+        "https://api.github.com/repos/heimgewebe/repoground/issues/1110/comments",
+        token="secret",
+        max_pages=1,
+        opener=_paginated_opener({1: [{} for _ in range(100)], 2: []}),
+    )
+    assert len(comments) == 100
+
+
+def test_paginated_fetch_fails_closed_beyond_cap() -> None:
+    with pytest.raises(ValueError, match="exceeds the 1-page limit"):
+        fetch_paginated_json(
+            "https://api.github.com/repos/heimgewebe/repoground/issues/1110/comments",
+            token="secret",
+            max_pages=1,
+            opener=_paginated_opener({1: [{} for _ in range(100)], 2: [{}]}),
+        )
+
+
+def test_paginated_fetch_rejects_non_github_api_url() -> None:
+    with pytest.raises(ValueError, match="https://api.github.com"):
+        fetch_paginated_json(
+            "https://example.invalid/comments",
+            token="secret",
+            opener=_paginated_opener({}),
+        )
+
+
+def test_paginated_fetch_fails_closed_on_request_error() -> None:
+    def failing_opener(request, *, timeout: int):
+        raise URLError("offline")
+
+    with pytest.raises(ValueError, match="page 1 could not be read"):
+        fetch_paginated_json(
+            "https://api.github.com/repos/heimgewebe/repoground/issues/1110/comments",
+            token="secret",
+            opener=failing_opener,
+        )
+
+
+def test_cli_accepts_authorization_from_second_comment_page(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GITHUB_TOKEN", "secret")
+    monkeypatch.setattr(
+        authorization,
+        "urlopen",
+        _paginated_opener(
+            {
+                1: [{"body": f"discussion-{index}"} for index in range(100)],
+                2: [trusted_comment()],
+            }
+        ),
+    )
+    assert (
+        main(
+            [
+                "verify-comments",
+                "--comments-url",
+                "https://api.github.com/repos/heimgewebe/repoground/issues/1110/comments",
+                "--marker",
+                MARKER,
+            ]
+        )
+        == 0
+    )
+
+
+def test_cli_resolves_associated_pr_from_second_page(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys,
+) -> None:
+    monkeypatch.setenv("GITHUB_TOKEN", "secret")
+    target = {
+        "number": 1110,
+        "head": {"sha": COMMIT},
+        "base": {"sha": BASE},
+        "merge_commit_sha": None,
+    }
+    monkeypatch.setattr(
+        authorization,
+        "urlopen",
+        _paginated_opener({1: [{} for _ in range(100)], 2: [target]}),
+    )
+    assert (
+        main(
+            [
+                "resolve-push-pr",
+                "--pull-requests-url",
+                "https://api.github.com/repos/heimgewebe/repoground/commits/commit/pulls",
+                "--commit-sha",
+                COMMIT,
+            ]
+        )
+        == 0
+    )
+    assert capsys.readouterr().out.strip() == f"1110 {COMMIT} {BASE}"
+
+
+
+def test_paginated_fetch_rejects_oversized_item_page() -> None:
+    with pytest.raises(ValueError, match="page 1 exceeds the item limit"):
+        fetch_paginated_json(
+            "https://api.github.com/repos/heimgewebe/repoground/issues/1110/comments",
+            token="secret",
+            opener=_paginated_opener({1: [{} for _ in range(101)]}),
+        )
+
+
+def test_cli_url_source_requires_github_token(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys,
+) -> None:
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    assert (
+        main(
+            [
+                "verify-comments",
+                "--comments-url",
+                "https://api.github.com/repos/heimgewebe/repoground/issues/1110/comments",
+                "--marker",
+                MARKER,
+            ]
+        )
+        == 2
+    )
+    assert "GitHub token is missing" in capsys.readouterr().err


### PR DESCRIPTION
## Ziel

Der Vertragslöschungs-Guard darf gültige Freigaben nach dem 100. PR-Kommentar nicht übersehen.

## Änderungen

- GitHub-API-Evidenz wird vollständig paginiert statt nur mit `per_page=100` einmal gelesen.
- Kommentare und zugehörige Pull Requests verwenden dieselbe begrenzte, fail-closed Abruflogik.
- Der Abruf ist auf `https://api.github.com`, 20 Nutzseiten, 100 Objekte pro Seite und 8 MiB pro Seite begrenzt.
- Netzwerkfehler, ungültiges JSON, fehlende Tokens, übergroße Seiten und Cap-Überschreitung blockieren geschlossen.
- Dateibasierte CLI-Eingaben bleiben für lokale und deterministische Tests kompatibel.

## Tests

- `python3 -m pytest tests/test_contract_deletion_authorization.py -q` — 21 passed
- `python3 -m ruff check scripts/ci/check_contract_deletion_authorization.py tests/test_contract_deletion_authorization.py` — passed
- `git diff --check` — passed

## Bureau

Setzt den registrierten Fund `candidate-7d9bf1f39a22860293df3163` um. Der Fund war als `promote` bewertet, aber noch nicht als kanonische Task veröffentlicht; diese Umsetzung beansprucht keine nachträgliche Taskbereitschaft.

## Grenzen

Die Änderung belegt vollständige Evidenz bis zum expliziten Cap von 2.000 Objekten. Größere Mengen werden nicht still abgeschnitten, sondern fail-closed abgewiesen.