### PR TITLE
fix(fleet): accept Grabowski resource schema v3

### DIFF
--- a/merger/repoground/tests/test_fleet_runtime.py
+++ b/merger/repoground/tests/test_fleet_runtime.py
@@ -926,9 +926,13 @@ def test_managed_build_residue_fresh_or_changed_stays_fail_closed(
     assert payload.read_bytes() == b"changed"
 
 
+@pytest.mark.parametrize("resource_schema_version", ["2", "3"])
 @pytest.mark.parametrize("lease_target", ["worktree", "build"])
 def test_exact_active_managed_build_lease_blocks_quarantine(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, lease_target: str
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    lease_target: str,
+    resource_schema_version: str,
 ) -> None:
     module = load_publisher()
     repo, sha = initialize_repository(tmp_path, "repo")
@@ -967,7 +971,8 @@ def test_exact_active_managed_build_lease_blocks_quarantine(
             """
         )
         connection.execute(
-            "INSERT INTO metadata(key, value) VALUES('schema_version', '2')"
+            "INSERT INTO metadata(key, value) VALUES('schema_version', ?)",
+            (resource_schema_version,),
         )
         target = worktree if lease_target == "worktree" else build
         now = int(time.time())
@@ -994,6 +999,9 @@ def test_exact_active_managed_build_lease_blocks_quarantine(
     assert blocker is not None
     assert blocker["classification"] == "active-legitimate"
     assert blocker["reason"] == "exact active Grabowski path lease"
+    assert blocker["lease_evidence"]["authority"] == (
+        f"grabowski-resources-sqlite-v{resource_schema_version}"
+    )
     leases = blocker["lease_evidence"]["active_leases"]
     assert leases == [
         {
@@ -1005,6 +1013,35 @@ def test_exact_active_managed_build_lease_blocks_quarantine(
     ]
     assert payload.read_bytes() == b"leased"
     assert not (source_root / module.MANAGED_BUILD_QUARANTINE_DIR_NAME).exists()
+
+
+def test_managed_build_lease_evidence_rejects_unknown_resource_schema(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    worktree = tmp_path / "managed"
+    build = worktree / "build"
+    build.mkdir(parents=True)
+    database = tmp_path / "resources.sqlite3"
+    with sqlite3.connect(database) as connection:
+        connection.executescript(
+            """
+            CREATE TABLE metadata(key TEXT PRIMARY KEY, value TEXT NOT NULL);
+            CREATE TABLE leases(
+                resource_key TEXT PRIMARY KEY,
+                owner_id TEXT NOT NULL,
+                expires_at_unix INTEGER NOT NULL,
+                updated_at_unix INTEGER NOT NULL
+            );
+            """
+        )
+        connection.execute(
+            "INSERT INTO metadata(key, value) VALUES('schema_version', '4')"
+        )
+    monkeypatch.setattr(module, "GRABOWSKI_RESOURCE_DB", database)
+
+    with pytest.raises(RuntimeError, match="canonical Grabowski lease schema is incompatible"):
+        module.managed_build_lease_evidence(worktree, build)
 
 
 def test_managed_build_quarantine_rolls_back_when_receipt_write_fails(

--- a/scripts/ops/repoground-publish-fleet
+++ b/scripts/ops/repoground-publish-fleet
@@ -90,6 +90,7 @@ GRABOWSKI_RESOURCE_DB = Path(
     os.environ.get("REPOGROUND_GRABOWSKI_RESOURCE_DB")
     or "/home/alex/.local/state/grabowski/resources.sqlite3"
 ).expanduser()
+SUPPORTED_GRABOWSKI_RESOURCE_SCHEMA_VERSIONS = frozenset({"2", "3"})
 QUARANTINE_DIR_NAME = ".repoground-prune-quarantine"
 PERSISTED_V1_QUARANTINE_DIR_NAME = "." + "r" + "b-prune-quarantine"
 READABLE_QUARANTINE_DIR_NAMES = (
@@ -1350,7 +1351,13 @@ def managed_build_lease_evidence(
                 "expires_at_unix",
                 "updated_at_unix",
             }
-            if schema_row != ("2",) or not required.issubset(columns):
+            schema_version = (
+                schema_row[0] if schema_row is not None and len(schema_row) == 1 else None
+            )
+            if (
+                schema_version not in SUPPORTED_GRABOWSKI_RESOURCE_SCHEMA_VERSIONS
+                or not required.issubset(columns)
+            ):
                 raise RuntimeError("canonical Grabowski lease schema is incompatible")
             placeholders = ",".join("?" for _ in resource_keys)
             now = int(time.time())
@@ -1365,7 +1372,7 @@ def managed_build_lease_evidence(
             raise
         raise RuntimeError("canonical Grabowski lease read failed") from exc
     return {
-        "authority": "grabowski-resources-sqlite-v2",
+        "authority": f"grabowski-resources-sqlite-v{schema_version}",
         "database": str(database),
         "checked_at_unix": now,
         "resource_keys": resource_keys,


### PR DESCRIPTION
## Problem
`repoground-publish-fleet-watch.service` failed while publishing `heimgewebe/grabowski` because `managed_build_lease_evidence()` accepted only Grabowski resource-store schema 2, while the live canonical store is schema 3 with lease contract v1 and `write_compatible=true`.

## Fix
- accept resource-store schema versions 2 and 3 only when the required lease columns are present;
- keep unknown future schemas fail-closed;
- bind the reported authority to the observed schema version;
- regression-test active-lease protection under both schema 2 and 3 and explicit rejection of schema 4.

## Verification
- `merger/repoground/tests/test_fleet_runtime.py`: 95 passed on current base;
- full non-browser/non-live-doc pytest suite: succeeded;
- repo-wide Ruff: passed;
- graph maintainability, module reachability and workflow-control-plane checks: passed;
- read-only probe against live `/home/alex/.local/state/grabowski/resources.sqlite3`: `authority=grabowski-resources-sqlite-v3`, no schema error.

The dirty Bureau RepoGround source remains fail-closed/deferred; this change does not relax that protection.