### PR TITLE
fix(docs): use RepoGround for fleet context proof

### DIFF
--- a/docs/proofs/repoground-fleet-context-profile-v1-proof.md
+++ b/docs/proofs/repoground-fleet-context-profile-v1-proof.md
@@ -1,4 +1,4 @@
-# RepoBrief Fleet Context Profile v1 Proof
+# RepoGround Fleet Context Profile v1 Proof
 
 ## Binding
 
@@ -17,7 +17,7 @@ The implementation was produced in the Bureau-created isolated RepoGround worktr
 The pre-implementation inventory was bound to immutable consumer revisions:
 
 - `heimgewebe/grabowski` at `fdc9266016a07c27c86925976a4b56c17b0483c6`: the normal context-pack path binds manifest identity, freshness, health, cited query results, and bounded ranges. It does not require the raw canonical dump, SQLite index, Python symbol index, or Python call graph in the normal context path.
-- `heimgewebe/systemkatalog` at `f7c6ecd0ada80194a57e2bf84d46823ab20559b7`: no active direct reader of individual RepoBrief bundle sidecars was found.
+- `heimgewebe/systemkatalog` at `f7c6ecd0ada80194a57e2bf84d46823ab20559b7`: no active direct reader of individual RepoGround bundle sidecars was found.
 
 These observations are revision-bound. They do not establish future compatibility after either consumer changes.
 

--- a/tests/test_naming_hard_cut.py
+++ b/tests/test_naming_hard_cut.py
@@ -97,6 +97,16 @@ def test_active_repository_has_no_runtime_aliases() -> None:
     assert scan_repository(ROOT) == []
 
 
+def test_new_fleet_context_proof_uses_current_product_name() -> None:
+    current = ROOT / "docs/proofs/repoground-fleet-context-profile-v1-proof.md"
+    former = ROOT / "docs/proofs/repobrief-fleet-context-profile-v1-proof.md"
+
+    assert current.is_file()
+    assert not former.exists()
+    proof = current.read_text(encoding="utf-8")
+    assert proof.startswith("# RepoGround Fleet Context Profile v1 Proof\n")
+    assert "RepoBrief" not in proof
+
 
 def test_protected_compatibility_contract_is_terminal_only() -> None:
     path = ROOT / "docs/contracts/repoground-compatibility-exit.v1.json"


### PR DESCRIPTION
## Summary
- rename the newly introduced fleet-context proof from the former product name to RepoGround
- update the proof heading and current consumer prose
- add a naming-hard-cut regression test for the canonical path and title

## Validation
- `python3 -m pytest tests/test_naming_hard_cut.py merger/repoground/tests/test_naming_doc.py merger/repoground/tests/test_naming_audit.py tests/test_repository_hygiene.py -q` — 42 passed
- `python3 -m ruff check tests/test_naming_hard_cut.py` — passed
- `git diff --check` — passed

## Revision-bound self-review
Reviewed commit `106d673e`. The change is limited to a 97%-similarity proof rename, two current product-name substitutions, and an exact regression guard. Historical proofs and persisted `repobrief.*` contract identities are unchanged. Git rename history preserves the original T008 evidence lineage.