### PR TITLE
feat(agent-consumption): bind declarations to trusted tool-read receipts (T005)

### DIFF
--- a/docs/architecture/agent-consumption-contract.md
+++ b/docs/architecture/agent-consumption-contract.md
@@ -5,6 +5,8 @@
 Required Reading Protocol Core implemented.
 Answer Compliance Contract v1 implemented.
 Agent Consumption Trace v1 implemented.
+Agent Tool-Read Receipts and Consumption Evidence Comparison v1 implemented
+(optional, declaration-vs-observation layer; no runtime interception).
 The Agent Entry Manifest core is implemented with a contract, producer and
 focused tests.
 The dedicated Agent Consumption CLI is implemented. Automatic bundle emission,
@@ -142,12 +144,20 @@ Commands:
 - `agent-consumption required`
 - `agent-consumption preflight`
 - `agent-consumption validate-trace`
+- `agent-consumption compare-evidence`
 
 `preflight` resolves required reading, can derive available roles from a Bundle Manifest, emits an Answer Compliance template, and optionally validates a supplied Answer Compliance file into an Agent Consumption Trace.
 
+`compare-evidence` compares Answer Compliance declarations with trusted
+tool-read receipts for one `task_id` and `repo_commit`. It reports
+`declared-only`, `observed-only`, `declared-and-observed`, or `unavailable`
+per artifact role. It does not prove semantic reading, relevance, correctness,
+or truth.
+
 The CLI is a thin execution layer. It does not create an Agent Entry Manifest,
 mutate Bundle Manifest, update Output Health/Post-Emit Health, enforce Export
-Safety, or prove actual reading.
+Safety, intercept runtime tool calls, require wrapper adoption, or prove actual
+semantic reading.
 
 ## Agent Consumption Trace
 
@@ -202,9 +212,115 @@ Deferred:
 - Output Health or Post-Emit Health integration
 - export-safety wiring
 - mandatory adoption by external agent wrappers
-- source-bound tool-read receipts that compare declarations with observed access events
-- cryptographic binding of those future receipts to task, commit and consumed artifact identities
+- runtime interception of arbitrary tool calls
+- cryptographic signing of receipts beyond deterministic SHA-256 binding
 
 The validator performs no I/O, holds no global state, and reuses the existing Required Reading resolution rather than re-deriving it.
 
 `available_roles` is supplied explicitly. When omitted, only required and recommended roles are treated as known, and any other declared role is conservatively warned. The trace does not infer roles from the Bundle Manifest. The `preflight` CLI can derive roles from a Bundle Manifest as operator convenience, but it still does not mutate or certify the bundle. Agent Entry Manifest consumption remains deferred, and the `ArtifactRole` enum is not extended here.
+
+---
+
+## Tool-Read Receipts and Consumption Evidence
+
+### Purpose
+
+The evidence layer is a **separate, optional** comparison surface that sits
+beside the declaration-only Agent Consumption Trace:
+
+1. Answer Compliance still declares what an answer claims it used.
+2. A **trusted wrapper or tool gateway** may mint a tool-read receipt when it
+   observes access to one artifact identity.
+3. `compare_agent_consumption_evidence` compares declarations and receipts for
+   **exactly the same** `task_id`, `repo_commit`, `artifact_role`, and immutable
+   artifact identity (`path` + `sha256` + `bytes`).
+
+The layer is deliberately data-sparing:
+
+- no artifact body/content is stored on the receipt;
+- secrets and content-bearing fields fail closed;
+- metadata size and character shapes are strictly bounded;
+- SHA-256 binding uses deterministic JSON serialization (`sort_keys`, compact
+  separators, UTF-8).
+
+### Trust boundary
+
+Only allowlisted issuers may produce observed evidence:
+
+| issuer.kind | issuer.id |
+|-------------|-----------|
+| `trusted_wrapper` | `repoground.agent_consumption.tool_read_wrapper` |
+| `tool_gateway` | `repoground.agent_consumption.tool_gateway` |
+
+Answer text, free-form self-declarations, and unknown issuer ids never mint
+observed evidence. The comparison rejects untrusted and invalid receipts
+without elevating any role to `declared-and-observed`.
+
+### Comparison states
+
+| state | meaning |
+|-------|---------|
+| `declared-only` | Role is declared in Answer Compliance; no accepted trusted receipt |
+| `observed-only` | Accepted trusted receipt exists; role was not declared |
+| `declared-and-observed` | Declaration and accepted trusted receipt for the same role (and matching identity when provided) |
+| `unavailable` | Role is expected but has neither declaration nor accepted observation |
+
+Rejected receipts are diagnosed and listed; they never raise the evidence state.
+
+### Rejection diagnostics that never elevate evidence
+
+| reason | meaning |
+|--------|---------|
+| `missing` | No usable declaration/observation material for the comparison set |
+| `stale` | Receipt age exceeds `max_age_seconds` relative to `as_of` |
+| `task_mismatch` | Receipt `task_id` differs from the bound task |
+| `commit_mismatch` | Receipt `repo_commit` differs from the bound commit |
+| `replay` | Duplicate `access_event_id` |
+| `artifact_mismatch` | Role identity conflicts with declared or previously accepted identity |
+| `untrusted_issuer` | Issuer not on the allowlist |
+| `privacy_violation` | Content/secret-bearing fields present |
+| `binding_mismatch` | `binding_sha256` / `receipt_sha256` does not recompute |
+| `invalid_receipt` | Structural or shape failure |
+
+### Retention, redaction, deletion
+
+Every receipt and evidence report carries:
+
+```text
+policy = ephemeral_comparison_input
+content_retained = false
+redaction = metadata_only
+deletion = safe_at_any_time
+```
+
+Operators may discard receipts at any time. Deletion never mutates repository
+content; absence becomes `missing` / `unavailable` rather than a stronger claim.
+
+### Files
+
+| File | Role |
+|------|------|
+| `merger/repoground/contracts/agent-tool-read-receipt.v1.schema.json` | Receipt JSON Schema |
+| `merger/repoground/contracts/agent-consumption-evidence.v1.schema.json` | Evidence comparison JSON Schema |
+| `merger/repoground/core/agent_consumption_receipts.py` | Mint/validate + `TrustedToolReadWrapper` |
+| `merger/repoground/core/agent_consumption_evidence.py` | Pure comparison: `compare_agent_consumption_evidence(...)` |
+| `merger/repoground/tests/test_agent_consumption_evidence.py` | Schema, determinism, negative, replay, freshness, mismatch, E2E tests |
+| `docs/contracts/agent-consumption-evidence-v1.md` | Contract surface notes |
+| `docs/proofs/agent-consumption-evidence-v1-proof.md` | Implementation proof |
+
+### Non-claims
+
+Evidence comparison does **not** establish:
+
+- semantic reading or understanding;
+- relevance of observed files to an answer;
+- answer correctness or claim truth;
+- complete context use;
+- test sufficiency, regression absence, or runtime behavior;
+- forensic readiness;
+- runtime interception or mandatory wrapper adoption;
+- that every wrapper emits trusted receipts.
+
+The existing Trace `does_not_establish` set remains intact for declaration
+comparison. Evidence comparison includes those nine boundaries and adds
+observation-specific non-claims.

--- a/docs/contracts/agent-consumption-evidence-v1.md
+++ b/docs/contracts/agent-consumption-evidence-v1.md
@@ -1,0 +1,59 @@
+# Agent Consumption Evidence v1
+
+Status: implemented contract surface (optional observation layer)
+
+Initiative: `REPOGROUND-AGENT-UTILITY-V1`
+Task: `REPOGROUND-AGENT-UTILITY-V1-T005`
+
+## Purpose
+
+Bind declared Agent Consumption statements to trusted tool-read receipts for the
+same task, repository commit, artifact role and immutable artifact identity —
+without storing source content and without claiming understanding, relevance,
+correctness or truth.
+
+## Surfaces
+
+| Contract | Kind | Module |
+|----------|------|--------|
+| `agent-tool-read-receipt.v1.schema.json` | `lenskit.agent_tool_read_receipt` | `agent_consumption_receipts.py` |
+| `agent-consumption-evidence.v1.schema.json` | `lenskit.agent_consumption_evidence` | `agent_consumption_evidence.py` |
+
+## Mint path
+
+Only:
+
+- `TrustedToolReadWrapper.observe_artifact_access(...)`
+- `mint_tool_read_receipt(...)` with an allowlisted issuer
+
+may create observed evidence. Answer Compliance remains declaration-only.
+
+## Comparison CLI
+
+```bash
+python3 -m merger.repoground.cli.main agent-consumption compare-evidence \
+  --answer-compliance path/to/answer-compliance.json \
+  --receipts path/to/receipts.json \
+  --task-id REPOGROUND-AGENT-UTILITY-V1-T005 \
+  --repo-commit <40-hex> \
+  [--expected-roles role_a,role_b] \
+  [--declared-identities path/to/identities.json] \
+  [--as-of 2026-08-05T22:00:00Z] \
+  [--max-age-seconds 3600] \
+  [--strict] \
+  [--out evidence.json]
+```
+
+## Retention
+
+Receipts are ephemeral comparison inputs:
+
+- no content retention
+- metadata-only redaction
+- safe deletion at any time
+
+## Non-claims
+
+A `declared-and-observed` state means only that a declaration and an accepted
+trusted receipt matched the bound task/commit/role/identity. It does not prove
+semantic reading, relevance, answer correctness, or truth.

--- a/docs/proofs/agent-consumption-evidence-v1-proof.md
+++ b/docs/proofs/agent-consumption-evidence-v1-proof.md
@@ -1,0 +1,91 @@
+# Agent Consumption Evidence v1 proof
+
+Task: `REPOGROUND-AGENT-UTILITY-V1-T005`
+
+Status: implementation proof for the optional declaration-vs-observation evidence layer.
+
+## Problem
+
+Answer Compliance and the Agent Consumption Trace compare declarations with
+required-reading expectations. That is formal self-consistency only. It does
+not record whether a trusted tool wrapper observed access to the declared
+artifact identity for the same task and repository commit.
+
+Without a separate observation layer, operators cannot distinguish:
+
+- declared-only claims;
+- trusted observations without declaration;
+- matching declaration and observation;
+- unavailable expected roles.
+
+Any observation layer that stored source content or treated answer text as
+evidence would over-claim privacy and truth.
+
+## Implemented surface
+
+This slice adds:
+
+- `agent-tool-read-receipt.v1.schema.json`
+- `agent-consumption-evidence.v1.schema.json`
+- `merger/repoground/core/agent_consumption_receipts.py`
+- `merger/repoground/core/agent_consumption_evidence.py`
+- CLI `agent-consumption compare-evidence`
+- focused schema, determinism, negative, replay, freshness, mismatch and E2E tests
+- architecture and contract documentation
+
+## Binding
+
+Each receipt deterministically binds:
+
+- `task_id`
+- `repo_commit` (40-hex SHA-1)
+- `artifact_role`
+- immutable `artifact_identity` (`path`, `sha256`, `bytes`)
+- `access_event_id`
+- allowlisted `issuer`
+
+via `binding_sha256` and full-document `receipt_sha256` over canonical JSON.
+Content is hashed for identity and discarded.
+
+## Trust and privacy
+
+- Only `trusted_wrapper` / `tool_gateway` allowlisted issuer ids elevate evidence.
+- Answer text and self-declarations have no mint path.
+- Forbidden content/secret keys fail closed.
+- Secret-like path or event-id material fails closed.
+- Receipt JSON size is bounded.
+
+## Comparison states
+
+Exactly:
+
+- `declared-only`
+- `observed-only`
+- `declared-and-observed`
+- `unavailable`
+
+Missing, stale, task-mismatch, commit-mismatch, replay and artifact-mismatch
+receipts are diagnosed and never produce a stronger evidence state.
+
+## Verification command
+
+```bash
+python3 -m pytest merger/repoground/tests/test_agent_consumption_evidence.py \
+  merger/repoground/tests/test_agent_consumption_trace.py \
+  merger/repoground/tests/test_cli_agent_consumption.py -q
+```
+
+## Non-claims / STOP
+
+This slice does not establish:
+
+- semantic reading;
+- relevance of observed files to later answers;
+- answer correctness or claim truth;
+- complete context use;
+- runtime interception of all tools;
+- mandatory adoption by external wrappers;
+- deployment or merge readiness;
+- cryptographic hardware-backed attestation.
+
+STOP: no runtime agent hook is installed; no deployment; no second initiative task.

--- a/merger/repoground/cli/cmd_agent_consumption.py
+++ b/merger/repoground/cli/cmd_agent_consumption.py
@@ -46,6 +46,50 @@ def register_agent_consumption_commands(subparsers) -> None:
     val_parser.add_argument("--strict", action="store_true", help="Treat 'warn' status as exit code 1")
     val_parser.add_argument("--out", "--output", dest="out", help="Output path for the trace JSON")
 
+    # compare-evidence command (declaration vs trusted tool-read receipts)
+    ev_parser = subparsers_ac.add_parser(
+        "compare-evidence",
+        help=(
+            "Compare Answer Compliance declarations with trusted tool-read "
+            "receipts for one task_id and repo_commit"
+        ),
+    )
+    ev_parser.add_argument(
+        "--answer-compliance",
+        required=True,
+        help="Path to Answer Compliance JSON (declaration layer only)",
+    )
+    ev_parser.add_argument(
+        "--receipts",
+        required=True,
+        help="Path to a JSON array of tool-read receipts, or an object with a receipts array",
+    )
+    ev_parser.add_argument("--task-id", required=True, help="Exact task identity binding")
+    ev_parser.add_argument(
+        "--repo-commit",
+        required=True,
+        help="Full lowercase 40-character repository commit SHA-1",
+    )
+    ev_parser.add_argument(
+        "--expected-roles",
+        help="Comma-separated roles expected even when undeclared/unobserved (become unavailable)",
+    )
+    ev_parser.add_argument(
+        "--declared-identities",
+        help="Optional JSON object mapping artifact roles to path/sha256/bytes identities",
+    )
+    ev_parser.add_argument(
+        "--as-of",
+        help="Optional ISO-8601 UTC timestamp (…Z) used for freshness comparison",
+    )
+    ev_parser.add_argument(
+        "--max-age-seconds",
+        type=int,
+        help="Optional maximum receipt age in seconds relative to --as-of",
+    )
+    ev_parser.add_argument("--strict", action="store_true", help="Treat 'warn' status as exit code 1")
+    ev_parser.add_argument("--out", "--output", dest="out", help="Output path for the evidence JSON")
+
 
 class AgentConsumptionCliError(Exception):
     """User-facing CLI input/output error."""
@@ -330,6 +374,58 @@ def run_agent_consumption_validate_trace(args: argparse.Namespace) -> int:
         return 2
 
 
