### PR TITLE
fix: harden RepoGround benchmark fairness

### DIFF
--- a/docs/proofs/repoground-vs-grep-read.v3-contract-proof.md
+++ b/docs/proofs/repoground-vs-grep-read.v3-contract-proof.md
@@ -1,58 +1,59 @@
-# RepoGround vs grep/read v3 — measurement-contract proof
+# RepoGround vs grep/read v3 — historical measurement-contract proof
 
-Scope: current benchmark measurement semantics only. This proof does **not**
-claim a new full-repository performance result.
+Status: **superseded by v4**. This document freezes the exact v3 measurement
+contract and must not be reinterpreted through the current v4 helper behavior.
+It does **not** establish a current product preference.
 
-## Current contract
+## Historical v3 contract
 
-`scripts/benchmarks/repoground_vs_grep_read.py` emits
+Before the v4 comparator correction,
+`scripts/benchmarks/repoground_vs_grep_read.py` emitted
 `repoground_vs_grep_read_benchmark` version `v3`.
 
-- The canonical CLI default remains `docs/retrieval/review_queries.v1.json`.
-- `review_queries.v2.json` is opt-in and separates locator targets
+- The canonical CLI default was `docs/retrieval/review_queries.v1.json`.
+- `review_queries.v2.json` was opt-in and separated locator targets
   (`expected_paths`) from source evidence (`expected_evidence`).
-- Legacy `expected_patterns` remains all-path for backward-compatible scoring.
-- Evidence is scored only from content exposed by the compared condition:
-  RepoGround exposes the selected indexed chunk content; grep/read exposes only
+- Legacy `expected_patterns` remained all-path for backward-compatible scoring.
+- Evidence was scored only from content exposed by the compared condition:
+  RepoGround exposed the selected indexed chunk content; grep/read exposed only
   the bounded source bytes returned in its reads.
-- Evidence can satisfy a case only when that visible payload belongs to a
+- Evidence could satisfy a case only when that visible payload belonged to a
   returned path matching one of the case's `expected_paths`; an unrelated hit
-  cannot supply evidence for a different expected path.
-- The grep/read response contains the bounded source content actually read, so
-  its `response_bytes` and bytes/4 token proxy charge that delivered text.
-- No full-file scoring oracle is used. Text outside a selected RepoGround chunk,
-  outside grep/read's bounded payload, or on an unrelated returned path cannot
+  could not supply evidence for a different expected path.
+- The grep/read response contained the bounded source content actually read, so
+  its `response_bytes` and bytes/4 token proxy charged that delivered text.
+- No full-file scoring oracle was used. Text outside a selected RepoGround chunk,
+  outside grep/read's bounded payload, or on an unrelated returned path could
   satisfy `expected_evidence`.
 
-## Deterministic current fixture measurement
+## Frozen deterministic v3 fixture measurement
 
-The committed benchmark regression fixture contains exactly this source file:
+The v3 regression fixture contained exactly this source file:
 
 ```text
 def widget():
     return 'widget'
 ```
 
-Its UTF-8 source payload is **34 bytes**. With ripgrep disabled, the current
-`python_utf8_substring` fallback returns one path and one bounded read. The
-canonical compact-JSON measurement of that grep/read result is **211 response
-bytes**, yielding a bytes/4 token proxy of **53**. The response includes the
-34-byte source content rather than only a `bytes_read` counter.
+Its UTF-8 source payload is **34 bytes**. With ripgrep disabled, the v3
+`python_utf8_substring` fallback returned one path and one bounded read. The
+canonical compact-JSON measurement of that **v3 response shape** is **211
+response bytes**, yielding a bytes/4 token proxy of **53**. The response includes
+the 34-byte source content rather than only a `bytes_read` counter.
 
