### PR TITLE
refactor(answer-grounding): reduce delta status complexity

### DIFF
--- a/merger/repoground/core/answer_grounding_delta.py
+++ b/merger/repoground/core/answer_grounding_delta.py
@@ -126,6 +126,16 @@ def _new_snapshot_freshness(
     return freshness if isinstance(freshness, Mapping) else None
 
 
+def _aggregate_status(statuses: list[str]) -> str:
+    if "drifted" in statuses:
+        return "drifted"
+    if "missing" in statuses:
+        return "missing"
+    if "not_comparable" in statuses or not statuses:
+        return "not_comparable"
+    return "valid"
+
+
 def check_answer_grounding_delta(
     old_declaration: Mapping[str, Any],
     *,
@@ -194,14 +204,7 @@ def check_answer_grounding_delta(
         })
 
     all_statuses = [item["status"] for item in citation_checks + range_checks]
-    if "drifted" in all_statuses:
-        status = "drifted"
-    elif "missing" in all_statuses:
-        status = "missing"
-    elif "not_comparable" in all_statuses or not all_statuses:
-        status = "not_comparable"
-    else:
-        status = "valid"
+    status = _aggregate_status(all_statuses)
 
     new_freshness = _new_snapshot_freshness(manifest_path, manifest_data)
     return {


### PR DESCRIPTION
## Summary
- extract the existing answer-grounding delta status precedence into a small internal helper
- preserve `drifted` > `missing` > `not_comparable` > `valid` semantics exactly
- leave citation/range evaluation, diagnostics, freshness reporting, and mutation-boundary claims unchanged

## Verification
- focused answer-grounding delta baseline and after-change suite → 8 passed
- broader answer-grounding/freshness slice → 43 passed
- combinatorial status-equivalence check → 781 sequences identical
- file-local Ruff C901 → clean
- repository maintainability → PASS; C901 184 → 183; `new_count=0`; excess_total 2197 → 2196
- `git diff --check` → clean

Closes #1207