### PR TITLE
refactor(ci): reduce workflow inventory complexity

### DIFF
--- a/scripts/ci/check_reusable_workflow_contracts.py
+++ b/scripts/ci/check_reusable_workflow_contracts.py
@@ -65,6 +65,37 @@ def _is_reusable_workflow(value: str) -> bool:
     return "/.github/workflows/" in target
 
 
+def _normalize_workflow_inventory(
+    caller_path: str,
+    raw_workflows: Any,
+    location: str,
+) -> tuple[list[dict[str, Any]], list[Finding]]:
+    findings: list[Finding] = []
+    if not isinstance(raw_workflows, list):
+        findings.append(
+            Finding(
+                caller_path,
+                "missing_transitive_workflow_inventory",
+                f"{location}: {raw_workflows!r}",
+            )
+        )
+        return [], findings
+
+    workflows: list[dict[str, Any]] = []
+    for index, value in enumerate(raw_workflows):
+        if not isinstance(value, dict):
+            findings.append(
+                Finding(
+                    caller_path,
+                    "invalid_transitive_workflow_entry",
+                    f"{location}[{index}]: {value!r}",
+                )
+            )
+            continue
+        workflows.append(value)
+    return workflows, findings
+
+
 def _inventory_findings(
     caller_path: str,
     node: dict[str, Any],
@@ -104,28 +135,10 @@ def _inventory_findings(
                 )
 
     raw_workflows = node.get("transitive_workflows")
-    if not isinstance(raw_workflows, list):
-        findings.append(
-            Finding(
-                caller_path,
-                "missing_transitive_workflow_inventory",
-                f"{location}: {raw_workflows!r}",
-            )
-        )
-        workflows: list[dict[str, Any]] = []
-    else:
-        workflows = []
-        for index, value in enumerate(raw_workflows):
-            if not isinstance(value, dict):
-                findings.append(
-                    Finding(
-                        caller_path,
-                        "invalid_transitive_workflow_entry",
-                        f"{location}[{index}]: {value!r}",
-                    )
-                )
-                continue
-            workflows.append(value)
+    workflows, workflow_findings = _normalize_workflow_inventory(
+        caller_path, raw_workflows, location
+    )
+    findings.extend(workflow_findings)
 
     required_closures = Counter(
         value for value in transitive_uses if _is_reusable_workflow(value)


### PR DESCRIPTION
## Summary
- extract transitive workflow inventory normalization from `_inventory_findings`
- preserve recursive workflow validation and finding order
- reduce one Ruff C901 legacy finding without adding new complexity debt

## Explicitly unchanged
- workflow closure calculation
- mutable action/workflow reference checks
- recursive validation semantics
- finding codes, details, and ordering
- caller permission/secret/condition validation

## Evidence
- baseline focused tests: 11/11 pass
- after focused tests: 11/11 pass
- adjacent workflow-contract tests: 19/19 pass
- direct old-vs-new matrix: 264/264 identical for findings, exceptions, and `.get()` access order
- reusable workflow contract checker: pass
- Ruff on changed file: pass
- maintainability: C901 176 -> 175; new_count=0; excess_total 2188 -> 2187; current_max=138
- `git diff --check`: pass

Closes #1225