-These values are deterministic for the committed fixture and current response
-shape. Regression tests additionally verify that source text outside a
-condition's visible payload or on an unrelated returned path cannot satisfy
-evidence, the explicit locator/evidence split, the canonical v1 default,
-root-level legacy path handling, and that every v2 evidence anchor occurs in at
-least one intended expected file.
+The 211-byte value is deliberately frozen as historical evidence. The current
+v4 response shape contains additional ranking and leakage-control metadata and
+is therefore expected to have a different byte count. The v3 proof regression
+test reconstructs this frozen response shape directly instead of calling the
+current comparator and thereby silently rewriting history.
 
 ## Full-repository boundary
 
-The repository does not commit a `bundle.index.sqlite`. A new full-repository
-v3 comparison therefore requires a fresh local RepoGround bundle/index plus the
-matching source tree. Until that run is produced and hash-bound, the historical
-`repoground-vs-grep-read.v2.json` remains evidence only for the old v2 harness.
-Its payload totals are not current v3 measurements and must not be used to
-claim a v3 preference.
+A fresh full-repository v3 run was produced on 2026-08-10, but the subsequent v4
+review exposed two material comparator contaminants: query-order truncation in
+the grep/read baseline and eligibility of self-measurement artifacts. The v3
+full-repository totals therefore remain diagnostic evidence for that exact old
+harness only and must not be used for a current product-preference claim.
 
-Current v3 product-level outcome: **unmeasured / no recommendation**.
+Current product decisions must use the v4 contract and a fresh hash-bound v4
+run. Historical v3 product-level outcome: **no valid recommendation**.

