### PR TITLE
fix: prioritize source evidence in review retrieval

### DIFF
--- a/merger/repoground/retrieval/review_query.py
+++ b/merger/repoground/retrieval/review_query.py
@@ -11,7 +11,9 @@ from .query_core import execute_query, normalize_excluded_paths
 from .review_router import plan_review_query
 
 
-_SOURCE_DEPRIORITIZED_LAYERS = frozenset({"contract", "docs", "test"})
+_SOURCE_DEPRIORITIZED_LAYERS = frozenset({"docs", "test"})
+_SOURCE_DEPRIORITIZED_PATH_PARTS = frozenset({"contracts"})
+_REVIEW_VARIANT_RANK = {"strict": 0, "relaxed": 1}
 _PATH_TOKEN_RE = re.compile(r"[^\W_]+")
 
 
@@ -31,24 +33,44 @@ def _rerank_source_lane(
     decorated = []
     for original_rank, hit in enumerate(hits, start=1):
         layer = str(hit.get("layer") or "").casefold()
+        path = str(hit.get("path") or "")
+        path_parts = {part.casefold() for part in Path(path).parts}
         path_tokens = {
-            token.casefold()
-            for token in _PATH_TOKEN_RE.findall(str(hit.get("path") or ""))
+            token.casefold() for token in _PATH_TOKEN_RE.findall(path)
         }
         path_anchor_matches = sum(anchor in path_tokens for anchor in anchors)
         non_source_layer = layer in _SOURCE_DEPRIORITIZED_LAYERS
+        non_source_path = bool(path_parts & _SOURCE_DEPRIORITIZED_PATH_PARTS)
+        non_source_penalty = int(non_source_layer or non_source_path)
         diagnostics = hit["why"].setdefault("diagnostics", {})
         review_diag = diagnostics["review_intent"]
+        variant = str(review_diag.get("variant") or "").casefold()
+        variant_rank = _REVIEW_VARIANT_RANK.get(variant, len(_REVIEW_VARIANT_RANK))
         review_diag["source_role_rerank"] = {
             "original_lane_rank": original_rank,
             "layer": layer or None,
+            "variant": variant or None,
+            "variant_rank": variant_rank,
             "non_source_layer_penalty": int(non_source_layer),
+            "non_source_path_penalty": int(non_source_path),
+            "non_source_penalty": non_source_penalty,
             "path_anchor_matches": path_anchor_matches,
             "anchor_term_count": len(anchors),
-            "method": "source_layer_then_path_anchor_coverage_then_original_rank",
+            "method": (
+                "source_role_then_variant_then_path_anchor_coverage_"
+                "then_original_rank"
+            ),
         }
         decorated.append(
-            ((int(non_source_layer), -path_anchor_matches, original_rank), hit)
+            (
+                (
+                    non_source_penalty,
+                    variant_rank,
+                    -path_anchor_matches,
+                    original_rank,
+                ),
+                hit,
+            )
         )
 
     reranked = [hit for _, hit in sorted(decorated, key=lambda item: item[0])]

--- a/merger/repoground/retrieval/review_query.py
+++ b/merger/repoground/retrieval/review_query.py
@@ -59,6 +59,17 @@ def _rerank_source_lane(
     return reranked
 
 
+def _rerank_review_lane(
+    lane_name: str,
+    hits: List[Dict[str, Any]],
+    *,
+    anchor_terms: List[str],
+) -> List[Dict[str, Any]]:
+    if lane_name != "source":
+        return hits
+    return _rerank_source_lane(hits, anchor_terms=anchor_terms)
+
+
 def _collect_unique_path_candidates(
     run_query: Callable[[int], Dict[str, Any]],
     *,
@@ -259,10 +270,11 @@ def execute_review_query(
             if len(lane_hits) >= candidate_path_target:
                 break
 
-        if lane["name"] == "source":
-            lane_hits = _rerank_source_lane(
-                lane_hits, anchor_terms=list(plan.get("anchor_terms") or [])
-            )
+        lane_hits = _rerank_review_lane(
+            lane["name"],
+            lane_hits,
+            anchor_terms=list(plan.get("anchor_terms") or []),
+        )
 
         lane_results.append((lane["name"], lane_hits))
         lane_summaries.append(

--- a/merger/repoground/retrieval/review_query.py
+++ b/merger/repoground/retrieval/review_query.py
@@ -3,11 +3,60 @@
 from __future__ import annotations
 
 import copy
+import re
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from .query_core import execute_query, normalize_excluded_paths
 from .review_router import plan_review_query
+
+
+_SOURCE_DEPRIORITIZED_LAYERS = frozenset({"contract", "docs", "test"})
+_PATH_TOKEN_RE = re.compile(r"[^\W_]+")
+
+
+def _rerank_source_lane(
+    hits: List[Dict[str, Any]], *, anchor_terms: List[str]
+) -> List[Dict[str, Any]]:
+    """Prefer source-like paths, then subject-rich paths, without dropping candidates.
+
+    The source review lane is intentionally broad so production code outside one
+    conventional directory remains eligible.  That breadth must not make tests,
+    docs, or contracts act as the source lane merely because their prose has a
+    stronger BM25 score.  Re-ranking is therefore soft and deterministic: known
+    non-source layers are demoted, subject terms in the repository path break
+    ties, and the existing query rank is the final tie-breaker.
+    """
+    anchors = [term.casefold() for term in anchor_terms if term]
+    decorated = []
+    for original_rank, hit in enumerate(hits, start=1):
+        layer = str(hit.get("layer") or "").casefold()
+        path_tokens = {
+            token.casefold()
+            for token in _PATH_TOKEN_RE.findall(str(hit.get("path") or ""))
+        }
+        path_anchor_matches = sum(anchor in path_tokens for anchor in anchors)
+        non_source_layer = layer in _SOURCE_DEPRIORITIZED_LAYERS
+        diagnostics = hit["why"].setdefault("diagnostics", {})
+        review_diag = diagnostics["review_intent"]
+        review_diag["source_role_rerank"] = {
+            "original_lane_rank": original_rank,
+            "layer": layer or None,
+            "non_source_layer_penalty": int(non_source_layer),
+            "path_anchor_matches": path_anchor_matches,
+            "anchor_term_count": len(anchors),
+            "method": "source_layer_then_path_anchor_coverage_then_original_rank",
+        }
+        decorated.append(
+            ((int(non_source_layer), -path_anchor_matches, original_rank), hit)
+        )
+
+    reranked = [hit for _, hit in sorted(decorated, key=lambda item: item[0])]
+    for lane_rank, hit in enumerate(reranked, start=1):
+        review_diag = hit["why"]["diagnostics"]["review_intent"]
+        review_diag["lane_rank"] = lane_rank
+        review_diag["source_role_rerank"]["reranked_lane_rank"] = lane_rank
+    return reranked
 
 
 def _collect_unique_path_candidates(
@@ -209,6 +258,11 @@ def execute_review_query(
                     break
             if len(lane_hits) >= candidate_path_target:
                 break
+
+        if lane["name"] == "source":
+            lane_hits = _rerank_source_lane(
+                lane_hits, anchor_terms=list(plan.get("anchor_terms") or [])
+            )
 
         lane_results.append((lane["name"], lane_hits))
         lane_summaries.append(

--- a/merger/repoground/tests/test_review_query_hardening.py
+++ b/merger/repoground/tests/test_review_query_hardening.py
@@ -2,7 +2,10 @@ import json
 
 from merger.repoground.retrieval import index_db
 from merger.repoground.retrieval.eval_core import do_eval
-from merger.repoground.retrieval.review_query import execute_review_query
+from merger.repoground.retrieval.review_query import (
+    _rerank_source_lane,
+    execute_review_query,
+)
 
 
 def _build_review_index(tmp_path, chunks):
@@ -122,3 +125,87 @@ def test_review_query_marks_non_executable_plan_as_legacy_fallback(tmp_path):
     assert condition["fallback_mode"] == "legacy"
     assert condition["ranking_algorithm_changed"] is False
     assert report["details"][0]["query_mode"] == "review_intent_fallback"
+
+
+def test_source_lane_rerank_prefers_source_layer_and_subject_path():
+    def hit(path, layer, lane_rank):
+        return {
+            "path": path,
+            "layer": layer,
+            "why": {
+                "diagnostics": {
+                    "review_intent": {
+                        "lane": "source",
+                        "variant": "strict",
+                        "lane_rank": lane_rank,
+                    }
+                }
+            },
+        }
+
+    hits = [
+        hit("merger/repoground/tests/test_output_health.py", "test", 1),
+        hit("docs/proofs/agent-reading-pack-proof.md", "docs", 2),
+        hit("merger/repoground/cli/cmd_agent_pack.py", "cli", 3),
+        hit("merger/repoground/core/agent_reading_pack.py", "core", 4),
+        hit("merger/repoground/core/bundle_surface_validate.py", "core", 5),
+    ]
+
+    reranked = _rerank_source_lane(hits, anchor_terms=["agent", "reading", "pack"])
+
+    assert [item["path"] for item in reranked[:3]] == [
+        "merger/repoground/core/agent_reading_pack.py",
+        "merger/repoground/cli/cmd_agent_pack.py",
+        "merger/repoground/core/bundle_surface_validate.py",
+    ]
+    diagnostic = reranked[0]["why"]["diagnostics"]["review_intent"][
+        "source_role_rerank"
+    ]
+    assert diagnostic["original_lane_rank"] == 4
+    assert diagnostic["reranked_lane_rank"] == 1
+    assert diagnostic["path_anchor_matches"] == 3
+    assert diagnostic["non_source_layer_penalty"] == 0
+
+
+def test_review_query_source_lane_does_not_let_test_prose_occupy_source_slot(tmp_path):
+    chunks = [
+        {
+            **_review_chunk("noise-test", "tests/test_output_health.py"),
+            "layer": "test",
+            "content": "agent reading pack " * 8,
+        },
+        {
+            **_review_chunk("noise-doc", "docs/proofs/agent-reading-pack-proof.md"),
+            "layer": "docs",
+            "content": "agent reading pack " * 8,
+        },
+        {
+            **_review_chunk("source", "src/core/agent_reading_pack.py"),
+            "layer": "core",
+            "content": "def produce_agent_reading_pack(): pass",
+        },
+        {
+            **_review_chunk("target-test", "tests/test_agent_reading_pack.py"),
+            "layer": "test",
+            "content": "agent reading pack producer",
+        },
+    ]
+    index_path = _build_review_index(tmp_path, chunks)
+
+    result = execute_review_query(
+        index_path,
+        "Find the Agent Reading Pack producer and its primary tests",
+        k=3,
+        explain=True,
+    )
+    paths = [item["path"] for item in result["results"]]
+
+    assert "src/core/agent_reading_pack.py" in paths
+    source_hit = next(
+        item
+        for item in result["results"]
+        if item["path"] == "src/core/agent_reading_pack.py"
+    )
+    review_diag = source_hit["why"]["diagnostics"]["review_intent"]
+    assert review_diag["selected_from_lane"] == "source"
+    assert review_diag["source_role_rerank"]["path_anchor_matches"] == 3

--- a/merger/repoground/tests/test_review_query_hardening.py
+++ b/merger/repoground/tests/test_review_query_hardening.py
@@ -146,9 +146,10 @@ def test_source_lane_rerank_prefers_source_layer_and_subject_path():
     hits = [
         hit("merger/repoground/tests/test_output_health.py", "test", 1),
         hit("docs/proofs/agent-reading-pack-proof.md", "docs", 2),
-        hit("merger/repoground/cli/cmd_agent_pack.py", "cli", 3),
-        hit("merger/repoground/core/agent_reading_pack.py", "core", 4),
-        hit("merger/repoground/core/bundle_surface_validate.py", "core", 5),
+        hit("merger/repoground/contracts/agent-reading-pack.json", "unknown", 3),
+        hit("merger/repoground/cli/cmd_agent_pack.py", "cli", 4),
+        hit("merger/repoground/core/agent_reading_pack.py", "core", 5),
+        hit("merger/repoground/core/bundle_surface_validate.py", "core", 6),
     ]
 
     reranked = _rerank_source_lane(hits, anchor_terms=["agent", "reading", "pack"])
@@ -161,10 +162,54 @@ def test_source_lane_rerank_prefers_source_layer_and_subject_path():
     diagnostic = reranked[0]["why"]["diagnostics"]["review_intent"][
         "source_role_rerank"
     ]
-    assert diagnostic["original_lane_rank"] == 4
+    assert diagnostic["original_lane_rank"] == 5
     assert diagnostic["reranked_lane_rank"] == 1
     assert diagnostic["path_anchor_matches"] == 3
     assert diagnostic["non_source_layer_penalty"] == 0
+    contract_hit = next(
+        item for item in reranked if "/contracts/" in item["path"]
+    )
+    contract_diag = contract_hit["why"]["diagnostics"]["review_intent"][
+        "source_role_rerank"
+    ]
+    assert contract_diag["layer"] == "unknown"
+    assert contract_diag["non_source_path_penalty"] == 1
+    assert contract_diag["non_source_penalty"] == 1
+
+
+def test_source_lane_rerank_preserves_strict_before_relaxed():
+    def hit(path, variant, lane_rank):
+        return {
+            "path": path,
+            "layer": "core",
+            "why": {
+                "diagnostics": {
+                    "review_intent": {
+                        "lane": "source",
+                        "variant": variant,
+                        "lane_rank": lane_rank,
+                    }
+                }
+            },
+        }
+
+    hits = [
+        hit("src/implementation.py", "strict", 1),
+        hit("src/alpha_beta.py", "relaxed", 2),
+    ]
+
+    reranked = _rerank_source_lane(hits, anchor_terms=["alpha", "beta"])
+
+    assert [item["path"] for item in reranked] == [
+        "src/implementation.py",
+        "src/alpha_beta.py",
+    ]
+    assert reranked[0]["why"]["diagnostics"]["review_intent"][
+        "source_role_rerank"
+    ]["variant_rank"] == 0
+    assert reranked[1]["why"]["diagnostics"]["review_intent"][
+        "source_role_rerank"
+    ]["variant_rank"] == 1
 
 
 def test_review_query_source_lane_does_not_let_test_prose_occupy_source_slot(tmp_path):


### PR DESCRIPTION
## Problem

The current v4 comparison exposes a concrete retrieval regression in the first `agent_pack` case: RepoGround returns the primary test and the `produce_agent_reading_pack` evidence, but the actual producer file `merger/repoground/core/agent_reading_pack.py` is pushed out of the top 10 because the broad `source` review lane can be occupied by test/docs/contract hits with stronger lexical scores.

## Change

- add a deterministic, soft rerank for the `source` review lane
- demote known non-source roles without dropping candidates: `test`/`docs` by emitted layer and `contracts/` by generic path role (the current index classifier emits contract paths as `layer="unknown"`)
- preserve the router invariant `strict` before `relaxed` within the same source-role class
- prefer repository paths covering more query anchor terms only after role and variant priority
- keep CLI/other/unknown production locations eligible; no hard-coded `core/` or `agent_pack` exception
- preserve original query rank as the final stable tie-breaker
- expose rerank diagnostics in `why.diagnostics.review_intent.source_role_rerank`

No goldset, expected-target, benchmark-harness, evidence-safety, or freshness logic is changed.

## Validation

- focused retrieval/benchmark tests: `34 passed`
- Ruff lint: pass
- maintainability ratchet: `execute_review_query` remains at complexity 24 (CI budget max 24)
- `git diff --check`: pass
- exact current v4/v2 full-repository benchmark: **FAIL -> PASS**
  - `agent_pack` expected targets missing: **1 -> 0**
  - `agent_pack` false-confidence cases: **1 -> 0**
  - producer implementation is returned in the top 10 and the primary test remains present
- canonical v4/v1 benchmark: **PASS**
  - RepoGround aggregate expected targets missing improved versus the current-main baseline
  - RepoGround aggregate false-confidence cases improved versus the current-main baseline

Both Codex P1 review findings were reproduced against the exact base and fixed with regression coverage.

The change is based on the exact clean `main`/bundle revision `2dfffba5f7693c4fce75f7aa799edbccc004604a`.