### PR TITLE
docs(ci): classify workflows and demote docs/tasks authority (T005)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,3 +35,9 @@ jobs:
 
       - name: Check production module reachability evidence
         run: python scripts/ci/check_module_reachability.py --root . --format json
+
+      - name: Check workflow control-plane inventory
+        run: python scripts/ci/check_workflow_control_plane.py --root . --format json
+
+      - name: Check entry-document links
+        run: python scripts/ci/check_entry_doc_links.py --root . --format json

--- a/config/workflow-control-plane.v1.json
+++ b/config/workflow-control-plane.v1.json
@@ -1,0 +1,176 @@
+{
+  "kind": "repoground.workflow_control_plane",
+  "schema_version": 1,
+  "task": "REPOGROUND-LEGACY-RECONCILIATION-V1-T005",
+  "revision_binding": {
+    "base_revision": "fe1e82dd12e102838b38f63fed59750b6d81a759",
+    "observed_at": "2026-07-30T06:21:44Z"
+  },
+  "class_semantics": {
+    "required_protection": "Must stay green on protected paths; primary merge-safety surface.",
+    "fast_feedback": "Narrow specialist gates for fast PR signal; not historical ballast.",
+    "diagnostic": "Provides diagnostics or ratchet reports; may be non-blocking or soft-fail without becoming product truth.",
+    "operator_command": "Operator/PR command automation; not a required content gate.",
+    "historical_ballast": "Reserved: no-op or superseded workflows pending removal (none in this inventory)."
+  },
+  "does_not_establish": [
+    "That every diagnostic workflow is free to delete.",
+    "That dual parity workflows are identical.",
+    "That classification alone changes required GitHub branch protection."
+  ],
+  "workflows": [
+    {
+      "path": ".github/workflows/ai-context-guard.yml",
+      "class": "required_protection",
+      "rationale": "Blocks unsafe AI-context / instruction drift.",
+      "sha256": "1786b00c649f86abe228fe57e803cdd3ae65cade0dbda2797158586987abade0",
+      "bytes": 2701
+    },
+    {
+      "path": ".github/workflows/anti-hallucination-lint.yml",
+      "class": "fast_feedback",
+      "rationale": "Focused contract lint for anti-hallucination rules.",
+      "sha256": "9786a221ca7c80199912fa8c65a352dcc63e302556b9b27a5a8798a887153c56",
+      "bytes": 2429
+    },
+    {
+      "path": ".github/workflows/codeql.yml",
+      "class": "required_protection",
+      "rationale": "Security analysis gate for Python.",
+      "sha256": "bebf50989d33d07b5880e0ece7f130097ae182a0eb13d6a92858e74b4b464866",
+      "bytes": 1931
+    },
+    {
+      "path": ".github/workflows/contracts-validate.yml",
+      "class": "required_protection",
+      "rationale": "Contract/schema/fixture integrity.",
+      "sha256": "af0b9f7544a8694221d4e729cf547ed347ea8b2d9171fbe170daea90a5d1de78",
+      "bytes": 10556
+    },
+    {
+      "path": ".github/workflows/doc-freshness.yml",
+      "class": "diagnostic",
+      "rationale": "Documentation freshness diagnostic (non-authoritative product truth).",
+      "sha256": "acb2c4f3e9ea0f039df3db00127aaf74e214fcc365029de4c04d8fdeb45bdd0d",
+      "bytes": 4017
+    },
+    {
+      "path": ".github/workflows/forensic-preflight-canary.yml",
+      "class": "diagnostic",
+      "rationale": "Forensic preflight canary; not full forensic promotion.",
+      "sha256": "5bcd6e47fd87414ffdaf2ab993e405fa64ac273f77fea05c165e320428f16a0b",
+      "bytes": 4701
+    },
+    {
+      "path": ".github/workflows/graph-bundle-sources.yml",
+      "class": "fast_feedback",
+      "rationale": "Graph bundle source contract.",
+      "sha256": "dd936420c963badfd234518afb7370d32d9c8d0320e21d7774e375ca45ba0fbf",
+      "bytes": 4502
+    },
+    {
+      "path": ".github/workflows/graph-model.yml",
+      "class": "diagnostic",
+      "rationale": "Graph model suite (broader than single contract).",
+      "sha256": "f02a19dcb16a249734a70315e39afd257e2873d3f42d952133647fa6f355faf7",
+      "bytes": 6430
+    },
+    {
+      "path": ".github/workflows/graph-quality-goldset.yml",
+      "class": "diagnostic",
+      "rationale": "Graph quality goldset evaluation.",
+      "sha256": "f2aa1a3bb94b77fb3db35ba71d9924f60751912bb7877038bf3d9a1145afc83a",
+      "bytes": 2816
+    },
+    {
+      "path": ".github/workflows/graph-source-roots.yml",
+      "class": "fast_feedback",
+      "rationale": "Graph source-root contract.",
+      "sha256": "e1caffb741c64cc85ca6ae01c65896ec2b3f45fafe8dea5b72ff7dd3e9f4bd3e",
+      "bytes": 2092
+    },
+    {
+      "path": ".github/workflows/lens-model.yml",
+      "class": "diagnostic",
+      "rationale": "Lens model suite.",
+      "sha256": "e1b0e3a0ebdce1add078612d2df981994a91ed8be7e6f22c9e5e2287005f526a",
+      "bytes": 16858
+    },
+    {
+      "path": ".github/workflows/lint.yml",
+      "class": "required_protection",
+      "rationale": "Ruff plus maintainability/reachability ratchets.",
+      "sha256": "1802a7f50ed8548f92c58e26cd1523ddaaa925aca46b372916996c6e0bd9eba7",
+      "bytes": 1383
+    },
+    {
+      "path": ".github/workflows/metrics.yml",
+      "class": "diagnostic",
+      "rationale": "Metrics snapshot/validation; scheduled/diagnostic posture.",
+      "sha256": "331c1e430de6d477c2c105c7afe319cfbe688cdf4b75cc6bfa6a7347924ed3c7",
+      "bytes": 2069
+    },
+    {
+      "path": ".github/workflows/parity-gate.yml",
+      "class": "fast_feedback",
+      "rationale": "Content vs diagnostic parity gate.",
+      "sha256": "b8b6f47c7a0151570a12a23d38f9c206057a20286f7535c8875013aa7fe906e7",
+      "bytes": 3137
+    },
+    {
+      "path": ".github/workflows/parity_check.yml",
+      "class": "fast_feedback",
+      "rationale": "Frontend parity guard (surface parity).",
+      "sha256": "12b73bc06de33ee269d92b20ba57cdb681d2b665ff59b59037a421ae273d24dc",
+      "bytes": 1632
+    },
+    {
+      "path": ".github/workflows/pr-heimgewebe-commands.yml",
+      "class": "operator_command",
+      "rationale": "PR comment command surface; not a merge gate.",
+      "sha256": "c802df6c42dbf0643fbb727366db743fb1f5b691a9e00d956e39465b5d42b71c",
+      "bytes": 563
+    },
+    {
+      "path": ".github/workflows/python-call-graph-goldset.yml",
+      "class": "diagnostic",
+      "rationale": "Call-graph goldset evaluation.",
+      "sha256": "7b3c2553fab8e05aefcce5d554fd3f5ece0512c393b6a4d31c840d0c7aafb4fd",
+      "bytes": 3900
+    },
+    {
+      "path": ".github/workflows/semantic-lock.yml",
+      "class": "required_protection",
+      "rationale": "Semantic identity / lock surface.",
+      "sha256": "68c31d6ebce296f15cb5693a5c5583281651371d8a0412375d8501359aa7b4b6",
+      "bytes": 3559
+    },
+    {
+      "path": ".github/workflows/task-index.yml",
+      "class": "diagnostic",
+      "rationale": "Planning registration / task-index ratchet (repo-local projection).",
+      "sha256": "9ce27d7b3cbce97a78c0d4a9b20cdf81e541e8718e3bf28e54ffc7d2ac205e3c",
+      "bytes": 5092
+    },
+    {
+      "path": ".github/workflows/test-suite.yml",
+      "class": "required_protection",
+      "rationale": "Primary pytest and browser gate surface.",
+      "sha256": "53f3aae139356cb1f69ef0831eec3ae6db0e84ffeb4b37ec754e89f4d3433ec0",
+      "bytes": 5315
+    },
+    {
+      "path": ".github/workflows/wgx-guard.yml",
+      "class": "required_protection",
+      "rationale": "wgx profile guard.",
+      "sha256": "6908956802b270bcb9f37066daa29c979ef4d4afa97d3ec914fa4ffc78469e66",
+      "bytes": 576
+    }
+  ],
+  "counts_by_class": {
+    "diagnostic": 8,
+    "fast_feedback": 5,
+    "operator_command": 1,
+    "required_protection": 7
+  }
+}

