### PR TITLE
fix: promote v2 review contract as benchmark default

### DIFF
--- a/docs/proofs/repoground-evidence-navigation-v1-proof.md
+++ b/docs/proofs/repoground-evidence-navigation-v1-proof.md
@@ -25,7 +25,7 @@ public compatibility aliases.
 ## Reproducible local benchmark
 
 `scripts/benchmarks/repoground_vs_grep_read.py` consumes the committed
-20-question `docs/retrieval/review_queries.v1.json` by default and an existing
+20-question `docs/retrieval/review_queries.v2.json` by default and an existing
 local index:
 
 ```bash
@@ -35,13 +35,18 @@ python3 scripts/benchmarks/repoground_vs_grep_read.py \
   --out /tmp/repoground-vs-grep-read.json
 ```
 
-The current harness emits report contract v3. Legacy `expected_patterns`
-retains its historical all-path meaning; the opt-in
-`docs/retrieval/review_queries.v2.json` separates `expected_paths` from
-`expected_evidence`. The grep/read condition now includes the bounded source
-content it actually reads in its measured response payload, so current
-`response_bytes` and token-proxy values are intentionally not comparable to the
-older v2 report's baseline payload accounting.
+The current harness emits report contract v5. The default v2 question contract
+separates `expected_paths` from `expected_evidence`; the historical v1 contract
+remains explicitly runnable with
+`--questions docs/retrieval/review_queries.v1.json` and retains its all-path
+`expected_patterns` meaning. Each v5 report records the selected question
+contract plus a repository-relative question path when that input is inside the
+measured repository; external absolute question paths are not persisted.
+
+The grep/read condition includes the bounded source content it actually reads in
+its measured response payload, so current `response_bytes` and token-proxy values
+are intentionally not comparable to older harness versions that used different
+payload accounting.
 
 False confidence is recorded only when a condition returned a result and is
 therefore presented as useful, while one or more expected targets are absent
@@ -61,20 +66,19 @@ The decision is fail-closed and has three outcomes:
 
 The committed `repoground-vs-grep-read.v2.json` is a **historical measurement
 from the v2 harness**. It remains immutable evidence for that earlier harness,
-not a current performance claim for report contract v3. Its recorded numbers
-were: 20 fixed questions; RepoGround missed 37 expected targets versus 60 for
-`grep/read`; both conditions had 20 false-confidence cases; RepoGround used
-551.335 ms versus 166.691 ms, emitted 292,150 raw bytes, and its 98,966-byte
-compact form was larger than the then-recorded 26,690-byte baseline.
+not a current performance claim. Its recorded numbers were: 20 fixed questions;
+RepoGround missed 37 expected targets versus 60 for `grep/read`; both conditions
+had 20 false-confidence cases; RepoGround used 551.335 ms versus 166.691 ms,
+emitted 292,150 raw bytes, and its 98,966-byte compact form was larger than the
+then-recorded 26,690-byte baseline.
 
-Those payload totals must not be compared with current v3 runs because v3
-charges grep/read for the bounded source text delivered to the consumer and
-uses the corrected locator/evidence scoring contract. See
-`repoground-vs-grep-read.v3-contract-proof.md` for current deterministic
-measurement-contract evidence. A new full-repository v3 performance report
-requires a fresh local bundle index; no such index is committed here, so this
-proof makes no new full-repository performance or preference claim.
+Those payload totals must not be compared with current v5 runs. v3 changed
+visible-payload accounting, v4 corrected comparator fairness, and v5 promotes
+the explicit locator/evidence question contract. Their historical contracts are
+preserved in `repoground-vs-grep-read.v3-contract-proof.md` and
+`repoground-vs-grep-read.v4-contract-proof.md`; current hash-bound default and
+legacy readbacks are documented in `repoground-vs-grep-read.v5-contract-proof.md`.
 
-No category is recommended and no default activation follows from the
-historical v2 measurement. The benchmark does not claim repository
-understanding, answer correctness or quality beyond the measured cases.
+The historical v2 measurement recommends no category and caused no default
+activation. The current benchmark still does not claim repository understanding,
+answer correctness or quality beyond the measured cases.

