### PR TITLE
fix(benchmark): separate locator and source evidence

### DIFF
--- a/docs/proofs/repoground-evidence-navigation-v1-proof.md
+++ b/docs/proofs/repoground-evidence-navigation-v1-proof.md
@@ -25,7 +25,8 @@ public compatibility aliases.
 ## Reproducible local benchmark
 
 `scripts/benchmarks/repoground_vs_grep_read.py` consumes the committed
-20-question `docs/retrieval/review_queries.v1.json` and an existing local index:
+20-question `docs/retrieval/review_queries.v1.json` by default and an existing
+local index:
 
 ```bash
 python3 scripts/benchmarks/repoground_vs_grep_read.py \
@@ -34,13 +35,13 @@ python3 scripts/benchmarks/repoground_vs_grep_read.py \
   --out /tmp/repoground-vs-grep-read.json
 ```
 
-It uses only local `rg` plus bounded file reads through RepoGround's existing
-review-intent FTS5/BM25 path. The v2 report hashes the index, fixed question
-set and local source tree. For every one of the same 20–30 questions and the
-same `k` limit, it records runtime, logical tool calls, spawned process calls,
-bounded source reads, response bytes, a documented bytes/4 token proxy,
-source/index freshness and false-confidence status. Aggregates contain the
-same measures and the total compact-response reduction.
+The current harness emits report contract v3. Legacy `expected_patterns`
+retains its historical all-path meaning; the opt-in
+`docs/retrieval/review_queries.v2.json` separates `expected_paths` from
+`expected_evidence`. The grep/read condition now includes the bounded source
+content it actually reads in its measured response payload, so current
+`response_bytes` and token-proxy values are intentionally not comparable to the
+older v2 report's baseline payload accounting.
 
 False confidence is recorded only when a condition returned a result and is
 therefore presented as useful, while one or more expected targets are absent
@@ -56,16 +57,24 @@ The decision is fail-closed and has three outcomes:
   benefit contract;
 - `fail` when compaction, freshness or relative quality regresses.
 
-The committed local report `repoground-vs-grep-read.v2.json` is
-`inconclusive`. On 20 fixed questions RepoGround missed 37 expected targets
-versus 60 for `grep/read`, but both conditions had 20 false-confidence cases.
-RepoGround used 551.335 ms versus 166.691 ms, emitted 292,150 raw bytes, and
-its 98,966-byte compact form was still larger than the 26,690-byte baseline.
-The committed run records `ripgrep` as the baseline search engine. When `rg` is
-not installed, the same harness uses a deterministic UTF-8 Python substring
-search, records `python_utf8_substring`, and starts no hidden subprocess. The
-report persists no absolute local paths and binds the benchmark script, index,
-question set and source tree by SHA-256.
-No category is recommended and no default activation follows from this slice.
-The benchmark does not claim repository understanding, answer correctness or
-quality beyond the measured cases.
+## Historical v2 measurement
+
+The committed `repoground-vs-grep-read.v2.json` is a **historical measurement
+from the v2 harness**. It remains immutable evidence for that earlier harness,
+not a current performance claim for report contract v3. Its recorded numbers
+were: 20 fixed questions; RepoGround missed 37 expected targets versus 60 for
+`grep/read`; both conditions had 20 false-confidence cases; RepoGround used
+551.335 ms versus 166.691 ms, emitted 292,150 raw bytes, and its 98,966-byte
+compact form was larger than the then-recorded 26,690-byte baseline.
+
+Those payload totals must not be compared with current v3 runs because v3
+charges grep/read for the bounded source text delivered to the consumer and
+uses the corrected locator/evidence scoring contract. See
+`repoground-vs-grep-read.v3-contract-proof.md` for current deterministic
+measurement-contract evidence. A new full-repository v3 performance report
+requires a fresh local bundle index; no such index is committed here, so this
+proof makes no new full-repository performance or preference claim.
+
+No category is recommended and no default activation follows from the
+historical v2 measurement. The benchmark does not claim repository
+understanding, answer correctness or quality beyond the measured cases.

--- a/docs/proofs/repoground-vs-grep-read.v3-contract-proof.md
+++ b/docs/proofs/repoground-vs-grep-read.v3-contract-proof.md
@@ -12,10 +12,13 @@ claim a new full-repository performance result.
 - `review_queries.v2.json` is opt-in and separates locator targets
   (`expected_paths`) from source evidence (`expected_evidence`).
 - Legacy `expected_patterns` remains all-path for backward-compatible scoring.
-- The grep/read response now contains the bounded source content actually read,
-  so its `response_bytes` and bytes/4 token proxy charge that delivered text.
-- Oracle reads used only to score expected evidence are not counted as condition
-  tool calls or payload; the report exposes that limitation.
+- Evidence is scored only from content exposed by the compared condition:
+  RepoGround exposes the selected indexed chunk content; grep/read exposes only
+  the bounded source bytes returned in its reads.
+- The grep/read response contains the bounded source content actually read, so
+  its `response_bytes` and bytes/4 token proxy charge that delivered text.
+- No full-file scoring oracle is used. Text outside a selected RepoGround chunk
+  or outside grep/read's bounded payload cannot satisfy `expected_evidence`.
 
 ## Deterministic current fixture measurement
 
@@ -33,7 +36,8 @@ bytes**, yielding a bytes/4 token proxy of **53**. The response includes the
 34-byte source content rather than only a `bytes_read` counter.
 
 These values are deterministic for the committed fixture and current response
-shape; the regression tests verify the source content itself, the explicit
+shape. Regression tests additionally verify that source text outside a
+condition's visible payload cannot satisfy evidence, the explicit
 locator/evidence split, the canonical v1 default, root-level legacy path
 handling, and that every v2 evidence anchor occurs in at least one intended
 expected file.

--- a/docs/proofs/repoground-vs-grep-read.v3-contract-proof.md
+++ b/docs/proofs/repoground-vs-grep-read.v3-contract-proof.md
@@ -15,10 +15,14 @@ claim a new full-repository performance result.
 - Evidence is scored only from content exposed by the compared condition:
   RepoGround exposes the selected indexed chunk content; grep/read exposes only
   the bounded source bytes returned in its reads.
+- Evidence can satisfy a case only when that visible payload belongs to a
+  returned path matching one of the case's `expected_paths`; an unrelated hit
+  cannot supply evidence for a different expected path.
 - The grep/read response contains the bounded source content actually read, so
   its `response_bytes` and bytes/4 token proxy charge that delivered text.
-- No full-file scoring oracle is used. Text outside a selected RepoGround chunk
-  or outside grep/read's bounded payload cannot satisfy `expected_evidence`.
+- No full-file scoring oracle is used. Text outside a selected RepoGround chunk,
+  outside grep/read's bounded payload, or on an unrelated returned path cannot
+  satisfy `expected_evidence`.
 
 ## Deterministic current fixture measurement
 
@@ -37,10 +41,10 @@ bytes**, yielding a bytes/4 token proxy of **53**. The response includes the
 
 These values are deterministic for the committed fixture and current response
 shape. Regression tests additionally verify that source text outside a
-condition's visible payload cannot satisfy evidence, the explicit
-locator/evidence split, the canonical v1 default, root-level legacy path
-handling, and that every v2 evidence anchor occurs in at least one intended
-expected file.
+condition's visible payload or on an unrelated returned path cannot satisfy
+evidence, the explicit locator/evidence split, the canonical v1 default,
+root-level legacy path handling, and that every v2 evidence anchor occurs in at
+least one intended expected file.
 
 ## Full-repository boundary
 

--- a/docs/proofs/repoground-vs-grep-read.v3-contract-proof.md
+++ b/docs/proofs/repoground-vs-grep-read.v3-contract-proof.md
@@ -1,0 +1,50 @@
+# RepoGround vs grep/read v3 — measurement-contract proof
+
+Scope: current benchmark measurement semantics only. This proof does **not**
+claim a new full-repository performance result.
+
+## Current contract
+
+`scripts/benchmarks/repoground_vs_grep_read.py` emits
+`repoground_vs_grep_read_benchmark` version `v3`.
+
+- The canonical CLI default remains `docs/retrieval/review_queries.v1.json`.
+- `review_queries.v2.json` is opt-in and separates locator targets
+  (`expected_paths`) from source evidence (`expected_evidence`).
+- Legacy `expected_patterns` remains all-path for backward-compatible scoring.
+- The grep/read response now contains the bounded source content actually read,
+  so its `response_bytes` and bytes/4 token proxy charge that delivered text.
+- Oracle reads used only to score expected evidence are not counted as condition
+  tool calls or payload; the report exposes that limitation.
+
+## Deterministic current fixture measurement
+
+The committed benchmark regression fixture contains exactly this source file:
+
+```text
+def widget():
+    return 'widget'
+```
+
+Its UTF-8 source payload is **34 bytes**. With ripgrep disabled, the current
+`python_utf8_substring` fallback returns one path and one bounded read. The
+canonical compact-JSON measurement of that grep/read result is **211 response
+bytes**, yielding a bytes/4 token proxy of **53**. The response includes the
+34-byte source content rather than only a `bytes_read` counter.
+
+These values are deterministic for the committed fixture and current response
+shape; the regression tests verify the source content itself, the explicit
+locator/evidence split, the canonical v1 default, root-level legacy path
+handling, and that every v2 evidence anchor occurs in at least one intended
+expected file.
+
+## Full-repository boundary
+
+The repository does not commit a `bundle.index.sqlite`. A new full-repository
+v3 comparison therefore requires a fresh local RepoGround bundle/index plus the
+matching source tree. Until that run is produced and hash-bound, the historical
+`repoground-vs-grep-read.v2.json` remains evidence only for the old v2 harness.
+Its payload totals are not current v3 measurements and must not be used to
+claim a v3 preference.
+
+Current v3 product-level outcome: **unmeasured / no recommendation**.

