### PR TITLE
Route repository verification through Metarepo

### DIFF
--- a/.github/reusable-workflow-contracts.json
+++ b/.github/reusable-workflow-contracts.json
@@ -29,30 +29,19 @@
     {
       "caller_path": ".github/workflows/wgx-guard.yml",
       "job": "guard",
-      "uses": "heimgewebe/wgx/.github/workflows/wgx-guard.yml@a7466bf2c3cb7fa3b261bfb2d008612abc0f85b1",
-      "source_content_sha256": "33784ef4748427adc0a183d44d118e445121ba91b3bc5f9d457b913bf292e19e",
+      "uses": "heimgewebe/metarepo/.github/workflows/reusable-repo-verify.yml@fe6950616b2d06343e284a56a8944e0a36f1f972",
+      "source_content_sha256": "b960e1080a991cfaf412f3242382c911281a65e9b33a110a1a822d5bbd2f3c4b",
       "required_permissions": {
         "contents": "read"
       },
       "required_secrets": [],
       "required_if_fragments": [],
       "transitive_uses": [
-        "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
-        "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
-        "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065",
-        "heimgewebe/metarepo/.github/workflows/reusable-validate-observatory.yml@dda0d036b3b4db935d3acbaa4c1b0fc76637cea9"
+        "actions/checkout@11d5960a326750d5838078e36cf38b85af677262",
+        "actions/checkout@11d5960a326750d5838078e36cf38b85af677262",
+        "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065"
       ],
-      "transitive_workflows": [
-        {
-          "uses": "heimgewebe/metarepo/.github/workflows/reusable-validate-observatory.yml@dda0d036b3b4db935d3acbaa4c1b0fc76637cea9",
-          "source_content_sha256": "e4b488f5b65e7bea50ea3c84979f162dd461965f782115d578b24bacdcc1eb15",
-          "transitive_uses": [
-            "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10",
-            "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e"
-          ],
-          "transitive_workflows": []
-        }
-      ]
+      "transitive_workflows": []
     }
   ],
   "does_not_establish": [

--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -13,6 +13,9 @@ permissions:
 
 jobs:
   guard:
-    # Fleet-Repos, die von metarepo aus via wgx up Templates beziehen,
-    # werden auf den kanonischen Guard-Workflow aus heimgewebe/wgx gesetzt.
-    uses: heimgewebe/wgx/.github/workflows/wgx-guard.yml@a7466bf2c3cb7fa3b261bfb2d008612abc0f85b1  # WGX PR #639 merge 2026-07-12
+    # Compatibility filename only: verification policy is owned by Metarepo.
+    uses: heimgewebe/metarepo/.github/workflows/reusable-repo-verify.yml@fe6950616b2d06343e284a56a8944e0a36f1f972
+    with:
+      mode: guard
+    permissions:
+      contents: read

--- a/config/workflow-control-plane.v1.json
+++ b/config/workflow-control-plane.v1.json
@@ -163,8 +163,8 @@
       "path": ".github/workflows/wgx-guard.yml",
       "class": "required_protection",
       "rationale": "wgx profile guard.",
-      "sha256": "6908956802b270bcb9f37066daa29c979ef4d4afa97d3ec914fa4ffc78469e66",
-      "bytes": 576
+      "sha256": "9cb7c5b0579d2b022fc68c926cd6e04695a09eb5441a6e716376b3640c192695",
+      "bytes": 556
     }
   ],
   "counts_by_class": {

--- a/merger/repoground/tests/test_reusable_workflow_contracts.py
+++ b/merger/repoground/tests/test_reusable_workflow_contracts.py
@@ -36,6 +36,28 @@ def _contract() -> dict:
     )
 
 
+def _contract_with_recursive_workflow() -> dict:
+    contract = _contract()
+    root = contract["contracts"][1]
+    workflow_use = (
+        "example/reusable/.github/workflows/check.yml@"
+        "0123456789abcdef0123456789abcdef01234567"
+    )
+    root["transitive_uses"].append(workflow_use)
+    root["transitive_workflows"] = [
+        {
+            "uses": workflow_use,
+            "source_content_sha256": "0" * 64,
+            "transitive_uses": [
+                "actions/checkout@11d5960a326750d5838078e36cf38b85af677262",
+                "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020",
+            ],
+            "transitive_workflows": [],
+        }
+    ]
+    return contract
+
+
 def test_repository_reusable_workflow_callers_match_contracts() -> None:
     assert scan(_repo_root()) == []
 
