### PR TITLE
refactor(cli): reduce service client dispatcher complexity

### DIFF
--- a/merger/repoground/cli/cmd_service_client.py
+++ b/merger/repoground/cli/cmd_service_client.py
@@ -934,6 +934,28 @@ def _cmd_profiles(args: argparse.Namespace) -> int:
     return 0
 
 
+def _service_client_handler(command: Any):
+    if command == "health":
+        return _cmd_health
+    if command == "artifacts":
+        return _cmd_artifacts
+    if command == "latest":
+        return _cmd_latest
+    if command == "jobs":
+        return _cmd_jobs
+    if command == "job":
+        return _cmd_job
+    if command == "run":
+        return _cmd_run
+    if command == "cancel":
+        return _cmd_cancel
+    if command == "logs":
+        return _cmd_logs
+    if command == "profiles":
+        return _cmd_profiles
+    return None
+
+
 def run_service_client(args: argparse.Namespace) -> int:
     if not hasattr(args, "service_client_cmd") or args.service_client_cmd is None:
         print("Usage: repoground service-client <subcommand>", file=sys.stderr)
@@ -942,24 +964,9 @@ def run_service_client(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
-    if args.service_client_cmd == "health":
-        return _cmd_health(args)
-    if args.service_client_cmd == "artifacts":
-        return _cmd_artifacts(args)
-    if args.service_client_cmd == "latest":
-        return _cmd_latest(args)
-    if args.service_client_cmd == "jobs":
-        return _cmd_jobs(args)
-    if args.service_client_cmd == "job":
-        return _cmd_job(args)
-    if args.service_client_cmd == "run":
-        return _cmd_run(args)
-    if args.service_client_cmd == "cancel":
-        return _cmd_cancel(args)
-    if args.service_client_cmd == "logs":
-        return _cmd_logs(args)
-    if args.service_client_cmd == "profiles":
-        return _cmd_profiles(args)
+    handler = _service_client_handler(args.service_client_cmd)
+    if handler is not None:
+        return handler(args)
     print(f"Unknown service-client subcommand: {args.service_client_cmd!r}", file=sys.stderr)
     return 2
 


### PR DESCRIPTION
Closes #1235.

## What changed

Extracted only ordered service-client subcommand handler selection into `_service_client_handler`.

Preserved:
- the exact existing `command == ...` comparison order;
- no hash/dictionary dispatch;
- missing-subcommand usage text and exit 2;
- unknown-subcommand stderr text and exit 2;
- handler selection and unchanged `args` object forwarding;
- every health/artifacts/latest/jobs/job/run/cancel/logs/profiles implementation.

## Local verification

- Full service-client test module: 101 passed before and after.
- Direct old-vs-new dispatch equivalence: 14 cases exact return/stdout/stderr/handler-call match, covering missing attr, None, all 9 known commands, unknown string, unhashable list and equality-probe object.
- Equality-probe comparison order identical: health → artifacts → latest → jobs.
- File-local C901: `run_service_client` removed; only 4 pre-existing findings remain elsewhere in the file; helper introduces no C901.
- Ruff excluding legacy C901: pass.
- Repo maintainability: pass; current_count 170, new_count 0, excess_total 2182, current_max 138.
- `git diff --check`: pass.

Reviewed implementation head: `e8c782e7db67e5bcce161cdd2da5fc7fbd477c81`.