### PR TITLE
fix(release): bind archive verification to one descriptor

### DIFF
--- a/docs/proofs/repoground-release-verifier-archive-identity-v1-proof.md
+++ b/docs/proofs/repoground-release-verifier-archive-identity-v1-proof.md
@@ -1,0 +1,25 @@
+# RepoGround release verifier archive identity proof
+
+- Base: `c0bd029f0be3f370cf946fb311380ea3ea9df4ea`
+- Source candidate: `candidate-58d06a2303501fdfef712ac9`
+- Finding: archive hashing, materialization, header inspection and reporting previously reopened the candidate path independently.
+- Fix: one `O_NOFOLLOW` descriptor now binds device, inode, metadata, byte size, SHA-256, gzip materialization and final report.
+- Negative control: replacing the archive path after hashing is rejected in both self-only and source-bound verification.
+- Scope: release verifier and release-packaging regressions only; no service or T004 files changed.
+
+## Verification
+
+- Scoped Ruff: pass.
+- Focused archive-identity regressions: `7 passed, 51 deselected`.
+- Complete release-packaging suite: `58 passed`.
+- Semantic lock reproduction: pass.
+- Repository-wide Ruff: pass.
+- Graph maintainability ratchet: pass.
+- Remaining non-browser/non-live suite excluding the two Bubblewrap-dependent sidecar files: `5125 passed, 12 skipped, 13 deselected`.
+- Unfiltered local suite: `5135 passed, 12 skipped, 13 deselected, 33 failed`; all 33 failures are confined to `tests/test_patch_evaluation_sidecar.py` and `tests/test_patch_evaluation_sidecar_host_readback.py` because the host rejected Bubblewrap namespace creation with `Resource temporarily unavailable`.
+- Exact-base control on unchanged `c0bd029f0be3f370cf946fb311380ea3ea9df4ea`: the representative sidecar test fails with the same Bubblewrap namespace error, so this local infrastructure failure is not introduced by the patch.
+
+## Boundaries
+
+- This proof establishes local regression and static-gate results, not GitHub CI or merge readiness.
+- The descriptor identity checks detect path replacement and ordinary in-place metadata changes; they do not claim mandatory exclusion against an equally privileged hostile process outside the verifier contract.

--- a/merger/repoground/tests/test_release_packaging.py
+++ b/merger/repoground/tests/test_release_packaging.py
@@ -860,11 +860,60 @@ def test_verifier_rejects_compressed_archive_over_limit(
     )
     monkeypatch.setattr(
         verifier_module,
-        "_sha256",
-        lambda path: pytest.fail(f"archive hashed before size rejection: {path}"),
+        "_hash_open_archive",
+        lambda handle: pytest.fail("archive hashed before size rejection"),
     )
     with pytest.raises(ValueError, match="compressed byte limit"):
         verify_release_candidate(candidate)
