### PR TITLE
fix(retrieval): restore query by republishing sqlite_index and reporting its absence

### DIFF
--- a/docs/contracts/repobrief-ask-frontdoor-v1.md
+++ b/docs/contracts/repobrief-ask-frontdoor-v1.md
@@ -36,11 +36,20 @@ The context pack must carry:
 - freshness status and caveats;
 - availability status and caveats;
 - required-reading result;
+- retrieval-infrastructure state;
 - retrieval hits;
 - resolved ranges;
 - answer scaffold;
 - forbidden operations;
 - mandatory non-claims.
+
+`availability` describes the snapshot; `retrieval_infrastructure` describes the
+search backend the pack queried. They are separate because a bundle can be
+perfectly available while carrying no index to search — a pack that reports only
+the former answers every query with zero hits and calls itself available, which
+a caller cannot distinguish from a repository that genuinely holds no match. A
+pack whose `retrieval_infrastructure.index_resolved` is false makes no claim
+about what the repository contains.
 
 ## Read-only boundary
 

--- a/merger/repoground/contracts/repobrief-ask-context-pack.v1.schema.json
+++ b/merger/repoground/contracts/repobrief-ask-context-pack.v1.schema.json
@@ -17,7 +17,8 @@
     "resolved_ranges",
     "answer_scaffold",
     "forbidden_operations",
-    "does_not_establish"
+    "does_not_establish",
+    "retrieval_infrastructure"
   ],
   "properties": {
     "kind": {
@@ -240,7 +241,10 @@
           "type": "string"
         },
         "fts_query": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "strategy": {
           "type": "string",
@@ -253,6 +257,41 @@
         "match_count": {
           "type": "integer",
           "minimum": 0
+        }
+      }
+    },
+    "retrieval_infrastructure": {
+      "type": "object",
+      "description": "State of the search backend this pack queried, kept separate from `availability` (which describes the snapshot). Distinguishes an absent index from an index that was searched and matched nothing.",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "index_resolved"
+      ],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "available",
+            "missing",
+            "invalid",
+            "unknown"
+          ]
+        },
+        "index_resolved": {
+          "type": "boolean"
+        },
+        "error_code": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "detail": {
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     },

--- a/merger/repoground/core/ask_context.py
+++ b/merger/repoground/core/ask_context.py
@@ -161,6 +161,7 @@ DOES_NOT_ESTABLISH = [
 ]
 _FRESHNESS_STATUSES = {"fresh", "stale", "unknown", "not_comparable", "not_applicable"}
 _AVAILABILITY_STATUSES = {"available", "partial", "missing", "unknown"}
+_RETRIEVAL_INFRASTRUCTURE_STATUSES = {"available", "missing", "invalid", "unknown"}
 _RANGE_STATUSES = {
     "resolved",
     "missing",
@@ -256,6 +257,33 @@ def _availability_block(snapshot: dict[str, Any]) -> dict[str, Any]:
                 "detail": "Snapshot availability metadata was unavailable.",
             }
         ],
+    }
+
+
+def _retrieval_infrastructure_block(query_result: dict[str, Any]) -> dict[str, Any]:
+    """Report whether the search backend itself resolved, separately from the bundle.
+
+    `_availability_block` describes the snapshot; it cannot see whether the FTS
+    index this pack queries actually exists. Keeping the two apart is what makes
+    "the index is absent" distinguishable from "the index was searched and held
+    nothing" — reporting the former as the latter tells the agent to rephrase a
+    query that no wording could ever answer.
+    """
+    status = query_result.get("status")
+    if status == "available":
+        return {
+            "status": "available",
+            "index_resolved": True,
+            "error_code": None,
+            "detail": None,
+        }
+    error_code = query_result.get("error_code")
+    detail = str(query_result.get("error") or "Query backend unavailable.")
+    return {
+        "status": _as_status(status, _RETRIEVAL_INFRASTRUCTURE_STATUSES, "unknown"),
+        "index_resolved": False,
+        "error_code": error_code,
+        "detail": detail,
     }
 
 
@@ -523,18 +551,26 @@ def build_ask_context_pack(
         "match_count": len(resolved_ranges),
     }
 
