### PR TITLE
feat(retrieval): harden call graph confidence and config relations

### DIFF
--- a/docs/proofs/repoground-agent-utility-t020-proof.md
+++ b/docs/proofs/repoground-agent-utility-t020-proof.md
@@ -1,0 +1,86 @@
+# RepoGround Agent Utility T020 proof
+
+Task: `REPOGROUND-AGENT-UTILITY-V1-T020`
+
+Base commit: `be022b1f40f9955f17001d426a655d4f427531c0`
+
+## Scope
+
+T020 hardens the existing static Python call-graph surface without pretending that a static graph is complete runtime truth.
+
+The current base already resolves the representative direct, imported-alias and module-alias Python cases. T020 therefore leaves the call-graph producer unchanged and hardens the consumer boundary instead:
+
+- one shared coverage/confidence projection reports resolved/candidate/ambiguous/unresolved ratios and unresolved reasons;
+- task-profile thresholds expose an explicit completeness caveat when observed static resolution is insufficient for that use;
+- skipped Python files force profile confidence to `insufficient` even when every observed edge resolved;
+- Config/Schema/Workflow evidence is modeled in the system-relation overlay, not as Python `calls` edges;
+- schema/config contract relations are provenance-bound S1 declarations and fail closed when the target endpoint kind is wrong.
+
+## Fixed goldset
+
+`docs/retrieval/repoground_agent_utility_t020_goldset.v1.json` binds T020 to the existing Python call-graph goldset and to fixed structural-relation fixtures.
+
+Required Python cases include:
+
+- direct local helper;
+- imported alias;
+- module alias / qualified call;
+- dynamic higher-order call;
+- ambiguous conditional definition.
+
+The machine evaluation of `python_call_graph_goldset.v1.json` on this base reported:
+
+- cases: 13/13 passing;
+- S1 precision: `1.0`;
+- target recall: `1.0`;
+- false positives: `0`;
+- false negatives: `0`;
+- true positives: `9`;
+- unresolved records: `4` (`0.307692` share);
+- skipped Python files: `0`.
+
+The T020 structural fixture additionally proves independent `declares_config`, `references_config`, and `validates_schema` relation families. Config relations have `contract_identity.kind=config`, target `config_contract`, S1 declared evidence and never become `calls` or `constructs` relations.
+
+## Coverage and confidence boundary
+
+`call_graph_coverage_confidence()` is deliberately a coverage proxy, not statistical confidence. It exposes:
+
+- `resolved_ratio` and per-status ratios;
+- unresolved counts by status and reason;
+- `skipped_files_count`;
+- task-profile assessments for basic questions, review, change impact, relevant-test search and grounding;
+- explicit caveats when a threshold is not met.
+
+Compatibility is retained for existing navigation consumers (`scope=observed_call_edges`; all observed edges resolved may still report `completeness=complete`). The stronger `model_scope=observed_static_python_call_edges` and nonclaims make clear what that word does not mean.
+
+The projection explicitly does **not** establish complete call graphs, caller/callee completeness, irrelevance of unresolved edges, runtime reachability or behaviour, statistical confidence, test sufficiency, change impact outside the model, review completeness or merge readiness.
+
+## Scale regression
+
+The existing fixed call-navigation benchmark was run with 50,000 synthetic calls and byte-equivalence enabled.
+
+Observed on the Heim-PC (CPython 3.10.12, x86_64, 32 logical CPUs):
+
+- status: `PASS`;
+- linear vs indexed response byte-equivalence: `true`;
+- process-local index build: `308.438 ms`;
+- indexed warm query-batch median: `53.131 ms`;
+- linear warm query-batch median: `811.245 ms`;
+- warm speedup: `15.2688x`;
+- persisted-sidecar warm median: `55.895 ms`.
+
+This benchmark does not establish performance on every machine/repository, runtime call-graph completeness or dynamic-dispatch coverage.
+
+## Regression checks
+
+Final focused regression selection before commit:
+
+- `211 passed, 10 skipped` across T020 goldset, system relations, impact context, call navigation, Python call graph and Python call-graph goldset;
+- targeted Ruff checks: pass;
+- `git diff --check`: pass.
+
+A repository-wide local pytest run progressed without reported failures through 44% but was cancelled after an unrelated long-running test stopped progress for several minutes. It is therefore **not** counted as passing evidence; pull-request CI remains the repository-wide authority.
+
+## Remaining boundary
+
+`system_relation_overlay` consumes already-collected, digest-bound relation evidence. It does not itself scan repositories for Config/Workflow relations. T020 establishes the typed, provenance-bound truth model and validation boundary; automatic collection is a separate producer concern and must not be inferred from this proof.

