### PR TITLE
fix(doctor): clarify Python runtime contract

### DIFF
--- a/merger/repoground/core/doctor.py
+++ b/merger/repoground/core/doctor.py
@@ -30,6 +30,8 @@ from merger.repoground.core.live_freshness import evaluate_live_freshness
 KIND = "repoground.doctor"
 VERSION = "1.0"
 STATUS_VALUES = ("available", "degraded", "blocked")
+CORE_PYTHON_MINIMUM = (3, 10)
+CI_RELEASE_PYTHON_BASELINE = (3, 12)
 _MAX_CONFIG_BYTES = 256 * 1024
 _GIT_TIMEOUT_SECONDS = 3
 _MAX_WRAPPER_BYTES = 16 * 1024
@@ -95,12 +97,16 @@ def _module_available(module: str) -> bool:
 
 def check_python_runtime() -> dict[str, Any]:
     version = tuple(sys.version_info[:3])
+    core_supported = version >= CORE_PYTHON_MINIMUM
     evidence = {
         "implementation": sys.implementation.name,
         "version": ".".join(str(item) for item in version),
-        "ci_release_baseline": "3.12",
+        "core_minimum": ".".join(str(item) for item in CORE_PYTHON_MINIMUM),
+        "core_runtime_supported": core_supported,
+        "ci_release_baseline": ".".join(str(item) for item in CI_RELEASE_PYTHON_BASELINE),
+        "ci_release_baseline_role": "reproducible_validation",
     }
-    if version < (3, 10):
+    if not core_supported:
         return _check(
             "python",
             "blocked",
@@ -109,7 +115,7 @@ def check_python_runtime() -> dict[str, Any]:
             next_action="Use Python 3.12, the current CI and release-candidate baseline.",
             evidence=evidence,
         )
-    if version[:2] != (3, 12):
+    if version[:2] != CI_RELEASE_PYTHON_BASELINE:
         return _check(
             "python",
             "degraded",

--- a/merger/repoground/tests/test_doctor.py
+++ b/merger/repoground/tests/test_doctor.py
@@ -27,6 +27,29 @@ def _available(check_id: str, *, optional: bool = False) -> dict:
     )
 
 
+def test_python_runtime_distinguishes_core_support_from_release_baseline(monkeypatch) -> None:
+    monkeypatch.setattr(doctor.sys, "version_info", (3, 10, 12))
+
+    check = doctor.check_python_runtime()
+
+    assert check["status"] == "degraded"
+    assert check["cause"] == "python_version_outside_ci_release_baseline"
+    assert check["evidence"]["core_minimum"] == "3.10"
+    assert check["evidence"]["core_runtime_supported"] is True
+    assert check["evidence"]["ci_release_baseline"] == "3.12"
+    assert check["evidence"]["ci_release_baseline_role"] == "reproducible_validation"
+
+
+def test_python_runtime_below_core_minimum_is_blocked(monkeypatch) -> None:
+    monkeypatch.setattr(doctor.sys, "version_info", (3, 9, 19))
+
+    check = doctor.check_python_runtime()
+
+    assert check["status"] == "blocked"
+    assert check["cause"] == "python_version_too_old"
+    assert check["evidence"]["core_runtime_supported"] is False
+
+
 def _wrapper_fixture(tmp_path: Path, *, installed: str, canonical: str) -> tuple[Path, Path]:
     source = tmp_path / "scripts" / "ops" / "repoground-cli-wrapper"
     source.parent.mkdir(parents=True)


### PR DESCRIPTION
Task: REPOGROUND-AGENT-UTILITY-V1-T025

Clarifies the existing Doctor contract without weakening it:
- Python >=3.10 remains the RepoGround core minimum.
- Python 3.12 remains the reproduced CI/release validation baseline.
- `doctor --json` now exposes both facts separately and machine-readably.
- Runtime status semantics are unchanged: <3.10 blocked, supported non-3.12 runtimes degraded, 3.12 available.

Validation:
- `python3 -m pytest -q merger/repoground/tests/test_doctor.py` -> 18 passed
- `python3 -m ruff check merger/repoground/core/doctor.py merger/repoground/tests/test_doctor.py` -> passed

The OS-managed Python installation is not modified.