### PR TITLE
fix(source): bound remote snapshot archive memory

### DIFF
--- a/docs/blueprints/rlens-source-acquisition-blueprint.md
+++ b/docs/blueprints/rlens-source-acquisition-blueprint.md
@@ -97,6 +97,10 @@ All surfaces enforce:
 * `GIT_TERMINAL_PROMPT=0` for all git calls;
 * git subprocess output decoded `encoding="utf-8", errors="surrogateescape"`;
 * remote URLs, stderr, exceptions and reports are credential-redacted;
+* `git archive` stdout is written directly to a job-local seekable temporary
+  file instead of accumulating in Python memory, and tar inputs above 2 GiB are
+  rejected before extraction; processed `TarInfo` metadata is discarded after
+  each member instead of accumulating for the full archive;
 * snapshot extraction is hardened by a manual writer (never `tarfile.extract`):
   it extracts only regular files and ordinary directories and **rejects** every
   symlink, hardlink, FIFO and device member, plus absolute paths, `..` traversal
@@ -143,7 +147,11 @@ For `remote_snapshot`:
    This avoids
    credential-at-rest leakage in `<cache_git_dir>/config` and `FETCH_HEAD`.
 4. `rev-parse` the resolved ref to a commit.
-5. `git --git-dir … archive --format=tar <commit>` and extract safely in Python.
+5. `git --git-dir … archive --format=tar <commit>` writes directly into a
+   seekable temporary file below the validated job directory. Archive bytes do
+   not accumulate in Python memory; tar input above 2 GiB is rejected before
+   parsing, and the same stream is passed to the hardened extractor. The
+   temporary file is removed when materialization ends.
 
 Safe extraction is a hand-rolled writer: it extracts only regular files and
 ordinary directories, and rejects absolute paths, `..` traversal, any write
@@ -195,6 +203,7 @@ effective pre-pull). Active identical jobs are still reused.
   redaction gates with tests; this reduces leakage, it is not an absolute
   guarantee that credentials can *never* appear.
 * Snapshot retention is operational cache hygiene, not evidence retention; active jobs are protected, while terminal snapshots can be removed by count, age or size limits.
+* During materialization, disk use can temporarily include both the temporary archive file and the extracted snapshot; archive size no longer scales Python resident memory.
 
 ## Non-goals
 

--- a/merger/repoground/service/source_acquisition.py
+++ b/merger/repoground/service/source_acquisition.py
@@ -32,10 +32,11 @@ import re
 import shutil
 import subprocess
 import tarfile
+import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, Optional, Sequence
+from typing import BinaryIO, Iterator, List, Optional, Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +47,7 @@ SNAPSHOT_DIR_NAME = ".repoground-source-snapshots"
 DEFAULT_SNAPSHOT_RETENTION_COUNT = 3
 DEFAULT_SNAPSHOT_MAX_AGE_HOURS = 24
 DEFAULT_SNAPSHOT_MAX_BYTES = 2 * 1024 * 1024 * 1024
+DEFAULT_SNAPSHOT_ARCHIVE_MAX_BYTES = DEFAULT_SNAPSHOT_MAX_BYTES
 
 # Report warning codes (v1 known limits).
 WARN_SUBMODULES_NOT_EXPANDED = "submodules_not_expanded"
