### PR TITLE
fix(core): resolve symbol index source type hints

### DIFF
--- a/merger/repoground/core/symbol_index_access.py
+++ b/merger/repoground/core/symbol_index_access.py
@@ -12,6 +12,9 @@ from pathlib import Path
 from typing import Any
 
 from merger.repoground.core import artifact_source_access as _artifact_source_access
+from merger.repoground.core.bounded_artifact_read import (
+    LoadedArtifactSource as _LoadedArtifactSource,
+)
 from merger.repoground.core.bundle_roles import (
     DOES_NOT_ESTABLISH as _DOES_NOT_ESTABLISH,
     read_only_mutation_boundary as _read_only_mutation_boundary,

--- a/merger/repoground/tests/test_bundle_access_decomposition.py
+++ b/merger/repoground/tests/test_bundle_access_decomposition.py
@@ -4,17 +4,25 @@ import hashlib
 import json
 import os
 from pathlib import Path
+import typing
 
 import pytest
 
 from merger.repoground.core import artifact_source_access
 from merger.repoground.core import bundle_access
+from merger.repoground.core import symbol_index_access
 from merger.repoground.core.bounded_artifact_read import (
     MAX_REGISTERED_ARTIFACT_BYTES,
     _descriptor_read_size,
     read_stable_regular_file_bytes,
 )
 from merger.repoground.core.manifest_snapshot import MAX_MANIFEST_BYTES
+
+
+def test_symbol_index_source_type_hints_resolve() -> None:
+    hints = typing.get_type_hints(symbol_index_access._load_symbol_index_source)
+
+    assert "return" in hints
 
 
 def test_descriptor_read_size_tracks_observed_file_not_hard_cap() -> None:


### PR DESCRIPTION
## Problem
`typing.get_type_hints(symbol_index_access._load_symbol_index_source)` failed with `NameError: _LoadedArtifactSource is not defined`, because the extracted module retained the annotation without importing its runtime type.

## Fix
- import `LoadedArtifactSource` under the existing private alias
- add a regression test that resolves the function's runtime type hints

## Validation
- reproduction before fix: confirmed `NameError`
- focused: `22 passed`
- full suite: `5222 passed, 12 skipped`
- configured Ruff ratchet: PASS
- `git diff --check`: PASS
- revision-bound self-review at `68a311b782eeb10c292e34241f62c6f03711f48d`: PASS; no unrelated changes