--- a/docs/proofs/repoground-vs-grep-read.v4-contract-proof.md
+++ b/docs/proofs/repoground-vs-grep-read.v4-contract-proof.md
@@ -1,0 +1,101 @@
+# RepoGround vs grep/read v4 — measurement-contract proof
+
+Scope: benchmark measurement semantics plus one hash-bound full-repository
+readback. This proof does **not** claim that RepoGround is generally better than
+bounded grep/read, and it does not change the product retrieval algorithm.
+
+## Why v4 is required
+
+The first fresh full-repository run of the v3 harness on 2026-08-10 exposed two
+measurement contaminants that can materially change the comparison:
+
+1. The grep/read baseline iterated query tokens in wording order and stopped as
+   soon as `k` unique paths had been collected. A framing token such as `find`
+   could therefore fill the whole result set before subject terms such as
+   `agent`, `reading`, or `pack` were searched.
+2. Goldsets, earlier benchmark reports, and earlier retrieval-promotion
+   diagnostics remained eligible retrieval targets. Those artifacts can contain
+   the benchmark questions or expected target names, so either side could learn
+   from the measurement itself instead of repository implementation evidence.
+
+These findings do not invalidate the v3 locator/evidence binding fixes. They do
+invalidate using v3 full-repository totals as a fair product-preference result.
+A changed comparator contract is therefore versioned explicitly as v4 rather
+than silently redefining v3.
+
+## v4 contract
+
+The v3 evidence-safety rules remain in force:
+
+- the canonical CLI default remains `docs/retrieval/review_queries.v1.json`;
+- `review_queries.v2.json` remains opt-in and separates `expected_paths` from
+  `expected_evidence`;
+- legacy `expected_patterns` remains all-path for backward-compatible scoring;
+- evidence is scored only from content visible in the compared condition and
+  only when that payload belongs to an expected path;
+- RepoGround compact-response accounting preserves content identity, range
+  references, freshness, and fallback metadata.
+
+v4 adds two symmetric fairness rules:
+
+- grep/read evaluates every distinct non-framing query term before ranking. Paths
+  are ordered deterministically by distinct matched query terms descending,
+  matched query terms present in the repository path descending, then repository
+  path lexicographically. The result therefore cannot depend on which generic
+  prompt word happened to occur first in the sentence.
+- both RepoGround and grep/read receive the same exact repository-path exclusion
+  set for self-measurement artifacts. The exclusion set is derived from the
+  selected question file plus these bounded patterns:
+  `docs/retrieval/review_queries.v*.json`,
+  `docs/proofs/repoground-vs-grep-read*`, and
+  `docs/diagnostics/retrieval-v*-default-promotion-*`.
+
+The report persists the resolved exclusions as repository-relative paths, along
+with the benchmark script, index, question-set, and repository-tree hashes.
+
+## Regression boundary
+
+Regression coverage proves that a repository containing many files matching only
+`find` cannot crowd out a file matching all meaningful subject terms. Separate
+coverage proves that benchmark/goldset artifacts are excluded from both the
+RepoGround and grep/read conditions.
+
+## Fresh full-repository readback
+
+The v4 harness was run against the healthy exact-current publication for
+RepoGround `main` at `182b73f27b9e16141c2a2016a5db051dbb73010e`. The bound
+SQLite index SHA-256 is
+`495c5ddbacb6e6ea86160489e6d617a29fb3e603f6022ca49500a9f4b681e868`.
+
+Canonical v1 report:
+
+- report SHA-256:
+  `d86338098533d594b7f7b9adda1eaf5e7835b44cf1be45d8f0ffbe53c7c7521a`;
+- status: `inconclusive`;
+- RepoGround missing expected targets: **35**; grep/read: **53**;
+- false-confidence cases: **20** for both conditions;
+- RepoGround aggregate compaction: **93.84%** reduction, all cases pass.
+
+Opt-in v2 report:
+
+- report SHA-256:
+  `2ef3d054b07db549a88e29cecea5b4647899ac2962807393c13d93fb2b579302`;
+- status: `fail` because of `quality_or_freshness_regression`;
+- RepoGround missing expected targets: **29**; grep/read: **51**;
+- false-confidence cases: **18** for both conditions;
+- RepoGround aggregate compaction: **93.84%** reduction, all cases pass;
+- the decisive local regression is category `agent_pack`: grep/read has zero
+  missing targets and zero false-confidence cases, while RepoGround has one
+  missing target and one false-confidence case.
+
+The aggregate target advantage is therefore real in this bounded corpus but is
+not sufficient for a RepoGround preference. The fail-closed category rule
+correctly prevents better global totals from hiding a local regression.
+
+## Decision boundary
+
+Historical v2 and v3 reports remain diagnostic evidence for their exact harness
+versions only. Under v4, payload compaction already clears its acceptance gate;
+the next measured product bottleneck is retrieval target coverage, beginning with
+the `agent_pack` regression. `context_compose` should not be prioritized from
+this benchmark until retrieval reaches an evidence-safe category result.

--- a/merger/repoground/tests/test_repoground_vs_grep_read_benchmark.py
+++ b/merger/repoground/tests/test_repoground_vs_grep_read_benchmark.py
@@ -47,7 +47,7 @@ def test_benchmark_writes_per_case_and_aggregate_measurements_with_input_hashes(
     root, index, questions = _fixture_index(tmp_path)
     report = module.run(index, root, questions, k=1)
 
-    assert report["version"] == "v3"
+    assert report["version"] == "v4"
     assert report["status"] == "inconclusive"
     assert len(report["cases"]) == 20
     assert report["acceptance"]["same_question_set"] is True
@@ -59,6 +59,11 @@ def test_benchmark_writes_per_case_and_aggregate_measurements_with_input_hashes(
     assert configuration["source_evidence_scoring"] == "condition_visible_payload"
     assert configuration["evidence_path_binding"] == "matched_expected_paths_only"
     assert configuration["repoground_visible_payload"] == "selected_index_chunk_content"
+    assert configuration["grep_read_token_selection"] == "deduped_nonframing_query_terms"
+    assert configuration["grep_read_path_ranking"] == (
+        "distinct_query_term_matches_desc_then_path_term_matches_desc_then_path"
+    )
+    assert configuration["benchmark_leakage_exclusion_globs"]
     assert set(report["inputs"]) >= {
         "benchmark_script_sha256", "index_sha256", "questions_sha256", "repo_tree_sha256",
     }
@@ -207,7 +212,7 @@ def test_benchmark_recommends_only_a_named_safe_benefit(monkeypatch, tmp_path):
     module = _benchmark_module()
     root, index, questions = _fixture_index(tmp_path)
 
-    def empty_grep_read(_root, question, k):
+    def empty_grep_read(_root, question, k, *, excluded_paths=None):
         return {"query": question, "k": k, "status": "available", "paths": [], "reads": []}, 1, 0
 
     monkeypatch.setattr(module, "_grep_read", empty_grep_read)
@@ -231,7 +236,7 @@ def test_benchmark_fails_on_quality_regression(monkeypatch, tmp_path):
         for _ in range(20)
     ]), encoding="utf-8")
 
