### PR TITLE
fix(sidecar): decouple process budget from loaded host baseline (T020)

### DIFF
--- a/docs/proofs/repoground-legacy-t020-process-budget-v1-proof.md
+++ b/docs/proofs/repoground-legacy-t020-process-budget-v1-proof.md
@@ -1,4 +1,4 @@
-# T020 proof: loaded-host process budget for the patch sidecar
+# T020 proof: loaded-host task budget for the patch sidecar
 
 Task: `REPOGROUND-LEGACY-RECONCILIATION-V1-T020`.
 
@@ -10,10 +10,10 @@ The sidecar previously wrapped Bubblewrap with:
 prlimit --nproc=256 -- bwrap ...
 ```
 
-On Linux, `RLIMIT_NPROC` is counted for the process's **real user ID**. It is
-not a child-process or PID-namespace quota. When the operator user already owns
-at least 256 processes, Bubblewrap can fail before the isolated payload starts
-with:
+On Linux, `RLIMIT_NPROC` is counted for the process's **real user ID** and,
+more precisely, accounts threads rather than only process leaders. It is not a
+child-process or PID-namespace quota. When the operator user already owns at
+least 256 tasks, Bubblewrap can fail before the isolated payload starts with:
 
 ```text
 bwrap: Creating new namespace failed: Resource temporarily unavailable
@@ -26,25 +26,26 @@ That couples a bounded command policy to unrelated pre-existing host load.
 `patch_evaluation_sidecar_process_budget.py` is installed as the final sidecar
 overlay. Immediately before each `prlimit` argv is built, it:
 
-1. counts visible `/proc/<pid>/status` entries whose real UID equals
+1. counts visible `/proc/<pid>/task/<tid>/status` entries whose real UID equals
    `os.getuid()`;
 2. treats the existing `_MAX_COMMAND_PROCESSES` value (`256`) as an
-   **incremental budget**;
-3. calculates `absolute_limit = current_real_uid_processes + 256`;
+   **incremental task budget**;
+3. calculates `absolute_limit = current_real_uid_tasks + 256`;
 4. clamps that value to the inherited hard `RLIMIT_NPROC`;
 5. fails closed when the inherited hard limit leaves no positive headroom;
 6. emits an explicit `soft:hard` pair to `prlimit`.
 
-Example from the bound failure model:
+Synthetic loaded-host regression model:
 
 ```text
-current real-UID processes: 270
+current real-UID tasks: 270
 configured incremental budget: 256
 inherited hard limit: 31422
 applied RLIMIT_NPROC: 526:526
 ```
 
-The old absolute `256` is therefore not reused.
+The old absolute `256` is therefore not reused. The value `270` above is a
+test-bound model, not a fresh live-host measurement.
 
 ## Security boundaries retained
 
@@ -56,16 +57,18 @@ The change does not remove or weaken:
 - command timeout and bounded log capture;
 - source/workspace fingerprinting and cleanup checks.
 
-A finite inherited hard `RLIMIT_NPROC` is never raised. Concurrent host process
-growth consumes sidecar headroom and can still make a command fail, which is a
-fail-closed outcome.
+A finite inherited hard `RLIMIT_NPROC` is never raised. Concurrent same-UID
+task growth consumes sidecar headroom and can still make a command fail, which
+is a fail-closed outcome. A disappearing or unreadable `/proc` task can only
+lower the measured baseline and therefore reduce the available sidecar
+headroom; it cannot silently expand the configured incremental budget.
 
 ## Epistemic boundary
 
 Linux does not provide a strict per-command quota through `RLIMIT_NPROC`:
-processes are accounted by real UID. If unrelated same-UID processes terminate
-after the baseline is measured, some absolute headroom becomes available. The
-implementation therefore claims only a bounded **launch-time incremental
+tasks are accounted by real UID. If unrelated same-UID tasks terminate after
+the baseline is measured, some absolute headroom becomes available. The
+implementation therefore claims only a bounded **launch-time incremental task
 budget**, not a globally isolated per-command kernel quota.
 
 A cgroup `pids.max` implementation would provide a stronger subtree quota, but
@@ -76,9 +79,10 @@ That larger operational change is not introduced here.
 
 `tests/test_patch_evaluation_sidecar_process_budget.py` proves:
 
-- `/proc` counting uses the real UID and tolerates normal process-table races;
-- a loaded-host baseline of 270 produces `526:526`, not the legacy absolute
-  `256`;
+- `/proc` counting visits individual threads and evaluates each task's real UID;
+- normal process-table races are tolerated fail-closed;
+- a loaded-host task baseline of 270 produces `526:526`, not the legacy
+  absolute `256`;
 - a finite inherited hard limit only reduces the effective budget;
 - zero inherited headroom fails closed;
 - generated `prlimit` argv uses the dynamic explicit soft/hard value;