@@ -100,7 +122,7 @@ def test_contract_rejects_invalid_root_source_hash(tmp_path: Path) -> None:
 
 
 def test_contract_rejects_missing_recursive_workflow_closure(tmp_path: Path) -> None:
-    contract = _contract()
+    contract = _contract_with_recursive_workflow()
     contract["contracts"][1]["transitive_workflows"] = []
     _write_fixture(tmp_path, contract)
     assert [finding.code for finding in scan(tmp_path)] == [
@@ -109,7 +131,7 @@ def test_contract_rejects_missing_recursive_workflow_closure(tmp_path: Path) -> 
 
 
 def test_contract_rejects_detached_recursive_workflow_closure(tmp_path: Path) -> None:
-    contract = _contract()
+    contract = _contract_with_recursive_workflow()
     closure = contract["contracts"][1]["transitive_workflows"][0]
     closure["uses"] = (
         "heimgewebe/metarepo/.github/workflows/other.yml@"
@@ -122,7 +144,7 @@ def test_contract_rejects_detached_recursive_workflow_closure(tmp_path: Path) ->
 
 
 def test_contract_rejects_mutable_recursive_action_ref(tmp_path: Path) -> None:
-    contract = _contract()
+    contract = _contract_with_recursive_workflow()
     closure = contract["contracts"][1]["transitive_workflows"][0]
     closure["transitive_uses"][1] = "actions/setup-node@v6"
     _write_fixture(tmp_path, contract)
@@ -132,7 +154,7 @@ def test_contract_rejects_mutable_recursive_action_ref(tmp_path: Path) -> None:
 
 
 def test_contract_rejects_invalid_recursive_source_hash(tmp_path: Path) -> None:
-    contract = _contract()
+    contract = _contract_with_recursive_workflow()
     closure = contract["contracts"][1]["transitive_workflows"][0]
     closure["source_content_sha256"] = "missing"
     _write_fixture(tmp_path, contract)
@@ -142,7 +164,7 @@ def test_contract_rejects_invalid_recursive_source_hash(tmp_path: Path) -> None:
 
 
 def test_contract_rejects_unrecorded_third_level_workflow(tmp_path: Path) -> None:
-    contract = _contract()
+    contract = _contract_with_recursive_workflow()
     closure = contract["contracts"][1]["transitive_workflows"][0]
     closure["transitive_uses"].append(
         "example/inner/.github/workflows/check.yml@"

--- a/tests/test_agent_frontdoor_metadata.py
+++ b/tests/test_agent_frontdoor_metadata.py
@@ -57,12 +57,16 @@ def test_wgx_active_identity_is_repoground() -> None:
     assert isinstance(tasks, dict)
     assert all("repoground" in str(command).lower() for command in tasks.values())
 
-    workflow = (ROOT / ".github/workflows/wgx-guard.yml").read_text(encoding="utf-8")
-    assert (
-        "heimgewebe/wgx/.github/workflows/wgx-guard.yml"
-        "@a7466bf2c3cb7fa3b261bfb2d008612abc0f85b1"
-        in workflow
+    workflow = _yaml(".github/workflows/wgx-guard.yml")
+    jobs = workflow["jobs"]
+    assert isinstance(jobs, dict)
+    guard = jobs["guard"]
+    assert isinstance(guard, dict)
+    assert guard["uses"] == (
+        "heimgewebe/metarepo/.github/workflows/reusable-repo-verify.yml"
+        "@fe6950616b2d06343e284a56a8944e0a36f1f972"
     )
+    assert guard["with"] == {"mode": "guard"}
     audit = (ROOT / "docs/architecture/inconsistencies.md").read_text(encoding="utf-8")
     assert "`profile: repoground`, `class: knowledge-compiler`" in audit
     assert "Historische Lenskit-/RepoLens-Belege werden nicht umgeschrieben" in audit


### PR DESCRIPTION
Migrate RepoGround repository verification away from direct WGX workflow ownership to the pinned Metarepo reusable verification workflow.

The repository-owned reusable workflow contract is migrated in the same PR and records the exact Metarepo workflow content SHA-256 plus its pinned transitive action inventory.

Local evidence:
- actionlint: pass
- repository-owned WGX guard task: pass
- reusable workflow caller contract checker: pass
- tests/test_agent_frontdoor_metadata.py: 4 passed
- ruff on changed test: pass
- diff --check: pass

Pinned Metarepo merge: fe6950616b2d06343e284a56a8944e0a36f1f972.