--- a/docs/proofs/repoground-vs-grep-read.v5-contract-proof.md
+++ b/docs/proofs/repoground-vs-grep-read.v5-contract-proof.md
@@ -1,0 +1,129 @@
+# RepoGround vs grep/read v5 — measurement-contract proof
+
+Scope: default question-contract selection for the existing bounded comparator.
+This version does **not** change RepoGround retrieval, grep/read ranking, the
+question text, goldset contents, evidence binding, compaction accounting, or
+freshness rules.
+
+## Why v5 is required
+
+v4 deliberately kept `docs/retrieval/review_queries.v1.json` as the CLI default.
+Its legacy `expected_patterns` field is defined as `all=>path` for backward
+compatibility. That field predates the distinction between a file locator and
+source evidence such as a symbol name.
+
+After PR #1186 fixed the measured `agent_pack` source-role regression, the exact
+v4 readback at `4001703e4aa0318d58135025a19406b74c1edb92` exposed the remaining
+v1 artifact cleanly. The v1 `agent_pack` cases still reported two missing targets
+and two false-confidence cases even though the expected implementation/test files
+were present. The remaining "missing" values were the symbols
+`produce_agent_reading_pack` and `REQUIRED_READING_BY_TASK`, which v1 must score
+as paths under its frozen contract. Re-ranking product retrieval to manufacture
+files with those names would optimize for a measurement artifact rather than
+repository usefulness.
+
+`review_queries.v2.json` already resolves that ambiguity without changing the 20
+questions or their path targets: it separates `expected_paths` from
+`expected_evidence`. The committed goldset contract tests prove that every v2
+question/category/filter/acceptance tuple matches v1 and that each v2 path target
+is exactly the path-shaped subset of the corresponding v1 patterns.
+
+Changing the default question contract is itself a measurement-contract change.
+It is therefore emitted as **v5** instead of silently redefining v4. The v4 proof
+and historical v4 reports remain evidence for v4 only.
+
+## v5 contract
+
+All v4 comparator and safety rules remain unchanged. v5 changes only question
+contract selection and explicit report metadata:
+
+- CLI default: `docs/retrieval/review_queries.v2.json`;
+- default question contract: `expected_paths+expected_evidence`;
+- explicit legacy path: `docs/retrieval/review_queries.v1.json`;
+- legacy question contract: `expected_patterns`;
+- legacy v1 `expected_patterns` semantics remain `all=>path` when selected;
+- report version is `v5`;
+- reports expose `default_questions_path` and `legacy_questions_path` so the
+  selection is machine-visible rather than inferred from prose.
+
+No goldset file is modified by this promotion.
+
+## Promotion evidence before v5
+
+The earlier default-promotion diagnostic from 2026-07-08 passed all measured
+non-regression gates — global recall/MRR, expected-target recall, every category,
+miss count, fallback, graph health, and range/citation health — but explicitly
+refused to mutate the default automatically. Its decision text required a later
+explicit promotion decision even when all gates passed.
+
+After PR #1186, v4 was rerun against the healthy publication at
+`4001703e4aa0318d58135025a19406b74c1edb92` with SQLite index SHA-256
+`4498a417ad88cbb13d49f393c1751c123d3a22b48b4a06af1ad74a357acafe29`.
+The explicit v2 report SHA-256 was
+`52860b81d7830f7b0182045e26d25ca76397442e6d9262e04c1cc253112227a9`:
+status `pass`, RepoGround 22 missing targets versus grep/read 51, RepoGround 15
+false-confidence cases versus grep/read 18, aggregate compaction 93.91%, and
+`agent_pack` at zero missing targets / zero false-confidence with
+`evidence_safe=true` and no quality regression.
+
+The corresponding explicit v1 v4 report SHA-256 was
+`9fc6306e2cb5a20e9d24b131438a12465d2abf91d38c7f2aff01cacfd2a78a2d`:
+status `pass`, but its `agent_pack` category retained the two structural
+symbol-as-path misses described above.
+
+## v5 exact-current readback
+
+While the v5 change was being prepared, RepoGround `main` advanced through the
+Ruff 0.16.2 and sentence-transformers 5.7.0 dependency updates. Neither touches
+the benchmark implementation or goldsets. The final promotion readback therefore
+uses the newer healthy exact-current publication at
+`add5ec5bfa0880eac8fb98ce5dded2331b5d3a6f`, not the earlier #1186 snapshot.
+
+Both v5 runs use the same clean source snapshot, the same index, `k=10`, and the
+same comparator implementation:
+
+- SQLite index SHA-256:
+  `a4226bfaa5fe3d09ddf5862e403b1815dd9e7ed10a153f68b67563ca913416a5`;
+- repository-tree SHA-256:
+  `eebed2ebaffe7f248a427478e508f634032bcea3e83093c0e7f7780845e05068`;
+- v5 benchmark script SHA-256:
+  `be8e3b3fe98ded5e2b0cc17b210e162bd0cc6d2806bf0a7017ae95255233e490`;
+- RepoGround source-index freshness: **20/20 fresh** in both runs.
+
+Canonical default invocation, with **no `--questions` argument**:
+
+- report SHA-256:
+  `c58d64dc65f3921901d0414ebb9f01321a5f9e3d407550c7c80fe70fc2852bd9`;
+- report version: `v5`;
+- status: `pass`;
+- `default_questions_path`: `docs/retrieval/review_queries.v2.json`;
+- `legacy_question_contract`: `expected_patterns`;
+- v2 question-set SHA-256:
+  `47c6aed16294e8543f65324f26342a846b89951e918e6e7880d3d7ea1e6754e9`;
+- RepoGround missing targets: **22**; grep/read: **51**;
+- RepoGround false-confidence cases: **15**; grep/read: **18**;
+- RepoGround aggregate compaction: **93.91%**, all cases pass;
+- `agent_pack`: zero missing targets, zero false-confidence cases,
+  `evidence_safe=true`, no quality regression.
+
+Explicit legacy invocation with `--questions docs/retrieval/review_queries.v1.json`:
+
+- report SHA-256:
+  `f1879b2cd01d583c8b125bee45616d14d0ac09bda2bb022debec3216b21ebf6d`;
+- report version: `v5`;
+- status: `pass`;
+- v1 question-set SHA-256 remains
+  `47f562e6c5b5b63205930e92186d406d33029f7330796312ca5844a177fc3f77`;
+- `legacy_expected_pattern_contract` remains `all=>path`;
+- RepoGround missing targets: **29**; grep/read: **53**;
+- RepoGround false-confidence cases: **19**; grep/read: **20**.
+
+## Decision boundary
+
+v5 becomes the canonical benchmark contract because it measures file location and
+source evidence as different things while preserving the same questions and v1
+file targets. v1 remains explicitly runnable for historical compatibility; v4
+remains historically frozen. This promotion does not establish repository
+understanding, answer correctness, unmeasured-query quality, or that every
+category is evidence-safe. It establishes only that the current default uses the
+more explicit question contract and that the legacy path remains reproducible.

