### PR TITLE
refactor(parity): reduce manifest hash-byte verification complexity

### DIFF
--- a/merger/repoground/core/parity_state.py
+++ b/merger/repoground/core/parity_state.py
@@ -169,6 +169,22 @@ def _artifact_path(manifest_path: Path, artifacts: Mapping[str, dict[str, Any]],
     return _resolve_manifest_artifact_path(manifest_path, role, rel)
 
 
+def _verify_canonical_dump_link(
+    manifest_path: Path,
+    artifacts: Mapping[str, dict[str, Any]],
+    links: Any,
+) -> bool:
+    if not isinstance(links, dict):
+        return True
+    expected_dump_sha = links.get("canonical_dump_index_sha256")
+    if not isinstance(expected_dump_sha, str):
+        return True
+    dump_path = _artifact_path(manifest_path, artifacts, "dump_index_json")
+    if not dump_path or not dump_path.exists():
+        return False
+    return _sha256_file(dump_path) == expected_dump_sha
+
+
 def _verify_manifest_hash_bytes(
     manifest_path: Path,
     manifest: Mapping[str, Any],
@@ -196,17 +212,9 @@ def _verify_manifest_hash_bytes(
         if _sha256_file(p) != sha:
             return False
 
-    links = manifest.get("links")
-    if isinstance(links, dict):
-        expected_dump_sha = links.get("canonical_dump_index_sha256")
-        if isinstance(expected_dump_sha, str):
-            dump_path = _artifact_path(manifest_path, artifacts, "dump_index_json")
-            if not dump_path or not dump_path.exists():
-                return False
-            if _sha256_file(dump_path) != expected_dump_sha:
-                return False
-
-    return True
+    return _verify_canonical_dump_link(
+        manifest_path, artifacts, manifest.get("links")
+    )
 
 
 def _read_sidecar(manifest_path: Path, artifacts: Mapping[str, dict[str, Any]]) -> dict[str, Any] | None:


### PR DESCRIPTION
## Summary
- extract only the optional `canonical_dump_index_sha256` link verification into a small internal helper
- preserve the per-artifact existence, byte-count, and SHA-256 verification loop unchanged
- preserve missing-link behavior and exact exception behavior for invalid dump artifact paths

## Verification
- parity suites before and after → 22 passed
- direct old-vs-new dump-link equivalence → 28 cases identical, including exceptions
- file-local Ruff C901 → target removed
- repository maintainability → PASS; C901 182 → 181; `new_count=0`; excess_total 2195 → 2193
- `git diff --check` → clean

Closes #1211