### PR TITLE
fix(retrieval): preserve Unicode in relaxed ask tokens

### DIFF
--- a/merger/repoground/core/ask_context.py
+++ b/merger/repoground/core/ask_context.py
@@ -101,7 +101,7 @@ def _content_tokens(query: str) -> list[str]:
     """Deterministic, order-preserving content tokens for relaxed retrieval."""
     tokens: list[str] = []
     seen: set[str] = set()
-    for token in re.findall(r"[a-z0-9_]+", query.lower()):
+    for token in re.findall(r"\b\w+\b", query.lower()):
         # Retain the original identifier and additionally expose its snake_case
         # parts.  FTS tokenizers differ in their underscore handling; the OR
         # fallback must be deterministic across both behaviours.

--- a/merger/repoground/tests/test_ask_retrieval_resilience.py
+++ b/merger/repoground/tests/test_ask_retrieval_resilience.py
@@ -84,6 +84,13 @@ def test_content_tokens_drop_stopwords_and_dedupe():
     assert _content_tokens("how does the is are") == []
 
 
+def test_content_tokens_preserve_unicode_words_for_or_fallback():
+    assert _content_tokens("Wie funktioniert die Übergabe?") == [
+        "funktioniert",
+        "übergabe",
+    ]
+
+
 def test_content_tokens_adds_deterministic_snake_case_parts_for_or_fallback():
     assert _content_tokens("How does build_live_repo_address work?") == [
         "build_live_repo_address",


### PR DESCRIPTION
## Summary
- preserve Unicode word characters in the relaxed ask-retrieval token fallback
- add a regression test for German umlaut terms such as `Übergabe`
- keep existing stopword, deduplication, and snake_case expansion semantics unchanged

## Reproduction
On `main` at `f7f4a0ac074f9fe47e3034b7dec8e71e7915d244`, `Wie funktioniert die Übergabe?` produced relaxed FTS tokens `"funktioniert" OR "bergabe"`. Against SQLite FTS5 `unicode61` content containing `Die Übergabe ist dokumentiert.`, that fallback returned 0 hits; `"übergabe"` returned 1.

## Verification
- regression test demonstrated red before the code change (`bergabe` vs `übergabe`)
- `test_ask_retrieval_resilience.py`: 8 passed
- related ask/routing suites: 22 passed
- `test_ask_context_cli.py`: 6 passed
- targeted Ruff: passed
- `git diff --check`: passed
- SQLite FTS5 reproduction after fix: 1 hit

Implementation is one tokenization-line change plus the regression test.