### PR TITLE
fix(retrieval): normalize decomposed ask tokens

### DIFF
--- a/merger/repoground/core/ask_context.py
+++ b/merger/repoground/core/ask_context.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+import unicodedata
 from pathlib import Path
 from typing import Any
 
@@ -101,7 +102,8 @@ def _content_tokens(query: str) -> list[str]:
     """Deterministic, order-preserving content tokens for relaxed retrieval."""
     tokens: list[str] = []
     seen: set[str] = set()
-    for token in re.findall(r"\b\w+\b", query.lower()):
+    normalized_query = unicodedata.normalize("NFC", query)
+    for token in re.findall(r"\b\w+\b", normalized_query.lower()):
         # Retain the original identifier and additionally expose its snake_case
         # parts.  FTS tokenizers differ in their underscore handling; the OR
         # fallback must be deterministic across both behaviours.

--- a/merger/repoground/tests/test_ask_retrieval_resilience.py
+++ b/merger/repoground/tests/test_ask_retrieval_resilience.py
@@ -9,6 +9,8 @@ Covers two guarantees added on top of the deterministic FTS retrieval:
   tasks do not have to parse it out of the excerpt text.
 """
 
+import unicodedata
+
 from merger.repoground.core.ask_context import (
     _content_tokens,
     _or_fts_query,
@@ -86,6 +88,15 @@ def test_content_tokens_drop_stopwords_and_dedupe():
 
 def test_content_tokens_preserve_unicode_words_for_or_fallback():
     assert _content_tokens("Wie funktioniert die Übergabe?") == [
+        "funktioniert",
+        "übergabe",
+    ]
+
+
+def test_content_tokens_normalize_decomposed_unicode_for_or_fallback():
+    query = unicodedata.normalize("NFD", "Wie funktioniert die Übergabe?")
+
+    assert _content_tokens(query) == [
         "funktioniert",
         "übergabe",
     ]


### PR DESCRIPTION
## Summary
- normalize relaxed ask-retrieval input to NFC before Unicode tokenization
- preserve canonically equivalent NFD text such as `U` + combining diaeresis as the intended token `übergabe`
- keep ranking, stopwords, snake_case expansion, and FTS strategy unchanged

## Reproduction
On `main` at `628b2030a8124f1578f8ab4c67e5e369e3c44e26`, the visible query `Wie funktioniert die Übergabe?` behaved differently depending only on Unicode encoding:
- NFC: tokens `funktioniert`, `übergabe`; SQLite FTS5 `unicode61` hit count = 1
- NFD: tokens `funktioniert`, `u`, `bergabe`; hit count = 0

## Verification
- regression test demonstrated red before the code change (`u`, `bergabe` vs `übergabe`)
- retrieval resilience suite: 9 passed
- related ask/routing suites: 28 passed
- all `test_ask*.py`: 29 passed
- NFC/NFD token invariants checked for `Übergabe`, `Größe geprüft`, `café`, `Ångström`, and snake_case identifiers
- targeted Ruff: passed
- `git diff --check`: passed
- SQLite FTS5 NFD reproduction after fix: 1 hit

The implementation is deliberately narrow: NFC normalization immediately before the existing Unicode-aware token regex.