+def _load_receipts(path: Path) -> list:
+    data = _read_json_any(path)
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict) and isinstance(data.get("receipts"), list):
+        return data["receipts"]
+    raise AgentConsumptionCliError(
+        f"Invalid receipts file {path}: expected a JSON array or an object "
+        "with a receipts array."
+    )
+
+
+def run_agent_consumption_compare_evidence(args: argparse.Namespace) -> int:
+    from merger.repoground.core.agent_consumption_evidence import (
+        compare_agent_consumption_evidence,
+    )
+
+    try:
+        ac_data = _read_json_object(Path(args.answer_compliance))
+        _require_keys(
+            ac_data,
+            {"declared_artifacts"},
+            label="Answer compliance",
+        )
+        receipts = _load_receipts(Path(args.receipts))
+        expected_roles = sorted(_parse_roles_csv(args.expected_roles))
+        declared_identities = None
+        if args.declared_identities:
+            declared_identities = _read_json_object(Path(args.declared_identities))
+
+        evidence = compare_agent_consumption_evidence(
+            ac_data,
+            receipts,
+            task_id=args.task_id,
+            repo_commit=args.repo_commit,
+            expected_roles=expected_roles or None,
+            declared_identities=declared_identities,
+            as_of=args.as_of,
+            max_age_seconds=args.max_age_seconds,
+        )
+
+        out_path = Path(args.out) if args.out else None
+        _write_json_or_stdout(evidence, out_path)
+        return _exit_for_status(evidence.get("status", "unknown"), strict=args.strict)
+    except AgentConsumptionCliError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 2
+    except Exception as e:
+        print(f"Error: unexpected failure: {e}", file=sys.stderr)
+        return 2
+
+
 def run_agent_consumption(args: argparse.Namespace) -> int:
     if args.agent_consumption_cmd == "required":
         return run_agent_consumption_required(args)
@@ -337,4 +433,6 @@ def run_agent_consumption(args: argparse.Namespace) -> int:
         return run_agent_consumption_preflight(args)
     if args.agent_consumption_cmd == "validate-trace":
         return run_agent_consumption_validate_trace(args)
+    if args.agent_consumption_cmd == "compare-evidence":
+        return run_agent_consumption_compare_evidence(args)
     return 2

--- a/merger/repoground/contracts/agent-consumption-evidence.v1.schema.json
+++ b/merger/repoground/contracts/agent-consumption-evidence.v1.schema.json
@@ -1,0 +1,246 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://heimgewebe.local/contracts/agent-consumption-evidence.v1.schema.json",
+  "title": "Agent Consumption Evidence Comparison (agent-consumption-evidence v1.0)",
+  "description": "Deterministic comparison of Answer Compliance declarations against trusted tool-read receipts for the same task_id, repo_commit, artifact_role and immutable artifact identity. Comparison only. Does not prove semantic reading, relevance, correctness, completeness, or truth.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "kind",
+    "version",
+    "task_id",
+    "repo_commit",
+    "status",
+    "comparisons",
+    "accepted_receipt_refs",
+    "rejected_receipts",
+    "diagnostics",
+    "retention",
+    "does_not_establish"
+  ],
+  "properties": {
+    "kind": {
+      "type": "string",
+      "const": "lenskit.agent_consumption_evidence"
+    },
+    "version": {
+      "type": "string",
+      "const": "1.0"
+    },
+    "task_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128
+    },
+    "repo_commit": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["pass", "warn", "fail"],
+      "description": "pass: no fail diagnostics and at least the comparison completed. warn: non-elevating caveats such as observed-only or rejected non-matching receipts. fail: input/invariant failure or untrusted elevation attempt."
+    },
+    "comparisons": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/comparison" }
+    },
+    "accepted_receipt_refs": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/receipt_ref" }
+    },
+    "rejected_receipts": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/rejected_receipt" }
+    },
+    "diagnostics": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/diagnostic" }
+    },
+    "retention": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "policy",
+        "content_retained",
+        "redaction",
+        "deletion"
+      ],
+      "properties": {
+        "policy": { "type": "string", "const": "ephemeral_comparison_input" },
+        "content_retained": { "type": "boolean", "const": false },
+        "redaction": { "type": "string", "const": "metadata_only" },
+        "deletion": { "type": "string", "const": "safe_at_any_time" }
+      }
+    },
+    "does_not_establish": {
+      "$ref": "#/definitions/does_not_establish_array"
+    }
+  },
+  "definitions": {
+    "comparison": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "artifact_role",
+        "state",
+        "declared",
+        "observed"
+      ],
+      "properties": {
+        "artifact_role": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "declared-only",
+            "observed-only",
+            "declared-and-observed",
+            "unavailable"
+          ]
+        },
+        "declared": { "type": "boolean" },
+        "observed": { "type": "boolean" },
+        "receipt_binding_sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "artifact_identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["path", "sha256", "bytes"],
+          "properties": {
+            "path": { "type": "string", "minLength": 1, "maxLength": 512 },
+            "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+            "bytes": { "type": "integer", "minimum": 0, "maximum": 268435456 }
+          }
+        }
+      }
+    },
+    "receipt_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "access_event_id",
+        "artifact_role",
+        "binding_sha256",
+        "receipt_sha256"
+      ],
+      "properties": {
+        "access_event_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "artifact_role": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "binding_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "receipt_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+      }
+    },
+    "rejected_receipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reason", "detail"],
+      "properties": {
+        "reason": {
+          "type": "string",
+          "enum": [
+            "missing",
+            "stale",
+            "task_mismatch",
+            "commit_mismatch",
+            "replay",
+            "artifact_mismatch",
+            "untrusted_issuer",
+            "invalid_receipt",
+            "privacy_violation",
+            "binding_mismatch"
+          ]
+        },
+        "detail": { "type": "string", "minLength": 1, "maxLength": 512 },
+        "access_event_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "artifact_role": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "receipt_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+      }
+    },
+    "diagnostic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "severity", "detail"],
+      "properties": {
+        "code": {
+          "type": "string",
+          "enum": [
+            "invalid_input_field",
+            "missing",
+            "stale",
+            "task_mismatch",
+            "commit_mismatch",
+            "replay",
+            "artifact_mismatch",
+            "untrusted_issuer",
+            "privacy_violation",
+            "binding_mismatch",
+            "declared_only",
+            "observed_only",
+            "unavailable",
+            "missing_negative_semantics"
+          ]
+        },
+        "severity": {
+          "type": "string",
+          "enum": ["info", "warn", "fail"]
+        },
+        "detail": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 512
+        },
+        "artifact_role": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        }
+      }
+    },
+    "does_not_establish_array": {
+      "type": "array",
+      "minItems": 13,
+      "maxItems": 13,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": [
+          "actual_reading_proven",
+          "semantic_reading",
+          "relevance_to_answer",
+          "answer_correct",
+          "repo_understood",
+          "all_relevant_context_used",
+          "claims_true",
+          "test_sufficiency",
+          "regression_absence",
+          "runtime_behavior",
+          "forensic_ready",
+          "runtime_interception",
+          "mandatory_wrapper_adoption"
+        ]
+      },
+      "allOf": [
+        { "contains": { "const": "actual_reading_proven" } },
+        { "contains": { "const": "semantic_reading" } },
+        { "contains": { "const": "relevance_to_answer" } },
+        { "contains": { "const": "answer_correct" } },
+        { "contains": { "const": "repo_understood" } },
+        { "contains": { "const": "all_relevant_context_used" } },
+        { "contains": { "const": "claims_true" } },
+        { "contains": { "const": "test_sufficiency" } },
+        { "contains": { "const": "regression_absence" } },
+        { "contains": { "const": "runtime_behavior" } },
+        { "contains": { "const": "forensic_ready" } },
+        { "contains": { "const": "runtime_interception" } },
+        { "contains": { "const": "mandatory_wrapper_adoption" } }
+      ],
+      "description": "Preserves existing agent-consumption negative semantics and adds observation-specific non-claims."
+    }
+  }
+}

--- a/merger/repoground/contracts/agent-tool-read-receipt.v1.schema.json
+++ b/merger/repoground/contracts/agent-tool-read-receipt.v1.schema.json
@@ -114,7 +114,7 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["kind", "id"],
-      "description": "Only allowlisted trusted_wrapper or tool_gateway issuers may mint observed evidence. Answer text and self-declarations are not issuers.",
+      "description": "Only allowlisted trusted_wrapper or tool_gateway issuers may mint observed evidence. Runtime allowlist couples kind to id exactly: trusted_wrapper↔repoground.agent_consumption.tool_read_wrapper and tool_gateway↔repoground.agent_consumption.tool_gateway. Answer text and self-declarations are not issuers.",
       "properties": {
         "kind": {
           "type": "string",
@@ -122,11 +122,40 @@
         },
         "id": {
           "type": "string",
-          "minLength": 1,
-          "maxLength": 128,
-          "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+          "enum": [
+            "repoground.agent_consumption.tool_read_wrapper",
+            "repoground.agent_consumption.tool_gateway"
+          ]
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "kind": { "const": "trusted_wrapper" } },
+            "required": ["kind"]
+          },
+          "then": {
+            "properties": {
+              "id": {
+                "const": "repoground.agent_consumption.tool_read_wrapper"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "kind": { "const": "tool_gateway" } },
+            "required": ["kind"]
+          },
+          "then": {
+            "properties": {
+              "id": {
+                "const": "repoground.agent_consumption.tool_gateway"
+              }
+            }
+          }
+        }
+      ]
     },
     "retention": {
       "type": "object",

--- a/merger/repoground/contracts/agent-tool-read-receipt.v1.schema.json
+++ b/merger/repoground/contracts/agent-tool-read-receipt.v1.schema.json
@@ -1,0 +1,193 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://heimgewebe.local/contracts/agent-tool-read-receipt.v1.schema.json",
+  "title": "Agent Tool-Read Receipt (agent-tool-read-receipt v1.0)",
+  "description": "Data-sparing, versioned observation that a trusted wrapper or tool gateway recorded access to one artifact identity for one task and one repository commit. Stores only bounded metadata and digests. Never stores artifact content. Does not establish semantic reading, relevance, answer correctness, or truth.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "kind",
+    "version",
+    "task_id",
+    "repo_commit",
+    "artifact_role",
+    "artifact_identity",
+    "access_event_id",
+    "observed_at",
+    "issuer",
+    "binding_sha256",
+    "receipt_sha256",
+    "retention",
+    "does_not_establish"
+  ],
+  "properties": {
+    "kind": {
+      "type": "string",
+      "const": "lenskit.agent_tool_read_receipt"
+    },
+    "version": {
+      "type": "string",
+      "const": "1.0"
+    },
+    "task_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$",
+      "description": "Exact task identity this observation is bound to."
+    },
+    "repo_commit": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$",
+      "description": "Full lowercase repository commit SHA-1 the access is bound to."
+    },
+    "artifact_role": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$",
+      "description": "Artifact role accessed (for example canonical_md). Role only; not content."
+    },
+    "artifact_identity": {
+      "$ref": "#/definitions/artifact_identity"
+    },
+    "access_event_id": {
+      "type": "string",
+      "minLength": 8,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$",
+      "description": "Unique identifier for this single access event. Used for replay detection."
+    },
+    "observed_at": {
+      "type": "string",
+      "minLength": 20,
+      "maxLength": 40,
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]{1,6})?Z$",
+      "description": "UTC observation timestamp (ISO-8601 with trailing Z)."
+    },
+    "issuer": {
+      "$ref": "#/definitions/issuer"
+    },
+    "binding_sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$",
+      "description": "SHA-256 of the deterministic binding material (task, commit, role, identity, event, issuer)."
+    },
+    "receipt_sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$",
+      "description": "SHA-256 of the full receipt without the receipt_sha256 field."
+    },
+    "retention": {
+      "$ref": "#/definitions/retention"
+    },
+    "does_not_establish": {
+      "$ref": "#/definitions/does_not_establish_array"
+    }
+  },
+  "definitions": {
+    "artifact_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256", "bytes"],
+      "description": "Immutable artifact identity without content. path is a relative locator; sha256 and bytes bind the bytes that were hashed at observation time.",
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 512,
+          "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$))[A-Za-z0-9._@+/-]+$",
+          "description": "Relative POSIX-like path locator. Never absolute. Never contains '..'."
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "bytes": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 268435456
+        }
+      }
+    },
+    "issuer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "id"],
+      "description": "Only allowlisted trusted_wrapper or tool_gateway issuers may mint observed evidence. Answer text and self-declarations are not issuers.",
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["trusted_wrapper", "tool_gateway"]
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+        }
+      }
+    },
+    "retention": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "policy",
+        "content_retained",
+        "redaction",
+        "deletion"
+      ],
+      "properties": {
+        "policy": {
+          "type": "string",
+          "const": "ephemeral_comparison_input",
+          "description": "Receipts are comparison inputs; long-term archival is operator-controlled and optional."
+        },
+        "content_retained": {
+          "type": "boolean",
+          "const": false,
+          "description": "Artifact body/content must never be retained in the receipt."
+        },
+        "redaction": {
+          "type": "string",
+          "const": "metadata_only",
+          "description": "Only role, path, digests, sizes, and binding identifiers are retained."
+        },
+        "deletion": {
+          "type": "string",
+          "const": "safe_at_any_time",
+          "description": "Deleting a receipt never corrupts source repositories; absence becomes missing/unavailable evidence."
+        }
+      }
+    },
+    "does_not_establish_array": {
+      "type": "array",
+      "minItems": 8,
+      "maxItems": 8,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": [
+          "semantic_reading",
+          "relevance_to_answer",
+          "answer_correct",
+          "claims_true",
+          "repo_understood",
+          "all_relevant_context_used",
+          "runtime_interception",
+          "mandatory_wrapper_adoption"
+        ]
+      },
+      "allOf": [
+        { "contains": { "const": "semantic_reading" } },
+        { "contains": { "const": "relevance_to_answer" } },
+        { "contains": { "const": "answer_correct" } },
+        { "contains": { "const": "claims_true" } },
+        { "contains": { "const": "repo_understood" } },
+        { "contains": { "const": "all_relevant_context_used" } },
+        { "contains": { "const": "runtime_interception" } },
+        { "contains": { "const": "mandatory_wrapper_adoption" } }
+      ]
+    }
+  }
+}

--- a/merger/repoground/core/agent_consumption_evidence.py
+++ b/merger/repoground/core/agent_consumption_evidence.py
@@ -18,11 +18,17 @@ Rejected observations (missing, stale, task-mismatch, commit-mismatch, replay,
 artifact-mismatch, untrusted issuer, privacy, invalid) never elevate evidence
 to ``declared-and-observed``.
 