--- a/docs/proofs/repoground-vs-grep-read.v5-contract-proof.md
+++ b/docs/proofs/repoground-vs-grep-read.v5-contract-proof.md
@@ -43,8 +43,12 @@ contract selection and explicit report metadata:
 - legacy question contract: `expected_patterns`;
 - legacy v1 `expected_patterns` semantics remain `all=>path` when selected;
 - report version is `v5`;
-- reports expose `default_questions_path` and `legacy_questions_path` so the
-  selection is machine-visible rather than inferred from prose.
+- reports expose `default_questions_path` and `legacy_questions_path`;
+- `selected_question_contract` records the contract actually inferred from the
+  selected question set for that run;
+- `inputs.questions_path` records the selected question file only when it can be
+  represented safely relative to the measured repository, otherwise it is null
+  with `questions_path_scope=external_not_persisted`.
 
 No goldset file is modified by this promotion.
 
@@ -87,16 +91,19 @@ same comparator implementation:
 - repository-tree SHA-256:
   `eebed2ebaffe7f248a427478e508f634032bcea3e83093c0e7f7780845e05068`;
 - v5 benchmark script SHA-256:
-  `be8e3b3fe98ded5e2b0cc17b210e162bd0cc6d2806bf0a7017ae95255233e490`;
+  `3aae0e890cd27dba48228ab34d3277f0bc6ef1781e68e10728c0e729a4b027d6`;
 - RepoGround source-index freshness: **20/20 fresh** in both runs.
 
 Canonical default invocation, with **no `--questions` argument**:
 
 - report SHA-256:
