### PR TITLE
fix(repoground): finish publication policy naming cut

### DIFF
--- a/docs/operations/repoground-publication-policy.md
+++ b/docs/operations/repoground-publication-policy.md
@@ -1,6 +1,6 @@
 # RepoGround publication policy
 
-`rb-publication-policy` manages the durable identity and retention contract for RepoGround publications. It does not generate RepoGround bundles itself. The publisher reserves a generation before writing payload data, completes the durable record after validating the bundle manifest, and runs retention through an explicit dry-run/apply cycle.
+`repoground-publication-policy` manages the durable identity and retention contract for RepoGround publications. It does not generate RepoGround bundles itself. The publisher reserves a generation before writing payload data, completes the durable record after validating the bundle manifest, and runs retention through an explicit dry-run/apply cycle.
 
 ## Storage separation
 
@@ -14,13 +14,15 @@ The policy refuses nested or identical roots. Retention removes only a validated
 Default roots:
 
 ```text
-Evidence: ~/.local/state/repobrief-publication-policy
+Evidence: ~/.local/state/repoground-publication-policy
 Payload:  ~/repos/manifest-publications
 ```
 
-Override them with `--evidence-root`, `--payload-root`, `RB_PUBLICATION_EVIDENCE_ROOT` or `RB_PUBLICATION_PAYLOAD_ROOT`.
+Override them with `--evidence-root`, `--payload-root`, `REPOGROUND_PUBLICATION_EVIDENCE_ROOT` or `REPOGROUND_PUBLICATION_PAYLOAD_ROOT`.
 
 ## Canonical identity
+
+Persisted v1 publication records intentionally retain their historical `repobrief.*` schema identities and the `lenskit_version` field. These are versioned data contracts, not active product aliases. New commands, environment variables, documentation paths, and default state locations use RepoGround terminology; existing record bytes are not rewritten by this naming migration.
 
 A publication identity contains:
 
@@ -38,13 +40,13 @@ The canonical JSON representation is hashed with SHA-256. `begin` is serialized 
 Compute an identity:
 
 ```bash
-scripts/ops/rb-publication-policy identity \
-  --repository heimgewebe__lenskit \
+scripts/ops/repoground-publication-policy identity \
+  --repository heimgewebe__repoground \
   --lane main \
   --repository-commit "$COMMIT" \
   --profile full-max \
   --configuration-sha256 "$CONFIG_SHA256" \
-  --lenskit-version "$LENSKIT_VERSION" \
+  --repoground-version "$REPOGROUND_VERSION" \
   --bundle-schema repobrief.bundle.v1 \
   --generator-inputs-sha256 "$GENERATOR_SHA256"
 ```
@@ -54,9 +56,9 @@ scripts/ops/rb-publication-policy identity \
 Reserve the intended payload path before generation:
 
 ```bash
-scripts/ops/rb-publication-policy begin \
+scripts/ops/repoground-publication-policy begin \
   [identity arguments] \
-  --payload /managed/payload/root/heimgewebe__lenskit/main/<generation>
+  --payload /managed/payload/root/heimgewebe__repoground/main/<generation>
 ```
 
 The result is one of:
@@ -68,7 +70,7 @@ The result is one of:
 After generation and bundle validation, complete the record:
 
 ```bash
-scripts/ops/rb-publication-policy complete \
+scripts/ops/repoground-publication-policy complete \
   --record <record-path> \
   --manifest <payload-path>/<bundle-manifest>
 ```
@@ -90,8 +92,8 @@ The values 3/7/8 and 48 hours are minimums, not merely defaults: CLI input and e
 Create a dry-run plan:
 
 ```bash
-scripts/ops/rb-publication-policy plan \
-  --repository heimgewebe__lenskit \
+scripts/ops/repoground-publication-policy plan \
+  --repository heimgewebe__repoground \
   --lane main \
   --output /safe/path/retention-plan.json
 ```
@@ -107,7 +109,7 @@ The plan binds every candidate to:
 Review the plan, then apply exactly its embedded hash:
 
 ```bash
-scripts/ops/rb-publication-policy apply \
+scripts/ops/repoground-publication-policy apply \
   --plan /safe/path/retention-plan.json \
   --expected-plan-sha256 <plan-sha256>
 ```
@@ -121,8 +123,8 @@ Apply journals each candidate before moving it. The payload is atomically rename
 Interrupted transactions are recovered with:
 
 ```bash
-scripts/ops/rb-publication-policy reconcile \
-  --repository heimgewebe__lenskit \
+scripts/ops/repoground-publication-policy reconcile \
+  --repository heimgewebe__repoground \
   --lane main
 ```
 
@@ -139,7 +141,7 @@ Reconciliation is idempotent:
 Pin a record with an explicit reason:
 
 ```bash
-scripts/ops/rb-publication-policy pin \
+scripts/ops/repoground-publication-policy pin \
   --record <record-path> \
   --reason "release comparison baseline"
 ```

