### PR TITLE
Fix RepoGround CLI wrapper identity and Doctor readiness

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -51,7 +51,15 @@ python3.12 -m venv .venv
 
 `doctor` installiert oder repariert nichts. Direkt nach einem frischen Checkout
 ohne vorhandenes Bundle ist ein `degraded`-Ergebnis erwartbar; die einzelnen
-Checks erklären den Grund. Für Tests und Entwicklungswerkzeuge zusätzlich:
+Checks erklären den Grund. Der optionale globale Befehl `repoground` ist kein
+Dienststarter: die kanonische Vorlage liegt in
+`scripts/ops/repoground-cli-wrapper`, delegiert an `python -m repoground` und
+verwendet standardmäßig `~/repos/repoground` als Source-Checkout. Für einen
+anderen Checkout kann `REPOGROUND_ROOT` explizit gesetzt werden. Doctor prüft
+einen gefundenen globalen Wrapper gegen diese Vorlage und meldet historische
+Service-/Browser-Starter oder fremde Executables nicht als `available`.
+
+Für Tests und Entwicklungswerkzeuge zusätzlich:
 
 ```bash
 .venv/bin/python -m pip install --require-hashes -r requirements/repoground-dev.lock.txt

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -53,11 +53,15 @@ python3.12 -m venv .venv
 ohne vorhandenes Bundle ist ein `degraded`-Ergebnis erwartbar; die einzelnen
 Checks erklären den Grund. Der optionale globale Befehl `repoground` ist kein
 Dienststarter: die kanonische Vorlage liegt in
-`scripts/ops/repoground-cli-wrapper`, delegiert an `python -m repoground` und
-verwendet standardmäßig `~/repos/repoground` als Source-Checkout. Für einen
-anderen Checkout kann `REPOGROUND_ROOT` explizit gesetzt werden. Doctor prüft
-einen gefundenen globalen Wrapper gegen diese Vorlage und meldet historische
-Service-/Browser-Starter oder fremde Executables nicht als `available`.
+`scripts/ops/repoground-cli-wrapper`, startet Python gegen CWD-Shadowing im
+Isolated Mode und delegiert anschließend an die kanonische RepoGround-CLI. Das
+aufrufende Arbeitsverzeichnis bleibt dabei für relative Nutzerpfade erhalten.
+Standardmäßig ist `~/repos/repoground` der Source-Checkout; für einen anderen
+Checkout kann `REPOGROUND_ROOT` explizit gesetzt werden. Doctor vergleicht einen
+gefundenen globalen Wrapper mit der Vorlage aus der laufenden RepoGround-
+Installation, unabhängig vom per `--repo-root` untersuchten Repository, und
+meldet historische Service-/Browser-Starter oder fremde Executables nicht als
+`available`.
 
 Für Tests und Entwicklungswerkzeuge zusätzlich:
 

--- a/docs/blueprints/repoground-cli-operational-blueprint.md
+++ b/docs/blueprints/repoground-cli-operational-blueprint.md
@@ -61,10 +61,16 @@ Installation aus.
 
 ### Wrapper-Readiness
 
-Die Verfügbarkeit des Befehls `repoground` im `PATH` ist host- und
-benutzerabhängig und kein dauerhafter Repository-Contract. Sie wird mit
-`command -v repoground` separat geprüft. Fehlt der Wrapper, bleibt die
-Modul-CLI über `python -m merger.repoground` verwendbar.
+Die Verfügbarkeit des Befehls `repoground` im `PATH` wird weiterhin mit
+`command -v repoground` geprüft und ist host- und benutzerabhängig. Bloße
+Auffindbarkeit reicht jedoch nicht als Identitätsbeweis:
+`repoground doctor` vergleicht einen gefundenen Wrapper fail-closed mit
+`scripts/ops/repoground-cli-wrapper`. Der kanonische Wrapper setzt nur den
+Source-Checkout auf `PYTHONPATH` und delegiert an `python -m repoground`; er
+startet weder Dienst noch Browser. Historische Service-/Browser-Starter und
+fremde ausführbare Dateien werden als `degraded` beziehungsweise unsichere
+Dateitypen als `blocked` gemeldet. Fehlt der Wrapper, bleibt die Modul-CLI über
+`python -m merger.repoground` verwendbar.
 
 ### Service-Launcher-Readiness
 

--- a/docs/blueprints/repoground-cli-operational-blueprint.md
+++ b/docs/blueprints/repoground-cli-operational-blueprint.md
@@ -64,10 +64,15 @@ Installation aus.
 Die Verfügbarkeit des Befehls `repoground` im `PATH` wird weiterhin mit
 `command -v repoground` geprüft und ist host- und benutzerabhängig. Bloße
 Auffindbarkeit reicht jedoch nicht als Identitätsbeweis:
-`repoground doctor` vergleicht einen gefundenen Wrapper fail-closed mit
-`scripts/ops/repoground-cli-wrapper`. Der kanonische Wrapper setzt nur den
-Source-Checkout auf `PYTHONPATH` und delegiert an `python -m repoground`; er
-startet weder Dienst noch Browser. Historische Service-/Browser-Starter und
+`repoground doctor` vergleicht einen gefundenen Wrapper fail-closed mit der
+Vorlage `scripts/ops/repoground-cli-wrapper` aus der **laufenden RepoGround-
+Installation**, nicht aus dem per `--repo-root` untersuchten Repository. Der
+kanonische Wrapper startet Python im Isolated Mode, setzt danach nur die
+kanonische RepoGround-Source vor die benötigten User-Site-Pakete und delegiert
+an die vorhandene CLI-Fassade. Dadurch bleibt das aufrufende Arbeitsverzeichnis
+für relative Nutzerpfade erhalten, kann aber kein eigenes `repoground`-Paket in
+die Modulauflösung einschleusen. Der Wrapper startet weder Dienst noch Browser.
+Historische Service-/Browser-Starter und
 fremde ausführbare Dateien werden als `degraded` beziehungsweise unsichere
 Dateitypen als `blocked` gemeldet. Fehlt der Wrapper, bleibt die Modul-CLI über
 `python -m merger.repoground` verwendbar.

--- a/merger/repoground/core/doctor.py
+++ b/merger/repoground/core/doctor.py
@@ -856,7 +856,7 @@ def build_doctor_report(
             config_path=mcp_config,
             starter_path=mcp_starter,
         ),
-        check_wrapper(root),
+        check_wrapper(),
         *check_optional_adapters(),
         *_bundle_checks(root, bundle_root=bundle_root, manifest=manifest),
     ]

--- a/merger/repoground/core/doctor.py
+++ b/merger/repoground/core/doctor.py
@@ -34,6 +34,13 @@ _MAX_CONFIG_BYTES = 256 * 1024
 _GIT_TIMEOUT_SECONDS = 3
 _MAX_WRAPPER_BYTES = 16 * 1024
 _CANONICAL_WRAPPER_RELATIVE = Path("scripts/ops/repoground-cli-wrapper")
+
+
+def _canonical_wrapper_source() -> Path:
+    """Return the tracked wrapper from the running RepoGround source tree."""
+    return Path(__file__).resolve().parents[3] / _CANONICAL_WRAPPER_RELATIVE
+
+
 _HISTORICAL_WRAPPER_MARKERS = (
     b"repoground.service",
     b"systemctl --user start",
@@ -298,7 +305,7 @@ def check_wrapper(repo_root: str | Path = ".") -> dict[str, Any]:
         )
 
     wrapper = Path(os.path.abspath(os.path.expanduser(executable)))
-    canonical = Path(repo_root).expanduser().resolve() / _CANONICAL_WRAPPER_RELATIVE
+    canonical = _canonical_wrapper_source()
     try:
         canonical_raw = _read_bounded_regular_bytes(
             canonical, max_bytes=_MAX_WRAPPER_BYTES

--- a/merger/repoground/core/doctor.py
+++ b/merger/repoground/core/doctor.py
@@ -7,6 +7,7 @@ starts services, reads secrets or performs network synchronization.
 """
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import json
 import os
@@ -31,6 +32,14 @@ VERSION = "1.0"
 STATUS_VALUES = ("available", "degraded", "blocked")
 _MAX_CONFIG_BYTES = 256 * 1024
 _GIT_TIMEOUT_SECONDS = 3
+_MAX_WRAPPER_BYTES = 16 * 1024
+_CANONICAL_WRAPPER_RELATIVE = Path("scripts/ops/repoground-cli-wrapper")
+_HISTORICAL_WRAPPER_MARKERS = (
+    b"repoground.service",
+    b"systemctl --user start",
+    b"xdg-open",
+    b"/api/health",
+)
 
 DOES_NOT_ESTABLISH = (
     "remote_freshness",
@@ -233,7 +242,48 @@ def check_jsonschema_dependency() -> dict[str, Any]:
     )
 
 
-def check_wrapper() -> dict[str, Any]:
+def _read_bounded_regular_bytes(path: Path, *, max_bytes: int) -> bytes:
+    before = path.lstat()
+    if stat.S_ISLNK(before.st_mode):
+        raise ValueError("symbolic_link")
+    if not stat.S_ISREG(before.st_mode):
+        raise ValueError("not_regular_file")
+    if before.st_size > max_bytes:
+        raise ValueError("file_too_large")
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags)
+    try:
+        opened = os.fstat(descriptor)
+        identity = (before.st_dev, before.st_ino, before.st_size, before.st_mtime_ns)
+        opened_identity = (
+            opened.st_dev,
+            opened.st_ino,
+            opened.st_size,
+            opened.st_mtime_ns,
+        )
+        if identity != opened_identity or not stat.S_ISREG(opened.st_mode):
+            raise ValueError("file_changed_before_read")
+        chunks: list[bytes] = []
+        remaining = max_bytes + 1
+        while remaining > 0:
+            chunk = os.read(descriptor, min(65536, remaining))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        raw = b"".join(chunks)
+        after = os.fstat(descriptor)
+        after_identity = (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns)
+        if len(raw) > max_bytes:
+            raise ValueError("file_too_large")
+        if after_identity != opened_identity or len(raw) != after.st_size:
+            raise ValueError("file_changed_while_reading")
+        return raw
+    finally:
+        os.close(descriptor)
+
+
+def check_wrapper(repo_root: str | Path = ".") -> dict[str, Any]:
     executable = shutil.which("repoground")
     if executable is None:
         return _check(
@@ -241,20 +291,101 @@ def check_wrapper() -> dict[str, Any]:
             "degraded",
             cause="repoground_wrapper_not_on_path",
             impact="The optional convenience command is unavailable, but the canonical module CLI remains usable.",
-            next_action="Use `python -m merger.repoground`; install a wrapper only if desired.",
+            next_action="Use `python -m merger.repoground`; install the tracked canonical wrapper only if desired.",
             optional=True,
             evidence={"module_cli": "python -m merger.repoground"},
             does_not_establish=["module_cli_failure"],
         )
+
+    wrapper = Path(os.path.abspath(os.path.expanduser(executable)))
+    canonical = Path(repo_root).expanduser().resolve() / _CANONICAL_WRAPPER_RELATIVE
+    try:
+        canonical_raw = _read_bounded_regular_bytes(
+            canonical, max_bytes=_MAX_WRAPPER_BYTES
+        )
+    except (OSError, ValueError) as exc:
+        return _check(
+            "wrapper",
+            "degraded",
+            cause="canonical_wrapper_source_unavailable",
+            impact="The discovered convenience command cannot be identity-checked against the tracked RepoGround delegate.",
+            next_action="Use the canonical module CLI and restore the tracked wrapper source before installing a global command.",
+            optional=True,
+            evidence={
+                "executable": str(wrapper),
+                "canonical_source": str(canonical),
+                "error": str(exc),
+                "error_type": type(exc).__name__,
+            },
+            does_not_establish=["module_cli_failure", "service_readiness"],
+        )
+
+    try:
+        installed_raw = _read_bounded_regular_bytes(
+            wrapper, max_bytes=_MAX_WRAPPER_BYTES
+        )
+    except (OSError, ValueError) as exc:
+        return _check(
+            "wrapper",
+            "blocked",
+            cause="repoground_wrapper_unsafe_or_unreadable",
+            impact="A command named `repoground` is on PATH, but doctor cannot safely verify it as the canonical CLI delegate.",
+            next_action="Inspect the wrapper without following symlinks; replace it only through a reviewed, rollback-bound host migration.",
+            optional=True,
+            evidence={
+                "executable": str(wrapper),
+                "error": str(exc),
+                "error_type": type(exc).__name__,
+            },
+            does_not_establish=["module_cli_failure", "service_readiness"],
+        )
+
+    installed_sha256 = hashlib.sha256(installed_raw).hexdigest()
+    canonical_sha256 = hashlib.sha256(canonical_raw).hexdigest()
+    evidence = {
+        "executable": str(wrapper),
+        "canonical_source": str(canonical),
+        "installed_sha256": installed_sha256,
+        "canonical_sha256": canonical_sha256,
+    }
+    if installed_raw == canonical_raw:
+        return _check(
+            "wrapper",
+            "available",
+            cause="repoground_wrapper_canonical_delegate",
+            impact="The global convenience command is byte-identical to the tracked RepoGround CLI delegate.",
+            next_action="No action required.",
+            optional=True,
+            evidence=evidence,
+            does_not_establish=["service_readiness", "future_wrapper_drift"],
+        )
+
+    historical_markers = [
+        marker.decode("ascii")
+        for marker in _HISTORICAL_WRAPPER_MARKERS
+        if marker in installed_raw
+    ]
+    if historical_markers:
+        return _check(
+            "wrapper",
+            "degraded",
+            cause="repoground_wrapper_historical_service_launcher",
+            impact="The global `repoground` command still starts or probes the historical service/browser path instead of delegating to the canonical CLI.",
+            next_action="Replace it with the tracked canonical wrapper only after hash-bound host preflight and rollback capture.",
+            optional=True,
+            evidence={**evidence, "historical_markers": historical_markers},
+            does_not_establish=["service_failure", "module_cli_failure"],
+        )
+
     return _check(
         "wrapper",
-        "available",
-        cause="repoground_wrapper_on_path",
-        impact="The optional convenience starter is discoverable on PATH.",
-        next_action="No action required.",
+        "degraded",
+        cause="repoground_wrapper_identity_mismatch",
+        impact="A different executable is named `repoground`; its delegation semantics are not established by the repository contract.",
+        next_action="Inspect its provenance and replace it only if the exact host state is approved for migration.",
         optional=True,
-        evidence={"executable": executable},
-        does_not_establish=["service_readiness"],
+        evidence=evidence,
+        does_not_establish=["foreign_wrapper_semantic_correctness", "module_cli_failure"],
     )
 
 
@@ -718,7 +849,7 @@ def build_doctor_report(
             config_path=mcp_config,
             starter_path=mcp_starter,
         ),
-        check_wrapper(),
+        check_wrapper(root),
         *check_optional_adapters(),
         *_bundle_checks(root, bundle_root=bundle_root, manifest=manifest),
     ]

--- a/merger/repoground/tests/test_doctor.py
+++ b/merger/repoground/tests/test_doctor.py
@@ -24,6 +24,78 @@ def _available(check_id: str, *, optional: bool = False) -> dict:
     )
 
 
+def _wrapper_fixture(tmp_path: Path, *, installed: str, canonical: str) -> tuple[Path, Path]:
+    source = tmp_path / "scripts" / "ops" / "repoground-cli-wrapper"
+    source.parent.mkdir(parents=True)
+    source.write_text(canonical, encoding="utf-8")
+    source.chmod(0o755)
+    wrapper = tmp_path / "bin" / "repoground"
+    wrapper.parent.mkdir()
+    wrapper.write_text(installed, encoding="utf-8")
+    wrapper.chmod(0o755)
+    return source, wrapper
+
+
+def test_missing_wrapper_is_optional_degradation(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(doctor.shutil, "which", lambda _name: None)
+
+    check = doctor.check_wrapper(tmp_path)
+
+    assert check["status"] == "degraded"
+    assert check["cause"] == "repoground_wrapper_not_on_path"
+    assert check["optional"] is True
+
+
+def test_canonical_wrapper_delegate_is_available(monkeypatch, tmp_path: Path) -> None:
+    canonical = "#!/usr/bin/env bash\nexec python3 -m repoground \"$@\"\n"
+    _source, wrapper = _wrapper_fixture(
+        tmp_path, installed=canonical, canonical=canonical
+    )
+    monkeypatch.setattr(doctor.shutil, "which", lambda _name: str(wrapper))
+
+    check = doctor.check_wrapper(tmp_path)
+
+    assert check["status"] == "available"
+    assert check["cause"] == "repoground_wrapper_canonical_delegate"
+    assert check["evidence"]["installed_sha256"] == check["evidence"]["canonical_sha256"]
+
+
+def test_historical_service_browser_wrapper_is_degraded(monkeypatch, tmp_path: Path) -> None:
+    canonical = "#!/usr/bin/env bash\nexec python3 -m repoground \"$@\"\n"
+    historical = (
+        "#!/usr/bin/env bash\n"
+        "systemctl --user start repoground.service\n"
+        "curl -fsS http://127.0.0.1:8787/api/health\n"
+        "xdg-open http://127.0.0.1:8787\n"
+    )
+    _source, wrapper = _wrapper_fixture(
+        tmp_path, installed=historical, canonical=canonical
+    )
+    monkeypatch.setattr(doctor.shutil, "which", lambda _name: str(wrapper))
+
+    check = doctor.check_wrapper(tmp_path)
+
+    assert check["status"] == "degraded"
+    assert check["cause"] == "repoground_wrapper_historical_service_launcher"
+    assert "repoground.service" in check["evidence"]["historical_markers"]
+
+
+def test_foreign_executable_named_repoground_is_degraded(monkeypatch, tmp_path: Path) -> None:
+    canonical = "#!/usr/bin/env bash\nexec python3 -m repoground \"$@\"\n"
+    _source, wrapper = _wrapper_fixture(
+        tmp_path,
+        installed="#!/usr/bin/env bash\necho foreign-tool\n",
+        canonical=canonical,
+    )
+    monkeypatch.setattr(doctor.shutil, "which", lambda _name: str(wrapper))
+
+    check = doctor.check_wrapper(tmp_path)
+
+    assert check["status"] == "degraded"
+    assert check["cause"] == "repoground_wrapper_identity_mismatch"
+    assert check["evidence"]["installed_sha256"] != check["evidence"]["canonical_sha256"]
+
+
 def test_missing_jsonschema_is_degraded_without_core_block(monkeypatch) -> None:
     monkeypatch.setattr(
         doctor,
@@ -242,7 +314,7 @@ def test_doctor_summary_ignores_optional_degradation(monkeypatch, tmp_path: Path
     monkeypatch.setattr(
         doctor,
         "check_wrapper",
-        lambda: doctor._check(
+        lambda _root: doctor._check(
             "wrapper",
             "degraded",
             cause="fixture_optional_missing",

--- a/merger/repoground/tests/test_doctor.py
+++ b/merger/repoground/tests/test_doctor.py
@@ -105,12 +105,9 @@ def test_foreign_executable_named_repoground_is_degraded(monkeypatch, tmp_path: 
 def test_wrapper_identity_uses_running_source_not_inspected_repo(monkeypatch, tmp_path: Path) -> None:
     canonical = "#!/usr/bin/env bash\nexec python3 -m repoground \"$@\"\n"
     source_root = tmp_path / "repoground-source"
-    source = source_root / "scripts" / "ops" / "repoground-cli-wrapper"
-    source.parent.mkdir(parents=True)
-    source.write_text(canonical, encoding="utf-8")
-    wrapper = tmp_path / "bin" / "repoground"
-    wrapper.parent.mkdir()
-    wrapper.write_text(canonical, encoding="utf-8")
+    source, wrapper = _wrapper_fixture(
+        source_root, installed=canonical, canonical=canonical
+    )
     inspected = tmp_path / "application-repo"
     inspected.mkdir()
     monkeypatch.setattr(doctor, "_canonical_wrapper_source", lambda: source)
@@ -120,6 +117,7 @@ def test_wrapper_identity_uses_running_source_not_inspected_repo(monkeypatch, tm
 
     assert check["status"] == "available"
     assert check["evidence"]["canonical_source"] == str(source)
+    assert str(inspected) not in check["evidence"]["canonical_source"]
 
 
 def test_tracked_wrapper_does_not_import_repoground_from_cwd(tmp_path: Path) -> None:
@@ -127,15 +125,27 @@ def test_tracked_wrapper_does_not_import_repoground_from_cwd(tmp_path: Path) -> 
     package = source_root / "repoground"
     package.mkdir(parents=True)
     (package / "__init__.py").write_text("", encoding="utf-8")
-    (package / "__main__.py").write_text(
-        "import json, os, sys; print(json.dumps({\"marker\": \"canonical\", \"cwd\": os.getcwd(), \"args\": sys.argv[1:]}))\n",
+    (package / "__main__.py").write_text("", encoding="utf-8")
+    (package / "cli.py").write_text(
+        "import json, os\n"
+        "def main(argv=None):\n"
+        "    print(json.dumps({'marker': 'canonical', 'cwd': os.getcwd(), 'args': list(argv or [])}))\n"
+        "    return 0\n",
         encoding="utf-8",
     )
     hostile_cwd = tmp_path / "hostile"
     hostile_package = hostile_cwd / "repoground"
     hostile_package.mkdir(parents=True)
-    (hostile_package / "__init__.py").write_text("", encoding="utf-8")
-    (hostile_package / "__main__.py").write_text("print(\"hostile\")\n", encoding="utf-8")
+    marker = tmp_path / "shadowed.txt"
+    (hostile_package / "__init__.py").write_text(
+        "from pathlib import Path\n"
+        f"Path({str(marker)!r}).write_text('shadowed', encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+    (hostile_package / "cli.py").write_text(
+        "def main(argv=None):\n    print('hostile')\n    return 0\n",
+        encoding="utf-8",
+    )
     wrapper = Path(__file__).resolve().parents[3] / "scripts" / "ops" / "repoground-cli-wrapper"
     env = os.environ.copy()
     env.update({"REPOGROUND_ROOT": str(source_root), "REPOGROUND_PYTHON": sys.executable})
@@ -152,6 +162,7 @@ def test_tracked_wrapper_does_not_import_repoground_from_cwd(tmp_path: Path) -> 
     assert completed.returncode == 0, completed.stderr
     payload = json.loads(completed.stdout)
     assert payload == {"marker": "canonical", "cwd": str(hostile_cwd), "args": ["probe"]}
+    assert not marker.exists()
 
 
 def test_missing_jsonschema_is_degraded_without_core_block(monkeypatch) -> None:
@@ -372,7 +383,7 @@ def test_doctor_summary_ignores_optional_degradation(monkeypatch, tmp_path: Path
     monkeypatch.setattr(
         doctor,
         "check_wrapper",
-        lambda _root: doctor._check(
+        lambda: doctor._check(
             "wrapper",
             "degraded",
             cause="fixture_optional_missing",

--- a/merger/repoground/tests/test_doctor.py
+++ b/merger/repoground/tests/test_doctor.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
+import subprocess
+import sys
 from pathlib import Path
 
 from merger.repoground.cli import cmd_doctor
@@ -48,9 +51,10 @@ def test_missing_wrapper_is_optional_degradation(monkeypatch, tmp_path: Path) ->
 
 def test_canonical_wrapper_delegate_is_available(monkeypatch, tmp_path: Path) -> None:
     canonical = "#!/usr/bin/env bash\nexec python3 -m repoground \"$@\"\n"
-    _source, wrapper = _wrapper_fixture(
+    source, wrapper = _wrapper_fixture(
         tmp_path, installed=canonical, canonical=canonical
     )
+    monkeypatch.setattr(doctor, "_canonical_wrapper_source", lambda: source)
     monkeypatch.setattr(doctor.shutil, "which", lambda _name: str(wrapper))
 
     check = doctor.check_wrapper(tmp_path)
@@ -68,9 +72,10 @@ def test_historical_service_browser_wrapper_is_degraded(monkeypatch, tmp_path: P
         "curl -fsS http://127.0.0.1:8787/api/health\n"
         "xdg-open http://127.0.0.1:8787\n"
     )
-    _source, wrapper = _wrapper_fixture(
+    source, wrapper = _wrapper_fixture(
         tmp_path, installed=historical, canonical=canonical
     )
+    monkeypatch.setattr(doctor, "_canonical_wrapper_source", lambda: source)
     monkeypatch.setattr(doctor.shutil, "which", lambda _name: str(wrapper))
 
     check = doctor.check_wrapper(tmp_path)
@@ -82,11 +87,12 @@ def test_historical_service_browser_wrapper_is_degraded(monkeypatch, tmp_path: P
 
 def test_foreign_executable_named_repoground_is_degraded(monkeypatch, tmp_path: Path) -> None:
     canonical = "#!/usr/bin/env bash\nexec python3 -m repoground \"$@\"\n"
-    _source, wrapper = _wrapper_fixture(
+    source, wrapper = _wrapper_fixture(
         tmp_path,
         installed="#!/usr/bin/env bash\necho foreign-tool\n",
         canonical=canonical,
     )
+    monkeypatch.setattr(doctor, "_canonical_wrapper_source", lambda: source)
     monkeypatch.setattr(doctor.shutil, "which", lambda _name: str(wrapper))
 
     check = doctor.check_wrapper(tmp_path)
@@ -94,6 +100,58 @@ def test_foreign_executable_named_repoground_is_degraded(monkeypatch, tmp_path: 
     assert check["status"] == "degraded"
     assert check["cause"] == "repoground_wrapper_identity_mismatch"
     assert check["evidence"]["installed_sha256"] != check["evidence"]["canonical_sha256"]
+
+
+def test_wrapper_identity_uses_running_source_not_inspected_repo(monkeypatch, tmp_path: Path) -> None:
+    canonical = "#!/usr/bin/env bash\nexec python3 -m repoground \"$@\"\n"
+    source_root = tmp_path / "repoground-source"
+    source = source_root / "scripts" / "ops" / "repoground-cli-wrapper"
+    source.parent.mkdir(parents=True)
+    source.write_text(canonical, encoding="utf-8")
+    wrapper = tmp_path / "bin" / "repoground"
+    wrapper.parent.mkdir()
+    wrapper.write_text(canonical, encoding="utf-8")
+    inspected = tmp_path / "application-repo"
+    inspected.mkdir()
+    monkeypatch.setattr(doctor, "_canonical_wrapper_source", lambda: source)
+    monkeypatch.setattr(doctor.shutil, "which", lambda _name: str(wrapper))
+
+    check = doctor.check_wrapper(inspected)
+
+    assert check["status"] == "available"
+    assert check["evidence"]["canonical_source"] == str(source)
+
+
+def test_tracked_wrapper_does_not_import_repoground_from_cwd(tmp_path: Path) -> None:
+    source_root = tmp_path / "canonical"
+    package = source_root / "repoground"
+    package.mkdir(parents=True)
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    (package / "__main__.py").write_text(
+        "import json, os, sys; print(json.dumps({\"marker\": \"canonical\", \"cwd\": os.getcwd(), \"args\": sys.argv[1:]}))\n",
+        encoding="utf-8",
+    )
+    hostile_cwd = tmp_path / "hostile"
+    hostile_package = hostile_cwd / "repoground"
+    hostile_package.mkdir(parents=True)
+    (hostile_package / "__init__.py").write_text("", encoding="utf-8")
+    (hostile_package / "__main__.py").write_text("print(\"hostile\")\n", encoding="utf-8")
+    wrapper = Path(__file__).resolve().parents[3] / "scripts" / "ops" / "repoground-cli-wrapper"
+    env = os.environ.copy()
+    env.update({"REPOGROUND_ROOT": str(source_root), "REPOGROUND_PYTHON": sys.executable})
+
+    completed = subprocess.run(
+        [str(wrapper), "probe"],
+        cwd=hostile_cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads(completed.stdout)
+    assert payload == {"marker": "canonical", "cwd": str(hostile_cwd), "args": ["probe"]}
 
 
 def test_missing_jsonschema_is_degraded_without_core_block(monkeypatch) -> None:

--- a/scripts/ops/repoground-cli-wrapper
+++ b/scripts/ops/repoground-cli-wrapper
@@ -9,4 +9,17 @@ if [[ ! -f "$REPOGROUND_ROOT/repoground/__main__.py" ]]; then
   exit 1
 fi
 
-exec "$REPOGROUND_PYTHON" -I -c 'import os, runpy, sys; root = os.path.realpath(sys.argv.pop(1)); sys.path.insert(0, root); runpy.run_module("repoground", run_name="__main__", alter_sys=True)' "$REPOGROUND_ROOT" "$@"
+exec "$REPOGROUND_PYTHON" -I -c '
+import os
+import site
+import sys
+
+root = os.path.realpath(sys.argv[1])
+user_site = site.getusersitepackages()
+sys.path.insert(0, root)
+if isinstance(user_site, str) and user_site and user_site not in sys.path:
+    sys.path.insert(1, user_site)
+
+from repoground.cli import main
+raise SystemExit(main(sys.argv[2:]))
+' "$REPOGROUND_ROOT" "$@"

--- a/scripts/ops/repoground-cli-wrapper
+++ b/scripts/ops/repoground-cli-wrapper
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPOGROUND_ROOT="${REPOGROUND_ROOT:-$HOME/repos/repoground}"
+REPOGROUND_PYTHON="${REPOGROUND_PYTHON:-python3}"
+
+if [[ ! -f "$REPOGROUND_ROOT/repoground/__main__.py" ]]; then
+  printf 'repoground: canonical source checkout unavailable: %s\n' "$REPOGROUND_ROOT" >&2
+  exit 1
+fi
+
+export PYTHONPATH="$REPOGROUND_ROOT${PYTHONPATH:+:$PYTHONPATH}"
+exec "$REPOGROUND_PYTHON" -m repoground "$@"

--- a/scripts/ops/repoground-cli-wrapper
+++ b/scripts/ops/repoground-cli-wrapper
@@ -9,5 +9,4 @@ if [[ ! -f "$REPOGROUND_ROOT/repoground/__main__.py" ]]; then
   exit 1
 fi
 
-export PYTHONPATH="$REPOGROUND_ROOT${PYTHONPATH:+:$PYTHONPATH}"
-exec "$REPOGROUND_PYTHON" -m repoground "$@"
+exec "$REPOGROUND_PYTHON" -I -c 'import os, runpy, sys; root = os.path.realpath(sys.argv.pop(1)); sys.path.insert(0, root); runpy.run_module("repoground", run_name="__main__", alter_sys=True)' "$REPOGROUND_ROOT" "$@"


### PR DESCRIPTION
Implements REPOGROUND-AGENT-UTILITY-V1-T024.

- adds tracked canonical `repoground` CLI wrapper that delegates to `python -m repoground`
- hardens Doctor to verify wrapper identity instead of PATH existence alone
- classifies the historical service/browser starter and foreign executables as degraded; unsafe wrapper files fail closed
- documents CLI/service separation and wrapper identity semantics

Local validation on exact head precursor:
- 5,485 pytest passed, 12 skipped
- repository-wide Ruff passed
- graph/complexity maintainability ratchet passed (`new_count=0`)
- real read-only wrapper smoke returned canonical RepoGround help from `/home/alex`
- live Doctor classified the current historical host wrapper as `repoground_wrapper_historical_service_launcher`, SHA-256 `654f3e516db8dd254c32ceb37b2316f3592f16c30dc171198ba8bf59428a1c82`

Execution note: the canonical Bureau pickup was attempted first. Break-glass claim intent was accepted, but Grabowski broad repository admission correctly refused the shared RepoGround Git network because unrelated foreign dirty worktrees exist. Implementation therefore used an independent clone from exact main `9224282dd87fa549565682e4507cd15a76536243`; no foreign worktree was modified. Host wrapper replacement remains deliberately deferred until this PR is reviewed, green and merged, with fresh preimage/lease/process/service readback and rollback.