### PR TITLE
fix(repoground): resolve remote default branch

### DIFF
--- a/merger/repoground/tests/test_fleet_runtime.py
+++ b/merger/repoground/tests/test_fleet_runtime.py
@@ -70,6 +70,194 @@ def load_publisher() -> ModuleType:
     return module
 
 
+def test_remote_head_prefers_remote_advertised_nonstandard_default_branch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    repo = tmp_path / "preview"
+    sha = "b2ba42acc074410e44f03bb2d0943c2c7fc1ef59"
+    calls: list[list[str]] = []
+
+    def fake_run(
+        argv: list[str],
+        cwd: Path | None = None,
+        check: bool = True,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(argv)
+        if argv[-3:] == ["fetch", "origin", "--prune"]:
+            return subprocess.CompletedProcess(argv, 0, stdout="")
+        if argv[-4:] == ["ls-remote", "--symref", "origin", "HEAD"]:
+            return subprocess.CompletedProcess(
+                argv,
+                0,
+                stdout=f"ref: refs/heads/gh-pages\tHEAD\n{sha}\tHEAD\n",
+            )
+        if argv[-2:] == ["rev-parse", "origin/gh-pages"]:
+            return subprocess.CompletedProcess(argv, 0, stdout=f"{sha}\n")
+        raise AssertionError(f"unexpected command: {argv}")
+
+    monkeypatch.setattr(module, "run", fake_run)
+
+    assert module.remote_head(repo) == ("origin/gh-pages", "gh-pages", sha)
+    assert len(calls) == 3
+    assert not any("set-head" in argv for argv in calls)
+
+
+def test_remote_head_rejects_remote_head_that_moves_after_fetch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    repo = tmp_path / "moving"
+    advertised_sha = "a" * 40
+    fetched_sha = "b" * 40
+
+    def fake_run(
+        argv: list[str],
+        cwd: Path | None = None,
+        check: bool = True,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        if argv[-3:] == ["fetch", "origin", "--prune"]:
+            return subprocess.CompletedProcess(argv, 0, stdout="")
+        if argv[-4:] == ["ls-remote", "--symref", "origin", "HEAD"]:
+            return subprocess.CompletedProcess(
+                argv,
+                0,
+                stdout=(
+                    "ref: refs/heads/trunk\tHEAD\n"
+                    f"{advertised_sha}\tHEAD\n"
+                ),
+            )
+        if argv[-2:] == ["rev-parse", "origin/trunk"]:
+            return subprocess.CompletedProcess(argv, 0, stdout=f"{fetched_sha}\n")
+        raise AssertionError(f"unexpected command: {argv}")
+
+    monkeypatch.setattr(module, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="moved during resolution"):
+        module.remote_head(repo)
+
+
+def test_remote_head_falls_back_to_existing_local_origin_head(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    repo = tmp_path / "demo"
+    sha = "a" * 40
+    calls: list[list[str]] = []
+
+    def fake_run(
+        argv: list[str],
+        cwd: Path | None = None,
+        check: bool = True,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(argv)
+        if argv[-3:] == ["fetch", "origin", "--prune"]:
+            return subprocess.CompletedProcess(argv, 0, stdout="")
+        if argv[-4:] == ["ls-remote", "--symref", "origin", "HEAD"]:
+            return subprocess.CompletedProcess(argv, 0, stdout=f"{sha}\tHEAD\n")
+        if argv[-3:] == ["symbolic-ref", "refs/remotes/origin/HEAD", "--short"]:
+            return subprocess.CompletedProcess(argv, 0, stdout="origin/release\n")
+        if argv[-2:] == ["rev-parse", "origin/release"]:
+            return subprocess.CompletedProcess(argv, 0, stdout=f"{sha}\n")
+        raise AssertionError(f"unexpected command: {argv}")
+
+    monkeypatch.setattr(module, "run", fake_run)
+
+    assert module.remote_head(repo) == ("origin/release", "release", sha)
+    assert not any("set-head" in argv for argv in calls)
+
+
+def test_remote_head_rejects_fallback_that_disagrees_with_remote_head_sha(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    repo = tmp_path / "stale-local-head"
+    advertised_sha = "a" * 40
+    local_sha = "b" * 40
+
+    def fake_run(
+        argv: list[str],
+        cwd: Path | None = None,
+        check: bool = True,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        if argv[-3:] == ["fetch", "origin", "--prune"]:
+            return subprocess.CompletedProcess(argv, 0, stdout="")
+        if argv[-4:] == ["ls-remote", "--symref", "origin", "HEAD"]:
+            return subprocess.CompletedProcess(argv, 0, stdout=f"{advertised_sha}\tHEAD\n")
+        if argv[-3:] == ["symbolic-ref", "refs/remotes/origin/HEAD", "--short"]:
+            return subprocess.CompletedProcess(argv, 0, stdout="origin/release\n")
+        if argv[-2:] == ["rev-parse", "origin/release"]:
+            return subprocess.CompletedProcess(argv, 0, stdout=f"{local_sha}\n")
+        raise AssertionError(f"unexpected command: {argv}")
+
+    monkeypatch.setattr(module, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="remote HEAD disagrees"):
+        module.remote_head(repo)
+
+
+def test_remote_head_remains_fail_closed_without_any_default_branch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    repo = tmp_path / "empty-default"
+    calls: list[list[str]] = []
+
+    def fake_run(
+        argv: list[str],
+        cwd: Path | None = None,
+        check: bool = True,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(argv)
+        if argv[-3:] == ["fetch", "origin", "--prune"]:
+            return subprocess.CompletedProcess(argv, 0, stdout="")
+        if argv[-4:] == ["ls-remote", "--symref", "origin", "HEAD"]:
+            return subprocess.CompletedProcess(argv, 0, stdout="")
+        if argv[-3:] == ["symbolic-ref", "refs/remotes/origin/HEAD", "--short"]:
+            return subprocess.CompletedProcess(argv, 1, stdout="")
+        if len(argv) >= 2 and argv[-2] == "rev-parse":
+            return subprocess.CompletedProcess(argv, 1, stdout="")
+        raise AssertionError(f"unexpected command: {argv}")
+
+    monkeypatch.setattr(module, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="no remote default branch"):
+        module.remote_head(repo)
+    assert not any("set-head" in argv for argv in calls)
+
+
+def test_remote_head_rejects_non_branch_remote_head_symref(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    repo = tmp_path / "malformed"
+    sha = "c" * 40
+
+    def fake_run(
+        argv: list[str],
+        cwd: Path | None = None,
+        check: bool = True,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        if argv[-3:] == ["fetch", "origin", "--prune"]:
+            return subprocess.CompletedProcess(argv, 0, stdout="")
+        if argv[-4:] == ["ls-remote", "--symref", "origin", "HEAD"]:
+            return subprocess.CompletedProcess(
+                argv, 0, stdout=f"ref: refs/tags/v1\tHEAD\n{sha}\tHEAD\n"
+            )
+        raise AssertionError(f"unexpected command: {argv}")
+
+    monkeypatch.setattr(module, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="does not advertise a branch"):
+        module.remote_head(repo)
+
+
 def test_publication_config_uses_compact_daily_profile(tmp_path: Path) -> None:
     module = load_publisher()
     default = module.RepoEntry(

--- a/merger/repoground/tests/test_fleet_runtime.py
+++ b/merger/repoground/tests/test_fleet_runtime.py
@@ -70,13 +70,23 @@ def load_publisher() -> ModuleType:
     return module
 
 
-def test_remote_head_prefers_remote_advertised_nonstandard_default_branch(
+def _is_advertised_branch_fetch(argv: list[str], branch: str) -> bool:
+    return argv[-4:] == [
+        "fetch",
+        "--no-tags",
+        "origin",
+        f"+refs/heads/{branch}:refs/remotes/origin/{branch}",
+    ]
+
+
+def test_remote_head_explicitly_fetches_remote_advertised_nonstandard_default_branch(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     module = load_publisher()
     repo = tmp_path / "preview"
     sha = "b2ba42acc074410e44f03bb2d0943c2c7fc1ef59"
     calls: list[list[str]] = []
+    advertised_fetched = False
 
     def fake_run(
         argv: list[str],
@@ -84,23 +94,31 @@ def test_remote_head_prefers_remote_advertised_nonstandard_default_branch(
         check: bool = True,
         env: dict[str, str] | None = None,
     ) -> subprocess.CompletedProcess[str]:
+        nonlocal advertised_fetched
         calls.append(argv)
-        if argv[-3:] == ["fetch", "origin", "--prune"]:
-            return subprocess.CompletedProcess(argv, 0, stdout="")
         if argv[-4:] == ["ls-remote", "--symref", "origin", "HEAD"]:
             return subprocess.CompletedProcess(
                 argv,
                 0,
                 stdout=f"ref: refs/heads/gh-pages\tHEAD\n{sha}\tHEAD\n",
             )
-        if argv[-2:] == ["rev-parse", "origin/gh-pages"]:
-            return subprocess.CompletedProcess(argv, 0, stdout=f"{sha}\n")
+        if _is_advertised_branch_fetch(argv, "gh-pages"):
+            advertised_fetched = True
+            return subprocess.CompletedProcess(argv, 0, stdout="")
+        if argv[-3:] == ["rev-parse", "--verify", "refs/remotes/origin/gh-pages"]:
+            return subprocess.CompletedProcess(
+                argv,
+                0 if advertised_fetched else 1,
+                stdout=f"{sha}\n" if advertised_fetched else "",
+            )
         raise AssertionError(f"unexpected command: {argv}")
 
     monkeypatch.setattr(module, "run", fake_run)
 
     assert module.remote_head(repo) == ("origin/gh-pages", "gh-pages", sha)
+    assert advertised_fetched is True
     assert len(calls) == 3
+    assert not any(argv[-3:] == ["fetch", "origin", "--prune"] for argv in calls)
     assert not any("set-head" in argv for argv in calls)
 
 
@@ -118,8 +136,6 @@ def test_remote_head_rejects_remote_head_that_moves_after_fetch(
         check: bool = True,
         env: dict[str, str] | None = None,
     ) -> subprocess.CompletedProcess[str]:
-        if argv[-3:] == ["fetch", "origin", "--prune"]:
-            return subprocess.CompletedProcess(argv, 0, stdout="")
         if argv[-4:] == ["ls-remote", "--symref", "origin", "HEAD"]:
             return subprocess.CompletedProcess(
                 argv,
@@ -129,7 +145,9 @@ def test_remote_head_rejects_remote_head_that_moves_after_fetch(
                     f"{advertised_sha}\tHEAD\n"
                 ),
             )
-        if argv[-2:] == ["rev-parse", "origin/trunk"]:
+        if _is_advertised_branch_fetch(argv, "trunk"):
+            return subprocess.CompletedProcess(argv, 0, stdout="")
+        if argv[-3:] == ["rev-parse", "--verify", "refs/remotes/origin/trunk"]:
             return subprocess.CompletedProcess(argv, 0, stdout=f"{fetched_sha}\n")
         raise AssertionError(f"unexpected command: {argv}")
 
@@ -237,6 +255,7 @@ def test_remote_head_rejects_non_branch_remote_head_symref(
     module = load_publisher()
     repo = tmp_path / "malformed"
     sha = "c" * 40
+    calls: list[list[str]] = []
 
     def fake_run(
         argv: list[str],
@@ -244,8 +263,7 @@ def test_remote_head_rejects_non_branch_remote_head_symref(
         check: bool = True,
         env: dict[str, str] | None = None,
     ) -> subprocess.CompletedProcess[str]:
-        if argv[-3:] == ["fetch", "origin", "--prune"]:
-            return subprocess.CompletedProcess(argv, 0, stdout="")
+        calls.append(argv)
         if argv[-4:] == ["ls-remote", "--symref", "origin", "HEAD"]:
             return subprocess.CompletedProcess(
                 argv, 0, stdout=f"ref: refs/tags/v1\tHEAD\n{sha}\tHEAD\n"
@@ -256,6 +274,74 @@ def test_remote_head_rejects_non_branch_remote_head_symref(
 
     with pytest.raises(RuntimeError, match="does not advertise a branch"):
         module.remote_head(repo)
+    assert calls == [
+        ["git", "-C", str(repo), "ls-remote", "--symref", "origin", "HEAD"]
+    ]
+
+
+def test_remote_head_rejects_unsafe_advertised_branch_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    repo = tmp_path / "unsafe"
+    sha = "d" * 40
+
+    def fake_run(
+        argv: list[str],
+        cwd: Path | None = None,
+        check: bool = True,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        if argv[-4:] == ["ls-remote", "--symref", "origin", "HEAD"]:
+            return subprocess.CompletedProcess(
+                argv,
+                0,
+                stdout=f"ref: refs/heads/feat/../escape\tHEAD\n{sha}\tHEAD\n",
+            )
+        raise AssertionError(f"unexpected command: {argv}")
+
+    monkeypatch.setattr(module, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="unsafe branch"):
+        module.remote_head(repo)
+
+
+def test_remote_head_fetches_nested_advertised_branch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = load_publisher()
+    repo = tmp_path / "nested"
+    sha = "e" * 40
+    advertised_fetched = False
+
+    def fake_run(
+        argv: list[str],
+        cwd: Path | None = None,
+        check: bool = True,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        nonlocal advertised_fetched
+        if argv[-4:] == ["ls-remote", "--symref", "origin", "HEAD"]:
+            return subprocess.CompletedProcess(
+                argv,
+                0,
+                stdout=f"ref: refs/heads/release/1.2\tHEAD\n{sha}\tHEAD\n",
+            )
+        if _is_advertised_branch_fetch(argv, "release/1.2"):
+            advertised_fetched = True
+            return subprocess.CompletedProcess(argv, 0, stdout="")
+        if argv[-3:] == [
+            "rev-parse",
+            "--verify",
+            "refs/remotes/origin/release/1.2",
+        ]:
+            return subprocess.CompletedProcess(argv, 0, stdout=f"{sha}\n")
+        raise AssertionError(f"unexpected command: {argv}")
+
+    monkeypatch.setattr(module, "run", fake_run)
+
+    assert module.remote_head(repo) == ("origin/release/1.2", "release/1.2", sha)
+    assert advertised_fetched is True
 
 
 def test_publication_config_uses_compact_daily_profile(tmp_path: Path) -> None:
@@ -373,6 +459,61 @@ def initialize_repository(tmp_path: Path, name: str = "repo") -> tuple[Path, str
     git(repo, "add", ".gitignore", "tracked.txt")
     git(repo, "commit", "-m", "initial")
     return repo, git(repo, "rev-parse", "HEAD")
+
+
+def test_remote_head_fetches_advertised_branch_from_single_branch_clone(
+    tmp_path: Path,
+) -> None:
+    module = load_publisher()
+    remote, _ = initialize_repository(tmp_path, "remote")
+    git(remote, "checkout", "-b", "gh-pages")
+    (remote / "index.html").write_text("preview\n", encoding="utf-8")
+    git(remote, "add", "index.html")
+    git(remote, "commit", "-m", "preview")
+    preview_sha = git(remote, "rev-parse", "HEAD")
+    git(remote, "symbolic-ref", "HEAD", "refs/heads/gh-pages")
+
+    clone = tmp_path / "single-branch"
+    completed = subprocess.run(
+        [
+            "git",
+            "clone",
+            "--single-branch",
+            "--branch",
+            "main",
+            str(remote),
+            str(clone),
+        ],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise AssertionError(
+            f"single-branch clone failed rc={completed.returncode}\n{completed.stdout}"
+        )
+    tracking = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(clone),
+            "rev-parse",
+            "--verify",
+            "refs/remotes/origin/gh-pages",
+        ],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    assert tracking.returncode != 0
+
+    assert module.remote_head(clone) == ("origin/gh-pages", "gh-pages", preview_sha)
+    assert (
+        git(clone, "rev-parse", "--verify", "refs/remotes/origin/gh-pages")
+        == preview_sha
+    )
 
 
 def write_managed_recovery_manifest(

--- a/scripts/ops/repoground-publish-fleet
+++ b/scripts/ops/repoground-publish-fleet
@@ -137,6 +137,7 @@ RETIRED_REPOSITORY_ALIASES = {
 }
 SOURCE_REVISION_RE = re.compile(r"^[0-9a-f]{40}$")
 SOURCE_RECOVERY_SCHEMA = "repoground.managed-source-recovery.v1"
+_UNSAFE_GIT_BRANCH_TOKENS = (" ", "\t", "\n", "..", "~", "^", ":", "?", "*", "[", "\\", "@{")
 
 
 @dataclass(frozen=True)
@@ -1943,54 +1944,96 @@ def ensure_tool_worktree() -> tuple[str, str]:
     return tool_sha, generator_inputs_sha(TOOL_WT)
 
 
-def remote_head(repo_path: Path) -> tuple[str, str, str]:
-    run(["git", "-C", str(repo_path), "fetch", "origin", "--prune"])
-    advertised = run(
-        ["git", "-C", str(repo_path), "ls-remote", "--symref", "origin", "HEAD"]
-    ).stdout.splitlines()
+def is_safe_git_branch_name(name: str) -> bool:
+    if not name or name.startswith(("-", ".", "/")):
+        return False
+    if name.endswith(("/", ".", ".lock")):
+        return False
+    if any(part == "" or part.startswith(".") for part in name.split("/")):
+        return False
+    return not any(token in name for token in _UNSAFE_GIT_BRANCH_TOKENS)
+
+
+def advertised_branch_name(remote_ref: str, repo_path: Path) -> str:
+    if not remote_ref.startswith("refs/heads/"):
+        raise RuntimeError(
+            f"remote HEAD does not advertise a branch for {repo_path}: {remote_ref}"
+        )
+    branch = remote_ref.removeprefix("refs/heads/")
+    if not branch:
+        raise RuntimeError(f"remote HEAD advertises an empty branch for {repo_path}")
+    if not is_safe_git_branch_name(branch):
+        raise RuntimeError(
+            f"remote HEAD advertises an unsafe branch for {repo_path}: {branch!r}"
+        )
+    return branch
+
+
+def parse_advertised_remote_head(
+    lines: list[str], repo_path: Path
+) -> tuple[str | None, str | None]:
     advertised_branch: str | None = None
     advertised_sha: str | None = None
-    for line in advertised:
+    for line in lines:
         value, separator, target = line.partition("\t")
         if not separator or target != "HEAD":
             continue
         if value.startswith("ref: "):
-            remote_ref = value.removeprefix("ref: ").strip()
-            if not remote_ref.startswith("refs/heads/"):
-                raise RuntimeError(
-                    f"remote HEAD does not advertise a branch for {repo_path}: {remote_ref}"
-                )
-            advertised_branch = remote_ref.removeprefix("refs/heads/")
-            if not advertised_branch:
-                raise RuntimeError(
-                    f"remote HEAD advertises an empty branch for {repo_path}"
-                )
+            advertised_branch = advertised_branch_name(
+                value.removeprefix("ref: ").strip(), repo_path
+            )
         elif SOURCE_REVISION_RE.fullmatch(value):
             advertised_sha = value
+    return advertised_branch, advertised_sha
+
+
+def fetch_remote_tracking_branch(repo_path: Path, branch: str) -> str:
+    tracking_ref = f"refs/remotes/origin/{branch}"
+    run(
+        [
+            "git",
+            "-C",
+            str(repo_path),
+            "fetch",
+            "--no-tags",
+            "origin",
+            f"+refs/heads/{branch}:{tracking_ref}",
+        ]
+    )
+    parsed = run(
+        ["git", "-C", str(repo_path), "rev-parse", "--verify", tracking_ref],
+        check=False,
+    )
+    revision = parsed.stdout.strip() if parsed.returncode == 0 else ""
+    if SOURCE_REVISION_RE.fullmatch(revision) is None:
+        raise RuntimeError(
+            f"remote default branch unavailable after fetch for {repo_path}: {branch}"
+        )
+    return revision
+
+
+def remote_head(repo_path: Path) -> tuple[str, str, str]:
+    advertised = run(
+        ["git", "-C", str(repo_path), "ls-remote", "--symref", "origin", "HEAD"]
+    ).stdout.splitlines()
+    advertised_branch, advertised_sha = parse_advertised_remote_head(
+        advertised, repo_path
+    )
     if advertised_branch is not None:
         if advertised_sha is None:
             raise RuntimeError(
                 f"remote default branch revision unavailable for {repo_path}: "
                 f"{advertised_branch}"
             )
-        advertised_ref = f"origin/{advertised_branch}"
-        local = run(
-            ["git", "-C", str(repo_path), "rev-parse", advertised_ref],
-            check=False,
-        )
-        local_sha = local.stdout.strip() if local.returncode == 0 else ""
-        if SOURCE_REVISION_RE.fullmatch(local_sha) is None:
-            raise RuntimeError(
-                f"remote default branch unavailable after fetch for {repo_path}: "
-                f"{advertised_branch}"
-            )
+        local_sha = fetch_remote_tracking_branch(repo_path, advertised_branch)
         if local_sha != advertised_sha:
             raise RuntimeError(
                 f"remote default branch moved during resolution for {repo_path}: "
                 f"{advertised_branch}"
             )
-        return advertised_ref, advertised_branch, local_sha
+        return f"origin/{advertised_branch}", advertised_branch, local_sha
 
+    run(["git", "-C", str(repo_path), "fetch", "origin", "--prune"])
     head = run(
         [
             "git",

--- a/scripts/ops/repoground-publish-fleet
+++ b/scripts/ops/repoground-publish-fleet
@@ -1945,6 +1945,52 @@ def ensure_tool_worktree() -> tuple[str, str]:
 
 def remote_head(repo_path: Path) -> tuple[str, str, str]:
     run(["git", "-C", str(repo_path), "fetch", "origin", "--prune"])
+    advertised = run(
+        ["git", "-C", str(repo_path), "ls-remote", "--symref", "origin", "HEAD"]
+    ).stdout.splitlines()
+    advertised_branch: str | None = None
+    advertised_sha: str | None = None
+    for line in advertised:
+        value, separator, target = line.partition("\t")
+        if not separator or target != "HEAD":
+            continue
+        if value.startswith("ref: "):
+            remote_ref = value.removeprefix("ref: ").strip()
+            if not remote_ref.startswith("refs/heads/"):
+                raise RuntimeError(
+                    f"remote HEAD does not advertise a branch for {repo_path}: {remote_ref}"
+                )
+            advertised_branch = remote_ref.removeprefix("refs/heads/")
+            if not advertised_branch:
+                raise RuntimeError(
+                    f"remote HEAD advertises an empty branch for {repo_path}"
+                )
+        elif SOURCE_REVISION_RE.fullmatch(value):
+            advertised_sha = value
+    if advertised_branch is not None:
+        if advertised_sha is None:
+            raise RuntimeError(
+                f"remote default branch revision unavailable for {repo_path}: "
+                f"{advertised_branch}"
+            )
+        advertised_ref = f"origin/{advertised_branch}"
+        local = run(
+            ["git", "-C", str(repo_path), "rev-parse", advertised_ref],
+            check=False,
+        )
+        local_sha = local.stdout.strip() if local.returncode == 0 else ""
+        if SOURCE_REVISION_RE.fullmatch(local_sha) is None:
+            raise RuntimeError(
+                f"remote default branch unavailable after fetch for {repo_path}: "
+                f"{advertised_branch}"
+            )
+        if local_sha != advertised_sha:
+            raise RuntimeError(
+                f"remote default branch moved during resolution for {repo_path}: "
+                f"{advertised_branch}"
+            )
+        return advertised_ref, advertised_branch, local_sha
+
     head = run(
         [
             "git",
@@ -1956,29 +2002,22 @@ def remote_head(repo_path: Path) -> tuple[str, str, str]:
         ],
         check=False,
     ).stdout.strip()
-    if not head:
-        run(
-            ["git", "-C", str(repo_path), "remote", "set-head", "origin", "-a"],
-            check=False,
-        )
-        head = run(
-            [
-                "git",
-                "-C",
-                str(repo_path),
-                "symbolic-ref",
-                "refs/remotes/origin/HEAD",
-                "--short",
-            ],
-            check=False,
-        ).stdout.strip()
     for ref in [head, "origin/main", "origin/master"]:
         if not ref:
             continue
         cp = run(["git", "-C", str(repo_path), "rev-parse", ref], check=False)
         if cp.returncode == 0:
+            revision = cp.stdout.strip()
+            if SOURCE_REVISION_RE.fullmatch(revision) is None:
+                raise RuntimeError(
+                    f"invalid remote default branch revision for {repo_path}: {revision!r}"
+                )
+            if advertised_sha is not None and revision != advertised_sha:
+                raise RuntimeError(
+                    f"remote HEAD disagrees with local default branch for {repo_path}: {ref}"
+                )
             branch = ref.split("/", 1)[1] if ref.startswith("origin/") else ref
-            return ref, branch, cp.stdout.strip()
+            return ref, branch, revision
     raise RuntimeError(f"no remote default branch for {repo_path}")
 
 


### PR DESCRIPTION
## Problem

Der Fleet-Publisher meldete `alexdermohr/hall-of-memory-preview` wiederholt als `no remote default branch`. Die frische Gegenprobe zeigte das Gegenteil: GitHub und `git ls-remote --symref origin HEAD` deklarieren `gh-pages` als Default-Branch. `remote_head()` kannte jedoch nur lokale `origin/HEAD`-Information sowie `main`/`master`-Fallbacks.

## Änderung

- liest zuerst den vom Remote selbst annoncierten `HEAD`-Symref
- holt einen angekündigten Default-Branch gezielt nach `refs/remotes/origin/<branch>` (`--no-tags`, bounded Refspec), auch bei `--single-branch`-Klonen
- unterstützt damit beliebige gültige Default-Branches wie `gh-pages`, `trunk` oder `release/1.2`
- bindet den Remote-HEAD-SHA an den lokal gefetchten Tracking-Ref; Bewegung/Widerspruch bleibt fail-closed
- lehnt unsichere Branch-Namen vor dem Fetch ab
- entfernt den bisherigen mutierenden `git remote set-head origin -a`-Versuch an Consumer-Repositories
- behält lokale `origin/HEAD`-, `main`- und `master`-Fallbacks für Remotes ohne Symref, aber nur konsistent mit einem ggf. annoncierten HEAD-SHA

Die Fleet-Fehlerpolitik wird nicht gelockert: Ein wirklich nicht auflösbarer oder widersprüchlicher Default-Branch bleibt ein Fehler.

## Review-Nachzug

Codex P1: nach `git fetch origin --prune` fehlt bei eingeschränktem Fetch-Refspec der Tracking-Ref des neuen Defaults. Behoben durch den gezielten Advertised-Branch-Fetch. Belegt durch einen echten `--single-branch --branch main`-Klon, dessen Remote-HEAD auf `gh-pages` steht.

## Validierung

- 9/9 gezielte `remote_head`-Fälle grün, inklusive Single-Branch-Reproduktion
- 111/111 Fleet-Runtime-Tests grün
- `ruff check` und `git diff --check` auf den geänderten Dateien grün
- Head: `e204b1210756e59d17672de16a2e785f009f94d5`

## Nichtaussagen

- keine automatische Reparatur fremder Repositories
- keine Abschwächung echter Remote-/Authentisierungs-/Ref-Fehler
- kein neuer Fleet-/Publisher-Pfad