### PR TITLE
feat(repoground): add component-delta agent benchmark

### DIFF
--- a/docs/architecture/language-structure-adapters.md
+++ b/docs/architecture/language-structure-adapters.md
@@ -144,24 +144,31 @@ ausgewiesen. Interpreterversion, Betriebssystem, Maschinenarchitektur und
 logische CPU-Zahl bleiben als Messumgebung sichtbar. Laufzeitwerte sind
 Umweltbeobachtungen und kein Cross-Machine-Reproduzierbarkeitsbeweis.
 
-Der Promotionspfad ist derzeit bewusst hart geschlossen. Ohne externes
+Der Promotionspfad bleibt standardmäßig hart geschlossen. Ohne externes
 `agent_benefit` bleibt der Status `keep_optional` mit
 `revision_bound_agent_benefit_missing`. Das Legacy-Argument `--agent-benefit`
-bleibt nur zur Eingabekompatibilität erhalten: Auch ein syntaktisch gültiges oder
-maximal positives Mapping ist **keine** Promotionsautorität und ergibt
-`keep_optional` mit `verified_component_delta_agent_benefit_missing`. Es gibt
-aktuell keinen Eingabepfad zu `eligible_for_explicit_promotion_review`.
+bleibt zur Eingabekompatibilität erhalten: Ein handgebautes oder bloß positives
+Aggregate ist **keine** Promotionsautorität und ergibt `keep_optional` mit
+`verified_component_delta_agent_benefit_missing`.
 
-Eine spätere Wiederöffnung erfordert einen verifizierten Component-Delta-Lauf im
-bestehenden generischen Agent-Benchmark. Baseline und Treatment müssen dabei
-denselben RepoGround-Kontext, dasselbe Modell, denselben Prompt, dasselbe Budget,
-dieselbe Source-Revision und denselben Grader verwenden; nur das revisions- und
-hashgebundene `language_structure_json` darf variieren. Erst eine solche über die
-generischen Receipt-, Scoring- und Pair-Integrity-Flächen geprüfte Messung darf
-wieder in eine separate Promotionsentscheidung eingehen. Die statischen
-Qualitäts-, Nullfall-, Determinismus- und Kostenmetriken dieses Benchmarks bleiben
-bis dahin Diagnoseevidenz, nicht Agentennutzen. `default_promoted` bleibt in
-jedem Fall `false`.
+Der generische Agent-Benchmark unterstützt dafür nun `component_delta`: Wir
+vergleichen dasselbe RepoGround einmal ohne und einmal mit genau einem
+Zusatzbaustein. Modell/Runner, Repo-Commit, Prompt, Budget, Tools und
+RepoGround-Kontext müssen identisch sein; nur das revisionsgebundene
+Komponentenartefakt darf variieren. Das Treatment-Artefakt wird relativ zum
+gebundenen Manifest gelesen, stabil und größenbegrenzt geprüft und gegen seine
+tatsächlichen Bytes gehasht. Die Evaluation bindet die Treatment-Artefakte
+eindeutig an ihre Repositories.
+
+`language_structure_json` akzeptiert daraus nur reale, vollständig gültige
+Paired-Agent-Runs mit verifizierter Pair-Isolation, passender Source-Revision,
+bytegebundenen Treatment-Artefakten, mindestens einer nützlichen Klasse und keiner
+schädlichen Klasse. Das öffnet ausschließlich
+`eligible_for_explicit_promotion_review`; `broad_activation_eligible` und
+`default_promoted` bleiben `false`. Der Component-Delta-Lauf beweist weder
+allgemeine Kausalität noch Runner-/Grader-Ehrlichkeit oder allgemeine
+Agentenüberlegenheit. Die statischen Qualitäts-, Nullfall-, Determinismus- und
+Kostenmetriken bleiben eigenständige Diagnoseevidenz.
 
 ## Nichtaussagen
 

--- a/docs/architecture/language-structure-adapters.md
+++ b/docs/architecture/language-structure-adapters.md
@@ -153,17 +153,21 @@ Aggregate ist **keine** Promotionsautorität und ergibt `keep_optional` mit
 
 Der generische Agent-Benchmark unterstützt dafür nun `component_delta`: Wir
 vergleichen dasselbe RepoGround einmal ohne und einmal mit genau einem
-Zusatzbaustein. Modell/Runner, Repo-Commit, Prompt, Budget, Tools und
-RepoGround-Kontext müssen identisch sein; nur das revisionsgebundene
+Zusatzbaustein. Modell/Runner, Repo-Commit, Prompt, Budget, Tools,
+Grading-Erwartungen und RepoGround-Kontext müssen identisch sein; nur das revisionsgebundene
 Komponentenartefakt darf variieren. Das Treatment-Artefakt wird relativ zum
-gebundenen Manifest gelesen, stabil und größenbegrenzt geprüft und gegen seine
-tatsächlichen Bytes gehasht. Die Evaluation bindet die Treatment-Artefakte
-eindeutig an ihre Repositories.
+gebundenen Manifest gelesen, stabil und größenbegrenzt geprüft, gegen die
+Manifest-Registrierung und seinen Komponentenvertrag validiert und an seine
+tatsächlichen Bytes gebunden. Für `language_structure_json` müssen zusätzlich
+Schema und `source.repository_commit` zum eingefrorenen Repository-Commit passen.
+Dieselbe Prüfung läuft unmittelbar vor dem Runner-Start erneut.
 
 `language_structure_json` akzeptiert daraus nur reale, vollständig gültige
 Paired-Agent-Runs mit verifizierter Pair-Isolation, passender Source-Revision,
 bytegebundenen Treatment-Artefakten, mindestens einer nützlichen Klasse und keiner
-schädlichen Klasse. Das öffnet ausschließlich
+schädlichen Klasse. Klassenmetriken und Entscheidung werden dabei aus den
+Fall-Scores und den in der Evaluation gebundenen Schwellenwerten neu abgeleitet;
+handgeschriebene Aggregate reichen nicht. Das öffnet ausschließlich
 `eligible_for_explicit_promotion_review`; `broad_activation_eligible` und
 `default_promoted` bleiben `false`. Der Component-Delta-Lauf beweist weder
 allgemeine Kausalität noch Runner-/Grader-Ehrlichkeit oder allgemeine

--- a/docs/architecture/language-structure-adapters.md
+++ b/docs/architecture/language-structure-adapters.md
@@ -154,20 +154,33 @@ Aggregate ist **keine** Promotionsautorität und ergibt `keep_optional` mit
 Der generische Agent-Benchmark unterstützt dafür nun `component_delta`: Wir
 vergleichen dasselbe RepoGround einmal ohne und einmal mit genau einem
 Zusatzbaustein. Modell/Runner, Repo-Commit, Prompt, Budget, Tools,
-Grading-Erwartungen und RepoGround-Kontext müssen identisch sein; nur das revisionsgebundene
-Komponentenartefakt darf variieren. Das Treatment-Artefakt wird relativ zum
-gebundenen Manifest gelesen, stabil und größenbegrenzt geprüft, gegen die
-Manifest-Registrierung und seinen Komponentenvertrag validiert und an seine
-tatsächlichen Bytes gebunden. Für `language_structure_json` müssen zusätzlich
-Schema und `source.repository_commit` zum eingefrorenen Repository-Commit passen.
-Dieselbe Prüfung läuft unmittelbar vor dem Runner-Start erneut.
+Grading-Erwartungen und MCP-Kommando müssen identisch sein. Das Treatment bindet
+das normale Manifest; die Baseline bindet ein zweites digestgebundenes Manifest,
+das nachweislich exakt dem Treatment-Manifest **minus** der getesteten
+Komponentenregistrierung entspricht. Dadurch kann die Baseline den Baustein auch
+nicht indirekt über `ask_context` oder einen anderen Manifest-Lookup laden. Der
+Vertrag wird beim Pairing erneut geprüft; unmittelbar vor dem Runner-Start wird
+zusätzlich verifiziert, dass das Baseline-Manifest die Komponente weiterhin nicht
+registriert.
+
+Das Treatment-Artefakt wird relativ zum gebundenen Manifest gelesen, stabil und
+größenbegrenzt geprüft, gegen die Manifest-Registrierung und seinen
+Komponentenvertrag validiert und an seine tatsächlichen Bytes gebunden. Für
+`language_structure_json` müssen zusätzlich Schema und
+`source.repository_commit` zum eingefrorenen Repository-Commit passen. Dieselbe
+Artefaktprüfung läuft unmittelbar vor dem Treatment-Runner erneut.
 
 `language_structure_json` akzeptiert daraus nur reale, vollständig gültige
 Paired-Agent-Runs mit verifizierter Pair-Isolation, passender Source-Revision,
 bytegebundenen Treatment-Artefakten, mindestens einer nützlichen Klasse und keiner
-schädlichen Klasse. Klassenmetriken und Entscheidung werden dabei aus den
-Fall-Scores und den in der Evaluation gebundenen Schwellenwerten neu abgeleitet;
-handgeschriebene Aggregate reichen nicht. Das öffnet ausschließlich
+schädlichen Klasse. Die Evaluation bindet Fingerabdrücke von Taskset, Requests,
+Receipts und Transkripten. Für Promotion genügt die Evaluation-Datei allein nicht:
+Taskset, Requests und Receipts müssen erneut vorliegen; externe Transkripte müssen
+weiterhin lesbar sein. Der bestehende Evaluator prüft diese Eingaben erneut und
+muss byte-/inhaltlich wieder genau dieselbe Evaluation erzeugen. Klassenmetriken
+und Entscheidung werden dabei aus den validierten Fall-Scores und den gebundenen
+Schwellenwerten neu abgeleitet; handgeschriebene Aggregate oder Fall-Scores reichen
+nicht. Das öffnet ausschließlich
 `eligible_for_explicit_promotion_review`; `broad_activation_eligible` und
 `default_promoted` bleiben `false`. Der Component-Delta-Lauf beweist weder
 allgemeine Kausalität noch Runner-/Grader-Ehrlichkeit oder allgemeine

--- a/docs/retrieval/task-profile-routing-evidence.v1.json
+++ b/docs/retrieval/task-profile-routing-evidence.v1.json
@@ -436,7 +436,7 @@
           },
           "evaluator": {
             "path": "merger/repoground/core/agent_benchmark_evaluation.py",
-            "sha256": "1146780d9139c0db44d02600e87047c29da2f987e4fcbaecc65ab3529b1765c2",
+            "sha256": "5bd8ef488c5334e434917a8684f16f1ccd5a7a66c04a53ce7ce77f7629425718",
             "version": "agent-benchmark-evaluation.v1"
           },
           "id": "agent-benchmark-grounding-unexecuted",

--- a/docs/retrieval/task-profile-routing-evidence.v1.json
+++ b/docs/retrieval/task-profile-routing-evidence.v1.json
@@ -436,7 +436,7 @@
           },
           "evaluator": {
             "path": "merger/repoground/core/agent_benchmark_evaluation.py",
-            "sha256": "297230d3b91489ca69d70146e7d7b204097eb60c8af5144dd6300e554040ea58",
+            "sha256": "1146780d9139c0db44d02600e87047c29da2f987e4fcbaecc65ab3529b1765c2",
             "version": "agent-benchmark-evaluation.v1"
           },
           "id": "agent-benchmark-grounding-unexecuted",

--- a/merger/repoground/cli/agent_benchmark.py
+++ b/merger/repoground/cli/agent_benchmark.py
@@ -201,7 +201,10 @@ def build_parser() -> argparse.ArgumentParser:
     plan.add_argument(
         "--manifest-bindings",
         required=True,
-        help="Repository-id to manifest/hash/MCP-command mapping.",
+        help=(
+            "Repository-id to manifest/hash/MCP-command mapping; "
+            "component_delta also requires component bindings."
+        ),
     )
     plan.add_argument("--repetitions", type=int, default=2)
     plan.add_argument("--out", required=True)

--- a/merger/repoground/contracts/agent-benchmark-evaluation.v1.schema.json
+++ b/merger/repoground/contracts/agent-benchmark-evaluation.v1.schema.json
@@ -24,6 +24,28 @@
     "taskset_id": {"type": "string", "minLength": 1},
     "taskset_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
     "measurement_scope": {"enum": ["synthetic_contract_fixture", "real_paired_agent_runs"]},
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["taskset_sha256", "requests_sha256", "receipts_sha256", "transcripts"],
+      "properties": {
+        "taskset_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "requests_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "receipts_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "transcripts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["request_id", "sha256"],
+            "properties": {
+              "request_id": {"type": "string", "minLength": 1},
+              "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+            }
+          }
+        }
+      }
+    },
     "thresholds": {
       "type": "object",
       "additionalProperties": false,

--- a/merger/repoground/contracts/agent-benchmark-evaluation.v1.schema.json
+++ b/merger/repoground/contracts/agent-benchmark-evaluation.v1.schema.json
@@ -109,6 +109,30 @@
       "minItems": 1,
       "uniqueItems": true,
       "items": {"type": "string", "minLength": 1}
+    },
+    "comparison": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "component", "source_revision", "treatment_artifacts", "pair_isolation_verified"],
+      "properties": {
+        "mode": {"const": "component_delta"},
+        "component": {"type": "string", "pattern": "^[a-z][a-z0-9_.-]+$"},
+        "source_revision": {"type": "string", "pattern": "^(?:[0-9a-f]{40}|[0-9a-f]{64})$"},
+        "treatment_artifacts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["repository_id", "artifact", "artifact_sha256"],
+            "properties": {
+              "repository_id": {"type": "string", "minLength": 1},
+              "artifact": {"type": "string", "minLength": 1},
+              "artifact_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+            }
+          }
+        },
+        "pair_isolation_verified": {"type": "boolean"}
+      }
     }
   },
   "definitions": {

--- a/merger/repoground/contracts/agent-benchmark-evaluation.v1.schema.json
+++ b/merger/repoground/contracts/agent-benchmark-evaluation.v1.schema.json
@@ -24,6 +24,22 @@
     "taskset_id": {"type": "string", "minLength": 1},
     "taskset_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
     "measurement_scope": {"enum": ["synthetic_contract_fixture", "real_paired_agent_runs"]},
+    "thresholds": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "minimum_success_rate_gain",
+        "maximum_class_success_regression",
+        "maximum_false_confidence_increase",
+        "minimum_efficiency_improvement"
+      ],
+      "properties": {
+        "minimum_success_rate_gain": {"type": "number", "minimum": 0, "maximum": 1},
+        "maximum_class_success_regression": {"type": "number", "minimum": 0, "maximum": 1},
+        "maximum_false_confidence_increase": {"type": "number", "minimum": 0, "maximum": 1},
+        "minimum_efficiency_improvement": {"type": "number", "minimum": 0, "maximum": 1}
+      }
+    },
     "run_count": {"type": "integer", "minimum": 0},
     "valid_run_count": {"type": "integer", "minimum": 0},
     "invalid_run_count": {"type": "integer", "minimum": 0},

--- a/merger/repoground/contracts/agent-benchmark-evaluation.v1.schema.json
+++ b/merger/repoground/contracts/agent-benchmark-evaluation.v1.schema.json
@@ -24,16 +24,6 @@
     "taskset_id": {"type": "string", "minLength": 1},
     "taskset_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
     "measurement_scope": {"enum": ["synthetic_contract_fixture", "real_paired_agent_runs"]},
-    "runner_execution": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["attested", "authority", "reason"],
-      "properties": {
-        "attested": {"type": "boolean"},
-        "authority": {"type": "string", "minLength": 1},
-        "reason": {"type": "string", "minLength": 1}
-      }
-    },
     "evidence": {
       "type": "object",
       "additionalProperties": false,

--- a/merger/repoground/contracts/agent-benchmark-evaluation.v1.schema.json
+++ b/merger/repoground/contracts/agent-benchmark-evaluation.v1.schema.json
@@ -24,6 +24,16 @@
     "taskset_id": {"type": "string", "minLength": 1},
     "taskset_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
     "measurement_scope": {"enum": ["synthetic_contract_fixture", "real_paired_agent_runs"]},
+    "runner_execution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["attested", "authority", "reason"],
+      "properties": {
+        "attested": {"type": "boolean"},
+        "authority": {"type": "string", "minLength": 1},
+        "reason": {"type": "string", "minLength": 1}
+      }
+    },
     "evidence": {
       "type": "object",
       "additionalProperties": false,

--- a/merger/repoground/contracts/agent-benchmark-run-request.v1.schema.json
+++ b/merger/repoground/contracts/agent-benchmark-run-request.v1.schema.json
@@ -119,6 +119,17 @@
       "minItems": 1,
       "uniqueItems": true,
       "items": {"type": "string", "minLength": 1}
+    },
+    "component_delta": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["component", "source_revision", "artifact", "artifact_sha256"],
+      "properties": {
+        "component": {"type": "string", "pattern": "^[a-z][a-z0-9_.-]+$"},
+        "source_revision": {"type": "string", "pattern": "^(?:[0-9a-f]{40}|[0-9a-f]{64})$"},
+        "artifact": {"type": ["string", "null"], "minLength": 1},
+        "artifact_sha256": {"type": ["string", "null"], "pattern": "^[0-9a-f]{64}$"}
+      }
     }
   }
 }

--- a/merger/repoground/contracts/agent-benchmark-taskset.v1.schema.json
+++ b/merger/repoground/contracts/agent-benchmark-taskset.v1.schema.json
@@ -148,6 +148,16 @@
       "minItems": 1,
       "uniqueItems": true,
       "items": {"type": "string", "minLength": 1}
