### PR TITLE
refactor(agent-export): reduce post-health binding complexity

### DIFF
--- a/merger/repoground/core/agent_export_gate.py
+++ b/merger/repoground/core/agent_export_gate.py
@@ -291,6 +291,22 @@ def _validate_post_health_schema(post_doc: Dict[str, Any]) -> Optional[str]:
     return None
 
 
+def _validate_pass_run_binding(
+    status: str,
+    manifest_run_id: Optional[str],
+    post_bundle_run_id: Any,
+) -> Optional[str]:
+    if status != "pass":
+        return None
+    if not isinstance(manifest_run_id, str) or not manifest_run_id.strip():
+        return "manifest run_id is missing or empty; cannot bind post_emit_health"
+    if not isinstance(post_bundle_run_id, str) or not post_bundle_run_id.strip():
+        return "post_emit_health bundle_run_id is missing or empty"
+    if post_bundle_run_id != manifest_run_id:
+        return "post_emit_health bundle_run_id does not match manifest run_id"
+    return None
+
+
 def _validate_post_health_binding(
     post_doc: Dict[str, Any],
     *,
@@ -321,13 +337,11 @@ def _validate_post_health_binding(
         return "post_emit_health bundle_manifest_path does not match the evaluated manifest"
 
     post_bundle_run_id = post_doc.get("bundle_run_id")
-    if status == "pass":
-        if not isinstance(manifest_run_id, str) or not manifest_run_id.strip():
-            return "manifest run_id is missing or empty; cannot bind post_emit_health"
-        if not isinstance(post_bundle_run_id, str) or not post_bundle_run_id.strip():
-            return "post_emit_health bundle_run_id is missing or empty"
-        if post_bundle_run_id != manifest_run_id:
-            return "post_emit_health bundle_run_id does not match manifest run_id"
+    run_binding_error = _validate_pass_run_binding(
+        status, manifest_run_id, post_bundle_run_id
+    )
+    if run_binding_error is not None:
+        return run_binding_error
 
     schema_error = _validate_post_health_schema(post_doc)
     if schema_error is not None:


### PR DESCRIPTION
## Summary
- extract the existing pass-only manifest/post-health run-id binding checks into a small internal helper
- preserve validation order and exact error precedence
- leave kind/version/status validation, manifest-path binding, schema validation, and public gate output unchanged

## Verification
- focused agent-export gate suite → 64 passed before and after
- broader agent-export/bundle-health/ground-snapshot slice → 113 passed
- run-binding equivalence → 196 combinations identical
- file-local Ruff C901 → target removed
- repository maintainability → PASS; C901 183 → 182; `new_count=0`; excess_total 2196 → 2195
- `git diff --check` → clean

Closes #1209