### PR TITLE
refactor(release): reduce release scan complexity

### DIFF
--- a/scripts/release/check_release_contract.py
+++ b/scripts/release/check_release_contract.py
@@ -569,12 +569,23 @@ def _check_workflows(root: Path) -> list[dict[str, str]]:
     return findings
 
 
-def scan(root: str | Path) -> dict[str, object]:
-    repo = Path(root).resolve()
+def _required_file_findings(repo: Path) -> list[dict[str, str]]:
     findings: list[dict[str, str]] = []
     for relative in REQUIRED_FILES:
         if not (repo / relative).is_file():
-            findings.append(_finding("RELEASE_FILE_MISSING", relative, "required release file is missing"))
+            findings.append(
+                _finding(
+                    "RELEASE_FILE_MISSING",
+                    relative,
+                    "required release file is missing",
+                )
+            )
+    return findings
+
+
+def scan(root: str | Path) -> dict[str, object]:
+    repo = Path(root).resolve()
+    findings = _required_file_findings(repo)
     if findings:
         return {"status": "fail", "findings": findings}
 


### PR DESCRIPTION
Closes #1231.

## What changed

Extracted only required-release-file presence collection from `scan` into `_required_file_findings`.

Preserved:
- exact `RELEASE_FILE_MISSING` code/path/detail/order;
- the same early `scan` fail return when any required file is absent;
- release-version, license, trademark, changelog, lock, semantic, workflow and follow-up-task checks;
- final report schema and `does_not_establish` claims.

## Local verification

- `merger/repoground/tests/test_release_packaging.py`: 58 passed before and after.
- Direct old-vs-new required-file equivalence: 32 patterns exact-match, including each of 28 required files missing individually, all missing, alternating groups, first+last missing, and all-present helper result.
- Full Ruff for `scripts/release/check_release_contract.py`: pass; the file now has no C901 findings.
- Repo maintainability ratchet: pass; C901 current_count 172, new_count 0, excess_total 2184, current_max 138.
- `git diff --check`: pass.

Reviewed implementation head: `606664d263e58008d3f51aee22ebc294b1d39d18`.