### PR TITLE
fix(benchmark): encode read-only SQLite index URI

### DIFF
--- a/merger/repoground/tests/test_repoground_vs_grep_read_v3_proof.py
+++ b/merger/repoground/tests/test_repoground_vs_grep_read_v3_proof.py
@@ -1,6 +1,9 @@
 import json
 
-from merger.repoground.tests.test_repoground_vs_grep_read_benchmark import _benchmark_module
+from merger.repoground.tests.test_repoground_vs_grep_read_benchmark import (
+    _benchmark_module,
+    _fixture_index,
+)
 
 
 def test_v3_fixture_payload_measurement_matches_contract_proof(monkeypatch, tmp_path):
@@ -21,3 +24,15 @@ def test_v3_fixture_payload_measurement_matches_contract_proof(monkeypatch, tmp_
     assert (response_bytes + 3) // 4 == 53
     assert process_calls == 0
     assert read_calls == 1
+
+
+def test_v3_readonly_index_uri_handles_uri_delimiters(tmp_path):
+    module = _benchmark_module()
+    root, index, questions = _fixture_index(tmp_path)
+    special_index = index.with_name("fixture?x#y.index.sqlite")
+    index.rename(special_index)
+
+    report = module.run(special_index, root, questions, k=1)
+
+    assert report["inputs"]["index_path"] == special_index.name
+    assert report["cases"][0]["repoground"]["paths"] == ["src/widget.py"]

--- a/scripts/benchmarks/repoground_vs_grep_read.py
+++ b/scripts/benchmarks/repoground_vs_grep_read.py
@@ -110,7 +110,8 @@ def _attach_repoground_visible_content(
     index: Path, result: dict[str, Any]
 ) -> list[tuple[str, str]]:
     """Expose exactly selected indexed chunks, preserving their path association."""
-    connection = sqlite3.connect(f"file:{index}?mode=ro", uri=True)
+    index_uri = f"{index.resolve().as_uri()}?mode=ro"
+    connection = sqlite3.connect(index_uri, uri=True)
     visible_payload: list[tuple[str, str]] = []
     try:
         for hit in result.get("results", []):


### PR DESCRIPTION
## Problem

The v3 benchmark opens the existing SQLite index read-only through a URI. A valid POSIX filename may contain URI delimiters such as `?` or `#`; interpolating the raw path into `file:{path}?mode=ro` lets SQLite interpret part of the filename as URI syntax and can open the wrong database.

## Fix

- construct the read-only SQLite URI from `Path.resolve().as_uri()` before appending `?mode=ro`
- add a regression test that renames a valid fixture index to `fixture?x#y.index.sqlite` and runs the benchmark successfully

## Scope

Two files only. No retrieval ranking, benchmark scoring, public API, runtime, or production behavior changes.

## Base

Exact base: `babaf9473db5e9c07625aeec8f2c3a87d3119ff5` (merged PR #1178). This follow-up exists because #1178 auto-merged before the final URI robustness review could be incorporated.