### PR TITLE
refactor(test): reduce source acquisition credential test complexity

### DIFF
--- a/merger/repoground/tests/test_source_acquisition.py
+++ b/merger/repoground/tests/test_source_acquisition.py
@@ -658,6 +658,36 @@ def test_remote_snapshot_warns_on_lfs_attributes_or_pointer(remote_and_local):
     assert sa.WARN_LFS_NOT_SMUDGED in result.warnings
 
 
+def _assert_remote_fetch_is_non_persistent(run_git_calls):
+    fetch_calls = [
+        call_args
+        for call_args in run_git_calls
+        if call_args and call_args[0] == "fetch"
+    ]
+    assert fetch_calls, "expected at least one direct fetch call"
+    for call_args in fetch_calls:
+        assert "--no-write-fetch-head" in call_args
+
+    for call_args in run_git_calls:
+        if call_args[0] == "remote":
+            assert "add" not in call_args
+            assert "set-url" not in call_args
+
+
+def _assert_secret_absent_from_cache(cache_git_dir: Path, secret: str):
+    config_file = cache_git_dir / "config"
+    if config_file.exists():
+        content = config_file.read_text(encoding="utf-8")
+        assert secret not in content
+        assert 'remote "origin"' not in content
+
+    if cache_git_dir.exists():
+        secret_bytes = secret.encode("utf-8")
+        for path in cache_git_dir.rglob("*"):
+            if path.is_file():
+                assert secret_bytes not in path.read_bytes(), f"secret leaked into cache file: {path}"
+
+
 def test_remote_snapshot_does_not_persist_remote_url_credentials_in_cache(tmp_path, monkeypatch):
     repo = tmp_path / "cred_repo"
     _git("init", "-b", "main", str(repo), cwd=tmp_path)
@@ -696,28 +726,10 @@ def test_remote_snapshot_does_not_persist_remote_url_credentials_in_cache(tmp_pa
     assert secret not in (result.stderr or "")
     assert secret not in (result.message or "")
 
-    fetch_calls = [call_args for call_args in run_git_calls if call_args and call_args[0] == "fetch"]
-    assert fetch_calls, "expected at least one direct fetch call"
-    for call_args in fetch_calls:
-        assert "--no-write-fetch-head" in call_args
-
-    for call_args in run_git_calls:
-        if call_args[0] == "remote":
-            assert "add" not in call_args
-            assert "set-url" not in call_args
+    _assert_remote_fetch_is_non_persistent(run_git_calls)
 
     cache_git_dir = tmp_path / "cache" / sa.SNAPSHOT_DIR_NAME / "job-cred-test" / "cred_repo.git"
-    config_file = cache_git_dir / "config"
-    if config_file.exists():
-        content = config_file.read_text(encoding="utf-8")
-        assert secret not in content
-        assert 'remote "origin"' not in content
-
-    if cache_git_dir.exists():
-        secret_bytes = secret.encode("utf-8")
-        for path in cache_git_dir.rglob("*"):
-            if path.is_file():
-                assert secret_bytes not in path.read_bytes(), f"secret leaked into cache file: {path}"
+    _assert_secret_absent_from_cache(cache_git_dir, secret)
 
 # --- 12. Fix 1: Non-origin upstream ---
 


### PR DESCRIPTION
Closes #1233.

## What changed

Extracted only named assertion helpers from `test_remote_snapshot_does_not_persist_remote_url_credentials_in_cache`:
- `_assert_remote_fetch_is_non_persistent`
- `_assert_secret_absent_from_cache`

Production code is untouched. The test setup, monkeypatches, secret value, materialization call, failure expectation, redaction assertions, direct-fetch requirement, forbidden remote mutations, config checks and recursive byte-level cache scan are preserved.

## Local verification

- Full `test_source_acquisition.py`: 49 passed before and after.
- Target credential test: 1 passed.
- Assert AST audit: old 12 assertions == new 12 assertions as an exact multiset.
- Critical security literals/messages preserved: 6/6.
- File-local C901: pass; target test no longer reported and helpers introduce no C901.
- Full Ruff for changed file: pass.
- Repo maintainability: pass; current_count 171, new_count 0, excess_total 2183, current_max 138.
- `git diff --check`: pass.

Reviewed implementation head: `88307a1525a800fd54b277af6c61547a7d8c1a3c`.