### PR TITLE
fix: revalidate release manifest before success

### DIFF
--- a/merger/repoground/tests/test_release_packaging.py
+++ b/merger/repoground/tests/test_release_packaging.py
@@ -795,6 +795,31 @@ def test_verifier_binds_sums_to_the_manifest_bytes_that_were_parsed(
         verify_release_candidate(candidate)
 
 
+def test_verifier_rejects_manifest_replaced_after_parsing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _repo(tmp_path)
+    candidate = tmp_path / "candidate-manifest-final-readback"
+    build_release_candidate(repo, candidate)
+    original_contract = verifier_module._contract_for_manifest
+
+    def replace_manifest_after_parsing(preview):
+        contract = original_contract(preview)
+        manifest_path = next(candidate.glob("*.release.json"))
+        replacement = manifest_path.with_suffix(".replacement")
+        replacement.write_bytes(manifest_path.read_bytes() + b"\n")
+        replacement.replace(manifest_path)
+        return contract
+
+    monkeypatch.setattr(
+        verifier_module,
+        "_contract_for_manifest",
+        replace_manifest_after_parsing,
+    )
+    with pytest.raises(ValueError, match="release manifest changed during verification"):
+        verify_release_candidate(candidate)
+
+
 def test_verifier_rejects_oversized_sums_before_line_processing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/scripts/release/verify_release_candidate.py
+++ b/scripts/release/verify_release_candidate.py
@@ -864,6 +864,7 @@ def _verify_release_candidate(
     contract: ReleaseContract,
     manifest: dict[str, object],
     manifest_path: Path,
+    manifest_bytes: bytes,
     manifest_sha256: str,
     repo: str | Path | None,
 ) -> dict[str, object]:
@@ -903,6 +904,15 @@ def _verify_release_candidate(
             _compare_with_repo(
                 Path(repo).expanduser().resolve(), manifest, tar_path, members
             )
+
+    current_manifest_bytes = _read_bounded_regular_file(
+        manifest_path,
+        label="release manifest",
+        max_bytes=MAX_MANIFEST_BYTES,
+    )
+    if current_manifest_bytes != manifest_bytes:
+        raise ValueError("release manifest changed during verification")
+
     project = manifest.get("project")
     assert isinstance(project, dict)
     return {
@@ -941,6 +951,7 @@ def verify_release_candidate(
         contract=contract,
         manifest=preview,
         manifest_path=manifest_path,
+        manifest_bytes=manifest_bytes,
         manifest_sha256=manifest_sha256,
         repo=repo,
     )


### PR DESCRIPTION
## Aufgabe

Behebt den nach dem Merge von PR #1114 auf dessen finalem Head veröffentlichten P1-Befund im Scope von `REPOGROUND-LEGACY-RECONCILIATION-V1-T019`.

## Fehler

Der Verifier band `SHA256SUMS` an die initial geparsten Manifestbytes, las den aktuellen Manifestpfad vor dem erfolgreichen Bericht aber nicht erneut. Ein atomarer Austausch nach dem Parsing konnte deshalb `status: pass` erzeugen, obwohl die aktuell am Pfad liegenden Bytes nicht mehr dem gemeldeten `manifest_sha256` entsprachen.

## Änderung

- übergibt die initial geparsten Manifestbytes an den inneren Verifier;
- liest den Manifestpfad unmittelbar vor dem Erfolgsbericht erneut über denselben begrenzten Regular-File-/No-Symlink-Vertrag;
- lehnt veränderte Bytes fail-closed ab;
- ergänzt einen Regressionstest mit atomarem Austausch ohne Aktualisierung von `SHA256SUMS`.

## Evidenz

- Manifest-/SHA256SUMS-Fokus: `9 passed`;
- vollständige Release-Packaging-Suite: `53 passed`;
- Ruff auf den geänderten Dateien: PASS;
- Graph-/Komplexitäts-Ratchet: PASS (`191` Findings, Maximum `138`, Überschuss `2342`, keine neuen Findings);
- Release-Vertrag: PASS;
- zwei deterministische Release-Kandidaten: identisch;
- beide source-bound Kandidatenverifikationen: PASS;
- `git diff --check`: PASS.

Der lokale Volltest erreichte `5130 passed, 12 skipped`; 33 Patch-Evaluation-Sidecar-Tests scheiterten gemeinsam vor ihrer Testlogik, weil der Host `bwrap: Creating new namespace failed: Resource temporarily unavailable` meldete. Die GitHub-Pflicht-CI muss den vollständigen Gate-Status auf diesem Head liefern.

## Grenzen

Der Patch behauptet keine Unveränderlichkeit nach dem finalen begrenzten Readback und erweitert nicht den allgemeinen Kandidaten-Snapshotvertrag für Archiv oder `SHA256SUMS`. Fremde Dirty-States und Worktrees wurden nicht verändert.