### PR TITLE
chore(deps): update contracts-mirror digest

### DIFF
--- a/.github/workflows/contracts-validate.yml
+++ b/.github/workflows/contracts-validate.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Verify 'uses:' pins for heimgewebe/contracts-mirror
         env:
           REQUIRED_REPO: "heimgewebe/contracts-mirror/.github/workflows/contracts-ajv-reusable.yml"
-          REQUIRED_REF: "0e5430c72b7948124e2b892da9473bdf8f8a120e"
+          REQUIRED_REF: "91fdff21d083eaf95fd42659ec9a4dc691d227a5"
         run: |
           set -euo pipefail
           shopt -s extglob
@@ -286,8 +286,8 @@ jobs:
   validate:
     name: "Validate fixtures via reusable workflow"
     needs: [version-sync-check, guard]
-    uses: heimgewebe/contracts-mirror/.github/workflows/contracts-ajv-reusable.yml@0e5430c72b7948124e2b892da9473bdf8f8a120e
+    uses: heimgewebe/contracts-mirror/.github/workflows/contracts-ajv-reusable.yml@91fdff21d083eaf95fd42659ec9a4dc691d227a5
     secrets: inherit
     with:
       fixtures_glob: ${{ vars.FIXTURES_GLOB || 'merger/repoground/contracts/examples/**/*.json merger/repoground/contracts/examples/**/*.jsonl' }}
-      contracts_ref: 0e5430c72b7948124e2b892da9473bdf8f8a120e
+      contracts_ref: 91fdff21d083eaf95fd42659ec9a4dc691d227a5

--- a/config/workflow-control-plane.v1.json
+++ b/config/workflow-control-plane.v1.json
@@ -44,7 +44,7 @@
       "path": ".github/workflows/contracts-validate.yml",
       "class": "required_protection",
       "rationale": "Contract/schema/fixture integrity.",
-      "sha256": "af0b9f7544a8694221d4e729cf547ed347ea8b2d9171fbe170daea90a5d1de78",
+      "sha256": "159af28e615ad85bf0c537b6b4ba07d71478d468ea7c8d5cc799ea003e5deb2b",
       "bytes": 10556
     },
     {


### PR DESCRIPTION
## Änderung

Frischer Ersatz für den geschlossenen, ungemergten Renovate-PR #1136.

Aktualisiert `heimgewebe/contracts-mirror` von
`0e5430c72b7948124e2b892da9473bdf8f8a120e`
auf den aktuellen `main`
`91fdff21d083eaf95fd42659ec9a4dc691d227a5`.

Gemeinsam geändert werden die drei gekoppelten Pin-Stellen:

1. `REQUIRED_REF`
2. `uses:` des wiederverwendeten Workflows
3. `contracts_ref`

Zusätzlich wird der absichtlich gepflegte SHA-256-Eintrag des Workflows in `config/workflow-control-plane.v1.json` auf `159af28e615ad85bf0c537b6b4ba07d71478d468ea7c8d5cc799ea003e5deb2b` aktualisiert. Die Dateigröße bleibt 10.556 Bytes.

## Warum neuer PR

Der erste Ersatz-PR #1142 wurde fail-closed geschlossen, nachdem seine CI den fehlenden Inventarpfad belegte. Seine grünen Checks werden nicht wiederverwendet.

## Scope

Exakt zwei Dateien:

- `.github/workflows/contracts-validate.yml`
- `config/workflow-control-plane.v1.json`

Keine Produktlogik, Lockdatei oder weitere Workflow-Abhängigkeit wird verändert.

## Lokale Prüfung

- aktuelle Basis: `a60d0dd93ad8b18bbbce94ccc1267c27ab0a34b9`
- Workflow-Kontrollinventar: grün, 21 Workflows, 0 Fehler
- GitHub-Actions-Pin-Prüfung: grün
- Reusable-Workflow-Vertrag: grün
- Ruff: grün
- Stub-Guard: grün
- Releasevertrag: grün
- `git diff --check`: grün
- vollständiger Pytest-Lauf läuft auf Head `73f2b801559da9fceef7a71bcf564f12cae5a579`

Bureau-Task: `OPERATOR-INTEGRATION-LOOP-V1-T023`
Bureau-Run: `BUR-RUN-20260801T160718Z-c67bd5904d`