@@ -94,5 +98,5 @@ logs, provenance and cleanup.
 This slice changes only the sidecar wrapper, one new overlay module, its tests
 and this proof. It does not touch `service/app.py`, the active T012 service split
 or any historical/dirty RepoGround worktree. It does not by itself mark T020 or
-its parent initiative verified; merge, CI and current-head readback remain
-required.
+its parent initiative verified; merge, CI, a non-root loaded-host canary and
+current-head readback remain required.

--- a/docs/proofs/repoground-legacy-t020-process-budget-v1-proof.md
+++ b/docs/proofs/repoground-legacy-t020-process-budget-v1-proof.md
@@ -1,0 +1,98 @@
+# T020 proof: loaded-host process budget for the patch sidecar
+
+Task: `REPOGROUND-LEGACY-RECONCILIATION-V1-T020`.
+
+## Problem
+
+The sidecar previously wrapped Bubblewrap with:
+
+```text
+prlimit --nproc=256 -- bwrap ...
+```
+
+On Linux, `RLIMIT_NPROC` is counted for the process's **real user ID**. It is
+not a child-process or PID-namespace quota. When the operator user already owns
+at least 256 processes, Bubblewrap can fail before the isolated payload starts
+with:
+
+```text
+bwrap: Creating new namespace failed: Resource temporarily unavailable
+```
+
+That couples a bounded command policy to unrelated pre-existing host load.
+
+## Change
+
+`patch_evaluation_sidecar_process_budget.py` is installed as the final sidecar
+overlay. Immediately before each `prlimit` argv is built, it:
+
+1. counts visible `/proc/<pid>/status` entries whose real UID equals
+   `os.getuid()`;
+2. treats the existing `_MAX_COMMAND_PROCESSES` value (`256`) as an
+   **incremental budget**;
+3. calculates `absolute_limit = current_real_uid_processes + 256`;
+4. clamps that value to the inherited hard `RLIMIT_NPROC`;
+5. fails closed when the inherited hard limit leaves no positive headroom;
+6. emits an explicit `soft:hard` pair to `prlimit`.
+
+Example from the bound failure model:
+
+```text
+current real-UID processes: 270
+configured incremental budget: 256
+inherited hard limit: 31422
+applied RLIMIT_NPROC: 526:526
+```
+
+The old absolute `256` is therefore not reused.
+
+## Security boundaries retained
+
+The change does not remove or weaken:
+
+- Bubblewrap PID, IPC, UTS, network and best-effort cgroup namespace isolation;
+- read-only system and Git-metadata mounts;
+- address-space, output-file, open-file and CPU limits;
+- command timeout and bounded log capture;
+- source/workspace fingerprinting and cleanup checks.
+
+A finite inherited hard `RLIMIT_NPROC` is never raised. Concurrent host process
+growth consumes sidecar headroom and can still make a command fail, which is a
+fail-closed outcome.
+
+## Epistemic boundary
+
+Linux does not provide a strict per-command quota through `RLIMIT_NPROC`:
+processes are accounted by real UID. If unrelated same-UID processes terminate
+after the baseline is measured, some absolute headroom becomes available. The
+implementation therefore claims only a bounded **launch-time incremental
+budget**, not a globally isolated per-command kernel quota.
+
+A cgroup `pids.max` implementation would provide a stronger subtree quota, but
+it would require proven delegated cgroup ownership on every supported runtime.
+That larger operational change is not introduced here.
+
+## Regression coverage
+
+`tests/test_patch_evaluation_sidecar_process_budget.py` proves:
+
+- `/proc` counting uses the real UID and tolerates normal process-table races;
+- a loaded-host baseline of 270 produces `526:526`, not the legacy absolute
+  `256`;
+- a finite inherited hard limit only reduces the effective budget;
+- zero inherited headroom fails closed;
+- generated `prlimit` argv uses the dynamic explicit soft/hard value;
+- on non-root Linux, a deliberately small incremental budget rejects a fork
+  storm while allowing the bounded command to start.
+
+The existing patch-sidecar and host-readback suites continue to cover
+Bubblewrap startup, filesystem/network isolation, mutation rejection, bounded
+logs, provenance and cleanup.
+
+## Delivery boundary
+
+This slice changes only the sidecar wrapper, one new overlay module, its tests
+and this proof. It does not touch `service/app.py`, the active T012 service split
+or any historical/dirty RepoGround worktree. It does not by itself mark T020 or
+its parent initiative verified; merge, CI and current-head readback remain
+required.

