### PR TITLE
refactor(bundle_access): extract artifact source access (T011 residual)

### DIFF
--- a/docs/proofs/repoground-legacy-t011-bundle-access-residual-source-20260730.md
+++ b/docs/proofs/repoground-legacy-t011-bundle-access-residual-source-20260730.md
@@ -1,0 +1,53 @@
+# T011 residual: artifact source access extraction
+
+Bureau task: `REPOGROUND-LEGACY-RECONCILIATION-V1-T011`
+
+## Context
+
+After the first T011 decomposition landed on main (modules
+`bundle_roles`, `bounded_artifact_read`, `sqlite_artifact_read`,
+`citation_projection`, `call_graph_validation`) and T012 service-router
+split merged as PR #1124, `bundle_access.py` still mixed orchestration
+with the shared fingerprint / bounded source-load cluster used by both
+query and call-navigation paths.
+
+## Change
+
+Extracted `merger/repoground/core/artifact_source_access.py` owning:
+
+- strong/weak stat identity and fingerprint matching
+- cache-validation mode (`REPOGROUND_CACHE_VALIDATION` + legacy strict hash)
+- stable descriptor-bound artifact and manifest reads
+- registered-role source load (`_read_registered_artifact_source`)
+- source currency checks (`_artifact_source_is_current` and helpers)
+
+`bundle_access.py` re-exports the historical private names so external
+callers and the public facade keep the same import path.
+
+## Structural result
+
+| File | Lines (approx) |
+| --- | ---: |
+| `bundle_access.py` before residual | 2618 |
+| `bundle_access.py` after residual | 2225 |
+| `artifact_source_access.py` (new) | 471 |
+
+Delta on the facade is about **-393 lines** without deleting fail-closed
+validation (code moved, some tests retargeted to the owning module).
+
+## Validation
+
+- `pytest merger/repoground/tests/test_call_navigation.py test_bundle_access_decomposition.py test_bundle_access_boundary.py test_source_citation_projection.py`: 100 passed
+- `ruff` F401 on touched modules: pass
+- `scripts/ci/check_graph_maintainability.py`: pass
+
+## Boundaries
+
+- Foreign dirty worktree `REPOGROUND-LEGACY-RECONCILIATION-V1-T004-current-20260727` was not modified (its uncommitted residue enlarges `bundle_access` and was not ported).
+- Does not close parent T004; T010 remains blocked on native T017; T013/T014 remain separate.
+- Does not claim call-navigation orchestration extraction (still in facade).
+
+## Does not establish
+
+- Production readiness of every dynamic consumer
+- That residual facade size meets a final T014 monolith budget

