### PR TITLE
refactor(merge): remove redundant inclusion-status branch

### DIFF
--- a/merger/repoground/core/merge.py
+++ b/merger/repoground/core/merge.py
@@ -2000,8 +2000,6 @@ def determine_inclusion_status(fi: "FileInfo", level: str, max_file_bytes: int) 
     if level == "summary":
         if fi.category in ["doc", "config", "contract"] or "ci" in tags or "ai-context" in tags or "wgx-profile" in tags:
             return "full"
-        if fi.category in ["source", "test"]:
-            return "full" if is_priority_file(fi) else "meta-only"
         return "full" if is_priority_file(fi) else "meta-only"
 
     if level in ("dev", "machine-lean"):


### PR DESCRIPTION
## Summary
- remove the redundant `summary` profile branch for `source`/`test`
- preserve the exact priority-file fallback already used by the immediately following branch
- add no helper and change no surrounding merge behavior

## Verification
- focused merge-core suite → 19 passed before and after
- broader merge-core + meta-density slice → 24 passed
- old-vs-new classification + `is_priority_file` call-count equivalence → 23,520 cases identical
- target Ruff C901 finding removed
- repository maintainability → PASS; C901 180 → 179; `new_count=0`; excess_total 2192 → 2191
- `git diff --check` → clean

Closes #1215