### PR TITLE
refactor(citation-map): reduce split-mode predicate complexity

### DIFF
--- a/merger/repoground/core/citation_map.py
+++ b/merger/repoground/core/citation_map.py
@@ -189,35 +189,24 @@ def _is_split_mode_noncanonical_chunk(chunk: Dict[str, Any]) -> bool:
       - source_range.status == "declared"
     """
     source_range = chunk.get("source_range")
-    source_status = chunk.get("source_status")
-
     if not isinstance(source_range, dict):
-        return False
-    if source_status != "full":
-        return False
-    if chunk.get("canonical_range") is not None:
-        return False
-    if chunk.get("content_range_ref") is not None:
-        return False
-
-    if chunk.get("content_artifact") != "merge_md":
-        return False
-    if not isinstance(chunk.get("content_range"), dict):
         return False
 
     chunk_path = chunk.get("path")
     source_file_path = source_range.get("file_path")
-    if not isinstance(chunk_path, str) or not chunk_path:
-        return False
-    if not isinstance(source_file_path, str) or not source_file_path:
-        return False
-    if chunk_path != source_file_path:
-        return False
-
-    if source_range.get("status") != "declared":
-        return False
-
-    return True
+    return (
+        chunk.get("source_status") == "full"
+        and chunk.get("canonical_range") is None
+        and chunk.get("content_range_ref") is None
+        and chunk.get("content_artifact") == "merge_md"
+        and isinstance(chunk.get("content_range"), dict)
+        and isinstance(chunk_path, str)
+        and bool(chunk_path)
+        and isinstance(source_file_path, str)
+        and bool(source_file_path)
+        and chunk_path == source_file_path
+        and source_range.get("status") == "declared"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/merger/repoground/core/citation_map.py
+++ b/merger/repoground/core/citation_map.py
@@ -189,18 +189,23 @@ def _is_split_mode_noncanonical_chunk(chunk: Dict[str, Any]) -> bool:
       - source_range.status == "declared"
     """
     source_range = chunk.get("source_range")
+    source_status = chunk.get("source_status")
+
     if not isinstance(source_range, dict):
+        return False
+    if (
+        source_status != "full"
+        or chunk.get("canonical_range") is not None
+        or chunk.get("content_range_ref") is not None
+        or chunk.get("content_artifact") != "merge_md"
+        or not isinstance(chunk.get("content_range"), dict)
+    ):
         return False
 
     chunk_path = chunk.get("path")
     source_file_path = source_range.get("file_path")
     return (
-        chunk.get("source_status") == "full"
-        and chunk.get("canonical_range") is None
-        and chunk.get("content_range_ref") is None
-        and chunk.get("content_artifact") == "merge_md"
-        and isinstance(chunk.get("content_range"), dict)
-        and isinstance(chunk_path, str)
+        isinstance(chunk_path, str)
         and bool(chunk_path)
         and isinstance(source_file_path, str)
         and bool(source_file_path)


### PR DESCRIPTION
## Summary
- simplify `_is_split_mode_noncanonical_chunk` into one explicit boolean predicate after the existing `source_range` type guard
- preserve every required split-mode exclusion condition and current citation-map behavior
- remove the legacy Ruff C901 finding without changing public output

## Verification
- `python3 -m pytest -q merger/repoground/tests/test_citation_map_producer.py` → 81 passed before and after
- target `_is_split_mode_noncanonical_chunk` no longer appears in file-local Ruff C901 output
- repository-wide maintainability gate → PASS; C901 current_count 186 → 185; `new_count=0`; excess_total 2199 → 2198
- `git diff --check` → clean

Closes #1203