### PR TITLE
feat(ops): add legacy source preflight inventory

### DIFF
--- a/merger/repoground/tests/test_legacy_source_inventory.py
+++ b/merger/repoground/tests/test_legacy_source_inventory.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / "scripts/ops/repoground-legacy-source-inventory"
+
+
+def _git(cwd: Path, *args: str) -> str:
+    completed = subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "RepoGround Test",
+            "GIT_AUTHOR_EMAIL": "repoground@example.invalid",
+            "GIT_COMMITTER_NAME": "RepoGround Test",
+            "GIT_COMMITTER_EMAIL": "repoground@example.invalid",
+            "GIT_OPTIONAL_LOCKS": "0",
+        },
+    )
+    return completed.stdout.strip()
+
+
+def _init_repo(path: Path) -> None:
+    path.mkdir(parents=True)
+    _git(path, "init", "-q")
+    (path / "tracked.txt").write_text("base\n", encoding="utf-8")
+    _git(path, "add", "tracked.txt")
+    _git(path, "commit", "-qm", "base")
+
+
+def _run(
+    legacy_root: Path,
+    canonical_root: Path,
+    proc_root: Path,
+) -> dict:
+    proc_root.mkdir(parents=True, exist_ok=True)
+    completed = subprocess.run(
+        [
+            str(SCRIPT),
+            "--root",
+            str(legacy_root),
+            "--canonical-root",
+            str(canonical_root),
+            "--proc-root",
+            str(proc_root),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(completed.stdout)
+
+
+@pytest.fixture
+def roots(tmp_path: Path) -> tuple[Path, Path, Path]:
+    legacy = tmp_path / ".repobrief-sources"
+    canonical = tmp_path / "repos"
+    proc = tmp_path / "proc"
+    legacy.mkdir()
+    canonical.mkdir()
+    proc.mkdir()
+    return legacy, canonical, proc
+
+
+def test_inventory_is_deterministic_and_advisory(
+    roots: tuple[Path, Path, Path],
+) -> None:
+    legacy, canonical, proc = roots
+    _init_repo(legacy / "owner__zeta__main")
+    _init_repo(legacy / "owner__alpha__main")
+
+    first = _run(legacy, canonical, proc)
+    second = _run(legacy, canonical, proc)
+
+    assert first == second
+    assert [item["name"] for item in first["entries"]] == [
+        "owner__alpha__main",
+        "owner__zeta__main",
+    ]
+    assert first["authority"] == "advisory-only"
+    assert first["lease_check_required"] is True
+    assert "lease_clearance" in first["does_not_establish"]
+    assert "deletion_authority" in first["does_not_establish"]
+
+
+def test_clean_independent_repo_is_only_a_preflight_candidate(
+    roots: tuple[Path, Path, Path],
+) -> None:
+    legacy, canonical, proc = roots
+    _init_repo(legacy / "owner__sample__main")
+
+    payload = _run(legacy, canonical, proc)
+    item = payload["entries"][0]
+
+    assert item["git_state"] == "clean"
+    assert item["shared_common_dir"] is False
+    assert item["canonical_checkout"]["exists"] is False
+    assert item["preflight_candidate"] is True
+    assert item["lease_check_required"] is True
+    assert item["authority"] == "advisory-only"
+    assert "deletion_authority" in item["does_not_establish"]
+    assert "safe_to_delete" not in item
+
+
+def test_dirty_repo_is_blocked(roots: tuple[Path, Path, Path]) -> None:
+    legacy, canonical, proc = roots
+    repo = legacy / "owner__sample__main"
+    _init_repo(repo)
+    (repo / "tracked.txt").write_text("dirty\n", encoding="utf-8")
+
+    payload = _run(legacy, canonical, proc)
+    item = payload["entries"][0]
+
+    assert item["git_state"] == "dirty"
+    assert item["preflight_candidate"] is False
+
+
+def test_linked_worktree_and_shared_canonical_common_dir_are_blocked(
+    roots: tuple[Path, Path, Path],
+) -> None:
+    legacy, canonical, proc = roots
+    source = canonical / "sample"
+    _init_repo(source)
+    linked = legacy / "owner__sample__main"
+    _git(source, "worktree", "add", "--detach", str(linked), "HEAD")
+
+    payload = _run(legacy, canonical, proc)
+    item = payload["entries"][0]
+
+    assert item["shared_common_dir"] is True
+    assert item["canonical_checkout"]["exists"] is True
+    assert item["canonical_checkout"]["shares_git_common_dir"] is True
+    assert item["preflight_candidate"] is False
+
+
+def test_non_git_directory_fails_closed(
+    roots: tuple[Path, Path, Path],
+) -> None:
+    legacy, canonical, proc = roots
+    (legacy / "owner__notes__main").mkdir()
+
+    payload = _run(legacy, canonical, proc)
+    item = payload["entries"][0]
+
+    assert item["git_repository"] is False
+    assert item["git_state"] == "unknown"
+    assert item["preflight_candidate"] is False
+    assert item["errors"]
+
+
+def test_process_cwd_conflict_blocks_candidate(
+    roots: tuple[Path, Path, Path],
+) -> None:
+    legacy, canonical, proc = roots
+    repo = legacy / "owner__sample__main"
+    _init_repo(repo)
+    pid = proc / "123"
+    pid.mkdir()
+    (pid / "cwd").symlink_to(repo)
+
+    payload = _run(legacy, canonical, proc)
+    item = payload["entries"][0]
+
+    assert item["process_cwd_conflicts"] == [
+        {"pid": 123, "cwd": str(repo.resolve())}
+    ]
+    assert item["preflight_candidate"] is False
+
+
+def test_incomplete_process_scan_fails_closed(
+    roots: tuple[Path, Path, Path],
+) -> None:
+    legacy, canonical, proc = roots
+    _init_repo(legacy / "owner__sample__main")
+    for pid in ("1", "2"):
+        pid_dir = proc / pid
+        pid_dir.mkdir()
+        (pid_dir / "cwd").symlink_to("/")
+
+    completed = subprocess.run(
+        [
+            str(SCRIPT),
+            "--root",
+            str(legacy),
+            "--canonical-root",
+            str(canonical),
+            "--proc-root",
+            str(proc),
+            "--max-proc-entries",
+            "1",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(completed.stdout)
+    item = payload["entries"][0]
+
+    assert payload["process_scan"]["complete"] is False
+    assert item["process_scan_complete"] is False
+    assert item["preflight_candidate"] is False
+    assert "process_scan_incomplete" in item["errors"]

--- a/scripts/ops/repoground-legacy-source-inventory
+++ b/scripts/ops/repoground-legacy-source-inventory
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""Read-only inventory for legacy RepoBrief fleet source checkouts.
+
+This tool is deliberately advisory. It gathers filesystem, Git and process
+evidence but never grants deletion authority and never interprets Grabowski
+leases.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+DEFAULT_ROOT = Path("/home/alex/repos/.repobrief-sources")
+DEFAULT_CANONICAL_ROOT = Path("/home/alex/repos")
+DEFAULT_PROC_ROOT = Path("/proc")
+DEFAULT_MAX_PROC_ENTRIES = 4096
+GIT_TIMEOUT_SECONDS = 5
+DOES_NOT_ESTABLISH = [
+    "lease_clearance",
+    "deletion_authority",
+    "cross_host_process_clearance",
+]
+
+
+def _run_git(path: Path, *args: str) -> tuple[bool, str, str]:
+    env = os.environ.copy()
+    env["GIT_OPTIONAL_LOCKS"] = "0"
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(path), *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=GIT_TIMEOUT_SECONDS,
+            env=env,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return False, "", f"{type(exc).__name__}: {exc}"
+    return completed.returncode == 0, completed.stdout, completed.stderr.strip()
+
+
+def _resolve_git_path(base: Path, raw: str) -> Path:
+    value = Path(raw.strip())
+    if not value.is_absolute():
+        value = base / value
+    return value.resolve(strict=False)
+
+
+def _infer_repo_name(entry_name: str) -> str | None:
+    parts = entry_name.split("__", 2)
+    if len(parts) != 3 or not parts[1]:
+        return None
+    return parts[1]
+
+
+def _parse_worktree_paths(output: str) -> list[Path]:
+    paths: list[Path] = []
+    for line in output.splitlines():
+        if line.startswith("worktree "):
+            paths.append(Path(line.removeprefix("worktree ")).resolve(strict=False))
+    return paths
+
+
+def _is_within(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _scan_process_cwds(proc_root: Path, max_entries: int) -> dict[str, Any]:
+    records: list[dict[str, Any]] = []
+    errors: list[str] = []
+    complete = True
+    try:
+        pid_dirs = sorted(
+            (p for p in proc_root.iterdir() if p.name.isdigit()),
+            key=lambda p: int(p.name),
+        )
+    except OSError as exc:
+        return {
+            "complete": False,
+            "records": [],
+            "errors": [f"proc_root_unreadable:{type(exc).__name__}"],
+            "scanned": 0,
+            "available": False,
+        }
+
+    if len(pid_dirs) > max_entries:
+        complete = False
+        errors.append(f"process_limit_exceeded:{len(pid_dirs)}>{max_entries}")
+        pid_dirs = pid_dirs[:max_entries]
+
+    for pid_dir in pid_dirs:
+        cwd_link = pid_dir / "cwd"
+        try:
+            target = os.readlink(cwd_link)
+        except FileNotFoundError:
+            # Processes race with /proc enumeration. Disappearance is not an
+            # evidence gap because the process no longer holds a live cwd.
+            continue
+        except (PermissionError, OSError) as exc:
+            complete = False
+            errors.append(f"pid_{pid_dir.name}_cwd_unreadable:{type(exc).__name__}")
+            continue
+        cwd = Path(target)
+        if not cwd.is_absolute():
+            cwd = (pid_dir / cwd).resolve(strict=False)
+        else:
+            cwd = cwd.resolve(strict=False)
+        records.append({"pid": int(pid_dir.name), "cwd": str(cwd)})
+
+    return {
+        "complete": complete,
+        "records": records,
+        "errors": errors,
+        "scanned": len(pid_dirs),
+        "available": True,
+    }
+
+
+def _git_inventory(entry: Path) -> dict[str, Any]:
+    errors: list[str] = []
+    inside_ok, inside_out, inside_err = _run_git(
+        entry, "rev-parse", "--is-inside-work-tree"
+    )
+    if not inside_ok or inside_out.strip() != "true":
+        if inside_err:
+            errors.append("git_probe_failed")
+        return {
+            "git_repository": False,
+            "git_state": "unknown",
+            "head": None,
+            "git_common_dir": None,
+            "worktree_paths": [],
+            "shared_common_dir": None,
+            "errors": errors or ["not_a_git_worktree"],
+        }
+
+    head_ok, head_out, _ = _run_git(entry, "rev-parse", "HEAD")
+    if not head_ok:
+        errors.append("head_unreadable")
+
+    common_ok, common_out, _ = _run_git(entry, "rev-parse", "--git-common-dir")
+    common_dir = None
+    if common_ok and common_out.strip():
+        common_dir = _resolve_git_path(entry, common_out)
+    else:
+        errors.append("git_common_dir_unreadable")
+
+    status_ok, status_out, _ = _run_git(
+        entry, "status", "--porcelain=v1", "--untracked-files=normal"
+    )
+    if status_ok:
+        git_state = "clean" if not status_out else "dirty"
+    else:
+        git_state = "unknown"
+        errors.append("git_status_unreadable")
+
+    worktrees_ok, worktrees_out, _ = _run_git(entry, "worktree", "list", "--porcelain")
+    worktree_paths: list[Path] = []
+    shared_common_dir: bool | None = None
+    if worktrees_ok:
+        worktree_paths = _parse_worktree_paths(worktrees_out)
+        entry_resolved = entry.resolve(strict=False)
+        related = [path for path in worktree_paths if path != entry_resolved]
+        shared_common_dir = bool(related)
+    else:
+        errors.append("git_worktree_list_unreadable")
+
+    return {
+        "git_repository": True,
+        "git_state": git_state,
+        "head": head_out.strip() if head_ok else None,
+        "git_common_dir": str(common_dir) if common_dir is not None else None,
+        "worktree_paths": [str(path) for path in worktree_paths],
+        "shared_common_dir": shared_common_dir,
+        "errors": errors,
+    }
+
+
+def _canonical_inventory(
+    entry_name: str,
+    canonical_root: Path,
+    legacy_git: dict[str, Any],
+) -> dict[str, Any]:
+    repo_name = _infer_repo_name(entry_name)
+    if repo_name is None:
+        return {
+            "repo_name": None,
+            "path": None,
+            "exists": None,
+            "git_common_dir": None,
+            "shares_git_common_dir": None,
+            "error": "repo_name_unparseable",
+        }
+
+    canonical = (canonical_root / repo_name).resolve(strict=False)
+    if not canonical.exists():
+        return {
+            "repo_name": repo_name,
+            "path": str(canonical),
+            "exists": False,
+            "git_common_dir": None,
+            "shares_git_common_dir": False,
+            "error": None,
+        }
+
+    ok, out, _ = _run_git(canonical, "rev-parse", "--git-common-dir")
+    if not ok or not out.strip():
+        return {
+            "repo_name": repo_name,
+            "path": str(canonical),
+            "exists": True,
+            "git_common_dir": None,
+            "shares_git_common_dir": None,
+            "error": "canonical_git_common_dir_unreadable",
+        }
+
+    canonical_common = _resolve_git_path(canonical, out)
+    legacy_common = legacy_git.get("git_common_dir")
+    shares = (
+        Path(legacy_common).resolve(strict=False) == canonical_common
+        if legacy_common
+        else None
+    )
+    return {
+        "repo_name": repo_name,
+        "path": str(canonical),
+        "exists": True,
+        "git_common_dir": str(canonical_common),
+        "shares_git_common_dir": shares,
+        "error": None,
+    }
+
+
+def _entry_inventory(
+    entry: Path,
+    canonical_root: Path,
+    process_scan: dict[str, Any],
+) -> dict[str, Any]:
+    resolved = entry.resolve(strict=False)
+    git_info = _git_inventory(entry)
+    canonical = _canonical_inventory(entry.name, canonical_root, git_info)
+
+    process_conflicts = [
+        record
+        for record in process_scan["records"]
+        if _is_within(Path(record["cwd"]), resolved)
+    ]
+    process_conflicts.sort(key=lambda item: item["pid"])
+
+    errors = list(git_info["errors"])
+    if canonical["error"]:
+        errors.append(canonical["error"])
+    if not process_scan["complete"]:
+        errors.append("process_scan_incomplete")
+
+    preflight_candidate = bool(
+        git_info["git_repository"]
+        and git_info["git_state"] == "clean"
+        and git_info["shared_common_dir"] is False
+        and canonical["shares_git_common_dir"] is False
+        and process_scan["complete"]
+        and not process_conflicts
+        and not errors
+    )
+
+    return {
+        "name": entry.name,
+        "path": str(resolved),
+        "exists": entry.exists(),
+        "is_directory": entry.is_dir(),
+        "git_repository": git_info["git_repository"],
+        "git_state": git_info["git_state"],
+        "head": git_info["head"],
+        "git_common_dir": git_info["git_common_dir"],
+        "worktree_paths": git_info["worktree_paths"],
+        "shared_common_dir": git_info["shared_common_dir"],
+        "canonical_checkout": canonical,
+        "process_cwd_conflicts": process_conflicts,
+        "process_scan_complete": process_scan["complete"],
+        "preflight_candidate": preflight_candidate,
+        "lease_check_required": True,
+        "authority": "advisory-only",
+        "does_not_establish": DOES_NOT_ESTABLISH,
+        "errors": sorted(set(errors)),
+    }
+
+
+def build_inventory(
+    root: Path,
+    canonical_root: Path,
+    proc_root: Path,
+    max_proc_entries: int,
+) -> dict[str, Any]:
+    root = root.resolve(strict=False)
+    canonical_root = canonical_root.resolve(strict=False)
+    proc_root = proc_root.resolve(strict=False)
+    process_scan = _scan_process_cwds(proc_root, max_proc_entries)
+
+    root_errors: list[str] = []
+    entries: list[dict[str, Any]] = []
+    try:
+        children = sorted(
+            (child for child in root.iterdir() if child.is_dir()),
+            key=lambda child: child.name,
+        )
+    except OSError as exc:
+        children = []
+        root_errors.append(f"legacy_root_unreadable:{type(exc).__name__}")
+
+    for child in children:
+        entries.append(_entry_inventory(child, canonical_root, process_scan))
+
+    return {
+        "schema_version": 1,
+        "root": str(root),
+        "canonical_root": str(canonical_root),
+        "authority": "advisory-only",
+        "lease_check_required": True,
+        "does_not_establish": DOES_NOT_ESTABLISH,
+        "process_scan": {
+            "proc_root": str(proc_root),
+            "complete": process_scan["complete"],
+            "available": process_scan["available"],
+            "scanned": process_scan["scanned"],
+            "error_count": len(process_scan["errors"]),
+            "errors": process_scan["errors"],
+        },
+        "summary": {
+            "entry_count": len(entries),
+            "preflight_candidate_count": sum(
+                1 for item in entries if item["preflight_candidate"]
+            ),
+            "blocked_count": sum(
+                1 for item in entries if not item["preflight_candidate"]
+            ),
+        },
+        "entries": entries,
+        "errors": root_errors,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Read-only advisory inventory of legacy RepoBrief source checkouts. "
+            "This command never grants deletion authority."
+        )
+    )
+    parser.add_argument("--root", type=Path, default=DEFAULT_ROOT)
+    parser.add_argument("--canonical-root", type=Path, default=DEFAULT_CANONICAL_ROOT)
+    parser.add_argument("--proc-root", type=Path, default=DEFAULT_PROC_ROOT)
+    parser.add_argument(
+        "--max-proc-entries",
+        type=int,
+        default=DEFAULT_MAX_PROC_ENTRIES,
+    )
+    parser.add_argument("--pretty", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    if args.max_proc_entries < 1:
+        raise SystemExit("--max-proc-entries must be >= 1")
+    payload = build_inventory(
+        args.root,
+        args.canonical_root,
+        args.proc_root,
+        args.max_proc_entries,
+    )
+    if args.pretty:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(json.dumps(payload, separators=(",", ":"), sort_keys=True))
+    return 0 if not payload["errors"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Zweck

Bereitet OPERATOR-ECOSYSTEM-REDUNDANCY-V1-T030 sicher vor, ohne die aktuell fremd reservierte Bureau-Queue oder Legacy-Checkouts zu mutieren.

## Änderung

- neues strikt read-only `scripts/ops/repoground-legacy-source-inventory`
- deterministische JSON-Inventur für `.repobrief-sources`
- klassifiziert Git clean/dirty, HEAD, `git-common-dir`, verknüpfte Worktrees und Prozess-CWD-Konflikte
- fail-closed bei unvollständiger Evidenz
- kennzeichnet jede Ausgabe als `advisory-only`; Lease-Freigabe und Löschautorität werden ausdrücklich nicht behauptet
- keinerlei Lösch-/Move-/Ref-/Prozess-Mutation

## Nachweis

- `python -m pytest -q merger/repoground/tests/test_legacy_source_inventory.py merger/repoground/tests/test_fleet_runtime.py merger/repoground/tests/test_naming_doc.py` → 108 passed
- `python -m ruff check scripts/ops/repoground-legacy-source-inventory merger/repoground/tests/test_legacy_source_inventory.py` → passed
- `git diff --cached --check` → passed
- Live-Read-only-Lauf gegen `/home/alex/repos/.repobrief-sources` erfolgreich; u. a. gemeinsame Git-Common-Dirs mit kanonischen Checkouts werden korrekt als Blocker sichtbar.

## Abgrenzung

Dieser PR schließt T030 nicht selbst: die autoritative Lease-Prüfung und eine spätere Entfernung sicher klassifizierter Altcheckouts bleiben im bestehenden Bureau-Task.