-  `c58d64dc65f3921901d0414ebb9f01321a5f9e3d407550c7c80fe70fc2852bd9`;
+  `45c69ec435ebfc84acca870cab6f831229e9a1fec49c78b807fb69730a0c56b8`;
 - report version: `v5`;
 - status: `pass`;
 - `default_questions_path`: `docs/retrieval/review_queries.v2.json`;
+- `selected_question_contract`: `expected_paths+expected_evidence`;
+- `inputs.questions_path`: `docs/retrieval/review_queries.v2.json` with
+  `questions_path_scope=repo_relative`;
 - `legacy_question_contract`: `expected_patterns`;
 - v2 question-set SHA-256:
   `47c6aed16294e8543f65324f26342a846b89951e918e6e7880d3d7ea1e6754e9`;
@@ -109,11 +116,14 @@ Canonical default invocation, with **no `--questions` argument**:
 Explicit legacy invocation with `--questions docs/retrieval/review_queries.v1.json`:
 
 - report SHA-256:
-  `f1879b2cd01d583c8b125bee45616d14d0ac09bda2bb022debec3216b21ebf6d`;
+  `60aa82ae4d4b9b90961f72cc4ad8fbb08e9e8b27cfb9ffd4e4d27ae709174a51`;
 - report version: `v5`;
 - status: `pass`;
 - v1 question-set SHA-256 remains
   `47f562e6c5b5b63205930e92186d406d33029f7330796312ca5844a177fc3f77`;
+- `selected_question_contract`: `expected_patterns`;
+- `inputs.questions_path`: `docs/retrieval/review_queries.v1.json` with
+  `questions_path_scope=repo_relative`;
 - `legacy_expected_pattern_contract` remains `all=>path`;
 - RepoGround missing targets: **29**; grep/read: **53**;
 - RepoGround false-confidence cases: **19**; grep/read: **20**.

