### PR TITLE
refactor(docmeta): reduce baseline entry complexity

### DIFF
--- a/scripts/docmeta/check_planning_registration.py
+++ b/scripts/docmeta/check_planning_registration.py
@@ -577,8 +577,7 @@ def _validate_baseline_path(path_str, index):
         )
 
 
-def _validate_baseline_entry(entry, index):
-    """Validate a single baseline entry dict. Raises BaselineError on violation."""
+def _validate_baseline_entry_shape(entry, index):
     if not isinstance(entry, dict):
         raise BaselineError(f"Baseline entry [{index}] must be an object.")
 
@@ -593,6 +592,11 @@ def _validate_baseline_entry(entry, index):
         raise BaselineError(
             f"Baseline entry [{index}] has unexpected field(s): {sorted(extra)}."
         )
+
+
+def _validate_baseline_entry(entry, index):
+    """Validate a single baseline entry dict. Raises BaselineError on violation."""
+    _validate_baseline_entry_shape(entry, index)
 
     eid = entry["id"]
     if not isinstance(eid, str) or not _BASELINE_ID_RE.match(eid):


### PR DESCRIPTION
## Summary
- extract only the initial baseline-entry shape validation into `_validate_baseline_entry_shape`
- preserve validation precedence and all downstream ID/path/code/kind/reason checks
- reduce `_validate_baseline_entry` from C901=11 to below the configured threshold

## Behavior preserved
- non-object rejection
- required-field order (`id`, `code`, `path`, `kind`, `reason`)
- unexpected-field reporting and ordering
- exact `BaselineError` type/messages
- ID syntax and computed-ID integrity
- path canonicality/traversal checks
- code/kind/reason validation

## Verification
- baseline focused suite: 173/173 passed
- after focused suite: 173/173 passed
- direct old-vs-new matrix: 1,209/1,209 identical outcomes and observed dict access traces
- file-local C901 findings: 6 -> 5; target finding removed
- repo maintainability: C901 175 -> 174; new_count=0; excess_total 2187 -> 2186; current_max=138; status=pass
- full Ruff on changed file: pass
- `git diff --check`: pass

Closes #1227