### PR TITLE
fix(pythonista): resolve init path type hint

### DIFF
--- a/merger/repoground/frontends/pythonista/merger_ui_init.py
+++ b/merger/repoground/frontends/pythonista/merger_ui_init.py
@@ -6,6 +6,7 @@ Behavior is unchanged; methods remain bound via Mixin inheritance.
 """
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Dict, List, Optional
 
 BUILD_GLOBAL_NAMES = (

--- a/merger/repoground/tests/test_pythonista_runtime_type_hints.py
+++ b/merger/repoground/tests/test_pythonista_runtime_type_hints.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+import typing
+
+from merger.repoground.frontends.pythonista.merger_ui_init import MergerUIInitMixin
+
+
+def test_merger_ui_init_hub_type_hint_resolves_at_runtime() -> None:
+    hints = typing.get_type_hints(MergerUIInitMixin.__init__)
+
+    assert hints["hub"] is Path
+    assert hints["return"] is type(None)


### PR DESCRIPTION
## Fehler

`typing.get_type_hints(MergerUIInitMixin.__init__)` scheiterte auf dem aktuellen `main` mit `NameError: name 'Path' is not defined`. Die öffentliche Annotation `hub: Path` war wegen des fehlenden Laufzeitimports nicht auflösbar.

## Änderung

- `Path` wird im extrahierten Pythonista-Init-Mixin zur Laufzeit importiert.
- Ein Regressionstest bindet die aufgelösten `hub`- und Rückgabeannotationen.

## Prüfung

- Ruff check und format check für den Regressionstest
- Python-Compile-Check für Quell- und Testdatei
- fokussierter Pytest-Regressionstest
- direkter Laufzeitbeweis über `typing.get_type_hints()`
- `git diff --check`

Das Init-Mixin verwendet absichtlich zur Laufzeit injizierte Build-Globals und besitzt bereits vor dieser Änderung eine nicht isoliert lint-/formatierbare Legacy-Oberfläche. Der Diff bleibt deshalb auf den fehlenden Import und den Regressionstest begrenzt. Keine Änderung am UI-Verhalten, Schema oder an Autoritätsgrenzen.