### PR TITLE
refactor: freeze raw call graph handoff

### DIFF
--- a/merger/repoground/architecture/call_graph.py
+++ b/merger/repoground/architecture/call_graph.py
@@ -51,6 +51,18 @@ class _ScopeFrame:
     type_alias_name: str | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class _RawCall:
+    """Immutable handoff from AST collection to deterministic resolution."""
+
+    start_line: int
+    start_col: int
+    end_line: int
+    end_col: int
+    func: ast.expr
+    stack: tuple[_ScopeFrame, ...]
+
+
 class _ModuleState:
     """Per-module definitions, imports, bindings and unresolved raw calls."""
 
@@ -65,7 +77,7 @@ class _ModuleState:
         self.module_aliases: dict[str, str] = {}
         self.imported_module_names: set[str] = set()
         self.binding_sources: dict[str, set[str]] = {}
-        self.calls: list[dict[str, Any]] = []
+        self.calls: list[_RawCall] = []
 
     def add_binding(self, name: str, source: str) -> None:
         self.binding_sources.setdefault(name, set()).add(source)
@@ -1205,15 +1217,15 @@ class _CallGraphVisitor(ast.NodeVisitor):
             if end_line == start_line and end_col < start_col:
                 end_col = start_col
             self.state.calls.append(
-                {
-                    "start_line": start_line,
-                    "start_col": start_col,
-                    "end_line": end_line,
-                    "end_col": end_col,
-                    "func": node.func,
+                _RawCall(
+                    start_line=start_line,
+                    start_col=start_col,
+                    end_line=end_line,
+                    end_col=end_col,
+                    func=node.func,
                     # The stack list changes while traversing; its frozen frames do not.
-                    "stack": tuple(self.stack),
-                }
+                    stack=tuple(self.stack),
+                )
             )
         self.generic_visit(node)
         return None
@@ -1618,9 +1630,9 @@ class _Resolver:
             return self._resolve_receiver_dotted(state, parts, stack)
         return self._resolve_module_dotted(state, parts, stack)
 
-    def resolve(self, state: _ModuleState, raw_call: dict[str, Any]) -> dict[str, Any]:
-        func = raw_call["func"]
-        stack = raw_call["stack"]
+    def resolve(self, state: _ModuleState, raw_call: _RawCall) -> dict[str, Any]:
+        func = raw_call.func
+        stack = raw_call.stack
         if isinstance(func, ast.Name):
             simple_name: str | None = func.id
             verdict = self._resolve_name(state, func.id, stack)
@@ -1634,13 +1646,11 @@ class _Resolver:
                 verdict = _verdict("unresolved", "dynamic_callee_expression")
         record = {
             "path": state.path,
-            "start_line": raw_call["start_line"],
-            "start_col": raw_call["start_col"],
-            "end_line": raw_call["end_line"],
-            "end_col": raw_call["end_col"],
-            "range_ref": _range_ref(
-                state.path, raw_call["start_line"], raw_call["end_line"]
-            ),
+            "start_line": raw_call.start_line,
+            "start_col": raw_call.start_col,
+            "end_line": raw_call.end_line,
+            "end_col": raw_call.end_col,
+            "range_ref": _range_ref(state.path, raw_call.start_line, raw_call.end_line),
             "callee_expression": ast.unparse(func),
             "simple_name": simple_name,
         }

--- a/merger/repoground/tests/test_python_call_graph.py
+++ b/merger/repoground/tests/test_python_call_graph.py
@@ -8,6 +8,7 @@ outcomes (ambiguous, dynamic, foreign, module scope, parse errors).
 
 import ast
 import json
+from dataclasses import FrozenInstanceError
 from pathlib import Path
 
 import jsonschema
@@ -17,6 +18,7 @@ from merger.repoground.architecture.call_graph import (
     DOES_NOT_ESTABLISH,
     MAX_SKIPPED_ERRORS,
     _CallGraphVisitor,
+    _RawCall,
     _Resolver,
     extract_python_calls,
     generate_call_graph_document,
@@ -2149,6 +2151,21 @@ def test_call_graph_schema_matches_shared_diagnostic_limit():
     assert set(DOES_NOT_ESTABLISH) <= set(
         schema["properties"]["does_not_establish"]["items"]["enum"]
     )
+
+
+def test_pending_call_handoff_is_typed_and_immutable():
+    tree = ast.parse("def caller():\n    return target()\n")
+    visitor = _CallGraphVisitor("sample.py", is_package=False)
+    visitor.visit(tree)
+
+    raw_call = visitor.state.calls[0]
+
+    assert isinstance(raw_call, _RawCall)
+    assert isinstance(raw_call.func, ast.Name)
+    assert isinstance(raw_call.stack, tuple)
+    assert raw_call.start_line == raw_call.end_line == 2
+    with pytest.raises(FrozenInstanceError):
+        raw_call.start_line = 99
 
 
 def test_missing_ast_end_position_is_normalized_to_valid_range():


### PR DESCRIPTION
## Änderung

Der Call-Graph-Produzent reicht intern noch nicht aufgelöste Aufrufe als frei veränderbare Wörterbücher vom AST-Visitor an den Resolver weiter. Dieser PR ersetzt diese interne Grenze durch `_RawCall`, einen eingefrorenen Datensatz mit festen Feldern.

`frozen=True` verhindert nachträgliche Änderungen. `slots=True` verhindert versehentliche Zusatzattribute und hält den Datensatz kompakt. Die öffentliche JSON-kompatible Call-Graph-Ausgabe bleibt unverändert.

## Umfang

Geändert werden genau zwei Dateien:

- `merger/repoground/architecture/call_graph.py`
- `merger/repoground/tests/test_python_call_graph.py`

Nicht enthalten sind neue Auflösungsregeln, öffentliche Artefaktfelder, Schema-/Versionsänderungen, Abhängigkeitsupdates oder breitere Refaktoren.

## Paritätsbeleg

Das unveränderte 13-Kategorien-Goldset liefert vor und nach der Umstellung:

- 16 Calls
- 0 übersprungene Dateien
- denselben normalisierten SHA-256: `647bb16d23b01a9318ed8b9c2ec31f3f122e5d0d7a631244439718ff9efec3ae`

Damit ist die erzeugte öffentliche Call-Graph-Struktur bitidentisch.

## Prüfungen auf Head `1f1d4c819bb1ec3ae9c4b02367fd5490db8c3803`

- gezielter Unveränderlichkeitstest ergänzt
- fokussierte Call-Graph-Suite: 94 bestanden
- Ruff-Lint: bestanden
- Ruff-C901-Produzentenprüfung: bestanden
- Workflow-Control-Plane: 21 Workflows, 0 Fehler
- Stub-Guard: bestanden
- Releasevertrag: bestanden
- GitHub-Actions-Pins: bestanden
- Reusable-Workflow-Vertrag: bestanden
- `git diff --check`: bestanden
- vollständige lokale Nicht-Browser-Suite läuft revisionsgebunden

Bureau-Task: `RPU-V1-T030`
Bureau-Run: `BUR-RUN-20260801T221842Z-142b827b53`