--- a/merger/repoground/core/artifact_source_access.py
+++ b/merger/repoground/core/artifact_source_access.py
@@ -1,0 +1,470 @@
+"""Pinned artifact source reads, fingerprints and cache-currency checks.
+
+Extracted from bundle_access as a T011 residual slice so integrity validation and
+bounded source loads are not entangled with call-navigation orchestration.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from pathlib import Path
+from threading import RLock
+from typing import Any
+
+from merger.repoground.core.bounded_artifact_read import (
+    MAX_REGISTERED_ARTIFACT_BYTES,
+    ArtifactSourceFingerprint,
+    LoadedArtifactSource,
+    declared_artifact_integrity,
+    file_identity,
+    read_stable_regular_file_bytes,
+)
+from merger.repoground.core.bundle_identity import is_bundle_manifest
+from merger.repoground.core.bundle_roles import (
+    resolve_unique_artifact,
+)
+from merger.repoground.core.citation_projection import (
+    is_non_empty_string,
+)
+from merger.repoground.core.manifest_snapshot import (
+    MAX_MANIFEST_BYTES,
+    active_manifest_snapshot,
+    resolve_manifest_path,
+)
+
+logger = logging.getLogger(__name__)
+
+CACHE_VALIDATION_ENV = "REPOGROUND_CACHE_VALIDATION"
+STRICT_SOURCE_HASH_ENV = "REPOGROUND_STRICT_CACHE_HASH"
+
+_CACHE_VALIDATION_LOCK = RLock()
+_WARNED_INVALID_CACHE_VALIDATION_VALUES: set[str] = set()
+
+def _stat_identity_is_strong(stat_result: os.stat_result) -> bool:
+    return all(
+        value != 0
+        for value in (
+            stat_result.st_dev,
+            stat_result.st_ino,
+            stat_result.st_mtime_ns,
+            stat_result.st_ctime_ns,
+        )
+    )
+
+
+def _stat_matches_identity(
+    stat_result: os.stat_result,
+    *,
+    device: int,
+    inode: int,
+    size: int,
+    mtime_ns: int,
+    ctime_ns: int,
+) -> bool:
+    def available(expected: int, observed: int) -> bool:
+        return expected == 0 or observed == expected
+
+    return (
+        available(device, stat_result.st_dev)
+        and available(inode, stat_result.st_ino)
+        and stat_result.st_size == size
+        and available(mtime_ns, stat_result.st_mtime_ns)
+        and available(ctime_ns, stat_result.st_ctime_ns)
+    )
+
+
+def _manifest_stat_matches_fingerprint(
+    fingerprint: ArtifactSourceFingerprint,
+    stat_result: os.stat_result,
+) -> bool:
+    return _stat_matches_identity(
+        stat_result,
+        device=fingerprint.manifest_device,
+        inode=fingerprint.manifest_inode,
+        size=fingerprint.manifest_size,
+        mtime_ns=fingerprint.manifest_mtime_ns,
+        ctime_ns=fingerprint.manifest_ctime_ns,
+    )
+
+
+def _artifact_stat_matches_fingerprint(
+    fingerprint: ArtifactSourceFingerprint,
+    stat_result: os.stat_result,
+) -> bool:
+    return _stat_matches_identity(
+        stat_result,
+        device=fingerprint.device,
+        inode=fingerprint.inode,
+        size=fingerprint.size,
+        mtime_ns=fingerprint.mtime_ns,
+        ctime_ns=fingerprint.ctime_ns,
+    )
+
+
+def _fingerprint_matches_active_manifest_snapshot(
+    fingerprint: ArtifactSourceFingerprint,
+) -> bool | None:
+    snapshot = active_manifest_snapshot(fingerprint.manifest_path)
+    if snapshot is None:
+        return None
+    return fingerprint.manifest_sha256 == snapshot.binding.sha256
+
+
+def _manifest_source_is_current(
+    fingerprint: ArtifactSourceFingerprint,
+) -> bool:
+    active_match = _fingerprint_matches_active_manifest_snapshot(fingerprint)
+    if active_match is not None:
+        return active_match
+    raw, current, failure, _detail = _read_stable_regular_file_bytes(
+        Path(fingerprint.manifest_path)
+    )
+    if failure is not None or raw is None or current is None:
+        return False
+    return (
+        _manifest_stat_matches_fingerprint(fingerprint, current)
+        and hashlib.sha256(raw).hexdigest() == fingerprint.manifest_sha256
+    )
+
+
+def _artifact_bytes_match_fingerprint(
+    fingerprint: ArtifactSourceFingerprint,
+    artifact_path: Path,
+) -> bool:
+    artifact_bytes, artifact_stat, failure, _detail = _read_stable_artifact_bytes(
+        artifact_path
+    )
+    if failure is not None or artifact_bytes is None or artifact_stat is None:
+        return False
+    if not _artifact_stat_matches_fingerprint(fingerprint, artifact_stat):
+        return False
+    if hashlib.sha256(artifact_bytes).hexdigest() != fingerprint.artifact_sha256:
+        return False
+    try:
+        artifact_after_stat = artifact_path.stat()
+    except OSError:
+        return False
+    return _artifact_stat_matches_fingerprint(
+        fingerprint,
+        artifact_after_stat,
+    )
+
+
+def _bound_artifact_source_is_current(
+    fingerprint: ArtifactSourceFingerprint,
+    artifact_path: Path,
+    *,
+    requires_content: bool,
+) -> bool:
+    if not requires_content:
+        try:
+            artifact_stat = artifact_path.stat()
+        except OSError:
+            return False
+        if _stat_identity_is_strong(artifact_stat):
+            return _artifact_stat_matches_fingerprint(
+                fingerprint,
+                artifact_stat,
+            )
+    return _artifact_bytes_match_fingerprint(fingerprint, artifact_path)
+
+
+def _fast_artifact_source_validation(
+    fingerprint: ArtifactSourceFingerprint,
+    manifest_path: Path,
+    artifact_path: Path,
+) -> bool | None:
+    try:
+        manifest_stat = manifest_path.stat()
+        artifact_stat = artifact_path.stat()
+    except OSError:
+        return False
+    if not (
+        _stat_identity_is_strong(manifest_stat)
+        and _stat_identity_is_strong(artifact_stat)
+    ):
+        return None
+    return _manifest_stat_matches_fingerprint(
+        fingerprint,
+        manifest_stat,
+    ) and _artifact_stat_matches_fingerprint(fingerprint, artifact_stat)
+
+
+def _source_bytes_match_fingerprint(
+    fingerprint: ArtifactSourceFingerprint,
+    manifest_path: Path,
+    artifact_path: Path,
+) -> bool:
+    manifest_bytes, manifest_stat, manifest_failure, _manifest_detail = (
+        _read_stable_regular_file_bytes(manifest_path)
+    )
+    if (
+        manifest_failure is not None
+        or manifest_bytes is None
+        or manifest_stat is None
+        or not _manifest_stat_matches_fingerprint(fingerprint, manifest_stat)
+        or hashlib.sha256(manifest_bytes).hexdigest() != fingerprint.manifest_sha256
+    ):
+        return False
+    if not _artifact_bytes_match_fingerprint(fingerprint, artifact_path):
+        return False
+    try:
+        manifest_after_stat = manifest_path.stat()
+    except OSError:
+        return False
+    return _manifest_stat_matches_fingerprint(
+        fingerprint,
+        manifest_after_stat,
+    )
+
+
+def _cache_validation_mode() -> str:
+    """Return the cache-validation mode while preserving legacy semantics.
+
+    ``REPOGROUND_CACHE_VALIDATION`` accepts only ``auto`` and ``strict``.
+    Any other non-empty value falls back to ``strict`` and is logged once per
+    distinct invalid value. The legacy
+    ``REPOGROUND_STRICT_CACHE_HASH`` switch remains supported when the
+    new variable is unset or empty: unset/empty/0/false/no/off means ``auto``;
+    every other non-empty legacy value means ``strict``.
+    """
+    configured_raw = os.environ.get(CACHE_VALIDATION_ENV, "")
+    configured = configured_raw.strip().lower()
+    if configured in {"auto", "strict"}:
+        return configured
+    if configured:
+        with _CACHE_VALIDATION_LOCK:
+            if configured_raw not in _WARNED_INVALID_CACHE_VALIDATION_VALUES:
+                _WARNED_INVALID_CACHE_VALIDATION_VALUES.add(configured_raw)
+                logger.warning(
+                    "Invalid %s value %r; falling back to strict cache validation",
+                    CACHE_VALIDATION_ENV,
+                    configured_raw,
+                )
+        return "strict"
+
+    legacy = os.environ.get(
+        STRICT_SOURCE_HASH_ENV, ""
+    ).strip().lower()
+    if legacy in {"", "0", "false", "no", "off"}:
+        return "auto"
+    return "strict"
+
+
+def _source_identity_is_strong(
+    fingerprint: ArtifactSourceFingerprint,
+) -> bool:
+    """Whether metadata can support the fast warm-cache validation path."""
+    return all(
+        value != 0
+        for value in (
+            fingerprint.manifest_device,
+            fingerprint.manifest_inode,
+            fingerprint.manifest_mtime_ns,
+            fingerprint.manifest_ctime_ns,
+            fingerprint.device,
+            fingerprint.inode,
+            fingerprint.mtime_ns,
+            fingerprint.ctime_ns,
+        )
+    )
+
+
+def _source_content_verification_required(
+    fingerprint: ArtifactSourceFingerprint,
+    *,
+    verify_content: bool,
+) -> bool:
+    return (
+        verify_content
+        or _cache_validation_mode() == "strict"
+        or not _source_identity_is_strong(fingerprint)
+    )
+
+
+def _read_stable_artifact_bytes(
+    artifact_path: Path,
+) -> tuple[bytes | None, os.stat_result | None, str | None, str | None]:
+    return read_stable_regular_file_bytes(
+        artifact_path,
+        max_bytes=MAX_REGISTERED_ARTIFACT_BYTES,
+    )
+
+
+def _read_stable_regular_file_bytes(
+    path: Path,
+    *,
+    max_bytes: int = MAX_MANIFEST_BYTES,
+) -> tuple[bytes | None, os.stat_result | None, str | None, str | None]:
+    return read_stable_regular_file_bytes(path, max_bytes=max_bytes)
+
+
+def _read_artifact_manifest_source(
+    manifest_path: Path,
+) -> tuple[
+    bytes | None,
+    Any,
+    tuple[int, int, int, int, int] | None,
+    str | None,
+    str | None,
+]:
+    snapshot = active_manifest_snapshot(manifest_path)
+    if snapshot is not None:
+        identity = snapshot.file_identity
+        return (
+            snapshot.raw,
+            snapshot.json_object(),
+            (identity[0], identity[1], identity[3], identity[4], identity[5]),
+            None,
+            None,
+        )
+    raw, manifest_stat, failure, detail = _read_stable_regular_file_bytes(
+        manifest_path
+    )
+    if failure == "too_large":
+        failure = "manifest_too_large"
+    if failure is not None:
+        return None, None, None, failure, detail
+    assert raw is not None and manifest_stat is not None
+    try:
+        manifest = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return None, None, None, "unreadable", str(exc)
+    if (
+        not is_bundle_manifest(manifest)
+        or not is_non_empty_string(manifest.get("run_id"))
+        or not isinstance(manifest.get("artifacts"), list)
+    ):
+        return (
+            None,
+            None,
+            None,
+            "manifest_invalid",
+            "bundle manifest identity, run_id, or artifacts are invalid",
+        )
+    return raw, manifest, file_identity(manifest_stat), None, None
+
+
+def _read_registered_artifact_source(
+    manifest_path: Path, role: str
+) -> tuple[
+    LoadedArtifactSource | None,
+    dict[str, Any] | None,
+    str | None,
+    str | None,
+]:
+    manifest_bytes, manifest, manifest_identity, failure, detail = (
+        _read_artifact_manifest_source(manifest_path)
+    )
+    if failure is not None:
+        return None, None, failure, detail
+    assert manifest_bytes is not None and manifest_identity is not None
+    if not isinstance(manifest, dict):
+        return None, None, "unreadable", "bundle manifest must be a JSON object"
+    try:
+        artifact_payload, artifact, resolution_failure = resolve_unique_artifact(
+            manifest_path,
+            manifest,
+            role,
+        )
+    except ValueError as exc:
+        return None, None, "unreadable", str(exc)
+    if resolution_failure is not None:
+        return None, artifact, resolution_failure, None
+    assert artifact_payload is not None and artifact is not None
+    artifact_path = Path(artifact["absolute_path"])
+    declared_bytes, declared_sha256, integrity_failure = (
+        declared_artifact_integrity(artifact_payload)
+    )
+    if integrity_failure is not None:
+        return None, artifact, integrity_failure, None
+    raw, artifact_stat, failure, detail = _read_stable_artifact_bytes(artifact_path)
+    if failure is not None:
+        return None, artifact, failure, detail
+    assert raw is not None and artifact_stat is not None
+    if declared_bytes is not None and declared_bytes != len(raw):
+        return None, artifact, "bytes_mismatch", None
+    actual_sha256 = hashlib.sha256(raw).hexdigest()
+    if declared_sha256 is not None and actual_sha256 != declared_sha256:
+        return None, artifact, "sha256_mismatch", None
+    fingerprint = ArtifactSourceFingerprint(
+        manifest_path=str(resolve_manifest_path(manifest_path)),
+        manifest_sha256=hashlib.sha256(manifest_bytes).hexdigest(),
+        manifest_device=manifest_identity[0],
+        manifest_inode=manifest_identity[1],
+        manifest_size=manifest_identity[2],
+        manifest_mtime_ns=manifest_identity[3],
+        manifest_ctime_ns=manifest_identity[4],
+        role=role,
+        absolute_path=str(artifact_path),
+        artifact_sha256=actual_sha256,
+        device=artifact_stat.st_dev,
+        inode=artifact_stat.st_ino,
+        size=artifact_stat.st_size,
+        mtime_ns=artifact_stat.st_mtime_ns,
+        ctime_ns=artifact_stat.st_ctime_ns,
+    )
+    if not _manifest_source_is_current(fingerprint):
+        return None, artifact, "source_changed", None
+    return (
+        LoadedArtifactSource(
+            manifest=manifest,
+            artifact=artifact,
+            raw=raw,
+            fingerprint=fingerprint,
+        ),
+        artifact,
+        None,
+        None,
+    )
+
+
+def _artifact_source_is_current(
+    fingerprint: ArtifactSourceFingerprint,
+    *,
+    verify_content: bool = False,
+) -> bool:
+    """Validate one cached generation without reparsing its JSON payload.
+
+    Cold loads and post-build checks always hash bytes read from one pinned file
+    descriptor. Request-bound lookups authorize the cached manifest hash only
+    from the active snapshot and never from transient path bytes. Other warm
+    lookups use the manifest hash plus strong file identity metadata.
+    ``REPOGROUND_CACHE_VALIDATION=strict`` forces a full hash on every lookup;
+    the legacy strict-hash switch remains supported. Weak identities such as
+    zero device or inode values automatically use strict validation.
+    """
+    manifest_path = Path(fingerprint.manifest_path)
+    artifact_path = Path(fingerprint.absolute_path)
+    active_manifest_match = _fingerprint_matches_active_manifest_snapshot(fingerprint)
+    if active_manifest_match is False:
+        return False
+
+    requires_content = _source_content_verification_required(
+        fingerprint,
+        verify_content=verify_content,
+    )
+    if active_manifest_match is True:
+        return _bound_artifact_source_is_current(
+            fingerprint,
+            artifact_path,
+            requires_content=requires_content,
+        )
+
+    if not requires_content:
+        fast_validation = _fast_artifact_source_validation(
+            fingerprint,
+            manifest_path,
+            artifact_path,
+        )
+        if fast_validation is not None:
+            return fast_validation
+    return _source_bytes_match_fingerprint(
+        fingerprint,
+        manifest_path,
+        artifact_path,
+    )
+

--- a/merger/repoground/core/bundle_access.py
+++ b/merger/repoground/core/bundle_access.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import hashlib
 import json
 import logging
 import os
@@ -21,14 +20,9 @@ from merger.repoground.core.call_navigation_index import (
     CallNavigationIndex,
     SymbolNavigationIndex,
 )
-from merger.repoground.core.bundle_identity import is_bundle_manifest
 from merger.repoground.core.bounded_artifact_read import (
-    MAX_REGISTERED_ARTIFACT_BYTES,
     ArtifactSourceFingerprint as _ArtifactSourceFingerprint,
     LoadedArtifactSource as _LoadedArtifactSource,
-    declared_artifact_integrity,
-    file_identity as _file_identity,
-    read_stable_regular_file_bytes,
 )
 from merger.repoground.core import bundle_roles as _bundle_roles
 from merger.repoground.core import citation_projection as _citation_projection_module
@@ -53,8 +47,6 @@ from merger.repoground.core.citation_projection import (
     project_source_citations as _project_source_citations,
 )
 from merger.repoground.core.manifest_snapshot import (
-    MAX_MANIFEST_BYTES,
-    active_manifest_snapshot,
     resolve_manifest_path,
 )
 from merger.repoground.core.response_projection import project_read_result
@@ -1072,8 +1064,6 @@ _CALL_NAV_DOES_NOT_ESTABLISH = tuple(
     dict.fromkeys([*_DOES_NOT_ESTABLISH, *_CALL_GRAPH_DOES_NOT_ESTABLISH])
 )
 _CALL_NAVIGATION_CACHE_MAX_ENTRIES = 2
-_CALL_NAVIGATION_CACHE_VALIDATION_ENV = "REPOGROUND_CACHE_VALIDATION"
-_CALL_NAVIGATION_STRICT_SOURCE_HASH_ENV = "REPOGROUND_STRICT_CACHE_HASH"
 
 
 @dataclass(frozen=True, slots=True)
@@ -1103,7 +1093,6 @@ class _ValidatedCallQuery:
 _CALL_NAVIGATION_CACHE: OrderedDict[_ArtifactSourceFingerprint, _CallNavigationState] = OrderedDict()
 _SYMBOL_NAVIGATION_CACHE: OrderedDict[tuple[_ArtifactSourceFingerprint, _ArtifactSourceFingerprint], _SymbolNavigationState] = OrderedDict()
 _CALL_NAVIGATION_CACHE_LOCK = RLock()
-_WARNED_INVALID_CACHE_VALIDATION_VALUES: set[str] = set()
 
 
 def _clear_call_navigation_caches() -> None:
@@ -1113,430 +1102,47 @@ def _clear_call_navigation_caches() -> None:
         _SYMBOL_NAVIGATION_CACHE.clear()
 
 
-def _stat_identity_is_strong(stat_result: os.stat_result) -> bool:
-    return all(
-        value != 0
-        for value in (
-            stat_result.st_dev,
-            stat_result.st_ino,
-            stat_result.st_mtime_ns,
-            stat_result.st_ctime_ns,
-        )
-    )
 
+from merger.repoground.core import artifact_source_access as _artifact_source_access
 
-def _stat_matches_identity(
-    stat_result: os.stat_result,
-    *,
-    device: int,
-    inode: int,
-    size: int,
-    mtime_ns: int,
-    ctime_ns: int,
-) -> bool:
-    def available(expected: int, observed: int) -> bool:
-        return expected == 0 or observed == expected
-
-    return (
-        available(device, stat_result.st_dev)
-        and available(inode, stat_result.st_ino)
-        and stat_result.st_size == size
-        and available(mtime_ns, stat_result.st_mtime_ns)
-        and available(ctime_ns, stat_result.st_ctime_ns)
-    )
-
-
-def _manifest_stat_matches_fingerprint(
-    fingerprint: _ArtifactSourceFingerprint,
-    stat_result: os.stat_result,
-) -> bool:
-    return _stat_matches_identity(
-        stat_result,
-        device=fingerprint.manifest_device,
-        inode=fingerprint.manifest_inode,
-        size=fingerprint.manifest_size,
-        mtime_ns=fingerprint.manifest_mtime_ns,
-        ctime_ns=fingerprint.manifest_ctime_ns,
-    )
-
-
-def _artifact_stat_matches_fingerprint(
-    fingerprint: _ArtifactSourceFingerprint,
-    stat_result: os.stat_result,
-) -> bool:
-    return _stat_matches_identity(
-        stat_result,
-        device=fingerprint.device,
-        inode=fingerprint.inode,
-        size=fingerprint.size,
-        mtime_ns=fingerprint.mtime_ns,
-        ctime_ns=fingerprint.ctime_ns,
-    )
-
-
-def _fingerprint_matches_active_manifest_snapshot(
-    fingerprint: _ArtifactSourceFingerprint,
-) -> bool | None:
-    snapshot = active_manifest_snapshot(fingerprint.manifest_path)
-    if snapshot is None:
-        return None
-    return fingerprint.manifest_sha256 == snapshot.binding.sha256
-
-
-def _manifest_source_is_current(
-    fingerprint: _ArtifactSourceFingerprint,
-) -> bool:
-    active_match = _fingerprint_matches_active_manifest_snapshot(fingerprint)
-    if active_match is not None:
-        return active_match
-    raw, current, failure, _detail = _read_stable_regular_file_bytes(
-        Path(fingerprint.manifest_path)
-    )
-    if failure is not None or raw is None or current is None:
-        return False
-    return (
-        _manifest_stat_matches_fingerprint(fingerprint, current)
-        and hashlib.sha256(raw).hexdigest() == fingerprint.manifest_sha256
-    )
-
-
-def _artifact_bytes_match_fingerprint(
-    fingerprint: _ArtifactSourceFingerprint,
-    artifact_path: Path,
-) -> bool:
-    artifact_bytes, artifact_stat, failure, _detail = _read_stable_artifact_bytes(
-        artifact_path
-    )
-    if failure is not None or artifact_bytes is None or artifact_stat is None:
-        return False
-    if not _artifact_stat_matches_fingerprint(fingerprint, artifact_stat):
-        return False
-    if hashlib.sha256(artifact_bytes).hexdigest() != fingerprint.artifact_sha256:
-        return False
-    try:
-        artifact_after_stat = artifact_path.stat()
-    except OSError:
-        return False
-    return _artifact_stat_matches_fingerprint(
-        fingerprint,
-        artifact_after_stat,
-    )
-
-
-def _bound_artifact_source_is_current(
-    fingerprint: _ArtifactSourceFingerprint,
-    artifact_path: Path,
-    *,
-    requires_content: bool,
-) -> bool:
-    if not requires_content:
-        try:
-            artifact_stat = artifact_path.stat()
-        except OSError:
-            return False
-        if _stat_identity_is_strong(artifact_stat):
-            return _artifact_stat_matches_fingerprint(
-                fingerprint,
-                artifact_stat,
-            )
-    return _artifact_bytes_match_fingerprint(fingerprint, artifact_path)
-
-
-def _fast_artifact_source_validation(
-    fingerprint: _ArtifactSourceFingerprint,
-    manifest_path: Path,
-    artifact_path: Path,
-) -> bool | None:
-    try:
-        manifest_stat = manifest_path.stat()
-        artifact_stat = artifact_path.stat()
-    except OSError:
-        return False
-    if not (
-        _stat_identity_is_strong(manifest_stat)
-        and _stat_identity_is_strong(artifact_stat)
-    ):
-        return None
-    return _manifest_stat_matches_fingerprint(
-        fingerprint,
-        manifest_stat,
-    ) and _artifact_stat_matches_fingerprint(fingerprint, artifact_stat)
-
-
-def _source_bytes_match_fingerprint(
-    fingerprint: _ArtifactSourceFingerprint,
-    manifest_path: Path,
-    artifact_path: Path,
-) -> bool:
-    manifest_bytes, manifest_stat, manifest_failure, _manifest_detail = (
-        _read_stable_regular_file_bytes(manifest_path)
-    )
-    if (
-        manifest_failure is not None
-        or manifest_bytes is None
-        or manifest_stat is None
-        or not _manifest_stat_matches_fingerprint(fingerprint, manifest_stat)
-        or hashlib.sha256(manifest_bytes).hexdigest() != fingerprint.manifest_sha256
-    ):
-        return False
-    if not _artifact_bytes_match_fingerprint(fingerprint, artifact_path):
-        return False
-    try:
-        manifest_after_stat = manifest_path.stat()
-    except OSError:
-        return False
-    return _manifest_stat_matches_fingerprint(
-        fingerprint,
-        manifest_after_stat,
-    )
-
-
-def _cache_validation_mode() -> str:
-    """Return the cache-validation mode while preserving legacy semantics.
-
-    ``REPOGROUND_CACHE_VALIDATION`` accepts only ``auto`` and ``strict``.
-    Any other non-empty value falls back to ``strict`` and is logged once per
-    distinct invalid value. The legacy
-    ``REPOGROUND_STRICT_CACHE_HASH`` switch remains supported when the
-    new variable is unset or empty: unset/empty/0/false/no/off means ``auto``;
-    every other non-empty legacy value means ``strict``.
-    """
-    configured_raw = os.environ.get(_CALL_NAVIGATION_CACHE_VALIDATION_ENV, "")
-    configured = configured_raw.strip().lower()
-    if configured in {"auto", "strict"}:
-        return configured
-    if configured:
-        with _CALL_NAVIGATION_CACHE_LOCK:
-            if configured_raw not in _WARNED_INVALID_CACHE_VALIDATION_VALUES:
-                _WARNED_INVALID_CACHE_VALIDATION_VALUES.add(configured_raw)
-                logger.warning(
-                    "Invalid %s value %r; falling back to strict cache validation",
-                    _CALL_NAVIGATION_CACHE_VALIDATION_ENV,
-                    configured_raw,
-                )
-        return "strict"
-
-    legacy = os.environ.get(
-        _CALL_NAVIGATION_STRICT_SOURCE_HASH_ENV, ""
-    ).strip().lower()
-    if legacy in {"", "0", "false", "no", "off"}:
-        return "auto"
-    return "strict"
-
-
-def _source_identity_is_strong(
-    fingerprint: _ArtifactSourceFingerprint,
-) -> bool:
-    """Whether metadata can support the fast warm-cache validation path."""
-    return all(
-        value != 0
-        for value in (
-            fingerprint.manifest_device,
-            fingerprint.manifest_inode,
-            fingerprint.manifest_mtime_ns,
-            fingerprint.manifest_ctime_ns,
-            fingerprint.device,
-            fingerprint.inode,
-            fingerprint.mtime_ns,
-            fingerprint.ctime_ns,
-        )
-    )
-
-
-def _source_content_verification_required(
-    fingerprint: _ArtifactSourceFingerprint,
-    *,
-    verify_content: bool,
-) -> bool:
-    return (
-        verify_content
-        or _cache_validation_mode() == "strict"
-        or not _source_identity_is_strong(fingerprint)
-    )
-
-
-def _read_stable_artifact_bytes(
-    artifact_path: Path,
-) -> tuple[bytes | None, os.stat_result | None, str | None, str | None]:
-    return read_stable_regular_file_bytes(
-        artifact_path,
-        max_bytes=MAX_REGISTERED_ARTIFACT_BYTES,
-    )
-
-
-def _read_stable_regular_file_bytes(
-    path: Path,
-    *,
-    max_bytes: int = MAX_MANIFEST_BYTES,
-) -> tuple[bytes | None, os.stat_result | None, str | None, str | None]:
-    return read_stable_regular_file_bytes(path, max_bytes=max_bytes)
-
-
-def _read_artifact_manifest_source(
-    manifest_path: Path,
-) -> tuple[
-    bytes | None,
-    Any,
-    tuple[int, int, int, int, int] | None,
-    str | None,
-    str | None,
-]:
-    snapshot = active_manifest_snapshot(manifest_path)
-    if snapshot is not None:
-        identity = snapshot.file_identity
-        return (
-            snapshot.raw,
-            snapshot.json_object(),
-            (identity[0], identity[1], identity[3], identity[4], identity[5]),
-            None,
-            None,
-        )
-    raw, manifest_stat, failure, detail = _read_stable_regular_file_bytes(
-        manifest_path
-    )
-    if failure == "too_large":
-        failure = "manifest_too_large"
-    if failure is not None:
-        return None, None, None, failure, detail
-    assert raw is not None and manifest_stat is not None
-    try:
-        manifest = json.loads(raw)
-    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-        return None, None, None, "unreadable", str(exc)
-    if (
-        not is_bundle_manifest(manifest)
-        or not _is_non_empty_string(manifest.get("run_id"))
-        or not isinstance(manifest.get("artifacts"), list)
-    ):
-        return (
-            None,
-            None,
-            None,
-            "manifest_invalid",
-            "bundle manifest identity, run_id, or artifacts are invalid",
-        )
-    return raw, manifest, _file_identity(manifest_stat), None, None
-
-
-def _read_registered_artifact_source(
-    manifest_path: Path, role: str
-) -> tuple[
-    _LoadedArtifactSource | None,
-    dict[str, Any] | None,
-    str | None,
-    str | None,
-]:
-    manifest_bytes, manifest, manifest_identity, failure, detail = (
-        _read_artifact_manifest_source(manifest_path)
-    )
-    if failure is not None:
-        return None, None, failure, detail
-    assert manifest_bytes is not None and manifest_identity is not None
-    if not isinstance(manifest, dict):
-        return None, None, "unreadable", "bundle manifest must be a JSON object"
-    try:
-        artifact_payload, artifact, resolution_failure = _resolve_unique_artifact(
-            manifest_path,
-            manifest,
-            role,
-        )
-    except ValueError as exc:
-        return None, None, "unreadable", str(exc)
-    if resolution_failure is not None:
-        return None, artifact, resolution_failure, None
-    assert artifact_payload is not None and artifact is not None
-    artifact_path = Path(artifact["absolute_path"])
-    declared_bytes, declared_sha256, integrity_failure = (
-        declared_artifact_integrity(artifact_payload)
-    )
-    if integrity_failure is not None:
-        return None, artifact, integrity_failure, None
-    raw, artifact_stat, failure, detail = _read_stable_artifact_bytes(artifact_path)
-    if failure is not None:
-        return None, artifact, failure, detail
-    assert raw is not None and artifact_stat is not None
-    if declared_bytes is not None and declared_bytes != len(raw):
-        return None, artifact, "bytes_mismatch", None
-    actual_sha256 = hashlib.sha256(raw).hexdigest()
-    if declared_sha256 is not None and actual_sha256 != declared_sha256:
-        return None, artifact, "sha256_mismatch", None
-    fingerprint = _ArtifactSourceFingerprint(
-        manifest_path=str(resolve_manifest_path(manifest_path)),
-        manifest_sha256=hashlib.sha256(manifest_bytes).hexdigest(),
-        manifest_device=manifest_identity[0],
-        manifest_inode=manifest_identity[1],
-        manifest_size=manifest_identity[2],
-        manifest_mtime_ns=manifest_identity[3],
-        manifest_ctime_ns=manifest_identity[4],
-        role=role,
-        absolute_path=str(artifact_path),
-        artifact_sha256=actual_sha256,
-        device=artifact_stat.st_dev,
-        inode=artifact_stat.st_ino,
-        size=artifact_stat.st_size,
-        mtime_ns=artifact_stat.st_mtime_ns,
-        ctime_ns=artifact_stat.st_ctime_ns,
-    )
-    if not _manifest_source_is_current(fingerprint):
-        return None, artifact, "source_changed", None
-    return (
-        _LoadedArtifactSource(
-            manifest=manifest,
-            artifact=artifact,
-            raw=raw,
-            fingerprint=fingerprint,
-        ),
-        artifact,
-        None,
-        None,
-    )
-
-
-def _artifact_source_is_current(
-    fingerprint: _ArtifactSourceFingerprint,
-    *,
-    verify_content: bool = False,
-) -> bool:
-    """Validate one cached generation without reparsing its JSON payload.
-
-    Cold loads and post-build checks always hash bytes read from one pinned file
-    descriptor. Request-bound lookups authorize the cached manifest hash only
-    from the active snapshot and never from transient path bytes. Other warm
-    lookups use the manifest hash plus strong file identity metadata.
-    ``REPOGROUND_CACHE_VALIDATION=strict`` forces a full hash on every lookup;
-    the legacy strict-hash switch remains supported. Weak identities such as
-    zero device or inode values automatically use strict validation.
-    """
-    manifest_path = Path(fingerprint.manifest_path)
-    artifact_path = Path(fingerprint.absolute_path)
-    active_manifest_match = _fingerprint_matches_active_manifest_snapshot(fingerprint)
-    if active_manifest_match is False:
-        return False
-
-    requires_content = _source_content_verification_required(
-        fingerprint,
-        verify_content=verify_content,
-    )
-    if active_manifest_match is True:
-        return _bound_artifact_source_is_current(
-            fingerprint,
-            artifact_path,
-            requires_content=requires_content,
-        )
-
-    if not requires_content:
-        fast_validation = _fast_artifact_source_validation(
-            fingerprint,
-            manifest_path,
-            artifact_path,
-        )
-        if fast_validation is not None:
-            return fast_validation
-    return _source_bytes_match_fingerprint(
-        fingerprint,
-        manifest_path,
-        artifact_path,
-    )
+_stat_identity_is_strong = _artifact_source_access._stat_identity_is_strong
+_stat_matches_identity = _artifact_source_access._stat_matches_identity
+_manifest_stat_matches_fingerprint = (
+    _artifact_source_access._manifest_stat_matches_fingerprint
+)
+_artifact_stat_matches_fingerprint = (
+    _artifact_source_access._artifact_stat_matches_fingerprint
+)
+_fingerprint_matches_active_manifest_snapshot = (
+    _artifact_source_access._fingerprint_matches_active_manifest_snapshot
+)
+_manifest_source_is_current = _artifact_source_access._manifest_source_is_current
+_artifact_bytes_match_fingerprint = (
+    _artifact_source_access._artifact_bytes_match_fingerprint
+)
+_bound_artifact_source_is_current = (
+    _artifact_source_access._bound_artifact_source_is_current
+)
+_fast_artifact_source_validation = (
+    _artifact_source_access._fast_artifact_source_validation
+)
+_source_bytes_match_fingerprint = (
+    _artifact_source_access._source_bytes_match_fingerprint
+)
+_cache_validation_mode = _artifact_source_access._cache_validation_mode
+_source_identity_is_strong = _artifact_source_access._source_identity_is_strong
+_source_content_verification_required = (
+    _artifact_source_access._source_content_verification_required
+)
+_read_stable_artifact_bytes = _artifact_source_access._read_stable_artifact_bytes
+_read_stable_regular_file_bytes = (
+    _artifact_source_access._read_stable_regular_file_bytes
+)
+_read_artifact_manifest_source = _artifact_source_access._read_artifact_manifest_source
+_read_registered_artifact_source = (
+    _artifact_source_access._read_registered_artifact_source
+)
+_artifact_source_is_current = _artifact_source_access._artifact_source_is_current
 
 def _cache_state(
     cache: OrderedDict[Any, Any], key: Any, state: Any

--- a/merger/repoground/tests/test_bundle_access_decomposition.py
+++ b/merger/repoground/tests/test_bundle_access_decomposition.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from merger.repoground.core import artifact_source_access
 from merger.repoground.core import bundle_access
 from merger.repoground.core.bounded_artifact_read import (
     MAX_REGISTERED_ARTIFACT_BYTES,
@@ -131,7 +132,7 @@ def test_declared_oversize_is_rejected_before_artifact_open(
         raise AssertionError("oversized declared artifact must not be opened")
 
     monkeypatch.setattr(
-        bundle_access,
+        artifact_source_access,
         "_read_stable_artifact_bytes",
         forbidden_read,
     )
@@ -339,8 +340,8 @@ def test_manifest_hash_is_rechecked_after_artifact_read_when_metadata_is_spoofed
         [_call_graph_record(artifact.name, raw=raw)],
     )
     original_manifest_stat = manifest.stat()
-    original_manifest_reader = bundle_access._read_stable_regular_file_bytes
-    original_artifact_reader = bundle_access._read_stable_artifact_bytes
+    original_manifest_reader = artifact_source_access._read_stable_regular_file_bytes
+    original_artifact_reader = artifact_source_access._read_stable_artifact_bytes
     original_path_stat = Path.stat
     changed = False
 
@@ -364,12 +365,12 @@ def test_manifest_hash_is_rechecked_after_artifact_read_when_metadata_is_spoofed
         return original_path_stat(path, *args, **kwargs)
 
     monkeypatch.setattr(
-        bundle_access,
+        artifact_source_access,
         "_read_stable_artifact_bytes",
         changing_artifact_reader,
     )
     monkeypatch.setattr(
-        bundle_access,
+        artifact_source_access,
         "_read_stable_regular_file_bytes",
         spoofed_manifest_reader,
     )

--- a/merger/repoground/tests/test_call_navigation.py
+++ b/merger/repoground/tests/test_call_navigation.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from merger.repoground.core import artifact_source_access
 from merger.repoground.core import bounded_artifact_read, bundle_access, mcp_tools
 from merger.repoground.core.bundle_access import (
     find_references,
@@ -31,10 +32,14 @@ OTHER_CALLER_ID = "py:pkg:c.py:function:other_caller"
 @pytest.fixture(autouse=True)
 def _reset_call_navigation_caches():
     bundle_access._clear_call_navigation_caches()
-    bundle_access._WARNED_INVALID_CACHE_VALIDATION_VALUES.clear()
+    artifact_source_access._WARNED_INVALID_CACHE_VALIDATION_VALUES.clear()
+    if hasattr(bundle_access, "_WARNED_INVALID_CACHE_VALIDATION_VALUES"):
+        bundle_access._WARNED_INVALID_CACHE_VALIDATION_VALUES.clear()
     yield
     bundle_access._clear_call_navigation_caches()
-    bundle_access._WARNED_INVALID_CACHE_VALIDATION_VALUES.clear()
+    artifact_source_access._WARNED_INVALID_CACHE_VALIDATION_VALUES.clear()
+    if hasattr(bundle_access, "_WARNED_INVALID_CACHE_VALIDATION_VALUES"):
+        bundle_access._WARNED_INVALID_CACHE_VALIDATION_VALUES.clear()
 
 
 def _sha(path: Path) -> str:
@@ -1189,12 +1194,12 @@ def test_warm_navigation_fast_path_does_not_reread_call_graph_bytes(
     monkeypatch.delenv("REPOGROUND_CACHE_VALIDATION", raising=False)
     monkeypatch.delenv("REPOGROUND_STRICT_CACHE_HASH", raising=False)
     monkeypatch.setattr(
-        bundle_access,
+        artifact_source_access,
         "_read_stable_regular_file_bytes",
         forbidden_stable_read,
     )
     monkeypatch.setattr(
-        bundle_access,
+        artifact_source_access,
         "_read_stable_artifact_bytes",
         forbidden_stable_read,
     )
@@ -1253,7 +1258,7 @@ def test_strict_navigation_cache_hash_uses_descriptor_pinned_read(
 
     monkeypatch.setenv("REPOGROUND_CACHE_VALIDATION", "strict")
     monkeypatch.setattr(
-        bundle_access, "_read_stable_artifact_bytes", counting_reader
+        artifact_source_access, "_read_stable_artifact_bytes", counting_reader
     )
 
     result = get_callers(manifest, "target", path="pkg/target.py")
@@ -1279,7 +1284,7 @@ def test_invalid_cache_validation_mode_falls_back_to_strict(
 
     monkeypatch.setenv("REPOGROUND_CACHE_VALIDATION", "typo")
     monkeypatch.setattr(
-        bundle_access, "_read_stable_artifact_bytes", counting_reader
+        artifact_source_access, "_read_stable_artifact_bytes", counting_reader
     )
 
     caplog.set_level("WARNING")
@@ -1343,7 +1348,7 @@ def test_weak_file_identity_automatically_uses_content_hash(
     monkeypatch.setattr(os, "lstat", weak_lstat)
     monkeypatch.setattr(Path, "stat", weak_path_stat)
     monkeypatch.setattr(
-        bundle_access,
+        artifact_source_access,
         "_read_stable_artifact_bytes",
         weak_identity_reader,
     )
@@ -1385,7 +1390,7 @@ def test_weak_manifest_identity_automatically_uses_content_hash(
     monkeypatch.delenv("REPOGROUND_CACHE_VALIDATION", raising=False)
     monkeypatch.delenv("REPOGROUND_STRICT_CACHE_HASH", raising=False)
     monkeypatch.setattr(
-        bundle_access,
+        artifact_source_access,
         "_read_stable_regular_file_bytes",
         weak_manifest_reader,
     )
@@ -1422,7 +1427,7 @@ def test_strict_warm_validation_rejects_tampered_bytes_with_same_identity(
         return bytes(tampered), stat_result, failure, detail
 
     monkeypatch.setattr(
-        bundle_access,
+        artifact_source_access,
         "_read_stable_artifact_bytes",
         tampered_reader,
     )
@@ -1484,7 +1489,7 @@ def test_manifest_change_during_full_verification_is_rejected(tmp_path, monkeypa
 
     monkeypatch.setenv("REPOGROUND_CACHE_VALIDATION", "strict")
     monkeypatch.setattr(
-        bundle_access,
+        artifact_source_access,
         "_read_stable_artifact_bytes",
         mutating_artifact_reader,
     )
@@ -1509,7 +1514,7 @@ def test_legacy_strict_hash_switch_remains_supported(tmp_path, monkeypatch):
     monkeypatch.delenv("REPOGROUND_CACHE_VALIDATION", raising=False)
     monkeypatch.setenv("REPOGROUND_STRICT_CACHE_HASH", "1")
     monkeypatch.setattr(
-        bundle_access,
+        artifact_source_access,
         "_read_stable_artifact_bytes",
         counting_reader,
     )


### PR DESCRIPTION
## Summary

Residual slice for **REPOGROUND-LEGACY-RECONCILIATION-V1-T011** after T012 merge (#1124).

Extracts the shared fingerprint / cache-validation / registered-role bounded source-load cluster from `bundle_access.py` into `artifact_source_access.py` so integrity checks are not entangled with call-navigation orchestration.

- `bundle_access.py`: 2618 → 2225 lines (−393)
- New `artifact_source_access.py`: 471 lines
- Historical private names re-exported from `bundle_access` for API parity
- Tests retarget monkeypatches to the owning module where internals are exercised

## Proof

`docs/proofs/repoground-legacy-t011-bundle-access-residual-source-20260730.md`

## Validation

- `pytest` related: **632 passed** (`bundle_access|call_navigation|citation|symbol_index|range_get|query_existing|snapshot`)
- focused: 100 passed (`test_call_navigation` + decomposition + boundary + citation)
- `ruff` F401 on touched modules: pass
- `scripts/ci/check_graph_maintainability.py`: pass

## Diff binding

- Head: `8df8c6f597bd3eabc17b185d8f39ab5cf9a574a4`
- Base: `origin/main` @ `20b9fa60` (includes #1124)

## Boundaries

- Does **not** close parent T004
- Foreign dirty T004 worktree was **not** mutated
- Call-navigation orchestration remains in the facade (next residual if needed)

## Does not establish

- Final T014 monolith budget
- Production consumer completeness beyond existing tests