--- a/docs/architecture/control-planes.md
+++ b/docs/architecture/control-planes.md
@@ -1,0 +1,35 @@
+# RepoGround control planes (truth layers)
+
+Status: accepted architecture boundary for the freigabefähigen slice of
+`REPOGROUND-LEGACY-RECONCILIATION-V1-T005`.
+
+## Layers
+
+| Layer | Authority | Typical paths | Normative for agents? |
+| --- | --- | --- | --- |
+| Product architecture & boundaries | Repo docs on `main` | `docs/architecture/*`, `README.md`, `docs/GETTING_STARTED.md` | Yes |
+| Live operator / initiative tasks | Bureau registry | `~/repos/bureau/registry/tasks/*` | Yes for task lifecycle |
+| Repo-local historical task projection | Local board/index only | `docs/tasks/*` | **No** – projection / ratchet surface |
+| Historical proofs | Evidence archive | `docs/proofs/*` | No – evidence, not current product contract |
+| Diagnostics snapshots | Generated/run evidence | `docs/diagnostics/*`, canary outputs | No – run-bound diagnostics |
+| CI control plane | Classified workflows | `.github/workflows/*` + `config/workflow-control-plane.v1.json` | Class-dependent (see inventory) |
+
+## Rules
+
+1. **Do not treat proofs as live product truth.** Proofs bind a past revision and
+   claim; they remain findable but are not the default reading surface for
+   “how the system works now”.
+2. **Do not treat `docs/tasks` as Bureau.** The local board/index may drive the
+   planning-registration ratchet and human navigation of historical TASK-*
+   rows. Canonical REPOGROUND-LEGACY-* / Bureau initiatives live in Bureau.
+3. **CI classes are explicit.** Every workflow must be classified in
+   `config/workflow-control-plane.v1.json`. Silent new workflows fail the
+   inventory check in `lint`.
+4. **Entry links stay resolvable.** The entry-document link gate covers the
+   fixed operator entry set (README, AGENTS, GETTING_STARTED, system map, …).
+
+## Does not establish
+
+- That proofs are worthless or may be mass-deleted without migration.
+- That every diagnostic workflow must become required branch protection.
+- That dual parity workflows are redundant copies of each other.

