### PR TITLE
fix(repoground): bind fleet publications to source revisions

### DIFF
--- a/docs/proofs/repoground-fleet-publication-v1-proof.md
+++ b/docs/proofs/repoground-fleet-publication-v1-proof.md
@@ -5,28 +5,34 @@ Bureau task: `heimgewebe/bureau#671`
 ## Implemented in this change
 
 - the active publisher uses `merger/repoground` generator inputs and no longer falls back to a Lenskit checkout;
+- the retired GitHub identity `heimgewebe/lenskit` is not discovered as an independent active publication lane; `heimgewebe/repoground` remains the canonical source identity;
 - the canonical user units are `repoground-publish-fleet-watch.service` and `.timer`;
 - the existing persisted state contract `repobrief.fleet-publication-state.v1` is retained and extended additively;
 - state records distinguish the generator Git commit from the generator-input digest and record the verified bundle-manifest path;
 - a successful publication is labelled only `fresh_at_publication`; a later unchanged run performs a new remote-head comparison;
 - generator preflight and true per-repository publication failures return a non-zero process status and preserve a machine-readable `fleet-last.json` receipt;
-- a pre-existing dirty managed source worktree is preserved and reported as `deferred`; it makes the fleet receipt visibly `warn` but does not make the whole service fail when no true publication failure occurred.
+- active publication sources are detached, revision-bound worktrees named with the exact source commit instead of a mutable per-ref checkout;
+- if such a revision-bound source contains tracked changes or an unproven managed `build/` residue, the publisher does not reset, delete, or rewrite it. It preserves that worktree, creates a separate clean worktree for the same commit, and writes a create-only `managed-source-recovery` receipt before using the replacement;
+- safely obsolete revision worktrees are removed only when they are clean, idle, and not protected by an exact active Grabowski lease. Dirty, active, leased, foreign, or otherwise ambiguous worktrees remain preserved;
+- the historical fixed per-ref managed source paths remain untouched. They no longer gate new publication, so old retained evidence or semantic dirty state cannot indefinitely poison the hourly fleet.
 
 ## Covered by repository tests
 
-The focused tests cover canonical input paths, independent RepoGround discovery, persisted-state field semantics, installer ordering, generator-preflight failure receipts, typed preservation of dirty managed source worktrees, non-fatal per-repository deferral, and an unchanged second run that creates no additional bundle and preserves publication time.
+The focused tests cover canonical generator inputs, retired Lenskit alias suppression, persisted-state semantics, installer ordering, generator-preflight failure receipts, tracked dirty-source preservation with clean same-commit replacement, unknown `build/`-residue preservation with clean same-commit replacement, safe revision-worktree pruning, structured true-failure receipts, and an unchanged second run that creates no additional bundle and preserves publication time.
 
-These tests do not establish that the user service has already been installed or that live repositories have already produced fresh bundles.
+These tests do not establish that the user service has already been installed, that Grabowski already accepts the new revision-bound source identity, or that live repositories have already produced fresh bundles through the new path.
 
 ## Post-merge live cutover
 
-1. Install the merged runtime with `scripts/ops/install_repoground_publish_fleet_runtime.sh --enable`.
-2. Verify the old `rb-publish-fleet-watch.*` units are disabled and absent, and the canonical timer is loaded and enabled.
-3. Run a targeted changed publication for RepoGround, then validate the emitted manifest and state record against the observed source and generator commits.
-4. Run the same targeted command again. It must report `unchanged`, create no new version directory, preserve `created_at`, and update only the bounded freshness observation.
-5. Exercise the negative path with isolated environment roots and a missing canonical generator input. It must return non-zero, write `fleet-last.json`, and leave production publications untouched.
-6. Only after those checks, allow the hourly timer to process the agreed core-repository fleet and inspect every failure before closing Bureau #671.
+1. Teach the consuming Grabowski bundle catalog/freshness reader to accept a revision-bound source name only when its embedded commit matches the bundle provenance exactly; retain fail-closed behaviour for malformed or ambiguous names.
+2. Install the merged RepoGround runtime with `scripts/ops/install_repoground_publish_fleet_runtime.sh --enable` only after that reader support is active.
+3. Verify the old `rb-publish-fleet-watch.*` units are disabled and absent, and the canonical timer is loaded and enabled.
+4. Run a targeted changed publication for RepoGround, then validate the emitted manifest, state record, source-worktree name, and Grabowski freshness result against the observed source and generator commits.
+5. Exercise a previously blocked repository and verify that an old fixed dirty/retained checkout is preserved while publication proceeds from the exact new revision path.
+6. Run the same targeted command again. It must report `unchanged`, create no new version directory, preserve `created_at`, and update only the bounded freshness observation.
+7. Exercise the negative path with isolated environment roots and a missing canonical generator input. It must return non-zero, write `fleet-last.json`, and leave production publications untouched.
+8. Only after those checks, allow the hourly timer to process the fleet and inspect every remaining true failure before closing Bureau #671.
 
 ## Interpretation boundary
 
