### PR TITLE
refactor(atlas): reduce snapshot delta complexity

### DIFF
--- a/merger/repoground/atlas/diff.py
+++ b/merger/repoground/atlas/diff.py
@@ -59,6 +59,28 @@ def _compare_file_sets(from_files: Dict[str, Dict[str, Any]], to_files: Dict[str
     return new_files, removed_files, changed_files
 
 
+def _resolve_inventory_paths(
+    atlas_base: Path,
+    from_snap: Dict[str, Any],
+    to_snap: Dict[str, Any],
+    from_snap_id: str,
+    to_snap_id: str,
+) -> Tuple[Path, Path]:
+    from_inv_path = None
+    if from_snap["inventory_ref"]:
+        from_inv_path = resolve_artifact_ref(atlas_base, from_snap["inventory_ref"])
+    to_inv_path = None
+    if to_snap["inventory_ref"]:
+        to_inv_path = resolve_artifact_ref(atlas_base, to_snap["inventory_ref"])
+
+    if not from_inv_path or not from_inv_path.exists():
+        raise FileNotFoundError(f"Inventory missing for snapshot {from_snap_id}")
+    if not to_inv_path or not to_inv_path.exists():
+        raise FileNotFoundError(f"Inventory missing for snapshot {to_snap_id}")
+
+    return from_inv_path, to_inv_path
+
+
 def compute_snapshot_delta(registry, from_snap_id: str, to_snap_id: str) -> Dict[str, Any]:
     from_snap = registry.get_snapshot(from_snap_id)
     to_snap = registry.get_snapshot(to_snap_id)
@@ -81,17 +103,9 @@ def compute_snapshot_delta(registry, from_snap_id: str, to_snap_id: str) -> Dict
         raise ValueError("Cannot compute snapshot delta without a canonical registry db_path.")
     atlas_base = resolve_atlas_base_dir(registry.db_path)
 
-    from_inv_path = None
-    if from_snap["inventory_ref"]:
-        from_inv_path = resolve_artifact_ref(atlas_base, from_snap["inventory_ref"])
-    to_inv_path = None
-    if to_snap["inventory_ref"]:
-        to_inv_path = resolve_artifact_ref(atlas_base, to_snap["inventory_ref"])
-
-    if not from_inv_path or not from_inv_path.exists():
-        raise FileNotFoundError(f"Inventory missing for snapshot {from_snap_id}")
-    if not to_inv_path or not to_inv_path.exists():
-        raise FileNotFoundError(f"Inventory missing for snapshot {to_snap_id}")
+    from_inv_path, to_inv_path = _resolve_inventory_paths(
+        atlas_base, from_snap, to_snap, from_snap_id, to_snap_id
+    )
 
     from_files = _load_inventory_index(from_inv_path)
     to_files = _load_inventory_index(to_inv_path)


### PR DESCRIPTION
## Summary
- extract paired Atlas inventory path resolution into a small internal helper
- preserve exact snapshot-delta validation order, error messages, path resolution, persisted delta schema, and registration behavior
- remove the legacy Ruff C901 finding from `compute_snapshot_delta` without changing public behavior

## Verification
- `python3 -m pytest -q merger/repoground/tests/test_atlas_diff.py` → 16 passed
- `ruff check --config ruff-ci.toml --select C901 merger/repoground/atlas/diff.py` → all checks passed
- `python3 scripts/ci/check_graph_maintainability.py --format json --root .` → PASS; C901 current_count 187 → 186; new_count 0
- `git diff --check f00f501a439c0fb189291714b141e75ea73c228d..4318ca0507836fddd3f9b681a0bfed2758284659` → clean

Closes #1201