### PR TITLE
feat(call-graph): add incremental bounded builds

### DIFF
--- a/docs/proofs/repoground-call-graph-incremental-parallel-v1-proof.md
+++ b/docs/proofs/repoground-call-graph-incremental-parallel-v1-proof.md
@@ -1,0 +1,167 @@
+# RepoGround Call-Graph Incremental and Bounded-Parallel v1 — T031 Proof
+
+Status: implemented and locally validated
+Bureau task: `RPU-V1-T031`
+Bureau run: `BUR-RUN-20260804T062104Z-4e825c0891`
+Base commit: `633568ce1e0880b729ff48e4ff77fd6ae69b351f`
+Producer version: `python-call-graph-v1-cache-1-py3.10`
+Measurement artifact: `repoground-call-graph-incremental-parallel-v1.measurement.json`
+Measurement SHA-256: `5e5ec7e9518b5d55116485dd8980e9441edf970bfc300b83dfb96c1376f2b283`
+
+## Problem
+
+Der bisherige Python-Call-Graph-Producer analysierte bei jedem Aufbau sämtliche
+Python-Dateien erneut und seriell. T031 durfte diese Kosten nur senken, wenn die
+öffentliche V1-Ausgabe, Parse-Diagnostik und globale Auflösung einem sauberen
+Vollaufbau entsprechen.
+
+## Umgesetzter Vertrag
+
+Die Erzeugung bleibt zweistufig:
+
+1. **Dateianalyse:** Definitionen, Bindungen, Importzustand und rohe Call-Sites
+   werden als unveränderlicher Snapshot erfasst. Jeder Cacheeintrag ist an den
+   relativen Pfad, den SHA-256 des vollständigen Inhalts, die Producer-Version
+   und die Python-Haupt-/Nebenversion gebunden.
+2. **Globale Auflösung:** Alle neuen und wiederverwendeten Snapshots werden bei
+   jedem Aufbau erneut zu einem vollständigen Modulbestand zusammengesetzt.
+   Caller-/Callee-Auflösung und kanonische Sortierung laufen vollständig neu.
+
+Der produktive `generate_call_graph_document`-Pfad verwendet einen
+prozesslokalen, per `RLock` geschützten Standardcache. `extract_python_calls`
+behält sein öffentliches Drei-Tupel bei und akzeptiert lediglich optionale
+Cache-, Worker-, Speicher- und Messparameter. Das öffentliche
+`python_call_graph`-Format und seine Version bleiben unverändert.
+
+## Invalidierung
+
+Tests belegen:
+
+- geänderte Dateien werden über ihren neuen Inhalts-Hash neu analysiert;
+- hinzugefügte Dateien sind neue Cache-Misses;
+- gelöschte Dateien verschwinden beim atomaren Cache-Ersatz;
+- umbenannte Dateien werden unter dem neuen Pfad neu analysiert;
+- Producer- oder Python-Versionswechsel verwerfen ältere Einträge;
+- fehlerhafte Dateien werden nicht als wiederverwendbare Snapshots gespeichert.
+
+Im finalen Messkorpus waren 702 Python-Dateien vorhanden. 700 erfolgreiche
+Dateisnapshots wurden gespeichert. Der unveränderte Lauf hatte 700 Treffer und
+zwei erneute Prüfungen; der Ein-Datei-Lauf 699 Treffer und drei Neuprüfungen.
+
+## Begrenzte Parallelität und Rückfall
+
+- Standardmäßig höchstens vier Prozesse, harte Obergrenze 32;
+- Parallelität erst ab acht Misses und 128 KiB Quelltext;
+- höchstens zwei Aufträge pro Worker und Batch;
+- standardmäßig 64 MiB logische Quelltext-Payload pro Batch;
+- größere Einzeldateien werden seriell verarbeitet;
+- fehlt `ProcessPoolExecutor`, läuft der vollständige serielle Pfad;
+- bei Executor- oder Workerfehlern werden alle parallelen Teilergebnisse
+  verworfen und sämtliche Misses vollständig seriell neu analysiert.
+
+Die 64-MiB-Grenze ist eine deterministische Payload-Grenze im Elternprozess,
+kein vollständiges RSS-Limit für ASTs oder Kindprozesse.
+
+## Ergebnisgleichheit
+
+Kalter Serienlauf, kalter Parallelaufbau, unveränderter Warmlauf und
+Ein-Datei-Lauf erzeugten denselben kanonischen Ergebnis-Hash:
+
+`c12547d4e4dad664f0eb0d8cbf3b8b063ea29db4ded8aa09e6653a94511a1295`
+
+Der Ein-Datei-Lauf wurde zusätzlich gegen einen frischen seriellen Vollaufbau
+des identischen temporären Repositoryzustands verglichen. Die Hashes waren
+gleich. Bestehende und neue Tests prüfen außerdem identische Call-Reihenfolge
+und identische Parse-Diagnostik.
+
+## Messaufbau
+
+- CPython 3.10.12;
+- Linux 7.0.11, x86_64, glibc 2.35;
+- 32 logische CPUs;
+- vollständiger Python-Bestand des geprüften RepoGround-Worktrees;
+- 702 Python-Dateien, 8.853.965 Byte;
+- Korpusmanifest:
+  `48474b3cb4aaf509b38c214cdc0441c476bbb43ba625266b809ba09325384eb1`;
+- drei Wiederholungen je Pfad;
+- vier Worker und 64 MiB Payload-Grenze;
+- kleine Änderung: ein Kommentar in der größten Python-Datei einer temporären
+  Korpuskopie; der echte Worktree wurde nicht verändert.
+
+## Messergebnisse
+
+| Pfad | Median | p95 | Beschleunigung |
+| --- | ---: | ---: | ---: |
+| kalt, seriell | 16.006,58 ms | 17.400,55 ms | 1,00× |
+| kalt, vier Prozesse | 10.267,54 ms | 11.707,53 ms | 1,56× |
+| unverändert, warmer Cache | 4.341,36 ms | 4.928,70 ms | 3,69× |
+| eine Datei geändert | 5.491,76 ms | 6.242,78 ms | 2,91× |
+
+Daraus folgen gegenüber der Serienbaseline:
+
+- kalte Parallelität: 35,9 Prozent weniger Zeit;
+- unveränderter Cachelauf: 72,9 Prozent weniger Zeit;
+- Ein-Datei-Lauf: 65,7 Prozent weniger Zeit.
+
+Der Parallelpfad analysierte alle 702 Dateien ohne Rückfall. Die größte
+beobachtete gebündelte Payload betrug 402.407 Byte und lag unter 64 MiB.
+
+Mit `tracemalloc` beobachteter Peak im Elternprozess:
+
+- kalt seriell: 156.208.461 Byte;
+- kalt parallel: 157.200.473 Byte;
+- unverändert warm: 120.715.772 Byte;
+- kleine Änderung: 124.323.552 Byte.
+
+Kindprozess-RSS ist darin nicht enthalten.
+
+## Qualitäts- und Wartbarkeitsbelege
+
+- Fokussierter Producer-Test: `58 passed, 10 skipped`;
+- direkte Veröffentlichungsgrenze: `115 passed, 10 skipped`;
+- Goldset-/Agentenwirkungstests: `95 passed, 10 skipped`;
+- vollständiger RepoGround-Testbestand: `5387 passed, 12 skipped`;
+- Ruff-Lint: grün;
+- Ruff-Format: kanonisch;
+- Graph-Wartbarkeitsratchet: grün;
+- fixer Goldstandard:
+  - S1-Präzision `1.0`;
+  - Ziel-Recall `1.0`;
+  - keine Fallregression;
+  - Kontextpfadreduktion `0.5454545454545454`;
+  - Call-Records-SHA-256
+    `6a26b3a4f0e2ba55d0e1a59c53b7980cc9204e9e7d6718103eab80b4100220e`;
+  - Goldset-SHA-256
+    `beab71b88895dd173d2622a9ad5bf3aae36b5cf37b2a430a8b26348e9533c681`.
+
+## Entscheidung
+
+Beide Optimierungen werden beibehalten. Sie liefern auf dem repräsentativen
+Korpus messbare Gewinne, bleiben bytegleich zum seriellen Producer und bestehen
+alle Qualitäts- und Wartbarkeitsgates. Der globale Resolver bleibt bewusst
+vollständig; dies begrenzt die Maximalbeschleunigung, verhindert aber veraltete
+Beziehungen zwischen geänderten und unveränderten Dateien.
+
+Es wird kein persistierter Cache und kein neues öffentliches Artefaktformat
+eingeführt.
+
+## Reproduktion
+
+```bash
+python -m merger.repoground.scripts.bench_call_graph_build . \
+  --repetitions 3 \
+  --max-workers 4 \
+  --output docs/proofs/repoground-call-graph-incremental-parallel-v1.measurement.json
+```
+
+## Nicht belegt
+
+Dieser Abschluss belegt nicht:
+
+- dieselbe Beschleunigung auf jedem Repository oder jeder Maschine;
+- ein hartes Gesamt-RSS-Limit einschließlich Kindprozessen;
+- semantische Vollständigkeit des statischen Call-Graphen;
+- Laufzeiterreichbarkeit oder dynamischen Dispatch;
+- Nutzen eines persistenten, prozessübergreifenden Caches;
+- Produktionskapazität, SLO-Erfüllung oder Mergefreigabe außerhalb des
+  revisionsgebundenen PR-Prozesses.