-A successful fleet run proves that bundles were produced from the recorded commits under the recorded generator. It does not prove repository understanding, retrieval quality, runtime correctness of the scanned software, or freshness after the recorded check time.
+A successful fleet run proves that bundles were produced from the recorded commits under the recorded generator and that the publication source satisfied the publisher hygiene gate at generation time. It does not prove repository understanding, retrieval quality, runtime correctness of the scanned software, or freshness after the recorded check time.

--- a/merger/repoground/tests/test_fleet_runtime.py
+++ b/merger/repoground/tests/test_fleet_runtime.py
@@ -2910,7 +2910,19 @@ def test_source_revision_prune_removes_only_clean_idle_unleased_worktrees(
     dirty_old = module.revision_source_worktree_path(
         entry, "main", source_sha, recovery_id="b" * 12
     )
-    for worktree in (current, clean_old, dirty_old):
+    foreign_prefix_match = module.source_worktree_path(entry, "main").with_name(
+        module.source_worktree_path(entry, "main").name + "--operator"
+    )
+    another_ref = module.revision_source_worktree_path(
+        entry, "main--feature", source_sha
+    )
+    for worktree in (
+        current,
+        clean_old,
+        dirty_old,
+        foreign_prefix_match,
+        another_ref,
+    ):
         git(repo, "worktree", "add", "--detach", str(worktree), source_sha)
     (dirty_old / "tracked.txt").write_text("operator change\n", encoding="utf-8")
 
@@ -2919,8 +2931,13 @@ def test_source_revision_prune_removes_only_clean_idle_unleased_worktrees(
     assert current.is_dir()
     assert not clean_old.exists()
     assert dirty_old.is_dir()
+    assert foreign_prefix_match.is_dir()
+    assert another_ref.is_dir()
     assert str(clean_old) in report["removed"]
-    assert any(row["path"] == str(dirty_old) for row in report["preserved"])
+    preserved = {row["path"]: row["reason"] for row in report["preserved"]}
+    assert str(dirty_old) in preserved
+    assert preserved[str(foreign_prefix_match)] == "source_identity_not_revision_bound"
+    assert preserved[str(another_ref)] == "source_identity_not_revision_bound"
     assert (dirty_old / "tracked.txt").read_text(encoding="utf-8") == "operator change\n"
 
 

--- a/merger/repoground/tests/test_fleet_runtime.py
+++ b/merger/repoground/tests/test_fleet_runtime.py
@@ -1606,14 +1606,15 @@ def test_fleet_fairness_converges_42_repository_backlog_with_limit_8(
     assert isinstance(evidence["publication_debt_seconds"], int)
 
 
-def test_changed_source_hygiene_preflight_runs_before_publication_limit() -> None:
+def test_publication_limit_precedes_source_materialization() -> None:
     source = PUBLISHER.read_text(encoding="utf-8")
-    changed = source.index("changed += 1")
-    preflight = source.index("source_hygiene_cleanup = preflight_existing_source_worktree", changed)
-    limit = source.index("if args.limit and published >= args.limit", changed)
+    main = source[source.index("def main("):]
+    changed = main.index("changed += 1")
+    limit = main.index("if args.limit and published >= args.limit", changed)
+    publish_call = main.index("publish(", limit)
 
-    assert changed < preflight < limit
-
+    assert changed < limit < publish_call
+    assert "preflight_existing_source_worktree(" not in source
 
 def test_managed_worktree_refuses_attached_foreign_or_non_worktree_paths(
     tmp_path: Path,
@@ -2510,7 +2511,7 @@ def test_regression_canonical_inputs_only() -> None:
     assert not any("repobrief" in path for path in module.GENERATOR_INPUT_PATHS)
 
 
-def test_regression_discover_captures_repoground_without_lenskit_alias(
+def test_regression_discover_canonicalizes_retired_lenskit_alias(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     module = load_publisher()
@@ -2536,10 +2537,30 @@ def test_regression_discover_captures_repoground_without_lenskit_alias(
     )
 
     entries = {entry.key: entry for entry in module.discover()}
+    assert set(entries) == {"heimgewebe/repoground"}
     assert entries["heimgewebe/repoground"].path == repoground
-    assert entries["heimgewebe/lenskit"].path == lenskit
-    assert entries["heimgewebe/repoground"].path != entries["heimgewebe/lenskit"].path
+    assert entries["heimgewebe/repoground"].repo == "repoground"
 
+
+def test_regression_discover_does_not_promote_retired_alias_without_canonical_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    repos_root = tmp_path / "repos"
+    repos_root.mkdir()
+    monkeypatch.setattr(module, "REPOS_ROOT", repos_root)
+
+    lenskit, _ = initialize_repository(repos_root, "lenskit")
+    git(
+        lenskit,
+        "remote",
+        "add",
+        "origin",
+        "git@github.com:heimgewebe/lenskit.git",
+    )
+
+    entries = module.discover()
+    assert entries == []
 
 def test_publication_state_separates_generator_commit_and_input_hash(
     tmp_path: Path,
@@ -2684,21 +2705,17 @@ def test_dirty_managed_worktree_is_typed_and_preserved(tmp_path: Path) -> None:
     assert receipt["status_truncated"] is False
 
 
-def test_dirty_source_worktree_is_deferred_without_poisoning_fleet(
+def test_legacy_dirty_source_no_longer_gates_revision_publication(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     module = load_publisher()
     roots = isolate_retention_roots(module, tmp_path, monkeypatch)
-    monkeypatch.setattr(module, "LOCK_PATH", tmp_path / "fleet.lock")
-    monkeypatch.setattr(module, "FLEET_LOG", roots["log"] / "fleet.log")
-    repo, source_sha = initialize_repository(tmp_path, "demo")
     source_root = tmp_path / "sources"
     source_root.mkdir()
     monkeypatch.setattr(module, "SOURCE_ROOT", source_root)
-    dirty_worktree = source_root / "heimgewebe__demo__main"
-    git(repo, "worktree", "add", "--detach", str(dirty_worktree), source_sha)
-    tracked = dirty_worktree / "tracked.txt"
-    tracked.write_text("operator-owned source change\n", encoding="utf-8")
+    monkeypatch.setattr(module, "FLEET_LOG", roots["log"] / "fleet.log")
+
+    repo, source_sha = initialize_repository(tmp_path, "demo")
     entry = module.RepoEntry(
         key="heimgewebe/demo",
         owner="heimgewebe",
@@ -2706,46 +2723,205 @@ def test_dirty_source_worktree_is_deferred_without_poisoning_fleet(
         path=repo,
         remote="git@github.com:heimgewebe/demo.git",
     )
-    monkeypatch.setattr(module, "discover", lambda: [entry])
-    monkeypatch.setattr(
-        module,
-        "prioritize_fleet_publication",
-        lambda entries: (entries, {"policy": "test"}),
+    legacy = module.source_worktree_path(entry, "main")
+    git(repo, "worktree", "add", "--detach", str(legacy), source_sha)
+    tracked = legacy / "tracked.txt"
+    tracked.write_text("historical operator change\n", encoding="utf-8")
+
+    source = module.ensure_source_worktree(entry, "main", source_sha)
+
+    assert source == module.revision_source_worktree_path(entry, "main", source_sha)
+    assert source != legacy
+    assert git(source, "rev-parse", "HEAD") == source_sha
+    assert git(source, "status", "--porcelain") == ""
+    assert tracked.read_text(encoding="utf-8") == "historical operator change\n"
+    assert git(legacy, "status", "--porcelain") == "M tracked.txt"
+    assert not (roots["state"] / "managed-source-recoveries").exists()
+
+
+def test_dirty_revision_source_is_preserved_and_replaced(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    roots = isolate_retention_roots(module, tmp_path, monkeypatch)
+    source_root = tmp_path / "sources"
+    source_root.mkdir()
+    monkeypatch.setattr(module, "SOURCE_ROOT", source_root)
+    monkeypatch.setattr(module, "FLEET_LOG", roots["log"] / "fleet.log")
+
+    repo, source_sha = initialize_repository(tmp_path, "demo")
+    entry = module.RepoEntry(
+        key="heimgewebe/demo",
+        owner="heimgewebe",
+        repo="demo",
+        path=repo,
+        remote="git@github.com:heimgewebe/demo.git",
     )
-    monkeypatch.setattr(
-        module,
-        "reconcile_prune_transactions",
-        lambda *, protected, apply: {"status": "ok"},
+    primary = module.revision_source_worktree_path(entry, "main", source_sha)
+    git(repo, "worktree", "add", "--detach", str(primary), source_sha)
+    tracked = primary / "tracked.txt"
+    tracked.write_text("operator-owned source change\n", encoding="utf-8")
+
+    replacement = module.ensure_source_worktree(entry, "main", source_sha)
+
+    assert replacement != primary
+    assert replacement.name.startswith(primary.name + "--recovery-")
+    assert tracked.read_text(encoding="utf-8") == "operator-owned source change\n"
+    assert git(primary, "status", "--porcelain") == "M tracked.txt"
+    assert git(replacement, "rev-parse", "HEAD") == source_sha
+    assert git(replacement, "status", "--porcelain") == ""
+    receipts = list((roots["state"] / "managed-source-recoveries").glob("*.json"))
+    assert len(receipts) == 1
+    receipt = json.loads(receipts[0].read_text(encoding="utf-8"))
+    assert receipt["schema"] == module.SOURCE_RECOVERY_SCHEMA
+    assert receipt["repository"] == "heimgewebe/demo"
+    assert receipt["source_commit"] == source_sha
+    assert receipt["preserved_worktree"] == str(primary)
+    assert receipt["replacement_worktree"] == str(replacement)
+    assert receipt["preserved_source_mutated"] is False
+    assert receipt["automatic_reset_authorized"] is False
+    assert receipt["reason"]["kind"] == "managed_worktree_dirty"
+
+def test_source_recovery_receipt_failure_rolls_back_clean_replacement(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    roots = isolate_retention_roots(module, tmp_path, monkeypatch)
+    source_root = tmp_path / "sources"
+    source_root.mkdir()
+    monkeypatch.setattr(module, "SOURCE_ROOT", source_root)
+    monkeypatch.setattr(module, "FLEET_LOG", roots["log"] / "fleet.log")
+
+    repo, source_sha = initialize_repository(tmp_path, "demo")
+    entry = module.RepoEntry(
+        key="heimgewebe/demo",
+        owner="heimgewebe",
+        repo="demo",
+        path=repo,
+        remote="git@github.com:heimgewebe/demo.git",
     )
-    monkeypatch.setattr(module, "ensure_tool_worktree", lambda: ("b" * 40, "c" * 64))
-    monkeypatch.setattr(
-        module,
-        "remote_head",
-        lambda path: ("origin/main", "main", source_sha),
-    )
-    monkeypatch.setattr(
-        module,
-        "publish",
-        lambda *args, **kwargs: pytest.fail("deferred repository must not publish"),
+    primary = module.revision_source_worktree_path(entry, "main", source_sha)
+    git(repo, "worktree", "add", "--detach", str(primary), source_sha)
+    tracked = primary / "tracked.txt"
+    tracked.write_text("preserve after receipt failure\n", encoding="utf-8")
+
+    def fail_receipt(**_kwargs: object) -> Path:
+        raise OSError("receipt store unavailable")
+
+    monkeypatch.setattr(module, "record_source_recovery", fail_receipt)
+
+    with pytest.raises(OSError, match="receipt store unavailable"):
+        module.ensure_source_worktree(entry, "main", source_sha)
+
+    assert tracked.read_text(encoding="utf-8") == "preserve after receipt failure\n"
+    assert git(primary, "status", "--porcelain") == "M tracked.txt"
+    assert sorted(path.name for path in source_root.iterdir()) == [primary.name]
+    assert not (roots["state"] / "managed-source-recoveries").exists()
+
+
+def test_unrelated_source_prepare_failure_remains_fail_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    source_root = tmp_path / "sources"
+    source_root.mkdir()
+    monkeypatch.setattr(module, "SOURCE_ROOT", source_root)
+    repo, source_sha = initialize_repository(tmp_path, "demo")
+    entry = module.RepoEntry(
+        key="heimgewebe/demo",
+        owner="heimgewebe",
+        repo="demo",
+        path=repo,
+        remote="git@github.com:heimgewebe/demo.git",
     )
 
-    assert module.main(["--repo", "heimgewebe/demo"]) == 0
-    assert tracked.read_text(encoding="utf-8") == "operator-owned source change\n"
-    receipt = json.loads((roots["log"] / "fleet-last.json").read_text(encoding="utf-8"))
-    assert receipt["status"] == "warn"
-    assert receipt["deferred"] == 1
-    assert receipt["failed"] == 0
-    detail = receipt["details"][0]
-    assert detail["status"] == "deferred"
-    assert detail["deferred_reason"] == "managed_source_worktree_dirty"
-    assert detail["managed_source_worktree"] == {
-        "reason": "managed_worktree_dirty",
-        "worktree": str(dirty_worktree),
-        "status_count": 1,
-        "status_sample": [{"code": " M", "path": "tracked.txt"}],
-        "status_truncated": False,
-        "automatic_reset_authorized": False,
-    }
+    def fail_prepare(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("unrelated worktree failure")
+
+    monkeypatch.setattr(module, "prepare_managed_worktree", fail_prepare)
+
+    with pytest.raises(RuntimeError, match="unrelated worktree failure"):
+        module.ensure_source_worktree(entry, "main", source_sha)
+    assert list(source_root.iterdir()) == []
+
+
+def test_unknown_build_residue_is_preserved_and_bypassed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    roots = isolate_retention_roots(module, tmp_path, monkeypatch)
+    source_root = tmp_path / "sources"
+    source_root.mkdir()
+    monkeypatch.setattr(module, "SOURCE_ROOT", source_root)
+    monkeypatch.setattr(module, "FLEET_LOG", roots["log"] / "fleet.log")
+    allow_no_active_managed_build_leases(module, monkeypatch)
+
+    repo, source_sha = initialize_repository(tmp_path, "demo")
+    entry = module.RepoEntry(
+        key="heimgewebe/demo",
+        owner="heimgewebe",
+        repo="demo",
+        path=repo,
+        remote="git@github.com:heimgewebe/demo.git",
+    )
+    primary = module.revision_source_worktree_path(entry, "main", source_sha)
+    git(repo, "worktree", "add", "--detach", str(primary), source_sha)
+    build = primary / "build"
+    build.mkdir()
+    artifact = build / "operator-artifact.txt"
+    artifact.write_text("retain me\n", encoding="utf-8")
+
+    replacement = module.ensure_source_worktree(entry, "main", source_sha)
+
+    assert replacement != primary
+    assert artifact.read_text(encoding="utf-8") == "retain me\n"
+    assert git(primary, "rev-parse", "HEAD") == source_sha
+    assert git(replacement, "rev-parse", "HEAD") == source_sha
+    assert git(replacement, "status", "--porcelain") == ""
+    receipts = list((roots["state"] / "managed-source-recoveries").glob("*.json"))
+    assert len(receipts) == 1
+    receipt = json.loads(receipts[0].read_text(encoding="utf-8"))
+    assert receipt["reason"]["kind"] == "managed_build_residue"
+    assert receipt["reason"]["receipt"]["classification"] == "unknown"
+    assert receipt["preserved_source_mutated"] is False
+
+
+def test_source_revision_prune_removes_only_clean_idle_unleased_worktrees(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    source_root = tmp_path / "sources"
+    source_root.mkdir()
+    monkeypatch.setattr(module, "SOURCE_ROOT", source_root)
+    allow_no_active_managed_build_leases(module, monkeypatch)
+
+    repo, source_sha = initialize_repository(tmp_path, "demo")
+    entry = module.RepoEntry(
+        key="heimgewebe/demo",
+        owner="heimgewebe",
+        repo="demo",
+        path=repo,
+        remote="git@github.com:heimgewebe/demo.git",
+    )
+    current = module.revision_source_worktree_path(entry, "main", source_sha)
+    clean_old = module.revision_source_worktree_path(
+        entry, "main", source_sha, recovery_id="a" * 12
+    )
+    dirty_old = module.revision_source_worktree_path(
+        entry, "main", source_sha, recovery_id="b" * 12
+    )
+    for worktree in (current, clean_old, dirty_old):
+        git(repo, "worktree", "add", "--detach", str(worktree), source_sha)
+    (dirty_old / "tracked.txt").write_text("operator change\n", encoding="utf-8")
+
+    report = module.prune_obsolete_revision_source_worktrees(entry, "main", current)
+
+    assert current.is_dir()
+    assert not clean_old.exists()
+    assert dirty_old.is_dir()
+    assert str(clean_old) in report["removed"]
+    assert any(row["path"] == str(dirty_old) for row in report["preserved"])
+    assert (dirty_old / "tracked.txt").read_text(encoding="utf-8") == "operator change\n"
 
 
 def test_dirty_generator_worktree_remains_a_hard_preflight_failure(
@@ -2821,7 +2997,7 @@ def test_managed_build_blocker_is_structured_in_fleet_receipt(
             reason="no exact publisher provenance",
         )
 
-    monkeypatch.setattr(module, "preflight_existing_source_worktree", block)
+    monkeypatch.setattr(module, "publish", lambda *args, **kwargs: block(entry, "main"))
 
     assert module.main(["--repo", "heimgewebe/demo"]) == 1
     receipt = json.loads((roots["log"] / "fleet-last.json").read_text(encoding="utf-8"))
@@ -2883,7 +3059,7 @@ def test_durable_retain_blocker_is_nonfatal_but_visible_in_fleet_receipt(
             },
         )
 
-    monkeypatch.setattr(module, "preflight_existing_source_worktree", retain)
+    monkeypatch.setattr(module, "publish", lambda *args, **kwargs: retain(entry, "main"))
 
     assert module.main(["--repo", "heimgewebe/demo"]) == 0
     receipt = json.loads((roots["log"] / "fleet-last.json").read_text(encoding="utf-8"))
@@ -2982,6 +3158,7 @@ def test_idempotent_second_run_does_not_publish_or_create_bundle(
             tmp_path / "fake-lease.json",
             str(manifest),
             "2026-07-14T10:00:00Z",
+            tmp_path / "fake-source-worktree",
         )
 
     monkeypatch.setattr(module, "publish", mock_publish)
@@ -2996,6 +3173,11 @@ def test_idempotent_second_run_does_not_publish_or_create_bundle(
         lambda path: ("origin/main", "main", source_sha),
     )
     monkeypatch.setattr(module, "clear_active_publication_lease", lambda path: None)
+    monkeypatch.setattr(
+        module,
+        "prune_obsolete_revision_source_worktrees",
+        lambda *args, **kwargs: {"removed": [], "preserved": []},
+    )
     monkeypatch.setattr(module, "prune_current_group", lambda *args, **kwargs: {})
     monkeypatch.setattr(module, "discover", lambda: [entry])
 

--- a/scripts/ops/repoground-publish-fleet
+++ b/scripts/ops/repoground-publish-fleet
@@ -2175,6 +2175,22 @@ def revision_source_worktree_path(
     return base.with_name(base.name + suffix)
 
 
+def is_revision_source_worktree(
+    entry: RepoEntry, ref_segment: str, candidate: Path
+) -> bool:
+    base = source_worktree_path(entry, ref_segment)
+    if candidate.parent != SOURCE_ROOT or not candidate.name.startswith(base.name + "--"):
+        return False
+    suffix = candidate.name[len(base.name) + 2 :]
+    return (
+        re.fullmatch(
+            r"[0-9a-f]{40}(?:--recovery-[0-9a-f]{12})?",
+            suffix,
+        )
+        is not None
+    )
+
+
 def record_source_recovery(
     *,
     entry: RepoEntry,
@@ -2282,6 +2298,14 @@ def prune_obsolete_revision_source_worktrees(
         return {"removed": removed, "preserved": preserved}
     for candidate in sorted(SOURCE_ROOT.iterdir()):
         if candidate == current or not candidate.name.startswith(prefix):
+            continue
+        if not is_revision_source_worktree(entry, ref_segment, candidate):
+            preserved.append(
+                {
+                    "path": str(candidate),
+                    "reason": "source_identity_not_revision_bound",
+                }
+            )
             continue
         try:
             assert_managed_worktree_clean(candidate, entry.path)

--- a/scripts/ops/repoground-publish-fleet
+++ b/scripts/ops/repoground-publish-fleet
@@ -132,6 +132,11 @@ EXCLUDE = {
     "manifest-publications",
 }
 EXCLUDED_REPO_KEYS = {"heimgewebe/vault-gewebe", "heimgewebe/heim-assi"}
+RETIRED_REPOSITORY_ALIASES = {
+    "heimgewebe/lenskit": "heimgewebe/repoground",
+}
+SOURCE_REVISION_RE = re.compile(r"^[0-9a-f]{40}$")
+SOURCE_RECOVERY_SCHEMA = "repoground.managed-source-recovery.v1"
 
 
 @dataclass(frozen=True)
@@ -348,6 +353,10 @@ def parse_github_remote(remote: str) -> tuple[str, str] | None:
     return match.group(1), match.group(2)
 
 
+def canonical_repository_key(key: str) -> str:
+    return RETIRED_REPOSITORY_ALIASES.get(key, key)
+
+
 def is_top_level_git(path: Path) -> bool:
     cp = run(
         ["git", "-C", str(path), "rev-parse", "--is-inside-work-tree"],
@@ -401,10 +410,14 @@ def discover() -> list[RepoEntry]:
         parsed = parse_github_remote(remote)
         if not parsed:
             continue
-        owner, repo = parsed
-        key = f"{owner}/{repo}"
+        observed_owner, observed_repo = parsed
+        observed_key = f"{observed_owner}/{observed_repo}"
+        if observed_key in RETIRED_REPOSITORY_ALIASES:
+            continue
+        key = canonical_repository_key(observed_key)
         if key in EXCLUDED_REPO_KEYS:
             continue
+        owner, repo = key.split("/", 1)
         entry = RepoEntry(key=key, owner=owner, repo=repo, path=path, remote=remote)
         score = score_candidate(owner, repo, path)
         previous = best.get(key)
@@ -455,7 +468,7 @@ def generator_repository_key() -> str | None:
     if not parsed:
         return None
     owner, repo = parsed
-    return f"{owner}/{repo}"
+    return canonical_repository_key(f"{owner}/{repo}")
 
 
 def prioritize_generator_repository(entries: list[RepoEntry]) -> list[RepoEntry]:
@@ -885,7 +898,7 @@ def repository_key_for_path(repo: Path) -> str | None:
     if parsed is None:
         return None
     owner, name = parsed
-    return f"{owner}/{name}"
+    return canonical_repository_key(f"{owner}/{name}")
 
 
 def managed_build_residue_quarantine_root(worktree: Path) -> Path:
@@ -2148,24 +2161,151 @@ def source_worktree_path(entry: RepoEntry, ref_segment: str) -> Path:
     )
 
 
-def preflight_existing_source_worktree(entry: RepoEntry, ref_segment: str) -> list[str]:
-    source_wt = source_worktree_path(entry, ref_segment)
-    if not source_wt.exists() and not source_wt.is_symlink():
-        return []
-    removed = cleanup_managed_disposable_artifacts(source_wt, entry.path)
-    assert_managed_worktree_clean(source_wt, entry.path)
-    return removed
+def revision_source_worktree_path(
+    entry: RepoEntry, ref_segment: str, sha: str, *, recovery_id: str | None = None
+) -> Path:
+    if not SOURCE_REVISION_RE.fullmatch(sha):
+        raise ValueError("source revision must be a 40-character lowercase Git commit")
+    base = source_worktree_path(entry, ref_segment)
+    suffix = f"--{sha}"
+    if recovery_id is not None:
+        if not re.fullmatch(r"[0-9a-f]{12}", recovery_id):
+            raise ValueError("source recovery id is invalid")
+        suffix += f"--recovery-{recovery_id}"
+    return base.with_name(base.name + suffix)
+
+
+def record_source_recovery(
+    *,
+    entry: RepoEntry,
+    ref_segment: str,
+    sha: str,
+    preserved: Path,
+    replacement: Path,
+    reason: dict[str, object],
+    recovery_id: str,
+) -> Path:
+    receipt_path = STATE_ROOT / "managed-source-recoveries" / f"{recovery_id}.json"
+    atomic_create_json(
+        receipt_path,
+        {
+            "schema": SOURCE_RECOVERY_SCHEMA,
+            "recovery_id": recovery_id,
+            "repository": entry.key,
+            "ref": ref_segment,
+            "source_commit": sha,
+            "preserved_worktree": str(preserved),
+            "replacement_worktree": str(replacement),
+            "reason": reason,
+            "preserved_source_mutated": False,
+            "automatic_reset_authorized": False,
+            "created_at_unix": int(time.time()),
+        },
+    )
+    return receipt_path
 
 
 def ensure_source_worktree(entry: RepoEntry, ref_segment: str, sha: str) -> Path:
-    source_wt = source_worktree_path(entry, ref_segment)
+    source_wt = revision_source_worktree_path(entry, ref_segment, sha)
     SOURCE_ROOT.mkdir(parents=True, exist_ok=True)
+    try:
+        prepare_managed_worktree(
+            source_wt,
+            expected_repo=entry.path,
+            target=sha,
+        )
+        return source_wt
+    except ManagedWorktreeDirtyError as exc:
+        reason: dict[str, object] = {
+            "kind": "managed_worktree_dirty",
+            "receipt": exc.receipt(),
+        }
+    except RuntimeError as exc:
+        blocker = parse_managed_build_blocker(exc)
+        if blocker is None:
+            raise
+        reason = {
+            "kind": "managed_build_residue",
+            "receipt": blocker,
+        }
+
+    recovery_id = uuid.uuid4().hex[:12]
+    replacement = revision_source_worktree_path(
+        entry, ref_segment, sha, recovery_id=recovery_id
+    )
     prepare_managed_worktree(
-        source_wt,
+        replacement,
         expected_repo=entry.path,
         target=sha,
     )
-    return source_wt
+    try:
+        receipt_path = record_source_recovery(
+            entry=entry,
+            ref_segment=ref_segment,
+            sha=sha,
+            preserved=source_wt,
+            replacement=replacement,
+            reason=reason,
+            recovery_id=recovery_id,
+        )
+    except Exception:
+        run(
+            ["git", "-C", str(entry.path), "worktree", "remove", str(replacement)],
+            check=False,
+        )
+        raise
+    log(
+        "SOURCE-RECOVERY "
+        + json.dumps(
+            {
+                "repository": entry.key,
+                "source_commit": sha,
+                "preserved": str(source_wt),
+                "replacement": str(replacement),
+                "receipt": str(receipt_path),
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    )
+    return replacement
+
+
+def prune_obsolete_revision_source_worktrees(
+    entry: RepoEntry, ref_segment: str, current: Path
+) -> dict[str, object]:
+    base = source_worktree_path(entry, ref_segment)
+    prefix = base.name + "--"
+    removed: list[str] = []
+    preserved: list[dict[str, str]] = []
+    if not SOURCE_ROOT.is_dir():
+        return {"removed": removed, "preserved": preserved}
+    for candidate in sorted(SOURCE_ROOT.iterdir()):
+        if candidate == current or not candidate.name.startswith(prefix):
+            continue
+        try:
+            assert_managed_worktree_clean(candidate, entry.path)
+            assert_managed_worktree_idle(candidate)
+            lease_evidence = managed_build_lease_evidence(
+                candidate, candidate / "build"
+            )
+            if lease_evidence.get("active_leases"):
+                preserved.append({"path": str(candidate), "reason": "active_lease"})
+                continue
+        except Exception as exc:
+            preserved.append({"path": str(candidate), "reason": str(exc)[:500]})
+            continue
+        result = run(
+            ["git", "-C", str(entry.path), "worktree", "remove", str(candidate)],
+            check=False,
+        )
+        if result.returncode == 0:
+            removed.append(str(candidate))
+        else:
+            preserved.append(
+                {"path": str(candidate), "reason": result.stdout[-500:] or "remove_failed"}
+            )
+    return {"removed": removed, "preserved": preserved}
 
 
 def active_lease_root() -> Path:
@@ -3176,7 +3316,7 @@ def publish(
     tool_sha: str,
     fingerprint: str,
     config: PublicationConfig,
-) -> tuple[dict[str, object], Path, Path, str, str]:
+) -> tuple[dict[str, object], Path, Path, str, str, Path]:
     repository = safe_segment(entry.repo)
     registry_repository = publication_repository(entry)
     ref_segment = safe_segment(branch)
@@ -3304,7 +3444,14 @@ def publish(
             + "\n",
             encoding="utf-8",
         )
-        return data, out_dir, active_lease, manifest_path, publication_created_at
+        return (
+            data,
+            out_dir,
+            active_lease,
+            manifest_path,
+            publication_created_at,
+            source_wt,
+        )
     except Exception:
         discard_generated_output(out_dir, root=out_base)
         clear_active_publication_lease(active_lease)
@@ -3622,22 +3769,25 @@ def main(argv: list[str]) -> int:
                     )
                     continue
                 changed += 1
-                source_hygiene_cleanup = preflight_existing_source_worktree(
-                    entry, ref_segment
-                )
                 if args.limit and published >= args.limit:
                     queued += 1
-                    queued_detail: dict[str, object] = {
-                        "repo": entry.key,
-                        "status": "queued",
-                        "source_sha": source_sha,
-                        "fingerprint": fingerprint,
-                    }
-                    if source_hygiene_cleanup:
-                        queued_detail["source_hygiene_cleanup"] = source_hygiene_cleanup
-                    details.append(queued_detail)
+                    details.append(
+                        {
+                            "repo": entry.key,
+                            "status": "queued",
+                            "source_sha": source_sha,
+                            "fingerprint": fingerprint,
+                        }
+                    )
                     continue
-                data, out_dir, active_lease, manifest_path, publication_created_at = (
+                (
+                    data,
+                    out_dir,
+                    active_lease,
+                    manifest_path,
+                    publication_created_at,
+                    source_wt,
+                ) = (
                     publish(
                         entry,
                         remote_ref=remote_ref,
@@ -3664,6 +3814,17 @@ def main(argv: list[str]) -> int:
                     published_now=True,
                 )
                 clear_active_publication_lease(active_lease)
+                try:
+                    source_prune_report = prune_obsolete_revision_source_worktrees(
+                        entry, ref_segment, source_wt
+                    )
+                except Exception as exc:
+                    prune_failed += 1
+                    source_prune_report = {
+                        "status": "warn",
+                        "error": str(exc)[:2000],
+                    }
+                    log(f"SOURCE-PRUNE-FAILED {entry.key}: {exc}")
                 published += 1
                 try:
                     prune_report = prune_current_group(
@@ -3695,9 +3856,9 @@ def main(argv: list[str]) -> int:
                     "generatedAt": generated,
                     "publication_dir": str(out_dir),
                     "prune": prune_report,
+                    "source_worktree": str(source_wt),
+                    "source_worktree_prune": source_prune_report,
                 }
-                if source_hygiene_cleanup:
-                    published_detail["source_hygiene_cleanup"] = source_hygiene_cleanup
                 details.append(published_detail)
             except ManagedWorktreeDirtyError as exc:
                 deferred += 1


### PR DESCRIPTION
## Problem

The hourly fleet publisher can remain unhealthy indefinitely when a mutable managed source checkout contains semantic dirty state or a retained `build/` residue from an older commit. The old GitHub identity `heimgewebe/lenskit` is also still discovered as an independent lane even though GitHub redirects it to RepoGround.

## Fix

- materialize publication sources in commit-bound detached worktrees
- preserve dirty/ambiguous source worktrees instead of resetting or deleting them
- create a clean same-commit recovery worktree plus create-only recovery receipt when the revision source itself is contaminated
- prune only clean, idle, unleased obsolete revision worktrees; cleanup failure is warning-only after a successful publication
- stop the historical mutable per-ref checkout from gating publication
- suppress the retired `heimgewebe/lenskit` lane from active fleet discovery
- document the required consumer cutover order

## Safety

The fix never authorizes destructive cleanup of semantic/unknown dirty source state. Unrelated/unknown preparation failures remain fail-closed. If recovery-receipt publication fails, the clean replacement is rolled back while the preserved source remains unchanged.

## Validation

- `101 passed` — `merger/repoground/tests/test_fleet_runtime.py`
- Ruff on modified Python files: pass
- `git diff --check`: pass

## Deployment dependency

Merge/deploy the companion Grabowski catalog change first so the consumer accepts revision-bound source provenance only when the embedded source commit exactly matches the manifest. Then merge/install this publisher change and perform live fleet readback.