### PR TITLE
fix(fleet-context): restore call navigation on the daily bundle

### DIFF
--- a/docs/proofs/fleet-context-call-navigation-restore-v1-proof.md
+++ b/docs/proofs/fleet-context-call-navigation-restore-v1-proof.md
@@ -13,18 +13,19 @@ The daily fleet publication resolves to the `fleet-context` profile
 `python_symbol_index_json` and `python_call_graph_json` to `profile_excluded`, so the
 published bundle carried neither artifact.
 
-All three agent-facing call-navigation tools failed closed against the live
+All four agent-facing call-navigation tools failed closed against the live
 publication `heimgewebe__repoground__main-max-260802-0701`:
 
 | Tool | Status | Error code |
 |---|---|---|
 | `find_symbol` | `missing` | `python_symbol_index_json_missing` |
+| `find_references` | `missing` | `python_call_graph_json_missing` |
 | `get_callers` | `missing` | `python_call_graph_json_missing` |
 | `get_callees` | `missing` | `python_call_graph_json_missing` |
 
 The bundle itself reported `freshness: fresh_exact` and `post_emit_health: pass`, and the
 profile evaluation reported `status: pass` with no excluded role present. Every existing
-gate was green while three tools were unreachable. No GitHub issue tracked it.
+gate was green while four tools were unreachable. No GitHub issue tracked it.
 
 `context_compose` degraded honestly over the same bundle (`status: degraded`, gap
 `source_unavailable/python_symbol_index_json`, skipped lanes `symbol_navigation` and
@@ -38,9 +39,9 @@ consumer "does not require the raw canonical dump, SQLite index, Python symbol i
 Python call graph **in the normal context path**".
 
 That statement is accurate and insufficient. The same consumer also exposes `find_symbol`,
-`get_callers`, and `get_callees`, which read exactly the two excluded artifacts. The
-inventory covered the context-pack path only, so the exclusion silently removed a second
-consumer path that was never inspected.
+`find_references`, `get_callers`, and `get_callees`, which read exactly the two
+excluded artifacts. The inventory covered the context-pack path only, so the exclusion
+silently removed a second consumer path that was never inspected.
 
 ## Decision
 
@@ -70,14 +71,15 @@ For context, the same `fleet-context` bundle for `heimgewebe__repoground` alread
 
 Only `resolved` call edges can produce callers or callees. Every other resolution status is
 an edge the resolver saw but could not bind, so any caller or callee list is complete only
-relative to the resolved share. The three call-graph tools now report
+relative to the resolved share. The three call-graph-backed navigation tools now report
 `call_graph_coverage` at the top level of the response:
 
-- `completeness`: `complete`, `partial`, or `unknown`
+- `scope`: `observed_call_edges` (never the repository-wide call graph)
+- `completeness`: `complete`, `partial`, or `unknown` within that scope
 - `resolved_call_edges` / `total_call_edges` / `resolved_ratio`
 - `unresolved_by_status` (per `candidate`, `ambiguous`, `unresolved`)
-- `does_not_establish`: `caller_completeness`, `callee_completeness`,
-  `unresolved_edges_are_irrelevant`
+- `does_not_establish`: `complete_call_graph`, `caller_completeness`,
+  `callee_completeness`, `unresolved_edges_are_irrelevant`
 
 `unknown` is reported when the graph carries no `resolution_counts`, so a graph that never
 declared coverage is not read as a complete one.
@@ -91,22 +93,24 @@ routinely unbound. Results looked exhaustive and were not.
 `merger/repoground/tests/test_publication_surface_smoke.py` emits a real publication through
 the same CLI path the fleet publisher uses
 (`merger.repoground.cli.ground external-manifest refresh --profile fleet-context`), then
-calls `find_symbol`, `get_callers`, and `get_callees` against the emitted manifest.
+calls the MCP frontdoors `find_symbol`, `find_references`, `get_callers`, and
+`get_callees` against the emitted manifest.
 
 The existing profile tests are assertions about the rule tables and stayed green throughout
 the regression. This test reads the shipped artifact back through the agent-facing surface,
 which is the only level at which the failure was observable.
 
-Verified to catch the regression: with the `profile_excluded` values restored, all four
-tests in the file fail (`assert 'missing' == 'available'`). With the fix in place, all four
+Verified to catch the regression: with the `profile_excluded` values restored, all five
+tests in the file fail (`assert 'missing' == 'available'`). With the fix in place, all five
 pass.
 
 ## Verification
 
-- `python3 -m pytest` → 5346 passed, 12 skipped
+- `python3 -m pytest` → 5347 passed, 12 skipped
 - `ruff check --config ruff-ci.toml .` → All checks passed
 - Live re-read after the fix, against a real `fleet-context` publication:
   `find_symbol` → `available`, 1 hit (`target`, `pkg/core.py`);
+  `find_references` → `available`, non-empty call-site list;
   `get_callers` → `available`, caller `pkg/caller.py`, coverage `complete` (ratio `1.0`);
   `get_callees` → `available`, non-empty callee list.
 - Publication report: `profile_evaluation.status: pass`,

--- a/docs/proofs/fleet-context-call-navigation-restore-v1-proof.md
+++ b/docs/proofs/fleet-context-call-navigation-restore-v1-proof.md
@@ -1,0 +1,122 @@
+# Fleet Context Call Navigation Restore v1 Proof
+
+## Binding
+
+- RepoGround baseline: `6a6e9ae227976fb9b2b596ca0a944e9f7c5d2d93` (`main`, clean worktree)
+- Regression introduced by: `288ced5fcc46d25e91cb671e103e6cd8d0382289` ("feat(repoground): compact daily fleet context")
+- Superseded decision: [`repoground-fleet-context-profile-v1-proof.md`](repoground-fleet-context-profile-v1-proof.md)
+
+## Observed failure
+
+The daily fleet publication resolves to the `fleet-context` profile
+(`publication_config` in `scripts/ops/repoground-publish-fleet`). That profile set
+`python_symbol_index_json` and `python_call_graph_json` to `profile_excluded`, so the
+published bundle carried neither artifact.
+
+All three agent-facing call-navigation tools failed closed against the live
+publication `heimgewebe__repoground__main-max-260802-0701`:
+
+| Tool | Status | Error code |
+|---|---|---|
+| `find_symbol` | `missing` | `python_symbol_index_json_missing` |
+| `get_callers` | `missing` | `python_call_graph_json_missing` |
+| `get_callees` | `missing` | `python_call_graph_json_missing` |
+
+The bundle itself reported `freshness: fresh_exact` and `post_emit_health: pass`, and the
+profile evaluation reported `status: pass` with no excluded role present. Every existing
+gate was green while three tools were unreachable. No GitHub issue tracked it.
+
+`context_compose` degraded honestly over the same bundle (`status: degraded`, gap
+`source_unavailable/python_symbol_index_json`, skipped lanes `symbol_navigation` and
+`call_graph`), which is the behaviour the call-navigation tools now adopt.
+
+## Cause
+
+The superseded decision recorded a consumer-boundary inventory bound to
+`heimgewebe/grabowski` at `fdc9266016a07c27c86925976a4b56c17b0483c6`. It concluded that the
+consumer "does not require the raw canonical dump, SQLite index, Python symbol index, or
+Python call graph **in the normal context path**".
+
+That statement is accurate and insufficient. The same consumer also exposes `find_symbol`,
+`get_callers`, and `get_callees`, which read exactly the two excluded artifacts. The
+inventory covered the context-pack path only, so the exclusion silently removed a second
+consumer path that was never inspected.
+
+## Decision
+
+`fleet-context` keeps `python_symbol_index_json` and `python_call_graph_json` at
+`recommended`. `sqlite_index` remains `profile_excluded` and remains the only role in
+`PROFILE_POST_EMIT_DROPPABLE_ROLES` for this profile.
+
+Alternative considered and rejected: resolving the call-navigation tools against a separate
+`agent-portable` or `full-max` bundle. Rejected because it is the larger and weaker
+contract — it would require publishing a second bundle per repository (increasing storage
+rather than reducing it) and would split freshness across two publications, so
+`fresh_exact` would no longer be one coherent claim for one repository.
+
+### Storage effect
+
+The compact intent is preserved. Measured on the published fleet bundles:
+
+| Repository | Bundle total | Restored indexes | Share |
+|---|---:|---:|---:|
+| `heimgewebe__semantAH` | 12 MB | 1.6 MB | ~13% |
+
+For context, the same `fleet-context` bundle for `heimgewebe__repoground` already carries a
+16 MB canonical Markdown, a 4.9 MB citation map, and a 2.7 MB architecture graph. The
+`sqlite_index` exclusion, which is retained, remains the dominant saving.
+
+## Degradation visibility
+
+Only `resolved` call edges can produce callers or callees. Every other resolution status is
+an edge the resolver saw but could not bind, so any caller or callee list is complete only
+relative to the resolved share. The three call-graph tools now report
+`call_graph_coverage` at the top level of the response:
+
+- `completeness`: `complete`, `partial`, or `unknown`
+- `resolved_call_edges` / `total_call_edges` / `resolved_ratio`
+- `unresolved_by_status` (per `candidate`, `ambiguous`, `unresolved`)
+- `does_not_establish`: `caller_completeness`, `callee_completeness`,
+  `unresolved_edges_are_irrelevant`
+
+`unknown` is reported when the graph carries no `resolution_counts`, so a graph that never
+declared coverage is not read as a complete one.
+
+This matters at the observed scale: the 2026-07-28 measurement over the fleet found 17,765
+of 67,836 call edges resolved (~26%), with module-qualified calls (`mod.target(...)`)
+routinely unbound. Results looked exhaustive and were not.
+
+## Regression guard
+
+`merger/repoground/tests/test_publication_surface_smoke.py` emits a real publication through
+the same CLI path the fleet publisher uses
+(`merger.repoground.cli.ground external-manifest refresh --profile fleet-context`), then
+calls `find_symbol`, `get_callers`, and `get_callees` against the emitted manifest.
+
+The existing profile tests are assertions about the rule tables and stayed green throughout
+the regression. This test reads the shipped artifact back through the agent-facing surface,
+which is the only level at which the failure was observable.
+
+Verified to catch the regression: with the `profile_excluded` values restored, all four
+tests in the file fail (`assert 'missing' == 'available'`). With the fix in place, all four
+pass.
+
+## Verification
+
+- `python3 -m pytest` → 5346 passed, 12 skipped
+- `ruff check --config ruff-ci.toml .` → All checks passed
+- Live re-read after the fix, against a real `fleet-context` publication:
+  `find_symbol` → `available`, 1 hit (`target`, `pkg/core.py`);
+  `get_callers` → `available`, caller `pkg/caller.py`, coverage `complete` (ratio `1.0`);
+  `get_callees` → `available`, non-empty callee list.
+- Publication report: `profile_evaluation.status: pass`,
+  `profile_excluded_present: []`, `removed_profile_excluded_artifacts` contains only the
+  SQLite index.
+
+## Does not establish
+
+- That the ~26% call-edge resolution rate is improved. This change makes the shortfall
+  visible; it does not raise it.
+- That other consumers of `fleet-context` were re-inventoried. Only the call-navigation
+  path was corrected.
+- Retrieval quality for natural-language queries, which remains keyword/FTS only.

--- a/merger/repoground/core/call_graph_navigation.py
+++ b/merger/repoground/core/call_graph_navigation.py
@@ -111,6 +111,14 @@ _CALL_GRAPH_DOES_NOT_ESTABLISH = CALL_GRAPH_PRODUCER_NONCLAIMS
 _CALL_NAV_DOES_NOT_ESTABLISH = tuple(
     dict.fromkeys([*_DOES_NOT_ESTABLISH, *_CALL_GRAPH_DOES_NOT_ESTABLISH])
 )
+# A caller or callee list is bounded by the resolved share of the call graph.
+# These are the claims a partial graph cannot support even when the returned
+# rows themselves are correct.
+_CALL_GRAPH_COVERAGE_DOES_NOT_ESTABLISH = (
+    "caller_completeness",
+    "callee_completeness",
+    "unresolved_edges_are_irrelevant",
+)
 _CALL_NAVIGATION_CACHE_MAX_ENTRIES = 2
 
 
@@ -524,6 +532,56 @@ def _detached_record(value: Any) -> dict[str, Any] | None:
     return _detached_json_value(value) if isinstance(value, dict) else None
 
 
+def _call_graph_coverage(data: dict[str, Any]) -> dict[str, Any]:
+    """State how much of the call graph actually resolved.
+
+    Only `resolved` edges can produce callers or callees. Every other status is
+    an edge the resolver saw but could not bind, so a caller or callee list is
+    complete only relative to the resolved share. Reporting that share beside
+    the results keeps a partial answer from reading as an exhaustive one.
+    """
+    raw = data.get("resolution_counts")
+    if not isinstance(raw, Mapping):
+        return {
+            "completeness": "unknown",
+            "reason": "call_graph_resolution_counts_unavailable",
+            "resolved_call_edges": None,
+            "total_call_edges": None,
+            "resolved_ratio": None,
+            "unresolved_by_status": {},
+            "does_not_establish": list(_CALL_GRAPH_COVERAGE_DOES_NOT_ESTABLISH),
+        }
+
+    counts = {
+        status: int(raw.get(status) or 0) for status in CALL_RESOLUTION_STATUSES
+    }
+    resolved = counts.get("resolved", 0)
+    total = sum(counts.values())
+    unresolved_by_status = {
+        status: value
+        for status, value in counts.items()
+        if status != "resolved" and value
+    }
+    if total <= 0:
+        completeness = "unknown"
+        ratio = None
+    elif not unresolved_by_status:
+        completeness = "complete"
+        ratio = 1.0
+    else:
+        completeness = "partial"
+        ratio = round(resolved / total, 6)
+    return {
+        "completeness": completeness,
+        "reason": None,
+        "resolved_call_edges": resolved,
+        "total_call_edges": total,
+        "resolved_ratio": ratio,
+        "unresolved_by_status": unresolved_by_status,
+        "does_not_establish": list(_CALL_GRAPH_COVERAGE_DOES_NOT_ESTABLISH),
+    }
+
+
 def _call_graph_metadata(data: dict[str, Any]) -> dict[str, Any]:
     return {
         "run_id": data.get("run_id"),
@@ -532,6 +590,7 @@ def _call_graph_metadata(data: dict[str, Any]) -> dict[str, Any]:
         "resolution_counts": _detached_record(data.get("resolution_counts")),
         "evidence_counts": _detached_record(data.get("evidence_counts")),
         "relation_counts": _detached_record(data.get("relation_counts")),
+        "coverage": _call_graph_coverage(data),
         **_call_graph_parse_diagnostics(data),
     }
 
@@ -919,6 +978,7 @@ def _find_references_full(
         "filters": {"path": path},
         "call_graph": _detached_record(artifact),
         "call_graph_metadata": _call_graph_metadata(data),
+        "call_graph_coverage": _call_graph_coverage(data),
         "availability": availability,
         "freshness": availability.get("freshness") if isinstance(availability, dict) else None,
         "total_match_count": len(matched),
@@ -1067,6 +1127,7 @@ def _get_callers_full(
         "call_graph": _detached_record(artifact),
         "symbol_index": _detached_record(symbol_artifact),
         "call_graph_metadata": _call_graph_metadata(data),
+        "call_graph_coverage": _call_graph_coverage(data),
         "availability": availability,
         "freshness": availability.get("freshness") if isinstance(availability, dict) else None,
         "total_caller_count": len(groups),
@@ -1214,6 +1275,7 @@ def _get_callees_full(
         "call_graph": _detached_record(artifact),
         "symbol_index": _detached_record(symbol_artifact),
         "call_graph_metadata": _call_graph_metadata(data),
+        "call_graph_coverage": _call_graph_coverage(data),
         "availability": availability,
         "freshness": availability.get("freshness") if isinstance(availability, dict) else None,
         "total_callee_count": len(groups),

--- a/merger/repoground/core/call_graph_navigation.py
+++ b/merger/repoground/core/call_graph_navigation.py
@@ -115,6 +115,7 @@ _CALL_NAV_DOES_NOT_ESTABLISH = tuple(
 # These are the claims a partial graph cannot support even when the returned
 # rows themselves are correct.
 _CALL_GRAPH_COVERAGE_DOES_NOT_ESTABLISH = (
+    "complete_call_graph",
     "caller_completeness",
     "callee_completeness",
     "unresolved_edges_are_irrelevant",
@@ -543,6 +544,7 @@ def _call_graph_coverage(data: dict[str, Any]) -> dict[str, Any]:
     raw = data.get("resolution_counts")
     if not isinstance(raw, Mapping):
         return {
+            "scope": "observed_call_edges",
             "completeness": "unknown",
             "reason": "call_graph_resolution_counts_unavailable",
             "resolved_call_edges": None,
@@ -572,6 +574,7 @@ def _call_graph_coverage(data: dict[str, Any]) -> dict[str, Any]:
         completeness = "partial"
         ratio = round(resolved / total, 6)
     return {
+        "scope": "observed_call_edges",
         "completeness": completeness,
         "reason": None,
         "resolved_call_edges": resolved,
@@ -590,7 +593,6 @@ def _call_graph_metadata(data: dict[str, Any]) -> dict[str, Any]:
         "resolution_counts": _detached_record(data.get("resolution_counts")),
         "evidence_counts": _detached_record(data.get("evidence_counts")),
         "relation_counts": _detached_record(data.get("relation_counts")),
-        "coverage": _call_graph_coverage(data),
         **_call_graph_parse_diagnostics(data),
     }
 

--- a/merger/repoground/core/snapshot_profiles.py
+++ b/merger/repoground/core/snapshot_profiles.py
@@ -152,13 +152,19 @@ PROFILE_ARTIFACT_RULES = {
         "python_symbol_index_json": REQ_RECOMMENDED,
         "python_call_graph_json": REQ_RECOMMENDED,
     },
+    # The daily fleet publication is the bundle the agent-facing call-navigation
+    # tools resolve against. Excluding the Python symbol index and call graph
+    # here removes `find_symbol`, `get_callers`, and `get_callees` from that
+    # surface entirely, so they stay part of the compact profile. `sqlite_index`
+    # remains excluded: it carries the bulk of the storage cost and no
+    # agent-facing read path consumes it.
     "fleet-context": {
         **BASE_RULES,
         "sqlite_index": REQ_EXCLUDED,
         "export_safety_report": REQ_REQUIRED,
         "retrieval_eval_json": REQ_RECOMMENDED,
-        "python_symbol_index_json": REQ_EXCLUDED,
-        "python_call_graph_json": REQ_EXCLUDED,
+        "python_symbol_index_json": REQ_RECOMMENDED,
+        "python_call_graph_json": REQ_RECOMMENDED,
     },
     "full-max": {
         **BASE_RULES,

--- a/merger/repoground/core/snapshot_profiles.py
+++ b/merger/repoground/core/snapshot_profiles.py
@@ -154,9 +154,10 @@ PROFILE_ARTIFACT_RULES = {
     },
     # The daily fleet publication is the bundle the agent-facing call-navigation
     # tools resolve against. Excluding the Python symbol index and call graph
-    # here removes `find_symbol`, `get_callers`, and `get_callees` from that
-    # surface entirely, so they stay part of the compact profile. `sqlite_index`
-    # remains excluded: it carries the bulk of the storage cost and no
+    # here removes `find_symbol`, `find_references`, `get_callers`, and
+    # `get_callees` from that surface entirely, so they stay part of the compact
+    # profile. `sqlite_index` remains excluded: it carries the bulk of the storage
+    # cost and no
     # agent-facing read path consumes it.
     "fleet-context": {
         **BASE_RULES,

--- a/merger/repoground/tests/test_call_navigation.py
+++ b/merger/repoground/tests/test_call_navigation.py
@@ -1607,6 +1607,8 @@ def test_call_graph_coverage_marks_a_partially_resolved_graph(tmp_path):
 
     assert result["status"] == "available"
     coverage = result["call_graph_coverage"]
+    assert "coverage" not in result["call_graph_metadata"]
+    assert coverage["scope"] == "observed_call_edges"
     assert coverage["completeness"] == "partial"
     assert coverage["total_call_edges"] == len(graph_payload["calls"])
     assert coverage["resolved_call_edges"] == baseline["resolved"]
@@ -1619,6 +1621,7 @@ def test_call_graph_coverage_marks_a_partially_resolved_graph(tmp_path):
         coverage["resolved_call_edges"] / coverage["total_call_edges"], 6
     )
     assert coverage["resolved_ratio"] < 1.0
+    assert "complete_call_graph" in coverage["does_not_establish"]
     assert "caller_completeness" in coverage["does_not_establish"]
 
 

--- a/merger/repoground/tests/test_call_navigation.py
+++ b/merger/repoground/tests/test_call_navigation.py
@@ -1544,3 +1544,127 @@ def test_legacy_strict_hash_switch_remains_supported(tmp_path, monkeypatch):
     result = get_callers(manifest, "target", path="pkg/target.py")
     assert result["status"] == "available"
     assert call_graph_reads >= 1
+
+
+def _recount(graph_payload: dict) -> None:
+    calls = graph_payload["calls"]
+    graph_payload["call_count"] = len(calls)
+    graph_payload["resolution_counts"] = _count(
+        calls, "resolution_status", ("resolved", "candidate", "ambiguous", "unresolved")
+    )
+    graph_payload["evidence_counts"] = _count(calls, "evidence_level", ("S0", "S1"))
+    graph_payload["relation_counts"] = _count(
+        calls, "relation_type", ("calls", "constructs")
+    )
+
+
+def _rewrite_graph(call_graph: Path, manifest: Path, graph_payload: dict) -> None:
+    _recount(graph_payload)
+    call_graph.write_text(json.dumps(graph_payload), encoding="utf-8")
+    _refresh_manifest_artifact(manifest, "python_call_graph_json", call_graph)
+
+
+def _unresolved_call(line: int, status: str) -> dict:
+    """One extra call row the resolver saw but could not bind to a target.
+
+    This is the module-qualified shape (`mod.target(...)`) that the resolver
+    routinely fails to bind, which is why coverage has to be reported.
+    """
+    return _call(
+        "pkg/c.py",
+        line,
+        caller_id=OTHER_CALLER_ID,
+        caller="other_caller",
+        expression="mod.target",
+        simple_name="target",
+        status=status,
+        reason="module_qualified_name",
+        candidate_ids=[TARGET_ID] if status == "candidate" else None,
+        caller_start_line=1,
+        caller_end_line=45,
+    )
+
+
+def test_call_graph_coverage_marks_a_partially_resolved_graph(tmp_path):
+    """A partial graph must not read as an exhaustive caller list."""
+    manifest, call_graph, _ = _write_bundle(tmp_path)
+    graph_payload = json.loads(call_graph.read_text(encoding="utf-8"))
+    baseline = _count(
+        graph_payload["calls"],
+        "resolution_status",
+        ("resolved", "candidate", "ambiguous", "unresolved"),
+    )
+    graph_payload["calls"].extend(
+        [
+            _unresolved_call(30, "candidate"),
+            _unresolved_call(31, "ambiguous"),
+            _unresolved_call(32, "unresolved"),
+        ]
+    )
+    _rewrite_graph(call_graph, manifest, graph_payload)
+
+    result = get_callers(manifest, "target", path="pkg/target.py", k=10)
+
+    assert result["status"] == "available"
+    coverage = result["call_graph_coverage"]
+    assert coverage["completeness"] == "partial"
+    assert coverage["total_call_edges"] == len(graph_payload["calls"])
+    assert coverage["resolved_call_edges"] == baseline["resolved"]
+    assert coverage["unresolved_by_status"] == {
+        "candidate": baseline["candidate"] + 1,
+        "ambiguous": baseline["ambiguous"] + 1,
+        "unresolved": baseline["unresolved"] + 1,
+    }
+    assert coverage["resolved_ratio"] == round(
+        coverage["resolved_call_edges"] / coverage["total_call_edges"], 6
+    )
+    assert coverage["resolved_ratio"] < 1.0
+    assert "caller_completeness" in coverage["does_not_establish"]
+
+
+def test_call_graph_coverage_marks_a_fully_resolved_graph(tmp_path):
+    manifest, call_graph, _ = _write_bundle(tmp_path)
+    graph_payload = json.loads(call_graph.read_text(encoding="utf-8"))
+    graph_payload["calls"] = [
+        call
+        for call in graph_payload["calls"]
+        if call["resolution_status"] == "resolved"
+    ]
+    _rewrite_graph(call_graph, manifest, graph_payload)
+
+    coverage = get_callers(manifest, "target", path="pkg/target.py", k=10)[
+        "call_graph_coverage"
+    ]
+    assert coverage["completeness"] == "complete"
+    assert coverage["resolved_ratio"] == 1.0
+    assert coverage["unresolved_by_status"] == {}
+
+
+def test_call_graph_coverage_is_unknown_without_resolution_counts(tmp_path):
+    """A graph that never reported counts must not be read as complete."""
+    manifest, call_graph, _ = _write_bundle(tmp_path)
+    data = json.loads(call_graph.read_text(encoding="utf-8"))
+    data.pop("resolution_counts", None)
+
+    coverage = call_graph_navigation._call_graph_coverage(data)
+
+    assert coverage["completeness"] == "unknown"
+    assert coverage["reason"] == "call_graph_resolution_counts_unavailable"
+    assert coverage["resolved_ratio"] is None
+    assert "caller_completeness" in coverage["does_not_establish"]
+
+
+def test_call_graph_coverage_is_reported_by_callees_and_references(tmp_path):
+    """All three call-graph tools share one coverage verdict."""
+    manifest, call_graph, _ = _write_bundle(tmp_path)
+    graph_payload = json.loads(call_graph.read_text(encoding="utf-8"))
+    graph_payload["calls"].append(_unresolved_call(33, "candidate"))
+    _rewrite_graph(call_graph, manifest, graph_payload)
+
+    callees = get_callees(manifest, "caller_one", path="pkg/a.py", k=10)
+    references = find_references(manifest, "target", k=10)
+
+    for result in (callees, references):
+        assert result["status"] == "available"
+        assert result["call_graph_coverage"]["completeness"] == "partial"
+        assert result["call_graph_coverage"] == callees["call_graph_coverage"]

--- a/merger/repoground/tests/test_publication_surface_smoke.py
+++ b/merger/repoground/tests/test_publication_surface_smoke.py
@@ -3,32 +3,32 @@
 The profile rules in `snapshot_profiles` and the tests around them only describe
 what a publication *should* contain. They stayed green when `fleet-context`
 started excluding `python_symbol_index_json` and `python_call_graph_json`, which
-silently removed `find_symbol`, `get_callers`, and `get_callees` from the
-agent-facing surface for two days without a single failing test.
+silently removed `find_symbol`, `find_references`, `get_callers`, and
+`get_callees` from the agent-facing surface for two days without a single
+failing test.
 
 This test closes that gap from the other end: it emits a real publication
-through the same CLI path the daily fleet publisher uses, then calls all three
+through the same CLI path the daily fleet publisher uses, then calls all four
 tools against the emitted manifest. It fails if the shipped bundle cannot answer
 them, regardless of what the profile tables claim.
 """
 
 from __future__ import annotations
 
+import importlib.machinery
+import importlib.util
 import json
 import subprocess
 import sys
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
-from merger.repoground.core.bundle_access import get_callees, get_callers
-from merger.repoground.core.mcp_tools import find_symbol
-
-# The profile the fleet publisher selects for ordinary daily publications.
-# Keep this in sync with `publication_config` in scripts/ops/repoground-publish-fleet.
-DAILY_FLEET_PROFILE = "fleet-context"
+from merger.repoground.core import mcp_tools
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
+PUBLISHER = REPO_ROOT / "scripts/ops/repoground-publish-fleet"
 
 CORE_MODULE = """\
 def helper(value):
@@ -46,6 +46,29 @@ from pkg.core import target
 def run_once(value):
     return target(value)
 """
+
+
+def _load_publisher() -> ModuleType:
+    module_name = "repoground_publish_fleet_surface_test"
+    loader = importlib.machinery.SourceFileLoader(module_name, str(PUBLISHER))
+    spec = importlib.util.spec_from_loader(module_name, loader)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    loader.exec_module(module)
+    return module
+
+
+def _daily_fleet_config(repo: Path):
+    publisher = _load_publisher()
+    entry = publisher.RepoEntry(
+        key="demo/demo",
+        owner="demo",
+        repo="demo",
+        path=repo,
+        remote="git@github.com:demo/demo.git",
+    )
+    return publisher.publication_config(entry)
 
 
 def _git(repo: Path, *args: str) -> None:
@@ -79,38 +102,41 @@ def _source_repo(tmp_path: Path) -> Path:
     return repo
 
 
-def _publish(tmp_path: Path, repo: Path) -> dict:
+def _publish(tmp_path: Path, repo: Path) -> tuple[dict, dict[str, object]]:
     publication_root = tmp_path / "pub"
     out_dir = publication_root / "gen"
     out_dir.mkdir(parents=True)
+    config = _daily_fleet_config(repo)
+    argv = [
+        sys.executable,
+        "-B",
+        "-m",
+        "merger.repoground.cli.ground",
+        "external-manifest",
+        "refresh",
+        "--repo",
+        str(repo),
+        "--out",
+        str(out_dir),
+        "--publication-root",
+        str(publication_root),
+        "--repository",
+        "demo__demo",
+        "--ref",
+        "main",
+        "--profile",
+        config.profile,
+        "--output-mode",
+        config.output_mode,
+        "--max-bytes",
+        str(config.max_bytes),
+        "--split-size",
+        config.split_size,
+    ]
+    if config.redact_secrets:
+        argv.append("--redact-secrets")
     completed = subprocess.run(
-        [
-            sys.executable,
-            "-B",
-            "-m",
-            "merger.repoground.cli.ground",
-            "external-manifest",
-            "refresh",
-            "--repo",
-            str(repo),
-            "--out",
-            str(out_dir),
-            "--publication-root",
-            str(publication_root),
-            "--repository",
-            "demo__demo",
-            "--ref",
-            "main",
-            "--profile",
-            DAILY_FLEET_PROFILE,
-            "--output-mode",
-            "dual",
-            "--max-bytes",
-            "0",
-            "--split-size",
-            "25MB",
-            "--redact-secrets",
-        ],
+        argv,
         cwd=REPO_ROOT,
         check=False,
         capture_output=True,
@@ -120,7 +146,7 @@ def _publish(tmp_path: Path, repo: Path) -> dict:
         f"publication failed ({completed.returncode}):\n{completed.stdout[-4000:]}\n"
         f"{completed.stderr[-4000:]}"
     )
-    return json.loads(completed.stdout)
+    return json.loads(completed.stdout), config.as_dict()
 
 
 def _published_manifest(tmp_path: Path) -> Path:
@@ -131,23 +157,32 @@ def _published_manifest(tmp_path: Path) -> Path:
 
 
 @pytest.fixture(scope="module")
-def published_bundle(tmp_path_factory) -> tuple[Path, dict]:
+def published_bundle(tmp_path_factory) -> tuple[Path, dict, dict[str, object]]:
     tmp_path = tmp_path_factory.mktemp("publication_surface")
     repo = _source_repo(tmp_path)
-    report = _publish(tmp_path, repo)
-    return _published_manifest(tmp_path), report
+    report, config = _publish(tmp_path, repo)
+    return _published_manifest(tmp_path), report, config
+
+
+def _available_mcp_result(response: dict, tool: str) -> dict:
+    assert response["tool"] == tool
+    assert response["status"] == "available"
+    result = response["result"]
+    assert result["status"] == "available", result.get("error")
+    assert result["projection"] == "repobrief.read_response.compact.v1"
+    return result
 
 
 @pytest.mark.publication_surface
 def test_daily_profile_publishes_the_call_navigation_artifacts(published_bundle):
-    manifest_path, report = published_bundle
+    manifest_path, report, config = published_bundle
     snapshot = report["snapshot"]
 
     assert report["status"] == "ok"
     assert snapshot["status"] == "ok"
-    assert snapshot["profile"] == DAILY_FLEET_PROFILE
+    assert snapshot["profile"] == config["profile"]
     evaluation = snapshot["profile_evaluation"]
-    assert evaluation["profile"] == DAILY_FLEET_PROFILE
+    assert evaluation["profile"] == config["profile"]
     assert evaluation["status"] == "pass"
     assert evaluation["profile_excluded_present"] == []
 
@@ -156,7 +191,7 @@ def test_daily_profile_publishes_the_call_navigation_artifacts(published_bundle)
     for role in ("python_symbol_index_json", "python_call_graph_json"):
         assert rules[role] != "profile_excluded", (
             f"{role} is excluded from the daily publication; "
-            "find_symbol/get_callers/get_callees cannot be served"
+            "find_symbol/find_references/get_callers/get_callees cannot be served"
         )
 
     # The storage intent of the compact profile is still honoured.
@@ -168,33 +203,59 @@ def test_daily_profile_publishes_the_call_navigation_artifacts(published_bundle)
 
 @pytest.mark.publication_surface
 def test_find_symbol_answers_against_the_published_bundle(published_bundle):
-    manifest_path, _ = published_bundle
+    manifest_path, _, _ = published_bundle
 
-    result = find_symbol(bundle_manifest=manifest_path, name="target", k=10)["result"]
+    result = _available_mcp_result(
+        mcp_tools.find_symbol(bundle_manifest=manifest_path, name="target", k=10),
+        "find_symbol",
+    )
 
-    assert result["status"] == "available", result.get("error")
     assert [(hit["name"], hit["path"]) for hit in result["hits"]] == [
         ("target", "pkg/core.py")
     ]
 
 
 @pytest.mark.publication_surface
+def test_find_references_answers_against_the_published_bundle(published_bundle):
+    manifest_path, _, _ = published_bundle
+
+    result = _available_mcp_result(
+        mcp_tools.find_references(bundle_manifest=manifest_path, name="target", k=10),
+        "find_references",
+    )
+
+    assert [(hit["simple_name"], hit["path"]) for hit in result["hits"]] == [
+        ("target", "pkg/caller.py")
+    ]
+    assert result["call_graph_coverage"]["scope"] == "observed_call_edges"
+    assert result["call_graph_coverage"]["completeness"] in {"complete", "partial"}
+
+
+@pytest.mark.publication_surface
 def test_get_callers_answers_against_the_published_bundle(published_bundle):
-    manifest_path, _ = published_bundle
+    manifest_path, _, _ = published_bundle
 
-    result = get_callers(manifest_path, "target", k=10)
+    result = _available_mcp_result(
+        mcp_tools.get_callers(bundle_manifest=manifest_path, name="target", k=10),
+        "get_callers",
+    )
 
-    assert result["status"] == "available", result.get("error")
     assert [caller["path"] for caller in result["callers"]] == ["pkg/caller.py"]
     assert result["call_graph_coverage"]["completeness"] in {"complete", "partial"}
 
 
 @pytest.mark.publication_surface
 def test_get_callees_answers_against_the_published_bundle(published_bundle):
-    manifest_path, _ = published_bundle
+    manifest_path, _, _ = published_bundle
 
-    result = get_callees(manifest_path, "run_once", k=10)
+    result = _available_mcp_result(
+        mcp_tools.get_callees(bundle_manifest=manifest_path, name="run_once", k=10),
+        "get_callees",
+    )
 
-    assert result["status"] == "available", result.get("error")
-    assert result["callees"], "run_once calls target; the callee list must not be empty"
+    assert [
+        (callee["callee_symbol"]["name"], callee["callee_symbol"]["path"])
+        for callee in result["callees"]
+    ] == [("target", "pkg/core.py")]
+    assert result["call_graph_coverage"]["scope"] == "observed_call_edges"
     assert result["call_graph_coverage"]["completeness"] in {"complete", "partial"}

--- a/merger/repoground/tests/test_publication_surface_smoke.py
+++ b/merger/repoground/tests/test_publication_surface_smoke.py
@@ -1,0 +1,200 @@
+"""End-to-end guard: the published daily bundle must serve call navigation.
+
+The profile rules in `snapshot_profiles` and the tests around them only describe
+what a publication *should* contain. They stayed green when `fleet-context`
+started excluding `python_symbol_index_json` and `python_call_graph_json`, which
+silently removed `find_symbol`, `get_callers`, and `get_callees` from the
+agent-facing surface for two days without a single failing test.
+
+This test closes that gap from the other end: it emits a real publication
+through the same CLI path the daily fleet publisher uses, then calls all three
+tools against the emitted manifest. It fails if the shipped bundle cannot answer
+them, regardless of what the profile tables claim.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from merger.repoground.core.bundle_access import get_callees, get_callers
+from merger.repoground.core.mcp_tools import find_symbol
+
+# The profile the fleet publisher selects for ordinary daily publications.
+# Keep this in sync with `publication_config` in scripts/ops/repoground-publish-fleet.
+DAILY_FLEET_PROFILE = "fleet-context"
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+CORE_MODULE = """\
+def helper(value):
+    return value + 1
+
+
+def target(value):
+    return helper(value)
+"""
+
+CALLER_MODULE = """\
+from pkg.core import target
+
+
+def run_once(value):
+    return target(value)
+"""
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _source_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "src"
+    (repo / "pkg").mkdir(parents=True)
+    (repo / "pkg" / "core.py").write_text(CORE_MODULE, encoding="utf-8")
+    (repo / "pkg" / "caller.py").write_text(CALLER_MODULE, encoding="utf-8")
+    (repo / "README.md").write_text("# demo\n", encoding="utf-8")
+    _git(repo, "init", "-q", ".")
+    _git(repo, "add", "-A")
+    _git(
+        repo,
+        "-c",
+        "user.email=smoke@example.invalid",
+        "-c",
+        "user.name=smoke",
+        "commit",
+        "-qm",
+        "init",
+    )
+    return repo
+
+
+def _publish(tmp_path: Path, repo: Path) -> dict:
+    publication_root = tmp_path / "pub"
+    out_dir = publication_root / "gen"
+    out_dir.mkdir(parents=True)
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-B",
+            "-m",
+            "merger.repoground.cli.ground",
+            "external-manifest",
+            "refresh",
+            "--repo",
+            str(repo),
+            "--out",
+            str(out_dir),
+            "--publication-root",
+            str(publication_root),
+            "--repository",
+            "demo__demo",
+            "--ref",
+            "main",
+            "--profile",
+            DAILY_FLEET_PROFILE,
+            "--output-mode",
+            "dual",
+            "--max-bytes",
+            "0",
+            "--split-size",
+            "25MB",
+            "--redact-secrets",
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, (
+        f"publication failed ({completed.returncode}):\n{completed.stdout[-4000:]}\n"
+        f"{completed.stderr[-4000:]}"
+    )
+    return json.loads(completed.stdout)
+
+
+def _published_manifest(tmp_path: Path) -> Path:
+    external = tmp_path / "pub" / "external" / "_bundles" / "demo__demo" / "main"
+    manifests = sorted(external.rglob("*_merge.bundle.manifest.json"))
+    assert manifests, f"no published bundle manifest under {external}"
+    return manifests[-1]
+
+
+@pytest.fixture(scope="module")
+def published_bundle(tmp_path_factory) -> tuple[Path, dict]:
+    tmp_path = tmp_path_factory.mktemp("publication_surface")
+    repo = _source_repo(tmp_path)
+    report = _publish(tmp_path, repo)
+    return _published_manifest(tmp_path), report
+
+
+@pytest.mark.publication_surface
+def test_daily_profile_publishes_the_call_navigation_artifacts(published_bundle):
+    manifest_path, report = published_bundle
+    snapshot = report["snapshot"]
+
+    assert report["status"] == "ok"
+    assert snapshot["status"] == "ok"
+    assert snapshot["profile"] == DAILY_FLEET_PROFILE
+    evaluation = snapshot["profile_evaluation"]
+    assert evaluation["profile"] == DAILY_FLEET_PROFILE
+    assert evaluation["status"] == "pass"
+    assert evaluation["profile_excluded_present"] == []
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    rules = manifest["capabilities"]["repobrief_profile_policy"]["artifact_rules"]
+    for role in ("python_symbol_index_json", "python_call_graph_json"):
+        assert rules[role] != "profile_excluded", (
+            f"{role} is excluded from the daily publication; "
+            "find_symbol/get_callers/get_callees cannot be served"
+        )
+
+    # The storage intent of the compact profile is still honoured.
+    assert rules["sqlite_index"] == "profile_excluded"
+    removed = " ".join(snapshot["removed_profile_excluded_artifacts"])
+    assert "python_symbol_index" not in removed
+    assert "python_call_graph" not in removed
+
+
+@pytest.mark.publication_surface
+def test_find_symbol_answers_against_the_published_bundle(published_bundle):
+    manifest_path, _ = published_bundle
+
+    result = find_symbol(bundle_manifest=manifest_path, name="target", k=10)["result"]
+
+    assert result["status"] == "available", result.get("error")
+    assert [(hit["name"], hit["path"]) for hit in result["hits"]] == [
+        ("target", "pkg/core.py")
+    ]
+
+
+@pytest.mark.publication_surface
+def test_get_callers_answers_against_the_published_bundle(published_bundle):
+    manifest_path, _ = published_bundle
+
+    result = get_callers(manifest_path, "target", k=10)
+
+    assert result["status"] == "available", result.get("error")
+    assert [caller["path"] for caller in result["callers"]] == ["pkg/caller.py"]
+    assert result["call_graph_coverage"]["completeness"] in {"complete", "partial"}
+
+
+@pytest.mark.publication_surface
+def test_get_callees_answers_against_the_published_bundle(published_bundle):
+    manifest_path, _ = published_bundle
+
+    result = get_callees(manifest_path, "run_once", k=10)
+
+    assert result["status"] == "available", result.get("error")
+    assert result["callees"], "run_once calls target; the callee list must not be empty"
+    assert result["call_graph_coverage"]["completeness"] in {"complete", "partial"}

--- a/merger/repoground/tests/test_snapshot_profiles.py
+++ b/merger/repoground/tests/test_snapshot_profiles.py
@@ -108,8 +108,18 @@ def test_fleet_context_preserves_citation_truth_without_heavy_indexes():
     assert rules["export_safety_report"] == "required"
     assert rules["retrieval_eval_json"] == "recommended"
     assert rules["sqlite_index"] == "profile_excluded"
-    assert rules["python_symbol_index_json"] == "profile_excluded"
-    assert rules["python_call_graph_json"] == "profile_excluded"
+
+
+def test_fleet_context_keeps_the_call_navigation_indexes():
+    """The daily fleet bundle backs find_symbol/get_callers/get_callees.
+
+    Excluding these two artifacts silently removed all three tools from the
+    agent-facing surface, so the compact profile must keep carrying them.
+    """
+    rules = PROFILE_ARTIFACT_RULES["fleet-context"]
+
+    assert rules["python_symbol_index_json"] == "recommended"
+    assert rules["python_call_graph_json"] == "recommended"
 
 
 def test_fleet_context_accepts_the_compact_surface_and_rejects_heavy_indexes():
@@ -125,6 +135,8 @@ def test_fleet_context_accepts_the_compact_surface_and_rejects_heavy_indexes():
         "export_safety_report",
         "snapshot_plan_json",
         "retrieval_eval_json",
+        "python_symbol_index_json",
+        "python_call_graph_json",
     }
 
     compact = evaluate_profile("fleet-context", compact_roles)
@@ -132,14 +144,9 @@ def test_fleet_context_accepts_the_compact_surface_and_rejects_heavy_indexes():
     assert compact["missing_required"] == []
     assert compact["profile_excluded_present"] == []
 
-    for role in (
-        "sqlite_index",
-        "python_symbol_index_json",
-        "python_call_graph_json",
-    ):
-        invalid = evaluate_profile("fleet-context", compact_roles | {role})
-        assert invalid["status"] == "fail"
-        assert invalid["profile_excluded_present"] == [role]
+    invalid = evaluate_profile("fleet-context", compact_roles | {"sqlite_index"})
+    assert invalid["status"] == "fail"
+    assert invalid["profile_excluded_present"] == ["sqlite_index"]
 
 
 def test_profile_output_mode_plan_is_machine_readable():
@@ -162,11 +169,7 @@ def test_profile_output_mode_plan_is_machine_readable():
     assert fleet_default["selected_output_mode"] == "dual"
     assert fleet_default["defaulted"] is True
     assert fleet_default["conflicts"] == []
-    assert fleet_default["excluded_roles"] == [
-        "sqlite_index",
-        "python_symbol_index_json",
-        "python_call_graph_json",
-    ]
+    assert fleet_default["excluded_roles"] == ["sqlite_index"]
     assert fleet_default["post_emit_dropped_roles"] == ["sqlite_index"]
 
     fleet_archive = profile_output_mode_plan("fleet-context", "archive")

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,3 +7,4 @@ asyncio_mode = auto
 markers =
     browser: tests requiring pytest-playwright/browser runtime
     doc_freshness_live: live registry verification tests (run against actual repo tree; non-blocking in CI)
+    publication_surface: end-to-end tests that emit a real publication and read it back through the agent-facing tools


### PR DESCRIPTION
## Was kaputt war

Die tägliche Fleet-Publikation läuft über das Profil `fleet-context`. Dieses Profil setzte `python_symbol_index_json` und `python_call_graph_json` seit `288ced5f` auf `profile_excluded`.

Damit waren **vier agentenseitige Navigationswerkzeuge nicht verfügbar**, frisch rückgelesen gegen die kanonische Publikation `heimgewebe__repoground__main-max-260802-0701`:

| Werkzeug | Status | Fehlercode |
|---|---|---|
| `find_symbol` | `missing` | `python_symbol_index_json_missing` |
| `find_references` | `missing` | `python_call_graph_json_missing` |
| `get_callers` | `missing` | `python_call_graph_json_missing` |
| `get_callees` | `missing` | `python_call_graph_json_missing` |

Dasselbe Bundle meldete zugleich `freshness: fresh_exact`, `post_emit_health: pass` und `profile_evaluation.status: pass`. Die bisherigen Gates waren also grün, obwohl die ausgelieferte Agentenschnittstelle unvollständig war.

## Ursache und Entscheidung

Die frühere `fleet-context`-Entscheidung inventarisierte den normalen Context-Pack-Pfad, nicht aber den separaten Werkzeugpfad. Beide Pfade verwenden dasselbe Bundle, aber nur der Werkzeugpfad benötigt den Python-Symbolindex und den Python-Call-Graph direkt.

Darum bleiben `python_symbol_index_json` und `python_call_graph_json` in `fleet-context` auf `recommended`. `sqlite_index` bleibt ausgeschlossen und bewahrt den dominanten Speichervorteil.

**Verworfene Alternative:** ein zweites `agent-portable`- oder `full-max`-Bundle nur für Navigation. Das würde mehr Speicher belegen und die Freshness-Aussage auf zwei Publikationen aufteilen.

## Ehrliche Abdeckung

Nur eindeutig `resolved`-Kanten können Caller oder Callees belegen. Die drei Call-Graph-Werkzeuge melden deshalb `call_graph_coverage` auf oberster Antwortebene:

- `scope: observed_call_edges`
- `completeness: complete | partial | unknown` innerhalb dieses begrenzten Scopes
- `resolved_call_edges`, `total_call_edges`, `resolved_ratio`
- `unresolved_by_status`
- `does_not_establish`, einschließlich `complete_call_graph`

Damit bedeutet `complete` ausdrücklich **nicht**, dass der Call-Graph des gesamten Repositories vollständig ist. Die Flottenmessung vom 28.07. fand 17.765 von 67.836 beobachteten Kanten eindeutig aufgelöst, rund 26 Prozent.

## Regressionsschutz und Self-Review

`test_publication_surface_smoke.py` erzeugt eine echte Publikation mit der **tatsächlichen Konfiguration des Fleet-Publishers** und liest sie über die öffentlichen MCP-Werkzeuge zurück:

- `find_symbol`
- `find_references`
- `get_callers`
- `get_callees`

Die erste PR-Fassung testete `get_callers` und `get_callees` nur über interne Python-Funktionen und ließ `find_references` aus. Der Self-Review hat diese Lücke geschlossen. Zusätzlich wurde die doppelte Ausgabe von Coverage-Daten in `call_graph_metadata` entfernt und der Coverage-Scope explizit gemacht.

Mit den regressiven `profile_excluded`-Werten fallen alle fünf Publikationsoberflächen-Tests. Mit dem Fix bestehen sie.

## Verifikation auf Head `c8797eb11aebc22415d35fd457b2b33b9646fb57`

- `python3 -m pytest -q` → **5.347 bestanden, 12 übersprungen**
- fokussierter Lauf → **90/90 bestanden**
- `ruff check --config ruff-ci.toml .` → **bestanden**
- `git diff --check origin/main...HEAD` → **bestanden**
- vollständiger PR-Diff SHA-256: `cea4a61461fe7c2c6329e77b24506cc14af7b64163701203d289275571e0db9a`

## Bewusst nicht in diesem PR

Die rund 26-prozentige Auflösungsquote wird hier nicht verbessert. Dieser PR stellt die Werkzeuge wieder her und macht ihre Evidenzgrenze maschinenlesbar. Eine Verbesserung der realen Auflösungsquote bleibt eine getrennte, messpflichtige Folgearbeit.