--- a/docs/retrieval/repoground_agent_utility_t020_goldset.v1.json
+++ b/docs/retrieval/repoground_agent_utility_t020_goldset.v1.json
@@ -1,0 +1,128 @@
+{
+  "kind": "repoground.agent_utility_t020_goldset",
+  "version": "1.0",
+  "task_id": "REPOGROUND-AGENT-UTILITY-V1-T020",
+  "python_call_goldset": "docs/retrieval/python_call_graph_goldset.v1.json",
+  "required_python_case_ids": [
+    "direct-local-helper",
+    "imported-normalize-alias",
+    "module-normalize-alias",
+    "dynamic-higher-order-call",
+    "ambiguous-conditional-definition"
+  ],
+  "required_python_metrics": {
+    "minimum_s1_precision": 0.97,
+    "minimum_target_recall": 1.0,
+    "maximum_false_positive_count": 0
+  },
+  "structural_relation_evidence": {
+    "kind": "repoground.system_relation_evidence",
+    "version": "1.0",
+    "producer": {
+      "name": "repoground-agent-utility-t020-goldset",
+      "version": "1.0"
+    },
+    "records": [
+      {
+        "relation": "declares_config",
+        "subject": {
+          "kind": "repository",
+          "identity": "heimgewebe/repoground"
+        },
+        "target": {
+          "kind": "config_contract",
+          "identity": "repoground.runtime"
+        },
+        "source": {
+          "path": "pyproject.toml",
+          "kind": "manifest",
+          "range": {
+            "start_line": 18,
+            "start_character": 0,
+            "end_line": 18,
+            "end_character": 80
+          }
+        },
+        "evidence_class": "config_declaration",
+        "contract_identity": {
+          "kind": "config",
+          "id": "repoground.runtime",
+          "version": "1.0"
+        }
+      },
+      {
+        "relation": "references_config",
+        "subject": {
+          "kind": "workflow",
+          "identity": ".github/workflows/release.yml"
+        },
+        "target": {
+          "kind": "config_contract",
+          "identity": "repoground.runtime"
+        },
+        "source": {
+          "path": ".github/workflows/release.yml",
+          "kind": "workflow",
+          "range": {
+            "start_line": 31,
+            "start_character": 0,
+            "end_line": 31,
+            "end_character": 80
+          }
+        },
+        "evidence_class": "workflow_config_reference",
+        "contract_identity": {
+          "kind": "config",
+          "id": "repoground.runtime",
+          "version": "1.0"
+        }
+      },
+      {
+        "relation": "validates_schema",
+        "subject": {
+          "kind": "validator",
+          "identity": "merger.repoground.core.relation_card_validate.validate_relation_card"
+        },
+        "target": {
+          "kind": "schema_contract",
+          "identity": "relation-card.v1"
+        },
+        "source": {
+          "path": "merger/repoground/core/relation_card_validate.py",
+          "kind": "source_file",
+          "range": {
+            "start_line": 42,
+            "start_character": 0,
+            "end_line": 42,
+            "end_character": 80
+          }
+        },
+        "evidence_class": "schema_validation_call",
+        "contract_identity": {
+          "kind": "schema",
+          "id": "https://repoground.merger/schemas/relation-card.v1.json",
+          "version": "1.0"
+        }
+      }
+    ]
+  },
+  "expected_structural_relations": [
+    "declares_config",
+    "references_config",
+    "validates_schema"
+  ],
+  "expected_structural_nonclaims": [
+    "schema_conformance",
+    "config_runtime_effect",
+    "runtime_behavior",
+    "relation_completeness"
+  ],
+  "scale_gate": {
+    "synthetic_call_count": 50000,
+    "requires_byte_equivalence": true,
+    "does_not_establish": [
+      "performance_on_all_machines",
+      "runtime_call_graph_completeness"
+    ]
+  }
+}

--- a/merger/repoground/contracts/system-relation-overlay.v1.schema.json
+++ b/merger/repoground/contracts/system-relation-overlay.v1.schema.json
@@ -76,6 +76,7 @@
         "artifact_freshness",
         "runtime_behavior",
         "runtime_correctness",
+        "config_runtime_effect",
         "relation_completeness",
         "default_promotion"
       ]
@@ -102,7 +103,9 @@
         "test_registration",
         "validates_schema",
         "produces_artifact",
-        "consumes_artifact"
+        "consumes_artifact",
+        "declares_config",
+        "references_config"
       ]
     },
     "evidence_class": {
@@ -113,7 +116,9 @@
         "test_import_or_reference",
         "test_naming_heuristic",
         "schema_validation_call",
-        "artifact_declaration"
+        "artifact_declaration",
+        "config_declaration",
+        "workflow_config_reference"
       ]
     },
     "endpoint_kind": {
@@ -129,7 +134,8 @@
         "artifact_producer",
         "artifact_consumer",
         "artifact_contract",
-        "workflow"
+        "workflow",
+        "config_contract"
       ]
     },
     "endpoint": {
@@ -164,7 +170,8 @@
             "workflow",
             "test_registry",
             "source_file",
-            "artifact_contract"
+            "artifact_contract",
+            "config_file"
           ]
         },
         "range": {"$ref": "#/definitions/range"}
@@ -228,6 +235,20 @@
             "level": {"const": "S1"},
             "strength": {"const": "declared"}
           }
+        },
+        {
+          "properties": {
+            "class": {"const": "config_declaration"},
+            "level": {"const": "S1"},
+            "strength": {"const": "declared"}
+          }
+        },
+        {
+          "properties": {
+            "class": {"const": "workflow_config_reference"},
+            "level": {"const": "S1"},
+            "strength": {"const": "declared"}
+          }
         }
       ]
     },