-    def perfect_grep_read(_root, question, k):
+    def perfect_grep_read(_root, question, k, *, excluded_paths=None):
         return {
             "query": question, "k": k, "status": "available",
             "paths": ["src/widget.py", "missing.py"], "reads": [],
@@ -256,3 +261,60 @@ def test_benchmark_uses_python_fallback_without_ripgrep(monkeypatch, tmp_path):
     }]
     assert process_calls == 0
     assert read_calls == 1
+
+
+def test_grep_read_ranks_all_meaningful_terms_instead_of_first_instruction_word(
+    monkeypatch, tmp_path
+):
+    module = _benchmark_module()
+    root = tmp_path / "repo"
+    target = root / "src/agent_reading_pack.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("agent reading pack producer tests\n", encoding="utf-8")
+    for ordinal in range(12):
+        decoy = root / "docs" / f"find-{ordinal:02d}.md"
+        decoy.parent.mkdir(parents=True, exist_ok=True)
+        decoy.write_text("find only\n", encoding="utf-8")
+
+    monkeypatch.setattr(module.shutil, "which", lambda _name: None)
+    result, process_calls, read_calls = module._grep_read(
+        root, "Find the Agent Reading Pack producer and its primary tests", 1
+    )
+
+    assert result["query_terms"] == ["agent", "reading", "pack", "producer", "tests"]
+    assert result["paths"] == ["src/agent_reading_pack.py"]
+    assert process_calls == 0
+    assert read_calls == 1
+
+
+def test_benchmark_excludes_self_measurement_artifacts_from_both_conditions(
+    monkeypatch, tmp_path
+):
+    module = _benchmark_module()
+    root, index, questions = _fixture_index(tmp_path)
+    leak_question = root / "docs/retrieval/review_queries.v1.json"
+    leak_question.parent.mkdir(parents=True)
+    leak_question.write_text("widget\n", encoding="utf-8")
+    leak_proof = root / "docs/proofs/repoground-vs-grep-read.v2.json"
+    leak_proof.parent.mkdir(parents=True)
+    leak_proof.write_text("widget\n", encoding="utf-8")
+
+    seen_exclusions = []
+    real_execute = module._execute_review_query
+
+    def capture_execute(*args, **kwargs):
+        seen_exclusions.extend(kwargs.get("excluded_paths") or [])
+        return real_execute(*args, **kwargs)
+
+    monkeypatch.setattr(module, "_execute_review_query", capture_execute)
+    monkeypatch.setattr(module.shutil, "which", lambda _name: None)
+    report = module.run(index, root, questions, k=1)
+
+    expected_exclusions = {
+        "docs/retrieval/review_queries.v1.json",
+        "docs/proofs/repoground-vs-grep-read.v2.json",
+    }
+    assert expected_exclusions <= set(seen_exclusions)
+    assert expected_exclusions <= set(report["inputs"]["benchmark_excluded_paths"])
+    assert report["cases"][0]["grep_read"]["paths"] == ["src/widget.py"]
+    assert not expected_exclusions.intersection(report["cases"][0]["repoground"]["paths"])