--- a/docs/architecture/product-boundaries.md
+++ b/docs/architecture/product-boundaries.md
@@ -74,3 +74,7 @@ contains no old copy or that historical documentation has no archival value.
 
 The product boundary is therefore operational rather than revisionist: active runtime and
 package surfaces are made coherent, while historical proof artifacts are left intact.
+
+## Related control-plane layers
+
+See [`control-planes.md`](control-planes.md) for the T005 separation of architecture, Bureau task truth, proofs, diagnostics and CI classes.

--- a/docs/proofs/repoground-legacy-t005-docs-ci-control-plane-20260730.md
+++ b/docs/proofs/repoground-legacy-t005-docs-ci-control-plane-20260730.md
@@ -1,0 +1,42 @@
+# T005 freigabefähiger Slice: Docs/CI control planes
+
+Bureau task: `REPOGROUND-LEGACY-RECONCILIATION-V1-T005`
+
+Base revision: post-merge `fe1e82dd` (includes T011 residual #1125 and T012 #1124).
+
+## Scope of this slice
+
+This is a **bounded control-plane slice**, not full T005 closeout:
+
+| Acceptance | This slice |
+| --- | --- |
+| task-truth | `docs/tasks/AUTHORITY.md`, board header, `index.json` `_authority` declare Bureau as canonical lifecycle for REPOGROUND-LEGACY-* |
+| ci-value | All 21 workflows classified in `config/workflow-control-plane.v1.json`; fail-closed inventory check in `lint` |
+| freshness | Entry-document link gate over fixed operator entry set; 0 broken links observed |
+| truth-layers | `docs/architecture/control-planes.md` separates architecture, Bureau, proofs, diagnostics, CI |
+| context-budget | Documented; default retrieval re-weighting of entire `docs/proofs/**` deferred |
+
+## Workflow classes (counts)
+
+See inventory `counts_by_class`. No workflow is classified as `historical_ballast` in this revision; dual parity surfaces remain `fast_feedback` with distinct roles.
+
+## Validation
+
+```bash
+python scripts/ci/check_workflow_control_plane.py --root . --format json
+python scripts/ci/check_entry_doc_links.py --root . --format json
+pytest scripts/ci/tests/test_workflow_control_plane.py -q
+```
+
+## Does not establish
+
+- Full archival migration of all historical proofs
+- Automatic removal of any workflow
+- That `docs/tasks` TASK-* rows are deleted
+- Parent T004 closeout
+
+## Follow-ups
+
+- Optional retrieval profile exclusion weights for `docs/proofs/**` and `docs/diagnostics/**`
+- Branch-protection alignment audit against `required_protection` class
+- Bureau registry state sync for T011/T012 after landed code

--- a/docs/tasks/AUTHORITY.md
+++ b/docs/tasks/AUTHORITY.md
@@ -1,0 +1,22 @@
+# docs/tasks authority boundary
+
+**Bureau is the canonical task lifecycle for RepoGround initiatives** such as
+`REPOGROUND-LEGACY-RECONCILIATION-V1-*`. Those tasks are owned in the Bureau
+registry (`registry/tasks/*.json` in the Bureau repository), not in this folder.
+
+## What lives here
+
+| Path | Role |
+| --- | --- |
+| `index.json` / `board.md` | Historical / human TASK-* projection and planning-registration ratchet input |
+| `planning-registration-baseline.json` | Baseline for the planning-registration CI ratchet |
+
+## What this is not
+
+- Not a second lifecycle truth that can override Bureau.
+- Not a claim surface for merge authority, deployment, or initiative closeout.
+- Not required reading for answering “what is the next REPOGROUND-LEGACY task?”
+  — use Bureau `what-now` / task registry instead.
+
+When Bureau and `docs/tasks` disagree on an initiative task, **Bureau wins**.
+Repo-local TASK-* rows remain useful for legacy planning hygiene only.

--- a/docs/tasks/board.md
+++ b/docs/tasks/board.md
@@ -6,7 +6,9 @@
 - `partial` – ein begrenzter Kern existiert, aber der deklarierte Task-Scope ist nicht vollständig erfüllt
 - `done` – der deklarierte Task-Scope ist abgeschlossen und belegt; separate Folgetasks oder Grenzen dürfen offen bleiben
 
-`done` bedeutet weder automatisch, dass eine Phase oder das Gesamtsystem vollständig ist, noch dass Produkt- oder Release-Reife erreicht wurde. Kanonische Taskstatus stehen in `docs/tasks/index.json`; dieses Board ist die menschenlesbare Projektion.
+`done` bedeutet weder automatisch, dass eine Phase oder das Gesamtsystem vollständig ist, noch dass Produkt- oder Release-Reife erreicht wurde.
+
+**Aufgabenwahrheit:** Für Bureau-Initiativen (z. B. `REPOGROUND-LEGACY-RECONCILIATION-V1-*`) ist **Bureau** kanonisch. `docs/tasks/index.json` und dieses Board sind eine **repo-lokale historische Projektion** und Ratchet-Fläche, keine zweite Lifecycle-Wahrheit. Siehe `docs/tasks/AUTHORITY.md` und `docs/architecture/control-planes.md`.
 
 ## Aktive Tasks
 

--- a/docs/tasks/index.json
+++ b/docs/tasks/index.json
@@ -1644,5 +1644,15 @@
         "Completion establishes public distribution only for the project-controlled source scope documented by the decision and source-distribution review; it does not clear bundled third-party binaries, wheels, containers, model weights or datasets."
       ]
     }