--- a/docs/proofs/repoground-call-graph-incremental-parallel-v1.measurement.json
+++ b/docs/proofs/repoground-call-graph-incremental-parallel-v1.measurement.json
@@ -1,0 +1,179 @@
+{
+  "cold_parallel": {
+    "build_report": {
+      "cache_entries": 700,
+      "cache_hits": 0,
+      "cache_misses": 702,
+      "max_in_flight_bytes": 67108864,
+      "max_workers": 4,
+      "parallel_eligible": true,
+      "parallel_fallback": false,
+      "parallel_fallback_reason": null,
+      "parallel_files": 702,
+      "peak_in_flight_bytes": 402407,
+      "producer_version": "python-call-graph-v1-cache-1-py3.10",
+      "python_file_count": 702,
+      "schema_version": 1,
+      "serial_files": 0
+    },
+    "memory_scope": "Parent-process Python allocations plus the producer's explicit source-payload budget; child-process RSS is not measured.",
+    "parent_peak_bytes": 157200473,
+    "result_sha256": "c12547d4e4dad664f0eb0d8cbf3b8b063ea29db4ded8aa09e6653a94511a1295",
+    "timing": {
+      "max_ms": 11707.529547,
+      "median_ms": 10267.536486,
+      "min_ms": 9106.118657,
+      "p95_ms": 11707.529547,
+      "repetitions": 3
+    }
+  },
+  "cold_serial": {
+    "build_report": {
+      "cache_entries": 700,
+      "cache_hits": 0,
+      "cache_misses": 702,
+      "max_in_flight_bytes": 67108864,
+      "max_workers": 1,
+      "parallel_eligible": false,
+      "parallel_fallback": false,
+      "parallel_fallback_reason": null,
+      "parallel_files": 0,
+      "peak_in_flight_bytes": 0,
+      "producer_version": "python-call-graph-v1-cache-1-py3.10",
+      "python_file_count": 702,
+      "schema_version": 1,
+      "serial_files": 702
+    },
+    "memory_scope": "Parent-process Python allocations plus the producer's explicit source-payload budget; child-process RSS is not measured.",
+    "parent_peak_bytes": 156208461,
+    "result_sha256": "c12547d4e4dad664f0eb0d8cbf3b8b063ea29db4ded8aa09e6653a94511a1295",
+    "timing": {
+      "max_ms": 17400.547151,
+      "median_ms": 16006.583635,
+      "min_ms": 12500.529288,
+      "p95_ms": 17400.547151,
+      "repetitions": 3
+    }
+  },
+  "configuration": {
+    "max_in_flight_bytes": 67108864,
+    "max_workers": 4,
+    "repetitions": 3
+  },
+  "corpus": {
+    "manifest_sha256": "48474b3cb4aaf509b38c214cdc0441c476bbb43ba625266b809ba09325384eb1",
+    "python_file_count": 702,
+    "python_source_bytes": 8853965
+  },
+  "decision": {
+    "cache_optimization_retained": true,
+    "parallel_optimization_retained": true,
+    "regressions": [],
+    "status": "pass"
+  },
+  "does_not_establish": [
+    "faster_all_repositories",
+    "child_process_peak_rss",
+    "semantic_correctness_beyond_equivalence_to_the_serial_producer",
+    "production_capacity_or_slo_compliance"
+  ],
+  "environment": {
+    "cpu_count": 32,
+    "platform": "Linux-7.0.11-76070011-generic-x86_64-with-glibc2.35",
+    "python": "3.10.12"
+  },
+  "equivalence": {
+    "cold_parallel": true,
+    "small_delta_clean_rebuild": true,
+    "warm_unchanged": true
+  },
+  "kind": "repoground_call_graph_incremental_parallel_measurement",
+  "observed_at_unix": 1785829396,
+  "producer_version": "python-call-graph-v1-cache-1-py3.10",
+  "schema_version": 1,
+  "small_delta": {
+    "build_report": {
+      "cache_entries": 700,
+      "cache_hits": 699,
+      "cache_misses": 3,
+      "max_in_flight_bytes": 67108864,
+      "max_workers": 4,
+      "parallel_eligible": false,
+      "parallel_fallback": false,
+      "parallel_fallback_reason": null,
+      "parallel_files": 0,
+      "peak_in_flight_bytes": 0,
+      "producer_version": "python-call-graph-v1-cache-1-py3.10",
+      "python_file_count": 702,
+      "schema_version": 1,
+      "serial_files": 3
+    },
+    "byte_equivalent_to_clean": true,
+    "clean_result_sha256": [
+      "c12547d4e4dad664f0eb0d8cbf3b8b063ea29db4ded8aa09e6653a94511a1295"
+    ],
+    "memory_scope": "Parent-process Python allocations plus the producer's explicit source-payload budget; child-process RSS is not measured.",
+    "mutated_path": "merger/repoground/core/merge.py",
+    "mutation": "append one comment in the temporary corpus",
+    "parent_peak_bytes": 124323552,
+    "result_sha256": [
+      "c12547d4e4dad664f0eb0d8cbf3b8b063ea29db4ded8aa09e6653a94511a1295"
+    ],
+    "timing": {
+      "max_ms": 6242.775215,
+      "median_ms": 5491.759583,
+      "min_ms": 5377.590772,
+      "p95_ms": 6242.775215,
+      "repetitions": 3
+    }
+  },
+  "speedup": {
+    "cold_parallel_vs_serial_median": 1.5589507431334975,
+    "small_delta_vs_cold_serial_median": 2.914654837504018,
+    "warm_unchanged_vs_cold_serial_median": 3.6869966037409334
+  },
+  "warm_unchanged": {
+    "build_report": {
+      "cache_entries": 700,
+      "cache_hits": 700,
+      "cache_misses": 2,
+      "max_in_flight_bytes": 67108864,
+      "max_workers": 4,
+      "parallel_eligible": false,
+      "parallel_fallback": false,
+      "parallel_fallback_reason": null,
+      "parallel_files": 0,
+      "peak_in_flight_bytes": 0,
+      "producer_version": "python-call-graph-v1-cache-1-py3.10",
+      "python_file_count": 702,
+      "schema_version": 1,
+      "serial_files": 2
+    },
+    "memory_scope": "Parent-process Python allocations plus the producer's explicit source-payload budget; child-process RSS is not measured.",
+    "parent_peak_bytes": 120715772,
+    "result_sha256": "c12547d4e4dad664f0eb0d8cbf3b8b063ea29db4ded8aa09e6653a94511a1295",
+    "seed_build_report": {
+      "cache_entries": 700,
+      "cache_hits": 0,
+      "cache_misses": 702,
+      "max_in_flight_bytes": 67108864,
+      "max_workers": 1,
+      "parallel_eligible": false,
+      "parallel_fallback": false,
+      "parallel_fallback_reason": null,
+      "parallel_files": 0,
+      "peak_in_flight_bytes": 0,
+      "producer_version": "python-call-graph-v1-cache-1-py3.10",
+      "python_file_count": 702,
+      "schema_version": 1,
+      "serial_files": 702
+    },
+    "timing": {
+      "max_ms": 4928.699905,
+      "median_ms": 4341.361101,
+      "min_ms": 3685.868839,
+      "p95_ms": 4928.699905,
+      "repetitions": 3
+    }
+  }
+}

