### PR TITLE
fix: bound release verifier resource use

### DIFF
--- a/docs/proofs/repoground-release-verifier-resource-limits-v1-proof.md
+++ b/docs/proofs/repoground-release-verifier-resource-limits-v1-proof.md
@@ -15,6 +15,7 @@ format, builder output, licensing decision, distribution status or product runti
 - one regular archive member: 16 MiB
 - total regular-file bytes: 128 MiB
 - expansion ratio: 200:1
+- archive members including the root entry: 10,000
 - archived LICENSE read: 1 MiB
 
 The current tracked tree is about 13.1 MiB and its largest file is below 0.31 MiB,

--- a/docs/proofs/repoground-release-verifier-resource-limits-v1-proof.md
+++ b/docs/proofs/repoground-release-verifier-resource-limits-v1-proof.md
@@ -1,0 +1,39 @@
+# RepoGround release verifier resource limits v1 — Proof
+
+## Scope
+
+This change is bound to RepoGround base commit
+`1634b55183447fa6e846e231a0b1e6880039fc17` and source candidate
+`candidate-f25824e798612dae155979be`, event `1513`.
+
+It hardens only release-candidate verification. It does not change the release
+format, builder output, licensing decision, distribution status or product runtime.
+
+## Limits
+
+- compressed archive: 64 MiB
+- one regular archive member: 16 MiB
+- total regular-file bytes: 128 MiB
+- expansion ratio: 200:1
+- archived LICENSE read: 1 MiB
+
+The current tracked tree is about 13.1 MiB and its largest file is below 0.31 MiB,
+so these limits retain substantial headroom.
+
+## Enforcement
+
+Tar metadata is inspected incrementally. Oversized members and aggregate limits are
+rejected before member payloads are read. Required member reads are chunked and
+bounded; source-bound content comparison checks declared size before reading.
+
+## Validation
+
+- targeted release-packaging tests
+- Ruff on changed Python files
+- complete repository test and CI readback on the final PR head
+
+## Non-claims
+
+This proof does not establish absence of CPU exhaustion below the limits, safety of
+arbitrary future archive formats, public exposure of the verifier, release readiness,
+deployment authorization or merge readiness before final review and CI.

--- a/docs/proofs/repoground-release-verifier-resource-limits-v1-proof.md
+++ b/docs/proofs/repoground-release-verifier-resource-limits-v1-proof.md
@@ -25,12 +25,13 @@ so these limits retain substantial headroom.
 
 ## Enforcement
 
-The compressed archive size is rejected before checksum hashing. Every archive scan
-uses one bounded decompression stream, so PAX and GNU extension payloads count before
-`tarfile` can turn them into logical members. Member count, member and aggregate limits
-are rejected before member payloads are read. Required member reads are chunked and
-bounded; source-bound content comparison batch-queries immutable Git object sizes
-before reading blobs.
+The compressed archive size is rejected before checksum hashing. Each verification
+materializes one bounded decompression stream and reuses the resulting Tar path for all
+checks, so PAX and GNU extension payloads count before `tarfile` can turn them into
+logical members without multiplying decompression work. Member count, member and
+aggregate limits are rejected before member payloads are read. Required member reads
+are chunked and bounded; source-bound content comparison batch-queries immutable Git
+object sizes before reading blobs.
 
 ## Validation
 

--- a/docs/proofs/repoground-release-verifier-resource-limits-v1-proof.md
+++ b/docs/proofs/repoground-release-verifier-resource-limits-v1-proof.md
@@ -31,7 +31,8 @@ once, so PAX and GNU extension payloads count before `tarfile` can turn them int
 logical members without multiplying decompression or parsing work. Later content checks
 use validated Tar offsets directly. Member count, member and aggregate limits are
 rejected before member payloads are read. Source-bound comparison uses one size batch
-and one persistent content batch for all immutable Git blobs.
+and one persistent content process, reading and discarding exactly one immutable Git
+blob at a time after validating the corresponding archive member shape.
 
 ## Validation
 

--- a/docs/proofs/repoground-release-verifier-resource-limits-v1-proof.md
+++ b/docs/proofs/repoground-release-verifier-resource-limits-v1-proof.md
@@ -14,6 +14,8 @@ format, builder output, licensing decision, distribution status or product runti
 - compressed archive: 64 MiB
 - one regular archive member: 16 MiB
 - total regular-file bytes: 128 MiB
+- uncompressed tar stream including metadata: 160 MiB
+- source-bound Git blob: 16 MiB
 - expansion ratio: 200:1
 - archive members including the root entry: 10,000
 - archived LICENSE read: 1 MiB
@@ -23,9 +25,11 @@ so these limits retain substantial headroom.
 
 ## Enforcement
 
-Tar metadata is inspected incrementally. Oversized members and aggregate limits are
-rejected before member payloads are read. Required member reads are chunked and
-bounded; source-bound content comparison checks declared size before reading.
+The compressed archive size is rejected before checksum hashing. Tar metadata is
+inspected incrementally; member count, metadata stream, member and aggregate limits
+are rejected before member payloads are read. Required member reads are chunked and
+bounded; source-bound content comparison batch-queries immutable Git object sizes
+before reading blobs.
 
 ## Validation
 

--- a/docs/proofs/repoground-release-verifier-resource-limits-v1-proof.md
+++ b/docs/proofs/repoground-release-verifier-resource-limits-v1-proof.md
@@ -25,8 +25,9 @@ so these limits retain substantial headroom.
 
 ## Enforcement
 
-The compressed archive size is rejected before checksum hashing. Tar metadata is
-inspected incrementally; member count, metadata stream, member and aggregate limits
+The compressed archive size is rejected before checksum hashing. Every archive scan
+uses one bounded decompression stream, so PAX and GNU extension payloads count before
+`tarfile` can turn them into logical members. Member count, member and aggregate limits
 are rejected before member payloads are read. Required member reads are chunked and
 bounded; source-bound content comparison batch-queries immutable Git object sizes
 before reading blobs.

--- a/docs/proofs/repoground-release-verifier-resource-limits-v1-proof.md
+++ b/docs/proofs/repoground-release-verifier-resource-limits-v1-proof.md
@@ -26,12 +26,12 @@ so these limits retain substantial headroom.
 ## Enforcement
 
 The compressed archive size is rejected before checksum hashing. Each verification
-materializes one bounded decompression stream and reuses the resulting Tar path for all
-checks, so PAX and GNU extension payloads count before `tarfile` can turn them into
-logical members without multiplying decompression work. Member count, member and
-aggregate limits are rejected before member payloads are read. Required member reads
-are chunked and bounded; source-bound content comparison batch-queries immutable Git
-object sizes before reading blobs.
+materializes one bounded decompression stream and parses the resulting Tar exactly
+once, so PAX and GNU extension payloads count before `tarfile` can turn them into
+logical members without multiplying decompression or parsing work. Later content checks
+use validated Tar offsets directly. Member count, member and aggregate limits are
+rejected before member payloads are read. Source-bound comparison uses one size batch
+and one persistent content batch for all immutable Git blobs.
 
 ## Validation
 

