### PR TITLE
refactor(retrieval): reduce miss-diagnostics complexity

### DIFF
--- a/merger/repoground/retrieval/eval_diagnostics.py
+++ b/merger/repoground/retrieval/eval_diagnostics.py
@@ -564,10 +564,7 @@ class RetrievalEvalDiagnosticsCalibrator:
         )
 
         # Detect staleness if applicable
-        if self._is_stale_indicator(expected_target):
-            details["staleness_indicator"] = "path_format_obsolete"
-            if primary_diagnosis != "stale_expected_target":
-                details["secondary_diagnoses"].append("index_stale")
+        self._annotate_staleness(expected_target, primary_diagnosis, details)
 
         record = DiagnosticsRecord(
             query_id=query_id,
@@ -641,6 +638,17 @@ class RetrievalEvalDiagnosticsCalibrator:
 
         # Fallback
         return "diagnostic_inconclusive"
+
+    def _annotate_staleness(
+        self,
+        expected_target: str,
+        primary_diagnosis: str,
+        details: Dict[str, Any],
+    ) -> None:
+        if self._is_stale_indicator(expected_target):
+            details["staleness_indicator"] = "path_format_obsolete"
+            if primary_diagnosis != "stale_expected_target":
+                details["secondary_diagnoses"].append("index_stale")
 
     def _is_stale_indicator(self, target: str) -> bool:
         """Check if target has staleness indicators (e.g., obsolete path format)."""


### PR DESCRIPTION
## Summary
- extract only the existing staleness-annotation block from `RetrievalEvalDiagnosticsCalibrator.diagnose_miss`
- preserve top-k handling, artifact loading, index/canonical/citation checks, miss classification, staleness detection calls, confidence, and result shape
- no schema, output-contract, or retrieval-index mutation changes

## Verification
- focused retrieval diagnostics suite → 43 passed before and after
- broader retrieval diagnostics/eval/review-metrics slice → 115 passed
- direct old-vs-new staleness mutation + `_is_stale_indicator` call-order equivalence → 96 cases identical
- file-local Ruff C901 → clean
- repository maintainability → PASS; C901 179 → 178; `new_count=0`; excess_total 2191 → 2190
- `git diff --check` → clean

Closes #1217