--- a/merger/repoground/tests/test_repoground_vs_grep_read_benchmark.py
+++ b/merger/repoground/tests/test_repoground_vs_grep_read_benchmark.py
@@ -58,6 +58,7 @@ def test_benchmark_writes_per_case_and_aggregate_measurements_with_input_hashes(
     assert configuration["legacy_question_contract"] == "expected_patterns"
     assert configuration["default_questions_path"] == "docs/retrieval/review_queries.v2.json"
     assert configuration["legacy_questions_path"] == "docs/retrieval/review_queries.v1.json"
+    assert configuration["selected_question_contract"] == "expected_patterns"
     assert configuration["source_evidence_scoring"] == "condition_visible_payload"
     assert configuration["evidence_path_binding"] == "matched_expected_paths_only"
     assert configuration["repoground_visible_payload"] == "selected_index_chunk_content"
@@ -71,6 +72,8 @@ def test_benchmark_writes_per_case_and_aggregate_measurements_with_input_hashes(
     }
     assert report["inputs"]["repo_root"] == "."
     assert report["inputs"]["index_path"] == index.name
+    assert report["inputs"]["questions_path"] is None
+    assert report["inputs"]["questions_path_scope"] == "external_not_persisted"
     assert report["inputs"]["absolute_paths_persisted"] is False
     assert str(tmp_path) not in json.dumps(report["inputs"])
     for case in report["cases"]:
@@ -85,6 +88,38 @@ def test_benchmark_writes_per_case_and_aggregate_measurements_with_input_hashes(
         assert case["repoground"]["compaction"]["pass"] is True
         assert case["repoground"]["false_confidence"] is False
     assert report["aggregates"]["repoground"]["compaction"]["aggregate_pass"] is True
+
+
+def test_benchmark_records_selected_contract_and_safe_repo_relative_question_path(tmp_path):
+    module = _benchmark_module()
+    root, index, _ = _fixture_index(tmp_path)
+    questions = root / "docs/retrieval/review_queries.v2.json"
+    questions.parent.mkdir(parents=True)
+    questions.write_text(
+        json.dumps(
+            [
+                {
+                    "query": "widget",
+                    "category": "fixture",
+                    "expected_paths": ["src/widget.py"],
+                    "expected_evidence": ["def widget"],
+                }
+                for _ in range(20)
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    report = module.run(index, root, questions, k=1)
+
+    assert report["configuration"]["selected_question_contract"] == (
+        "expected_paths+expected_evidence"
+    )
+    assert report["inputs"]["questions_path"] == (
+        "docs/retrieval/review_queries.v2.json"
+    )
+    assert report["inputs"]["questions_path_scope"] == "repo_relative"
+    assert str(tmp_path) not in json.dumps(report["inputs"])
 
 
 def test_benchmark_cli_defaults_to_v2_question_contract(monkeypatch, tmp_path):

--- a/merger/repoground/tests/test_repoground_vs_grep_read_benchmark.py
+++ b/merger/repoground/tests/test_repoground_vs_grep_read_benchmark.py
@@ -47,15 +47,17 @@ def test_benchmark_writes_per_case_and_aggregate_measurements_with_input_hashes(
     root, index, questions = _fixture_index(tmp_path)
     report = module.run(index, root, questions, k=1)
 
-    assert report["version"] == "v4"
+    assert report["version"] == "v5"
     assert report["status"] == "inconclusive"
     assert len(report["cases"]) == 20
     assert report["acceptance"]["same_question_set"] is True
     assert report["acceptance"]["same_k"] == 1
     configuration = report["configuration"]
     assert configuration["legacy_expected_pattern_contract"] == "all=>path"
-    assert configuration["default_question_contract"] == "expected_patterns"
-    assert configuration["opt_in_question_contract"] == "expected_paths+expected_evidence"
+    assert configuration["default_question_contract"] == "expected_paths+expected_evidence"
+    assert configuration["legacy_question_contract"] == "expected_patterns"
+    assert configuration["default_questions_path"] == "docs/retrieval/review_queries.v2.json"
+    assert configuration["legacy_questions_path"] == "docs/retrieval/review_queries.v1.json"
     assert configuration["source_evidence_scoring"] == "condition_visible_payload"
     assert configuration["evidence_path_binding"] == "matched_expected_paths_only"
     assert configuration["repoground_visible_payload"] == "selected_index_chunk_content"
@@ -83,6 +85,34 @@ def test_benchmark_writes_per_case_and_aggregate_measurements_with_input_hashes(
         assert case["repoground"]["compaction"]["pass"] is True
         assert case["repoground"]["false_confidence"] is False
     assert report["aggregates"]["repoground"]["compaction"]["aggregate_pass"] is True
+
+
+def test_benchmark_cli_defaults_to_v2_question_contract(monkeypatch, tmp_path):
+    module = _benchmark_module()
+    captured = {}
+
+    def fake_run(index, repo_root, questions_path, k):
+        captured["questions_path"] = questions_path
+        return {"status": "inconclusive"}
+
+    output = tmp_path / "measurement.json"
+    monkeypatch.setattr(module, "run", fake_run)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "repoground_vs_grep_read.py",
+            "--index",
+            "fixture.index.sqlite",
+            "--repo-root",
+            ".",
+            "--out",
+            str(output),
+        ],
+    )
+
+    assert module.main() == 0
+    assert captured["questions_path"] == Path("docs/retrieval/review_queries.v2.json")
 
 
 def test_legacy_expected_patterns_preserve_root_level_path_targets():

--- a/merger/repoground/tests/test_review_query_goldset_contract.py
+++ b/merger/repoground/tests/test_review_query_goldset_contract.py
@@ -47,10 +47,25 @@ def test_review_queries_v2_evidence_is_bound_to_expected_files():
             )
 
 
-def test_benchmark_cli_keeps_canonical_v1_goldset_as_default():
+def test_benchmark_cli_uses_v2_goldset_as_canonical_default():
     script = (
         _repo_root() / "scripts" / "benchmarks" / "repoground_vs_grep_read.py"
     ).read_text(encoding="utf-8")
 
-    assert 'default=Path("docs/retrieval/review_queries.v1.json")' in script
-    assert 'default=Path("docs/retrieval/review_queries.v2.json")' not in script
+    assert 'default=Path("docs/retrieval/review_queries.v2.json")' in script
+    assert 'default=Path("docs/retrieval/review_queries.v1.json")' not in script
+
+
+def test_v5_default_promotion_does_not_rewrite_v4_contract():
+    proofs = _repo_root() / "docs" / "proofs"
+    v4 = (proofs / "repoground-vs-grep-read.v4-contract-proof.md").read_text(
+        encoding="utf-8"
+    )
+    v5 = (proofs / "repoground-vs-grep-read.v5-contract-proof.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "canonical CLI default remains `docs/retrieval/review_queries.v1.json`" in v4
+    assert "report version is `v5`" in v5
+    assert "CLI default: `docs/retrieval/review_queries.v2.json`" in v5
+    assert "explicit legacy path: `docs/retrieval/review_queries.v1.json`" in v5

--- a/scripts/benchmarks/repoground_vs_grep_read.py
+++ b/scripts/benchmarks/repoground_vs_grep_read.py
@@ -82,14 +82,18 @@ def _tokens(question: str) -> list[str]:
     return useful or raw
 
 
+def _repository_relative_path(root: Path, path: Path) -> str | None:
+    try:
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except ValueError:
+        return None
+
+
 def _benchmark_excluded_paths(root: Path, questions_path: Path) -> list[str]:
     root = root.resolve()
     excluded: set[str] = set()
-    try:
-        relative_questions = questions_path.resolve().relative_to(root).as_posix()
-    except ValueError:
-        pass
-    else:
+    relative_questions = _repository_relative_path(root, questions_path)
+    if relative_questions is not None:
         excluded.add(relative_questions)
 
     for pattern in _BENCHMARK_LEAKAGE_GLOBS:
@@ -117,6 +121,20 @@ def _expected_contract(case: dict[str, Any]) -> tuple[list[str], list[str]]:
             list(case.get("expected_evidence") or []),
         )
     return list(case.get("expected_patterns") or []), []
+
+
+def _selected_question_contract(questions: list[dict[str, Any]]) -> str:
+    contracts = {
+        (
+            "expected_paths+expected_evidence"
+            if "expected_paths" in case or "expected_evidence" in case
+            else "expected_patterns"
+        )
+        for case in questions
+    }
+    if len(contracts) == 1:
+        return next(iter(contracts))
+    return "mixed"
 
 
 def _expected_targets(
@@ -458,6 +476,8 @@ def run(index: Path, repo_root: Path, questions_path: Path, k: int) -> dict[str,
     root = repo_root.resolve()
     index = index.resolve()
     index_mtime_ns = index.stat().st_mtime_ns
+    selected_question_contract = _selected_question_contract(questions)
+    questions_repository_path = _repository_relative_path(root, questions_path)
     benchmark_excluded_paths = _benchmark_excluded_paths(root, questions_path)
     cases = []
     for ordinal, case in enumerate(questions, start=1):
@@ -566,6 +586,7 @@ def run(index: Path, repo_root: Path, questions_path: Path, k: int) -> dict[str,
             "legacy_question_contract": "expected_patterns",
             "default_questions_path": "docs/retrieval/review_queries.v2.json",
             "legacy_questions_path": "docs/retrieval/review_queries.v1.json",
+            "selected_question_contract": selected_question_contract,
             "source_evidence_scoring": "condition_visible_payload",
             "evidence_path_binding": "matched_expected_paths_only",
             "repoground_visible_payload": "selected_index_chunk_content",
@@ -580,6 +601,12 @@ def run(index: Path, repo_root: Path, questions_path: Path, k: int) -> dict[str,
             "benchmark_script_sha256": _sha256(Path(__file__)),
             "index_sha256": _sha256(index),
             "questions_sha256": _sha256(questions_path),
+            "questions_path": questions_repository_path,
+            "questions_path_scope": (
+                "repo_relative"
+                if questions_repository_path is not None
+                else "external_not_persisted"
+            ),
             "repo_tree_sha256": _tree_sha256(root),
             "index_path": index.name,
             "repo_root": ".",

--- a/scripts/benchmarks/repoground_vs_grep_read.py
+++ b/scripts/benchmarks/repoground_vs_grep_read.py
@@ -545,7 +545,7 @@ def run(index: Path, repo_root: Path, questions_path: Path, k: int) -> dict[str,
 
     return {
         "kind": "repoground_vs_grep_read_benchmark",
-        "version": "v4",
+        "version": "v5",
         "status": status,
         "acceptance": {
             "same_question_set": True,
@@ -562,8 +562,10 @@ def run(index: Path, repo_root: Path, questions_path: Path, k: int) -> dict[str,
             "read_limit_bytes": READ_LIMIT_BYTES,
             "token_proxy_bytes_per_token": TOKEN_PROXY_BYTES_PER_TOKEN,
             "legacy_expected_pattern_contract": "all=>path",
-            "default_question_contract": "expected_patterns",
-            "opt_in_question_contract": "expected_paths+expected_evidence",
+            "default_question_contract": "expected_paths+expected_evidence",
+            "legacy_question_contract": "expected_patterns",
+            "default_questions_path": "docs/retrieval/review_queries.v2.json",
+            "legacy_questions_path": "docs/retrieval/review_queries.v1.json",
             "source_evidence_scoring": "condition_visible_payload",
             "evidence_path_binding": "matched_expected_paths_only",
             "repoground_visible_payload": "selected_index_chunk_content",
@@ -606,7 +608,7 @@ def main() -> int:
     parser.add_argument(
         "--questions",
         type=Path,
-        default=Path("docs/retrieval/review_queries.v1.json"),
+        default=Path("docs/retrieval/review_queries.v2.json"),
     )
     parser.add_argument("--k", type=int, default=10)
     parser.add_argument("--out", type=Path, required=True)


### PR DESCRIPTION
## Problem

The canonical benchmark default is still `review_queries.v1.json`. Its frozen legacy `expected_patterns => all paths` contract conflates file locators with symbol evidence, so the two `agent_pack` cases retain structural symbol-as-path misses even after the real retrieval regression was fixed in #1186.

## Change

- version the changed measurement contract explicitly as v5; v4 remains historically frozen
- make `review_queries.v2.json` the CLI default
- keep `review_queries.v1.json` explicitly runnable as the legacy contract
- record the actually selected question contract in every report
- persist the selected question file only as a safe repository-relative path; external absolute paths are not persisted
- update the live benchmark usage proof to v5/v2 semantics
- add regression coverage proving v2 preserves all 20 questions and v1 path targets and that v4 is not rewritten
- add a hash-bound v5 contract proof

No retrieval/ranking product code and no goldset contents are changed.

## Validation

- affected retrieval/benchmark suite: `42 passed`
- targeted Ruff: pass
- `git diff --check`: pass
- exact-current canonical publication: `add5ec5bfa0880eac8fb98ce5dded2331b5d3a6f`, 20/20 fresh
- v5 default invocation (no `--questions`): PASS, report SHA-256 `45c69ec435ebfc84acca870cab6f831229e9a1fec49c78b807fb69730a0c56b8`; selected contract `expected_paths+expected_evidence`; repo-relative question path `docs/retrieval/review_queries.v2.json`
- explicit v1 compatibility invocation: PASS, report SHA-256 `60aa82ae4d4b9b90961f72cc4ad8fbb08e9e8b27cfb9ffd4e4d27ae709174a51`; selected contract `expected_patterns`; repo-relative question path `docs/retrieval/review_queries.v1.json`
- v2/default: RepoGround missing targets 22 vs grep/read 51; false-confidence 15 vs 18; aggregate compaction 93.91%; `agent_pack` 0/0 and evidence-safe
- v1 legacy remains `all=>path` and preserves its historical question-set SHA-256
- both Codex P2 findings on the first PR head were reproduced, fixed, replied to, and resolved