--- a/merger/repoground/tests/test_repoground_vs_grep_read_v3_proof.py
+++ b/merger/repoground/tests/test_repoground_vs_grep_read_v3_proof.py
@@ -6,15 +6,24 @@ from merger.repoground.tests.test_repoground_vs_grep_read_benchmark import (
 )
 
 
-def test_v3_fixture_payload_measurement_matches_contract_proof(monkeypatch, tmp_path):
-    module = _benchmark_module()
-    root = tmp_path / "repo"
-    source = root / "src" / "widget.py"
-    source.parent.mkdir(parents=True)
-    source.write_text("def widget():\n    return 'widget'\n", encoding="utf-8")
-    monkeypatch.setattr(module.shutil, "which", lambda _name: None)
-
-    result, process_calls, read_calls = module._grep_read(root, "widget", 1)
+def test_v3_fixture_payload_measurement_matches_contract_proof():
+    # v3 is a frozen historical contract after the v4 comparator change. Keep
+    # this fixture independent from the current _grep_read response shape so a
+    # later benchmark version cannot silently rewrite the v3 proof measurement.
+    result = {
+        "query": "widget",
+        "k": 1,
+        "status": "available",
+        "search_engine": "python_utf8_substring",
+        "paths": ["src/widget.py"],
+        "reads": [
+            {
+                "path": "src/widget.py",
+                "bytes_read": 34,
+                "content": "def widget():\n    return 'widget'\n",
+            }
+        ],
+    }
     response_bytes = len(
         json.dumps(result, sort_keys=True, separators=(",", ":")).encode("utf-8")
     )
