### PR TITLE
fix: ignore empty SCIP relationships

### DIFF
--- a/merger/repoground/core/_scip_adapter_records.py
+++ b/merger/repoground/core/_scip_adapter_records.py
@@ -190,6 +190,8 @@ def _relationship_records(
             )
         )
         return []
+    if not relationships:
+        return []
     source = _relationship_source(
         source_symbol,
         path=path,

--- a/merger/repoground/tests/test_scip_adapter_hardening.py
+++ b/merger/repoground/tests/test_scip_adapter_hardening.py
@@ -115,3 +115,69 @@ def test_relationship_never_borrows_definition_from_another_document():
         and item["symbol"] == SYMBOL
         for item in artifact["degradations"]
     )
+
+
+def _relationship_only_index(symbol_information):
+    return {
+        "metadata": _metadata(),
+        "documents": [
+            {
+                "relativePath": "src/main.py",
+                "language": "python",
+                "positionEncoding": "UTF32CodeUnitOffsetFromLineStart",
+                "occurrences": [],
+                "symbols": [symbol_information],
+            }
+        ],
+    }
+
+
+def test_missing_or_empty_relationships_do_not_require_source_definition():
+    for symbol_information in (
+        {"symbol": SYMBOL},
+        {"symbol": SYMBOL, "relationships": []},
+    ):
+        artifact = _normalize(_relationship_only_index(symbol_information))
+
+        assert artifact["status"] == "available"
+        assert artifact["languages"] == ["python"]
+        assert artifact["record_count"] == 0
+        assert artifact["records"] == []
+        assert artifact["degradations"] == []
+        assert artifact["consumer_enablement"] == {
+            "requires_language_benchmark": True,
+            "eligible_for_review": False,
+            "default_promoted": False,
+        }
+
+
+def test_malformed_relationships_remain_fail_closed_without_definition_lookup():
+    artifact = _normalize(
+        _relationship_only_index({"symbol": SYMBOL, "relationships": {}})
+    )
+
+    assert artifact["status"] == "degraded"
+    assert artifact["record_count"] == 0
+    assert [item["code"] for item in artifact["degradations"]] == [
+        "relationships_invalid"
+    ]
+
+
+def test_nonempty_relationships_still_require_exact_source_definition():
+    artifact = _normalize(
+        _relationship_only_index(
+            {
+                "symbol": SYMBOL,
+                "relationships": [
+                    {"symbol": TARGET, "isImplementation": True}
+                ],
+            }
+        )
+    )
+
+    assert artifact["status"] == "degraded"
+    assert artifact["record_count"] == 0
+    assert any(
+        item["code"] == "relationship_source_definition_missing"
+        for item in artifact["degradations"]
+    )


### PR DESCRIPTION
## Summary
- treat omitted or empty `SymbolInformation.relationships` as no relationship evidence
- preserve fail-closed handling for malformed and non-empty relationship data
- add regression coverage for empty, malformed, and missing-definition cases

## Evidence
- Head: `3b68d2f4789804e11849a51e001abefecfec73c1`
- Diff SHA-256: `3f771d31ce89311bedcbe39459d075ba74365b6816100839c5ded77cf6e29cf9`
- Focused SCIP tests: 24 passed
- Focused hardening file: 6 passed
- Full RepoGround tests: 5167 passed, 12 skipped
- Ruff: all checks passed
- `git diff --check`: passed

Bureau task: `RPU-V1-T035`