### PR TITLE
fix(retrieval): bind hybrid commit to manifest provenance

### DIFF
--- a/merger/repoground/retrieval/hybrid_activation.py
+++ b/merger/repoground/retrieval/hybrid_activation.py
@@ -30,6 +30,8 @@ DOES_NOT_ESTABLISH = [
     "answer_correctness",
     "test_sufficiency",
     "merge_readiness",
+    "current_repository_git_object_presence",
+    "freshness_against_remote",
 ]
 
 
@@ -37,6 +39,14 @@ def _is_sha256(value: object) -> bool:
     return (
         isinstance(value, str)
         and len(value) == 64
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def _is_git_commit(value: object) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 40
         and all(character in "0123456789abcdef" for character in value)
     )
 
@@ -77,6 +87,81 @@ def _verify_file_binding(
         return
     if _is_sha256(declared_sha256) and observed_sha256 != declared_sha256:
         errors.append(f"{field}_sha256 must match {field}_path contents")
+
+
+def _load_bound_manifest(
+    path: str | Path,
+    declared_sha256: str,
+    *,
+    errors: list[str],
+) -> Mapping[str, Any] | None:
+    candidate = Path(path)
+    if not candidate.is_file():
+        errors.append("bundle_manifest_path must reference a readable regular file")
+        return None
+    try:
+        payload = candidate.read_bytes()
+    except OSError:
+        errors.append("bundle_manifest_path must reference a readable regular file")
+        return None
+    observed_sha256 = hashlib.sha256(payload).hexdigest()
+    if _is_sha256(declared_sha256) and observed_sha256 != declared_sha256:
+        errors.append("bundle_manifest_sha256 must match bundle_manifest_path contents")
+    try:
+        manifest = json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        errors.append("bundle_manifest_path must contain valid UTF-8 JSON")
+        return None
+    if not isinstance(manifest, Mapping):
+        errors.append("bundle_manifest_path JSON must be an object")
+        return None
+    return manifest
+
+
+def _bind_repository_commit_to_manifest(
+    manifest: Mapping[str, Any],
+    repository_commit: str,
+    *,
+    errors: list[str],
+) -> dict[str, Any] | None:
+    provenance = manifest.get("snapshot_provenance")
+    repositories = (
+        provenance.get("repositories") if isinstance(provenance, Mapping) else None
+    )
+    if not isinstance(repositories, list):
+        errors.append(
+            "bundle_manifest snapshot_provenance must record repository provenance"
+        )
+        return None
+    present = [
+        item
+        for item in repositories
+        if isinstance(item, Mapping) and item.get("provenance_status") == "present"
+    ]
+    if len(present) != 1:
+        errors.append(
+            "repository_commit binding requires exactly one present repository in "
+            "bundle_manifest snapshot_provenance"
+        )
+        return None
+    repository = present[0]
+    manifest_commit = repository.get("git_commit")
+    if not _is_git_commit(manifest_commit):
+        errors.append(
+            "bundle_manifest snapshot provenance git_commit must be a 40-character "
+            "lowercase hexadecimal commit"
+        )
+        return None
+    if _is_git_commit(repository_commit) and repository_commit != manifest_commit:
+        errors.append(
+            "repository_commit must match bundle_manifest snapshot provenance git_commit"
+        )
+    return {
+        "source": "bundle_manifest.snapshot_provenance",
+        "repository_name": repository.get("name"),
+        "provenance_status": repository.get("provenance_status"),
+        "git_commit": manifest_commit,
+    }
 
 
 def validate_model_binding(
@@ -173,20 +258,24 @@ def build_hybrid_route_binding(
         field="index",
         errors=errors,
     )
-    _verify_file_binding(
+    manifest = _load_bound_manifest(
         bundle_manifest_path,
         bundle_manifest_sha256,
-        field="bundle_manifest",
         errors=errors,
     )
-    if not (
-        isinstance(repository_commit, str)
-        and len(repository_commit) == 40
-        and all(character in "0123456789abcdef" for character in repository_commit)
-    ):
+    if not _is_git_commit(repository_commit):
         errors.append(
             "repository_commit must be a 40-character lowercase hexadecimal commit"
         )
+    repository_commit_binding = (
+        _bind_repository_commit_to_manifest(
+            manifest,
+            repository_commit,
+            errors=errors,
+        )
+        if manifest is not None
+        else None
+    )
     evidence_path = Path(routing_evidence_path).resolve()
     binding = {
         "kind": "repoground.hybrid_retrieval_binding",
@@ -207,6 +296,7 @@ def build_hybrid_route_binding(
             "sha256": bundle_manifest_sha256,
         },
         "repository_commit": repository_commit,
+        "repository_commit_binding": repository_commit_binding,
         "routing_evidence": {
             "path": str(evidence_path),
             "sha256": file_sha256(evidence_path),

--- a/merger/repoground/tests/test_t019_agent_utility.py
+++ b/merger/repoground/tests/test_t019_agent_utility.py
@@ -26,6 +26,33 @@ COMMIT = "cfd341b00c6a36125a014dbfa54cf78c8215da75"
 SHA = "a" * 64
 
 
+def _write_binding_manifest(path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "snapshot_provenance": {
+                    "version": "v1",
+                    "repositories": [
+                        {
+                            "name": "repoground",
+                            "repo_root": None,
+                            "repo_remote": "https://github.com/heimgewebe/repoground.git",
+                            "git_commit": COMMIT,
+                            "git_dirty": False,
+                            "git_branch": "main",
+                            "provenance_status": "present",
+                            "freshness_basis": "git_commit",
+                        }
+                    ],
+                    "does_not_establish": ["freshness_against_remote"],
+                }
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+
 def test_multilingual_goldset_is_complete_and_targets_real_paths() -> None:
     goldset = load_goldset(GOLDSET)
     assert validate_goldset(goldset) == []
@@ -76,7 +103,7 @@ def test_hybrid_binding_requires_exact_model_index_manifest_and_commit(
     index = tmp_path / "index.sqlite"
     manifest = tmp_path / "bundle.manifest.json"
     index.write_bytes(b"index")
-    manifest.write_text("{}", encoding="utf-8")
+    _write_binding_manifest(manifest)
     policy = {
         "model_name": "local-fixture-model",
         "dimensions": 8,
@@ -138,7 +165,7 @@ def test_runtime_activation_passes_policy_only_after_gate(
     index = tmp_path / "index.sqlite"
     manifest = tmp_path / "bundle.manifest.json"
     index.write_bytes(b"index")
-    manifest.write_text("{}", encoding="utf-8")
+    _write_binding_manifest(manifest)
     policy = {
         "model_name": "local-fixture-model",
         "dimensions": 8,

--- a/merger/repoground/tests/test_t019_hybrid_binding_integrity.py
+++ b/merger/repoground/tests/test_t019_hybrid_binding_integrity.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -12,11 +13,45 @@ COMMIT = "cfd341b00c6a36125a014dbfa54cf78c8215da75"
 SHA = "a" * 64
 
 
+def _write_manifest(
+    path: Path,
+    *,
+    commit: str = COMMIT,
+    repositories: list[dict[str, object]] | None = None,
+) -> None:
+    if repositories is None:
+        repositories = [
+            {
+                "name": "repoground",
+                "repo_root": None,
+                "repo_remote": "https://github.com/heimgewebe/repoground.git",
+                "git_commit": commit,
+                "git_dirty": False,
+                "git_branch": "main",
+                "provenance_status": "present",
+                "freshness_basis": "git_commit",
+            }
+        ]
+    path.write_text(
+        json.dumps(
+            {
+                "snapshot_provenance": {
+                    "version": "v1",
+                    "repositories": repositories,
+                    "does_not_establish": ["freshness_against_remote"],
+                }
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+
 def _valid_binding_inputs(tmp_path: Path) -> dict[str, object]:
     index = tmp_path / "index.sqlite"
     manifest = tmp_path / "bundle.manifest.json"
     index.write_bytes(b"index")
-    manifest.write_text("{}", encoding="utf-8")
+    _write_manifest(manifest)
     policy = {
         "model_name": "local-fixture-model",
         "dimensions": 8,
@@ -86,14 +121,14 @@ def test_binding_rejects_unreadable_manifest_file(
 ) -> None:
     inputs = _valid_binding_inputs(tmp_path)
     manifest = Path(inputs["bundle_manifest_path"])
-    real_file_sha256 = hybrid_activation.file_sha256
+    real_read_bytes = Path.read_bytes
 
-    def unreadable_manifest(path: str | Path) -> str:
-        if Path(path) == manifest:
+    def unreadable_manifest(path: Path) -> bytes:
+        if path == manifest:
             raise PermissionError("fixture: unreadable manifest")
-        return real_file_sha256(path)
+        return real_read_bytes(path)
 
-    monkeypatch.setattr(hybrid_activation, "file_sha256", unreadable_manifest)
+    monkeypatch.setattr(Path, "read_bytes", unreadable_manifest)
 
     binding = hybrid_activation.build_hybrid_route_binding(**inputs)
 
@@ -126,3 +161,84 @@ def test_binding_rejects_noncanonical_repository_commit(
         "repository_commit must be a 40-character lowercase hexadecimal commit"
         in binding["errors"]
     )
+
+
+def test_binding_rejects_manifest_commit_mismatch(tmp_path: Path) -> None:
+    inputs = _valid_binding_inputs(tmp_path)
+    manifest = Path(inputs["bundle_manifest_path"])
+    _write_manifest(manifest, commit="d" * 40)
+    inputs["bundle_manifest_sha256"] = hybrid_activation.file_sha256(manifest)
+
+    binding = hybrid_activation.build_hybrid_route_binding(**inputs)
+
+    assert binding["status"] == "invalid"
+    assert (
+        "repository_commit must match bundle_manifest snapshot provenance git_commit"
+        in binding["errors"]
+    )
+
+
+def test_binding_rejects_missing_manifest_provenance(tmp_path: Path) -> None:
+    inputs = _valid_binding_inputs(tmp_path)
+    manifest = Path(inputs["bundle_manifest_path"])
+    manifest.write_text("{}", encoding="utf-8")
+    inputs["bundle_manifest_sha256"] = hybrid_activation.file_sha256(manifest)
+
+    binding = hybrid_activation.build_hybrid_route_binding(**inputs)
+
+    assert binding["status"] == "invalid"
+    assert (
+        "bundle_manifest snapshot_provenance must record repository provenance"
+        in binding["errors"]
+    )
+
+
+def test_binding_rejects_ambiguous_multi_repository_manifest(tmp_path: Path) -> None:
+    inputs = _valid_binding_inputs(tmp_path)
+    manifest = Path(inputs["bundle_manifest_path"])
+    repositories = [
+        {
+            "name": "repoground",
+            "git_commit": COMMIT,
+            "provenance_status": "present",
+        },
+        {
+            "name": "other",
+            "git_commit": "d" * 40,
+            "provenance_status": "present",
+        },
+    ]
+    _write_manifest(manifest, repositories=repositories)
+    inputs["bundle_manifest_sha256"] = hybrid_activation.file_sha256(manifest)
+
+    binding = hybrid_activation.build_hybrid_route_binding(**inputs)
+
+    assert binding["status"] == "invalid"
+    assert (
+        "repository_commit binding requires exactly one present repository in "
+        "bundle_manifest snapshot_provenance"
+        in binding["errors"]
+    )
+
+
+def test_binding_records_manifest_commit_boundary_without_live_git_probe(
+    tmp_path: Path,
+) -> None:
+    inputs = _valid_binding_inputs(tmp_path)
+    manifest = Path(inputs["bundle_manifest_path"])
+    historical_commit = "d" * 40
+    _write_manifest(manifest, commit=historical_commit)
+    inputs["bundle_manifest_sha256"] = hybrid_activation.file_sha256(manifest)
+    inputs["repository_commit"] = historical_commit
+
+    binding = hybrid_activation.build_hybrid_route_binding(**inputs)
+
+    assert binding["status"] == "bound"
+    assert binding["repository_commit_binding"] == {
+        "source": "bundle_manifest.snapshot_provenance",
+        "repository_name": "repoground",
+        "provenance_status": "present",
+        "git_commit": historical_commit,
+    }
+    assert "current_repository_git_object_presence" in binding["does_not_establish"]
+    assert "freshness_against_remote" in binding["does_not_establish"]


### PR DESCRIPTION
Bureau-Task: REPOGROUND-AGENT-UTILITY-V1-T019

## Problem

T019 requires the optional hybrid retrieval lane to bind the repository commit together with its index and bundle manifest. After PR #1160, `repository_commit` was syntactically validated as 40 lowercase hex characters, but that did not bind it to the exact snapshot evidence.

## Fix

- parse the already SHA-256-bound bundle manifest from the same bytes used for digest verification
- require exactly one `provenance_status=present` repository for the current singular `repository_commit` contract
- require `repository_commit` to equal that manifest repository's `snapshot_provenance.git_commit`
- fail closed on missing/invalid provenance, commit mismatch, invalid manifest JSON, and ambiguous multi-repository manifests
- expose `repository_commit_binding` in the binding result
- explicitly state that snapshot binding does not establish current local Git-object presence or freshness against the remote
- add no Git subprocess, network dependency, or new repository-path parameter

## Why this boundary

The bundle manifest already records `snapshot_provenance.repositories[].git_commit`, produced from the repository HEAD when the snapshot is created. Binding to that hash-verified manifest proves which snapshot commit the hybrid artifacts belong to without conflating snapshot identity with today's repository or GitHub state.

## Verification

- focused T019 tests: 19 passed
- full RepoGround suite: 5446 passed, 12 skipped
- official `ruff check --config ruff-ci.toml .`: passed
- `git diff --check`: passed
- live canary against canonical fresh RepoGround bundle manifest SHA `7cc223a4944f0a83264ce70531d3a28af7e05c54817057eaf36ddffdbca04ca8`: `status=bound`, no errors, commit binding `2d3f596d46c2c50b57167e5499b21898d7835bb6`

Bureau candidate `candidate-63a3c31004b4bfb664bbe373` was assessed as `merge` into existing T019 rather than a separate task.
