### PR TITLE
feat(repoground): collect revision-bound system relations

### DIFF
--- a/docs/proofs/repoground-agent-utility-t022-proof.md
+++ b/docs/proofs/repoground-agent-utility-t022-proof.md
@@ -10,14 +10,18 @@ relations and a fail-closed consumer path into Agent Impact Context.
 The producer supports only these static sources:
 
 - root `pyproject.toml` first-level `[tool.NAME]` tables → `declares_config`;
-- tracked `*.schema.json` files with a literal top-level `$id` → `declares_schema`;
-- direct `.github/workflows/*.yml|*.yaml` static local
+- tracked `*.schema.json` files with exactly one literal top-level `$id` →
+  `declares_schema`;
+- direct job-level `.github/workflows/*.yml|*.yaml` static local
   `uses: ./.github/workflows/...` references whose target exists in the same Git
   commit → `references_workflow`.
 
-Dynamic, generated, ambiguous, missing-target, invalid, oversized, sensitive,
-non-regular and unsupported cases are omitted or reported with a reason. They
-are not inferred.
+Workflow relations come from parsed YAML mapping structure rather than raw-line
+matching, so text inside block scalars such as `run: |` cannot become a
+relation. Duplicate top-level schema `$id` keys are ambiguous and therefore
+omitted. Dynamic, generated, ambiguous, missing-target, invalid, oversized,
+sensitive, non-regular and unsupported cases are likewise omitted or reported
+with a reason. They are not inferred.
 
 ## Revision binding
 
@@ -25,6 +29,12 @@ are not inferred.
 verifies that it names a local Git commit object. Candidate metadata and file
 bytes are then read from the Git object database for that commit. The mutable
 working tree is not a producer input.
+
+The Git tree index is read with a hard streaming byte cap: the producer
+terminates the child process as soon as the configured candidate-index budget
+would be exceeded instead of buffering unbounded output first. Blob bytes that
+were actually read count against the total byte budget even when decoding or
+later parsing fails.
 
 The result includes an explicit `revision_binding` receipt. The context adapter
 rejects the evidence unless all of these are coherent:
@@ -38,16 +48,21 @@ rejects the evidence unless all of these are coherent:
 A mismatch produces a visible `blocked` or `missing` structural-evidence state
 and projects zero structural records.
 
-## Relation separation
+## Relation separation and shared record bound
 
 System relations remain a separate structure lane. They do not become Python
 `calls` or `constructs` edges. Agent Impact Context exposes them under optional
 `structural_relations`; existing relation behavior remains unchanged when the
 new evidence input is absent.
 
+Producer, overlay normalizer and context consumer share the same hard maximum of
+4096 evidence records. The producer truncates deterministically at that bound
+and reports `record_budget_exhausted`; externally supplied evidence above the
+same bound is rejected rather than partly trusted.
+
 `references_workflow` is deliberately S0/reference evidence. Config and schema
 declarations are S1/declaration evidence. This keeps the S1 lane limited to
-facts that are explicitly declared in static source text.
+facts that are explicitly declared in static source structure.
 
 ## Goldset gate
 
@@ -77,9 +92,13 @@ Focused tests cover:
 - commit-object reads remaining stable when the working tree is dirty;
 - malformed and missing commit rejection;
 - deterministic output;
-- bounded file, byte and candidate-index budgets;
+- bounded file, byte, candidate-index and record budgets;
+- candidate-index termination while Git output is being read;
+- invalid UTF-8 blobs still consuming the bytes actually read;
 - dynamic and missing workflow targets;
-- nested versus top-level schema `$id` handling;
+- YAML block-scalar text not masquerading as a `uses` mapping key;
+- duplicate, nested and missing top-level schema `$id` handling;
+- shared producer/consumer record-limit compatibility;
 - optional Python 3.10 TOML-parser absence failing closed;
 - raw-evidence digest tampering;
 - producer revision-binding tampering;

--- a/docs/proofs/repoground-agent-utility-t022-proof.md
+++ b/docs/proofs/repoground-agent-utility-t022-proof.md
@@ -1,0 +1,137 @@
+# RepoGround Agent Utility V1 — T022 Proof Contract
+
+Task: `REPOGROUND-AGENT-UTILITY-V1-T022`
+
+## What this change establishes
+
+T022 adds a bounded, offline producer for selected repository-level structural
+relations and a fail-closed consumer path into Agent Impact Context.
+
+The producer supports only these static sources:
+
+- root `pyproject.toml` first-level `[tool.NAME]` tables → `declares_config`;
+- tracked `*.schema.json` files with a literal top-level `$id` → `declares_schema`;
+- direct `.github/workflows/*.yml|*.yaml` static local
+  `uses: ./.github/workflows/...` references whose target exists in the same Git
+  commit → `references_workflow`.
+
+Dynamic, generated, ambiguous, missing-target, invalid, oversized, sensitive,
+non-regular and unsupported cases are omitted or reported with a reason. They
+are not inferred.
+
+## Revision binding
+
+`collect_system_relation_evidence()` accepts an exact repository commit and
+verifies that it names a local Git commit object. Candidate metadata and file
+bytes are then read from the Git object database for that commit. The mutable
+working tree is not a producer input.
+
+The result includes an explicit `revision_binding` receipt. The context adapter
+rejects the evidence unless all of these are coherent:
+
+1. expected repository commit;
+2. producer repository commit;
+3. producer `revision_binding` with `mode=git_commit_object` and `verified=true`;
+4. SHA-256 of the raw evidence object;
+5. a fresh normalization of that evidence through `system_relation_overlay`.
+
+A mismatch produces a visible `blocked` or `missing` structural-evidence state
+and projects zero structural records.
+
+## Relation separation
+
+System relations remain a separate structure lane. They do not become Python
+`calls` or `constructs` edges. Agent Impact Context exposes them under optional
+`structural_relations`; existing relation behavior remains unchanged when the
+new evidence input is absent.
+
+`references_workflow` is deliberately S0/reference evidence. Config and schema
+declarations are S1/declaration evidence. This keeps the S1 lane limited to
+facts that are explicitly declared in static source text.
+
+## Goldset gate
+
+The fixed goldset is:
+
+`docs/retrieval/repoground_agent_utility_t022_goldset.v1.json`
+
+It contains positive, ambiguous and true-null cases and is evaluated by:
+
+`merger/repoground/tests/test_agent_utility_t022_goldset.py`
+
+The checked gate requires:
+
+- precision: `1.0`;
+- recall: `1.0`;
+- source-range accuracy: `1.0`;
+- S1 false positives: `0`;
+- exact omission reasons for ambiguous cases.
+
+Each synthetic case is materialized as a real Git repository and evaluated
+against its exact committed fixture HEAD.
+
+## Regression and safety checks
+
+Focused tests cover:
+
+- commit-object reads remaining stable when the working tree is dirty;
+- malformed and missing commit rejection;
+- deterministic output;
+- bounded file, byte and candidate-index budgets;
+- dynamic and missing workflow targets;
+- nested versus top-level schema `$id` handling;
+- optional Python 3.10 TOML-parser absence failing closed;
+- raw-evidence digest tampering;
+- producer revision-binding tampering;
+- overlay tampering;
+- Agent Impact Context commit mismatch without false target activation;
+- schema validation of the extended Agent Impact Context.
+
+The existing T020 overlay and Agent Impact Context suites are run together with
+the new T022 tests to guard backward compatibility.
+
+## Revision-bound scale gate
+
+The reproducible benchmark is:
+
+`merger/repoground/scripts/bench_system_relation_producer.py`
+
+It must be run against the exact candidate Git HEAD, for example:
+
+```text
+python -m merger.repoground.scripts.bench_system_relation_producer \
+  --repo . \
+  --commit "$(git rev-parse HEAD)" \
+  --identity heimgewebe/repoground \
+  --repetitions 3
+```
+
+The default practical gates are:
+
+- p95 producer runtime ≤ 5000 ms;
+- Python allocation peak ≤ 64 MiB;
+- canonical result artifact ≤ 2 MiB;
+- one deterministic result digest across repetitions.
+
+The benchmark reports candidate count, scanned bytes, candidate-index bytes,
+record count, omission count, relation kinds, runtime, memory and artifact size.
+The exact final-HEAD benchmark receipt belongs in the PR/closeout evidence so it
+can be bound to the immutable reviewed revision without creating a
+self-referential commit.
+
+## Explicit non-claims
+
+This change does **not** establish:
+
+- runtime config effect;
+- schema conformance or validation execution;
+- workflow execution or workflow validity;
+- complete repository relation coverage;
+- runtime behavior or correctness;
+- merge readiness by itself;
+- agent-utility benefit sufficient for default activation.
+
+The producer is local and network-disabled by construction, does not read
+secret-file contents, and reads only supported tracked candidates from Git
+objects. Broader or default agent-context activation remains gated on a separate
+paired agent-utility benefit proof.

--- a/docs/retrieval/repoground_agent_utility_t022_goldset.v1.json
+++ b/docs/retrieval/repoground_agent_utility_t022_goldset.v1.json
@@ -1,0 +1,105 @@
+{
+  "kind": "repoground.agent_utility_t022_goldset",
+  "version": "1.0",
+  "task_id": "REPOGROUND-AGENT-UTILITY-V1-T022",
+  "repository_identity": "repoground/goldset",
+  "revision_policy": "materialized_fixture_git_head",
+  "gates": {
+    "minimum_precision": 1.0,
+    "minimum_recall": 1.0,
+    "minimum_range_accuracy": 1.0,
+    "maximum_s1_false_positive_count": 0,
+    "require_exact_omission_reasons": true
+  },
+  "cases": [
+    {
+      "id": "explicit-pyproject-config",
+      "class": "positive",
+      "files": {
+        "pyproject.toml": "[tool.alpha]\nenabled = true\n\n[project]\nname = \"demo\"\n"
+      },
+      "expected_records": [
+        {
+          "relation": "declares_config",
+          "target_identity": "pyproject.tool.alpha",
+          "path": "pyproject.toml",
+          "start_line": 1,
+          "evidence_level": "S1"
+        }
+      ],
+      "expected_omission_reasons": []
+    },
+    {
+      "id": "literal-schema-id",
+      "class": "positive",
+      "files": {
+        "contracts/widget.schema.json": "{\n  \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n  \"$id\": \"https://example.test/schemas/widget.schema.json\",\n  \"type\": \"object\"\n}\n"
+      },
+      "expected_records": [
+        {
+          "relation": "declares_schema",
+          "target_identity": "https://example.test/schemas/widget.schema.json",
+          "path": "contracts/widget.schema.json",
+          "start_line": 3,
+          "evidence_level": "S1"
+        }
+      ],
+      "expected_omission_reasons": []
+    },
+    {
+      "id": "static-local-workflow-reference",
+      "class": "positive",
+      "files": {
+        ".github/workflows/reuse.yml": "name: reuse\non:\n  workflow_call:\njobs: {}\n",
+        ".github/workflows/caller.yml": "name: caller\njobs:\n  delegated:\n    uses: ./.github/workflows/reuse.yml\n"
+      },
+      "expected_records": [
+        {
+          "relation": "references_workflow",
+          "target_identity": ".github/workflows/reuse.yml",
+          "path": ".github/workflows/caller.yml",
+          "start_line": 4,
+          "evidence_level": "S0"
+        }
+      ],
+      "expected_omission_reasons": []
+    },
+    {
+      "id": "dynamic-workflow-reference",
+      "class": "ambiguous",
+      "files": {
+        ".github/workflows/caller.yml": "name: caller\njobs:\n  delegated:\n    uses: ${{ matrix.workflow }}\n"
+      },
+      "expected_records": [],
+      "expected_omission_reasons": ["dynamic_workflow_reference"]
+    },
+    {
+      "id": "missing-local-workflow-target",
+      "class": "ambiguous",
+      "files": {
+        ".github/workflows/caller.yml": "name: caller\njobs:\n  delegated:\n    uses: ./.github/workflows/missing.yml\n"
+      },
+      "expected_records": [],
+      "expected_omission_reasons": ["workflow_target_missing"]
+    },
+    {
+      "id": "nested-schema-id-only",
+      "class": "ambiguous",
+      "files": {
+        "contracts/nested.schema.json": "{\n  \"type\": \"object\",\n  \"properties\": {\n    \"value\": {\"$id\": \"https://example.test/nested\", \"type\": \"string\"}\n  }\n}\n"
+      },
+      "expected_records": [],
+      "expected_omission_reasons": ["schema_id_missing_or_nonliteral"]
+    },
+    {
+      "id": "true-null-unrelated-files",
+      "class": "true_null",
+      "files": {
+        "README.md": "# Ordinary repository\n",
+        "data.json": "{\"name\": \"ordinary data\"}\n"
+      },
+      "expected_records": [],
+      "expected_omission_reasons": []
+    }
+  ]
+}

--- a/merger/repoground/contracts/agent-impact-context.v1.schema.json
+++ b/merger/repoground/contracts/agent-impact-context.v1.schema.json
@@ -106,6 +106,9 @@
     "composition": {
       "type": "object"
     },
+    "structural_relations": {
+      "type": "object"
+    },
     "edit_context": {
       "type": "object"
     },

--- a/merger/repoground/contracts/system-relation-overlay.v1.schema.json
+++ b/merger/repoground/contracts/system-relation-overlay.v1.schema.json
@@ -105,7 +105,9 @@
         "produces_artifact",
         "consumes_artifact",
         "declares_config",
-        "references_config"
+        "references_config",
+        "declares_schema",
+        "references_workflow"
       ]
     },
     "evidence_class": {
@@ -118,7 +120,9 @@
         "schema_validation_call",
         "artifact_declaration",
         "config_declaration",
-        "workflow_config_reference"
+        "workflow_config_reference",
+        "schema_declaration",
+        "workflow_reference"
       ]
     },
     "endpoint_kind": {
@@ -171,7 +175,8 @@
             "test_registry",
             "source_file",
             "artifact_contract",
-            "config_file"
+            "config_file",
+            "schema_file"
           ]
         },
         "range": {"$ref": "#/definitions/range"}
@@ -248,6 +253,20 @@
             "class": {"const": "workflow_config_reference"},
             "level": {"const": "S1"},
             "strength": {"const": "declared"}
+          }
+        },
+        {
+          "properties": {
+            "class": {"const": "schema_declaration"},
+            "level": {"const": "S1"},
+            "strength": {"const": "declared"}
+          }
+        },
+        {
+          "properties": {
+            "class": {"const": "workflow_reference"},
+            "level": {"const": "S0"},
+            "strength": {"const": "referenced"}
           }
         }
       ]
@@ -493,6 +512,31 @@
                   "kind": {"enum": ["manifest", "workflow", "test_registry"]}
                 }
               }
+            }
+          }
+        },
+        {
+          "if": {"properties": {"relation": {"const": "declares_schema"}}},
+          "then": {
+            "properties": {
+              "evidence": {"properties": {"class": {"const": "schema_declaration"}}},
+              "source": {"properties": {"kind": {"const": "schema_file"}}},
+              "target": {"properties": {"kind": {"const": "schema_contract"}}},
+              "contract_identity": {
+                "type": "object",
+                "properties": {"kind": {"const": "schema"}}
+              }
+            }
+          }
+        },
+        {
+          "if": {"properties": {"relation": {"const": "references_workflow"}}},
+          "then": {
+            "properties": {
+              "evidence": {"properties": {"class": {"const": "workflow_reference"}}},
+              "source": {"properties": {"kind": {"const": "workflow"}}},
+              "target": {"properties": {"kind": {"const": "workflow"}}},
+              "contract_identity": {"type": "null"}
             }
           }
         }

--- a/merger/repoground/core/__init__.py
+++ b/merger/repoground/core/__init__.py
@@ -8,13 +8,19 @@ from merger.repoground.core.system_relation_overlay import (
     SystemRelationOverlayError,
     normalize_system_relation_evidence,
 )
