### PR TITLE
fix(repoground): patch lock-generator pip

### DIFF
--- a/docs/release/release-policy.md
+++ b/docs/release/release-policy.md
@@ -60,7 +60,7 @@ Exactly one lock-generator contract is supported. Its version source is
 `requirements/repoground-lock-tools.in`:
 
 - CPython `3.12.3` from the digest-pinned container wrapper;
-- `pip==25.3`;
+- `pip==26.1.2`;
 - `pip-tools==7.6.0`.
 
 The pip pin is part of the contract because pip-tools imports pip internals.

--- a/merger/repoground/tests/test_dependency_lock_toolchain.py
+++ b/merger/repoground/tests/test_dependency_lock_toolchain.py
@@ -20,7 +20,7 @@ ROOT = Path(__file__).resolve().parents[3]
 SUPPORTED = ToolchainObservation(
     implementation="CPython",
     python="3.12.3",
-    pip="25.3",
+    pip="26.1.2",
     pip_tools="7.6.0",
 )
 
@@ -30,7 +30,7 @@ def _fixture_repo(tmp_path: Path) -> tuple[Path, dict[str, bytes]]:
     (repo / "requirements").mkdir(parents=True)
     (repo / "merger/repoground").mkdir(parents=True)
     (repo / "requirements/repoground-lock-tools.in").write_text(
-        "# lock-python==3.12.3\npip==25.3\npip-tools==7.6.0\n",
+        "# lock-python==3.12.3\npip==26.1.2\npip-tools==7.6.0\n",
         encoding="utf-8",
     )
     for name in ("runtime", "dev", "browser"):
@@ -63,7 +63,7 @@ def _assert_locks(repo: Path, expected: dict[str, bytes]) -> None:
 def test_repository_contract_binds_python_pip_and_pip_tools() -> None:
     contract = load_contract(ROOT)
     assert contract.python == "3.12.3"
-    assert contract.pip == "25.3"
+    assert contract.pip == "26.1.2"
     assert contract.pip_tools == "7.6.0"
     assert environment_findings(contract, SUPPORTED) == []
 
@@ -80,10 +80,10 @@ def test_mismatch_report_includes_every_expected_and_observed_version() -> None:
     report_environment(contract, observed, stream)
     report = stream.getvalue()
     assert "Python: expected=3.12.3 observed=3.12.3" in report
-    assert "pip: expected=25.3 observed=26.2" in report
+    assert "pip: expected=26.1.2 observed=26.2" in report
     assert "pip-tools: expected=7.6.0 observed=7.6.0" in report
     assert environment_findings(contract, observed) == [
-        "pip version mismatch: expected=25.3 observed=26.2"
+        "pip version mismatch: expected=26.1.2 observed=26.2"
     ]
 
 

--- a/requirements/repoground-lock-tools.in
+++ b/requirements/repoground-lock-tools.in
@@ -1,4 +1,4 @@
 # The only supported toolchain for regenerating the reviewed hash locks.
 # lock-python==3.12.3
-pip==25.3
+pip==26.1.2
 pip-tools==7.6.0

--- a/requirements/repoground-lock-tools.lock.txt
+++ b/requirements/repoground-lock-tools.lock.txt
@@ -34,9 +34,9 @@ wheel==0.47.0 \
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==25.3 \
-    --hash=sha256:8d0538dbbd7babbd207f261ed969c65de439f6bc9e5dbd3b3b9a77f25d95f343 \
-    --hash=sha256:9655943313a94722b7774661c21049070f6bbb0a1516bf02f7c8d5d9201514cd
+pip==26.1.2 \
+    --hash=sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab \
+    --hash=sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605
     # via
     #   -r requirements/repoground-lock-tools.in
     #   pip-tools


### PR DESCRIPTION
Task: REPOGROUND-AGENT-UTILITY-V1-FU-PIP-SECURITY-PIN-20260812

## Summary
- pin the lock-generator toolchain to pip 26.1.2, the first version covering all currently open pip advisories
- regenerate only the lock-tools hash lock through the canonical generator
- update the release contract and focused toolchain tests

## Validation
- exact Playwright build container: CPython 3.12.3 + pip 26.1.2 + pip-tools 7.6.0; dev/browser dry-run compile PASS
- scripts/release/compile_dependency_locks.sh --check: PASS / all locks reproducible
- pytest -q merger/repoground/tests/test_dependency_lock_toolchain.py merger/repoground/tests/test_release_packaging.py: 64 passed
- python3 scripts/release/check_release_contract.py: PASS, zero findings
- ruff check --config ruff-ci.toml .: PASS
- git diff --check: PASS

## Scope
Runtime, dev and browser locks remain byte-identical; only the lock-generator closure changes. pip 26.2 is intentionally not selected because the repository already proves it incompatible with pip-tools 7.6.0, while the exact 26.1.2 pair was freshly reproduced successfully.