### PR TITLE
perf(release): reuse source-bound tar reader

### DIFF
--- a/docs/proofs/repoground-release-verifier-closeout-v1-proof.md
+++ b/docs/proofs/repoground-release-verifier-closeout-v1-proof.md
@@ -6,8 +6,11 @@ This proof is bound to `REPOGROUND-LEGACY-RECONCILIATION-V1-T019` and starts
 from merge commit `37a83704695532f8c8d17a532709e3de92cafb38`.
 
 PR #1113 established the archive, member, decompressed-stream, compression-ratio,
-member-count and single-blob content-processing limits. This closeout does not
-restate that implementation as new work. It closes two remaining input surfaces.
+member-count and single-blob content-processing limits. The original closeout does
+not restate that implementation as new work; it closed two remaining input surfaces.
+This final increment is additionally bound to Bureau candidate
+`candidate-9248b3c145824dd946f1614a`, event `1583`, and source commit
+`5318daaad4eceed60cd752eacd057ec74bbd9e49`.
 
 ## Candidate metadata limits
 
@@ -37,6 +40,14 @@ now also rejects the aggregate Git-tree content above 128 MiB before the persist
 The existing content path still reads, validates and discards at most one bounded
 blob at a time.
 
+## Source-bound Tar reader
+
+The source-bound repository comparison opens the already materialized Tar content
+once and reuses that binary reader for every regular Git-tree entry. Each read seeks
+to the `TarInfo.offset_data` position that was previously validated by the bounded
+archive scan. Existing path-set, type, mode, size, symlink and byte-content checks
+remain unchanged, and the reader is closed when the comparison scope ends.
+
 ## Adversarial regressions
 
 The release packaging suite covers:
@@ -47,6 +58,8 @@ The release packaging suite covers:
 - oversized `SHA256SUMS` rejected before line processing;
 - symlinked `SHA256SUMS` rejected before reading;
 - aggregate Git-blob overflow rejected before the content batch starts;
+- all source-bound entry comparisons reuse one open materialized-Tar reader and close
+  it after the comparison;
 - the archive, PAX/GNU, member-count, compression and single-blob protections from
   PR #1113.
 

