### PR TITLE
Add compact RepoBrief fleet context profile

### DIFF
--- a/docs/operations/repobrief-publication-policy.md
+++ b/docs/operations/repobrief-publication-policy.md
@@ -151,3 +151,27 @@ Remove the pin with `unpin --record <record-path>`. Orphaned or malformed pin me
 The existing fleet publisher already computes a scoped content identity and skips unchanged successful publications. The policy module supplies the stronger durable reservation, anchor selection, pin, TTL and evidence/payload separation contract.
 
 RBV1-T026 is merged. This policy remains a separate control module and is not silently wired into the live fleet publisher by this change. Any production integration requires its own exact dry-run, payload-candidate binding and rollout evidence; this implementation performs no live retention by itself.
+
+## Daily fleet context profile
+
+Normal daily fleet publication uses `fleet-context` with `dual` output. The
+profile preserves canonical Markdown, the bundle manifest, the agent reading
+pack, citation map, chunk index, output and post-emit health, bundle-surface
+validation, and the export-safety report.
+
+The SQLite retrieval index, Python symbol index, and Python call graph are
+`profile_excluded`. The dual renderer creates the citation and chunk surfaces;
+profile finalization then removes those three heavy, regenerable indexes before
+publication. They remain available through the explicit `full-max` diagnostic
+profile, but are not duplicated in every daily fleet generation.
+The retrieval evaluation remains recommended rather than canonical truth.
+
+`vault-gewebe` remains on `agent-portable` with `dual` output. This exception
+prevents the daily migration from silently narrowing its existing security and
+agent contract.
+
+The migration changes only newly generated fleet payloads. Existing generations
+continue to follow the retention, pin, transaction, and crash-recovery contract
+above. Missing or stale citation, chunk, or health evidence remains a profile
+failure; the compact profile does not establish repository understanding,
+runtime causality, test sufficiency, or future consumer compatibility.

--- a/docs/proofs/repobrief-fleet-context-profile-v1-proof.md
+++ b/docs/proofs/repobrief-fleet-context-profile-v1-proof.md
@@ -1,0 +1,77 @@
+# RepoBrief Fleet Context Profile v1 Proof
+
+## Binding
+
+- Bureau task: `OPERATOR-ECOSYSTEM-REDUNDANCY-V1-T008`
+- Bureau run: `BUR-RUN-20260731T152008Z-287eff15d0`
+- RepoGround baseline: `f49a978e161797fb6a1740f5c9b723bb2ae054af`
+- Measurement summary SHA-256: `e2651cdd00fd5d849f46f43f971970bcc2d9e1ea3a6e15cad9025d776b9f1fdf`
+- Full receipt SHA-256: `59dd6445a65d560bb4a573cb67b744b226f092af12067a842bb371a3b59a9755`
+- Rejected archive receipt SHA-256: `2d1bb28679b6549d26d7ffb450169e6aa4966ab116b79e291c0d9ffce815a6c2`
+- Accepted compact receipt SHA-256: `45f34fa085583c371f01e0406c0919c1884f8605630a38231422e580da26de54`
+
+The implementation was produced in the Bureau-created isolated RepoGround worktree. The coordinated claim covered the publication component and the six exact source, test, policy, and proof paths. It did not authorize foreign-worktree cleanup, merge, or deployment.
+
+## Consumer boundary
+
+The pre-implementation inventory was bound to immutable consumer revisions:
+
+- `heimgewebe/grabowski` at `fdc9266016a07c27c86925976a4b56c17b0483c6`: the normal context-pack path binds manifest identity, freshness, health, cited query results, and bounded ranges. It does not require the raw canonical dump, SQLite index, Python symbol index, or Python call graph in the normal context path.
+- `heimgewebe/systemkatalog` at `f7c6ecd0ada80194a57e2bf84d46823ab20559b7`: no active direct reader of individual RepoBrief bundle sidecars was found.
+
+These observations are revision-bound. They do not establish future compatibility after either consumer changes.
+
+## Decision
+
+Ordinary daily fleet publication uses the agent-facing `fleet-context` profile with `dual` output. The dual renderer creates the citation map and chunk index. Profile finalization then removes these heavy, regenerable artifacts from the published surface:
+
+- `sqlite_index`
+- `python_symbol_index_json`
+- `python_call_graph_json`
+
+The compact profile still requires canonical Markdown, the bundle manifest, the agent reading pack, the citation map, the chunk index, output health, post-emit health, bundle-surface validation, and the export-safety report. The snapshot plan and retrieval evaluation remain recommended.
+
+`full-max` remains the explicit diagnostic path. `vault-gewebe` remains on `agent-portable` with `dual` output so this migration does not silently narrow its existing contract.
+
+## Rejected alternative
+
+The first candidate used `fleet-context` with `archive` output. The real receipt returned `fail` because both `citation_map_jsonl` and `chunk_index_jsonl` were missing required artifacts. That candidate was rejected without a commit. Storage reduction is not accepted when it weakens citation truth.
+
+## Same-repository storage measurement
+
+Both accepted runs used the same committed synthetic repository, source commit `e193aa630fc969609a776627fb2f7e6c02389a35`. The corpus contained 120 Python modules, 20 Markdown documents, and one README.
+
+| Variant | Published bytes | Profile result |
+|---|---:|---|
+| `full-max` / `dual` | 2,207,247 | `warn` because the recommended relation-card artifact was absent |
+| `fleet-context` / `dual` | 1,264,876 | `pass` |
+
+Measured effect:
+
+- saved bytes: **942,371**;
+- reduction: **42.6944%**;
+- required context roles preserved: canonical Markdown, manifest, agent pack, citation map, chunk index, all health controls, and export-safety report;
+- removed heavy artifacts: SQLite index, Python symbol index, and Python call graph.
+
+The accepted compact receipt listed the three removed files explicitly. Its profile evaluation reported no missing required or recommended artifacts and no excluded role still present.
+
+## Compatibility and migration
+
+The fleet publisher selects `fleet-context` only for new ordinary fleet publications. Existing generations remain governed by the existing retention, pin, transaction, and crash-recovery policy. This change deletes no existing published generation. Operators can still request `full-max` when SQLite or Python diagnostic indexes are needed.
+
+## Validation
+
+- focused profile and fleet-routing tests: `4 passed`;
+- broader profile, fleet, snapshot-CLI, and symbol-consumer tests: `142 passed`;
+- full repository suite: `5269 passed`, `12 skipped`, and three Web-UI cases timed out while loading `http://localhost:8000/`;
+- exact isolated rerun of those three Web-UI cases: `3 passed` without code changes;
+- repository-wide Ruff with `ruff-ci.toml`: passed;
+- Python compilation of the changed implementation files: passed;
+- `git diff --check`: passed;
+- real full-versus-compact snapshot generation: both accepted commands completed; compact profile `pass`.
+
+The three full-suite failures were outside the changed publication surface and shared the same `Page.goto` timeout. Their isolated rerun is evidence of a transient browser/static-server startup failure, not proof that the Web-UI tests can never be flaky.
+
+## Does not establish
+
+This proof does not establish search parity without SQLite, complete repository understanding, runtime causality, test sufficiency beyond the executed checks, absence of future consumer changes, a permanently non-flaky Web UI, full CI success, or merge readiness by itself.

