### PR TITLE
refactor(merge): reduce tree rendering complexity

### DIFF
--- a/merger/repoground/core/merge.py
+++ b/merger/repoground/core/merge.py
@@ -3071,6 +3071,29 @@ def _generate_run_id(
     return "-".join(components)
 
 
+def _append_tree_lines(node: Dict[str, Any], indent: str, lines: List[str]) -> None:
+    dirs = []
+    files = []
+    for k, v in node.items():
+        if v:
+            dirs.append(k)
+        else:
+            files.append(k)
+    for d in sorted(dirs):
+        lines.append(f"{indent}📁 {d}/")
+        _append_tree_lines(node[d], indent + "    ", lines)
+    for f in sorted(files):
+        # Optional: Hyperlinking in Tree
+        # Needs rel path reconstruction which is tricky in this recursive walk without passing it down
+        # For v2.3 Spec 6.3: 📄 [filename](#file-…)
+        # We need to construct the full relative path to generate the anchor.
+        # Since we don't pass the path down easily here, let's skip tree linking for this iteration
+        # to keep it robust, or do a simple approximation if needed.
+        # Actually, we can use a lookup if we want, but "optional" in spec allows skipping.
+        # Let's stick to plain text for now to avoid complexity in build_tree.
+        lines.append(f"{indent}📄 {f}")
+
+
 def build_tree(file_infos: List[FileInfo]) -> str:
     by_root: Dict[str, List[Path]] = {}
 
@@ -3098,29 +3121,7 @@ def build_tree(file_infos: List[FileInfo]) -> str:
                     node[p] = {}
                 node = node[p]
 
-        def walk(node, indent, root_lbl):
-            dirs = []
-            files = []
-            for k, v in node.items():
-                if v:
-                    dirs.append(k)
-                else:
-                    files.append(k)
-            for d in sorted(dirs):
-                lines.append(f"{indent}📁 {d}/")
-                walk(node[d], indent + "    ", root_lbl)
-            for f in sorted(files):
-                # Optional: Hyperlinking in Tree
-                # Needs rel path reconstruction which is tricky in this recursive walk without passing it down
-                # For v2.3 Spec 6.3: 📄 [filename](#file-…)
-                # We need to construct the full relative path to generate the anchor.
-                # Since we don't pass the path down easily here, let's skip tree linking for this iteration
-                # to keep it robust, or do a simple approximation if needed.
-                # Actually, we can use a lookup if we want, but "optional" in spec allows skipping.
-                # Let's stick to plain text for now to avoid complexity in build_tree.
-                lines.append(f"{indent}📄 {f}")
-
-        walk(tree, "    ", root)
+        _append_tree_lines(tree, "    ", lines)
     lines.append("```")
     return "\n".join(lines)
 


### PR DESCRIPTION
## Summary
- extract only the nested recursive tree-line renderer from `build_tree` into `_append_tree_lines`
- preserve root ordering, directory-before-file ordering, lexical sorting, indentation, emoji/text output, and empty-tree behavior
- leave tree construction and report integration unchanged

## Verification
- merge-core + report-renderer golden baseline/after → 57 passed
- broader merge/report parsing/meta slice → 66 passed
- direct old-vs-new full tree output equivalence → 1,201 generated cases identical byte-for-byte
- target Ruff C901 finding removed
- repository maintainability → PASS; C901 178 → 177; `new_count=0`; excess_total 2190 → 2189
- `git diff --check` → clean

Closes #1221