-  ]
+  ],
+  "_authority": {
+    "canonical_task_lifecycle": "bureau",
+    "this_file": "repo_local_historical_projection",
+    "see": "docs/tasks/AUTHORITY.md",
+    "does_not_establish": [
+      "Bureau closeout",
+      "Merge or deploy authority",
+      "Override of REPOGROUND-LEGACY-* registry state"
+    ]
+  }
 }

--- a/scripts/ci/check_entry_doc_links.py
+++ b/scripts/ci/check_entry_doc_links.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Fail-closed entry-document link check for RepoGround.
+
+Scans a fixed set of entry documents for relative Markdown links that point
+to missing paths. Historical proof/diagnostic surfaces are not scanned here;
+this gate only protects the operator entry surface named by T005 freshness.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+
+DEFAULT_ENTRY_DOCS = (
+    "README.md",
+    "AGENTS.md",
+    "CONTRIBUTING.md",
+    "docs/GETTING_STARTED.md",
+    "docs/FAQ.md",
+    "docs/glossary.md",
+    "docs/roadmap.md",
+    "docs/architecture/system-map.repoground.md",
+    "docs/architecture/product-boundaries.md",
+    "docs/roadmap/repoground-master-roadmap.md",
+)
+
+
+def _iter_broken(root: Path, docs: tuple[str, ...]) -> list[dict[str, str]]:
+    broken: list[dict[str, str]] = []
+    for rel in docs:
+        doc = root / rel
+        if not doc.is_file():
+            broken.append(
+                {
+                    "doc": rel,
+                    "href": "",
+                    "label": "",
+                    "reason": "entry_doc_missing",
+                }
+            )
+            continue
+        text = doc.read_text(encoding="utf-8")
+        for label, href in LINK_RE.findall(text):
+            if href.startswith(("http://", "https://", "mailto:", "#")):
+                continue
+            href_path = href.split("#", 1)[0].strip()
+            if not href_path:
+                continue
+            target = (doc.parent / href_path).resolve()
+            try:
+                target.relative_to(root.resolve())
+            except ValueError:
+                broken.append(
+                    {
+                        "doc": rel,
+                        "href": href,
+                        "label": label,
+                        "reason": "outside_repo",
+                    }
+                )
+                continue
+            if not target.exists():
+                broken.append(
+                    {
+                        "doc": rel,
+                        "href": href,
+                        "label": label,
+                        "reason": "missing_target",
+                    }
+                )
+    return broken
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path("."))
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+    )
+    args = parser.parse_args(argv)
+    root = args.root.resolve()
+    findings = _iter_broken(root, DEFAULT_ENTRY_DOCS)
+    report = {
+        "ok": not findings,
+        "entry_doc_count": len(DEFAULT_ENTRY_DOCS),
+        "broken_count": len(findings),
+        "broken": findings,
+    }
+    if args.format == "json":
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        if findings:
+            print("entry doc link check: FAIL")
+            for item in findings:
+                print(
+                    f"  - {item['doc']}: {item['href'] or '(missing doc)'} "
+                    f"({item['reason']})"
+                )
+        else:
+            print(
+                "entry doc link check: PASS "
+                f"({report['entry_doc_count']} entry docs, 0 broken links)"
+            )
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/check_workflow_control_plane.py
+++ b/scripts/ci/check_workflow_control_plane.py
@@ -13,6 +13,7 @@ import hashlib
 import json
 import sys
 from pathlib import Path
