### PR TITLE
chore(deps): update contracts-mirror digest

### DIFF
--- a/.github/workflows/contracts-validate.yml
+++ b/.github/workflows/contracts-validate.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Verify 'uses:' pins for heimgewebe/contracts-mirror
         env:
           REQUIRED_REPO: "heimgewebe/contracts-mirror/.github/workflows/contracts-ajv-reusable.yml"
-          REQUIRED_REF: "0e5430c72b7948124e2b892da9473bdf8f8a120e"
+          REQUIRED_REF: "91fdff21d083eaf95fd42659ec9a4dc691d227a5"
         run: |
           set -euo pipefail
           shopt -s extglob
@@ -286,8 +286,8 @@ jobs:
   validate:
     name: "Validate fixtures via reusable workflow"
     needs: [version-sync-check, guard]
-    uses: heimgewebe/contracts-mirror/.github/workflows/contracts-ajv-reusable.yml@0e5430c72b7948124e2b892da9473bdf8f8a120e
+    uses: heimgewebe/contracts-mirror/.github/workflows/contracts-ajv-reusable.yml@91fdff21d083eaf95fd42659ec9a4dc691d227a5
     secrets: inherit
     with:
       fixtures_glob: ${{ vars.FIXTURES_GLOB || 'merger/repoground/contracts/examples/**/*.json merger/repoground/contracts/examples/**/*.jsonl' }}
-      contracts_ref: 0e5430c72b7948124e2b892da9473bdf8f8a120e
+      contracts_ref: 91fdff21d083eaf95fd42659ec9a4dc691d227a5


### PR DESCRIPTION
## Änderung

Ersetzt den weiterhin sinnvollen, geschlossenen und ungemergten Renovate-PR #1136 durch einen frischen PR vom aktuellen RepoGround-`main`.

Der Commit-Digest von `heimgewebe/contracts-mirror` wird von

`0e5430c72b7948124e2b892da9473bdf8f8a120e`

auf den weiterhin aktuellen `main`

`91fdff21d083eaf95fd42659ec9a4dc691d227a5`

aktualisiert.

## Behebung der alten Blocker

Der alte PR änderte nicht alle gekoppelten Pin-Stellen und fiel deshalb im statischen Versionsabgleich durch. Dieser Ersatz aktualisiert gemeinsam:

1. `REQUIRED_REF`
2. den `uses:`-Digest des wiederverwendeten Workflows
3. `contracts_ref`

## Scope

Exakt eine Datei und drei Zeilen:

- `.github/workflows/contracts-validate.yml`

Keine Produktlogik, keine Lockdatei und keine weitere Workflow-Abhängigkeit wird verändert.

## Lokale Prüfung

- frische Basis: `a60d0dd93ad8b18bbbce94ccc1267c27ab0a34b9`
- GitHub-Actions-Pin-Prüfung: bestanden
- Reusable-Workflow-Vertrag: bestanden
- Dreifach-Pin-Gleichheit: bestanden
- Ruff: bestanden
- Stub-Guard: bestanden
- Releasevertrag: bestanden
- `git diff --check`: bestanden
- vollständiger Pytest-Lauf läuft auf Head `66690faaff4c2b3f84a2cf49190f7d8dba5df826`

Bureau-Task: `OPERATOR-INTEGRATION-LOOP-V1-T023`
Bureau-Run: `BUR-RUN-20260801T153440Z-24942d1ef4`