--- a/docs/proofs/repoground-publication-policy-naming-v1-proof.md
+++ b/docs/proofs/repoground-publication-policy-naming-v1-proof.md
@@ -1,0 +1,165 @@
+# RepoGround publication-policy naming v1 — proof and cutover contract
+
+Bureau task: `REPOGROUND-LEGACY-RECONCILIATION-V1-T021`
+
+Authoritative Bureau run: `BUR-RUN-20260801T010609Z-887777f424`
+
+Repository baseline: `c11446cb7bdf0c166f804fd71f89786bf8ea5396`
+
+Adopted implementation source: `8cf18c930f024cc6950f539d3d1acd76aec8c8a3`
+
+Claim-branch implementation commit before this proof: `507c48ff7a766453241361757106b771b3e118fd`
+
+## Claim proved by this change
+
+The active publication-policy surface uses RepoGround names for the command,
+documentation path, environment variables, version option, and default evidence
+root. Existing persisted v1 records intentionally keep their historical
+`repobrief.*` schema identifiers and the `lenskit_version` field. The naming cut
+does not rewrite existing records, manifests, payloads, or historical proofs.
+
+## Recovery provenance
+
+The first coordinated run, `BUR-RUN-20260731T212630Z-f4ac5418b3`, adopted the
+same implementation tree and wrote the initial proof draft. Its worker stopped
+without terminalising the run; the leases later expired and no process or open
+RepoGround pull request remained. Before recovery, its dirty worktree was bound
+to explicit retention at exact head
+`507c48ff7a766453241361757106b771b3e118fd`. The run was then marked `failed`
+with the stale-worker reason, and its unchanged leases were released through
+the coordinated pickup release contract.
+
+The current run re-claimed T021 after that terminal readback. Commits
+`8cf18c930f024cc6950f539d3d1acd76aec8c8a3` and
+`507c48ff7a766453241361757106b771b3e118fd` have the same parent and the same
+Git tree `aae3be5f7a7bb6c1ba39953898cc1f9a170441cb`; their direct diff is empty.
+The current branch therefore fast-forwarded to the exact previously tested
+implementation instead of recreating or rewriting it.
+
+This recovery does not make the predecessor worktree disposable and does not
+transfer authority from its uncommitted bytes. It remains retained until the
+current run is terminal and its result is independently readable.
+
+## Bound pre-cutover inventory
+
+The first inventory was read while the predecessor run held the command paths,
+both state roots, the publication component, and the fleet timer. It established:
+
+- `~/.local/bin/rb-publication-policy` was a regular, non-symlink file with
+  SHA-256 `64278d6fe48b95931f7c75386004694ef3cf9c02aa4bef7f5e18b035cf90f68c`
+  and contained the exact retirement marker
+  `rb-publication-policy is deprecated; use repoground-publication-policy`.
+- `~/.local/bin/repoground-publication-policy` was a regular file with SHA-256
+  `0d61e95897f6cc67cc98e7a5007872961a1dbc54a0cfc88c42f809e1390b096a`.
+- Neither `~/.local/state/repobrief-publication-policy` nor
+  `~/.local/state/repoground-publication-policy` existed.
+- No matching `rb-publication-policy` or `repoground-publication-policy`
+  process was active in the bounded process read.
+- No user-systemd unit referenced either publication-policy command; the only
+  matching live file was the installed retirement delegate itself.
+- `repoground-publish-fleet-watch.timer` was loaded, enabled, active and
+  waiting, with `Result=success`.
+
+Because this observation predates the current run, it is historical evidence,
+not current host truth. The current run must repeat the bounded command, state,
+process and timer inventory immediately before the post-merge installer effect.
+Neither inventory proves that no unknown future or external consumer exists.
+
+## Repository changes
+
+- The current operations document is
+  `docs/operations/repoground-publication-policy.md`; the former active document
+  path is removed.
+- `repoground-publication-policy` defaults new evidence to
+  `~/.local/state/repoground-publication-policy` and accepts only the current
+  `REPOGROUND_PUBLICATION_*` overrides and `--repoground-version` surface.
+- The installer validates old and new publisher and publication-policy roots
+  before stopping units. It rejects symlinks, non-directories, and dual truth.
+- A sole historical publication-policy directory is moved to the RepoGround
+  path without rewriting its contents. The target is created with mode `0700`.
+- The canonical command is installed before the known retirement delegate is
+  removed. An unknown file, symlink, or non-regular object at the legacy command
+  path fails closed before any service effect.
+- Naming audits now detect the retired command and state-root surface in live
+  process and configuration inventories.
+
+## Migration decision for the observed host
+
+Both publication-policy state roots were absent in the initial inventory. The
+current pre-effect readback must confirm whether this remains true. If so, the
+live cutover must not claim a data migration: the installer creates the
+canonical RepoGround root and removes only the hash-observed retirement
+delegate after installing the canonical command. It must be invoked with
+`--enable` only if the fresh timer readback still shows the timer enabled and
+active.
+
+Repository tests separately cover the old-root-only migration and prove byte
+preservation for a persisted record containing
+`repobrief.publication-record.v1` and `lenskit_version`. They also cover dual
+roots and an unknown legacy command as pre-effect failures.
+
+## Persisted identity boundary
+
+The active CLI option `--repoground-version` continues to populate the persisted
+`lenskit_version` field. Existing `repobrief.*` bundle and record schema IDs
+remain versioned data identities. This change does not establish a new data
+schema version and grants no permission to rename or rewrite persisted v1 data.
+
+## Verification receipts
+
+Predecessor-run focused verification on implementation commit `507c48ff`:
+
+- command: `python3 -m pytest -q merger/repoground/tests/test_publication_policy.py merger/repoground/tests/test_fleet_runtime.py merger/repoground/tests/test_naming_audit.py tests/test_naming_hard_cut.py`
+- result: `159 passed in 15.59s`
+- durable job: `grabowski-job-1be92d63690a`
+- finalization receipt SHA-256:
+  `67d535d7b8817c26df7996ace7a3083013d40ec65a896738a9811f44d9beeb99`
+
+Current-run verification on the proof-bearing working tree:
+
+- affected suite: `168 passed in 16.15s`;
+- Ruff: `All checks passed!`;
+- staged-diff whitespace check: passed;
+- installer shell syntax job: `grabowski-job-6f03e32b7935`, succeeded with
+  finalization receipt SHA-256
+  `2d005d29be7f9c46bc2c184bc466be473e2a5b9dcfa3f0c45f41c3080677b5e9`;
+- full suite job: `grabowski-job-63a15bf9a87b`;
+- full suite result: `5282 passed, 12 skipped in 195.72s`;
+- full-suite finalization receipt SHA-256:
+  `f48440a94354b11039ba848bf7f0253c90588a50482d7badba53b2882a25020a`.
+
+GitHub CI, merge and live installation remain separate revision-bound gates and
+are not predeclared successful here.
+
+## Post-merge cutover and readback
+
+1. Re-read the exact merged commit and the four host paths above.
+2. Re-read matching processes, systemd references and the fleet timer state.
+3. Preserve the observed enabled/disabled timer policy; use `--enable` only
+   when the fresh pre-effect state is enabled and active.
+4. Run `scripts/ops/install_repoground_publish_fleet_runtime.sh` from the exact
+   merged checkout with the preserved timer policy.
+5. Verify the canonical installed command matches the merged source.
+6. Verify the former wrapper and former state root are absent.
+7. Verify the canonical state root is a non-symlink directory with mode `0700`.
+8. Verify the fleet timer retains its prior enabled policy and is healthy; when
+   enabled it must be loaded, active and waiting with a successful result.
+9. Record exact before/after hashes and systemd readback in the Bureau run
+   evidence before terminalising the task.
+
+## Rollback boundary
+
+Revert the exact implementation merge and reinstall the prior canonical runtime
+from a bound checkout. If a historical policy root was moved, stop the timer and
+move the same unchanged directory back only when the canonical path is the sole
+root and the historical path is absent. Any dual-root, symlink, type, ownership,
+or content ambiguity fails closed for manual review. Historical records and
+proofs must not be rewritten or deleted.
+
+## Nonclaims
+
+This proof does not establish global absence of unknown consumers, future
+consumer compatibility, permission to modify foreign worktrees, permission to
+rewrite historical evidence, automatic schema migration, task completion,
+merge readiness, successful live installation, or permission to delete the
+retained predecessor worktree.