@@ -22,11 +31,9 @@ def test_v3_fixture_payload_measurement_matches_contract_proof(monkeypatch, tmp_
     assert result["reads"][0]["bytes_read"] == 34
     assert response_bytes == 211
     assert (response_bytes + 3) // 4 == 53
-    assert process_calls == 0
-    assert read_calls == 1
 
 
-def test_v3_readonly_index_uri_handles_uri_delimiters(tmp_path):
+def test_readonly_index_uri_handles_uri_delimiters(tmp_path):
     module = _benchmark_module()
     root, index, questions = _fixture_index(tmp_path)
     special_index = index.with_name("fixture?x#y.index.sqlite")

--- a/scripts/benchmarks/repoground_vs_grep_read.py
+++ b/scripts/benchmarks/repoground_vs_grep_read.py
@@ -33,6 +33,23 @@ COMPACTION_REQUIRED_PERCENT = 60.0
 TOKEN_PROXY_BYTES_PER_TOKEN = 4
 READ_LIMIT_BYTES = 4096
 
+_GREP_READ_FRAMING_STOPWORDS = frozenset(
+    {
+        "and", "are", "both", "does", "during", "find", "for", "from",
+        "get", "give", "how", "into", "its", "locate", "primary",
+        "repository", "show", "that", "the", "this", "used", "uses",
+        "using", "what", "where", "which", "with",
+    }
+)
+
+# Evaluation artifacts can contain the benchmark questions or prior expected
+# targets. Returning them would let either condition learn from the test itself.
+_BENCHMARK_LEAKAGE_GLOBS = (
+    "docs/retrieval/review_queries.v*.json",
+    "docs/proofs/repoground-vs-grep-read*",
+    "docs/diagnostics/retrieval-v*-default-promotion-*",
+)
+
 
 def _execute_review_query(*args: Any, **kwargs: Any) -> dict[str, Any]:
     from merger.repoground.retrieval.review_query import execute_review_query
@@ -60,7 +77,26 @@ def _tree_sha256(root: Path) -> str:
 
 
 def _tokens(question: str) -> list[str]:
-    return list(dict.fromkeys(re.findall(r"[A-Za-z0-9_]{3,}", question.lower())))
+    raw = list(dict.fromkeys(re.findall(r"[A-Za-z0-9_]{3,}", question.lower())))
+    useful = [token for token in raw if token not in _GREP_READ_FRAMING_STOPWORDS]
+    return useful or raw
+
+
+def _benchmark_excluded_paths(root: Path, questions_path: Path) -> list[str]:
+    root = root.resolve()
+    excluded: set[str] = set()
+    try:
+        relative_questions = questions_path.resolve().relative_to(root).as_posix()
+    except ValueError:
+        pass
+    else:
+        excluded.add(relative_questions)
+
+    for pattern in _BENCHMARK_LEAKAGE_GLOBS:
+        for path in root.glob(pattern):
+            if path.is_file() and not path.is_symlink():
+                excluded.add(path.relative_to(root).as_posix())
+    return sorted(excluded)
 
 
 def _target_state(candidates: list[str], expected: list[str]) -> dict[str, Any]:
@@ -201,12 +237,21 @@ def _python_matching_paths(root: Path, token: str) -> list[Path]:
     return matches
 
 
-def _grep_read(root: Path, question: str, k: int) -> tuple[dict[str, Any], int, int]:
-    paths: list[str] = []
+def _grep_read(
+    root: Path,
+    question: str,
+    k: int,
+    *,
+    excluded_paths: list[str] | None = None,
+) -> tuple[dict[str, Any], int, int]:
+    tokens = _tokens(question)
+    excluded = set(excluded_paths or [])
+    match_counts: Counter[str] = Counter()
     process_calls = 0
     ripgrep = shutil.which("rg")
     search_engine = "ripgrep" if ripgrep else "python_utf8_substring"
-    for token in _tokens(question):
+
+    for token in tokens:
         if ripgrep:
             process_calls += 1
             run = subprocess.run(
@@ -218,18 +263,24 @@ def _grep_read(root: Path, question: str, k: int) -> tuple[dict[str, Any], int, 
             candidates = [Path(raw) for raw in run.stdout.splitlines()]
         else:
             candidates = _python_matching_paths(root, token)
+
+        seen_for_token: set[str] = set()
         for path in candidates:
             try:
                 relative = path.relative_to(root).as_posix()
             except ValueError:
                 continue
-            if relative not in paths:
-                paths.append(relative)
-            if len(paths) >= k:
-                break
-        if len(paths) >= k:
-            break
+            if relative in excluded or relative in seen_for_token:
+                continue
+            seen_for_token.add(relative)
+            match_counts[relative] += 1
 
+    def rank_key(relative: str) -> tuple[int, int, str]:
+        path_text = relative.casefold()
+        path_term_matches = sum(token in path_text for token in tokens)
+        return (-match_counts[relative], -path_term_matches, relative)
+
+    paths = sorted(match_counts, key=rank_key)[:k]
     reads = []
     for relative in paths:
         with (root / relative).open("rb") as handle:
@@ -244,8 +295,14 @@ def _grep_read(root: Path, question: str, k: int) -> tuple[dict[str, Any], int, 
         "k": k,
         "status": "available",
         "search_engine": search_engine,
+        "query_terms": tokens,
+        "ranking": "distinct_query_term_matches_desc_then_path_term_matches_desc_then_path",
         "paths": paths,
         "reads": reads,
+        "applied_exclusions": {
+            "paths": sorted(excluded),
+            "reason": "benchmark_leakage_control",
+        },
     }, process_calls, len(reads)
 
 
@@ -401,13 +458,16 @@ def run(index: Path, repo_root: Path, questions_path: Path, k: int) -> dict[str,
     root = repo_root.resolve()
     index = index.resolve()
     index_mtime_ns = index.stat().st_mtime_ns
+    benchmark_excluded_paths = _benchmark_excluded_paths(root, questions_path)
     cases = []
     for ordinal, case in enumerate(questions, start=1):
         query = case["query"]
         expected_paths, expected_evidence = _expected_contract(case)
 
         started = time.perf_counter_ns()
-        rg_result = _execute_review_query(index, query, k=k)
+        rg_result = _execute_review_query(
+            index, query, k=k, excluded_paths=benchmark_excluded_paths
+        )
         rg_visible_payload = _attach_repoground_visible_content(index, rg_result)
         rg_runtime = time.perf_counter_ns() - started
         rg_paths = [hit["path"] for hit in rg_result["results"]]
@@ -415,7 +475,9 @@ def run(index: Path, repo_root: Path, questions_path: Path, k: int) -> dict[str,
         rg_compact = _compact_repoground_response(rg_result, rg_freshness)
 
         started = time.perf_counter_ns()
-        grep_result, process_calls, read_calls = _grep_read(root, query, k)
+        grep_result, process_calls, read_calls = _grep_read(
+            root, query, k, excluded_paths=benchmark_excluded_paths
+        )
         grep_runtime = time.perf_counter_ns() - started
         grep_paths = grep_result["paths"]
         grep_visible_payload = [
@@ -483,7 +545,7 @@ def run(index: Path, repo_root: Path, questions_path: Path, k: int) -> dict[str,
 
     return {
         "kind": "repoground_vs_grep_read_benchmark",
-        "version": "v3",
+        "version": "v4",
         "status": status,
         "acceptance": {
             "same_question_set": True,
@@ -506,6 +568,11 @@ def run(index: Path, repo_root: Path, questions_path: Path, k: int) -> dict[str,
             "evidence_path_binding": "matched_expected_paths_only",
             "repoground_visible_payload": "selected_index_chunk_content",
             "grep_read_visible_payload": f"first_{READ_LIMIT_BYTES}_source_bytes_per_path",
+            "grep_read_token_selection": "deduped_nonframing_query_terms",
+            "grep_read_path_ranking": (
+                "distinct_query_term_matches_desc_then_path_term_matches_desc_then_path"
+            ),
+            "benchmark_leakage_exclusion_globs": list(_BENCHMARK_LEAKAGE_GLOBS),
         },
         "inputs": {
             "benchmark_script_sha256": _sha256(Path(__file__)),
@@ -514,6 +581,7 @@ def run(index: Path, repo_root: Path, questions_path: Path, k: int) -> dict[str,
             "repo_tree_sha256": _tree_sha256(root),
             "index_path": index.name,
             "repo_root": ".",
+            "benchmark_excluded_paths": benchmark_excluded_paths,
             "absolute_paths_persisted": False,
         },
         "environment": {


### PR DESCRIPTION
## Summary
- version the benchmark contract as v4 because the v3 grep/read baseline stopped after the first generic query terms could fill k results
- exclude benchmark/goldset/self-measurement artifacts symmetrically from both RepoGround and grep/read
- rank the grep/read baseline only after evaluating all meaningful query terms
- add regression coverage and a hash-bound full-repository v4 proof

## Validation
- `python3 -m pytest merger/repoground/tests/test_repoground_vs_grep_read_benchmark.py merger/repoground/tests/test_review_query.py -q` -> 23 passed
- `python3 -m ruff check scripts/benchmarks/repoground_vs_grep_read.py merger/repoground/tests/test_repoground_vs_grep_read_benchmark.py` -> all checks passed
- fresh v4 canonical-v1 report on exact RepoGround main `182b73f27b9e16141c2a2016a5db051dbb73010e`: inconclusive, RepoGround 35 missing targets vs grep/read 53; compaction 93.84%
- fresh v4 opt-in-v2 report: fail-closed on `agent_pack`; RepoGround 29 missing targets vs grep/read 51 overall, but `agent_pack` is locally worse (1 missing / 1 false-confidence vs 0 / 0)

## Non-claims
This PR fixes measurement fairness only. It does not change product retrieval and does not claim a RepoGround preference from the v4 data. The measured `agent_pack` retrieval follow-up is recorded in Bureau as `candidate-4bc57406b044e893d1a1da47` and assessed `promote`.
