### PR TITLE
fix: complete release verifier resource bounds

### DIFF
--- a/docs/proofs/repoground-release-verifier-closeout-v1-proof.md
+++ b/docs/proofs/repoground-release-verifier-closeout-v1-proof.md
@@ -23,8 +23,10 @@ matches the pre-open `lstat` result. A read of one additional byte detects growt
 past the declared limit.
 
 The release manifest is parsed once and the same parsed object is carried into the
-full verification path. This avoids a second unbound manifest read between contract
-selection and candidate validation.
+full verification path. Its digest is computed from those captured bytes and reused
+for `SHA256SUMS` verification and the final report, so a later pathname replacement
+cannot authenticate different bytes. This also avoids a second unbound manifest read
+between contract selection and candidate validation.
 
 ## Source-bound repository limit
 
@@ -41,6 +43,7 @@ The release packaging suite covers:
 
 - oversized manifest rejected before JSON parsing;
 - symlinked manifest rejected before reading;
+- post-parse manifest replacement rejected because checksums remain bound to the captured bytes;
 - oversized `SHA256SUMS` rejected before line processing;
 - symlinked `SHA256SUMS` rejected before reading;
 - aggregate Git-blob overflow rejected before the content batch starts;

--- a/docs/proofs/repoground-release-verifier-closeout-v1-proof.md
+++ b/docs/proofs/repoground-release-verifier-closeout-v1-proof.md
@@ -1,0 +1,65 @@
+# RepoGround Release-Verifier Closeout v1
+
+## Scope
+
+This proof is bound to `REPOGROUND-LEGACY-RECONCILIATION-V1-T019` and starts
+from merge commit `37a83704695532f8c8d17a532709e3de92cafb38`.
+
+PR #1113 established the archive, member, decompressed-stream, compression-ratio,
+member-count and single-blob content-processing limits. This closeout does not
+restate that implementation as new work. It closes two remaining input surfaces.
+
+## Candidate metadata limits
+
+The verifier now applies these ceilings before JSON parsing or checksum-line
+processing:
+
+- release manifest: 1 MiB
+- `SHA256SUMS`: 64 KiB
+
+Both files must be regular non-symlink files. Reading uses an opened descriptor,
+checks the opened file type and verifies that its device/inode identity still
+matches the pre-open `lstat` result. A read of one additional byte detects growth
+past the declared limit.
+
+The release manifest is parsed once and the same parsed object is carried into the
+full verification path. This avoids a second unbound manifest read between contract
+selection and candidate validation.
+
+## Source-bound repository limit
+
+Every immutable Git blob remains individually limited to 16 MiB. The size preflight
+now also rejects the aggregate Git-tree content above 128 MiB before the persistent
+`git cat-file --batch` content process is opened.
+
+The existing content path still reads, validates and discards at most one bounded
+blob at a time.
+
+## Adversarial regressions
+
+The release packaging suite covers:
+
+- oversized manifest rejected before JSON parsing;
+- symlinked manifest rejected before reading;
+- oversized `SHA256SUMS` rejected before line processing;
+- symlinked `SHA256SUMS` rejected before reading;
+- aggregate Git-blob overflow rejected before the content batch starts;
+- the archive, PAX/GNU, member-count, compression and single-blob protections from
+  PR #1113.
+
+## Validation
+
+Required final evidence:
+
+- targeted release-packaging tests;
+- repository hygiene and naming tests;
+- Ruff;
+- graph/complexity maintainability ratchet;
+- full pytest and CodeQL on the final PR head;
+- post-merge CI readback.
+
+## Non-claims
+
+This proof does not establish public exposure of the verifier, absence of all CPU
+exhaustion below the selected ceilings, release readiness, deployment authorization,
+or permission to modify or clean foreign dirty worktrees.

--- a/merger/repoground/tests/test_release_packaging.py
+++ b/merger/repoground/tests/test_release_packaging.py
@@ -123,6 +123,13 @@ def _rewrite_sums(candidate: Path) -> None:
     )
 
 
