### PR TITLE
Implement safe runtime artifact retention GC (T018)

### DIFF
--- a/docs/architecture/artifact-inventory.md
+++ b/docs/architecture/artifact-inventory.md
@@ -88,4 +88,4 @@ Dateiendung ist Kleidung; Autorität ist Identität.
    - `deletion_mode`: `"not_supported_by_policy"`.
 
    Legacy-Einträge (ohne Lifecycle-/Retention-Felder) werden beim Lookup via `_with_runtime_metadata()` transparent backgefüllt und dabei nicht auf Platte zurückgeschrieben.
-   **Kein GC, kein TTL, kein automatisches Löschen.** Diese Entscheidung ist jetzt explizit und maschinenlesbar in `merger/repoground/service/runtime_artifact_retention.py` dokumentiert; sie ist keine Cleanup-Engine.
+   **Kein TTL und kein automatisches oder Lookup-seitiges GC.** T018 ergänzt separat `runtime-artifact-manual-gc.v1`: konservative Zeit-/Anzahl-/Byte-Budgets erzeugen nur einen deterministischen Dry-run. Eine Wirkung erfordert vollständige Schutzbelege für aktive Sessions, Pins und nichtterminale externe Referenzen sowie einen unveränderten Plan- und Store-Hash. Apply schreibt Transaction/Receipt vor bzw. nach dem Effekt und liest Storeintegrität und geschützte IDs erneut zurück.

--- a/docs/architecture/runtime-matrix.md
+++ b/docs/architecture/runtime-matrix.md
@@ -56,7 +56,6 @@ Runtime-Artefakte (`query_trace`, `context_bundle`, `agent_query_session`) trage
 | `gc_mode` | `"not_implemented"` |
 | `deletion_mode` | `"not_supported_by_policy"` |
 
-Die maschinenlesbare Policy liegt in `merger/repoground/service/runtime_artifact_retention.py` (`policy_id: "runtime-artifact-retention.v1"`, `status: "explicitly_deferred"`).
+Die maschinenlesbare Lookup-Policy liegt in `merger/repoground/service/runtime_artifact_retention.py` (`policy_id: "runtime-artifact-retention.v1"`, `status: "explicitly_deferred"`). Die Metadaten oben bleiben unverändert: Lookup und Zeitablauf löschen nichts.
 
-**Kein GC. Keine TTL. Keine automatische Löschung.**
-Die Policy macht die Deferral-Entscheidung explizit; sie ist keine Cleanup-Engine.
+**Keine TTL und keine automatische Löschung.** Zusätzlich existiert `runtime-artifact-manual-gc.v1` als expliziter Operatorpfad: Budgetüberschreitungen erzeugen zunächst nur einen hashgebundenen Plan; Apply benötigt vollständige, frisch geprüfte Schutzreferenzen und schreibt auditierbare Transaction-/Receipt-Belege.

--- a/docs/proofs/runtime-artifact-retention-gc-v1-proof.md
+++ b/docs/proofs/runtime-artifact-retention-gc-v1-proof.md
@@ -1,0 +1,41 @@
+# Runtime Artifact Manual GC v1 — T018 proof
+
+This proof records the implementation boundary for Bureau task `REPOGROUND-AGENT-UTILITY-V1-T018`. It supersedes only the historical statement that no manual GC path existed; the lookup contract from `runtime-artifact-retention.v1` remains unchanged.
+
+## Policy and budgets
+
+`runtime-artifact-manual-gc.v1` is opt-in. It has no scheduler and `automatic_delete=false`. The conservative profile uses:
+
+| Artifact type | Max age | Max count | Max bytes |
+|---|---:|---:|---:|
+| `query_trace` | 90 days | 25,000 | 512 MiB |
+| `context_bundle` | 90 days | 10,000 | 2 GiB |
+| `agent_query_session` | 180 days | 25,000 | 512 MiB |
+
+Crossing a budget creates only a dry-run candidate. Stored artifact metadata remains `retention_policy=unbounded_currently`, `ttl_enabled=false`, `gc_enabled=false`; lookup never expires or removes an artifact.
+
+## Plan-before-effect
+
+`runtime_artifact_gc_plan.py` builds deterministic plans from one exact store SHA-256. Each candidate records its ID, type, created time, estimated bytes, entry hash and all applicable budget reasons. `plan_sha256` binds the entire plan. Apply rejects a changed plan or changed store preimage.
+
+## Reference protection
+
+Protection evidence must declare `reference_state=complete`. Unknown global or external-reference state blocks fail-closed. Pins and nonterminal external references are protected. Active `agent_query_session` artifacts protect themselves plus referenced `query_trace_id` and `context_bundle_id`; missing or malformed session references also block. A newly protected candidate between plan and apply is skipped rather than deleted.
+
+## Race, filesystem and recovery safety
+
+`RuntimeArtifactGCStore` and normal `QueryArtifactStore` writes share `.query_artifacts.lock`. Normal writers reload the store from disk under that lock, so a stale process cannot resurrect a GC-removed entry. Rooted filesystem primitives use no-follow descriptor-bound reads/writes. Storage, transaction, receipt and store entries are owner/type checked.
+
+Before the store effect, Apply writes a transaction record containing pre/post hashes and the intended receipt body. After the effect it re-reads the store, verifies the post hash and checks protected IDs. If the effect completed but its final receipt is missing, the next exact replay reconstructs the receipt idempotently. Other normal store writes remain blocked while an unfinished transaction lacks its receipt.
+
+## Acceptance mapping
+
+- `policy-profiles`: explicit age/count/byte budgets; automatic deletion remains disabled.
+- `plan-before-effect`: deterministic dry-run, candidate reasons, expected release and exact plan/store binding.
+- `reference-protection`: active sessions, their artifact graph, pins and nonterminal external evidence are protected; unknown state blocks.
+- `safe-gc`: inter-process lock, no-follow rooted filesystem operations, ownership checks, transaction/receipt ledger and idempotent recovery.
+- `retention-readback`: receipt reports deleted objects/bytes; store post-hash and protected-artifact readability are rechecked.
+
+## Regression evidence
+
+Dedicated tests live in `merger/repoground/tests/test_runtime_artifact_gc.py`; legacy retention tests remain in `test_runtime_artifact_retention.py`. Merge-grade evidence is provided by the PR-bound CI and exact-head test receipts.