@@ -236,7 +257,7 @@
       "additionalProperties": false,
       "required": ["kind", "id", "version"],
       "properties": {
-        "kind": {"enum": ["schema", "artifact"]},
+        "kind": {"enum": ["schema", "artifact", "config"]},
         "id": {"type": "string", "minLength": 1, "maxLength": 4096},
         "version": {"type": "string", "minLength": 1, "maxLength": 128}
       }
@@ -323,6 +344,9 @@
               "source": {
                 "properties": {"kind": {"const": "source_file"}}
               },
+              "target": {
+                "properties": {"kind": {"const": "schema_contract"}}
+              },
               "contract_identity": {
                 "type": "object",
                 "properties": {"kind": {"const": "schema"}}
@@ -356,6 +380,50 @@
               "contract_identity": {
                 "type": "object",
                 "properties": {"kind": {"const": "artifact"}}
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {"relation": {"const": "declares_config"}}
+          },
+          "then": {
+            "properties": {
+              "evidence": {
+                "properties": {"class": {"const": "config_declaration"}}
+              },
+              "source": {
+                "properties": {"kind": {"enum": ["manifest", "config_file"]}}
+              },
+              "target": {
+                "properties": {"kind": {"const": "config_contract"}}
+              },
+              "contract_identity": {
+                "type": "object",
+                "properties": {"kind": {"const": "config"}}
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {"relation": {"const": "references_config"}}
+          },
+          "then": {
+            "properties": {
+              "evidence": {
+                "properties": {"class": {"const": "workflow_config_reference"}}
+              },
+              "source": {
+                "properties": {"kind": {"const": "workflow"}}
+              },
+              "target": {
+                "properties": {"kind": {"const": "config_contract"}}
+              },
+              "contract_identity": {
+                "type": "object",
+                "properties": {"kind": {"const": "config"}}
               }
             }
           }

--- a/merger/repoground/core/agent_impact_context.py
+++ b/merger/repoground/core/agent_impact_context.py
@@ -13,6 +13,9 @@ from pathlib import PurePosixPath
 from typing import Any
 
 from merger.repoground.architecture.path_classification import is_test_path as _is_test_path
+from merger.repoground.core.call_graph_confidence import (
+    call_graph_coverage_confidence as _shared_call_graph_coverage,
+)
 
 KIND = "repobrief.agent_impact_context"
 VERSION = "1.0"
@@ -1859,6 +1862,9 @@ def build_agent_impact_context(
     unresolved_risks: list[dict[str, Any]] = []
     call_graph_coverage_gaps: list[dict[str, Any]] = []
     edit_selection: dict[str, Any] = {}
+    call_graph_coverage = (
+        _shared_call_graph_coverage(call_graph) if call_graph else {}
+    )
     # Impact consumers need trusted call relations as evidence, but edit-only
     # selection, unresolved-risk projection and coverage-gap semantics stay
     # confined to edit mode. Missing optional call graphs therefore do not
@@ -1878,6 +1884,24 @@ def build_agent_impact_context(
             expected_run_id=run_id,
             expected_digest=digest,
         )
+        if request.mode == "edit":
+            assessment = _mapping(
+                _mapping(call_graph_coverage.get("task_profile_confidence")).get(
+                    "change_impact"
+                )
+            )
+            if (
+                assessment.get("status") != "sufficient"
+                and call_graph_coverage.get("skipped_files_count") == 0
+            ):
+                call_graph_coverage_gaps.append(
+                    {
+                        "kind": "call_graph_confidence_gap",
+                        "task_profile": "change_impact",
+                        "assessment": dict(assessment),
+                        "coverage_reason": "call_graph_below_task_profile_boundary",
+                    }
+                )
 
     if request.mode == "impact":
         impact_call_relations = direct_callers + direct_callees
@@ -1958,6 +1982,7 @@ def build_agent_impact_context(
                 "changed_test_paths_establish_coverage": False,
                 "current_read_evidence_from_graph_or_symbols_only": True,
                 "query_context_used": bool(_query_items(query_context)),
+                "call_graph_coverage": call_graph_coverage if call_graph else None,
             },
         }
     )
@@ -1982,6 +2007,7 @@ def build_agent_impact_context(
             ),
             "selection": edit_selection,
             "nonverdicts": list(_EDIT_CONTEXT_NONVERDICTS),
+            "call_graph_coverage": call_graph_coverage,
             "call_graph_coverage_gaps": call_graph_coverage_gaps,
             "relation_count": len(relations),
             "direct_caller_count": len(direct_callers),

--- a/merger/repoground/core/call_graph_confidence.py
+++ b/merger/repoground/core/call_graph_confidence.py
@@ -1,0 +1,179 @@
+"""Conservative call-graph coverage and task-profile confidence boundaries.
+
+This module scores only the static resolution surface already present in a
+``python_call_graph_json`` document. The score is a coverage proxy, not a
+statistical confidence estimate and not evidence of runtime completeness.
+"""
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from collections.abc import Mapping
+from typing import Any
+
+RESOLUTION_STATUSES = ("resolved", "candidate", "ambiguous", "unresolved")
+TASK_PROFILE_MIN_RESOLVED_RATIO = {
+    "basic_repo_question": 0.50,
+    "review": 0.80,
+    "change_impact": 0.75,
+    "find_relevant_tests": 0.70,
+    "ground_claim": 0.90,
+}
+DOES_NOT_ESTABLISH = (
+    "complete_call_graph",
+    "caller_completeness",
+    "callee_completeness",
+    "unresolved_edges_are_irrelevant",
+    "runtime_reachability",
+    "runtime_behavior",
+    "statistical_confidence",
+    "test_sufficiency",
+    "change_impact_outside_the_model",
+    "review_completeness",
+    "merge_readiness",
+)
+
+
+def _ratio(value: int, total: int) -> float | None:
+    return round(value / total, 6) if total > 0 else None
+
+
+def _counts(data: Mapping[str, Any]) -> dict[str, int] | None:
+    raw = data.get("resolution_counts")
+    if not isinstance(raw, Mapping):
+        return None
+    counts: dict[str, int] = {}
+    for status in RESOLUTION_STATUSES:
+        value = raw.get(status, 0)
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            return None
+        counts[status] = value
+    return counts
+
+
+def _unresolved_causes(data: Mapping[str, Any]) -> dict[str, dict[str, int]]:
+    causes: dict[str, Counter[str]] = defaultdict(Counter)
+    calls = data.get("calls")
+    if not isinstance(calls, list):
+        return {}
+    for call in calls:
+        if not isinstance(call, Mapping):
+            continue
+        status = call.get("resolution_status")
+        if status not in RESOLUTION_STATUSES or status == "resolved":
+            continue
+        reason = call.get("resolution_reason")
+        label = reason if isinstance(reason, str) and reason else "unspecified"
+        causes[str(status)][label] += 1
+    return {
+        status: dict(sorted(counter.items()))
+        for status, counter in sorted(causes.items())
+    }
+
+
+def _profile_assessments(
+    *,
+    resolved_ratio: float | None,
+    skipped_files_count: int,
+) -> dict[str, dict[str, Any]]:
+    assessments: dict[str, dict[str, Any]] = {}
+    for profile, threshold in TASK_PROFILE_MIN_RESOLVED_RATIO.items():
+        if resolved_ratio is None:
+            status = "unknown"
+            caveat = "No observed call edges are available for a coverage judgement."
+        elif skipped_files_count > 0:
+            status = "insufficient"
+            caveat = (
+                "Python files were skipped during parsing; repository-wide call "
+                "completeness cannot be inferred."
+            )
+        elif resolved_ratio < threshold:
+            status = "insufficient"
+            caveat = (
+                f"Observed resolved ratio {resolved_ratio:.6f} is below the "
+                f"{profile} threshold {threshold:.2f}."
+            )
+        else:
+            status = "sufficient"
+            caveat = None
+        assessments[profile] = {
+            "status": status,
+            "minimum_resolved_ratio": threshold,
+            "observed_resolved_ratio": resolved_ratio,
+            "completeness_caveat": caveat,
+        }
+    return assessments
+
+
+def call_graph_coverage_confidence(data: Mapping[str, Any]) -> dict[str, Any]:
+    """Project ratios, causes and explicit task-profile confidence boundaries."""
+    counts = _counts(data)
+    skipped = data.get("skipped_files_count", 0)
+    skipped_files_count = (
+        skipped
+        if isinstance(skipped, int) and not isinstance(skipped, bool) and skipped >= 0
+        else 0
+    )
+    if counts is None:
+        return {
+            "scope": "observed_call_edges",
+            "model_scope": "observed_static_python_call_edges",
+            "completeness": "unknown",
+            "reason": "call_graph_resolution_counts_unavailable",
+            "resolved_call_edges": None,
+            "total_call_edges": None,
+            "resolved_ratio": None,
+            "status_ratios": {status: None for status in RESOLUTION_STATUSES},
+            "unresolved_by_status": {},
+            "unresolved_by_reason": {},
+            "skipped_files_count": skipped_files_count,
+            "confidence_model": "observed_resolution_coverage_proxy",
+            "task_profile_confidence": _profile_assessments(
+                resolved_ratio=None,
+                skipped_files_count=skipped_files_count,
+            ),
+            "does_not_establish": list(DOES_NOT_ESTABLISH),
+        }
+
+    total = sum(counts.values())
+    resolved = counts["resolved"]
+    resolved_ratio = _ratio(resolved, total)
+    unresolved_by_status = {
+        status: value
+        for status, value in counts.items()
+        if status != "resolved" and value
+    }
+    if total <= 0:
+        completeness = "unknown"
+    elif unresolved_by_status or skipped_files_count:
+        completeness = "partial"
+    else:
+        completeness = "complete"
+    return {
+        "scope": "observed_call_edges",
+        "model_scope": "observed_static_python_call_edges",
+        "completeness": completeness,
+        "reason": None,
+        "resolved_call_edges": resolved,
+        "total_call_edges": total,
+        "resolved_ratio": resolved_ratio,
+        "status_ratios": {
+            status: _ratio(value, total) for status, value in counts.items()
+        },
+        "unresolved_by_status": unresolved_by_status,
+        "unresolved_by_reason": _unresolved_causes(data),
+        "skipped_files_count": skipped_files_count,
+        "confidence_model": "observed_resolution_coverage_proxy",
+        "task_profile_confidence": _profile_assessments(
+            resolved_ratio=resolved_ratio,
+            skipped_files_count=skipped_files_count,
+        ),
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }
+
+
+__all__ = [
+    "DOES_NOT_ESTABLISH",
+    "RESOLUTION_STATUSES",
+    "TASK_PROFILE_MIN_RESOLVED_RATIO",
+    "call_graph_coverage_confidence",
+]

--- a/merger/repoground/core/call_graph_navigation.py
+++ b/merger/repoground/core/call_graph_navigation.py
@@ -24,6 +24,9 @@ from merger.repoground.architecture.call_graph_contract import (
     REQUIRED_NONCLAIMS as CALL_GRAPH_REQUIRED_NONCLAIMS,
 )
 from merger.repoground.core import call_graph_validation as _call_graph_validation
+from merger.repoground.core.call_graph_confidence import (
+    call_graph_coverage_confidence as _shared_call_graph_coverage,
+)
 from merger.repoground.core.call_navigation_index import (
     CallNavigationIndex,
     SymbolNavigationIndex,
@@ -110,15 +113,6 @@ _CALL_GRAPH_DOES_NOT_ESTABLISH = CALL_GRAPH_PRODUCER_NONCLAIMS
 
 _CALL_NAV_DOES_NOT_ESTABLISH = tuple(
     dict.fromkeys([*_DOES_NOT_ESTABLISH, *_CALL_GRAPH_DOES_NOT_ESTABLISH])
-)
-# A caller or callee list is bounded by the resolved share of the call graph.
-# These are the claims a partial graph cannot support even when the returned
-# rows themselves are correct.
-_CALL_GRAPH_COVERAGE_DOES_NOT_ESTABLISH = (
-    "complete_call_graph",
-    "caller_completeness",
-    "callee_completeness",
-    "unresolved_edges_are_irrelevant",
 )
 _CALL_NAVIGATION_CACHE_MAX_ENTRIES = 2
 
@@ -534,55 +528,7 @@ def _detached_record(value: Any) -> dict[str, Any] | None:
 
 
 def _call_graph_coverage(data: dict[str, Any]) -> dict[str, Any]:
-    """State how much of the call graph actually resolved.
-
-    Only `resolved` edges can produce callers or callees. Every other status is
-    an edge the resolver saw but could not bind, so a caller or callee list is
-    complete only relative to the resolved share. Reporting that share beside
-    the results keeps a partial answer from reading as an exhaustive one.
-    """
-    raw = data.get("resolution_counts")
-    if not isinstance(raw, Mapping):
-        return {
-            "scope": "observed_call_edges",
-            "completeness": "unknown",
-            "reason": "call_graph_resolution_counts_unavailable",
-            "resolved_call_edges": None,
-            "total_call_edges": None,
-            "resolved_ratio": None,
-            "unresolved_by_status": {},
-            "does_not_establish": list(_CALL_GRAPH_COVERAGE_DOES_NOT_ESTABLISH),
-        }
-
-    counts = {
-        status: int(raw.get(status) or 0) for status in CALL_RESOLUTION_STATUSES
-    }
-    resolved = counts.get("resolved", 0)
-    total = sum(counts.values())
-    unresolved_by_status = {
-        status: value
-        for status, value in counts.items()
-        if status != "resolved" and value
-    }
-    if total <= 0:
-        completeness = "unknown"
-        ratio = None
-    elif not unresolved_by_status:
-        completeness = "complete"
-        ratio = 1.0
-    else:
-        completeness = "partial"
-        ratio = round(resolved / total, 6)
-    return {
-        "scope": "observed_call_edges",
-        "completeness": completeness,
-        "reason": None,
-        "resolved_call_edges": resolved,
-        "total_call_edges": total,
-        "resolved_ratio": ratio,
-        "unresolved_by_status": unresolved_by_status,
-        "does_not_establish": list(_CALL_GRAPH_COVERAGE_DOES_NOT_ESTABLISH),
-    }
+    return _shared_call_graph_coverage(data)
 
 
 def _call_graph_metadata(data: dict[str, Any]) -> dict[str, Any]:

--- a/merger/repoground/core/system_relation_overlay.py
+++ b/merger/repoground/core/system_relation_overlay.py
@@ -35,6 +35,7 @@ ENDPOINT_KINDS = frozenset(
         "artifact_consumer",
         "artifact_contract",
         "workflow",
+        "config_contract",
     }
 )
 
@@ -46,6 +47,8 @@ EVIDENCE_PROFILES = {
     "test_naming_heuristic": ("S0", "heuristic"),
     "schema_validation_call": ("S1", "declared"),
     "artifact_declaration": ("S1", "declared"),
+    "config_declaration": ("S1", "declared"),
+    "workflow_config_reference": ("S1", "declared"),
 }
 
 SOURCE_KINDS_BY_EVIDENCE = {
@@ -60,6 +63,8 @@ SOURCE_KINDS_BY_EVIDENCE = {
     "artifact_declaration": frozenset(
         {"manifest", "workflow", "source_file", "artifact_contract"}
     ),
+    "config_declaration": frozenset({"manifest", "config_file"}),
+    "workflow_config_reference": frozenset({"workflow"}),
 }
 
 RELATION_RULES = {
@@ -84,6 +89,7 @@ RELATION_RULES = {
     "validates_schema": {
         "evidence": frozenset({"schema_validation_call"}),
         "contract_kind": "schema",
+        "target_kind": "schema_contract",
     },
     "produces_artifact": {
         "evidence": frozenset({"artifact_declaration"}),
@@ -92,6 +98,16 @@ RELATION_RULES = {
     "consumes_artifact": {
         "evidence": frozenset({"artifact_declaration"}),
         "contract_kind": "artifact",
+    },
+    "declares_config": {
+        "evidence": frozenset({"config_declaration"}),
+        "contract_kind": "config",
+        "target_kind": "config_contract",
+    },
+    "references_config": {
+        "evidence": frozenset({"workflow_config_reference"}),
+        "contract_kind": "config",
+        "target_kind": "config_contract",
     },
 }
 
@@ -109,6 +125,7 @@ DOES_NOT_ESTABLISH = (
     "artifact_freshness",
     "runtime_behavior",
     "runtime_correctness",
+    "config_runtime_effect",
     "relation_completeness",
     "default_promotion",
 )
@@ -294,10 +311,17 @@ def _normalize_record(value: Any, *, index: int) -> dict[str, Any]:
             f"evidence_class {evidence_class!r} is incompatible with relation {relation!r}"
         )
     evidence_level, evidence_strength = EVIDENCE_PROFILES[evidence_class]
+    subject = _endpoint(mapping["subject"], label="subject")
+    target = _endpoint(mapping["target"], label="target")
+    expected_target_kind = rule.get("target_kind")
+    if expected_target_kind is not None and target["kind"] != expected_target_kind:
+        raise SystemRelationOverlayError(
+            f"target.kind must be {expected_target_kind!r} for relation {relation!r}"
+        )
     record = {
         "relation": relation,
-        "subject": _endpoint(mapping["subject"], label="subject"),
-        "target": _endpoint(mapping["target"], label="target"),
+        "subject": subject,
+        "target": target,
         "source": _source(mapping["source"], evidence_class=evidence_class),
         "evidence": {
             "class": evidence_class,

--- a/merger/repoground/tests/test_agent_impact_context.py
+++ b/merger/repoground/tests/test_agent_impact_context.py
@@ -428,6 +428,29 @@ def test_agent_impact_context_is_schema_valid_and_deterministic() -> None:
     assert set(DOES_NOT_ESTABLISH) <= set(first["does_not_establish"])
 
 
+def test_edit_context_exposes_task_profile_call_graph_confidence() -> None:
+    result = _context()
+
+    coverage = result["edit_context"]["call_graph_coverage"]
+    assert coverage["resolved_ratio"] == 0.75
+    assert coverage["status_ratios"] == {
+        "resolved": 0.75,
+        "candidate": 0.25,
+        "ambiguous": 0.0,
+        "unresolved": 0.0,
+    }
+    assert coverage["unresolved_by_reason"] == {
+        "candidate": {"name_match_not_unique": 1}
+    }
+    assert coverage["task_profile_confidence"]["change_impact"] == {
+        "status": "sufficient",
+        "minimum_resolved_ratio": 0.75,
+        "observed_resolved_ratio": 0.75,
+        "completeness_caveat": None,
+    }
+    assert result["composition"]["call_graph_coverage"] == coverage
+
+
 def test_target_symbols_preserve_requested_path_diversity_before_filling() -> None:
     test_path = "scripts/ci/tests/test_kubernetes_platform_contract.py"
     source_path = "scripts/platform/kind_reference.py"

--- a/merger/repoground/tests/test_agent_utility_t020_goldset.py
+++ b/merger/repoground/tests/test_agent_utility_t020_goldset.py
@@ -1,0 +1,146 @@
+import hashlib
+import json
+from pathlib import Path
+
+import jsonschema
+
+from merger.repoground.architecture.call_graph_quality_eval import (
+    evaluate_python_call_graph_goldset,
+)
+from merger.repoground.core.call_graph_confidence import call_graph_coverage_confidence
+from merger.repoground.core.system_relation_overlay import normalize_system_relation_evidence
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+GOLDSET_PATH = REPO_ROOT / "docs/retrieval/repoground_agent_utility_t020_goldset.v1.json"
+OVERLAY_SCHEMA = (
+    REPO_ROOT / "merger/repoground/contracts/system-relation-overlay.v1.schema.json"
+)
+
+
+def _load_goldset() -> dict:
+    return json.loads(GOLDSET_PATH.read_text(encoding="utf-8"))
+
+
+def _canonical_sha256(value: object) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def test_t020_goldset_binds_python_resolution_and_structural_relation_evidence() -> None:
+    goldset = _load_goldset()
+    python_goldset = REPO_ROOT / goldset["python_call_goldset"]
+    report = evaluate_python_call_graph_goldset(python_goldset)
+    cases = {case["id"]: case for case in report["cases"]}
+
+    assert goldset["task_id"] == "REPOGROUND-AGENT-UTILITY-V1-T020"
+    assert set(goldset["required_python_case_ids"]) <= set(cases)
+    assert all(cases[case_id]["passed"] for case_id in goldset["required_python_case_ids"])
+    thresholds = goldset["required_python_metrics"]
+    assert report["metrics"]["s1_precision"] >= thresholds["minimum_s1_precision"]
+    assert report["metrics"]["target_recall"] >= thresholds["minimum_target_recall"]
+    assert report["metrics"]["false_positive_count"] <= thresholds["maximum_false_positive_count"]
+
+    evidence = goldset["structural_relation_evidence"]
+    overlay = normalize_system_relation_evidence(
+        evidence,
+        evidence_sha256=_canonical_sha256(evidence),
+        repository_commit="b" * 40,
+    )
+    jsonschema.validate(
+        overlay,
+        json.loads(OVERLAY_SCHEMA.read_text(encoding="utf-8")),
+    )
+    assert overlay["status"] == "available"
+    assert overlay["relation_kinds"] == goldset["expected_structural_relations"]
+    assert set(goldset["expected_structural_nonclaims"]) <= set(
+        overlay["does_not_establish"]
+    )
+
+    config_records = [
+        record
+        for record in overlay["records"]
+        if record["contract_identity"]
+        and record["contract_identity"]["kind"] == "config"
+    ]
+    assert {record["relation"] for record in config_records} == {
+        "declares_config",
+        "references_config",
+    }
+    assert all(record["relation"] not in {"calls", "constructs"} for record in config_records)
+    assert all(record["evidence"]["level"] == "S1" for record in config_records)
+
+
+def test_t020_confidence_boundaries_expose_ratios_causes_and_profile_caveats() -> None:
+    graph = {
+        "resolution_counts": {
+            "resolved": 7,
+            "candidate": 1,
+            "ambiguous": 1,
+            "unresolved": 1,
+        },
+        "calls": [
+            {
+                "resolution_status": "candidate",
+                "resolution_reason": "name_match_not_unique",
+            },
+            {
+                "resolution_status": "ambiguous",
+                "resolution_reason": "local_module_function_multiple_definitions",
+            },
+            {
+                "resolution_status": "unresolved",
+                "resolution_reason": "dynamic_callee_expression",
+            },
+        ],
+        "skipped_files_count": 0,
+    }
+
+    coverage = call_graph_coverage_confidence(graph)
+
+    assert coverage["resolved_ratio"] == 0.7
+    assert coverage["status_ratios"] == {
+        "resolved": 0.7,
+        "candidate": 0.1,
+        "ambiguous": 0.1,
+        "unresolved": 0.1,
+    }
+    assert coverage["unresolved_by_reason"] == {
+        "ambiguous": {"local_module_function_multiple_definitions": 1},
+        "candidate": {"name_match_not_unique": 1},
+        "unresolved": {"dynamic_callee_expression": 1},
+    }
+    assert coverage["task_profile_confidence"]["basic_repo_question"]["status"] == "sufficient"
+    assert coverage["task_profile_confidence"]["find_relevant_tests"]["status"] == "sufficient"
+    for profile in ("change_impact", "review", "ground_claim"):
+        assessment = coverage["task_profile_confidence"][profile]
+        assert assessment["status"] == "insufficient"
+        assert "below" in assessment["completeness_caveat"]
+    assert "statistical_confidence" in coverage["does_not_establish"]
+    assert "change_impact_outside_the_model" in coverage["does_not_establish"]
+
+
+def test_t020_skipped_python_files_force_profile_caveats() -> None:
+    coverage = call_graph_coverage_confidence(
+        {
+            "resolution_counts": {
+                "resolved": 10,
+                "candidate": 0,
+                "ambiguous": 0,
+                "unresolved": 0,
+            },
+            "calls": [],
+            "skipped_files_count": 1,
+        }
+    )
+
+    assert coverage["completeness"] == "partial"
+    assert coverage["resolved_ratio"] == 1.0
+    assert all(
+        assessment["status"] == "insufficient"
+        for assessment in coverage["task_profile_confidence"].values()
+    )
+    assert all(
+        "skipped" in assessment["completeness_caveat"]
+        for assessment in coverage["task_profile_confidence"].values()
+    )

--- a/merger/repoground/tests/test_system_relation_overlay.py
+++ b/merger/repoground/tests/test_system_relation_overlay.py
@@ -159,6 +159,38 @@ def _evidence() -> dict:
                     "version": "1.0",
                 },
             ),
+            _record(
+                "declares_config",
+                "repository",
+                "heimgewebe/repoground",
+                "config_contract",
+                "repoground.runtime",
+                "pyproject.toml",
+                "manifest",
+                18,
+                "config_declaration",
+                {
+                    "kind": "config",
+                    "id": "repoground.runtime",
+                    "version": "1.0",
+                },
+            ),
+            _record(
+                "references_config",
+                "workflow",
+                ".github/workflows/release.yml",
+                "config_contract",
+                "repoground.runtime",
+                ".github/workflows/release.yml",
+                "workflow",
+                31,
+                "workflow_config_reference",
+                {
+                    "kind": "config",
+                    "id": "repoground.runtime",
+                    "version": "1.0",
+                },
+            ),
         ],
     }
 
@@ -187,12 +219,14 @@ def test_projects_all_relation_families_with_fixed_navigation_boundary():
     assert artifact["authority"] == "navigation_index"
     assert artifact["canonicality"] == "derived"
     assert artifact["risk_class"] == "navigation"
-    assert artifact["record_count"] == 8
+    assert artifact["record_count"] == 10
     assert artifact["relation_kinds"] == [
         "build_target",
         "consumes_artifact",
+        "declares_config",
         "package_target",
         "produces_artifact",
+        "references_config",
         "test_registration",
         "validates_schema",
     ]
@@ -211,6 +245,7 @@ def test_projects_all_relation_families_with_fixed_navigation_boundary():
     assert "test_sufficiency" in artifact["does_not_establish"]
     assert "schema_conformance" in artifact["does_not_establish"]
     assert "artifact_materialization" in artifact["does_not_establish"]
+    assert "config_runtime_effect" in artifact["does_not_establish"]
     assert "not evidence that the relation is absent" in artifact["absence_semantics"]
 
 
@@ -273,6 +308,45 @@ def test_schema_and_artifact_relations_preserve_contract_identity():
     )
 
 
+def test_config_relations_are_typed_separately_from_python_calls():
+    records = [
+        record
+        for record in _artifact()["records"]
+        if record["relation"] in {"declares_config", "references_config"}
+    ]
+
+    assert [record["relation"] for record in records] == [
+        "declares_config",
+        "references_config",
+    ]
+    assert all(record["contract_identity"]["kind"] == "config" for record in records)
+    assert all(record["target"]["kind"] == "config_contract" for record in records)
+    assert all(record["relation"] not in {"calls", "constructs"} for record in records)
+    assert records[0]["source"]["path"] == "pyproject.toml"
+    assert records[1]["source"]["path"] == ".github/workflows/release.yml"
+
+
+@pytest.mark.parametrize(
+    ("relation", "expected_target_kind"),
+    [
+        ("validates_schema", "schema_contract"),
+        ("declares_config", "config_contract"),
+        ("references_config", "config_contract"),
+    ],
+)
+def test_contract_relations_reject_wrong_target_kind(relation, expected_target_kind):
+    evidence = _evidence()
+    record = next(item for item in evidence["records"] if item["relation"] == relation)
+    record["target"]["kind"] = "repository"
+
+    with pytest.raises(SystemRelationOverlayError, match=f"target.kind must be '{expected_target_kind}'"):
+        normalize_system_relation_evidence(
+            evidence,
+            evidence_sha256=EVIDENCE_SHA,
+            repository_commit=REPOSITORY_COMMIT,
+        )
+
+
 def test_output_and_record_ids_are_deterministic_under_input_reordering():
     first = _evidence()
     second = copy.deepcopy(first)
@@ -292,7 +366,7 @@ def test_exact_duplicates_are_deduplicated_and_reported():
     artifact = _artifact(evidence)
 
     assert artifact["status"] == "degraded"
-    assert artifact["record_count"] == 8
+    assert artifact["record_count"] == 10
     assert artifact["degradations"] == [
         {
             "code": "duplicate_records_deduplicated",


### PR DESCRIPTION
## Summary

Implements `REPOGROUND-AGENT-UTILITY-V1-T020` on base `be022b1f40f9955f17001d426a655d4f427531c0`.

- centralizes static call-graph coverage/confidence reporting with resolved/candidate/ambiguous/unresolved ratios, causes and task-profile caveats;
- keeps the existing navigation compatibility surface while making the static-model boundary explicit;
- adds typed, provenance-bound Config/Workflow relations to the existing system-relation overlay and strengthens Schema target typing;
- keeps Config/Schema/Workflow relations separate from Python call edges;
- adds a fixed T020 goldset and proof document;
- preserves explicit nonclaims: graph coverage is not runtime truth, test sufficiency, out-of-model impact, review completeness or merge readiness.

## Evidence

- focused final regression: `211 passed, 10 skipped`;
- targeted Ruff: pass;
- staged `git diff --check`: pass;
- Python call-graph goldset: S1 precision `1.0`, target recall `1.0`, false positives `0`, false negatives `0`;
- fixed 50k-call navigation benchmark: byte-equivalent responses, process-local index build `308.438 ms`, warm indexed batch `53.131 ms` vs linear `811.245 ms` (~`15.27x` speedup).

The repository-wide local pytest run was deliberately not counted as passing evidence: it reached 44% without reported failures, then stalled in an unrelated long-running test and was cancelled. PR CI is the repository-wide authority.

## Boundary

`system_relation_overlay` validates already-collected, digest-bound structural evidence. Automatic Config/Workflow evidence collection is a separate producer concern and is not claimed by T020.

Proof: `docs/proofs/repoground-agent-utility-t020-proof.md`