+Invalid comparison bindings (empty/invalid ``task_id``, invalid ``repo_commit``,
+invalid explicit ``as_of``, or invalid ``max_age_seconds``) fail closed: no
+receipt is accepted, no ``observed=true`` or ``declared-and-observed`` state is
+emitted, and schema-placeholder fields never stand in for a trusted observation.
+
 This comparison does not establish semantic reading, relevance, correctness,
 completeness, forensic readiness, runtime interception or mandatory adoption.
 It preserves the nine agent-consumption ``does_not_establish`` boundaries and
 adds observation-specific non-claims.
 """
+
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
@@ -73,6 +79,31 @@ _WARN = "warn"
 _INFO = "info"
 
 _COMMIT_LEN = 40
+_SCHEMA_PLACEHOLDER_TASK = "unknown"
+_SCHEMA_PLACEHOLDER_COMMIT = "0" * _COMMIT_LEN
+
+_PRIVACY_FORBIDDEN_KEYS = frozenset(
+    {
+        "content",
+        "body",
+        "text",
+        "raw",
+        "source_text",
+        "source_content",
+        "payload",
+        "blob",
+        "data",
+        "file_bytes",
+        "bytes_content",
+        "secret",
+        "secrets",
+        "token",
+        "password",
+        "api_key",
+        "private_key",
+        "authorization",
+    }
+)
 
 
 def compare_agent_consumption_evidence(
@@ -100,35 +131,28 @@ def compare_agent_consumption_evidence(
     declared_roles = _declared_roles(answer_compliance, diagnostics)
     expected = _role_set(expected_roles, "expected_roles", diagnostics)
     identity_index = _declared_identity_index(declared_identities, diagnostics)
-    as_of_dt = _parse_as_of(as_of, diagnostics)
-    max_age = _normalize_max_age(max_age_seconds, diagnostics)
+    as_of_dt, as_of_ok = _parse_as_of(as_of, diagnostics)
+    max_age, max_age_ok = _normalize_max_age(max_age_seconds, diagnostics)
+    # Bound comparison only accepts observations when every binding input is
+    # schema-valid. Placeholder task/commit values remain schema fields only.
+    accept_observations = (
+        task is not None and commit is not None and as_of_ok and max_age_ok
+    )
 
     accepted_by_role: dict[str, dict[str, Any]] = {}
     accepted_refs: list[dict[str, str]] = []
     seen_events: dict[str, str] = {}
-    raw_receipts = list(receipts) if isinstance(receipts, Sequence) and not isinstance(
-        receipts, (str, bytes, bytearray)
-    ) else []
-    if receipts is not None and not isinstance(receipts, Sequence):
-        diagnostics.append(
-            _diag(
-                "invalid_input_field",
-                _FAIL,
-                "receipts must be an array of receipt objects.",
-            )
-        )
-        raw_receipts = []
-    elif isinstance(receipts, (str, bytes, bytearray)):
-        diagnostics.append(
-            _diag(
-                "invalid_input_field",
-                _FAIL,
-                "receipts must be an array of receipt objects.",
-            )
-        )
-        raw_receipts = []
+    raw_receipts = _normalize_receipts_input(receipts, diagnostics)
 
     for index, raw in enumerate(raw_receipts):
+        if not accept_observations:
+            _reject_unbound_receipt(
+                raw,
+                index=index,
+                rejected=rejected,
+                diagnostics=diagnostics,
+            )
+            continue
         _ingest_receipt(
             raw,
             index=index,
@@ -144,7 +168,98 @@ def compare_agent_consumption_evidence(
             diagnostics=diagnostics,
         )
 
+    # Fail-closed binding: never report observed elevation without valid binds.
+    if not accept_observations:
+        accepted_by_role.clear()
+        accepted_refs.clear()
+
     roles = sorted(set(declared_roles) | set(accepted_by_role) | expected)
+    comparisons = _build_comparisons(
+        roles=roles,
+        declared_roles=declared_roles,
+        accepted_by_role=accepted_by_role,
+        expected=expected,
+        diagnostics=diagnostics,
+    )
+
+    if not roles:
+        diagnostics.append(
+            _diag(
+                "missing",
+                _WARN,
+                "No declared roles, accepted receipts, or expected roles were supplied.",
+            )
+        )
+
+    return _evidence(
+        task_id=task if task is not None else _SCHEMA_PLACEHOLDER_TASK,
+        repo_commit=commit if commit is not None else _SCHEMA_PLACEHOLDER_COMMIT,
+        comparisons=comparisons,
+        accepted_refs=accepted_refs,
+        rejected=rejected,
+        diagnostics=diagnostics,
+    )
+
+
+def _normalize_receipts_input(
+    receipts: Sequence[Any] | None,
+    diagnostics: list[dict[str, Any]],
+) -> list[Any]:
+    if receipts is None:
+        return []
+    if isinstance(receipts, (str, bytes, bytearray)) or not isinstance(
+        receipts, Sequence
+    ):
+        diagnostics.append(
+            _diag(
+                "invalid_input_field",
+                _FAIL,
+                "receipts must be an array of receipt objects.",
+            )
+        )
+        return []
+    return list(receipts)
+
+
+def _reject_unbound_receipt(
+    raw: Any,
+    *,
+    index: int,
+    rejected: list[dict[str, Any]],
+    diagnostics: list[dict[str, Any]],
+) -> None:
+    """Reject a receipt because the comparison binding is not trustworthy."""
+    label = f"receipts[{index}]"
+    access_event_id = None
+    artifact_role = None
+    receipt_sha256 = None
+    if isinstance(raw, Mapping):
+        access_event_id = _maybe_str(raw.get("access_event_id"))
+        artifact_role = _maybe_str(raw.get("artifact_role"))
+        receipt_sha256 = _maybe_hex(raw.get("receipt_sha256"))
+    _reject(
+        rejected,
+        diagnostics,
+        reason="invalid_receipt",
+        code="invalid_input_field",
+        detail=(
+            f"{label} cannot elevate evidence because the comparison binding "
+            "(task_id, repo_commit, as_of, and/or max_age_seconds) is invalid."
+        ),
+        access_event_id=access_event_id,
+        artifact_role=artifact_role,
+        receipt_sha256=receipt_sha256,
+    )
+
+
+def _build_comparisons(
+    *,
+    roles: list[str],
+    declared_roles: set[str],
+    accepted_by_role: dict[str, dict[str, Any]],
+    expected: set[str],
+    diagnostics: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
     comparisons: list[dict[str, Any]] = []
     for role in roles:
         declared = role in declared_roles
@@ -192,32 +307,15 @@ def compare_agent_consumption_evidence(
             item["receipt_binding_sha256"] = observed_receipt["binding_sha256"]
             item["artifact_identity"] = deepcopy(observed_receipt["artifact_identity"])
         comparisons.append(item)
-
-    if not roles:
-        diagnostics.append(
-            _diag(
-                "missing",
-                _WARN,
-                "No declared roles, accepted receipts, or expected roles were supplied.",
-            )
-        )
-
-    return _evidence(
-        task_id=task or "unknown",
-        repo_commit=commit or ("0" * _COMMIT_LEN),
-        comparisons=comparisons,
-        accepted_refs=accepted_refs,
-        rejected=rejected,
-        diagnostics=diagnostics,
-    )
+    return comparisons
 
 
 def _ingest_receipt(
     raw: Any,
     *,
     index: int,
-    task_id: str | None,
-    repo_commit: str | None,
+    task_id: str,
+    repo_commit: str,
     as_of_dt: datetime | None,
     max_age: int | None,
     identity_index: dict[str, dict[str, Any]],
@@ -238,49 +336,101 @@ def _ingest_receipt(
         )
         return
 
+    if _reject_privacy_fields(
+        raw, label=label, rejected=rejected, diagnostics=diagnostics
+    ):
+        return
+
+    receipt = _validated_receipt_or_reject(
+        raw, label=label, rejected=rejected, diagnostics=diagnostics
+    )
+    if receipt is None:
+        return
+
+    if _reject_replay(
+        receipt,
+        label=label,
+        seen_events=seen_events,
+        rejected=rejected,
+        diagnostics=diagnostics,
+    ):
+        return
+
+    if _reject_binding_mismatch(
+        receipt,
+        label=label,
+        task_id=task_id,
+        repo_commit=repo_commit,
+        rejected=rejected,
+        diagnostics=diagnostics,
+    ):
+        return
+
+    if _reject_stale(
+        receipt,
+        label=label,
+        as_of_dt=as_of_dt,
+        max_age=max_age,
+        rejected=rejected,
+        diagnostics=diagnostics,
+    ):
+        return
+
+    if _reject_identity_conflicts(
+        receipt,
+        label=label,
+        identity_index=identity_index,
+        accepted_by_role=accepted_by_role,
+        accepted_refs=accepted_refs,
+        rejected=rejected,
+        diagnostics=diagnostics,
+    ):
+        return
+
+    _accept_receipt(
+        receipt,
+        accepted_by_role=accepted_by_role,
+        accepted_refs=accepted_refs,
+        seen_events=seen_events,
+    )
+
+
+def _reject_privacy_fields(
+    raw: Mapping[str, Any],
+    *,
+    label: str,
+    rejected: list[dict[str, Any]],
+    diagnostics: list[dict[str, Any]],
+) -> bool:
     # Privacy fail-closed before structural validation so content-bearing forgeries
     # never become observations.
     forbidden = sorted(
-        k
-        for k in raw
-        if isinstance(k, str)
-        and k
-        in {
-            "content",
-            "body",
-            "text",
-            "raw",
-            "source_text",
-            "source_content",
-            "payload",
-            "blob",
-            "data",
-            "file_bytes",
-            "bytes_content",
-            "secret",
-            "secrets",
-            "token",
-            "password",
-            "api_key",
-            "private_key",
-            "authorization",
-        }
+        k for k in raw if isinstance(k, str) and k in _PRIVACY_FORBIDDEN_KEYS
     )
-    if forbidden:
-        _reject(
-            rejected,
-            diagnostics,
-            reason="privacy_violation",
-            code="privacy_violation",
-            detail=f"{label} contains forbidden content/secret fields: {', '.join(forbidden)}.",
-            access_event_id=_maybe_str(raw.get("access_event_id")),
-            artifact_role=_maybe_str(raw.get("artifact_role")),
-            receipt_sha256=_maybe_hex(raw.get("receipt_sha256")),
-        )
-        return
+    if not forbidden:
+        return False
+    _reject(
+        rejected,
+        diagnostics,
+        reason="privacy_violation",
+        code="privacy_violation",
+        detail=f"{label} contains forbidden content/secret fields: {', '.join(forbidden)}.",
+        access_event_id=_maybe_str(raw.get("access_event_id")),
+        artifact_role=_maybe_str(raw.get("artifact_role")),
+        receipt_sha256=_maybe_hex(raw.get("receipt_sha256")),
+    )
+    return True
 
+
+def _validated_receipt_or_reject(
+    raw: Mapping[str, Any],
+    *,
+    label: str,
+    rejected: list[dict[str, Any]],
+    diagnostics: list[dict[str, Any]],
+) -> dict[str, Any] | None:
     try:
-        receipt = validate_tool_read_receipt(raw)
+        return validate_tool_read_receipt(raw)
     except ToolReadReceiptError as exc:
         message = str(exc)
         if "allowlisted trusted source" in message or "issuer.kind" in message:
@@ -305,28 +455,49 @@ def _ingest_receipt(
             artifact_role=_maybe_str(raw.get("artifact_role")),
             receipt_sha256=_maybe_hex(raw.get("receipt_sha256")),
         )
-        return
+        return None
 
+
+def _reject_replay(
+    receipt: Mapping[str, Any],
+    *,
+    label: str,
+    seen_events: Mapping[str, str],
+    rejected: list[dict[str, Any]],
+    diagnostics: list[dict[str, Any]],
+) -> bool:
     event_id = receipt["access_event_id"]
-    if event_id in seen_events:
-        _reject(
-            rejected,
-            diagnostics,
-            reason="replay",
-            code="replay",
-            detail=(
-                f"{label} replays access_event_id '{event_id}' already seen for "
-                f"binding {seen_events[event_id][:12]}…; replay never elevates evidence."
-            ),
-            access_event_id=event_id,
-            artifact_role=receipt["artifact_role"],
-            receipt_sha256=receipt["receipt_sha256"],
-        )
-        # A replay must not keep a previously accepted observation for the same
-        # event, and must not add a second observation.
-        return
+    if event_id not in seen_events:
+        return False
+    _reject(
+        rejected,
+        diagnostics,
+        reason="replay",
+        code="replay",
+        detail=(
+            f"{label} replays access_event_id '{event_id}' already seen for "
+            f"binding {seen_events[event_id][:12]}…; replay never elevates evidence."
+        ),
+        access_event_id=event_id,
+        artifact_role=receipt["artifact_role"],
+        receipt_sha256=receipt["receipt_sha256"],
+    )
+    # A replay must not keep a previously accepted observation for the same
+    # event, and must not add a second observation.
+    return True
 
-    if task_id is not None and receipt["task_id"] != task_id:
+
+def _reject_binding_mismatch(
+    receipt: Mapping[str, Any],
+    *,
+    label: str,
+    task_id: str,
+    repo_commit: str,
+    rejected: list[dict[str, Any]],
+    diagnostics: list[dict[str, Any]],
+) -> bool:
+    event_id = receipt["access_event_id"]
+    if receipt["task_id"] != task_id:
         _reject(
             rejected,
             diagnostics,
@@ -340,57 +511,83 @@ def _ingest_receipt(
             artifact_role=receipt["artifact_role"],
             receipt_sha256=receipt["receipt_sha256"],
         )
-        return
-
-    if repo_commit is not None and receipt["repo_commit"] != repo_commit:
+        return True
+    if receipt["repo_commit"] != repo_commit:
         _reject(
             rejected,
             diagnostics,
             reason="commit_mismatch",
             code="commit_mismatch",
+            detail=(f"{label} repo_commit does not match the bound repository commit."),
+            access_event_id=event_id,
+            artifact_role=receipt["artifact_role"],
+            receipt_sha256=receipt["receipt_sha256"],
+        )
+        return True
+    return False
+
+
+def _reject_stale(
+    receipt: Mapping[str, Any],
+    *,
+    label: str,
+    as_of_dt: datetime | None,
+    max_age: int | None,
+    rejected: list[dict[str, Any]],
+    diagnostics: list[dict[str, Any]],
+) -> bool:
+    if max_age is None or as_of_dt is None:
+        return False
+    event_id = receipt["access_event_id"]
+    observed_dt = _parse_timestamp(receipt["observed_at"])
+    if observed_dt is None:
+        _reject(
+            rejected,
+            diagnostics,
+            reason="invalid_receipt",
+            code="invalid_input_field",
+            detail=f"{label} observed_at could not be parsed for freshness.",
+            access_event_id=event_id,
+            artifact_role=receipt["artifact_role"],
+            receipt_sha256=receipt["receipt_sha256"],
+        )
+        return True
+    age = (as_of_dt - observed_dt).total_seconds()
+    if age > max_age or age < 0:
+        _reject(
+            rejected,
+            diagnostics,
+            reason="stale",
+            code="stale",
             detail=(
-                f"{label} repo_commit does not match the bound repository commit."
+                f"{label} is stale or not-yet-valid relative to as_of "
+                f"(age_seconds={age}, max_age_seconds={max_age})."
             ),
             access_event_id=event_id,
             artifact_role=receipt["artifact_role"],
             receipt_sha256=receipt["receipt_sha256"],
         )
-        return
+        return True
+    return False
 
-    if max_age is not None and as_of_dt is not None:
-        observed_dt = _parse_timestamp(receipt["observed_at"])
-        if observed_dt is None:
-            _reject(
-                rejected,
-                diagnostics,
-                reason="invalid_receipt",
-                code="invalid_input_field",
-                detail=f"{label} observed_at could not be parsed for freshness.",
-                access_event_id=event_id,
-                artifact_role=receipt["artifact_role"],
-                receipt_sha256=receipt["receipt_sha256"],
-            )
-            return
-        age = (as_of_dt - observed_dt).total_seconds()
-        if age > max_age or age < 0:
-            _reject(
-                rejected,
-                diagnostics,
-                reason="stale",
-                code="stale",
-                detail=(
-                    f"{label} is stale or not-yet-valid relative to as_of "
-                    f"(age_seconds={age}, max_age_seconds={max_age})."
-                ),
-                access_event_id=event_id,
-                artifact_role=receipt["artifact_role"],
-                receipt_sha256=receipt["receipt_sha256"],
-            )
-            return
 
+def _reject_identity_conflicts(
+    receipt: Mapping[str, Any],
+    *,
+    label: str,
+    identity_index: Mapping[str, Mapping[str, Any]],
+    accepted_by_role: dict[str, dict[str, Any]],
+    accepted_refs: list[dict[str, str]],
+    rejected: list[dict[str, Any]],
+    diagnostics: list[dict[str, Any]],
+) -> bool:
     role = receipt["artifact_role"]
+    event_id = receipt["access_event_id"]
     expected_identity = identity_index.get(role)
-    if expected_identity is not None and expected_identity != receipt["artifact_identity"]:
+    if (
+        expected_identity is not None
+        and expected_identity != receipt["artifact_identity"]
+    ):
         _reject(
             rejected,
             diagnostics,
@@ -404,7 +601,7 @@ def _ingest_receipt(
             artifact_role=role,
             receipt_sha256=receipt["receipt_sha256"],
         )
-        return
+        return True
 
     prior = accepted_by_role.get(role)
     if prior is not None and prior["artifact_identity"] != receipt["artifact_identity"]:
@@ -424,12 +621,26 @@ def _ingest_receipt(
         # Downgrade the prior acceptance: conflicting identities remove observed
         # elevation for the role.
         del accepted_by_role[role]
-        accepted_refs[:] = [ref for ref in accepted_refs if ref["artifact_role"] != role]
-        return
+        accepted_refs[:] = [
+            ref for ref in accepted_refs if ref["artifact_role"] != role
+        ]
+        return True
+    return False
 
+
+def _accept_receipt(
+    receipt: Mapping[str, Any],
+    *,
+    accepted_by_role: dict[str, dict[str, Any]],
+    accepted_refs: list[dict[str, str]],
+    seen_events: dict[str, str],
+) -> None:
+    event_id = receipt["access_event_id"]
+    role = receipt["artifact_role"]
+    prior = accepted_by_role.get(role)
     seen_events[event_id] = receipt["binding_sha256"]
     if prior is None:
-        accepted_by_role[role] = receipt
+        accepted_by_role[role] = dict(receipt)
         accepted_refs.append(
             {
                 "access_event_id": event_id,
@@ -576,8 +787,10 @@ def _require_bound_str(
 
 
 def _require_commit(value: Any, diagnostics: list[dict[str, Any]]) -> str | None:
-    if isinstance(value, str) and len(value) == _COMMIT_LEN and all(
-        ch in "0123456789abcdef" for ch in value
+    if (
+        isinstance(value, str)
+        and len(value) == _COMMIT_LEN
+        and all(ch in "0123456789abcdef" for ch in value)
     ):
         return value
     diagnostics.append(
@@ -592,9 +805,14 @@ def _require_commit(value: Any, diagnostics: list[dict[str, Any]]) -> str | None
 
 def _normalize_max_age(
     value: int | None, diagnostics: list[dict[str, Any]]
-) -> int | None:
+) -> tuple[int | None, bool]:
+    """Return (normalized_max_age, binding_ok).
+
+    ``None`` input is valid (no freshness window). Invalid explicit values fail
+    the comparison binding so no receipt can elevate evidence.
+    """
     if value is None:
-        return None
+        return None, True
     if not isinstance(value, int) or isinstance(value, bool) or value < 0:
         diagnostics.append(
             _diag(
@@ -603,15 +821,20 @@ def _normalize_max_age(
                 "max_age_seconds must be a non-negative integer when provided.",
             )
         )
-        return None
-    return value
+        return None, False
+    return value, True
 
 
 def _parse_as_of(
     value: str | None, diagnostics: list[dict[str, Any]]
-) -> datetime | None:
+) -> tuple[datetime | None, bool]:
+    """Return (as_of datetime, binding_ok).
+
+    Omitted ``as_of`` uses wall-clock UTC and keeps the binding valid. An
+    explicit invalid timestamp fails closed (no receipt acceptance).
+    """
     if value is None:
-        return datetime.now(timezone.utc)
+        return datetime.now(timezone.utc), True
     parsed = _parse_timestamp(value)
     if parsed is None:
         diagnostics.append(
@@ -621,8 +844,8 @@ def _parse_as_of(
                 "as_of must be an ISO-8601 UTC timestamp ending with Z.",
             )
         )
-        return datetime.now(timezone.utc)
-    return parsed
+        return None, False
+    return parsed, True
 
 
 def _parse_timestamp(value: str) -> datetime | None:
@@ -639,8 +862,10 @@ def _maybe_str(value: Any) -> str | None:
 
 
 def _maybe_hex(value: Any) -> str | None:
-    if isinstance(value, str) and len(value) == 64 and all(
-        ch in "0123456789abcdef" for ch in value
+    if (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(ch in "0123456789abcdef" for ch in value)
     ):
         return value
     return None
@@ -735,9 +960,7 @@ def _evidence(
             item["binding_sha256"],
         ),
     )
-    ordered_comparisons = sorted(
-        comparisons, key=lambda item: item["artifact_role"]
-    )
+    ordered_comparisons = sorted(comparisons, key=lambda item: item["artifact_role"])
     return {
         "kind": KIND,
         "version": VERSION,

--- a/merger/repoground/core/agent_consumption_evidence.py
+++ b/merger/repoground/core/agent_consumption_evidence.py
@@ -1,0 +1,753 @@
+"""Compare declared agent consumption with trusted tool-read receipts.
+
+Layers:
+
+* Answer Compliance = declaration only
+* Trusted tool-read receipts = observation metadata only
+* This module = deterministic comparison for the same task_id, repo_commit,
+  artifact_role and immutable artifact identity
+
+Comparison states (exactly):
+
+* ``declared-only``
+* ``observed-only``
+* ``declared-and-observed``
+* ``unavailable``
+
+Rejected observations (missing, stale, task-mismatch, commit-mismatch, replay,
+artifact-mismatch, untrusted issuer, privacy, invalid) never elevate evidence
+to ``declared-and-observed``.
+
+This comparison does not establish semantic reading, relevance, correctness,
+completeness, forensic readiness, runtime interception or mandatory adoption.
+It preserves the nine agent-consumption ``does_not_establish`` boundaries and
+adds observation-specific non-claims.
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from copy import deepcopy
+from datetime import datetime, timezone
+from typing import Any
+
+from merger.repoground.core.agent_consumption_receipts import (
+    RETENTION,
+    ToolReadReceiptError,
+    validate_tool_read_receipt,
+)
+from merger.repoground.core.agent_consumption_validate import (
+    DOES_NOT_ESTABLISH as TRACE_DOES_NOT_ESTABLISH,
+)
+
+KIND = "lenskit.agent_consumption_evidence"
+VERSION = "1.0"
+
+COMPARISON_STATES = (
+    "declared-only",
+    "observed-only",
+    "declared-and-observed",
+    "unavailable",
+)
+
+# Preserve the nine declaration/trace boundaries and add observation non-claims.
+DOES_NOT_ESTABLISH: tuple[str, ...] = (
+    "actual_reading_proven",
+    "semantic_reading",
+    "relevance_to_answer",
+    "answer_correct",
+    "repo_understood",
+    "all_relevant_context_used",
+    "claims_true",
+    "test_sufficiency",
+    "regression_absence",
+    "runtime_behavior",
+    "forensic_ready",
+    "runtime_interception",
+    "mandatory_wrapper_adoption",
+)
+
+assert set(TRACE_DOES_NOT_ESTABLISH).issubset(set(DOES_NOT_ESTABLISH))
+
+_FAIL = "fail"
+_WARN = "warn"
+_INFO = "info"
+
+_COMMIT_LEN = 40
+
+
+def compare_agent_consumption_evidence(
+    answer_compliance: Mapping[str, Any] | None,
+    receipts: Sequence[Any] | None,
+    *,
+    task_id: str,
+    repo_commit: str,
+    expected_roles: Sequence[str] | None = None,
+    declared_identities: Mapping[str, Mapping[str, Any]] | None = None,
+    as_of: str | None = None,
+    max_age_seconds: int | None = None,
+) -> dict[str, Any]:
+    """Compare declarations with trusted receipts for one task and commit.
+
+    ``answer_compliance`` may be a full Answer Compliance object or a minimal
+    mapping that provides ``declared_artifacts``. Self-declarations never mint
+    observed evidence.
+    """
+    diagnostics: list[dict[str, Any]] = []
+    rejected: list[dict[str, Any]] = []
+
+    task = _require_bound_str(task_id, "task_id", diagnostics)
+    commit = _require_commit(repo_commit, diagnostics)
+    declared_roles = _declared_roles(answer_compliance, diagnostics)
+    expected = _role_set(expected_roles, "expected_roles", diagnostics)
+    identity_index = _declared_identity_index(declared_identities, diagnostics)
+    as_of_dt = _parse_as_of(as_of, diagnostics)
+    max_age = _normalize_max_age(max_age_seconds, diagnostics)
+
+    accepted_by_role: dict[str, dict[str, Any]] = {}
+    accepted_refs: list[dict[str, str]] = []
+    seen_events: dict[str, str] = {}
+    raw_receipts = list(receipts) if isinstance(receipts, Sequence) and not isinstance(
+        receipts, (str, bytes, bytearray)
+    ) else []
+    if receipts is not None and not isinstance(receipts, Sequence):
+        diagnostics.append(
+            _diag(
+                "invalid_input_field",
+                _FAIL,
+                "receipts must be an array of receipt objects.",
+            )
+        )
+        raw_receipts = []
+    elif isinstance(receipts, (str, bytes, bytearray)):
+        diagnostics.append(
+            _diag(
+                "invalid_input_field",
+                _FAIL,
+                "receipts must be an array of receipt objects.",
+            )
+        )
+        raw_receipts = []
+
+    for index, raw in enumerate(raw_receipts):
+        _ingest_receipt(
+            raw,
+            index=index,
+            task_id=task,
+            repo_commit=commit,
+            as_of_dt=as_of_dt,
+            max_age=max_age,
+            identity_index=identity_index,
+            accepted_by_role=accepted_by_role,
+            accepted_refs=accepted_refs,
+            seen_events=seen_events,
+            rejected=rejected,
+            diagnostics=diagnostics,
+        )
+
+    roles = sorted(set(declared_roles) | set(accepted_by_role) | expected)
+    comparisons: list[dict[str, Any]] = []
+    for role in roles:
+        declared = role in declared_roles
+        observed_receipt = accepted_by_role.get(role)
+        observed = observed_receipt is not None
+        if declared and observed:
+            state = "declared-and-observed"
+        elif declared and not observed:
+            state = "declared-only"
+            diagnostics.append(
+                _diag(
+                    "declared_only",
+                    _WARN,
+                    f"Artifact role '{role}' was declared but not observed by a trusted receipt.",
+                    artifact_role=role,
+                )
+            )
+        elif observed and not declared:
+            state = "observed-only"
+            diagnostics.append(
+                _diag(
+                    "observed_only",
+                    _WARN,
+                    f"Artifact role '{role}' was observed but not declared.",
+                    artifact_role=role,
+                )
+            )
+        else:
+            state = "unavailable"
+            diagnostics.append(
+                _diag(
+                    "unavailable",
+                    _WARN if role in expected else _INFO,
+                    f"Artifact role '{role}' has neither declaration nor trusted observation.",
+                    artifact_role=role,
+                )
+            )
+        item: dict[str, Any] = {
+            "artifact_role": role,
+            "state": state,
+            "declared": declared,
+            "observed": observed,
+        }
+        if observed_receipt is not None:
+            item["receipt_binding_sha256"] = observed_receipt["binding_sha256"]
+            item["artifact_identity"] = deepcopy(observed_receipt["artifact_identity"])
+        comparisons.append(item)
+
+    if not roles:
+        diagnostics.append(
+            _diag(
+                "missing",
+                _WARN,
+                "No declared roles, accepted receipts, or expected roles were supplied.",
+            )
+        )
+
+    return _evidence(
+        task_id=task or "unknown",
+        repo_commit=commit or ("0" * _COMMIT_LEN),
+        comparisons=comparisons,
+        accepted_refs=accepted_refs,
+        rejected=rejected,
+        diagnostics=diagnostics,
+    )
+
+
+def _ingest_receipt(
+    raw: Any,
+    *,
+    index: int,
+    task_id: str | None,
+    repo_commit: str | None,
+    as_of_dt: datetime | None,
+    max_age: int | None,
+    identity_index: dict[str, dict[str, Any]],
+    accepted_by_role: dict[str, dict[str, Any]],
+    accepted_refs: list[dict[str, str]],
+    seen_events: dict[str, str],
+    rejected: list[dict[str, Any]],
+    diagnostics: list[dict[str, Any]],
+) -> None:
+    label = f"receipts[{index}]"
+    if not isinstance(raw, Mapping):
+        _reject(
+            rejected,
+            diagnostics,
+            reason="invalid_receipt",
+            code="invalid_input_field",
+            detail=f"{label} is not an object and cannot elevate evidence.",
+        )
+        return
+
+    # Privacy fail-closed before structural validation so content-bearing forgeries
+    # never become observations.
+    forbidden = sorted(
+        k
+        for k in raw
+        if isinstance(k, str)
+        and k
+        in {
+            "content",
+            "body",
+            "text",
+            "raw",
+            "source_text",
+            "source_content",
+            "payload",
+            "blob",
+            "data",
+            "file_bytes",
+            "bytes_content",
+            "secret",
+            "secrets",
+            "token",
+            "password",
+            "api_key",
+            "private_key",
+            "authorization",
+        }
+    )
+    if forbidden:
+        _reject(
+            rejected,
+            diagnostics,
+            reason="privacy_violation",
+            code="privacy_violation",
+            detail=f"{label} contains forbidden content/secret fields: {', '.join(forbidden)}.",
+            access_event_id=_maybe_str(raw.get("access_event_id")),
+            artifact_role=_maybe_str(raw.get("artifact_role")),
+            receipt_sha256=_maybe_hex(raw.get("receipt_sha256")),
+        )
+        return
+
+    try:
+        receipt = validate_tool_read_receipt(raw)
+    except ToolReadReceiptError as exc:
+        message = str(exc)
+        if "allowlisted trusted source" in message or "issuer.kind" in message:
+            reason = "untrusted_issuer"
+            code = "untrusted_issuer"
+        elif "secret-like" in message or "forbidden" in message:
+            reason = "privacy_violation"
+            code = "privacy_violation"
+        elif "binding_sha256" in message or "receipt_sha256" in message:
+            reason = "binding_mismatch"
+            code = "binding_mismatch"
+        else:
+            reason = "invalid_receipt"
+            code = "invalid_input_field"
+        _reject(
+            rejected,
+            diagnostics,
+            reason=reason,
+            code=code,
+            detail=f"{label} rejected: {message}",
+            access_event_id=_maybe_str(raw.get("access_event_id")),
+            artifact_role=_maybe_str(raw.get("artifact_role")),
+            receipt_sha256=_maybe_hex(raw.get("receipt_sha256")),
+        )
+        return
+
+    event_id = receipt["access_event_id"]
+    if event_id in seen_events:
+        _reject(
+            rejected,
+            diagnostics,
+            reason="replay",
+            code="replay",
+            detail=(
+                f"{label} replays access_event_id '{event_id}' already seen for "
+                f"binding {seen_events[event_id][:12]}…; replay never elevates evidence."
+            ),
+            access_event_id=event_id,
+            artifact_role=receipt["artifact_role"],
+            receipt_sha256=receipt["receipt_sha256"],
+        )
+        # A replay must not keep a previously accepted observation for the same
+        # event, and must not add a second observation.
+        return
+
+    if task_id is not None and receipt["task_id"] != task_id:
+        _reject(
+            rejected,
+            diagnostics,
+            reason="task_mismatch",
+            code="task_mismatch",
+            detail=(
+                f"{label} task_id '{receipt['task_id']}' does not match bound "
+                f"task_id '{task_id}'."
+            ),
+            access_event_id=event_id,
+            artifact_role=receipt["artifact_role"],
+            receipt_sha256=receipt["receipt_sha256"],
+        )
+        return
+
+    if repo_commit is not None and receipt["repo_commit"] != repo_commit:
+        _reject(
+            rejected,
+            diagnostics,
+            reason="commit_mismatch",
+            code="commit_mismatch",
+            detail=(
+                f"{label} repo_commit does not match the bound repository commit."
+            ),
+            access_event_id=event_id,
+            artifact_role=receipt["artifact_role"],
+            receipt_sha256=receipt["receipt_sha256"],
+        )
+        return
+
+    if max_age is not None and as_of_dt is not None:
+        observed_dt = _parse_timestamp(receipt["observed_at"])
+        if observed_dt is None:
+            _reject(
+                rejected,
+                diagnostics,
+                reason="invalid_receipt",
+                code="invalid_input_field",
+                detail=f"{label} observed_at could not be parsed for freshness.",
+                access_event_id=event_id,
+                artifact_role=receipt["artifact_role"],
+                receipt_sha256=receipt["receipt_sha256"],
+            )
+            return
+        age = (as_of_dt - observed_dt).total_seconds()
+        if age > max_age or age < 0:
+            _reject(
+                rejected,
+                diagnostics,
+                reason="stale",
+                code="stale",
+                detail=(
+                    f"{label} is stale or not-yet-valid relative to as_of "
+                    f"(age_seconds={age}, max_age_seconds={max_age})."
+                ),
+                access_event_id=event_id,
+                artifact_role=receipt["artifact_role"],
+                receipt_sha256=receipt["receipt_sha256"],
+            )
+            return
+
+    role = receipt["artifact_role"]
+    expected_identity = identity_index.get(role)
+    if expected_identity is not None and expected_identity != receipt["artifact_identity"]:
+        _reject(
+            rejected,
+            diagnostics,
+            reason="artifact_mismatch",
+            code="artifact_mismatch",
+            detail=(
+                f"{label} artifact identity for role '{role}' does not match the "
+                "declared immutable identity."
+            ),
+            access_event_id=event_id,
+            artifact_role=role,
+            receipt_sha256=receipt["receipt_sha256"],
+        )
+        return
+
+    prior = accepted_by_role.get(role)
+    if prior is not None and prior["artifact_identity"] != receipt["artifact_identity"]:
+        _reject(
+            rejected,
+            diagnostics,
+            reason="artifact_mismatch",
+            code="artifact_mismatch",
+            detail=(
+                f"{label} conflicts with a previously accepted identity for role "
+                f"'{role}'; neither identity elevates evidence further."
+            ),
+            access_event_id=event_id,
+            artifact_role=role,
+            receipt_sha256=receipt["receipt_sha256"],
+        )
+        # Downgrade the prior acceptance: conflicting identities remove observed
+        # elevation for the role.
+        del accepted_by_role[role]
+        accepted_refs[:] = [ref for ref in accepted_refs if ref["artifact_role"] != role]
+        return
+
+    seen_events[event_id] = receipt["binding_sha256"]
+    if prior is None:
+        accepted_by_role[role] = receipt
+        accepted_refs.append(
+            {
+                "access_event_id": event_id,
+                "artifact_role": role,
+                "binding_sha256": receipt["binding_sha256"],
+                "receipt_sha256": receipt["receipt_sha256"],
+            }
+        )
+
+
+def _declared_roles(
+    answer_compliance: Mapping[str, Any] | None,
+    diagnostics: list[dict[str, Any]],
+) -> set[str]:
+    if answer_compliance is None:
+        return set()
+    if not isinstance(answer_compliance, Mapping):
+        diagnostics.append(
+            _diag(
+                "invalid_input_field",
+                _FAIL,
+                "answer_compliance must be a JSON object.",
+            )
+        )
+        return set()
+    value = answer_compliance.get("declared_artifacts")
+    if value is None:
+        return set()
+    if isinstance(value, str):
+        return {value} if value else set()
+    if not isinstance(value, (list, tuple, set, frozenset)):
+        diagnostics.append(
+            _diag(
+                "invalid_input_field",
+                _FAIL,
+                "declared_artifacts must be an array of non-empty strings.",
+            )
+        )
+        return set()
+    roles = {item for item in value if isinstance(item, str) and item}
+    if len(roles) != len(list(value)):
+        diagnostics.append(
+            _diag(
+                "invalid_input_field",
+                _FAIL,
+                "declared_artifacts must contain only non-empty strings.",
+            )
+        )
+    return roles
+
+
+def _role_set(
+    roles: Sequence[str] | None,
+    label: str,
+    diagnostics: list[dict[str, Any]],
+) -> set[str]:
+    if roles is None:
+        return set()
+    if isinstance(roles, str) or not isinstance(roles, Sequence):
+        diagnostics.append(
+            _diag(
+                "invalid_input_field",
+                _FAIL,
+                f"{label} must be an array of non-empty strings.",
+            )
+        )
+        return set()
+    valid = {item for item in roles if isinstance(item, str) and item}
+    if len(valid) != len(list(roles)):
+        diagnostics.append(
+            _diag(
+                "invalid_input_field",
+                _FAIL,
+                f"{label} must contain only non-empty strings.",
+            )
+        )
+    return valid
+
+
+def _declared_identity_index(
+    declared_identities: Mapping[str, Mapping[str, Any]] | None,
+    diagnostics: list[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    if declared_identities is None:
+        return {}
+    if not isinstance(declared_identities, Mapping):
+        diagnostics.append(
+            _diag(
+                "invalid_input_field",
+                _FAIL,
+                "declared_identities must be an object keyed by artifact role.",
+            )
+        )
+        return {}
+    result: dict[str, dict[str, Any]] = {}
+    for role, identity in declared_identities.items():
+        if not isinstance(role, str) or not role or not isinstance(identity, Mapping):
+            diagnostics.append(
+                _diag(
+                    "invalid_input_field",
+                    _FAIL,
+                    "declared_identities entries must map roles to identity objects.",
+                    artifact_role=role if isinstance(role, str) else None,
+                )
+            )
+            continue
+        path = identity.get("path")
+        digest = identity.get("sha256")
+        size = identity.get("bytes")
+        if (
+            not isinstance(path, str)
+            or not path
+            or not isinstance(digest, str)
+            or not isinstance(size, int)
+            or isinstance(size, bool)
+            or size < 0
+        ):
+            diagnostics.append(
+                _diag(
+                    "invalid_input_field",
+                    _FAIL,
+                    f"declared identity for '{role}' is incomplete.",
+                    artifact_role=role,
+                )
+            )
+            continue
+        result[role] = {"path": path, "sha256": digest, "bytes": size}
+    return result
+
+
+def _require_bound_str(
+    value: Any, label: str, diagnostics: list[dict[str, Any]]
+) -> str | None:
+    if isinstance(value, str) and value:
+        return value
+    diagnostics.append(
+        _diag(
+            "invalid_input_field",
+            _FAIL,
+            f"{label} must be a non-empty string.",
+        )
+    )
+    return None
+
+
+def _require_commit(value: Any, diagnostics: list[dict[str, Any]]) -> str | None:
+    if isinstance(value, str) and len(value) == _COMMIT_LEN and all(
+        ch in "0123456789abcdef" for ch in value
+    ):
+        return value
+    diagnostics.append(
+        _diag(
+            "invalid_input_field",
+            _FAIL,
+            "repo_commit must be a 40-character lowercase hex SHA-1.",
+        )
+    )
+    return None
+
+
+def _normalize_max_age(
+    value: int | None, diagnostics: list[dict[str, Any]]
+) -> int | None:
+    if value is None:
+        return None
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        diagnostics.append(
+            _diag(
+                "invalid_input_field",
+                _FAIL,
+                "max_age_seconds must be a non-negative integer when provided.",
+            )
+        )
+        return None
+    return value
+
+
+def _parse_as_of(
+    value: str | None, diagnostics: list[dict[str, Any]]
+) -> datetime | None:
+    if value is None:
+        return datetime.now(timezone.utc)
+    parsed = _parse_timestamp(value)
+    if parsed is None:
+        diagnostics.append(
+            _diag(
+                "invalid_input_field",
+                _FAIL,
+                "as_of must be an ISO-8601 UTC timestamp ending with Z.",
+            )
+        )
+        return datetime.now(timezone.utc)
+    return parsed
+
+
+def _parse_timestamp(value: str) -> datetime | None:
+    if not isinstance(value, str) or not value.endswith("Z"):
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _maybe_str(value: Any) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _maybe_hex(value: Any) -> str | None:
+    if isinstance(value, str) and len(value) == 64 and all(
+        ch in "0123456789abcdef" for ch in value
+    ):
+        return value
+    return None
+
+
+def _reject(
+    rejected: list[dict[str, Any]],
+    diagnostics: list[dict[str, Any]],
+    *,
+    reason: str,
+    code: str,
+    detail: str,
+    access_event_id: str | None = None,
+    artifact_role: str | None = None,
+    receipt_sha256: str | None = None,
+) -> None:
+    item: dict[str, Any] = {"reason": reason, "detail": detail}
+    if access_event_id is not None:
+        item["access_event_id"] = access_event_id
+    if artifact_role is not None:
+        item["artifact_role"] = artifact_role
+    if receipt_sha256 is not None:
+        item["receipt_sha256"] = receipt_sha256
+    rejected.append(item)
+    # Forgeries and structural invalidity fail closed. Bound mismatches remain
+    # explicit diagnostics but never elevate evidence.
+    fail_reasons = {
+        "privacy_violation",
+        "untrusted_issuer",
+        "invalid_receipt",
+        "binding_mismatch",
+    }
+    severity = _FAIL if reason in fail_reasons else _WARN
+    diagnostics.append(_diag(code, severity, detail, artifact_role=artifact_role))
+
+
+def _diag(
+    code: str,
+    severity: str,
+    detail: str,
+    *,
+    artifact_role: str | None = None,
+) -> dict[str, Any]:
+    item = {"code": code, "severity": severity, "detail": detail}
+    if artifact_role is not None:
+        item["artifact_role"] = artifact_role
+    return item
+
+
+def _status_from_diagnostics(diagnostics: list[dict[str, Any]]) -> str:
+    severities = {item["severity"] for item in diagnostics}
+    if _FAIL in severities:
+        return "fail"
+    if _WARN in severities:
+        return "warn"
+    return "pass"
+
+
+def _evidence(
+    *,
+    task_id: str,
+    repo_commit: str,
+    comparisons: list[dict[str, Any]],
+    accepted_refs: list[dict[str, str]],
+    rejected: list[dict[str, Any]],
+    diagnostics: list[dict[str, Any]],
+) -> dict[str, Any]:
+    severity_weight = {"fail": 0, "warn": 1, "info": 2}
+    ordered_diagnostics = sorted(
+        diagnostics,
+        key=lambda d: (
+            severity_weight.get(d.get("severity"), 3),
+            d["code"],
+            d.get("artifact_role", ""),
+            d["detail"],
+        ),
+    )
+    ordered_rejected = sorted(
+        rejected,
+        key=lambda item: (
+            item["reason"],
+            item.get("artifact_role", ""),
+            item.get("access_event_id", ""),
+            item["detail"],
+        ),
+    )
+    ordered_refs = sorted(
+        accepted_refs,
+        key=lambda item: (
+            item["artifact_role"],
+            item["access_event_id"],
+            item["binding_sha256"],
+        ),
+    )
+    ordered_comparisons = sorted(
+        comparisons, key=lambda item: item["artifact_role"]
+    )
+    return {
+        "kind": KIND,
+        "version": VERSION,
+        "task_id": task_id,
+        "repo_commit": repo_commit,
+        "status": _status_from_diagnostics(ordered_diagnostics),
+        "comparisons": ordered_comparisons,
+        "accepted_receipt_refs": ordered_refs,
+        "rejected_receipts": ordered_rejected,
+        "diagnostics": ordered_diagnostics,
+        "retention": dict(RETENTION),
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }

--- a/merger/repoground/core/agent_consumption_receipts.py
+++ b/merger/repoground/core/agent_consumption_receipts.py
@@ -1,0 +1,491 @@
+"""Trusted tool-read receipts for agent-consumption evidence.
+
+This module mints and validates data-sparing observation receipts that bind one
+access event to exactly:
+
+* a task identity
+* a repository commit
+* an artifact role
+* an immutable artifact identity (path + sha256 + byte count)
+
+Receipts never store artifact content. Answer text, free-form self-declarations
+and untrusted issuers cannot mint observed evidence. A valid receipt is only a
+binding record: it does not establish semantic reading, relevance, correctness
+or truth.
+
+Retention / redaction / deletion (documented contract):
+
+* policy: ``ephemeral_comparison_input`` — operator-controlled retention only
+* content_retained: always false
+* redaction: metadata_only (role, path, digests, sizes, binding ids)
+* deletion: safe_at_any_time — absence becomes missing/unavailable evidence
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from typing import Any
+
+KIND = "lenskit.agent_tool_read_receipt"
+VERSION = "1.0"
+
+TRUSTED_WRAPPER_ISSUER_ID = "repoground.agent_consumption.tool_read_wrapper"
+TRUSTED_GATEWAY_ISSUER_ID = "repoground.agent_consumption.tool_gateway"
+
+TRUSTED_ISSUERS: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("trusted_wrapper", TRUSTED_WRAPPER_ISSUER_ID),
+        ("tool_gateway", TRUSTED_GATEWAY_ISSUER_ID),
+    }
+)
+
+DOES_NOT_ESTABLISH: tuple[str, ...] = (
+    "semantic_reading",
+    "relevance_to_answer",
+    "answer_correct",
+    "claims_true",
+    "repo_understood",
+    "all_relevant_context_used",
+    "runtime_interception",
+    "mandatory_wrapper_adoption",
+)
+
+RETENTION: dict[str, Any] = {
+    "policy": "ephemeral_comparison_input",
+    "content_retained": False,
+    "redaction": "metadata_only",
+    "deletion": "safe_at_any_time",
+}
+
+MAX_TASK_ID_LEN = 128
+MAX_ROLE_LEN = 128
+MAX_PATH_LEN = 512
+MAX_EVENT_ID_LEN = 128
+MAX_ISSUER_ID_LEN = 128
+MAX_ARTIFACT_BYTES = 256 * 1024 * 1024
+MAX_RECEIPT_JSON_BYTES = 8 * 1024
+
+_COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_TASK_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+_ROLE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+_EVENT_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$")
+_ISSUER_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+_PATH_RE = re.compile(r"^(?!/)(?!.*(?:^|/)\.\.(?:/|$))[A-Za-z0-9._@+/-]+$")
+_OBSERVED_AT_RE = re.compile(
+    r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]{1,6})?Z$"
+)
+
+# Fail-closed content / secret surface. Presence of these keys rejects minting
+# and validation: receipts are metadata-only.
+_FORBIDDEN_KEYS = frozenset(
+    {
+        "content",
+        "body",
+        "text",
+        "raw",
+        "source_text",
+        "source_content",
+        "payload",
+        "blob",
+        "data",
+        "file_bytes",
+        "bytes_content",
+        "secret",
+        "secrets",
+        "token",
+        "password",
+        "api_key",
+        "private_key",
+        "authorization",
+    }
+)
+
+_SECRET_PATTERNS = (
+    re.compile(r"eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+"),
+    re.compile(r"AKIA[0-9A-Z]{16}"),
+    re.compile(r"-----BEGIN (?:(?:RSA|EC|DSA|OPENSSH) )?PRIVATE KEY-----"),
+    re.compile(r"(?i)(api[_-]?key|access[_-]?token|secret[_-]?key)\s*[:=]\s*\S{8,}"),
+    re.compile(r"(?i)(password|passwd|pwd)\s*[:=]\s*\S{6,}"),
+)
+
+
+class ToolReadReceiptError(ValueError):
+    """Receipt minting or validation failed closed."""
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def sha256_json(value: Any) -> str:
+    return hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def utc_now_iso() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _reject_forbidden_keys(mapping: Mapping[str, Any], *, label: str) -> None:
+    bad = sorted(k for k in mapping if k in _FORBIDDEN_KEYS or not isinstance(k, str))
+    if bad:
+        raise ToolReadReceiptError(
+            f"{label} contains forbidden or non-string keys: {', '.join(map(str, bad))}"
+        )
+    for key, value in mapping.items():
+        if isinstance(value, Mapping):
+            _reject_forbidden_keys(value, label=f"{label}.{key}")
+
+
+def _reject_secrets(text: str, *, label: str) -> None:
+    for pattern in _SECRET_PATTERNS:
+        if pattern.search(text):
+            raise ToolReadReceiptError(
+                f"{label} fails closed: secret-like material is not allowed in receipts"
+            )
+
+
+def _require_str(
+    value: Any,
+    *,
+    label: str,
+    pattern: re.Pattern[str],
+    max_len: int,
+    min_len: int = 1,
+) -> str:
+    if not isinstance(value, str):
+        raise ToolReadReceiptError(f"{label} must be a string")
+    if len(value) < min_len or len(value) > max_len:
+        raise ToolReadReceiptError(f"{label} length out of bounds")
+    if pattern.fullmatch(value) is None:
+        raise ToolReadReceiptError(f"{label} has an invalid shape")
+    _reject_secrets(value, label=label)
+    return value
+
+
+def _normalize_identity(raw: Mapping[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        raise ToolReadReceiptError("artifact_identity must be an object")
+    _reject_forbidden_keys(raw, label="artifact_identity")
+    path = _require_str(
+        raw.get("path"), label="artifact_identity.path", pattern=_PATH_RE, max_len=MAX_PATH_LEN
+    )
+    digest = raw.get("sha256")
+    if not isinstance(digest, str) or _SHA256_RE.fullmatch(digest) is None:
+        raise ToolReadReceiptError("artifact_identity.sha256 must be a lowercase hex SHA-256")
+    size = raw.get("bytes")
+    if not isinstance(size, int) or isinstance(size, bool) or size < 0 or size > MAX_ARTIFACT_BYTES:
+        raise ToolReadReceiptError("artifact_identity.bytes is out of bounds")
+    identity = {"path": path, "sha256": digest, "bytes": size}
+    if set(raw) - {"path", "sha256", "bytes"}:
+        raise ToolReadReceiptError("artifact_identity has unexpected fields")
+    return identity
+
+
+def _normalize_issuer(raw: Mapping[str, Any] | None) -> dict[str, str]:
+    if not isinstance(raw, Mapping):
+        raise ToolReadReceiptError("issuer must be an object")
+    _reject_forbidden_keys(raw, label="issuer")
+    kind = raw.get("kind")
+    issuer_id = raw.get("id")
+    if kind not in ("trusted_wrapper", "tool_gateway"):
+        raise ToolReadReceiptError("issuer.kind must be trusted_wrapper or tool_gateway")
+    issuer_id = _require_str(
+        issuer_id,
+        label="issuer.id",
+        pattern=_ISSUER_ID_RE,
+        max_len=MAX_ISSUER_ID_LEN,
+    )
+    if (kind, issuer_id) not in TRUSTED_ISSUERS:
+        raise ToolReadReceiptError(
+            f"issuer ({kind!r}, {issuer_id!r}) is not an allowlisted trusted source"
+        )
+    if set(raw) - {"kind", "id"}:
+        raise ToolReadReceiptError("issuer has unexpected fields")
+    return {"kind": kind, "id": issuer_id}
+
+
+def binding_material(
+    *,
+    task_id: str,
+    repo_commit: str,
+    artifact_role: str,
+    artifact_identity: Mapping[str, Any],
+    access_event_id: str,
+    issuer: Mapping[str, str],
+) -> dict[str, Any]:
+    return {
+        "access_event_id": access_event_id,
+        "artifact_identity": {
+            "bytes": artifact_identity["bytes"],
+            "path": artifact_identity["path"],
+            "sha256": artifact_identity["sha256"],
+        },
+        "artifact_role": artifact_role,
+        "issuer": {"id": issuer["id"], "kind": issuer["kind"]},
+        "kind": KIND,
+        "repo_commit": repo_commit,
+        "task_id": task_id,
+        "version": VERSION,
+    }
+
+
+def compute_binding_sha256(
+    *,
+    task_id: str,
+    repo_commit: str,
+    artifact_role: str,
+    artifact_identity: Mapping[str, Any],
+    access_event_id: str,
+    issuer: Mapping[str, str],
+) -> str:
+    return sha256_json(
+        binding_material(
+            task_id=task_id,
+            repo_commit=repo_commit,
+            artifact_role=artifact_role,
+            artifact_identity=artifact_identity,
+            access_event_id=access_event_id,
+            issuer=issuer,
+        )
+    )
+
+
+def _bounded_receipt_size(receipt: Mapping[str, Any]) -> None:
+    encoded = canonical_json(receipt).encode("utf-8")
+    if len(encoded) > MAX_RECEIPT_JSON_BYTES:
+        raise ToolReadReceiptError(
+            f"receipt exceeds {MAX_RECEIPT_JSON_BYTES} bytes after deterministic serialization"
+        )
+
+
+def mint_tool_read_receipt(
+    *,
+    task_id: str,
+    repo_commit: str,
+    artifact_role: str,
+    artifact_identity: Mapping[str, Any],
+    access_event_id: str,
+    issuer: Mapping[str, str] | None = None,
+    observed_at: str | None = None,
+) -> dict[str, Any]:
+    """Mint one trusted receipt. Content is never accepted or stored."""
+    task = _require_str(
+        task_id, label="task_id", pattern=_TASK_ID_RE, max_len=MAX_TASK_ID_LEN
+    )
+    commit = _require_str(
+        repo_commit, label="repo_commit", pattern=_COMMIT_RE, max_len=40, min_len=40
+    )
+    role = _require_str(
+        artifact_role, label="artifact_role", pattern=_ROLE_RE, max_len=MAX_ROLE_LEN
+    )
+    event_id = _require_str(
+        access_event_id,
+        label="access_event_id",
+        pattern=_EVENT_ID_RE,
+        max_len=MAX_EVENT_ID_LEN,
+        min_len=8,
+    )
+    identity = _normalize_identity(artifact_identity)
+    issuer_obj = _normalize_issuer(
+        issuer
+        if issuer is not None
+        else {"kind": "trusted_wrapper", "id": TRUSTED_WRAPPER_ISSUER_ID}
+    )
+    observed = observed_at if observed_at is not None else utc_now_iso()
+    if not isinstance(observed, str) or _OBSERVED_AT_RE.fullmatch(observed) is None:
+        raise ToolReadReceiptError("observed_at must be an ISO-8601 UTC timestamp ending with Z")
+
+    binding = compute_binding_sha256(
+        task_id=task,
+        repo_commit=commit,
+        artifact_role=role,
+        artifact_identity=identity,
+        access_event_id=event_id,
+        issuer=issuer_obj,
+    )
+    receipt: dict[str, Any] = {
+        "kind": KIND,
+        "version": VERSION,
+        "task_id": task,
+        "repo_commit": commit,
+        "artifact_role": role,
+        "artifact_identity": identity,
+        "access_event_id": event_id,
+        "observed_at": observed,
+        "issuer": issuer_obj,
+        "binding_sha256": binding,
+        "retention": dict(RETENTION),
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }
+    receipt["receipt_sha256"] = sha256_json(receipt)
+    _bounded_receipt_size(receipt)
+    return receipt
+
+
+def validate_tool_read_receipt(receipt: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate a receipt fail-closed and return a normalized copy."""
+    if not isinstance(receipt, Mapping):
+        raise ToolReadReceiptError("receipt must be an object")
+    _reject_forbidden_keys(receipt, label="receipt")
+    if receipt.get("kind") != KIND or receipt.get("version") != VERSION:
+        raise ToolReadReceiptError("receipt kind/version mismatch")
+
+    required = {
+        "kind",
+        "version",
+        "task_id",
+        "repo_commit",
+        "artifact_role",
+        "artifact_identity",
+        "access_event_id",
+        "observed_at",
+        "issuer",
+        "binding_sha256",
+        "receipt_sha256",
+        "retention",
+        "does_not_establish",
+    }
+    extra = set(receipt) - required
+    if extra:
+        raise ToolReadReceiptError(
+            f"receipt has unexpected fields: {', '.join(sorted(extra))}"
+        )
+    missing = required - set(receipt)
+    if missing:
+        raise ToolReadReceiptError(
+            f"receipt missing fields: {', '.join(sorted(missing))}"
+        )
+
+    task = _require_str(
+        receipt["task_id"], label="task_id", pattern=_TASK_ID_RE, max_len=MAX_TASK_ID_LEN
+    )
+    commit = _require_str(
+        receipt["repo_commit"],
+        label="repo_commit",
+        pattern=_COMMIT_RE,
+        max_len=40,
+        min_len=40,
+    )
+    role = _require_str(
+        receipt["artifact_role"],
+        label="artifact_role",
+        pattern=_ROLE_RE,
+        max_len=MAX_ROLE_LEN,
+    )
+    event_id = _require_str(
+        receipt["access_event_id"],
+        label="access_event_id",
+        pattern=_EVENT_ID_RE,
+        max_len=MAX_EVENT_ID_LEN,
+        min_len=8,
+    )
+    identity = _normalize_identity(receipt.get("artifact_identity"))
+    issuer = _normalize_issuer(receipt.get("issuer"))
+    observed = receipt.get("observed_at")
+    if not isinstance(observed, str) or _OBSERVED_AT_RE.fullmatch(observed) is None:
+        raise ToolReadReceiptError("observed_at must be an ISO-8601 UTC timestamp ending with Z")
+
+    expected_binding = compute_binding_sha256(
+        task_id=task,
+        repo_commit=commit,
+        artifact_role=role,
+        artifact_identity=identity,
+        access_event_id=event_id,
+        issuer=issuer,
+    )
+    if receipt.get("binding_sha256") != expected_binding:
+        raise ToolReadReceiptError("binding_sha256 does not match deterministic binding")
+
+    retention = receipt.get("retention")
+    if not isinstance(retention, Mapping) or dict(retention) != RETENTION:
+        raise ToolReadReceiptError("retention policy is incomplete or altered")
+
+    dne = receipt.get("does_not_establish")
+    if not isinstance(dne, list) or set(dne) != set(DOES_NOT_ESTABLISH) or len(dne) != len(
+        DOES_NOT_ESTABLISH
+    ):
+        raise ToolReadReceiptError("does_not_establish must match the fixed receipt boundary")
+
+    without_digest = {
+        "kind": KIND,
+        "version": VERSION,
+        "task_id": task,
+        "repo_commit": commit,
+        "artifact_role": role,
+        "artifact_identity": identity,
+        "access_event_id": event_id,
+        "observed_at": observed,
+        "issuer": issuer,
+        "binding_sha256": expected_binding,
+        "retention": dict(RETENTION),
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }
+    expected_receipt_sha = sha256_json(without_digest)
+    if receipt.get("receipt_sha256") != expected_receipt_sha:
+        raise ToolReadReceiptError("receipt_sha256 does not match deterministic serialization")
+
+    normalized = {**without_digest, "receipt_sha256": expected_receipt_sha}
+    _bounded_receipt_size(normalized)
+    return normalized
+
+
+def identity_from_bytes(*, path: str, content: bytes) -> dict[str, Any]:
+    """Derive identity metadata from bytes without retaining the content."""
+    if not isinstance(content, (bytes, bytearray)):
+        raise ToolReadReceiptError("content must be bytes for hashing only")
+    if len(content) > MAX_ARTIFACT_BYTES:
+        raise ToolReadReceiptError("content exceeds maximum artifact size for hashing")
+    return {
+        "path": path,
+        "sha256": sha256_bytes(bytes(content)),
+        "bytes": len(content),
+    }
+
+
+class TrustedToolReadWrapper:
+    """Allowlisted mint path for observed tool-read receipts.
+
+    Callers pass path and content solely so the wrapper can hash identity
+    metadata. Content is never stored on the receipt. Answer text and self-
+    declarations have no mint path on this class.
+    """
+
+    issuer_kind = "trusted_wrapper"
+    issuer_id = TRUSTED_WRAPPER_ISSUER_ID
+
+    def observe_artifact_access(
+        self,
+        *,
+        task_id: str,
+        repo_commit: str,
+        artifact_role: str,
+        path: str,
+        content: bytes,
+        access_event_id: str,
+        observed_at: str | None = None,
+    ) -> dict[str, Any]:
+        identity = identity_from_bytes(path=path, content=content)
+        # Explicitly drop any reference to content after hashing.
+        del content
+        return mint_tool_read_receipt(
+            task_id=task_id,
+            repo_commit=repo_commit,
+            artifact_role=artifact_role,
+            artifact_identity=identity,
+            access_event_id=access_event_id,
+            issuer={"kind": self.issuer_kind, "id": self.issuer_id},
+            observed_at=observed_at,
+        )

--- a/merger/repoground/core/agent_reading_pack.py
+++ b/merger/repoground/core/agent_reading_pack.py
@@ -636,6 +636,14 @@ def render_agent_reading_pack(model: PackModel) -> str:
     lines.append("- `answer-compliance.v1`: answer-side declaration of artifacts, ranges and non-claims.")
     lines.append("- `agent-consumption-trace.v1`: comparison of required reading and declared consumption.")
     lines.append(
+        "- `agent-tool-read-receipt.v1`: trusted wrapper/gateway observation bound to "
+        "task, commit, role and artifact identity (no content)."
+    )
+    lines.append(
+        "- `agent-consumption-evidence.v1`: declaration-vs-receipt comparison states "
+        "declared-only / observed-only / declared-and-observed / unavailable."
+    )
+    lines.append(
         "- CLI: `python3 -m merger.repoground.cli.main agent-consumption required "
         "--task-profile <profile> ...`"
     )
@@ -644,8 +652,11 @@ def render_agent_reading_pack(model: PackModel) -> str:
         "- CLI: `python3 -m merger.repoground.cli.main agent-consumption validate-trace ...`"
     )
     lines.append(
-        "- does_not_establish: actual_reading_proven, answer_correct, repo_understood, "
-        "all_relevant_context_used or claims_true."
+        "- CLI: `python3 -m merger.repoground.cli.main agent-consumption compare-evidence ...`"
+    )
+    lines.append(
+        "- does_not_establish: actual_reading_proven, semantic_reading, relevance_to_answer, "
+        "answer_correct, repo_understood, all_relevant_context_used or claims_true."
     )
     lines.append("")
 

--- a/merger/repoground/tests/test_agent_consumption_evidence.py
+++ b/merger/repoground/tests/test_agent_consumption_evidence.py
@@ -1,0 +1,504 @@
+"""Schema, determinism, negative, freshness, replay, mismatch and E2E tests
+for agent tool-read receipts and consumption evidence comparison.
+"""
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+try:
+    import jsonschema
+except ImportError:  # pragma: no cover - optional in minimal envs
+    jsonschema = None
+
+from merger.repoground.core.agent_consumption_evidence import (
+    DOES_NOT_ESTABLISH as EVIDENCE_DNE,
+    KIND as EVIDENCE_KIND,
+    VERSION as EVIDENCE_VERSION,
+    compare_agent_consumption_evidence,
+)
+from merger.repoground.core.agent_consumption_receipts import (
+    DOES_NOT_ESTABLISH as RECEIPT_DNE,
+    KIND as RECEIPT_KIND,
+    TRUSTED_WRAPPER_ISSUER_ID,
+    ToolReadReceiptError,
+    TrustedToolReadWrapper,
+    canonical_json,
+    compute_binding_sha256,
+    mint_tool_read_receipt,
+    sha256_json,
+    validate_tool_read_receipt,
+)
+from merger.repoground.core.agent_consumption_validate import (
+    DOES_NOT_ESTABLISH as TRACE_DNE,
+)
+
+_CONTRACTS = Path(__file__).resolve().parent.parent / "contracts"
+_RECEIPT_SCHEMA = _CONTRACTS / "agent-tool-read-receipt.v1.schema.json"
+_EVIDENCE_SCHEMA = _CONTRACTS / "agent-consumption-evidence.v1.schema.json"
+
+_TASK = "REPOGROUND-AGENT-UTILITY-V1-T005"
+_COMMIT = "76ffaaaab3890d85e3db1c46e828809868c4df46"
+_AS_OF = "2026-08-05T22:00:00Z"
+
+
+def _require_jsonschema() -> None:
+    if jsonschema is None:
+        pytest.skip("jsonschema not installed")
+
+
+def _load_schema(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _answer_compliance(roles: list[str] | None = None) -> dict:
+    return {
+        "kind": "lenskit.answer_compliance",
+        "version": "1.0",
+        "task_profile": "pr_review",
+        "declared_artifacts": list(roles or ["canonical_md", "agent_reading_pack"]),
+        "declared_citations": [],
+        "declared_ranges": [],
+        "unread_required_artifacts": [],
+        "unread_recommended_artifacts": [],
+        "epistemic_gaps": [],
+        "does_not_establish": list(TRACE_DNE),
+    }
+
+
+def _mint(
+    *,
+    role: str = "canonical_md",
+    path: str = "bundle/canonical.md",
+    content: bytes = b"# canonical\n",
+    event_id: str = "evt-canonical-001",
+    task_id: str = _TASK,
+    repo_commit: str = _COMMIT,
+    observed_at: str = "2026-08-05T21:59:00Z",
+) -> dict:
+    wrapper = TrustedToolReadWrapper()
+    return wrapper.observe_artifact_access(
+        task_id=task_id,
+        repo_commit=repo_commit,
+        artifact_role=role,
+        path=path,
+        content=content,
+        access_event_id=event_id,
+        observed_at=observed_at,
+    )
+
+
+def _states(evidence: dict) -> dict[str, str]:
+    return {item["artifact_role"]: item["state"] for item in evidence["comparisons"]}
+
+
+def _reasons(evidence: dict) -> set[str]:
+    return {item["reason"] for item in evidence["rejected_receipts"]}
+
+
+def _codes(evidence: dict) -> set[str]:
+    return {item["code"] for item in evidence["diagnostics"]}
+
+
+# ── Schema ──────────────────────────────────────────────────────────────────
+
+
+def test_receipt_schema_accepts_wrapper_mint():
+    _require_jsonschema()
+    receipt = _mint()
+    jsonschema.validate(instance=receipt, schema=_load_schema(_RECEIPT_SCHEMA))
+
+
+def test_evidence_schema_accepts_declared_and_observed():
+    _require_jsonschema()
+    receipt = _mint()
+    evidence = compare_agent_consumption_evidence(
+        _answer_compliance(["canonical_md"]),
+        [receipt],
+        task_id=_TASK,
+        repo_commit=_COMMIT,
+    )
+    jsonschema.validate(instance=evidence, schema=_load_schema(_EVIDENCE_SCHEMA))
+    assert evidence["kind"] == EVIDENCE_KIND
+    assert evidence["version"] == EVIDENCE_VERSION
+    assert _states(evidence)["canonical_md"] == "declared-and-observed"
+
+
+def test_receipt_schema_rejects_content_field():
+    _require_jsonschema()
+    receipt = _mint()
+    receipt["content"] = "should never be stored"
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=receipt, schema=_load_schema(_RECEIPT_SCHEMA))
+
+
+# ── Determinism ─────────────────────────────────────────────────────────────
+
+
+def test_binding_and_receipt_hashes_are_deterministic():
+    r1 = _mint(content=b"same-bytes")
+    r2 = _mint(content=b"same-bytes")
+    assert r1["binding_sha256"] == r2["binding_sha256"]
+    assert r1["receipt_sha256"] == r2["receipt_sha256"]
+    assert r1["artifact_identity"]["sha256"] == r2["artifact_identity"]["sha256"]
+    assert "content" not in r1
+    assert "same-bytes" not in canonical_json(r1)
+    assert r1["retention"]["content_retained"] is False
+
+
+def test_binding_sha256_matches_helper():
+    receipt = _mint()
+    expected = compute_binding_sha256(
+        task_id=receipt["task_id"],
+        repo_commit=receipt["repo_commit"],
+        artifact_role=receipt["artifact_role"],
+        artifact_identity=receipt["artifact_identity"],
+        access_event_id=receipt["access_event_id"],
+        issuer=receipt["issuer"],
+    )
+    assert receipt["binding_sha256"] == expected
+    without = {k: v for k, v in receipt.items() if k != "receipt_sha256"}
+    assert receipt["receipt_sha256"] == sha256_json(without)
+
+
+def test_comparison_output_is_deterministic():
+    receipt = _mint()
+    ac = _answer_compliance(["canonical_md", "agent_reading_pack"])
+    a = compare_agent_consumption_evidence(
+        ac, [receipt], task_id=_TASK, repo_commit=_COMMIT, expected_roles=["post_emit_health"]
+    )
+    b = compare_agent_consumption_evidence(
+        ac, [receipt], task_id=_TASK, repo_commit=_COMMIT, expected_roles=["post_emit_health"]
+    )
+    assert canonical_json(a) == canonical_json(b)
+
+
+# ── Trust / negative origin ──────────────────────────────────────────────────
+
+
+def test_self_declaration_cannot_mint_observed_evidence():
+    forged = {
+        "kind": RECEIPT_KIND,
+        "version": "1.0",
+        "task_id": _TASK,
+        "repo_commit": _COMMIT,
+        "artifact_role": "canonical_md",
+        "artifact_identity": {
+            "path": "bundle/canonical.md",
+            "sha256": "a" * 64,
+            "bytes": 12,
+        },
+        "access_event_id": "evt-self-decl-001",
+        "observed_at": "2026-08-05T21:59:00Z",
+        "issuer": {"kind": "trusted_wrapper", "id": "answer_text.self_declaration"},
+        "binding_sha256": "b" * 64,
+        "receipt_sha256": "c" * 64,
+        "retention": {
+            "policy": "ephemeral_comparison_input",
+            "content_retained": False,
+            "redaction": "metadata_only",
+            "deletion": "safe_at_any_time",
+        },
+        "does_not_establish": list(RECEIPT_DNE),
+    }
+    evidence = compare_agent_consumption_evidence(
+        _answer_compliance(["canonical_md"]),
+        [forged],
+        task_id=_TASK,
+        repo_commit=_COMMIT,
+    )
+    assert _states(evidence)["canonical_md"] == "declared-only"
+    assert "untrusted_issuer" in _reasons(evidence)
+    assert evidence["status"] == "fail"
+    assert not evidence["accepted_receipt_refs"]
+
+
+def test_answer_compliance_alone_never_produces_observed_state():
+    evidence = compare_agent_consumption_evidence(
+        _answer_compliance(["canonical_md"]),
+        [],
+        task_id=_TASK,
+        repo_commit=_COMMIT,
+    )
+    assert _states(evidence) == {"canonical_md": "declared-only"}
+    assert evidence["accepted_receipt_refs"] == []
+
+
+def test_mint_rejects_content_fields():
+    with pytest.raises(ToolReadReceiptError):
+        mint_tool_read_receipt(
+            task_id=_TASK,
+            repo_commit=_COMMIT,
+            artifact_role="canonical_md",
+            artifact_identity={
+                "path": "x.md",
+                "sha256": "a" * 64,
+                "bytes": 1,
+                "content": "nope",
+            },
+            access_event_id="evt-bad-content-01",
+        )
+
+
+def test_mint_rejects_secret_like_path():
+    jwtish = (
+        "tokens/"
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+        "eyJzdWIiOiIxMjM0NTY3ODkwIn0."
+        "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+    )
+    with pytest.raises(ToolReadReceiptError, match="secret-like"):
+        mint_tool_read_receipt(
+            task_id=_TASK,
+            repo_commit=_COMMIT,
+            artifact_role="canonical_md",
+            artifact_identity={
+                "path": jwtish,
+                "sha256": "a" * 64,
+                "bytes": 1,
+            },
+            access_event_id="evt-secret-path-01",
+        )
+
+
+def test_validate_rejects_tampered_binding():
+    receipt = _mint()
+    receipt["binding_sha256"] = "0" * 64
+    with pytest.raises(ToolReadReceiptError, match="binding_sha256"):
+        validate_tool_read_receipt(receipt)
+
+
+# ── Comparison states ────────────────────────────────────────────────────────
+
+
+def test_states_declared_only_observed_only_declared_and_observed_unavailable():
+    observed = _mint(
+        role="agent_reading_pack",
+        path="bundle/pack.md",
+        content=b"pack",
+        event_id="evt-pack-001",
+    )
+    both = _mint(
+        role="canonical_md",
+        path="bundle/canonical.md",
+        content=b"canon",
+        event_id="evt-canon-001",
+    )
+    evidence = compare_agent_consumption_evidence(
+        _answer_compliance(["canonical_md", "citation_map_jsonl"]),
+        [observed, both],
+        task_id=_TASK,
+        repo_commit=_COMMIT,
+        expected_roles=["post_emit_health"],
+    )
+    states = _states(evidence)
+    assert states["canonical_md"] == "declared-and-observed"
+    assert states["citation_map_jsonl"] == "declared-only"
+    assert states["agent_reading_pack"] == "observed-only"
+    assert states["post_emit_health"] == "unavailable"
+    assert set(EVIDENCE_DNE) >= set(TRACE_DNE)
+    assert "semantic_reading" in evidence["does_not_establish"]
+    assert "actual_reading_proven" in evidence["does_not_establish"]
+
+
+# ── Freshness / replay / mismatch ────────────────────────────────────────────
+
+
+def test_stale_receipt_never_elevates():
+    stale = _mint(observed_at="2026-08-05T12:00:00Z", event_id="evt-stale-001")
+    evidence = compare_agent_consumption_evidence(
+        _answer_compliance(["canonical_md"]),
+        [stale],
+        task_id=_TASK,
+        repo_commit=_COMMIT,
+        as_of=_AS_OF,
+        max_age_seconds=60,
+    )
+    assert _states(evidence)["canonical_md"] == "declared-only"
+    assert "stale" in _reasons(evidence)
+    assert "stale" in _codes(evidence)
+    assert not evidence["accepted_receipt_refs"]
+
+
+def test_task_mismatch_never_elevates():
+    foreign = _mint(task_id="OTHER-TASK-001", event_id="evt-task-mis-001")
+    evidence = compare_agent_consumption_evidence(
+        _answer_compliance(["canonical_md"]),
+        [foreign],
+        task_id=_TASK,
+        repo_commit=_COMMIT,
+    )
+    assert _states(evidence)["canonical_md"] == "declared-only"
+    assert "task_mismatch" in _reasons(evidence)
+
+
+def test_commit_mismatch_never_elevates():
+    foreign = _mint(repo_commit="a" * 40, event_id="evt-commit-mis-001")
+    evidence = compare_agent_consumption_evidence(
+        _answer_compliance(["canonical_md"]),
+        [foreign],
+        task_id=_TASK,
+        repo_commit=_COMMIT,
+    )
+    assert _states(evidence)["canonical_md"] == "declared-only"
+    assert "commit_mismatch" in _reasons(evidence)
+
+
+def test_replay_never_elevates_twice():
+    first = _mint(event_id="evt-replay-001", content=b"body-a")
+    second = copy.deepcopy(first)
+    # Same event id presented again is a replay even if the payload is identical.
+    evidence = compare_agent_consumption_evidence(
+        _answer_compliance(["canonical_md"]),
+        [first, second],
+        task_id=_TASK,
+        repo_commit=_COMMIT,
+    )
+    assert "replay" in _reasons(evidence)
+    assert len(evidence["accepted_receipt_refs"]) == 1
+    assert _states(evidence)["canonical_md"] == "declared-and-observed"
+
+
+def test_artifact_mismatch_with_declared_identity_never_elevates():
+    receipt = _mint(content=b"actual-bytes", event_id="evt-art-mis-001")
+    declared_identities = {
+        "canonical_md": {
+            "path": "bundle/canonical.md",
+            "sha256": "f" * 64,
+            "bytes": 999,
+        }
+    }
+    evidence = compare_agent_consumption_evidence(
+        _answer_compliance(["canonical_md"]),
+        [receipt],
+        task_id=_TASK,
+        repo_commit=_COMMIT,
+        declared_identities=declared_identities,
+    )
+    assert _states(evidence)["canonical_md"] == "declared-only"
+    assert "artifact_mismatch" in _reasons(evidence)
+    assert not evidence["accepted_receipt_refs"]
+
+
+def test_conflicting_identities_for_same_role_remove_observation():
+    a = _mint(content=b"one", event_id="evt-conflict-a")
+    b = _mint(content=b"two", event_id="evt-conflict-b")
+    evidence = compare_agent_consumption_evidence(
+        _answer_compliance(["canonical_md"]),
+        [a, b],
+        task_id=_TASK,
+        repo_commit=_COMMIT,
+    )
+    assert "artifact_mismatch" in _reasons(evidence)
+    assert _states(evidence)["canonical_md"] == "declared-only"
+    assert not evidence["accepted_receipt_refs"]
+
+
+def test_privacy_violation_receipt_fails_closed():
+    receipt = _mint(event_id="evt-privacy-001")
+    poisoned = dict(receipt)
+    poisoned["content"] = "raw repository text must not elevate evidence"
+    evidence = compare_agent_consumption_evidence(
+        _answer_compliance(["canonical_md"]),
+        [poisoned],
+        task_id=_TASK,
+        repo_commit=_COMMIT,
+    )
+    assert "privacy_violation" in _reasons(evidence)
+    assert _states(evidence)["canonical_md"] == "declared-only"
+    assert evidence["status"] == "fail"
+
+
+# ── E2E wrapper adoption ─────────────────────────────────────────────────────
+
+
+def test_e2e_trusted_wrapper_declaration_comparison_without_semantic_overclaim():
+    wrapper = TrustedToolReadWrapper()
+    assert wrapper.issuer_id == TRUSTED_WRAPPER_ISSUER_ID
+
+    content_a = b"# Agent Reading Pack\nnavigation only\n"
+    content_b = b"# Canonical\ntruth source\n"
+    receipts = [
+        wrapper.observe_artifact_access(
+            task_id=_TASK,
+            repo_commit=_COMMIT,
+            artifact_role="agent_reading_pack",
+            path="out/agent_reading_pack.md",
+            content=content_a,
+            access_event_id="evt-e2e-pack-001",
+            observed_at="2026-08-05T21:58:30Z",
+        ),
+        wrapper.observe_artifact_access(
+            task_id=_TASK,
+            repo_commit=_COMMIT,
+            artifact_role="canonical_md",
+            path="out/canonical.md",
+            content=content_b,
+            access_event_id="evt-e2e-canon-001",
+            observed_at="2026-08-05T21:58:45Z",
+        ),
+    ]
+    # Content must not leak into receipts.
+    for receipt in receipts:
+        encoded = canonical_json(receipt)
+        assert "navigation only" not in encoded
+        assert "truth source" not in encoded
+        validate_tool_read_receipt(receipt)
+
+    ac = _answer_compliance(["canonical_md", "agent_reading_pack", "citation_map_jsonl"])
+    evidence = compare_agent_consumption_evidence(
+        ac,
+        receipts,
+        task_id=_TASK,
+        repo_commit=_COMMIT,
+        as_of=_AS_OF,
+        max_age_seconds=3600,
+        expected_roles=["post_emit_health"],
+        declared_identities={
+            "canonical_md": receipts[1]["artifact_identity"],
+            "agent_reading_pack": receipts[0]["artifact_identity"],
+        },
+    )
+
+    states = _states(evidence)
+    assert states["canonical_md"] == "declared-and-observed"
+    assert states["agent_reading_pack"] == "declared-and-observed"
+    assert states["citation_map_jsonl"] == "declared-only"
+    assert states["post_emit_health"] == "unavailable"
+    assert len(evidence["accepted_receipt_refs"]) == 2
+    assert evidence["status"] in {"pass", "warn"}
+
+    # Explicit non-claims: observation is not semantic reading / truth.
+    for boundary in (
+        "semantic_reading",
+        "relevance_to_answer",
+        "answer_correct",
+        "claims_true",
+        "actual_reading_proven",
+        "runtime_interception",
+        "mandatory_wrapper_adoption",
+    ):
+        assert boundary in evidence["does_not_establish"]
+
+    if jsonschema is not None:
+        jsonschema.validate(instance=evidence, schema=_load_schema(_EVIDENCE_SCHEMA))
+        for receipt in receipts:
+            jsonschema.validate(instance=receipt, schema=_load_schema(_RECEIPT_SCHEMA))
+
+
+def test_trace_does_not_establish_boundaries_remain_subset():
+    assert set(TRACE_DNE).issubset(set(EVIDENCE_DNE))
+    assert list(TRACE_DNE) == [
+        "actual_reading_proven",
+        "answer_correct",
+        "repo_understood",
+        "all_relevant_context_used",
+        "claims_true",
+        "test_sufficiency",
+        "regression_absence",
+        "runtime_behavior",
+        "forensic_ready",
+    ]

--- a/merger/repoground/tests/test_agent_consumption_evidence.py
+++ b/merger/repoground/tests/test_agent_consumption_evidence.py
@@ -1,6 +1,7 @@
 """Schema, determinism, negative, freshness, replay, mismatch and E2E tests
 for agent tool-read receipts and consumption evidence comparison.
 """
+
 from __future__ import annotations
 
 import copy
@@ -135,6 +136,51 @@ def test_receipt_schema_rejects_content_field():
         jsonschema.validate(instance=receipt, schema=_load_schema(_RECEIPT_SCHEMA))
 
 
+def test_receipt_schema_rejects_unknown_issuer_id():
+    _require_jsonschema()
+    receipt = _mint()
+    receipt["issuer"] = {
+        "kind": "trusted_wrapper",
+        "id": "answer_text.self_declaration",
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=receipt, schema=_load_schema(_RECEIPT_SCHEMA))
+
+
+def test_receipt_schema_rejects_kind_id_mismatch_wrapper_with_gateway_id():
+    _require_jsonschema()
+    receipt = _mint()
+    receipt["issuer"] = {
+        "kind": "trusted_wrapper",
+        "id": "repoground.agent_consumption.tool_gateway",
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=receipt, schema=_load_schema(_RECEIPT_SCHEMA))
+
+
+def test_receipt_schema_rejects_kind_id_mismatch_gateway_with_wrapper_id():
+    _require_jsonschema()
+    receipt = _mint()
+    receipt["issuer"] = {
+        "kind": "tool_gateway",
+        "id": "repoground.agent_consumption.tool_read_wrapper",
+    }
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=receipt, schema=_load_schema(_RECEIPT_SCHEMA))
+
+
+def test_receipt_schema_accepts_tool_gateway_issuer_pair():
+    _require_jsonschema()
+    receipt = _mint()
+    # Schema-only instance: runtime mint path uses trusted_wrapper by default.
+    receipt["issuer"] = {
+        "kind": "tool_gateway",
+        "id": "repoground.agent_consumption.tool_gateway",
+    }
+    # Hashes are intentionally stale here; schema does not recompute digests.
+    jsonschema.validate(instance=receipt, schema=_load_schema(_RECEIPT_SCHEMA))
+
+
 # ── Determinism ─────────────────────────────────────────────────────────────
 
 
@@ -168,10 +214,18 @@ def test_comparison_output_is_deterministic():
     receipt = _mint()
     ac = _answer_compliance(["canonical_md", "agent_reading_pack"])
     a = compare_agent_consumption_evidence(
-        ac, [receipt], task_id=_TASK, repo_commit=_COMMIT, expected_roles=["post_emit_health"]
+        ac,
+        [receipt],
+        task_id=_TASK,
+        repo_commit=_COMMIT,
+        expected_roles=["post_emit_health"],
     )
     b = compare_agent_consumption_evidence(
-        ac, [receipt], task_id=_TASK, repo_commit=_COMMIT, expected_roles=["post_emit_health"]
+        ac,
+        [receipt],
+        task_id=_TASK,
+        repo_commit=_COMMIT,
+        expected_roles=["post_emit_health"],
     )
     assert canonical_json(a) == canonical_json(b)
 
@@ -412,6 +466,80 @@ def test_privacy_violation_receipt_fails_closed():
     assert evidence["status"] == "fail"
 
 
+# ── Fail-closed comparison bindings ──────────────────────────────────────────
+
+
+def _assert_no_trusted_observation(evidence: dict) -> None:
+    assert evidence["accepted_receipt_refs"] == []
+    assert all(item["observed"] is False for item in evidence["comparisons"])
+    assert all(
+        item["state"] != "declared-and-observed" for item in evidence["comparisons"]
+    )
+    assert evidence["status"] == "fail"
+    assert "invalid_input_field" in _codes(evidence)
+    if jsonschema is not None:
+        jsonschema.validate(instance=evidence, schema=_load_schema(_EVIDENCE_SCHEMA))
+
+
+def test_empty_task_id_never_accepts_receipts_or_observes():
+    receipt = _mint(event_id="evt-empty-task-001")
+    evidence = compare_agent_consumption_evidence(
+        _answer_compliance(["canonical_md"]),
+        [receipt],
+        task_id="",
+        repo_commit=_COMMIT,
+    )
+    _assert_no_trusted_observation(evidence)
+    assert evidence["task_id"] == "unknown"
+    assert _states(evidence)["canonical_md"] == "declared-only"
+
+
+def test_invalid_repo_commit_never_accepts_receipts_or_observes():
+    receipt = _mint(event_id="evt-bad-commit-001")
+    evidence = compare_agent_consumption_evidence(
+        _answer_compliance(["canonical_md"]),
+        [receipt],
+        task_id=_TASK,
+        repo_commit="not-a-commit",
+    )
+    _assert_no_trusted_observation(evidence)
+    # Schema placeholder only — not a trusted observation binding.
+    assert evidence["repo_commit"] == "0" * 40
+    assert _states(evidence)["canonical_md"] == "declared-only"
+
+
+def test_invalid_explicit_as_of_never_accepts_receipts_or_observes():
+    receipt = _mint(event_id="evt-bad-asof-001")
+    evidence = compare_agent_consumption_evidence(
+        _answer_compliance(["canonical_md"]),
+        [receipt],
+        task_id=_TASK,
+        repo_commit=_COMMIT,
+        as_of="not-a-timestamp",
+        max_age_seconds=3600,
+    )
+    _assert_no_trusted_observation(evidence)
+    assert evidence["task_id"] == _TASK
+    assert evidence["repo_commit"] == _COMMIT
+    assert _states(evidence)["canonical_md"] == "declared-only"
+
+
+def test_invalid_max_age_seconds_never_accepts_receipts_or_observes():
+    receipt = _mint(event_id="evt-bad-max-age-001")
+    evidence = compare_agent_consumption_evidence(
+        _answer_compliance(["canonical_md"]),
+        [receipt],
+        task_id=_TASK,
+        repo_commit=_COMMIT,
+        as_of=_AS_OF,
+        max_age_seconds=-1,
+    )
+    _assert_no_trusted_observation(evidence)
+    assert evidence["task_id"] == _TASK
+    assert evidence["repo_commit"] == _COMMIT
+    assert _states(evidence)["canonical_md"] == "declared-only"
+
+
 # ── E2E wrapper adoption ─────────────────────────────────────────────────────
 
 
@@ -448,7 +576,9 @@ def test_e2e_trusted_wrapper_declaration_comparison_without_semantic_overclaim()
         assert "truth source" not in encoded
         validate_tool_read_receipt(receipt)
 
-    ac = _answer_compliance(["canonical_md", "agent_reading_pack", "citation_map_jsonl"])
+    ac = _answer_compliance(
+        ["canonical_md", "agent_reading_pack", "citation_map_jsonl"]
+    )
     evidence = compare_agent_consumption_evidence(
         ac,
         receipts,

--- a/merger/repoground/tests/test_cli_agent_consumption.py
+++ b/merger/repoground/tests/test_cli_agent_consumption.py
@@ -508,3 +508,127 @@ def test_cli_preflight_invalid_manifest_shape(tmp_path, capsys):
 
     assert rc == 2
     assert "expected artifacts array" in capsys.readouterr().err
+
+
+def test_cli_compare_evidence_declared_and_observed(tmp_path, capsys):
+    from merger.repoground.core.agent_consumption_receipts import TrustedToolReadWrapper
+
+    task_id = "REPOGROUND-AGENT-UTILITY-V1-T005"
+    commit = "76ffaaaab3890d85e3db1c46e828809868c4df46"
+    receipt = TrustedToolReadWrapper().observe_artifact_access(
+        task_id=task_id,
+        repo_commit=commit,
+        artifact_role="canonical_md",
+        path="out/canonical.md",
+        content=b"# canonical\n",
+        access_event_id="evt-cli-canon-001",
+        observed_at="2026-08-05T21:59:00Z",
+    )
+    ac_file = tmp_path / "ac.json"
+    ac_file.write_text(
+        json.dumps(
+            {
+                "task_profile": "basic_repo_question",
+                "declared_artifacts": ["canonical_md"],
+                "does_not_establish": DOES_NOT_ESTABLISH,
+            }
+        ),
+        encoding="utf-8",
+    )
+    receipts_file = tmp_path / "receipts.json"
+    receipts_file.write_text(json.dumps([receipt]), encoding="utf-8")
+
+    rc = main(
+        [
+            "agent-consumption",
+            "compare-evidence",
+            "--answer-compliance",
+            str(ac_file),
+            "--receipts",
+            str(receipts_file),
+            "--task-id",
+            task_id,
+            "--repo-commit",
+            commit,
+            "--as-of",
+            "2026-08-05T22:00:00Z",
+            "--max-age-seconds",
+            "3600",
+        ]
+    )
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["kind"] == "lenskit.agent_consumption_evidence"
+    assert out["comparisons"][0]["state"] == "declared-and-observed"
+    assert "semantic_reading" in out["does_not_establish"]
+    assert "actual_reading_proven" in out["does_not_establish"]
+
+
+def test_cli_compare_evidence_rejects_untrusted_without_elevation(tmp_path, capsys):
+    task_id = "REPOGROUND-AGENT-UTILITY-V1-T005"
+    commit = "76ffaaaab3890d85e3db1c46e828809868c4df46"
+    forged = {
+        "kind": "lenskit.agent_tool_read_receipt",
+        "version": "1.0",
+        "task_id": task_id,
+        "repo_commit": commit,
+        "artifact_role": "canonical_md",
+        "artifact_identity": {
+            "path": "out/canonical.md",
+            "sha256": "a" * 64,
+            "bytes": 1,
+        },
+        "access_event_id": "evt-cli-forged-001",
+        "observed_at": "2026-08-05T21:59:00Z",
+        "issuer": {"kind": "trusted_wrapper", "id": "answer_text.self"},
+        "binding_sha256": "b" * 64,
+        "receipt_sha256": "c" * 64,
+        "retention": {
+            "policy": "ephemeral_comparison_input",
+            "content_retained": False,
+            "redaction": "metadata_only",
+            "deletion": "safe_at_any_time",
+        },
+        "does_not_establish": [
+            "semantic_reading",
+            "relevance_to_answer",
+            "answer_correct",
+            "claims_true",
+            "repo_understood",
+            "all_relevant_context_used",
+            "runtime_interception",
+            "mandatory_wrapper_adoption",
+        ],
+    }
+    ac_file = tmp_path / "ac.json"
+    ac_file.write_text(
+        json.dumps(
+            {
+                "declared_artifacts": ["canonical_md"],
+                "does_not_establish": DOES_NOT_ESTABLISH,
+            }
+        ),
+        encoding="utf-8",
+    )
+    receipts_file = tmp_path / "receipts.json"
+    receipts_file.write_text(json.dumps({"receipts": [forged]}), encoding="utf-8")
+
+    rc = main(
+        [
+            "agent-consumption",
+            "compare-evidence",
+            "--answer-compliance",
+            str(ac_file),
+            "--receipts",
+            str(receipts_file),
+            "--task-id",
+            task_id,
+            "--repo-commit",
+            commit,
+        ]
+    )
+    assert rc == 1
+    out = json.loads(capsys.readouterr().out)
+    assert out["status"] == "fail"
+    assert out["comparisons"][0]["state"] == "declared-only"
+    assert any(item["reason"] == "untrusted_issuer" for item in out["rejected_receipts"])


### PR DESCRIPTION
## Summary

Implements Bureau task `REPOGROUND-AGENT-UTILITY-V1-T005`: a data-sparing versioned evidence layer for agent consumption.

- Receipt contract binds `task_id`, `repo_commit`, `artifact_role`, and immutable artifact identity (path + sha256 + bytes) without storing content.
- Only allowlisted `trusted_wrapper` / `tool_gateway` issuers mint observed evidence; answer text and self-declarations cannot.
- Comparison states: `declared-only`, `observed-only`, `declared-and-observed`, `unavailable`.
- Missing, stale, task/commit/artifact mismatch, replay, untrusted issuer, privacy and binding failures never elevate evidence.
- **Fail-closed comparison bindings:** invalid/empty `task_id`, invalid `repo_commit`, invalid explicit `as_of`, or invalid `max_age_seconds` never accept receipts, never set `observed=true`, never emit `declared-and-observed`. Schema placeholders (`unknown` / zero-commit) are not trusted observations.
- **Schema coherence:** `agent-tool-read-receipt.v1.schema.json` enumerates runtime issuer IDs and couples kind↔id.
- **Maintainability:** `_ingest_receipt` split into testable helpers; C901 no longer introduces findings (no ratchet, no noqa).
- CLI: `agent-consumption compare-evidence`.
- Docs, schemas, trusted wrapper, and focused + full-suite tests.

## Validation (head `573de8ae0387fdf31b287ded4386f098bb5721b7`)

- Focused: `pytest merger/repoground/tests/test_agent_consumption_evidence.py` — **29 passed**
- Related CLI: `pytest merger/repoground/tests/test_cli_agent_consumption.py` — **24 passed**
- Full suite: `pytest -m 'not browser and not doc_freshness_live'` — **5412 passed**, 12 skipped
- `python scripts/ci/check_graph_maintainability.py --root . --format json` — **pass**, current_count=189, new_count=0, baseline=189
- Ruff check/format on touched files — clean
- `git diff --check` — clean

## Non-claims / out of scope

Does **not** establish semantic reading, relevance, correctness, truth, runtime interception, mandatory wrapper adoption, merge readiness, or deployment. Not merged and not deployed by this PR.

Base HEAD: `76ffaaaab3890d85e3db1c46e828809868c4df46`
Feature HEAD: `573de8ae0387fdf31b287ded4386f098bb5721b7`