--- a/merger/repoground/tests/test_release_packaging.py
+++ b/merger/repoground/tests/test_release_packaging.py
@@ -735,6 +735,24 @@ def test_verifier_rejects_excessive_compression_ratio(
         verify_release_candidate(candidate)
 
 
+def test_verifier_rejects_archive_member_count_over_limit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _repo(tmp_path)
+    candidate = tmp_path / "candidate-member-count-limit"
+    build_release_candidate(repo, candidate)
+    manifest_path = next(candidate.glob("*.release.json"))
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["archive"]["tracked_entry_count"] = 1
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    _rewrite_sums(candidate)
+    monkeypatch.setattr(verifier_module, "MAX_ARCHIVE_MEMBERS", 2)
+    with pytest.raises(ValueError, match="member count limit"):
+        verify_release_candidate(candidate)
+
+
 def test_legacy_repobrief_release_identity_is_rejected(tmp_path: Path) -> None:
     repo = _repo(tmp_path)
     candidate = tmp_path / "candidate"

--- a/merger/repoground/tests/test_release_packaging.py
+++ b/merger/repoground/tests/test_release_packaging.py
@@ -248,6 +248,41 @@ def _replace_archive_member_payload(
     _rewrite_sums(candidate)
 
 
+
+def _add_global_pax_header(candidate: Path, payload_bytes: int) -> None:
+    archive_path = next(candidate.glob("*.tar.gz"))
+    manifest_path = next(candidate.glob("*.release.json"))
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    members: list[tuple[tarfile.TarInfo, bytes | None]] = []
+    with tarfile.open(archive_path, mode="r:gz") as tar:
+        for member in tar.getmembers():
+            handle = tar.extractfile(member) if member.isfile() else None
+            members.append((member, handle.read() if handle is not None else None))
+
+    tar_buffer = io.BytesIO()
+    with tarfile.open(
+        fileobj=tar_buffer,
+        mode="w",
+        format=tarfile.PAX_FORMAT,
+        pax_headers={"comment": "0" * payload_bytes},
+    ) as tar:
+        for member, content in members:
+            tar.addfile(member, io.BytesIO(content) if content is not None else None)
+    compressed = io.BytesIO()
+    with gzip.GzipFile(
+        filename="", mode="wb", fileobj=compressed, compresslevel=9, mtime=0
+    ) as gz:
+        gz.write(tar_buffer.getvalue())
+    archive_path.write_bytes(compressed.getvalue())
+    manifest["archive"]["bytes"] = archive_path.stat().st_size
+    manifest["archive"]["sha256"] = hashlib.sha256(
+        archive_path.read_bytes()
+    ).hexdigest()
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    _rewrite_sums(candidate)
+
 def test_candidate_build_is_byte_reproducible_and_source_bound(tmp_path: Path) -> None:
     repo = _repo(tmp_path)
     first = tmp_path / "first"
@@ -754,6 +789,25 @@ def test_source_bound_verifier_checks_blob_size_before_read(
     )
     with pytest.raises(ValueError, match="repository blob exceeds byte limit"):
         verify_release_candidate(candidate, repo=repo)
+
+
+def test_verifier_bounds_global_pax_metadata_before_first_member(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _repo(tmp_path)
+    candidate = tmp_path / "candidate-pax-metadata-limit"
+    build_release_candidate(repo, candidate)
+    _add_global_pax_header(candidate, payload_bytes=4096)
+    monkeypatch.setattr(verifier_module, "MAX_ARCHIVE_STREAM_BYTES", 1024)
+    monkeypatch.setattr(
+        verifier_module,
+        "_validate_archive_member",
+        lambda *args, **kwargs: pytest.fail(
+            "logical archive member yielded before PAX metadata limit"
+        ),
+    )
+    with pytest.raises(ValueError, match="uncompressed stream byte limit"):
+        verify_release_candidate(candidate)
 
 
 def test_verifier_rejects_excessive_compression_ratio(

--- a/merger/repoground/tests/test_release_packaging.py
+++ b/merger/repoground/tests/test_release_packaging.py
@@ -19,6 +19,7 @@ from scripts.release.build_release_candidate import (
     safe_symlink_target,
 )
 from scripts.release.check_release_contract import scan
+import scripts.release.verify_release_candidate as verifier_module
 from scripts.release.verify_release_candidate import verify_release_candidate
 
 ROOT = Path(__file__).resolve().parents[3]
@@ -196,6 +197,47 @@ def _rename_archive_member(
         gz.write(tar_buffer.getvalue())
     archive_path.write_bytes(compressed.getvalue())
 
+    manifest["archive"]["bytes"] = archive_path.stat().st_size
+    manifest["archive"]["sha256"] = hashlib.sha256(
+        archive_path.read_bytes()
+    ).hexdigest()
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    _rewrite_sums(candidate)
+
+
+def _replace_archive_member_payload(
+    candidate: Path, target_relative: str, payload: bytes
+) -> None:
+    archive_path = next(candidate.glob("*.tar.gz"))
+    manifest_path = next(candidate.glob("*.release.json"))
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    prefix = manifest["archive"]["prefix"]
+    target_name = f"{prefix}{target_relative}"
+    members: list[tuple[tarfile.TarInfo, bytes | None]] = []
+    replaced = False
+    with tarfile.open(archive_path, mode="r:gz") as tar:
+        for member in tar.getmembers():
+            handle = tar.extractfile(member) if member.isfile() else None
+            content = handle.read() if handle is not None else None
+            if member.name == target_name:
+                content = payload
+                member.size = len(payload)
+                replaced = True
+            members.append((member, content))
+    assert replaced
+
+    tar_buffer = io.BytesIO()
+    with tarfile.open(fileobj=tar_buffer, mode="w", format=tarfile.GNU_FORMAT) as tar:
+        for member, content in members:
+            tar.addfile(member, io.BytesIO(content) if content is not None else None)
+    compressed = io.BytesIO()
+    with gzip.GzipFile(
+        filename="", mode="wb", fileobj=compressed, compresslevel=9, mtime=0
+    ) as gz:
+        gz.write(tar_buffer.getvalue())
+    archive_path.write_bytes(compressed.getvalue())
     manifest["archive"]["bytes"] = archive_path.stat().st_size
     manifest["archive"]["sha256"] = hashlib.sha256(
         archive_path.read_bytes()
@@ -634,6 +676,63 @@ def test_verifier_rejects_noncanonical_alias_for_retired_release_contract(
     kwargs = {"repo": repo} if source_bound else {}
     with pytest.raises(ValueError, match="unsafe archive member"):
         verify_release_candidate(candidate, **kwargs)
+
+
+@pytest.mark.parametrize("source_bound", (False, True))
+def test_verifier_rejects_oversized_archive_member_before_read(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    source_bound: bool,
+) -> None:
+    repo = _repo(tmp_path)
+    candidate = tmp_path / "candidate-oversized-member"
+    build_release_candidate(repo, candidate)
+    limit = 1024
+    _replace_archive_member_payload(
+        candidate,
+        "LICENSE",
+        b"Apache License\nVersion 2.0\n" + b"0" * limit,
+    )
+    monkeypatch.setattr(verifier_module, "MAX_ARCHIVE_MEMBER_BYTES", limit)
+    kwargs = {"repo": repo} if source_bound else {}
+    with pytest.raises(ValueError, match="exceeds byte limit: .*LICENSE"):
+        verify_release_candidate(candidate, **kwargs)
+
+
+def test_verifier_rejects_compressed_archive_over_limit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _repo(tmp_path)
+    candidate = tmp_path / "candidate-compressed-limit"
+    build_release_candidate(repo, candidate)
+    archive_path = next(candidate.glob("*.tar.gz"))
+    monkeypatch.setattr(
+        verifier_module, "MAX_ARCHIVE_BYTES", archive_path.stat().st_size - 1
+    )
+    with pytest.raises(ValueError, match="compressed byte limit"):
+        verify_release_candidate(candidate)
+
+
+def test_verifier_rejects_total_uncompressed_bytes_over_limit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _repo(tmp_path)
+    candidate = tmp_path / "candidate-total-limit"
+    build_release_candidate(repo, candidate)
+    monkeypatch.setattr(verifier_module, "MAX_ARCHIVE_TOTAL_BYTES", 1)
+    with pytest.raises(ValueError, match="total uncompressed byte limit"):
+        verify_release_candidate(candidate)
+
+
+def test_verifier_rejects_excessive_compression_ratio(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _repo(tmp_path)
+    candidate = tmp_path / "candidate-ratio-limit"
+    build_release_candidate(repo, candidate)
+    monkeypatch.setattr(verifier_module, "MAX_ARCHIVE_COMPRESSION_RATIO", 1)
+    with pytest.raises(ValueError, match="compression ratio limit"):
+        verify_release_candidate(candidate)
 
 
 def test_legacy_repobrief_release_identity_is_rejected(tmp_path: Path) -> None:

--- a/merger/repoground/tests/test_release_packaging.py
+++ b/merger/repoground/tests/test_release_packaging.py
@@ -776,6 +776,26 @@ def test_verifier_rejects_archive_stream_bytes_over_limit(
         verify_release_candidate(candidate)
 
 
+def test_source_bound_verifier_batches_blob_content_reads(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _repo(tmp_path)
+    candidate = tmp_path / "candidate-batched-blobs"
+    build_release_candidate(repo, candidate)
+    original = verifier_module.subprocess.Popen
+    batch_calls = 0
+
+    def counted_popen(argv, *args, **kwargs):
+        nonlocal batch_calls
+        if argv[:3] == ["git", "cat-file", "--batch"]:
+            batch_calls += 1
+        return original(argv, *args, **kwargs)
+
+    monkeypatch.setattr(verifier_module.subprocess, "Popen", counted_popen)
+    assert verify_release_candidate(candidate, repo=repo)["status"] == "pass"
+    assert batch_calls == 1
+
+
 def test_source_bound_verifier_checks_blob_size_before_read(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -783,11 +803,14 @@ def test_source_bound_verifier_checks_blob_size_before_read(
     candidate = tmp_path / "candidate-repository-blob-limit"
     build_release_candidate(repo, candidate)
     monkeypatch.setattr(verifier_module, "MAX_REPOSITORY_BLOB_BYTES", 1)
-    monkeypatch.setattr(
-        verifier_module,
-        "read_blob",
-        lambda *args: pytest.fail("repository blob read before size rejection"),
-    )
+    original_popen = verifier_module.subprocess.Popen
+
+    def reject_content_batch(argv, *args, **kwargs):
+        if argv[:3] == ["git", "cat-file", "--batch"]:
+            pytest.fail("repository content batch started before size rejection")
+        return original_popen(argv, *args, **kwargs)
+
+    monkeypatch.setattr(verifier_module.subprocess, "Popen", reject_content_batch)
     with pytest.raises(ValueError, match="repository blob exceeds byte limit"):
         verify_release_candidate(candidate, repo=repo)
 
@@ -801,22 +824,31 @@ def test_verifier_materializes_archive_once_per_verification(
     repo = _repo(tmp_path)
     candidate = tmp_path / "candidate-single-materialization"
     build_release_candidate(repo, candidate)
-    original = verifier_module._materialized_bounded_tar
-    calls = 0
+    original_materialize = verifier_module._materialized_bounded_tar
+    original_tar_open = verifier_module.tarfile.open
+    materializations = 0
+    tar_opens = 0
 
     @contextmanager
     def counted_materialization(archive_path: Path):
-        nonlocal calls
-        calls += 1
-        with original(archive_path) as tar_path:
+        nonlocal materializations
+        materializations += 1
+        with original_materialize(archive_path) as tar_path:
             yield tar_path
+
+    def counted_tar_open(*args, **kwargs):
+        nonlocal tar_opens
+        tar_opens += 1
+        return original_tar_open(*args, **kwargs)
 
     monkeypatch.setattr(
         verifier_module, "_materialized_bounded_tar", counted_materialization
     )
+    monkeypatch.setattr(verifier_module.tarfile, "open", counted_tar_open)
     kwargs = {"repo": repo} if source_bound else {}
     assert verify_release_candidate(candidate, **kwargs)["status"] == "pass"
-    assert calls == 1
+    assert materializations == 1
+    assert tar_opens == 1
 
 
 def test_verifier_bounds_global_pax_metadata_before_first_member(

--- a/merger/repoground/tests/test_release_packaging.py
+++ b/merger/repoground/tests/test_release_packaging.py
@@ -8,6 +8,7 @@ import os
 import subprocess
 import sys
 import tarfile
+from contextlib import contextmanager
 from pathlib import Path
 
 import jsonschema
@@ -789,6 +790,33 @@ def test_source_bound_verifier_checks_blob_size_before_read(
     )
     with pytest.raises(ValueError, match="repository blob exceeds byte limit"):
         verify_release_candidate(candidate, repo=repo)
+
+
+@pytest.mark.parametrize("source_bound", (False, True))
+def test_verifier_materializes_archive_once_per_verification(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    source_bound: bool,
+) -> None:
+    repo = _repo(tmp_path)
+    candidate = tmp_path / "candidate-single-materialization"
+    build_release_candidate(repo, candidate)
+    original = verifier_module._materialized_bounded_tar
+    calls = 0
+
+    @contextmanager
+    def counted_materialization(archive_path: Path):
+        nonlocal calls
+        calls += 1
+        with original(archive_path) as tar_path:
+            yield tar_path
+
+    monkeypatch.setattr(
+        verifier_module, "_materialized_bounded_tar", counted_materialization
+    )
+    kwargs = {"repo": repo} if source_bound else {}
+    assert verify_release_candidate(candidate, **kwargs)["status"] == "pass"
+    assert calls == 1
 
 
 def test_verifier_bounds_global_pax_metadata_before_first_member(

--- a/merger/repoground/tests/test_release_packaging.py
+++ b/merger/repoground/tests/test_release_packaging.py
@@ -709,6 +709,11 @@ def test_verifier_rejects_compressed_archive_over_limit(
     monkeypatch.setattr(
         verifier_module, "MAX_ARCHIVE_BYTES", archive_path.stat().st_size - 1
     )
+    monkeypatch.setattr(
+        verifier_module,
+        "_sha256",
+        lambda path: pytest.fail(f"archive hashed before size rejection: {path}"),
+    )
     with pytest.raises(ValueError, match="compressed byte limit"):
         verify_release_candidate(candidate)
 
@@ -722,6 +727,33 @@ def test_verifier_rejects_total_uncompressed_bytes_over_limit(
     monkeypatch.setattr(verifier_module, "MAX_ARCHIVE_TOTAL_BYTES", 1)
     with pytest.raises(ValueError, match="total uncompressed byte limit"):
         verify_release_candidate(candidate)
+
+
+def test_verifier_rejects_archive_stream_bytes_over_limit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _repo(tmp_path)
+    candidate = tmp_path / "candidate-stream-limit"
+    build_release_candidate(repo, candidate)
+    monkeypatch.setattr(verifier_module, "MAX_ARCHIVE_STREAM_BYTES", 1)
+    with pytest.raises(ValueError, match="uncompressed stream byte limit"):
+        verify_release_candidate(candidate)
+
+
+def test_source_bound_verifier_checks_blob_size_before_read(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _repo(tmp_path)
+    candidate = tmp_path / "candidate-repository-blob-limit"
+    build_release_candidate(repo, candidate)
+    monkeypatch.setattr(verifier_module, "MAX_REPOSITORY_BLOB_BYTES", 1)
+    monkeypatch.setattr(
+        verifier_module,
+        "read_blob",
+        lambda *args: pytest.fail("repository blob read before size rejection"),
+    )
+    with pytest.raises(ValueError, match="repository blob exceeds byte limit"):
+        verify_release_candidate(candidate, repo=repo)
 
 
 def test_verifier_rejects_excessive_compression_ratio(

--- a/merger/repoground/tests/test_release_packaging.py
+++ b/merger/repoground/tests/test_release_packaging.py
@@ -796,6 +796,30 @@ def test_source_bound_verifier_batches_blob_content_reads(
     assert batch_calls == 1
 
 
+def test_source_bound_verifier_streams_one_blob_at_a_time(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _repo(tmp_path)
+    candidate = tmp_path / "candidate-streamed-blobs"
+    build_release_candidate(repo, candidate)
+    original = verifier_module._read_repository_blob_batch
+    live_blobs = 0
+    peak_live_blobs = 0
+
+    def counted_read(process, entry, expected_size):
+        nonlocal live_blobs, peak_live_blobs
+        live_blobs += 1
+        peak_live_blobs = max(peak_live_blobs, live_blobs)
+        try:
+            return original(process, entry, expected_size)
+        finally:
+            live_blobs -= 1
+
+    monkeypatch.setattr(verifier_module, "_read_repository_blob_batch", counted_read)
+    assert verify_release_candidate(candidate, repo=repo)["status"] == "pass"
+    assert peak_live_blobs == 1
+
+
 def test_source_bound_verifier_checks_blob_size_before_read(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/scripts/release/verify_release_candidate.py
+++ b/scripts/release/verify_release_candidate.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import argparse
-import gzip
 import hashlib
 import json
 import re
@@ -154,6 +153,41 @@ def _verify_sums(
         raise ValueError("SHA256SUMS does not match candidate files")
 
 
+def _validate_archive_member(member: tarfile.TarInfo, *, prefix: str) -> None:
+    if not _safe_name(member.name):
+        raise ValueError(f"unsafe archive member: {member.name!r}")
+    root_name = prefix.rstrip("/")
+    if member.name != root_name and not member.name.startswith(prefix):
+        raise ValueError(f"member outside archive prefix: {member.name!r}")
+    if member.uid != 0 or member.gid != 0 or member.mtime != 0:
+        raise ValueError(f"non-normalized metadata: {member.name!r}")
+    if not (member.isdir() or member.isfile() or member.issym()):
+        raise ValueError(f"unsupported archive member type: {member.name!r}")
+    if member.issym():
+        relative_path = member.name[len(prefix):]
+        if not safe_symlink_target(relative_path, member.linkname):
+            raise ValueError(
+                f"unsafe symlink target {member.linkname!r} at {member.name!r}"
+            )
+
+
+def _account_archive_member(member: tarfile.TarInfo, total_file_bytes: int) -> int:
+    if not member.isfile():
+        return total_file_bytes
+    if member.size < 0 or member.size > MAX_ARCHIVE_MEMBER_BYTES:
+        raise ValueError(
+            f"archive member exceeds byte limit: {member.name}: "
+            f"{member.size} > {MAX_ARCHIVE_MEMBER_BYTES}"
+        )
+    updated_total = total_file_bytes + member.size
+    if updated_total > MAX_ARCHIVE_TOTAL_BYTES:
+        raise ValueError(
+            "archive exceeds total uncompressed byte limit: "
+            f"{updated_total} > {MAX_ARCHIVE_TOTAL_BYTES}"
+        )
+    return updated_total
+
+
 def _archive_members(
     manifest: dict[str, object],
     archive_path: Path,
@@ -190,34 +224,9 @@ def _archive_members(
         for member in tar:
             if member.name in members:
                 raise ValueError(f"duplicate archive member: {member.name}")
+            _validate_archive_member(member, prefix=prefix)
+            total_file_bytes = _account_archive_member(member, total_file_bytes)
             observed_order.append(member.name)
-            if not _safe_name(member.name):
-                raise ValueError(f"unsafe archive member: {member.name!r}")
-            if member.name != prefix.rstrip("/") and not member.name.startswith(prefix):
-                raise ValueError(f"member outside archive prefix: {member.name!r}")
-            if member.uid != 0 or member.gid != 0 or member.mtime != 0:
-                raise ValueError(f"non-normalized metadata: {member.name!r}")
-            if not (member.isdir() or member.isfile() or member.issym()):
-                raise ValueError(f"unsupported archive member type: {member.name!r}")
-            if member.isfile():
-                if member.size < 0 or member.size > MAX_ARCHIVE_MEMBER_BYTES:
-                    raise ValueError(
-                        f"archive member exceeds byte limit: {member.name}: "
-                        f"{member.size} > {MAX_ARCHIVE_MEMBER_BYTES}"
-                    )
-                total_file_bytes += member.size
-                if total_file_bytes > MAX_ARCHIVE_TOTAL_BYTES:
-                    raise ValueError(
-                        "archive exceeds total uncompressed byte limit: "
-                        f"{total_file_bytes} > {MAX_ARCHIVE_TOTAL_BYTES}"
-                    )
-            if member.issym():
-                relative_path = member.name[len(prefix):]
-                if not safe_symlink_target(relative_path, member.linkname):
-                    raise ValueError(
-                        f"unsafe symlink target {member.linkname!r} "
-                        f"at {member.name!r}"
-                    )
             members[member.name] = member
     compression_ratio = total_file_bytes / actual_bytes
     if compression_ratio > MAX_ARCHIVE_COMPRESSION_RATIO:
@@ -491,6 +500,34 @@ def _verify_manifest_contract(
     if not isinstance(nonclaims, list) or not set(DOES_NOT_ESTABLISH).issubset(nonclaims):
         raise ValueError("manifest does_not_establish boundary is incomplete")
 
+def _compare_archive_entry(
+    tar: tarfile.TarFile,
+    member: tarfile.TarInfo,
+    *,
+    entry_path: str,
+    entry_mode: str,
+    blob: bytes,
+) -> None:
+    if entry_mode == "120000":
+        target = blob.decode("utf-8", errors="surrogateescape")
+        if not member.issym() or member.linkname != target:
+            raise ValueError(f"symlink mismatch: {entry_path}")
+        return
+    expected_mode = 0o755 if entry_mode == "100755" else 0o644
+    if not member.isfile() or member.mode != expected_mode:
+        raise ValueError(f"mode/type mismatch: {entry_path}")
+    if len(blob) > MAX_ARCHIVE_MEMBER_BYTES:
+        raise ValueError(f"repository blob exceeds byte limit: {entry_path}")
+    if member.size != len(blob):
+        raise ValueError(f"content byte size mismatch: {entry_path}")
+    handle = tar.extractfile(member)
+    if handle is None:
+        raise ValueError(f"cannot read archive member: {entry_path}")
+    content = _read_limited(handle, name=entry_path, max_bytes=len(blob))
+    if content != blob:
+        raise ValueError(f"content mismatch: {entry_path}")
+
+
 def _compare_with_repo(
     repo: Path,
     manifest: dict[str, object],
@@ -517,31 +554,16 @@ def _compare_with_repo(
     if observed_names != expected_names:
         raise ValueError("archive path set does not match Git tree")
 
-    with gzip.open(archive_path, "rb") as gz:
-        with tarfile.open(fileobj=gz, mode="r:") as tar:
-            for entry in expected_entries:
-                member = tar.getmember(f"{prefix}{entry.path}")
-                blob = read_blob(repo, commit, entry.path)
-                if entry.mode == "120000":
-                    target = blob.decode("utf-8", errors="surrogateescape")
-                    if not member.issym() or member.linkname != target:
-                        raise ValueError(f"symlink mismatch: {entry.path}")
-                    continue
-                expected_mode = 0o755 if entry.mode == "100755" else 0o644
-                if not member.isfile() or member.mode != expected_mode:
-                    raise ValueError(f"mode/type mismatch: {entry.path}")
-                if len(blob) > MAX_ARCHIVE_MEMBER_BYTES:
-                    raise ValueError(f"repository blob exceeds byte limit: {entry.path}")
-                if member.size != len(blob):
-                    raise ValueError(f"content byte size mismatch: {entry.path}")
-                handle = tar.extractfile(member)
-                if handle is None:
-                    raise ValueError(f"cannot read archive member: {entry.path}")
-                content = _read_limited(
-                    handle, name=entry.path, max_bytes=len(blob)
-                )
-                if content != blob:
-                    raise ValueError(f"content mismatch: {entry.path}")
+    with tarfile.open(archive_path, mode="r:gz") as tar:
+        for entry in expected_entries:
+            member = tar.getmember(f"{prefix}{entry.path}")
+            _compare_archive_entry(
+                tar,
+                member,
+                entry_path=entry.path,
+                entry_mode=entry.mode,
+                blob=read_blob(repo, commit, entry.path),
+            )
 
 
 def _contract_for_manifest(manifest: dict[str, object]) -> ReleaseContract:

--- a/scripts/release/verify_release_candidate.py
+++ b/scripts/release/verify_release_candidate.py
@@ -70,6 +70,13 @@ CANONICAL_CONTRACT = ReleaseContract(
     compatibility_mode="canonical_repoground_v1",
 )
 
+MAX_ARCHIVE_BYTES = 64 * 1024 * 1024
+MAX_ARCHIVE_MEMBER_BYTES = 16 * 1024 * 1024
+MAX_ARCHIVE_TOTAL_BYTES = 128 * 1024 * 1024
+MAX_ARCHIVE_COMPRESSION_RATIO = 200
+MAX_LICENSE_BYTES = 1024 * 1024
+READ_CHUNK_BYTES = 1024 * 1024
+
 
 def _sha256(path: Path) -> str:
     digest = hashlib.sha256()
@@ -156,44 +163,68 @@ def _archive_members(
     expected_sha = archive.get("sha256")
     expected_bytes = archive.get("bytes")
     prefix = archive.get("prefix")
+    actual_bytes = archive_path.stat().st_size
     if _sha256(archive_path) != expected_sha:
         raise ValueError("archive SHA-256 does not match manifest")
-    if archive_path.stat().st_size != expected_bytes:
+    if actual_bytes != expected_bytes:
         raise ValueError("archive byte size does not match manifest")
+    if actual_bytes > MAX_ARCHIVE_BYTES:
+        raise ValueError(
+            f"archive exceeds compressed byte limit: {actual_bytes} > {MAX_ARCHIVE_BYTES}"
+        )
     if (
         not isinstance(prefix, str)
         or not prefix.endswith("/")
         or not _safe_name(prefix[:-1])
     ):
         raise ValueError("archive prefix is invalid")
-    raw = archive_path.read_bytes()
+    with archive_path.open("rb") as handle:
+        raw = handle.read(8)
     if len(raw) < 8 or int.from_bytes(raw[4:8], "little") != 0:
         raise ValueError("gzip timestamp is not normalized to zero")
 
     members: dict[str, tarfile.TarInfo] = {}
     observed_order: list[str] = []
-    with gzip.open(archive_path, "rb") as gz:
-        with tarfile.open(fileobj=gz, mode="r:") as tar:
-            for member in tar.getmembers():
-                if member.name in members:
-                    raise ValueError(f"duplicate archive member: {member.name}")
-                observed_order.append(member.name)
-                if not _safe_name(member.name):
-                    raise ValueError(f"unsafe archive member: {member.name!r}")
-                if member.name != prefix.rstrip("/") and not member.name.startswith(prefix):
-                    raise ValueError(f"member outside archive prefix: {member.name!r}")
-                if member.uid != 0 or member.gid != 0 or member.mtime != 0:
-                    raise ValueError(f"non-normalized metadata: {member.name!r}")
-                if not (member.isdir() or member.isfile() or member.issym()):
-                    raise ValueError(f"unsupported archive member type: {member.name!r}")
-                if member.issym():
-                    relative_path = member.name[len(prefix):]
-                    if not safe_symlink_target(relative_path, member.linkname):
-                        raise ValueError(
-                            f"unsafe symlink target {member.linkname!r} "
-                            f"at {member.name!r}"
-                        )
-                members[member.name] = member
+    total_file_bytes = 0
+    with tarfile.open(archive_path, mode="r:gz") as tar:
+        for member in tar:
+            if member.name in members:
+                raise ValueError(f"duplicate archive member: {member.name}")
+            observed_order.append(member.name)
+            if not _safe_name(member.name):
+                raise ValueError(f"unsafe archive member: {member.name!r}")
+            if member.name != prefix.rstrip("/") and not member.name.startswith(prefix):
+                raise ValueError(f"member outside archive prefix: {member.name!r}")
+            if member.uid != 0 or member.gid != 0 or member.mtime != 0:
+                raise ValueError(f"non-normalized metadata: {member.name!r}")
+            if not (member.isdir() or member.isfile() or member.issym()):
+                raise ValueError(f"unsupported archive member type: {member.name!r}")
+            if member.isfile():
+                if member.size < 0 or member.size > MAX_ARCHIVE_MEMBER_BYTES:
+                    raise ValueError(
+                        f"archive member exceeds byte limit: {member.name}: "
+                        f"{member.size} > {MAX_ARCHIVE_MEMBER_BYTES}"
+                    )
+                total_file_bytes += member.size
+                if total_file_bytes > MAX_ARCHIVE_TOTAL_BYTES:
+                    raise ValueError(
+                        "archive exceeds total uncompressed byte limit: "
+                        f"{total_file_bytes} > {MAX_ARCHIVE_TOTAL_BYTES}"
+                    )
+            if member.issym():
+                relative_path = member.name[len(prefix):]
+                if not safe_symlink_target(relative_path, member.linkname):
+                    raise ValueError(
+                        f"unsafe symlink target {member.linkname!r} "
+                        f"at {member.name!r}"
+                    )
+            members[member.name] = member
+    compression_ratio = total_file_bytes / actual_bytes
+    if compression_ratio > MAX_ARCHIVE_COMPRESSION_RATIO:
+        raise ValueError(
+            "archive exceeds compression ratio limit: "
+            f"{compression_ratio:.1f} > {MAX_ARCHIVE_COMPRESSION_RATIO}"
+        )
     expected_count = archive.get("tracked_entry_count")
     if len(members) != expected_count + 1:
         raise ValueError("archive member count does not match manifest")
@@ -229,19 +260,47 @@ def _reject_retired_release_contract_members(
         )
 
 
-def _read_archive_member(archive_path: Path, name: str) -> bytes:
-    with gzip.open(archive_path, "rb") as gz:
-        with tarfile.open(fileobj=gz, mode="r:") as tar:
-            try:
-                member = tar.getmember(name)
-            except KeyError as exc:
-                raise ValueError(f"required archive member is missing: {name}") from exc
-            if not member.isfile():
-                raise ValueError(f"required archive member is not a file: {name}")
-            handle = tar.extractfile(member)
-            if handle is None:
-                raise ValueError(f"cannot read required archive member: {name}")
-            return handle.read()
+def _read_limited(handle: object, *, name: str, max_bytes: int) -> bytes:
+    read = getattr(handle, "read", None)
+    if not callable(read):
+        raise ValueError(f"cannot read required archive member: {name}")
+    chunks: list[bytes] = []
+    observed = 0
+    while observed <= max_bytes:
+        chunk = read(min(READ_CHUNK_BYTES, max_bytes + 1 - observed))
+        if not chunk:
+            break
+        chunks.append(chunk)
+        observed += len(chunk)
+    if observed > max_bytes:
+        raise ValueError(f"archive member exceeds read limit: {name}")
+    return b"".join(chunks)
+
+
+def _read_archive_member(
+    archive_path: Path,
+    name: str,
+    *,
+    max_bytes: int = MAX_ARCHIVE_MEMBER_BYTES,
+) -> bytes:
+    with tarfile.open(archive_path, mode="r:gz") as tar:
+        try:
+            member = tar.getmember(name)
+        except KeyError as exc:
+            raise ValueError(f"required archive member is missing: {name}") from exc
+        if not member.isfile():
+            raise ValueError(f"required archive member is not a file: {name}")
+        if member.size > max_bytes:
+            raise ValueError(
+                f"archive member exceeds byte limit: {name}: {member.size} > {max_bytes}"
+            )
+        handle = tar.extractfile(member)
+        if handle is None:
+            raise ValueError(f"cannot read required archive member: {name}")
+        content = _read_limited(handle, name=name, max_bytes=max_bytes)
+        if len(content) != member.size:
+            raise ValueError(f"archive member byte size mismatch: {name}")
+        return content
 
 
 
@@ -262,8 +321,18 @@ def _verify_dependency_locks(
         if not isinstance(path, str):
             raise ValueError("manifest dependency lock path is invalid")
         observed_paths.append(path)
-        content = _read_archive_member(archive_path, f"{expected_prefix}{path}")
-        if record.get("bytes") != len(content):
+        expected_size = record.get("bytes")
+        if (
+            not isinstance(expected_size, int)
+            or isinstance(expected_size, bool)
+            or expected_size < 0
+            or expected_size > MAX_ARCHIVE_MEMBER_BYTES
+        ):
+            raise ValueError(f"dependency lock byte size is invalid: {path}")
+        content = _read_archive_member(
+            archive_path, f"{expected_prefix}{path}", max_bytes=expected_size
+        )
+        if expected_size != len(content):
             raise ValueError(f"dependency lock byte size mismatch: {path}")
         if record.get("sha256") != hashlib.sha256(content).hexdigest():
             raise ValueError(f"dependency lock SHA-256 mismatch: {path}")
@@ -281,8 +350,20 @@ def _verify_semantic_record(
         raise ValueError(f"semantic extension record is invalid: {expected_path}")
     if record.get("path") != expected_path:
         raise ValueError(f"semantic extension path mismatch: {expected_path}")
-    content = _read_archive_member(archive_path, f"{expected_prefix}{expected_path}")
-    if record.get("bytes") != len(content):
+    expected_size = record.get("bytes")
+    if (
+        not isinstance(expected_size, int)
+        or isinstance(expected_size, bool)
+        or expected_size < 0
+        or expected_size > MAX_ARCHIVE_MEMBER_BYTES
+    ):
+        raise ValueError(f"semantic extension byte size is invalid: {expected_path}")
+    content = _read_archive_member(
+        archive_path,
+        f"{expected_prefix}{expected_path}",
+        max_bytes=expected_size,
+    )
+    if expected_size != len(content):
         raise ValueError(f"semantic extension byte size mismatch: {expected_path}")
     if record.get("sha256") != hashlib.sha256(content).hexdigest():
         raise ValueError(f"semantic extension SHA-256 mismatch: {expected_path}")
@@ -397,7 +478,9 @@ def _verify_manifest_contract(
     _verify_dependency_locks(manifest, archive_path, expected_prefix, contract)
 
     license_content = _read_archive_member(
-        archive_path, f"{expected_prefix}LICENSE"
+        archive_path,
+        f"{expected_prefix}LICENSE",
+        max_bytes=MAX_LICENSE_BYTES,
     ).decode("utf-8")
     if "Apache License" not in license_content or "Version 2.0" not in license_content:
         raise ValueError("archived LICENSE does not contain Apache-2.0")
@@ -447,8 +530,17 @@ def _compare_with_repo(
                 expected_mode = 0o755 if entry.mode == "100755" else 0o644
                 if not member.isfile() or member.mode != expected_mode:
                     raise ValueError(f"mode/type mismatch: {entry.path}")
+                if len(blob) > MAX_ARCHIVE_MEMBER_BYTES:
+                    raise ValueError(f"repository blob exceeds byte limit: {entry.path}")
+                if member.size != len(blob):
+                    raise ValueError(f"content byte size mismatch: {entry.path}")
                 handle = tar.extractfile(member)
-                if handle is None or handle.read() != blob:
+                if handle is None:
+                    raise ValueError(f"cannot read archive member: {entry.path}")
+                content = _read_limited(
+                    handle, name=entry.path, max_bytes=len(blob)
+                )
+                if content != blob:
                     raise ValueError(f"content mismatch: {entry.path}")
 
 

--- a/scripts/release/verify_release_candidate.py
+++ b/scripts/release/verify_release_candidate.py
@@ -34,7 +34,6 @@ from scripts.release.build_release_candidate import (
     TreeEntry,
     VERSION_RE,
     list_tree,
-    read_blob,
     resolve_tree,
     safe_symlink_target,
 )
@@ -369,36 +368,34 @@ def _read_limited(handle: object, *, name: str, max_bytes: int) -> bytes:
 
 
 def _read_archive_member(
-    archive_path: Path,
+    tar_path: Path,
+    members: dict[str, tarfile.TarInfo],
     name: str,
     *,
     max_bytes: int = MAX_ARCHIVE_MEMBER_BYTES,
 ) -> bytes:
-    with _open_bounded_tar(archive_path) as tar:
-        for member in tar:
-            if member.name != name:
-                continue
-            if not member.isfile():
-                raise ValueError(f"required archive member is not a file: {name}")
-            if member.size > max_bytes:
-                raise ValueError(
-                    f"archive member exceeds byte limit: {name}: "
-                    f"{member.size} > {max_bytes}"
-                )
-            handle = tar.extractfile(member)
-            if handle is None:
-                raise ValueError(f"cannot read required archive member: {name}")
-            content = _read_limited(handle, name=name, max_bytes=max_bytes)
-            if len(content) != member.size:
-                raise ValueError(f"archive member byte size mismatch: {name}")
-            return content
-    raise ValueError(f"required archive member is missing: {name}")
+    member = members.get(name)
+    if member is None:
+        raise ValueError(f"required archive member is missing: {name}")
+    if not member.isfile():
+        raise ValueError(f"required archive member is not a file: {name}")
+    if member.size > max_bytes:
+        raise ValueError(
+            f"archive member exceeds byte limit: {name}: {member.size} > {max_bytes}"
+        )
+    with tar_path.open("rb") as handle:
+        handle.seek(member.offset_data)
+        content = handle.read(member.size)
+    if len(content) != member.size:
+        raise ValueError(f"archive member byte size mismatch: {name}")
+    return content
 
 
 
 def _verify_dependency_locks(
     manifest: dict[str, object],
-    archive_path: Path,
+    tar_path: Path,
+    members: dict[str, tarfile.TarInfo],
     expected_prefix: str,
     contract: ReleaseContract,
 ) -> None:
@@ -422,7 +419,10 @@ def _verify_dependency_locks(
         ):
             raise ValueError(f"dependency lock byte size is invalid: {path}")
         content = _read_archive_member(
-            archive_path, f"{expected_prefix}{path}", max_bytes=expected_size
+            tar_path,
+            members,
+            f"{expected_prefix}{path}",
+            max_bytes=expected_size,
         )
         if expected_size != len(content):
             raise ValueError(f"dependency lock byte size mismatch: {path}")
@@ -433,7 +433,8 @@ def _verify_dependency_locks(
 
 
 def _verify_semantic_record(
-    archive_path: Path,
+    tar_path: Path,
+    members: dict[str, tarfile.TarInfo],
     expected_prefix: str,
     record: object,
     expected_path: str,
@@ -451,7 +452,8 @@ def _verify_semantic_record(
     ):
         raise ValueError(f"semantic extension byte size is invalid: {expected_path}")
     content = _read_archive_member(
-        archive_path,
+        tar_path,
+        members,
         f"{expected_prefix}{expected_path}",
         max_bytes=expected_size,
     )
@@ -462,7 +464,8 @@ def _verify_semantic_record(
 
 
 def _verify_semantic_target(
-    archive_path: Path,
+    tar_path: Path,
+    members: dict[str, tarfile.TarInfo],
     expected_prefix: str,
     target: object,
     contract: ReleaseContract,
@@ -474,22 +477,24 @@ def _verify_semantic_target(
     if target.get("id") != contract.semantic_target_id:
         raise ValueError("semantic extension target identity mismatch")
     _verify_semantic_record(
-        archive_path, expected_prefix, target.get("input"), contract.semantic_input_path
+        tar_path, members, expected_prefix, target.get("input"), contract.semantic_input_path
     )
     _verify_semantic_record(
-        archive_path,
+        tar_path,
+        members,
         expected_prefix,
         target.get("constraints"),
         contract.semantic_constraints_path,
     )
     _verify_semantic_record(
-        archive_path, expected_prefix, target.get("lock"), contract.semantic_lock_path
+        tar_path, members, expected_prefix, target.get("lock"), contract.semantic_lock_path
     )
 
 
 def _verify_semantic_extension(
     manifest: dict[str, object],
-    archive_path: Path,
+    tar_path: Path,
+    members: dict[str, tarfile.TarInfo],
     expected_prefix: str,
     contract: ReleaseContract,
 ) -> None:
@@ -503,7 +508,8 @@ def _verify_semantic_extension(
     if semantic.get("unsupported_target_policy") != "fail_closed":
         raise ValueError("semantic extension unsupported-target policy mismatch")
     _verify_semantic_record(
-        archive_path,
+        tar_path,
+        members,
         expected_prefix,
         semantic.get("platform_contract"),
         contract.semantic_platform_contract_path,
@@ -511,12 +517,13 @@ def _verify_semantic_extension(
     targets = semantic.get("targets")
     if not isinstance(targets, list) or len(targets) != 1:
         raise ValueError("semantic extension target count mismatch")
-    _verify_semantic_target(archive_path, expected_prefix, targets[0], contract)
+    _verify_semantic_target(tar_path, members, expected_prefix, targets[0], contract)
 
 
 def _verify_manifest_contract(
     manifest: dict[str, object],
-    archive_path: Path,
+    tar_path: Path,
+    members: dict[str, tarfile.TarInfo],
     contract: ReleaseContract,
 ) -> None:
     if manifest.get("$schema") != contract.schema_uri:
@@ -567,17 +574,18 @@ def _verify_manifest_contract(
     }:
         raise ValueError("manifest archive normalization mismatch")
 
-    _verify_dependency_locks(manifest, archive_path, expected_prefix, contract)
+    _verify_dependency_locks(manifest, tar_path, members, expected_prefix, contract)
 
     license_content = _read_archive_member(
-        archive_path,
+        tar_path,
+        members,
         f"{expected_prefix}LICENSE",
         max_bytes=MAX_LICENSE_BYTES,
     ).decode("utf-8")
     if "Apache License" not in license_content or "Version 2.0" not in license_content:
         raise ValueError("archived LICENSE does not contain Apache-2.0")
 
-    _verify_semantic_extension(manifest, archive_path, expected_prefix, contract)
+    _verify_semantic_extension(manifest, tar_path, members, expected_prefix, contract)
 
     nonclaims = manifest.get("does_not_establish")
     if not isinstance(nonclaims, list) or not set(DOES_NOT_ESTABLISH).issubset(nonclaims):
@@ -620,17 +628,56 @@ def _repository_blob_sizes(
     return sizes
 
 
-def _read_repository_blob(
-    repo: Path, commit: str, entry: TreeEntry, expected_size: int
-) -> bytes:
-    blob = read_blob(repo, commit, entry.path)
-    if len(blob) != expected_size:
-        raise ValueError(f"repository blob byte size mismatch: {entry.path}")
-    return blob
+def _repository_blobs(
+    repo: Path,
+    entries: tuple[TreeEntry, ...],
+    expected_sizes: dict[str, int],
+) -> dict[str, bytes]:
+    process = subprocess.Popen(
+        ["git", "cat-file", "--batch"],
+        cwd=repo,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if process.stdin is None or process.stdout is None or process.stderr is None:
+        process.kill()
+        process.wait()
+        raise ValueError("git cat-file --batch pipes are unavailable")
+    blobs: dict[str, bytes] = {}
+    try:
+        for entry in entries:
+            process.stdin.write(f"{entry.object_id}\n".encode("ascii"))
+            process.stdin.flush()
+            header = process.stdout.readline().decode("ascii").strip()
+            object_id, object_type, raw_size = header.split(" ")
+            expected_size = expected_sizes[entry.path]
+            if (
+                object_id != entry.object_id
+                or object_type != "blob"
+                or not raw_size.isdigit()
+                or int(raw_size) != expected_size
+            ):
+                raise ValueError(f"invalid Git blob content response: {entry.path}")
+            blob = process.stdout.read(expected_size)
+            if len(blob) != expected_size or process.stdout.read(1) != b"\n":
+                raise ValueError(f"repository blob byte size mismatch: {entry.path}")
+            blobs[entry.path] = blob
+        process.stdin.close()
+        returncode = process.wait()
+        if returncode != 0:
+            detail = process.stderr.read().decode("utf-8", errors="replace").strip()
+            raise ValueError(f"git cat-file --batch failed: {detail}")
+        return blobs
+    except Exception:
+        process.kill()
+        process.wait()
+        raise
 
 
 def _compare_archive_entry(
-    tar: tarfile.TarFile,
+    tar_path: Path,
+    members: dict[str, tarfile.TarInfo],
     member: tarfile.TarInfo,
     *,
     entry_path: str,
@@ -649,10 +696,12 @@ def _compare_archive_entry(
         raise ValueError(f"repository blob exceeds byte limit: {entry_path}")
     if member.size != len(blob):
         raise ValueError(f"content byte size mismatch: {entry_path}")
-    handle = tar.extractfile(member)
-    if handle is None:
-        raise ValueError(f"cannot read archive member: {entry_path}")
-    content = _read_limited(handle, name=entry_path, max_bytes=len(blob))
+    content = _read_archive_member(
+        tar_path,
+        members,
+        member.name,
+        max_bytes=len(blob),
+    )
     if content != blob:
         raise ValueError(f"content mismatch: {entry_path}")
 
@@ -679,32 +728,22 @@ def _compare_with_repo(
 
     expected_entries = list_tree(repo, commit)
     blob_sizes = _repository_blob_sizes(repo, expected_entries)
+    blobs = _repository_blobs(repo, expected_entries, blob_sizes)
     expected_names = {f"{prefix}{entry.path}" for entry in expected_entries}
     observed_names = {name for name in members if name != prefix.rstrip("/")}
     if observed_names != expected_names:
         raise ValueError("archive path set does not match Git tree")
 
-    with _open_bounded_tar(archive_path) as tar:
-        iterator = iter(tar)
-        root_member = next(iterator, None)
-        if root_member is None or root_member.name != prefix.rstrip("/"):
-            raise ValueError("archive root member is missing or out of order")
-        for entry in expected_entries:
-            member = next(iterator, None)
-            expected_name = f"{prefix}{entry.path}"
-            if member is None or member.name != expected_name:
-                raise ValueError(f"archive member order mismatch: {entry.path}")
-            _compare_archive_entry(
-                tar,
-                member,
-                entry_path=entry.path,
-                entry_mode=entry.mode,
-                blob=_read_repository_blob(
-                    repo, commit, entry, blob_sizes[entry.path]
-                ),
-            )
-        if next(iterator, None) is not None:
-            raise ValueError("archive contains unexpected trailing members")
+    for entry in expected_entries:
+        member = members[f"{prefix}{entry.path}"]
+        _compare_archive_entry(
+            archive_path,
+            members,
+            member,
+            entry_path=entry.path,
+            entry_mode=entry.mode,
+            blob=blobs[entry.path],
+        )
 
 
 def _contract_for_manifest(manifest: dict[str, object]) -> ReleaseContract:
@@ -744,7 +783,7 @@ def _verify_release_candidate(
         prefix = archive.get("prefix")
         assert isinstance(prefix, str)
         _reject_retired_release_contract_members(members, prefix)
-        _verify_manifest_contract(manifest, tar_path, contract)
+        _verify_manifest_contract(manifest, tar_path, members, contract)
         if repo is not None:
             _compare_with_repo(
                 Path(repo).expanduser().resolve(), manifest, tar_path, members

--- a/scripts/release/verify_release_candidate.py
+++ b/scripts/release/verify_release_candidate.py
@@ -628,11 +628,8 @@ def _repository_blob_sizes(
     return sizes
 
 
-def _repository_blobs(
-    repo: Path,
-    entries: tuple[TreeEntry, ...],
-    expected_sizes: dict[str, int],
-) -> dict[str, bytes]:
+@contextmanager
+def _open_repository_blob_batch(repo: Path) -> Iterator[subprocess.Popen[bytes]]:
     process = subprocess.Popen(
         ["git", "cat-file", "--batch"],
         cwd=repo,
@@ -644,35 +641,80 @@ def _repository_blobs(
         process.kill()
         process.wait()
         raise ValueError("git cat-file --batch pipes are unavailable")
-    blobs: dict[str, bytes] = {}
     try:
-        for entry in entries:
-            process.stdin.write(f"{entry.object_id}\n".encode("ascii"))
-            process.stdin.flush()
-            header = process.stdout.readline().decode("ascii").strip()
-            object_id, object_type, raw_size = header.split(" ")
-            expected_size = expected_sizes[entry.path]
-            if (
-                object_id != entry.object_id
-                or object_type != "blob"
-                or not raw_size.isdigit()
-                or int(raw_size) != expected_size
-            ):
-                raise ValueError(f"invalid Git blob content response: {entry.path}")
-            blob = process.stdout.read(expected_size)
-            if len(blob) != expected_size or process.stdout.read(1) != b"\n":
-                raise ValueError(f"repository blob byte size mismatch: {entry.path}")
-            blobs[entry.path] = blob
+        yield process
         process.stdin.close()
         returncode = process.wait()
         if returncode != 0:
             detail = process.stderr.read().decode("utf-8", errors="replace").strip()
             raise ValueError(f"git cat-file --batch failed: {detail}")
-        return blobs
     except Exception:
-        process.kill()
-        process.wait()
+        if process.poll() is None:
+            process.kill()
+            process.wait()
         raise
+
+
+def _read_exact_batch_bytes(handle: object, size: int, *, path: str) -> bytes:
+    read = getattr(handle, "read", None)
+    if not callable(read):
+        raise ValueError("git cat-file --batch output is unavailable")
+    chunks: list[bytes] = []
+    remaining = size
+    while remaining:
+        chunk = read(min(READ_CHUNK_BYTES, remaining))
+        if not chunk:
+            raise ValueError(f"repository blob byte size mismatch: {path}")
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def _read_repository_blob_batch(
+    process: subprocess.Popen[bytes],
+    entry: TreeEntry,
+    expected_size: int,
+) -> bytes:
+    if process.stdin is None or process.stdout is None:
+        raise ValueError("git cat-file --batch pipes are unavailable")
+    process.stdin.write(f"{entry.object_id}\n".encode("ascii"))
+    process.stdin.flush()
+    header = process.stdout.readline(256)
+    if not header or len(header) >= 256:
+        raise ValueError(f"invalid Git blob content response: {entry.path}")
+    fields = header.decode("ascii", errors="strict").strip().split(" ")
+    if len(fields) != 3:
+        raise ValueError(f"invalid Git blob content response: {entry.path}")
+    object_id, object_type, raw_size = fields
+    if (
+        object_id != entry.object_id
+        or object_type != "blob"
+        or not raw_size.isdigit()
+        or int(raw_size) != expected_size
+    ):
+        raise ValueError(f"invalid Git blob content response: {entry.path}")
+    blob = _read_exact_batch_bytes(process.stdout, expected_size, path=entry.path)
+    if process.stdout.read(1) != b"\n":
+        raise ValueError(f"repository blob byte size mismatch: {entry.path}")
+    return blob
+
+
+def _validate_archive_entry_shape(
+    member: tarfile.TarInfo,
+    *,
+    entry_path: str,
+    entry_mode: str,
+    expected_size: int,
+) -> None:
+    if entry_mode == "120000":
+        if not member.issym():
+            raise ValueError(f"symlink mismatch: {entry_path}")
+        return
+    expected_mode = 0o755 if entry_mode == "100755" else 0o644
+    if not member.isfile() or member.mode != expected_mode:
+        raise ValueError(f"mode/type mismatch: {entry_path}")
+    if member.size != expected_size:
+        raise ValueError(f"content byte size mismatch: {entry_path}")
 
 
 def _compare_archive_entry(
@@ -686,16 +728,9 @@ def _compare_archive_entry(
 ) -> None:
     if entry_mode == "120000":
         target = blob.decode("utf-8", errors="surrogateescape")
-        if not member.issym() or member.linkname != target:
+        if member.linkname != target:
             raise ValueError(f"symlink mismatch: {entry_path}")
         return
-    expected_mode = 0o755 if entry_mode == "100755" else 0o644
-    if not member.isfile() or member.mode != expected_mode:
-        raise ValueError(f"mode/type mismatch: {entry_path}")
-    if len(blob) > MAX_ARCHIVE_MEMBER_BYTES:
-        raise ValueError(f"repository blob exceeds byte limit: {entry_path}")
-    if member.size != len(blob):
-        raise ValueError(f"content byte size mismatch: {entry_path}")
     content = _read_archive_member(
         tar_path,
         members,
@@ -728,22 +763,30 @@ def _compare_with_repo(
 
     expected_entries = list_tree(repo, commit)
     blob_sizes = _repository_blob_sizes(repo, expected_entries)
-    blobs = _repository_blobs(repo, expected_entries, blob_sizes)
     expected_names = {f"{prefix}{entry.path}" for entry in expected_entries}
     observed_names = {name for name in members if name != prefix.rstrip("/")}
     if observed_names != expected_names:
         raise ValueError("archive path set does not match Git tree")
 
-    for entry in expected_entries:
-        member = members[f"{prefix}{entry.path}"]
-        _compare_archive_entry(
-            archive_path,
-            members,
-            member,
-            entry_path=entry.path,
-            entry_mode=entry.mode,
-            blob=blobs[entry.path],
-        )
+    with _open_repository_blob_batch(repo) as process:
+        for entry in expected_entries:
+            member = members[f"{prefix}{entry.path}"]
+            expected_size = blob_sizes[entry.path]
+            _validate_archive_entry_shape(
+                member,
+                entry_path=entry.path,
+                entry_mode=entry.mode,
+                expected_size=expected_size,
+            )
+            blob = _read_repository_blob_batch(process, entry, expected_size)
+            _compare_archive_entry(
+                archive_path,
+                members,
+                member,
+                entry_path=entry.path,
+                entry_mode=entry.mode,
+                blob=blob,
+            )
 
 
 def _contract_for_manifest(manifest: dict[str, object]) -> ReleaseContract:

--- a/scripts/release/verify_release_candidate.py
+++ b/scripts/release/verify_release_candidate.py
@@ -73,6 +73,7 @@ MAX_ARCHIVE_BYTES = 64 * 1024 * 1024
 MAX_ARCHIVE_MEMBER_BYTES = 16 * 1024 * 1024
 MAX_ARCHIVE_TOTAL_BYTES = 128 * 1024 * 1024
 MAX_ARCHIVE_COMPRESSION_RATIO = 200
+MAX_ARCHIVE_MEMBERS = 10_000
 MAX_LICENSE_BYTES = 1024 * 1024
 READ_CHUNK_BYTES = 1024 * 1024
 
@@ -171,6 +172,25 @@ def _validate_archive_member(member: tarfile.TarInfo, *, prefix: str) -> None:
             )
 
 
+def _expected_archive_member_count(archive: dict[str, object]) -> int:
+    expected_count = archive.get("tracked_entry_count")
+    if not isinstance(expected_count, int) or isinstance(expected_count, bool):
+        raise ValueError("archive tracked-entry count is invalid")
+    if expected_count < 0 or expected_count + 1 > MAX_ARCHIVE_MEMBERS:
+        raise ValueError(
+            "archive exceeds member count limit: "
+            f"{expected_count + 1} > {MAX_ARCHIVE_MEMBERS}"
+        )
+    return expected_count
+
+
+def _ensure_archive_member_capacity(member_count: int) -> None:
+    if member_count >= MAX_ARCHIVE_MEMBERS:
+        raise ValueError(
+            f"archive exceeds member count limit: more than {MAX_ARCHIVE_MEMBERS}"
+        )
+
+
 def _account_archive_member(member: tarfile.TarInfo, total_file_bytes: int) -> int:
     if not member.isfile():
         return total_file_bytes
@@ -197,6 +217,7 @@ def _archive_members(
     expected_sha = archive.get("sha256")
     expected_bytes = archive.get("bytes")
     prefix = archive.get("prefix")
+    expected_count = _expected_archive_member_count(archive)
     actual_bytes = archive_path.stat().st_size
     if _sha256(archive_path) != expected_sha:
         raise ValueError("archive SHA-256 does not match manifest")
@@ -222,6 +243,7 @@ def _archive_members(
     total_file_bytes = 0
     with tarfile.open(archive_path, mode="r:gz") as tar:
         for member in tar:
+            _ensure_archive_member_capacity(len(members))
             if member.name in members:
                 raise ValueError(f"duplicate archive member: {member.name}")
             _validate_archive_member(member, prefix=prefix)
@@ -234,7 +256,6 @@ def _archive_members(
             "archive exceeds compression ratio limit: "
             f"{compression_ratio:.1f} > {MAX_ARCHIVE_COMPRESSION_RATIO}"
         )
-    expected_count = archive.get("tracked_entry_count")
     if len(members) != expected_count + 1:
         raise ValueError("archive member count does not match manifest")
     root_name = prefix.rstrip("/")

--- a/scripts/release/verify_release_candidate.py
+++ b/scripts/release/verify_release_candidate.py
@@ -87,10 +87,9 @@ READ_CHUNK_BYTES = 1024 * 1024
 
 
 @contextmanager
-def _open_bounded_tar(archive_path: Path) -> Iterator[tarfile.TarFile]:
-    with _materialized_bounded_tar(archive_path) as tar_path:
-        with tarfile.open(tar_path, mode="r:") as tar:
-            yield tar
+def _open_bounded_tar(tar_path: Path) -> Iterator[tarfile.TarFile]:
+    with tarfile.open(tar_path, mode="r:") as tar:
+        yield tar
 
 
 def _sha256(path: Path) -> str:
@@ -276,6 +275,7 @@ def _account_archive_member(member: tarfile.TarInfo, total_file_bytes: int) -> i
 def _archive_members(
     manifest: dict[str, object],
     archive_path: Path,
+    tar_path: Path,
 ) -> dict[str, tarfile.TarInfo]:
     archive = manifest["archive"]
     assert isinstance(archive, dict)
@@ -302,7 +302,7 @@ def _archive_members(
     members: dict[str, tarfile.TarInfo] = {}
     observed_order: list[str] = []
     total_file_bytes = 0
-    with _open_bounded_tar(archive_path) as tar:
+    with _open_bounded_tar(tar_path) as tar:
         for member in tar:
             _ensure_archive_member_capacity(len(members))
             if member.name in members:
@@ -737,17 +737,18 @@ def _verify_release_candidate(
     if license_data.get("distribution_status") != DISTRIBUTION_STATUS:
         raise ValueError("distribution boundary mismatch")
 
-    members = _archive_members(manifest, archive_path)
-    archive = manifest.get("archive")
-    assert isinstance(archive, dict)
-    prefix = archive.get("prefix")
-    assert isinstance(prefix, str)
-    _reject_retired_release_contract_members(members, prefix)
-    _verify_manifest_contract(manifest, archive_path, contract)
-    if repo is not None:
-        _compare_with_repo(
-            Path(repo).expanduser().resolve(), manifest, archive_path, members
-        )
+    with _materialized_bounded_tar(archive_path) as tar_path:
+        members = _archive_members(manifest, archive_path, tar_path)
+        archive = manifest.get("archive")
+        assert isinstance(archive, dict)
+        prefix = archive.get("prefix")
+        assert isinstance(prefix, str)
+        _reject_retired_release_contract_members(members, prefix)
+        _verify_manifest_contract(manifest, tar_path, contract)
+        if repo is not None:
+            _compare_with_repo(
+                Path(repo).expanduser().resolve(), manifest, tar_path, members
+            )
     project = manifest.get("project")
     assert isinstance(project, dict)
     return {

--- a/scripts/release/verify_release_candidate.py
+++ b/scripts/release/verify_release_candidate.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 import argparse
+import gzip
 import hashlib
 import json
 import re
 import subprocess
 import sys
+import tempfile
 import tarfile
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -82,6 +86,13 @@ MAX_LICENSE_BYTES = 1024 * 1024
 READ_CHUNK_BYTES = 1024 * 1024
 
 
+@contextmanager
+def _open_bounded_tar(archive_path: Path) -> Iterator[tarfile.TarFile]:
+    with _materialized_bounded_tar(archive_path) as tar_path:
+        with tarfile.open(tar_path, mode="r:") as tar:
+            yield tar
+
+
 def _sha256(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as handle:
@@ -97,6 +108,40 @@ def _compressed_archive_size(archive_path: Path) -> int:
             f"archive exceeds compressed byte limit: {actual_bytes} > {MAX_ARCHIVE_BYTES}"
         )
     return actual_bytes
+
+
+@contextmanager
+def _materialized_bounded_tar(archive_path: Path) -> Iterator[Path]:
+    compressed_bytes = _compressed_archive_size(archive_path)
+    with tempfile.TemporaryDirectory(
+        prefix="repoground-release-verifier-"
+    ) as temporary:
+        tar_path = Path(temporary) / "candidate.tar"
+        observed = 0
+        with gzip.open(archive_path, "rb") as source, tar_path.open("wb") as target:
+            while observed <= MAX_ARCHIVE_STREAM_BYTES:
+                chunk = source.read(
+                    min(
+                        READ_CHUNK_BYTES,
+                        MAX_ARCHIVE_STREAM_BYTES + 1 - observed,
+                    )
+                )
+                if not chunk:
+                    break
+                target.write(chunk)
+                observed += len(chunk)
+        if observed > MAX_ARCHIVE_STREAM_BYTES:
+            raise ValueError(
+                "archive exceeds uncompressed stream byte limit: "
+                f"{observed} > {MAX_ARCHIVE_STREAM_BYTES}"
+            )
+        if observed > compressed_bytes * MAX_ARCHIVE_COMPRESSION_RATIO:
+            ratio = observed / compressed_bytes
+            raise ValueError(
+                "archive exceeds compression ratio limit: "
+                f"{ratio:.1f} > {MAX_ARCHIVE_COMPRESSION_RATIO}"
+            )
+        yield tar_path
 
 
 def _safe_name(name: str) -> bool:
@@ -257,7 +302,7 @@ def _archive_members(
     members: dict[str, tarfile.TarInfo] = {}
     observed_order: list[str] = []
     total_file_bytes = 0
-    with tarfile.open(archive_path, mode="r:gz") as tar:
+    with _open_bounded_tar(archive_path) as tar:
         for member in tar:
             _ensure_archive_member_capacity(len(members))
             if member.name in members:
@@ -329,24 +374,25 @@ def _read_archive_member(
     *,
     max_bytes: int = MAX_ARCHIVE_MEMBER_BYTES,
 ) -> bytes:
-    with tarfile.open(archive_path, mode="r:gz") as tar:
-        try:
-            member = tar.getmember(name)
-        except KeyError as exc:
-            raise ValueError(f"required archive member is missing: {name}") from exc
-        if not member.isfile():
-            raise ValueError(f"required archive member is not a file: {name}")
-        if member.size > max_bytes:
-            raise ValueError(
-                f"archive member exceeds byte limit: {name}: {member.size} > {max_bytes}"
-            )
-        handle = tar.extractfile(member)
-        if handle is None:
-            raise ValueError(f"cannot read required archive member: {name}")
-        content = _read_limited(handle, name=name, max_bytes=max_bytes)
-        if len(content) != member.size:
-            raise ValueError(f"archive member byte size mismatch: {name}")
-        return content
+    with _open_bounded_tar(archive_path) as tar:
+        for member in tar:
+            if member.name != name:
+                continue
+            if not member.isfile():
+                raise ValueError(f"required archive member is not a file: {name}")
+            if member.size > max_bytes:
+                raise ValueError(
+                    f"archive member exceeds byte limit: {name}: "
+                    f"{member.size} > {max_bytes}"
+                )
+            handle = tar.extractfile(member)
+            if handle is None:
+                raise ValueError(f"cannot read required archive member: {name}")
+            content = _read_limited(handle, name=name, max_bytes=max_bytes)
+            if len(content) != member.size:
+                raise ValueError(f"archive member byte size mismatch: {name}")
+            return content
+    raise ValueError(f"required archive member is missing: {name}")
 
 
 
@@ -638,9 +684,16 @@ def _compare_with_repo(
     if observed_names != expected_names:
         raise ValueError("archive path set does not match Git tree")
 
-    with tarfile.open(archive_path, mode="r:gz") as tar:
+    with _open_bounded_tar(archive_path) as tar:
+        iterator = iter(tar)
+        root_member = next(iterator, None)
+        if root_member is None or root_member.name != prefix.rstrip("/"):
+            raise ValueError("archive root member is missing or out of order")
         for entry in expected_entries:
-            member = tar.getmember(f"{prefix}{entry.path}")
+            member = next(iterator, None)
+            expected_name = f"{prefix}{entry.path}"
+            if member is None or member.name != expected_name:
+                raise ValueError(f"archive member order mismatch: {entry.path}")
             _compare_archive_entry(
                 tar,
                 member,
@@ -650,6 +703,8 @@ def _compare_with_repo(
                     repo, commit, entry, blob_sizes[entry.path]
                 ),
             )
+        if next(iterator, None) is not None:
+            raise ValueError("archive contains unexpected trailing members")
 
 
 def _contract_for_manifest(manifest: dict[str, object]) -> ReleaseContract:

--- a/scripts/release/verify_release_candidate.py
+++ b/scripts/release/verify_release_candidate.py
@@ -4,6 +4,7 @@ import argparse
 import hashlib
 import json
 import re
+import subprocess
 import sys
 import tarfile
 from dataclasses import dataclass
@@ -26,6 +27,7 @@ from scripts.release.build_release_candidate import (
     SEMANTIC_PLATFORM_CONTRACT_PATH,
     SEMANTIC_TARGET_ID,
     SCHEMA_URI,
+    TreeEntry,
     VERSION_RE,
     list_tree,
     read_blob,
@@ -72,8 +74,10 @@ CANONICAL_CONTRACT = ReleaseContract(
 MAX_ARCHIVE_BYTES = 64 * 1024 * 1024
 MAX_ARCHIVE_MEMBER_BYTES = 16 * 1024 * 1024
 MAX_ARCHIVE_TOTAL_BYTES = 128 * 1024 * 1024
+MAX_ARCHIVE_STREAM_BYTES = 160 * 1024 * 1024
 MAX_ARCHIVE_COMPRESSION_RATIO = 200
 MAX_ARCHIVE_MEMBERS = 10_000
+MAX_REPOSITORY_BLOB_BYTES = MAX_ARCHIVE_MEMBER_BYTES
 MAX_LICENSE_BYTES = 1024 * 1024
 READ_CHUNK_BYTES = 1024 * 1024
 
@@ -84,6 +88,15 @@ def _sha256(path: Path) -> str:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def _compressed_archive_size(archive_path: Path) -> int:
+    actual_bytes = archive_path.stat().st_size
+    if actual_bytes > MAX_ARCHIVE_BYTES:
+        raise ValueError(
+            f"archive exceeds compressed byte limit: {actual_bytes} > {MAX_ARCHIVE_BYTES}"
+        )
+    return actual_bytes
 
 
 def _safe_name(name: str) -> bool:
@@ -192,6 +205,13 @@ def _ensure_archive_member_capacity(member_count: int) -> None:
 
 
 def _account_archive_member(member: tarfile.TarInfo, total_file_bytes: int) -> int:
+    padded_size = ((member.size + 511) // 512) * 512
+    stream_end = member.offset_data + padded_size
+    if member.offset < 0 or member.offset_data < 0 or stream_end > MAX_ARCHIVE_STREAM_BYTES:
+        raise ValueError(
+            "archive exceeds uncompressed stream byte limit: "
+            f"{stream_end} > {MAX_ARCHIVE_STREAM_BYTES}"
+        )
     if not member.isfile():
         return total_file_bytes
     if member.size < 0 or member.size > MAX_ARCHIVE_MEMBER_BYTES:
@@ -218,15 +238,11 @@ def _archive_members(
     expected_bytes = archive.get("bytes")
     prefix = archive.get("prefix")
     expected_count = _expected_archive_member_count(archive)
-    actual_bytes = archive_path.stat().st_size
+    actual_bytes = _compressed_archive_size(archive_path)
     if _sha256(archive_path) != expected_sha:
         raise ValueError("archive SHA-256 does not match manifest")
     if actual_bytes != expected_bytes:
         raise ValueError("archive byte size does not match manifest")
-    if actual_bytes > MAX_ARCHIVE_BYTES:
-        raise ValueError(
-            f"archive exceeds compressed byte limit: {actual_bytes} > {MAX_ARCHIVE_BYTES}"
-        )
     if (
         not isinstance(prefix, str)
         or not prefix.endswith("/")
@@ -521,6 +537,52 @@ def _verify_manifest_contract(
     if not isinstance(nonclaims, list) or not set(DOES_NOT_ESTABLISH).issubset(nonclaims):
         raise ValueError("manifest does_not_establish boundary is incomplete")
 
+def _repository_blob_sizes(
+    repo: Path, entries: tuple[TreeEntry, ...]
+) -> dict[str, int]:
+    object_ids = [entry.object_id for entry in entries]
+    completed = subprocess.run(
+        [
+            "git",
+            "cat-file",
+            "--batch-check=%(objectname) %(objecttype) %(objectsize)",
+        ],
+        cwd=repo,
+        input=("\n".join(object_ids) + "\n").encode("ascii"),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.decode("utf-8", errors="replace").strip()
+        raise ValueError(f"git cat-file --batch-check failed: {detail}")
+    lines = completed.stdout.decode("ascii").splitlines()
+    if len(lines) != len(entries):
+        raise ValueError("git blob size response count mismatch")
+    sizes: dict[str, int] = {}
+    for entry, line in zip(entries, lines, strict=True):
+        object_id, object_type, raw_size = line.split(" ")
+        if object_id != entry.object_id or object_type != "blob" or not raw_size.isdigit():
+            raise ValueError(f"invalid Git blob size response: {entry.path}")
+        size = int(raw_size)
+        if size > MAX_REPOSITORY_BLOB_BYTES:
+            raise ValueError(
+                f"repository blob exceeds byte limit: {entry.path}: "
+                f"{size} > {MAX_REPOSITORY_BLOB_BYTES}"
+            )
+        sizes[entry.path] = size
+    return sizes
+
+
+def _read_repository_blob(
+    repo: Path, commit: str, entry: TreeEntry, expected_size: int
+) -> bytes:
+    blob = read_blob(repo, commit, entry.path)
+    if len(blob) != expected_size:
+        raise ValueError(f"repository blob byte size mismatch: {entry.path}")
+    return blob
+
+
 def _compare_archive_entry(
     tar: tarfile.TarFile,
     member: tarfile.TarInfo,
@@ -570,6 +632,7 @@ def _compare_with_repo(
         raise ValueError("manifest prefix is invalid")
 
     expected_entries = list_tree(repo, commit)
+    blob_sizes = _repository_blob_sizes(repo, expected_entries)
     expected_names = {f"{prefix}{entry.path}" for entry in expected_entries}
     observed_names = {name for name in members if name != prefix.rstrip("/")}
     if observed_names != expected_names:
@@ -583,7 +646,9 @@ def _compare_with_repo(
                 member,
                 entry_path=entry.path,
                 entry_mode=entry.mode,
-                blob=read_blob(repo, commit, entry.path),
+                blob=_read_repository_blob(
+                    repo, commit, entry, blob_sizes[entry.path]
+                ),
             )
 
 
@@ -606,6 +671,7 @@ def _verify_release_candidate(
     )
     if not archive_path.is_file():
         raise ValueError("candidate archive is missing")
+    _compressed_archive_size(archive_path)
     _verify_sums(manifest_path, archive_path, sums_path)
 
     license_data = manifest.get("license")


### PR DESCRIPTION
## Zweck

Behebt den digestgebundenen Bureau-Fund `candidate-f25824e798612dae155979be`, Event `1513`: Der Release-Verifier akzeptierte stark komprimierte Archive und las Tar- sowie Git-Inhalte ohne vollständige Ressourcenobergrenzen.

## Umsetzung

- maximal 64 MiB komprimiertes Archiv, geprüft vor jeder Prüfsumme
- maximal 160 MiB vollständig dekomprimierter Tar-Stream und Expansionsverhältnis 200:1
- maximal 16 MiB pro regulärem Archivmitglied, 128 MiB reguläre Nutzdaten insgesamt
- maximal 10.000 Archivmitglieder einschließlich Wurzeleintrag
- maximal 1 MiB für die archivierte Lizenz
- genau eine begrenzte Dekompression und genau ein Tar-Parse pro Verifikation
- spätere Tar-Inhaltsprüfungen verwenden validierte Offsets der materialisierten Datei
- Git-Objektgrößen werden in einem Batch vorab geprüft
- Git-Inhalte werden über genau einen persistenten `git cat-file --batch`-Prozess jeweils einzeln gelesen, verglichen und verworfen
- Archivtyp und erwartete Größe werden vor jedem Git-Inhaltsread validiert

## Validierung

- `58 passed` für Repository-Hygiene, Naming-Hard-Cut und Release-Packaging
- Ruff: erfolgreich
- Graph-/Komplexitäts-Ratchet: erfolgreich; 191 statt Budget 193 C901-Findings, Überschuss 2.342 statt Budget 2.348
- `git diff --check`: erfolgreich
- vollständige GitHub-CI wird auf dem finalen Head neu ausgeführt
- lokaler Volltest auf dem ersten Head: `5128 passed, 12 skipped, 33 failed`; alle 33 Fehler stammen vom belegten Host-Bubblewrap-Fehler `Creating new namespace failed: Resource temporarily unavailable`

## Grenzen

Der PR ändert weder Releaseformat noch Builderausgabe, Lizenz- oder Distributionsentscheidung. Er beweist keine vollständige CPU-DoS-Freiheit unterhalb der Limits und keine öffentliche Erreichbarkeit des Verifiers.

## Identität

Basis: `1634b55183447fa6e846e231a0b1e6880039fc17`
Finaler Head: `90f148a5`