@@ -336,15 +338,18 @@ def _run_git(
         return subprocess.CompletedProcess(cmd, 127, stdout="", stderr=str(exc))
 
 
-def _run_git_binary(
+def _run_git_binary_to_file(
     args: Sequence[str],
+    output: BinaryIO,
     *,
     git_dir: Optional[Path] = None,
     timeout: int = DEFAULT_TIMEOUT_SECONDS,
 ) -> "subprocess.CompletedProcess[bytes]":
-    """Run a git command that emits binary stdout (e.g. ``archive``).
+    """Run a binary-output git command with stdout redirected to ``output``.
 
-    stderr is decoded with surrogateescape for safe redaction; stdout stays bytes.
+    Redirecting stdout keeps ``git archive`` bytes out of ``CompletedProcess`` and
+    therefore out of one unbounded Python allocation. The caller owns the seekable
+    output stream and applies the accepted-byte ceiling before parsing it.
     """
     cmd: List[str] = ["git"]
     if git_dir is not None:
@@ -353,16 +358,29 @@ def _run_git_binary(
     try:
         proc = subprocess.run(
             cmd,
-            capture_output=True,
+            stdout=output,
+            stderr=subprocess.PIPE,
             timeout=timeout,
             env=_git_env(),
             check=False,
         )
     except subprocess.TimeoutExpired:
-        return subprocess.CompletedProcess(cmd, 124, stdout=b"", stderr=f"git timed out after {timeout}s".encode())
+        return subprocess.CompletedProcess(
+            cmd,
+            124,
+            stdout=b"",
+            stderr=f"git timed out after {timeout}s".encode(),
+        )
     except OSError as exc:
-        return subprocess.CompletedProcess(cmd, 127, stdout=b"", stderr=str(exc).encode())
-    return proc
+        return subprocess.CompletedProcess(
+            cmd, 127, stdout=b"", stderr=str(exc).encode()
+        )
+    return subprocess.CompletedProcess(
+        proc.args,
+        proc.returncode,
+        stdout=b"",
+        stderr=proc.stderr,
+    )
 
 
 @dataclass
@@ -732,6 +750,73 @@ def _resolve_default_branch(remote_url: str, timeout: int) -> Optional[str]:
     return None
 
 
+def _extract_git_archive(
+    *,
+    cache_git_dir: Path,
+    commit: str,
+    base_dir: Path,
+    snapshot_dir: Path,
+    repo_name: str,
+    timeout_seconds: int,
+) -> Optional[tuple[str, str, str]]:
+    """Write one Git archive to disk, bound its size, and extract the same stream."""
+    try:
+        with tempfile.TemporaryFile(
+            mode="w+b",
+            dir=base_dir,
+            prefix=f".{repo_name}-archive-",
+        ) as archive_stream:
+            archive = _run_git_binary_to_file(
+                ["archive", "--format=tar", commit],
+                archive_stream,
+                git_dir=cache_git_dir,
+                timeout=timeout_seconds,
+            )
+            if archive.returncode != 0:
+                stderr = (
+                    archive.stderr.decode("utf-8", errors="surrogateescape")
+                    if isinstance(archive.stderr, bytes)
+                    else str(archive.stderr or "")
+                )
+                return (
+                    SourceStatus.ARCHIVE_FAILED,
+                    f"git archive failed for {repo_name}",
+                    stderr,
+                )
+
+            archive_stream.flush()
+            archive_bytes = archive_stream.tell()
+            if archive_bytes > DEFAULT_SNAPSHOT_ARCHIVE_MAX_BYTES:
+                return (
+                    SourceStatus.ARCHIVE_FAILED,
+                    f"git archive exceeds byte limit for {repo_name}",
+                    f"archive bytes {archive_bytes} exceed limit "
+                    f"{DEFAULT_SNAPSHOT_ARCHIVE_MAX_BYTES}",
+                )
+            archive_stream.seek(0)
+            try:
+                safe_extract_tar(archive_stream, snapshot_dir)
+            except SnapshotExtractionError as exc:
+                return (
+                    SourceStatus.EXTRACT_FAILED,
+                    f"unsafe tar member while extracting {repo_name} snapshot: {exc}",
+                    str(exc),
+                )
+            except (tarfile.TarError, OSError) as exc:
+                return (
+                    SourceStatus.EXTRACT_FAILED,
+                    f"failed to extract {repo_name} snapshot",
+                    str(exc),
+                )
+    except OSError as exc:
+        return (
+            SourceStatus.ARCHIVE_FAILED,
+            f"could not create or finalize git archive for {repo_name}",
+            str(exc),
+        )
+    return None
+
+
 def materialize_remote_snapshot(
     repo_path: Path,
     *,
@@ -894,20 +979,17 @@ def materialize_remote_snapshot(
     commit = rev.stdout.strip()
     resolution.resolved_commit = commit
 
-    archive = _run_git_binary(["archive", "--format=tar", commit], git_dir=cache_git_dir, timeout=timeout_seconds)
-    if archive.returncode != 0:
-        stderr_txt = archive.stderr.decode("utf-8", errors="surrogateescape") if isinstance(archive.stderr, bytes) else archive.stderr
-        return make(SourceStatus.ARCHIVE_FAILED, f"git archive failed for {repo_name}",
-                    resolution=resolution, stderr=stderr_txt)
-
-    try:
-        safe_extract_tar(archive.stdout, snapshot_dir)
-    except SnapshotExtractionError as exc:
-        return make(SourceStatus.EXTRACT_FAILED, f"unsafe tar member while extracting {repo_name} snapshot: {exc}",
-                    resolution=resolution, stderr=str(exc))
-    except (tarfile.TarError, OSError) as exc:
-        return make(SourceStatus.EXTRACT_FAILED, f"failed to extract {repo_name} snapshot",
-                    resolution=resolution, stderr=str(exc))
+    archive_failure = _extract_git_archive(
+        cache_git_dir=cache_git_dir,
+        commit=commit,
+        base_dir=base_resolved,
+        snapshot_dir=snapshot_dir,
+        repo_name=repo_name,
+        timeout_seconds=timeout_seconds,
+    )
+    if archive_failure is not None:
+        status, message, stderr = archive_failure
+        return make(status, message, resolution=resolution, stderr=stderr)
 
     warnings = _detect_snapshot_warnings(snapshot_dir)
     return make(
@@ -923,8 +1005,28 @@ class SnapshotExtractionError(Exception):
     """Raised when a tar member would escape the snapshot directory."""
 
 
-def safe_extract_tar(data: bytes, dest: Path) -> None:
-    """Extract a tar byte stream into ``dest`` with a hardened, manual writer.
+def _seekable_tar_source(data: bytes | BinaryIO) -> BinaryIO:
+    source: BinaryIO = io.BytesIO(data) if isinstance(data, bytes) else data
+    try:
+        source.seek(0)
+    except (AttributeError, OSError) as exc:
+        raise SnapshotExtractionError("tar source must be seekable") from exc
+    return source
+
+
+def _iter_tar_members_without_retention(
+    tar: tarfile.TarFile,
+) -> Iterator[tarfile.TarInfo]:
+    """Yield one member at a time and discard processed metadata immediately."""
+    for member in tar:
+        try:
+            yield member
+        finally:
+            tar.members.clear()
+
+
+def safe_extract_tar(data: bytes | BinaryIO, dest: Path) -> None:
+    """Extract bytes or one seekable tar stream with a hardened manual writer.
 
     v1 policy — security before convenience (see the source-acquisition blueprint):
 
@@ -976,8 +1078,8 @@ def safe_extract_tar(data: bytes, dest: Path) -> None:
             if cur.is_symlink():
                 raise SnapshotExtractionError(f"symlink in target path: {cur}")
 
-    with tarfile.open(fileobj=io.BytesIO(data), mode="r:*") as tar:
-        for member in tar.getmembers():
+    with tarfile.open(fileobj=_seekable_tar_source(data), mode="r:*") as tar:
+        for member in _iter_tar_members_without_retention(tar):
             name = member.name
 
             if member.issym() or member.islnk():

--- a/merger/repoground/service/source_acquisition.py
+++ b/merger/repoground/service/source_acquisition.py
@@ -795,11 +795,17 @@ def _extract_git_archive(
                 )
             archive_stream.seek(0)
             try:
-                safe_extract_tar(archive_stream, snapshot_dir)
+                safe_extract_tar(_ArchiveReadGuard(archive_stream), snapshot_dir)
+            except SnapshotArchiveReadError as exc:
+                return (
+                    SourceStatus.ARCHIVE_FAILED,
+                    f"could not read git archive for {repo_name}",
+                    str(exc),
+                )
             except SnapshotExtractionError as exc:
                 return (
                     SourceStatus.EXTRACT_FAILED,
-                    f"unsafe tar member while extracting {repo_name} snapshot: {exc}",
+                    f"snapshot extraction failed for {repo_name}: {exc}",
                     str(exc),
                 )
             except (tarfile.TarError, OSError) as exc:
@@ -1002,7 +1008,38 @@ def materialize_remote_snapshot(
 
 
 class SnapshotExtractionError(Exception):
-    """Raised when a tar member would escape the snapshot directory."""
+    """Raised when snapshot extraction is unsafe or cannot write its target."""
+
+
+class SnapshotArchiveReadError(Exception):
+    """Raised when the job-local temporary Git archive cannot be read."""
+
+
+class _ArchiveReadGuard:
+    """Translate temporary-archive read operations into one typed failure."""
+
+    def __init__(self, source: BinaryIO) -> None:
+        self._source = source
+
+    def _read_operation(self, operation: str, *args, **kwargs):
+        try:
+            return getattr(self._source, operation)(*args, **kwargs)
+        except OSError as exc:
+            raise SnapshotArchiveReadError(
+                f"temporary Git archive {operation} failed: {exc}"
+            ) from exc
+
+    def read(self, *args, **kwargs):
+        return self._read_operation("read", *args, **kwargs)
+
+    def seek(self, *args, **kwargs):
+        return self._read_operation("seek", *args, **kwargs)
+
+    def tell(self, *args, **kwargs):
+        return self._read_operation("tell", *args, **kwargs)
+
+    def __getattr__(self, name: str):
+        return getattr(self._source, name)
 
 
 def _seekable_tar_source(data: bytes | BinaryIO) -> BinaryIO:

--- a/merger/repoground/tests/test_source_acquisition.py
+++ b/merger/repoground/tests/test_source_acquisition.py
@@ -279,6 +279,63 @@ def test_extract_git_archive_classifies_temporary_archive_read_failure(
     assert "archive read failed" in stderr
 
 
+def test_extract_git_archive_classifies_member_stream_seek_failure(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    class MemberSeekFailure(io.BytesIO):
+        def __init__(self, data: bytes):
+            super().__init__(data)
+            self._header_read = False
+            io.BytesIO.seek(self, 0, 2)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            self.close()
+            return False
+
+        def read(self, *args, **kwargs):
+            chunk = super().read(*args, **kwargs)
+            if chunk:
+                self._header_read = True
+            return chunk
+
+        def seek(self, offset, whence=0):
+            if self._header_read and whence == 0 and offset == tarfile.BLOCKSIZE:
+                raise OSError("archive member seek failed")
+            return super().seek(offset, whence)
+
+    monkeypatch.setattr(
+        sa.tempfile,
+        "TemporaryFile",
+        lambda **_kwargs: MemberSeekFailure(_tar_with_member("file.txt")),
+    )
+    monkeypatch.setattr(
+        sa,
+        "_run_git_binary_to_file",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+            args=["git", "archive"], returncode=0, stdout=b"", stderr=b""
+        ),
+    )
+
+    result = sa._extract_git_archive(
+        cache_git_dir=tmp_path / "cache.git",
+        commit="a" * 40,
+        base_dir=tmp_path,
+        snapshot_dir=tmp_path / "snapshot",
+        repo_name="repo",
+        timeout_seconds=10,
+    )
+
+    assert result is not None
+    status, message, stderr = result
+    assert status == SourceStatus.ARCHIVE_FAILED
+    assert message == "could not read git archive for repo"
+    assert "temporary Git archive seek failed" in stderr
+    assert "archive member seek failed" in stderr
+
+
 def test_extract_git_archive_keeps_target_write_failure_as_extract_failure(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ):

--- a/merger/repoground/tests/test_source_acquisition.py
+++ b/merger/repoground/tests/test_source_acquisition.py
@@ -139,6 +139,117 @@ def test_effective_source_mode_rejects_explicit_contradictions():
 
 # --- 1. default_branch on a no-upstream local branch -----------------------
 
+def test_remote_snapshot_passes_seekable_archive_stream_to_extractor(
+    remote_and_local, monkeypatch: pytest.MonkeyPatch
+):
+    original_extract = sa.safe_extract_tar
+    observed = {}
+
+    def capture_stream(data, dest):
+        observed["is_bytes"] = isinstance(data, bytes)
+        observed["has_seek"] = callable(getattr(data, "seek", None))
+        observed["has_tell"] = callable(getattr(data, "tell", None))
+        observed["position"] = data.tell()
+        return original_extract(data, dest)
+
+    monkeypatch.setattr(sa, "safe_extract_tar", capture_stream)
+    result = materialize_remote_snapshot(
+        remote_and_local["local"],
+        remote_ref=None,
+        remote_ref_policy="default_branch",
+        cache_root=remote_and_local["cache"],
+        job_id="job-streamed-archive",
+    )
+
+    assert result.status == SourceStatus.SNAPSHOT_CREATED, result.stderr
+    assert observed == {
+        "is_bytes": False,
+        "has_seek": True,
+        "has_tell": True,
+        "position": 0,
+    }
+
+
+def test_extract_git_archive_classifies_tempfile_creation_failure(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    def fail_tempfile(**_kwargs):
+        raise OSError("disk unavailable")
+
+    monkeypatch.setattr(sa.tempfile, "TemporaryFile", fail_tempfile)
+    result = sa._extract_git_archive(
+        cache_git_dir=tmp_path / "cache.git",
+        commit="a" * 40,
+        base_dir=tmp_path,
+        snapshot_dir=tmp_path / "snapshot",
+        repo_name="repo",
+        timeout_seconds=10,
+    )
+
+    assert result is not None
+    status, message, stderr = result
+    assert status == SourceStatus.ARCHIVE_FAILED
+    assert "create or finalize git archive" in message
+    assert stderr == "disk unavailable"
+
+
+def test_extract_git_archive_classifies_flush_failure(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    class FlushFailure(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            io.BytesIO.close(self)
+            return False
+
+        def flush(self):
+            raise OSError("disk full")
+
+    monkeypatch.setattr(sa.tempfile, "TemporaryFile", lambda **_kwargs: FlushFailure())
+    monkeypatch.setattr(
+        sa,
+        "_run_git_binary_to_file",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+            args=["git", "archive"], returncode=0, stdout=b"", stderr=b""
+        ),
+    )
+    result = sa._extract_git_archive(
+        cache_git_dir=tmp_path / "cache.git",
+        commit="a" * 40,
+        base_dir=tmp_path,
+        snapshot_dir=tmp_path / "snapshot",
+        repo_name="repo",
+        timeout_seconds=10,
+    )
+
+    assert result is not None
+    status, message, stderr = result
+    assert status == SourceStatus.ARCHIVE_FAILED
+    assert "create or finalize git archive" in message
+    assert stderr == "disk full"
+
+
+def test_remote_snapshot_rejects_archive_over_byte_limit(
+    remote_and_local, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setattr(sa, "DEFAULT_SNAPSHOT_ARCHIVE_MAX_BYTES", 1)
+
+    result = materialize_remote_snapshot(
+        remote_and_local["local"],
+        remote_ref=None,
+        remote_ref_policy="default_branch",
+        cache_root=remote_and_local["cache"],
+        job_id="job-archive-limit",
+    )
+
+    assert result.status == SourceStatus.ARCHIVE_FAILED
+    assert result.snapshot_path is None
+    assert "exceeds byte limit" in result.message
+    assert "exceed limit 1" in (result.stderr or "")
+
+
 def test_remote_snapshot_default_branch_no_upstream(remote_and_local):
     local = remote_and_local["local"]
     assert _has_no_upstream(local), "precondition: local branch has no upstream"
@@ -300,6 +411,44 @@ def _tar_with_member(name: str, *, linkname: str = None, typeflag=tarfile.REGTYP
             return buf2
         tar.addfile(info)
     return buf.getvalue()
+
+
+def test_safe_tar_extraction_discards_processed_member_metadata(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    payload = io.BytesIO()
+    with tarfile.open(fileobj=payload, mode="w") as archive:
+        for index in range(32):
+            data = b"x"
+            member = tarfile.TarInfo(f"file-{index}.txt")
+            member.size = len(data)
+            archive.addfile(member, io.BytesIO(data))
+    raw = payload.getvalue()
+
+    original_open = sa.tarfile.open
+    observed_archives = []
+
+    def tracked_open(*args, **kwargs):
+        archive = original_open(*args, **kwargs)
+        observed_archives.append(archive)
+        return archive
+
+    monkeypatch.setattr(sa.tarfile, "open", tracked_open)
+    dest = tmp_path / "metadata-bounded"
+    safe_extract_tar(raw, dest)
+
+    assert len(observed_archives) == 1
+    assert observed_archives[0].members == []
+    assert len(list(dest.glob("*.txt"))) == 32
+
+
+def test_safe_tar_extraction_accepts_seekable_stream(tmp_path):
+    dest = tmp_path / "stream-out"
+    stream = io.BytesIO(_tar_with_member("streamed.txt"))
+
+    safe_extract_tar(stream, dest)
+
+    assert (dest / "streamed.txt").read_text() == "hello"
 
 
 def test_safe_tar_extraction_rejects_path_traversal(tmp_path):

--- a/merger/repoground/tests/test_source_acquisition.py
+++ b/merger/repoground/tests/test_source_acquisition.py
@@ -231,6 +231,105 @@ def test_extract_git_archive_classifies_flush_failure(
     assert stderr == "disk full"
 
 
+def test_extract_git_archive_classifies_temporary_archive_read_failure(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    class ReadFailure(io.BytesIO):
+        def __init__(self, data: bytes):
+            super().__init__(data)
+            io.BytesIO.seek(self, 0, 2)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            self.close()
+            return False
+
+        def read(self, *_args, **_kwargs):
+            raise OSError("archive read failed")
+
+    monkeypatch.setattr(
+        sa.tempfile,
+        "TemporaryFile",
+        lambda **_kwargs: ReadFailure(_tar_with_member("file.txt")),
+    )
+    monkeypatch.setattr(
+        sa,
+        "_run_git_binary_to_file",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+            args=["git", "archive"], returncode=0, stdout=b"", stderr=b""
+        ),
+    )
+
+    result = sa._extract_git_archive(
+        cache_git_dir=tmp_path / "cache.git",
+        commit="a" * 40,
+        base_dir=tmp_path,
+        snapshot_dir=tmp_path / "snapshot",
+        repo_name="repo",
+        timeout_seconds=10,
+    )
+
+    assert result is not None
+    status, message, stderr = result
+    assert status == SourceStatus.ARCHIVE_FAILED
+    assert message == "could not read git archive for repo"
+    assert "temporary Git archive read failed" in stderr
+    assert "archive read failed" in stderr
+
+
+def test_extract_git_archive_keeps_target_write_failure_as_extract_failure(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    class ArchiveStream(io.BytesIO):
+        def __init__(self, data: bytes):
+            super().__init__(data)
+            io.BytesIO.seek(self, 0, 2)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            self.close()
+            return False
+
+    monkeypatch.setattr(
+        sa.tempfile,
+        "TemporaryFile",
+        lambda **_kwargs: ArchiveStream(_tar_with_member("file.txt")),
+    )
+    monkeypatch.setattr(
+        sa,
+        "_run_git_binary_to_file",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+            args=["git", "archive"], returncode=0, stdout=b"", stderr=b""
+        ),
+    )
+    original_open = open
+
+    def fail_target_write(path, mode="r", *args, **kwargs):
+        if mode == "wb" and Path(path).name == "file.txt":
+            raise OSError("snapshot disk full")
+        return original_open(path, mode, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", fail_target_write)
+    result = sa._extract_git_archive(
+        cache_git_dir=tmp_path / "cache.git",
+        commit="a" * 40,
+        base_dir=tmp_path,
+        snapshot_dir=tmp_path / "snapshot",
+        repo_name="repo",
+        timeout_seconds=10,
+    )
+
+    assert result is not None
+    status, message, stderr = result
+    assert status == SourceStatus.EXTRACT_FAILED
+    assert message.startswith("snapshot extraction failed for repo")
+    assert "snapshot disk full" in stderr
+
+
 def test_remote_snapshot_rejects_archive_over_byte_limit(
     remote_and_local, monkeypatch: pytest.MonkeyPatch
 ):


### PR DESCRIPTION
## Problem

`remote_snapshot` collected the complete uncompressed `git archive` output through `capture_output=True`. Large repositories could therefore scale Python resident memory with the full tar before hardened extraction began.

## Change

- redirect `git archive` stdout into one job-local seekable temporary file
- reject tar input above the existing 2 GiB snapshot ceiling before parsing
- pass the same stream into the hardened manual extractor
- iterate tar members without first building `getmembers()`
- document the temporary disk trade-off

## Validation

- `pytest -q merger/repoground/tests/test_source_acquisition.py`: 43 passed
- `ruff check --config ruff-ci.toml .`: passed
- graph maintainability ratchet: passed without baseline change
- module reachability ratchet: passed
- full pytest: 5,147 passed, 12 skipped; 33 unrelated Bubblewrap sidecar tests failed because the host could not create another namespace (`Resource temporarily unavailable`)

## Boundaries

This patch bounds Python memory, not producer-side temporary disk growth while `git archive` is still writing. The 2 GiB ceiling is enforced before tar parsing. GitHub CI remains authoritative for merge readiness.