--- a/tests/test_patch_evaluation_sidecar_process_budget.py
+++ b/tests/test_patch_evaluation_sidecar_process_budget.py
@@ -65,6 +65,7 @@ def test_task_count_uses_each_thread_real_uid_and_ignores_proc_races(
     _write_task_status(tmp_path, "200", "200", 1000)
     (tmp_path / "not-a-pid").mkdir()
     (tmp_path / "300" / "task" / "300").mkdir(parents=True)
+    (tmp_path / "400").mkdir()  # process vanished before its task directory opened
 
     assert process_budget._count_real_uid_tasks(proc_root=tmp_path, real_uid=1000) == 3
 

--- a/tests/test_patch_evaluation_sidecar_process_budget.py
+++ b/tests/test_patch_evaluation_sidecar_process_budget.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "tools" / "patch_evaluation_sidecar_process_budget.py"
+SPEC = importlib.util.spec_from_file_location(
+    "patch_evaluation_sidecar_process_budget_tested", MODULE_PATH
+)
+assert SPEC is not None and SPEC.loader is not None
+process_budget = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(process_budget)
+
+
+def _install(*, configured_budget: int = 256):
+    prlimit = shutil.which("prlimit") or "/usr/bin/prlimit"
+    legacy = SimpleNamespace(
+        __file__=str(ROOT / "tools" / "patch_evaluation_sidecar_legacy.py"),
+        EvaluationError=RuntimeError,
+        _resolve_system_tool=lambda name: Path(prlimit),
+    )
+    hardening = SimpleNamespace(
+        __file__=str(ROOT / "tools" / "patch_evaluation_sidecar_hardening.py"),
+        _MAX_ADDRESS_SPACE_BYTES=4 * 1024 * 1024 * 1024,
+        _MAX_COMMAND_FILE_BYTES=1024 * 1024 * 1024,
+        _MAX_COMMAND_PROCESSES=configured_budget,
+        _MAX_COMMAND_OPEN_FILES=1024,
+    )
+    host_readback = SimpleNamespace(
+        __file__=str(ROOT / "tools" / "patch_evaluation_sidecar_host_readback.py")
+    )
+    process_budget.apply_process_budget(
+        legacy,
+        hardening,
+        host_readback,
+        wrapper_path=ROOT / "tools" / "patch_evaluation_sidecar.py",
+    )
+    return legacy, hardening
+
+
+def test_process_count_uses_real_uid_and_ignores_proc_races(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _install()
+    for pid, uid in (("100", 1000), ("101", 1001), ("102", 1000)):
+        directory = tmp_path / pid
+        directory.mkdir()
+        (directory / "status").write_text(
+            f"Name:\ttest\nUid:\t{uid}\t{uid}\t{uid}\t{uid}\n",
+            encoding="utf-8",
+        )
+    (tmp_path / "not-a-pid").mkdir()
+    (tmp_path / "103").mkdir()  # vanished/unreadable status race
+
+    assert (
+        process_budget._count_real_uid_processes(proc_root=tmp_path, real_uid=1000)
+        == 2
+    )
+
+
+def test_loaded_host_limit_is_baseline_plus_incremental_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install(configured_budget=256)
+    monkeypatch.setattr(process_budget, "_count_real_uid_processes", lambda **_: 270)
+    monkeypatch.setattr(process_budget, "_inherited_nproc_hard_limit", lambda: 31422)
+
+    snapshot = process_budget._effective_nproc_limit()
+
+    assert snapshot == {
+        "real_uid_processes": 270,
+        "configured_incremental_budget": 256,
+        "effective_incremental_budget": 256,
+        "absolute_limit": 526,
+        "inherited_hard_limit": 31422,
+    }
+
+
+def test_finite_inherited_hard_limit_only_reduces_headroom(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install(configured_budget=256)
+    monkeypatch.setattr(process_budget, "_count_real_uid_processes", lambda **_: 270)
+    monkeypatch.setattr(process_budget, "_inherited_nproc_hard_limit", lambda: 300)
+
+    snapshot = process_budget._effective_nproc_limit()
+
+    assert snapshot["absolute_limit"] == 300
+    assert snapshot["effective_incremental_budget"] == 30
+
+
+def test_no_inherited_process_headroom_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install(configured_budget=256)
+    monkeypatch.setattr(process_budget, "_count_real_uid_processes", lambda **_: 270)
+    monkeypatch.setattr(process_budget, "_inherited_nproc_hard_limit", lambda: 270)
+
+    with pytest.raises(RuntimeError, match="no process headroom remains"):
+        process_budget._effective_nproc_limit()
+
+
+def test_prlimit_argv_no_longer_uses_absolute_legacy_ceiling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install(configured_budget=256)
+    monkeypatch.setattr(process_budget, "_count_real_uid_processes", lambda **_: 270)
+    monkeypatch.setattr(process_budget, "_inherited_nproc_hard_limit", lambda: 31422)
+
+    argv = process_budget._limited_sandbox_argv(["/usr/bin/true"], 10)
+
+    assert "--nproc=526:526" in argv
+    assert "--nproc=256" not in argv
+    assert argv[-2:] == ["--", "/usr/bin/true"]
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="RLIMIT_NPROC is Linux-specific")
+@pytest.mark.skipif(os.getuid() == 0, reason="Linux does not enforce RLIMIT_NPROC for root")
+def test_small_incremental_budget_rejects_fork_storm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install(configured_budget=6)
+    script = (
+        "import subprocess,sys; children=[]; stopped=False\n"
+        "try:\n"
+        "  for _ in range(64):\n"
+        "    try: children.append(subprocess.Popen([sys.executable,'-c','import time; time.sleep(2)']))\n"
+        "    except OSError: stopped=True; break\n"
+        "  print(len(children), int(stopped))\n"
+        "finally:\n"
+        "  [p.terminate() for p in children]\n"
+        "  [p.wait(timeout=5) for p in children]\n"
+    )
+    argv = process_budget._limited_sandbox_argv([sys.executable, "-c", script], 10)
+
+    completed = subprocess.run(
+        argv,
+        text=True,
+        capture_output=True,
+        check=True,
+        timeout=20,
+    )
+    spawned, stopped = map(int, completed.stdout.split())
+
+    assert stopped == 1
+    assert spawned < 64

--- a/tests/test_patch_evaluation_sidecar_process_budget.py
+++ b/tests/test_patch_evaluation_sidecar_process_budget.py
@@ -46,37 +46,40 @@ def _install(*, configured_budget: int = 256):
     return legacy, hardening
 
 
-def test_process_count_uses_real_uid_and_ignores_proc_races(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+def _write_task_status(proc_root: Path, pid: str, tid: str, uid: int) -> None:
+    directory = proc_root / pid / "task" / tid
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "status").write_text(
+        f"Name:\ttest\nUid:\t{uid}\t{uid}\t{uid}\t{uid}\n",
+        encoding="utf-8",
+    )
+
+
+def test_task_count_uses_each_thread_real_uid_and_ignores_proc_races(
+    tmp_path: Path,
 ) -> None:
     _install()
-    for pid, uid in (("100", 1000), ("101", 1001), ("102", 1000)):
-        directory = tmp_path / pid
-        directory.mkdir()
-        (directory / "status").write_text(
-            f"Name:\ttest\nUid:\t{uid}\t{uid}\t{uid}\t{uid}\n",
-            encoding="utf-8",
-        )
+    _write_task_status(tmp_path, "100", "100", 1000)
+    _write_task_status(tmp_path, "100", "101", 1000)
+    _write_task_status(tmp_path, "100", "102", 1001)
+    _write_task_status(tmp_path, "200", "200", 1000)
     (tmp_path / "not-a-pid").mkdir()
-    (tmp_path / "103").mkdir()  # vanished/unreadable status race
+    (tmp_path / "300" / "task" / "300").mkdir(parents=True)
 
-    assert (
-        process_budget._count_real_uid_processes(proc_root=tmp_path, real_uid=1000)
-        == 2
-    )
+    assert process_budget._count_real_uid_tasks(proc_root=tmp_path, real_uid=1000) == 3
 
 
 def test_loaded_host_limit_is_baseline_plus_incremental_budget(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _install(configured_budget=256)
-    monkeypatch.setattr(process_budget, "_count_real_uid_processes", lambda **_: 270)
+    monkeypatch.setattr(process_budget, "_count_real_uid_tasks", lambda **_: 270)
     monkeypatch.setattr(process_budget, "_inherited_nproc_hard_limit", lambda: 31422)
 
     snapshot = process_budget._effective_nproc_limit()
 
     assert snapshot == {
-        "real_uid_processes": 270,
+        "real_uid_tasks": 270,
         "configured_incremental_budget": 256,
         "effective_incremental_budget": 256,
         "absolute_limit": 526,
@@ -88,7 +91,7 @@ def test_finite_inherited_hard_limit_only_reduces_headroom(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _install(configured_budget=256)
-    monkeypatch.setattr(process_budget, "_count_real_uid_processes", lambda **_: 270)
+    monkeypatch.setattr(process_budget, "_count_real_uid_tasks", lambda **_: 270)
     monkeypatch.setattr(process_budget, "_inherited_nproc_hard_limit", lambda: 300)
 
     snapshot = process_budget._effective_nproc_limit()
@@ -97,14 +100,14 @@ def test_finite_inherited_hard_limit_only_reduces_headroom(
     assert snapshot["effective_incremental_budget"] == 30
 
 
-def test_no_inherited_process_headroom_fails_closed(
+def test_no_inherited_task_headroom_fails_closed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _install(configured_budget=256)
-    monkeypatch.setattr(process_budget, "_count_real_uid_processes", lambda **_: 270)
+    monkeypatch.setattr(process_budget, "_count_real_uid_tasks", lambda **_: 270)
     monkeypatch.setattr(process_budget, "_inherited_nproc_hard_limit", lambda: 270)
 
-    with pytest.raises(RuntimeError, match="no process headroom remains"):
+    with pytest.raises(RuntimeError, match="no task headroom remains"):
         process_budget._effective_nproc_limit()
 
 
@@ -112,7 +115,7 @@ def test_prlimit_argv_no_longer_uses_absolute_legacy_ceiling(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _install(configured_budget=256)
-    monkeypatch.setattr(process_budget, "_count_real_uid_processes", lambda **_: 270)
+    monkeypatch.setattr(process_budget, "_count_real_uid_tasks", lambda **_: 270)
     monkeypatch.setattr(process_budget, "_inherited_nproc_hard_limit", lambda: 31422)
 
     argv = process_budget._limited_sandbox_argv(["/usr/bin/true"], 10)
@@ -124,9 +127,7 @@ def test_prlimit_argv_no_longer_uses_absolute_legacy_ceiling(
 
 @pytest.mark.skipif(sys.platform != "linux", reason="RLIMIT_NPROC is Linux-specific")
 @pytest.mark.skipif(os.getuid() == 0, reason="Linux does not enforce RLIMIT_NPROC for root")
-def test_small_incremental_budget_rejects_fork_storm(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_small_incremental_budget_rejects_fork_storm() -> None:
     _install(configured_budget=6)
     script = (
         "import subprocess,sys; children=[]; stopped=False\n"

--- a/tools/patch_evaluation_sidecar.py
+++ b/tools/patch_evaluation_sidecar.py
@@ -12,6 +12,7 @@ _ROOT = Path(__file__).resolve().parent
 _LEGACY_PATH = _ROOT / "patch_evaluation_sidecar_legacy.py"
 _HARDENING_PATH = _ROOT / "patch_evaluation_sidecar_hardening.py"
 _HOST_READBACK_PATH = _ROOT / "patch_evaluation_sidecar_host_readback.py"
+_PROCESS_BUDGET_PATH = _ROOT / "patch_evaluation_sidecar_process_budget.py"
 
 
 def _load(name: str, path: Path) -> types.ModuleType:
@@ -27,9 +28,18 @@ def _load(name: str, path: Path) -> types.ModuleType:
 _legacy = _load("patch_evaluation_sidecar_legacy", _LEGACY_PATH)
 _hardening = _load("patch_evaluation_sidecar_hardening", _HARDENING_PATH)
 _host_readback = _load("patch_evaluation_sidecar_host_readback", _HOST_READBACK_PATH)
+_process_budget = _load(
+    "patch_evaluation_sidecar_process_budget", _PROCESS_BUDGET_PATH
+)
 _hardening.apply_hardening(_legacy, wrapper_path=__file__)
 _host_readback.apply_host_readback_hardening(
     _legacy, _hardening, wrapper_path=__file__
+)
+_process_budget.apply_process_budget(
+    _legacy,
+    _hardening,
+    _host_readback,
+    wrapper_path=__file__,
 )
 
 
@@ -42,6 +52,7 @@ class _SidecarProxy(types.ModuleType):
             "_legacy",
             "_hardening",
             "_host_readback",
+            "_process_budget",
         }:
             super().__setattr__(name, value)
             return

--- a/tools/patch_evaluation_sidecar_process_budget.py
+++ b/tools/patch_evaluation_sidecar_process_budget.py
@@ -1,0 +1,197 @@
+"""Loaded-host process-budget overlay for the patch evaluation sidecar.
+
+Linux ``RLIMIT_NPROC`` is counted against the real user ID, not against one
+subprocess tree.  An absolute value such as 256 therefore prevents a sandbox
+from starting when the operator user already owns at least 256 processes.
+
+This overlay keeps the same configured command budget, but translates it to an
+absolute limit at launch time: current real-UID process count plus the bounded
+incremental budget.  The value is clamped to the inherited hard limit.  This is
+fail-closed under concurrent host growth and deliberately does not claim a
+strict per-command kernel quota, which RLIMIT_NPROC cannot provide.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import os
+from pathlib import Path
+from typing import Any, Sequence
+
+try:
+    import resource
+except ImportError:  # pragma: no cover - the sidecar is Linux-only
+    resource = None  # type: ignore[assignment]
+
+_LEGACY: Any = None
+_HARDENING: Any = None
+_HOST_READBACK: Any = None
+_WRAPPER_PATH: Path | None = None
+
+
+def _m() -> Any:
+    if _LEGACY is None or _HARDENING is None:
+        raise RuntimeError("process-budget hardening has not been installed")
+    return _LEGACY
+
+
+def _evaluation_error(message: str) -> Exception:
+    legacy = _m()
+    error_type = getattr(legacy, "EvaluationError", RuntimeError)
+    return error_type(message)
+
+
+def _count_real_uid_processes(
+    *, proc_root: Path = Path("/proc"), real_uid: int | None = None
+) -> int:
+    """Count visible processes whose real UID matches the current real UID.
+
+    ``/proc`` changes while it is scanned.  Vanished or unreadable entries are
+    ignored; under-counting only reduces the computed headroom and therefore
+    fails closed when the process table is heavily contended.
+    """
+
+    uid = os.getuid() if real_uid is None else real_uid
+    count = 0
+    try:
+        entries = proc_root.iterdir()
+    except OSError as exc:
+        raise _evaluation_error(f"could not inspect process table: {exc}") from exc
+
+    for entry in entries:
+        if not entry.name.isdigit():
+            continue
+        try:
+            status = (entry / "status").read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for line in status.splitlines():
+            if not line.startswith("Uid:"):
+                continue
+            fields = line.split()
+            if len(fields) >= 2:
+                try:
+                    if int(fields[1]) == uid:
+                        count += 1
+                except ValueError:
+                    pass
+            break
+    return count
+
+
+def _inherited_nproc_hard_limit() -> int | None:
+    if resource is None or not hasattr(resource, "RLIMIT_NPROC"):
+        raise _evaluation_error("RLIMIT_NPROC is unavailable on this platform")
+    _soft, hard = resource.getrlimit(resource.RLIMIT_NPROC)
+    if hard == resource.RLIM_INFINITY:
+        return None
+    return int(hard)
+
+
+def _effective_nproc_limit(
+    *, proc_root: Path = Path("/proc"), real_uid: int | None = None
+) -> dict[str, int | None]:
+    """Return the absolute RLIMIT_NPROC derived from current host load.
+
+    The configured value remains an incremental budget.  A finite inherited
+    hard limit may reduce that budget, but it is never raised or bypassed.
+    """
+
+    hardening = _HARDENING
+    if hardening is None:
+        raise RuntimeError("process-budget hardening has not been installed")
+
+    configured_budget = int(hardening._MAX_COMMAND_PROCESSES)
+    if configured_budget <= 0:
+        raise _evaluation_error("configured command process budget must be positive")
+
+    baseline = _count_real_uid_processes(proc_root=proc_root, real_uid=real_uid)
+    inherited_hard = _inherited_nproc_hard_limit()
+    requested_limit = baseline + configured_budget
+    absolute_limit = (
+        requested_limit
+        if inherited_hard is None
+        else min(requested_limit, inherited_hard)
+    )
+    effective_budget = absolute_limit - baseline
+    if effective_budget <= 0:
+        hard_label = "unlimited" if inherited_hard is None else str(inherited_hard)
+        raise _evaluation_error(
+            "no process headroom remains for the sandbox "
+            f"(real_uid_processes={baseline}, inherited_hard_limit={hard_label})"
+        )
+
+    return {
+        "real_uid_processes": baseline,
+        "configured_incremental_budget": configured_budget,
+        "effective_incremental_budget": effective_budget,
+        "absolute_limit": absolute_limit,
+        "inherited_hard_limit": inherited_hard,
+    }
+
+
+def _limited_sandbox_argv(argv: Sequence[str], timeout_seconds: float) -> list[str]:
+    legacy = _m()
+    hardening = _HARDENING
+    assert hardening is not None
+
+    prlimit = legacy._resolve_system_tool("prlimit")
+    process_limit = _effective_nproc_limit()["absolute_limit"]
+    assert isinstance(process_limit, int)
+    cpu_seconds = max(2, int(math.ceil(timeout_seconds)) + 2)
+    return [
+        str(prlimit),
+        f"--as={hardening._MAX_ADDRESS_SPACE_BYTES}",
+        f"--fsize={hardening._MAX_COMMAND_FILE_BYTES}",
+        f"--nproc={process_limit}:{process_limit}",
+        f"--nofile={hardening._MAX_COMMAND_OPEN_FILES}",
+        f"--cpu={cpu_seconds}",
+        "--",
+        *argv,
+    ]
+
+
+def _producer_digest() -> str:
+    legacy = _m()
+    hardening = _HARDENING
+    host_readback = _HOST_READBACK
+    wrapper_path = _WRAPPER_PATH
+    if hardening is None or host_readback is None or wrapper_path is None:
+        raise RuntimeError("process-budget producer identity is incomplete")
+
+    digest = hashlib.sha256()
+    paths = {
+        Path(legacy.__file__).resolve(),
+        Path(hardening.__file__).resolve(),
+        Path(host_readback.__file__).resolve(),
+        Path(__file__).resolve(),
+        wrapper_path.resolve(),
+    }
+    for path in sorted(paths, key=str):
+        digest.update(path.name.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return "sha256:" + digest.hexdigest()
+
+
+def apply_process_budget(
+    legacy: Any,
+    hardening: Any,
+    host_readback: Any,
+    *,
+    wrapper_path: str | Path,
+) -> None:
+    """Install the process-budget overlay after the other sidecar overlays."""
+
+    global _LEGACY, _HARDENING, _HOST_READBACK, _WRAPPER_PATH
+    _LEGACY = legacy
+    _HARDENING = hardening
+    _HOST_READBACK = host_readback
+    _WRAPPER_PATH = Path(wrapper_path)
+
+    hardening._limited_sandbox_argv = _limited_sandbox_argv
+    legacy._limited_sandbox_argv = _limited_sandbox_argv
+    hardening._producer_digest = _producer_digest
+    legacy._producer_digest = _producer_digest

--- a/tools/patch_evaluation_sidecar_process_budget.py
+++ b/tools/patch_evaluation_sidecar_process_budget.py
@@ -1,11 +1,12 @@
 """Loaded-host process-budget overlay for the patch evaluation sidecar.
 
-Linux ``RLIMIT_NPROC`` is counted against the real user ID, not against one
-subprocess tree.  An absolute value such as 256 therefore prevents a sandbox
-from starting when the operator user already owns at least 256 processes.
+Linux ``RLIMIT_NPROC`` is counted against the real user ID and, more precisely,
+counts threads rather than only process leaders.  An absolute value such as 256
+therefore prevents a sandbox from starting when the operator user already owns
+at least 256 tasks.
 
 This overlay keeps the same configured command budget, but translates it to an
-absolute limit at launch time: current real-UID process count plus the bounded
+absolute limit at launch time: current real-UID task count plus the bounded
 incremental budget.  The value is clamped to the inherited hard limit.  This is
 fail-closed under concurrent host growth and deliberately does not claim a
 strict per-command kernel quota, which RLIMIT_NPROC cannot provide.
@@ -42,41 +43,55 @@ def _evaluation_error(message: str) -> Exception:
     return error_type(message)
 
 
-def _count_real_uid_processes(
+def _status_real_uid(status_path: Path) -> int | None:
+    try:
+        status = status_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    for line in status.splitlines():
+        if not line.startswith("Uid:"):
+            continue
+        fields = line.split()
+        if len(fields) < 2:
+            return None
+        try:
+            return int(fields[1])
+        except ValueError:
+            return None
+    return None
+
+
+def _count_real_uid_tasks(
     *, proc_root: Path = Path("/proc"), real_uid: int | None = None
 ) -> int:
-    """Count visible processes whose real UID matches the current real UID.
+    """Count visible Linux tasks whose real UID matches ``real_uid``.
 
-    ``/proc`` changes while it is scanned.  Vanished or unreadable entries are
-    ignored; under-counting only reduces the computed headroom and therefore
-    fails closed when the process table is heavily contended.
+    ``RLIMIT_NPROC`` accounts threads.  Therefore each ``/proc/<pid>/task/<tid>``
+    entry is inspected rather than counting only top-level process directories.
+    ``/proc`` changes while it is scanned; vanished or unreadable entries are
+    ignored.  Any resulting undercount lowers the computed absolute limit and
+    can only consume sidecar headroom, so the race remains fail-closed.
     """
 
     uid = os.getuid() if real_uid is None else real_uid
     count = 0
     try:
-        entries = proc_root.iterdir()
+        processes = proc_root.iterdir()
     except OSError as exc:
         raise _evaluation_error(f"could not inspect process table: {exc}") from exc
 
-    for entry in entries:
-        if not entry.name.isdigit():
+    for process in processes:
+        if not process.name.isdigit():
             continue
         try:
-            status = (entry / "status").read_text(encoding="utf-8", errors="replace")
+            tasks = (process / "task").iterdir()
         except OSError:
             continue
-        for line in status.splitlines():
-            if not line.startswith("Uid:"):
+        for task in tasks:
+            if not task.name.isdigit():
                 continue
-            fields = line.split()
-            if len(fields) >= 2:
-                try:
-                    if int(fields[1]) == uid:
-                        count += 1
-                except ValueError:
-                    pass
-            break
+            if _status_real_uid(task / "status") == uid:
+                count += 1
     return count
 
 
@@ -94,7 +109,7 @@ def _effective_nproc_limit(
 ) -> dict[str, int | None]:
     """Return the absolute RLIMIT_NPROC derived from current host load.
 
-    The configured value remains an incremental budget.  A finite inherited
+    The configured value remains an incremental task budget.  A finite inherited
     hard limit may reduce that budget, but it is never raised or bypassed.
     """
 
@@ -106,7 +121,7 @@ def _effective_nproc_limit(
     if configured_budget <= 0:
         raise _evaluation_error("configured command process budget must be positive")
 
-    baseline = _count_real_uid_processes(proc_root=proc_root, real_uid=real_uid)
+    baseline = _count_real_uid_tasks(proc_root=proc_root, real_uid=real_uid)
     inherited_hard = _inherited_nproc_hard_limit()
     requested_limit = baseline + configured_budget
     absolute_limit = (
@@ -118,12 +133,12 @@ def _effective_nproc_limit(
     if effective_budget <= 0:
         hard_label = "unlimited" if inherited_hard is None else str(inherited_hard)
         raise _evaluation_error(
-            "no process headroom remains for the sandbox "
-            f"(real_uid_processes={baseline}, inherited_hard_limit={hard_label})"
+            "no task headroom remains for the sandbox "
+            f"(real_uid_tasks={baseline}, inherited_hard_limit={hard_label})"
         )
 
     return {
-        "real_uid_processes": baseline,
+        "real_uid_tasks": baseline,
         "configured_incremental_budget": configured_budget,
         "effective_incremental_budget": effective_budget,
         "absolute_limit": absolute_limit,

--- a/tools/patch_evaluation_sidecar_process_budget.py
+++ b/tools/patch_evaluation_sidecar_process_budget.py
@@ -76,7 +76,7 @@ def _count_real_uid_tasks(
     uid = os.getuid() if real_uid is None else real_uid
     count = 0
     try:
-        processes = proc_root.iterdir()
+        processes = list(proc_root.iterdir())
     except OSError as exc:
         raise _evaluation_error(f"could not inspect process table: {exc}") from exc
 
@@ -84,7 +84,7 @@ def _count_real_uid_tasks(
         if not process.name.isdigit():
             continue
         try:
-            tasks = (process / "task").iterdir()
+            tasks = list((process / "task").iterdir())
         except OSError:
             continue
         for task in tasks:
@@ -119,7 +119,7 @@ def _effective_nproc_limit(
 
     configured_budget = int(hardening._MAX_COMMAND_PROCESSES)
     if configured_budget <= 0:
-        raise _evaluation_error("configured command process budget must be positive")
+        raise _evaluation_error("configured command task budget must be positive")
 
     baseline = _count_real_uid_tasks(proc_root=proc_root, real_uid=real_uid)
     inherited_hard = _inherited_nproc_hard_limit()


### PR DESCRIPTION
## Summary

- interpret the existing 256-task sidecar ceiling as an incremental launch-time budget instead of an absolute real-UID `RLIMIT_NPROC`
- count current real-UID **threads** through `/proc/<pid>/task/<tid>/status`, clamp to the inherited hard limit, and fail closed when no task headroom remains
- preserve Bubblewrap namespaces and all existing address-space, file-size, open-file, CPU, timeout, log and provenance boundaries
- bind the new overlay into the producer digest and deterministic release source set

## Bureau

- Task: `REPOGROUND-LEGACY-RECONCILIATION-V1-T020`
- This path is intentionally separate from the active dirty T012 `service/app.py` worktree.
- Merge does **not** mark T020 verified; a non-root Canary on the loaded Heim-PC remains required.

## Review follow-up

The initial implementation and Codex review found that Linux `RLIMIT_NPROC` counts threads, not only process leaders. The final implementation inspects each visible task under `/proc/<pid>/task/<tid>` and its real UID. A later Self-Review also hardened deferred `Path.iterdir()` races by materializing procfs listings within their `OSError` boundaries.

## Validation — final head

Head: `42da6b83e53910fb0b7877777a6bf209e1cc9b50`

- GitHub workflows: 7/7 PASS
- full Pytest suite: PASS
- non-root Bubblewrap runtime verification: PASS
- fork-storm regression: PASS within the full suite
- deterministic release candidate/source-set comparison: PASS
- lint: PASS
- contracts: PASS
- CodeQL: PASS
- browser and WebUI: PASS
- open review threads: 0
- methodically separate Self-Review: PASS; no independence claimed

## Security boundary

The implementation does not remove process limiting. It derives the absolute `prlimit` value as `current real-UID tasks + configured incremental budget`, never raises a finite inherited hard limit, and retains all other sidecar isolation and resource controls.

## Known epistemic limit

`RLIMIT_NPROC` is real-UID-scoped, not subtree-scoped. This PR therefore claims a bounded launch-time incremental task budget, not a strict cgroup-equivalent per-command quota. Concurrent task growth remains fail-closed; task termination after the measurement can free shared UID headroom.

Base: `fa132e9e7b1042fa7b33206a20a237ff11dfe0e2`
Final reviewed head: `42da6b83e53910fb0b7877777a6bf209e1cc9b50`