+from merger.repoground.core.system_relation_producer import (
+    SystemRelationProducerError,
+    collect_system_relation_evidence,
+)
 
 __core_version__ = "2.4.0"
 
 __all__ = [
     "ScipAdapterError",
     "SystemRelationOverlayError",
+    "SystemRelationProducerError",
     "benchmark_identity",
+    "collect_system_relation_evidence",
     "evaluate_scip_adapter",
     "normalize_scip_index",
     "normalize_system_relation_evidence",

--- a/merger/repoground/core/agent_impact_context.py
+++ b/merger/repoground/core/agent_impact_context.py
@@ -1756,6 +1756,55 @@ def _select_impact_relations(
 
 
 
+
+def _system_relation_context_for_request(
+    *,
+    repository_commit: Any,
+    system_relation_result: Any,
+    paths: set[str],
+    max_items: int,
+    gaps: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    if repository_commit is None and system_relation_result is None:
+        return None
+    context = project_system_relation_context(
+        system_relation_result,
+        repository_commit=repository_commit,
+        target_paths=paths,
+        max_items=max_items,
+    )
+    status = context.get("status")
+    if status in {"blocked", "missing"}:
+        gaps.append(
+            {
+                "source": "system_relation_evidence",
+                "status": status,
+                "reason": context.get("reason"),
+                "binding": context.get("binding"),
+            }
+        )
+    return context
+
+
+def _structural_context_resolves_target(context: Mapping[str, Any] | None) -> bool:
+    return bool(
+        context
+        and context.get("status") == "available"
+        and context.get("records")
+    )
+
+
+def _attach_structural_context(
+    result: dict[str, Any],
+    context: Mapping[str, Any] | None,
+) -> None:
+    if context is None:
+        return
+    result["structural_relations"] = dict(context)
+    result["composition"]["system_relation_evidence_used"] = (
+        _structural_context_resolves_target(context)
+    )
+
 def build_agent_impact_context(
     *,
     target_path: Any = None,
@@ -1816,24 +1865,13 @@ def build_agent_impact_context(
         )
 
     paths = set(request.paths)
-    structural_context = None
-    if repository_commit is not None or system_relation_result is not None:
-        structural_context = project_system_relation_context(
-            system_relation_result,
-            repository_commit=repository_commit,
-            target_paths=paths,
-            max_items=request.max_items,
-        )
-        structural_status = structural_context.get("status")
-        if structural_status in {"blocked", "missing"}:
-            gaps.append(
-                {
-                    "source": "system_relation_evidence",
-                    "status": structural_status,
-                    "reason": structural_context.get("reason"),
-                    "binding": structural_context.get("binding"),
-                }
-            )
+    structural_context = _system_relation_context_for_request(
+        repository_commit=repository_commit,
+        system_relation_result=system_relation_result,
+        paths=paths,
+        max_items=request.max_items,
+        gaps=gaps,
+    )
     (
         target_symbols,
         all_target_symbols,
@@ -1958,11 +1996,7 @@ def build_agent_impact_context(
     resolved_target = bool(
         target_symbols
         or any(path in id_by_path for path in paths)
-        or (
-            structural_context is not None
-            and structural_context.get("status") == "available"
-            and structural_context.get("records")
-        )
+        or _structural_context_resolves_target(structural_context)
     )
     result = _base_result(
         status=_result_status(
@@ -2015,12 +2049,7 @@ def build_agent_impact_context(
             },
         }
     )
-    if structural_context is not None:
-        result["structural_relations"] = structural_context
-        result["composition"]["system_relation_evidence_used"] = bool(
-            structural_context.get("status") == "available"
-            and structural_context.get("records")
-        )
+    _attach_structural_context(result, structural_context)
 
     if request.mode == "edit":
         selected_call_relations = (

--- a/merger/repoground/core/agent_impact_context.py
+++ b/merger/repoground/core/agent_impact_context.py
@@ -16,6 +16,9 @@ from merger.repoground.architecture.path_classification import is_test_path as _
 from merger.repoground.core.call_graph_confidence import (
     call_graph_coverage_confidence as _shared_call_graph_coverage,
 )
+from merger.repoground.core.system_relation_context import (
+    project_system_relation_context,
+)
 
 KIND = "repobrief.agent_impact_context"
 VERSION = "1.0"
@@ -1767,6 +1770,8 @@ def build_agent_impact_context(
     relation_cards: Any = None,
     query_context: Any = None,
     source_statuses: Any = None,
+    repository_commit: Any = None,
+    system_relation_result: Any = None,
 ) -> dict[str, Any]:
     """Build a bounded impact/edit context from existing RepoGround artifacts."""
 
@@ -1811,6 +1816,24 @@ def build_agent_impact_context(
         )
 
     paths = set(request.paths)
+    structural_context = None
+    if repository_commit is not None or system_relation_result is not None:
+        structural_context = project_system_relation_context(
+            system_relation_result,
+            repository_commit=repository_commit,
+            target_paths=paths,
+            max_items=request.max_items,
+        )
+        structural_status = structural_context.get("status")
+        if structural_status in {"blocked", "missing"}:
+            gaps.append(
+                {
+                    "source": "system_relation_evidence",
+                    "status": structural_status,
+                    "reason": structural_context.get("reason"),
+                    "binding": structural_context.get("binding"),
+                }
+            )
     (
         target_symbols,
         all_target_symbols,
@@ -1933,7 +1956,13 @@ def build_agent_impact_context(
         )
     )
     resolved_target = bool(
-        target_symbols or any(path in id_by_path for path in paths)
+        target_symbols
+        or any(path in id_by_path for path in paths)
+        or (
+            structural_context is not None
+            and structural_context.get("status") == "available"
+            and structural_context.get("records")
+        )
     )
     result = _base_result(
         status=_result_status(
@@ -1986,6 +2015,13 @@ def build_agent_impact_context(
             },
         }
     )
+    if structural_context is not None:
+        result["structural_relations"] = structural_context
+        result["composition"]["system_relation_evidence_used"] = bool(
+            structural_context.get("status") == "available"
+            and structural_context.get("records")
+        )
+
     if request.mode == "edit":
         selected_call_relations = (
             edit_selection["direct_callers"]["selected"]

--- a/merger/repoground/core/system_relation_context.py
+++ b/merger/repoground/core/system_relation_context.py
@@ -7,6 +7,7 @@ from collections.abc import Iterable, Mapping
 from typing import Any
 
 from merger.repoground.core.system_relation_overlay import (
+    MAX_EVIDENCE_RECORDS,
     SystemRelationOverlayError,
     normalize_system_relation_evidence,
 )
@@ -15,8 +16,6 @@ KIND = "repoground.system_relation_context"
 VERSION = "1.0"
 PRODUCER_RESULT_KIND = "repoground.system_relation_producer_result"
 PRODUCER_RESULT_VERSION = "1.0"
-MAX_EVIDENCE_RECORDS = 4096
-
 ABSENCE_SEMANTICS = (
     "Missing projected records mean only that coherent supplied evidence did not "
     "establish a supported relation for these target paths."

--- a/merger/repoground/core/system_relation_context.py
+++ b/merger/repoground/core/system_relation_context.py
@@ -119,42 +119,35 @@ def _record_relevant(record: Mapping[str, Any], target_paths: set[str]) -> bool:
     )
 
 
-def project_system_relation_context(
+def _missing(expected_commit: str) -> dict[str, Any]:
+    result = _base("missing")
+    result["reason"] = "system_relation_evidence_missing"
+    result["binding"] = {
+        "expected_repository_commit": expected_commit,
+        "observed_repository_commit": None,
+        "expected_evidence_sha256": None,
+        "observed_evidence_sha256": None,
+    }
+    return result
+
+
+def _producer_binding(
     producer_result: Any,
     *,
-    repository_commit: Any,
-    target_paths: Iterable[str],
-    max_items: int = 25,
-) -> dict[str, Any]:
-    """Project relevant relations only after commit and digest coherence checks."""
-    expected_commit = _expected_commit(repository_commit)
-    if expected_commit is None:
-        return _blocked("expected_repository_commit_invalid")
-    if producer_result is None:
-        result = _base("missing")
-        result["reason"] = "system_relation_evidence_missing"
-        result["binding"] = {
-            "expected_repository_commit": expected_commit,
-            "observed_repository_commit": None,
-            "expected_evidence_sha256": None,
-            "observed_evidence_sha256": None,
-        }
-        return result
+    expected_commit: str,
+) -> tuple[dict[str, Any] | None, Any, Mapping[str, Any] | None]:
     if not isinstance(producer_result, Mapping):
         return _blocked(
-            "producer_result_not_object",
-            expected_commit=expected_commit,
-        )
+            "producer_result_not_object", expected_commit=expected_commit
+        ), None, None
     if producer_result.get("kind") != PRODUCER_RESULT_KIND:
         return _blocked(
-            "producer_result_kind_incompatible",
-            expected_commit=expected_commit,
-        )
+            "producer_result_kind_incompatible", expected_commit=expected_commit
+        ), None, None
     if producer_result.get("version") != PRODUCER_RESULT_VERSION:
         return _blocked(
-            "producer_result_version_incompatible",
-            expected_commit=expected_commit,
-        )
+            "producer_result_version_incompatible", expected_commit=expected_commit
+        ), None, None
 
     repository = producer_result.get("repository")
     observed_commit = (
@@ -165,21 +158,35 @@ def project_system_relation_context(
             "repository_commit_mismatch",
             expected_commit=expected_commit,
             observed_commit=observed_commit,
-        )
+        ), observed_commit, None
 
     revision_binding = producer_result.get("revision_binding")
-    if (
-        not isinstance(revision_binding, Mapping)
-        or revision_binding.get("mode") != "git_commit_object"
-        or revision_binding.get("repository_commit") != expected_commit
-        or revision_binding.get("verified") is not True
-    ):
+    binding_valid = (
+        isinstance(revision_binding, Mapping)
+        and revision_binding.get("mode") == "git_commit_object"
+        and revision_binding.get("repository_commit") == expected_commit
+        and revision_binding.get("verified") is True
+    )
+    if not binding_valid:
         return _blocked(
             "revision_binding_incompatible",
             expected_commit=expected_commit,
             observed_commit=observed_commit,
-        )
+        ), observed_commit, None
+    return None, observed_commit, revision_binding
 
+
+def _validated_overlay(
+    producer_result: Mapping[str, Any],
+    *,
+    expected_commit: str,
+    observed_commit: Any,
+) -> tuple[
+    dict[str, Any] | None,
+    str | None,
+    str | None,
+    dict[str, Any] | None,
+]:
     evidence = producer_result.get("evidence")
     expected_digest = producer_result.get("evidence_sha256")
     if not isinstance(evidence, Mapping):
@@ -188,7 +195,7 @@ def project_system_relation_context(
             expected_commit=expected_commit,
             observed_commit=observed_commit,
             expected_digest=expected_digest,
-        )
+        ), None, None, None
     raw_records = evidence.get("records")
     if not isinstance(raw_records, list):
         return _blocked(
@@ -196,21 +203,22 @@ def project_system_relation_context(
             expected_commit=expected_commit,
             observed_commit=observed_commit,
             expected_digest=expected_digest,
-        )
+        ), None, None, None
     if len(raw_records) > MAX_EVIDENCE_RECORDS:
         return _blocked(
             "evidence_record_limit_exceeded",
             expected_commit=expected_commit,
             observed_commit=observed_commit,
             expected_digest=expected_digest,
-        )
+        ), None, None, None
     if not isinstance(expected_digest, str) or len(expected_digest) != 64:
         return _blocked(
             "evidence_digest_invalid",
             expected_commit=expected_commit,
             observed_commit=observed_commit,
             expected_digest=expected_digest,
-        )
+        ), None, None, None
+
     observed_digest = _canonical_sha256(evidence)
     if observed_digest != expected_digest:
         return _blocked(
@@ -219,7 +227,7 @@ def project_system_relation_context(
             observed_commit=observed_commit,
             expected_digest=expected_digest,
             observed_digest=observed_digest,
-        )
+        ), expected_digest, observed_digest, None
 
     supplied_overlay = producer_result.get("overlay")
     if not isinstance(supplied_overlay, Mapping):
@@ -229,7 +237,7 @@ def project_system_relation_context(
             observed_commit=observed_commit,
             expected_digest=expected_digest,
             observed_digest=observed_digest,
-        )
+        ), expected_digest, observed_digest, None
     try:
         normalized = normalize_system_relation_evidence(
             evidence,
@@ -243,7 +251,7 @@ def project_system_relation_context(
             observed_commit=observed_commit,
             expected_digest=expected_digest,
             observed_digest=observed_digest,
-        )
+        ), expected_digest, observed_digest, None
     if dict(supplied_overlay) != normalized:
         return _blocked(
             "overlay_revalidation_mismatch",
@@ -251,7 +259,43 @@ def project_system_relation_context(
             observed_commit=observed_commit,
             expected_digest=expected_digest,
             observed_digest=observed_digest,
-        )
+        ), expected_digest, observed_digest, None
+    return None, expected_digest, observed_digest, normalized
+
+
+def project_system_relation_context(
+    producer_result: Any,
+    *,
+    repository_commit: Any,
+    target_paths: Iterable[str],
+    max_items: int = 25,
+) -> dict[str, Any]:
+    """Project relevant relations only after commit and digest coherence checks."""
+    expected_commit = _expected_commit(repository_commit)
+    if expected_commit is None:
+        return _blocked("expected_repository_commit_invalid")
+    if producer_result is None:
+        return _missing(expected_commit)
+
+    binding_error, observed_commit, revision_binding = _producer_binding(
+        producer_result,
+        expected_commit=expected_commit,
+    )
+    if binding_error is not None:
+        return binding_error
+    assert isinstance(producer_result, Mapping)
+    assert revision_binding is not None
+
+    overlay_error, expected_digest, observed_digest, normalized = _validated_overlay(
+        producer_result,
+        expected_commit=expected_commit,
+        observed_commit=observed_commit,
+    )
+    if overlay_error is not None:
+        return overlay_error
+    assert expected_digest is not None
+    assert observed_digest is not None
+    assert normalized is not None
 
     paths = _target_path_set(target_paths)
     relevant = [

--- a/merger/repoground/core/system_relation_context.py
+++ b/merger/repoground/core/system_relation_context.py
@@ -1,0 +1,293 @@
+"""Commit- and digest-gated context projection for system relation evidence."""
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from merger.repoground.core.system_relation_overlay import (
+    SystemRelationOverlayError,
+    normalize_system_relation_evidence,
+)
+
+KIND = "repoground.system_relation_context"
+VERSION = "1.0"
+PRODUCER_RESULT_KIND = "repoground.system_relation_producer_result"
+PRODUCER_RESULT_VERSION = "1.0"
+MAX_EVIDENCE_RECORDS = 4096
+
+ABSENCE_SEMANTICS = (
+    "Missing projected records mean only that coherent supplied evidence did not "
+    "establish a supported relation for these target paths."
+)
+DOES_NOT_ESTABLISH = (
+    "repository_truth",
+    "relation_completeness",
+    "runtime_behavior",
+    "runtime_correctness",
+    "config_runtime_effect",
+    "schema_conformance",
+    "workflow_execution",
+    "merge_readiness",
+)
+
+
+def _canonical_sha256(value: Any) -> str:
+    payload = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _expected_commit(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    commit = value.strip()
+    if len(commit) not in {40, 64}:
+        return None
+    if any(character not in "0123456789abcdef" for character in commit):
+        return None
+    return commit
+
+
+def _base(status: str) -> dict[str, Any]:
+    return {
+        "kind": KIND,
+        "version": VERSION,
+        "status": status,
+        "source": None,
+        "records": [],
+        "record_count": 0,
+        "relevant_record_count": 0,
+        "omitted_relevant_count": 0,
+        "reason": None,
+        "absence_semantics": ABSENCE_SEMANTICS,
+        "does_not_establish": list(DOES_NOT_ESTABLISH),
+    }
+
+
+def _blocked(
+    reason: str,
+    *,
+    expected_commit: str | None = None,
+    observed_commit: Any = None,
+    expected_digest: Any = None,
+    observed_digest: Any = None,
+) -> dict[str, Any]:
+    result = _base("blocked")
+    result["reason"] = reason
+    result["binding"] = {
+        "expected_repository_commit": expected_commit,
+        "observed_repository_commit": (
+            observed_commit if isinstance(observed_commit, str) else None
+        ),
+        "expected_evidence_sha256": (
+            expected_digest if isinstance(expected_digest, str) else None
+        ),
+        "observed_evidence_sha256": (
+            observed_digest if isinstance(observed_digest, str) else None
+        ),
+    }
+    return result
+
+
+def _target_path_set(value: Iterable[str]) -> set[str]:
+    return {
+        path
+        for path in value
+        if isinstance(path, str) and path and not path.startswith("/")
+    }
+
+
+def _record_relevant(record: Mapping[str, Any], target_paths: set[str]) -> bool:
+    source = record.get("source")
+    subject = record.get("subject")
+    target = record.get("target")
+    source_path = source.get("path") if isinstance(source, Mapping) else None
+    subject_identity = (
+        subject.get("identity") if isinstance(subject, Mapping) else None
+    )
+    target_identity = target.get("identity") if isinstance(target, Mapping) else None
+    return bool(
+        source_path in target_paths
+        or subject_identity in target_paths
+        or target_identity in target_paths
+    )
+
+
+def project_system_relation_context(
+    producer_result: Any,
+    *,
+    repository_commit: Any,
+    target_paths: Iterable[str],
+    max_items: int = 25,
+) -> dict[str, Any]:
+    """Project relevant relations only after commit and digest coherence checks."""
+    expected_commit = _expected_commit(repository_commit)
+    if expected_commit is None:
+        return _blocked("expected_repository_commit_invalid")
+    if producer_result is None:
+        result = _base("missing")
+        result["reason"] = "system_relation_evidence_missing"
+        result["binding"] = {
+            "expected_repository_commit": expected_commit,
+            "observed_repository_commit": None,
+            "expected_evidence_sha256": None,
+            "observed_evidence_sha256": None,
+        }
+        return result
+    if not isinstance(producer_result, Mapping):
+        return _blocked(
+            "producer_result_not_object",
+            expected_commit=expected_commit,
+        )
+    if producer_result.get("kind") != PRODUCER_RESULT_KIND:
+        return _blocked(
+            "producer_result_kind_incompatible",
+            expected_commit=expected_commit,
+        )
+    if producer_result.get("version") != PRODUCER_RESULT_VERSION:
+        return _blocked(
+            "producer_result_version_incompatible",
+            expected_commit=expected_commit,
+        )
+
+    repository = producer_result.get("repository")
+    observed_commit = (
+        repository.get("commit") if isinstance(repository, Mapping) else None
+    )
+    if observed_commit != expected_commit:
+        return _blocked(
+            "repository_commit_mismatch",
+            expected_commit=expected_commit,
+            observed_commit=observed_commit,
+        )
+
+    revision_binding = producer_result.get("revision_binding")
+    if (
+        not isinstance(revision_binding, Mapping)
+        or revision_binding.get("mode") != "git_commit_object"
+        or revision_binding.get("repository_commit") != expected_commit
+        or revision_binding.get("verified") is not True
+    ):
+        return _blocked(
+            "revision_binding_incompatible",
+            expected_commit=expected_commit,
+            observed_commit=observed_commit,
+        )
+
+    evidence = producer_result.get("evidence")
+    expected_digest = producer_result.get("evidence_sha256")
+    if not isinstance(evidence, Mapping):
+        return _blocked(
+            "evidence_not_object",
+            expected_commit=expected_commit,
+            observed_commit=observed_commit,
+            expected_digest=expected_digest,
+        )
+    raw_records = evidence.get("records")
+    if not isinstance(raw_records, list):
+        return _blocked(
+            "evidence_records_not_list",
+            expected_commit=expected_commit,
+            observed_commit=observed_commit,
+            expected_digest=expected_digest,
+        )
+    if len(raw_records) > MAX_EVIDENCE_RECORDS:
+        return _blocked(
+            "evidence_record_limit_exceeded",
+            expected_commit=expected_commit,
+            observed_commit=observed_commit,
+            expected_digest=expected_digest,
+        )
+    if not isinstance(expected_digest, str) or len(expected_digest) != 64:
+        return _blocked(
+            "evidence_digest_invalid",
+            expected_commit=expected_commit,
+            observed_commit=observed_commit,
+            expected_digest=expected_digest,
+        )
+    observed_digest = _canonical_sha256(evidence)
+    if observed_digest != expected_digest:
+        return _blocked(
+            "evidence_digest_mismatch",
+            expected_commit=expected_commit,
+            observed_commit=observed_commit,
+            expected_digest=expected_digest,
+            observed_digest=observed_digest,
+        )
+
+    supplied_overlay = producer_result.get("overlay")
+    if not isinstance(supplied_overlay, Mapping):
+        return _blocked(
+            "overlay_not_object",
+            expected_commit=expected_commit,
+            observed_commit=observed_commit,
+            expected_digest=expected_digest,
+            observed_digest=observed_digest,
+        )
+    try:
+        normalized = normalize_system_relation_evidence(
+            evidence,
+            evidence_sha256=expected_digest,
+            repository_commit=expected_commit,
+        )
+    except SystemRelationOverlayError:
+        return _blocked(
+            "evidence_contract_invalid",
+            expected_commit=expected_commit,
+            observed_commit=observed_commit,
+            expected_digest=expected_digest,
+            observed_digest=observed_digest,
+        )
+    if dict(supplied_overlay) != normalized:
+        return _blocked(
+            "overlay_revalidation_mismatch",
+            expected_commit=expected_commit,
+            observed_commit=observed_commit,
+            expected_digest=expected_digest,
+            observed_digest=observed_digest,
+        )
+
+    paths = _target_path_set(target_paths)
+    relevant = [
+        dict(record)
+        for record in normalized["records"]
+        if _record_relevant(record, paths)
+    ]
+    limit = max(1, min(200, int(max_items)))
+    selected = relevant[:limit]
+    result = _base("available")
+    result.update(
+        {
+            "source": {
+                "repository_commit": expected_commit,
+                "evidence_sha256": expected_digest,
+                "producer": dict(normalized["source"]["producer"]),
+                "revision_binding": dict(revision_binding),
+            },
+            "records": selected,
+            "record_count": len(normalized["records"]),
+            "relevant_record_count": len(relevant),
+            "omitted_relevant_count": max(0, len(relevant) - len(selected)),
+            "binding": {
+                "expected_repository_commit": expected_commit,
+                "observed_repository_commit": observed_commit,
+                "expected_evidence_sha256": expected_digest,
+                "observed_evidence_sha256": observed_digest,
+            },
+        }
+    )
+    return result
+
+
+__all__ = [
+    "DOES_NOT_ESTABLISH",
+    "KIND",
+    "VERSION",
+    "project_system_relation_context",
+]

--- a/merger/repoground/core/system_relation_overlay.py
+++ b/merger/repoground/core/system_relation_overlay.py
@@ -46,9 +46,11 @@ EVIDENCE_PROFILES = {
     "test_import_or_reference": ("S0", "referenced"),
     "test_naming_heuristic": ("S0", "heuristic"),
     "schema_validation_call": ("S1", "declared"),
+    "schema_declaration": ("S1", "declared"),
     "artifact_declaration": ("S1", "declared"),
     "config_declaration": ("S1", "declared"),
     "workflow_config_reference": ("S1", "declared"),
+    "workflow_reference": ("S0", "referenced"),
 }
 
 SOURCE_KINDS_BY_EVIDENCE = {
@@ -60,11 +62,13 @@ SOURCE_KINDS_BY_EVIDENCE = {
     "test_import_or_reference": frozenset({"source_file"}),
     "test_naming_heuristic": frozenset({"source_file"}),
     "schema_validation_call": frozenset({"source_file"}),
+    "schema_declaration": frozenset({"schema_file"}),
     "artifact_declaration": frozenset(
         {"manifest", "workflow", "source_file", "artifact_contract"}
     ),
     "config_declaration": frozenset({"manifest", "config_file"}),
     "workflow_config_reference": frozenset({"workflow"}),
+    "workflow_reference": frozenset({"workflow"}),
 }
 
 RELATION_RULES = {
@@ -91,6 +95,11 @@ RELATION_RULES = {
         "contract_kind": "schema",
         "target_kind": "schema_contract",
     },
+    "declares_schema": {
+        "evidence": frozenset({"schema_declaration"}),
+        "contract_kind": "schema",
+        "target_kind": "schema_contract",
+    },
     "produces_artifact": {
         "evidence": frozenset({"artifact_declaration"}),
         "contract_kind": "artifact",
@@ -98,6 +107,11 @@ RELATION_RULES = {
     "consumes_artifact": {
         "evidence": frozenset({"artifact_declaration"}),
         "contract_kind": "artifact",
+    },
+    "references_workflow": {
+        "evidence": frozenset({"workflow_reference"}),
+        "contract_kind": None,
+        "target_kind": "workflow",
     },
     "declares_config": {
         "evidence": frozenset({"config_declaration"}),

--- a/merger/repoground/core/system_relation_overlay.py
+++ b/merger/repoground/core/system_relation_overlay.py
@@ -20,6 +20,7 @@ SOURCE_VERSION = "1.0"
 AUTHORITY = "navigation_index"
 CANONICALITY = "derived"
 RISK_CLASS = "navigation"
+MAX_EVIDENCE_RECORDS = 4096
 
 ENDPOINT_KINDS = frozenset(
     {
@@ -398,6 +399,10 @@ def normalize_system_relation_evidence(
     records_value = mapping["records"]
     if not isinstance(records_value, list):
         raise SystemRelationOverlayError("evidence.records must be a list")
+    if len(records_value) > MAX_EVIDENCE_RECORDS:
+        raise SystemRelationOverlayError(
+            f"evidence.records exceeds maximum {MAX_EVIDENCE_RECORDS}"
+        )
 
     unique: dict[str, dict[str, Any]] = {}
     duplicate_count = 0
@@ -460,6 +465,7 @@ def normalize_system_relation_evidence(
 
 
 __all__ = [
+    "MAX_EVIDENCE_RECORDS",
     "SystemRelationOverlayError",
     "normalize_system_relation_evidence",
 ]

--- a/merger/repoground/core/system_relation_producer.py
+++ b/merger/repoground/core/system_relation_producer.py
@@ -269,6 +269,43 @@ def _omission(
     return result
 
 
+def _parse_git_candidate(
+    raw_entry: bytes,
+) -> tuple[tuple[str, str, int, str] | None, dict[str, Any] | None]:
+    try:
+        metadata, raw_path = raw_entry.split(b"\t", 1)
+        mode, object_type, object_id, raw_size = metadata.split()
+    except ValueError:
+        raise SystemRelationProducerError(
+            "git candidate index contained an invalid entry"
+        ) from None
+
+    path_fingerprint = hashlib.sha256(raw_path).hexdigest()[:16]
+    try:
+        relative = raw_path.decode("utf-8")
+    except UnicodeDecodeError:
+        return None, _omission(
+            f"<non-utf8-path:{path_fingerprint}>",
+            "non_utf8_path_omitted",
+        )
+    if not _safe_repo_path(relative):
+        return None, _omission(relative, "unsafe_path_omitted")
+
+    candidate_kind = _candidate_kind(relative)
+    if candidate_kind is None:
+        return None, None
+    if _sensitive_path(relative):
+        return None, _omission(relative, "sensitive_path_omitted")
+    if object_type != b"blob" or mode == b"120000":
+        return None, _omission(relative, "non_regular_file_omitted")
+    try:
+        size = int(raw_size)
+        object_id_text = object_id.decode("ascii")
+    except (ValueError, UnicodeDecodeError):
+        return None, _omission(relative, "git_metadata_invalid")
+    return (relative, object_id_text, size, candidate_kind), None
+
+
 def _git_candidates(
     root: Path,
     *,
@@ -296,44 +333,12 @@ def _git_candidates(
     for raw_entry in payload.split(b"\x00"):
         if not raw_entry:
             continue
-        try:
-            metadata, raw_path = raw_entry.split(b"\t", 1)
-            mode, object_type, object_id, raw_size = metadata.split()
-        except ValueError:
-            raise SystemRelationProducerError(
-                "git candidate index contained an invalid entry"
-            ) from None
-        path_fingerprint = hashlib.sha256(raw_path).hexdigest()[:16]
-        try:
-            relative = raw_path.decode("utf-8")
-        except UnicodeDecodeError:
-            omissions.append(
-                _omission(
-                    f"<non-utf8-path:{path_fingerprint}>",
-                    "non_utf8_path_omitted",
-                )
-            )
-            continue
-        if not _safe_repo_path(relative):
-            omissions.append(_omission(relative, "unsafe_path_omitted"))
-            continue
-        candidate_kind = _candidate_kind(relative)
-        if candidate_kind is None:
-            continue
-        if _sensitive_path(relative):
-            omissions.append(_omission(relative, "sensitive_path_omitted"))
-            continue
-        if object_type != b"blob" or mode == b"120000":
-            omissions.append(_omission(relative, "non_regular_file_omitted"))
-            continue
-        try:
-            size = int(raw_size)
-            object_id_text = object_id.decode("ascii")
-        except (ValueError, UnicodeDecodeError):
-            omissions.append(_omission(relative, "git_metadata_invalid"))
-            continue
-        available_paths.add(relative)
-        candidates.append((relative, object_id_text, size, candidate_kind))
+        candidate, omission = _parse_git_candidate(raw_entry)
+        if omission is not None:
+            omissions.append(omission)
+        if candidate is not None:
+            candidates.append(candidate)
+            available_paths.add(candidate[0])
 
     candidates.sort(key=lambda item: item[0])
     omissions.sort(key=_omission_order)
@@ -631,6 +636,60 @@ def _omission_order(item: Mapping[str, Any]) -> tuple[str, str, int, str]:
     )
 
 
+
+def _candidate_text(
+    root: Path,
+    candidate: tuple[str, str, int, str],
+    *,
+    scanned_bytes: int,
+    max_file_bytes: int,
+    max_total_bytes: int,
+) -> tuple[str | None, dict[str, Any] | None]:
+    relative, object_id, size, _candidate_kind_value = candidate
+    if size > max_file_bytes:
+        return None, _omission(relative, "file_too_large", detail=str(size))
+    if scanned_bytes + size > max_total_bytes:
+        return None, _omission(
+            relative, "total_byte_budget_exhausted", detail=str(size)
+        )
+    try:
+        payload = _git_blob(root, object_id)
+    except SystemRelationProducerError:
+        return None, _omission(relative, "git_blob_read_failed")
+    if len(payload) != size:
+        return None, _omission(relative, "git_blob_size_mismatch")
+    try:
+        return payload.decode("utf-8"), None
+    except UnicodeDecodeError:
+        return None, _omission(relative, "invalid_utf8")
+
+
+def _scan_candidate_text(
+    text: str,
+    candidate: tuple[str, str, int, str],
+    *,
+    repository_identity: str,
+    available_paths: set[str],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    relative, _object_id, _size, candidate_kind = candidate
+    if candidate_kind == "pyproject":
+        return _scan_pyproject(
+            text,
+            relative=relative,
+            repository_identity=repository_identity,
+        )
+    if candidate_kind == "schema":
+        return _scan_schema(
+            text,
+            relative=relative,
+            repository_identity=repository_identity,
+        )
+    return _scan_workflow(
+        text,
+        relative=relative,
+        available_paths=available_paths,
+    )
+
 def collect_system_relation_evidence(
     repository_root: str | Path,
     *,
@@ -673,7 +732,8 @@ def collect_system_relation_evidence(
     scanned_bytes = 0
     considered_candidates = 0
 
-    for index, (relative, object_id, size, candidate_kind) in enumerate(candidates):
+    for index, candidate in enumerate(candidates):
+        relative = candidate[0]
         if index >= max_files:
             remaining = len(candidates) - index
             omissions.append(
@@ -689,50 +749,25 @@ def collect_system_relation_evidence(
             )
             break
         considered_candidates += 1
-        if size > max_file_bytes:
-            omissions.append(
-                _omission(relative, "file_too_large", detail=str(size))
-            )
+        text, omission = _candidate_text(
+            root,
+            candidate,
+            scanned_bytes=scanned_bytes,
+            max_file_bytes=max_file_bytes,
+            max_total_bytes=max_total_bytes,
+        )
+        if omission is not None:
+            omissions.append(omission)
             continue
-        if scanned_bytes + size > max_total_bytes:
-            omissions.append(
-                _omission(relative, "total_byte_budget_exhausted", detail=str(size))
-            )
-            continue
-        try:
-            payload = _git_blob(root, object_id)
-        except SystemRelationProducerError:
-            omissions.append(_omission(relative, "git_blob_read_failed"))
-            continue
-        if len(payload) != size:
-            omissions.append(_omission(relative, "git_blob_size_mismatch"))
-            continue
-        try:
-            text = payload.decode("utf-8")
-        except UnicodeDecodeError:
-            omissions.append(_omission(relative, "invalid_utf8"))
-            continue
-
+        assert text is not None
         scanned_files += 1
-        scanned_bytes += len(payload)
-        if candidate_kind == "pyproject":
-            found, skipped = _scan_pyproject(
-                text,
-                relative=relative,
-                repository_identity=identity,
-            )
-        elif candidate_kind == "schema":
-            found, skipped = _scan_schema(
-                text,
-                relative=relative,
-                repository_identity=identity,
-            )
-        else:
-            found, skipped = _scan_workflow(
-                text,
-                relative=relative,
-                available_paths=available_paths,
-            )
+        scanned_bytes += len(text.encode("utf-8"))
+        found, skipped = _scan_candidate_text(
+            text,
+            candidate,
+            repository_identity=identity,
+            available_paths=available_paths,
+        )
         records.extend(found)
         omissions.extend(skipped)
 

--- a/merger/repoground/core/system_relation_producer.py
+++ b/merger/repoground/core/system_relation_producer.py
@@ -1,0 +1,800 @@
+"""Conservative revision-bound producer for static repository relations.
+
+The producer intentionally supports only a small set of declarations whose
+meaning can be established from repository text without executing code:
+
+* root ``pyproject.toml`` first-level ``[tool.NAME]`` tables declare config contracts;
+* ``*.schema.json`` files with a top-level literal ``$id`` declare schema contracts;
+* local GitHub workflow ``uses: ./.github/workflows/...`` entries reference an
+  existing workflow file in the same commit.
+
+Candidates and file bytes are read from the Git object database of the requested
+commit, never from the mutable working tree. Everything dynamic or ambiguous is
+omitted rather than inferred. The result is deterministic and suitable for
+``system_relation_overlay`` normalization, but it is not runtime truth and does
+not establish config effects, schema conformance or workflow execution.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+from collections.abc import Mapping
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10 compatibility
+    try:
+        import tomli as tomllib
+    except ModuleNotFoundError:
+        tomllib = None
+
+from merger.repoground.core.system_relation_overlay import (
+    normalize_system_relation_evidence,
+)
+
+KIND = "repoground.system_relation_producer_result"
+VERSION = "1.0"
+EVIDENCE_KIND = "repoground.system_relation_evidence"
+EVIDENCE_VERSION = "1.0"
+PRODUCER_NAME = "repoground.system_relation_producer"
+PRODUCER_VERSION = "1.0"
+
+DEFAULT_MAX_FILES = 512
+DEFAULT_MAX_FILE_BYTES = 1_048_576
+DEFAULT_MAX_TOTAL_BYTES = 8_388_608
+DEFAULT_MAX_CANDIDATE_INDEX_BYTES = 4_194_304
+_GIT_TIMEOUT_SECONDS = 10
+_SUPPORTED_RELATIONS = (
+    "declares_config",
+    "declares_schema",
+    "references_workflow",
+)
+_SUPPORTED_SOURCES = (
+    "root pyproject.toml first-level [tool.NAME] tables",
+    "tracked *.schema.json with a top-level literal $id",
+    "tracked .github/workflows/*.yml|*.yaml static local reusable-workflow references",
+)
+_DOES_NOT_ESTABLISH = (
+    "repository_truth_beyond_requested_commit",
+    "complete_repository_relation_coverage",
+    "runtime_config_effect",
+    "schema_conformance",
+    "schema_validation_execution",
+    "workflow_execution",
+    "workflow_validity",
+    "runtime_behavior",
+    "runtime_correctness",
+    "default_activation",
+)
+_SENSITIVE_PARTS = frozenset(
+    {
+        ".env",
+        "secret",
+        "secrets",
+        "credential",
+        "credentials",
+        "private-key",
+        "private_key",
+        "tokens",
+    }
+)
+_TOOL_TABLE_RE = re.compile(
+    r"^(?P<prefix>\s*)\[tool\.(?P<name>[A-Za-z0-9_-]+)\]\s*(?:#.*)?$"
+)
+_WORKFLOW_USES_RE = re.compile(
+    r"^(?P<prefix>\s*)uses\s*:\s*(?P<quote>['\"]?)(?P<value>[^'\"\s#]+)(?P=quote)\s*(?:#.*)?$"
+)
+
+
+class SystemRelationProducerError(ValueError):
+    """Raised when the producer request or revision source is unsafe."""
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def _canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(_canonical_bytes(value)).hexdigest()
+
+
+def _commit(value: Any) -> str:
+    if not isinstance(value, str):
+        raise SystemRelationProducerError("repository_commit must be a string")
+    commit = value.strip()
+    if len(commit) not in {40, 64} or any(
+        character not in "0123456789abcdef" for character in commit
+    ):
+        raise SystemRelationProducerError(
+            "repository_commit must be a lowercase 40- or 64-character digest"
+        )
+    return commit
+
+
+def _repository_identity(value: Any) -> str:
+    if not isinstance(value, str):
+        raise SystemRelationProducerError("repository_identity must be a string")
+    identity = value.strip()
+    if not identity or len(identity) > 4096 or "\x00" in identity:
+        raise SystemRelationProducerError(
+            "repository_identity must be non-empty and bounded"
+        )
+    return identity
+
+
+def _positive_int(value: Any, *, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise SystemRelationProducerError(f"{field} must be an integer >= 1")
+    return value
+
+
+def _git_environment() -> dict[str, str]:
+    environment = dict(os.environ)
+    environment.update(
+        {
+            "GIT_NO_LAZY_FETCH": "1",
+            "GIT_TERMINAL_PROMPT": "0",
+            "GIT_ASKPASS": "/bin/false",
+        }
+    )
+    return environment
+
+
+def _git_stdout(
+    root: Path,
+    arguments: list[str],
+    *,
+    operation: str,
+) -> bytes:
+    command = [
+        "git",
+        "-c",
+        "core.pager=cat",
+        "-c",
+        "core.hooksPath=/dev/null",
+        "-c",
+        "diff.external=",
+        "-c",
+        "protocol.file.allow=never",
+        "-C",
+        str(root),
+        *arguments,
+    ]
+    try:
+        completed = subprocess.run(
+            command,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=_GIT_TIMEOUT_SECONDS,
+            env=_git_environment(),
+        )
+    except FileNotFoundError as exc:
+        raise SystemRelationProducerError("git executable is unavailable") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise SystemRelationProducerError(
+            f"git {operation} exceeded the bounded timeout"
+        ) from exc
+    if completed.returncode != 0:
+        raise SystemRelationProducerError(f"git {operation} failed")
+    return completed.stdout
+
+
+def _verify_revision_source(root: Path, commit: str) -> None:
+    raw_root = _git_stdout(
+        root,
+        ["rev-parse", "--show-toplevel"],
+        operation="repository-root verification",
+    )
+    try:
+        observed_root = Path(raw_root.decode("utf-8").strip()).resolve(strict=True)
+    except (UnicodeDecodeError, OSError) as exc:
+        raise SystemRelationProducerError("git repository root is invalid") from exc
+    if observed_root != root:
+        raise SystemRelationProducerError(
+            "repository_root must be the Git repository toplevel"
+        )
+    object_type = _git_stdout(
+        root,
+        ["cat-file", "-t", commit],
+        operation="commit verification",
+    ).strip()
+    if object_type != b"commit":
+        raise SystemRelationProducerError(
+            "repository_commit must identify a local Git commit object"
+        )
+
+
+def _safe_repo_path(relative: str) -> bool:
+    parsed = PurePosixPath(relative)
+    return bool(
+        relative
+        and not relative.startswith("/")
+        and "\\" not in relative
+        and "//" not in relative
+        and all(part not in {"", ".", ".."} for part in parsed.parts)
+    )
+
+
+def _sensitive_path(relative: str) -> bool:
+    for raw_part in PurePosixPath(relative).parts:
+        part = raw_part.casefold()
+        stem = part.rsplit(".", 1)[0]
+        if part in _SENSITIVE_PARTS or stem in _SENSITIVE_PARTS:
+            return True
+        if "credential" in part or "private_key" in part or "private-key" in part:
+            return True
+    return False
+
+
+def _candidate_kind(relative: str) -> str | None:
+    path = PurePosixPath(relative)
+    if relative == "pyproject.toml":
+        return "pyproject"
+    if path.name.endswith(".schema.json"):
+        return "schema"
+    parts = path.parts
+    if (
+        len(parts) == 3
+        and parts[:2] == (".github", "workflows")
+        and path.suffix.casefold() in {".yml", ".yaml"}
+    ):
+        return "workflow"
+    return None
+
+
+def _omission(
+    path: str,
+    reason: str,
+    *,
+    line: int | None = None,
+    detail: str | None = None,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {"path": path, "reason": reason}
+    if line is not None:
+        result["line"] = line
+    if detail is not None:
+        result["detail"] = detail[:512]
+    return result
+
+
+def _git_candidates(
+    root: Path,
+    *,
+    commit: str,
+    max_candidate_index_bytes: int,
+) -> tuple[
+    list[tuple[str, str, int, str]],
+    list[dict[str, Any]],
+    set[str],
+    int,
+]:
+    payload = _git_stdout(
+        root,
+        ["ls-tree", "-r", "-z", "--long", commit],
+        operation="candidate enumeration",
+    )
+    if len(payload) > max_candidate_index_bytes:
+        raise SystemRelationProducerError(
+            "candidate index exceeds max_candidate_index_bytes"
+        )
+
+    candidates: list[tuple[str, str, int, str]] = []
+    omissions: list[dict[str, Any]] = []
+    available_paths: set[str] = set()
+    for raw_entry in payload.split(b"\x00"):
+        if not raw_entry:
+            continue
+        try:
+            metadata, raw_path = raw_entry.split(b"\t", 1)
+            mode, object_type, object_id, raw_size = metadata.split()
+        except ValueError:
+            raise SystemRelationProducerError(
+                "git candidate index contained an invalid entry"
+            ) from None
+        path_fingerprint = hashlib.sha256(raw_path).hexdigest()[:16]
+        try:
+            relative = raw_path.decode("utf-8")
+        except UnicodeDecodeError:
+            omissions.append(
+                _omission(
+                    f"<non-utf8-path:{path_fingerprint}>",
+                    "non_utf8_path_omitted",
+                )
+            )
+            continue
+        if not _safe_repo_path(relative):
+            omissions.append(_omission(relative, "unsafe_path_omitted"))
+            continue
+        candidate_kind = _candidate_kind(relative)
+        if candidate_kind is None:
+            continue
+        if _sensitive_path(relative):
+            omissions.append(_omission(relative, "sensitive_path_omitted"))
+            continue
+        if object_type != b"blob" or mode == b"120000":
+            omissions.append(_omission(relative, "non_regular_file_omitted"))
+            continue
+        try:
+            size = int(raw_size)
+            object_id_text = object_id.decode("ascii")
+        except (ValueError, UnicodeDecodeError):
+            omissions.append(_omission(relative, "git_metadata_invalid"))
+            continue
+        available_paths.add(relative)
+        candidates.append((relative, object_id_text, size, candidate_kind))
+
+    candidates.sort(key=lambda item: item[0])
+    omissions.sort(key=_omission_order)
+    return candidates, omissions, available_paths, len(payload)
+
+
+def _git_blob(root: Path, object_id: str) -> bytes:
+    return _git_stdout(
+        root,
+        ["cat-file", "blob", object_id],
+        operation="blob read",
+    )
+
+
+def _line_range(
+    line_number: int,
+    line: str,
+    *,
+    start_character: int = 0,
+) -> dict[str, int]:
+    end_character = len(line.rstrip("\r\n"))
+    return {
+        "start_line": line_number,
+        "start_character": start_character,
+        "end_line": line_number,
+        "end_character": end_character,
+    }
+
+
+def _raw_record(
+    *,
+    relation: str,
+    subject_kind: str,
+    subject_identity: str,
+    target_kind: str,
+    target_identity: str,
+    path: str,
+    source_kind: str,
+    source_range: Mapping[str, int],
+    evidence_class: str,
+    contract_identity: Mapping[str, str] | None,
+) -> dict[str, Any]:
+    return {
+        "relation": relation,
+        "subject": {"kind": subject_kind, "identity": subject_identity},
+        "target": {"kind": target_kind, "identity": target_identity},
+        "source": {
+            "path": path,
+            "kind": source_kind,
+            "range": dict(source_range),
+        },
+        "evidence_class": evidence_class,
+        "contract_identity": (
+            dict(contract_identity) if contract_identity is not None else None
+        ),
+    }
+
+
+def _scan_pyproject(
+    text: str,
+    *,
+    relative: str,
+    repository_identity: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    if tomllib is None:
+        return [], [_omission(relative, "toml_parser_unavailable")]
+    try:
+        parsed = tomllib.loads(text)
+    except (tomllib.TOMLDecodeError, ValueError) as exc:
+        return [], [_omission(relative, "invalid_toml", detail=str(exc))]
+    tool_table = parsed.get("tool") if isinstance(parsed, Mapping) else None
+    if not isinstance(tool_table, Mapping):
+        return [], []
+
+    records: list[dict[str, Any]] = []
+    seen_names: set[str] = set()
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        match = _TOOL_TABLE_RE.match(line)
+        if match is None:
+            continue
+        name = match.group("name")
+        if name in seen_names or name not in tool_table:
+            continue
+        seen_names.add(name)
+        contract_id = f"pyproject.tool.{name}"
+        records.append(
+            _raw_record(
+                relation="declares_config",
+                subject_kind="repository",
+                subject_identity=repository_identity,
+                target_kind="config_contract",
+                target_identity=contract_id,
+                path=relative,
+                source_kind="manifest",
+                source_range=_line_range(
+                    line_number,
+                    line,
+                    start_character=len(match.group("prefix")),
+                ),
+                evidence_class="config_declaration",
+                contract_identity={
+                    "kind": "config",
+                    "id": contract_id,
+                    "version": "unversioned",
+                },
+            )
+        )
+    return records, []
+
+
+def _json_depths_by_offset(text: str) -> list[int]:
+    depths: list[int] = [0] * len(text)
+    depth = 0
+    in_string = False
+    escaped = False
+    for index, character in enumerate(text):
+        depths[index] = depth
+        if in_string:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                in_string = False
+        else:
+            if character == '"':
+                in_string = True
+            elif character in "{[":
+                depth += 1
+            elif character in "}]":
+                depth = max(0, depth - 1)
+    return depths
+
+
+def _top_level_json_key_range(
+    text: str,
+    *,
+    key: str,
+    expected_value: str,
+) -> dict[str, int] | None:
+    depths = _json_depths_by_offset(text)
+    pattern = re.compile(
+        rf'"{re.escape(key)}"\s*:\s*(?P<value>"(?:\\.|[^"\\])*")'
+    )
+    for match in pattern.finditer(text):
+        if match.start() >= len(depths) or depths[match.start()] != 1:
+            continue
+        try:
+            observed = json.loads(match.group("value"))
+        except json.JSONDecodeError:
+            continue
+        if observed != expected_value:
+            continue
+        line_number = text.count("\n", 0, match.start()) + 1
+        line_start = text.rfind("\n", 0, match.start()) + 1
+        line_end = text.find("\n", match.start())
+        if line_end < 0:
+            line_end = len(text)
+        line = text[line_start:line_end]
+        return _line_range(
+            line_number,
+            line,
+            start_character=match.start() - line_start,
+        )
+    return None
+
+
+def _scan_schema(
+    text: str,
+    *,
+    relative: str,
+    repository_identity: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        return [], [_omission(relative, "invalid_json_schema", detail=str(exc))]
+    if not isinstance(parsed, Mapping):
+        return [], [_omission(relative, "schema_root_not_object")]
+    schema_id = parsed.get("$id")
+    if not isinstance(schema_id, str) or not schema_id.strip():
+        return [], [_omission(relative, "schema_id_missing_or_nonliteral")]
+    schema_id = schema_id.strip()
+    source_range = _top_level_json_key_range(
+        text,
+        key="$id",
+        expected_value=schema_id,
+    )
+    if source_range is None:
+        return [], [_omission(relative, "schema_id_range_unresolved")]
+    record = _raw_record(
+        relation="declares_schema",
+        subject_kind="repository",
+        subject_identity=repository_identity,
+        target_kind="schema_contract",
+        target_identity=schema_id,
+        path=relative,
+        source_kind="schema_file",
+        source_range=source_range,
+        evidence_class="schema_declaration",
+        contract_identity={
+            "kind": "schema",
+            "id": schema_id,
+            "version": "unversioned",
+        },
+    )
+    return [record], []
+
+
+def _workflow_target(value: str) -> str | None:
+    if not value.startswith("./.github/workflows/"):
+        return None
+    relative = value[2:]
+    path = PurePosixPath(relative)
+    if (
+        path.suffix.casefold() not in {".yml", ".yaml"}
+        or any(part in {"", ".", ".."} for part in path.parts)
+    ):
+        return None
+    return path.as_posix()
+
+
+def _scan_workflow(
+    text: str,
+    *,
+    relative: str,
+    available_paths: set[str],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    records: list[dict[str, Any]] = []
+    omissions: list[dict[str, Any]] = []
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        if "uses:" not in line:
+            continue
+        if "${{" in line:
+            omissions.append(
+                _omission(relative, "dynamic_workflow_reference", line=line_number)
+            )
+            continue
+        match = _WORKFLOW_USES_RE.match(line)
+        if match is None:
+            if ".github/workflows" in line:
+                omissions.append(
+                    _omission(relative, "ambiguous_workflow_reference", line=line_number)
+                )
+            continue
+        value = match.group("value")
+        target = _workflow_target(value)
+        if target is None:
+            if ".github/workflows" in value:
+                omissions.append(
+                    _omission(relative, "unsupported_workflow_reference", line=line_number)
+                )
+            continue
+        if target not in available_paths:
+            omissions.append(
+                _omission(
+                    relative,
+                    "workflow_target_missing",
+                    line=line_number,
+                    detail=target,
+                )
+            )
+            continue
+        records.append(
+            _raw_record(
+                relation="references_workflow",
+                subject_kind="workflow",
+                subject_identity=relative,
+                target_kind="workflow",
+                target_identity=target,
+                path=relative,
+                source_kind="workflow",
+                source_range=_line_range(
+                    line_number,
+                    line,
+                    start_character=len(match.group("prefix")),
+                ),
+                evidence_class="workflow_reference",
+                contract_identity=None,
+            )
+        )
+    return records, omissions
+
+
+def _record_order(record: Mapping[str, Any]) -> bytes:
+    return _canonical_bytes(record)
+
+
+def _omission_order(item: Mapping[str, Any]) -> tuple[str, str, int, str]:
+    return (
+        str(item.get("path", "")),
+        str(item.get("reason", "")),
+        int(item.get("line", 0) or 0),
+        str(item.get("detail", "")),
+    )
+
+
+def collect_system_relation_evidence(
+    repository_root: str | Path,
+    *,
+    repository_identity: str,
+    repository_commit: str,
+    max_files: int = DEFAULT_MAX_FILES,
+    max_file_bytes: int = DEFAULT_MAX_FILE_BYTES,
+    max_total_bytes: int = DEFAULT_MAX_TOTAL_BYTES,
+    max_candidate_index_bytes: int = DEFAULT_MAX_CANDIDATE_INDEX_BYTES,
+) -> dict[str, Any]:
+    """Collect bounded static relation evidence from one exact Git commit."""
+    identity = _repository_identity(repository_identity)
+    commit = _commit(repository_commit)
+    max_files = _positive_int(max_files, field="max_files")
+    max_file_bytes = _positive_int(max_file_bytes, field="max_file_bytes")
+    max_total_bytes = _positive_int(max_total_bytes, field="max_total_bytes")
+    max_candidate_index_bytes = _positive_int(
+        max_candidate_index_bytes,
+        field="max_candidate_index_bytes",
+    )
+
+    root = Path(repository_root).expanduser()
+    try:
+        root = root.resolve(strict=True)
+    except OSError as exc:
+        raise SystemRelationProducerError(
+            f"repository_root must resolve to an existing directory: {exc}"
+        ) from exc
+    if not root.is_dir():
+        raise SystemRelationProducerError("repository_root must be a directory")
+
+    _verify_revision_source(root, commit)
+    candidates, omissions, available_paths, candidate_index_bytes = _git_candidates(
+        root,
+        commit=commit,
+        max_candidate_index_bytes=max_candidate_index_bytes,
+    )
+    records: list[dict[str, Any]] = []
+    scanned_files = 0
+    scanned_bytes = 0
+    considered_candidates = 0
+
+    for index, (relative, object_id, size, candidate_kind) in enumerate(candidates):
+        if index >= max_files:
+            remaining = len(candidates) - index
+            omissions.append(
+                _omission(
+                    relative,
+                    "file_budget_exhausted",
+                    detail=(
+                        f"remaining_candidate_count={remaining}"
+                        if remaining > 1
+                        else None
+                    ),
+                )
+            )
+            break
+        considered_candidates += 1
+        if size > max_file_bytes:
+            omissions.append(
+                _omission(relative, "file_too_large", detail=str(size))
+            )
+            continue
+        if scanned_bytes + size > max_total_bytes:
+            omissions.append(
+                _omission(relative, "total_byte_budget_exhausted", detail=str(size))
+            )
+            continue
+        try:
+            payload = _git_blob(root, object_id)
+        except SystemRelationProducerError:
+            omissions.append(_omission(relative, "git_blob_read_failed"))
+            continue
+        if len(payload) != size:
+            omissions.append(_omission(relative, "git_blob_size_mismatch"))
+            continue
+        try:
+            text = payload.decode("utf-8")
+        except UnicodeDecodeError:
+            omissions.append(_omission(relative, "invalid_utf8"))
+            continue
+
+        scanned_files += 1
+        scanned_bytes += len(payload)
+        if candidate_kind == "pyproject":
+            found, skipped = _scan_pyproject(
+                text,
+                relative=relative,
+                repository_identity=identity,
+            )
+        elif candidate_kind == "schema":
+            found, skipped = _scan_schema(
+                text,
+                relative=relative,
+                repository_identity=identity,
+            )
+        else:
+            found, skipped = _scan_workflow(
+                text,
+                relative=relative,
+                available_paths=available_paths,
+            )
+        records.extend(found)
+        omissions.extend(skipped)
+
+    records.sort(key=_record_order)
+    omissions.sort(key=_omission_order)
+    evidence = {
+        "kind": EVIDENCE_KIND,
+        "version": EVIDENCE_VERSION,
+        "producer": {"name": PRODUCER_NAME, "version": PRODUCER_VERSION},
+        "records": records,
+    }
+    evidence_sha256 = _canonical_sha256(evidence)
+    overlay = normalize_system_relation_evidence(
+        evidence,
+        evidence_sha256=evidence_sha256,
+        repository_commit=commit,
+    )
+    revision_binding = {
+        "mode": "git_commit_object",
+        "repository_commit": commit,
+        "verified": True,
+    }
+    return {
+        "kind": KIND,
+        "version": VERSION,
+        "repository": {"identity": identity, "commit": commit},
+        "revision_binding": revision_binding,
+        "producer_contract": {
+            "supported_sources": list(_SUPPORTED_SOURCES),
+            "supported_relations": list(_SUPPORTED_RELATIONS),
+            "dynamic_or_ambiguous_references": "omitted_with_reason",
+            "repository_source": "git_object_database",
+            "working_tree_reads": False,
+            "network_access": False,
+            "secret_file_scanning": False,
+        },
+        "evidence_sha256": evidence_sha256,
+        "evidence": evidence,
+        "overlay": overlay,
+        "omissions": omissions,
+        "scan": {
+            "candidate_count": len(candidates),
+            "considered_candidate_count": considered_candidates,
+            "scanned_file_count": scanned_files,
+            "scanned_bytes": scanned_bytes,
+            "candidate_index_bytes": candidate_index_bytes,
+            "limits": {
+                "max_files": max_files,
+                "max_file_bytes": max_file_bytes,
+                "max_total_bytes": max_total_bytes,
+                "max_candidate_index_bytes": max_candidate_index_bytes,
+            },
+        },
+        "absence_semantics": (
+            "Missing records mean only that this bounded producer did not establish "
+            "a supported static relation in the requested commit; they do not establish absence."
+        ),
+        "does_not_establish": list(_DOES_NOT_ESTABLISH),
+    }
+
+
+__all__ = [
+    "SystemRelationProducerError",
+    "collect_system_relation_evidence",
+]

--- a/merger/repoground/core/system_relation_producer.py
+++ b/merger/repoground/core/system_relation_producer.py
@@ -20,7 +20,9 @@ import hashlib
 import json
 import os
 import re
+import select
 import subprocess
+import time
 from collections.abc import Mapping
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -34,8 +36,15 @@ except ModuleNotFoundError:  # Python 3.10 compatibility
         tomllib = None
 
 from merger.repoground.core.system_relation_overlay import (
+    MAX_EVIDENCE_RECORDS,
     normalize_system_relation_evidence,
 )
+from merger.repoground.core.yaml_compat import ensure_pyyaml_collections_abc_compat
+
+try:
+    import yaml
+except ModuleNotFoundError:
+    yaml = None
 
 KIND = "repoground.system_relation_producer_result"
 VERSION = "1.0"
@@ -85,9 +94,6 @@ _SENSITIVE_PARTS = frozenset(
 )
 _TOOL_TABLE_RE = re.compile(
     r"^(?P<prefix>\s*)\[tool\.(?P<name>[A-Za-z0-9_-]+)\]\s*(?:#.*)?$"
-)
-_WORKFLOW_USES_RE = re.compile(
-    r"^(?P<prefix>\s*)uses\s*:\s*(?P<quote>['\"]?)(?P<value>[^'\"\s#]+)(?P=quote)\s*(?:#.*)?$"
 )
 
 
@@ -190,6 +196,80 @@ def _git_stdout(
         raise SystemRelationProducerError(f"git {operation} failed")
     return completed.stdout
 
+
+def _git_stdout_bounded(
+    root: Path,
+    arguments: list[str],
+    *,
+    operation: str,
+    max_bytes: int,
+) -> bytes:
+    command = [
+        "git",
+        "-c",
+        "core.pager=cat",
+        "-c",
+        "core.hooksPath=/dev/null",
+        "-c",
+        "diff.external=",
+        "-c",
+        "protocol.file.allow=never",
+        "-C",
+        str(root),
+        *arguments,
+    ]
+    try:
+        process = subprocess.Popen(
+            command,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            env=_git_environment(),
+        )
+    except FileNotFoundError as exc:
+        raise SystemRelationProducerError("git executable is unavailable") from exc
+
+    deadline = time.monotonic() + _GIT_TIMEOUT_SECONDS
+    chunks: list[bytes] = []
+    size = 0
+    try:
+        assert process.stdout is not None
+        while True:
+            remaining_seconds = deadline - time.monotonic()
+            if remaining_seconds <= 0:
+                raise subprocess.TimeoutExpired(command, _GIT_TIMEOUT_SECONDS)
+            ready, _, _ = select.select(
+                [process.stdout], [], [], remaining_seconds
+            )
+            if not ready:
+                raise subprocess.TimeoutExpired(command, _GIT_TIMEOUT_SECONDS)
+            chunk = os.read(
+                process.stdout.fileno(),
+                min(65_536, max_bytes - size + 1),
+            )
+            if not chunk:
+                break
+            size += len(chunk)
+            if size > max_bytes:
+                raise SystemRelationProducerError(
+                    f"git {operation} exceeds max_bytes={max_bytes}"
+                )
+            chunks.append(chunk)
+        remaining_seconds = max(0.001, deadline - time.monotonic())
+        returncode = process.wait(timeout=remaining_seconds)
+    except subprocess.TimeoutExpired as exc:
+        process.kill()
+        process.wait()
+        raise SystemRelationProducerError(
+            f"git {operation} exceeded the bounded timeout"
+        ) from exc
+    except BaseException:
+        process.kill()
+        process.wait()
+        raise
+    if returncode != 0:
+        raise SystemRelationProducerError(f"git {operation} failed")
+    return b"".join(chunks)
 
 def _verify_revision_source(root: Path, commit: str) -> None:
     raw_root = _git_stdout(
@@ -317,15 +397,12 @@ def _git_candidates(
     set[str],
     int,
 ]:
-    payload = _git_stdout(
+    payload = _git_stdout_bounded(
         root,
         ["ls-tree", "-r", "-z", "--long", commit],
         operation="candidate enumeration",
+        max_bytes=max_candidate_index_bytes,
     )
-    if len(payload) > max_candidate_index_bytes:
-        raise SystemRelationProducerError(
-            "candidate index exceeds max_candidate_index_bytes"
-        )
 
     candidates: list[tuple[str, str, int, str]] = []
     omissions: list[dict[str, Any]] = []
@@ -506,6 +583,10 @@ def _top_level_json_key_range(
     return None
 
 
+class _JSONObjectPairs(list):
+    pass
+
+
 def _scan_schema(
     text: str,
     *,
@@ -513,15 +594,18 @@ def _scan_schema(
     repository_identity: str,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     try:
-        parsed = json.loads(text)
+        parsed = json.loads(text, object_pairs_hook=_JSONObjectPairs)
     except json.JSONDecodeError as exc:
         return [], [_omission(relative, "invalid_json_schema", detail=str(exc))]
-    if not isinstance(parsed, Mapping):
+    if not isinstance(parsed, _JSONObjectPairs):
         return [], [_omission(relative, "schema_root_not_object")]
-    schema_id = parsed.get("$id")
-    if not isinstance(schema_id, str) or not schema_id.strip():
+
+    schema_ids = [value for key, value in parsed if key == "$id"]
+    if len(schema_ids) > 1:
+        return [], [_omission(relative, "schema_id_ambiguous_duplicate")]
+    if not schema_ids or not isinstance(schema_ids[0], str) or not schema_ids[0].strip():
         return [], [_omission(relative, "schema_id_missing_or_nonliteral")]
-    schema_id = schema_id.strip()
+    schema_id = schema_ids[0].strip()
     source_range = _top_level_json_key_range(
         text,
         key="$id",
@@ -547,7 +631,6 @@ def _scan_schema(
     )
     return [record], []
 
-
 def _workflow_target(value: str) -> str | None:
     if not value.startswith("./.github/workflows/"):
         return None
@@ -561,6 +644,86 @@ def _workflow_target(value: str) -> str | None:
     return path.as_posix()
 
 
+def _yaml_mapping_entries(node: Any, key: str) -> list[tuple[Any, Any]]:
+    if getattr(node, "id", None) != "mapping":
+        return []
+    return [
+        (key_node, value_node)
+        for key_node, value_node in node.value
+        if getattr(key_node, "id", None) == "scalar"
+        and key_node.value == key
+    ]
+
+
+def _workflow_job_uses_entry(
+    job_node: Any,
+    *,
+    relative: str,
+) -> tuple[tuple[int, int, str] | None, dict[str, Any] | None]:
+    uses_entries = _yaml_mapping_entries(job_node, "uses")
+    if len(uses_entries) > 1:
+        line = uses_entries[0][0].start_mark.line + 1
+        return None, _omission(
+            relative, "duplicate_workflow_uses_key", line=line
+        )
+    if not uses_entries:
+        return None, None
+    key_node, value_node = uses_entries[0]
+    line = key_node.start_mark.line + 1
+    if (
+        getattr(value_node, "id", None) != "scalar"
+        or value_node.start_mark.line != key_node.start_mark.line
+        or getattr(value_node, "style", None) in {"|", ">"}
+    ):
+        return None, _omission(
+            relative, "ambiguous_workflow_reference", line=line
+        )
+    return (
+        line,
+        key_node.start_mark.column,
+        str(value_node.value).strip(),
+    ), None
+
+
+def _workflow_uses_entries(
+    text: str,
+    *,
+    relative: str,
+) -> tuple[list[tuple[int, int, str]], list[dict[str, Any]]]:
+    if yaml is None:
+        return [], [_omission(relative, "yaml_parser_unavailable")]
+    ensure_pyyaml_collections_abc_compat()
+    try:
+        document = yaml.compose(text)
+    except yaml.YAMLError as exc:
+        return [], [_omission(relative, "invalid_workflow_yaml", detail=str(exc))]
+    if document is None:
+        return [], []
+
+    jobs_entries = _yaml_mapping_entries(document, "jobs")
+    if len(jobs_entries) > 1:
+        return [], [_omission(relative, "duplicate_workflow_jobs_key")]
+    if not jobs_entries:
+        return [], []
+    jobs_node = jobs_entries[0][1]
+    if getattr(jobs_node, "id", None) != "mapping":
+        return [], [_omission(relative, "workflow_jobs_not_mapping")]
+
+    entries: list[tuple[int, int, str]] = []
+    omissions: list[dict[str, Any]] = []
+    for _job_key, job_node in jobs_node.value:
+        entry, omission = _workflow_job_uses_entry(
+            job_node, relative=relative
+        )
+        if entry is not None:
+            entries.append(entry)
+        if omission is not None:
+            omissions.append(omission)
+    entries.sort()
+    omissions.sort(key=_omission_order)
+    return entries, omissions
+
+
 def _scan_workflow(
     text: str,
     *,
@@ -568,23 +731,14 @@ def _scan_workflow(
     available_paths: set[str],
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     records: list[dict[str, Any]] = []
-    omissions: list[dict[str, Any]] = []
-    for line_number, line in enumerate(text.splitlines(), start=1):
-        if "uses:" not in line:
-            continue
-        if "${{" in line:
+    entries, omissions = _workflow_uses_entries(text, relative=relative)
+    lines = text.splitlines()
+    for line_number, start_character, value in entries:
+        if "${{" in value:
             omissions.append(
                 _omission(relative, "dynamic_workflow_reference", line=line_number)
             )
             continue
-        match = _WORKFLOW_USES_RE.match(line)
-        if match is None:
-            if ".github/workflows" in line:
-                omissions.append(
-                    _omission(relative, "ambiguous_workflow_reference", line=line_number)
-                )
-            continue
-        value = match.group("value")
         target = _workflow_target(value)
         if target is None:
             if ".github/workflows" in value:
@@ -602,6 +756,7 @@ def _scan_workflow(
                 )
             )
             continue
+        line = lines[line_number - 1]
         records.append(
             _raw_record(
                 relation="references_workflow",
@@ -614,14 +769,14 @@ def _scan_workflow(
                 source_range=_line_range(
                     line_number,
                     line,
-                    start_character=len(match.group("prefix")),
+                    start_character=start_character,
                 ),
                 evidence_class="workflow_reference",
                 contract_identity=None,
             )
         )
+    omissions.sort(key=_omission_order)
     return records, omissions
-
 
 def _record_order(record: Mapping[str, Any]) -> bytes:
     return _canonical_bytes(record)
@@ -644,25 +799,27 @@ def _candidate_text(
     scanned_bytes: int,
     max_file_bytes: int,
     max_total_bytes: int,
-) -> tuple[str | None, dict[str, Any] | None]:
+) -> tuple[str | None, dict[str, Any] | None, int]:
     relative, object_id, size, _candidate_kind_value = candidate
     if size > max_file_bytes:
-        return None, _omission(relative, "file_too_large", detail=str(size))
+        return None, _omission(relative, "file_too_large", detail=str(size)), 0
     if scanned_bytes + size > max_total_bytes:
-        return None, _omission(
-            relative, "total_byte_budget_exhausted", detail=str(size)
+        return (
+            None,
+            _omission(relative, "total_byte_budget_exhausted", detail=str(size)),
+            0,
         )
     try:
         payload = _git_blob(root, object_id)
     except SystemRelationProducerError:
-        return None, _omission(relative, "git_blob_read_failed")
-    if len(payload) != size:
-        return None, _omission(relative, "git_blob_size_mismatch")
+        return None, _omission(relative, "git_blob_read_failed"), 0
+    bytes_read = len(payload)
+    if bytes_read != size:
+        return None, _omission(relative, "git_blob_size_mismatch"), bytes_read
     try:
-        return payload.decode("utf-8"), None
+        return payload.decode("utf-8"), None, bytes_read
     except UnicodeDecodeError:
-        return None, _omission(relative, "invalid_utf8")
-
+        return None, _omission(relative, "invalid_utf8"), bytes_read
 
 def _scan_candidate_text(
     text: str,
@@ -689,6 +846,28 @@ def _scan_candidate_text(
         relative=relative,
         available_paths=available_paths,
     )
+
+def _extend_records_bounded(
+    records: list[dict[str, Any]],
+    found: list[dict[str, Any]],
+    *,
+    relative: str,
+    omissions: list[dict[str, Any]],
+) -> bool:
+    remaining = MAX_EVIDENCE_RECORDS - len(records)
+    if len(found) <= remaining:
+        records.extend(found)
+        return False
+    records.extend(found[:remaining])
+    omissions.append(
+        _omission(
+            relative,
+            "record_budget_exhausted",
+            detail=f"omitted_record_count={len(found) - remaining}",
+        )
+    )
+    return True
+
 
 def collect_system_relation_evidence(
     repository_root: str | Path,
@@ -749,27 +928,34 @@ def collect_system_relation_evidence(
             )
             break
         considered_candidates += 1
-        text, omission = _candidate_text(
+        text, omission, bytes_read = _candidate_text(
             root,
             candidate,
             scanned_bytes=scanned_bytes,
             max_file_bytes=max_file_bytes,
             max_total_bytes=max_total_bytes,
         )
+        if bytes_read or text is not None:
+            scanned_files += 1
+        scanned_bytes += bytes_read
         if omission is not None:
             omissions.append(omission)
             continue
         assert text is not None
-        scanned_files += 1
-        scanned_bytes += len(text.encode("utf-8"))
         found, skipped = _scan_candidate_text(
             text,
             candidate,
             repository_identity=identity,
             available_paths=available_paths,
         )
-        records.extend(found)
         omissions.extend(skipped)
+        if _extend_records_bounded(
+            records,
+            found,
+            relative=relative,
+            omissions=omissions,
+        ):
+            break
 
     records.sort(key=_record_order)
     omissions.sort(key=_omission_order)
@@ -819,6 +1005,7 @@ def collect_system_relation_evidence(
                 "max_file_bytes": max_file_bytes,
                 "max_total_bytes": max_total_bytes,
                 "max_candidate_index_bytes": max_candidate_index_bytes,
+                "max_records": MAX_EVIDENCE_RECORDS,
             },
         },
         "absence_semantics": (

--- a/merger/repoground/scripts/bench_system_relation_producer.py
+++ b/merger/repoground/scripts/bench_system_relation_producer.py
@@ -1,0 +1,164 @@
+"""Revision-bound scale check for the static system-relation producer."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import statistics
+import time
+import tracemalloc
+from pathlib import Path
+from typing import Any
+
+from merger.repoground.core.system_relation_producer import (
+    collect_system_relation_evidence,
+)
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def _p95(samples: list[float]) -> float:
+    ordered = sorted(samples)
+    index = max(0, min(len(ordered) - 1, round(len(ordered) * 0.95) - 1))
+    return ordered[index]
+
+
+def run_benchmark(
+    repository_root: Path,
+    *,
+    repository_identity: str,
+    repository_commit: str,
+    repetitions: int,
+    max_runtime_ms: float,
+    max_peak_bytes: int,
+    max_artifact_bytes: int,
+) -> dict[str, Any]:
+    if repetitions < 1:
+        raise ValueError("repetitions must be >= 1")
+
+    elapsed_ms: list[float] = []
+    peak_bytes: list[int] = []
+    artifact_bytes: list[int] = []
+    result_digests: set[str] = set()
+    evidence_digests: set[str] = set()
+    representative: dict[str, Any] | None = None
+
+    for _ in range(repetitions):
+        tracemalloc.start()
+        started = time.perf_counter_ns()
+        try:
+            result = collect_system_relation_evidence(
+                repository_root,
+                repository_identity=repository_identity,
+                repository_commit=repository_commit,
+            )
+            elapsed = (time.perf_counter_ns() - started) / 1_000_000
+            _, peak = tracemalloc.get_traced_memory()
+        finally:
+            tracemalloc.stop()
+        payload = _canonical_bytes(result)
+        elapsed_ms.append(elapsed)
+        peak_bytes.append(peak)
+        artifact_bytes.append(len(payload))
+        result_digests.add(hashlib.sha256(payload).hexdigest())
+        evidence_digests.add(result["evidence_sha256"])
+        representative = result
+
+    if len(result_digests) != 1 or len(evidence_digests) != 1:
+        raise RuntimeError("system-relation producer output was nondeterministic")
+    assert representative is not None
+
+    runtime_p95_ms = _p95(elapsed_ms)
+    peak_max_bytes = max(peak_bytes)
+    artifact_max_bytes = max(artifact_bytes)
+    gates = {
+        "runtime_p95_ms": {
+            "observed": runtime_p95_ms,
+            "maximum": max_runtime_ms,
+            "passed": runtime_p95_ms <= max_runtime_ms,
+        },
+        "python_peak_bytes": {
+            "observed": peak_max_bytes,
+            "maximum": max_peak_bytes,
+            "passed": peak_max_bytes <= max_peak_bytes,
+        },
+        "artifact_bytes": {
+            "observed": artifact_max_bytes,
+            "maximum": max_artifact_bytes,
+            "passed": artifact_max_bytes <= max_artifact_bytes,
+        },
+        "deterministic_output": {
+            "observed_unique_result_digests": len(result_digests),
+            "maximum": 1,
+            "passed": len(result_digests) == 1,
+        },
+    }
+    return {
+        "kind": "repoground.system_relation_producer_benchmark",
+        "version": "1.0",
+        "repository": {
+            "identity": repository_identity,
+            "commit": repository_commit,
+        },
+        "repetitions": repetitions,
+        "timing_ms": {
+            "median": statistics.median(elapsed_ms),
+            "p95": runtime_p95_ms,
+            "minimum": min(elapsed_ms),
+            "maximum": max(elapsed_ms),
+        },
+        "python_peak_bytes": peak_max_bytes,
+        "artifact_bytes": artifact_max_bytes,
+        "result_sha256": next(iter(result_digests)),
+        "evidence_sha256": next(iter(evidence_digests)),
+        "producer_scan": representative["scan"],
+        "record_count": len(representative["evidence"]["records"]),
+        "omission_count": len(representative["omissions"]),
+        "relation_kinds": representative["overlay"]["relation_kinds"],
+        "gates": gates,
+        "passed": all(gate["passed"] for gate in gates.values()),
+        "memory_scope": (
+            "Python allocations in the benchmark process measured with tracemalloc; "
+            "short-lived Git child-process RSS is not included."
+        ),
+        "activation_policy": (
+            "This benchmark establishes bounded producer cost only. It does not "
+            "authorize broader or default agent-context activation without a paired "
+            "agent-utility benefit proof."
+        ),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", type=Path, required=True)
+    parser.add_argument("--commit", required=True)
+    parser.add_argument("--identity", default="heimgewebe/repoground")
+    parser.add_argument("--repetitions", type=int, default=3)
+    parser.add_argument("--max-runtime-ms", type=float, default=5000.0)
+    parser.add_argument("--max-peak-bytes", type=int, default=64 * 1024 * 1024)
+    parser.add_argument("--max-artifact-bytes", type=int, default=2 * 1024 * 1024)
+    args = parser.parse_args()
+
+    report = run_benchmark(
+        args.repo,
+        repository_identity=args.identity,
+        repository_commit=args.commit,
+        repetitions=args.repetitions,
+        max_runtime_ms=args.max_runtime_ms,
+        max_peak_bytes=args.max_peak_bytes,
+        max_artifact_bytes=args.max_artifact_bytes,
+    )
+    print(json.dumps(report, ensure_ascii=False, sort_keys=True, indent=2))
+    return 0 if report["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/merger/repoground/tests/git_fixture.py
+++ b/merger/repoground/tests/git_fixture.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+_GIT_IDENTITY = (
+    "-c",
+    "user.name=RepoGround Tests",
+    "-c",
+    "user.email=repoground-tests@example.invalid",
+)
+
+
+def _run(root: Path, *arguments: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *_GIT_IDENTITY, *arguments],
+        cwd=root,
+        check=check,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env={**os.environ, "GIT_TERMINAL_PROMPT": "0", "GIT_ASKPASS": "/bin/false"},
+    )
+
+
+def commit_fixture(root: Path) -> str:
+    """Commit the current fixture files and return the exact Git HEAD."""
+    root.mkdir(parents=True, exist_ok=True)
+    if not (root / ".git").exists():
+        _run(root, "init", "-q")
+    _run(root, "add", "--all")
+    head = _run(root, "rev-parse", "--verify", "HEAD", check=False)
+    if head.returncode != 0:
+        _run(root, "commit", "-qm", "fixture")
+    else:
+        staged = _run(root, "diff", "--cached", "--quiet", "HEAD", "--", check=False)
+        if staged.returncode not in {0, 1}:
+            raise RuntimeError(staged.stderr.strip() or "git diff --cached failed")
+        if staged.returncode == 1:
+            _run(root, "commit", "-qm", "fixture")
+    return _run(root, "rev-parse", "HEAD").stdout.strip()

--- a/merger/repoground/tests/test_agent_impact_system_relations.py
+++ b/merger/repoground/tests/test_agent_impact_system_relations.py
@@ -1,0 +1,107 @@
+import copy
+import json
+from pathlib import Path
+
+import jsonschema
+
+from merger.repoground.core.agent_impact_context import build_agent_impact_context
+from merger.repoground.core.system_relation_producer import (
+    collect_system_relation_evidence,
+)
+from merger.repoground.tests.git_fixture import commit_fixture
+
+OTHER_COMMIT = "0" * 40
+SCHEMA_PATH = Path(__file__).resolve().parents[1] / "contracts" / "agent-impact-context.v1.schema.json"
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _producer_result(root: Path) -> dict:
+    _write(root / "pyproject.toml", "[tool.repoground]\nenabled = true\n")
+    commit = commit_fixture(root)
+    return collect_system_relation_evidence(
+        root,
+        repository_identity="example/repository",
+        repository_commit=commit,
+    )
+
+
+def test_impact_context_uses_coherent_structural_evidence_without_call_graph_mixing(tmp_path):
+    producer_result = _producer_result(tmp_path)
+
+    context = build_agent_impact_context(
+        target_path="pyproject.toml",
+        repository_commit=producer_result["repository"]["commit"],
+        system_relation_result=producer_result,
+    )
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    jsonschema.validate(context, schema)
+
+    assert context["status"] == "partial"
+    assert context["target"]["paths"] == ["pyproject.toml"]
+    assert context["relations"] == []
+    assert context["structural_relations"]["status"] == "available"
+    assert context["structural_relations"]["relevant_record_count"] == 1
+    relation = context["structural_relations"]["records"][0]
+    assert relation["relation"] == "declares_config"
+    assert relation["relation"] not in {"calls", "constructs"}
+    assert context["composition"]["system_relation_evidence_used"] is True
+
+
+def test_impact_context_blocks_commit_mismatch_without_false_target_activation(tmp_path):
+    producer_result = _producer_result(tmp_path)
+
+    context = build_agent_impact_context(
+        target_path="pyproject.toml",
+        repository_commit=OTHER_COMMIT,
+        system_relation_result=producer_result,
+    )
+
+    assert context["status"] == "missing_target"
+    assert context["structural_relations"]["status"] == "blocked"
+    assert context["structural_relations"]["reason"] == "repository_commit_mismatch"
+    assert context["structural_relations"]["records"] == []
+    assert context["composition"]["system_relation_evidence_used"] is False
+    assert any(
+        gap.get("source") == "system_relation_evidence"
+        and gap.get("reason") == "repository_commit_mismatch"
+        for gap in context["gaps"]
+    )
+
+
+def test_impact_context_blocks_digest_mismatch_without_false_target_activation(tmp_path):
+    producer_result = _producer_result(tmp_path)
+    tampered = copy.deepcopy(producer_result)
+    tampered["evidence"]["producer"]["version"] = "tampered"
+
+    context = build_agent_impact_context(
+        target_path="pyproject.toml",
+        repository_commit=producer_result["repository"]["commit"],
+        system_relation_result=tampered,
+    )
+
+    assert context["status"] == "missing_target"
+    assert context["structural_relations"]["status"] == "blocked"
+    assert context["structural_relations"]["reason"] == "evidence_digest_mismatch"
+    assert context["structural_relations"]["records"] == []
+    assert context["composition"]["system_relation_evidence_used"] is False
+
+
+def test_impact_context_makes_missing_structural_evidence_visible_when_requested():
+    context = build_agent_impact_context(
+        target_path="pyproject.toml",
+        repository_commit="f" * 40,
+        system_relation_result=None,
+    )
+
+    assert context["structural_relations"]["status"] == "missing"
+    assert context["structural_relations"]["reason"] == "system_relation_evidence_missing"
+    assert context["composition"]["system_relation_evidence_used"] is False
+    assert any(
+        gap.get("source") == "system_relation_evidence"
+        and gap.get("status") == "missing"
+        for gap in context["gaps"]
+    )

--- a/merger/repoground/tests/test_agent_utility_t022_goldset.py
+++ b/merger/repoground/tests/test_agent_utility_t022_goldset.py
@@ -1,0 +1,158 @@
+import json
+from pathlib import Path
+
+import merger.repoground.core as core_api
+from merger.repoground.tests.git_fixture import commit_fixture
+
+
+GOLDSET_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "docs"
+    / "retrieval"
+    / "repoground_agent_utility_t022_goldset.v1.json"
+)
+
+
+def _load_goldset() -> dict:
+    return json.loads(GOLDSET_PATH.read_text(encoding="utf-8"))
+
+
+def _write_case(root: Path, files: dict[str, str]) -> None:
+    for relative, content in files.items():
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+
+def _semantic_key(record: dict) -> tuple[str, str, str, str]:
+    return (
+        str(record["relation"]),
+        str(record["target"]["identity"]),
+        str(record["source"]["path"]),
+        str(record["evidence"]["level"]),
+    )
+
+
+def _expected_key(record: dict) -> tuple[str, str, str, str]:
+    return (
+        str(record["relation"]),
+        str(record["target_identity"]),
+        str(record["path"]),
+        str(record["evidence_level"]),
+    )
+
+
+def test_t022_goldset_meets_precision_recall_range_and_omission_gates(tmp_path):
+    goldset = _load_goldset()
+    assert goldset["kind"] == "repoground.agent_utility_t022_goldset"
+    assert goldset["version"] == "1.0"
+    assert goldset["task_id"] == "REPOGROUND-AGENT-UTILITY-V1-T022"
+    assert goldset["revision_policy"] == "materialized_fixture_git_head"
+    assert {case["class"] for case in goldset["cases"]} >= {
+        "positive",
+        "ambiguous",
+        "true_null",
+    }
+
+    predicted_count = 0
+    expected_count = 0
+    true_positive_count = 0
+    range_match_count = 0
+    s1_false_positive_count = 0
+    omission_mismatches: list[dict] = []
+
+    for case in goldset["cases"]:
+        case_root = tmp_path / case["id"]
+        case_root.mkdir()
+        _write_case(case_root, case["files"])
+        commit = commit_fixture(case_root)
+        result = core_api.collect_system_relation_evidence(
+            case_root,
+            repository_identity=goldset["repository_identity"],
+            repository_commit=commit,
+        )
+        assert result["revision_binding"] == {
+            "mode": "git_commit_object",
+            "repository_commit": commit,
+            "verified": True,
+        }
+        predicted = result["overlay"]["records"]
+        expected = case["expected_records"]
+        predicted_by_key = {_semantic_key(record): record for record in predicted}
+        expected_by_key = {_expected_key(record): record for record in expected}
+
+        predicted_keys = set(predicted_by_key)
+        expected_keys = set(expected_by_key)
+        matched = predicted_keys & expected_keys
+        false_positive_keys = predicted_keys - expected_keys
+
+        predicted_count += len(predicted_keys)
+        expected_count += len(expected_keys)
+        true_positive_count += len(matched)
+        s1_false_positive_count += sum(
+            1 for key in false_positive_keys if key[3] == "S1"
+        )
+        for key in matched:
+            actual_range = predicted_by_key[key]["source"]["range"]
+            expected_line = int(expected_by_key[key]["start_line"])
+            if (
+                actual_range["start_line"] == expected_line
+                and actual_range["end_line"] == expected_line
+            ):
+                range_match_count += 1
+
+        observed_omissions = sorted(item["reason"] for item in result["omissions"])
+        expected_omissions = sorted(case["expected_omission_reasons"])
+        if observed_omissions != expected_omissions:
+            omission_mismatches.append(
+                {
+                    "case_id": case["id"],
+                    "expected": expected_omissions,
+                    "observed": observed_omissions,
+                }
+            )
+
+    false_positive_count = predicted_count - true_positive_count
+    false_negative_count = expected_count - true_positive_count
+    precision = (
+        true_positive_count / predicted_count if predicted_count else 1.0
+    )
+    recall = true_positive_count / expected_count if expected_count else 1.0
+    range_accuracy = (
+        range_match_count / true_positive_count if true_positive_count else 1.0
+    )
+    metrics = {
+        "cases": len(goldset["cases"]),
+        "predicted_records": predicted_count,
+        "expected_records": expected_count,
+        "true_positives": true_positive_count,
+        "false_positives": false_positive_count,
+        "false_negatives": false_negative_count,
+        "precision": precision,
+        "recall": recall,
+        "range_accuracy": range_accuracy,
+        "s1_false_positive_count": s1_false_positive_count,
+        "omission_mismatches": omission_mismatches,
+    }
+    gates = goldset["gates"]
+
+    assert precision >= gates["minimum_precision"], metrics
+    assert recall >= gates["minimum_recall"], metrics
+    assert range_accuracy >= gates["minimum_range_accuracy"], metrics
+    assert s1_false_positive_count <= gates["maximum_s1_false_positive_count"], metrics
+    if gates["require_exact_omission_reasons"]:
+        assert omission_mismatches == [], metrics
+
+    assert metrics == {
+        "cases": 7,
+        "predicted_records": 3,
+        "expected_records": 3,
+        "true_positives": 3,
+        "false_positives": 0,
+        "false_negatives": 0,
+        "precision": 1.0,
+        "recall": 1.0,
+        "range_accuracy": 1.0,
+        "s1_false_positive_count": 0,
+        "omission_mismatches": [],
+    }

--- a/merger/repoground/tests/test_system_relation_context.py
+++ b/merger/repoground/tests/test_system_relation_context.py
@@ -1,0 +1,131 @@
+import copy
+from pathlib import Path
+
+from merger.repoground.core.system_relation_context import (
+    project_system_relation_context,
+)
+from merger.repoground.core.system_relation_producer import (
+    collect_system_relation_evidence,
+)
+from merger.repoground.tests.git_fixture import commit_fixture
+
+OTHER_COMMIT = "e" * 40
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _result(root: Path) -> dict:
+    _write(
+        root / ".github" / "workflows" / "reuse.yml",
+        "name: reuse\non:\n  workflow_call:\njobs: {}\n",
+    )
+    _write(
+        root / ".github" / "workflows" / "caller.yml",
+        "name: caller\njobs:\n  delegated:\n    uses: ./.github/workflows/reuse.yml\n",
+    )
+    commit = commit_fixture(root)
+    return collect_system_relation_evidence(
+        root,
+        repository_identity="example/repository",
+        repository_commit=commit,
+    )
+
+
+def test_projects_only_relevant_records_after_commit_and_digest_revalidation(tmp_path):
+    producer_result = _result(tmp_path)
+
+    context = project_system_relation_context(
+        producer_result,
+        repository_commit=producer_result["repository"]["commit"],
+        target_paths={".github/workflows/reuse.yml"},
+    )
+
+    assert context["status"] == "available"
+    assert context["relevant_record_count"] == 1
+    assert context["records"][0]["relation"] == "references_workflow"
+    assert context["records"][0]["target"]["identity"] == ".github/workflows/reuse.yml"
+    assert context["binding"] == {
+        "expected_repository_commit": producer_result["repository"]["commit"],
+        "observed_repository_commit": producer_result["repository"]["commit"],
+        "expected_evidence_sha256": producer_result["evidence_sha256"],
+        "observed_evidence_sha256": producer_result["evidence_sha256"],
+    }
+
+
+def test_commit_mismatch_blocks_without_projecting_records(tmp_path):
+    producer_result = _result(tmp_path)
+
+    context = project_system_relation_context(
+        producer_result,
+        repository_commit=OTHER_COMMIT,
+        target_paths={".github/workflows/caller.yml"},
+    )
+
+    assert context["status"] == "blocked"
+    assert context["reason"] == "repository_commit_mismatch"
+    assert context["records"] == []
+
+
+def test_revision_binding_mismatch_blocks_without_projecting_records(tmp_path):
+    producer_result = _result(tmp_path)
+    tampered = copy.deepcopy(producer_result)
+    tampered["revision_binding"]["verified"] = False
+
+    context = project_system_relation_context(
+        tampered,
+        repository_commit=producer_result["repository"]["commit"],
+        target_paths={".github/workflows/caller.yml"},
+    )
+
+    assert context["status"] == "blocked"
+    assert context["reason"] == "revision_binding_incompatible"
+    assert context["records"] == []
+
+
+def test_digest_mismatch_blocks_without_projecting_records(tmp_path):
+    producer_result = _result(tmp_path)
+    tampered = copy.deepcopy(producer_result)
+    tampered["evidence"]["producer"]["version"] = "tampered"
+
+    context = project_system_relation_context(
+        tampered,
+        repository_commit=producer_result["repository"]["commit"],
+        target_paths={".github/workflows/caller.yml"},
+    )
+
+    assert context["status"] == "blocked"
+    assert context["reason"] == "evidence_digest_mismatch"
+    assert context["records"] == []
+
+
+def test_overlay_mismatch_blocks_after_raw_evidence_revalidation(tmp_path):
+    producer_result = _result(tmp_path)
+    tampered = copy.deepcopy(producer_result)
+    tampered["overlay"]["records"] = []
+    tampered["overlay"]["record_count"] = 0
+
+    context = project_system_relation_context(
+        tampered,
+        repository_commit=producer_result["repository"]["commit"],
+        target_paths={".github/workflows/caller.yml"},
+    )
+
+    assert context["status"] == "blocked"
+    assert context["reason"] == "overlay_revalidation_mismatch"
+    assert context["records"] == []
+
+
+def test_missing_optional_evidence_is_visible_without_false_activation():
+    context = project_system_relation_context(
+        None,
+        repository_commit=OTHER_COMMIT,
+        target_paths={"pyproject.toml"},
+    )
+
+    assert context["status"] == "missing"
+    assert context["reason"] == "system_relation_evidence_missing"
+    assert context["records"] == []
+    assert context["relevant_record_count"] == 0

--- a/merger/repoground/tests/test_system_relation_overlay.py
+++ b/merger/repoground/tests/test_system_relation_overlay.py
@@ -7,6 +7,7 @@ import pytest
 
 import merger.repoground.core as core_api
 from merger.repoground.core.system_relation_overlay import (
+    MAX_EVIDENCE_RECORDS,
     SystemRelationOverlayError,
     normalize_system_relation_evidence,
 )
@@ -539,3 +540,20 @@ def test_public_core_api_exports_overlay_without_promoting_it():
     )
     assert "normalize_system_relation_evidence" in core_api.__all__
     assert core_api.__core_version__ == "2.4.0"
+
+def test_overlay_rejects_raw_record_count_above_shared_limit():
+    evidence = _evidence()
+    evidence["records"] = [
+        copy.deepcopy(evidence["records"][0])
+        for _ in range(MAX_EVIDENCE_RECORDS + 1)
+    ]
+
+    with pytest.raises(
+        SystemRelationOverlayError,
+        match=f"exceeds maximum {MAX_EVIDENCE_RECORDS}",
+    ):
+        normalize_system_relation_evidence(
+            evidence,
+            evidence_sha256=EVIDENCE_SHA,
+            repository_commit=REPOSITORY_COMMIT,
+        )

--- a/merger/repoground/tests/test_system_relation_producer.py
+++ b/merger/repoground/tests/test_system_relation_producer.py
@@ -5,6 +5,7 @@ import pytest
 
 import merger.repoground.core.system_relation_producer as producer
 from merger.repoground.core.system_relation_overlay import (
+    MAX_EVIDENCE_RECORDS,
     normalize_system_relation_evidence,
 )
 from merger.repoground.tests.git_fixture import commit_fixture
@@ -15,6 +16,11 @@ REPOSITORY_IDENTITY = "example/repository"
 def _write(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
+
+
+def _write_bytes(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(payload)
 
 
 def _collect(root: Path, **kwargs):
@@ -171,7 +177,6 @@ def test_schema_without_literal_top_level_id_is_reported_not_inferred(tmp_path):
     ]
 
 
-
 def test_generic_schema_version_field_is_not_promoted_to_contract_identity(tmp_path):
     _write(
         tmp_path / "contracts" / "versioned.schema.json",
@@ -185,6 +190,7 @@ def test_generic_schema_version_field_is_not_promoted_to_contract_identity(tmp_p
         "id": "https://example.test/versioned",
         "version": "unversioned",
     }
+
 
 def test_nested_schema_id_does_not_masquerade_as_top_level_declaration(tmp_path):
     _write(
@@ -299,6 +305,7 @@ def test_repository_commit_must_be_revision_bound(tmp_path, commit):
             repository_commit=commit,
         )
 
+
 def test_missing_toml_parser_omits_config_instead_of_failing_import(tmp_path, monkeypatch):
     _write(tmp_path / "pyproject.toml", "[tool.alpha]\nenabled = true\n")
     monkeypatch.setattr(producer, "tomllib", None)
@@ -308,4 +315,90 @@ def test_missing_toml_parser_omits_config_instead_of_failing_import(tmp_path, mo
     assert result["evidence"]["records"] == []
     assert result["omissions"] == [
         {"path": "pyproject.toml", "reason": "toml_parser_unavailable"}
+    ]
+
+def test_workflow_block_scalar_text_cannot_masquerade_as_uses_key(tmp_path):
+    _write(
+        tmp_path / ".github" / "workflows" / "reuse.yml",
+        "name: reuse\non:\n  workflow_call:\njobs: {}\n",
+    )
+    _write(
+        tmp_path / ".github" / "workflows" / "caller.yml",
+        "name: caller\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n"
+        "      - run: |\n          echo preparing\n"
+        "          uses: ./.github/workflows/reuse.yml\n",
+    )
+
+    result = _collect(tmp_path)
+
+    assert result["evidence"]["records"] == []
+    assert result["omissions"] == []
+
+
+def test_duplicate_top_level_schema_id_is_ambiguous_not_declared(tmp_path):
+    _write(
+        tmp_path / "contracts" / "duplicate.schema.json",
+        '{"$id":"https://example.test/first","$id":"https://example.test/second","type":"object"}\n',
+    )
+
+    result = _collect(tmp_path)
+
+    assert result["evidence"]["records"] == []
+    assert result["omissions"] == [
+        {
+            "path": "contracts/duplicate.schema.json",
+            "reason": "schema_id_ambiguous_duplicate",
+        }
+    ]
+
+
+def test_candidate_index_limit_is_enforced_while_git_output_is_read(tmp_path):
+    _write(tmp_path / "README.md", "tracked fixture\n")
+    commit = commit_fixture(tmp_path)
+
+    with pytest.raises(
+        producer.SystemRelationProducerError,
+        match="candidate enumeration exceeds max_bytes=32",
+    ):
+        producer.collect_system_relation_evidence(
+            tmp_path,
+            repository_identity=REPOSITORY_IDENTITY,
+            repository_commit=commit,
+            max_candidate_index_bytes=32,
+        )
+
+
+def test_invalid_utf8_blob_reads_still_consume_total_byte_budget(tmp_path):
+    for name in ("a.schema.json", "b.schema.json", "c.schema.json"):
+        _write_bytes(tmp_path / name, b"\xff" * 64)
+
+    result = _collect(tmp_path, max_file_bytes=64, max_total_bytes=128)
+
+    assert result["scan"]["scanned_bytes"] == 128
+    assert result["scan"]["scanned_file_count"] == 2
+    assert [item["reason"] for item in result["omissions"]] == [
+        "invalid_utf8",
+        "invalid_utf8",
+        "total_byte_budget_exhausted",
+    ]
+
+
+def test_producer_record_count_is_capped_at_shared_consumer_limit(tmp_path):
+    content = "".join(
+        f"[tool.item_{index}]\nenabled = true\n"
+        for index in range(MAX_EVIDENCE_RECORDS + 1)
+    )
+    _write(tmp_path / "pyproject.toml", content)
+
+    result = _collect(tmp_path)
+
+    assert len(result["evidence"]["records"]) == MAX_EVIDENCE_RECORDS
+    assert result["overlay"]["record_count"] == MAX_EVIDENCE_RECORDS
+    assert result["scan"]["limits"]["max_records"] == MAX_EVIDENCE_RECORDS
+    assert result["omissions"] == [
+        {
+            "path": "pyproject.toml",
+            "reason": "record_budget_exhausted",
+            "detail": "omitted_record_count=1",
+        }
     ]

--- a/merger/repoground/tests/test_system_relation_producer.py
+++ b/merger/repoground/tests/test_system_relation_producer.py
@@ -1,0 +1,311 @@
+import json
+from pathlib import Path
+
+import pytest
+
+import merger.repoground.core.system_relation_producer as producer
+from merger.repoground.core.system_relation_overlay import (
+    normalize_system_relation_evidence,
+)
+from merger.repoground.tests.git_fixture import commit_fixture
+
+REPOSITORY_IDENTITY = "example/repository"
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _collect(root: Path, **kwargs):
+    commit = commit_fixture(root)
+    return producer.collect_system_relation_evidence(
+        root,
+        repository_identity=REPOSITORY_IDENTITY,
+        repository_commit=commit,
+        **kwargs,
+    )
+
+
+def test_collects_only_explicit_config_schema_and_local_workflow_relations(tmp_path):
+    _write(
+        tmp_path / "pyproject.toml",
+        "[tool.repoground]\nenabled = true\n\n[tool.ruff]\nline-length = 100\n",
+    )
+    _write(
+        tmp_path / "schemas" / "widget.schema.json",
+        json.dumps(
+            {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "$id": "https://example.test/schemas/widget.schema.json",
+                "type": "object",
+            },
+            indent=2,
+        )
+        + "\n",
+    )
+    _write(
+        tmp_path / ".github" / "workflows" / "reuse.yml",
+        "name: reuse\non:\n  workflow_call:\njobs: {}\n",
+    )
+    _write(
+        tmp_path / ".github" / "workflows" / "caller.yml",
+        "name: caller\njobs:\n  delegated:\n    uses: ./.github/workflows/reuse.yml\n",
+    )
+
+    result = _collect(tmp_path)
+    evidence = result["evidence"]
+    overlay = result["overlay"]
+
+    assert evidence["kind"] == "repoground.system_relation_evidence"
+    assert evidence["version"] == "1.0"
+    assert evidence["producer"] == {
+        "name": "repoground.system_relation_producer",
+        "version": "1.0",
+    }
+    assert {record["relation"] for record in evidence["records"]} == {
+        "declares_config",
+        "declares_schema",
+        "references_workflow",
+    }
+    assert [
+        record["target"]["identity"]
+        for record in evidence["records"]
+        if record["relation"] == "declares_config"
+    ] == ["pyproject.tool.repoground", "pyproject.tool.ruff"]
+
+    schema_record = next(
+        record for record in evidence["records"] if record["relation"] == "declares_schema"
+    )
+    assert schema_record["contract_identity"] == {
+        "kind": "schema",
+        "id": "https://example.test/schemas/widget.schema.json",
+        "version": "unversioned",
+    }
+    assert schema_record["source"]["kind"] == "schema_file"
+    assert schema_record["source"]["range"]["start_line"] == 3
+
+    workflow_record = next(
+        record
+        for record in evidence["records"]
+        if record["relation"] == "references_workflow"
+    )
+    assert workflow_record["subject"] == {
+        "kind": "workflow",
+        "identity": ".github/workflows/caller.yml",
+    }
+    assert workflow_record["target"] == {
+        "kind": "workflow",
+        "identity": ".github/workflows/reuse.yml",
+    }
+    assert workflow_record["contract_identity"] is None
+    assert workflow_record["source"]["range"]["start_line"] == 4
+
+    assert overlay["source"]["repository_commit"] == result["repository"]["commit"]
+    assert result["revision_binding"] == {
+        "mode": "git_commit_object",
+        "repository_commit": result["repository"]["commit"],
+        "verified": True,
+    }
+    assert overlay["source"]["evidence_sha256"] == result["evidence_sha256"]
+    assert overlay["relation_kinds"] == [
+        "declares_config",
+        "declares_schema",
+        "references_workflow",
+    ]
+    assert all(
+        record["relation"] not in {"calls", "constructs"}
+        for record in overlay["records"]
+    )
+    assert result["producer_contract"]["repository_source"] == "git_object_database"
+    assert result["producer_contract"]["working_tree_reads"] is False
+    assert result["producer_contract"]["network_access"] is False
+    assert result["producer_contract"]["secret_file_scanning"] is False
+
+
+def test_dynamic_ambiguous_and_missing_workflow_targets_are_omitted(tmp_path):
+    _write(
+        tmp_path / ".github" / "workflows" / "caller.yml",
+        "name: caller\njobs:\n  dynamic:\n    uses: ${{ matrix.workflow }}\n  missing:\n    uses: ./.github/workflows/missing.yml\n",
+    )
+
+    result = _collect(tmp_path)
+
+    assert result["evidence"]["records"] == []
+    reasons = [item["reason"] for item in result["omissions"]]
+    assert reasons == [
+        "dynamic_workflow_reference",
+        "workflow_target_missing",
+    ]
+    assert result["overlay"]["status"] == "degraded"
+    assert result["overlay"]["degradations"][0]["code"] == "records_empty"
+
+
+def test_true_null_case_does_not_infer_relations_from_unrelated_files(tmp_path):
+    _write(tmp_path / "README.md", "# no structural declarations here\n")
+    _write(tmp_path / "data.json", '{"name": "ordinary data"}\n')
+
+    result = _collect(tmp_path)
+
+    assert result["scan"]["candidate_count"] == 0
+    assert result["scan"]["scanned_file_count"] == 0
+    assert result["evidence"]["records"] == []
+    assert result["omissions"] == []
+    assert "do not establish absence" in result["absence_semantics"]
+
+
+def test_schema_without_literal_top_level_id_is_reported_not_inferred(tmp_path):
+    _write(
+        tmp_path / "schemas" / "anonymous.schema.json",
+        '{"$schema": "http://json-schema.org/draft-07/schema#", "type": "object"}\n',
+    )
+
+    result = _collect(tmp_path)
+
+    assert result["evidence"]["records"] == []
+    assert result["omissions"] == [
+        {
+            "path": "schemas/anonymous.schema.json",
+            "reason": "schema_id_missing_or_nonliteral",
+        }
+    ]
+
+
+
+def test_generic_schema_version_field_is_not_promoted_to_contract_identity(tmp_path):
+    _write(
+        tmp_path / "contracts" / "versioned.schema.json",
+        '{"$id":"https://example.test/versioned","version":"999","type":"object"}\n',
+    )
+
+    result = _collect(tmp_path)
+
+    assert result["evidence"]["records"][0]["contract_identity"] == {
+        "kind": "schema",
+        "id": "https://example.test/versioned",
+        "version": "unversioned",
+    }
+
+def test_nested_schema_id_does_not_masquerade_as_top_level_declaration(tmp_path):
+    _write(
+        tmp_path / "schemas" / "nested.schema.json",
+        "{\n"
+        '  "type": "object",\n'
+        '  "properties": {\n'
+        '    "nested": {"$id": "https://example.test/nested", "type": "string"}\n'
+        "  }\n"
+        "}\n",
+    )
+
+    result = _collect(tmp_path)
+
+    assert result["evidence"]["records"] == []
+    assert result["omissions"][0]["reason"] == "schema_id_missing_or_nonliteral"
+
+
+def test_invalid_or_oversized_candidates_fail_closed(tmp_path):
+    _write(tmp_path / "pyproject.toml", "[tool.broken\n")
+    _write(
+        tmp_path / "schemas" / "huge.schema.json",
+        '{"$id":"https://example.test/huge","padding":"' + ("x" * 256) + '"}\n',
+    )
+
+    result = _collect(tmp_path, max_file_bytes=128)
+
+    assert result["evidence"]["records"] == []
+    assert {item["reason"] for item in result["omissions"]} == {
+        "invalid_toml",
+        "file_too_large",
+    }
+
+
+def test_file_budget_is_deterministic_and_visible(tmp_path):
+    _write(
+        tmp_path / "a.schema.json",
+        '{"$id":"https://example.test/a","type":"object"}\n',
+    )
+    _write(
+        tmp_path / "b.schema.json",
+        '{"$id":"https://example.test/b","type":"object"}\n',
+    )
+
+    result = _collect(tmp_path, max_files=1)
+
+    assert len(result["evidence"]["records"]) == 1
+    assert result["evidence"]["records"][0]["target"]["identity"] == "https://example.test/a"
+    assert result["omissions"] == [
+        {"path": "b.schema.json", "reason": "file_budget_exhausted"}
+    ]
+
+
+def test_evidence_and_overlay_are_deterministic(tmp_path):
+    _write(tmp_path / "pyproject.toml", "[tool.zeta]\nx = 1\n[tool.alpha]\ny = 2\n")
+
+    first = _collect(tmp_path)
+    second = _collect(tmp_path)
+
+    assert first == second
+    assert len(first["evidence_sha256"]) == 64
+    assert first["overlay"] == normalize_system_relation_evidence(
+        first["evidence"],
+        evidence_sha256=first["evidence_sha256"],
+        repository_commit=first["repository"]["commit"],
+    )
+
+
+def test_requested_commit_is_read_from_git_objects_not_dirty_worktree(tmp_path):
+    _write(tmp_path / "pyproject.toml", "[tool.alpha]\nenabled = true\n")
+    commit = commit_fixture(tmp_path)
+    first = producer.collect_system_relation_evidence(
+        tmp_path,
+        repository_identity=REPOSITORY_IDENTITY,
+        repository_commit=commit,
+    )
+
+    _write(tmp_path / "pyproject.toml", "[tool.beta]\nenabled = true\n")
+    second = producer.collect_system_relation_evidence(
+        tmp_path,
+        repository_identity=REPOSITORY_IDENTITY,
+        repository_commit=commit,
+    )
+
+    assert first == second
+    assert [record["target"]["identity"] for record in second["evidence"]["records"]] == [
+        "pyproject.tool.alpha"
+    ]
+
+
+def test_well_formed_but_missing_commit_is_rejected(tmp_path):
+    _write(tmp_path / "README.md", "fixture\n")
+    commit_fixture(tmp_path)
+
+    with pytest.raises(producer.SystemRelationProducerError, match="commit verification failed"):
+        producer.collect_system_relation_evidence(
+            tmp_path,
+            repository_identity=REPOSITORY_IDENTITY,
+            repository_commit="b" * 40,
+        )
+
+
+@pytest.mark.parametrize(
+    "commit",
+    ["", "ABC", "g" * 40, "a" * 39, "a" * 41],
+)
+def test_repository_commit_must_be_revision_bound(tmp_path, commit):
+    with pytest.raises(producer.SystemRelationProducerError, match="repository_commit"):
+        producer.collect_system_relation_evidence(
+            tmp_path,
+            repository_identity=REPOSITORY_IDENTITY,
+            repository_commit=commit,
+        )
+
+def test_missing_toml_parser_omits_config_instead_of_failing_import(tmp_path, monkeypatch):
+    _write(tmp_path / "pyproject.toml", "[tool.alpha]\nenabled = true\n")
+    monkeypatch.setattr(producer, "tomllib", None)
+
+    result = _collect(tmp_path)
+
+    assert result["evidence"]["records"] == []
+    assert result["omissions"] == [
+        {"path": "pyproject.toml", "reason": "toml_parser_unavailable"}
+    ]


### PR DESCRIPTION
## Summary
- collect bounded config/schema/workflow relation evidence from exact Git commit objects
- keep structural relations separate from Python call/construct edges and fail closed on commit/digest/revalidation mismatches
- parse workflow `uses` from YAML structure, reject ambiguous duplicate schema IDs, and enforce streaming/tree/blob/record budgets
- keep producer, overlay and consumer aligned on a shared 4096-record maximum

## Evidence
- exact head: `0d768361cf94aef9b28c1aff514238f50e62ff53`
- focused T020/T022/impact regression suite: 102 passed
- CI-grade Ruff: passed locally
- maintainability ratchet: passed locally; new complexity violations 0; finding count 189; excess total 2307
- goldset: precision 1.0, recall 1.0, range accuracy 1.0, S1 false positives 0
- scale gate (3 runs): p95 751.113 ms, Python peak 1,307,972 bytes, artifact 123,215 bytes, deterministic output
- canonical PR diff SHA-256: `e0ea996a66283751ed0ffd7220d1666b9e36103aab150867e6c4f6ec3a20ef4e`
- all five GitHub review findings addressed with regression tests and review threads resolved

## Safety boundary
Dynamic or ambiguous references are omitted rather than inferred. Workflow references are S0. Config/schema declarations are S1. The producer reads tracked commit objects, not the mutable working tree. This does not establish runtime config effects, schema conformance, workflow execution, complete relation coverage, or permission for default activation without a paired agent-utility proof.