### PR TITLE
feat(graph): add system relation overlay

### DIFF
--- a/merger/repoground/contracts/system-relation-overlay.v1.schema.json
+++ b/merger/repoground/contracts/system-relation-overlay.v1.schema.json
@@ -1,0 +1,465 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://repoground.merger/schemas/system-relation-overlay.v1.json",
+  "title": "RepoGround system relation overlay v1",
+  "description": "Derived navigation relations for build targets, package targets, test registration, schema validation and artifact flow. Records remain provenance-bound evidence and do not prove execution, correctness, completeness or artifact materialization.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "kind",
+    "version",
+    "authority",
+    "canonicality",
+    "risk_class",
+    "status",
+    "source",
+    "relation_kinds",
+    "evidence_classes",
+    "records",
+    "record_count",
+    "degradations",
+    "consumer_enablement",
+    "absence_semantics",
+    "does_not_establish"
+  ],
+  "properties": {
+    "kind": {"const": "repoground.system_relation_overlay"},
+    "version": {"const": "1.0"},
+    "authority": {"const": "navigation_index"},
+    "canonicality": {"const": "derived"},
+    "risk_class": {"const": "navigation"},
+    "status": {"enum": ["available", "degraded"]},
+    "source": {"$ref": "#/definitions/source_provenance"},
+    "relation_kinds": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {"$ref": "#/definitions/relation_kind"}
+    },
+    "evidence_classes": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {"$ref": "#/definitions/evidence_class"}
+    },
+    "records": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/record"}
+    },
+    "record_count": {"type": "integer", "minimum": 0},
+    "degradations": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/degradation"}
+    },
+    "consumer_enablement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["eligible_for_review", "default_promoted"],
+      "properties": {
+        "eligible_for_review": {"const": false},
+        "default_promoted": {"const": false}
+      }
+    },
+    "absence_semantics": {
+      "const": "A missing record means only that this evidence document did not establish the relation. It is not evidence that the relation is absent."
+    },
+    "does_not_establish": {
+      "const": [
+        "repository_truth",
+        "build_execution",
+        "build_success",
+        "package_publishability",
+        "test_execution",
+        "test_collection",
+        "test_sufficiency",
+        "schema_validation_success",
+        "schema_conformance",
+        "artifact_materialization",
+        "artifact_freshness",
+        "runtime_behavior",
+        "runtime_correctness",
+        "relation_completeness",
+        "default_promotion"
+      ]
+    }
+  },
+  "definitions": {
+    "digest64": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "commit": {
+      "type": "string",
+      "pattern": "^(?:[a-f0-9]{40}|[a-f0-9]{64})$"
+    },
+    "repo_path": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?!/)(?![A-Za-z]:)(?!.*(?:^|/)\\.\\.?(?:/|$))(?!.*//)(?!.*\\\\).+$"
+    },
+    "relation_kind": {
+      "enum": [
+        "build_target",
+        "package_target",
+        "test_registration",
+        "validates_schema",
+        "produces_artifact",
+        "consumes_artifact"
+      ]
+    },
+    "evidence_class": {
+      "enum": [
+        "manifest_declaration",
+        "workflow_declaration",
+        "explicit_test_registration",
+        "test_import_or_reference",
+        "test_naming_heuristic",
+        "schema_validation_call",
+        "artifact_declaration"
+      ]
+    },
+    "endpoint_kind": {
+      "enum": [
+        "repository",
+        "package",
+        "build_target",
+        "package_target",
+        "test",
+        "test_target",
+        "validator",
+        "schema_contract",
+        "artifact_producer",
+        "artifact_consumer",
+        "artifact_contract",
+        "workflow"
+      ]
+    },
+    "endpoint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "identity"],
+      "properties": {
+        "kind": {"$ref": "#/definitions/endpoint_kind"},
+        "identity": {"type": "string", "minLength": 1, "maxLength": 4096}
+      }
+    },
+    "range": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["start_line", "start_character", "end_line", "end_character"],
+      "properties": {
+        "start_line": {"type": "integer", "minimum": 1},
+        "start_character": {"type": "integer", "minimum": 0},
+        "end_line": {"type": "integer", "minimum": 1},
+        "end_character": {"type": "integer", "minimum": 0}
+      }
+    },
+    "relation_source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "kind", "range"],
+      "properties": {
+        "path": {"$ref": "#/definitions/repo_path"},
+        "kind": {
+          "enum": [
+            "manifest",
+            "workflow",
+            "test_registry",
+            "source_file",
+            "artifact_contract"
+          ]
+        },
+        "range": {"$ref": "#/definitions/range"}
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["class", "level", "strength"],
+      "properties": {
+        "class": {"$ref": "#/definitions/evidence_class"},
+        "level": {"enum": ["S0", "S1"]},
+        "strength": {"enum": ["declared", "referenced", "heuristic"]}
+      },
+      "oneOf": [
+        {
+          "properties": {
+            "class": {"const": "manifest_declaration"},
+            "level": {"const": "S1"},
+            "strength": {"const": "declared"}
+          }
+        },
+        {
+          "properties": {
+            "class": {"const": "workflow_declaration"},
+            "level": {"const": "S1"},
+            "strength": {"const": "declared"}
+          }
+        },
+        {
+          "properties": {
+            "class": {"const": "explicit_test_registration"},
+            "level": {"const": "S1"},
+            "strength": {"const": "declared"}
+          }
+        },
+        {
+          "properties": {
+            "class": {"const": "test_import_or_reference"},
+            "level": {"const": "S0"},
+            "strength": {"const": "referenced"}
+          }
+        },
+        {
+          "properties": {
+            "class": {"const": "test_naming_heuristic"},
+            "level": {"const": "S0"},
+            "strength": {"const": "heuristic"}
+          }
+        },
+        {
+          "properties": {
+            "class": {"const": "schema_validation_call"},
+            "level": {"const": "S1"},
+            "strength": {"const": "declared"}
+          }
+        },
+        {
+          "properties": {
+            "class": {"const": "artifact_declaration"},
+            "level": {"const": "S1"},
+            "strength": {"const": "declared"}
+          }
+        }
+      ]
+    },
+    "contract_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "id", "version"],
+      "properties": {
+        "kind": {"enum": ["schema", "artifact"]},
+        "id": {"type": "string", "minLength": 1, "maxLength": 4096},
+        "version": {"type": "string", "minLength": 1, "maxLength": 128}
+      }
+    },
+    "record": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "record_id_sha256",
+        "relation",
+        "subject",
+        "target",
+        "source",
+        "evidence",
+        "contract_identity"
+      ],
+      "properties": {
+        "record_id_sha256": {"$ref": "#/definitions/digest64"},
+        "relation": {"$ref": "#/definitions/relation_kind"},
+        "subject": {"$ref": "#/definitions/endpoint"},
+        "target": {"$ref": "#/definitions/endpoint"},
+        "source": {"$ref": "#/definitions/relation_source"},
+        "evidence": {"$ref": "#/definitions/evidence"},
+        "contract_identity": {
+          "anyOf": [
+            {"$ref": "#/definitions/contract_identity"},
+            {"type": "null"}
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "relation": {"enum": ["build_target", "package_target"]}
+            }
+          },
+          "then": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "class": {
+                    "enum": ["manifest_declaration", "workflow_declaration"]
+                  }
+                }
+              },
+              "source": {
+                "properties": {"kind": {"enum": ["manifest", "workflow"]}}
+              },
+              "contract_identity": {"type": "null"}
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {"relation": {"const": "test_registration"}}
+          },
+          "then": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "class": {
+                    "enum": [
+                      "explicit_test_registration",
+                      "test_import_or_reference",
+                      "test_naming_heuristic"
+                    ]
+                  }
+                }
+              },
+              "contract_identity": {"type": "null"}
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {"relation": {"const": "validates_schema"}}
+          },
+          "then": {
+            "properties": {
+              "evidence": {
+                "properties": {"class": {"const": "schema_validation_call"}}
+              },
+              "source": {
+                "properties": {"kind": {"const": "source_file"}}
+              },
+              "contract_identity": {
+                "type": "object",
+                "properties": {"kind": {"const": "schema"}}
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "relation": {"enum": ["produces_artifact", "consumes_artifact"]}
+            }
+          },
+          "then": {
+            "properties": {
+              "evidence": {
+                "properties": {"class": {"const": "artifact_declaration"}}
+              },
+              "source": {
+                "properties": {
+                  "kind": {
+                    "enum": [
+                      "manifest",
+                      "workflow",
+                      "source_file",
+                      "artifact_contract"
+                    ]
+                  }
+                }
+              },
+              "contract_identity": {
+                "type": "object",
+                "properties": {"kind": {"const": "artifact"}}
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "evidence": {
+                "properties": {"class": {"const": "manifest_declaration"}}
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "source": {"properties": {"kind": {"const": "manifest"}}}
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "evidence": {
+                "properties": {"class": {"const": "workflow_declaration"}}
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "source": {"properties": {"kind": {"const": "workflow"}}}
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "class": {
+                    "enum": [
+                      "test_import_or_reference",
+                      "test_naming_heuristic",
+                      "schema_validation_call"
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "source": {"properties": {"kind": {"const": "source_file"}}}
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "evidence": {
+                "properties": {"class": {"const": "explicit_test_registration"}}
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "source": {
+                "properties": {
+                  "kind": {"enum": ["manifest", "workflow", "test_registry"]}
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "source_provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["format", "evidence_sha256", "repository_commit", "producer"],
+      "properties": {
+        "format": {"const": "repoground_system_relation_evidence_v1"},
+        "evidence_sha256": {"$ref": "#/definitions/digest64"},
+        "repository_commit": {"$ref": "#/definitions/commit"},
+        "producer": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name", "version"],
+          "properties": {
+            "name": {"type": "string", "minLength": 1, "maxLength": 256},
+            "version": {"type": "string", "minLength": 1, "maxLength": 128}
+          }
+        }
+      }
+    },
+    "degradation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "message", "count"],
+      "properties": {
+        "code": {
+          "enum": ["duplicate_records_deduplicated", "records_empty"]
+        },
+        "message": {"type": "string", "minLength": 1},
+        "count": {"type": "integer", "minimum": 0}
+      }
+    }
+  }
+}

--- a/merger/repoground/core/__init__.py
+++ b/merger/repoground/core/__init__.py
@@ -4,12 +4,18 @@ from merger.repoground.core.scip_adapter import (
     evaluate_scip_adapter,
     normalize_scip_index,
 )
+from merger.repoground.core.system_relation_overlay import (
+    SystemRelationOverlayError,
+    normalize_system_relation_evidence,
+)
 
 __core_version__ = "2.4.0"
 
 __all__ = [
     "ScipAdapterError",
+    "SystemRelationOverlayError",
     "benchmark_identity",
     "evaluate_scip_adapter",
     "normalize_scip_index",
+    "normalize_system_relation_evidence",
 ]

--- a/merger/repoground/core/system_relation_overlay.py
+++ b/merger/repoground/core/system_relation_overlay.py
@@ -1,0 +1,427 @@
+"""Deterministic build, test, schema and artifact relation overlay.
+
+The adapter consumes an already collected, digest-bound evidence document. It does
+not scan repositories, run builds or tests, validate schemas, materialize artifacts,
+or promote derived navigation evidence into repository truth.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from typing import Any
+
+from merger.repoground.core.lens_facets import _normalize_path
+
+KIND = "repoground.system_relation_overlay"
+VERSION = "1.0"
+SOURCE_KIND = "repoground.system_relation_evidence"
+SOURCE_VERSION = "1.0"
+AUTHORITY = "navigation_index"
+CANONICALITY = "derived"
+RISK_CLASS = "navigation"
+
+ENDPOINT_KINDS = frozenset(
+    {
+        "repository",
+        "package",
+        "build_target",
+        "package_target",
+        "test",
+        "test_target",
+        "validator",
+        "schema_contract",
+        "artifact_producer",
+        "artifact_consumer",
+        "artifact_contract",
+        "workflow",
+    }
+)
+
+EVIDENCE_PROFILES = {
+    "manifest_declaration": ("S1", "declared"),
+    "workflow_declaration": ("S1", "declared"),
+    "explicit_test_registration": ("S1", "declared"),
+    "test_import_or_reference": ("S0", "referenced"),
+    "test_naming_heuristic": ("S0", "heuristic"),
+    "schema_validation_call": ("S1", "declared"),
+    "artifact_declaration": ("S1", "declared"),
+}
+
+SOURCE_KINDS_BY_EVIDENCE = {
+    "manifest_declaration": frozenset({"manifest"}),
+    "workflow_declaration": frozenset({"workflow"}),
+    "explicit_test_registration": frozenset(
+        {"manifest", "workflow", "test_registry"}
+    ),
+    "test_import_or_reference": frozenset({"source_file"}),
+    "test_naming_heuristic": frozenset({"source_file"}),
+    "schema_validation_call": frozenset({"source_file"}),
+    "artifact_declaration": frozenset(
+        {"manifest", "workflow", "source_file", "artifact_contract"}
+    ),
+}
+
+RELATION_RULES = {
+    "build_target": {
+        "evidence": frozenset({"manifest_declaration", "workflow_declaration"}),
+        "contract_kind": None,
+    },
+    "package_target": {
+        "evidence": frozenset({"manifest_declaration", "workflow_declaration"}),
+        "contract_kind": None,
+    },
+    "test_registration": {
+        "evidence": frozenset(
+            {
+                "explicit_test_registration",
+                "test_import_or_reference",
+                "test_naming_heuristic",
+            }
+        ),
+        "contract_kind": None,
+    },
+    "validates_schema": {
+        "evidence": frozenset({"schema_validation_call"}),
+        "contract_kind": "schema",
+    },
+    "produces_artifact": {
+        "evidence": frozenset({"artifact_declaration"}),
+        "contract_kind": "artifact",
+    },
+    "consumes_artifact": {
+        "evidence": frozenset({"artifact_declaration"}),
+        "contract_kind": "artifact",
+    },
+}
+
+DOES_NOT_ESTABLISH = (
+    "repository_truth",
+    "build_execution",
+    "build_success",
+    "package_publishability",
+    "test_execution",
+    "test_collection",
+    "test_sufficiency",
+    "schema_validation_success",
+    "schema_conformance",
+    "artifact_materialization",
+    "artifact_freshness",
+    "runtime_behavior",
+    "runtime_correctness",
+    "relation_completeness",
+    "default_promotion",
+)
+
+ABSENCE_SEMANTICS = (
+    "A missing record means only that this evidence document did not establish "
+    "the relation. It is not evidence that the relation is absent."
+)
+
+
+class SystemRelationOverlayError(ValueError):
+    """Raised when relation evidence cannot be normalized safely."""
+
+
+def _canonical_sha256(value: Any) -> str:
+    payload = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _text(value: Any, *, label: str, maximum: int = 4096) -> str:
+    if not isinstance(value, str):
+        raise SystemRelationOverlayError(f"{label} must be a string")
+    cleaned = value.strip()
+    if not cleaned or len(cleaned) > maximum or "\x00" in cleaned:
+        raise SystemRelationOverlayError(f"{label} must be non-empty and bounded")
+    return cleaned
+
+
+def _sha256(value: Any, *, label: str) -> str:
+    cleaned = _text(value, label=label, maximum=64)
+    if len(cleaned) != 64 or any(character not in "0123456789abcdef" for character in cleaned):
+        raise SystemRelationOverlayError(
+            f"{label} must be a lowercase SHA-256 digest"
+        )
+    return cleaned
+
+
+def _commit(value: Any) -> str:
+    cleaned = _text(value, label="repository_commit", maximum=64)
+    if len(cleaned) not in {40, 64} or any(
+        character not in "0123456789abcdef" for character in cleaned
+    ):
+        raise SystemRelationOverlayError(
+            "repository_commit must be a lowercase 40- or 64-character digest"
+        )
+    return cleaned
+
+
+def _exact_mapping(value: Any, *, label: str, keys: set[str]) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise SystemRelationOverlayError(f"{label} must be an object")
+    observed = set(value)
+    if observed != keys:
+        raise SystemRelationOverlayError(
+            f"{label} fields must be exactly {sorted(keys)!r}; observed {sorted(observed)!r}"
+        )
+    return value
+
+
+def _path(value: Any) -> str:
+    try:
+        return _normalize_path(value)
+    except (TypeError, ValueError) as exc:
+        raise SystemRelationOverlayError(
+            f"source.path is not a safe repository-relative path: {value!r}"
+        ) from exc
+
+
+def _integer(value: Any, *, label: str, minimum: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        raise SystemRelationOverlayError(f"{label} must be an integer >= {minimum}")
+    return value
+
+
+def _source_range(value: Any) -> dict[str, int]:
+    mapping = _exact_mapping(
+        value,
+        label="source.range",
+        keys={"start_line", "start_character", "end_line", "end_character"},
+    )
+    normalized = {
+        "start_line": _integer(mapping["start_line"], label="start_line", minimum=1),
+        "start_character": _integer(
+            mapping["start_character"], label="start_character", minimum=0
+        ),
+        "end_line": _integer(mapping["end_line"], label="end_line", minimum=1),
+        "end_character": _integer(
+            mapping["end_character"], label="end_character", minimum=0
+        ),
+    }
+    if (normalized["end_line"], normalized["end_character"]) < (
+        normalized["start_line"],
+        normalized["start_character"],
+    ):
+        raise SystemRelationOverlayError("source.range end precedes its start")
+    return normalized
+
+
+def _endpoint(value: Any, *, label: str) -> dict[str, str]:
+    mapping = _exact_mapping(value, label=label, keys={"kind", "identity"})
+    kind = _text(mapping["kind"], label=f"{label}.kind", maximum=64)
+    if kind not in ENDPOINT_KINDS:
+        raise SystemRelationOverlayError(f"unsupported {label}.kind: {kind!r}")
+    return {
+        "kind": kind,
+        "identity": _text(mapping["identity"], label=f"{label}.identity"),
+    }
+
+
+def _contract_identity(value: Any, *, expected_kind: str | None) -> dict[str, str] | None:
+    if expected_kind is None:
+        if value is not None:
+            raise SystemRelationOverlayError(
+                "contract_identity must be null for build, package and test relations"
+            )
+        return None
+    mapping = _exact_mapping(
+        value,
+        label="contract_identity",
+        keys={"kind", "id", "version"},
+    )
+    kind = _text(mapping["kind"], label="contract_identity.kind", maximum=32)
+    if kind != expected_kind:
+        raise SystemRelationOverlayError(
+            f"contract_identity.kind must be {expected_kind!r}"
+        )
+    return {
+        "kind": kind,
+        "id": _text(mapping["id"], label="contract_identity.id"),
+        "version": _text(
+            mapping["version"], label="contract_identity.version", maximum=128
+        ),
+    }
+
+
+def _source(value: Any, *, evidence_class: str) -> dict[str, Any]:
+    mapping = _exact_mapping(
+        value,
+        label="source",
+        keys={"path", "kind", "range"},
+    )
+    source_kind = _text(mapping["kind"], label="source.kind", maximum=64)
+    allowed = SOURCE_KINDS_BY_EVIDENCE[evidence_class]
+    if source_kind not in allowed:
+        raise SystemRelationOverlayError(
+            f"source.kind {source_kind!r} is incompatible with evidence_class "
+            f"{evidence_class!r}; expected one of {sorted(allowed)!r}"
+        )
+    return {
+        "path": _path(mapping["path"]),
+        "kind": source_kind,
+        "range": _source_range(mapping["range"]),
+    }
+
+
+def _normalize_record(value: Any, *, index: int) -> dict[str, Any]:
+    mapping = _exact_mapping(
+        value,
+        label=f"records[{index}]",
+        keys={
+            "relation",
+            "subject",
+            "target",
+            "source",
+            "evidence_class",
+            "contract_identity",
+        },
+    )
+    relation = _text(mapping["relation"], label="relation", maximum=64)
+    rule = RELATION_RULES.get(relation)
+    if rule is None:
+        raise SystemRelationOverlayError(f"unsupported relation: {relation!r}")
+    evidence_class = _text(
+        mapping["evidence_class"], label="evidence_class", maximum=64
+    )
+    if evidence_class not in rule["evidence"]:
+        raise SystemRelationOverlayError(
+            f"evidence_class {evidence_class!r} is incompatible with relation {relation!r}"
+        )
+    evidence_level, evidence_strength = EVIDENCE_PROFILES[evidence_class]
+    record = {
+        "relation": relation,
+        "subject": _endpoint(mapping["subject"], label="subject"),
+        "target": _endpoint(mapping["target"], label="target"),
+        "source": _source(mapping["source"], evidence_class=evidence_class),
+        "evidence": {
+            "class": evidence_class,
+            "level": evidence_level,
+            "strength": evidence_strength,
+        },
+        "contract_identity": _contract_identity(
+            mapping["contract_identity"], expected_kind=rule["contract_kind"]
+        ),
+    }
+    return {"record_id_sha256": _canonical_sha256(record), **record}
+
+
+def _record_order(record: Mapping[str, Any]) -> tuple[Any, ...]:
+    source_range = record["source"]["range"]
+    contract = record["contract_identity"] or {"kind": "", "id": "", "version": ""}
+    return (
+        record["relation"],
+        record["subject"]["kind"],
+        record["subject"]["identity"],
+        record["target"]["kind"],
+        record["target"]["identity"],
+        record["source"]["path"],
+        source_range["start_line"],
+        source_range["start_character"],
+        source_range["end_line"],
+        source_range["end_character"],
+        record["evidence"]["class"],
+        contract["kind"],
+        contract["id"],
+        contract["version"],
+        record["record_id_sha256"],
+    )
+
+
+def _producer(value: Any) -> dict[str, str]:
+    mapping = _exact_mapping(value, label="producer", keys={"name", "version"})
+    return {
+        "name": _text(mapping["name"], label="producer.name", maximum=256),
+        "version": _text(mapping["version"], label="producer.version", maximum=128),
+    }
+
+
+def normalize_system_relation_evidence(
+    evidence: Mapping[str, Any],
+    *,
+    evidence_sha256: str,
+    repository_commit: str,
+) -> dict[str, Any]:
+    """Normalize typed repository evidence into a derived relation overlay."""
+    mapping = _exact_mapping(
+        evidence,
+        label="evidence",
+        keys={"kind", "version", "producer", "records"},
+    )
+    if mapping["kind"] != SOURCE_KIND:
+        raise SystemRelationOverlayError(f"evidence.kind must be {SOURCE_KIND!r}")
+    if mapping["version"] != SOURCE_VERSION:
+        raise SystemRelationOverlayError(f"evidence.version must be {SOURCE_VERSION!r}")
+    records_value = mapping["records"]
+    if not isinstance(records_value, list):
+        raise SystemRelationOverlayError("evidence.records must be a list")
+
+    unique: dict[str, dict[str, Any]] = {}
+    duplicate_count = 0
+    for index, raw_record in enumerate(records_value):
+        record = _normalize_record(raw_record, index=index)
+        record_id = record["record_id_sha256"]
+        if record_id in unique:
+            duplicate_count += 1
+            continue
+        unique[record_id] = record
+
+    records = sorted(unique.values(), key=_record_order)
+    degradations: list[dict[str, Any]] = []
+    if duplicate_count:
+        degradations.append(
+            {
+                "code": "duplicate_records_deduplicated",
+                "message": "Exact duplicate relation records were removed deterministically.",
+                "count": duplicate_count,
+            }
+        )
+    if not records:
+        degradations.append(
+            {
+                "code": "records_empty",
+                "message": "The evidence document established no relation records.",
+                "count": 0,
+            }
+        )
+
+    return {
+        "kind": KIND,
+        "version": VERSION,
+        "authority": AUTHORITY,
+        "canonicality": CANONICALITY,
+        "risk_class": RISK_CLASS,
+        "status": "degraded" if degradations else "available",
+        "source": {
+            "format": "repoground_system_relation_evidence_v1",
+            "evidence_sha256": _sha256(
+                evidence_sha256, label="evidence_sha256"
+            ),
+            "repository_commit": _commit(repository_commit),
+            "producer": _producer(mapping["producer"]),
+        },
+        "relation_kinds": sorted({record["relation"] for record in records}),
+        "evidence_classes": sorted(
+            {record["evidence"]["class"] for record in records}
+        ),
+        "records": records,
+        "record_count": len(records),
+        "degradations": degradations,
+        "consumer_enablement": {
+            "eligible_for_review": False,
+            "default_promoted": False,
+        },
+        "absence_semantics": ABSENCE_SEMANTICS,
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }
+
+
+__all__ = [
+    "SystemRelationOverlayError",
+    "normalize_system_relation_evidence",
+]

--- a/merger/repoground/tests/test_system_relation_overlay.py
+++ b/merger/repoground/tests/test_system_relation_overlay.py
@@ -1,0 +1,467 @@
+import copy
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+import merger.repoground.core as core_api
+from merger.repoground.core.system_relation_overlay import (
+    SystemRelationOverlayError,
+    normalize_system_relation_evidence,
+)
+
+EVIDENCE_SHA = "a" * 64
+REPOSITORY_COMMIT = "b" * 40
+
+
+def _range(start_line: int, end_line: int | None = None) -> dict[str, int]:
+    return {
+        "start_line": start_line,
+        "start_character": 0,
+        "end_line": start_line if end_line is None else end_line,
+        "end_character": 80,
+    }
+
+
+def _record(
+    relation: str,
+    subject_kind: str,
+    subject_identity: str,
+    target_kind: str,
+    target_identity: str,
+    path: str,
+    source_kind: str,
+    start_line: int,
+    evidence_class: str,
+    contract_identity=None,
+):
+    return {
+        "relation": relation,
+        "subject": {"kind": subject_kind, "identity": subject_identity},
+        "target": {"kind": target_kind, "identity": target_identity},
+        "source": {
+            "path": path,
+            "kind": source_kind,
+            "range": _range(start_line),
+        },
+        "evidence_class": evidence_class,
+        "contract_identity": contract_identity,
+    }
+
+
+def _evidence() -> dict:
+    return {
+        "kind": "repoground.system_relation_evidence",
+        "version": "1.0",
+        "producer": {"name": "fixture-collector", "version": "1.2.3"},
+        "records": [
+            _record(
+                "build_target",
+                "repository",
+                "heimgewebe/repoground",
+                "build_target",
+                "python-wheel",
+                "pyproject.toml",
+                "manifest",
+                10,
+                "manifest_declaration",
+            ),
+            _record(
+                "package_target",
+                "package",
+                "repoground",
+                "package_target",
+                "release-wheel",
+                ".github/workflows/release.yml",
+                "workflow",
+                30,
+                "workflow_declaration",
+            ),
+            _record(
+                "test_registration",
+                "test",
+                "tests/test_cli.py::test_run",
+                "test_target",
+                "merger.repoground.cli.main",
+                "pytest.ini",
+                "test_registry",
+                2,
+                "explicit_test_registration",
+            ),
+            _record(
+                "test_registration",
+                "test",
+                "tests/test_cli.py::test_dispatch",
+                "test_target",
+                "merger.repoground.cli.main",
+                "merger/repoground/tests/test_cli.py",
+                "source_file",
+                14,
+                "test_import_or_reference",
+            ),
+            _record(
+                "test_registration",
+                "test",
+                "tests/test_guess.py::test_name_only",
+                "test_target",
+                "merger.repoground.core.guessed",
+                "merger/repoground/tests/test_guess.py",
+                "source_file",
+                7,
+                "test_naming_heuristic",
+            ),
+            _record(
+                "validates_schema",
+                "validator",
+                "merger.repoground.core.relation_card_validate.validate_relation_card",
+                "schema_contract",
+                "relation-card.v1",
+                "merger/repoground/core/relation_card_validate.py",
+                "source_file",
+                42,
+                "schema_validation_call",
+                {
+                    "kind": "schema",
+                    "id": "https://repoground.merger/schemas/relation-card.v1.json",
+                    "version": "1.0",
+                },
+            ),
+            _record(
+                "produces_artifact",
+                "artifact_producer",
+                "merger.repoground.core.bundle_sidecars.write_relation_cards_jsonl",
+                "artifact_contract",
+                "relation_cards_jsonl",
+                "merger/repoground/core/bundle_sidecars.py",
+                "source_file",
+                150,
+                "artifact_declaration",
+                {
+                    "kind": "artifact",
+                    "id": "relation_cards_jsonl",
+                    "version": "1.0",
+                },
+            ),
+            _record(
+                "consumes_artifact",
+                "artifact_consumer",
+                "merger.repoground.core.relation_card_validate.validate_relation_cards",
+                "artifact_contract",
+                "relation_cards_jsonl",
+                "merger/repoground/core/relation_card_validate.py",
+                "source_file",
+                80,
+                "artifact_declaration",
+                {
+                    "kind": "artifact",
+                    "id": "relation_cards_jsonl",
+                    "version": "1.0",
+                },
+            ),
+        ],
+    }
+
+
+def _artifact(evidence=None):
+    return normalize_system_relation_evidence(
+        _evidence() if evidence is None else evidence,
+        evidence_sha256=EVIDENCE_SHA,
+        repository_commit=REPOSITORY_COMMIT,
+    )
+
+
+def _schema() -> dict:
+    path = (
+        Path(__file__).parent.parent
+        / "contracts"
+        / "system-relation-overlay.v1.schema.json"
+    )
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_projects_all_relation_families_with_fixed_navigation_boundary():
+    artifact = _artifact()
+
+    assert artifact["status"] == "available"
+    assert artifact["authority"] == "navigation_index"
+    assert artifact["canonicality"] == "derived"
+    assert artifact["risk_class"] == "navigation"
+    assert artifact["record_count"] == 8
+    assert artifact["relation_kinds"] == [
+        "build_target",
+        "consumes_artifact",
+        "package_target",
+        "produces_artifact",
+        "test_registration",
+        "validates_schema",
+    ]
+    assert artifact["source"] == {
+        "format": "repoground_system_relation_evidence_v1",
+        "evidence_sha256": EVIDENCE_SHA,
+        "repository_commit": REPOSITORY_COMMIT,
+        "producer": {"name": "fixture-collector", "version": "1.2.3"},
+    }
+    assert artifact["consumer_enablement"] == {
+        "eligible_for_review": False,
+        "default_promoted": False,
+    }
+    assert "runtime_correctness" in artifact["does_not_establish"]
+    assert "build_success" in artifact["does_not_establish"]
+    assert "test_sufficiency" in artifact["does_not_establish"]
+    assert "schema_conformance" in artifact["does_not_establish"]
+    assert "artifact_materialization" in artifact["does_not_establish"]
+    assert "not evidence that the relation is absent" in artifact["absence_semantics"]
+
+
+def test_build_and_package_relations_keep_manifest_or_workflow_ranges():
+    records = {
+        record["relation"]: record
+        for record in _artifact()["records"]
+        if record["relation"] in {"build_target", "package_target"}
+    }
+
+    assert records["build_target"]["source"] == {
+        "path": "pyproject.toml",
+        "kind": "manifest",
+        "range": _range(10),
+    }
+    assert records["package_target"]["source"] == {
+        "path": ".github/workflows/release.yml",
+        "kind": "workflow",
+        "range": _range(30),
+    }
+
+
+def test_test_registration_distinguishes_declared_reference_and_heuristic_evidence():
+    profiles = {
+        record["evidence"]["class"]: (
+            record["evidence"]["level"],
+            record["evidence"]["strength"],
+        )
+        for record in _artifact()["records"]
+        if record["relation"] == "test_registration"
+    }
+
+    assert profiles == {
+        "explicit_test_registration": ("S1", "declared"),
+        "test_import_or_reference": ("S0", "referenced"),
+        "test_naming_heuristic": ("S0", "heuristic"),
+    }
+
+
+def test_schema_and_artifact_relations_preserve_contract_identity():
+    records = _artifact()["records"]
+    schema_record = next(
+        record for record in records if record["relation"] == "validates_schema"
+    )
+    artifact_records = [
+        record
+        for record in records
+        if record["relation"] in {"produces_artifact", "consumes_artifact"}
+    ]
+
+    assert schema_record["contract_identity"] == {
+        "kind": "schema",
+        "id": "https://repoground.merger/schemas/relation-card.v1.json",
+        "version": "1.0",
+    }
+    assert all(
+        record["contract_identity"]
+        == {"kind": "artifact", "id": "relation_cards_jsonl", "version": "1.0"}
+        for record in artifact_records
+    )
+
+
+def test_output_and_record_ids_are_deterministic_under_input_reordering():
+    first = _evidence()
+    second = copy.deepcopy(first)
+    second["records"].reverse()
+
+    assert _artifact(first) == _artifact(second)
+    assert all(
+        len(record["record_id_sha256"]) == 64
+        for record in _artifact(first)["records"]
+    )
+
+
+def test_exact_duplicates_are_deduplicated_and_reported():
+    evidence = _evidence()
+    evidence["records"].append(copy.deepcopy(evidence["records"][0]))
+
+    artifact = _artifact(evidence)
+
+    assert artifact["status"] == "degraded"
+    assert artifact["record_count"] == 8
+    assert artifact["degradations"] == [
+        {
+            "code": "duplicate_records_deduplicated",
+            "message": "Exact duplicate relation records were removed deterministically.",
+            "count": 1,
+        }
+    ]
+
+
+def test_empty_evidence_is_explicitly_degraded_not_silent_success():
+    evidence = _evidence()
+    evidence["records"] = []
+
+    artifact = _artifact(evidence)
+
+    assert artifact["status"] == "degraded"
+    assert artifact["record_count"] == 0
+    assert artifact["relation_kinds"] == []
+    assert artifact["evidence_classes"] == []
+    assert artifact["degradations"][0]["code"] == "records_empty"
+
+
+@pytest.mark.parametrize("path", ["../escape.toml", "/absolute.toml", "a//b.toml"])
+def test_unsafe_repository_paths_fail_closed(path):
+    evidence = _evidence()
+    evidence["records"][0]["source"]["path"] = path
+
+    with pytest.raises(SystemRelationOverlayError, match="safe repository-relative path"):
+        _artifact(evidence)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("start_line", 0),
+        ("start_character", -1),
+        ("end_line", True),
+        ("end_character", -1),
+    ],
+)
+def test_invalid_ranges_fail_closed(field, value):
+    evidence = _evidence()
+    evidence["records"][0]["source"]["range"][field] = value
+
+    with pytest.raises(SystemRelationOverlayError, match="must be an integer"):
+        _artifact(evidence)
+
+
+def test_reversed_range_fails_closed():
+    evidence = _evidence()
+    evidence["records"][0]["source"]["range"] = {
+        "start_line": 4,
+        "start_character": 0,
+        "end_line": 3,
+        "end_character": 80,
+    }
+
+    with pytest.raises(SystemRelationOverlayError, match="end precedes"):
+        _artifact(evidence)
+
+
+@pytest.mark.parametrize(
+    ("relation", "evidence_class"),
+    [
+        ("build_target", "test_naming_heuristic"),
+        ("test_registration", "manifest_declaration"),
+        ("validates_schema", "artifact_declaration"),
+        ("produces_artifact", "schema_validation_call"),
+    ],
+)
+def test_relation_and_evidence_class_mismatches_fail_closed(relation, evidence_class):
+    evidence = _evidence()
+    evidence["records"][0]["relation"] = relation
+    evidence["records"][0]["evidence_class"] = evidence_class
+
+    with pytest.raises(SystemRelationOverlayError, match="incompatible with relation"):
+        _artifact(evidence)
+
+
+def test_evidence_class_and_source_kind_mismatch_fails_closed():
+    evidence = _evidence()
+    evidence["records"][0]["source"]["kind"] = "workflow"
+
+    with pytest.raises(SystemRelationOverlayError, match="incompatible with evidence_class"):
+        _artifact(evidence)
+
+
+def test_schema_and_artifact_relations_require_matching_contract_kinds():
+    evidence = _evidence()
+    schema_record = next(
+        record for record in evidence["records"] if record["relation"] == "validates_schema"
+    )
+    schema_record["contract_identity"]["kind"] = "artifact"
+
+    with pytest.raises(SystemRelationOverlayError, match="must be 'schema'"):
+        _artifact(evidence)
+
+
+def test_build_test_and_package_relations_reject_contract_identity():
+    evidence = _evidence()
+    evidence["records"][0]["contract_identity"] = {
+        "kind": "artifact",
+        "id": "unexpected",
+        "version": "1.0",
+    }
+
+    with pytest.raises(SystemRelationOverlayError, match="must be null"):
+        _artifact(evidence)
+
+
+@pytest.mark.parametrize(
+    ("evidence_sha256", "repository_commit", "match"),
+    [
+        ("bad", REPOSITORY_COMMIT, "evidence_sha256"),
+        (EVIDENCE_SHA, "bad", "repository_commit"),
+    ],
+)
+def test_invalid_provenance_digests_fail_closed(
+    evidence_sha256, repository_commit, match
+):
+    with pytest.raises(SystemRelationOverlayError, match=match):
+        normalize_system_relation_evidence(
+            _evidence(),
+            evidence_sha256=evidence_sha256,
+            repository_commit=repository_commit,
+        )
+
+
+def test_input_shapes_are_strict_and_reject_unbound_metadata():
+    evidence = _evidence()
+    evidence["records"][0]["confidence"] = 1.0
+
+    with pytest.raises(SystemRelationOverlayError, match="fields must be exactly"):
+        _artifact(evidence)
+
+
+def test_artifact_matches_contract_and_contract_rejects_semantic_upgrades():
+    artifact = _artifact()
+    schema = _schema()
+
+    jsonschema.Draft7Validator.check_schema(schema)
+    jsonschema.validate(instance=artifact, schema=schema)
+
+    upgraded = copy.deepcopy(artifact)
+    heuristic = next(
+        record
+        for record in upgraded["records"]
+        if record["evidence"]["class"] == "test_naming_heuristic"
+    )
+    heuristic["evidence"]["level"] = "S1"
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=upgraded, schema=schema)
+
+    wrong_contract = copy.deepcopy(artifact)
+    schema_record = next(
+        record
+        for record in wrong_contract["records"]
+        if record["relation"] == "validates_schema"
+    )
+    schema_record["contract_identity"]["kind"] = "artifact"
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=wrong_contract, schema=schema)
+
+
+def test_public_core_api_exports_overlay_without_promoting_it():
+    assert core_api.SystemRelationOverlayError is SystemRelationOverlayError
+    assert (
+        core_api.normalize_system_relation_evidence
+        is normalize_system_relation_evidence
+    )
+    assert "normalize_system_relation_evidence" in core_api.__all__
+    assert core_api.__core_version__ == "2.4.0"


### PR DESCRIPTION
## Ergebnis

Implementiert `RPU-V1-T028` als getrennten, deterministischen Systemrelations-Adapter. Der bestehende imports-only Relation-Card-Vertrag wird nicht verbreitert.

## Relationen

- Build- und Package-Ziele mit exaktem Manifest-/Workflow-Quellbereich
- Testregistrierung getrennt nach expliziter Registrierung, Import/Referenz und Namensheuristik
- `validates_schema` mit gebundener Schema-Vertragsidentität
- `produces_artifact` / `consumes_artifact` mit gebundener Artefakt-Vertragsidentität

## Evidenzgrenzen

- deklarierte Beziehungen: S1
- Import-/Referenzbelege: S0
- Namensheuristik: S0
- gesamtes Eingangsdokument an SHA-256, Repository-Commit und Producer gebunden
- deterministische Sortierung und Record-IDs
- keine Standardpromotion
- keine Aussage über Build-/Testausführung, Schemaerfolg, Artefaktmaterialisierung oder Runtime-Korrektheit
- fehlende Relation ist ausdrücklich kein Abwesenheitsbeleg

## Prüfung

- neue Tests: 27 bestanden
- öffentliche Core-API, SCIP und Anti-Halluzinationslint: 71 bestanden, 1 übersprungen
- angrenzende Graph-Regression: 215 bestanden, 10 übersprungen
- vollständige RepoGround-Suite: 5.377 bestanden, 12 übersprungen
- Ruff: grün
- Anti-Halluzinations-Contract-Lint: 96 Contracts, 0 Fehler, 0 Deferrals
- `git diff --cached --check`: grün

Bureau: `RPU-V1-T028`
Bureau run: `BUR-RUN-20260803T103515Z-fb40be404c`