### PR TITLE
refactor(ci): reduce browser gate environment complexity

### DIFF
--- a/merger/repoground/tests/test_browser_gate_contract.py
+++ b/merger/repoground/tests/test_browser_gate_contract.py
@@ -1,9 +1,14 @@
 import ast
 import re
+import sys
+from contextlib import nullcontext
 from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import Mock, call
 
 import yaml
 
+from scripts.ci import check_browser_gate_environment as browser_gate
 from scripts.ci.check_browser_gate_environment import EXPECTED_VERSIONS
 
 ROOT = Path(__file__).resolve().parents[3]
@@ -12,6 +17,7 @@ IMAGE = (
     "aa81288e738725378becba5b3e06cb0f3a7f012a610e87e8d767a090ea3f740d"
 )
 SHA40_RE = re.compile(r"^[0-9a-f]{40}$")
+BROWSER_EXECUTABLE = "/ms-playwright/chromium-123/chrome-linux/chrome"
 
 
 def _requirements() -> dict[str, str]:
@@ -73,3 +79,114 @@ def test_browser_suite_contains_all_current_browser_flows() -> None:
         and node.name.startswith("test_")
     ]
     assert len(tests) >= 10
+
+
+def test_browser_environment_reports_package_and_root_drift_without_smoke(
+    monkeypatch,
+) -> None:
+    lookup_order: list[str] = []
+
+    def fake_version(package: str) -> str:
+        lookup_order.append(package)
+        if package == "playwright":
+            raise browser_gate.importlib.metadata.PackageNotFoundError(package)
+        if package == "pytest":
+            return "0.0"
+        return EXPECTED_VERSIONS[package]
+
+    monkeypatch.setattr(browser_gate.importlib.metadata, "version", fake_version)
+    monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", "/wrong-root")
+
+    report = browser_gate.inspect_environment()
+
+    assert lookup_order == sorted(EXPECTED_VERSIONS)
+    assert report == {
+        "kind": "lenskit.browser_gate_environment_check",
+        "version": "v1",
+        "status": "fail",
+        "expected_browser_root": "/ms-playwright",
+        "observed_browser_root": "/wrong-root",
+        "expected_versions": EXPECTED_VERSIONS,
+        "observed_versions": {
+            "playwright": None,
+            "pytest": "0.0",
+            "pytest-asyncio": "1.4.0",
+            "pytest-base-url": "2.1.0",
+            "pytest-playwright": "0.8.0",
+        },
+        "chromium_executable": None,
+        "chromium_version": None,
+        "smoke_page_title": None,
+        "findings": [
+            "package version mismatch for playwright: expected 1.62.0, found None",
+            "package version mismatch for pytest: expected 9.1.1, found 0.0",
+            "PLAYWRIGHT_BROWSERS_PATH mismatch: expected /ms-playwright, found /wrong-root",
+        ],
+        "does_not_establish": [
+            "coverage of every browser interaction",
+            "cross-browser compatibility",
+            "absence of rendering regressions",
+            "dependency safety",
+            "test completeness",
+        ],
+    }
+
+
+def test_browser_environment_success_preserves_smoke_calls(monkeypatch) -> None:
+    page = SimpleNamespace(
+        set_content=Mock(),
+        title=Mock(return_value="lenskit-browser-gate-smoke"),
+    )
+    browser = SimpleNamespace(
+        version="123.0",
+        new_page=Mock(return_value=page),
+        close=Mock(),
+    )
+    chromium = SimpleNamespace(
+        executable_path=BROWSER_EXECUTABLE,
+        launch=Mock(return_value=browser),
+    )
+    playwright = SimpleNamespace(chromium=chromium)
+    sync_api = ModuleType("playwright.sync_api")
+    sync_api.sync_playwright = Mock(return_value=nullcontext(playwright))
+    package = ModuleType("playwright")
+    package.sync_api = sync_api
+
+    monkeypatch.setitem(sys.modules, "playwright", package)
+    monkeypatch.setitem(sys.modules, "playwright.sync_api", sync_api)
+    monkeypatch.setattr(
+        browser_gate.importlib.metadata,
+        "version",
+        lambda package_name: EXPECTED_VERSIONS[package_name],
+    )
+    monkeypatch.setattr(Path, "is_file", lambda self: True)
+    monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", "/ms-playwright")
+
+    report = browser_gate.inspect_environment()
+
+    assert sync_api.sync_playwright.call_count == 1
+    assert chromium.launch.call_args == call(headless=True)
+    assert browser.new_page.call_count == 1
+    assert page.set_content.call_args == call("<title>lenskit-browser-gate-smoke</title>")
+    assert page.title.call_count == 1
+    assert browser.close.call_count == 1
+    assert report == {
+        "kind": "lenskit.browser_gate_environment_check",
+        "version": "v1",
+        "status": "pass",
+        "expected_browser_root": "/ms-playwright",
+        "observed_browser_root": "/ms-playwright",
+        "expected_versions": EXPECTED_VERSIONS,
+        "observed_versions": EXPECTED_VERSIONS,
+        "chromium_executable": BROWSER_EXECUTABLE,
+        "chromium_version": "123.0",
+        "smoke_page_title": "lenskit-browser-gate-smoke",
+        "findings": [],
+        "does_not_establish": [
+            "coverage of every browser interaction",
+            "cross-browser compatibility",
+            "absence of rendering regressions",
+            "dependency safety",
+            "test completeness",
+        ],
+    }

--- a/scripts/ci/check_browser_gate_environment.py
+++ b/scripts/ci/check_browser_gate_environment.py
@@ -20,7 +20,7 @@ KIND = "lenskit.browser_gate_environment_check"
 VERSION = "v1"
 
 
-def inspect_environment() -> dict[str, object]:
+def _inspect_package_versions() -> tuple[dict[str, str | None], list[str]]:
     findings: list[str] = []
     observed_versions: dict[str, str | None] = {}
     for package, expected in sorted(EXPECTED_VERSIONS.items()):
@@ -33,6 +33,11 @@ def inspect_environment() -> dict[str, object]:
             findings.append(
                 f"package version mismatch for {package}: expected {expected}, found {observed}"
             )
+    return observed_versions, findings
+
+
+def inspect_environment() -> dict[str, object]:
+    observed_versions, findings = _inspect_package_versions()
 
     configured_root = Path(os.environ.get("PLAYWRIGHT_BROWSERS_PATH", ""))
     if configured_root != EXPECTED_BROWSER_ROOT:


### PR DESCRIPTION
Closes #1237.

## What changed

Characterization-first refactor of `inspect_environment`:
- added direct tests for package/root drift and the successful Playwright smoke path before production refactoring;
- extracted only pinned package-version inspection into `_inspect_package_versions`;
- browser-root validation, Chromium executable validation, Playwright launch/smoke/close logic and report schema remain unchanged.

## Equivalence evidence

- Existing browser-gate contract tests: 3/3 passed before adding characterization.
- Characterization tests against unchanged production code: 5/5 passed before the production extraction.
- Final browser-gate contract tests: 5/5 passed.
- Direct old-vs-new package matrix: 243/243 combinations exact full-report match with identical sorted lookup order.
- Direct old-vs-new successful browser smoke: exact full-report and call-trace match (`sync enter`, `launch(headless=True)`, page creation, title content, title read, close, context exit).
- Full Ruff for both changed files: pass.
- Repo maintainability: pass; current_count 169, new_count 0, excess_total 2181, current_max 138.
- `git diff --check`: pass.

One C901 target only. Reviewed implementation head: `ab2e2a55e1ec4f17bd728103ce967d7012bd36f9`.