+
+
+@pytest.mark.parametrize("source_bound", (False, True))
+def test_verifier_opens_archive_once_for_hash_and_materialization(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, source_bound: bool
+) -> None:
+    repo = _repo(tmp_path)
+    candidate = tmp_path / "candidate-single-archive-open"
+    build_release_candidate(repo, candidate)
+    archive_path = next(candidate.glob("*.tar.gz"))
+    original_open = verifier_module.os.open
+    archive_opens = 0
+
+    def counted_open(path, flags, *args, **kwargs):
+        nonlocal archive_opens
+        if Path(path) == archive_path:
+            archive_opens += 1
+        return original_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(verifier_module.os, "open", counted_open)
+    kwargs = {"repo": repo} if source_bound else {}
+    assert verify_release_candidate(candidate, **kwargs)["status"] == "pass"
+    assert archive_opens == 1
+
+
+@pytest.mark.parametrize("source_bound", (False, True))
+def test_verifier_rejects_archive_path_replacement_after_hash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, source_bound: bool
+) -> None:
+    repo = _repo(tmp_path)
+    candidate = tmp_path / "candidate-archive-replacement"
+    build_release_candidate(repo, candidate)
+    archive_path = next(candidate.glob("*.tar.gz"))
+    replacement = tmp_path / "replacement.tar.gz"
+    replacement.write_bytes(archive_path.read_bytes())
+    original_materialize = verifier_module._materialized_bounded_tar
+
+    @contextmanager
+    def replace_after_hash(opened_archive):
+        replacement.replace(archive_path)
+        with original_materialize(opened_archive) as tar_path:
+            yield tar_path
+
+    monkeypatch.setattr(
+        verifier_module, "_materialized_bounded_tar", replace_after_hash
+    )
+    kwargs = {"repo": repo} if source_bound else {}
+    with pytest.raises(ValueError, match="candidate archive changed during verification"):
+        verify_release_candidate(candidate, **kwargs)
 
 
 def test_verifier_rejects_total_uncompressed_bytes_over_limit(
@@ -1006,10 +1055,10 @@ def test_verifier_materializes_archive_once_per_verification(
     tar_opens = 0
 
     @contextmanager
-    def counted_materialization(archive_path: Path):
+    def counted_materialization(opened_archive):
         nonlocal materializations
         materializations += 1
-        with original_materialize(archive_path) as tar_path:
+        with original_materialize(opened_archive) as tar_path:
             yield tar_path
 
     def counted_tar_open(*args, **kwargs):

--- a/scripts/release/verify_release_candidate.py
+++ b/scripts/release/verify_release_candidate.py
@@ -60,6 +60,19 @@ class ReleaseContract:
     compatibility_mode: str
 
 
+ArchiveIdentity = tuple[int, int, int, int, int, int, int, int, int]
+
+
+@dataclass(frozen=True)
+class OpenedArchive:
+    path: Path
+    handle: BinaryIO
+    identity: ArchiveIdentity
+    compressed_bytes: int
+    sha256: str
+    header: bytes
+
+
 CANONICAL_CONTRACT = ReleaseContract(
     kind=KIND,
     version=CONTRACT_VERSION,
@@ -97,32 +110,117 @@ def _open_bounded_tar(tar_path: Path) -> Iterator[tarfile.TarFile]:
         yield tar
 
 
-def _sha256(path: Path) -> str:
+def _archive_identity(metadata: os.stat_result) -> ArchiveIdentity:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_nlink,
+        metadata.st_uid,
+        metadata.st_gid,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+    )
+
+
+def _hash_open_archive(handle: BinaryIO) -> tuple[str, bytes]:
     digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
-def _compressed_archive_size(archive_path: Path) -> int:
-    actual_bytes = archive_path.stat().st_size
-    if actual_bytes > MAX_ARCHIVE_BYTES:
+    header = b""
+    observed = 0
+    handle.seek(0)
+    while observed <= MAX_ARCHIVE_BYTES:
+        chunk = handle.read(min(READ_CHUNK_BYTES, MAX_ARCHIVE_BYTES + 1 - observed))
+        if not chunk:
+            break
+        if len(header) < 8:
+            header += chunk[: 8 - len(header)]
+        digest.update(chunk)
+        observed += len(chunk)
+    if observed > MAX_ARCHIVE_BYTES:
         raise ValueError(
-            f"archive exceeds compressed byte limit: {actual_bytes} > {MAX_ARCHIVE_BYTES}"
+            f"archive exceeds compressed byte limit: {observed} > {MAX_ARCHIVE_BYTES}"
         )
-    return actual_bytes
+    handle.seek(0)
+    return digest.hexdigest(), header
+
+
+def _assert_opened_archive_unchanged(archive: OpenedArchive) -> None:
+    try:
+        opened = os.fstat(archive.handle.fileno())
+        linked = archive.path.lstat()
+    except OSError as exc:
+        raise ValueError("candidate archive changed during verification") from exc
+    if (
+        not stat.S_ISREG(opened.st_mode)
+        or not stat.S_ISREG(linked.st_mode)
+        or archive.path.is_symlink()
+        or _archive_identity(opened) != archive.identity
+        or _archive_identity(linked) != archive.identity
+    ):
+        raise ValueError("candidate archive changed during verification")
 
 
 @contextmanager
-def _materialized_bounded_tar(archive_path: Path) -> Iterator[Path]:
-    compressed_bytes = _compressed_archive_size(archive_path)
+def _open_candidate_archive(archive_path: Path) -> Iterator[OpenedArchive]:
+    try:
+        linked = archive_path.lstat()
+    except OSError as exc:
+        raise ValueError("candidate archive must be a regular non-symlink file") from exc
+    if not stat.S_ISREG(linked.st_mode) or archive_path.is_symlink():
+        raise ValueError("candidate archive must be a regular non-symlink file")
+    if not hasattr(os, "O_NOFOLLOW"):
+        raise ValueError("candidate archive no-follow open is unavailable")
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | os.O_NOFOLLOW
+    try:
+        descriptor = os.open(archive_path, flags)
+    except OSError as exc:
+        raise ValueError("candidate archive must be a regular non-symlink file") from exc
+    handle = os.fdopen(descriptor, "rb")
+    try:
+        opened = os.fstat(handle.fileno())
+        identity = _archive_identity(opened)
+        if not stat.S_ISREG(opened.st_mode) or identity != _archive_identity(linked):
+            raise ValueError("candidate archive changed before it could be opened safely")
+        compressed_bytes = opened.st_size
+        if compressed_bytes > MAX_ARCHIVE_BYTES:
+            raise ValueError(
+                "archive exceeds compressed byte limit: "
+                f"{compressed_bytes} > {MAX_ARCHIVE_BYTES}"
+            )
+        archive_sha256, header = _hash_open_archive(handle)
+        archive = OpenedArchive(
+            path=archive_path,
+            handle=handle,
+            identity=identity,
+            compressed_bytes=compressed_bytes,
+            sha256=archive_sha256,
+            header=header,
+        )
+        _assert_opened_archive_unchanged(archive)
+        try:
+            yield archive
+        except BaseException:
+            raise
+        else:
+            _assert_opened_archive_unchanged(archive)
+    finally:
+        handle.close()
+
+
+@contextmanager
+def _materialized_bounded_tar(archive: OpenedArchive) -> Iterator[Path]:
+    _assert_opened_archive_unchanged(archive)
+    archive.handle.seek(0)
     with tempfile.TemporaryDirectory(
         prefix="repoground-release-verifier-"
     ) as temporary:
         tar_path = Path(temporary) / "candidate.tar"
         observed = 0
-        with gzip.open(archive_path, "rb") as source, tar_path.open("wb") as target:
+        with (
+            gzip.GzipFile(fileobj=archive.handle, mode="rb") as source,
+            tar_path.open("wb") as target,
+        ):
             while observed <= MAX_ARCHIVE_STREAM_BYTES:
                 chunk = source.read(
                     min(
@@ -134,13 +232,14 @@ def _materialized_bounded_tar(archive_path: Path) -> Iterator[Path]:
                     break
                 target.write(chunk)
                 observed += len(chunk)
+        _assert_opened_archive_unchanged(archive)
         if observed > MAX_ARCHIVE_STREAM_BYTES:
             raise ValueError(
                 "archive exceeds uncompressed stream byte limit: "
                 f"{observed} > {MAX_ARCHIVE_STREAM_BYTES}"
             )
-        if observed > compressed_bytes * MAX_ARCHIVE_COMPRESSION_RATIO:
-            ratio = observed / compressed_bytes
+        if observed > archive.compressed_bytes * MAX_ARCHIVE_COMPRESSION_RATIO:
+            ratio = observed / archive.compressed_bytes
             raise ValueError(
                 "archive exceeds compression ratio limit: "
                 f"{ratio:.1f} > {MAX_ARCHIVE_COMPRESSION_RATIO}"
@@ -239,12 +338,13 @@ def _verify_sums(
     manifest_path: Path,
     manifest_sha256: str,
     archive_path: Path,
+    archive_sha256: str,
     sums_path: Path,
 ) -> None:
     if not sums_path.is_file():
         raise ValueError("SHA256SUMS is missing")
     expected = {
-        archive_path.name: _sha256(archive_path),
+        archive_path.name: archive_sha256,
         manifest_path.name: manifest_sha256,
     }
     sums_text = _read_bounded_regular_file(
@@ -328,7 +428,7 @@ def _account_archive_member(member: tarfile.TarInfo, total_file_bytes: int) -> i
 
 def _archive_members(
     manifest: dict[str, object],
-    archive_path: Path,
+    opened_archive: OpenedArchive,
     tar_path: Path,
 ) -> dict[str, tarfile.TarInfo]:
     archive = manifest["archive"]
@@ -337,8 +437,8 @@ def _archive_members(
     expected_bytes = archive.get("bytes")
     prefix = archive.get("prefix")
     expected_count = _expected_archive_member_count(archive)
-    actual_bytes = _compressed_archive_size(archive_path)
-    if _sha256(archive_path) != expected_sha:
+    actual_bytes = opened_archive.compressed_bytes
+    if opened_archive.sha256 != expected_sha:
         raise ValueError("archive SHA-256 does not match manifest")
     if actual_bytes != expected_bytes:
         raise ValueError("archive byte size does not match manifest")
@@ -348,9 +448,10 @@ def _archive_members(
         or not _safe_name(prefix[:-1])
     ):
         raise ValueError("archive prefix is invalid")
-    with archive_path.open("rb") as handle:
-        raw = handle.read(8)
-    if len(raw) < 8 or int.from_bytes(raw[4:8], "little") != 0:
+    if (
+        len(opened_archive.header) < 8
+        or int.from_bytes(opened_archive.header[4:8], "little") != 0
+    ):
         raise ValueError("gzip timestamp is not normalized to zero")
 
     members: dict[str, tarfile.TarInfo] = {}
@@ -876,55 +977,58 @@ def _verify_release_candidate(
     )
     if not archive_path.is_file():
         raise ValueError("candidate archive is missing")
-    _compressed_archive_size(archive_path)
-    _verify_sums(
-        manifest_path,
-        manifest_sha256,
-        archive_path,
-        sums_path,
-    )
 
-    license_data = manifest.get("license")
-    if not isinstance(license_data, dict):
-        raise ValueError("license object is missing")
-    if license_data.get("expression") != contract.license_expression:
-        raise ValueError("license expression mismatch")
-    if license_data.get("distribution_status") != DISTRIBUTION_STATUS:
-        raise ValueError("distribution boundary mismatch")
+    with _open_candidate_archive(archive_path) as opened_archive:
+        _verify_sums(
+            manifest_path,
+            manifest_sha256,
+            archive_path,
+            opened_archive.sha256,
+            sums_path,
+        )
 
-    with _materialized_bounded_tar(archive_path) as tar_path:
-        members = _archive_members(manifest, archive_path, tar_path)
-        archive = manifest.get("archive")
-        assert isinstance(archive, dict)
-        prefix = archive.get("prefix")
-        assert isinstance(prefix, str)
-        _reject_retired_release_contract_members(members, prefix)
-        _verify_manifest_contract(manifest, tar_path, members, contract)
-        if repo is not None:
-            _compare_with_repo(
-                Path(repo).expanduser().resolve(), manifest, tar_path, members
-            )
+        license_data = manifest.get("license")
+        if not isinstance(license_data, dict):
+            raise ValueError("license object is missing")
+        if license_data.get("expression") != contract.license_expression:
+            raise ValueError("license expression mismatch")
+        if license_data.get("distribution_status") != DISTRIBUTION_STATUS:
+            raise ValueError("distribution boundary mismatch")
 
-    current_manifest_bytes = _read_bounded_regular_file(
-        manifest_path,
-        label="release manifest",
-        max_bytes=MAX_MANIFEST_BYTES,
-    )
-    if current_manifest_bytes != manifest_bytes:
-        raise ValueError("release manifest changed during verification")
+        with _materialized_bounded_tar(opened_archive) as tar_path:
+            members = _archive_members(manifest, opened_archive, tar_path)
+            archive = manifest.get("archive")
+            assert isinstance(archive, dict)
+            prefix = archive.get("prefix")
+            assert isinstance(prefix, str)
+            _reject_retired_release_contract_members(members, prefix)
+            _verify_manifest_contract(manifest, tar_path, members, contract)
+            if repo is not None:
+                _compare_with_repo(
+                    Path(repo).expanduser().resolve(), manifest, tar_path, members
+                )
 
-    project = manifest.get("project")
-    assert isinstance(project, dict)
-    return {
-        "status": "pass",
-        "candidate_id": project["candidate_id"],
-        "archive_sha256": _sha256(archive_path),
-        "manifest_sha256": manifest_sha256,
-        "member_count": len(members),
-        "source_bound": repo is not None,
-        "distribution_status": DISTRIBUTION_STATUS,
-        "compatibility_mode": contract.compatibility_mode,
-    }
+        current_manifest_bytes = _read_bounded_regular_file(
+            manifest_path,
+            label="release manifest",
+            max_bytes=MAX_MANIFEST_BYTES,
+        )
+        if current_manifest_bytes != manifest_bytes:
+            raise ValueError("release manifest changed during verification")
+
+        project = manifest.get("project")
+        assert isinstance(project, dict)
+        report = {
+            "status": "pass",
+            "candidate_id": project["candidate_id"],
+            "archive_sha256": opened_archive.sha256,
+            "manifest_sha256": manifest_sha256,
+            "member_count": len(members),
+            "source_bound": repo is not None,
+            "distribution_status": DISTRIBUTION_STATUS,
+            "compatibility_mode": contract.compatibility_mode,
+        }
+    return report
 
 
 def verify_release_candidate(


### PR DESCRIPTION
## Problem

The release verifier previously hashed, materialized, inspected and reported the candidate archive through independent path opens. A concurrent path replacement could therefore separate the reported SHA-256 from the archive bytes actually verified.

## Fix

- open the candidate archive exactly once with `O_NOFOLLOW`;
- bind descriptor and path identity with device, inode and metadata fields;
- hash, inspect the gzip header and materialize through the same descriptor;
- reuse the bound SHA-256 and byte size for checksum, manifest and final-report validation;
- reject archive-path replacement in self-only and source-bound verification.

## Revision binding

- Base: `c0bd029f0be3f370cf946fb311380ea3ea9df4ea`
- Head: `9f0213bfe508e25792f654cc304e4f1cb2b6432f`
- Canonical `git-diff.v1` SHA-256: `4be78dcad6a6fc7678b36f67f49fe40d48ca5ae133887e69df7f4f529bef044c`
- Diff artifact: `17db5431c3e2403c991b5da9739b28ba`
- Diff receipt SHA-256: `2c311f203ee3aa1d7ea88878d17f44380707eb25b837dfc79a7f4fa7eb1ad945`
- Bureau candidate: `candidate-58d06a2303501fdfef712ac9`

## Verification

- scoped and repository-wide Ruff: pass;
- focused archive-identity tests: 7 passed;
- complete release-packaging suite: 58 passed;
- semantic-lock reproduction: pass;
- graph maintainability ratchet: pass;
- remaining non-browser/non-live suite excluding two Bubblewrap-dependent sidecar files: 5125 passed, 12 skipped, 13 deselected;
- GitHub required checks on the exact head: pass, including CodeQL, pytest-full, release-candidate, browser-tests, Ruff and contract validation.

The unfiltered local suite has 33 failures only in the two Bubblewrap sidecar files because the host currently rejects namespace creation. A representative test fails identically on the unchanged base commit, so this is not introduced by the patch.

## Review

A direct head- and diff-bound security review found no material issue. There are no review threads. This is a transparent Self-Review and is not independent. The current external reviewer route is recommended by the catalog but marked `execution_eligible_if_separately_authorized=false`, so no independent review is claimed.

## Boundaries

This PR does not touch `merger/repoground/service/*`, does not modify parallel T004 work, and does not claim merge execution while another owner holds the broad RepoGround lease.