### PR TITLE
fix(fleet): defer dirty managed source worktrees

### DIFF
--- a/docs/proofs/repoground-fleet-publication-v1-proof.md
+++ b/docs/proofs/repoground-fleet-publication-v1-proof.md
@@ -9,11 +9,12 @@ Bureau task: `heimgewebe/bureau#671`
 - the existing persisted state contract `repobrief.fleet-publication-state.v1` is retained and extended additively;
 - state records distinguish the generator Git commit from the generator-input digest and record the verified bundle-manifest path;
 - a successful publication is labelled only `fresh_at_publication`; a later unchanged run performs a new remote-head comparison;
-- generator preflight and per-repository failures return a non-zero process status and preserve a machine-readable `fleet-last.json` receipt.
+- generator preflight and true per-repository publication failures return a non-zero process status and preserve a machine-readable `fleet-last.json` receipt;
+- a pre-existing dirty managed source worktree is preserved and reported as `deferred`; it makes the fleet receipt visibly `warn` but does not make the whole service fail when no true publication failure occurred.
 
 ## Covered by repository tests
 
-The focused tests cover canonical input paths, independent RepoGround discovery, persisted-state field semantics, installer ordering, generator-preflight failure receipts, and an unchanged second run that creates no additional bundle and preserves publication time.
+The focused tests cover canonical input paths, independent RepoGround discovery, persisted-state field semantics, installer ordering, generator-preflight failure receipts, typed preservation of dirty managed source worktrees, non-fatal per-repository deferral, and an unchanged second run that creates no additional bundle and preserves publication time.
 
 These tests do not establish that the user service has already been installed or that live repositories have already produced fresh bundles.
 

--- a/merger/repoground/tests/test_fleet_runtime.py
+++ b/merger/repoground/tests/test_fleet_runtime.py
@@ -2627,6 +2627,121 @@ def test_regression_canonical_unit_names_and_installer_cutover_order() -> None:
     assert install_position < reload_position < enable_position
 
 