--- a/docs/retrieval/review_queries.v2.json
+++ b/docs/retrieval/review_queries.v2.json
@@ -207,7 +207,7 @@
       "merger/repoground/tests/test_merge_security.py"
     ],
     "expected_evidence": [
-      "safe_join"
+      "resolve_secure_path"
     ],
     "filters": {},
     "accept_criteria": {
@@ -221,7 +221,7 @@
       "merger/repoground/tests/test_service_artifact_security.py"
     ],
     "expected_evidence": [
-      "artifact_path"
+      "test_download_symlink_bypass_blocked"
     ],
     "filters": {},
     "accept_criteria": {
@@ -267,7 +267,7 @@
       "merger/repoground/contracts/range-ref.v2.schema.json"
     ],
     "expected_evidence": [
-      "range_ref_resolution"
+      "resolve_range_ref"
     ],
     "filters": {},
     "accept_criteria": {

--- a/docs/retrieval/review_queries.v2.json
+++ b/docs/retrieval/review_queries.v2.json
@@ -1,0 +1,292 @@
+[
+  {
+    "query": "Find the Agent Reading Pack producer and its primary tests",
+    "category": "agent_pack",
+    "expected_paths": [
+      "merger/repoground/core/agent_reading_pack.py",
+      "merger/repoground/tests/test_agent_reading_pack.py"
+    ],
+    "expected_evidence": [
+      "produce_agent_reading_pack"
+    ],
+    "filters": {},
+    "accept_criteria": {
+      "recall_at_10": 0.2
+    }
+  },
+  {
+    "query": "Find the Agent Reading Pack task-profile usage rules",
+    "category": "agent_pack",
+    "expected_paths": [
+      "merger/repoground/tests/test_agent_reading_pack_usage_rules.py"
+    ],
+    "expected_evidence": [
+      "REQUIRED_READING_BY_TASK"
+    ],
+    "filters": {},
+    "accept_criteria": {
+      "recall_at_10": 0.2
+    }
+  },
+  {
+    "query": "Find claim-to-evidence map production, tests, and contract",
+    "category": "claim_evidence",
+    "expected_paths": [
+      "merger/repoground/core/claim_evidence_map.py",
+      "merger/repoground/tests/test_claim_evidence_map.py",
+      "merger/repoground/contracts/claim-evidence-map.v1.schema.json"
+    ],
+    "expected_evidence": [],
+    "filters": {},
+    "accept_criteria": {
+      "recall_at_10": 0.2
+    }
+  },
+  {
+    "query": "Find citation map production, producer tests, and schema",
+    "category": "citation_map",
+    "expected_paths": [
+      "merger/repoground/core/citation_map.py",
+      "merger/repoground/tests/test_citation_map_producer.py",
+      "merger/repoground/contracts/citation-map.v1.schema.json"
+    ],
+    "expected_evidence": [],
+    "filters": {},
+    "accept_criteria": {
+      "recall_at_10": 0.2
+    }
+  },
+  {
+    "query": "Find post-emit health checks, tests, and contract",
+    "category": "post_emit_health",
+    "expected_paths": [
+      "merger/repoground/core/post_emit_health.py",
+      "merger/repoground/tests/test_post_emit_health.py",
+      "merger/repoground/contracts/post-emit-health.v1.schema.json"
+    ],
+    "expected_evidence": [],
+    "filters": {},
+    "accept_criteria": {
+      "recall_at_10": 0.2
+    }
+  },
+  {
+    "query": "Find bundle surface validation implementation, tests, and contract",
+    "category": "bundle_surface",
+    "expected_paths": [
+      "merger/repoground/core/bundle_surface_validate.py",
+      "merger/repoground/tests/test_bundle_surface_validate.py",
+      "merger/repoground/contracts/bundle-surface-validation.v1.schema.json"
+    ],
+    "expected_evidence": [],
+    "filters": {},
+    "accept_criteria": {
+      "recall_at_10": 0.2
+    }
+  },
+  {
+    "query": "Find the bundle manifest contract and its integration and schema tests",
+    "category": "bundle_manifest",
+    "expected_paths": [
+      "merger/repoground/contracts/bundle-manifest.v1.schema.json",
+      "merger/repoground/tests/test_bundle_manifest_integration.py",
+      "merger/repoground/tests/test_bundle_manifest_schema.py"
+    ],
+    "expected_evidence": [],
+    "filters": {},
+    "accept_criteria": {
+      "recall_at_10": 0.2
+    }
+  },
+  {
+    "query": "Find retrieval evaluation metrics implementation, tests, and output contract",
+    "category": "retrieval",
+    "expected_paths": [
+      "merger/repoground/retrieval/eval_core.py",
+      "merger/repoground/tests/test_retrieval_eval.py",
+      "merger/repoground/contracts/retrieval-eval.v1.schema.json"
+    ],
+    "expected_evidence": [],
+    "filters": {},
+    "accept_criteria": {
+      "recall_at_10": 0.2
+    }
+  },
+  {
+    "query": "Find retrieval miss diagnostics implementation and tests",
+    "category": "retrieval",
+    "expected_paths": [
+      "merger/repoground/retrieval/eval_diagnostics.py",
+      "merger/repoground/tests/test_retrieval_eval_diagnostics.py"
+    ],
+    "expected_evidence": [
+      "miss_taxonomy"
+    ],
+    "filters": {},
+    "accept_criteria": {
+      "recall_at_10": 0.2
+    }
+  },
+  {
+    "query": "Find retrieval router selection logic and router tests",
+    "category": "router",
+    "expected_paths": [
+      "merger/repoground/retrieval/router.py",
+      "merger/repoground/tests/test_router.py"
+    ],
+    "expected_evidence": [
+      "route_query"
+    ],
+    "filters": {},
+    "accept_criteria": {
+      "recall_at_10": 0.2
+    }
+  },
+  {
+    "query": "Find the RepoGround query CLI command and its registration",
+    "category": "cli",
+    "expected_paths": [
+      "merger/repoground/cli/cmd_query.py",
+      "merger/repoground/cli/main.py"
+    ],
+    "expected_evidence": [
+      "run_query"
+    ],
+    "filters": {},
+    "accept_criteria": {
+      "recall_at_10": 0.2
+    }
+  },
+  {
+    "query": "Find the RepoGround retrieval eval CLI command and its registration",
+    "category": "cli",
+    "expected_paths": [
+      "merger/repoground/cli/cmd_eval.py",
+      "merger/repoground/cli/main.py"
+    ],
+    "expected_evidence": [
+      "run_eval"
+    ],
+    "filters": {},
+    "accept_criteria": {
+      "recall_at_10": 0.2
+    }
+  },
+  {
+    "query": "Find the contracts inventory and contracts matrix documentation",
+    "category": "contracts",
+    "expected_paths": [
+      "merger/repoground/contracts/",
+      "docs/contracts/contracts-matrix.md"
+    ],
+    "expected_evidence": [],
+    "filters": {},
+    "accept_criteria": {
+      "recall_at_10": 0.2
+    }
+  },
+  {
+    "query": "Find retrieval and evidence JSON contracts used during review",
+    "category": "contracts",
+    "expected_paths": [
+      "merger/repoground/contracts/retrieval-eval.v1.schema.json",
+      "merger/repoground/contracts/claim-evidence-map.v1.schema.json",
+      "merger/repoground/contracts/citation-map.v1.schema.json"
+    ],
+    "expected_evidence": [],
+    "filters": {},
+    "accept_criteria": {
+      "recall_at_10": 0.2
+    }
+  },
+  {
+    "query": "Find repository path security enforcement and merge security tests",
+    "category": "security",
+    "expected_paths": [
+      "merger/repoground/core/path_security.py",
+      "merger/repoground/tests/test_merge_security.py"
+    ],
+    "expected_evidence": [
+      "safe_join"
+    ],
+    "filters": {},
+    "accept_criteria": {
+      "recall_at_10": 0.2
+    }
+  },
+  {
+    "query": "Find service artifact path security coverage",
+    "category": "security",
+    "expected_paths": [
+      "merger/repoground/tests/test_service_artifact_security.py"
+    ],
+    "expected_evidence": [
+      "artifact_path"
+    ],
+    "filters": {},
+    "accept_criteria": {
+      "recall_at_10": 0.2
+    }
+  },
+  {
+    "query": "Find source acquisition implementation, tests, and report contract",
+    "category": "source_acquisition",
+    "expected_paths": [
+      "merger/repoground/service/source_acquisition.py",
+      "merger/repoground/tests/test_source_acquisition.py",
+      "merger/repoground/contracts/source-acquisition-report.v1.schema.json"
+    ],
+    "expected_evidence": [],
+    "filters": {},
+    "accept_criteria": {
+      "recall_at_10": 0.2
+    }
+  },
+  {
+    "query": "Find PR-Schau bundle production, verification, tests, and contract",
+    "category": "pr_schau",
+    "expected_paths": [
+      "merger/repoground/core/pr_schau_bundle.py",
+      "merger/repoground/cli/pr_schau_verify.py",
+      "merger/repoground/tests/test_pr_schau_verify_units.py",
+      "merger/repoground/contracts/pr-schau.v1.schema.json"
+    ],
+    "expected_evidence": [],
+    "filters": {},
+    "accept_criteria": {
+      "recall_at_10": 0.2
+    }
+  },
+  {
+    "query": "Find range reference resolution, tests, and both contract versions",
+    "category": "range_ref",
+    "expected_paths": [
+      "merger/repoground/core/range_resolver.py",
+      "merger/repoground/tests/test_range_resolver.py",
+      "merger/repoground/contracts/range-ref.v1.schema.json",
+      "merger/repoground/contracts/range-ref.v2.schema.json"
+    ],
+    "expected_evidence": [
+      "range_ref_resolution"
+    ],
+    "filters": {},
+    "accept_criteria": {
+      "recall_at_10": 0.2
+    }
+  },
+  {
+    "query": "Find lens selection implementation and tests",
+    "category": "lenses",
+    "expected_paths": [
+      "merger/repoground/core/lenses.py",
+      "merger/repoground/tests/test_lenses.py"
+    ],
+    "expected_evidence": [
+      "infer_lens"
+    ],
+    "filters": {},
+    "accept_criteria": {
+      "recall_at_10": 0.2
+    }
+  }
+]

--- a/merger/repoground/tests/test_repoground_vs_grep_read_benchmark.py
+++ b/merger/repoground/tests/test_repoground_vs_grep_read_benchmark.py
@@ -57,6 +57,7 @@ def test_benchmark_writes_per_case_and_aggregate_measurements_with_input_hashes(
     assert configuration["default_question_contract"] == "expected_patterns"
     assert configuration["opt_in_question_contract"] == "expected_paths+expected_evidence"
     assert configuration["source_evidence_scoring"] == "condition_visible_payload"
+    assert configuration["evidence_path_binding"] == "matched_expected_paths_only"
     assert configuration["repoground_visible_payload"] == "selected_index_chunk_content"
     assert set(report["inputs"]) >= {
         "benchmark_script_sha256", "index_sha256", "questions_sha256", "repo_tree_sha256",
@@ -125,6 +126,23 @@ def test_source_evidence_cannot_use_text_outside_condition_payload(tmp_path):
     assert repo_targets["source_evidence"]["missing"] == ["def widget"]
     assert report["cases"][0]["repoground"]["false_confidence"] is True
     assert grep_targets["source_evidence"]["found"] == ["def widget"]
+
+
+def test_source_evidence_cannot_leak_from_unrelated_visible_path():
+    module = _benchmark_module()
+    targets = module._expected_targets(
+        ["src/widget.py", "src/unrelated.py"],
+        [
+            ("src/widget.py", "widget implementation"),
+            ("src/unrelated.py", "def widget(): pass"),
+        ],
+        ["src/widget.py"],
+        ["def widget"],
+    )
+
+    assert targets["paths"]["found"] == ["src/widget.py"]
+    assert targets["source_evidence"]["found"] == []
+    assert targets["source_evidence"]["missing"] == ["def widget"]
 
 
 def test_benchmark_marks_missing_source_evidence_as_false_confidence(tmp_path):

--- a/merger/repoground/tests/test_repoground_vs_grep_read_benchmark.py
+++ b/merger/repoground/tests/test_repoground_vs_grep_read_benchmark.py
@@ -45,10 +45,15 @@ def test_benchmark_writes_per_case_and_aggregate_measurements_with_input_hashes(
 
     report = module.run(index, root, questions, k=1)
 
+    assert report["version"] == "v3"
     assert report["status"] == "inconclusive"
     assert len(report["cases"]) == 20
     assert report["acceptance"]["same_question_set"] is True
     assert report["acceptance"]["same_k"] == 1
+    assert report["configuration"]["legacy_expected_pattern_contract"] == (
+        "slash=>path; no-slash=>source_evidence"
+    )
+    assert report["configuration"]["oracle_reads_counted_as_condition_calls"] is False
     assert set(report["inputs"]) >= {
         "benchmark_script_sha256", "index_sha256", "questions_sha256", "repo_tree_sha256",
     }
@@ -68,6 +73,47 @@ def test_benchmark_writes_per_case_and_aggregate_measurements_with_input_hashes(
         assert case["repoground"]["compaction"]["pass"] is True
         assert case["repoground"]["false_confidence"] is False
     assert report["aggregates"]["repoground"]["compaction"]["aggregate_pass"] is True
+
+
+def test_benchmark_separates_locator_and_source_evidence_targets(tmp_path):
+    module = _benchmark_module()
+    root, index, questions = _fixture_index(tmp_path)
+    questions.write_text(json.dumps([
+        {"query": "widget", "category": "fixture", "expected_patterns": ["src/widget.py", "def widget"]}
+        for _ in range(20)
+    ]), encoding="utf-8")
+
+    report = module.run(index, root, questions, k=1)
+
+    for condition in ("repoground", "grep_read"):
+        targets = report["cases"][0][condition]["expected_targets"]
+        assert targets["paths"]["found"] == ["src/widget.py"]
+        assert targets["paths"]["missing"] == []
+        assert targets["source_evidence"]["found"] == ["def widget"]
+        assert targets["source_evidence"]["missing"] == []
+        assert report["cases"][0][condition]["false_confidence"] is False
+
+
+def test_benchmark_marks_missing_source_evidence_as_false_confidence(tmp_path):
+    module = _benchmark_module()
+    root, index, questions = _fixture_index(tmp_path)
+    questions.write_text(json.dumps([
+        {
+            "query": "widget",
+            "category": "fixture",
+            "expected_patterns": ["src/widget.py", "def missing_widget"],
+        }
+        for _ in range(20)
+    ]), encoding="utf-8")
+
+    report = module.run(index, root, questions, k=1)
+
+    for condition in ("repoground", "grep_read"):
+        targets = report["cases"][0][condition]["expected_targets"]
+        assert targets["paths"]["missing"] == []
+        assert targets["source_evidence"]["missing"] == ["def missing_widget"]
+        assert report["cases"][0][condition]["false_confidence"] is True
+        assert report["aggregates"][condition]["false_confidence_cases"] == 20
 
 
 def test_benchmark_defines_false_confidence_for_missing_targets_or_stale_sources(tmp_path):
@@ -165,5 +211,10 @@ def test_benchmark_uses_python_fallback_without_ripgrep(monkeypatch, tmp_path):
 
     assert result["search_engine"] == "python_utf8_substring"
     assert result["paths"] == ["src/widget.py"]
+    assert result["reads"] == [{
+        "path": "src/widget.py",
+        "bytes_read": len("def widget():\n    return 'widget'\n".encode("utf-8")),
+        "content": "def widget():\n    return 'widget'\n",
+    }]
     assert process_calls == 0
     assert read_calls == 1

--- a/merger/repoground/tests/test_repoground_vs_grep_read_benchmark.py
+++ b/merger/repoground/tests/test_repoground_vs_grep_read_benchmark.py
@@ -50,8 +50,9 @@ def test_benchmark_writes_per_case_and_aggregate_measurements_with_input_hashes(
     assert len(report["cases"]) == 20
     assert report["acceptance"]["same_question_set"] is True
     assert report["acceptance"]["same_k"] == 1
-    assert report["configuration"]["legacy_expected_pattern_contract"] == (
-        "slash=>path; no-slash=>source_evidence"
+    assert report["configuration"]["legacy_expected_pattern_contract"] == "all=>path"
+    assert report["configuration"]["preferred_question_contract"] == (
+        "expected_paths+expected_evidence"
     )
     assert report["configuration"]["oracle_reads_counted_as_condition_calls"] is False
     assert set(report["inputs"]) >= {
@@ -75,11 +76,27 @@ def test_benchmark_writes_per_case_and_aggregate_measurements_with_input_hashes(
     assert report["aggregates"]["repoground"]["compaction"]["aggregate_pass"] is True
 
 
+def test_legacy_expected_patterns_preserve_root_level_path_targets():
+    module = _benchmark_module()
+
+    paths, evidence = module._expected_contract({
+        "expected_patterns": ["missing.py", "README", "src/widget.py"],
+    })
+
+    assert paths == ["missing.py", "README", "src/widget.py"]
+    assert evidence == []
+
+
 def test_benchmark_separates_locator_and_source_evidence_targets(tmp_path):
     module = _benchmark_module()
     root, index, questions = _fixture_index(tmp_path)
     questions.write_text(json.dumps([
-        {"query": "widget", "category": "fixture", "expected_patterns": ["src/widget.py", "def widget"]}
+        {
+            "query": "widget",
+            "category": "fixture",
+            "expected_paths": ["src/widget.py"],
+            "expected_evidence": ["def widget"],
+        }
         for _ in range(20)
     ]), encoding="utf-8")
 
@@ -101,7 +118,8 @@ def test_benchmark_marks_missing_source_evidence_as_false_confidence(tmp_path):
         {
             "query": "widget",
             "category": "fixture",
-            "expected_patterns": ["src/widget.py", "def missing_widget"],
+            "expected_paths": ["src/widget.py"],
+            "expected_evidence": ["def missing_widget"],
         }
         for _ in range(20)
     ]), encoding="utf-8")

--- a/merger/repoground/tests/test_repoground_vs_grep_read_benchmark.py
+++ b/merger/repoground/tests/test_repoground_vs_grep_read_benchmark.py
@@ -120,7 +120,11 @@ def test_benchmark_defines_false_confidence_for_missing_targets_or_stale_sources
     module = _benchmark_module()
     root, index, questions = _fixture_index(tmp_path)
     questions.write_text(json.dumps([
-        {"query": "widget", "expected_patterns": ["src/widget.py", "missing.py"]}
+        {
+            "query": "widget",
+            "expected_paths": ["src/widget.py", "missing.py"],
+            "expected_evidence": [],
+        }
         for _ in range(20)
     ]), encoding="utf-8")
 
@@ -185,7 +189,12 @@ def test_benchmark_fails_on_quality_regression(monkeypatch, tmp_path):
     root, index, questions = _fixture_index(tmp_path)
     (root / "missing.py").write_text("# baseline-only target\n", encoding="utf-8")
     questions.write_text(json.dumps([
-        {"query": "widget", "category": "fixture", "expected_patterns": ["src/widget.py", "missing.py"]}
+        {
+            "query": "widget",
+            "category": "fixture",
+            "expected_paths": ["src/widget.py", "missing.py"],
+            "expected_evidence": [],
+        }
         for _ in range(20)
     ]), encoding="utf-8")
 

--- a/merger/repoground/tests/test_repoground_vs_grep_read_benchmark.py
+++ b/merger/repoground/tests/test_repoground_vs_grep_read_benchmark.py
@@ -6,6 +6,9 @@ from pathlib import Path
 from merger.repoground.retrieval import index_db
 
 
+VISIBLE_SOURCE = "def widget():\n    return 'widget'\n"
+
+
 def _benchmark_module():
     root = Path(__file__).resolve().parents[3]
     path = root / "scripts/benchmarks/repoground_vs_grep_read.py"
@@ -16,18 +19,18 @@ def _benchmark_module():
     return module
 
 
-def _fixture_index(tmp_path):
+def _fixture_index(tmp_path, *, indexed_content=VISIBLE_SOURCE):
     root = tmp_path / "repo"
     source = root / "src/widget.py"
     source.parent.mkdir(parents=True)
-    source.write_text("def widget():\n    return 'widget'\n", encoding="utf-8")
+    source.write_text(VISIBLE_SOURCE, encoding="utf-8")
     dump = tmp_path / "dump.json"
     chunks = tmp_path / "chunks.jsonl"
     index = tmp_path / "fixture.index.sqlite"
     dump.write_text("{}", encoding="utf-8")
     chunks.write_text(json.dumps({
         "chunk_id": "widget", "repo_id": "fixture", "path": "src/widget.py",
-        "content": "widget implementation", "start_line": 1, "end_line": 2,
+        "content": indexed_content, "start_line": 1, "end_line": 2,
         "layer": "core", "artifact_type": "code", "content_sha256": "a" * 64,
     }) + "\n", encoding="utf-8")
     index_db.build_index(dump, chunks, index)
@@ -42,7 +45,6 @@ def _fixture_index(tmp_path):
 def test_benchmark_writes_per_case_and_aggregate_measurements_with_input_hashes(tmp_path):
     module = _benchmark_module()
     root, index, questions = _fixture_index(tmp_path)
-
     report = module.run(index, root, questions, k=1)
 
     assert report["version"] == "v3"
@@ -50,12 +52,12 @@ def test_benchmark_writes_per_case_and_aggregate_measurements_with_input_hashes(
     assert len(report["cases"]) == 20
     assert report["acceptance"]["same_question_set"] is True
     assert report["acceptance"]["same_k"] == 1
-    assert report["configuration"]["legacy_expected_pattern_contract"] == "all=>path"
-    assert report["configuration"]["default_question_contract"] == "expected_patterns"
-    assert report["configuration"]["opt_in_question_contract"] == (
-        "expected_paths+expected_evidence"
-    )
-    assert report["configuration"]["oracle_reads_counted_as_condition_calls"] is False
+    configuration = report["configuration"]
+    assert configuration["legacy_expected_pattern_contract"] == "all=>path"
+    assert configuration["default_question_contract"] == "expected_patterns"
+    assert configuration["opt_in_question_contract"] == "expected_paths+expected_evidence"
+    assert configuration["source_evidence_scoring"] == "condition_visible_payload"
+    assert configuration["repoground_visible_payload"] == "selected_index_chunk_content"
     assert set(report["inputs"]) >= {
         "benchmark_script_sha256", "index_sha256", "questions_sha256", "repo_tree_sha256",
     }
@@ -79,11 +81,9 @@ def test_benchmark_writes_per_case_and_aggregate_measurements_with_input_hashes(
 
 def test_legacy_expected_patterns_preserve_root_level_path_targets():
     module = _benchmark_module()
-
     paths, evidence = module._expected_contract({
         "expected_patterns": ["missing.py", "README", "src/widget.py"],
     })
-
     assert paths == ["missing.py", "README", "src/widget.py"]
     assert evidence == []
 
@@ -93,23 +93,38 @@ def test_benchmark_separates_locator_and_source_evidence_targets(tmp_path):
     root, index, questions = _fixture_index(tmp_path)
     questions.write_text(json.dumps([
         {
-            "query": "widget",
-            "category": "fixture",
-            "expected_paths": ["src/widget.py"],
-            "expected_evidence": ["def widget"],
+            "query": "widget", "category": "fixture",
+            "expected_paths": ["src/widget.py"], "expected_evidence": ["def widget"],
         }
         for _ in range(20)
     ]), encoding="utf-8")
-
     report = module.run(index, root, questions, k=1)
 
     for condition in ("repoground", "grep_read"):
         targets = report["cases"][0][condition]["expected_targets"]
         assert targets["paths"]["found"] == ["src/widget.py"]
-        assert targets["paths"]["missing"] == []
         assert targets["source_evidence"]["found"] == ["def widget"]
         assert targets["source_evidence"]["missing"] == []
         assert report["cases"][0][condition]["false_confidence"] is False
+
+
+def test_source_evidence_cannot_use_text_outside_condition_payload(tmp_path):
+    module = _benchmark_module()
+    root, index, questions = _fixture_index(tmp_path, indexed_content="widget implementation")
+    questions.write_text(json.dumps([
+        {
+            "query": "widget", "category": "fixture",
+            "expected_paths": ["src/widget.py"], "expected_evidence": ["def widget"],
+        }
+        for _ in range(20)
+    ]), encoding="utf-8")
+    report = module.run(index, root, questions, k=1)
+
+    repo_targets = report["cases"][0]["repoground"]["expected_targets"]
+    grep_targets = report["cases"][0]["grep_read"]["expected_targets"]
+    assert repo_targets["source_evidence"]["missing"] == ["def widget"]
+    assert report["cases"][0]["repoground"]["false_confidence"] is True
+    assert grep_targets["source_evidence"]["found"] == ["def widget"]
 
 
 def test_benchmark_marks_missing_source_evidence_as_false_confidence(tmp_path):
@@ -117,14 +132,11 @@ def test_benchmark_marks_missing_source_evidence_as_false_confidence(tmp_path):
     root, index, questions = _fixture_index(tmp_path)
     questions.write_text(json.dumps([
         {
-            "query": "widget",
-            "category": "fixture",
-            "expected_paths": ["src/widget.py"],
-            "expected_evidence": ["def missing_widget"],
+            "query": "widget", "category": "fixture",
+            "expected_paths": ["src/widget.py"], "expected_evidence": ["def missing_widget"],
         }
         for _ in range(20)
     ]), encoding="utf-8")
-
     report = module.run(index, root, questions, k=1)
 
     for condition in ("repoground", "grep_read"):
@@ -139,16 +151,10 @@ def test_benchmark_defines_false_confidence_for_missing_targets_or_stale_sources
     module = _benchmark_module()
     root, index, questions = _fixture_index(tmp_path)
     questions.write_text(json.dumps([
-        {
-            "query": "widget",
-            "expected_paths": ["src/widget.py", "missing.py"],
-            "expected_evidence": [],
-        }
+        {"query": "widget", "expected_paths": ["src/widget.py", "missing.py"], "expected_evidence": []}
         for _ in range(20)
     ]), encoding="utf-8")
-
     report = module.run(index, root, questions, k=1)
-
     assert report["cases"][0]["repoground"]["useful_displayed"] is True
     assert report["cases"][0]["repoground"]["false_confidence"] is True
     assert report["aggregates"]["repoground"]["false_confidence_cases"] == 20
@@ -162,7 +168,6 @@ def test_benchmark_cli_writes_a_local_hashed_report(monkeypatch, tmp_path):
         "repoground_vs_grep_read.py", "--index", str(index), "--repo-root", str(root),
         "--questions", str(questions), "--k", "1", "--out", str(output),
     ])
-
     assert module.main() == 0
     persisted = json.loads(output.read_text(encoding="utf-8"))
     assert persisted["status"] == "inconclusive"
@@ -173,14 +178,8 @@ def test_benchmark_cli_writes_a_local_hashed_report(monkeypatch, tmp_path):
 def test_benchmark_fails_closed_when_compaction_requirement_is_not_met(monkeypatch, tmp_path):
     module = _benchmark_module()
     root, index, questions = _fixture_index(tmp_path)
-    monkeypatch.setattr(
-        module,
-        "_compact_repoground_response",
-        lambda result, freshness: {"unnecessary": "x" * 50_000},
-    )
-
+    monkeypatch.setattr(module, "_compact_repoground_response", lambda result, freshness: {"unnecessary": "x" * 50_000})
     report = module.run(index, root, questions, k=1)
-
     assert report["status"] == "fail"
     assert report["acceptance"]["failure_reasons"] == ["compaction_below_60_percent"]
     assert report["aggregates"]["repoground"]["compaction"]["all_cases_pass"] is False
@@ -195,7 +194,6 @@ def test_benchmark_recommends_only_a_named_safe_benefit(monkeypatch, tmp_path):
 
     monkeypatch.setattr(module, "_grep_read", empty_grep_read)
     report = module.run(index, root, questions, k=1)
-
     assert report["status"] == "pass"
     assert report["acceptance"]["recommended_categories"] == ["fixture"]
     assert report["acceptance"]["preference_recommendation"] == "repoground"
@@ -209,10 +207,8 @@ def test_benchmark_fails_on_quality_regression(monkeypatch, tmp_path):
     (root / "missing.py").write_text("# baseline-only target\n", encoding="utf-8")
     questions.write_text(json.dumps([
         {
-            "query": "widget",
-            "category": "fixture",
-            "expected_paths": ["src/widget.py", "missing.py"],
-            "expected_evidence": [],
+            "query": "widget", "category": "fixture",
+            "expected_paths": ["src/widget.py", "missing.py"], "expected_evidence": [],
         }
         for _ in range(20)
     ]), encoding="utf-8")
@@ -225,7 +221,6 @@ def test_benchmark_fails_on_quality_regression(monkeypatch, tmp_path):
 
     monkeypatch.setattr(module, "_grep_read", perfect_grep_read)
     report = module.run(index, root, questions, k=1)
-
     assert report["status"] == "fail"
     assert report["acceptance"]["failure_reasons"] == ["quality_or_freshness_regression"]
 
@@ -234,15 +229,12 @@ def test_benchmark_uses_python_fallback_without_ripgrep(monkeypatch, tmp_path):
     module = _benchmark_module()
     root, _, _ = _fixture_index(tmp_path)
     monkeypatch.setattr(module.shutil, "which", lambda _name: None)
-
     result, process_calls, read_calls = module._grep_read(root, "widget", 1)
-
     assert result["search_engine"] == "python_utf8_substring"
     assert result["paths"] == ["src/widget.py"]
     assert result["reads"] == [{
-        "path": "src/widget.py",
-        "bytes_read": len("def widget():\n    return 'widget'\n".encode("utf-8")),
-        "content": "def widget():\n    return 'widget'\n",
+        "path": "src/widget.py", "bytes_read": len(VISIBLE_SOURCE.encode("utf-8")),
+        "content": VISIBLE_SOURCE,
     }]
     assert process_calls == 0
     assert read_calls == 1

--- a/merger/repoground/tests/test_repoground_vs_grep_read_benchmark.py
+++ b/merger/repoground/tests/test_repoground_vs_grep_read_benchmark.py
@@ -51,7 +51,8 @@ def test_benchmark_writes_per_case_and_aggregate_measurements_with_input_hashes(
     assert report["acceptance"]["same_question_set"] is True
     assert report["acceptance"]["same_k"] == 1
     assert report["configuration"]["legacy_expected_pattern_contract"] == "all=>path"
-    assert report["configuration"]["preferred_question_contract"] == (
+    assert report["configuration"]["default_question_contract"] == "expected_patterns"
+    assert report["configuration"]["opt_in_question_contract"] == (
         "expected_paths+expected_evidence"
     )
     assert report["configuration"]["oracle_reads_counted_as_condition_calls"] is False

--- a/merger/repoground/tests/test_repoground_vs_grep_read_v3_proof.py
+++ b/merger/repoground/tests/test_repoground_vs_grep_read_v3_proof.py
@@ -1,0 +1,23 @@
+import json
+
+from merger.repoground.tests.test_repoground_vs_grep_read_benchmark import _benchmark_module
+
+
+def test_v3_fixture_payload_measurement_matches_contract_proof(monkeypatch, tmp_path):
+    module = _benchmark_module()
+    root = tmp_path / "repo"
+    source = root / "src" / "widget.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("def widget():\n    return 'widget'\n", encoding="utf-8")
+    monkeypatch.setattr(module.shutil, "which", lambda _name: None)
+
+    result, process_calls, read_calls = module._grep_read(root, "widget", 1)
+    response_bytes = len(
+        json.dumps(result, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    )
+
+    assert result["reads"][0]["bytes_read"] == 34
+    assert response_bytes == 211
+    assert (response_bytes + 3) // 4 == 53
+    assert process_calls == 0
+    assert read_calls == 1

--- a/merger/repoground/tests/test_review_query_goldset_contract.py
+++ b/merger/repoground/tests/test_review_query_goldset_contract.py
@@ -2,9 +2,12 @@ import json
 from pathlib import Path
 
 
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
 def _load_goldset(name: str):
-    root = Path(__file__).resolve().parents[3]
-    path = root / "docs" / "retrieval" / name
+    path = _repo_root() / "docs" / "retrieval" / name
     return json.loads(path.read_text(encoding="utf-8"))
 
 
@@ -21,3 +24,12 @@ def test_review_queries_v2_is_lossless_split_of_v1():
         assert new["accept_criteria"] == old["accept_criteria"]
         assert "expected_patterns" not in new
         assert new["expected_paths"] + new["expected_evidence"] == old["expected_patterns"]
+
+
+def test_benchmark_cli_keeps_canonical_v1_goldset_as_default():
+    script = (
+        _repo_root() / "scripts" / "benchmarks" / "repoground_vs_grep_read.py"
+    ).read_text(encoding="utf-8")
+
+    assert 'default=Path("docs/retrieval/review_queries.v1.json")' in script
+    assert 'default=Path("docs/retrieval/review_queries.v2.json")' not in script

--- a/merger/repoground/tests/test_review_query_goldset_contract.py
+++ b/merger/repoground/tests/test_review_query_goldset_contract.py
@@ -1,0 +1,23 @@
+import json
+from pathlib import Path
+
+
+def _load_goldset(name: str):
+    root = Path(__file__).resolve().parents[3]
+    path = root / "docs" / "retrieval" / name
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_review_queries_v2_is_lossless_split_of_v1():
+    legacy = _load_goldset("review_queries.v1.json")
+    explicit = _load_goldset("review_queries.v2.json")
+
+    assert len(legacy) == len(explicit) == 20
+
+    for old, new in zip(legacy, explicit, strict=True):
+        assert new["query"] == old["query"]
+        assert new["category"] == old["category"]
+        assert new["filters"] == old["filters"]
+        assert new["accept_criteria"] == old["accept_criteria"]
+        assert "expected_patterns" not in new
+        assert new["expected_paths"] + new["expected_evidence"] == old["expected_patterns"]

--- a/merger/repoground/tests/test_review_query_goldset_contract.py
+++ b/merger/repoground/tests/test_review_query_goldset_contract.py
@@ -11,7 +11,7 @@ def _load_goldset(name: str):
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def test_review_queries_v2_is_lossless_split_of_v1():
+def test_review_queries_v2_preserves_v1_questions_and_path_targets():
     legacy = _load_goldset("review_queries.v1.json")
     explicit = _load_goldset("review_queries.v2.json")
 
@@ -23,7 +23,28 @@ def test_review_queries_v2_is_lossless_split_of_v1():
         assert new["filters"] == old["filters"]
         assert new["accept_criteria"] == old["accept_criteria"]
         assert "expected_patterns" not in new
-        assert new["expected_paths"] + new["expected_evidence"] == old["expected_patterns"]
+        legacy_path_targets = [
+            pattern for pattern in old["expected_patterns"] if "/" in pattern
+        ]
+        assert new["expected_paths"] == legacy_path_targets
+
+
+def test_review_queries_v2_evidence_is_bound_to_expected_files():
+    root = _repo_root()
+    explicit = _load_goldset("review_queries.v2.json")
+
+    for case in explicit:
+        target_texts = []
+        for relative in case["expected_paths"]:
+            path = root / relative
+            if path.is_file():
+                target_texts.append(path.read_text(encoding="utf-8", errors="replace"))
+
+        for evidence in case["expected_evidence"]:
+            assert any(evidence in text for text in target_texts), (
+                f"evidence {evidence!r} is absent from expected files for "
+                f"{case['query']!r}"
+            )
 
 
 def test_benchmark_cli_keeps_canonical_v1_goldset_as_default():

--- a/scripts/benchmarks/repoground_vs_grep_read.py
+++ b/scripts/benchmarks/repoground_vs_grep_read.py
@@ -76,22 +76,19 @@ def _target_state(candidates: list[str], expected: list[str]) -> dict[str, Any]:
 
 
 def _expected_contract(case: dict[str, Any]) -> tuple[list[str], list[str]]:
-    """Split locator targets from source-evidence targets.
+    """Return explicit locator and source-evidence targets.
 
-    New question sets may declare ``expected_paths`` and ``expected_evidence``
-    explicitly.  The committed v1 question set predates that contract and mixes
-    both forms in ``expected_patterns``; repository-relative targets contain a
-    slash, while bare identifiers are treated as source evidence.
+    New question sets declare ``expected_paths`` and ``expected_evidence``
+    explicitly.  Legacy ``expected_patterns`` retains the original benchmark
+    semantics: every entry is a path target.  This is intentionally not guessed
+    from spelling because repository-root paths and bare symbols are ambiguous.
     """
     if "expected_paths" in case or "expected_evidence" in case:
         expected_paths = list(case.get("expected_paths") or [])
         expected_evidence = list(case.get("expected_evidence") or [])
         return expected_paths, expected_evidence
 
-    legacy = list(case.get("expected_patterns") or [])
-    expected_paths = [pattern for pattern in legacy if "/" in pattern]
-    expected_evidence = [pattern for pattern in legacy if "/" not in pattern]
-    return expected_paths, expected_evidence
+    return list(case.get("expected_patterns") or []), []
 
 
 def _source_evidence_targets(
@@ -474,7 +471,8 @@ def run(index: Path, repo_root: Path, questions_path: Path, k: int) -> dict[str,
             "k": k,
             "read_limit_bytes": READ_LIMIT_BYTES,
             "token_proxy_bytes_per_token": TOKEN_PROXY_BYTES_PER_TOKEN,
-            "legacy_expected_pattern_contract": "slash=>path; no-slash=>source_evidence",
+            "legacy_expected_pattern_contract": "all=>path",
+            "preferred_question_contract": "expected_paths+expected_evidence",
             "source_evidence_scoring": "full_returned_source_file_oracle",
             "oracle_reads_counted_as_condition_calls": False,
         },
@@ -503,7 +501,7 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--index", required=True, type=Path)
     parser.add_argument("--repo-root", required=True, type=Path)
-    parser.add_argument("--questions", type=Path, default=Path("docs/retrieval/review_queries.v1.json"))
+    parser.add_argument("--questions", type=Path, default=Path("docs/retrieval/review_queries.v2.json"))
     parser.add_argument("--k", type=int, default=10)
     parser.add_argument("--out", type=Path, required=True)
     args = parser.parse_args()

--- a/scripts/benchmarks/repoground_vs_grep_read.py
+++ b/scripts/benchmarks/repoground_vs_grep_read.py
@@ -65,10 +65,84 @@ def _tokens(question: str) -> list[str]:
     return list(dict.fromkeys(re.findall(r"[A-Za-z0-9_]{3,}", question.lower())))
 
 
-def _expected_targets(paths: list[str], expected: list[str]) -> dict[str, Any]:
-    found = [pattern for pattern in expected if any(pattern in path for path in paths)]
+def _target_state(candidates: list[str], expected: list[str]) -> dict[str, Any]:
+    found = [
+        pattern
+        for pattern in expected
+        if any(pattern in candidate for candidate in candidates)
+    ]
     missing = [pattern for pattern in expected if pattern not in found]
     return {"expected": expected, "found": found, "missing": missing}
+
+
+def _expected_contract(case: dict[str, Any]) -> tuple[list[str], list[str]]:
+    """Split locator targets from source-evidence targets.
+
+    New question sets may declare ``expected_paths`` and ``expected_evidence``
+    explicitly.  The committed v1 question set predates that contract and mixes
+    both forms in ``expected_patterns``; repository-relative targets contain a
+    slash, while bare identifiers are treated as source evidence.
+    """
+    if "expected_paths" in case or "expected_evidence" in case:
+        expected_paths = list(case.get("expected_paths") or [])
+        expected_evidence = list(case.get("expected_evidence") or [])
+        return expected_paths, expected_evidence
+
+    legacy = list(case.get("expected_patterns") or [])
+    expected_paths = [pattern for pattern in legacy if "/" in pattern]
+    expected_evidence = [pattern for pattern in legacy if "/" not in pattern]
+    return expected_paths, expected_evidence
+
+
+def _source_evidence_targets(
+    root: Path,
+    paths: list[str],
+    expected: list[str],
+) -> dict[str, Any]:
+    """Score source evidence in returned paths without charging oracle reads.
+
+    These reads are benchmark ground-truth checks, not payload shown to either
+    condition.  Keeping them outside measured tool/source-read counts prevents
+    the scoring oracle itself from changing the compared interaction cost.
+    """
+    if not expected:
+        return _target_state([], expected)
+
+    resolved_root = root.resolve()
+    source_texts: list[str] = []
+    for relative in paths:
+        candidate = resolved_root / relative
+        if candidate.is_symlink():
+            continue
+        try:
+            resolved = candidate.resolve()
+            resolved.relative_to(resolved_root)
+        except (OSError, ValueError):
+            continue
+        if not resolved.is_file():
+            continue
+        try:
+            source_texts.append(resolved.read_text(encoding="utf-8", errors="replace"))
+        except OSError:
+            continue
+    return _target_state(source_texts, expected)
+
+
+def _expected_targets(
+    root: Path,
+    paths: list[str],
+    expected_paths: list[str],
+    expected_evidence: list[str],
+) -> dict[str, Any]:
+    path_state = _target_state(paths, expected_paths)
+    evidence_state = _source_evidence_targets(root, paths, expected_evidence)
+    return {
+        "expected": path_state["expected"] + evidence_state["expected"],
+        "found": path_state["found"] + evidence_state["found"],
+        "missing": path_state["missing"] + evidence_state["missing"],
+        "paths": path_state,
+        "source_evidence": evidence_state,
+    }
 
 
 def _source_freshness(paths: list[str], root: Path, index_mtime_ns: int | None) -> dict[str, Any]:
@@ -169,7 +243,12 @@ def _grep_read(root: Path, question: str, k: int) -> tuple[dict[str, Any], int, 
     reads = []
     for relative in paths:
         with (root / relative).open("rb") as handle:
-            reads.append({"path": relative, "bytes_read": len(handle.read(READ_LIMIT_BYTES))})
+            payload = handle.read(READ_LIMIT_BYTES)
+        reads.append({
+            "path": relative,
+            "bytes_read": len(payload),
+            "content": payload.decode("utf-8", errors="replace"),
+        })
     result = {
         "query": question,
         "k": k,
@@ -181,11 +260,22 @@ def _grep_read(root: Path, question: str, k: int) -> tuple[dict[str, Any], int, 
     return result, process_calls, len(reads)
 
 
-def _measurement(condition: str, result: dict[str, Any], *, runtime_ns: int, process_calls: int,
-                 source_read_calls: int, paths: list[str], expected: list[str], freshness: dict[str, Any],
-                 compact: dict[str, Any] | None = None) -> dict[str, Any]:
+def _measurement(
+    condition: str,
+    result: dict[str, Any],
+    *,
+    runtime_ns: int,
+    process_calls: int,
+    source_read_calls: int,
+    paths: list[str],
+    expected_paths: list[str],
+    expected_evidence: list[str],
+    root: Path,
+    freshness: dict[str, Any],
+    compact: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     response_bytes = len(json.dumps(result, sort_keys=True, separators=(",", ":")).encode("utf-8"))
-    target_state = _expected_targets(paths, expected)
+    target_state = _expected_targets(root, paths, expected_paths, expected_evidence)
     useful_displayed = bool(paths)
     false_confidence = useful_displayed and (
         bool(target_state["missing"]) or freshness["status"] != "fresh"
@@ -300,7 +390,7 @@ def run(index: Path, repo_root: Path, questions_path: Path, k: int) -> dict[str,
     cases = []
     for ordinal, case in enumerate(questions, start=1):
         query = case["query"]
-        expected = case["expected_patterns"]
+        expected_paths, expected_evidence = _expected_contract(case)
         started = time.perf_counter_ns()
         rg_result = _execute_review_query(index, query, k=k)
         rg_runtime = time.perf_counter_ns() - started
@@ -312,7 +402,7 @@ def run(index: Path, repo_root: Path, questions_path: Path, k: int) -> dict[str,
         grep_result, process_calls, read_calls = _grep_read(root, query, k)
         grep_runtime = time.perf_counter_ns() - started
         grep_paths = grep_result["paths"]
-        # rg/read deliberately does not consume the index; its source freshness
+        # grep/read deliberately does not consume the index; its source freshness
         # is therefore recorded independently rather than pretending index use.
         grep_freshness = _source_freshness(grep_paths, root, None)
         cases.append({
@@ -320,12 +410,31 @@ def run(index: Path, repo_root: Path, questions_path: Path, k: int) -> dict[str,
             "query": query,
             "category": case.get("category"),
             "k": k,
-            "repoground": _measurement("repoground", rg_result, runtime_ns=rg_runtime, process_calls=0,
-                                         source_read_calls=0, paths=rg_paths, expected=expected,
-                                         freshness=rg_freshness, compact=rg_compact),
-            "grep_read": _measurement("grep_read", grep_result, runtime_ns=grep_runtime,
-                                        process_calls=process_calls, source_read_calls=read_calls,
-                                        paths=grep_paths, expected=expected, freshness=grep_freshness),
+            "repoground": _measurement(
+                "repoground",
+                rg_result,
+                runtime_ns=rg_runtime,
+                process_calls=0,
+                source_read_calls=0,
+                paths=rg_paths,
+                expected_paths=expected_paths,
+                expected_evidence=expected_evidence,
+                root=root,
+                freshness=rg_freshness,
+                compact=rg_compact,
+            ),
+            "grep_read": _measurement(
+                "grep_read",
+                grep_result,
+                runtime_ns=grep_runtime,
+                process_calls=process_calls,
+                source_read_calls=read_calls,
+                paths=grep_paths,
+                expected_paths=expected_paths,
+                expected_evidence=expected_evidence,
+                root=root,
+                freshness=grep_freshness,
+            ),
         })
     aggregates = {name: _aggregate(cases, name) for name in ("repoground", "grep_read")}
     compaction = aggregates["repoground"]["compaction"]
@@ -349,7 +458,7 @@ def run(index: Path, repo_root: Path, questions_path: Path, k: int) -> dict[str,
         inconclusive_reasons = ["no_named_category_with_safe_reproducible_benefit"]
     return {
         "kind": "repoground_vs_grep_read_benchmark",
-        "version": "v2",
+        "version": "v3",
         "status": status,
         "acceptance": {
             "same_question_set": True,
@@ -361,7 +470,14 @@ def run(index: Path, repo_root: Path, questions_path: Path, k: int) -> dict[str,
             "preference_recommendation": "repoground" if recommended_categories else None,
         },
         "category_decisions": category_decisions,
-        "configuration": {"k": k, "read_limit_bytes": READ_LIMIT_BYTES, "token_proxy_bytes_per_token": TOKEN_PROXY_BYTES_PER_TOKEN},
+        "configuration": {
+            "k": k,
+            "read_limit_bytes": READ_LIMIT_BYTES,
+            "token_proxy_bytes_per_token": TOKEN_PROXY_BYTES_PER_TOKEN,
+            "legacy_expected_pattern_contract": "slash=>path; no-slash=>source_evidence",
+            "source_evidence_scoring": "full_returned_source_file_oracle",
+            "oracle_reads_counted_as_condition_calls": False,
+        },
         "inputs": {
             "benchmark_script_sha256": _sha256(Path(__file__)),
             "index_sha256": _sha256(index),
@@ -374,7 +490,12 @@ def run(index: Path, repo_root: Path, questions_path: Path, k: int) -> dict[str,
         "environment": {"python": sys.version.split()[0], "platform": platform.platform(), "pid": os.getpid()},
         "cases": cases,
         "aggregates": aggregates,
-        "does_not_establish": ["repository_understanding", "answer_correctness", "unmeasured_query_quality"],
+        "does_not_establish": [
+            "repository_understanding",
+            "answer_correctness",
+            "unmeasured_query_quality",
+            "agent_visible_source_evidence",
+        ],
     }
 
 

--- a/scripts/benchmarks/repoground_vs_grep_read.py
+++ b/scripts/benchmarks/repoground_vs_grep_read.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Measure RepoGround retrieval against bounded local text search and reads.
 
-Ripgrep is preferred when installed.  A deterministic UTF-8 Python substring
+Ripgrep is preferred when installed. A deterministic UTF-8 Python substring
 search is used otherwise, and every case records the selected search engine.
-No network, installation or repository mutation is performed.  A report is
+No network, installation or repository mutation is performed. A report is
 always written when argument validation succeeds, including when acceptance
 gates fail, so a failed run remains inspectable and reproducible.
 """
@@ -17,6 +17,7 @@ import os
 import platform
 import re
 import shutil
+import sqlite3
 import subprocess
 import sys
 import time
@@ -24,7 +25,6 @@ from collections import Counter
 from pathlib import Path
 from typing import Any
 
-# Permit direct execution from any checkout directory without installation.
 REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
@@ -35,7 +35,6 @@ READ_LIMIT_BYTES = 4096
 
 
 def _execute_review_query(*args: Any, **kwargs: Any) -> dict[str, Any]:
-    """Late import keeps this script directly executable without installation."""
     from merger.repoground.retrieval.review_query import execute_review_query
 
     return execute_review_query(*args, **kwargs)
@@ -50,7 +49,6 @@ def _sha256(path: Path) -> str:
 
 
 def _tree_sha256(root: Path) -> str:
-    """Hash the local source input without including VCS metadata or symlinks."""
     digest = hashlib.sha256()
     for path in sorted(root.rglob("*")):
         if ".git" in path.parts or not path.is_file() or path.is_symlink():
@@ -76,63 +74,24 @@ def _target_state(candidates: list[str], expected: list[str]) -> dict[str, Any]:
 
 
 def _expected_contract(case: dict[str, Any]) -> tuple[list[str], list[str]]:
-    """Return explicit locator and source-evidence targets.
-
-    New question sets declare ``expected_paths`` and ``expected_evidence``
-    explicitly.  Legacy ``expected_patterns`` retains the original benchmark
-    semantics: every entry is a path target.  This is intentionally not guessed
-    from spelling because repository-root paths and bare symbols are ambiguous.
-    """
+    """Return explicit locator and evidence targets without guessing legacy strings."""
     if "expected_paths" in case or "expected_evidence" in case:
-        expected_paths = list(case.get("expected_paths") or [])
-        expected_evidence = list(case.get("expected_evidence") or [])
-        return expected_paths, expected_evidence
-
+        return (
+            list(case.get("expected_paths") or []),
+            list(case.get("expected_evidence") or []),
+        )
     return list(case.get("expected_patterns") or []), []
 
 
-def _source_evidence_targets(
-    root: Path,
-    paths: list[str],
-    expected: list[str],
-) -> dict[str, Any]:
-    """Score source evidence in returned paths without charging oracle reads.
-
-    These reads are benchmark ground-truth checks, not payload shown to either
-    condition.  Keeping them outside measured tool/source-read counts prevents
-    the scoring oracle itself from changing the compared interaction cost.
-    """
-    if not expected:
-        return _target_state([], expected)
-
-    resolved_root = root.resolve()
-    source_texts: list[str] = []
-    for relative in paths:
-        candidate = resolved_root / relative
-        if candidate.is_symlink():
-            continue
-        try:
-            resolved = candidate.resolve()
-            resolved.relative_to(resolved_root)
-        except (OSError, ValueError):
-            continue
-        if not resolved.is_file():
-            continue
-        try:
-            source_texts.append(resolved.read_text(encoding="utf-8", errors="replace"))
-        except OSError:
-            continue
-    return _target_state(source_texts, expected)
-
-
 def _expected_targets(
-    root: Path,
     paths: list[str],
+    visible_texts: list[str],
     expected_paths: list[str],
     expected_evidence: list[str],
 ) -> dict[str, Any]:
+    """Score only locators and text actually exposed by this condition."""
     path_state = _target_state(paths, expected_paths)
-    evidence_state = _source_evidence_targets(root, paths, expected_evidence)
+    evidence_state = _target_state(visible_texts, expected_evidence)
     return {
         "expected": path_state["expected"] + evidence_state["expected"],
         "found": path_state["found"] + evidence_state["found"],
@@ -142,7 +101,30 @@ def _expected_targets(
     }
 
 
-def _source_freshness(paths: list[str], root: Path, index_mtime_ns: int | None) -> dict[str, Any]:
+def _attach_repoground_visible_content(index: Path, result: dict[str, Any]) -> list[str]:
+    """Expose exactly the selected indexed chunks and return their visible text."""
+    connection = sqlite3.connect(f"file:{index}?mode=ro", uri=True)
+    visible_texts: list[str] = []
+    try:
+        for hit in result.get("results", []):
+            chunk_id = hit.get("chunk_id")
+            row = None
+            if isinstance(chunk_id, str) and chunk_id:
+                row = connection.execute(
+                    "SELECT content FROM chunks_fts WHERE chunk_id = ? LIMIT 1",
+                    (chunk_id,),
+                ).fetchone()
+            content = row[0] if row and isinstance(row[0], str) else ""
+            hit["content"] = content
+            visible_texts.append(content)
+    finally:
+        connection.close()
+    return visible_texts
+
+
+def _source_freshness(
+    paths: list[str], root: Path, index_mtime_ns: int | None
+) -> dict[str, Any]:
     missing: list[str] = []
     newer_than_index: list[str] = []
     for relative in paths:
@@ -165,8 +147,9 @@ def _source_freshness(paths: list[str], root: Path, index_mtime_ns: int | None) 
     }
 
 
-def _compact_repoground_response(result: dict[str, Any], freshness: dict[str, Any]) -> dict[str, Any]:
-    """Keep navigation evidence, source freshness and fallback details only."""
+def _compact_repoground_response(
+    result: dict[str, Any], freshness: dict[str, Any]
+) -> dict[str, Any]:
     hits = []
     for hit in result.get("results", []):
         hits.append({
@@ -191,7 +174,6 @@ def _compact_repoground_response(result: dict[str, Any], freshness: dict[str, An
 
 
 def _python_matching_paths(root: Path, token: str) -> list[Path]:
-    """Return deterministic text-file matches when ripgrep is unavailable."""
     needle = token.casefold()
     matches: list[Path] = []
     for path in sorted(root.rglob("*")):
@@ -237,6 +219,7 @@ def _grep_read(root: Path, question: str, k: int) -> tuple[dict[str, Any], int, 
                 break
         if len(paths) >= k:
             break
+
     reads = []
     for relative in paths:
         with (root / relative).open("rb") as handle:
@@ -246,15 +229,14 @@ def _grep_read(root: Path, question: str, k: int) -> tuple[dict[str, Any], int, 
             "bytes_read": len(payload),
             "content": payload.decode("utf-8", errors="replace"),
         })
-    result = {
+    return {
         "query": question,
         "k": k,
         "status": "available",
         "search_engine": search_engine,
         "paths": paths,
         "reads": reads,
-    }
-    return result, process_calls, len(reads)
+    }, process_calls, len(reads)
 
 
 def _measurement(
@@ -265,14 +247,18 @@ def _measurement(
     process_calls: int,
     source_read_calls: int,
     paths: list[str],
+    visible_texts: list[str],
     expected_paths: list[str],
     expected_evidence: list[str],
-    root: Path,
     freshness: dict[str, Any],
     compact: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    response_bytes = len(json.dumps(result, sort_keys=True, separators=(",", ":")).encode("utf-8"))
-    target_state = _expected_targets(root, paths, expected_paths, expected_evidence)
+    response_bytes = len(
+        json.dumps(result, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    )
+    target_state = _expected_targets(
+        paths, visible_texts, expected_paths, expected_evidence
+    )
     useful_displayed = bool(paths)
     false_confidence = useful_displayed and (
         bool(target_state["missing"]) or freshness["status"] != "fresh"
@@ -294,14 +280,19 @@ def _measurement(
     if result.get("search_engine"):
         item["search_engine"] = result["search_engine"]
     if compact is not None:
-        compact_bytes = len(json.dumps(compact, sort_keys=True, separators=(",", ":")).encode("utf-8"))
+        compact_bytes = len(
+            json.dumps(compact, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        )
         reduction = (1 - compact_bytes / max(response_bytes, 1)) * 100
         item["compaction"] = {
             "compact_response_bytes": compact_bytes,
             "byte_reduction_percent": round(max(0.0, reduction), 2),
             "required_percent": COMPACTION_REQUIRED_PERCENT,
             "pass": reduction >= COMPACTION_REQUIRED_PERCENT,
-            "preserved": ["chunk_id", "path", "line_range", "content_sha256", "range_ref", "freshness", "fallback"],
+            "preserved": [
+                "chunk_id", "path", "line_range", "content_sha256",
+                "range_ref", "freshness", "fallback",
+            ],
         }
     return item
 
@@ -317,7 +308,9 @@ def _aggregate(cases: list[dict[str, Any]], condition: str) -> dict[str, Any]:
         "source_read_calls": sum(row["source_read_calls"] for row in rows),
         "response_bytes": sum(row["response_bytes"] for row in rows),
         "token_proxy": sum(row["token_proxy"] for row in rows),
-        "expected_targets_missing": sum(len(row["expected_targets"]["missing"]) for row in rows),
+        "expected_targets_missing": sum(
+            len(row["expected_targets"]["missing"]) for row in rows
+        ),
         "false_confidence_cases": sum(bool(row["false_confidence"]) for row in rows),
         "source_index_freshness": dict(sorted(freshness.items())),
     }
@@ -345,20 +338,33 @@ def _category_decisions(cases: list[dict[str, Any]]) -> dict[str, dict[str, Any]
     for category, rows in sorted(grouped.items()):
         repoground_rows = [row["repoground"] for row in rows]
         grep_rows = [row["grep_read"] for row in rows]
-        repoground_missing = sum(len(row["expected_targets"]["missing"]) for row in repoground_rows)
-        grep_missing = sum(len(row["expected_targets"]["missing"]) for row in grep_rows)
-        repoground_false_confidence = sum(bool(row["false_confidence"]) for row in repoground_rows)
-        grep_false_confidence = sum(bool(row["false_confidence"]) for row in grep_rows)
+        repoground_missing = sum(
+            len(row["expected_targets"]["missing"]) for row in repoground_rows
+        )
+        grep_missing = sum(
+            len(row["expected_targets"]["missing"]) for row in grep_rows
+        )
+        repoground_false_confidence = sum(
+            bool(row["false_confidence"]) for row in repoground_rows
+        )
+        grep_false_confidence = sum(
+            bool(row["false_confidence"]) for row in grep_rows
+        )
         unsafe_freshness = sum(
-            row["source_index_freshness"]["status"] != "fresh" for row in repoground_rows
+            row["source_index_freshness"]["status"] != "fresh"
+            for row in repoground_rows
         )
         compaction_pass = all(row["compaction"]["pass"] for row in repoground_rows)
         measurable_benefit = repoground_missing < grep_missing
         no_quality_regression = (
-            repoground_false_confidence <= grep_false_confidence and unsafe_freshness == 0
+            repoground_false_confidence <= grep_false_confidence
+            and unsafe_freshness == 0
         )
         evidence_safe = repoground_false_confidence == 0
-        recommended = measurable_benefit and no_quality_regression and evidence_safe and compaction_pass
+        recommended = (
+            measurable_benefit and no_quality_regression
+            and evidence_safe and compaction_pass
+        )
         decisions[category] = {
             "case_count": len(rows),
             "repoground_expected_targets_missing": repoground_missing,
@@ -381,6 +387,7 @@ def run(index: Path, repo_root: Path, questions_path: Path, k: int) -> dict[str,
         raise ValueError("questions must contain 20 to 30 fixed cases")
     if k < 1:
         raise ValueError("k must be at least 1")
+
     root = repo_root.resolve()
     index = index.resolve()
     index_mtime_ns = index.stat().st_mtime_ns
@@ -388,8 +395,10 @@ def run(index: Path, repo_root: Path, questions_path: Path, k: int) -> dict[str,
     for ordinal, case in enumerate(questions, start=1):
         query = case["query"]
         expected_paths, expected_evidence = _expected_contract(case)
+
         started = time.perf_counter_ns()
         rg_result = _execute_review_query(index, query, k=k)
+        rg_visible_texts = _attach_repoground_visible_content(index, rg_result)
         rg_runtime = time.perf_counter_ns() - started
         rg_paths = [hit["path"] for hit in rg_result["results"]]
         rg_freshness = _source_freshness(rg_paths, root, index_mtime_ns)
@@ -399,9 +408,12 @@ def run(index: Path, repo_root: Path, questions_path: Path, k: int) -> dict[str,
         grep_result, process_calls, read_calls = _grep_read(root, query, k)
         grep_runtime = time.perf_counter_ns() - started
         grep_paths = grep_result["paths"]
-        # grep/read deliberately does not consume the index; its source freshness
-        # is therefore recorded independently rather than pretending index use.
+        grep_visible_texts = [
+            read.get("content", "") for read in grep_result.get("reads", [])
+            if isinstance(read.get("content", ""), str)
+        ]
         grep_freshness = _source_freshness(grep_paths, root, None)
+
         cases.append({
             "ordinal": ordinal,
             "query": query,
@@ -414,9 +426,9 @@ def run(index: Path, repo_root: Path, questions_path: Path, k: int) -> dict[str,
                 process_calls=0,
                 source_read_calls=0,
                 paths=rg_paths,
+                visible_texts=rg_visible_texts,
                 expected_paths=expected_paths,
                 expected_evidence=expected_evidence,
-                root=root,
                 freshness=rg_freshness,
                 compact=rg_compact,
             ),
@@ -427,23 +439,26 @@ def run(index: Path, repo_root: Path, questions_path: Path, k: int) -> dict[str,
                 process_calls=process_calls,
                 source_read_calls=read_calls,
                 paths=grep_paths,
+                visible_texts=grep_visible_texts,
                 expected_paths=expected_paths,
                 expected_evidence=expected_evidence,
-                root=root,
                 freshness=grep_freshness,
             ),
         })
+
     aggregates = {name: _aggregate(cases, name) for name in ("repoground", "grep_read")}
     compaction = aggregates["repoground"]["compaction"]
     category_decisions = _category_decisions(cases)
     recommended_categories = [
-        category for category, decision in category_decisions.items() if decision["recommended"]
+        category for category, decision in category_decisions.items()
+        if decision["recommended"]
     ]
     failure_reasons: list[str] = []
     if not (compaction["all_cases_pass"] and compaction["aggregate_pass"]):
         failure_reasons.append("compaction_below_60_percent")
     if any(not decision["no_quality_regression"] for decision in category_decisions.values()):
         failure_reasons.append("quality_or_freshness_regression")
+
     if failure_reasons:
         status = "fail"
         inconclusive_reasons: list[str] = []
@@ -453,6 +468,7 @@ def run(index: Path, repo_root: Path, questions_path: Path, k: int) -> dict[str,
     else:
         status = "inconclusive"
         inconclusive_reasons = ["no_named_category_with_safe_reproducible_benefit"]
+
     return {
         "kind": "repoground_vs_grep_read_benchmark",
         "version": "v3",
@@ -474,8 +490,9 @@ def run(index: Path, repo_root: Path, questions_path: Path, k: int) -> dict[str,
             "legacy_expected_pattern_contract": "all=>path",
             "default_question_contract": "expected_patterns",
             "opt_in_question_contract": "expected_paths+expected_evidence",
-            "source_evidence_scoring": "full_returned_source_file_oracle",
-            "oracle_reads_counted_as_condition_calls": False,
+            "source_evidence_scoring": "condition_visible_payload",
+            "repoground_visible_payload": "selected_index_chunk_content",
+            "grep_read_visible_payload": f"first_{READ_LIMIT_BYTES}_source_bytes_per_path",
         },
         "inputs": {
             "benchmark_script_sha256": _sha256(Path(__file__)),
@@ -486,14 +503,17 @@ def run(index: Path, repo_root: Path, questions_path: Path, k: int) -> dict[str,
             "repo_root": ".",
             "absolute_paths_persisted": False,
         },
-        "environment": {"python": sys.version.split()[0], "platform": platform.platform(), "pid": os.getpid()},
+        "environment": {
+            "python": sys.version.split()[0],
+            "platform": platform.platform(),
+            "pid": os.getpid(),
+        },
         "cases": cases,
         "aggregates": aggregates,
         "does_not_establish": [
             "repository_understanding",
             "answer_correctness",
             "unmeasured_query_quality",
-            "agent_visible_source_evidence",
         ],
     }
 
@@ -502,7 +522,11 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--index", required=True, type=Path)
     parser.add_argument("--repo-root", required=True, type=Path)
-    parser.add_argument("--questions", type=Path, default=Path("docs/retrieval/review_queries.v1.json"))
+    parser.add_argument(
+        "--questions",
+        type=Path,
+        default=Path("docs/retrieval/review_queries.v1.json"),
+    )
     parser.add_argument("--k", type=int, default=10)
     parser.add_argument("--out", type=Path, required=True)
     args = parser.parse_args()

--- a/scripts/benchmarks/repoground_vs_grep_read.py
+++ b/scripts/benchmarks/repoground_vs_grep_read.py
@@ -85,13 +85,18 @@ def _expected_contract(case: dict[str, Any]) -> tuple[list[str], list[str]]:
 
 def _expected_targets(
     paths: list[str],
-    visible_texts: list[str],
+    visible_payload: list[tuple[str, str]],
     expected_paths: list[str],
     expected_evidence: list[str],
 ) -> dict[str, Any]:
-    """Score only locators and text actually exposed by this condition."""
+    """Score evidence only from visible payload belonging to expected paths."""
     path_state = _target_state(paths, expected_paths)
-    evidence_state = _target_state(visible_texts, expected_evidence)
+    eligible_texts = [
+        text
+        for path, text in visible_payload
+        if any(expected_path in path for expected_path in expected_paths)
+    ]
+    evidence_state = _target_state(eligible_texts, expected_evidence)
     return {
         "expected": path_state["expected"] + evidence_state["expected"],
         "found": path_state["found"] + evidence_state["found"],
@@ -101,10 +106,12 @@ def _expected_targets(
     }
 
 
-def _attach_repoground_visible_content(index: Path, result: dict[str, Any]) -> list[str]:
-    """Expose exactly the selected indexed chunks and return their visible text."""
+def _attach_repoground_visible_content(
+    index: Path, result: dict[str, Any]
+) -> list[tuple[str, str]]:
+    """Expose exactly selected indexed chunks, preserving their path association."""
     connection = sqlite3.connect(f"file:{index}?mode=ro", uri=True)
-    visible_texts: list[str] = []
+    visible_payload: list[tuple[str, str]] = []
     try:
         for hit in result.get("results", []):
             chunk_id = hit.get("chunk_id")
@@ -116,10 +123,12 @@ def _attach_repoground_visible_content(index: Path, result: dict[str, Any]) -> l
                 ).fetchone()
             content = row[0] if row and isinstance(row[0], str) else ""
             hit["content"] = content
-            visible_texts.append(content)
+            path = hit.get("path")
+            if isinstance(path, str):
+                visible_payload.append((path, content))
     finally:
         connection.close()
-    return visible_texts
+    return visible_payload
 
 
 def _source_freshness(
@@ -247,7 +256,7 @@ def _measurement(
     process_calls: int,
     source_read_calls: int,
     paths: list[str],
-    visible_texts: list[str],
+    visible_payload: list[tuple[str, str]],
     expected_paths: list[str],
     expected_evidence: list[str],
     freshness: dict[str, Any],
@@ -257,7 +266,7 @@ def _measurement(
         json.dumps(result, sort_keys=True, separators=(",", ":")).encode("utf-8")
     )
     target_state = _expected_targets(
-        paths, visible_texts, expected_paths, expected_evidence
+        paths, visible_payload, expected_paths, expected_evidence
     )
     useful_displayed = bool(paths)
     false_confidence = useful_displayed and (
@@ -398,7 +407,7 @@ def run(index: Path, repo_root: Path, questions_path: Path, k: int) -> dict[str,
 
         started = time.perf_counter_ns()
         rg_result = _execute_review_query(index, query, k=k)
-        rg_visible_texts = _attach_repoground_visible_content(index, rg_result)
+        rg_visible_payload = _attach_repoground_visible_content(index, rg_result)
         rg_runtime = time.perf_counter_ns() - started
         rg_paths = [hit["path"] for hit in rg_result["results"]]
         rg_freshness = _source_freshness(rg_paths, root, index_mtime_ns)
@@ -408,9 +417,11 @@ def run(index: Path, repo_root: Path, questions_path: Path, k: int) -> dict[str,
         grep_result, process_calls, read_calls = _grep_read(root, query, k)
         grep_runtime = time.perf_counter_ns() - started
         grep_paths = grep_result["paths"]
-        grep_visible_texts = [
-            read.get("content", "") for read in grep_result.get("reads", [])
-            if isinstance(read.get("content", ""), str)
+        grep_visible_payload = [
+            (read["path"], read["content"])
+            for read in grep_result.get("reads", [])
+            if isinstance(read.get("path"), str)
+            and isinstance(read.get("content"), str)
         ]
         grep_freshness = _source_freshness(grep_paths, root, None)
 
@@ -426,7 +437,7 @@ def run(index: Path, repo_root: Path, questions_path: Path, k: int) -> dict[str,
                 process_calls=0,
                 source_read_calls=0,
                 paths=rg_paths,
-                visible_texts=rg_visible_texts,
+                visible_payload=rg_visible_payload,
                 expected_paths=expected_paths,
                 expected_evidence=expected_evidence,
                 freshness=rg_freshness,
@@ -439,7 +450,7 @@ def run(index: Path, repo_root: Path, questions_path: Path, k: int) -> dict[str,
                 process_calls=process_calls,
                 source_read_calls=read_calls,
                 paths=grep_paths,
-                visible_texts=grep_visible_texts,
+                visible_payload=grep_visible_payload,
                 expected_paths=expected_paths,
                 expected_evidence=expected_evidence,
                 freshness=grep_freshness,
@@ -491,6 +502,7 @@ def run(index: Path, repo_root: Path, questions_path: Path, k: int) -> dict[str,
             "default_question_contract": "expected_patterns",
             "opt_in_question_contract": "expected_paths+expected_evidence",
             "source_evidence_scoring": "condition_visible_payload",
+            "evidence_path_binding": "matched_expected_paths_only",
             "repoground_visible_payload": "selected_index_chunk_content",
             "grep_read_visible_payload": f"first_{READ_LIMIT_BYTES}_source_bytes_per_path",
         },

--- a/scripts/benchmarks/repoground_vs_grep_read.py
+++ b/scripts/benchmarks/repoground_vs_grep_read.py
@@ -472,7 +472,8 @@ def run(index: Path, repo_root: Path, questions_path: Path, k: int) -> dict[str,
             "read_limit_bytes": READ_LIMIT_BYTES,
             "token_proxy_bytes_per_token": TOKEN_PROXY_BYTES_PER_TOKEN,
             "legacy_expected_pattern_contract": "all=>path",
-            "preferred_question_contract": "expected_paths+expected_evidence",
+            "default_question_contract": "expected_patterns",
+            "opt_in_question_contract": "expected_paths+expected_evidence",
             "source_evidence_scoring": "full_returned_source_file_oracle",
             "oracle_reads_counted_as_condition_calls": False,
         },
@@ -501,7 +502,7 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--index", required=True, type=Path)
     parser.add_argument("--repo-root", required=True, type=Path)
-    parser.add_argument("--questions", type=Path, default=Path("docs/retrieval/review_queries.v2.json"))
+    parser.add_argument("--questions", type=Path, default=Path("docs/retrieval/review_queries.v1.json"))
     parser.add_argument("--k", type=int, default=10)
     parser.add_argument("--out", type=Path, required=True)
     args = parser.parse_args()


### PR DESCRIPTION
## Problem

`repoground_vs_grep_read.py` mixed path and symbol expectations in one legacy field, and the grep/read baseline read source bytes without charging that delivered content to `response_bytes`. Its evidence scoring could also pass on text outside the content actually exposed by either condition or from an unrelated returned path. These effects distorted the benchmark.

## Change

- preserve legacy `expected_patterns` exactly as the old all-path contract, including repository-root paths
- add opt-in `review_queries.v2.json` with explicit `expected_paths` / `expected_evidence`
- keep canonical `review_queries.v1.json` as the CLI default until v2 receives separate schema/registry/proof versioning
- replace stale v2 evidence anchors with strings actually present in intended target files and enforce that binding in tests
- score evidence only from condition-visible payload: selected RepoGround index-chunk content vs. grep/read's bounded returned source content
- require evidence payload to belong to a returned path matching one of the case's expected paths; unrelated hits cannot satisfy another target's evidence
- include selected RepoGround chunk content and bounded grep/read source content in measured response payloads
- expose default vs. opt-in contracts, visible-payload scoring, and expected-path binding in v3 report metadata
- mark the checked-in v2 full-repository measurement explicitly historical because its payload accounting predates this change
- add `repoground-vs-grep-read.v3-contract-proof.md` with current deterministic fixture measurements (34 source bytes, 211 grep/read response bytes, token proxy 53) and bind those values to regression tests
- make no new full-repository v3 performance claim because no bundle index is committed; a fresh hash-bound local index is required for that measurement

## Scope

No retrieval ranking, public API, runtime, bundle format, canonical goldset schema, or production behavior changes.

## Validation

Regression coverage checks legacy root-path handling, explicit locator/evidence scoring, evidence-to-target binding, visible-payload boundaries, cross-path evidence leakage, canonical v1 default selection, payload accounting, and v3 fixture proof metrics. Full repository CI is required before merge.

## Base

Exact base at branch creation: `1a0b1f2e534f94505286b4a94fd9ccdf6079e7d0`.