--- a/merger/repoground/tests/test_release_packaging.py
+++ b/merger/repoground/tests/test_release_packaging.py
@@ -970,6 +970,27 @@ def test_source_bound_verifier_rejects_total_blob_bytes_before_content_batch(
         verify_release_candidate(candidate, repo=repo)
 
 
+def test_source_bound_verifier_reuses_one_materialized_tar_reader(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _repo(tmp_path)
+    candidate = tmp_path / "candidate-single-tar-reader"
+    build_release_candidate(repo, candidate)
+    original = verifier_module._compare_archive_entry
+    observed_handles: list[object] = []
+
+    def counted_compare(tar_handle, member, **kwargs):
+        assert not tar_handle.closed
+        observed_handles.append(tar_handle)
+        return original(tar_handle, member, **kwargs)
+
+    monkeypatch.setattr(verifier_module, "_compare_archive_entry", counted_compare)
+    assert verify_release_candidate(candidate, repo=repo)["status"] == "pass"
+    assert len(observed_handles) > 1
+    assert all(handle is observed_handles[0] for handle in observed_handles)
+    assert observed_handles[0].closed
+
+
 @pytest.mark.parametrize("source_bound", (False, True))
 def test_verifier_materializes_archive_once_per_verification(
     tmp_path: Path,

--- a/scripts/release/verify_release_candidate.py
+++ b/scripts/release/verify_release_candidate.py
@@ -15,6 +15,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
+from typing import BinaryIO
 
 if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
@@ -779,8 +780,7 @@ def _validate_archive_entry_shape(
 
 
 def _compare_archive_entry(
-    tar_path: Path,
-    members: dict[str, tarfile.TarInfo],
+    tar_handle: BinaryIO,
     member: tarfile.TarInfo,
     *,
     entry_path: str,
@@ -792,12 +792,10 @@ def _compare_archive_entry(
         if member.linkname != target:
             raise ValueError(f"symlink mismatch: {entry_path}")
         return
-    content = _read_archive_member(
-        tar_path,
-        members,
-        member.name,
-        max_bytes=len(blob),
-    )
+    tar_handle.seek(member.offset_data)
+    content = tar_handle.read(member.size)
+    if len(content) != member.size:
+        raise ValueError(f"archive member byte size mismatch: {member.name}")
     if content != blob:
         raise ValueError(f"content mismatch: {entry_path}")
 
@@ -829,7 +827,10 @@ def _compare_with_repo(
     if observed_names != expected_names:
         raise ValueError("archive path set does not match Git tree")
 
-    with _open_repository_blob_batch(repo) as process:
+    with (
+        archive_path.open("rb") as tar_handle,
+        _open_repository_blob_batch(repo) as process,
+    ):
         for entry in expected_entries:
             member = members[f"{prefix}{entry.path}"]
             expected_size = blob_sizes[entry.path]
@@ -841,8 +842,7 @@ def _compare_with_repo(
             )
             blob = _read_repository_blob_batch(process, entry, expected_size)
             _compare_archive_entry(
-                archive_path,
-                members,
+                tar_handle,
                 member,
                 entry_path=entry.path,
                 entry_mode=entry.mode,


### PR DESCRIPTION
## Ziel

Schließt die aktivierte Bureau-Aufgabe `REPOGROUND-LEGACY-RECONCILIATION-V1-T019` ab: Der source-bound Releasevergleich öffnet den bereits materialisierten Tar-Inhalt nur einmal und verwendet diesen Leser für alle Git-Dateivergleiche wieder.

## Bindung

- Bureau-Run: `BUR-RUN-20260728T200808Z-b714d1aa05`
- Bureau-Kandidat: `candidate-9248b3c145824dd946f1614a`
- korrigiertes Source-Event: `1583`
- Basis: `5318daaad4eceed60cd752eacd057ec74bbd9e49`
- Head: `555ba94de69aec5a9af332b9402357dd0a7e90b5`
- Quellbefund-SHA-256: `3aacae92f6372ed11d86edf8aff23aba995b557865d335651867676b6ad94552`
- vollständiger Diff-SHA-256: `983ef84cdd9d5b2acfc47b4d986dcb5eafbc565af8b8f90c8736abba71f5cd23`

## Änderung

- `_compare_with_repo` öffnet den materialisierten Tar-Pfad einmal zusammen mit dem persistenten `git cat-file --batch`-Prozess.
- `_compare_archive_entry` liest reguläre Dateien über das zuvor validierte `TarInfo.offset_data` aus demselben binären Handle.
- Kurze Reads werden weiterhin geschlossen abgelehnt.
- Symlink-, Pfad-, Typ-, Modus-, Größen-, Gesamtgrößen-, Kompressions-, Memberzahl- und Bytevergleichsgrenzen bleiben unverändert.
- Ein Regressionstest belegt dieselbe Handle-Instanz bei mehreren Vergleichen und deren Schließung nach dem Scope.
- Der revisionsgebundene Proof wurde ergänzt.

## Lokale Evidenz

- Release-Packaging: **54/54 bestanden**
- Ruff mit `ruff-ci.toml`: bestanden
- Graph-Maintainability: bestanden, 191 Funde gegenüber Ratchet 193, Maximum 138 unverändert
- Module-Reachability: bestanden
- No-Test-Stubs: bestanden
- `git diff --check`: bestanden
- Release-Vertrag: bestanden
- zwei unabhängige Release-Bauten: byteidentisch
  - Archiv-SHA-256: `d046677876c4395698706218f094a3c58552bce7b06c2a98b3d18a5a355c760a`
  - Manifest-SHA-256: `b8298954d01c351d2ab07939c6f9ed340db62db17f39a9a752a7e597e888045e`
  - 1.231 getrackte Einträge, 1.232 Archivmitglieder
- beide Kandidaten source-bound verifiziert

## Vollsuite und separater Hostfund

Der lokale breite Lauf ergab **5.131 bestanden, 12 übersprungen, 13 abgewählt und 33 fehlgeschlagen**. Alle 33 Fehler liegen ausschließlich im Patch-Evaluation-Sidecar und reproduzieren denselben bestehenden Hostvertrag: Der reale Nutzer hatte 270 Prozesse, während der Sidecar absolut `RLIMIT_NPROC=256` setzt; Bubblewrap scheitert daher vor dem Testinhalt mit `Resource temporarily unavailable`.

Dieser Befund ist nicht Teil des Drei-Dateien-Scopes und wurde separat als Bureau-Kandidat `candidate-42d6e66788f4de185c119598` registriert. CI auf einem frischen Runner muss die Vollsuite entscheiden.

## Review

Revisionsgebundener Operator-Self-Review auf Head `555ba94d…`: PASS. Geprüft wurden Offset- und Streamgrenzen, Typ/Modus/Größe vor dem Read, Symlinkpfad, Short-Read-Ablehnung, Blob-Batch und Proof-Aussagen.

Unabhängiger Review konnte nicht geliefert werden:
- Claude Opus: Sitzungsbudget ausgeschöpft, kein Ergebnis.
- Gemini-Kontrast: konfigurierte externe Runner-Quelle fehlt, kein Ergebnis.

Diese Lücke wird nicht als PASS gewertet. Merge bleibt an vollständige GitHub-CI, erneuten finalen Head/Diff-Review und erwartete Head-SHA gebunden.

## Restunsicherheit

Nichtkanonische GNU-Sparse-Tar-Dateien werden beim rohen Offset-Lesen nicht rekonstruiert und würden daher fail-closed am Bytevergleich scheitern. RepoGround erzeugt kanonische normale Tar-Dateien; der PR erweitert keine behauptete Sparse-Kompatibilität.