+def test_dirty_managed_worktree_is_typed_and_preserved(tmp_path: Path) -> None:
+    module = load_publisher()
+    repo, sha = initialize_repository(tmp_path)
+    worktree = tmp_path / "managed"
+    git(repo, "worktree", "add", "--detach", str(worktree), sha)
+    tracked = worktree / "tracked.txt"
+    tracked.write_text("operator-owned change\n", encoding="utf-8")
+
+    with pytest.raises(module.ManagedWorktreeDirtyError) as caught:
+        module.assert_managed_worktree_clean(worktree, repo)
+
+    assert tracked.read_text(encoding="utf-8") == "operator-owned change\n"
+    receipt = caught.value.receipt()
+    assert receipt["reason"] == "managed_worktree_dirty"
+    assert receipt["automatic_reset_authorized"] is False
+    assert receipt["status_count"] == 1
+    assert receipt["status_sample"] == [{"code": " M", "path": "tracked.txt"}]
+    assert receipt["status_truncated"] is False
+
+
+def test_dirty_source_worktree_is_deferred_without_poisoning_fleet(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    roots = isolate_retention_roots(module, tmp_path, monkeypatch)
+    monkeypatch.setattr(module, "LOCK_PATH", tmp_path / "fleet.lock")
+    monkeypatch.setattr(module, "FLEET_LOG", roots["log"] / "fleet.log")
+    repo, source_sha = initialize_repository(tmp_path, "demo")
+    source_root = tmp_path / "sources"
+    source_root.mkdir()
+    monkeypatch.setattr(module, "SOURCE_ROOT", source_root)
+    dirty_worktree = source_root / "heimgewebe__demo__main"
+    git(repo, "worktree", "add", "--detach", str(dirty_worktree), source_sha)
+    tracked = dirty_worktree / "tracked.txt"
+    tracked.write_text("operator-owned source change\n", encoding="utf-8")
+    entry = module.RepoEntry(
+        key="heimgewebe/demo",
+        owner="heimgewebe",
+        repo="demo",
+        path=repo,
+        remote="git@github.com:heimgewebe/demo.git",
+    )
+    monkeypatch.setattr(module, "discover", lambda: [entry])
+    monkeypatch.setattr(
+        module,
+        "prioritize_fleet_publication",
+        lambda entries: (entries, {"policy": "test"}),
+    )
+    monkeypatch.setattr(
+        module,
+        "reconcile_prune_transactions",
+        lambda *, protected, apply: {"status": "ok"},
+    )
+    monkeypatch.setattr(module, "ensure_tool_worktree", lambda: ("b" * 40, "c" * 64))
+    monkeypatch.setattr(
+        module,
+        "remote_head",
+        lambda path: ("origin/main", "main", source_sha),
+    )
+    monkeypatch.setattr(
+        module,
+        "publish",
+        lambda *args, **kwargs: pytest.fail("deferred repository must not publish"),
+    )
+
+    assert module.main(["--repo", "heimgewebe/demo"]) == 0
+    assert tracked.read_text(encoding="utf-8") == "operator-owned source change\n"
+    receipt = json.loads((roots["log"] / "fleet-last.json").read_text(encoding="utf-8"))
+    assert receipt["status"] == "warn"
+    assert receipt["deferred"] == 1
+    assert receipt["failed"] == 0
+    detail = receipt["details"][0]
+    assert detail["status"] == "deferred"
+    assert detail["deferred_reason"] == "managed_source_worktree_dirty"
+    assert detail["managed_source_worktree"] == {
+        "reason": "managed_worktree_dirty",
+        "worktree": str(dirty_worktree),
+        "status_count": 1,
+        "status_sample": [{"code": " M", "path": "tracked.txt"}],
+        "status_truncated": False,
+        "automatic_reset_authorized": False,
+    }
+
+
+def test_dirty_generator_worktree_remains_a_hard_preflight_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    roots = isolate_retention_roots(module, tmp_path, monkeypatch)
+    monkeypatch.setattr(module, "LOCK_PATH", tmp_path / "fleet.lock")
+    monkeypatch.setattr(module, "FLEET_LOG", roots["log"] / "fleet.log")
+    entry = module.RepoEntry(
+        key="heimgewebe/demo",
+        owner="heimgewebe",
+        repo="demo",
+        path=tmp_path / "demo",
+        remote="git@github.com:heimgewebe/demo.git",
+    )
+    monkeypatch.setattr(module, "discover", lambda: [entry])
+    dirty_tool = tmp_path / "tool-worktree"
+
+    def dirty_generator() -> tuple[str, str]:
+        raise module.ManagedWorktreeDirtyError(dirty_tool, [(" M", "generator.py")])
+
+    monkeypatch.setattr(module, "ensure_tool_worktree", dirty_generator)
+
+    assert module.main(["--repo", "heimgewebe/demo"]) == 1
+    receipt = json.loads((roots["log"] / "fleet-last.json").read_text(encoding="utf-8"))
+    assert receipt["status"] == "error"
+    assert receipt["phase"] == "generator_preflight"
+    assert receipt["failed"] == 1
+    assert "managed worktree is not clean" in receipt["error"]
+    assert "deferred" not in receipt
+
+
 def test_managed_build_blocker_is_structured_in_fleet_receipt(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/scripts/ops/repoground-publish-fleet
+++ b/scripts/ops/repoground-publish-fleet
@@ -167,6 +167,34 @@ class PrunePlan:
     bytes: int
 
 
+class ManagedWorktreeDirtyError(RuntimeError):
+    """Preserve semantic changes in a managed worktree instead of resetting them."""
+
+    def __init__(self, path: Path, status: list[tuple[str, str]]) -> None:
+        self.path = path
+        self.status_count = len(status)
+        self.status_sample = tuple(status[:20])
+        sample = "\n".join(
+            f"{code} {relative}" for code, relative in self.status_sample
+        )
+        super().__init__(
+            f"managed worktree is not clean; refusing reset or cleanup: {path}\n{sample}"
+        )
+
+    def receipt(self) -> dict[str, object]:
+        return {
+            "reason": "managed_worktree_dirty",
+            "worktree": str(self.path),
+            "status_count": self.status_count,
+            "status_sample": [
+                {"code": code, "path": relative}
+                for code, relative in self.status_sample
+            ],
+            "status_truncated": self.status_count > len(self.status_sample),
+            "automatic_reset_authorized": False,
+        }
+
+
 def run(
     argv: list[str],
     cwd: Path | None = None,
@@ -1747,12 +1775,7 @@ def cleanup_managed_disposable_artifacts(path: Path, expected_repo: Path) -> lis
     for code, relative in status:
         artifact = managed_disposable_artifact_root(relative)
         if code not in {"??", "!!"} or artifact is None:
-            sample = "\n".join(
-                f"{row_code} {row_path}" for row_code, row_path in status[:20]
-            )
-            raise RuntimeError(
-                f"managed worktree is not clean; refusing reset or cleanup: {path}\n{sample}"
-            )
+            raise ManagedWorktreeDirtyError(path, status)
         roots.add(artifact)
     assert_managed_worktree_idle(path)
     retained: list[Path] = []
@@ -1787,10 +1810,7 @@ def assert_managed_worktree_clean(path: Path, expected_repo: Path) -> None:
     assert_managed_worktree_identity(path, expected_repo)
     status = managed_worktree_status(path)
     if status:
-        sample = "\n".join(f"{code} {relative}" for code, relative in status[:20])
-        raise RuntimeError(
-            f"managed worktree is not clean; refusing reset or cleanup: {path}\n{sample}"
-        )
+        raise ManagedWorktreeDirtyError(path, status)
 
 
 def generation_environment(cache_root: Path) -> dict[str, str]:
@@ -3544,7 +3564,8 @@ def main(argv: list[str]) -> int:
             log(f"GENERATOR-PREFLIGHT-FAILED: {exc}")
             print(json.dumps(summary, indent=2, sort_keys=True))
             return 1
-        changed = published = skipped = failed = queued = retained = prune_failed = 0
+        changed = published = skipped = failed = queued = retained = deferred = 0
+        prune_failed = 0
         details: list[dict[str, object]] = []
         protected: set[Path] = set()
         reconciliation = reconcile_prune_transactions(protected=protected, apply=True)
@@ -3671,6 +3692,21 @@ def main(argv: list[str]) -> int:
                 if source_hygiene_cleanup:
                     published_detail["source_hygiene_cleanup"] = source_hygiene_cleanup
                 details.append(published_detail)
+            except ManagedWorktreeDirtyError as exc:
+                deferred += 1
+                details.append(
+                    {
+                        "repo": entry.key,
+                        "status": "deferred",
+                        "deferred_reason": "managed_source_worktree_dirty",
+                        "managed_source_worktree": exc.receipt(),
+                    }
+                )
+                log(
+                    f"DEFERRED {entry.key}: managed source worktree is dirty; "
+                    "automatic reset refused"
+                )
+                continue
             except Exception as exc:
                 residue_blocker = parse_managed_build_blocker(exc)
                 if (
@@ -3698,7 +3734,7 @@ def main(argv: list[str]) -> int:
                 details.append(failed_detail)
                 log(f"FAILED {entry.key}: {exc}")
         summary: dict[str, object] = {
-            "status": "warn" if failed or retained else "ok",
+            "status": "warn" if failed or retained or deferred else "ok",
             "mode": mode,
             "count": len(entries),
             "changed": changed,
@@ -3706,6 +3742,7 @@ def main(argv: list[str]) -> int:
             "skipped": skipped,
             "queued": queued,
             "retained": retained,
+            "deferred": deferred,
             "failed": failed,
             "prune_failed": prune_failed,
             "retention": args.retention,
@@ -3730,6 +3767,7 @@ def main(argv: list[str]) -> int:
                         "skipped",
                         "queued",
                         "retained",
+                        "deferred",
                         "failed",
                         "prune_failed",
                         "retention",


### PR DESCRIPTION
## Problem
The hourly fleet publisher has repeatedly exited 1 because one managed Bureau source worktree contains pre-existing operator-owned changes. RepoGround correctly refuses to reset that worktree, but the fleet loop classified this safe refusal as a publisher failure, making the entire systemd service red even while other repositories continued to publish.

## Change
- introduce a typed `ManagedWorktreeDirtyError` with bounded machine-readable evidence
- preserve pre-existing dirty managed source worktrees and report the repository as `deferred`
- keep the fleet receipt visibly `warn`, but return success when there are no true publication failures
- keep generator preflight failures and publisher-created worktree dirtiness hard failures
- never authorize or perform an automatic reset of semantic source changes

## Verification
- real Git regression: dirty managed source worktree remains byte-for-byte unchanged and the repository is deferred
- generator dirty-worktree path remains a hard preflight failure
- `python3 -B -m pytest -p no:cacheprovider merger/repoground/tests/test_fleet_runtime.py` → 92 passed
- `python3 -B -m ruff check scripts/ops/repoground-publish-fleet merger/repoground/tests/test_fleet_runtime.py` → all checks passed
- `git diff --check` → clean