+    },
+    "comparison": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "component", "source_revision"],
+      "properties": {
+        "mode": {"const": "component_delta"},
+        "component": {"type": "string", "pattern": "^[a-z][a-z0-9_.-]+$"},
+        "source_revision": {"type": "string", "pattern": "^(?:[0-9a-f]{40}|[0-9a-f]{64})$"}
+      }
     }
   },
   "definitions": {

--- a/merger/repoground/core/agent_benchmark.py
+++ b/merger/repoground/core/agent_benchmark.py
@@ -351,9 +351,11 @@ def _decode_runner_output(raw: bytes) -> dict[str, Any]:
 
 
 def _verify_execution_component_artifact(request: Mapping[str, Any]) -> None:
+    if "component_delta" not in request:
+        return
     binding = request.get("component_delta")
     if not isinstance(binding, Mapping):
-        return
+        raise AgentBenchmarkError("component_delta execution binding is invalid")
     artifact = binding.get("artifact")
     artifact_sha256 = binding.get("artifact_sha256")
     condition = request.get("condition")

--- a/merger/repoground/core/agent_benchmark.py
+++ b/merger/repoground/core/agent_benchmark.py
@@ -33,13 +33,20 @@ from merger.repoground.core.agent_benchmark_common import (
     validate_taskset,
     write_json_atomic,
 )
-from merger.repoground.core.agent_benchmark_components import verify_component_artifact_binding
+from merger.repoground.core.agent_benchmark_components import (
+    verify_component_artifact_binding,
+    verify_component_free_manifest_binding,
+    verify_component_manifest_delta,
+)
 from merger.repoground.core.agent_benchmark_evaluation import (
     score_receipt,
     validate_evaluation,
     validate_evaluation_derivations,
 )
-from merger.repoground.core.agent_benchmark_integrity import evaluate_paired_runs
+from merger.repoground.core.agent_benchmark_integrity import (
+    evaluate_paired_runs,
+    validate_evaluation_evidence,
+)
 from merger.repoground.core.agent_benchmark_policy import BENCHMARK_REPETITIONS
 from merger.repoground.core.agent_benchmark_receipts import validate_receipt
 
@@ -123,10 +130,38 @@ def _repobrief_binding(
         raise AgentBenchmarkError(
             f"missing RepoGround manifest binding for {repository_id}"
         )
+    manifest_key = (
+        "baseline_manifest"
+        if condition == "baseline" and comparison_mode(taskset) == COMPONENT_DELTA_MODE
+        else "manifest"
+    )
+    sha_key = (
+        "baseline_manifest_sha256"
+        if condition == "baseline" and comparison_mode(taskset) == COMPONENT_DELTA_MODE
+        else "manifest_sha256"
+    )
+    manifest = binding.get(manifest_key)
+    manifest_sha256 = binding.get(sha_key)
+    mcp_command = binding.get("mcp_command")
+    if (
+        not isinstance(manifest, str)
+        or not manifest
+        or not isinstance(manifest_sha256, str)
+        or not isinstance(mcp_command, list)
+        or not mcp_command
+        or not all(isinstance(item, str) and item for item in mcp_command)
+    ):
+        if condition == "baseline" and comparison_mode(taskset) == COMPONENT_DELTA_MODE:
+            raise AgentBenchmarkError(
+                f"component_delta requires a component-free baseline manifest for {repository_id}"
+            )
+        raise AgentBenchmarkError(
+            f"invalid RepoGround manifest binding for {repository_id} condition {condition}"
+        )
     return {
-        "manifest": str(binding["manifest"]),
-        "manifest_sha256": str(binding["manifest_sha256"]),
-        "mcp_command": list(binding["mcp_command"]),
+        "manifest": manifest,
+        "manifest_sha256": manifest_sha256,
+        "mcp_command": list(mcp_command),
     }
 
 
@@ -141,14 +176,6 @@ def _component_delta_binding(
     comparison = comparison_contract(taskset)
     component = str(comparison["component"])
     repository_id = str(repository["id"])
-    result: dict[str, Any] = {
-        "component": component,
-        "source_revision": str(comparison["source_revision"]),
-        "artifact": None,
-        "artifact_sha256": None,
-    }
-    if condition == "baseline":
-        return result
     repository_binding = manifest_bindings.get(repository_id)
     components = mapping_value(
         repository_binding.get("components") if isinstance(repository_binding, Mapping) else None
@@ -168,7 +195,19 @@ def _component_delta_binding(
         )
     artifact_path = str(artifact["artifact"])
     artifact_sha256 = str(artifact["artifact_sha256"])
-    verify_component_artifact_binding(
+    baseline_manifest = repository_binding.get("baseline_manifest")
+    baseline_manifest_sha256 = repository_binding.get("baseline_manifest_sha256")
+    if not isinstance(baseline_manifest, str) or not isinstance(
+        baseline_manifest_sha256, str
+    ):
+        raise AgentBenchmarkError(
+            f"component_delta requires a component-free baseline manifest for {repository_id}"
+        )
+    verify_component_manifest_delta(
+        {
+            "manifest": baseline_manifest,
+            "manifest_sha256": baseline_manifest_sha256,
+        },
         repository_binding,
         repository_id=repository_id,
         repository_commit=str(repository["commit"]),
@@ -176,8 +215,15 @@ def _component_delta_binding(
         artifact_path=artifact_path,
         expected_sha256=artifact_sha256,
     )
-    result["artifact"] = artifact_path
-    result["artifact_sha256"] = artifact_sha256
+    result: dict[str, Any] = {
+        "component": component,
+        "source_revision": str(comparison["source_revision"]),
+        "artifact": None,
+        "artifact_sha256": None,
+    }
+    if condition == "treatment":
+        result["artifact"] = artifact_path
+        result["artifact_sha256"] = artifact_sha256
     return result
 
 
@@ -329,6 +375,23 @@ def _verify_execution_component_artifact(request: Mapping[str, Any]) -> None:
     if condition == "baseline":
         if artifact is not None or artifact_sha256 is not None:
             raise AgentBenchmarkError("component_delta baseline cannot execute with an artifact")
+        repobrief = request.get("repobrief")
+        repository = request.get("repository")
+        component = binding.get("component")
+        repository_id = mapping_value(repository).get("id")
+        if (
+            not isinstance(repobrief, Mapping)
+            or not isinstance(component, str)
+            or not component
+            or not isinstance(repository_id, str)
+            or not repository_id
+        ):
+            raise AgentBenchmarkError(
+                "component_delta baseline RepoGround binding is invalid"
+            )
+        verify_component_free_manifest_binding(
+            repobrief, repository_id=repository_id, component=component
+        )
         return
     if (
         condition != "treatment"
@@ -425,6 +488,7 @@ __all__ = [
     "sha256_json",
     "validate_evaluation",
     "validate_evaluation_derivations",
+    "validate_evaluation_evidence",
     "validate_receipt",
     "validate_taskset",
     "write_json_atomic",

--- a/merger/repoground/core/agent_benchmark.py
+++ b/merger/repoground/core/agent_benchmark.py
@@ -10,7 +10,6 @@ import os
 import subprocess
 import tempfile
 from collections.abc import Mapping, Sequence
-from pathlib import Path
 from typing import Any
 
 from merger.repoground.core.agent_benchmark_common import (
@@ -34,10 +33,11 @@ from merger.repoground.core.agent_benchmark_common import (
     validate_taskset,
     write_json_atomic,
 )
-from merger.repoground.core.agent_benchmark_evaluation import score_receipt, validate_evaluation
-from merger.repoground.core.bounded_artifact_read import (
-    MAX_REGISTERED_ARTIFACT_BYTES,
-    read_stable_regular_file_bytes,
+from merger.repoground.core.agent_benchmark_components import verify_component_artifact_binding
+from merger.repoground.core.agent_benchmark_evaluation import (
+    score_receipt,
+    validate_evaluation,
+    validate_evaluation_derivations,
 )
 from merger.repoground.core.agent_benchmark_integrity import evaluate_paired_runs
 from merger.repoground.core.agent_benchmark_policy import BENCHMARK_REPETITIONS
@@ -130,55 +130,19 @@ def _repobrief_binding(
     }
 
 
-def _verify_component_artifact_bytes(
-    repository_binding: Mapping[str, Any],
-    *,
-    repository_id: str,
-    artifact_path: str,
-    expected_sha256: str,
-) -> None:
-    manifest = repository_binding.get("manifest")
-    if not isinstance(manifest, str) or not manifest or not Path(manifest).is_absolute():
-        raise AgentBenchmarkError(
-            f"component artifact requires an absolute manifest binding for {repository_id}"
-        )
-    if not is_repository_relative_path(artifact_path):
-        raise AgentBenchmarkError(
-            f"component artifact path is not repository-relative for {repository_id}"
-        )
-    artifact_root = Path(manifest).parent.resolve(strict=False)
-    candidate = artifact_root / artifact_path
-    try:
-        candidate.resolve(strict=False).relative_to(artifact_root)
-    except ValueError as exc:
-        raise AgentBenchmarkError(
-            f"component artifact escapes manifest root for {repository_id}"
-        ) from exc
-    raw, _identity, failure, detail = read_stable_regular_file_bytes(
-        candidate, max_bytes=MAX_REGISTERED_ARTIFACT_BYTES
-    )
-    if failure is not None or raw is None:
-        suffix = f": {detail}" if detail else ""
-        raise AgentBenchmarkError(
-            f"component artifact {failure or 'unreadable'} for {repository_id}{suffix}"
-        )
-    if sha256_bytes(raw) != expected_sha256:
-        raise AgentBenchmarkError(
-            f"component artifact SHA-256 mismatch for {repository_id}"
-        )
-
-
 def _component_delta_binding(
     taskset: Mapping[str, Any],
     condition: str,
-    repository_id: str,
+    repository: Mapping[str, Any],
     manifest_bindings: Mapping[str, Mapping[str, Any]],
 ) -> dict[str, Any] | None:
     if comparison_mode(taskset) != COMPONENT_DELTA_MODE:
         return None
     comparison = comparison_contract(taskset)
+    component = str(comparison["component"])
+    repository_id = str(repository["id"])
     result: dict[str, Any] = {
-        "component": str(comparison["component"]),
+        "component": component,
         "source_revision": str(comparison["source_revision"]),
         "artifact": None,
         "artifact_sha256": None,
@@ -189,7 +153,7 @@ def _component_delta_binding(
     components = mapping_value(
         repository_binding.get("components") if isinstance(repository_binding, Mapping) else None
     )
-    artifact = mapping_value(components.get(str(comparison["component"])))
+    artifact = mapping_value(components.get(component))
     if (
         artifact.get("source_revision") != comparison["source_revision"]
         or not isinstance(artifact.get("artifact"), str)
@@ -197,15 +161,18 @@ def _component_delta_binding(
         or not isinstance(artifact.get("artifact_sha256"), str)
         or len(str(artifact.get("artifact_sha256"))) != 64
         or any(ch not in "0123456789abcdef" for ch in str(artifact.get("artifact_sha256")))
+        or not isinstance(repository_binding, Mapping)
     ):
         raise AgentBenchmarkError(
             f"missing or invalid component artifact binding for {repository_id}"
         )
     artifact_path = str(artifact["artifact"])
     artifact_sha256 = str(artifact["artifact_sha256"])
-    _verify_component_artifact_bytes(
+    verify_component_artifact_binding(
         repository_binding,
         repository_id=repository_id,
+        repository_commit=str(repository["commit"]),
+        component=component,
         artifact_path=artifact_path,
         expected_sha256=artifact_sha256,
     )
@@ -271,7 +238,7 @@ def _build_request(
         **(
             {"component_delta": component_delta}
             if (component_delta := _component_delta_binding(
-                taskset, condition, repository_id, manifest_bindings
+                taskset, condition, repository, manifest_bindings
             )) is not None
             else {}
         ),
@@ -379,12 +346,26 @@ def _verify_execution_component_artifact(request: Mapping[str, Any]) -> None:
     repository_id = repository.get("id")
     if not isinstance(manifest, str) or not isinstance(repository_id, str) or not repository_id:
         raise AgentBenchmarkError("component_delta execution RepoGround binding is invalid")
-    _verify_component_artifact_bytes(
-        {"manifest": manifest},
+    component = binding.get("component")
+    repository_commit = repository.get("commit")
+    manifest_sha256 = repobrief.get("manifest_sha256")
+    if (
+        not isinstance(component, str)
+        or not component
+        or not isinstance(repository_commit, str)
+        or not repository_commit
+        or not isinstance(manifest_sha256, str)
+    ):
+        raise AgentBenchmarkError("component_delta execution provenance binding is invalid")
+    verify_component_artifact_binding(
+        {"manifest": manifest, "manifest_sha256": manifest_sha256},
         repository_id=repository_id,
+        repository_commit=repository_commit,
+        component=component,
         artifact_path=artifact,
         expected_sha256=artifact_sha256,
     )
+
 
 def execute_runner(
     command: Sequence[str],
@@ -443,6 +424,7 @@ __all__ = [
     "sha256_bytes",
     "sha256_json",
     "validate_evaluation",
+    "validate_evaluation_derivations",
     "validate_receipt",
     "validate_taskset",
     "write_json_atomic",

--- a/merger/repoground/core/agent_benchmark.py
+++ b/merger/repoground/core/agent_benchmark.py
@@ -211,6 +211,7 @@ def _component_delta_binding(
         repository_binding,
         repository_id=repository_id,
         repository_commit=str(repository["commit"]),
+        source_revision=str(comparison["source_revision"]),
         component=component,
         artifact_path=artifact_path,
         expected_sha256=artifact_sha256,
@@ -376,21 +377,31 @@ def _verify_execution_component_artifact(request: Mapping[str, Any]) -> None:
         if artifact is not None or artifact_sha256 is not None:
             raise AgentBenchmarkError("component_delta baseline cannot execute with an artifact")
         repobrief = request.get("repobrief")
-        repository = request.get("repository")
+        repository = mapping_value(request.get("repository"))
         component = binding.get("component")
-        repository_id = mapping_value(repository).get("id")
+        source_revision = binding.get("source_revision")
+        repository_id = repository.get("id")
+        repository_commit = repository.get("commit")
         if (
             not isinstance(repobrief, Mapping)
             or not isinstance(component, str)
             or not component
+            or not isinstance(source_revision, str)
+            or not source_revision
             or not isinstance(repository_id, str)
             or not repository_id
+            or not isinstance(repository_commit, str)
+            or not repository_commit
         ):
             raise AgentBenchmarkError(
                 "component_delta baseline RepoGround binding is invalid"
             )
         verify_component_free_manifest_binding(
-            repobrief, repository_id=repository_id, component=component
+            repobrief,
+            repository_id=repository_id,
+            repository_commit=repository_commit,
+            source_revision=source_revision,
+            component=component,
         )
         return
     if (
@@ -424,6 +435,7 @@ def _verify_execution_component_artifact(request: Mapping[str, Any]) -> None:
         {"manifest": manifest, "manifest_sha256": manifest_sha256},
         repository_id=repository_id,
         repository_commit=repository_commit,
+        source_revision=str(binding.get("source_revision", "")),
         component=component,
         artifact_path=artifact,
         expected_sha256=artifact_sha256,

--- a/merger/repoground/core/agent_benchmark.py
+++ b/merger/repoground/core/agent_benchmark.py
@@ -34,7 +34,7 @@ from merger.repoground.core.agent_benchmark_common import (
     validate_taskset,
     write_json_atomic,
 )
-from merger.repoground.core.agent_benchmark_evaluation import score_receipt
+from merger.repoground.core.agent_benchmark_evaluation import score_receipt, validate_evaluation
 from merger.repoground.core.bounded_artifact_read import (
     MAX_REGISTERED_ARTIFACT_BYTES,
     read_stable_regular_file_bytes,
@@ -349,6 +349,41 @@ def _decode_runner_output(raw: bytes) -> dict[str, Any]:
     return value
 
 
+
+def _verify_execution_component_artifact(request: Mapping[str, Any]) -> None:
+    binding = request.get("component_delta")
+    if not isinstance(binding, Mapping):
+        return
+    artifact = binding.get("artifact")
+    artifact_sha256 = binding.get("artifact_sha256")
+    condition = request.get("condition")
+    if condition == "baseline":
+        if artifact is not None or artifact_sha256 is not None:
+            raise AgentBenchmarkError("component_delta baseline cannot execute with an artifact")
+        return
+    if (
+        condition != "treatment"
+        or not isinstance(artifact, str)
+        or not artifact
+        or not isinstance(artifact_sha256, str)
+        or len(artifact_sha256) != 64
+    ):
+        raise AgentBenchmarkError("component_delta execution artifact binding is invalid")
+    repobrief = request.get("repobrief")
+    repository = request.get("repository")
+    if not isinstance(repobrief, Mapping) or not isinstance(repository, Mapping):
+        raise AgentBenchmarkError("component_delta execution requires RepoGround repository binding")
+    manifest = repobrief.get("manifest")
+    repository_id = repository.get("id")
+    if not isinstance(manifest, str) or not isinstance(repository_id, str) or not repository_id:
+        raise AgentBenchmarkError("component_delta execution RepoGround binding is invalid")
+    _verify_component_artifact_bytes(
+        {"manifest": manifest},
+        repository_id=repository_id,
+        artifact_path=artifact,
+        expected_sha256=artifact_sha256,
+    )
+
 def execute_runner(
     command: Sequence[str],
     request: Mapping[str, Any],
@@ -362,6 +397,7 @@ def execute_runner(
         raise AgentBenchmarkError("runner command must be a non-empty string array")
     if timeout_seconds < 1:
         raise AgentBenchmarkError("runner timeout must be positive")
+    _verify_execution_component_artifact(request)
     request_bytes = (canonical_json(request) + "\n").encode("utf-8")
     with tempfile.TemporaryFile() as stdout_file, tempfile.TemporaryFile() as stderr_file:
         try:
@@ -404,6 +440,7 @@ __all__ = [
     "score_receipt",
     "sha256_bytes",
     "sha256_json",
+    "validate_evaluation",
     "validate_receipt",
     "validate_taskset",
     "write_json_atomic",

--- a/merger/repoground/core/agent_benchmark.py
+++ b/merger/repoground/core/agent_benchmark.py
@@ -10,16 +10,20 @@ import os
 import subprocess
 import tempfile
 from collections.abc import Mapping, Sequence
+from pathlib import Path
 from typing import Any
 
 from merger.repoground.core.agent_benchmark_common import (
     AgentBenchmarkError,
+    COMPONENT_DELTA_MODE,
     DOES_NOT_ESTABLISH,
     MAX_JSON_BYTES,
     MAX_RUNNER_STDERR_BYTES,
     REQUEST_KIND,
     VERSION,
     canonical_json,
+    comparison_contract,
+    comparison_mode,
     is_repository_relative_path,
     list_value,
     load_json,
@@ -31,6 +35,10 @@ from merger.repoground.core.agent_benchmark_common import (
     write_json_atomic,
 )
 from merger.repoground.core.agent_benchmark_evaluation import score_receipt
+from merger.repoground.core.bounded_artifact_read import (
+    MAX_REGISTERED_ARTIFACT_BYTES,
+    read_stable_regular_file_bytes,
+)
 from merger.repoground.core.agent_benchmark_integrity import evaluate_paired_runs
 from merger.repoground.core.agent_benchmark_policy import BENCHMARK_REPETITIONS
 from merger.repoground.core.agent_benchmark_receipts import validate_receipt
@@ -103,11 +111,12 @@ def _condition_order(case_index: int, repetition: int) -> tuple[str, str]:
 
 
 def _repobrief_binding(
+    taskset: Mapping[str, Any],
     condition: str,
     repository_id: str,
     manifest_bindings: Mapping[str, Mapping[str, Any]],
 ) -> dict[str, Any] | None:
-    if condition == "baseline":
+    if condition == "baseline" and comparison_mode(taskset) != COMPONENT_DELTA_MODE:
         return None
     binding = manifest_bindings.get(repository_id)
     if not isinstance(binding, Mapping):
@@ -119,6 +128,90 @@ def _repobrief_binding(
         "manifest_sha256": str(binding["manifest_sha256"]),
         "mcp_command": list(binding["mcp_command"]),
     }
+
+
+def _verify_component_artifact_bytes(
+    repository_binding: Mapping[str, Any],
+    *,
+    repository_id: str,
+    artifact_path: str,
+    expected_sha256: str,
+) -> None:
+    manifest = repository_binding.get("manifest")
+    if not isinstance(manifest, str) or not manifest or not Path(manifest).is_absolute():
+        raise AgentBenchmarkError(
+            f"component artifact requires an absolute manifest binding for {repository_id}"
+        )
+    if not is_repository_relative_path(artifact_path):
+        raise AgentBenchmarkError(
+            f"component artifact path is not repository-relative for {repository_id}"
+        )
+    artifact_root = Path(manifest).parent.resolve(strict=False)
+    candidate = artifact_root / artifact_path
+    try:
+        candidate.resolve(strict=False).relative_to(artifact_root)
+    except ValueError as exc:
+        raise AgentBenchmarkError(
+            f"component artifact escapes manifest root for {repository_id}"
+        ) from exc
+    raw, _identity, failure, detail = read_stable_regular_file_bytes(
+        candidate, max_bytes=MAX_REGISTERED_ARTIFACT_BYTES
+    )
+    if failure is not None or raw is None:
+        suffix = f": {detail}" if detail else ""
+        raise AgentBenchmarkError(
+            f"component artifact {failure or 'unreadable'} for {repository_id}{suffix}"
+        )
+    if sha256_bytes(raw) != expected_sha256:
+        raise AgentBenchmarkError(
+            f"component artifact SHA-256 mismatch for {repository_id}"
+        )
+
+
+def _component_delta_binding(
+    taskset: Mapping[str, Any],
+    condition: str,
+    repository_id: str,
+    manifest_bindings: Mapping[str, Mapping[str, Any]],
+) -> dict[str, Any] | None:
+    if comparison_mode(taskset) != COMPONENT_DELTA_MODE:
+        return None
+    comparison = comparison_contract(taskset)
+    result: dict[str, Any] = {
+        "component": str(comparison["component"]),
+        "source_revision": str(comparison["source_revision"]),
+        "artifact": None,
+        "artifact_sha256": None,
+    }
+    if condition == "baseline":
+        return result
+    repository_binding = manifest_bindings.get(repository_id)
+    components = mapping_value(
+        repository_binding.get("components") if isinstance(repository_binding, Mapping) else None
+    )
+    artifact = mapping_value(components.get(str(comparison["component"])))
+    if (
+        artifact.get("source_revision") != comparison["source_revision"]
+        or not isinstance(artifact.get("artifact"), str)
+        or not artifact.get("artifact")
+        or not isinstance(artifact.get("artifact_sha256"), str)
+        or len(str(artifact.get("artifact_sha256"))) != 64
+        or any(ch not in "0123456789abcdef" for ch in str(artifact.get("artifact_sha256")))
+    ):
+        raise AgentBenchmarkError(
+            f"missing or invalid component artifact binding for {repository_id}"
+        )
+    artifact_path = str(artifact["artifact"])
+    artifact_sha256 = str(artifact["artifact_sha256"])
+    _verify_component_artifact_bytes(
+        repository_binding,
+        repository_id=repository_id,
+        artifact_path=artifact_path,
+        expected_sha256=artifact_sha256,
+    )
+    result["artifact"] = artifact_path
+    result["artifact_sha256"] = artifact_sha256
+    return result
 
 
 def _build_request(
@@ -173,7 +266,14 @@ def _build_request(
             ),
         },
         "repobrief": _repobrief_binding(
-            condition, repository_id, manifest_bindings
+            taskset, condition, repository_id, manifest_bindings
+        ),
+        **(
+            {"component_delta": component_delta}
+            if (component_delta := _component_delta_binding(
+                taskset, condition, repository_id, manifest_bindings
+            )) is not None
+            else {}
         ),
         "isolation": {
             "fresh_session": True,

--- a/merger/repoground/core/agent_benchmark_common.py
+++ b/merger/repoground/core/agent_benchmark_common.py
@@ -17,6 +17,8 @@ EVALUATION_KIND = "repobrief.agent_benchmark_evaluation"
 VERSION = "1.0"
 CATEGORIES = ("navigation", "structural", "grounding_freshness")
 CONDITIONS = ("baseline", "treatment")
+LEGACY_COMPARISON_MODE = "repoground_vs_baseline"
+COMPONENT_DELTA_MODE = "component_delta"
 NON_ANSWER_OUTCOMES = {
     "abstain",
     "stale",
@@ -192,6 +194,42 @@ def _repository_ids(taskset: Mapping[str, Any]) -> tuple[set[str], list[str]]:
     return set(identifiers), errors
 
 
+def comparison_contract(taskset: Mapping[str, Any]) -> Mapping[str, Any]:
+    return mapping_value(taskset.get("comparison"))
+
+
+def comparison_mode(taskset: Mapping[str, Any]) -> str:
+    comparison = comparison_contract(taskset)
+    if not comparison:
+        return LEGACY_COMPARISON_MODE
+    return str(comparison.get("mode", ""))
+
+
+def _validate_comparison(taskset: Mapping[str, Any]) -> list[str]:
+    comparison = comparison_contract(taskset)
+    if not comparison:
+        return []
+    if comparison.get("mode") != COMPONENT_DELTA_MODE:
+        return ["comparison mode is unsupported"]
+    component = comparison.get("component")
+    source_revision = comparison.get("source_revision")
+    errors: list[str] = []
+    component_valid = (
+        isinstance(component, str)
+        and len(component) >= 2
+        and "a" <= component[0] <= "z"
+        and all(
+            "a" <= char <= "z" or "0" <= char <= "9" or char in "_.-"
+            for char in component[1:]
+        )
+    )
+    if not component_valid:
+        errors.append("component_delta component is invalid")
+    if not isinstance(source_revision, str) or len(source_revision) not in {40, 64} or any(ch not in "0123456789abcdef" for ch in source_revision):
+        errors.append("component_delta source_revision is invalid")
+    return errors
+
+
 def _validate_tool_policy(taskset: Mapping[str, Any]) -> list[str]:
     policy = mapping_value(taskset.get("tool_policy"))
     baseline = {str(item) for item in list_value(policy.get("baseline"))}
@@ -203,7 +241,12 @@ def _validate_tool_policy(taskset: Mapping[str, Any]) -> list[str]:
         errors.append("treatment tools must include every baseline tool")
     if not REPOBRIEF_TOOLS.issubset(treatment):
         errors.append("treatment tool policy misses required RepoGround tools")
-    if baseline.intersection(REPOBRIEF_TOOLS):
+    if comparison_mode(taskset) == COMPONENT_DELTA_MODE:
+        if baseline != treatment:
+            errors.append("component_delta tool policies must be identical")
+        if not REPOBRIEF_TOOLS.issubset(baseline):
+            errors.append("component_delta baseline must expose RepoGround tools")
+    elif baseline.intersection(REPOBRIEF_TOOLS):
         errors.append("baseline tool policy must not expose RepoGround tools")
     return errors
 
@@ -251,6 +294,7 @@ def validate_taskset(taskset: Mapping[str, Any]) -> list[str]:
     errors = _validate_taskset_identity(taskset)
     repository_ids, repository_errors = _repository_ids(taskset)
     errors.extend(repository_errors)
+    errors.extend(_validate_comparison(taskset))
     errors.extend(_validate_tool_policy(taskset))
     cases = list_value(taskset.get("cases"))
     errors.extend(_validate_case_shape(cases))
@@ -275,9 +319,11 @@ def require_valid_taskset(taskset: Mapping[str, Any]) -> None:
 __all__ = [
     "AgentBenchmarkError",
     "CATEGORIES",
+    "COMPONENT_DELTA_MODE",
     "CONDITIONS",
     "DOES_NOT_ESTABLISH",
     "EVALUATION_KIND",
+    "LEGACY_COMPARISON_MODE",
     "MAX_JSON_BYTES",
     "MAX_RUNNER_STDERR_BYTES",
     "NON_ANSWER_OUTCOMES",
@@ -286,6 +332,8 @@ __all__ = [
     "TASKSET_KIND",
     "VERSION",
     "canonical_json",
+    "comparison_contract",
+    "comparison_mode",
     "is_repository_relative_path",
     "list_value",
     "load_json",

--- a/merger/repoground/core/agent_benchmark_common.py
+++ b/merger/repoground/core/agent_benchmark_common.py
@@ -199,16 +199,19 @@ def comparison_contract(taskset: Mapping[str, Any]) -> Mapping[str, Any]:
 
 
 def comparison_mode(taskset: Mapping[str, Any]) -> str:
-    comparison = comparison_contract(taskset)
-    if not comparison:
+    if "comparison" not in taskset:
         return LEGACY_COMPARISON_MODE
+    comparison = comparison_contract(taskset)
     return str(comparison.get("mode", ""))
 
 
 def _validate_comparison(taskset: Mapping[str, Any]) -> list[str]:
-    comparison = comparison_contract(taskset)
-    if not comparison:
+    if "comparison" not in taskset:
         return []
+    raw_comparison = taskset.get("comparison")
+    if not isinstance(raw_comparison, Mapping) or not raw_comparison:
+        return ["comparison contract is invalid"]
+    comparison = raw_comparison
     if comparison.get("mode") != COMPONENT_DELTA_MODE:
         return ["comparison mode is unsupported"]
     component = comparison.get("component")
@@ -269,13 +272,15 @@ def _validate_case_shape(cases: list[Any]) -> list[str]:
 
 
 def _validate_case(
-    case: Mapping[str, Any], *, repository_ids: set[str]
+    case: Mapping[str, Any], *, repository_ids: set[str], require_identical_expectations: bool = False
 ) -> tuple[list[str], bool]:
     case_id = str(case.get("id", ""))
     errors: list[str] = []
     if case.get("repository_id") not in repository_ids:
         errors.append(f"case {case_id} references an unknown repository")
     expectations = mapping_value(case.get("expectations"))
+    if require_identical_expectations and expectations.get("baseline") != expectations.get("treatment"):
+        errors.append(f"case {case_id} component_delta expectations must be identical")
     negative = False
     for condition in CONDITIONS:
         expectation = mapping_value(expectations.get(condition))
@@ -299,9 +304,12 @@ def validate_taskset(taskset: Mapping[str, Any]) -> list[str]:
     cases = list_value(taskset.get("cases"))
     errors.extend(_validate_case_shape(cases))
     negative_count = 0
+    require_identical_expectations = comparison_mode(taskset) == COMPONENT_DELTA_MODE
     for raw_case in cases:
         case_errors, negative = _validate_case(
-            mapping_value(raw_case), repository_ids=repository_ids
+            mapping_value(raw_case),
+            repository_ids=repository_ids,
+            require_identical_expectations=require_identical_expectations,
         )
         errors.extend(case_errors)
         negative_count += int(negative)

--- a/merger/repoground/core/agent_benchmark_components.py
+++ b/merger/repoground/core/agent_benchmark_components.py
@@ -80,6 +80,30 @@ def _validate_schema(
         raise AgentBenchmarkError(f"{label} contract invalid: {errors[0].message}")
 
 
+def _load_bound_manifest(
+    binding: Mapping[str, Any], *, repository_id: str, label: str
+) -> tuple[Path, Mapping[str, Any]]:
+    manifest_value = binding.get("manifest")
+    manifest_sha256 = binding.get("manifest_sha256")
+    if (
+        not isinstance(manifest_value, str)
+        or not manifest_value
+        or not Path(manifest_value).is_absolute()
+        or not _sha256_digest(manifest_sha256)
+    ):
+        raise AgentBenchmarkError(
+            f"{label} requires an absolute digest-bound manifest for {repository_id}"
+        )
+    manifest_path = Path(manifest_value)
+    manifest_raw = _stable_bytes(manifest_path, label=f"{label} for {repository_id}")
+    if sha256_bytes(manifest_raw) != manifest_sha256:
+        raise AgentBenchmarkError(f"{label} SHA-256 mismatch for {repository_id}")
+    manifest = _json_object(manifest_raw, label=f"{label} for {repository_id}")
+    if bundle_identity(manifest) is None:
+        raise AgentBenchmarkError(f"{label} identity is invalid for {repository_id}")
+    return manifest_path, manifest
+
+
 def _registered_artifact(
     manifest: Mapping[str, Any],
     *,
@@ -121,17 +145,6 @@ def verify_component_artifact_binding(
     contract = _COMPONENT_CONTRACTS.get(component)
     if contract is None:
         raise AgentBenchmarkError(f"unsupported component_delta contract: {component}")
-    manifest_value = repository_binding.get("manifest")
-    manifest_sha256 = repository_binding.get("manifest_sha256")
-    if (
-        not isinstance(manifest_value, str)
-        or not manifest_value
-        or not Path(manifest_value).is_absolute()
-        or not _sha256_digest(manifest_sha256)
-    ):
-        raise AgentBenchmarkError(
-            f"component artifact requires an absolute digest-bound manifest for {repository_id}"
-        )
     if not is_repository_relative_path(artifact_path) or not _sha256_digest(
         expected_sha256
     ):
@@ -139,21 +152,11 @@ def verify_component_artifact_binding(
             f"component artifact binding is invalid for {repository_id}"
         )
 
-    manifest_path = Path(manifest_value)
-    manifest_raw = _stable_bytes(
-        manifest_path, label=f"component manifest for {repository_id}"
+    manifest_path, manifest = _load_bound_manifest(
+        repository_binding,
+        repository_id=repository_id,
+        label="component manifest",
     )
-    if sha256_bytes(manifest_raw) != manifest_sha256:
-        raise AgentBenchmarkError(
-            f"component manifest SHA-256 mismatch for {repository_id}"
-        )
-    manifest = _json_object(
-        manifest_raw, label=f"component manifest for {repository_id}"
-    )
-    if bundle_identity(manifest) is None:
-        raise AgentBenchmarkError(
-            f"component manifest identity is invalid for {repository_id}"
-        )
     registered = _registered_artifact(
         manifest,
         component=component,
@@ -197,3 +200,82 @@ def verify_component_artifact_binding(
         raise AgentBenchmarkError(
             f"component artifact provenance mismatch for {repository_id}"
         )
+
+def verify_component_free_manifest_binding(
+    repository_binding: Mapping[str, Any],
+    *,
+    repository_id: str,
+    component: str,
+) -> None:
+    """Verify the baseline manifest cannot expose the tested component."""
+
+    _path, manifest = _load_bound_manifest(
+        repository_binding,
+        repository_id=repository_id,
+        label="component-free baseline manifest",
+    )
+    artifacts = manifest.get("artifacts")
+    if not isinstance(artifacts, list):
+        raise AgentBenchmarkError("component-free baseline manifest has no artifact registry")
+    if any(
+        isinstance(item, Mapping) and item.get("role") == component
+        for item in artifacts
+    ):
+        raise AgentBenchmarkError(
+            f"component-free baseline manifest still registers {component} for {repository_id}"
+        )
+
+
+def verify_component_manifest_delta(
+    baseline_binding: Mapping[str, Any],
+    treatment_binding: Mapping[str, Any],
+    *,
+    repository_id: str,
+    repository_commit: str,
+    component: str,
+    artifact_path: str,
+    expected_sha256: str,
+) -> None:
+    """Prove baseline and treatment manifests differ only by the component artifact."""
+
+    verify_component_artifact_binding(
+        treatment_binding,
+        repository_id=repository_id,
+        repository_commit=repository_commit,
+        component=component,
+        artifact_path=artifact_path,
+        expected_sha256=expected_sha256,
+    )
+    verify_component_free_manifest_binding(
+        baseline_binding, repository_id=repository_id, component=component
+    )
+    _baseline_path, baseline_manifest = _load_bound_manifest(
+        baseline_binding,
+        repository_id=repository_id,
+        label="component-free baseline manifest",
+    )
+    _treatment_path, treatment_manifest = _load_bound_manifest(
+        treatment_binding,
+        repository_id=repository_id,
+        label="component manifest",
+    )
+    treatment_artifacts = treatment_manifest.get("artifacts")
+    if not isinstance(treatment_artifacts, list):
+        raise AgentBenchmarkError("component manifest has no artifact registry")
+    expected_baseline = dict(treatment_manifest)
+    expected_baseline["artifacts"] = [
+        item
+        for item in treatment_artifacts
+        if not (isinstance(item, Mapping) and item.get("role") == component)
+    ]
+    if baseline_manifest != expected_baseline:
+        raise AgentBenchmarkError(
+            f"baseline/treatment manifests differ beyond {component} for {repository_id}"
+        )
+
+
+__all__ = [
+    "verify_component_artifact_binding",
+    "verify_component_free_manifest_binding",
+    "verify_component_manifest_delta",
+]

--- a/merger/repoground/core/agent_benchmark_components.py
+++ b/merger/repoground/core/agent_benchmark_components.py
@@ -17,6 +17,7 @@ from merger.repoground.core.bounded_artifact_read import (
     read_stable_regular_file_bytes,
 )
 from merger.repoground.core.bundle_identity import bundle_identity
+from merger.repoground.core.language_structure_access import load_language_structure_artifact
 
 
 _COMPONENT_CONTRACTS = {
@@ -131,11 +132,44 @@ def _registered_artifact(
     return registered
 
 
+def _verify_manifest_provenance(
+    manifest: Mapping[str, Any],
+    *,
+    repository_id: str,
+    repository_commit: str,
+    source_revision: str,
+) -> None:
+    provenance = manifest.get("snapshot_provenance")
+    repositories = (
+        provenance.get("repositories") if isinstance(provenance, Mapping) else None
+    )
+    if (
+        not isinstance(repositories, list)
+        or len(repositories) != 1
+        or not isinstance(repositories[0], Mapping)
+        or repositories[0].get("git_commit") != repository_commit
+    ):
+        raise AgentBenchmarkError(
+            f"component manifest repository commit mismatch for {repository_id}"
+        )
+    generator = manifest.get("generator")
+    runtime = generator.get("runtime") if isinstance(generator, Mapping) else None
+    if (
+        not isinstance(runtime, Mapping)
+        or runtime.get("git_commit") != source_revision
+        or runtime.get("git_dirty") is not False
+    ):
+        raise AgentBenchmarkError(
+            f"component generator provenance mismatch for {repository_id}"
+        )
+
+
 def verify_component_artifact_binding(
     repository_binding: Mapping[str, Any],
     *,
     repository_id: str,
     repository_commit: str,
+    source_revision: str,
     component: str,
     artifact_path: str,
     expected_sha256: str,
@@ -156,6 +190,12 @@ def verify_component_artifact_binding(
         repository_binding,
         repository_id=repository_id,
         label="component manifest",
+    )
+    _verify_manifest_provenance(
+        manifest,
+        repository_id=repository_id,
+        repository_commit=repository_commit,
+        source_revision=source_revision,
     )
     registered = _registered_artifact(
         manifest,
@@ -200,19 +240,34 @@ def verify_component_artifact_binding(
         raise AgentBenchmarkError(
             f"component artifact provenance mismatch for {repository_id}"
         )
+    production = load_language_structure_artifact(manifest_path)
+    if production.get("status") != "available":
+        raise AgentBenchmarkError(
+            "component artifact rejected by production loader for "
+            f"{repository_id}: {production.get('reason') or production.get('status')}"
+        )
+
 
 def verify_component_free_manifest_binding(
     repository_binding: Mapping[str, Any],
     *,
     repository_id: str,
+    repository_commit: str,
+    source_revision: str,
     component: str,
 ) -> None:
     """Verify the baseline manifest cannot expose the tested component."""
 
-    _path, manifest = _load_bound_manifest(
+    manifest_path, manifest = _load_bound_manifest(
         repository_binding,
         repository_id=repository_id,
         label="component-free baseline manifest",
+    )
+    _verify_manifest_provenance(
+        manifest,
+        repository_id=repository_id,
+        repository_commit=repository_commit,
+        source_revision=source_revision,
     )
     artifacts = manifest.get("artifacts")
     if not isinstance(artifacts, list):
@@ -224,6 +279,15 @@ def verify_component_free_manifest_binding(
         raise AgentBenchmarkError(
             f"component-free baseline manifest still registers {component} for {repository_id}"
         )
+    production = load_language_structure_artifact(manifest_path)
+    if not (
+        production.get("status") == "missing"
+        and production.get("reason") == "language_structure_not_registered"
+    ):
+        raise AgentBenchmarkError(
+            "component-free baseline manifest remains production-loader usable for "
+            f"{repository_id}: {production.get('reason') or production.get('status')}"
+        )
 
 
 def verify_component_manifest_delta(
@@ -232,6 +296,7 @@ def verify_component_manifest_delta(
     *,
     repository_id: str,
     repository_commit: str,
+    source_revision: str,
     component: str,
     artifact_path: str,
     expected_sha256: str,
@@ -242,12 +307,17 @@ def verify_component_manifest_delta(
         treatment_binding,
         repository_id=repository_id,
         repository_commit=repository_commit,
+        source_revision=source_revision,
         component=component,
         artifact_path=artifact_path,
         expected_sha256=expected_sha256,
     )
     verify_component_free_manifest_binding(
-        baseline_binding, repository_id=repository_id, component=component
+        baseline_binding,
+        repository_id=repository_id,
+        repository_commit=repository_commit,
+        source_revision=source_revision,
+        component=component,
     )
     _baseline_path, baseline_manifest = _load_bound_manifest(
         baseline_binding,

--- a/merger/repoground/core/agent_benchmark_components.py
+++ b/merger/repoground/core/agent_benchmark_components.py
@@ -1,0 +1,199 @@
+"""Validate component-delta artifacts against their registered RepoGround contracts."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from merger.repoground.core.agent_benchmark_common import (
+    AgentBenchmarkError,
+    is_repository_relative_path,
+    sha256_bytes,
+)
+from merger.repoground.core.bounded_artifact_read import (
+    MAX_REGISTERED_ARTIFACT_BYTES,
+    read_stable_regular_file_bytes,
+)
+from merger.repoground.core.bundle_identity import bundle_identity
+
+
+_COMPONENT_CONTRACTS = {
+    "language_structure_json": {
+        "contract": {"id": "language-structure", "version": "v1"},
+        "schema": "language-structure.v1.schema.json",
+    }
+}
+
+
+def _sha256_digest(value: Any) -> bool:
+    return bool(
+        isinstance(value, str)
+        and len(value) == 64
+        and all(ch in "0123456789abcdef" for ch in value)
+    )
+
+
+def _stable_bytes(path: Path, *, label: str) -> bytes:
+    raw, _identity, failure, detail = read_stable_regular_file_bytes(
+        path, max_bytes=MAX_REGISTERED_ARTIFACT_BYTES
+    )
+    if failure is not None or raw is None:
+        suffix = f": {detail}" if detail else ""
+        raise AgentBenchmarkError(f"{label} {failure or 'unreadable'}{suffix}")
+    return raw
+
+
+def _json_object(raw: bytes, *, label: str) -> Mapping[str, Any]:
+    try:
+        value = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise AgentBenchmarkError(f"{label} is not one UTF-8 JSON object") from exc
+    if not isinstance(value, Mapping):
+        raise AgentBenchmarkError(f"{label} must be one JSON object")
+    return value
+
+
+def _validate_schema(
+    document: Mapping[str, Any], *, schema_name: str, label: str
+) -> None:
+    try:
+        import jsonschema
+    except ModuleNotFoundError as exc:
+        raise AgentBenchmarkError(
+            f"{label} schema validation unavailable: jsonschema is not installed"
+        ) from exc
+    schema_path = Path(__file__).resolve().parents[1] / "contracts" / schema_name
+    try:
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        jsonschema.Draft7Validator.check_schema(schema)
+        errors = sorted(
+            jsonschema.Draft7Validator(schema).iter_errors(document),
+            key=lambda item: list(item.path),
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError, jsonschema.SchemaError) as exc:
+        raise AgentBenchmarkError(
+            f"{label} schema validation unavailable: {exc}"
+        ) from exc
+    if errors:
+        raise AgentBenchmarkError(f"{label} contract invalid: {errors[0].message}")
+
+
+def _registered_artifact(
+    manifest: Mapping[str, Any],
+    *,
+    component: str,
+    artifact_path: str,
+    expected_sha256: str,
+) -> Mapping[str, Any]:
+    artifacts = manifest.get("artifacts")
+    if not isinstance(artifacts, list):
+        raise AgentBenchmarkError("component manifest has no artifact registry")
+    matches = [
+        item
+        for item in artifacts
+        if isinstance(item, Mapping) and item.get("role") == component
+    ]
+    if len(matches) != 1:
+        raise AgentBenchmarkError(
+            f"component manifest must register exactly one {component} artifact"
+        )
+    registered = matches[0]
+    if registered.get("path") != artifact_path:
+        raise AgentBenchmarkError("component manifest artifact path mismatch")
+    if registered.get("sha256") != expected_sha256:
+        raise AgentBenchmarkError("component manifest artifact SHA-256 mismatch")
+    return registered
+
+
+def verify_component_artifact_binding(
+    repository_binding: Mapping[str, Any],
+    *,
+    repository_id: str,
+    repository_commit: str,
+    component: str,
+    artifact_path: str,
+    expected_sha256: str,
+) -> None:
+    """Verify manifest membership, component contract, provenance, and exact bytes."""
+
+    contract = _COMPONENT_CONTRACTS.get(component)
+    if contract is None:
+        raise AgentBenchmarkError(f"unsupported component_delta contract: {component}")
+    manifest_value = repository_binding.get("manifest")
+    manifest_sha256 = repository_binding.get("manifest_sha256")
+    if (
+        not isinstance(manifest_value, str)
+        or not manifest_value
+        or not Path(manifest_value).is_absolute()
+        or not _sha256_digest(manifest_sha256)
+    ):
+        raise AgentBenchmarkError(
+            f"component artifact requires an absolute digest-bound manifest for {repository_id}"
+        )
+    if not is_repository_relative_path(artifact_path) or not _sha256_digest(
+        expected_sha256
+    ):
+        raise AgentBenchmarkError(
+            f"component artifact binding is invalid for {repository_id}"
+        )
+
+    manifest_path = Path(manifest_value)
+    manifest_raw = _stable_bytes(
+        manifest_path, label=f"component manifest for {repository_id}"
+    )
+    if sha256_bytes(manifest_raw) != manifest_sha256:
+        raise AgentBenchmarkError(
+            f"component manifest SHA-256 mismatch for {repository_id}"
+        )
+    manifest = _json_object(
+        manifest_raw, label=f"component manifest for {repository_id}"
+    )
+    if bundle_identity(manifest) is None:
+        raise AgentBenchmarkError(
+            f"component manifest identity is invalid for {repository_id}"
+        )
+    registered = _registered_artifact(
+        manifest,
+        component=component,
+        artifact_path=artifact_path,
+        expected_sha256=expected_sha256,
+    )
+    if registered.get("contract") != contract["contract"]:
+        raise AgentBenchmarkError(
+            f"component manifest contract mismatch for {repository_id}"
+        )
+
+    artifact_root = manifest_path.parent.resolve(strict=False)
+    candidate = artifact_root / artifact_path
+    try:
+        candidate.resolve(strict=False).relative_to(artifact_root)
+    except ValueError as exc:
+        raise AgentBenchmarkError(
+            f"component artifact escapes manifest root for {repository_id}"
+        ) from exc
+    artifact_raw = _stable_bytes(
+        candidate, label=f"component artifact for {repository_id}"
+    )
+    if sha256_bytes(artifact_raw) != expected_sha256:
+        raise AgentBenchmarkError(
+            f"component artifact SHA-256 mismatch for {repository_id}"
+        )
+    document = _json_object(
+        artifact_raw, label=f"component artifact for {repository_id}"
+    )
+    _validate_schema(
+        document,
+        schema_name=str(contract["schema"]),
+        label=f"component artifact for {repository_id}",
+    )
+    source = document.get("source")
+    if (
+        not isinstance(source, Mapping)
+        or source.get("repository_commit") != repository_commit
+        or source.get("bundle_manifest") != manifest_path.name
+    ):
+        raise AgentBenchmarkError(
+            f"component artifact provenance mismatch for {repository_id}"
+        )

--- a/merger/repoground/core/agent_benchmark_evaluation.py
+++ b/merger/repoground/core/agent_benchmark_evaluation.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from collections import Counter, defaultdict
+import json
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
@@ -20,6 +21,31 @@ from merger.repoground.core.agent_benchmark_common import (
     sha256_json,
 )
 from merger.repoground.core.agent_benchmark_receipts import validate_receipt
+
+
+
+def validate_evaluation(evaluation: Mapping[str, Any]) -> list[str]:
+    """Validate a complete v1 evaluation against its canonical JSON Schema."""
+
+    try:
+        import jsonschema
+    except ModuleNotFoundError:
+        return ["evaluation schema validation unavailable: jsonschema is not installed"]
+    schema_path = (
+        Path(__file__).resolve().parents[1]
+        / "contracts"
+        / "agent-benchmark-evaluation.v1.schema.json"
+    )
+    try:
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        jsonschema.Draft7Validator.check_schema(schema)
+    except (OSError, UnicodeError, json.JSONDecodeError, jsonschema.SchemaError) as exc:
+        return [f"evaluation schema validation unavailable: {exc}"]
+    validator = jsonschema.Draft7Validator(schema)
+    return [
+        error.message
+        for error in sorted(validator.iter_errors(evaluation), key=lambda item: list(item.path))
+    ]
 
 
 def _citation_key(value: Mapping[str, Any]) -> tuple[str, int, int] | None:
@@ -573,4 +599,4 @@ def evaluate_paired_runs(
     }
 
 
-__all__ = ["evaluate_paired_runs", "score_receipt"]
+__all__ = ["evaluate_paired_runs", "score_receipt", "validate_evaluation"]

--- a/merger/repoground/core/agent_benchmark_evaluation.py
+++ b/merger/repoground/core/agent_benchmark_evaluation.py
@@ -554,6 +554,60 @@ def _decision(
     }
 
 
+def validate_evaluation_derivations(evaluation: Mapping[str, Any]) -> list[str]:
+    """Recompute every aggregate derived from case scores and frozen thresholds."""
+
+    try:
+        thresholds = evaluation.get("thresholds")
+        cases = evaluation.get("cases")
+        classes = evaluation.get("classes")
+        measurement_scope = evaluation.get("measurement_scope")
+        if (
+            not isinstance(thresholds, Mapping)
+            or not isinstance(cases, list)
+            or not isinstance(classes, list)
+            or measurement_scope not in {
+                "synthetic_contract_fixture",
+                "real_paired_agent_runs",
+            }
+        ):
+            return ["evaluation derivation inputs are invalid"]
+        expected_classes = _class_results(
+            cases,
+            thresholds=thresholds,
+            measurement_scope=str(measurement_scope),
+        )
+        errors: list[str] = []
+        if classes != expected_classes:
+            errors.append("evaluation classes do not match case scores and thresholds")
+        expected_decision = _decision(
+            expected_classes, measurement_scope=str(measurement_scope)
+        )
+        if evaluation.get("decision") != expected_decision:
+            errors.append("evaluation decision does not match recomputed classes")
+        valid_run_count = sum(
+            int(mapping_value(item.get(condition)).get("valid") is True)
+            for item in cases
+            if isinstance(item, Mapping)
+            for condition in CONDITIONS
+        )
+        run_count = evaluation.get("run_count")
+        if (
+            isinstance(run_count, bool)
+            or not isinstance(run_count, int)
+            or run_count < len(cases) * len(CONDITIONS)
+        ):
+            errors.append("evaluation run_count is inconsistent with case scores")
+        else:
+            if evaluation.get("valid_run_count") != valid_run_count:
+                errors.append("evaluation valid_run_count does not match case scores")
+            if evaluation.get("invalid_run_count") != run_count - valid_run_count:
+                errors.append("evaluation invalid_run_count does not match case scores")
+        return errors
+    except (KeyError, TypeError, ValueError, OverflowError):
+        return ["evaluation derivations are invalid"]
+
+
 def evaluate_paired_runs(
     taskset: Mapping[str, Any],
     requests: Sequence[Mapping[str, Any]],
@@ -589,6 +643,7 @@ def evaluate_paired_runs(
         "taskset_id": str(taskset["id"]),
         "taskset_sha256": sha256_json(taskset),
         "measurement_scope": measurement_scope,
+        "thresholds": dict(mapping_value(taskset.get("thresholds"))),
         "run_count": max(expected_run_count, len(receipts)),
         "valid_run_count": valid_run_count,
         "invalid_run_count": expected_run_count - valid_run_count + extra_receipts,
@@ -599,4 +654,9 @@ def evaluate_paired_runs(
     }
 
 
-__all__ = ["evaluate_paired_runs", "score_receipt", "validate_evaluation"]
+__all__ = [
+    "evaluate_paired_runs",
+    "score_receipt",
+    "validate_evaluation",
+    "validate_evaluation_derivations",
+]

--- a/merger/repoground/core/agent_benchmark_evaluation.py
+++ b/merger/repoground/core/agent_benchmark_evaluation.py
@@ -1,8 +1,8 @@
 """Score paired benchmark receipts and classify bounded task classes."""
 from __future__ import annotations
 
-from collections import Counter, defaultdict
 import json
+from collections import Counter, defaultdict
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any

--- a/merger/repoground/core/agent_benchmark_integrity.py
+++ b/merger/repoground/core/agent_benchmark_integrity.py
@@ -196,6 +196,33 @@ def _comparison_evidence(
         ),
     }
 
+
+
+def _evaluation_input_evidence(
+    taskset: Mapping[str, Any],
+    requests: Sequence[Mapping[str, Any]],
+    receipts: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    ordered_requests = sorted(
+        (dict(item) for item in requests), key=lambda item: str(item.get("request_id", ""))
+    )
+    ordered_receipts = sorted(
+        (dict(item) for item in receipts), key=lambda item: str(item.get("request_id", ""))
+    )
+    transcripts = [
+        {
+            "request_id": str(item.get("request_id", "")),
+            "sha256": str(mapping_value(item.get("transcript")).get("sha256", "")),
+        }
+        for item in ordered_receipts
+    ]
+    return {
+        "taskset_sha256": sha256_json(taskset),
+        "requests_sha256": sha256_json(ordered_requests),
+        "receipts_sha256": sha256_json(ordered_receipts),
+        "transcripts": transcripts,
+    }
+
 def evaluate_paired_runs(
     taskset: Mapping[str, Any],
     requests: Sequence[Mapping[str, Any]],
@@ -239,6 +266,7 @@ def evaluate_paired_runs(
         "taskset_id": str(taskset["id"]),
         "taskset_sha256": sha256_json(taskset),
         "measurement_scope": measurement_scope,
+        "evidence": _evaluation_input_evidence(taskset, requests, receipts),
         "thresholds": dict(mapping_value(taskset.get("thresholds"))),
         "run_count": run_count,
         "valid_run_count": valid_run_count,
@@ -254,4 +282,32 @@ def evaluate_paired_runs(
     return result
 
 
-__all__ = ["evaluate_paired_runs"]
+def validate_evaluation_evidence(
+    evaluation: Mapping[str, Any],
+    taskset: Mapping[str, Any],
+    requests: Sequence[Mapping[str, Any]],
+    receipts: Sequence[Mapping[str, Any]],
+    *,
+    transcript_root: str | Path | None = None,
+) -> list[str]:
+    """Re-evaluate the bound run inputs and require byte/digest-equivalent evidence."""
+
+    measurement_scope = evaluation.get("measurement_scope")
+    if measurement_scope not in {"synthetic_contract_fixture", "real_paired_agent_runs"}:
+        return ["evaluation measurement_scope is invalid"]
+    try:
+        recomputed = evaluate_paired_runs(
+            taskset,
+            requests,
+            receipts,
+            measurement_scope=str(measurement_scope),
+            transcript_root=transcript_root,
+        )
+    except (AgentBenchmarkError, KeyError, TypeError, ValueError, OverflowError) as exc:
+        return [f"evaluation input revalidation failed: {exc}"]
+    if dict(evaluation) != recomputed:
+        return ["evaluation does not match re-evaluated taskset, requests, receipts, and transcripts"]
+    return []
+
+
+__all__ = ["evaluate_paired_runs", "validate_evaluation_evidence"]

--- a/merger/repoground/core/agent_benchmark_integrity.py
+++ b/merger/repoground/core/agent_benchmark_integrity.py
@@ -239,6 +239,7 @@ def evaluate_paired_runs(
         "taskset_id": str(taskset["id"]),
         "taskset_sha256": sha256_json(taskset),
         "measurement_scope": measurement_scope,
+        "thresholds": dict(mapping_value(taskset.get("thresholds"))),
         "run_count": run_count,
         "valid_run_count": valid_run_count,
         "invalid_run_count": run_count - valid_run_count,

--- a/merger/repoground/core/agent_benchmark_integrity.py
+++ b/merger/repoground/core/agent_benchmark_integrity.py
@@ -266,6 +266,11 @@ def evaluate_paired_runs(
         "taskset_id": str(taskset["id"]),
         "taskset_sha256": sha256_json(taskset),
         "measurement_scope": measurement_scope,
+        "runner_execution": {
+            "attested": False,
+            "authority": "none",
+            "reason": "trusted runner execution attestation is not available in benchmark v1",
+        },
         "evidence": _evaluation_input_evidence(taskset, requests, receipts),
         "thresholds": dict(mapping_value(taskset.get("thresholds"))),
         "run_count": run_count,

--- a/merger/repoground/core/agent_benchmark_integrity.py
+++ b/merger/repoground/core/agent_benchmark_integrity.py
@@ -266,11 +266,6 @@ def evaluate_paired_runs(
         "taskset_id": str(taskset["id"]),
         "taskset_sha256": sha256_json(taskset),
         "measurement_scope": measurement_scope,
-        "runner_execution": {
-            "attested": False,
-            "authority": "none",
-            "reason": "trusted runner execution attestation is not available in benchmark v1",
-        },
         "evidence": _evaluation_input_evidence(taskset, requests, receipts),
         "thresholds": dict(mapping_value(taskset.get("thresholds"))),
         "run_count": run_count,

--- a/merger/repoground/core/agent_benchmark_integrity.py
+++ b/merger/repoground/core/agent_benchmark_integrity.py
@@ -9,9 +9,12 @@ from typing import Any
 from merger.repoground.core.agent_benchmark_common import (
     AgentBenchmarkError,
     CONDITIONS,
+    COMPONENT_DELTA_MODE,
     DOES_NOT_ESTABLISH,
     EVALUATION_KIND,
     VERSION,
+    comparison_contract,
+    comparison_mode,
     list_value,
     mapping_value,
     require_valid_taskset,
@@ -103,7 +106,7 @@ def _harden_pair(
         score = result.get(condition)
         if isinstance(score, dict):
             _append_errors(score, condition_errors.get(condition, []))
-    pair_errors = pair_request_errors(requests)
+    pair_errors = pair_request_errors(taskset, requests)
     if pair_errors:
         for condition in CONDITIONS:
             score = result.get(condition)
@@ -148,6 +151,51 @@ def _complete_case_results(
     return completed
 
 
+
+def _comparison_evidence(
+    taskset: Mapping[str, Any], requests: Sequence[Mapping[str, Any]], cases: Sequence[Mapping[str, Any]]
+) -> dict[str, Any] | None:
+    if comparison_mode(taskset) != COMPONENT_DELTA_MODE:
+        return None
+    comparison = comparison_contract(taskset)
+    treatment_artifacts = sorted(
+        {
+            (
+                str(mapping_value(request.get("repository")).get("id")),
+                str(mapping_value(request.get("component_delta")).get("artifact")),
+                str(mapping_value(request.get("component_delta")).get("artifact_sha256")),
+            )
+            for request in requests
+            if request.get("condition") == "treatment"
+            and isinstance(mapping_value(request.get("repository")).get("id"), str)
+            and isinstance(mapping_value(request.get("component_delta")).get("artifact"), str)
+            and isinstance(mapping_value(request.get("component_delta")).get("artifact_sha256"), str)
+        }
+    )
+    expected = set(expected_pair_keys(taskset))
+    observed = {
+        (str(item.get("case_id")), int(item.get("repetition") or 0)) for item in cases
+    }
+    return {
+        "mode": COMPONENT_DELTA_MODE,
+        "component": str(comparison.get("component", "")),
+        "source_revision": str(comparison.get("source_revision", "")),
+        "treatment_artifacts": [
+            {
+                "repository_id": repository_id,
+                "artifact": artifact,
+                "artifact_sha256": artifact_sha256,
+            }
+            for repository_id, artifact, artifact_sha256 in treatment_artifacts
+        ],
+        "pair_isolation_verified": (
+            bool(expected)
+            and observed == expected
+            and len(cases) == len(expected)
+            and all(item.get("pair_valid") is True for item in cases)
+        ),
+    }
+
 def evaluate_paired_runs(
     taskset: Mapping[str, Any],
     requests: Sequence[Mapping[str, Any]],
@@ -185,7 +233,7 @@ def evaluate_paired_runs(
     )
     expected_run_count = len(expected_pair_keys(taskset)) * len(CONDITIONS)
     run_count = max(expected_run_count, len(requests), len(receipts))
-    return {
+    result = {
         "kind": EVALUATION_KIND,
         "version": VERSION,
         "taskset_id": str(taskset["id"]),
@@ -199,6 +247,10 @@ def evaluate_paired_runs(
         "decision": _decision(classes, measurement_scope=measurement_scope),
         "does_not_establish": list(DOES_NOT_ESTABLISH),
     }
+    comparison = _comparison_evidence(taskset, requests, cases)
+    if comparison is not None:
+        result["comparison"] = comparison
+    return result
 
 
 __all__ = ["evaluate_paired_runs"]

--- a/merger/repoground/core/agent_benchmark_requests.py
+++ b/merger/repoground/core/agent_benchmark_requests.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 
 from merger.repoground.core.agent_benchmark_common import (
+    AgentBenchmarkError,
     COMPONENT_DELTA_MODE,
     CONDITIONS,
     REQUEST_KIND,
@@ -16,6 +17,7 @@ from merger.repoground.core.agent_benchmark_common import (
     sha256_json,
 )
 from merger.repoground.core.agent_benchmark_policy import BENCHMARK_REPETITIONS
+from merger.repoground.core.agent_benchmark_components import verify_component_manifest_delta
 
 
 def _repository_map(taskset: Mapping[str, Any]) -> dict[str, Mapping[str, Any]]:
@@ -210,9 +212,13 @@ def _component_delta_pair_errors(
     baseline: Mapping[str, Any], treatment: Mapping[str, Any]
 ) -> list[str]:
     errors: list[str] = []
-    for field in ("repository", "prompt", "allowed_tools", "budgets", "repobrief", "isolation"):
+    for field in ("repository", "prompt", "allowed_tools", "budgets", "isolation"):
         if baseline.get(field) != treatment.get(field):
             errors.append(f"component_delta paired requests disagree on {field}")
+    baseline_repobrief = mapping_value(baseline.get("repobrief"))
+    treatment_repobrief = mapping_value(treatment.get("repobrief"))
+    if baseline_repobrief.get("mcp_command") != treatment_repobrief.get("mcp_command"):
+        errors.append("component_delta paired requests disagree on RepoGround MCP command")
     baseline_delta = mapping_value(baseline.get("component_delta"))
     treatment_delta = mapping_value(treatment.get("component_delta"))
     for field in ("component", "source_revision"):
@@ -220,8 +226,33 @@ def _component_delta_pair_errors(
             errors.append(f"component_delta paired requests disagree on {field}")
     if baseline_delta.get("artifact") is not None or baseline_delta.get("artifact_sha256") is not None:
         errors.append("component_delta baseline unexpectedly contains artifact evidence")
-    if treatment_delta.get("artifact") is None or treatment_delta.get("artifact_sha256") is None:
+    artifact = treatment_delta.get("artifact")
+    artifact_sha256 = treatment_delta.get("artifact_sha256")
+    if artifact is None or artifact_sha256 is None:
         errors.append("component_delta treatment is missing artifact evidence")
+        return errors
+    repository = mapping_value(treatment.get("repository"))
+    repository_id = repository.get("id")
+    repository_commit = repository.get("commit")
+    component = treatment_delta.get("component")
+    if not all(
+        isinstance(value, str) and value
+        for value in (repository_id, repository_commit, component, artifact, artifact_sha256)
+    ):
+        errors.append("component_delta manifest isolation binding is incomplete")
+        return errors
+    try:
+        verify_component_manifest_delta(
+            baseline_repobrief,
+            treatment_repobrief,
+            repository_id=str(repository_id),
+            repository_commit=str(repository_commit),
+            component=str(component),
+            artifact_path=str(artifact),
+            expected_sha256=str(artifact_sha256),
+        )
+    except AgentBenchmarkError as exc:
+        errors.append(f"component_delta manifest isolation invalid: {exc}")
     return errors
 
 

--- a/merger/repoground/core/agent_benchmark_requests.py
+++ b/merger/repoground/core/agent_benchmark_requests.py
@@ -5,9 +5,12 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 
 from merger.repoground.core.agent_benchmark_common import (
+    COMPONENT_DELTA_MODE,
     CONDITIONS,
     REQUEST_KIND,
     VERSION,
+    comparison_contract,
+    comparison_mode,
     list_value,
     mapping_value,
     sha256_json,
@@ -115,10 +118,43 @@ def _validate_policy(
     }:
         errors.append("request isolation contract is invalid")
     repobrief = request.get("repobrief")
-    if condition == "baseline" and repobrief is not None:
-        errors.append("baseline request must not contain RepoGround binding")
-    if condition == "treatment" and not isinstance(repobrief, Mapping):
-        errors.append("treatment request requires RepoGround binding")
+    if comparison_mode(taskset) == COMPONENT_DELTA_MODE:
+        if not isinstance(repobrief, Mapping):
+            errors.append("component_delta request requires RepoGround binding")
+        errors.extend(_validate_component_delta(taskset, request, condition=condition))
+    else:
+        if condition == "baseline" and repobrief is not None:
+            errors.append("baseline request must not contain RepoGround binding")
+        if condition == "treatment" and not isinstance(repobrief, Mapping):
+            errors.append("treatment request requires RepoGround binding")
+        if "component_delta" in request:
+            errors.append("legacy request must not contain component_delta binding")
+    return errors
+
+
+def _validate_component_delta(
+    taskset: Mapping[str, Any], request: Mapping[str, Any], *, condition: str
+) -> list[str]:
+    comparison = comparison_contract(taskset)
+    binding = mapping_value(request.get("component_delta"))
+    errors: list[str] = []
+    if binding.get("component") != comparison.get("component"):
+        errors.append("component_delta component does not match taskset")
+    if binding.get("source_revision") != comparison.get("source_revision"):
+        errors.append("component_delta source_revision does not match taskset")
+    artifact = binding.get("artifact")
+    artifact_sha256 = binding.get("artifact_sha256")
+    if condition == "baseline":
+        if artifact is not None or artifact_sha256 is not None:
+            errors.append("component_delta baseline must not bind an artifact")
+    elif (
+        not isinstance(artifact, str)
+        or not artifact
+        or not isinstance(artifact_sha256, str)
+        or len(artifact_sha256) != 64
+        or any(ch not in "0123456789abcdef" for ch in artifact_sha256)
+    ):
+        errors.append("component_delta treatment artifact binding is invalid")
     return errors
 
 
@@ -171,6 +207,7 @@ def expected_pair_keys(taskset: Mapping[str, Any]) -> list[tuple[str, int]]:
 
 
 def pair_request_errors(
+    taskset: Mapping[str, Any],
     requests: Sequence[Mapping[str, Any]],
 ) -> list[str]:
     """Validate cross-condition provider and pairing invariants."""
@@ -186,6 +223,21 @@ def pair_request_errors(
         errors.append("paired requests use different runner configuration")
     if {first.get("condition"), second.get("condition")} != set(CONDITIONS):
         errors.append("paired requests do not contain baseline and treatment")
+    if comparison_mode(taskset) == COMPONENT_DELTA_MODE:
+        baseline = first if first.get("condition") == "baseline" else second
+        treatment = second if baseline is first else first
+        for field in ("repository", "prompt", "allowed_tools", "budgets", "repobrief", "isolation"):
+            if baseline.get(field) != treatment.get(field):
+                errors.append(f"component_delta paired requests disagree on {field}")
+        baseline_delta = mapping_value(baseline.get("component_delta"))
+        treatment_delta = mapping_value(treatment.get("component_delta"))
+        for field in ("component", "source_revision"):
+            if baseline_delta.get(field) != treatment_delta.get(field):
+                errors.append(f"component_delta paired requests disagree on {field}")
+        if baseline_delta.get("artifact") is not None or baseline_delta.get("artifact_sha256") is not None:
+            errors.append("component_delta baseline unexpectedly contains artifact evidence")
+        if treatment_delta.get("artifact") is None or treatment_delta.get("artifact_sha256") is None:
+            errors.append("component_delta treatment is missing artifact evidence")
     return errors
 
 

--- a/merger/repoground/core/agent_benchmark_requests.py
+++ b/merger/repoground/core/agent_benchmark_requests.py
@@ -206,6 +206,25 @@ def expected_pair_keys(taskset: Mapping[str, Any]) -> list[tuple[str, int]]:
     ]
 
 
+def _component_delta_pair_errors(
+    baseline: Mapping[str, Any], treatment: Mapping[str, Any]
+) -> list[str]:
+    errors: list[str] = []
+    for field in ("repository", "prompt", "allowed_tools", "budgets", "repobrief", "isolation"):
+        if baseline.get(field) != treatment.get(field):
+            errors.append(f"component_delta paired requests disagree on {field}")
+    baseline_delta = mapping_value(baseline.get("component_delta"))
+    treatment_delta = mapping_value(treatment.get("component_delta"))
+    for field in ("component", "source_revision"):
+        if baseline_delta.get(field) != treatment_delta.get(field):
+            errors.append(f"component_delta paired requests disagree on {field}")
+    if baseline_delta.get("artifact") is not None or baseline_delta.get("artifact_sha256") is not None:
+        errors.append("component_delta baseline unexpectedly contains artifact evidence")
+    if treatment_delta.get("artifact") is None or treatment_delta.get("artifact_sha256") is None:
+        errors.append("component_delta treatment is missing artifact evidence")
+    return errors
+
+
 def pair_request_errors(
     taskset: Mapping[str, Any],
     requests: Sequence[Mapping[str, Any]],
@@ -226,18 +245,7 @@ def pair_request_errors(
     if comparison_mode(taskset) == COMPONENT_DELTA_MODE:
         baseline = first if first.get("condition") == "baseline" else second
         treatment = second if baseline is first else first
-        for field in ("repository", "prompt", "allowed_tools", "budgets", "repobrief", "isolation"):
-            if baseline.get(field) != treatment.get(field):
-                errors.append(f"component_delta paired requests disagree on {field}")
-        baseline_delta = mapping_value(baseline.get("component_delta"))
-        treatment_delta = mapping_value(treatment.get("component_delta"))
-        for field in ("component", "source_revision"):
-            if baseline_delta.get(field) != treatment_delta.get(field):
-                errors.append(f"component_delta paired requests disagree on {field}")
-        if baseline_delta.get("artifact") is not None or baseline_delta.get("artifact_sha256") is not None:
-            errors.append("component_delta baseline unexpectedly contains artifact evidence")
-        if treatment_delta.get("artifact") is None or treatment_delta.get("artifact_sha256") is None:
-            errors.append("component_delta treatment is missing artifact evidence")
+        errors.extend(_component_delta_pair_errors(baseline, treatment))
     return errors
 
 

--- a/merger/repoground/core/agent_benchmark_requests.py
+++ b/merger/repoground/core/agent_benchmark_requests.py
@@ -247,6 +247,7 @@ def _component_delta_pair_errors(
             treatment_repobrief,
             repository_id=str(repository_id),
             repository_commit=str(repository_commit),
+            source_revision=str(treatment_delta.get("source_revision", "")),
             component=str(component),
             artifact_path=str(artifact),
             expected_sha256=str(artifact_sha256),

--- a/merger/repoground/core/language_structure_benchmark.py
+++ b/merger/repoground/core/language_structure_benchmark.py
@@ -530,16 +530,10 @@ def _agent_benefit_thresholds_sufficient(agent_benefit: Mapping[str, Any]) -> bo
     )
 
 
-def _verified_component_delta_agent_benefit(
+def _agent_benefit_inputs_revalidate(
     agent_benefit: Mapping[str, Any],
-    *,
-    source_revision: str,
     evidence_inputs: Mapping[str, Any] | None,
 ) -> bool:
-    if validate_evaluation(agent_benefit) or validate_evaluation_derivations(
-        agent_benefit
-    ):
-        return False
     if not isinstance(evidence_inputs, Mapping):
         return False
     taskset = evidence_inputs.get("taskset")
@@ -557,13 +551,32 @@ def _verified_component_delta_agent_benefit(
         or (transcript_root is not None and not isinstance(transcript_root, (str, Path)))
     ):
         return False
-    if validate_evaluation_evidence(
+    return not validate_evaluation_evidence(
         agent_benefit,
         taskset,
         requests,
         receipts,
         transcript_root=transcript_root,
+    )
+
+
+def _verified_component_delta_agent_benefit(
+    agent_benefit: Mapping[str, Any],
+    *,
+    source_revision: str,
+    evidence_inputs: Mapping[str, Any] | None,
+) -> bool:
+    if validate_evaluation(agent_benefit) or validate_evaluation_derivations(
+        agent_benefit
     ):
+        return False
+    runner_execution = agent_benefit.get("runner_execution")
+    if (
+        not isinstance(runner_execution, Mapping)
+        or runner_execution.get("attested") is not True
+    ):
+        return False
+    if not _agent_benefit_inputs_revalidate(agent_benefit, evidence_inputs):
         return False
     comparison = agent_benefit.get("comparison")
     decision = agent_benefit.get("decision")

--- a/merger/repoground/core/language_structure_benchmark.py
+++ b/merger/repoground/core/language_structure_benchmark.py
@@ -18,6 +18,7 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
+from merger.repoground.core.agent_benchmark_evaluation import validate_evaluation
 from merger.repoground.core.agent_benchmark_common import (
     CATEGORIES,
     is_repository_relative_path,
@@ -500,6 +501,8 @@ def _promotion_measurements(
 def _verified_component_delta_agent_benefit(
     agent_benefit: Mapping[str, Any], *, source_revision: str
 ) -> bool:
+    if validate_evaluation(agent_benefit):
+        return False
     comparison = agent_benefit.get("comparison")
     decision = agent_benefit.get("decision")
     cases = agent_benefit.get("cases")

--- a/merger/repoground/core/language_structure_benchmark.py
+++ b/merger/repoground/core/language_structure_benchmark.py
@@ -18,6 +18,10 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
+from merger.repoground.core.agent_benchmark_common import (
+    CATEGORIES,
+    is_repository_relative_path,
+)
 from merger.repoground.core.bounded_artifact_read import (
     read_stable_regular_file_bytes,
 )
@@ -434,16 +438,207 @@ def _promotion_report_binding(
     return str(source_revision), goldset_sha256, case_count
 
 
+def _promotion_measurements(
+    report: Mapping[str, Any],
+) -> tuple[tuple[float, float, float, float], float, int, int, int, int, int] | None:
+    metrics = report.get("metrics")
+    aggregate = metrics.get("aggregate") if isinstance(metrics, Mapping) else None
+    costs = report.get("costs")
+    nulls = report.get("true_nulls")
+    if (
+        not isinstance(aggregate, Mapping)
+        or set(aggregate) != {"symbol", "relations", "ranges"}
+        or not all(_metric_contract_valid(aggregate[lane]) for lane in aggregate)
+        or not isinstance(costs, Mapping)
+        or not isinstance(nulls, Mapping)
+    ):
+        return None
+    rates = (
+        _finite_rate(aggregate.get("symbol", {}).get("recall")),
+        _finite_rate(aggregate.get("relations", {}).get("precision")),
+        _finite_rate(aggregate.get("relations", {}).get("recall")),
+        _finite_rate(aggregate.get("ranges", {}).get("recall")),
+    )
+    latency_median = _finite_nonnegative(costs.get("latency_ms_median"))
+    latency = _finite_nonnegative(costs.get("latency_ms_p95"))
+    peak_memory = _nonnegative_integer(costs.get("peak_memory_bytes_max"))
+    index_size_total = _nonnegative_integer(costs.get("index_size_bytes_total"))
+    index_size = _nonnegative_integer(costs.get("index_size_bytes_max"))
+    null_case_count = _nonnegative_integer(nulls.get("case_count"))
+    null_pass_count = _nonnegative_integer(nulls.get("pass_count"))
+    null_false_positives = _nonnegative_integer(nulls.get("false_positive_records"))
+    values = (
+        *rates,
+        latency_median,
+        latency,
+        peak_memory,
+        index_size_total,
+        index_size,
+        null_case_count,
+        null_pass_count,
+        null_false_positives,
+    )
+    if any(value is None for value in values):
+        return None
+    if (
+        float(latency) < float(latency_median)
+        or int(index_size_total) < int(index_size)
+        or int(null_pass_count) > int(null_case_count)
+    ):
+        return None
+    return (
+        tuple(float(value) for value in rates),
+        float(latency),
+        int(peak_memory),
+        int(index_size),
+        int(null_case_count),
+        int(null_pass_count),
+        int(null_false_positives),
+    )
+
+
+def _verified_component_delta_agent_benefit(
+    agent_benefit: Mapping[str, Any], *, source_revision: str
+) -> bool:
+    comparison = agent_benefit.get("comparison")
+    decision = agent_benefit.get("decision")
+    cases = agent_benefit.get("cases")
+    classes = agent_benefit.get("classes")
+    if not (
+        agent_benefit.get("kind") == "repobrief.agent_benchmark_evaluation"
+        and agent_benefit.get("version") == "1.0"
+        and isinstance(agent_benefit.get("taskset_id"), str)
+        and bool(agent_benefit.get("taskset_id"))
+        and isinstance(agent_benefit.get("taskset_sha256"), str)
+        and _SHA256_RE.fullmatch(str(agent_benefit.get("taskset_sha256"))) is not None
+        and agent_benefit.get("measurement_scope") == "real_paired_agent_runs"
+        and isinstance(comparison, Mapping)
+        and comparison.get("mode") == "component_delta"
+        and comparison.get("component") == "language_structure_json"
+        and comparison.get("source_revision") == source_revision
+        and comparison.get("pair_isolation_verified") is True
+        and isinstance(decision, Mapping)
+        and decision.get("status") == "useful_class"
+        and decision.get("default_promoted") is False
+        and decision.get("harmful_classes") == []
+        and isinstance(cases, list)
+        and bool(cases)
+        and all(isinstance(item, Mapping) and item.get("pair_valid") is True for item in cases)
+        and isinstance(classes, list)
+        and len(classes) == len(CATEGORIES)
+        and all(
+            isinstance(item, Mapping)
+            and item.get("category") in CATEGORIES
+            and item.get("classification") in {"useful", "neutral"}
+            and isinstance(item.get("valid_pair_count"), int)
+            and not isinstance(item.get("valid_pair_count"), bool)
+            and int(item.get("valid_pair_count")) > 0
+            for item in classes
+        )
+        and {str(item.get("category")) for item in classes} == set(CATEGORIES)
+        and sum(int(item.get("valid_pair_count")) for item in classes) == len(cases)
+        and {
+            str(item.get("category"))
+            for item in classes
+            if isinstance(item, Mapping) and item.get("classification") == "useful"
+        }
+        == set(decision.get("useful_classes", []))
+        and bool(decision.get("useful_classes"))
+    ):
+        return False
+    run_count = _nonnegative_integer(agent_benefit.get("run_count"))
+    valid_run_count = _nonnegative_integer(agent_benefit.get("valid_run_count"))
+    invalid_run_count = _nonnegative_integer(agent_benefit.get("invalid_run_count"))
+    if (
+        run_count is None
+        or run_count == 0
+        or run_count != 2 * len(cases)
+        or valid_run_count != run_count
+        or invalid_run_count != 0
+    ):
+        return False
+    artifacts = comparison.get("treatment_artifacts")
+    if not isinstance(artifacts, list) or not artifacts:
+        return False
+    repository_ids: set[str] = set()
+    for item in artifacts:
+        if not isinstance(item, Mapping):
+            return False
+        repository_id = item.get("repository_id")
+        artifact = item.get("artifact")
+        artifact_sha256 = item.get("artifact_sha256")
+        if (
+            not isinstance(repository_id, str)
+            or not repository_id
+            or repository_id in repository_ids
+            or not is_repository_relative_path(artifact)
+            or not isinstance(artifact_sha256, str)
+            or _SHA256_RE.fullmatch(artifact_sha256) is None
+        ):
+            return False
+        repository_ids.add(repository_id)
+    return True
+
+
 def decide_language_adapter_promotion(
     report: Mapping[str, Any], *, agent_benefit: Mapping[str, Any] | None = None
 ) -> dict[str, Any]:
     """Fail closed until verified component-delta agent evidence exists."""
     try:
-        if _promotion_report_binding(report) is None:
+        report_binding = _promotion_report_binding(report)
+        if report_binding is None:
             return _keep_optional("benchmark_revision_binding_invalid")
+        source_revision, _goldset_sha256, _case_count = report_binding
         if not isinstance(agent_benefit, Mapping):
             return _keep_optional("revision_bound_agent_benefit_missing")
-        return _keep_optional("verified_component_delta_agent_benefit_missing")
+        if not _verified_component_delta_agent_benefit(
+            agent_benefit, source_revision=source_revision
+        ):
+            return _keep_optional("verified_component_delta_agent_benefit_missing")
+        measurements = _promotion_measurements(report)
+        if measurements is None:
+            return _keep_optional("benchmark_metrics_or_costs_invalid")
+        (
+            quality_rates,
+            latency_p95,
+            peak_memory,
+            index_size,
+            null_case_count,
+            null_pass_count,
+            null_false_positives,
+        ) = measurements
+        deterministic = report.get("determinism", {}).get(
+            "semantic_projection_repeated_equal"
+        )
+        degradation_complete = report.get("degradation_expectations", {}).get(
+            "exact_match"
+        )
+        symbol_recall, relation_precision, relation_recall, range_recall = quality_rates
+        quality_gates_pass = (
+            symbol_recall >= 0.8
+            and relation_precision >= 0.9
+            and relation_recall >= 0.8
+            and range_recall >= 0.9
+            and null_case_count >= 2
+            and null_pass_count == null_case_count
+            and null_false_positives == 0
+            and deterministic is True
+            and degradation_complete is True
+            and latency_p95 <= 500.0
+            and peak_memory <= 64 * 1024 * 1024
+            and index_size <= 16 * 1024 * 1024
+        )
+        if not quality_gates_pass:
+            return _keep_optional("quality_null_determinism_or_cost_gate_not_met")
+        return {
+            "status": "eligible_for_explicit_promotion_review",
+            "broad_activation_eligible": False,
+            "default_promoted": False,
+            "reason": "verified_component_delta_agent_benefit_and_quality_gates_passed",
+            "source_revision": source_revision,
+            "goldset_sha256": _goldset_sha256,
+            "decision_authority": "none; explicit reviewed configuration change required",
+        }
     except (KeyError, TypeError, ValueError, OverflowError):
         return _keep_optional("promotion_input_malformed")
 

--- a/merger/repoground/core/language_structure_benchmark.py
+++ b/merger/repoground/core/language_structure_benchmark.py
@@ -18,7 +18,10 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
-from merger.repoground.core.agent_benchmark_evaluation import validate_evaluation
+from merger.repoground.core.agent_benchmark_evaluation import (
+    validate_evaluation,
+    validate_evaluation_derivations,
+)
 from merger.repoground.core.agent_benchmark_common import (
     CATEGORIES,
     is_repository_relative_path,
@@ -498,10 +501,39 @@ def _promotion_measurements(
     )
 
 
+def _agent_benefit_thresholds_sufficient(agent_benefit: Mapping[str, Any]) -> bool:
+    thresholds = agent_benefit.get("thresholds")
+    if not isinstance(thresholds, Mapping):
+        return False
+    minimum_success_gain = _finite_rate(thresholds.get("minimum_success_rate_gain"))
+    maximum_success_regression = _finite_rate(
+        thresholds.get("maximum_class_success_regression")
+    )
+    maximum_false_confidence = _finite_rate(
+        thresholds.get("maximum_false_confidence_increase")
+    )
+    minimum_efficiency = _finite_rate(thresholds.get("minimum_efficiency_improvement"))
+    if None in {
+        minimum_success_gain,
+        maximum_success_regression,
+        maximum_false_confidence,
+        minimum_efficiency,
+    }:
+        return False
+    return bool(
+        float(minimum_success_gain) >= 0.1
+        and float(maximum_success_regression) <= 0.05
+        and float(maximum_false_confidence) <= 0.0
+        and float(minimum_efficiency) >= 0.2
+    )
+
+
 def _verified_component_delta_agent_benefit(
     agent_benefit: Mapping[str, Any], *, source_revision: str
 ) -> bool:
-    if validate_evaluation(agent_benefit):
+    if validate_evaluation(agent_benefit) or validate_evaluation_derivations(
+        agent_benefit
+    ):
         return False
     comparison = agent_benefit.get("comparison")
     decision = agent_benefit.get("decision")
@@ -515,6 +547,7 @@ def _verified_component_delta_agent_benefit(
         and isinstance(agent_benefit.get("taskset_sha256"), str)
         and _SHA256_RE.fullmatch(str(agent_benefit.get("taskset_sha256"))) is not None
         and agent_benefit.get("measurement_scope") == "real_paired_agent_runs"
+        and _agent_benefit_thresholds_sufficient(agent_benefit)
         and isinstance(comparison, Mapping)
         and comparison.get("mode") == "component_delta"
         and comparison.get("component") == "language_structure_json"

--- a/merger/repoground/core/language_structure_benchmark.py
+++ b/merger/repoground/core/language_structure_benchmark.py
@@ -570,12 +570,6 @@ def _verified_component_delta_agent_benefit(
         agent_benefit
     ):
         return False
-    runner_execution = agent_benefit.get("runner_execution")
-    if (
-        not isinstance(runner_execution, Mapping)
-        or runner_execution.get("attested") is not True
-    ):
-        return False
     if not _agent_benefit_inputs_revalidate(agent_benefit, evidence_inputs):
         return False
     comparison = agent_benefit.get("comparison")
@@ -656,7 +650,10 @@ def _verified_component_delta_agent_benefit(
         ):
             return False
         repository_ids.add(repository_id)
-    return True
+    # Benchmark v1 has no trusted runner-origin attestation contract.
+    # Internal consistency and bound evidence are necessary, but cannot by
+    # themselves prove that an authorized runner actually executed the pair.
+    return False
 
 
 def decide_language_adapter_promotion(

--- a/merger/repoground/core/language_structure_benchmark.py
+++ b/merger/repoground/core/language_structure_benchmark.py
@@ -22,9 +22,11 @@ from merger.repoground.core.agent_benchmark_evaluation import (
     validate_evaluation,
     validate_evaluation_derivations,
 )
+from merger.repoground.core.agent_benchmark_integrity import validate_evaluation_evidence
 from merger.repoground.core.agent_benchmark_common import (
     CATEGORIES,
     is_repository_relative_path,
+    load_json,
 )
 from merger.repoground.core.bounded_artifact_read import (
     read_stable_regular_file_bytes,
@@ -529,10 +531,38 @@ def _agent_benefit_thresholds_sufficient(agent_benefit: Mapping[str, Any]) -> bo
 
 
 def _verified_component_delta_agent_benefit(
-    agent_benefit: Mapping[str, Any], *, source_revision: str
+    agent_benefit: Mapping[str, Any],
+    *,
+    source_revision: str,
+    evidence_inputs: Mapping[str, Any] | None,
 ) -> bool:
     if validate_evaluation(agent_benefit) or validate_evaluation_derivations(
         agent_benefit
+    ):
+        return False
+    if not isinstance(evidence_inputs, Mapping):
+        return False
+    taskset = evidence_inputs.get("taskset")
+    requests = evidence_inputs.get("requests")
+    receipts = evidence_inputs.get("receipts")
+    transcript_root = evidence_inputs.get("transcript_root")
+    if (
+        not isinstance(taskset, Mapping)
+        or not isinstance(requests, list)
+        or not requests
+        or not all(isinstance(item, Mapping) for item in requests)
+        or not isinstance(receipts, list)
+        or not receipts
+        or not all(isinstance(item, Mapping) for item in receipts)
+        or (transcript_root is not None and not isinstance(transcript_root, (str, Path)))
+    ):
+        return False
+    if validate_evaluation_evidence(
+        agent_benefit,
+        taskset,
+        requests,
+        receipts,
+        transcript_root=transcript_root,
     ):
         return False
     comparison = agent_benefit.get("comparison")
@@ -617,7 +647,10 @@ def _verified_component_delta_agent_benefit(
 
 
 def decide_language_adapter_promotion(
-    report: Mapping[str, Any], *, agent_benefit: Mapping[str, Any] | None = None
+    report: Mapping[str, Any],
+    *,
+    agent_benefit: Mapping[str, Any] | None = None,
+    agent_benefit_inputs: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Fail closed until verified component-delta agent evidence exists."""
     try:
@@ -628,7 +661,9 @@ def decide_language_adapter_promotion(
         if not isinstance(agent_benefit, Mapping):
             return _keep_optional("revision_bound_agent_benefit_missing")
         if not _verified_component_delta_agent_benefit(
-            agent_benefit, source_revision=source_revision
+            agent_benefit,
+            source_revision=source_revision,
+            evidence_inputs=agent_benefit_inputs,
         ):
             return _keep_optional("verified_component_delta_agent_benefit_missing")
         measurements = _promotion_measurements(report)
@@ -701,6 +736,7 @@ def evaluate_language_structure_goldset(
     repo_root: str | Path,
     source_revision: str,
     agent_benefit: Mapping[str, Any] | None = None,
+    agent_benefit_inputs: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Measure semantic quality separately from environment-dependent resource cost."""
     root = Path(repo_root).resolve()
@@ -981,9 +1017,21 @@ def evaluate_language_structure_goldset(
         ],
     }
     report["promotion"] = decide_language_adapter_promotion(
-        report, agent_benefit=agent_benefit
+        report,
+        agent_benefit=agent_benefit,
+        agent_benefit_inputs=agent_benefit_inputs,
     )
     return report
+
+
+def _load_benchmark_object_directory(path: str | Path) -> list[dict[str, Any]]:
+    root = Path(path).expanduser().resolve()
+    if not root.is_dir():
+        raise ValueError(f"benchmark evidence directory missing: {root}")
+    paths = sorted(root.glob("*.json"))
+    if not paths:
+        raise ValueError(f"benchmark evidence directory is empty: {root}")
+    return [load_json(item) for item in paths]
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -996,10 +1044,14 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--agent-benefit",
         help=(
-            "legacy external benefit input; retained for compatibility but cannot "
-            "authorize promotion until the verified component-delta harness exists"
+            "component-delta evaluation; promotion additionally requires its bound "
+            "taskset, requests, receipts, and any transcript artifacts"
         ),
     )
+    parser.add_argument("--agent-benefit-taskset")
+    parser.add_argument("--agent-benefit-requests")
+    parser.add_argument("--agent-benefit-receipts")
+    parser.add_argument("--agent-benefit-transcript-root")
     args = parser.parse_args(argv)
     goldset = load_language_goldset(args.goldset)
     agent_benefit = None
@@ -1013,11 +1065,29 @@ def main(argv: list[str] | None = None) -> int:
                 f"agent benefit read failed: {failure or 'unreadable'}{suffix}"
             )
         agent_benefit = json.loads(raw.decode("utf-8"))
+    evidence_args = (
+        args.agent_benefit_taskset,
+        args.agent_benefit_requests,
+        args.agent_benefit_receipts,
+    )
+    if any(evidence_args) and (not args.agent_benefit or not all(evidence_args)):
+        raise ValueError(
+            "agent benefit taskset, requests, and receipts must be supplied together with --agent-benefit"
+        )
+    agent_benefit_inputs = None
+    if args.agent_benefit and all(evidence_args):
+        agent_benefit_inputs = {
+            "taskset": load_json(args.agent_benefit_taskset),
+            "requests": _load_benchmark_object_directory(args.agent_benefit_requests),
+            "receipts": _load_benchmark_object_directory(args.agent_benefit_receipts),
+            "transcript_root": args.agent_benefit_transcript_root,
+        }
     report = evaluate_language_structure_goldset(
         goldset,
         repo_root=args.repo_root,
         source_revision=args.source_revision,
         agent_benefit=agent_benefit,
+        agent_benefit_inputs=agent_benefit_inputs,
     )
     print(json.dumps(report, indent=2, sort_keys=True, ensure_ascii=False))
     return 0

--- a/merger/repoground/tests/test_agent_benchmark.py
+++ b/merger/repoground/tests/test_agent_benchmark.py
@@ -644,6 +644,19 @@ def test_execute_runner_rechecks_unchanged_component_artifact_before_start(
     assert marker.read_text(encoding="utf-8") == "started"
 
 
+def test_execute_runner_rejects_malformed_component_delta_binding_before_start(
+    tmp_path: Path,
+) -> None:
+    treatment, _artifact = _component_treatment_execution_setup(tmp_path)
+    treatment["component_delta"] = None
+    command, marker = _marker_runner(tmp_path)
+
+    with pytest.raises(AgentBenchmarkError, match="execution binding is invalid"):
+        execute_runner(command, treatment, timeout_seconds=5, max_stdout_bytes=1024)
+
+    assert not marker.exists()
+
+
 def test_execute_runner_rejects_changed_component_artifact_before_start(
     tmp_path: Path,
 ) -> None:

--- a/merger/repoground/tests/test_agent_benchmark.py
+++ b/merger/repoground/tests/test_agent_benchmark.py
@@ -22,6 +22,9 @@ from merger.repoground.core.agent_benchmark import (
     validate_taskset,
 )
 
+from merger.repoground.core.agent_benchmark_requests import pair_request_errors
+from merger.repoground.core.bounded_artifact_read import MAX_REGISTERED_ARTIFACT_BYTES
+
 REPO_ROOT = Path(__file__).resolve().parents[3]
 TASKSET_PATH = REPO_ROOT / "docs/retrieval/repobrief_agent_benchmark_taskset.v1.json"
 CONTRACT_ROOT = REPO_ROOT / "merger/repoground/contracts"
@@ -685,3 +688,311 @@ def test_transcript_content_is_nonempty_and_bounded(tmp_path: Path) -> None:
     assert "transcript exceeds configured limit" in validate_receipt(
         request, oversized, transcript_root=tmp_path
     )
+
+
+COMPONENT_REVISION = "a" * 40
+
+
+def _component_taskset() -> dict:
+    taskset = copy.deepcopy(_taskset())
+    taskset["comparison"] = {
+        "mode": "component_delta",
+        "component": "language_structure_json",
+        "source_revision": COMPONENT_REVISION,
+    }
+    taskset["tool_policy"]["baseline"] = copy.deepcopy(
+        taskset["tool_policy"]["treatment"]
+    )
+    return taskset
+
+
+def _component_bindings(tmp_path: Path) -> dict[str, dict]:
+    bindings: dict[str, dict] = {}
+    for repository in _taskset()["repositories"]:
+        repository_id = repository["id"]
+        root = tmp_path / repository_id
+        root.mkdir(parents=True)
+        manifest = root / f"{repository_id}.bundle.manifest.json"
+        manifest_raw = (json.dumps({"repository_id": repository_id}) + "\n").encode()
+        manifest.write_bytes(manifest_raw)
+        artifact = root / "language_structure.json"
+        artifact_raw = (json.dumps({"repository_id": repository_id, "component": "language_structure_json"}) + "\n").encode()
+        artifact.write_bytes(artifact_raw)
+        bindings[repository_id] = {
+            "manifest": str(manifest),
+            "manifest_sha256": sha256_bytes(manifest_raw),
+            "mcp_command": ["python", "-m", "merger.repoground.mcp_server"],
+            "components": {
+                "language_structure_json": {
+                    "source_revision": COMPONENT_REVISION,
+                    "artifact": artifact.name,
+                    "artifact_sha256": sha256_bytes(artifact_raw),
+                }
+            },
+        }
+    return bindings
+
+
+def _component_requests(tmp_path: Path) -> tuple[dict, list[dict], dict[str, dict]]:
+    taskset = _component_taskset()
+    bindings = _component_bindings(tmp_path)
+    requests = build_run_requests(
+        taskset, runner=RUNNER, manifest_bindings=bindings, repetitions=2
+    )
+    return taskset, requests, bindings
+
+
+def test_component_delta_taskset_contract_is_fail_closed() -> None:
+    taskset = _component_taskset()
+    Draft7Validator(_schema("taskset")).validate(taskset)
+    assert validate_taskset(taskset) == []
+
+    mutations = []
+    unknown_mode = copy.deepcopy(taskset)
+    unknown_mode["comparison"]["mode"] = "unknown"
+    mutations.append(unknown_mode)
+    invalid_component = copy.deepcopy(taskset)
+    invalid_component["comparison"]["component"] = "A"
+    mutations.append(invalid_component)
+    one_character_component = copy.deepcopy(taskset)
+    one_character_component["comparison"]["component"] = "a"
+    mutations.append(one_character_component)
+    invalid_revision = copy.deepcopy(taskset)
+    invalid_revision["comparison"]["source_revision"] = "a" * 39
+    mutations.append(invalid_revision)
+    split_tools = copy.deepcopy(taskset)
+    split_tools["tool_policy"]["baseline"] = ["glob", "grep", "read_file", "search"]
+    mutations.append(split_tools)
+    missing_repoground = copy.deepcopy(taskset)
+    missing_repoground["tool_policy"]["baseline"] = [
+        tool
+        for tool in missing_repoground["tool_policy"]["baseline"]
+        if tool not in {"ask_context", "repobrief_resource_read", "grounding_verify", "live_freshness"}
+    ]
+    mutations.append(missing_repoground)
+    for mutated in mutations:
+        assert validate_taskset(mutated)
+
+
+def test_component_delta_requests_differ_only_by_bound_artifact(tmp_path: Path) -> None:
+    taskset, requests, bindings = _component_requests(tmp_path)
+    schema = Draft7Validator(_schema("request"))
+    by_pair: dict[str, list[dict]] = defaultdict(list)
+    for request in requests:
+        schema.validate(request)
+        by_pair[request["pair_id"]].append(request)
+    assert by_pair
+    for pair in by_pair.values():
+        assert pair_request_errors(taskset, pair) == []
+        baseline = next(item for item in pair if item["condition"] == "baseline")
+        treatment = next(item for item in pair if item["condition"] == "treatment")
+        for field in (
+            "repository",
+            "runner",
+            "prompt",
+            "allowed_tools",
+            "budgets",
+            "repobrief",
+            "isolation",
+        ):
+            assert baseline[field] == treatment[field]
+        repository_id = treatment["repository"]["id"]
+        expected = bindings[repository_id]["components"]["language_structure_json"]
+        assert baseline["component_delta"] == {
+            "component": "language_structure_json",
+            "source_revision": COMPONENT_REVISION,
+            "artifact": None,
+            "artifact_sha256": None,
+        }
+        assert treatment["component_delta"] == {
+            "component": "language_structure_json",
+            "source_revision": COMPONENT_REVISION,
+            "artifact": expected["artifact"],
+            "artifact_sha256": expected["artifact_sha256"],
+        }
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "components_missing",
+        "component_missing",
+        "artifact_missing",
+        "sha_missing",
+        "revision_mismatch",
+        "sha_invalid",
+        "file_missing",
+        "path_escape",
+        "sha_mismatch",
+    ],
+)
+def test_component_delta_artifact_binding_fails_closed(
+    tmp_path: Path, mutation: str
+) -> None:
+    taskset = _component_taskset()
+    bindings = _component_bindings(tmp_path)
+    repository_id = taskset["repositories"][0]["id"]
+    binding = bindings[repository_id]
+    component = binding["components"]["language_structure_json"]
+    if mutation == "components_missing":
+        binding.pop("components")
+    elif mutation == "component_missing":
+        binding["components"].pop("language_structure_json")
+    elif mutation == "artifact_missing":
+        component.pop("artifact")
+    elif mutation == "sha_missing":
+        component.pop("artifact_sha256")
+    elif mutation == "revision_mismatch":
+        component["source_revision"] = "b" * 40
+    elif mutation == "sha_invalid":
+        component["artifact_sha256"] = "z" * 64
+    elif mutation == "file_missing":
+        (Path(binding["manifest"]).parent / component["artifact"]).unlink()
+    elif mutation == "path_escape":
+        component["artifact"] = "../outside.json"
+    elif mutation == "sha_mismatch":
+        component["artifact_sha256"] = "f" * 64
+    with pytest.raises(AgentBenchmarkError):
+        build_run_requests(
+            taskset, runner=RUNNER, manifest_bindings=bindings, repetitions=2
+        )
+
+
+def test_component_delta_artifact_size_and_stability_fail_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    taskset = _component_taskset()
+    bindings = _component_bindings(tmp_path / "large")
+    repository_id = taskset["repositories"][0]["id"]
+    binding = bindings[repository_id]
+    component = binding["components"]["language_structure_json"]
+    artifact = Path(binding["manifest"]).parent / component["artifact"]
+    with artifact.open("wb") as handle:
+        handle.truncate(MAX_REGISTERED_ARTIFACT_BYTES + 1)
+    with pytest.raises(AgentBenchmarkError, match="too_large"):
+        build_run_requests(
+            taskset, runner=RUNNER, manifest_bindings=bindings, repetitions=2
+        )
+
+    stable_bindings = _component_bindings(tmp_path / "unstable")
+    monkeypatch.setattr(
+        "merger.repoground.core.agent_benchmark.read_stable_regular_file_bytes",
+        lambda *_args, **_kwargs: (None, None, "source_changed", "changed"),
+    )
+    with pytest.raises(AgentBenchmarkError, match="source_changed"):
+        build_run_requests(
+            taskset, runner=RUNNER, manifest_bindings=stable_bindings, repetitions=2
+        )
+
+
+def test_component_delta_pair_isolation_rejects_every_forbidden_difference(
+    tmp_path: Path,
+) -> None:
+    taskset, requests, _bindings = _component_requests(tmp_path)
+    pair_id = requests[0]["pair_id"]
+    pair = [item for item in requests if item["pair_id"] == pair_id]
+    assert pair_request_errors(taskset, pair) == []
+
+    def mutate_treatment(name: str) -> list[dict]:
+        mutated = copy.deepcopy(pair)
+        treatment = next(item for item in mutated if item["condition"] == "treatment")
+        if name == "repository_commit":
+            treatment["repository"]["commit"] = "f" * 40
+        elif name == "runner":
+            treatment["runner"]["model"] = "other"
+        elif name == "prompt":
+            treatment["prompt"] += " changed"
+        elif name == "allowed_tools":
+            treatment["allowed_tools"] = treatment["allowed_tools"][:-1]
+        elif name == "budgets":
+            treatment["budgets"]["max_tool_calls"] += 1
+        elif name == "manifest":
+            treatment["repobrief"]["manifest"] += ".other"
+        elif name == "manifest_sha256":
+            treatment["repobrief"]["manifest_sha256"] = "f" * 64
+        elif name == "mcp_command":
+            treatment["repobrief"]["mcp_command"] = ["other"]
+        elif name == "component":
+            treatment["component_delta"]["component"] = "other_component"
+        elif name == "source_revision":
+            treatment["component_delta"]["source_revision"] = "b" * 40
+        elif name == "treatment_artifact_missing":
+            treatment["component_delta"]["artifact"] = None
+            treatment["component_delta"]["artifact_sha256"] = None
+        else:
+            raise AssertionError(name)
+        return mutated
+
+    for name in (
+        "repository_commit",
+        "runner",
+        "prompt",
+        "allowed_tools",
+        "budgets",
+        "manifest",
+        "manifest_sha256",
+        "mcp_command",
+        "component",
+        "source_revision",
+        "treatment_artifact_missing",
+    ):
+        assert pair_request_errors(taskset, mutate_treatment(name)), name
+
+    baseline_mutated = copy.deepcopy(pair)
+    baseline = next(item for item in baseline_mutated if item["condition"] == "baseline")
+    baseline["component_delta"]["artifact"] = "unexpected.json"
+    baseline["component_delta"]["artifact_sha256"] = "f" * 64
+    assert pair_request_errors(taskset, baseline_mutated)
+
+
+def test_component_delta_evaluation_binds_repository_artifacts_and_complete_pairs(
+    tmp_path: Path,
+) -> None:
+    taskset, requests, _bindings = _component_requests(tmp_path)
+    cases = _cases(taskset)
+    receipts = [_receipt(request, cases[request["case_id"]]) for request in requests]
+    result = evaluate_paired_runs(
+        taskset, requests, receipts, measurement_scope="real_paired_agent_runs"
+    )
+    Draft7Validator(_schema("evaluation")).validate(result)
+    comparison = result["comparison"]
+    assert comparison["pair_isolation_verified"] is True
+    assert comparison["mode"] == "component_delta"
+    assert comparison["component"] == "language_structure_json"
+    assert comparison["source_revision"] == COMPONENT_REVISION
+    assert {item["repository_id"] for item in comparison["treatment_artifacts"]} == {
+        item["id"] for item in taskset["repositories"]
+    }
+    assert all(len(item["artifact_sha256"]) == 64 for item in comparison["treatment_artifacts"])
+
+    missing_pair = requests[0]["pair_id"]
+    filtered_requests = [item for item in requests if item["pair_id"] != missing_pair]
+    allowed_request_ids = {item["request_id"] for item in filtered_requests}
+    filtered_receipts = [
+        item for item in receipts if item["request_id"] in allowed_request_ids
+    ]
+    incomplete = evaluate_paired_runs(
+        taskset,
+        filtered_requests,
+        filtered_receipts,
+        measurement_scope="real_paired_agent_runs",
+    )
+    assert incomplete["comparison"]["pair_isolation_verified"] is False
+
+
+    baseline_only_requests = [
+        item for item in requests if item["condition"] == "baseline"
+    ]
+    baseline_request_ids = {item["request_id"] for item in baseline_only_requests}
+    baseline_only_receipts = [
+        item for item in receipts if item["request_id"] in baseline_request_ids
+    ]
+    baseline_only = evaluate_paired_runs(
+        taskset,
+        baseline_only_requests,
+        baseline_only_receipts,
+        measurement_scope="real_paired_agent_runs",
+    )
+    Draft7Validator(_schema("evaluation")).validate(baseline_only)
+    assert baseline_only["comparison"]["treatment_artifacts"] == []
+    assert baseline_only["comparison"]["pair_isolation_verified"] is False

--- a/merger/repoground/tests/test_agent_benchmark.py
+++ b/merger/repoground/tests/test_agent_benchmark.py
@@ -27,6 +27,7 @@ from merger.repoground.core.agent_benchmark import (
 
 from merger.repoground.core.agent_benchmark_requests import pair_request_errors
 from merger.repoground.core.bounded_artifact_read import MAX_REGISTERED_ARTIFACT_BYTES
+from merger.repoground.core.language_structure_access import load_language_structure_artifact
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 TASKSET_PATH = REPO_ROOT / "docs/retrieval/repobrief_agent_benchmark_taskset.v1.json"
@@ -890,7 +891,7 @@ def _language_structure_fixture(
     *, repository_id: str, repository_commit: str, manifest_name: str
 ) -> dict:
     def summary(adapter_id: str) -> dict:
-        return {
+        value = {
             "status": "available",
             "adapter": {"id": adapter_id, "version": "1.0"},
             "supported_files": [],
@@ -902,6 +903,10 @@ def _language_structure_fixture(
             "scanned_file_count": 0,
             "record_count": 0,
         }
+        if adapter_id == "rust-static-structure":
+            value["scip_adapter"] = {"id": "rust-scip-structure", "version": "1.0"}
+            value["scip_record_count"] = 0
+        return value
 
     return {
         "kind": "repoground.language_structure",
@@ -933,7 +938,19 @@ def _language_structure_fixture(
             "status": "keep_optional",
             "reason": "contract fixture",
         },
-        "does_not_establish": ["agent usefulness"],
+        "does_not_establish": [
+            "repository_truth",
+            "complete_symbol_index",
+            "complete_call_graph",
+            "complete_dependency_graph",
+            "runtime_behavior",
+            "dynamic_dispatch_resolution",
+            "macro_expansion",
+            "generated_code_coverage",
+            "python_ast_equivalence",
+            "test_sufficiency",
+            "default_promotion",
+        ],
     }
 
 
@@ -964,14 +981,40 @@ def _component_bindings(
         manifest_document = {
             "kind": "repoground.bundle.manifest",
             "version": "2.0",
+            "run_id": f"fixture-{repository_id}",
+            "created_at": "2026-08-15T00:00:00Z",
+            "generator": {
+                "name": "repoground",
+                "version": "fixture",
+                "config_sha256": "c" * 64,
+                "runtime": {
+                    "module": "merger.repoground.core.bundle",
+                    "python_version": "3.11",
+                    "git_commit": source_revision,
+                    "git_dirty": False,
+                },
+            },
             "artifacts": [
                 {
                     "role": "language_structure_json",
                     "path": artifact.name,
+                    "content_type": "application/json",
+                    "bytes": len(artifact_raw),
                     "sha256": artifact_sha256,
                     "contract": {"id": "language-structure", "version": "v1"},
+                    "interpretation": {"mode": "contract"},
+                    "authority": "navigation_index",
+                    "canonicality": "derived",
+                    "risk_class": "navigation",
+                    "regenerable": True,
+                    "staleness_sensitive": True,
                 }
             ],
+            "links": {"canonical_dump_index_sha256": "d" * 64},
+            "capabilities": {},
+            "snapshot_provenance": {
+                "repositories": [{"git_commit": repository["commit"]}]
+            },
         }
         manifest_raw = (json.dumps(manifest_document, sort_keys=True) + "\n").encode()
         manifest.write_bytes(manifest_raw)
@@ -1321,6 +1364,18 @@ def test_component_delta_requires_exact_component_free_baseline_manifest(
         build_run_requests(
             taskset, runner=RUNNER, manifest_bindings=bindings, repetitions=2
         )
+
+
+def test_component_delta_baseline_is_missing_through_production_loader(
+    tmp_path: Path,
+) -> None:
+    bindings = _component_bindings(tmp_path)
+    binding = next(iter(bindings.values()))
+
+    loaded = load_language_structure_artifact(Path(binding["baseline_manifest"]))
+
+    assert loaded["status"] == "missing"
+    assert loaded["reason"] == "language_structure_not_registered"
 
 
 def test_component_delta_requires_manifest_registration_and_component_contract(

--- a/merger/repoground/tests/test_agent_benchmark.py
+++ b/merger/repoground/tests/test_agent_benchmark.py
@@ -18,6 +18,7 @@ from merger.repoground.core.agent_benchmark import (
     score_receipt,
     sha256_bytes,
     sha256_json,
+    validate_evaluation,
     validate_receipt,
     validate_taskset,
 )
@@ -606,6 +607,21 @@ def test_execute_runner_accepts_one_json_object_without_shell(tmp_path: Path) ->
     assert result == {"seen": "demo"}
 
 
+def test_execute_runner_rechecks_component_artifact_after_planning(tmp_path: Path) -> None:
+    _taskset_value, requests, bindings = _component_requests(tmp_path)
+    treatment = next(item for item in requests if item["condition"] == "treatment")
+    repository_id = treatment["repository"]["id"]
+    artifact = Path(bindings[repository_id]["manifest"]).parent / treatment["component_delta"]["artifact"]
+    artifact.write_text("tampered-after-plan", encoding="utf-8")
+    with pytest.raises(AgentBenchmarkError, match="artifact SHA-256 mismatch"):
+        execute_runner(
+            [sys.executable, "-c", "raise SystemExit('runner must not start')"],
+            treatment,
+            timeout_seconds=5,
+            max_stdout_bytes=1024,
+        )
+
+
 def test_execute_runner_rejects_oversized_or_invalid_output(tmp_path: Path) -> None:
     oversized = tmp_path / "oversized.py"
     oversized.write_text("print('x' * 1000)\n", encoding="utf-8")
@@ -740,6 +756,27 @@ def _component_requests(tmp_path: Path) -> tuple[dict, list[dict], dict[str, dic
         taskset, runner=RUNNER, manifest_bindings=bindings, repetitions=2
     )
     return taskset, requests, bindings
+
+
+def test_complete_evaluation_contract_rejects_incomplete_objects(tmp_path: Path) -> None:
+    taskset, requests, _bindings = _component_requests(tmp_path)
+    cases = _cases(taskset)
+    receipts = [_receipt(request, cases[request["case_id"]]) for request in requests]
+    evaluation = evaluate_paired_runs(
+        taskset, requests, receipts, measurement_scope="real_paired_agent_runs"
+    )
+    assert validate_evaluation(evaluation) == []
+    Draft7Validator(_schema("evaluation")).validate(evaluation)
+
+    incomplete = copy.deepcopy(evaluation)
+    incomplete["cases"][0]["baseline"].pop("duration_ms")
+    assert validate_evaluation(incomplete)
+    incomplete = copy.deepcopy(evaluation)
+    incomplete["decision"].pop("reason")
+    assert validate_evaluation(incomplete)
+    incomplete = copy.deepcopy(evaluation)
+    incomplete.pop("does_not_establish")
+    assert validate_evaluation(incomplete)
 
 
 def test_component_delta_taskset_contract_is_fail_closed() -> None:

--- a/merger/repoground/tests/test_agent_benchmark.py
+++ b/merger/repoground/tests/test_agent_benchmark.py
@@ -20,6 +20,7 @@ from merger.repoground.core.agent_benchmark import (
     sha256_json,
     validate_evaluation,
     validate_evaluation_derivations,
+    validate_evaluation_evidence,
     validate_receipt,
     validate_taskset,
 )
@@ -742,6 +743,26 @@ def test_execute_runner_rejects_component_artifact_sha_tamper_before_start(
     assert not marker.exists()
 
 
+def test_execute_runner_rejects_baseline_manifest_that_reintroduces_component(
+    tmp_path: Path,
+) -> None:
+    _taskset_value, requests, bindings = _component_requests(tmp_path)
+    baseline = next(item for item in requests if item["condition"] == "baseline")
+    treatment = next(item for item in requests if item["condition"] == "treatment")
+    repository_id = treatment["repository"]["id"]
+    binding = bindings[repository_id]
+    baseline_manifest = Path(binding["baseline_manifest"])
+    treatment_raw = Path(binding["manifest"]).read_bytes()
+    baseline_manifest.write_bytes(treatment_raw)
+    baseline["repobrief"]["manifest_sha256"] = sha256_bytes(treatment_raw)
+    command, marker = _marker_runner(tmp_path)
+
+    with pytest.raises(AgentBenchmarkError, match="still registers language_structure_json"):
+        execute_runner(command, baseline, timeout_seconds=5, max_stdout_bytes=1024)
+
+    assert not marker.exists()
+
+
 def test_execute_runner_component_delta_baseline_does_not_read_artifact(
     tmp_path: Path,
 ) -> None:
@@ -848,12 +869,12 @@ def test_transcript_content_is_nonempty_and_bounded(tmp_path: Path) -> None:
 COMPONENT_REVISION = "a" * 40
 
 
-def _component_taskset() -> dict:
+def _component_taskset(*, source_revision: str = COMPONENT_REVISION) -> dict:
     taskset = copy.deepcopy(_taskset())
     taskset["comparison"] = {
         "mode": "component_delta",
         "component": "language_structure_json",
-        "source_revision": COMPONENT_REVISION,
+        "source_revision": source_revision,
     }
     taskset["tool_policy"]["baseline"] = copy.deepcopy(
         taskset["tool_policy"]["treatment"]
@@ -916,13 +937,16 @@ def _language_structure_fixture(
     }
 
 
-def _component_bindings(tmp_path: Path) -> dict[str, dict]:
+def _component_bindings(
+    tmp_path: Path, *, source_revision: str = COMPONENT_REVISION
+) -> dict[str, dict]:
     bindings: dict[str, dict] = {}
     for repository in _taskset()["repositories"]:
         repository_id = repository["id"]
         root = tmp_path / repository_id
         root.mkdir(parents=True)
         manifest = root / f"{repository_id}.bundle.manifest.json"
+        baseline_manifest = root / f"{repository_id}.baseline.bundle.manifest.json"
         artifact = root / "language_structure.json"
         artifact_raw = (
             json.dumps(
@@ -951,13 +975,21 @@ def _component_bindings(tmp_path: Path) -> dict[str, dict]:
         }
         manifest_raw = (json.dumps(manifest_document, sort_keys=True) + "\n").encode()
         manifest.write_bytes(manifest_raw)
+        baseline_manifest_document = copy.deepcopy(manifest_document)
+        baseline_manifest_document["artifacts"] = []
+        baseline_manifest_raw = (
+            json.dumps(baseline_manifest_document, sort_keys=True) + "\n"
+        ).encode()
+        baseline_manifest.write_bytes(baseline_manifest_raw)
         bindings[repository_id] = {
             "manifest": str(manifest),
             "manifest_sha256": sha256_bytes(manifest_raw),
+            "baseline_manifest": str(baseline_manifest),
+            "baseline_manifest_sha256": sha256_bytes(baseline_manifest_raw),
             "mcp_command": ["python", "-m", "merger.repoground.mcp_server"],
             "components": {
                 "language_structure_json": {
-                    "source_revision": COMPONENT_REVISION,
+                    "source_revision": source_revision,
                     "artifact": artifact.name,
                     "artifact_sha256": artifact_sha256,
                 }
@@ -1069,6 +1101,41 @@ def test_evaluation_derivations_are_recomputed_from_case_scores(
     assert validate_evaluation_derivations(forged_decision)
 
 
+def test_evaluation_is_bound_to_requests_receipts_and_transcripts(
+    tmp_path: Path,
+) -> None:
+    taskset, requests, _bindings = _component_requests(tmp_path)
+    cases = _cases(taskset)
+    receipts = [_receipt(request, cases[request["case_id"]]) for request in requests]
+    evaluation = evaluate_paired_runs(
+        taskset, requests, receipts, measurement_scope="real_paired_agent_runs"
+    )
+
+    assert validate_evaluation_evidence(evaluation, taskset, requests, receipts) == []
+    assert evaluation["evidence"]["taskset_sha256"] == sha256_json(taskset)
+    assert len(evaluation["evidence"]["transcripts"]) == len(receipts)
+
+    forged_evaluation = copy.deepcopy(evaluation)
+    forged_evaluation["cases"][0]["baseline"]["success"] = not forged_evaluation["cases"][0][
+        "baseline"
+    ]["success"]
+    assert validate_evaluation_evidence(
+        forged_evaluation, taskset, requests, receipts
+    )
+
+    changed_receipts = copy.deepcopy(receipts)
+    changed_receipts[0]["duration_ms"] += 1
+    assert validate_evaluation_evidence(
+        evaluation, taskset, requests, changed_receipts
+    )
+
+    changed_requests = copy.deepcopy(requests)
+    changed_requests[0]["budgets"]["max_tool_calls"] += 1
+    assert validate_evaluation_evidence(
+        evaluation, taskset, changed_requests, receipts
+    )
+
+
 def test_explicit_empty_comparison_contract_fails_semantic_validation() -> None:
     taskset = copy.deepcopy(_taskset())
     taskset["comparison"] = {}
@@ -1111,12 +1178,23 @@ def test_component_delta_requests_differ_only_by_bound_artifact(tmp_path: Path) 
             "prompt",
             "allowed_tools",
             "budgets",
-            "repobrief",
             "isolation",
         ):
             assert baseline[field] == treatment[field]
+        assert baseline["repobrief"]["mcp_command"] == treatment["repobrief"]["mcp_command"]
         repository_id = treatment["repository"]["id"]
-        expected = bindings[repository_id]["components"]["language_structure_json"]
+        binding = bindings[repository_id]
+        assert baseline["repobrief"] == {
+            "manifest": binding["baseline_manifest"],
+            "manifest_sha256": binding["baseline_manifest_sha256"],
+            "mcp_command": binding["mcp_command"],
+        }
+        assert treatment["repobrief"] == {
+            "manifest": binding["manifest"],
+            "manifest_sha256": binding["manifest_sha256"],
+            "mcp_command": binding["mcp_command"],
+        }
+        expected = binding["components"]["language_structure_json"]
         assert baseline["component_delta"] == {
             "component": "language_structure_json",
             "source_revision": COMPONENT_REVISION,
@@ -1205,6 +1283,44 @@ def _rewrite_component_fixture(
     manifest_raw = (json.dumps(manifest, sort_keys=True) + "\n").encode()
     manifest_path.write_bytes(manifest_raw)
     binding["manifest_sha256"] = sha256_bytes(manifest_raw)
+
+
+def test_component_delta_requires_exact_component_free_baseline_manifest(
+    tmp_path: Path,
+) -> None:
+    taskset = _component_taskset()
+    bindings = _component_bindings(tmp_path / "missing")
+    repository_id = taskset["repositories"][0]["id"]
+    bindings[repository_id].pop("baseline_manifest")
+    bindings[repository_id].pop("baseline_manifest_sha256")
+    with pytest.raises(AgentBenchmarkError, match="component-free baseline manifest"):
+        build_run_requests(
+            taskset, runner=RUNNER, manifest_bindings=bindings, repetitions=2
+        )
+
+    bindings = _component_bindings(tmp_path / "leak")
+    binding = bindings[repository_id]
+    baseline_path = Path(binding["baseline_manifest"])
+    treatment_raw = Path(binding["manifest"]).read_bytes()
+    baseline_path.write_bytes(treatment_raw)
+    binding["baseline_manifest_sha256"] = sha256_bytes(treatment_raw)
+    with pytest.raises(AgentBenchmarkError, match="still registers language_structure_json"):
+        build_run_requests(
+            taskset, runner=RUNNER, manifest_bindings=bindings, repetitions=2
+        )
+
+    bindings = _component_bindings(tmp_path / "unrelated")
+    binding = bindings[repository_id]
+    baseline_path = Path(binding["baseline_manifest"])
+    baseline_document = json.loads(baseline_path.read_text(encoding="utf-8"))
+    baseline_document["run_id"] = "unrelated-change"
+    baseline_raw = (json.dumps(baseline_document, sort_keys=True) + "\n").encode()
+    baseline_path.write_bytes(baseline_raw)
+    binding["baseline_manifest_sha256"] = sha256_bytes(baseline_raw)
+    with pytest.raises(AgentBenchmarkError, match="differ beyond language_structure_json"):
+        build_run_requests(
+            taskset, runner=RUNNER, manifest_bindings=bindings, repetitions=2
+        )
 
 
 def test_component_delta_requires_manifest_registration_and_component_contract(

--- a/merger/repoground/tests/test_agent_benchmark.py
+++ b/merger/repoground/tests/test_agent_benchmark.py
@@ -607,20 +607,129 @@ def test_execute_runner_accepts_one_json_object_without_shell(tmp_path: Path) ->
     assert result == {"seen": "demo"}
 
 
-def test_execute_runner_rechecks_component_artifact_after_planning(tmp_path: Path) -> None:
+def _component_treatment_execution_setup(tmp_path: Path) -> tuple[dict, Path]:
     _taskset_value, requests, bindings = _component_requests(tmp_path)
     treatment = next(item for item in requests if item["condition"] == "treatment")
     repository_id = treatment["repository"]["id"]
-    artifact = Path(bindings[repository_id]["manifest"]).parent / treatment["component_delta"]["artifact"]
-    artifact.write_text("tampered-after-plan", encoding="utf-8")
-    with pytest.raises(AgentBenchmarkError, match="artifact SHA-256 mismatch"):
-        execute_runner(
-            [sys.executable, "-c", "raise SystemExit('runner must not start')"],
-            treatment,
-            timeout_seconds=5,
-            max_stdout_bytes=1024,
-        )
+    artifact = (
+        Path(bindings[repository_id]["manifest"]).parent
+        / treatment["component_delta"]["artifact"]
+    )
+    return treatment, artifact
 
+
+def _marker_runner(tmp_path: Path) -> tuple[list[str], Path]:
+    marker = tmp_path / "runner-started.txt"
+    runner = tmp_path / "marker-runner.py"
+    runner.write_text(
+        "import json, sys\n"
+        "from pathlib import Path\n"
+        "Path(sys.argv[1]).write_text('started', encoding='utf-8')\n"
+        "request = json.load(sys.stdin)\n"
+        "print(json.dumps({'request_id': request['request_id']}))\n",
+        encoding="utf-8",
+    )
+    return [sys.executable, str(runner), str(marker)], marker
+
+
+def test_execute_runner_rechecks_unchanged_component_artifact_before_start(
+    tmp_path: Path,
+) -> None:
+    treatment, _artifact = _component_treatment_execution_setup(tmp_path)
+    command, marker = _marker_runner(tmp_path)
+
+    result = execute_runner(command, treatment, timeout_seconds=5, max_stdout_bytes=1024)
+
+    assert result == {"request_id": treatment["request_id"]}
+    assert marker.read_text(encoding="utf-8") == "started"
+
+
+def test_execute_runner_rejects_changed_component_artifact_before_start(
+    tmp_path: Path,
+) -> None:
+    treatment, artifact = _component_treatment_execution_setup(tmp_path)
+    artifact.write_text("tampered-after-plan", encoding="utf-8")
+    command, marker = _marker_runner(tmp_path)
+
+    with pytest.raises(AgentBenchmarkError, match="artifact SHA-256 mismatch"):
+        execute_runner(command, treatment, timeout_seconds=5, max_stdout_bytes=1024)
+
+    assert not marker.exists()
+
+
+def test_execute_runner_rejects_deleted_component_artifact_before_start(
+    tmp_path: Path,
+) -> None:
+    treatment, artifact = _component_treatment_execution_setup(tmp_path)
+    artifact.unlink()
+    command, marker = _marker_runner(tmp_path)
+
+    with pytest.raises(AgentBenchmarkError):
+        execute_runner(command, treatment, timeout_seconds=5, max_stdout_bytes=1024)
+
+    assert not marker.exists()
+
+
+def test_execute_runner_rejects_component_artifact_symlink_before_start(
+    tmp_path: Path,
+) -> None:
+    treatment, artifact = _component_treatment_execution_setup(tmp_path)
+    target = artifact.with_name("symlink-target.json")
+    target.write_bytes(artifact.read_bytes())
+    artifact.unlink()
+    artifact.symlink_to(target.name)
+    command, marker = _marker_runner(tmp_path)
+
+    with pytest.raises(AgentBenchmarkError):
+        execute_runner(command, treatment, timeout_seconds=5, max_stdout_bytes=1024)
+
+    assert not marker.exists()
+
+
+def test_execute_runner_rejects_component_artifact_root_escape_before_start(
+    tmp_path: Path,
+) -> None:
+    treatment, _artifact = _component_treatment_execution_setup(tmp_path)
+    treatment["component_delta"]["artifact"] = "../outside.json"
+    command, marker = _marker_runner(tmp_path)
+
+    with pytest.raises(AgentBenchmarkError):
+        execute_runner(command, treatment, timeout_seconds=5, max_stdout_bytes=1024)
+
+    assert not marker.exists()
+
+
+def test_execute_runner_rejects_component_artifact_sha_tamper_before_start(
+    tmp_path: Path,
+) -> None:
+    treatment, _artifact = _component_treatment_execution_setup(tmp_path)
+    treatment["component_delta"]["artifact_sha256"] = "0" * 64
+    command, marker = _marker_runner(tmp_path)
+
+    with pytest.raises(AgentBenchmarkError, match="artifact SHA-256 mismatch"):
+        execute_runner(command, treatment, timeout_seconds=5, max_stdout_bytes=1024)
+
+    assert not marker.exists()
+
+
+def test_execute_runner_component_delta_baseline_does_not_read_artifact(
+    tmp_path: Path,
+) -> None:
+    _taskset_value, requests, bindings = _component_requests(tmp_path)
+    baseline = next(item for item in requests if item["condition"] == "baseline")
+    treatment = next(item for item in requests if item["condition"] == "treatment")
+    repository_id = treatment["repository"]["id"]
+    artifact = (
+        Path(bindings[repository_id]["manifest"]).parent
+        / treatment["component_delta"]["artifact"]
+    )
+    artifact.unlink()
+    command, marker = _marker_runner(tmp_path)
+
+    result = execute_runner(command, baseline, timeout_seconds=5, max_stdout_bytes=1024)
+
+    assert result == {"request_id": baseline["request_id"]}
+    assert marker.read_text(encoding="utf-8") == "started"
 
 def test_execute_runner_rejects_oversized_or_invalid_output(tmp_path: Path) -> None:
     oversized = tmp_path / "oversized.py"
@@ -770,6 +879,9 @@ def test_complete_evaluation_contract_rejects_incomplete_objects(tmp_path: Path)
 
     incomplete = copy.deepcopy(evaluation)
     incomplete["cases"][0]["baseline"].pop("duration_ms")
+    assert validate_evaluation(incomplete)
+    incomplete = copy.deepcopy(evaluation)
+    incomplete["classes"][0]["efficiency"].pop("duration")
     assert validate_evaluation(incomplete)
     incomplete = copy.deepcopy(evaluation)
     incomplete["decision"].pop("reason")

--- a/merger/repoground/tests/test_agent_benchmark.py
+++ b/merger/repoground/tests/test_agent_benchmark.py
@@ -885,64 +885,52 @@ def test_component_delta_artifact_size_and_stability_fail_closed(
         )
 
 
-def test_component_delta_pair_isolation_rejects_every_forbidden_difference(
-    tmp_path: Path,
+def _set_nested_value(target: dict, path: tuple[str, ...], value) -> None:
+    current = target
+    for key in path[:-1]:
+        current = current[key]
+    current[path[-1]] = value
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        (("repository", "commit"), "f" * 40),
+        (("runner", "model"), "other"),
+        (("prompt",), "changed prompt"),
+        (("allowed_tools",), []),
+        (("budgets", "max_tool_calls"), 999),
+        (("repobrief", "manifest"), "other.manifest.json"),
+        (("repobrief", "manifest_sha256"), "f" * 64),
+        (("repobrief", "mcp_command"), ["other"]),
+        (("component_delta", "component"), "other_component"),
+        (("component_delta", "source_revision"), "b" * 40),
+        (("component_delta", "artifact"), None),
+    ],
+)
+def test_component_delta_pair_isolation_rejects_forbidden_difference(
+    tmp_path: Path, path: tuple[str, ...], value
 ) -> None:
     taskset, requests, _bindings = _component_requests(tmp_path)
     pair_id = requests[0]["pair_id"]
     pair = [item for item in requests if item["pair_id"] == pair_id]
     assert pair_request_errors(taskset, pair) == []
+    mutated = copy.deepcopy(pair)
+    treatment = next(item for item in mutated if item["condition"] == "treatment")
+    _set_nested_value(treatment, path, value)
+    assert pair_request_errors(taskset, mutated)
 
-    def mutate_treatment(name: str) -> list[dict]:
-        mutated = copy.deepcopy(pair)
-        treatment = next(item for item in mutated if item["condition"] == "treatment")
-        if name == "repository_commit":
-            treatment["repository"]["commit"] = "f" * 40
-        elif name == "runner":
-            treatment["runner"]["model"] = "other"
-        elif name == "prompt":
-            treatment["prompt"] += " changed"
-        elif name == "allowed_tools":
-            treatment["allowed_tools"] = treatment["allowed_tools"][:-1]
-        elif name == "budgets":
-            treatment["budgets"]["max_tool_calls"] += 1
-        elif name == "manifest":
-            treatment["repobrief"]["manifest"] += ".other"
-        elif name == "manifest_sha256":
-            treatment["repobrief"]["manifest_sha256"] = "f" * 64
-        elif name == "mcp_command":
-            treatment["repobrief"]["mcp_command"] = ["other"]
-        elif name == "component":
-            treatment["component_delta"]["component"] = "other_component"
-        elif name == "source_revision":
-            treatment["component_delta"]["source_revision"] = "b" * 40
-        elif name == "treatment_artifact_missing":
-            treatment["component_delta"]["artifact"] = None
-            treatment["component_delta"]["artifact_sha256"] = None
-        else:
-            raise AssertionError(name)
-        return mutated
 
-    for name in (
-        "repository_commit",
-        "runner",
-        "prompt",
-        "allowed_tools",
-        "budgets",
-        "manifest",
-        "manifest_sha256",
-        "mcp_command",
-        "component",
-        "source_revision",
-        "treatment_artifact_missing",
-    ):
-        assert pair_request_errors(taskset, mutate_treatment(name)), name
-
-    baseline_mutated = copy.deepcopy(pair)
-    baseline = next(item for item in baseline_mutated if item["condition"] == "baseline")
+def test_component_delta_pair_isolation_rejects_baseline_artifact(
+    tmp_path: Path,
+) -> None:
+    taskset, requests, _bindings = _component_requests(tmp_path)
+    pair_id = requests[0]["pair_id"]
+    mutated = copy.deepcopy([item for item in requests if item["pair_id"] == pair_id])
+    baseline = next(item for item in mutated if item["condition"] == "baseline")
     baseline["component_delta"]["artifact"] = "unexpected.json"
     baseline["component_delta"]["artifact_sha256"] = "f" * 64
-    assert pair_request_errors(taskset, baseline_mutated)
+    assert pair_request_errors(taskset, mutated)
 
 
 def test_component_delta_evaluation_binds_repository_artifacts_and_complete_pairs(

--- a/merger/repoground/tests/test_agent_benchmark.py
+++ b/merger/repoground/tests/test_agent_benchmark.py
@@ -19,6 +19,7 @@ from merger.repoground.core.agent_benchmark import (
     sha256_bytes,
     sha256_json,
     validate_evaluation,
+    validate_evaluation_derivations,
     validate_receipt,
     validate_taskset,
 )
@@ -44,7 +45,14 @@ BINDINGS = {
     repository_id: {
         "manifest": f"/bench/{repository_id}.bundle.manifest.json",
         "manifest_sha256": (str(index + 1) * 64)[:64],
-        "mcp_command": ["python", "-m", "merger.repoground", "mcp", "--bundle-root", "/bench"],
+        "mcp_command": [
+            "python",
+            "-m",
+            "merger.repoground",
+            "mcp",
+            "--bundle-root",
+            "/bench",
+        ],
     }
     for index, repository_id in enumerate(("lenskit", "grabowski", "weltgewebe"))
 }
@@ -220,7 +228,9 @@ def test_frozen_taskset_matches_schema_and_semantic_contract() -> None:
         ),
     ],
 )
-def test_taskset_semantic_validation_rejects_manipulation(mutation, expected: str) -> None:
+def test_taskset_semantic_validation_rejects_manipulation(
+    mutation, expected: str
+) -> None:
     taskset = _taskset()
     mutation(taskset)
     assert any(expected in error for error in validate_taskset(taskset))
@@ -357,7 +367,9 @@ def test_pair_plan_requires_treatment_manifest_binding() -> None:
     taskset = _taskset()
     incomplete = dict(BINDINGS)
     incomplete.pop("grabowski")
-    with pytest.raises(AgentBenchmarkError, match="missing RepoGround manifest binding"):
+    with pytest.raises(
+        AgentBenchmarkError, match="missing RepoGround manifest binding"
+    ):
         build_run_requests(
             taskset,
             runner=RUNNER,
@@ -453,9 +465,7 @@ def test_synthetic_fixtures_can_never_establish_usefulness() -> None:
     Draft7Validator(_schema("evaluation")).validate(result)
     assert result["decision"]["status"] == "synthetic_only"
     assert result["decision"]["default_promoted"] is False
-    assert {item["classification"] for item in result["classes"]} == {
-        "synthetic_only"
-    }
+    assert {item["classification"] for item in result["classes"]} == {"synthetic_only"}
 
 
 def test_real_paired_evaluation_requires_reproduced_direction() -> None:
@@ -543,7 +553,9 @@ def test_reused_session_or_workspace_invalidates_pair() -> None:
 def test_entire_missing_pair_remains_visible_and_invalid() -> None:
     taskset, requests, receipts = _requests_and_receipts(treatment_factor=0.5)
     missing_pair = requests[0]["pair_id"]
-    filtered_requests = [request for request in requests if request["pair_id"] != missing_pair]
+    filtered_requests = [
+        request for request in requests if request["pair_id"] != missing_pair
+    ]
     valid_request_ids = {request["request_id"] for request in filtered_requests}
     filtered_receipts = [
         receipt for receipt in receipts if receipt["request_id"] in valid_request_ids
@@ -585,7 +597,10 @@ def test_request_manipulation_invalidates_matching_receipt() -> None:
     )
     condition_score = affected[target["condition"]]
     assert condition_score["valid"] is False
-    assert "request prompt does not match frozen case" in condition_score["invalid_reasons"]
+    assert (
+        "request prompt does not match frozen case"
+        in condition_score["invalid_reasons"]
+    )
     assert result["decision"]["status"] == "insufficient_evidence"
 
 
@@ -638,7 +653,9 @@ def test_execute_runner_rechecks_unchanged_component_artifact_before_start(
     treatment, _artifact = _component_treatment_execution_setup(tmp_path)
     command, marker = _marker_runner(tmp_path)
 
-    result = execute_runner(command, treatment, timeout_seconds=5, max_stdout_bytes=1024)
+    result = execute_runner(
+        command, treatment, timeout_seconds=5, max_stdout_bytes=1024
+    )
 
     assert result == {"request_id": treatment["request_id"]}
     assert marker.read_text(encoding="utf-8") == "started"
@@ -744,6 +761,7 @@ def test_execute_runner_component_delta_baseline_does_not_read_artifact(
     assert result == {"request_id": baseline["request_id"]}
     assert marker.read_text(encoding="utf-8") == "started"
 
+
 def test_execute_runner_rejects_oversized_or_invalid_output(tmp_path: Path) -> None:
     oversized = tmp_path / "oversized.py"
     oversized.write_text("print('x' * 1000)\n", encoding="utf-8")
@@ -764,6 +782,7 @@ def test_execute_runner_rejects_oversized_or_invalid_output(tmp_path: Path) -> N
             timeout_seconds=5,
             max_stdout_bytes=1024,
         )
+
 
 def test_receipt_rejects_invalid_status_and_timestamps() -> None:
     taskset = _taskset()
@@ -805,9 +824,7 @@ def test_transcript_content_is_nonempty_and_bounded(tmp_path: Path) -> None:
     case = _cases(taskset)[request["case_id"]]
 
     empty = _receipt(request, case)
-    empty["transcript"].update(
-        {"inline": "", "bytes": 0, "sha256": sha256_bytes(b"")}
-    )
+    empty["transcript"].update({"inline": "", "bytes": 0, "sha256": sha256_bytes(b"")})
     assert "transcript must not be empty" in validate_receipt(request, empty)
 
     oversized_path = tmp_path / "oversized-transcript.json"
@@ -841,7 +858,62 @@ def _component_taskset() -> dict:
     taskset["tool_policy"]["baseline"] = copy.deepcopy(
         taskset["tool_policy"]["treatment"]
     )
+    for case in taskset["cases"]:
+        case["expectations"]["baseline"] = copy.deepcopy(
+            case["expectations"]["treatment"]
+        )
     return taskset
+
+
+def _language_structure_fixture(
+    *, repository_id: str, repository_commit: str, manifest_name: str
+) -> dict:
+    def summary(adapter_id: str) -> dict:
+        return {
+            "status": "available",
+            "adapter": {"id": adapter_id, "version": "1.0"},
+            "supported_files": [],
+            "supported_symbols": [],
+            "supported_relations": [],
+            "range_basis": "fixture",
+            "explicit_limits": [],
+            "candidate_file_count": 0,
+            "scanned_file_count": 0,
+            "record_count": 0,
+        }
+
+    return {
+        "kind": "repoground.language_structure",
+        "version": "1.0",
+        "authority": "navigation_index",
+        "canonicality": "derived",
+        "risk_class": "navigation",
+        "run_id": f"fixture-{repository_id}",
+        "status": "available",
+        "source": {
+            "repository_root_name": repository_id,
+            "repository_commit": repository_commit,
+            "bundle_manifest": manifest_name,
+            "canonical_dump_index_sha256": "d" * 64,
+            "network_used": False,
+            "secrets_read": False,
+            "workspace_state_used_beyond_bound_source": False,
+        },
+        "languages": {
+            "bash": summary("bash-static-structure"),
+            "rust": summary("rust-static-structure"),
+        },
+        "records": [],
+        "record_count": 0,
+        "degradations": [],
+        "truncation": None,
+        "promotion": {
+            "default_promoted": False,
+            "status": "keep_optional",
+            "reason": "contract fixture",
+        },
+        "does_not_establish": ["agent usefulness"],
+    }
 
 
 def _component_bindings(tmp_path: Path) -> dict[str, dict]:
@@ -851,11 +923,34 @@ def _component_bindings(tmp_path: Path) -> dict[str, dict]:
         root = tmp_path / repository_id
         root.mkdir(parents=True)
         manifest = root / f"{repository_id}.bundle.manifest.json"
-        manifest_raw = (json.dumps({"repository_id": repository_id}) + "\n").encode()
-        manifest.write_bytes(manifest_raw)
         artifact = root / "language_structure.json"
-        artifact_raw = (json.dumps({"repository_id": repository_id, "component": "language_structure_json"}) + "\n").encode()
+        artifact_raw = (
+            json.dumps(
+                _language_structure_fixture(
+                    repository_id=repository_id,
+                    repository_commit=repository["commit"],
+                    manifest_name=manifest.name,
+                ),
+                sort_keys=True,
+            )
+            + "\n"
+        ).encode()
         artifact.write_bytes(artifact_raw)
+        artifact_sha256 = sha256_bytes(artifact_raw)
+        manifest_document = {
+            "kind": "repoground.bundle.manifest",
+            "version": "2.0",
+            "artifacts": [
+                {
+                    "role": "language_structure_json",
+                    "path": artifact.name,
+                    "sha256": artifact_sha256,
+                    "contract": {"id": "language-structure", "version": "v1"},
+                }
+            ],
+        }
+        manifest_raw = (json.dumps(manifest_document, sort_keys=True) + "\n").encode()
+        manifest.write_bytes(manifest_raw)
         bindings[repository_id] = {
             "manifest": str(manifest),
             "manifest_sha256": sha256_bytes(manifest_raw),
@@ -864,7 +959,7 @@ def _component_bindings(tmp_path: Path) -> dict[str, dict]:
                 "language_structure_json": {
                     "source_revision": COMPONENT_REVISION,
                     "artifact": artifact.name,
-                    "artifact_sha256": sha256_bytes(artifact_raw),
+                    "artifact_sha256": artifact_sha256,
                 }
             },
         }
@@ -880,7 +975,9 @@ def _component_requests(tmp_path: Path) -> tuple[dict, list[dict], dict[str, dic
     return taskset, requests, bindings
 
 
-def test_complete_evaluation_contract_rejects_incomplete_objects(tmp_path: Path) -> None:
+def test_complete_evaluation_contract_rejects_incomplete_objects(
+    tmp_path: Path,
+) -> None:
     taskset, requests, _bindings = _component_requests(tmp_path)
     cases = _cases(taskset)
     receipts = [_receipt(request, cases[request["case_id"]]) for request in requests]
@@ -929,11 +1026,71 @@ def test_component_delta_taskset_contract_is_fail_closed() -> None:
     missing_repoground["tool_policy"]["baseline"] = [
         tool
         for tool in missing_repoground["tool_policy"]["baseline"]
-        if tool not in {"ask_context", "repobrief_resource_read", "grounding_verify", "live_freshness"}
+        if tool
+        not in {
+            "ask_context",
+            "repobrief_resource_read",
+            "grounding_verify",
+            "live_freshness",
+        }
     ]
     mutations.append(missing_repoground)
     for mutated in mutations:
         assert validate_taskset(mutated)
+
+
+def test_evaluation_derivations_are_recomputed_from_case_scores(
+    tmp_path: Path,
+) -> None:
+    taskset, requests, _bindings = _component_requests(tmp_path)
+    cases = _cases(taskset)
+    receipts = [_receipt(request, cases[request["case_id"]]) for request in requests]
+    evaluation = evaluate_paired_runs(
+        taskset, requests, receipts, measurement_scope="real_paired_agent_runs"
+    )
+
+    assert validate_evaluation(evaluation) == []
+    assert validate_evaluation_derivations(evaluation) == []
+
+    legacy_v1 = copy.deepcopy(evaluation)
+    legacy_v1.pop("thresholds")
+    assert validate_evaluation(legacy_v1) == []
+    assert validate_evaluation_derivations(legacy_v1)
+
+    forged_class = copy.deepcopy(evaluation)
+    forged_class["classes"][0]["classification"] = "useful"
+    assert validate_evaluation_derivations(forged_class)
+
+    forged_decision = copy.deepcopy(evaluation)
+    forged_decision["decision"]["status"] = "useful_class"
+    forged_decision["decision"]["useful_classes"] = [
+        forged_decision["classes"][0]["category"]
+    ]
+    assert validate_evaluation_derivations(forged_decision)
+
+
+def test_explicit_empty_comparison_contract_fails_semantic_validation() -> None:
+    taskset = copy.deepcopy(_taskset())
+    taskset["comparison"] = {}
+
+    assert "comparison contract is invalid" in validate_taskset(taskset)
+
+
+def test_component_delta_requires_identical_grading_expectations() -> None:
+    taskset = _component_taskset()
+    baseline = taskset["cases"][0]["expectations"]["baseline"]
+    treatment = taskset["cases"][0]["expectations"]["treatment"]
+    baseline["outcome"] = "abstain" if treatment["outcome"] != "abstain" else "answer"
+
+    errors = validate_taskset(taskset)
+
+    assert any(
+        "component_delta expectations must be identical" in error for error in errors
+    )
+    with pytest.raises(
+        AgentBenchmarkError, match="component_delta expectations must be identical"
+    ):
+        build_run_requests(taskset, runner=RUNNER, manifest_bindings={}, repetitions=2)
 
 
 def test_component_delta_requests_differ_only_by_bound_artifact(tmp_path: Path) -> None:
@@ -1020,6 +1177,101 @@ def test_component_delta_artifact_binding_fails_closed(
         )
 
 
+def _rewrite_component_fixture(
+    binding: dict,
+    *,
+    mutate_artifact=None,
+    mutate_manifest=None,
+) -> None:
+    manifest_path = Path(binding["manifest"])
+    component = binding["components"]["language_structure_json"]
+    artifact_path = manifest_path.parent / component["artifact"]
+    artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+    if mutate_artifact is not None:
+        mutate_artifact(artifact)
+    artifact_raw = (json.dumps(artifact, sort_keys=True) + "\n").encode()
+    artifact_path.write_bytes(artifact_raw)
+    component["artifact_sha256"] = sha256_bytes(artifact_raw)
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    registered = next(
+        item
+        for item in manifest.get("artifacts", [])
+        if item.get("role") == "language_structure_json"
+    )
+    registered["sha256"] = component["artifact_sha256"]
+    if mutate_manifest is not None:
+        mutate_manifest(manifest)
+    manifest_raw = (json.dumps(manifest, sort_keys=True) + "\n").encode()
+    manifest_path.write_bytes(manifest_raw)
+    binding["manifest_sha256"] = sha256_bytes(manifest_raw)
+
+
+def test_component_delta_requires_manifest_registration_and_component_contract(
+    tmp_path: Path,
+) -> None:
+    taskset = _component_taskset()
+    bindings = _component_bindings(tmp_path)
+    repository_id = taskset["repositories"][0]["id"]
+    binding = bindings[repository_id]
+    manifest_path = Path(binding["manifest"])
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["artifacts"] = []
+    manifest_raw = (json.dumps(manifest, sort_keys=True) + "\n").encode()
+    manifest_path.write_bytes(manifest_raw)
+    binding["manifest_sha256"] = sha256_bytes(manifest_raw)
+    with pytest.raises(
+        AgentBenchmarkError, match="exactly one language_structure_json"
+    ):
+        build_run_requests(
+            taskset, runner=RUNNER, manifest_bindings=bindings, repetitions=2
+        )
+
+    bindings = _component_bindings(tmp_path / "contract")
+    repository_id = taskset["repositories"][0]["id"]
+    binding = bindings[repository_id]
+    _rewrite_component_fixture(
+        binding,
+        mutate_manifest=lambda value: value["artifacts"][0].update(
+            contract={"id": "wrong-contract", "version": "v1"}
+        ),
+    )
+    with pytest.raises(AgentBenchmarkError, match="contract mismatch"):
+        build_run_requests(
+            taskset, runner=RUNNER, manifest_bindings=bindings, repetitions=2
+        )
+
+
+def test_component_delta_requires_schema_valid_revision_bound_component(
+    tmp_path: Path,
+) -> None:
+    taskset = _component_taskset()
+    bindings = _component_bindings(tmp_path / "revision")
+    repository_id = taskset["repositories"][0]["id"]
+    binding = bindings[repository_id]
+    _rewrite_component_fixture(
+        binding,
+        mutate_artifact=lambda value: value["source"].update(
+            repository_commit="f" * 40
+        ),
+    )
+    with pytest.raises(AgentBenchmarkError, match="provenance mismatch"):
+        build_run_requests(
+            taskset, runner=RUNNER, manifest_bindings=bindings, repetitions=2
+        )
+
+    bindings = _component_bindings(tmp_path / "schema")
+    repository_id = taskset["repositories"][0]["id"]
+    binding = bindings[repository_id]
+    _rewrite_component_fixture(
+        binding, mutate_artifact=lambda value: value.pop("source")
+    )
+    with pytest.raises(AgentBenchmarkError, match="contract invalid"):
+        build_run_requests(
+            taskset, runner=RUNNER, manifest_bindings=bindings, repetitions=2
+        )
+
+
 def test_component_delta_artifact_size_and_stability_fail_closed(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1038,7 +1290,7 @@ def test_component_delta_artifact_size_and_stability_fail_closed(
 
     stable_bindings = _component_bindings(tmp_path / "unstable")
     monkeypatch.setattr(
-        "merger.repoground.core.agent_benchmark.read_stable_regular_file_bytes",
+        "merger.repoground.core.agent_benchmark_components.read_stable_regular_file_bytes",
         lambda *_args, **_kwargs: (None, None, "source_changed", "changed"),
     )
     with pytest.raises(AgentBenchmarkError, match="source_changed"):
@@ -1113,7 +1365,9 @@ def test_component_delta_evaluation_binds_repository_artifacts_and_complete_pair
     assert {item["repository_id"] for item in comparison["treatment_artifacts"]} == {
         item["id"] for item in taskset["repositories"]
     }
-    assert all(len(item["artifact_sha256"]) == 64 for item in comparison["treatment_artifacts"])
+    assert all(
+        len(item["artifact_sha256"]) == 64 for item in comparison["treatment_artifacts"]
+    )
 
     missing_pair = requests[0]["pair_id"]
     filtered_requests = [item for item in requests if item["pair_id"] != missing_pair]
@@ -1128,7 +1382,6 @@ def test_component_delta_evaluation_binds_repository_artifacts_and_complete_pair
         measurement_scope="real_paired_agent_runs",
     )
     assert incomplete["comparison"]["pair_isolation_verified"] is False
-
 
     baseline_only_requests = [
         item for item in requests if item["condition"] == "baseline"

--- a/merger/repoground/tests/test_language_structure_adapters.py
+++ b/merger/repoground/tests/test_language_structure_adapters.py
@@ -1038,6 +1038,46 @@ def test_benchmark_separates_quality_null_cost_and_fail_closed_promotion(tmp_pat
             "pair_isolation_verified": True,
         },
     }
+    score = {
+        "valid": True,
+        "success": True,
+        "outcome_match": True,
+        "target_hit_rate": 1.0,
+        "false_hit_count": 0,
+        "citation_match_rate": 1.0,
+        "false_confidence": False,
+        "duration_ms": 1,
+        "tool_call_count": 1,
+        "input_tokens": 1,
+        "output_tokens": 1,
+        "tool_bytes": 1,
+        "invalid_reasons": [],
+    }
+    for index, case in enumerate(verified_component_delta["cases"]):
+        case.update(
+            case_id=f"case-{index}",
+            category=("navigation", "structural", "grounding_freshness")[index],
+            repetition=1,
+            baseline=copy.deepcopy(score),
+            treatment=copy.deepcopy(score),
+        )
+    efficiency = {
+        key: {"baseline_mean": 1.0, "treatment_mean": 1.0, "improvement_ratio": 0.0}
+        for key in ("duration", "tool_calls", "input_tokens", "output_tokens", "tool_bytes")
+    }
+    for item in verified_component_delta["classes"]:
+        item.update(
+            baseline_success_rate=1.0,
+            treatment_success_rate=1.0,
+            success_rate_delta=0.0,
+            baseline_false_confidence_rate=0.0,
+            treatment_false_confidence_rate=0.0,
+            false_confidence_delta=0.0,
+            efficiency=copy.deepcopy(efficiency),
+        )
+    verified_component_delta["decision"]["reason"] = "fixture reproduces bounded component benefit"
+    verified_component_delta["does_not_establish"] = ["default promotion"]
+
     accepted = decide_language_adapter_promotion(
         report, agent_benefit=verified_component_delta
     )
@@ -1069,6 +1109,9 @@ def test_benchmark_separates_quality_null_cost_and_fail_closed_promotion(tmp_pat
         lambda value: value["classes"][0].update(classification="harmful"),
         lambda value: value["decision"].update(harmful_classes=["navigation"]),
         lambda value: value["decision"].update(default_promoted=True),
+        lambda value: value["decision"].pop("reason"),
+        lambda value: value["cases"][0]["baseline"].pop("duration_ms"),
+        lambda value: value.pop("does_not_establish"),
     ):
         mutated = copy.deepcopy(verified_component_delta)
         mutate(mutated)

--- a/merger/repoground/tests/test_language_structure_adapters.py
+++ b/merger/repoground/tests/test_language_structure_adapters.py
@@ -1111,6 +1111,7 @@ def test_benchmark_separates_quality_null_cost_and_fail_closed_promotion(tmp_pat
         lambda value: value["decision"].update(default_promoted=True),
         lambda value: value["decision"].pop("reason"),
         lambda value: value["cases"][0]["baseline"].pop("duration_ms"),
+        lambda value: value["classes"][0]["efficiency"].pop("duration"),
         lambda value: value.pop("does_not_establish"),
     ):
         mutated = copy.deepcopy(verified_component_delta)

--- a/merger/repoground/tests/test_language_structure_adapters.py
+++ b/merger/repoground/tests/test_language_structure_adapters.py
@@ -995,49 +995,6 @@ def test_benchmark_separates_quality_null_cost_and_fail_closed_promotion(tmp_pat
         == "revision_bound_agent_benefit_missing"
     )
 
-    verified_component_delta = {
-        "kind": "repobrief.agent_benchmark_evaluation",
-        "version": "1.0",
-        "taskset_id": "language-structure-component-delta-fixture",
-        "taskset_sha256": "d" * 64,
-        "measurement_scope": "real_paired_agent_runs",
-        "run_count": 6,
-        "valid_run_count": 6,
-        "invalid_run_count": 0,
-        "cases": [
-            {"pair_valid": True},
-            {"pair_valid": True},
-            {"pair_valid": True},
-        ],
-        "classes": [
-            {"category": "navigation", "valid_pair_count": 1, "classification": "useful"},
-            {"category": "structural", "valid_pair_count": 1, "classification": "neutral"},
-            {
-                "category": "grounding_freshness",
-                "valid_pair_count": 1,
-                "classification": "neutral",
-            },
-        ],
-        "decision": {
-            "status": "useful_class",
-            "useful_classes": ["navigation"],
-            "harmful_classes": [],
-            "default_promoted": False,
-        },
-        "comparison": {
-            "mode": "component_delta",
-            "component": "language_structure_json",
-            "source_revision": revision,
-            "treatment_artifacts": [
-                {
-                    "repository_id": "fixture",
-                    "artifact": "language_structure.json",
-                    "artifact_sha256": "e" * 64,
-                }
-            ],
-            "pair_isolation_verified": True,
-        },
-    }
     score = {
         "valid": True,
         "success": True,
@@ -1053,30 +1010,115 @@ def test_benchmark_separates_quality_null_cost_and_fail_closed_promotion(tmp_pat
         "tool_bytes": 1,
         "invalid_reasons": [],
     }
-    for index, case in enumerate(verified_component_delta["cases"]):
-        case.update(
-            case_id=f"case-{index}",
-            category=("navigation", "structural", "grounding_freshness")[index],
-            repetition=1,
-            baseline=copy.deepcopy(score),
-            treatment=copy.deepcopy(score),
-        )
+    cases = []
+    for category in ("navigation", "structural", "grounding_freshness"):
+        for repetition in (1, 2):
+            baseline = copy.deepcopy(score)
+            treatment = copy.deepcopy(score)
+            if category == "navigation":
+                baseline["success"] = False
+            cases.append(
+                {
+                    "case_id": f"{category}-{repetition}",
+                    "category": category,
+                    "repetition": repetition,
+                    "pair_valid": True,
+                    "baseline": baseline,
+                    "treatment": treatment,
+                }
+            )
     efficiency = {
-        key: {"baseline_mean": 1.0, "treatment_mean": 1.0, "improvement_ratio": 0.0}
-        for key in ("duration", "tool_calls", "input_tokens", "output_tokens", "tool_bytes")
-    }
-    for item in verified_component_delta["classes"]:
-        item.update(
-            baseline_success_rate=1.0,
-            treatment_success_rate=1.0,
-            success_rate_delta=0.0,
-            baseline_false_confidence_rate=0.0,
-            treatment_false_confidence_rate=0.0,
-            false_confidence_delta=0.0,
-            efficiency=copy.deepcopy(efficiency),
+        key: {
+            "baseline_mean": 1.0,
+            "treatment_mean": 1.0,
+            "improvement_ratio": 0.0,
+        }
+        for key in (
+            "duration",
+            "tool_calls",
+            "input_tokens",
+            "output_tokens",
+            "tool_bytes",
         )
-    verified_component_delta["decision"]["reason"] = "fixture reproduces bounded component benefit"
-    verified_component_delta["does_not_establish"] = ["default promotion"]
+    }
+    verified_component_delta = {
+        "kind": "repobrief.agent_benchmark_evaluation",
+        "version": "1.0",
+        "taskset_id": "language-structure-component-delta-fixture",
+        "taskset_sha256": "d" * 64,
+        "measurement_scope": "real_paired_agent_runs",
+        "thresholds": {
+            "minimum_success_rate_gain": 0.1,
+            "maximum_class_success_regression": 0.05,
+            "maximum_false_confidence_increase": 0.0,
+            "minimum_efficiency_improvement": 0.2,
+        },
+        "run_count": 12,
+        "valid_run_count": 12,
+        "invalid_run_count": 0,
+        "cases": cases,
+        "classes": [
+            {
+                "category": "navigation",
+                "valid_pair_count": 2,
+                "baseline_success_rate": 0.0,
+                "treatment_success_rate": 1.0,
+                "success_rate_delta": 1.0,
+                "baseline_false_confidence_rate": 0.0,
+                "treatment_false_confidence_rate": 0.0,
+                "false_confidence_delta": 0.0,
+                "efficiency": copy.deepcopy(efficiency),
+                "classification": "useful",
+            },
+            {
+                "category": "structural",
+                "valid_pair_count": 2,
+                "baseline_success_rate": 1.0,
+                "treatment_success_rate": 1.0,
+                "success_rate_delta": 0.0,
+                "baseline_false_confidence_rate": 0.0,
+                "treatment_false_confidence_rate": 0.0,
+                "false_confidence_delta": 0.0,
+                "efficiency": copy.deepcopy(efficiency),
+                "classification": "neutral",
+            },
+            {
+                "category": "grounding_freshness",
+                "valid_pair_count": 2,
+                "baseline_success_rate": 1.0,
+                "treatment_success_rate": 1.0,
+                "success_rate_delta": 0.0,
+                "baseline_false_confidence_rate": 0.0,
+                "treatment_false_confidence_rate": 0.0,
+                "false_confidence_delta": 0.0,
+                "efficiency": copy.deepcopy(efficiency),
+                "classification": "neutral",
+            },
+        ],
+        "decision": {
+            "status": "useful_class",
+            "useful_classes": ["navigation"],
+            "harmful_classes": [],
+            "default_promoted": False,
+            "reason": (
+                "at least one class met a reproducible benefit threshold without regression"
+            ),
+        },
+        "does_not_establish": ["default promotion"],
+        "comparison": {
+            "mode": "component_delta",
+            "component": "language_structure_json",
+            "source_revision": revision,
+            "treatment_artifacts": [
+                {
+                    "repository_id": "fixture",
+                    "artifact": "language_structure.json",
+                    "artifact_sha256": "e" * 64,
+                }
+            ],
+            "pair_isolation_verified": True,
+        },
+    }
 
     accepted = decide_language_adapter_promotion(
         report, agent_benefit=verified_component_delta
@@ -1094,6 +1136,8 @@ def test_benchmark_separates_quality_null_cost_and_fail_closed_promotion(tmp_pat
     bad_mutations = []
     for mutate in (
         lambda value: value.update(measurement_scope="synthetic_contract_fixture"),
+        lambda value: value["thresholds"].update(minimum_success_rate_gain=0.0),
+        lambda value: value["thresholds"].update(maximum_class_success_regression=0.5),
         lambda value: value["comparison"].update(component="other_component"),
         lambda value: value["comparison"].update(source_revision="b" * 40),
         lambda value: value["comparison"].update(pair_isolation_verified=False),
@@ -1126,7 +1170,7 @@ def test_benchmark_separates_quality_null_cost_and_fail_closed_promotion(tmp_pat
     missing_class["classes"].pop()
     bad_mutations.append(missing_class)
     inconsistent_pair_total = copy.deepcopy(verified_component_delta)
-    inconsistent_pair_total["classes"][0]["valid_pair_count"] = 2
+    inconsistent_pair_total["classes"][0]["valid_pair_count"] = 3
     bad_mutations.append(inconsistent_pair_total)
     neutral_only = copy.deepcopy(verified_component_delta)
     neutral_only["classes"][0]["classification"] = "neutral"

--- a/merger/repoground/tests/test_language_structure_adapters.py
+++ b/merger/repoground/tests/test_language_structure_adapters.py
@@ -995,6 +995,115 @@ def test_benchmark_separates_quality_null_cost_and_fail_closed_promotion(tmp_pat
         == "revision_bound_agent_benefit_missing"
     )
 
+    verified_component_delta = {
+        "kind": "repobrief.agent_benchmark_evaluation",
+        "version": "1.0",
+        "taskset_id": "language-structure-component-delta-fixture",
+        "taskset_sha256": "d" * 64,
+        "measurement_scope": "real_paired_agent_runs",
+        "run_count": 6,
+        "valid_run_count": 6,
+        "invalid_run_count": 0,
+        "cases": [
+            {"pair_valid": True},
+            {"pair_valid": True},
+            {"pair_valid": True},
+        ],
+        "classes": [
+            {"category": "navigation", "valid_pair_count": 1, "classification": "useful"},
+            {"category": "structural", "valid_pair_count": 1, "classification": "neutral"},
+            {
+                "category": "grounding_freshness",
+                "valid_pair_count": 1,
+                "classification": "neutral",
+            },
+        ],
+        "decision": {
+            "status": "useful_class",
+            "useful_classes": ["navigation"],
+            "harmful_classes": [],
+            "default_promoted": False,
+        },
+        "comparison": {
+            "mode": "component_delta",
+            "component": "language_structure_json",
+            "source_revision": revision,
+            "treatment_artifacts": [
+                {
+                    "repository_id": "fixture",
+                    "artifact": "language_structure.json",
+                    "artifact_sha256": "e" * 64,
+                }
+            ],
+            "pair_isolation_verified": True,
+        },
+    }
+    accepted = decide_language_adapter_promotion(
+        report, agent_benefit=verified_component_delta
+    )
+    assert accepted == {
+        "status": "eligible_for_explicit_promotion_review",
+        "broad_activation_eligible": False,
+        "default_promoted": False,
+        "reason": "verified_component_delta_agent_benefit_and_quality_gates_passed",
+        "source_revision": revision,
+        "goldset_sha256": report["goldset_sha256"],
+        "decision_authority": "none; explicit reviewed configuration change required",
+    }
+
+    bad_mutations = []
+    for mutate in (
+        lambda value: value.update(measurement_scope="synthetic_contract_fixture"),
+        lambda value: value["comparison"].update(component="other_component"),
+        lambda value: value["comparison"].update(source_revision="b" * 40),
+        lambda value: value["comparison"].update(pair_isolation_verified=False),
+        lambda value: value["comparison"]["treatment_artifacts"][0].update(
+            artifact="../escape.json"
+        ),
+        lambda value: value["comparison"]["treatment_artifacts"][0].update(
+            artifact_sha256="z" * 64
+        ),
+        lambda value: value.update(run_count=4),
+        lambda value: value.update(valid_run_count=5, invalid_run_count=1),
+        lambda value: value["cases"][0].update(pair_valid=False),
+        lambda value: value["classes"][0].update(classification="harmful"),
+        lambda value: value["decision"].update(harmful_classes=["navigation"]),
+        lambda value: value["decision"].update(default_promoted=True),
+    ):
+        mutated = copy.deepcopy(verified_component_delta)
+        mutate(mutated)
+        bad_mutations.append(mutated)
+    duplicate_artifact = copy.deepcopy(verified_component_delta)
+    duplicate_artifact["comparison"]["treatment_artifacts"].append(
+        copy.deepcopy(duplicate_artifact["comparison"]["treatment_artifacts"][0])
+    )
+    bad_mutations.append(duplicate_artifact)
+    missing_class = copy.deepcopy(verified_component_delta)
+    missing_class["classes"].pop()
+    bad_mutations.append(missing_class)
+    inconsistent_pair_total = copy.deepcopy(verified_component_delta)
+    inconsistent_pair_total["classes"][0]["valid_pair_count"] = 2
+    bad_mutations.append(inconsistent_pair_total)
+    neutral_only = copy.deepcopy(verified_component_delta)
+    neutral_only["classes"][0]["classification"] = "neutral"
+    neutral_only["decision"]["useful_classes"] = []
+    neutral_only["decision"]["status"] = "neutral"
+    bad_mutations.append(neutral_only)
+    for mutated in bad_mutations:
+        assert (
+            decide_language_adapter_promotion(report, agent_benefit=mutated)["reason"]
+            == "verified_component_delta_agent_benefit_missing"
+        )
+
+    degraded_report = copy.deepcopy(report)
+    degraded_report["determinism"]["semantic_projection_repeated_equal"] = False
+    assert (
+        decide_language_adapter_promotion(
+            degraded_report, agent_benefit=verified_component_delta
+        )["reason"]
+        == "quality_null_determinism_or_cost_gate_not_met"
+    )
+
     malformed_report = json.loads(json.dumps(report))
     malformed_report["goldset_sha256"] = "z" * 64
     assert (

--- a/merger/repoground/tests/test_language_structure_adapters.py
+++ b/merger/repoground/tests/test_language_structure_adapters.py
@@ -1045,20 +1045,37 @@ def test_benchmark_separates_quality_null_cost_and_fail_closed_promotion(tmp_pat
         == "verified_component_delta_agent_benefit_missing"
     )
 
+    assert verified_component_delta["runner_execution"] == {
+        "attested": False,
+        "authority": "none",
+        "reason": "trusted runner execution attestation is not available in benchmark v1",
+    }
     accepted = decide_language_adapter_promotion(
         report,
         agent_benefit=verified_component_delta,
         agent_benefit_inputs=verified_inputs,
     )
     assert accepted == {
-        "status": "eligible_for_explicit_promotion_review",
+        "status": "keep_optional",
         "broad_activation_eligible": False,
         "default_promoted": False,
-        "reason": "verified_component_delta_agent_benefit_and_quality_gates_passed",
-        "source_revision": revision,
-        "goldset_sha256": report["goldset_sha256"],
-        "decision_authority": "none; explicit reviewed configuration change required",
+        "reason": "verified_component_delta_agent_benefit_missing",
     }
+
+    forged_attestation = copy.deepcopy(verified_component_delta)
+    forged_attestation["runner_execution"] = {
+        "attested": True,
+        "authority": "fixture-forgery",
+        "reason": "hand-written",
+    }
+    assert (
+        decide_language_adapter_promotion(
+            report,
+            agent_benefit=forged_attestation,
+            agent_benefit_inputs=verified_inputs,
+        )["reason"]
+        == "verified_component_delta_agent_benefit_missing"
+    )
 
     tampered_inputs = copy.deepcopy(verified_inputs)
     tampered_inputs["receipts"][0]["duration_ms"] += 1
@@ -1154,7 +1171,7 @@ def test_benchmark_separates_quality_null_cost_and_fail_closed_promotion(tmp_pat
             agent_benefit=verified_component_delta,
             agent_benefit_inputs=verified_inputs,
         )["reason"]
-        == "quality_null_determinism_or_cost_gate_not_met"
+        == "verified_component_delta_agent_benefit_missing"
     )
 
     malformed_report = json.loads(json.dumps(report))

--- a/merger/repoground/tests/test_language_structure_adapters.py
+++ b/merger/repoground/tests/test_language_structure_adapters.py
@@ -13,6 +13,7 @@ import pytest
 
 from merger.repoground.core import doctor
 from merger.repoground.core.agent_benchmark import build_run_requests, evaluate_paired_runs
+from merger.repoground.core.agent_benchmark_evaluation import validate_evaluation
 from merger.repoground.core.bash_structure_adapter import scan_bash_repository
 from merger.repoground.core.language_structure import (
     build_language_structure_document,
@@ -1045,11 +1046,24 @@ def test_benchmark_separates_quality_null_cost_and_fail_closed_promotion(tmp_pat
         == "verified_component_delta_agent_benefit_missing"
     )
 
-    assert verified_component_delta["runner_execution"] == {
-        "attested": False,
-        "authority": "none",
-        "reason": "trusted runner execution attestation is not available in benchmark v1",
+    assert "runner_execution" not in verified_component_delta
+
+    forged_attestation = copy.deepcopy(verified_component_delta)
+    forged_attestation["runner_execution"] = {
+        "attested": True,
+        "authority": "fixture-forgery",
+        "reason": "hand-written",
     }
+    assert validate_evaluation(forged_attestation)
+    assert (
+        decide_language_adapter_promotion(
+            report,
+            agent_benefit=forged_attestation,
+            agent_benefit_inputs=verified_inputs,
+        )["reason"]
+        == "verified_component_delta_agent_benefit_missing"
+    )
+
     accepted = decide_language_adapter_promotion(
         report,
         agent_benefit=verified_component_delta,
@@ -1061,21 +1075,6 @@ def test_benchmark_separates_quality_null_cost_and_fail_closed_promotion(tmp_pat
         "default_promoted": False,
         "reason": "verified_component_delta_agent_benefit_missing",
     }
-
-    forged_attestation = copy.deepcopy(verified_component_delta)
-    forged_attestation["runner_execution"] = {
-        "attested": True,
-        "authority": "fixture-forgery",
-        "reason": "hand-written",
-    }
-    assert (
-        decide_language_adapter_promotion(
-            report,
-            agent_benefit=forged_attestation,
-            agent_benefit_inputs=verified_inputs,
-        )["reason"]
-        == "verified_component_delta_agent_benefit_missing"
-    )
 
     tampered_inputs = copy.deepcopy(verified_inputs)
     tampered_inputs["receipts"][0]["duration_ms"] += 1

--- a/merger/repoground/tests/test_language_structure_adapters.py
+++ b/merger/repoground/tests/test_language_structure_adapters.py
@@ -12,6 +12,7 @@ import jsonschema
 import pytest
 
 from merger.repoground.core import doctor
+from merger.repoground.core.agent_benchmark import build_run_requests, evaluate_paired_runs
 from merger.repoground.core.bash_structure_adapter import scan_bash_repository
 from merger.repoground.core.language_structure import (
     build_language_structure_document,
@@ -30,6 +31,13 @@ from merger.repoground.core.language_structure_benchmark import (
 from merger.repoground.core.rust_structure_adapter import (
     _rust_call_evidence,
     scan_rust_repository,
+)
+from merger.repoground.tests.test_agent_benchmark import (
+    RUNNER as AGENT_RUNNER,
+    _cases as _agent_cases,
+    _component_bindings as _agent_component_bindings,
+    _component_taskset as _agent_component_taskset,
+    _receipt as _agent_receipt,
 )
 
 COMMIT = "b" * 40
@@ -995,133 +1003,52 @@ def test_benchmark_separates_quality_null_cost_and_fail_closed_promotion(tmp_pat
         == "revision_bound_agent_benefit_missing"
     )
 
-    score = {
-        "valid": True,
-        "success": True,
-        "outcome_match": True,
-        "target_hit_rate": 1.0,
-        "false_hit_count": 0,
-        "citation_match_rate": 1.0,
-        "false_confidence": False,
-        "duration_ms": 1,
-        "tool_call_count": 1,
-        "input_tokens": 1,
-        "output_tokens": 1,
-        "tool_bytes": 1,
-        "invalid_reasons": [],
-    }
-    cases = []
-    for category in ("navigation", "structural", "grounding_freshness"):
-        for repetition in (1, 2):
-            baseline = copy.deepcopy(score)
-            treatment = copy.deepcopy(score)
-            if category == "navigation":
-                baseline["success"] = False
-            cases.append(
-                {
-                    "case_id": f"{category}-{repetition}",
-                    "category": category,
-                    "repetition": repetition,
-                    "pair_valid": True,
-                    "baseline": baseline,
-                    "treatment": treatment,
-                }
-            )
-    efficiency = {
-        key: {
-            "baseline_mean": 1.0,
-            "treatment_mean": 1.0,
-            "improvement_ratio": 0.0,
-        }
-        for key in (
-            "duration",
-            "tool_calls",
-            "input_tokens",
-            "output_tokens",
-            "tool_bytes",
+    agent_taskset = _agent_component_taskset(source_revision=revision)
+    agent_bindings = _agent_component_bindings(
+        tmp_path / "agent-evidence", source_revision=revision
+    )
+    agent_requests = build_run_requests(
+        agent_taskset,
+        runner=AGENT_RUNNER,
+        manifest_bindings=agent_bindings,
+        repetitions=2,
+    )
+    agent_cases = _agent_cases(agent_taskset)
+    agent_receipts = []
+    for request in agent_requests:
+        case = agent_cases[request["case_id"]]
+        answer_override = None
+        if request["condition"] == "baseline" and case["category"] == "navigation":
+            answer_override = {
+                "outcome": "abstain",
+                "asserted_sufficient_evidence": False,
+            }
+        agent_receipts.append(
+            _agent_receipt(request, case, answer_override=answer_override)
         )
-    }
-    verified_component_delta = {
-        "kind": "repobrief.agent_benchmark_evaluation",
-        "version": "1.0",
-        "taskset_id": "language-structure-component-delta-fixture",
-        "taskset_sha256": "d" * 64,
-        "measurement_scope": "real_paired_agent_runs",
-        "thresholds": {
-            "minimum_success_rate_gain": 0.1,
-            "maximum_class_success_regression": 0.05,
-            "maximum_false_confidence_increase": 0.0,
-            "minimum_efficiency_improvement": 0.2,
-        },
-        "run_count": 12,
-        "valid_run_count": 12,
-        "invalid_run_count": 0,
-        "cases": cases,
-        "classes": [
-            {
-                "category": "navigation",
-                "valid_pair_count": 2,
-                "baseline_success_rate": 0.0,
-                "treatment_success_rate": 1.0,
-                "success_rate_delta": 1.0,
-                "baseline_false_confidence_rate": 0.0,
-                "treatment_false_confidence_rate": 0.0,
-                "false_confidence_delta": 0.0,
-                "efficiency": copy.deepcopy(efficiency),
-                "classification": "useful",
-            },
-            {
-                "category": "structural",
-                "valid_pair_count": 2,
-                "baseline_success_rate": 1.0,
-                "treatment_success_rate": 1.0,
-                "success_rate_delta": 0.0,
-                "baseline_false_confidence_rate": 0.0,
-                "treatment_false_confidence_rate": 0.0,
-                "false_confidence_delta": 0.0,
-                "efficiency": copy.deepcopy(efficiency),
-                "classification": "neutral",
-            },
-            {
-                "category": "grounding_freshness",
-                "valid_pair_count": 2,
-                "baseline_success_rate": 1.0,
-                "treatment_success_rate": 1.0,
-                "success_rate_delta": 0.0,
-                "baseline_false_confidence_rate": 0.0,
-                "treatment_false_confidence_rate": 0.0,
-                "false_confidence_delta": 0.0,
-                "efficiency": copy.deepcopy(efficiency),
-                "classification": "neutral",
-            },
-        ],
-        "decision": {
-            "status": "useful_class",
-            "useful_classes": ["navigation"],
-            "harmful_classes": [],
-            "default_promoted": False,
-            "reason": (
-                "at least one class met a reproducible benefit threshold without regression"
-            ),
-        },
-        "does_not_establish": ["default promotion"],
-        "comparison": {
-            "mode": "component_delta",
-            "component": "language_structure_json",
-            "source_revision": revision,
-            "treatment_artifacts": [
-                {
-                    "repository_id": "fixture",
-                    "artifact": "language_structure.json",
-                    "artifact_sha256": "e" * 64,
-                }
-            ],
-            "pair_isolation_verified": True,
-        },
+    verified_component_delta = evaluate_paired_runs(
+        agent_taskset,
+        agent_requests,
+        agent_receipts,
+        measurement_scope="real_paired_agent_runs",
+    )
+    verified_inputs = {
+        "taskset": agent_taskset,
+        "requests": agent_requests,
+        "receipts": agent_receipts,
     }
 
+    assert (
+        decide_language_adapter_promotion(
+            report, agent_benefit=verified_component_delta
+        )["reason"]
+        == "verified_component_delta_agent_benefit_missing"
+    )
+
     accepted = decide_language_adapter_promotion(
-        report, agent_benefit=verified_component_delta
+        report,
+        agent_benefit=verified_component_delta,
+        agent_benefit_inputs=verified_inputs,
     )
     assert accepted == {
         "status": "eligible_for_explicit_promotion_review",
@@ -1132,6 +1059,38 @@ def test_benchmark_separates_quality_null_cost_and_fail_closed_promotion(tmp_pat
         "goldset_sha256": report["goldset_sha256"],
         "decision_authority": "none; explicit reviewed configuration change required",
     }
+
+    tampered_inputs = copy.deepcopy(verified_inputs)
+    tampered_inputs["receipts"][0]["duration_ms"] += 1
+    assert (
+        decide_language_adapter_promotion(
+            report,
+            agent_benefit=verified_component_delta,
+            agent_benefit_inputs=tampered_inputs,
+        )["reason"]
+        == "verified_component_delta_agent_benefit_missing"
+    )
+
+    first_treatment = next(
+        item for item in agent_requests if item["condition"] == "treatment"
+    )
+    artifact_path = (
+        Path(first_treatment["repobrief"]["manifest"]).parent
+        / first_treatment["component_delta"]["artifact"]
+    )
+    artifact_raw = artifact_path.read_bytes()
+    artifact_path.write_text("{}\n", encoding="utf-8")
+    try:
+        assert (
+            decide_language_adapter_promotion(
+                report,
+                agent_benefit=verified_component_delta,
+                agent_benefit_inputs=verified_inputs,
+            )["reason"]
+            == "verified_component_delta_agent_benefit_missing"
+        )
+    finally:
+        artifact_path.write_bytes(artifact_raw)
 
     bad_mutations = []
     for mutate in (
@@ -1179,7 +1138,11 @@ def test_benchmark_separates_quality_null_cost_and_fail_closed_promotion(tmp_pat
     bad_mutations.append(neutral_only)
     for mutated in bad_mutations:
         assert (
-            decide_language_adapter_promotion(report, agent_benefit=mutated)["reason"]
+            decide_language_adapter_promotion(
+                report,
+                agent_benefit=mutated,
+                agent_benefit_inputs=verified_inputs,
+            )["reason"]
             == "verified_component_delta_agent_benefit_missing"
         )
 
@@ -1187,7 +1150,9 @@ def test_benchmark_separates_quality_null_cost_and_fail_closed_promotion(tmp_pat
     degraded_report["determinism"]["semantic_projection_repeated_equal"] = False
     assert (
         decide_language_adapter_promotion(
-            degraded_report, agent_benefit=verified_component_delta
+            degraded_report,
+            agent_benefit=verified_component_delta,
+            agent_benefit_inputs=verified_inputs,
         )["reason"]
         == "quality_null_determinism_or_cost_gate_not_met"
     )


### PR DESCRIPTION
## Was ändert sich

- erweitert den vorhandenen Agent-Benchmark um `component_delta`
- erlaubt RepoGround in Baseline und Treatment bei identischem Setup
- bindet genau ein Komponentenartefakt revisions- und SHA256-gebunden als beabsichtigtes Delta
- validiert die tatsächlichen Artefaktbytes fail-closed
- bindet `language_structure_json` als schmalen Consumer an die generische Paired-Agent-Evaluation

## Was ändert sich ausdrücklich nicht

- kein zweiter Benchmark
- kein neuer Grader
- kein neuer Receipt-Vertrag
- kein automatisches Default- oder Broad-Promotion-Gate
- Legacy `repoground_vs_baseline` bleibt kompatibel

## Validierung

- 86 zielnahe Tests grün
- Ruff grün
- `git diff --check` grün
- Self-Review auf Pair-Isolation, Artifact-Identity, Legacy-Kompatibilität und fail-closed Promotion abgeschlossen
