### PR TITLE
refactor(release): reduce workflow contract complexity

### DIFF
--- a/scripts/release/check_release_contract.py
+++ b/scripts/release/check_release_contract.py
@@ -495,6 +495,30 @@ def _path_filter_blocks(header: str) -> list[set[str]]:
     return blocks
 
 
+def _workflow_install_finding(
+    relative: str, lineno: int, stripped: str
+) -> dict[str, str] | None:
+    if re.search(r"\bpip(?:3)?\s+install\b", stripped) is None:
+        return None
+    if "--upgrade pip" in stripped:
+        return _finding(
+            "WORKFLOW_PIP_UPGRADE",
+            relative,
+            f"line {lineno}: mutable pip upgrade",
+        )
+    if (
+        "--require-hashes" not in stripped
+        or "repoground-" not in stripped
+        or ".lock.txt" not in stripped
+    ):
+        return _finding(
+            "WORKFLOW_UNLOCKED_INSTALL",
+            relative,
+            f"line {lineno}: {stripped}",
+        )
+    return None
+
+
 def _check_workflows(root: Path) -> list[dict[str, str]]:
     findings: list[dict[str, str]] = []
     workflow_dir = root / ".github/workflows"
@@ -507,28 +531,9 @@ def _check_workflows(root: Path) -> list[dict[str, str]]:
         text = path.read_text(encoding="utf-8")
         for lineno, line in enumerate(text.splitlines(), 1):
             stripped = line.strip()
-            if re.search(r"\bpip(?:3)?\s+install\b", stripped):
-                if "--upgrade pip" in stripped:
-                    findings.append(
-                        _finding(
-                            "WORKFLOW_PIP_UPGRADE",
-                            relative,
-                            f"line {lineno}: mutable pip upgrade",
-                        )
-                    )
-                    continue
-                if (
-                    "--require-hashes" not in stripped
-                    or "repoground-" not in stripped
-                    or ".lock.txt" not in stripped
-                ):
-                    findings.append(
-                        _finding(
-                            "WORKFLOW_UNLOCKED_INSTALL",
-                            relative,
-                            f"line {lineno}: {stripped}",
-                        )
-                    )
+            finding = _workflow_install_finding(relative, lineno, stripped)
+            if finding is not None:
+                findings.append(finding)
 
         jobs_match = re.search(r"(?m)^jobs:\s*$", text)
         if jobs_match is None:


### PR DESCRIPTION
Closes #1229.

## What changed

Extracted only per-line `pip install` finding classification from `_check_workflows` into `_workflow_install_finding`.

Preserved:
- workflow traversal and sorting;
- exact finding codes, paths, details, and order;
- `WORKFLOW_PIP_UPGRADE` precedence over unlocked-install detection;
- lock discovery and path-trigger checks;
- Python 3.12 lock-matrix validation;
- all other release-contract logic.

## Local verification

- `merger/repoground/tests/test_release_packaging.py`: 58 passed.
- Direct old-vs-new line classification: 49/49 cases exact-match.
- Direct old-vs-new full workflow scan over 96 synthetic workflow files / 239 findings: exact-match.
- File-local C901: `_check_workflows` no longer reported; remaining `scan` C901=11 is pre-existing and out of scope.
- Repo maintainability ratchet: pass; current C901 count 173, new_count 0, excess_total 2185, current_max 138.
- Ruff excluding legacy C901: pass.
- `py_compile`: pass.
- `git diff --check`: pass.

Reviewed implementation head: `e47562a722a46a22e6ffaaafc319b96a893f76a2`.