### PR TITLE
chore(test): update pytest to 9.1.1

### DIFF
--- a/requirements-browser.txt
+++ b/requirements-browser.txt
@@ -1,6 +1,6 @@
 # Browser-gate top-level pins. The Playwright package version must match the
 # digest-pinned official container in .github/workflows/test-suite.yml.
-pytest==9.0.3
+pytest==9.1.1
 pytest-asyncio==1.4.0
 pytest-playwright==0.8.0
 playwright==1.61.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pytest==9.0.3
+pytest==9.1.1
 pytest-asyncio==1.4.0
 ruff==0.15.13
 fastapi>=0.119,<1

--- a/requirements/repoground-browser.lock.txt
+++ b/requirements/repoground-browser.lock.txt
@@ -220,9 +220,10 @@ pygments==2.20.0 \
     --hash=sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f \
     --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
     # via pytest
-pytest==9.0.3 \
-    --hash=sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9 \
-    --hash=sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c
+pytest==9.1.1 \
+    --hash=sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313 \
+    --hash=sha256:254daf971112e2f991880363a93b8d0f43f1d3438d41ddbfe85dfbe37dd56b21 \
+    --hash=sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c
     # via
     #   -r requirements-browser.txt
     #   pytest-asyncio

--- a/requirements/repoground-dev.lock.txt
+++ b/requirements/repoground-dev.lock.txt
@@ -284,9 +284,10 @@ pygments==2.20.0 \
     --hash=sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f \
     --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
     # via pytest
-pytest==9.0.3 \
-    --hash=sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9 \
-    --hash=sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c
+pytest==9.1.1 \
+    --hash=sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313 \
+    --hash=sha256:254daf971112e2f991880363a93b8d0f43f1d3438d41ddbfe85dfbe37dd56b21 \
+    --hash=sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c
     # via
     #   -r requirements-dev.txt
     #   pytest-asyncio

--- a/scripts/ci/check_browser_gate_environment.py
+++ b/scripts/ci/check_browser_gate_environment.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 EXPECTED_VERSIONS = {
     "playwright": "1.61.0",
-    "pytest": "9.0.3",
+    "pytest": "9.1.1",
     "pytest-asyncio": "1.4.0",
     "pytest-base-url": "2.1.0",
     "pytest-playwright": "0.8.0",


### PR DESCRIPTION
## Änderung

- aktualisiert pytest in `requirements-dev.txt` und `requirements-browser.txt` von 9.0.3 auf 9.1.1
- erzeugt die beiden Python-3.12-Hash-Lockdateien reproduzierbar neu
- aktualisiert den Browser-Gate-Vertrag auf pytest 9.1.1
- ändert keine weitere direkte oder transitive Paketversion, keine Produktionsabhängigkeit und keinen Produktcode

## Reproduzierbarkeit

Lock-Generator:

`uvx --python 3.12 --from pip-tools==7.6.0 --with pip==25.3 pip-compile --generate-hashes --no-emit-index-url --strip-extras ...`

Eine erneute Erzeugung beider Lockdateien erzeugt keinen Git-Diff. Beide Locks wurden mit `--require-hashes` in frische Python-3.12-Umgebungen installiert; `uv pip check` meldet für Dev und Browser vollständige Kompatibilität.

## Lokale Prüfung

- pytest-Version: 9.1.1
- Browser-Vertragsprüfung: 3/3 bestanden
- vollständiger Lauf: 5266 bestanden, 2 übersprungen, 13 abgewählt; 14 Fehlschläge ausschließlich in `tests/test_patch_evaluation_sidecar.py`
- Einzelreproduktion dieser 14 lokalen Fehler: Bubblewrap kann in der Grabowski-Einheit kein `NETLINK_ROUTE`-Socket für Loopback anlegen; einfacher Bubblewrap-Probeprozess funktioniert
- GitHub-`pytest-full` richtet Bubblewrap auf dem Runner ausdrücklich ein und ist für die autoritative Prüfung dieser 14 Fälle vorgesehen
- Ruff: bestanden
- Stub-Guard: bestanden
- Releasevertrag: bestanden
- beide Dependency-Umgebungen: kompatibel
- `git diff --check`: bestanden

Der lokale Browser-Environment-Checker bestätigt alle erwarteten Paketversionen einschließlich pytest 9.1.1; nur das GitHub-Container-Browserverzeichnis `/ms-playwright` enthält lokal keinen Chromium-Build. Der erforderliche Browser wird im CI-Container bereitgestellt.

## Scope

Exakt fünf Dateien:

- `requirements-dev.txt`
- `requirements-browser.txt`
- `requirements/repoground-dev.lock.txt`
- `requirements/repoground-browser.lock.txt`
- `scripts/ci/check_browser_gate_environment.py`

Bureau-Task: `REPOGROUND-LEGACY-RECONCILIATION-V1-T022`
Bureau-Run: `BUR-RUN-20260801T115506Z-bbba607037`