### PR TITLE
fix(retrieval): verify hybrid binding file digests

### DIFF
--- a/merger/repoground/retrieval/hybrid_activation.py
+++ b/merger/repoground/retrieval/hybrid_activation.py
@@ -59,6 +59,26 @@ def file_sha256(path: str | Path) -> str:
     return digest.hexdigest()
 
 
+def _verify_file_binding(
+    path: str | Path,
+    declared_sha256: str,
+    *,
+    field: str,
+    errors: list[str],
+) -> None:
+    candidate = Path(path)
+    if not candidate.is_file():
+        errors.append(f"{field}_path must reference a readable regular file")
+        return
+    try:
+        observed_sha256 = file_sha256(candidate)
+    except OSError:
+        errors.append(f"{field}_path must reference a readable regular file")
+        return
+    if _is_sha256(declared_sha256) and observed_sha256 != declared_sha256:
+        errors.append(f"{field}_sha256 must match {field}_path contents")
+
+
 def validate_model_binding(
     model_binding: Mapping[str, Any],
     embedding_policy: Mapping[str, Any],
@@ -147,8 +167,26 @@ def build_hybrid_route_binding(
         errors.append("index_sha256 must be a lowercase SHA-256")
     if not _is_sha256(bundle_manifest_sha256):
         errors.append("bundle_manifest_sha256 must be a lowercase SHA-256")
-    if not isinstance(repository_commit, str) or len(repository_commit) != 40:
-        errors.append("repository_commit must be a 40-character commit")
+    _verify_file_binding(
+        index_path,
+        index_sha256,
+        field="index",
+        errors=errors,
+    )
+    _verify_file_binding(
+        bundle_manifest_path,
+        bundle_manifest_sha256,
+        field="bundle_manifest",
+        errors=errors,
+    )
+    if not (
+        isinstance(repository_commit, str)
+        and len(repository_commit) == 40
+        and all(character in "0123456789abcdef" for character in repository_commit)
+    ):
+        errors.append(
+            "repository_commit must be a 40-character lowercase hexadecimal commit"
+        )
     evidence_path = Path(routing_evidence_path).resolve()
     binding = {
         "kind": "repoground.hybrid_retrieval_binding",

--- a/merger/repoground/tests/test_t019_hybrid_binding_integrity.py
+++ b/merger/repoground/tests/test_t019_hybrid_binding_integrity.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from merger.repoground.retrieval import hybrid_activation
+
+ROOT = Path(__file__).resolve().parents[3]
+ROUTING_EVIDENCE = ROOT / "docs/retrieval/task-profile-routing-evidence.v1.json"
+COMMIT = "cfd341b00c6a36125a014dbfa54cf78c8215da75"
+SHA = "a" * 64
+
+
+def _valid_binding_inputs(tmp_path: Path) -> dict[str, object]:
+    index = tmp_path / "index.sqlite"
+    manifest = tmp_path / "bundle.manifest.json"
+    index.write_bytes(b"index")
+    manifest.write_text("{}", encoding="utf-8")
+    policy = {
+        "model_name": "local-fixture-model",
+        "dimensions": 8,
+        "provider": "local",
+        "similarity_metric": "cosine",
+        "fallback_behavior": "ignore",
+    }
+    model = {
+        "model_name": "local-fixture-model",
+        "model_revision": "fixture-v1",
+        "model_artifact_sha256": SHA,
+        "tokenizer_sha256": "b" * 64,
+    }
+    activation = hybrid_activation.resolve_profile_activation(
+        ROUTING_EVIDENCE,
+        task_profile="review",
+        explicit_opt_in=True,
+    )
+    return {
+        "activation": activation,
+        "embedding_policy": policy,
+        "model_binding": model,
+        "index_path": index,
+        "index_sha256": hybrid_activation.file_sha256(index),
+        "bundle_manifest_path": manifest,
+        "bundle_manifest_sha256": hybrid_activation.file_sha256(manifest),
+        "repository_commit": COMMIT,
+        "routing_evidence_path": ROUTING_EVIDENCE,
+    }
+
+
+def test_binding_rejects_index_digest_mismatch(tmp_path: Path) -> None:
+    inputs = _valid_binding_inputs(tmp_path)
+    inputs["index_sha256"] = "0" * 64
+
+    binding = hybrid_activation.build_hybrid_route_binding(**inputs)
+
+    assert binding["status"] == "invalid"
+    assert "index_sha256 must match index_path contents" in binding["errors"]
+
+
+def test_binding_rejects_manifest_digest_mismatch(tmp_path: Path) -> None:
+    inputs = _valid_binding_inputs(tmp_path)
+    inputs["bundle_manifest_sha256"] = "1" * 64
+
+    binding = hybrid_activation.build_hybrid_route_binding(**inputs)
+
+    assert binding["status"] == "invalid"
+    assert (
+        "bundle_manifest_sha256 must match bundle_manifest_path contents"
+        in binding["errors"]
+    )
+
+
+def test_binding_rejects_missing_index_file(tmp_path: Path) -> None:
+    inputs = _valid_binding_inputs(tmp_path)
+    inputs["index_path"] = tmp_path / "missing-index.sqlite"
+
+    binding = hybrid_activation.build_hybrid_route_binding(**inputs)
+
+    assert binding["status"] == "invalid"
+    assert "index_path must reference a readable regular file" in binding["errors"]
+
+
+def test_binding_rejects_unreadable_manifest_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    inputs = _valid_binding_inputs(tmp_path)
+    manifest = Path(inputs["bundle_manifest_path"])
+    real_file_sha256 = hybrid_activation.file_sha256
+
+    def unreadable_manifest(path: str | Path) -> str:
+        if Path(path) == manifest:
+            raise PermissionError("fixture: unreadable manifest")
+        return real_file_sha256(path)
+
+    monkeypatch.setattr(hybrid_activation, "file_sha256", unreadable_manifest)
+
+    binding = hybrid_activation.build_hybrid_route_binding(**inputs)
+
+    assert binding["status"] == "invalid"
+    assert (
+        "bundle_manifest_path must reference a readable regular file"
+        in binding["errors"]
+    )
+
+
+@pytest.mark.parametrize(
+    "repository_commit",
+    [
+        "z" * 40,
+        "A" * 40,
+        "0" * 39,
+        "0" * 41,
+    ],
+)
+def test_binding_rejects_noncanonical_repository_commit(
+    tmp_path: Path, repository_commit: str
+) -> None:
+    inputs = _valid_binding_inputs(tmp_path)
+    inputs["repository_commit"] = repository_commit
+
+    binding = hybrid_activation.build_hybrid_route_binding(**inputs)
+
+    assert binding["status"] == "invalid"
+    assert (
+        "repository_commit must be a 40-character lowercase hexadecimal commit"
+        in binding["errors"]
+    )


### PR DESCRIPTION
Bureau-Task: REPOGROUND-AGENT-UTILITY-V1-T019

## Problem

T019 requires the hybrid retrieval lane to bind the exact index and bundle manifest. `build_hybrid_route_binding` only validated that supplied SHA-256 values looked syntactically valid, so unrelated 64-hex digests could still produce `status: bound`.

## Fix

- hash the actual index and bundle-manifest files and fail closed on mismatch
- fail closed when either bound file is missing or unreadable
- require `repository_commit` to be exactly 40 lowercase hexadecimal characters
- preserve the existing deterministic lexical fallback and successful binding shape
- add focused regression tests for digest mismatch, unavailable files, and noncanonical commit ids

## Verification

- reproduced the former false-green case before the fix: wrong `00…` / `11…` digests returned `status: bound`
- same reproduction after the fix returns `status: invalid` with both mismatch errors
- focused T019 tests: 15 passed
- full repository suite: 5442 passed, 12 skipped
- Ruff on changed production/test files: passed
- `git diff --check`: passed

Candidate `candidate-5439d0d5e8e21c13f11a622c` was assessed by Bureau as `merge` into existing T019 rather than as a new task.