+    retrieval_infrastructure = _retrieval_infrastructure_block(query_result)
+    if not retrieval_infrastructure["index_resolved"]:
+        # The pack cannot be more available than the backend it queries. Without
+        # this, a bundle published without `sqlite_index` answers every query
+        # with `available` and zero hits, which reads as "the repo contains
+        # nothing matching" instead of "nothing was searched".
+        availability = {
+            "status": "missing",
+            "caveats": list(availability.get("caveats") or [])
+            + [
+                {
+                    "kind": "missing_artifact",
+                    "detail": retrieval_infrastructure["detail"],
+                }
+            ],
+        }
+
     caveats = list(freshness.get("caveats") or []) + list(
         availability.get("caveats") or []
     )
-    if query_result.get("status") != "available":
-        caveats.append(
-            {
-                "kind": "missing_artifact",
-                "detail": str(
-                    query_result.get("error") or "Query evidence unavailable."
-                ),
-            }
-        )
     if truncated:
         caveats.append(
             {
@@ -553,7 +589,7 @@ def build_ask_context_pack(
                 ),
             }
         )
-    elif not resolved_ranges:
+    elif not resolved_ranges and retrieval_infrastructure["index_resolved"]:
         caveats.append(
             {
                 "kind": "other",
@@ -579,6 +615,7 @@ def build_ask_context_pack(
         "availability": availability,
         "required_reading": required_reading,
         "retrieval": retrieval,
+        "retrieval_infrastructure": retrieval_infrastructure,
         "retrieval_hits": retrieval_hits,
         "resolved_ranges": resolved_ranges,
         "answer_scaffold": {

--- a/merger/repoground/core/mcp_tools.py
+++ b/merger/repoground/core/mcp_tools.py
@@ -578,14 +578,26 @@ def query_existing_index(
         max_answer_tokens=1,
         k=k,
     )
+    # The frontdoor status must follow the search backend, not the fact that a
+    # pack was produced. A pack is always produced — including when no index
+    # exists to query — so hardcoding "available" here is what turned a missing
+    # `sqlite_index` into a silent zero-result answer.
+    retrieval_infrastructure = pack["retrieval_infrastructure"]
     result = {
         "kind": READ_ONLY_KIND,
         "version": READ_ONLY_VERSION,
         "tool": "query_existing_index",
-        "status": "available",
+        # `missing` for an absent index, `invalid` for a rejected request — the
+        # same vocabulary `_invalid_read_result` uses for the other read tools.
+        "status": (
+            "available"
+            if retrieval_infrastructure["index_resolved"]
+            else retrieval_infrastructure["status"]
+        ),
         "route": "text_retrieval",
         "intent": {"kind": "text_retrieval"},
         "retrieval": pack["retrieval"],
+        "retrieval_infrastructure": retrieval_infrastructure,
         "retrieval_hits": pack["retrieval_hits"],
         "resolved_ranges": pack["resolved_ranges"],
         "budget": pack["budget"],

--- a/merger/repoground/core/snapshot_profiles.py
+++ b/merger/repoground/core/snapshot_profiles.py
@@ -152,16 +152,22 @@ PROFILE_ARTIFACT_RULES = {
         "python_symbol_index_json": REQ_RECOMMENDED,
         "python_call_graph_json": REQ_RECOMMENDED,
     },
-    # The daily fleet publication is the bundle the agent-facing call-navigation
-    # tools resolve against. Excluding the Python symbol index and call graph
-    # here removes `find_symbol`, `find_references`, `get_callers`, and
-    # `get_callees` from that surface entirely, so they stay part of the compact
-    # profile. `sqlite_index` remains excluded: it carries the bulk of the storage
-    # cost and no
-    # agent-facing read path consumes it.
+    # The daily fleet publication is the bundle every agent-facing read path
+    # resolves against, so an artifact excluded here is not merely smaller — it
+    # removes the tools built on it. Excluding the Python symbol index and call
+    # graph removed `find_symbol`, `find_references`, `get_callers`, and
+    # `get_callees`; excluding `sqlite_index` removed `query`, whose FTS runs
+    # against exactly that index (see `core/ask_context.py`).
+    #
+    # `sqlite_index` was previously excluded on the premise that it "carries the
+    # bulk of the storage cost and no agent-facing read path consumes it".
+    # Measured against the 2026-08-07 repoground publication, both halves were
+    # wrong: the index is 21.2 MB of a 201 MB bundle (~10.5%), against a
+    # published 65 MB call graph (~32%), and rebuilds in 0.55 s from the already
+    # published chunk index. It stays in the profile.
     "fleet-context": {
         **BASE_RULES,
-        "sqlite_index": REQ_EXCLUDED,
+        "sqlite_index": REQ_RECOMMENDED,
         "export_safety_report": REQ_REQUIRED,
         "retrieval_eval_json": REQ_RECOMMENDED,
         "python_symbol_index_json": REQ_RECOMMENDED,

--- a/merger/repoground/tests/test_ask_frontdoor_contracts.py
+++ b/merger/repoground/tests/test_ask_frontdoor_contracts.py
@@ -82,6 +82,12 @@ def _context_pack():
             "missing_recommended": ["citation_map_jsonl"],
             "status": "warn",
         },
+        "retrieval_infrastructure": {
+            "status": "available",
+            "index_resolved": True,
+            "error_code": None,
+            "detail": None,
+        },
         "retrieval_hits": [{"artifact_role": "canonical_md", "ref": "hit-1", "score": 1.0, "citation_id": "cit_0000000000000001"}],
         "resolved_ranges": [{"artifact_role": "canonical_md", "status": "resolved", "range_ref": {"file_path": "demo.md"}, "content_sha256": SHA}],
         "answer_scaffold": {
@@ -119,6 +125,19 @@ def test_context_pack_schema_accepts_context_and_scaffold():
 def test_context_pack_requires_resolved_ranges_and_hits():
     pack = _context_pack()
     del pack["resolved_ranges"]
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=pack, schema=_schema(CONTEXT_SCHEMA))
+
+
+def test_context_pack_requires_retrieval_infrastructure():
+    """A pack must always state whether its search backend resolved.
+
+    Leaving this optional would let a consumer read a pack with no hits and no
+    infrastructure block as an empty result, which is exactly how a missing
+    `sqlite_index` stayed invisible.
+    """
+    pack = _context_pack()
+    del pack["retrieval_infrastructure"]
     with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(instance=pack, schema=_schema(CONTEXT_SCHEMA))
 

--- a/merger/repoground/tests/test_mcp_query_routing.py
+++ b/merger/repoground/tests/test_mcp_query_routing.py
@@ -148,6 +148,12 @@ def test_query_uses_text_retrieval_for_broad_question(monkeypatch):
             },
             "retrieval_hits": [],
             "resolved_ranges": [],
+            "retrieval_infrastructure": {
+                "status": "available",
+                "index_resolved": True,
+                "error_code": None,
+                "detail": None,
+            },
             "budget": {"max_context_tokens": 1000},
             "availability": {"status": "available", "caveats": []},
             "freshness": {"status": "fresh", "caveats": []},

--- a/merger/repoground/tests/test_publication_surface_smoke.py
+++ b/merger/repoground/tests/test_publication_surface_smoke.py
@@ -188,17 +188,125 @@ def test_daily_profile_publishes_the_call_navigation_artifacts(published_bundle)
 
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     rules = manifest["capabilities"]["repobrief_profile_policy"]["artifact_rules"]
-    for role in ("python_symbol_index_json", "python_call_graph_json"):
+    # Every role here backs an agent-facing tool. Excluding one does not shrink
+    # that tool's answers, it removes the tool: the symbol index and call graph
+    # carry find_symbol/find_references/get_callers/get_callees, `sqlite_index`
+    # carries `query`.
+    for role, tools in (
+        ("python_symbol_index_json", "find_symbol/find_references"),
+        ("python_call_graph_json", "get_callers/get_callees"),
+        ("sqlite_index", "query"),
+    ):
         assert rules[role] != "profile_excluded", (
-            f"{role} is excluded from the daily publication; "
-            "find_symbol/find_references/get_callers/get_callees cannot be served"
+            f"{role} is excluded from the daily publication; {tools} cannot be served"
         )
 
-    # The storage intent of the compact profile is still honoured.
-    assert rules["sqlite_index"] == "profile_excluded"
     removed = " ".join(snapshot["removed_profile_excluded_artifacts"])
     assert "python_symbol_index" not in removed
     assert "python_call_graph" not in removed
+    assert "sqlite" not in removed
+
+
+@pytest.mark.publication_surface
+def test_query_answers_against_the_published_bundle(published_bundle):
+    """`query` must find an identifier the published bundle demonstrably contains.
+
+    This is the assertion whose absence let `sqlite_index` be dropped from the
+    daily profile: `query` kept reporting `available` while returning nothing for
+    every input, including identifiers present in the indexed source.
+    """
+    manifest_path, _, _ = published_bundle
+
+    response = mcp_tools.query_existing_index(
+        bundle_manifest=manifest_path, query="helper", k=5
+    )
+
+    assert response["status"] == "available", response.get("retrieval_infrastructure")
+    assert response["retrieval_infrastructure"]["index_resolved"] is True
+    assert response["retrieval"]["strategy"] != "none"
+    assert response["retrieval"]["match_count"] > 0
+    assert any(
+        entry.get("source_path") == "pkg/core.py"
+        for entry in response["resolved_ranges"]
+    ), response["resolved_ranges"]
+
+
+@pytest.mark.publication_surface
+def test_query_returns_no_hits_for_an_absent_term(published_bundle):
+    """A term genuinely absent from the repo must be an empty answer, not an error.
+
+    Paired with the test above this pins both directions: without it, "always
+    returns hits" would pass just as happily as a working index.
+    """
+    manifest_path, _, _ = published_bundle
+
+    response = mcp_tools.query_existing_index(
+        bundle_manifest=manifest_path, query="zzzqqqxyzabsentidentifier", k=5
+    )
+
+    assert response["status"] == "available"
+    assert response["retrieval_infrastructure"]["index_resolved"] is True
+    assert response["retrieval"]["match_count"] == 0
+    assert response["resolved_ranges"] == []
+
+
+@pytest.mark.publication_surface
+def test_query_results_depend_on_the_query(published_bundle):
+    """Different queries must produce different evidence.
+
+    `context_compose` feeds its `query_snippets` lane from these ranges, so a
+    query-independent result there is this failure one layer up: two unrelated
+    queries composed byte-identical context while the index was missing.
+    """
+    manifest_path, _, _ = published_bundle
+
+    helper_ranges = mcp_tools.query_existing_index(
+        bundle_manifest=manifest_path, query="helper", k=5
+    )["resolved_ranges"]
+    caller_ranges = mcp_tools.query_existing_index(
+        bundle_manifest=manifest_path, query="run_once", k=5
+    )["resolved_ranges"]
+
+    assert helper_ranges and caller_ranges
+    assert helper_ranges != caller_ranges
+    assert any(r.get("source_path") == "pkg/caller.py" for r in caller_ranges)
+
+
+@pytest.mark.publication_surface
+def test_query_reports_unavailable_when_the_search_index_is_absent(
+    published_bundle, tmp_path
+):
+    """Missing search infrastructure must surface, not masquerade as no results.
+
+    The profile fix restores the index; this pins the behaviour that made its
+    absence undetectable for days. A bundle without `sqlite_index` previously
+    answered `status: available` with zero hits and advised the caller to
+    rephrase — indistinguishable from a genuinely empty repository.
+    """
+    manifest_path, _, _ = published_bundle
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["artifacts"] = [
+        artifact
+        for artifact in manifest["artifacts"]
+        if artifact.get("role") != "sqlite_index"
+    ]
+    stripped = tmp_path / manifest_path.name
+    stripped.write_text(json.dumps(manifest), encoding="utf-8")
+
+    response = mcp_tools.query_existing_index(
+        bundle_manifest=stripped, query="helper", k=5
+    )
+
+    assert response["status"] == "missing"
+    infrastructure = response["retrieval_infrastructure"]
+    assert infrastructure["index_resolved"] is False
+    assert infrastructure["error_code"] == "sqlite_index_missing"
+    assert response["availability"]["status"] == "missing"
+    # The "rephrase your query" advice is actively wrong here and must not appear.
+    assert not any(
+        "Rephrase" in caveat.get("detail", "")
+        for caveat in response["answer_caveats"]
+    ), response["answer_caveats"]
 
 
 @pytest.mark.publication_surface

--- a/merger/repoground/tests/test_snapshot_profiles.py
+++ b/merger/repoground/tests/test_snapshot_profiles.py
@@ -100,29 +100,32 @@ def test_profile_rules_match_expected_high_signal_requirements():
     assert PROFILE_ARTIFACT_RULES["local-private"]["citation_map_jsonl"] == "optional"
 
 
-def test_fleet_context_preserves_citation_truth_without_heavy_indexes():
+def test_fleet_context_preserves_citation_truth():
     rules = PROFILE_ARTIFACT_RULES["fleet-context"]
 
     assert rules["citation_map_jsonl"] == "required"
     assert rules["chunk_index_jsonl"] == "required"
     assert rules["export_safety_report"] == "required"
     assert rules["retrieval_eval_json"] == "recommended"
-    assert rules["sqlite_index"] == "profile_excluded"
 
 
-def test_fleet_context_keeps_the_call_navigation_indexes():
-    """The daily fleet bundle backs find_symbol/get_callers/get_callees.
+def test_fleet_context_keeps_every_index_an_agent_tool_reads():
+    """The daily fleet bundle is what the agent-facing tools resolve against.
 
-    Excluding these two artifacts silently removed all three tools from the
-    agent-facing surface, so the compact profile must keep carrying them.
+    Each of these artifacts backs a tool rather than merely enriching one, so
+    excluding any of them removes the tool outright: the symbol index and call
+    graph carry find_symbol/find_references/get_callers/get_callees, and
+    `sqlite_index` carries `query`. Both exclusions have happened, and both
+    passed every profile-level test while the tools returned nothing.
     """
     rules = PROFILE_ARTIFACT_RULES["fleet-context"]
 
     assert rules["python_symbol_index_json"] == "recommended"
     assert rules["python_call_graph_json"] == "recommended"
+    assert rules["sqlite_index"] == "recommended"
 
 
-def test_fleet_context_accepts_the_compact_surface_and_rejects_heavy_indexes():
+def test_fleet_context_accepts_the_agent_facing_surface():
     compact_roles = {
         "canonical_md",
         "bundle_manifest",
@@ -139,14 +142,18 @@ def test_fleet_context_accepts_the_compact_surface_and_rejects_heavy_indexes():
         "python_call_graph_json",
     }
 
-    compact = evaluate_profile("fleet-context", compact_roles)
-    assert compact["status"] == "pass"
-    assert compact["missing_required"] == []
-    assert compact["profile_excluded_present"] == []
+    # `sqlite_index` is the backing store for `query`. A fleet publication that
+    # omits it still emits, but it must not evaluate as a clean pass: that is the
+    # signal which was missing while `query` silently answered nothing.
+    without_search = evaluate_profile("fleet-context", compact_roles)
+    assert without_search["status"] == "warn"
+    assert without_search["missing_required"] == []
+    assert "sqlite_index" in without_search["missing_recommended"]
 
-    invalid = evaluate_profile("fleet-context", compact_roles | {"sqlite_index"})
-    assert invalid["status"] == "fail"
-    assert invalid["profile_excluded_present"] == ["sqlite_index"]
+    with_search = evaluate_profile("fleet-context", compact_roles | {"sqlite_index"})
+    assert with_search["status"] == "pass"
+    assert with_search["missing_required"] == []
+    assert with_search["profile_excluded_present"] == []
 
 
 def test_profile_output_mode_plan_is_machine_readable():
@@ -169,8 +176,8 @@ def test_profile_output_mode_plan_is_machine_readable():
     assert fleet_default["selected_output_mode"] == "dual"
     assert fleet_default["defaulted"] is True
     assert fleet_default["conflicts"] == []
-    assert fleet_default["excluded_roles"] == ["sqlite_index"]
-    assert fleet_default["post_emit_dropped_roles"] == ["sqlite_index"]
+    assert fleet_default["excluded_roles"] == []
+    assert fleet_default["post_emit_dropped_roles"] == []
 
     fleet_archive = profile_output_mode_plan("fleet-context", "archive")
     assert fleet_archive["selected_output_mode"] == "archive"


### PR DESCRIPTION
## Was kaputt war

`repoground_query` lieferte **0 Treffer für jede Eingabe** — auch für Identifier, die im indizierten Quelltext nachweislich vorkommen — und meldete dabei `status: available` ohne Caveat.

```
query("resolve_profile_activation")  →  strategy: "none", fts_query: null, match_count: 0
```

Zwei Ursachen, beide hier behoben.

## 1. Der Index war nicht publiziert

Das tägliche `fleet-context`-Profil schloss `sqlite_index` aus. Genau gegen diesen FTS-Speicher sucht `core/ask_context.py`. Begründet war der Ausschluss im Kommentar mit *"carries the bulk of the storage cost and no agent-facing read path consumes it"*.

Gegen die Publikation vom 2026-08-07 gemessen sind **beide Hälften falsch**:

| | Größe | Anteil am 201-MB-Bundle |
|---|---|---|
| `sqlite_index` | 21,2 MB | ~10,5 % |
| `python_call_graph_json` (publiziert) | 65,1 MB | ~32 % |

Der Index baut in **0,55 s** aus dem ohnehin publizierten `chunk_index.jsonl`. Und `query` *ist* der agent-facing Consumer. Die Regel steht jetzt auf `recommended`, wie in `agent-portable`.

Gegenprobe mit vorhandenem Index: `resolve_profile_activation` → 3 Treffer statt 0.

## 2. Das Fehlen war unsichtbar

Der Profilfix allein hätte einen Rückfall wieder still gemacht. `mcp_tools` setzte `status: "available"` fest verdrahtet, weil ein Pack erzeugt wurde — und ein Pack wird auch dann erzeugt, wenn es keinen Index zu befragen gibt.

`build_ask_context_pack` leitet jetzt einen `retrieval_infrastructure`-Block aus dem Backend ab, stuft `availability` auf `missing` herab, wenn der Index nicht auflöst, und unterdrückt den Hinweis *"Rephrase with concrete code identifiers"*, der sachlich falsch ist, wenn gar nichts durchsucht wurde. Der Frontdoor-Status folgt dem Backend mit derselben `missing`/`invalid`-Vokabel wie die übrigen Read-Tools.

`availability` beschreibt den Snapshot, `retrieval_infrastructure` das Suchbackend — sie werden getrennt gehalten, weil ein Bundle einwandfrei verfügbar sein kann und trotzdem keinen Index mitführt.

## Warum das ein Muster ist

Das ist die **zweite** agent-facing Oberfläche, die eine Profiländerung still entfernt hat; die erste war die Call-Navigation (#1148). Beide Male blieben sämtliche Gates grün — `freshness: fresh_exact`, `post_emit_health: pass`, `profile_evaluation: pass` — weil Profiltests nur Regeltabellen prüfen.

Der Publication-Surface-Smoke-Test deckt jetzt `query` end-to-end gegen eine echte Publikation ab:

- ein im Quelltext vorhandener Identifier liefert Treffer
- ein tatsächlich abwesender Begriff liefert korrekt 0
- verschiedene Queries liefern verschiedene Evidenz (das speist die `query_snippets`-Lane von `context_compose`)
- ein um `sqlite_index` bereinigtes Bundle meldet `missing` statt einer leeren Antwort

**Dreht man die Profilzeile zurück, fallen vier dieser Tests.** Vorher fiel keiner.

Zusätzlich evaluiert `fleet-context` ohne den Index jetzt als `warn` statt `pass` — das Signal, das gefehlt hat.

## Verifikation

| Lauf | Ergebnis |
|---|---|
| `pytest -q -m "not browser and not doc_freshness_live"` (CI-Auswahl) | 5426 passed, 12 skipped, 13 deselected |
| `pytest -q -m browser` (separater CI-Job) | 10 passed |
| `ruff check` (geänderte Dateien) | All checks passed, unverändert zur Baseline |

Die Formatabweichung in `snapshot_profiles.py` unter `ruff format --check` besteht identisch auf `main` und wurde nicht angefasst.

## Bewusst nicht enthalten

`merger/repoground/retrieval/hybrid_activation.py` (#1157/T019) hat **keinen Produktions-Consumer** — nur einen Re-Export in `retrieval/__init__.py` und Tests; der MCP-`query`-Pfad läuft unverändert über `build_ask_context_pack`. Die Budgetierungshälfte (`select_relevance_budgeted_context`) ist dagegen echt verdrahtet. Das ist ein eigenständiges Problem und gehört nicht in diesen Fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)