+def _replace_with_external_symlink(path: Path, tmp_path: Path) -> None:
+    target = tmp_path / f"{path.name}.target"
+    target.write_bytes(path.read_bytes())
+    path.unlink()
+    os.symlink(target, path)
+
+
 def _reverse_archive_members(candidate: Path) -> None:
     archive_path = next(candidate.glob("*.tar.gz"))
     members: list[tuple[tarfile.TarInfo, bytes | None]] = []
@@ -735,6 +742,63 @@ def test_verifier_rejects_oversized_archive_member_before_read(
         verify_release_candidate(candidate, **kwargs)
 
 
+def test_verifier_rejects_oversized_manifest_before_json_parsing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _repo(tmp_path)
+    candidate = tmp_path / "candidate-manifest-limit"
+    build_release_candidate(repo, candidate)
+    manifest_path = next(candidate.glob("*.release.json"))
+    monkeypatch.setattr(
+        verifier_module, "MAX_MANIFEST_BYTES", manifest_path.stat().st_size - 1
+    )
+    monkeypatch.setattr(
+        verifier_module.json,
+        "loads",
+        lambda *args, **kwargs: pytest.fail("manifest parsed before size rejection"),
+    )
+    with pytest.raises(ValueError, match="release manifest exceeds byte limit"):
+        verify_release_candidate(candidate)
+
+
+def test_verifier_rejects_symlinked_manifest_before_read(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    candidate = tmp_path / "candidate-manifest-symlink"
+    build_release_candidate(repo, candidate)
+    manifest_path = next(candidate.glob("*.release.json"))
+    _replace_with_external_symlink(manifest_path, tmp_path)
+    with pytest.raises(ValueError, match="release manifest must be a regular non-symlink"):
+        verify_release_candidate(candidate)
+
+
+def test_verifier_rejects_oversized_sums_before_line_processing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _repo(tmp_path)
+    candidate = tmp_path / "candidate-sums-limit"
+    build_release_candidate(repo, candidate)
+    sums_path = candidate / "SHA256SUMS"
+    monkeypatch.setattr(
+        verifier_module, "MAX_SHA256SUMS_BYTES", sums_path.stat().st_size - 1
+    )
+    monkeypatch.setattr(
+        verifier_module.re,
+        "fullmatch",
+        lambda *args, **kwargs: pytest.fail("SHA256SUMS processed before size rejection"),
+    )
+    with pytest.raises(ValueError, match="SHA256SUMS exceeds byte limit"):
+        verify_release_candidate(candidate)
+
+
+def test_verifier_rejects_symlinked_sums_before_read(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    candidate = tmp_path / "candidate-sums-symlink"
+    build_release_candidate(repo, candidate)
+    _replace_with_external_symlink(candidate / "SHA256SUMS", tmp_path)
+    with pytest.raises(ValueError, match="candidate directory may contain regular files only"):
+        verify_release_candidate(candidate)
+
+
 def test_verifier_rejects_compressed_archive_over_limit(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -836,6 +900,24 @@ def test_source_bound_verifier_checks_blob_size_before_read(
 
     monkeypatch.setattr(verifier_module.subprocess, "Popen", reject_content_batch)
     with pytest.raises(ValueError, match="repository blob exceeds byte limit"):
+        verify_release_candidate(candidate, repo=repo)
+
+
+def test_source_bound_verifier_rejects_total_blob_bytes_before_content_batch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _repo(tmp_path)
+    candidate = tmp_path / "candidate-repository-total-limit"
+    build_release_candidate(repo, candidate)
+    monkeypatch.setattr(verifier_module, "MAX_REPOSITORY_TOTAL_BYTES", 1)
+    monkeypatch.setattr(
+        verifier_module,
+        "_open_repository_blob_batch",
+        lambda *args, **kwargs: pytest.fail(
+            "repository content batch started before total-size rejection"
+        ),
+    )
+    with pytest.raises(ValueError, match="repository blobs exceed total byte limit"):
         verify_release_candidate(candidate, repo=repo)
 
 

--- a/merger/repoground/tests/test_release_packaging.py
+++ b/merger/repoground/tests/test_release_packaging.py
@@ -771,6 +771,30 @@ def test_verifier_rejects_symlinked_manifest_before_read(tmp_path: Path) -> None
         verify_release_candidate(candidate)
 
 
+def test_verifier_binds_sums_to_the_manifest_bytes_that_were_parsed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _repo(tmp_path)
+    candidate = tmp_path / "candidate-manifest-byte-binding"
+    build_release_candidate(repo, candidate)
+    original_contract = verifier_module._contract_for_manifest
+
+    def replace_manifest_after_parsing(preview):
+        contract = original_contract(preview)
+        manifest_path = next(candidate.glob("*.release.json"))
+        manifest_path.write_bytes(manifest_path.read_bytes() + b"\n")
+        _rewrite_sums(candidate)
+        return contract
+
+    monkeypatch.setattr(
+        verifier_module,
+        "_contract_for_manifest",
+        replace_manifest_after_parsing,
+    )
+    with pytest.raises(ValueError, match="SHA256SUMS does not match"):
+        verify_release_candidate(candidate)
+
+
 def test_verifier_rejects_oversized_sums_before_line_processing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/scripts/release/verify_release_candidate.py
+++ b/scripts/release/verify_release_candidate.py
@@ -236,6 +236,7 @@ def _load_candidate(
 
 def _verify_sums(
     manifest_path: Path,
+    manifest_sha256: str,
     archive_path: Path,
     sums_path: Path,
 ) -> None:
@@ -243,7 +244,7 @@ def _verify_sums(
         raise ValueError("SHA256SUMS is missing")
     expected = {
         archive_path.name: _sha256(archive_path),
-        manifest_path.name: _sha256(manifest_path),
+        manifest_path.name: manifest_sha256,
     }
     sums_text = _read_bounded_regular_file(
         sums_path,
@@ -863,6 +864,7 @@ def _verify_release_candidate(
     contract: ReleaseContract,
     manifest: dict[str, object],
     manifest_path: Path,
+    manifest_sha256: str,
     repo: str | Path | None,
 ) -> dict[str, object]:
     manifest, manifest_path, archive_path, sums_path = _load_candidate(
@@ -874,7 +876,12 @@ def _verify_release_candidate(
     if not archive_path.is_file():
         raise ValueError("candidate archive is missing")
     _compressed_archive_size(archive_path)
-    _verify_sums(manifest_path, archive_path, sums_path)
+    _verify_sums(
+        manifest_path,
+        manifest_sha256,
+        archive_path,
+        sums_path,
+    )
 
     license_data = manifest.get("license")
     if not isinstance(license_data, dict):
@@ -902,7 +909,7 @@ def _verify_release_candidate(
         "status": "pass",
         "candidate_id": project["candidate_id"],
         "archive_sha256": _sha256(archive_path),
-        "manifest_sha256": _sha256(manifest_path),
+        "manifest_sha256": manifest_sha256,
         "member_count": len(members),
         "source_bound": repo is not None,
         "distribution_status": DISTRIBUTION_STATUS,
@@ -919,13 +926,13 @@ def verify_release_candidate(
     if not candidate_path.is_dir():
         raise ValueError(f"candidate directory is missing: {candidate_path}")
     manifest_path = _candidate_manifest_path(candidate_path)
-    preview = json.loads(
-        _read_bounded_regular_file(
-            manifest_path,
-            label="release manifest",
-            max_bytes=MAX_MANIFEST_BYTES,
-        ).decode("utf-8")
+    manifest_bytes = _read_bounded_regular_file(
+        manifest_path,
+        label="release manifest",
+        max_bytes=MAX_MANIFEST_BYTES,
     )
+    manifest_sha256 = hashlib.sha256(manifest_bytes).hexdigest()
+    preview = json.loads(manifest_bytes.decode("utf-8"))
     if not isinstance(preview, dict):
         raise ValueError("release manifest must be a JSON object")
     contract = _contract_for_manifest(preview)
@@ -934,6 +941,7 @@ def verify_release_candidate(
         contract=contract,
         manifest=preview,
         manifest_path=manifest_path,
+        manifest_sha256=manifest_sha256,
         repo=repo,
     )
 

--- a/scripts/release/verify_release_candidate.py
+++ b/scripts/release/verify_release_candidate.py
@@ -4,8 +4,10 @@ import argparse
 import gzip
 import hashlib
 import json
+import os
 import re
 import subprocess
+import stat
 import sys
 import tempfile
 import tarfile
@@ -80,7 +82,10 @@ MAX_ARCHIVE_TOTAL_BYTES = 128 * 1024 * 1024
 MAX_ARCHIVE_STREAM_BYTES = 160 * 1024 * 1024
 MAX_ARCHIVE_COMPRESSION_RATIO = 200
 MAX_ARCHIVE_MEMBERS = 10_000
+MAX_MANIFEST_BYTES = 1024 * 1024
+MAX_SHA256SUMS_BYTES = 64 * 1024
 MAX_REPOSITORY_BLOB_BYTES = MAX_ARCHIVE_MEMBER_BYTES
+MAX_REPOSITORY_TOTAL_BYTES = MAX_ARCHIVE_TOTAL_BYTES
 MAX_LICENSE_BYTES = 1024 * 1024
 READ_CHUNK_BYTES = 1024 * 1024
 
@@ -142,6 +147,51 @@ def _materialized_bounded_tar(archive_path: Path) -> Iterator[Path]:
         yield tar_path
 
 
+def _read_bounded_regular_file(
+    path: Path,
+    *,
+    label: str,
+    max_bytes: int,
+) -> bytes:
+    try:
+        before = path.lstat()
+    except OSError as exc:
+        raise ValueError(f"{label} must be a regular non-symlink file") from exc
+    if not stat.S_ISREG(before.st_mode):
+        raise ValueError(f"{label} must be a regular non-symlink file")
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise ValueError(f"{label} must be a regular non-symlink file") from exc
+    with os.fdopen(descriptor, "rb") as handle:
+        opened = os.fstat(handle.fileno())
+        if not stat.S_ISREG(opened.st_mode) or (
+            opened.st_dev,
+            opened.st_ino,
+        ) != (before.st_dev, before.st_ino):
+            raise ValueError(f"{label} changed before it could be read safely")
+        if opened.st_size > max_bytes:
+            raise ValueError(
+                f"{label} exceeds byte limit: {opened.st_size} > {max_bytes}"
+            )
+        content = handle.read(max_bytes + 1)
+    if len(content) > max_bytes:
+        raise ValueError(f"{label} exceeds read limit: {max_bytes}")
+    return content
+
+
+def _candidate_manifest_path(candidate_dir: Path) -> Path:
+    manifests = sorted(
+        item
+        for item in candidate_dir.iterdir()
+        if item.name.endswith(".release.json")
+    )
+    if len(manifests) != 1:
+        raise ValueError(f"expected exactly one release manifest, found {len(manifests)}")
+    return manifests[0]
+
+
 def _safe_name(name: str) -> bool:
     path = Path(name)
     raw_parts = name.split("/")
@@ -154,13 +204,11 @@ def _safe_name(name: str) -> bool:
 
 
 def _load_candidate(
-    candidate_dir: Path, contract: ReleaseContract
+    candidate_dir: Path,
+    contract: ReleaseContract,
+    manifest: dict[str, object],
+    manifest_path: Path,
 ) -> tuple[dict[str, object], Path, Path, Path]:
-    manifests = sorted(candidate_dir.glob("*.release.json"))
-    if len(manifests) != 1:
-        raise ValueError(f"expected exactly one release manifest, found {len(manifests)}")
-    manifest_path = manifests[0]
-    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     if manifest.get("kind") != contract.kind or manifest.get("version") != contract.version:
         raise ValueError("release manifest kind/version mismatch")
     archive = manifest.get("archive")
@@ -197,8 +245,13 @@ def _verify_sums(
         archive_path.name: _sha256(archive_path),
         manifest_path.name: _sha256(manifest_path),
     }
+    sums_text = _read_bounded_regular_file(
+        sums_path,
+        label="SHA256SUMS",
+        max_bytes=MAX_SHA256SUMS_BYTES,
+    ).decode("utf-8")
     observed: dict[str, str] = {}
-    for line in sums_path.read_text(encoding="utf-8").splitlines():
+    for line in sums_text.splitlines():
         match = re.fullmatch(r"([0-9a-f]{64})  ([^/]+)", line)
         if not match:
             raise ValueError(f"invalid SHA256SUMS line: {line!r}")
@@ -614,6 +667,7 @@ def _repository_blob_sizes(
     if len(lines) != len(entries):
         raise ValueError("git blob size response count mismatch")
     sizes: dict[str, int] = {}
+    total_bytes = 0
     for entry, line in zip(entries, lines, strict=True):
         object_id, object_type, raw_size = line.split(" ")
         if object_id != entry.object_id or object_type != "blob" or not raw_size.isdigit():
@@ -623,6 +677,12 @@ def _repository_blob_sizes(
             raise ValueError(
                 f"repository blob exceeds byte limit: {entry.path}: "
                 f"{size} > {MAX_REPOSITORY_BLOB_BYTES}"
+            )
+        total_bytes += size
+        if total_bytes > MAX_REPOSITORY_TOTAL_BYTES:
+            raise ValueError(
+                "repository blobs exceed total byte limit: "
+                f"{total_bytes} > {MAX_REPOSITORY_TOTAL_BYTES}"
             )
         sizes[entry.path] = size
     return sizes
@@ -801,10 +861,15 @@ def _verify_release_candidate(
     candidate_path: Path,
     *,
     contract: ReleaseContract,
+    manifest: dict[str, object],
+    manifest_path: Path,
     repo: str | Path | None,
 ) -> dict[str, object]:
     manifest, manifest_path, archive_path, sums_path = _load_candidate(
-        candidate_path, contract
+        candidate_path,
+        contract,
+        manifest,
+        manifest_path,
     )
     if not archive_path.is_file():
         raise ValueError("candidate archive is missing")
@@ -853,14 +918,24 @@ def verify_release_candidate(
     candidate_path = Path(candidate_dir).expanduser().resolve()
     if not candidate_path.is_dir():
         raise ValueError(f"candidate directory is missing: {candidate_path}")
-    manifests = sorted(candidate_path.glob("*.release.json"))
-    if len(manifests) != 1:
-        raise ValueError(f"expected exactly one release manifest, found {len(manifests)}")
-    preview = json.loads(manifests[0].read_text(encoding="utf-8"))
+    manifest_path = _candidate_manifest_path(candidate_path)
+    preview = json.loads(
+        _read_bounded_regular_file(
+            manifest_path,
+            label="release manifest",
+            max_bytes=MAX_MANIFEST_BYTES,
+        ).decode("utf-8")
+    )
     if not isinstance(preview, dict):
         raise ValueError("release manifest must be a JSON object")
     contract = _contract_for_manifest(preview)
-    return _verify_release_candidate(candidate_path, contract=contract, repo=repo)
+    return _verify_release_candidate(
+        candidate_path,
+        contract=contract,
+        manifest=preview,
+        manifest_path=manifest_path,
+        repo=repo,
+    )
 
 
 def main() -> int:


### PR DESCRIPTION
## Aufgabe

Schließt `REPOGROUND-LEGACY-RECONCILIATION-V1-T019` auf Basis von Merge-Commit `37a83704695532f8c8d17a532709e3de92cafb38` ab.

## Änderungen

- begrenzt das Release-Manifest vor JSON-Parsing auf 1 MiB;
- begrenzt `SHA256SUMS` vor Zeilenverarbeitung auf 64 KiB;
- akzeptiert beide Steuerdateien nur als reguläre Nicht-Symlink-Dateien und bindet den geöffneten Deskriptor an die vorab gelesene Dateiidentität;
- liest und parst das Manifest nur einmal;
- begrenzt die Gesamtsumme aller source-bound Git-Blobs vor dem Content-Batch auf 128 MiB;
- ergänzt adversariale Regressionstests und einen eigenen T019-Closeout-Proof.

## Lokale Evidenz

- `63 passed` für Repository-Hygiene, Naming-Hard-Cut und Release-Packaging;
- Ruff: PASS;
- Graph-/Komplexitäts-Ratchet: PASS, 191 Findings, Überschuss 2342, keine neuen Findings;
- `git diff --check`: PASS.

## Grenzen

Der Patch behauptet weder öffentliche Verifier-Exposition noch vollständige Abwesenheit von CPU-DoS unterhalb der gewählten Grenzen. Fremde schmutzige Worktrees wurden nicht verändert.