+from typing import Any
 
 ALLOWED_CLASSES = frozenset(
     {
@@ -31,6 +32,84 @@ def _sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
+def _load_inventory(path: Path) -> tuple[dict[str, Any] | None, list[str]]:
+    errors: list[str] = []
+    if not path.is_file():
+        return None, [f"missing inventory: {INVENTORY_REL}"]
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return None, [f"unreadable inventory: {exc}"]
+    if not isinstance(payload, dict):
+        return None, ["inventory root must be an object"]
+    if payload.get("kind") != "repoground.workflow_control_plane":
+        errors.append("inventory kind must be repoground.workflow_control_plane")
+    if payload.get("schema_version") != 1:
+        errors.append("inventory schema_version must be 1")
+    listed = payload.get("workflows")
+    if not isinstance(listed, list) or not listed:
+        errors.append("inventory.workflows must be a non-empty list")
+    return payload, errors
+
+
+def _on_disk_workflows(root: Path) -> dict[str, Path] | list[str]:
+    workflows_dir = root / WORKFLOWS_REL
+    if not workflows_dir.is_dir():
+        return [f"missing workflows dir: {WORKFLOWS_REL}"]
+    return {
+        str(path.relative_to(root)).replace("\\", "/"): path
+        for path in sorted(workflows_dir.glob("*.yml"))
+    }
+
+
+def _check_entry(
+    entry: Any,
+    index: int,
+    seen_paths: set[str],
+    on_disk: dict[str, Path],
+) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(entry, dict):
+        return [f"workflows[{index}] must be an object"]
+    path = entry.get("path")
+    klass = entry.get("class")
+    digest = entry.get("sha256")
+    if not isinstance(path, str) or not path:
+        return [f"workflows[{index}].path must be a non-empty string"]
+    if path in seen_paths:
+        errors.append(f"duplicate inventory path: {path}")
+    seen_paths.add(path)
+    if klass not in ALLOWED_CLASSES:
+        errors.append(f"{path}: unknown class {klass!r}")
+    if path not in on_disk:
+        errors.append(f"{path}: listed but missing on disk")
+        return errors
+    actual = _sha256(on_disk[path])
+    if not isinstance(digest, str) or len(digest) != 64:
+        errors.append(f"{path}: sha256 must be a 64-char hex digest")
+    elif actual != digest:
+        errors.append(
+            f"{path}: sha256 drift (inventory={digest[:12]}… disk={actual[:12]}…); "
+            "refresh config/workflow-control-plane.v1.json after intentional workflow edits"
+        )
+    return errors
+
+
+def _validate_inventory(
+    payload: dict[str, Any],
+    on_disk: dict[str, Path],
+) -> list[str]:
+    errors: list[str] = []
+    listed = payload.get("workflows")
+    assert isinstance(listed, list)
+    seen_paths: set[str] = set()
+    for index, entry in enumerate(listed):
+        errors.extend(_check_entry(entry, index, seen_paths, on_disk))
+    for path in sorted(set(on_disk) - seen_paths):
+        errors.append(f"{path}: on disk but not classified in inventory")
+    return errors
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--root", type=Path, default=Path("."))
@@ -42,94 +121,37 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
     root = args.root.resolve()
-    inventory_path = root / INVENTORY_REL
-    workflows_dir = root / WORKFLOWS_REL
 
-    errors: list[str] = []
-    if not inventory_path.is_file():
-        errors.append(f"missing inventory: {INVENTORY_REL}")
-        return _emit(args.format, errors, {})
-    if not workflows_dir.is_dir():
-        errors.append(f"missing workflows dir: {WORKFLOWS_REL}")
-        return _emit(args.format, errors, {})
-
-    try:
-        payload = json.loads(inventory_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        errors.append(f"unreadable inventory: {exc}")
-        return _emit(args.format, errors, {})
-
-    if payload.get("kind") != "repoground.workflow_control_plane":
-        errors.append("inventory kind must be repoground.workflow_control_plane")
-    if payload.get("schema_version") != 1:
-        errors.append("inventory schema_version must be 1")
-
-    listed = payload.get("workflows")
-    if not isinstance(listed, list) or not listed:
-        errors.append("inventory.workflows must be a non-empty list")
-        return _emit(args.format, errors, payload if isinstance(payload, dict) else {})
-
-    on_disk = {
-        str(path.relative_to(root)).replace("\\", "/"): path
-        for path in sorted(workflows_dir.glob("*.yml"))
-    }
-    seen_paths: set[str] = set()
-    for index, entry in enumerate(listed):
-        if not isinstance(entry, dict):
-            errors.append(f"workflows[{index}] must be an object")
-            continue
-        path = entry.get("path")
-        klass = entry.get("class")
-        digest = entry.get("sha256")
-        if not isinstance(path, str) or not path:
-            errors.append(f"workflows[{index}].path must be a non-empty string")
-            continue
-        if path in seen_paths:
-            errors.append(f"duplicate inventory path: {path}")
-        seen_paths.add(path)
-        if klass not in ALLOWED_CLASSES:
-            errors.append(f"{path}: unknown class {klass!r}")
-        if path not in on_disk:
-            errors.append(f"{path}: listed but missing on disk")
-            continue
-        actual = _sha256(on_disk[path])
-        if not isinstance(digest, str) or len(digest) != 64:
-            errors.append(f"{path}: sha256 must be a 64-char hex digest")
-        elif actual != digest:
-            errors.append(
-                f"{path}: sha256 drift (inventory={digest[:12]}… disk={actual[:12]}…); "
-                "refresh config/workflow-control-plane.v1.json after intentional workflow edits"
-            )
-
-    for path in sorted(set(on_disk) - seen_paths):
-        errors.append(f"{path}: on disk but not classified in inventory")
-
-    return _emit(args.format, errors, payload)
+    payload, errors = _load_inventory(root / INVENTORY_REL)
+    disk = _on_disk_workflows(root)
+    if isinstance(disk, list):
+        errors.extend(disk)
+    elif payload is not None:
+        errors.extend(_validate_inventory(payload, disk))
+    return _emit(args.format, errors, payload or {})
 
 
-def _emit(fmt: str, errors: list[str], payload: dict) -> int:
+def _emit(fmt: str, errors: list[str], payload: dict[str, Any]) -> int:
+    workflows = payload.get("workflows")
     report = {
         "ok": not errors,
         "error_count": len(errors),
         "errors": errors,
         "inventory": str(INVENTORY_REL),
-        "workflow_count": len(payload.get("workflows") or [])
-        if isinstance(payload.get("workflows"), list)
-        else 0,
+        "workflow_count": len(workflows) if isinstance(workflows, list) else 0,
         "counts_by_class": payload.get("counts_by_class"),
     }
     if fmt == "json":
         print(json.dumps(report, indent=2, sort_keys=True))
+    elif errors:
+        print("workflow control-plane check: FAIL")
+        for item in errors:
+            print(f"  - {item}")
     else:
-        if errors:
-            print("workflow control-plane check: FAIL")
-            for item in errors:
-                print(f"  - {item}")
-        else:
-            print(
-                "workflow control-plane check: PASS "
-                f"({report['workflow_count']} workflows classified)"
-            )
+        print(
+            "workflow control-plane check: PASS "
+            f"({report['workflow_count']} workflows classified)"
+        )
     return 1 if errors else 0
 
 

--- a/scripts/ci/check_workflow_control_plane.py
+++ b/scripts/ci/check_workflow_control_plane.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Fail-closed inventory check for RepoGround workflow control-plane classes.
+
+Validates that every file under ``.github/workflows/*.yml`` is listed exactly
+once in ``config/workflow-control-plane.v1.json`` with a known class and a
+matching SHA-256 identity. Prevents silent workflow drift after T005.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+ALLOWED_CLASSES = frozenset(
+    {
+        "required_protection",
+        "fast_feedback",
+        "diagnostic",
+        "operator_command",
+        "historical_ballast",
+    }
+)
+INVENTORY_REL = Path("config/workflow-control-plane.v1.json")
+WORKFLOWS_REL = Path(".github/workflows")
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path("."))
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format (default: text).",
+    )
+    args = parser.parse_args(argv)
+    root = args.root.resolve()
+    inventory_path = root / INVENTORY_REL
+    workflows_dir = root / WORKFLOWS_REL
+
+    errors: list[str] = []
+    if not inventory_path.is_file():
+        errors.append(f"missing inventory: {INVENTORY_REL}")
+        return _emit(args.format, errors, {})
+    if not workflows_dir.is_dir():
+        errors.append(f"missing workflows dir: {WORKFLOWS_REL}")
+        return _emit(args.format, errors, {})
+
+    try:
+        payload = json.loads(inventory_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        errors.append(f"unreadable inventory: {exc}")
+        return _emit(args.format, errors, {})
+
+    if payload.get("kind") != "repoground.workflow_control_plane":
+        errors.append("inventory kind must be repoground.workflow_control_plane")
+    if payload.get("schema_version") != 1:
+        errors.append("inventory schema_version must be 1")
+
+    listed = payload.get("workflows")
+    if not isinstance(listed, list) or not listed:
+        errors.append("inventory.workflows must be a non-empty list")
+        return _emit(args.format, errors, payload if isinstance(payload, dict) else {})
+
+    on_disk = {
+        str(path.relative_to(root)).replace("\\", "/"): path
+        for path in sorted(workflows_dir.glob("*.yml"))
+    }
+    seen_paths: set[str] = set()
+    for index, entry in enumerate(listed):
+        if not isinstance(entry, dict):
+            errors.append(f"workflows[{index}] must be an object")
+            continue
+        path = entry.get("path")
+        klass = entry.get("class")
+        digest = entry.get("sha256")
+        if not isinstance(path, str) or not path:
+            errors.append(f"workflows[{index}].path must be a non-empty string")
+            continue
+        if path in seen_paths:
+            errors.append(f"duplicate inventory path: {path}")
+        seen_paths.add(path)
+        if klass not in ALLOWED_CLASSES:
+            errors.append(f"{path}: unknown class {klass!r}")
+        if path not in on_disk:
+            errors.append(f"{path}: listed but missing on disk")
+            continue
+        actual = _sha256(on_disk[path])
+        if not isinstance(digest, str) or len(digest) != 64:
+            errors.append(f"{path}: sha256 must be a 64-char hex digest")
+        elif actual != digest:
+            errors.append(
+                f"{path}: sha256 drift (inventory={digest[:12]}… disk={actual[:12]}…); "
+                "refresh config/workflow-control-plane.v1.json after intentional workflow edits"
+            )
+
+    for path in sorted(set(on_disk) - seen_paths):
+        errors.append(f"{path}: on disk but not classified in inventory")
+
+    return _emit(args.format, errors, payload)
+
+
+def _emit(fmt: str, errors: list[str], payload: dict) -> int:
+    report = {
+        "ok": not errors,
+        "error_count": len(errors),
+        "errors": errors,
+        "inventory": str(INVENTORY_REL),
+        "workflow_count": len(payload.get("workflows") or [])
+        if isinstance(payload.get("workflows"), list)
+        else 0,
+        "counts_by_class": payload.get("counts_by_class"),
+    }
+    if fmt == "json":
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        if errors:
+            print("workflow control-plane check: FAIL")
+            for item in errors:
+                print(f"  - {item}")
+        else:
+            print(
+                "workflow control-plane check: PASS "
+                f"({report['workflow_count']} workflows classified)"
+            )
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/tests/test_workflow_control_plane.py
+++ b/scripts/ci/tests/test_workflow_control_plane.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_workflow_control_plane_passes_on_repo_root() -> None:
+    proc = subprocess.run(
+        [sys.executable, str(ROOT / "scripts/ci/check_workflow_control_plane.py"), "--root", str(ROOT), "--format", "json"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    report = json.loads(proc.stdout)
+    assert report["ok"] is True
+    assert report["workflow_count"] >= 1
+
+
+def test_entry_doc_links_pass_on_repo_root() -> None:
+    proc = subprocess.run(
+        [sys.executable, str(ROOT / "scripts/ci/check_entry_doc_links.py"), "--root", str(ROOT), "--format", "json"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    report = json.loads(proc.stdout)
+    assert report["ok"] is True
+    assert report["broken_count"] == 0
+
+
+def test_inventory_classes_are_known() -> None:
+    payload = json.loads((ROOT / "config/workflow-control-plane.v1.json").read_text())
+    allowed = {
+        "required_protection",
+        "fast_feedback",
+        "diagnostic",
+        "operator_command",
+        "historical_ballast",
+    }
+    for entry in payload["workflows"]:
+        assert entry["class"] in allowed


### PR DESCRIPTION
## Summary

Freigabefähiger Slice for **REPOGROUND-LEGACY-RECONCILIATION-V1-T005** on main after merge of #1125.

### Changes

1. **Task truth** — `docs/tasks/AUTHORITY.md` + board/`index.json` declare Bureau as the canonical lifecycle for `REPOGROUND-LEGACY-*`; `docs/tasks` is a repo-local historical projection only.
2. **CI control plane** — `config/workflow-control-plane.v1.json` classifies all **21** workflows (`required_protection` 7, `fast_feedback` 5, `diagnostic` 8, `operator_command` 1). Fail-closed checker in `lint`.
3. **Freshness** — entry-document link gate over the fixed operator entry set (0 broken links observed).
4. **Truth layers** — `docs/architecture/control-planes.md`.

### Validation

- `python scripts/ci/check_workflow_control_plane.py --root . --format json` → ok
- `python scripts/ci/check_entry_doc_links.py --root . --format json` → ok
- `pytest scripts/ci/tests/test_workflow_control_plane.py` → 3 passed

### Head / base

- Head: `350d1db950391ae806cdeb3b54dc5c6d517aedfd`
- Base: `origin/main` @ `fe1e82dd` (#1125)

### Does not establish

- Full proof archival / retrieval re-weight
- Removal of any workflow
- Parent T004 closeout
- Full T005 acceptance without follow-ups

### Bureau

Selected after `what-now` showed T004 ready but claim-blocked by open #1125; #1125 was merged first, then this free T005 slice.