--- a/merger/repoground/architecture/call_graph.py
+++ b/merger/repoground/architecture/call_graph.py
@@ -8,10 +8,13 @@ lexical bindings. Everything else remains explicit S0 navigation evidence.
 from __future__ import annotations
 
 import ast
+import hashlib
 import os
-from operator import attrgetter
+import sys
 from dataclasses import dataclass, field, replace
+from operator import attrgetter
 from pathlib import Path
+from threading import RLock
 from typing import Any, Iterable, Iterator, Sequence
 
 from merger.repoground.architecture.call_graph_contract import (
@@ -24,6 +27,11 @@ from merger.repoground.architecture.symbol_index import (
     _range_ref,
     _symbol_id,
 )
+
+try:
+    from concurrent.futures import ProcessPoolExecutor as _ProcessPoolExecutor
+except ImportError:  # pragma: no cover - platform-dependent stdlib surface
+    _ProcessPoolExecutor = None
 
 RESOLUTION_STATUSES = ("resolved", "candidate", "ambiguous", "unresolved")
 EVIDENCE_LEVELS = ("S0", "S1")
@@ -61,6 +69,97 @@ class _RawCall:
     end_col: int
     func: ast.expr
     stack: tuple[_ScopeFrame, ...]
+
+
+CALL_GRAPH_CACHE_SCHEMA_VERSION = 1
+CALL_GRAPH_PRODUCER_VERSION = (
+    f"python-call-graph-v1-cache-{CALL_GRAPH_CACHE_SCHEMA_VERSION}-"
+    f"py{sys.version_info.major}.{sys.version_info.minor}"
+)
+DEFAULT_CALL_GRAPH_MAX_WORKERS = max(1, min(4, os.cpu_count() or 1))
+DEFAULT_CALL_GRAPH_MAX_IN_FLIGHT_BYTES = 64 * 1024 * 1024
+_MIN_PARALLEL_FILES = 8
+_MIN_PARALLEL_BYTES = 128 * 1024
+
+
+@dataclass(frozen=True, slots=True)
+class _CachedRawCall:
+    start_line: int
+    start_col: int
+    end_line: int
+    end_col: int
+    callee_expression: str
+    stack: tuple[_ScopeFrame, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _ModuleSnapshot:
+    path: str
+    module: str
+    functions: tuple[tuple[str, tuple[str, ...]], ...]
+    classes: tuple[tuple[str, tuple[str, ...]], ...]
+    methods: tuple[tuple[str, str, tuple[str, ...]], ...]
+    symbol_kinds: tuple[tuple[str, str], ...]
+    from_imports: tuple[tuple[str, str, str], ...]
+    module_aliases: tuple[tuple[str, str], ...]
+    imported_module_names: tuple[str, ...]
+    binding_sources: tuple[tuple[str, tuple[str, ...]], ...]
+    calls: tuple[_CachedRawCall, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _CallGraphCacheEntry:
+    content_sha256: str
+    producer_version: str
+    snapshot: _ModuleSnapshot
+
+
+@dataclass(slots=True)
+class CallGraphBuildCache:
+    """Process-local, input-bound cache of immutable per-file analysis snapshots."""
+
+    _entries: dict[str, _CallGraphCacheEntry] = field(
+        default_factory=dict, init=False, repr=False
+    )
+    _lock: Any = field(default_factory=RLock, init=False, repr=False, compare=False)
+
+    def lookup(self, path: str, content_sha256: str) -> _ModuleSnapshot | None:
+        with self._lock:
+            entry = self._entries.get(path)
+            if (
+                entry is None
+                or entry.content_sha256 != content_sha256
+                or entry.producer_version != CALL_GRAPH_PRODUCER_VERSION
+            ):
+                return None
+            return entry.snapshot
+
+    def replace(self, entries: dict[str, _CallGraphCacheEntry]) -> None:
+        with self._lock:
+            self._entries = dict(entries)
+
+    @property
+    def entry_count(self) -> int:
+        with self._lock:
+            return len(self._entries)
+
+
+_DEFAULT_BUILD_CACHE = CallGraphBuildCache()
+
+
+@dataclass(frozen=True, slots=True)
+class _PythonFileInput:
+    path: Path
+    relative_path: str
+    content_sha256: str
+    size_bytes: int
+    is_package: bool
+
+
+@dataclass(frozen=True, slots=True)
+class _ParseOutcome:
+    snapshot: _ModuleSnapshot | None
+    error: str | None = None
 
 
 class _ModuleState:
@@ -1659,13 +1758,235 @@ class _Resolver:
         return record
 
 
-def extract_python_calls(
-    repo_root: Path,
-) -> tuple[list[dict[str, Any]], int, list[str]]:
-    """Return deterministic call records plus bounded parse diagnostics."""
-    modules: dict[str, list[_ModuleState]] = {}
-    skipped_files_count = 0
-    skipped_errors: list[str] = []
+def _snapshot_module_state(state: _ModuleState) -> _ModuleSnapshot:
+    return _ModuleSnapshot(
+        path=state.path,
+        module=state.module,
+        functions=tuple(
+            (name, tuple(values)) for name, values in sorted(state.functions.items())
+        ),
+        classes=tuple(
+            (name, tuple(values)) for name, values in sorted(state.classes.items())
+        ),
+        methods=tuple(
+            (owner, name, tuple(values))
+            for (owner, name), values in sorted(state.methods.items())
+        ),
+        symbol_kinds=tuple(sorted(state.symbol_kinds.items())),
+        from_imports=tuple(
+            (name, module, original)
+            for name, (module, original) in sorted(state.from_imports.items())
+        ),
+        module_aliases=tuple(sorted(state.module_aliases.items())),
+        imported_module_names=tuple(sorted(state.imported_module_names)),
+        binding_sources=tuple(
+            (name, tuple(sorted(values)))
+            for name, values in sorted(state.binding_sources.items())
+        ),
+        calls=tuple(
+            _CachedRawCall(
+                start_line=raw_call.start_line,
+                start_col=raw_call.start_col,
+                end_line=raw_call.end_line,
+                end_col=raw_call.end_col,
+                callee_expression=ast.unparse(raw_call.func),
+                stack=raw_call.stack,
+            )
+            for raw_call in state.calls
+        ),
+    )
+
+
+def _restore_module_state(snapshot: _ModuleSnapshot) -> _ModuleState:
+    state = _ModuleState(snapshot.path, snapshot.module)
+    state.functions = {name: list(values) for name, values in snapshot.functions}
+    state.classes = {name: list(values) for name, values in snapshot.classes}
+    state.methods = {
+        (owner, name): list(values) for owner, name, values in snapshot.methods
+    }
+    state.symbol_kinds = dict(snapshot.symbol_kinds)
+    state.from_imports = {
+        name: (module, original) for name, module, original in snapshot.from_imports
+    }
+    state.module_aliases = dict(snapshot.module_aliases)
+    state.imported_module_names = set(snapshot.imported_module_names)
+    state.binding_sources = {
+        name: set(values) for name, values in snapshot.binding_sources
+    }
+    state.calls = [
+        _RawCall(
+            start_line=raw_call.start_line,
+            start_col=raw_call.start_col,
+            end_line=raw_call.end_line,
+            end_col=raw_call.end_col,
+            func=ast.parse(raw_call.callee_expression, mode="eval").body,
+            stack=raw_call.stack,
+        )
+        for raw_call in snapshot.calls
+    ]
+    return state
+
+
+def _parse_python_source(
+    relative_path: str,
+    filename: str,
+    is_package: bool,
+    source: str,
+) -> _ParseOutcome:
+    try:
+        tree = ast.parse(source, filename=filename)
+    except SyntaxError as exc:
+        return _ParseOutcome(
+            snapshot=None,
+            error=(f"Failed to parse {relative_path}: {type(exc).__name__} - {exc}"),
+        )
+    visitor = _CallGraphVisitor(relative_path, is_package=is_package)
+    visitor.visit(tree)
+    return _ParseOutcome(snapshot=_snapshot_module_state(visitor.state))
+
+
+def _fingerprint_python_file(path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    size = 0
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+            size += len(chunk)
+    return digest.hexdigest(), size
+
+
+def _read_parse_input(item: _PythonFileInput) -> tuple[str | None, str | None]:
+    try:
+        payload = item.path.read_bytes()
+        if hashlib.sha256(payload).hexdigest() != item.content_sha256:
+            raise OSError("source changed while the call graph was being generated")
+        return payload.decode("utf-8"), None
+    except (OSError, UnicodeDecodeError) as exc:
+        return None, (
+            f"Failed to parse {item.relative_path}: {type(exc).__name__} - {exc}"
+        )
+
+
+def _parse_serial(
+    items: Sequence[_PythonFileInput],
+) -> dict[str, _ParseOutcome]:
+    outcomes: dict[str, _ParseOutcome] = {}
+    for item in items:
+        source, error = _read_parse_input(item)
+        if error is not None:
+            outcomes[item.relative_path] = _ParseOutcome(None, error)
+            continue
+        assert source is not None
+        outcomes[item.relative_path] = _parse_python_source(
+            item.relative_path,
+            str(item.path),
+            item.is_package,
+            source,
+        )
+    return outcomes
+
+
+def _parse_bounded_parallel(
+    items: Sequence[_PythonFileInput],
+    *,
+    max_workers: int,
+    max_in_flight_bytes: int,
+) -> tuple[dict[str, _ParseOutcome], int, int, str | None]:
+    outcomes: dict[str, _ParseOutcome] = {}
+    peak_in_flight_bytes = 0
+    parallel_files = 0
+    executor_type = _ProcessPoolExecutor
+    if executor_type is None:
+        return (
+            _parse_serial(items),
+            0,
+            0,
+            "ProcessPoolExecutor unavailable",
+        )
+    try:
+        with executor_type(max_workers=max_workers) as executor:
+            index = 0
+            while index < len(items):
+                batch: list[tuple[_PythonFileInput, str]] = []
+                batch_bytes = 0
+                while index < len(items):
+                    item = items[index]
+                    if item.size_bytes > max_in_flight_bytes:
+                        source, error = _read_parse_input(item)
+                        outcomes[item.relative_path] = (
+                            _ParseOutcome(None, error)
+                            if error is not None
+                            else _parse_python_source(
+                                item.relative_path,
+                                str(item.path),
+                                item.is_package,
+                                source or "",
+                            )
+                        )
+                        index += 1
+                        continue
+                    if batch and (
+                        len(batch) >= max_workers * 2
+                        or batch_bytes + item.size_bytes > max_in_flight_bytes
+                    ):
+                        break
+                    source, error = _read_parse_input(item)
+                    index += 1
+                    if error is not None:
+                        outcomes[item.relative_path] = _ParseOutcome(None, error)
+                        continue
+                    assert source is not None
+                    batch.append((item, source))
+                    batch_bytes += len(source.encode("utf-8"))
+                if not batch:
+                    continue
+                peak_in_flight_bytes = max(peak_in_flight_bytes, batch_bytes)
+                futures = [
+                    executor.submit(
+                        _parse_python_source,
+                        item.relative_path,
+                        str(item.path),
+                        item.is_package,
+                        source,
+                    )
+                    for item, source in batch
+                ]
+                for (item, _), future in zip(batch, futures):
+                    outcomes[item.relative_path] = future.result()
+                    parallel_files += 1
+        return outcomes, parallel_files, peak_in_flight_bytes, None
+    except Exception as exc:
+        # Discard every parallel result. A complete serial retry prevents a
+        # worker failure from producing a mixed or partial graph.
+        return (
+            _parse_serial(items),
+            0,
+            0,
+            f"{type(exc).__name__}: {exc}",
+        )
+
+
+def _normalized_worker_count(max_workers: int | None) -> int:
+    value = DEFAULT_CALL_GRAPH_MAX_WORKERS if max_workers is None else max_workers
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError("max_workers must be a positive integer or None")
+    return min(value, 32)
+
+
+def _collect_python_inputs(
+    repo_root: Path, cache: CallGraphBuildCache | None
+) -> tuple[
+    list[str],
+    dict[str, _PythonFileInput],
+    dict[str, _ParseOutcome],
+    int,
+    list[_PythonFileInput],
+]:
+    ordered_paths: list[str] = []
+    inputs: dict[str, _PythonFileInput] = {}
+    outcomes: dict[str, _ParseOutcome] = {}
+    cache_hits = 0
+    cache_misses: list[_PythonFileInput] = []
     for root, dirs, files in os.walk(repo_root, topdown=True):
         dirs[:] = sorted(
             directory for directory in dirs if directory not in EXCLUDED_DIRS
@@ -1675,18 +1996,111 @@ def extract_python_calls(
                 continue
             path = Path(root) / file_name
             rel_path = path.relative_to(repo_root).as_posix()
+            ordered_paths.append(rel_path)
             try:
-                tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-            except (OSError, SyntaxError, UnicodeDecodeError) as exc:
-                skipped_files_count += 1
-                if len(skipped_errors) < MAX_SKIPPED_ERRORS:
-                    skipped_errors.append(
-                        f"Failed to parse {rel_path}: {type(exc).__name__} - {exc}"
-                    )
+                content_sha256, size_bytes = _fingerprint_python_file(path)
+            except OSError as exc:
+                outcomes[rel_path] = _ParseOutcome(
+                    None,
+                    f"Failed to parse {rel_path}: {type(exc).__name__} - {exc}",
+                )
                 continue
-            visitor = _CallGraphVisitor(rel_path, is_package=file_name == "__init__.py")
-            visitor.visit(tree)
-            modules.setdefault(visitor.state.module, []).append(visitor.state)
+            item = _PythonFileInput(
+                path=path,
+                relative_path=rel_path,
+                content_sha256=content_sha256,
+                size_bytes=size_bytes,
+                is_package=file_name == "__init__.py",
+            )
+            inputs[rel_path] = item
+            snapshot = None if cache is None else cache.lookup(rel_path, content_sha256)
+            if snapshot is None:
+                cache_misses.append(item)
+                continue
+            try:
+                _restore_module_state(snapshot)
+            except (SyntaxError, ValueError, TypeError):
+                cache_misses.append(item)
+                continue
+            outcomes[rel_path] = _ParseOutcome(snapshot=snapshot)
+            cache_hits += 1
+    return ordered_paths, inputs, outcomes, cache_hits, cache_misses
+
+
+def _assemble_module_states(
+    ordered_paths: Sequence[str],
+    inputs: dict[str, _PythonFileInput],
+    outcomes: dict[str, _ParseOutcome],
+    cache: CallGraphBuildCache | None,
+) -> tuple[dict[str, list[_ModuleState]], int, list[str]]:
+    modules: dict[str, list[_ModuleState]] = {}
+    current_cache_entries: dict[str, _CallGraphCacheEntry] = {}
+    skipped_files_count = 0
+    skipped_errors: list[str] = []
+    for rel_path in ordered_paths:
+        outcome = outcomes[rel_path]
+        if outcome.error is not None or outcome.snapshot is None:
+            skipped_files_count += 1
+            if len(skipped_errors) < MAX_SKIPPED_ERRORS:
+                skipped_errors.append(outcome.error or f"Failed to parse {rel_path}")
+            continue
+        state = _restore_module_state(outcome.snapshot)
+        modules.setdefault(state.module, []).append(state)
+        item = inputs[rel_path]
+        current_cache_entries[rel_path] = _CallGraphCacheEntry(
+            content_sha256=item.content_sha256,
+            producer_version=CALL_GRAPH_PRODUCER_VERSION,
+            snapshot=outcome.snapshot,
+        )
+    if cache is not None:
+        cache.replace(current_cache_entries)
+    return modules, skipped_files_count, skipped_errors
+
+
+def extract_python_calls(
+    repo_root: Path,
+    *,
+    cache: CallGraphBuildCache | None = None,
+    max_workers: int | None = None,
+    max_in_flight_bytes: int = DEFAULT_CALL_GRAPH_MAX_IN_FLIGHT_BYTES,
+    build_report: dict[str, Any] | None = None,
+) -> tuple[list[dict[str, Any]], int, list[str]]:
+    """Return deterministic calls with optional hash-bound reuse and parsing."""
+    workers = _normalized_worker_count(max_workers)
+    if (
+        isinstance(max_in_flight_bytes, bool)
+        or not isinstance(max_in_flight_bytes, int)
+        or max_in_flight_bytes < 1
+    ):
+        raise ValueError("max_in_flight_bytes must be a positive integer")
+
+    ordered_paths, inputs, outcomes, cache_hits, cache_misses = _collect_python_inputs(
+        repo_root, cache
+    )
+
+    parallel_eligible = (
+        workers > 1
+        and len(cache_misses) >= _MIN_PARALLEL_FILES
+        and sum(item.size_bytes for item in cache_misses) >= _MIN_PARALLEL_BYTES
+    )
+    parallel_files = 0
+    peak_in_flight_bytes = 0
+    fallback_reason: str | None = None
+    if parallel_eligible:
+        parsed, parallel_files, peak_in_flight_bytes, fallback_reason = (
+            _parse_bounded_parallel(
+                cache_misses,
+                max_workers=workers,
+                max_in_flight_bytes=max_in_flight_bytes,
+            )
+        )
+    else:
+        parsed = _parse_serial(cache_misses)
+    outcomes.update(parsed)
+
+    modules, skipped_files_count, skipped_errors = _assemble_module_states(
+        ordered_paths, inputs, outcomes, cache
+    )
 
     resolver = _Resolver(modules)
     calls = [
@@ -1704,13 +2118,46 @@ def extract_python_calls(
             item["caller_symbol_id"] or "",
         )
     )
+    if build_report is not None:
+        build_report.clear()
+        build_report.update(
+            {
+                "schema_version": 1,
+                "producer_version": CALL_GRAPH_PRODUCER_VERSION,
+                "python_file_count": len(ordered_paths),
+                "cache_hits": cache_hits,
+                "cache_misses": len(cache_misses),
+                "cache_entries": 0 if cache is None else cache.entry_count,
+                "max_workers": workers,
+                "parallel_eligible": parallel_eligible,
+                "parallel_files": parallel_files,
+                "serial_files": len(cache_misses) - parallel_files,
+                "max_in_flight_bytes": max_in_flight_bytes,
+                "peak_in_flight_bytes": peak_in_flight_bytes,
+                "parallel_fallback": fallback_reason is not None,
+                "parallel_fallback_reason": fallback_reason,
+            }
+        )
     return calls, skipped_files_count, skipped_errors
 
 
 def generate_call_graph_document(
-    repo_root: Path, run_id: str, canonical_sha256: str
+    repo_root: Path,
+    run_id: str,
+    canonical_sha256: str,
+    *,
+    cache: CallGraphBuildCache | None = None,
+    max_workers: int | None = None,
+    max_in_flight_bytes: int = DEFAULT_CALL_GRAPH_MAX_IN_FLIGHT_BYTES,
+    build_report: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    calls, skipped_count, skipped_errors = extract_python_calls(repo_root)
+    calls, skipped_count, skipped_errors = extract_python_calls(
+        repo_root,
+        cache=_DEFAULT_BUILD_CACHE if cache is None else cache,
+        max_workers=max_workers,
+        max_in_flight_bytes=max_in_flight_bytes,
+        build_report=build_report,
+    )
     resolution_counts = {status: 0 for status in RESOLUTION_STATUSES}
     evidence_counts = {level: 0 for level in EVIDENCE_LEVELS}
     relation_counts = {relation: 0 for relation in RELATION_TYPES}

--- a/merger/repoground/scripts/bench_call_graph_build.py
+++ b/merger/repoground/scripts/bench_call_graph_build.py
@@ -1,0 +1,425 @@
+"""Benchmark cold, bounded-parallel, warm and small-delta call-graph builds."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import shutil
+import statistics
+import tempfile
+import time
+import tracemalloc
+from pathlib import Path
+from typing import Any, Callable
+
+from merger.repoground.architecture.call_graph import (
+    CALL_GRAPH_PRODUCER_VERSION,
+    DEFAULT_CALL_GRAPH_MAX_IN_FLIGHT_BYTES,
+    DEFAULT_CALL_GRAPH_MAX_WORKERS,
+    CallGraphBuildCache,
+    extract_python_calls,
+)
+from merger.repoground.architecture.symbol_index import EXCLUDED_DIRS
+
+BuildResult = tuple[dict[str, Any], dict[str, Any]]
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _timing_summary(samples: list[float]) -> dict[str, float | int]:
+    ordered = sorted(samples)
+    p95_index = max(0, min(len(ordered) - 1, round(len(ordered) * 0.95) - 1))
+    return {
+        "repetitions": len(ordered),
+        "median_ms": statistics.median(ordered),
+        "p95_ms": ordered[p95_index],
+        "min_ms": ordered[0],
+        "max_ms": ordered[-1],
+    }
+
+
+def _result_payload(
+    calls: list[dict[str, Any]],
+    skipped_files_count: int,
+    skipped_errors: list[str],
+) -> dict[str, Any]:
+    return {
+        "calls": calls,
+        "skipped_files_count": skipped_files_count,
+        "skipped_errors": skipped_errors,
+    }
+
+
+def _build(
+    repo_root: Path,
+    *,
+    cache: CallGraphBuildCache,
+    max_workers: int,
+    max_in_flight_bytes: int,
+) -> BuildResult:
+    report: dict[str, Any] = {}
+    calls, skipped_count, skipped_errors = extract_python_calls(
+        repo_root,
+        cache=cache,
+        max_workers=max_workers,
+        max_in_flight_bytes=max_in_flight_bytes,
+        build_report=report,
+    )
+    return _result_payload(calls, skipped_count, skipped_errors), report
+
+
+def _measure(
+    fn: Callable[[], BuildResult],
+    repetitions: int,
+) -> dict[str, Any]:
+    elapsed_samples: list[float] = []
+    parent_peak_bytes: list[int] = []
+    result_digests: set[str] = set()
+    representative_report: dict[str, Any] | None = None
+    for _ in range(repetitions):
+        tracemalloc.start()
+        started = time.perf_counter_ns()
+        try:
+            payload, report = fn()
+            elapsed_ms = (time.perf_counter_ns() - started) / 1_000_000
+            _, peak = tracemalloc.get_traced_memory()
+        finally:
+            tracemalloc.stop()
+        elapsed_samples.append(elapsed_ms)
+        parent_peak_bytes.append(peak)
+        result_digests.add(_sha256_bytes(_canonical_bytes(payload)))
+        representative_report = report
+    if len(result_digests) != 1:
+        raise RuntimeError(
+            f"nondeterministic benchmark results: {sorted(result_digests)}"
+        )
+    return {
+        "timing": _timing_summary(elapsed_samples),
+        "parent_peak_bytes": max(parent_peak_bytes),
+        "result_sha256": next(iter(result_digests)),
+        "build_report": representative_report,
+        "memory_scope": (
+            "Parent-process Python allocations plus the producer's explicit "
+            "source-payload budget; child-process RSS is not measured."
+        ),
+    }
+
+
+def _copy_python_corpus(source_root: Path, destination_root: Path) -> dict[str, Any]:
+    manifest: list[dict[str, Any]] = []
+    for root, dirs, files in os.walk(source_root, topdown=True):
+        dirs[:] = sorted(
+            directory for directory in dirs if directory not in EXCLUDED_DIRS
+        )
+        for file_name in sorted(files):
+            if not file_name.endswith(".py"):
+                continue
+            source = Path(root) / file_name
+            if source.is_symlink() or not source.is_file():
+                continue
+            relative = source.relative_to(source_root)
+            destination = destination_root / relative
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(source, destination)
+            size_bytes = destination.stat().st_size
+            manifest.append(
+                {
+                    "path": relative.as_posix(),
+                    "size_bytes": size_bytes,
+                    "sha256": _sha256_file(destination),
+                }
+            )
+    if not manifest:
+        raise RuntimeError(f"no Python files found under {source_root}")
+    return {
+        "python_file_count": len(manifest),
+        "python_source_bytes": sum(item["size_bytes"] for item in manifest),
+        "manifest_sha256": _sha256_bytes(_canonical_bytes(manifest)),
+    }
+
+
+def _largest_python_file(repo_root: Path) -> Path:
+    candidates = [path for path in repo_root.rglob("*.py") if path.is_file()]
+    if not candidates:
+        raise RuntimeError("benchmark corpus has no Python files")
+    return max(candidates, key=lambda path: (path.stat().st_size, path.as_posix()))
+
+
+def _measure_small_delta(
+    repo_root: Path,
+    *,
+    target: Path,
+    baseline_sha256: str,
+    repetitions: int,
+    max_workers: int,
+    max_in_flight_bytes: int,
+) -> dict[str, Any]:
+    elapsed_samples: list[float] = []
+    parent_peak_bytes: list[int] = []
+    delta_digests: set[str] = set()
+    clean_digests: set[str] = set()
+    representative_report: dict[str, Any] | None = None
+    original = target.read_bytes()
+    for repetition in range(repetitions):
+        cache = CallGraphBuildCache()
+        baseline, _ = _build(
+            repo_root,
+            cache=cache,
+            max_workers=1,
+            max_in_flight_bytes=max_in_flight_bytes,
+        )
+        observed_baseline = _sha256_bytes(_canonical_bytes(baseline))
+        if observed_baseline != baseline_sha256:
+            raise RuntimeError("small-delta baseline drifted before mutation")
+        marker = f"\n# repoground call-graph benchmark delta {repetition}\n".encode()
+        target.write_bytes(original + marker)
+        try:
+            tracemalloc.start()
+            started = time.perf_counter_ns()
+            try:
+                incremental, report = _build(
+                    repo_root,
+                    cache=cache,
+                    max_workers=max_workers,
+                    max_in_flight_bytes=max_in_flight_bytes,
+                )
+                elapsed_ms = (time.perf_counter_ns() - started) / 1_000_000
+                _, peak = tracemalloc.get_traced_memory()
+            finally:
+                tracemalloc.stop()
+            clean, _ = _build(
+                repo_root,
+                cache=CallGraphBuildCache(),
+                max_workers=1,
+                max_in_flight_bytes=max_in_flight_bytes,
+            )
+        finally:
+            target.write_bytes(original)
+        incremental_sha = _sha256_bytes(_canonical_bytes(incremental))
+        clean_sha = _sha256_bytes(_canonical_bytes(clean))
+        if incremental_sha != clean_sha:
+            raise RuntimeError("small-delta build differs from a clean serial rebuild")
+        elapsed_samples.append(elapsed_ms)
+        parent_peak_bytes.append(peak)
+        delta_digests.add(incremental_sha)
+        clean_digests.add(clean_sha)
+        representative_report = report
+    return {
+        "timing": _timing_summary(elapsed_samples),
+        "parent_peak_bytes": max(parent_peak_bytes),
+        "result_sha256": sorted(delta_digests),
+        "clean_result_sha256": sorted(clean_digests),
+        "byte_equivalent_to_clean": delta_digests == clean_digests,
+        "build_report": representative_report,
+        "mutated_path": target.relative_to(repo_root).as_posix(),
+        "mutation": "append one comment in the temporary corpus",
+        "memory_scope": (
+            "Parent-process Python allocations plus the producer's explicit "
+            "source-payload budget; child-process RSS is not measured."
+        ),
+    }
+
+
+def _ratio(numerator: float, denominator: float) -> float:
+    return numerator / max(denominator, 1e-9)
+
+
+def benchmark(
+    source_root: Path,
+    *,
+    repetitions: int,
+    max_workers: int,
+    max_in_flight_bytes: int,
+) -> dict[str, Any]:
+    with tempfile.TemporaryDirectory(prefix="repoground-call-graph-bench-") as temp:
+        corpus_root = Path(temp) / "corpus"
+        corpus = _copy_python_corpus(source_root, corpus_root)
+
+        cold_serial = _measure(
+            lambda: _build(
+                corpus_root,
+                cache=CallGraphBuildCache(),
+                max_workers=1,
+                max_in_flight_bytes=max_in_flight_bytes,
+            ),
+            repetitions,
+        )
+        baseline_sha = str(cold_serial["result_sha256"])
+
+        cold_parallel = _measure(
+            lambda: _build(
+                corpus_root,
+                cache=CallGraphBuildCache(),
+                max_workers=max_workers,
+                max_in_flight_bytes=max_in_flight_bytes,
+            ),
+            repetitions,
+        )
+
+        warm_cache = CallGraphBuildCache()
+        warm_seed, warm_seed_report = _build(
+            corpus_root,
+            cache=warm_cache,
+            max_workers=1,
+            max_in_flight_bytes=max_in_flight_bytes,
+        )
+        if _sha256_bytes(_canonical_bytes(warm_seed)) != baseline_sha:
+            raise RuntimeError("warm-cache seed differs from cold serial result")
+        warm = _measure(
+            lambda: _build(
+                corpus_root,
+                cache=warm_cache,
+                max_workers=max_workers,
+                max_in_flight_bytes=max_in_flight_bytes,
+            ),
+            repetitions,
+        )
+        warm["seed_build_report"] = warm_seed_report
+
+        small_delta = _measure_small_delta(
+            corpus_root,
+            target=_largest_python_file(corpus_root),
+            baseline_sha256=baseline_sha,
+            repetitions=repetitions,
+            max_workers=max_workers,
+            max_in_flight_bytes=max_in_flight_bytes,
+        )
+
+    serial_median = float(cold_serial["timing"]["median_ms"])
+    parallel_median = float(cold_parallel["timing"]["median_ms"])
+    warm_median = float(warm["timing"]["median_ms"])
+    delta_median = float(small_delta["timing"]["median_ms"])
+    parallel_equivalent = cold_parallel["result_sha256"] == baseline_sha
+    warm_equivalent = warm["result_sha256"] == baseline_sha
+    delta_equivalent = bool(small_delta["byte_equivalent_to_clean"])
+    parallel_report = cold_parallel.get("build_report") or {}
+    parallel_speedup = _ratio(serial_median, parallel_median)
+    warm_speedup = _ratio(serial_median, warm_median)
+    delta_speedup = _ratio(serial_median, delta_median)
+
+    parallel_retained = bool(
+        parallel_equivalent
+        and not parallel_report.get("parallel_fallback")
+        and int(parallel_report.get("parallel_files", 0)) > 0
+        and parallel_speedup >= 1.0
+    )
+    cache_retained = bool(
+        warm_equivalent
+        and delta_equivalent
+        and warm_speedup >= 1.0
+        and delta_speedup >= 1.0
+    )
+    regressions = []
+    if parallel_speedup < 1.0:
+        regressions.append("cold_parallel_slower_than_cold_serial")
+    if warm_speedup < 1.0:
+        regressions.append("warm_cache_slower_than_cold_serial")
+    if delta_speedup < 1.0:
+        regressions.append("small_delta_slower_than_cold_serial")
+
+    return {
+        "schema_version": 1,
+        "kind": "repoground_call_graph_incremental_parallel_measurement",
+        "producer_version": CALL_GRAPH_PRODUCER_VERSION,
+        "observed_at_unix": int(time.time()),
+        "environment": {
+            "python": platform.python_version(),
+            "platform": platform.platform(),
+            "cpu_count": os.cpu_count(),
+        },
+        "configuration": {
+            "repetitions": repetitions,
+            "max_workers": max_workers,
+            "max_in_flight_bytes": max_in_flight_bytes,
+        },
+        "corpus": corpus,
+        "cold_serial": cold_serial,
+        "cold_parallel": cold_parallel,
+        "warm_unchanged": warm,
+        "small_delta": small_delta,
+        "equivalence": {
+            "cold_parallel": parallel_equivalent,
+            "warm_unchanged": warm_equivalent,
+            "small_delta_clean_rebuild": delta_equivalent,
+        },
+        "speedup": {
+            "cold_parallel_vs_serial_median": parallel_speedup,
+            "warm_unchanged_vs_cold_serial_median": warm_speedup,
+            "small_delta_vs_cold_serial_median": delta_speedup,
+        },
+        "decision": {
+            "parallel_optimization_retained": parallel_retained,
+            "cache_optimization_retained": cache_retained,
+            "regressions": regressions,
+            "status": "pass" if parallel_retained and cache_retained else "review",
+        },
+        "does_not_establish": [
+            "faster_all_repositories",
+            "child_process_peak_rss",
+            "semantic_correctness_beyond_equivalence_to_the_serial_producer",
+            "production_capacity_or_slo_compliance",
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("repo", type=Path)
+    parser.add_argument("--repetitions", type=int, default=5)
+    parser.add_argument(
+        "--max-workers",
+        type=int,
+        default=DEFAULT_CALL_GRAPH_MAX_WORKERS,
+    )
+    parser.add_argument(
+        "--max-in-flight-bytes",
+        type=int,
+        default=DEFAULT_CALL_GRAPH_MAX_IN_FLIGHT_BYTES,
+    )
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    if args.repetitions < 1:
+        parser.error("--repetitions must be positive")
+    if args.max_workers < 1:
+        parser.error("--max-workers must be positive")
+    if args.max_in_flight_bytes < 1:
+        parser.error("--max-in-flight-bytes must be positive")
+
+    result = benchmark(
+        args.repo.resolve(),
+        repetitions=args.repetitions,
+        max_workers=args.max_workers,
+        max_in_flight_bytes=args.max_in_flight_bytes,
+    )
+    rendered = json.dumps(result, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+    return 0 if result["decision"]["status"] == "pass" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/merger/repoground/tests/test_python_call_graph.py
+++ b/merger/repoground/tests/test_python_call_graph.py
@@ -14,7 +14,9 @@ from pathlib import Path
 import jsonschema
 import pytest
 
+from merger.repoground.architecture import call_graph as call_graph_module
 from merger.repoground.architecture.call_graph import (
+    CallGraphBuildCache,
     DOES_NOT_ESTABLISH,
     MAX_SKIPPED_ERRORS,
     _CallGraphVisitor,
@@ -1119,9 +1121,7 @@ def captured_name_guard_success_terminates(value, allowed):
         if call["callee_expression"] == "run"
     }
 
-    assert {
-        name: call["evidence_level"] for name, call in run_calls.items()
-    } == {
+    assert {name: call["evidence_level"] for name, call in run_calls.items()} == {
         "capture_success_terminates": "S1",
         "capture_success_falls_through": "S0",
         "unrelated_capture_guard_success_terminates": "S1",
@@ -1130,15 +1130,17 @@ def captured_name_guard_success_terminates(value, allowed):
     assert run_calls["capture_success_terminates"]["resolution_reason"] == (
         "local_imported_internal_name"
     )
-    assert run_calls["unrelated_capture_guard_success_terminates"][
-        "resolution_reason"
-    ] == "local_imported_internal_name"
+    assert (
+        run_calls["unrelated_capture_guard_success_terminates"]["resolution_reason"]
+        == "local_imported_internal_name"
+    )
     assert run_calls["capture_success_falls_through"]["resolution_reason"] == (
         "lexically_shadowed_name"
     )
-    assert run_calls["captured_name_guard_success_terminates"][
-        "resolution_reason"
-    ] == "lexically_shadowed_name"
+    assert (
+        run_calls["captured_name_guard_success_terminates"]["resolution_reason"]
+        == "lexically_shadowed_name"
+    )
 
 
 def test_try_fallthrough_keeps_only_safe_reachable_import_paths(tmp_path):
@@ -2509,3 +2511,215 @@ def test_redefined_module_function_is_not_treated_as_direct_recursion(tmp_path):
     assert call["evidence_level"] == "S0"
     assert call["resolution_reason"] == "local_module_function_multiple_definitions"
     assert call["resolved_target_ids"] == []
+
+
+def _write_incremental_fixture(root: Path, *, file_count: int = 4) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    padding = "\n".join(f"PAD_{index} = {index}" for index in range(900))
+    for index in range(file_count):
+        (root / f"module_{index}.py").write_text(
+            f"def target_{index}(value):\n"
+            f"    return value\n\n"
+            f"def caller_{index}(value):\n"
+            f"    return target_{index}(value)\n\n"
+            f"{padding}\n",
+            encoding="utf-8",
+        )
+
+
+def test_incremental_cache_invalidates_file_set_and_content(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    _write_incremental_fixture(repo_root)
+    cache = CallGraphBuildCache()
+    cold_report: dict[str, object] = {}
+    cold = extract_python_calls(
+        repo_root,
+        cache=cache,
+        max_workers=1,
+        build_report=cold_report,
+    )
+    warm_report: dict[str, object] = {}
+    warm = extract_python_calls(
+        repo_root,
+        cache=cache,
+        max_workers=1,
+        build_report=warm_report,
+    )
+    assert warm == cold
+    assert warm_report["cache_hits"] == 4
+    assert warm_report["cache_misses"] == 0
+
+    changed = repo_root / "module_1.py"
+    changed.write_text(
+        changed.read_text(encoding="utf-8")
+        + "\ndef extra(value):\n    return target_1(value)\n",
+        encoding="utf-8",
+    )
+    (repo_root / "module_2.py").rename(repo_root / "renamed.py")
+    (repo_root / "module_3.py").unlink()
+    (repo_root / "added.py").write_text(
+        "def added(value):\n    return value\n",
+        encoding="utf-8",
+    )
+
+    incremental_report: dict[str, object] = {}
+    incremental = extract_python_calls(
+        repo_root,
+        cache=cache,
+        max_workers=1,
+        build_report=incremental_report,
+    )
+    clean = extract_python_calls(
+        repo_root,
+        cache=CallGraphBuildCache(),
+        max_workers=1,
+    )
+    assert incremental == clean
+    assert incremental_report["cache_hits"] == 1
+    assert incremental_report["cache_misses"] == 3
+    assert incremental_report["cache_entries"] == 4
+
+
+def test_cache_entries_are_bound_to_producer_version(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_root = tmp_path / "repo"
+    _write_incremental_fixture(repo_root, file_count=2)
+    cache = CallGraphBuildCache()
+    extract_python_calls(repo_root, cache=cache, max_workers=1)
+
+    monkeypatch.setattr(
+        call_graph_module,
+        "CALL_GRAPH_PRODUCER_VERSION",
+        "python-call-graph-v1-cache-forced-invalidation",
+    )
+    report: dict[str, object] = {}
+    invalidated = extract_python_calls(
+        repo_root,
+        cache=cache,
+        max_workers=1,
+        build_report=report,
+    )
+    clean = extract_python_calls(repo_root, max_workers=1)
+    assert invalidated == clean
+    assert report["cache_hits"] == 0
+    assert report["cache_misses"] == 2
+
+
+def test_bounded_parallel_build_is_byte_equivalent(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    _write_incremental_fixture(repo_root, file_count=12)
+    serial = extract_python_calls(repo_root, max_workers=1)
+    report: dict[str, object] = {}
+    parallel = extract_python_calls(
+        repo_root,
+        max_workers=2,
+        max_in_flight_bytes=50_000,
+        build_report=report,
+    )
+    assert parallel == serial
+    assert report["parallel_eligible"] is True
+    assert report["parallel_files"] == 12
+    assert 0 < report["peak_in_flight_bytes"] <= 50_000
+    assert report["parallel_fallback"] is False
+
+
+def test_parallel_failure_discards_partial_results_and_retries_serially(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_root = tmp_path / "repo"
+    _write_incremental_fixture(repo_root, file_count=12)
+    serial = extract_python_calls(repo_root, max_workers=1)
+
+    class BrokenExecutor:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            pass
+
+        def __enter__(self) -> "BrokenExecutor":
+            raise RuntimeError("forced worker failure")
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    monkeypatch.setattr(call_graph_module, "_ProcessPoolExecutor", BrokenExecutor)
+    report: dict[str, object] = {}
+    fallback = extract_python_calls(
+        repo_root,
+        max_workers=2,
+        build_report=report,
+    )
+    assert fallback == serial
+    assert report["parallel_fallback"] is True
+    assert report["parallel_files"] == 0
+    assert report["serial_files"] == 12
+    assert "forced worker failure" in str(report["parallel_fallback_reason"])
+
+
+@pytest.mark.parametrize(
+    ("max_workers", "max_in_flight_bytes"),
+    [(0, 1024), (True, 1024), (1, 0), (1, True)],
+)
+def test_incremental_build_rejects_invalid_bounds(
+    tmp_path: Path,
+    max_workers: object,
+    max_in_flight_bytes: object,
+) -> None:
+    with pytest.raises(ValueError):
+        extract_python_calls(
+            tmp_path,
+            max_workers=max_workers,  # type: ignore[arg-type]
+            max_in_flight_bytes=max_in_flight_bytes,  # type: ignore[arg-type]
+        )
+
+
+def test_generate_document_uses_process_local_default_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_root = tmp_path / "repo"
+    _write_incremental_fixture(repo_root)
+    monkeypatch.setattr(
+        call_graph_module,
+        "_DEFAULT_BUILD_CACHE",
+        CallGraphBuildCache(),
+    )
+    first_report: dict[str, object] = {}
+    first = generate_call_graph_document(
+        repo_root,
+        "run-1",
+        "a" * 64,
+        max_workers=1,
+        build_report=first_report,
+    )
+    second_report: dict[str, object] = {}
+    second = generate_call_graph_document(
+        repo_root,
+        "run-1",
+        "a" * 64,
+        max_workers=1,
+        build_report=second_report,
+    )
+    assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)
+    assert first_report["cache_hits"] == 0
+    assert first_report["cache_misses"] == 4
+    assert second_report["cache_hits"] == 4
+    assert second_report["cache_misses"] == 0
+
+
+def test_unavailable_process_pool_falls_back_to_complete_serial_build(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_root = tmp_path / "repo"
+    _write_incremental_fixture(repo_root, file_count=12)
+    serial = extract_python_calls(repo_root, max_workers=1)
+    monkeypatch.setattr(call_graph_module, "_ProcessPoolExecutor", None)
+    report: dict[str, object] = {}
+    fallback = extract_python_calls(
+        repo_root,
+        max_workers=2,
+        build_report=report,
+    )
+    assert fallback == serial
+    assert report["parallel_fallback"] is True
+    assert report["parallel_files"] == 0
+    assert report["serial_files"] == 12
+    assert report["parallel_fallback_reason"] == "ProcessPoolExecutor unavailable"


### PR DESCRIPTION
## Zweck

Setzt Bureau-Aufgabe `RPU-V1-T031` um: hashgebundene Wiederverwendung dateilokaler Python-Call-Graph-Analysen und begrenzte parallele Kaltaufbauten, ohne das öffentliche V1-Artefakt oder die globale Auflösung zu verändern.

## Umsetzung

- unveränderliche Dateisnapshots, gebunden an relativen Pfad, Inhalts-SHA-256, Producer- und Python-Version;
- prozesslokaler, gelockter Standardcache im produktiven Dokumentgenerator;
- vollständige globale Auflösung bei jedem Aufbau;
- höchstens vier Worker standardmäßig, harte Obergrenze 32;
- 64 MiB Quelltext-Payload-Grenze und höchstens zwei Aufträge je Worker/Batch;
- vollständiger serieller Neuversuch bei Workerfehlern oder fehlendem Prozesspool;
- reproduzierbarer Benchmark und revisionsgebundener Proof.

## Messung

Korpus: 702 Python-Dateien, 8.853.965 Byte, drei Wiederholungen.

- kalt seriell: 16.006,58 ms Median;
- kalt parallel: 10.267,54 ms, 1,56× / 35,9 % weniger Zeit;
- unverändert warm: 4.341,36 ms, 3,69× / 72,9 % weniger Zeit;
- eine Datei geändert: 5.491,76 ms, 2,91× / 65,7 % weniger Zeit;
- kanonischer Ergebnis-Hash in allen Varianten identisch: `c12547d4e4dad664f0eb0d8cbf3b8b063ea29db4ded8aa09e6653a94511a1295`;
- Messartefakt-SHA-256: `5e5ec7e9518b5d55116485dd8980e9441edf970bfc300b83dfb96c1376f2b283`.

## Prüfung

- vollständiger Pytest-Lauf: 5387 bestanden, 12 übersprungen;
- fokussiert: 58 bestanden, 10 übersprungen;
- direkte Veröffentlichungsgrenze: 115 bestanden, 10 übersprungen;
- Goldset/Agentenwirkung: 95 bestanden, 10 übersprungen;
- S1-Präzision 1,0, Ziel-Recall 1,0, keine Fallregression;
- Ruff-Lint und Ruff-Format grün;
- Wartbarkeitsratchet, Modul-Erreichbarkeit, Workflow-Inventar, Dokumentlinks und `git diff --check` grün.

## Grenzen

- kein persistierter, prozessübergreifender Cache;
- kein hartes Gesamt-RSS-Limit für Kindprozesse;
- keine neue Behauptung semantischer Vollständigkeit, Laufzeiterreichbarkeit oder dynamischen Dispatchs;
- fremde Dirty-, Retention- und Archiv-Worktrees wurden nicht verändert.

Bureau run: `BUR-RUN-20260804T062104Z-4e825c0891`
Base: `633568ce1e0880b729ff48e4ff77fd6ae69b351f`
Head: `7cf9233b83a874e375d2377b1a46c6ecfc1f4a04`