--- a/docs/service-api.md
+++ b/docs/service-api.md
@@ -241,9 +241,9 @@ All runtime artifacts stored in the `QueryArtifactStore` (`query_trace`, `contex
 
 - Policy ID: `runtime-artifact-retention.v1`.
 - Policy status: `explicitly_deferred`.
-- No GC (Garbage Collection) is applied.
-- No TTL (Time-to-Live) is set.
-- No automatic deletion occurs.
+- Query and lookup paths apply no automatic GC (Garbage Collection).
+- No TTL (Time-to-Live) is set and no automatic deletion occurs.
+- A separate manual store operation is available through `QueryArtifactStore.retention_plan()` / `apply_retention()`; it is not triggered by an HTTP lookup/query request and requires complete protection evidence plus the exact plan/store hash.
 - Store diagnostics expose the policy ID and status without rewriting the store.
 - Legacy entries missing these fields are transparently backfilled on read and are not rewritten by lookup.
 

--- a/merger/repoground/service/query_artifact_store.py
+++ b/merger/repoground/service/query_artifact_store.py
@@ -1,12 +1,23 @@
-import json
+import contextlib
 import copy
+import json
+import logging
 import threading
 import uuid
-import logging
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
+from ..core.rooted_filesystem import (
+    RootedFilesystemError,
+    atomic_write_bytes,
+    exclusive_file_lock,
+    make_directories,
+    path_exists,
+    read_regular_bytes,
+)
+from .runtime_artifact_gc import RuntimeArtifactGCError
+from .runtime_artifact_gc_store import RuntimeArtifactGCStore
 from .runtime_artifact_retention import (
     RETENTION_POLICY_ID,
     runtime_artifact_metadata_table,
@@ -16,6 +27,7 @@ from .runtime_artifact_retention import (
 logger = logging.getLogger(__name__)
 
 _STORE_FILENAME = "query_artifacts.json"
+_LOCK_FILENAME = ".query_artifacts.lock"
 
 # Per-type classification metadata injected into every stored entry.
 # The table is derived from the machine-readable retention policy so lookup
@@ -85,8 +97,8 @@ class QueryArtifactStore:
     after the store location changes (e.g. different merges_dir).
 
     Known limitations:
-    - Retention policy is explicit and machine-readable, but TTL and GC are
-      deliberately disabled: the store grows unbounded.
+    - Lookup remains TTL-free and has no automatic GC. Manual retention effects
+      require an explicit hash-bound plan/apply call with complete protection evidence.
     - No federation artifact support.
 
     Storage format: JSON list at {storage_dir}/query_artifacts.json.
@@ -94,32 +106,78 @@ class QueryArtifactStore:
     """
 
     def __init__(self, storage_dir: Path):
-        self.storage_dir = storage_dir
-        self.storage_dir.mkdir(parents=True, exist_ok=True)
+        self.storage_dir = Path(storage_dir)
+        try:
+            make_directories(self.storage_dir, mode=0o700)
+        except RootedFilesystemError as exc:
+            raise RuntimeArtifactGCError(
+                "unsafe_store_directory", f"artifact storage directory is unsafe: {self.storage_dir}"
+            ) from exc
         self._store_file = self.storage_dir / _STORE_FILENAME
+        self._lock_file = self.storage_dir / _LOCK_FILENAME
         self._cache: Dict[str, Dict[str, Any]] = {}
         self._lock = threading.RLock()
         self._load()
 
+    def _read_store_locked(self) -> bytes:
+        if not path_exists(self._store_file):
+            self._cache = {}
+            return b"[]"
+        try:
+            payload = read_regular_bytes(self._store_file)
+            data = json.loads(payload.decode("utf-8"))
+        except (RootedFilesystemError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise RuntimeArtifactGCError(
+                "unsafe_store_entry", f"query artifact store cannot be read safely: {self._store_file}"
+            ) from exc
+        if not isinstance(data, list):
+            raise RuntimeArtifactGCError("invalid_store_json", "query artifact store root must be a list")
+        loaded: Dict[str, Dict[str, Any]] = {}
+        for index, entry in enumerate(data):
+            if not isinstance(entry, dict):
+                raise RuntimeArtifactGCError(
+                    "invalid_store_entry", f"query artifact store entry {index} is not an object"
+                )
+            artifact_id = entry.get("id")
+            if not isinstance(artifact_id, str) or not artifact_id or artifact_id in loaded:
+                raise RuntimeArtifactGCError(
+                    "invalid_store_entry", f"query artifact store entry {index} has an invalid/duplicate id"
+                )
+            loaded[artifact_id] = entry
+        self._cache = loaded
+        return payload
+
     def _load(self) -> None:
         with self._lock:
-            if not self._store_file.exists():
-                return
             try:
-                data = json.loads(self._store_file.read_text(encoding="utf-8"))
-                for entry in data:
-                    self._cache[entry["id"]] = entry
-            except Exception as e:
-                logger.error("Failed to load query artifacts from %s: %s", self._store_file, e)
+                with exclusive_file_lock(self._lock_file, mode=0o600):
+                    self._read_store_locked()
+            except (RuntimeArtifactGCError, RootedFilesystemError) as exc:
+                logger.error("Failed to load query artifacts from %s: %s", self._store_file, exc)
+                self._cache = {}
 
-    def _save(self) -> None:
-        tmp = self._store_file.with_suffix(".tmp")
-        tmp.parent.mkdir(parents=True, exist_ok=True)
-        tmp.write_text(
-            json.dumps(list(self._cache.values()), indent=2),
-            encoding="utf-8",
-        )
-        tmp.replace(self._store_file)
+    @contextlib.contextmanager
+    def _disk_lock(self) -> Iterator[bytes]:
+        with self._lock:
+            try:
+                with exclusive_file_lock(self._lock_file, mode=0o600):
+                    yield self._read_store_locked()
+            except RuntimeArtifactGCError:
+                raise
+            except RootedFilesystemError as exc:
+                raise RuntimeArtifactGCError(
+                    "unsafe_store_entry", f"query artifact store lock is unsafe: {self._lock_file}"
+                ) from exc
+
+    def _save(self) -> bytes:
+        payload = json.dumps(list(self._cache.values()), indent=2).encode("utf-8")
+        try:
+            atomic_write_bytes(self._store_file, payload, mode=0o600)
+        except RootedFilesystemError as exc:
+            raise RuntimeArtifactGCError(
+                "store_write_failed", f"query artifact store write failed: {self._store_file}"
+            ) from exc
+        return payload
 
     def store(
         self,
@@ -163,7 +221,8 @@ class QueryArtifactStore:
             **runtime_meta,
         }
 
-        with self._lock:
+        with self._disk_lock():
+            RuntimeArtifactGCStore(self.storage_dir).assert_no_pending()
             self._cache[artifact_id] = entry
             self._save()
 
@@ -176,32 +235,59 @@ class QueryArtifactStore:
         backfilling from _RUNTIME_ARTIFACT_METADATA for legacy entries that
         predate the metadata schema addition.
         """
-        with self._lock:
+        with self._disk_lock():
             raw = self._cache.get(artifact_id)
             if raw is None:
                 return None
             return _with_runtime_metadata(raw)
 
     def get_all(self) -> List[Dict[str, Any]]:
-        with self._lock:
+        with self._disk_lock():
             return sorted(
                 (_with_runtime_metadata(e) for e in self._cache.values()),
                 key=lambda e: e.get("created_at", ""),
                 reverse=True,
             )
 
+    def retention_plan(
+        self,
+        *,
+        protection: Dict[str, Any],
+        as_of: Optional[str] = None,
+        profile_id: str = "conservative",
+    ) -> Dict[str, Any]:
+        """Return a deterministic manual-GC dry-run without changing artifacts."""
+        return RuntimeArtifactGCStore(self.storage_dir).plan(
+            protection=protection,
+            as_of=as_of,
+            profile_id=profile_id,
+        )
+
+    def apply_retention(
+        self,
+        *,
+        plan: Dict[str, Any],
+        protection: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Apply one exact plan and refresh this instance from the disk readback."""
+        receipt = RuntimeArtifactGCStore(self.storage_dir).apply(
+            plan=plan,
+            protection=protection,
+        )
+        self._load()
+        return receipt
+
     def diagnostics(self) -> Dict[str, Any]:
         """Return a read-only retention diagnostics snapshot of the store.
 
-        The store currently has no GC and no TTL: it grows unbounded for the
-        lifetime of the underlying JSON file.  This method surfaces what *is*
-        there (counts, age range, on-disk size) so operators can observe
-        growth without enabling any deletion path.
+        Lookup and normal store writes remain TTL-free and have no automatic GC.
+        This method surfaces counts, age range and on-disk size without invoking
+        the separate manual plan/apply retention path.
 
         Read-only contract:
-        - Does not mutate the in-memory cache.
+        - May refresh the in-memory cache from disk so concurrent GC is observed.
         - Does not write to or truncate the on-disk store file.
-        - Does not enable any retention/GC/TTL behaviour.
+        - Does not run manual GC or enable automatic retention/TTL behaviour.
         - Does not enumerate artifact IDs or payloads.
 
         Legacy entries written before the runtime-metadata schema (which may
@@ -231,7 +317,7 @@ class QueryArtifactStore:
                 ``ttl_enabled``             — const ``False``
                 ``retention_policy_id``  — machine-readable policy id
         """
-        with self._lock:
+        with self._disk_lock():
             total = len(self._cache)
             by_type: Dict[str, int] = {}
             oldest: Optional[str] = None

--- a/merger/repoground/service/runtime_artifact_gc.py
+++ b/merger/repoground/service/runtime_artifact_gc.py
@@ -1,0 +1,35 @@
+"""Public manual runtime-artifact GC planning contract.
+
+Validation/protection and deterministic budget planning are split into small
+modules so the public surface stays stable without accumulating a monolithic
+planner. This facade is effect-free; filesystem effects remain in
+:mod:`runtime_artifact_gc_store`.
+"""
+from .runtime_artifact_gc_plan import build_retention_plan, verify_retention_plan
+from .runtime_artifact_gc_support import (
+    GC_PLAN_KIND,
+    GC_PLAN_VERSION,
+    GC_PROTECTION_KIND,
+    GC_PROTECTION_VERSION,
+    RuntimeArtifactGCError,
+    canonical_json,
+    normalize_protection,
+    protected_artifacts,
+    sha256_bytes,
+    sha256_json,
+)
+
+__all__ = [
+    "GC_PLAN_KIND",
+    "GC_PLAN_VERSION",
+    "GC_PROTECTION_KIND",
+    "GC_PROTECTION_VERSION",
+    "RuntimeArtifactGCError",
+    "build_retention_plan",
+    "canonical_json",
+    "normalize_protection",
+    "protected_artifacts",
+    "sha256_bytes",
+    "sha256_json",
+    "verify_retention_plan",
+]

--- a/merger/repoground/service/runtime_artifact_gc_plan.py
+++ b/merger/repoground/service/runtime_artifact_gc_plan.py
@@ -1,0 +1,320 @@
+"""Deterministic budget planning for manual runtime-artifact GC."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Mapping, Sequence
+
+from .runtime_artifact_gc_support import (
+    GC_PLAN_KIND,
+    GC_PLAN_VERSION,
+    RuntimeArtifactGCError,
+    canonical_json,
+    entry_index,
+    iso_z,
+    normalize_protection,
+    parse_aware_datetime,
+    protected_artifacts,
+    sha256_json,
+    validated_budgets,
+)
+from .runtime_artifact_retention import RUNTIME_ARTIFACT_TYPES
+
+
+def _entry_size(entry: Mapping[str, Any]) -> int:
+    return len(canonical_json(entry).encode("utf-8"))
+
+
+def _entry_created_at(artifact_id: str, value: Any) -> datetime | None:
+    try:
+        return parse_aware_datetime(value, label=f"{artifact_id}.created_at")
+    except RuntimeArtifactGCError:
+        return None
+
+
+def _collect_entry_info(
+    index: Mapping[str, Mapping[str, Any]],
+    protected: Dict[str, set[str]],
+) -> tuple[Dict[str, Dict[str, Any]], Dict[str, list[str]]]:
+    info: Dict[str, Dict[str, Any]] = {}
+    by_type: Dict[str, list[str]] = {artifact_type: [] for artifact_type in RUNTIME_ARTIFACT_TYPES}
+    for artifact_id, entry in index.items():
+        artifact_type = entry.get("artifact_type")
+        created_raw = entry.get("created_at")
+        created_dt = None
+        if artifact_type in RUNTIME_ARTIFACT_TYPES:
+            created_dt = _entry_created_at(artifact_id, created_raw)
+            by_type[artifact_type].append(artifact_id)
+            if created_dt is None:
+                protected.setdefault(artifact_id, set()).add("created_at_unknown")
+        else:
+            protected.setdefault(artifact_id, set()).add("unknown_artifact_type")
+        info[artifact_id] = {
+            "artifact_id": artifact_id,
+            "artifact_type": artifact_type,
+            "created_at": created_raw if isinstance(created_raw, str) else None,
+            "created_dt": created_dt,
+            "estimated_bytes": _entry_size(entry),
+            "entry_sha256": sha256_json(entry),
+        }
+    return info, by_type
+
+
+def _ordered_ids(ids: Sequence[str], info: Mapping[str, Mapping[str, Any]]) -> list[str]:
+    return sorted(
+        ids,
+        key=lambda artifact_id: (
+            info[artifact_id]["created_dt"] is None,
+            info[artifact_id]["created_dt"] or datetime.max.replace(tzinfo=timezone.utc),
+            artifact_id,
+        ),
+    )
+
+
+def _add_candidate(
+    reasons: Dict[str, set[str]],
+    protected: Mapping[str, Any],
+    artifact_id: str,
+    reason: str,
+) -> None:
+    if artifact_id not in protected:
+        reasons.setdefault(artifact_id, set()).add(reason)
+
+
+def _mark_age_pressure(
+    *,
+    ordered: Sequence[str],
+    info: Mapping[str, Mapping[str, Any]],
+    protected: Mapping[str, Any],
+    reasons: Dict[str, set[str]],
+    cutoff: datetime,
+) -> None:
+    for artifact_id in ordered:
+        created_dt = info[artifact_id]["created_dt"]
+        if created_dt is not None and created_dt < cutoff:
+            _add_candidate(reasons, protected, artifact_id, "age_budget")
+
+
+def _mark_count_pressure(
+    *,
+    ordered: Sequence[str],
+    protected: Mapping[str, Any],
+    reasons: Dict[str, set[str]],
+    count_to_release: int,
+) -> None:
+    marked = 0
+    for artifact_id in ordered:
+        if marked >= count_to_release:
+            return
+        if artifact_id in protected:
+            continue
+        _add_candidate(reasons, protected, artifact_id, "count_budget")
+        marked += 1
+
+
+def _mark_byte_pressure(
+    *,
+    ordered: Sequence[str],
+    info: Mapping[str, Mapping[str, Any]],
+    protected: Mapping[str, Any],
+    reasons: Dict[str, set[str]],
+    bytes_to_release: int,
+) -> None:
+    marked = 0
+    for artifact_id in ordered:
+        if marked >= bytes_to_release:
+            return
+        if artifact_id in protected:
+            continue
+        _add_candidate(reasons, protected, artifact_id, "bytes_budget")
+        marked += int(info[artifact_id]["estimated_bytes"])
+
+
+def _selected_ids(
+    *,
+    artifact_type: str,
+    reasons: Mapping[str, Any],
+    info: Mapping[str, Mapping[str, Any]],
+) -> set[str]:
+    return {
+        artifact_id
+        for artifact_id in reasons
+        if info[artifact_id]["artifact_type"] == artifact_type
+    }
+
+
+def _mark_type_budget_pressure(
+    *,
+    artifact_type: str,
+    ids: Sequence[str],
+    budget: Mapping[str, int],
+    info: Mapping[str, Mapping[str, Any]],
+    protected: Mapping[str, Any],
+    reasons: Dict[str, set[str]],
+    as_of_dt: datetime,
+) -> Dict[str, int]:
+    ordered = _ordered_ids(ids, info)
+    _mark_age_pressure(
+        ordered=ordered,
+        info=info,
+        protected=protected,
+        reasons=reasons,
+        cutoff=as_of_dt - timedelta(seconds=budget["max_age_seconds"]),
+    )
+    _mark_count_pressure(
+        ordered=ordered,
+        protected=protected,
+        reasons=reasons,
+        count_to_release=max(0, len(ids) - budget["max_count"]),
+    )
+    total_bytes = sum(int(info[artifact_id]["estimated_bytes"]) for artifact_id in ids)
+    _mark_byte_pressure(
+        ordered=ordered,
+        info=info,
+        protected=protected,
+        reasons=reasons,
+        bytes_to_release=max(0, total_bytes - budget["max_bytes"]),
+    )
+    selected = _selected_ids(artifact_type=artifact_type, reasons=reasons, info=info)
+    remaining_count = len(ids) - len(selected)
+    remaining_bytes = total_bytes - sum(
+        int(info[artifact_id]["estimated_bytes"]) for artifact_id in selected
+    )
+    return {
+        "count_over_budget": max(0, remaining_count - budget["max_count"]),
+        "bytes_over_budget": max(0, remaining_bytes - budget["max_bytes"]),
+    }
+
+
+def _candidate_rows(
+    reasons: Mapping[str, set[str]], info: Mapping[str, Mapping[str, Any]]
+) -> list[dict[str, Any]]:
+    ordered = sorted(
+        reasons,
+        key=lambda artifact_id: (
+            str(info[artifact_id]["artifact_type"]),
+            info[artifact_id]["created_dt"] or datetime.max.replace(tzinfo=timezone.utc),
+            artifact_id,
+        ),
+    )
+    return [
+        {
+            "artifact_id": artifact_id,
+            "artifact_type": info[artifact_id]["artifact_type"],
+            "created_at": info[artifact_id]["created_at"],
+            "estimated_bytes": info[artifact_id]["estimated_bytes"],
+            "entry_sha256": info[artifact_id]["entry_sha256"],
+            "reasons": sorted(reasons[artifact_id]),
+        }
+        for artifact_id in ordered
+    ]
+
+
+def _unresolved_budgets(
+    *,
+    by_type: Mapping[str, Sequence[str]],
+    budgets: Mapping[str, Mapping[str, int]],
+    info: Mapping[str, Mapping[str, Any]],
+    protected: Mapping[str, Any],
+    reasons: Dict[str, set[str]],
+    as_of_dt: datetime,
+) -> Dict[str, Dict[str, int]]:
+    return {
+        artifact_type: _mark_type_budget_pressure(
+            artifact_type=artifact_type,
+            ids=by_type[artifact_type],
+            budget=budgets[artifact_type],
+            info=info,
+            protected=protected,
+            reasons=reasons,
+            as_of_dt=as_of_dt,
+        )
+        for artifact_type in RUNTIME_ARTIFACT_TYPES
+    }
+
+
+def build_retention_plan(
+    *,
+    entries: Sequence[Mapping[str, Any]],
+    store_sha256: str,
+    protection: Mapping[str, Any],
+    as_of: str,
+    profile_id: str,
+    budgets: Mapping[str, Any],
+) -> Dict[str, Any]:
+    """Build one deterministic, effect-free plan from an exact store snapshot."""
+    if (
+        not isinstance(store_sha256, str)
+        or len(store_sha256) != 64
+        or any(character not in "0123456789abcdef" for character in store_sha256)
+    ):
+        raise RuntimeArtifactGCError("invalid_store_sha256", "store_sha256 must be a SHA-256 hex digest")
+    as_of_dt = parse_aware_datetime(as_of, label="as_of")
+    validated = validated_budgets(budgets)
+    explicit_protected, canonical_protection = protected_artifacts(entries, protection)
+    index = entry_index(entries)
+    protected: Dict[str, set[str]] = {
+        artifact_id: set(values) for artifact_id, values in explicit_protected.items()
+    }
+    info, by_type = _collect_entry_info(index, protected)
+    reasons: Dict[str, set[str]] = {}
+    unresolved = _unresolved_budgets(
+        by_type=by_type,
+        budgets=validated,
+        info=info,
+        protected=protected,
+        reasons=reasons,
+        as_of_dt=as_of_dt,
+    )
+    candidates = _candidate_rows(reasons, info)
+    body: Dict[str, Any] = {
+        "kind": GC_PLAN_KIND,
+        "schema_version": GC_PLAN_VERSION,
+        "profile_id": profile_id,
+        "as_of": iso_z(as_of_dt),
+        "store_sha256": store_sha256,
+        "protection_sha256": sha256_json(canonical_protection),
+        "protection": canonical_protection,
+        "budgets": validated,
+        "automatic_delete": False,
+        "requires_explicit_apply": True,
+        "candidates": candidates,
+        "protected": [
+            {"artifact_id": artifact_id, "reasons": sorted(values)}
+            for artifact_id, values in sorted(protected.items())
+        ],
+        "unresolved_budgets": unresolved,
+        "expected_release": {
+            "objects": len(candidates),
+            "estimated_bytes": sum(int(item["estimated_bytes"]) for item in candidates),
+        },
+        "does_not_establish": [
+            "apply_authority",
+            "future_reference_state",
+            "future_store_identity",
+            "automatic_deletion",
+        ],
+    }
+    body["plan_sha256"] = sha256_json(body)
+    return body
+
+
+def verify_retention_plan(plan: Mapping[str, Any]) -> Dict[str, Any]:
+    if not isinstance(plan, Mapping):
+        raise RuntimeArtifactGCError("invalid_plan", "plan must be an object")
+    rendered = json.loads(json.dumps(plan))
+    provided = rendered.pop("plan_sha256", None)
+    if (
+        not isinstance(provided, str)
+        or len(provided) != 64
+        or any(character not in "0123456789abcdef" for character in provided)
+    ):
+        raise RuntimeArtifactGCError("invalid_plan", "plan_sha256 is missing or malformed")
+    if rendered.get("kind") != GC_PLAN_KIND or rendered.get("schema_version") != GC_PLAN_VERSION:
+        raise RuntimeArtifactGCError("invalid_plan", "unsupported plan kind or schema version")
+    if provided != sha256_json(rendered):
+        raise RuntimeArtifactGCError("plan_hash_mismatch", "plan content does not match plan_sha256")
+    rendered["plan_sha256"] = provided
+    validated_budgets(rendered.get("budgets"))
+    normalize_protection(rendered.get("protection"))
+    return rendered

--- a/merger/repoground/service/runtime_artifact_gc_store.py
+++ b/merger/repoground/service/runtime_artifact_gc_store.py
@@ -1,0 +1,511 @@
+"""Race-safe plan/apply effects for manual query-artifact GC."""
+from __future__ import annotations
+
+import copy
+import json
+import os
+import stat
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional
+
+from ..core.rooted_filesystem import (
+    RootedFilesystemError,
+    atomic_write_bytes,
+    exclusive_file_lock,
+    exclusive_write_bytes,
+    lstat_path,
+    make_directories,
+    path_exists,
+    read_regular_bytes,
+)
+from .runtime_artifact_gc import (
+    RuntimeArtifactGCError,
+    build_retention_plan,
+    canonical_json,
+    sha256_bytes,
+    sha256_json,
+    verify_retention_plan,
+)
+from .runtime_artifact_retention import (
+    MANUAL_GC_DEFAULT_PROFILE,
+    runtime_artifact_gc_profile,
+)
+
+_STORE_FILENAME = "query_artifacts.json"
+_LOCK_FILENAME = ".query_artifacts.lock"
+_RECEIPT_DIRNAME = "retention-receipts"
+_TRANSACTION_DIRNAME = "retention-transactions"
+_RECEIPT_KIND = "lenskit.runtime_artifact_gc_receipt"
+_TRANSACTION_KIND = "lenskit.runtime_artifact_gc_transaction"
+_SCHEMA_VERSION = 1
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _plan_stem(value: str) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value) != 64
+        or any(character not in "0123456789abcdef" for character in value)
+    ):
+        raise RuntimeArtifactGCError("invalid_plan", "plan_sha256 must be lowercase SHA-256")
+    return value
+
+
+class RuntimeArtifactGCStore:
+    """Manual GC bound to one store directory and one inter-process lock."""
+
+    def __init__(self, storage_dir: Path):
+        self.storage_dir = Path(storage_dir)
+        self.store_file = self.storage_dir / _STORE_FILENAME
+        self.lock_file = self.storage_dir / _LOCK_FILENAME
+        self.receipt_dir = self.storage_dir / _RECEIPT_DIRNAME
+        self.transaction_dir = self.storage_dir / _TRANSACTION_DIRNAME
+        try:
+            make_directories(self.storage_dir, mode=0o700)
+        except RootedFilesystemError as exc:
+            raise RuntimeArtifactGCError(
+                "unsafe_store_directory", f"unsafe artifact storage directory: {self.storage_dir}"
+            ) from exc
+        self._assert_owned(
+            self.storage_dir,
+            label="artifact storage directory",
+            directory=True,
+        )
+
+    def _assert_owned(self, path: Path, *, label: str, directory: bool = False) -> None:
+        try:
+            if not path_exists(path):
+                return
+            metadata = lstat_path(path)
+        except RootedFilesystemError as exc:
+            raise RuntimeArtifactGCError("unsafe_store_entry", f"cannot safely inspect {label}") from exc
+        predicate = stat.S_ISDIR if directory else stat.S_ISREG
+        if not predicate(metadata.st_mode):
+            raise RuntimeArtifactGCError(
+                "unsafe_store_entry", f"{label} is not a {'directory' if directory else 'regular file'}"
+            )
+        if hasattr(os, "geteuid") and metadata.st_uid != os.geteuid():
+            raise RuntimeArtifactGCError("foreign_store_owner", f"{label} has a foreign owner")
+
+    def _ensure_audit_dirs(self) -> None:
+        try:
+            make_directories(self.receipt_dir, mode=0o700)
+            make_directories(self.transaction_dir, mode=0o700)
+        except RootedFilesystemError as exc:
+            raise RuntimeArtifactGCError(
+                "unsafe_audit_directory", "retention audit directories are unsafe"
+            ) from exc
+        self._assert_owned(self.receipt_dir, label="receipt directory", directory=True)
+        self._assert_owned(self.transaction_dir, label="transaction directory", directory=True)
+
+    def _read_store(self) -> tuple[list[dict[str, Any]], bytes]:
+        try:
+            if not path_exists(self.store_file):
+                return [], b"[]"
+            self._assert_owned(self.store_file, label="query artifact store")
+            payload = read_regular_bytes(self.store_file)
+            data = json.loads(payload.decode("utf-8"))
+        except (RootedFilesystemError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise RuntimeArtifactGCError(
+                "unsafe_store_entry", "query artifact store cannot be read safely"
+            ) from exc
+        if not isinstance(data, list):
+            raise RuntimeArtifactGCError("invalid_store_json", "query artifact store root must be a list")
+        seen: set[str] = set()
+        rendered: list[dict[str, Any]] = []
+        for index, entry in enumerate(data):
+            if not isinstance(entry, dict):
+                raise RuntimeArtifactGCError(
+                    "invalid_store_entry", f"query artifact entry {index} is not an object"
+                )
+            artifact_id = entry.get("id")
+            if not isinstance(artifact_id, str) or not artifact_id or artifact_id in seen:
+                raise RuntimeArtifactGCError(
+                    "invalid_store_entry", f"query artifact entry {index} has an invalid/duplicate id"
+                )
+            seen.add(artifact_id)
+            rendered.append(entry)
+        return rendered, payload
+
+    def _receipt_path(self, plan_sha256: str) -> Path:
+        return self.receipt_dir / f"{_plan_stem(plan_sha256)}.json"
+
+    def _transaction_path(self, plan_sha256: str) -> Path:
+        return self.transaction_dir / f"{_plan_stem(plan_sha256)}.json"
+
+    def _read_json(self, path: Path, *, label: str) -> Dict[str, Any]:
+        self._assert_owned(path, label=label)
+        try:
+            parsed = json.loads(read_regular_bytes(path).decode("utf-8"))
+        except (RootedFilesystemError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise RuntimeArtifactGCError("invalid_audit_record", f"invalid {label}") from exc
+        if not isinstance(parsed, dict):
+            raise RuntimeArtifactGCError("invalid_audit_record", f"{label} must be an object")
+        return parsed
+
+    def _verify_receipt(self, receipt: Dict[str, Any], plan_sha256: str) -> Dict[str, Any]:
+        digest = receipt.get("receipt_sha256")
+        body = copy.deepcopy(receipt)
+        body.pop("receipt_sha256", None)
+        if (
+            not isinstance(digest, str)
+            or sha256_json(body) != digest
+            or body.get("kind") != _RECEIPT_KIND
+            or body.get("plan_sha256") != plan_sha256
+        ):
+            raise RuntimeArtifactGCError("invalid_receipt", "retention receipt binding is invalid")
+        return receipt
+
+    def _verify_transaction(self, transaction: Dict[str, Any], plan_sha256: str) -> Dict[str, Any]:
+        digest = transaction.get("transaction_sha256")
+        body = copy.deepcopy(transaction)
+        body.pop("transaction_sha256", None)
+        if (
+            not isinstance(digest, str)
+            or sha256_json(body) != digest
+            or body.get("kind") != _TRANSACTION_KIND
+            or body.get("plan_sha256") != plan_sha256
+        ):
+            raise RuntimeArtifactGCError("invalid_transaction", "retention transaction binding is invalid")
+        return transaction
+
+    def assert_no_pending(self, *, allow_plan_sha256: Optional[str] = None) -> None:
+        """Block normal writes while an effect may lack its final receipt."""
+        self._ensure_audit_dirs()
+        try:
+            entries = sorted(self.transaction_dir.iterdir(), key=lambda item: item.name)
+        except OSError as exc:
+            raise RuntimeArtifactGCError(
+                "unsafe_audit_directory", "transaction directory cannot be enumerated"
+            ) from exc
+        for path in entries:
+            stem = path.stem
+            if (
+                path.suffix != ".json"
+                or len(stem) != 64
+                or any(character not in "0123456789abcdef" for character in stem)
+            ):
+                raise RuntimeArtifactGCError(
+                    "unsafe_audit_entry", f"unexpected transaction entry {path.name!r}"
+                )
+            receipt_path = self._receipt_path(stem)
+            if path_exists(receipt_path):
+                self._verify_receipt(
+                    self._read_json(receipt_path, label="retention receipt"), stem
+                )
+                continue
+            if stem == allow_plan_sha256:
+                continue
+            raise RuntimeArtifactGCError(
+                "retention_transaction_pending",
+                f"unfinished retention transaction {stem} must be recovered first",
+            )
+
+    def plan(
+        self,
+        *,
+        protection: Mapping[str, Any],
+        as_of: Optional[str] = None,
+        profile_id: str = MANUAL_GC_DEFAULT_PROFILE,
+    ) -> Dict[str, Any]:
+        try:
+            budgets = runtime_artifact_gc_profile(profile_id)
+        except ValueError as exc:
+            raise RuntimeArtifactGCError("unknown_profile", str(exc)) from exc
+        with exclusive_file_lock(self.lock_file, mode=0o600):
+            self.assert_no_pending()
+            entries, payload = self._read_store()
+            return build_retention_plan(
+                entries=entries,
+                store_sha256=sha256_bytes(payload),
+                protection=protection,
+                as_of=as_of or _utc_now_iso(),
+                profile_id=profile_id,
+                budgets=budgets,
+            )
+
+    def _receipt_response(
+        self,
+        receipt: Dict[str, Any],
+        *,
+        idempotent_replay: bool,
+        recovered_after_effect: bool,
+    ) -> Dict[str, Any]:
+        response = copy.deepcopy(receipt)
+        response["idempotent_replay"] = idempotent_replay
+        response["recovered_after_effect"] = recovered_after_effect
+        return response
+
+    def _finalize_receipt(
+        self,
+        transaction: Dict[str, Any],
+        *,
+        recovered_after_effect: bool,
+    ) -> Dict[str, Any]:
+        plan_sha256 = transaction["plan_sha256"]
+        path = self._receipt_path(plan_sha256)
+        if path_exists(path):
+            receipt = self._verify_receipt(self._read_json(path, label="retention receipt"), plan_sha256)
+            return self._receipt_response(
+                receipt, idempotent_replay=True, recovered_after_effect=recovered_after_effect
+            )
+        body = copy.deepcopy(transaction["receipt_body"])
+        receipt = {**body, "receipt_sha256": sha256_json(body)}
+        try:
+            exclusive_write_bytes(path, (canonical_json(receipt) + "\n").encode(), mode=0o600)
+        except RootedFilesystemError as exc:
+            if path_exists(path):
+                receipt = self._verify_receipt(
+                    self._read_json(path, label="retention receipt"), plan_sha256
+                )
+                return self._receipt_response(
+                    receipt, idempotent_replay=True, recovered_after_effect=recovered_after_effect
+                )
+            raise RuntimeArtifactGCError("receipt_write_failed", "retention receipt write failed") from exc
+        return self._receipt_response(
+            receipt,
+            idempotent_replay=recovered_after_effect,
+            recovered_after_effect=recovered_after_effect,
+        )
+
+    def _existing_receipt(self, plan_sha256: str) -> Optional[Dict[str, Any]]:
+        path = self._receipt_path(plan_sha256)
+        if not path_exists(path):
+            return None
+        receipt = self._verify_receipt(
+            self._read_json(path, label="retention receipt"), plan_sha256
+        )
+        return self._receipt_response(
+            receipt, idempotent_replay=True, recovered_after_effect=False
+        )
+
+    def _recover_transaction(
+        self, plan_sha256: str, current_sha256: str
+    ) -> Optional[Dict[str, Any]]:
+        path = self._transaction_path(plan_sha256)
+        if not path_exists(path):
+            return None
+        transaction = self._verify_transaction(
+            self._read_json(path, label="retention transaction"), plan_sha256
+        )
+        if current_sha256 == transaction["post_store_sha256"]:
+            return self._finalize_receipt(transaction, recovered_after_effect=True)
+        if current_sha256 != transaction["pre_store_sha256"]:
+            raise RuntimeArtifactGCError(
+                "transaction_state_ambiguous",
+                "store matches neither transaction pre-image nor post-image",
+            )
+        return None
+
+    def _current_protection(
+        self,
+        *,
+        verified: Mapping[str, Any],
+        entries: list[dict[str, Any]],
+        current_sha256: str,
+        protection: Mapping[str, Any],
+    ) -> tuple[Dict[str, Any], set[str]]:
+        current_plan = build_retention_plan(
+            entries=entries,
+            store_sha256=current_sha256,
+            protection=protection,
+            as_of=verified["as_of"],
+            profile_id=verified["profile_id"],
+            budgets=verified["budgets"],
+        )
+        planned = {row["artifact_id"] for row in verified.get("protected", [])}
+        current = {row["artifact_id"] for row in current_plan.get("protected", [])}
+        if not planned.issubset(current):
+            raise RuntimeArtifactGCError(
+                "protection_weakened",
+                f"apply removed protected artifacts: {sorted(planned-current)}",
+            )
+        return current_plan, current
+
+    def _validated_candidates(
+        self,
+        *,
+        verified: Mapping[str, Any],
+        entries: list[dict[str, Any]],
+    ) -> tuple[Dict[str, Dict[str, Any]], Dict[str, Dict[str, Any]]]:
+        candidates = {row["artifact_id"]: row for row in verified.get("candidates", [])}
+        index = {entry["id"]: entry for entry in entries}
+        for artifact_id, candidate in candidates.items():
+            current = index.get(artifact_id)
+            if current is None or sha256_json(current) != candidate.get("entry_sha256"):
+                raise RuntimeArtifactGCError(
+                    "candidate_identity_changed", f"candidate {artifact_id!r} changed"
+                )
+        return candidates, index
+
+    def _prepared_transaction(
+        self,
+        *,
+        verified: Mapping[str, Any],
+        plan_sha256: str,
+        entries: list[dict[str, Any]],
+        current_bytes: bytes,
+        current_sha256: str,
+        current_plan: Mapping[str, Any],
+        current_protected: set[str],
+        candidates: Mapping[str, Mapping[str, Any]],
+        index: Mapping[str, Mapping[str, Any]],
+    ) -> tuple[Dict[str, Any], bytes, str, list[str], list[str]]:
+        delete_ids = sorted(set(candidates) - current_protected)
+        skipped = sorted(set(candidates) & current_protected)
+        post_entries = [
+            entry for entry in entries if entry["id"] not in set(delete_ids)
+        ]
+        post_bytes = (
+            json.dumps(post_entries, indent=2).encode() if delete_ids else current_bytes
+        )
+        post_sha256 = sha256_bytes(post_bytes)
+        protected_readback = sorted(current_protected & set(index))
+        receipt_body = {
+            "kind": _RECEIPT_KIND,
+            "schema_version": _SCHEMA_VERSION,
+            "status": "applied",
+            "plan_sha256": plan_sha256,
+            "profile_id": verified["profile_id"],
+            "applied_at": _utc_now_iso(),
+            "pre_store_sha256": current_sha256,
+            "post_store_sha256": post_sha256,
+            "protection_sha256": current_plan["protection_sha256"],
+            "deleted": {
+                "objects": len(delete_ids),
+                "bytes": max(0, len(current_bytes) - len(post_bytes)),
+            },
+            "skipped_newly_protected": skipped,
+            "effects": [
+                {
+                    "artifact_id": artifact_id,
+                    "artifact_type": candidates[artifact_id]["artifact_type"],
+                    "entry_sha256": candidates[artifact_id]["entry_sha256"],
+                    "reasons": list(candidates[artifact_id]["reasons"]),
+                }
+                for artifact_id in delete_ids
+            ],
+            "protected_readback": protected_readback,
+            "integrity_readback": {
+                "store_json_valid": True,
+                "post_store_sha256": post_sha256,
+                "protected_artifacts_readable": protected_readback,
+            },
+        }
+        transaction_body = {
+            "kind": _TRANSACTION_KIND,
+            "schema_version": _SCHEMA_VERSION,
+            "plan_sha256": plan_sha256,
+            "prepared_at": _utc_now_iso(),
+            "pre_store_sha256": current_sha256,
+            "post_store_sha256": post_sha256,
+            "delete_ids": delete_ids,
+            "receipt_body": receipt_body,
+        }
+        transaction = {
+            **transaction_body,
+            "transaction_sha256": sha256_json(transaction_body),
+        }
+        return transaction, post_bytes, post_sha256, delete_ids, protected_readback
+
+    def _write_effect(
+        self,
+        *,
+        plan_sha256: str,
+        transaction: Mapping[str, Any],
+        post_bytes: bytes,
+        delete_ids: list[str],
+    ) -> None:
+        try:
+            atomic_write_bytes(
+                self._transaction_path(plan_sha256),
+                (canonical_json(transaction) + "\n").encode(),
+                mode=0o600,
+            )
+            if delete_ids:
+                self._assert_owned(self.store_file, label="query artifact store")
+                atomic_write_bytes(self.store_file, post_bytes, mode=0o600)
+        except RootedFilesystemError as exc:
+            raise RuntimeArtifactGCError(
+                "gc_effect_failed", "manual GC effect write failed"
+            ) from exc
+
+    def _verify_effect_readback(
+        self, *, post_sha256: str, protected_readback: list[str]
+    ) -> None:
+        readback_entries, readback_bytes = self._read_store()
+        if sha256_bytes(readback_bytes) != post_sha256:
+            raise RuntimeArtifactGCError(
+                "post_apply_integrity_failed",
+                "store readback differs from expected post-image",
+            )
+        readback_ids = {entry["id"] for entry in readback_entries}
+        missing = sorted(set(protected_readback) - readback_ids)
+        if missing:
+            raise RuntimeArtifactGCError(
+                "post_apply_protection_failed",
+                f"protected artifacts disappeared: {missing}",
+            )
+
+    def apply(
+        self,
+        *,
+        plan: Mapping[str, Any],
+        protection: Mapping[str, Any],
+    ) -> Dict[str, Any]:
+        verified = verify_retention_plan(plan)
+        plan_sha256 = verified["plan_sha256"]
+        with exclusive_file_lock(self.lock_file, mode=0o600):
+            self.assert_no_pending(allow_plan_sha256=plan_sha256)
+            existing = self._existing_receipt(plan_sha256)
+            if existing is not None:
+                return existing
+            entries, current_bytes = self._read_store()
+            current_sha256 = sha256_bytes(current_bytes)
+            recovered = self._recover_transaction(plan_sha256, current_sha256)
+            if recovered is not None:
+                return recovered
+            if current_sha256 != verified["store_sha256"]:
+                raise RuntimeArtifactGCError(
+                    "store_snapshot_changed",
+                    "store changed after dry-run; create a fresh plan",
+                )
+            current_plan, current_protected = self._current_protection(
+                verified=verified,
+                entries=entries,
+                current_sha256=current_sha256,
+                protection=protection,
+            )
+            candidates, index = self._validated_candidates(
+                verified=verified, entries=entries
+            )
+            transaction, post_bytes, post_sha256, delete_ids, protected_readback = (
+                self._prepared_transaction(
+                    verified=verified,
+                    plan_sha256=plan_sha256,
+                    entries=entries,
+                    current_bytes=current_bytes,
+                    current_sha256=current_sha256,
+                    current_plan=current_plan,
+                    current_protected=current_protected,
+                    candidates=candidates,
+                    index=index,
+                )
+            )
+            self._write_effect(
+                plan_sha256=plan_sha256,
+                transaction=transaction,
+                post_bytes=post_bytes,
+                delete_ids=delete_ids,
+            )
+            self._verify_effect_readback(
+                post_sha256=post_sha256,
+                protected_readback=protected_readback,
+            )
+            return self._finalize_receipt(
+                transaction, recovered_after_effect=False
+            )

--- a/merger/repoground/service/runtime_artifact_gc_support.py
+++ b/merger/repoground/service/runtime_artifact_gc_support.py
@@ -1,0 +1,240 @@
+"""Validation and protection helpers for manual runtime-artifact GC."""
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, Mapping, Sequence
+
+from .runtime_artifact_retention import RUNTIME_ARTIFACT_TYPES
+
+GC_PLAN_KIND = "lenskit.runtime_artifact_gc_plan"
+GC_PLAN_VERSION = 1
+GC_PROTECTION_KIND = "lenskit.runtime_artifact_gc_protection"
+GC_PROTECTION_VERSION = 1
+
+_REFERENCE_STATES = frozenset({"complete", "unknown"})
+_EXTERNAL_REFERENCE_STATES = frozenset({"nonterminal", "terminal", "unknown"})
+
+
+class RuntimeArtifactGCError(ValueError):
+    """Fail-closed manual-GC planning or verification error."""
+
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        super().__init__(f"{code}: {message}")
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def sha256_json(value: Any) -> str:
+    return hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def parse_aware_datetime(value: Any, *, label: str) -> datetime:
+    if not isinstance(value, str) or not value:
+        raise RuntimeArtifactGCError("invalid_timestamp", f"{label} must be an ISO-8601 string")
+    candidate = f"{value[:-1]}+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(candidate)
+    except ValueError as exc:
+        raise RuntimeArtifactGCError("invalid_timestamp", f"{label} is not valid ISO-8601") from exc
+    if parsed.tzinfo is None:
+        raise RuntimeArtifactGCError("invalid_timestamp", f"{label} must include a timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def iso_z(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _string_list(value: Any, *, label: str) -> list[str]:
+    if not isinstance(value, list) or any(not isinstance(item, str) or not item for item in value):
+        raise RuntimeArtifactGCError("invalid_protection", f"{label} must be a list of non-empty strings")
+    if len(value) != len(set(value)):
+        raise RuntimeArtifactGCError("invalid_protection", f"{label} contains duplicates")
+    return sorted(value)
+
+
+def _normalize_external_reference(raw: Any, *, index: int) -> dict[str, str]:
+    if not isinstance(raw, Mapping):
+        raise RuntimeArtifactGCError(
+            "invalid_protection", f"external_references[{index}] must be an object"
+        )
+    fields = {name: raw.get(name) for name in ("artifact_id", "kind", "state", "reference")}
+    if not all(isinstance(item, str) and item for item in fields.values()):
+        raise RuntimeArtifactGCError(
+            "invalid_protection",
+            f"external_references[{index}] fields must be non-empty strings",
+        )
+    state = fields["state"]
+    if state not in _EXTERNAL_REFERENCE_STATES:
+        raise RuntimeArtifactGCError(
+            "invalid_protection", f"external_references[{index}].state is unsupported"
+        )
+    if state == "unknown":
+        raise RuntimeArtifactGCError(
+            "reference_state_unknown",
+            f"external reference {fields['reference']!r} has unknown terminality",
+        )
+    return {name: str(value) for name, value in fields.items()}
+
+
+def _normalize_external_references(value: Any) -> list[dict[str, str]]:
+    if not isinstance(value, list):
+        raise RuntimeArtifactGCError("invalid_protection", "external_references must be a list")
+    external = [_normalize_external_reference(raw, index=index) for index, raw in enumerate(value)]
+    keys = [(item["artifact_id"], item["kind"], item["reference"]) for item in external]
+    if len(keys) != len(set(keys)):
+        raise RuntimeArtifactGCError("invalid_protection", "duplicate external reference")
+    return sorted(external, key=lambda item: (item["artifact_id"], item["kind"], item["reference"]))
+
+
+def normalize_protection(protection: Mapping[str, Any]) -> Dict[str, Any]:
+    """Validate and canonicalise one complete protection-evidence document."""
+    if not isinstance(protection, Mapping):
+        raise RuntimeArtifactGCError("invalid_protection", "protection must be an object")
+    if protection.get("schema_version") != GC_PROTECTION_VERSION:
+        raise RuntimeArtifactGCError("invalid_protection", "unsupported protection schema_version")
+    reference_state = protection.get("reference_state")
+    if reference_state not in _REFERENCE_STATES:
+        raise RuntimeArtifactGCError("invalid_protection", "reference_state must be complete or unknown")
+    if reference_state != "complete":
+        raise RuntimeArtifactGCError(
+            "reference_state_unknown",
+            "manual GC requires complete reference evidence; unknown state blocks planning/apply",
+        )
+    return {
+        "schema_version": GC_PROTECTION_VERSION,
+        "kind": GC_PROTECTION_KIND,
+        "reference_state": "complete",
+        "active_session_ids": _string_list(
+            protection.get("active_session_ids", []), label="active_session_ids"
+        ),
+        "pinned_artifact_ids": _string_list(
+            protection.get("pinned_artifact_ids", []), label="pinned_artifact_ids"
+        ),
+        "external_references": _normalize_external_references(
+            protection.get("external_references", [])
+        ),
+    }
+
+
+def entry_index(entries: Sequence[Mapping[str, Any]]) -> dict[str, Mapping[str, Any]]:
+    index: dict[str, Mapping[str, Any]] = {}
+    for entry in entries:
+        artifact_id = entry.get("id") if isinstance(entry, Mapping) else None
+        if not isinstance(artifact_id, str) or not artifact_id:
+            raise RuntimeArtifactGCError("invalid_store_entry", "every artifact entry requires a non-empty id")
+        if artifact_id in index:
+            raise RuntimeArtifactGCError("duplicate_artifact_id", f"duplicate artifact id {artifact_id!r}")
+        index[artifact_id] = entry
+    return index
+
+
+def _protect(reasons: Dict[str, set[str]], index: Mapping[str, Any], artifact_id: str, reason: str) -> None:
+    if artifact_id in index:
+        reasons.setdefault(artifact_id, set()).add(reason)
+
+
+def _session_reference_ids(
+    session_id: str,
+    session: Mapping[str, Any],
+    index: Mapping[str, Any],
+) -> list[tuple[str, str]]:
+    data = session.get("data")
+    refs = data.get("artifact_refs") if isinstance(data, Mapping) else None
+    if refs is None:
+        refs = {}
+    if not isinstance(refs, Mapping):
+        raise RuntimeArtifactGCError(
+            "active_session_reference_invalid",
+            f"active session {session_id!r} artifact_refs is not an object",
+        )
+    resolved: list[tuple[str, str]] = []
+    for field in ("query_trace_id", "context_bundle_id"):
+        referenced = refs.get(field)
+        if referenced is None:
+            continue
+        if not isinstance(referenced, str) or not referenced:
+            raise RuntimeArtifactGCError(
+                "active_session_reference_invalid",
+                f"active session {session_id!r} has invalid {field}",
+            )
+        if referenced not in index:
+            raise RuntimeArtifactGCError(
+                "active_session_reference_missing",
+                f"active session {session_id!r} references missing artifact {referenced!r}",
+            )
+        resolved.append((field, referenced))
+    return resolved
+
+
+def _protect_active_session(
+    session_id: str,
+    *,
+    index: Mapping[str, Mapping[str, Any]],
+    reasons: Dict[str, set[str]],
+) -> None:
+    session = index.get(session_id)
+    if session is None:
+        raise RuntimeArtifactGCError(
+            "active_session_missing", f"active session artifact {session_id!r} is absent"
+        )
+    if session.get("artifact_type") != "agent_query_session":
+        raise RuntimeArtifactGCError(
+            "active_session_type_mismatch",
+            f"active session {session_id!r} is not an agent_query_session",
+        )
+    _protect(reasons, index, session_id, "active_session")
+    for field, referenced in _session_reference_ids(session_id, session, index):
+        _protect(reasons, index, referenced, f"active_session_ref:{session_id}:{field}")
+
+
+def protected_artifacts(
+    entries: Sequence[Mapping[str, Any]], protection: Mapping[str, Any]
+) -> tuple[Dict[str, list[str]], Dict[str, Any]]:
+    """Return protected artifact IDs/reasons and canonical protection evidence."""
+    canonical = normalize_protection(protection)
+    index = entry_index(entries)
+    reasons: Dict[str, set[str]] = {}
+    for artifact_id in canonical["pinned_artifact_ids"]:
+        _protect(reasons, index, artifact_id, "pin")
+    for ref in canonical["external_references"]:
+        if ref["state"] == "nonterminal":
+            _protect(reasons, index, ref["artifact_id"], f"external:{ref['kind']}:{ref['reference']}")
+    for session_id in canonical["active_session_ids"]:
+        _protect_active_session(session_id, index=index, reasons=reasons)
+    return (
+        {artifact_id: sorted(values) for artifact_id, values in sorted(reasons.items())},
+        canonical,
+    )
+
+
+def validated_budgets(budgets: Mapping[str, Any]) -> Dict[str, Dict[str, int]]:
+    if not isinstance(budgets, Mapping) or set(budgets) != set(RUNTIME_ARTIFACT_TYPES):
+        raise RuntimeArtifactGCError("invalid_budgets", "budgets must cover every runtime artifact type")
+    result: Dict[str, Dict[str, int]] = {}
+    expected = {"max_age_seconds", "max_count", "max_bytes"}
+    for artifact_type in RUNTIME_ARTIFACT_TYPES:
+        raw = budgets.get(artifact_type)
+        if not isinstance(raw, Mapping) or set(raw) != expected:
+            raise RuntimeArtifactGCError(
+                "invalid_budgets", f"budget for {artifact_type} must contain {sorted(expected)}"
+            )
+        rendered: Dict[str, int] = {}
+        for field in sorted(expected):
+            value = raw.get(field)
+            if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+                raise RuntimeArtifactGCError(
+                    "invalid_budgets", f"{artifact_type}.{field} must be a positive integer"
+                )
+            rendered[field] = value
+        result[artifact_type] = rendered
+    return result

--- a/merger/repoground/service/runtime_artifact_retention.py
+++ b/merger/repoground/service/runtime_artifact_retention.py
@@ -1,8 +1,9 @@
 """Machine-readable retention policy for query runtime artifacts.
 
-This module is deliberately policy-only. It does not delete artifacts, schedule
-GC, mutate stores, or assign TTLs. The current explicit policy is
-``unbounded_currently`` for all query runtime artifacts.
+Per-artifact lookup metadata remains deliberately TTL-free and unbounded: no
+artifact expires merely because time passes and lookup never deletes. T018
+adds a separate *manual* plan/apply GC policy with conservative storage
+budgets. The manual policy has no scheduler and no automatic effect.
 """
 from __future__ import annotations
 
@@ -12,6 +13,8 @@ from typing import Any, Dict
 RETENTION_POLICY_KIND = "lenskit.runtime_artifact_retention_policy"
 RETENTION_POLICY_VERSION = "v1"
 RETENTION_POLICY_ID = "runtime-artifact-retention.v1"
+MANUAL_GC_POLICY_ID = "runtime-artifact-manual-gc.v1"
+MANUAL_GC_DEFAULT_PROFILE = "conservative"
 
 RUNTIME_ARTIFACT_TYPES: tuple[str, ...] = (
     "query_trace",
@@ -21,6 +24,29 @@ RUNTIME_ARTIFACT_TYPES: tuple[str, ...] = (
 
 RETENTION_STATE_UNBOUNDED = "unbounded_currently"
 LIFECYCLE_STATUS_ACTIVE = "active"
+
+# These are soft planning budgets, not TTLs. Crossing one or more limits only
+# makes an unprotected artifact a candidate in an explicit dry-run plan.
+# No automatic process consumes these values.
+_MANUAL_GC_PROFILES: Dict[str, Dict[str, Dict[str, int]]] = {
+    "conservative": {
+        "query_trace": {
+            "max_age_seconds": 90 * 24 * 60 * 60,
+            "max_count": 25_000,
+            "max_bytes": 512 * 1024 * 1024,
+        },
+        "context_bundle": {
+            "max_age_seconds": 90 * 24 * 60 * 60,
+            "max_count": 10_000,
+            "max_bytes": 2 * 1024 * 1024 * 1024,
+        },
+        "agent_query_session": {
+            "max_age_seconds": 180 * 24 * 60 * 60,
+            "max_count": 25_000,
+            "max_bytes": 512 * 1024 * 1024,
+        },
+    }
+}
 
 DOES_NOT_ESTABLISH: tuple[str, ...] = (
     "ttl_is_active",
@@ -107,11 +133,23 @@ def runtime_artifact_metadata_for(artifact_type: str) -> Dict[str, Any]:
         raise ValueError(f"unknown runtime artifact type: {artifact_type!r}") from exc
 
 
-def runtime_artifact_retention_policy() -> Dict[str, Any]:
-    """Return the current machine-readable retention policy.
+def runtime_artifact_gc_profile(
+    profile_id: str = MANUAL_GC_DEFAULT_PROFILE,
+) -> Dict[str, Dict[str, int]]:
+    """Return one named manual-GC budget profile as an independent copy."""
+    try:
+        return copy.deepcopy(_MANUAL_GC_PROFILES[profile_id])
+    except KeyError as exc:
+        raise ValueError(f"unknown runtime artifact GC profile: {profile_id!r}") from exc
 
-    The policy explicitly defers TTL/GC/deletion behaviour. It is a diagnostic
-    and contract surface, not a cleanup engine.
+
+def runtime_artifact_retention_policy() -> Dict[str, Any]:
+    """Return the machine-readable retention and manual-GC policy.
+
+    The established lookup policy remains unchanged: TTL/automatic GC/deletion
+    are deferred. T018 adds a separate manual operator path that requires a
+    deterministic dry-run and an exact plan-hash-bound apply with fresh
+    protection evidence.
     """
     return {
         "kind": RETENTION_POLICY_KIND,
@@ -130,7 +168,23 @@ def runtime_artifact_retention_policy() -> Dict[str, Any]:
             "mode": "not_implemented",
             "automatic_delete": False,
             "requires_explicit_future_policy": True,
-            "rationale": "No automatic or manual GC entrypoint is implemented by this policy slice.",
+            "rationale": "No automatic GC entrypoint is enabled by this policy slice.",
+        },
+        "manual_gc": {
+            "policy_id": MANUAL_GC_POLICY_ID,
+            "enabled": True,
+            "mode": "explicit_plan_hash_bound_apply",
+            "automatic_delete": False,
+            "default_profile": MANUAL_GC_DEFAULT_PROFILE,
+            "profiles": copy.deepcopy(_MANUAL_GC_PROFILES),
+            "reference_state_required": "complete",
+            "unknown_reference_state_blocks": True,
+            "apply_requires_fresh_protection": True,
+            "receipts_required": True,
+            "rationale": (
+                "Budgets create reviewable candidates only; active sessions, pins and "
+                "nonterminal external evidence remain protected."
+            ),
         },
         "no_surprise_delete": {
             "existing_artifacts_deleted_by_this_policy": False,

--- a/merger/repoground/tests/test_runtime_artifact_gc.py
+++ b/merger/repoground/tests/test_runtime_artifact_gc.py
@@ -1,0 +1,429 @@
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from merger.repoground.service.query_artifact_store import QueryArtifactStore
+from merger.repoground.service.runtime_artifact_gc import (
+    RuntimeArtifactGCError,
+    build_retention_plan,
+)
+from merger.repoground.service.runtime_artifact_retention import (
+    MANUAL_GC_DEFAULT_PROFILE,
+    RUNTIME_ARTIFACT_TYPES,
+    runtime_artifact_gc_profile,
+    runtime_artifact_retention_policy,
+)
+
+
+def _entry(
+    artifact_id: str,
+    artifact_type: str,
+    created_at: str,
+    *,
+    artifact_refs=None,
+    payload_size: int = 0,
+):
+    data = {"payload": "x" * payload_size}
+    if artifact_type == "agent_query_session":
+        data["artifact_refs"] = artifact_refs or {}
+    return {
+        "id": artifact_id,
+        "artifact_type": artifact_type,
+        "data": data,
+        "provenance": {"source_query": "q", "timestamp": created_at, "run_id": "run-1"},
+        "created_at": created_at,
+        "retention_policy": "unbounded_currently",
+    }
+
+
+def _protection(*, active=(), pins=(), external=(), reference_state="complete"):
+    return {
+        "schema_version": 1,
+        "reference_state": reference_state,
+        "active_session_ids": list(active),
+        "pinned_artifact_ids": list(pins),
+        "external_references": list(external),
+    }
+
+
+def _tiny_budgets():
+    return {
+        artifact_type: {
+            "max_age_seconds": 10,
+            "max_count": 1,
+            "max_bytes": 450,
+        }
+        for artifact_type in RUNTIME_ARTIFACT_TYPES
+    }
+
+
+def _write_store(storage_dir: Path, entries) -> QueryArtifactStore:
+    storage_dir.mkdir(parents=True, exist_ok=True)
+    (storage_dir / "query_artifacts.json").write_text(json.dumps(entries, indent=2), encoding="utf-8")
+    return QueryArtifactStore(storage_dir)
+
+
+def test_policy_exposes_manual_budget_profile_without_automatic_delete():
+    policy = runtime_artifact_retention_policy()
+    manual = policy["manual_gc"]
+
+    assert policy["default_retention_policy"] == "unbounded_currently"
+    assert policy["ttl"]["enabled"] is False
+    assert policy["gc"]["automatic_delete"] is False
+    assert manual["enabled"] is True
+    assert manual["automatic_delete"] is False
+    assert manual["mode"] == "explicit_plan_hash_bound_apply"
+    assert manual["default_profile"] == MANUAL_GC_DEFAULT_PROFILE
+    assert manual["unknown_reference_state_blocks"] is True
+    assert set(manual["profiles"][MANUAL_GC_DEFAULT_PROFILE]) == set(RUNTIME_ARTIFACT_TYPES)
+    for budget in runtime_artifact_gc_profile().values():
+        assert set(budget) == {"max_age_seconds", "max_count", "max_bytes"}
+        assert all(value > 0 for value in budget.values())
+
+
+def test_plan_is_deterministic_and_records_age_count_and_bytes_reasons():
+    entries = [
+        _entry("qart-a", "query_trace", "2025-01-01T00:00:00Z", payload_size=300),
+        _entry("qart-b", "query_trace", "2025-01-02T00:00:00Z", payload_size=300),
+        _entry("qart-c", "query_trace", "2025-01-03T00:00:00Z", payload_size=300),
+    ]
+    kwargs = dict(
+        entries=entries,
+        store_sha256="a" * 64,
+        protection=_protection(),
+        as_of="2026-01-01T00:00:00Z",
+        profile_id="test",
+        budgets=_tiny_budgets(),
+    )
+
+    first = build_retention_plan(**kwargs)
+    second = build_retention_plan(**kwargs)
+
+    assert first == second
+    assert first["plan_sha256"] == second["plan_sha256"]
+    assert first["automatic_delete"] is False
+    assert first["requires_explicit_apply"] is True
+    assert first["expected_release"]["objects"] == 3
+    all_reasons = {reason for candidate in first["candidates"] for reason in candidate["reasons"]}
+    assert "age_budget" in all_reasons
+    assert "count_budget" in all_reasons or "bytes_budget" in all_reasons
+
+
+def test_active_session_protects_itself_and_referenced_artifacts():
+    entries = [
+        _entry("qart-trace", "query_trace", "2020-01-01T00:00:00Z"),
+        _entry("qart-bundle", "context_bundle", "2020-01-01T00:00:00Z"),
+        _entry(
+            "qart-session",
+            "agent_query_session",
+            "2020-01-01T00:00:00Z",
+            artifact_refs={
+                "query_trace_id": "qart-trace",
+                "context_bundle_id": "qart-bundle",
+            },
+        ),
+    ]
+    plan = build_retention_plan(
+        entries=entries,
+        store_sha256="b" * 64,
+        protection=_protection(active=("qart-session",)),
+        as_of="2026-01-01T00:00:00Z",
+        profile_id="test",
+        budgets=_tiny_budgets(),
+    )
+
+    assert plan["candidates"] == []
+    protected = {row["artifact_id"]: row["reasons"] for row in plan["protected"]}
+    assert "active_session" in protected["qart-session"]
+    assert any(reason.startswith("active_session_ref:qart-session") for reason in protected["qart-trace"])
+    assert any(reason.startswith("active_session_ref:qart-session") for reason in protected["qart-bundle"])
+
+
+def test_pin_and_nonterminal_external_reference_are_protected():
+    entries = [
+        _entry("qart-pin", "query_trace", "2020-01-01T00:00:00Z"),
+        _entry("qart-pr", "context_bundle", "2020-01-01T00:00:00Z"),
+    ]
+    plan = build_retention_plan(
+        entries=entries,
+        store_sha256="c" * 64,
+        protection=_protection(
+            pins=("qart-pin",),
+            external=(
+                {
+                    "artifact_id": "qart-pr",
+                    "kind": "pull_request",
+                    "state": "nonterminal",
+                    "reference": "heimgewebe/repoground#123",
+                },
+            ),
+        ),
+        as_of="2026-01-01T00:00:00Z",
+        profile_id="test",
+        budgets=_tiny_budgets(),
+    )
+
+    assert plan["candidates"] == []
+    protected = {row["artifact_id"] for row in plan["protected"]}
+    assert protected == {"qart-pin", "qart-pr"}
+
+
+def test_unknown_reference_state_blocks_plan():
+    with pytest.raises(RuntimeArtifactGCError) as excinfo:
+        build_retention_plan(
+            entries=[_entry("qart-a", "query_trace", "2020-01-01T00:00:00Z")],
+            store_sha256="d" * 64,
+            protection=_protection(reference_state="unknown"),
+            as_of="2026-01-01T00:00:00Z",
+            profile_id="test",
+            budgets=_tiny_budgets(),
+        )
+    assert excinfo.value.code == "reference_state_unknown"
+
+
+def test_unknown_created_at_is_protected_not_deleted():
+    entry = _entry("qart-a", "query_trace", "2020-01-01T00:00:00Z")
+    entry["created_at"] = "not-a-date"
+    plan = build_retention_plan(
+        entries=[entry],
+        store_sha256="e" * 64,
+        protection=_protection(),
+        as_of="2026-01-01T00:00:00Z",
+        profile_id="test",
+        budgets=_tiny_budgets(),
+    )
+    assert plan["candidates"] == []
+    assert plan["protected"] == [{"artifact_id": "qart-a", "reasons": ["created_at_unknown"]}]
+
+
+def test_store_apply_rejects_tampered_plan_hash(tmp_path):
+    store = _write_store(
+        tmp_path,
+        [_entry("qart-a", "query_trace", "2020-01-01T00:00:00Z")],
+    )
+    plan = store.retention_plan(
+        protection=_protection(),
+        as_of="2026-01-01T00:00:00Z",
+    )
+    plan["expected_release"]["objects"] += 1
+
+    with pytest.raises(RuntimeArtifactGCError) as excinfo:
+        store.apply_retention(plan=plan, protection=_protection())
+    assert excinfo.value.code == "plan_hash_mismatch"
+
+
+def test_store_apply_rejects_changed_snapshot(tmp_path):
+    store = _write_store(
+        tmp_path,
+        [_entry("qart-old", "query_trace", "2020-01-01T00:00:00Z")],
+    )
+    plan = store.retention_plan(
+        protection=_protection(),
+        as_of="2026-01-01T00:00:00Z",
+    )
+    other = QueryArtifactStore(tmp_path)
+    other.store(
+        "query_trace",
+        {"new": True},
+        {"source_query": "q", "timestamp": "2026-01-01T00:00:00Z"},
+    )
+
+    with pytest.raises(RuntimeArtifactGCError) as excinfo:
+        store.apply_retention(plan=plan, protection=_protection())
+    assert excinfo.value.code == "store_snapshot_changed"
+
+
+def test_new_pin_between_plan_and_apply_skips_candidate_and_receipt_is_idempotent(tmp_path):
+    store = _write_store(
+        tmp_path,
+        [_entry("qart-old", "query_trace", "2020-01-01T00:00:00Z")],
+    )
+    plan = store.retention_plan(
+        protection=_protection(),
+        as_of="2026-01-01T00:00:00Z",
+    )
+
+    receipt = store.apply_retention(
+        plan=plan,
+        protection=_protection(pins=("qart-old",)),
+    )
+    assert receipt["status"] == "applied"
+    assert receipt["deleted"]["objects"] == 0
+    assert receipt["skipped_newly_protected"] == ["qart-old"]
+    assert store.get("qart-old") is not None
+
+    replay = store.apply_retention(
+        plan=plan,
+        protection=_protection(pins=("qart-old",)),
+    )
+    assert replay["receipt_sha256"] == receipt["receipt_sha256"]
+    assert replay["idempotent_replay"] is True
+
+
+def test_apply_deletes_candidate_and_other_store_instance_observes_change(tmp_path):
+    store = _write_store(
+        tmp_path,
+        [_entry("qart-old", "query_trace", "2020-01-01T00:00:00Z")],
+    )
+    stale_reader = QueryArtifactStore(tmp_path)
+    plan = store.retention_plan(
+        protection=_protection(),
+        as_of="2026-01-01T00:00:00Z",
+    )
+
+    receipt = store.apply_retention(plan=plan, protection=_protection())
+
+    assert receipt["deleted"]["objects"] == 1
+    assert receipt["deleted"]["bytes"] > 0
+    assert receipt["integrity_readback"]["post_store_sha256"]
+    assert store.get("qart-old") is None
+    assert stale_reader.get("qart-old") is None
+
+    replay = store.apply_retention(plan=plan, protection=_protection())
+    assert replay["idempotent_replay"] is True
+    assert replay["receipt_sha256"] == receipt["receipt_sha256"]
+
+
+def test_apply_recovers_receipt_when_effect_completed_before_receipt(tmp_path):
+    store = _write_store(
+        tmp_path,
+        [_entry("qart-old", "query_trace", "2020-01-01T00:00:00Z")],
+    )
+    plan = store.retention_plan(
+        protection=_protection(),
+        as_of="2026-01-01T00:00:00Z",
+    )
+    receipt = store.apply_retention(plan=plan, protection=_protection())
+    receipt_path = tmp_path / "retention-receipts" / f"{plan['plan_sha256']}.json"
+    receipt_path.unlink()
+
+    recovered = store.apply_retention(plan=plan, protection=_protection())
+
+    assert recovered["receipt_sha256"] == receipt["receipt_sha256"]
+    assert recovered["recovered_after_effect"] is True
+    assert receipt_path.exists()
+
+
+def test_symlink_store_is_rejected_fail_closed(tmp_path):
+    outside = tmp_path / "outside.json"
+    outside.write_text("[]", encoding="utf-8")
+    storage = tmp_path / "store"
+    storage.mkdir()
+    (storage / "query_artifacts.json").symlink_to(outside)
+    store = QueryArtifactStore(storage)
+
+    with pytest.raises(RuntimeArtifactGCError) as excinfo:
+        store.retention_plan(
+            protection=_protection(),
+            as_of="2026-01-01T00:00:00Z",
+        )
+    assert excinfo.value.code == "unsafe_store_entry"
+
+
+def test_stale_writer_reloads_disk_before_store_and_does_not_resurrect_gc_entries(tmp_path):
+    store = _write_store(
+        tmp_path,
+        [_entry("qart-old", "query_trace", "2020-01-01T00:00:00Z")],
+    )
+    stale_writer = QueryArtifactStore(tmp_path)
+    plan = store.retention_plan(
+        protection=_protection(),
+        as_of="2026-01-01T00:00:00Z",
+    )
+    store.apply_retention(plan=plan, protection=_protection())
+
+    new_id = stale_writer.store(
+        "query_trace",
+        {"new": True},
+        {"source_query": "q", "timestamp": "2026-01-01T00:00:00Z"},
+    )
+
+    assert stale_writer.get("qart-old") is None
+    assert stale_writer.get(new_id) is not None
+    ids = {
+        entry["id"]
+        for entry in json.loads((tmp_path / "query_artifacts.json").read_text(encoding="utf-8"))
+    }
+    assert "qart-old" not in ids
+    assert new_id in ids
+
+
+def test_pending_gc_transaction_blocks_normal_store_until_receipt_recovery(tmp_path):
+    store = _write_store(
+        tmp_path,
+        [_entry("qart-old", "query_trace", "2020-01-01T00:00:00Z")],
+    )
+    plan = store.retention_plan(
+        protection=_protection(),
+        as_of="2026-01-01T00:00:00Z",
+    )
+    store.apply_retention(plan=plan, protection=_protection())
+    receipt_path = tmp_path / "retention-receipts" / f"{plan['plan_sha256']}.json"
+    receipt_path.unlink()
+
+    writer = QueryArtifactStore(tmp_path)
+    with pytest.raises(RuntimeArtifactGCError) as excinfo:
+        writer.store(
+            "query_trace",
+            {"blocked": True},
+            {"source_query": "q", "timestamp": "2026-01-01T00:00:00Z"},
+        )
+    assert excinfo.value.code == "retention_transaction_pending"
+
+    recovered = store.apply_retention(plan=plan, protection=_protection())
+    assert recovered["recovered_after_effect"] is True
+    writer.store(
+        "query_trace",
+        {"after_recovery": True},
+        {"source_query": "q", "timestamp": "2026-01-01T00:00:00Z"},
+    )
+
+def test_gc_rejects_foreign_owned_storage_directory(monkeypatch, tmp_path):
+    from merger.repoground.service import runtime_artifact_gc_store as gc_store
+
+    original_lstat = gc_store.lstat_path
+
+    def foreign_storage_lstat(path):
+        metadata = original_lstat(path)
+        if Path(path) != tmp_path:
+            return metadata
+        values = list(metadata)
+        values[4] = os.geteuid() + 1
+        return os.stat_result(values)
+
+    monkeypatch.setattr(gc_store, "lstat_path", foreign_storage_lstat)
+
+    with pytest.raises(RuntimeArtifactGCError) as excinfo:
+        gc_store.RuntimeArtifactGCStore(tmp_path)
+    assert excinfo.value.code == "foreign_store_owner"
+
+def test_symlink_receipt_cannot_mask_pending_transaction(tmp_path):
+    store = _write_store(
+        tmp_path,
+        [_entry("qart-old", "query_trace", "2020-01-01T00:00:00Z")],
+    )
+    plan = store.retention_plan(
+        protection=_protection(),
+        as_of="2026-01-01T00:00:00Z",
+    )
+    store.apply_retention(plan=plan, protection=_protection())
+
+    receipt_path = tmp_path / "retention-receipts" / f"{plan['plan_sha256']}.json"
+    outside = tmp_path / "outside-receipt.json"
+    outside.write_bytes(receipt_path.read_bytes())
+    receipt_path.unlink()
+    receipt_path.symlink_to(outside)
+
+    writer = QueryArtifactStore(tmp_path)
+    with pytest.raises(RuntimeArtifactGCError) as excinfo:
+        writer.store(
+            "query_trace",
+            {"must_not_write": True},
+            {"source_query": "q", "timestamp": "2026-01-01T00:00:00Z"},
+        )
+
+    assert excinfo.value.code == "unsafe_store_entry"
+    persisted = json.loads((tmp_path / "query_artifacts.json").read_text(encoding="utf-8"))
+    assert persisted == []


### PR DESCRIPTION
## Summary
- add conservative per-artifact age/count/byte budgets without changing the existing unbounded lookup/TTL contract
- add deterministic dry-run planning with exact plan/store hashes and fresh protection evidence
- protect active sessions and their trace/context references, pins, and nonterminal external evidence; unknown reference state blocks
- add inter-process locking, no-follow/ownership checks, transaction/receipt recovery, idempotent replay, and post-apply integrity readback
- document the manual GC boundary and T018 acceptance proof

## Validation
- 22 runtime-artifact GC/retention tests passed on the final security-hardened code
- Ruff and graph maintainability pass; new complexity violations: 0
- affected lookup/query regression suite passed: 129 tests
- full Python suite passed immediately before the final receipt-symlink hardening: 5610 passed, 12 skipped, 13 deselected; required PR CI must rerun the full suite on this exact head before merge

No automatic GC, TTL expiry, lookup-side deletion, or scheduler is enabled.