### PR TITLE
feat(repoground): publish optional language structure in fleet

### DIFF
--- a/merger/repoground/cli/cmd_ground.py
+++ b/merger/repoground/cli/cmd_ground.py
@@ -530,6 +530,14 @@ def register_ground_command_groups(ground_parser: argparse.ArgumentParser) -> No
     create_parser.add_argument("--path-filter")
     create_parser.add_argument("--ext", action="append")
     create_parser.add_argument("--output-mode", choices=["archive", "retrieval", "dual"])
+    create_parser.add_argument(
+        "--language-structure",
+        action="store_true",
+        help=(
+            "Explicitly emit the optional commit-bound Rust/Bash language_structure "
+            "sidecar when the selected profile permits it"
+        ),
+    )
     create_redaction = create_parser.add_mutually_exclusive_group()
     create_redaction.add_argument(
         "--redact-secrets", action="store_true", dest="redact_secrets"
@@ -771,6 +779,14 @@ def register_ground_command_groups(ground_parser: argparse.ArgumentParser) -> No
     external_refresh_parser.add_argument("--path-filter")
     external_refresh_parser.add_argument("--ext", action="append")
     external_refresh_parser.add_argument("--output-mode", choices=["archive", "retrieval", "dual"])
+    external_refresh_parser.add_argument(
+        "--language-structure",
+        action="store_true",
+        help=(
+            "Explicitly emit the optional commit-bound Rust/Bash language_structure "
+            "sidecar when the selected profile permits it"
+        ),
+    )
     refresh_redaction = external_refresh_parser.add_mutually_exclusive_group()
     refresh_redaction.add_argument(
         "--redact-secrets", action="store_true", dest="redact_secrets"
@@ -996,6 +1012,7 @@ def run_external_manifest_refresh(args: argparse.Namespace) -> int:
         max_bytes=args.max_bytes, split_size=args.split_size, path_filter=args.path_filter,
         ext=args.ext, output_mode=args.output_mode, redact_secrets=args.redact_secrets,
         include_hidden=args.include_hidden,
+        language_structure=bool(getattr(args, "language_structure", False)),
         latest_complete_registry=None,
     )
     snapshot_stdout = io.StringIO()
@@ -1463,7 +1480,16 @@ def build_snapshot_create_result(args: argparse.Namespace) -> dict[str, Any]:
     max_bytes = parse_human_size(args.max_bytes)
     split_size = parse_human_size(args.split_size)
     ext_filter = parse_extensions(args.ext)
-    extras = ExtrasConfig(json_sidecar=True, augment_sidecar=True)
+    language_structure_enabled = bool(getattr(args, "language_structure", False))
+    if language_structure_enabled and "language_structure_json" in profile_excluded_roles(profile):
+        raise ValueError(
+            f"profile {profile} excludes language_structure_json; explicit generation is forbidden"
+        )
+    extras = ExtrasConfig(
+        json_sidecar=True,
+        augment_sidecar=True,
+        language_structure=language_structure_enabled,
+    )
 
     summary = scan_repo(
         repo,

--- a/merger/repoground/cli/cmd_ground.py
+++ b/merger/repoground/cli/cmd_ground.py
@@ -498,6 +498,20 @@ def parse_extensions(values: Iterable[str] | None) -> list[str] | None:
     return sorted(set(result)) or None
 
 
+def _snapshot_extras(
+    profile: str, *, language_structure: bool = False
+) -> ExtrasConfig:
+    if language_structure and "language_structure_json" in profile_excluded_roles(profile):
+        raise ValueError(
+            f"profile {profile} excludes language_structure_json; explicit generation is forbidden"
+        )
+    return ExtrasConfig(
+        json_sidecar=True,
+        augment_sidecar=True,
+        language_structure=language_structure,
+    )
+
+
 def register_ground_command_groups(ground_parser: argparse.ArgumentParser) -> None:
     ground_subparsers = ground_parser.add_subparsers(
         dest="ground_cmd",
@@ -1480,15 +1494,9 @@ def build_snapshot_create_result(args: argparse.Namespace) -> dict[str, Any]:
     max_bytes = parse_human_size(args.max_bytes)
     split_size = parse_human_size(args.split_size)
     ext_filter = parse_extensions(args.ext)
-    language_structure_enabled = bool(getattr(args, "language_structure", False))
-    if language_structure_enabled and "language_structure_json" in profile_excluded_roles(profile):
-        raise ValueError(
-            f"profile {profile} excludes language_structure_json; explicit generation is forbidden"
-        )
-    extras = ExtrasConfig(
-        json_sidecar=True,
-        augment_sidecar=True,
-        language_structure=language_structure_enabled,
+    extras = _snapshot_extras(
+        profile,
+        language_structure=bool(getattr(args, "language_structure", False)),
     )
 
     summary = scan_repo(

--- a/merger/repoground/tests/test_fleet_runtime.py
+++ b/merger/repoground/tests/test_fleet_runtime.py
@@ -88,11 +88,44 @@ def test_publication_config_uses_compact_daily_profile(tmp_path: Path) -> None:
     )
 
     assert module.publication_config(default) == module.PublicationConfig(
-        profile="fleet-context"
+        profile="fleet-context", language_structure=True
     )
     assert module.publication_config(vault) == module.PublicationConfig(
-        profile="agent-portable"
+        profile="agent-portable", language_structure=True
     )
+    assert module.publication_config(default).as_dict()["language_structure"] is True
+
+
+def test_fleet_refresh_command_explicitly_opts_into_language_structure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    publication_root = tmp_path / "publications"
+    monkeypatch.setattr(module, "PUB_ROOT", publication_root)
+    config = module.PublicationConfig(
+        profile="fleet-context", language_structure=True
+    )
+
+    command = module.build_refresh_command(
+        source_wt=tmp_path / "source",
+        out_dir=publication_root / "bundle",
+        registry_repository="heimgewebe__demo",
+        ref_segment="main",
+        config=config,
+    )
+
+    assert command[command.index("--profile") + 1] == "fleet-context"
+    assert "--language-structure" in command
+    assert command[command.index("--publication-root") + 1] == str(publication_root)
+
+    disabled = module.build_refresh_command(
+        source_wt=tmp_path / "source",
+        out_dir=publication_root / "bundle",
+        registry_repository="heimgewebe__demo",
+        ref_segment="main",
+        config=module.PublicationConfig(profile="fleet-context"),
+    )
+    assert "--language-structure" not in disabled
 
 
 def allow_no_active_managed_build_leases(

--- a/merger/repoground/tests/test_ground_snapshot_cli.py
+++ b/merger/repoground/tests/test_ground_snapshot_cli.py
@@ -91,6 +91,7 @@ def test_snapshot_create_dispatches_existing_generator(monkeypatch, tmp_path, ca
     assert calls["write"]["args"][5] == 0
     assert calls["write"]["args"][6] is False
     assert calls["write"]["kwargs"]["generator_info"]["name"] == "repobrief"
+    assert calls["write"]["kwargs"]["extras"].language_structure is False
 
     manifest_data = json.loads((out / "repo_merge.bundle.manifest.json").read_text(encoding="utf-8"))
     assert manifest_data["capabilities"]["repobrief_profile"] == "agent-portable"
@@ -104,6 +105,90 @@ def test_snapshot_create_dispatches_existing_generator(monkeypatch, tmp_path, ca
     assert emitted["export_safety_report"].endswith(".export_safety_report.json")
     assert "export_safety_report" not in emitted["profile_evaluation"]["missing_required"]
     assert "forensic_ready" in emitted["does_not_establish"]
+
+
+def test_snapshot_create_language_structure_requires_explicit_opt_in(
+    monkeypatch, tmp_path
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "README.md").write_text("hello\n", encoding="utf-8")
+    out = tmp_path / "briefs"
+    observed = {}
+
+    def fake_scan_repo(*args, **kwargs):
+        return {
+            "name": "repo",
+            "root": repo,
+            "files": [],
+            "total_files": 0,
+            "total_bytes": 0,
+            "ext_hist": {},
+        }
+
+    def fake_write_reports_v2(*args, **kwargs):
+        observed["language_structure"] = kwargs["extras"].language_structure
+        manifest = out / "repo_merge.bundle.manifest.json"
+        manifest.parent.mkdir(parents=True, exist_ok=True)
+        manifest.write_text(
+            json.dumps({"kind": "repolens.bundle.manifest", "capabilities": {}}),
+            encoding="utf-8",
+        )
+        return FakeArtifacts(manifest)
+
+    monkeypatch.setattr(cmd_ground, "scan_repo", fake_scan_repo)
+    monkeypatch.setattr(cmd_ground, "write_reports_v2", fake_write_reports_v2)
+    monkeypatch.setattr(
+        cmd_ground, "finalize_snapshot_bundle", _stub_successful_finalization
+    )
+
+    rc = main([
+        "ground",
+        "snapshot",
+        "create",
+        "--repo",
+        str(repo),
+        "--out",
+        str(out),
+        "--profile",
+        "fleet-context",
+        "--language-structure",
+    ])
+
+    assert rc == 0
+    assert observed["language_structure"] is True
+
+
+def test_public_share_rejects_explicit_language_structure_before_generation(
+    monkeypatch, tmp_path
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    out = tmp_path / "briefs"
+    called = False
+
+    def fake_scan_repo(*args, **kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("generation must not start for excluded language structure")
+
+    monkeypatch.setattr(cmd_ground, "scan_repo", fake_scan_repo)
+
+    rc = main([
+        "ground",
+        "snapshot",
+        "create",
+        "--repo",
+        str(repo),
+        "--out",
+        str(out),
+        "--profile",
+        "public-share",
+        "--language-structure",
+    ])
+
+    assert rc == 2
+    assert called is False
 
 
 def test_snapshot_create_rejects_missing_repo_without_creating_snapshot(tmp_path):
@@ -380,6 +465,7 @@ def test_external_manifest_refresh_returns_exit_2_for_bundle_generation_resolver
             output_mode="dual",
             redact_secrets=False,
             include_hidden=False,
+            language_structure=False,
         )
     )
 

--- a/scripts/ops/repoground-publish-fleet
+++ b/scripts/ops/repoground-publish-fleet
@@ -155,6 +155,7 @@ class PublicationConfig:
     redact_secrets: bool = True
     max_bytes: int = 0
     split_size: str = "25MB"
+    language_structure: bool = False
 
     def as_dict(self) -> dict[str, object]:
         return {
@@ -163,6 +164,7 @@ class PublicationConfig:
             "redact_secrets": self.redact_secrets,
             "max_bytes": self.max_bytes,
             "split_size": self.split_size,
+            "language_structure": self.language_structure,
         }
 
 
@@ -438,9 +440,12 @@ def safe_segment(raw: str) -> str:
 
 
 def publication_config(entry: RepoEntry) -> PublicationConfig:
+    # T021 keeps language structure opt-in globally. The fleet publisher is the
+    # explicit internal opt-in: consumers still decide independently whether to
+    # use the sidecar, and public-share never routes through this configuration.
     if entry.repo == "vault-gewebe":
-        return PublicationConfig(profile="agent-portable")
-    return PublicationConfig(profile="fleet-context")
+        return PublicationConfig(profile="agent-portable", language_structure=True)
+    return PublicationConfig(profile="fleet-context", language_structure=True)
 
 
 def publication_repository(entry: RepoEntry) -> str:
@@ -3331,6 +3336,47 @@ def prune_all_special(
     ]
 
 
+def build_refresh_command(
+    *,
+    source_wt: Path,
+    out_dir: Path,
+    registry_repository: str,
+    ref_segment: str,
+    config: PublicationConfig,
+) -> list[str]:
+    command = [
+        "python3",
+        "-B",
+        "-m",
+        "merger.repoground.cli.ground",
+        "external-manifest",
+        "refresh",
+        "--repo",
+        str(source_wt),
+        "--out",
+        str(out_dir),
+        "--publication-root",
+        str(PUB_ROOT),
+        "--repository",
+        registry_repository,
+        "--ref",
+        ref_segment,
+        "--profile",
+        config.profile,
+        "--output-mode",
+        config.output_mode,
+        "--max-bytes",
+        str(config.max_bytes),
+        "--split-size",
+        config.split_size,
+    ]
+    if config.redact_secrets:
+        command.append("--redact-secrets")
+    if config.language_structure:
+        command.append("--language-structure")
+    return command
+
+
 def publish(
     entry: RepoEntry,
     *,
@@ -3360,34 +3406,13 @@ def publish(
         fingerprint=fingerprint,
         publication_dir=out_dir,
     )
-    command = [
-        "python3",
-        "-B",
-        "-m",
-        "merger.repoground.cli.ground",
-        "external-manifest",
-        "refresh",
-        "--repo",
-        str(source_wt),
-        "--out",
-        str(out_dir),
-        "--publication-root",
-        str(PUB_ROOT),
-        "--repository",
-        registry_repository,
-        "--ref",
-        ref_segment,
-        "--profile",
-        config.profile,
-        "--output-mode",
-        config.output_mode,
-        "--max-bytes",
-        str(config.max_bytes),
-        "--split-size",
-        config.split_size,
-    ]
-    if config.redact_secrets:
-        command.append("--redact-secrets")
+    command = build_refresh_command(
+        source_wt=source_wt,
+        out_dir=out_dir,
+        registry_repository=registry_repository,
+        ref_segment=ref_segment,
+        config=config,
+    )
     try:
         STATE_ROOT.mkdir(parents=True, exist_ok=True)
         residue_provenance = arm_managed_build_residue_provenance(


### PR DESCRIPTION
Implements Bureau task REPOGROUND-AGENT-UTILITY-V1-T027.

- keeps `ExtrasConfig.language_structure` and ordinary snapshot creation opt-in/default-off
- adds an explicit `--language-structure` generation switch
- rejects the switch for `public-share`, where `language_structure_json` is profile-excluded
- makes the internal Fleet publisher explicitly opt in and binds that choice into its publication fingerprint
- adds regression coverage for the Fleet command path and snapshot/profile boundary

Local evidence on exact head `17b66042a094dcf0be4e1d279e4fbed5f758d8dd`: 68 focused tests passed; repository-wide Ruff passed; a real clean Rust/Bash fixture emitted a manifest-bound language_structure sidecar only with explicit opt-in, while public-share failed closed. Full pytest is running under Grabowski and will be read back before merge.

This does not promote Rust/Bash consumers or task-profile routing and does not claim downstream agent-benefit; T021's consumer-promotion gate remains intact.