--- a/docs/proofs/repoground-publication-policy-naming-v1-proof.md
+++ b/docs/proofs/repoground-publication-policy-naming-v1-proof.md
@@ -77,9 +77,11 @@ Neither inventory proves that no unknown future or external consumer exists.
   before stopping units. It rejects symlinks, non-directories, and dual truth.
 - A sole historical publication-policy directory is moved to the RepoGround
   path without rewriting its contents. The target is created with mode `0700`.
-- The canonical command is installed before the known retirement delegate is
-  removed. An unknown file, symlink, or non-regular object at the legacy command
-  path fails closed before any service effect.
+- The canonical command is installed before the retirement delegate is
+  removed. Removal requires the exact pre-cutover SHA-256
+  `64278d6fe48b95931f7c75386004694ef3cf9c02aa4bef7f5e18b035cf90f68c`;
+  the marker text alone is insufficient. An unknown file, marker-spoofing file,
+  symlink, or non-regular object fails closed before any service effect.
 - Naming audits now detect the retired command and state-root surface in live
   process and configuration inventories.
 
@@ -96,7 +98,8 @@ active.
 Repository tests separately cover the old-root-only migration and prove byte
 preservation for a persisted record containing
 `repobrief.publication-record.v1` and `lenskit_version`. They also cover dual
-roots and an unknown legacy command as pre-effect failures.
+roots, an unknown legacy command, and a marker-spoofing file as pre-effect
+failures.
 
 ## Persisted identity boundary
 
@@ -115,18 +118,19 @@ Predecessor-run focused verification on implementation commit `507c48ff`:
 - finalization receipt SHA-256:
   `67d535d7b8817c26df7996ace7a3083013d40ec65a896738a9811f44d9beeb99`
 
-Current-run verification on the proof-bearing working tree:
+Current-run verification after the digest-bound wrapper hardening:
 
-- affected suite: `168 passed in 16.15s`;
+- focused wrapper identity tests: `4 passed, 85 deselected`;
+- affected suite: `169 passed in 15.84s`;
 - Ruff: `All checks passed!`;
 - staged-diff whitespace check: passed;
-- installer shell syntax job: `grabowski-job-6f03e32b7935`, succeeded with
+- installer shell syntax job: `grabowski-job-a4cf9ed6ac29`, succeeded with
   finalization receipt SHA-256
-  `2d005d29be7f9c46bc2c184bc466be473e2a5b9dcfa3f0c45f41c3080677b5e9`;
-- full suite job: `grabowski-job-63a15bf9a87b`;
-- full suite result: `5282 passed, 12 skipped in 195.72s`;
+  `fcde9501b7459c50ad6b73b189555bacf68b972b383c89aae244636f6d8b5d35`;
+- full suite job: `grabowski-job-f71a24724fb0`;
+- full suite result: `5283 passed, 12 skipped in 196.45s`;
 - full-suite finalization receipt SHA-256:
-  `f48440a94354b11039ba848bf7f0253c90588a50482d7badba53b2882a25020a`.
+  `b9f49b048a4cae9e098efdf1ec5c77b5723ef7d97bf1f5f17773ea6f81fe6983`.
 
 GitHub CI, merge and live installation remain separate revision-bound gates and
 are not predeclared successful here.

--- a/merger/repoground/core/naming_audit.py
+++ b/merger/repoground/core/naming_audit.py
@@ -31,7 +31,7 @@ SOURCE_SUFFIXES = {".py", ".sh", ".js", ".html"}
 # intentionally not scanned here: retired names remain valid evidence there.
 ACTIVE_GUIDANCE_PATHS: tuple[str, ...] = (
     "docs/operations/repobrief-fleet-retention.md",
-    "docs/operations/repobrief-publication-policy.md",
+    "docs/operations/repoground-publication-policy.md",
     "docs/sync/metarepo-sync.md",
     "docs/architecture/heimgewebe-infra-role.md",
     "docs/adr/001-secure-fs-navigation.md",
@@ -132,6 +132,7 @@ def _external_alias_patterns() -> dict[str, tuple[str, ...]]:
             "repo" + "brief-mcp-stdio.py",
             "r" + "lens-client",
             "r" + "lens-launcher.sh",
+            "r" + "b-publication-policy",
         ),
         "former-resource-scheme": ("repo" + "brief://",),
         "former-environment": (
@@ -149,6 +150,7 @@ def _external_alias_patterns() -> dict[str, tuple[str, ...]]:
             ".repo" + "Lens-state.json",
             ".repo" + "lens/pr-schau",
             "/.local/state/" + "repobrief-publish/",
+            "/.local/state/" + "repobrief-publication-policy",
             "/logs/" + "repobrief-publish",
             "." + "rb-prune-quarantine",
         ),
@@ -195,6 +197,7 @@ def _is_prompt_process(argv: list[str]) -> bool:
 def _matched_process_aliases(argv: list[str]) -> list[str]:
     matches: set[str] = set()
     former_command = "repo" + "brief"
+    former_publication_command = "r" + "b-publication-policy"
     prompt_process = _is_prompt_process(argv)
     skip_next_as_prompt = False
     for token in argv:
@@ -213,11 +216,11 @@ def _matched_process_aliases(argv: list[str]) -> list[str]:
         # or path token and therefore must not block a live cutover.
         if prompt_process and any(character.isspace() for character in token):
             continue
-        if token == former_command:
+        if token in {former_command, former_publication_command}:
             matches.add("former-command-alias")
         matches.update(_matched_external_aliases(token))
         basename = Path(token).name
-        if basename == former_command:
+        if basename in {former_command, former_publication_command}:
             matches.add("former-command-alias")
         matches.update(_matched_external_aliases(basename))
     return sorted(matches)