--- a/merger/repoground/core/snapshot_profiles.py
+++ b/merger/repoground/core/snapshot_profiles.py
@@ -21,6 +21,7 @@ VALID_REQUIREMENTS = (REQ_REQUIRED, REQ_RECOMMENDED, REQ_OPTIONAL, REQ_NA, REQ_E
 PROFILE_LEVELS = {
     "local-private": "dev",
     "agent-portable": "max",
+    "fleet-context": "max",
     "full-max": "max",
     "pr-review": "dev",
     "security-export-review": "max",
@@ -41,6 +42,14 @@ PROFILE_EXPORT_SEMANTICS = {
         "exportable": True,
     },
     "agent-portable": {
+        "agent_facing": True,
+        "public_facing": False,
+        "redaction_required": True,
+        "post_emit_health_required": True,
+        "agent_export_gate_required": True,
+        "exportable": True,
+    },
+    "fleet-context": {
         "agent_facing": True,
         "public_facing": False,
         "redaction_required": True,
@@ -142,6 +151,14 @@ PROFILE_ARTIFACT_RULES = {
         "retrieval_eval_json": REQ_RECOMMENDED,
         "python_symbol_index_json": REQ_RECOMMENDED,
         "python_call_graph_json": REQ_RECOMMENDED,
+    },
+    "fleet-context": {
+        **BASE_RULES,
+        "sqlite_index": REQ_EXCLUDED,
+        "export_safety_report": REQ_REQUIRED,
+        "retrieval_eval_json": REQ_RECOMMENDED,
+        "python_symbol_index_json": REQ_EXCLUDED,
+        "python_call_graph_json": REQ_EXCLUDED,
     },
     "full-max": {
         **BASE_RULES,
@@ -303,6 +320,10 @@ PROFILE_DEFAULT_OUTPUT_MODES = {
     "public-share": "archive",
 }
 
+PROFILE_POST_EMIT_DROPPABLE_ROLES = {
+    "fleet-context": frozenset({"sqlite_index"}),
+}
+
 OUTPUT_MODE_ARTIFACT_ROLES = {
     "archive": frozenset(),
     "retrieval": frozenset({"sqlite_index"}),
@@ -320,18 +341,23 @@ def profile_output_mode_conflicts(profile: str, output_mode: str) -> tuple[str, 
         raise ValueError(f"unknown RepoGround output mode: {output_mode}")
     excluded = set(profile_excluded_roles(profile))
     produced = set(OUTPUT_MODE_ARTIFACT_ROLES[output_mode])
-    return tuple(sorted(excluded & produced))
+    droppable = set(PROFILE_POST_EMIT_DROPPABLE_ROLES.get(profile, ()))
+    return tuple(sorted((excluded & produced) - droppable))
 
 
 def profile_output_mode_plan(profile: str, requested_output_mode: str | None = None) -> dict[str, Any]:
     selected_output_mode = requested_output_mode or profile_default_output_mode(profile)
     conflicts = profile_output_mode_conflicts(profile, selected_output_mode)
+    excluded_roles = set(profile_excluded_roles(profile))
+    produced_roles = set(OUTPUT_MODE_ARTIFACT_ROLES[selected_output_mode])
+    droppable_roles = set(PROFILE_POST_EMIT_DROPPABLE_ROLES.get(profile, ()))
     return {
         "profile": profile,
         "requested_output_mode": requested_output_mode,
         "selected_output_mode": selected_output_mode,
         "defaulted": requested_output_mode is None,
         "conflicts": list(conflicts),
-        "excluded_roles": list(profile_excluded_roles(profile)),
-        "conflict_candidate_roles": sorted(OUTPUT_MODE_ARTIFACT_ROLES[selected_output_mode]),
+        "excluded_roles": [role for role in ARTIFACT_ORDER if role in excluded_roles],
+        "conflict_candidate_roles": sorted(produced_roles),
+        "post_emit_dropped_roles": sorted(excluded_roles & produced_roles & droppable_roles),
     }

--- a/merger/repoground/tests/test_fleet_runtime.py
+++ b/merger/repoground/tests/test_fleet_runtime.py
@@ -44,6 +44,31 @@ def load_publisher() -> ModuleType:
     return module
 
 
+def test_publication_config_uses_compact_daily_profile(tmp_path: Path) -> None:
+    module = load_publisher()
+    default = module.RepoEntry(
+        key="heimgewebe/demo",
+        owner="heimgewebe",
+        repo="demo",
+        path=tmp_path / "demo",
+        remote="git@github.com:heimgewebe/demo.git",
+    )
+    vault = module.RepoEntry(
+        key="heimgewebe/vault-gewebe",
+        owner="heimgewebe",
+        repo="vault-gewebe",
+        path=tmp_path / "vault-gewebe",
+        remote="git@github.com:heimgewebe/vault-gewebe.git",
+    )
+
+    assert module.publication_config(default) == module.PublicationConfig(
+        profile="fleet-context"
+    )
+    assert module.publication_config(vault) == module.PublicationConfig(
+        profile="agent-portable"
+    )
+
+
 def allow_no_active_managed_build_leases(
     module: ModuleType, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/merger/repoground/tests/test_snapshot_profiles.py
+++ b/merger/repoground/tests/test_snapshot_profiles.py
@@ -15,6 +15,7 @@ def test_all_profiles_are_machine_readable_and_complete():
     assert set(profile_names()) == {
         "local-private",
         "agent-portable",
+        "fleet-context",
         "full-max",
         "pr-review",
         "security-export-review",
@@ -99,6 +100,48 @@ def test_profile_rules_match_expected_high_signal_requirements():
     assert PROFILE_ARTIFACT_RULES["local-private"]["citation_map_jsonl"] == "optional"
 
 
+def test_fleet_context_preserves_citation_truth_without_heavy_indexes():
+    rules = PROFILE_ARTIFACT_RULES["fleet-context"]
+
+    assert rules["citation_map_jsonl"] == "required"
+    assert rules["chunk_index_jsonl"] == "required"
+    assert rules["export_safety_report"] == "required"
+    assert rules["retrieval_eval_json"] == "recommended"
+    assert rules["sqlite_index"] == "profile_excluded"
+    assert rules["python_symbol_index_json"] == "profile_excluded"
+    assert rules["python_call_graph_json"] == "profile_excluded"
+
+
+def test_fleet_context_accepts_the_compact_surface_and_rejects_heavy_indexes():
+    compact_roles = {
+        "canonical_md",
+        "bundle_manifest",
+        "agent_reading_pack",
+        "citation_map_jsonl",
+        "chunk_index_jsonl",
+        "output_health",
+        "post_emit_health",
+        "bundle_surface_validation",
+        "export_safety_report",
+        "snapshot_plan_json",
+        "retrieval_eval_json",
+    }
+
+    compact = evaluate_profile("fleet-context", compact_roles)
+    assert compact["status"] == "pass"
+    assert compact["missing_required"] == []
+    assert compact["profile_excluded_present"] == []
+
+    for role in (
+        "sqlite_index",
+        "python_symbol_index_json",
+        "python_call_graph_json",
+    ):
+        invalid = evaluate_profile("fleet-context", compact_roles | {role})
+        assert invalid["status"] == "fail"
+        assert invalid["profile_excluded_present"] == [role]
+
+
 def test_profile_output_mode_plan_is_machine_readable():
     public_default = profile_output_mode_plan("public-share")
     assert public_default["selected_output_mode"] == "archive"
@@ -114,6 +157,23 @@ def test_profile_output_mode_plan_is_machine_readable():
     assert public_dual["selected_output_mode"] == "dual"
     assert public_dual["defaulted"] is False
     assert public_dual["conflicts"] == ["sqlite_index"]
+
+    fleet_default = profile_output_mode_plan("fleet-context")
+    assert fleet_default["selected_output_mode"] == "dual"
+    assert fleet_default["defaulted"] is True
+    assert fleet_default["conflicts"] == []
+    assert fleet_default["excluded_roles"] == [
+        "sqlite_index",
+        "python_symbol_index_json",
+        "python_call_graph_json",
+    ]
+    assert fleet_default["post_emit_dropped_roles"] == ["sqlite_index"]
+
+    fleet_archive = profile_output_mode_plan("fleet-context", "archive")
+    assert fleet_archive["selected_output_mode"] == "archive"
+    assert fleet_archive["defaulted"] is False
+    assert fleet_archive["conflicts"] == []
+    assert fleet_archive["post_emit_dropped_roles"] == []
 
     agent_default = profile_output_mode_plan("agent-portable")
     assert agent_default["selected_output_mode"] == "dual"

--- a/scripts/ops/repoground-publish-fleet
+++ b/scripts/ops/repoground-publish-fleet
@@ -396,8 +396,9 @@ def safe_segment(raw: str) -> str:
 
 
 def publication_config(entry: RepoEntry) -> PublicationConfig:
-    profile = "agent-portable" if entry.repo == "vault-gewebe" else "full-max"
-    return PublicationConfig(profile=profile)
+    if entry.repo == "vault-gewebe":
+        return PublicationConfig(profile="agent-portable")
+    return PublicationConfig(profile="fleet-context")
 
 
 def publication_repository(entry: RepoEntry) -> str:


### PR DESCRIPTION
## Änderung

- führt das agentenfähige Profil `fleet-context` für normale tägliche Fleet-Publikationen ein
- erhält Markdown, Manifest, Agenten-Lesepass, Zitierkarte, Chunk-Index und Gesundheits-/Exportbelege
- entfernt nach der `dual`-Erzeugung nur SQLite-Index, Python-Symbolindex und Python-Call-Graph aus der veröffentlichten Profilfläche
- belässt `full-max` als Diagnosepfad und `vault-gewebe` unverändert auf `agent-portable`
- ergänzt Profil-, Routing-, Policy- und Messbelege

## Verworfener Alternativpfad

`archive` wäre kleiner, entfernte im realen Lauf aber auch Zitierkarte und Chunk-Index. Die Profilprüfung schlug deshalb korrekt fehl. Dieser Entwurf wurde verworfen; der PR nutzt `dual` plus kontrollierte Profilbereinigung.

## Gemessene Wirkung

Dasselbe synthetische, committed Repository wurde mit beiden Profilen erzeugt:

- `full-max/dual`: 2.207.247 Byte
- `fleet-context/dual`: 1.264.876 Byte
- Einsparung: 942.371 Byte beziehungsweise 42,6944 %

Der kompakte Receipt meldet `pass`, behält alle erforderlichen Kontextrollen und listet exakt die drei entfernten schweren Indizes.

## Validierung

- fokussiert: 4 Tests bestanden
- betroffene Profil-/Fleet-/Snapshot-/Symbolflächen: 142 Tests bestanden
- vollständige Suite: 5.269 bestanden, 12 übersprungen; drei Web-UI-Fälle scheiterten gemeinsam an einem `Page.goto`-Timeout gegen `localhost:8000`
- exakter isolierter Wiederholungslauf dieser drei Fälle: 3 bestanden, ohne Codeänderung
- repo-weites Ruff: bestanden
- Python-Kompilierung: bestanden
- `git diff --check`: bestanden

## Bindung

- Bureau-Task: `OPERATOR-ECOSYSTEM-REDUNDANCY-V1-T008`
- Bureau-Run: `BUR-RUN-20260731T152008Z-287eff15d0`
- geprüfter Head: `288ced5fcc46d25e91cb671e103e6cd8d0382289`
- Basis: `f49a978e161797fb6a1740f5c9b723bb2ae054af`
- Umfang: exakt sechs geleaste Quell-, Test-, Policy- und Belegpfade