--- a/merger/repoground/tests/test_fleet_runtime.py
+++ b/merger/repoground/tests/test_fleet_runtime.py
@@ -2840,3 +2840,111 @@ def test_idempotent_second_run_does_not_publish_or_create_bundle(
     assert second["publication_dir"] == first["publication_dir"]
     assert second["provenance"]["freshness"]["status"] == "fresh"
     assert second["provenance"]["freshness"]["live_recheck_required"] is False
+
+def _fake_systemctl_environment(tmp_path: Path, home: Path) -> tuple[dict[str, str], Path]:
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    log = tmp_path / "systemctl.log"
+    systemctl = fake_bin / "systemctl"
+    systemctl.write_text(
+        "#!/usr/bin/env bash\n"
+        "printf '%s\\n' \"$*\" >> \"$SYSTEMCTL_LOG\"\n",
+        encoding="utf-8",
+    )
+    systemctl.chmod(0o755)
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "HOME": str(home),
+            "PATH": f"{fake_bin}:{environment['PATH']}",
+            "SYSTEMCTL_LOG": str(log),
+        }
+    )
+    return environment, log
+
+
+def test_runtime_installer_migrates_publication_policy_state_and_removes_wrapper(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    old_root = home / ".local/state/repobrief-publication-policy"
+    new_root = home / ".local/state/repoground-publication-policy"
+    old_root.mkdir(parents=True)
+    record = old_root / "records/example.json"
+    record.parent.mkdir()
+    original = b'{"schema":"repobrief.publication-record.v1","lenskit_version":"3.0.0"}\n'
+    record.write_bytes(original)
+
+    bin_dir = home / ".local/bin"
+    bin_dir.mkdir(parents=True)
+    legacy = bin_dir / "rb-publication-policy"
+    legacy.write_text(
+        "#!/usr/bin/env python3\n"
+        'print("rb-publication-policy is deprecated; use repoground-publication-policy")\n',
+        encoding="utf-8",
+    )
+    legacy.chmod(0o755)
+    environment, _ = _fake_systemctl_environment(tmp_path, home)
+
+    completed = subprocess.run(
+        [str(INSTALLER)],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        env=environment,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert not old_root.exists()
+    assert (new_root / "records/example.json").read_bytes() == original
+    assert new_root.stat().st_mode & 0o777 == 0o700
+    assert (bin_dir / "repoground-publication-policy").is_file()
+    assert not legacy.exists()
+
+
+def test_runtime_installer_rejects_dual_publication_policy_state_roots(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    (home / ".local/state/repobrief-publication-policy").mkdir(parents=True)
+    (home / ".local/state/repoground-publication-policy").mkdir(parents=True)
+    environment, systemctl_log = _fake_systemctl_environment(tmp_path, home)
+
+    completed = subprocess.run(
+        [str(INSTALLER)],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        env=environment,
+    )
+
+    assert completed.returncode == 1
+    assert "refusing dual truth" in completed.stderr
+    assert not systemctl_log.exists()
+
+
+def test_runtime_installer_rejects_unknown_legacy_publication_command(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    legacy = home / ".local/bin/rb-publication-policy"
+    legacy.parent.mkdir(parents=True)
+    legacy.write_text("#!/bin/sh\necho unrelated\n", encoding="utf-8")
+    legacy.chmod(0o755)
+    environment, systemctl_log = _fake_systemctl_environment(tmp_path, home)
+
+    completed = subprocess.run(
+        [str(INSTALLER)],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        env=environment,
+    )
+
+    assert completed.returncode == 1
+    assert "unknown file at legacy publication-policy command path" in completed.stderr
+    assert legacy.is_file()
+    assert not systemctl_log.exists()

--- a/merger/repoground/tests/test_fleet_runtime.py
+++ b/merger/repoground/tests/test_fleet_runtime.py
@@ -31,6 +31,32 @@ LEGACY_SYSTEMKATALOG_WATCH = (
     ROOT / "scripts/ops/repobrief-publish-systemkatalog-main-if-changed"
 )
 UNIT_DIR = ROOT / "ops/systemd/repoground-fleet"
+LEGACY_PUBLICATION_POLICY_WRAPPER = '''#!/usr/bin/env python3
+"""Deprecated RepoBrief publication-policy entry point.
+
+Use ``repoground-publication-policy``. This delegate remains during RepoGround
+3.x so existing automation continues to execute the same implementation.
+"""
+
+from __future__ import annotations
+
+import runpy
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    target = Path(__file__).with_name("repoground-publication-policy")
+    print(
+        "rb-publication-policy is deprecated; use repoground-publication-policy",
+        file=sys.stderr,
+    )
+    runpy.run_path(str(target), run_name="__main__")
+
+
+if __name__ == "__main__":
+    main()
+'''
 
 
 def load_publisher() -> ModuleType:
@@ -2878,11 +2904,7 @@ def test_runtime_installer_migrates_publication_policy_state_and_removes_wrapper
     bin_dir = home / ".local/bin"
     bin_dir.mkdir(parents=True)
     legacy = bin_dir / "rb-publication-policy"
-    legacy.write_text(
-        "#!/usr/bin/env python3\n"
-        'print("rb-publication-policy is deprecated; use repoground-publication-policy")\n',
-        encoding="utf-8",
-    )
+    legacy.write_text(LEGACY_PUBLICATION_POLICY_WRAPPER, encoding="utf-8")
     legacy.chmod(0o755)
     environment, _ = _fake_systemctl_environment(tmp_path, home)
 
@@ -2932,6 +2954,35 @@ def test_runtime_installer_rejects_unknown_legacy_publication_command(
     legacy = home / ".local/bin/rb-publication-policy"
     legacy.parent.mkdir(parents=True)
     legacy.write_text("#!/bin/sh\necho unrelated\n", encoding="utf-8")
+    legacy.chmod(0o755)
+    environment, systemctl_log = _fake_systemctl_environment(tmp_path, home)
+
+    completed = subprocess.run(
+        [str(INSTALLER)],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        env=environment,
+    )
+
+    assert completed.returncode == 1
+    assert "unknown file at legacy publication-policy command path" in completed.stderr
+    assert legacy.is_file()
+    assert not systemctl_log.exists()
+
+def test_runtime_installer_rejects_legacy_publication_marker_spoof(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    legacy = home / ".local/bin/rb-publication-policy"
+    legacy.parent.mkdir(parents=True)
+    legacy.write_text(
+        "#!/bin/sh\n"
+        "# rb-publication-policy is deprecated; use repoground-publication-policy\n"
+        "echo unrelated\n",
+        encoding="utf-8",
+    )
     legacy.chmod(0o755)
     environment, systemctl_log = _fake_systemctl_environment(tmp_path, home)
 

--- a/merger/repoground/tests/test_naming_audit.py
+++ b/merger/repoground/tests/test_naming_audit.py
@@ -170,6 +170,43 @@ def test_process_audit_detects_former_fleet_env_and_storage(tmp_path: Path) -> N
     ]
 
 
+def test_process_audit_detects_retired_publication_policy_surface(
+    tmp_path: Path,
+) -> None:
+    proc = tmp_path / "proc"
+    old_command = "r" + "b-publication-policy"
+    old_state = "/home/alex/.local/state/" + "repobrief-publication-policy"
+    _write_process(proc, 123, f"/home/alex/.local/bin/{old_command}", old_state)
+
+    finding = scan_processes(proc)[0]
+
+    assert finding["matched_aliases"] == [
+        "former-command-alias",
+        "former-runtime-storage",
+    ]
+    assert finding["matched_names"] == [_former_product()]
+
+
+def test_config_audit_detects_retired_publication_policy_surface(
+    tmp_path: Path,
+) -> None:
+    config = tmp_path / "publication.json"
+    old_command = "r" + "b-publication-policy"
+    old_state = "/home/alex/.local/state/" + "repobrief-publication-policy"
+    config.write_text(
+        json.dumps({"command": old_command, "root": old_state}),
+        encoding="utf-8",
+    )
+
+    finding = scan_configs([config])[0]
+
+    assert finding["matched_aliases"] == [
+        "former-command-alias",
+        "former-runtime-storage",
+    ]
+    assert finding["matched_names"] == [_former_product()]
+
+
 def test_config_audit_is_hash_only_for_concrete_aliases(tmp_path: Path) -> None:
     config = tmp_path / "config.json"
     config.write_text(

--- a/merger/repoground/tests/test_publication_policy.py
+++ b/merger/repoground/tests/test_publication_policy.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import concurrent.futures
 import datetime as dt
 import json
+import runpy
 import shutil
 import subprocess
 from pathlib import Path
@@ -768,6 +769,93 @@ def test_orphan_pin_fails_closed(tmp_path: Path) -> None:
             policy=RetentionPolicy(),
             now=now,
         )
+
+
+def test_cli_defaults_use_repoground_state_root_and_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    script = (
+        Path(__file__).resolve().parents[3]
+        / "scripts"
+        / "ops"
+        / "repoground-publication-policy"
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv(
+        "RB_PUBLICATION_EVIDENCE_ROOT", str(tmp_path / "ignored-legacy-evidence")
+    )
+    monkeypatch.setenv(
+        "RB_PUBLICATION_PAYLOAD_ROOT", str(tmp_path / "ignored-legacy-payload")
+    )
+    values = runpy.run_path(str(script), run_name="repoground_policy_defaults_test")
+
+    assert values["DEFAULT_EVIDENCE_ROOT"] == (
+        tmp_path / ".local/state/repoground-publication-policy"
+    )
+    assert values["DEFAULT_PAYLOAD_ROOT"] == tmp_path / "repos/manifest-publications"
+
+    canonical_evidence = tmp_path / "canonical-evidence"
+    canonical_payload = tmp_path / "canonical-payload"
+    monkeypatch.setenv(
+        "REPOGROUND_PUBLICATION_EVIDENCE_ROOT", str(canonical_evidence)
+    )
+    monkeypatch.setenv("REPOGROUND_PUBLICATION_PAYLOAD_ROOT", str(canonical_payload))
+    overridden = runpy.run_path(
+        str(script), run_name="repoground_policy_overrides_test"
+    )
+    assert overridden["DEFAULT_EVIDENCE_ROOT"] == canonical_evidence
+    assert overridden["DEFAULT_PAYLOAD_ROOT"] == canonical_payload
+
+
+def test_cli_rejects_former_lenskit_version_option(tmp_path: Path) -> None:
+    script = (
+        Path(__file__).resolve().parents[3]
+        / "scripts"
+        / "ops"
+        / "repoground-publication-policy"
+    )
+    common = [
+        "identity",
+        "--repository",
+        "heimgewebe__repoground",
+        "--lane",
+        "main",
+        "--repository-commit",
+        "1" * 40,
+        "--profile",
+        "full-max",
+        "--configuration-sha256",
+        "2" * 64,
+        "--repoground-version",
+        "3.0.0",
+        "--bundle-schema",
+        "repobrief.bundle.v1",
+        "--generator-inputs-sha256",
+        "3" * 64,
+    ]
+    rejected = subprocess.run(
+        [str(script), *common, "--lenskit-version", "3.0.0"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        env={"HOME": str(tmp_path)},
+    )
+    assert rejected.returncode == 2
+    assert "--lenskit-version" in rejected.stderr
+
+    accepted = subprocess.run(
+        [str(script), *common],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        env={"HOME": str(tmp_path)},
+    )
+    assert accepted.returncode == 0
+    payload = json.loads(accepted.stdout)
+    assert payload["identity"]["lenskit_version"] == "3.0.0"
+    assert payload["identity"]["bundle_schema"] == "repobrief.bundle.v1"
 
 
 def test_cli_round_trip_enforces_identity_noop(tmp_path: Path) -> None:

--- a/scripts/ops/install_repoground_publish_fleet_runtime.sh
+++ b/scripts/ops/install_repoground_publish_fleet_runtime.sh
@@ -7,6 +7,10 @@ UNIT_DIR=${HOME}/.config/systemd/user
 ENABLE=0
 OLD_STATE_ROOT=${HOME}/.local/state/repobrief-publish/fleet
 STATE_ROOT=${HOME}/.local/state/repoground-publish/fleet
+OLD_POLICY_STATE_ROOT=${HOME}/.local/state/repobrief-publication-policy
+POLICY_STATE_ROOT=${HOME}/.local/state/repoground-publication-policy
+LEGACY_POLICY_COMMAND=${BIN_DIR}/rb-publication-policy
+LEGACY_POLICY_MARKER='rb-publication-policy is deprecated; use repoground-publication-policy'
 LOG_ROOT=${HOME}/logs/repoground-publish
 
 if [[ ${1:-} == "--enable" ]]; then
@@ -34,13 +38,6 @@ OLD_UNITS=(
   repobrief-publish-systemkatalog-main.timer
 )
 
-install -d -m 0755 "$BIN_DIR" "$UNIT_DIR"
-systemctl --user disable --now repoground-publish-fleet-watch.timer 2>/dev/null || true
-systemctl --user stop repoground-publish-fleet-watch.service 2>/dev/null || true
-for unit in "${OLD_TIMERS[@]}"; do
-  systemctl --user disable --now "$unit" 2>/dev/null || true
-done
-
 if [[ -L $OLD_STATE_ROOT || -L $STATE_ROOT ]]; then
   echo "publisher state roots must not be symlinks" >&2
   exit 1
@@ -57,14 +54,56 @@ if [[ -d $OLD_STATE_ROOT && -d $STATE_ROOT ]]; then
   echo "both old and RepoGround publisher state roots exist; refusing dual truth" >&2
   exit 1
 fi
+if [[ -L $OLD_POLICY_STATE_ROOT || -L $POLICY_STATE_ROOT ]]; then
+  echo "publication-policy state roots must not be symlinks" >&2
+  exit 1
+fi
+if [[ -e $OLD_POLICY_STATE_ROOT && ! -d $OLD_POLICY_STATE_ROOT ]]; then
+  echo "old publication-policy state root is not a directory: $OLD_POLICY_STATE_ROOT" >&2
+  exit 1
+fi
+if [[ -e $POLICY_STATE_ROOT && ! -d $POLICY_STATE_ROOT ]]; then
+  echo "RepoGround publication-policy state root is not a directory: $POLICY_STATE_ROOT" >&2
+  exit 1
+fi
+if [[ -d $OLD_POLICY_STATE_ROOT && -d $POLICY_STATE_ROOT ]]; then
+  echo "both old and RepoGround publication-policy state roots exist; refusing dual truth" >&2
+  exit 1
+fi
+if [[ -L $LEGACY_POLICY_COMMAND ]]; then
+  echo "legacy publication-policy command must not be a symlink: $LEGACY_POLICY_COMMAND" >&2
+  exit 1
+fi
+if [[ -e $LEGACY_POLICY_COMMAND && ! -f $LEGACY_POLICY_COMMAND ]]; then
+  echo "legacy publication-policy command is not a regular file: $LEGACY_POLICY_COMMAND" >&2
+  exit 1
+fi
+if [[ -f $LEGACY_POLICY_COMMAND ]] && ! grep -Fq -- "$LEGACY_POLICY_MARKER" "$LEGACY_POLICY_COMMAND"; then
+  echo "unknown file at legacy publication-policy command path: $LEGACY_POLICY_COMMAND" >&2
+  exit 1
+fi
+
+install -d -m 0755 "$BIN_DIR" "$UNIT_DIR"
+systemctl --user disable --now repoground-publish-fleet-watch.timer 2>/dev/null || true
+systemctl --user stop repoground-publish-fleet-watch.service 2>/dev/null || true
+for unit in "${OLD_TIMERS[@]}"; do
+  systemctl --user disable --now "$unit" 2>/dev/null || true
+done
+
 if [[ -d $OLD_STATE_ROOT ]]; then
   install -d -m 0755 "$(dirname "$STATE_ROOT")"
   mv -- "$OLD_STATE_ROOT" "$STATE_ROOT"
 fi
+if [[ -d $OLD_POLICY_STATE_ROOT ]]; then
+  install -d -m 0700 "$(dirname "$POLICY_STATE_ROOT")"
+  mv -- "$OLD_POLICY_STATE_ROOT" "$POLICY_STATE_ROOT"
+fi
 install -d -m 0755 "$STATE_ROOT" "$LOG_ROOT"
+install -d -m 0700 "$POLICY_STATE_ROOT"
 
 install -m 0755 "$ROOT/scripts/ops/repoground-publish-fleet" "$BIN_DIR/repoground-publish-fleet"
 install -m 0755 "$ROOT/scripts/ops/repoground-publication-policy" "$BIN_DIR/repoground-publication-policy"
+rm -f -- "$LEGACY_POLICY_COMMAND"
 install -m 0755 "$ROOT/scripts/ops/repoground-publish-systemkatalog-main" \
   "$BIN_DIR/repoground-publish-systemkatalog-main"
 install -m 0755 "$ROOT/scripts/ops/repoground-publish-systemkatalog-main-if-changed" \

--- a/scripts/ops/install_repoground_publish_fleet_runtime.sh
+++ b/scripts/ops/install_repoground_publish_fleet_runtime.sh
@@ -11,6 +11,7 @@ OLD_POLICY_STATE_ROOT=${HOME}/.local/state/repobrief-publication-policy
 POLICY_STATE_ROOT=${HOME}/.local/state/repoground-publication-policy
 LEGACY_POLICY_COMMAND=${BIN_DIR}/rb-publication-policy
 LEGACY_POLICY_MARKER='rb-publication-policy is deprecated; use repoground-publication-policy'
+LEGACY_POLICY_SHA256='64278d6fe48b95931f7c75386004694ef3cf9c02aa4bef7f5e18b035cf90f68c'
 LOG_ROOT=${HOME}/logs/repoground-publish
 
 if [[ ${1:-} == "--enable" ]]; then
@@ -78,9 +79,13 @@ if [[ -e $LEGACY_POLICY_COMMAND && ! -f $LEGACY_POLICY_COMMAND ]]; then
   echo "legacy publication-policy command is not a regular file: $LEGACY_POLICY_COMMAND" >&2
   exit 1
 fi
-if [[ -f $LEGACY_POLICY_COMMAND ]] && ! grep -Fq -- "$LEGACY_POLICY_MARKER" "$LEGACY_POLICY_COMMAND"; then
-  echo "unknown file at legacy publication-policy command path: $LEGACY_POLICY_COMMAND" >&2
-  exit 1
+if [[ -f $LEGACY_POLICY_COMMAND ]]; then
+  read -r legacy_policy_observed_sha256 _ < <(sha256sum -- "$LEGACY_POLICY_COMMAND")
+  if [[ $legacy_policy_observed_sha256 != "$LEGACY_POLICY_SHA256" ]] ||
+    ! grep -Fq -- "$LEGACY_POLICY_MARKER" "$LEGACY_POLICY_COMMAND"; then
+    echo "unknown file at legacy publication-policy command path: $LEGACY_POLICY_COMMAND" >&2
+    exit 1
+  fi
 fi
 
 install -d -m 0755 "$BIN_DIR" "$UNIT_DIR"

--- a/scripts/ops/repoground-publication-policy
+++ b/scripts/ops/repoground-publication-policy
@@ -34,7 +34,7 @@ from merger.repoground.core.publication_policy import (  # noqa: E402
 
 DEFAULT_EVIDENCE_ROOT = _env_path(
     "REPOGROUND_PUBLICATION_EVIDENCE_ROOT",
-    Path.home() / ".local" / "state" / "repobrief-publication-policy",
+    Path.home() / ".local" / "state" / "repoground-publication-policy",
 )
 DEFAULT_PAYLOAD_ROOT = _env_path(
     "REPOGROUND_PUBLICATION_PAYLOAD_ROOT",

--- a/tests/test_naming_hard_cut.py
+++ b/tests/test_naming_hard_cut.py
@@ -108,6 +108,33 @@ def test_new_fleet_context_proof_uses_current_product_name() -> None:
     assert "RepoBrief" not in proof
 
 
+def test_publication_policy_current_surface_uses_repoground_names() -> None:
+    current = ROOT / "docs/operations/repoground-publication-policy.md"
+    former = ROOT / "docs/operations/repobrief-publication-policy.md"
+
+    assert current.is_file()
+    assert not former.exists()
+    assert not (ROOT / "scripts/ops/rb-publication-policy").exists()
+    text = current.read_text(encoding="utf-8")
+    for expected in (
+        "repoground-publication-policy",
+        "REPOGROUND_PUBLICATION_EVIDENCE_ROOT",
+        "REPOGROUND_PUBLICATION_PAYLOAD_ROOT",
+        "--repoground-version",
+        "~/.local/state/repoground-publication-policy",
+    ):
+        assert expected in text
+    for former_name in (
+        "`rb-publication-policy`",
+        "RB_PUBLICATION_",
+        "--lenskit-version",
+        "~/.local/state/repobrief-publication-policy",
+    ):
+        assert former_name not in text
+    assert "`repobrief.*` schema identities" in text
+    assert "`lenskit_version` field" in text
+
+
 def test_protected_compatibility_contract_is_terminal_only() -> None:
     path = ROOT / "docs/contracts/repoground-compatibility-exit.v1.json"
     data = json.loads(path.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Bureau binding

- Task: `REPOGROUND-LEGACY-RECONCILIATION-V1-T021`
- Run: `BUR-RUN-20260801T010609Z-887777f424`
- Current reviewed head: `272060a6`
- Baseline: `c11446cb7bdf0c166f804fd71f89786bf8ea5396`

## Change

- rename the active operations document to `repoground-publication-policy.md`
- use `repoground-publication-policy`, `REPOGROUND_PUBLICATION_*`, and `--repoground-version` on current surfaces
- default new policy evidence to `~/.local/state/repoground-publication-policy`
- migrate a sole historical state root without rewriting record bytes
- reject symlinks, invalid types, and simultaneous old/new roots before service effects
- remove the retired `rb-publication-policy` delegate only when its exact inventoried SHA-256 matches
- reject a file that merely copies the retirement marker
- preserve persisted `repobrief.*` schemas and `lenskit_version`
- bind recovery, rollback boundaries, receipts, and nonclaims in the proof

## Local verification on current head

- focused wrapper identity tests: `4 passed, 85 deselected`
- affected tests: `169 passed in 15.84s`
- full suite: `5283 passed, 12 skipped in 196.45s`
- Ruff: passed
- `git diff --check`: passed
- installer `bash -n`: passed
- full-suite receipt: `b9f49b048a4cae9e098efdf1ec5c77b5723ef7d97bf1f5f17773ea6f81fe6983`
- shell-syntax receipt: `fcde9501b7459c50ad6b73b189555bacf68b972b383c89aae244636f6d8b5d35`

## Review separation

The first implementation review covered naming, migration, and data-identity preservation. A separate final self-review found that marker-only wrapper recognition was too weak; commit `272060a6` binds removal to the exact live-inventoried wrapper digest and adds a marker-spoofing regression test.

## Safety boundary

This change does not rewrite historical records or proofs, does not claim global absence of unknown consumers, and does not perform the host cutover before merge and fresh readback.