### PR TITLE
refactor(extractor): reduce extractor main complexity

### DIFF
--- a/merger/repoground/core/extractor.py
+++ b/merger/repoground/core/extractor.py
@@ -1119,6 +1119,21 @@ def run_extractor(
     return (0 if failures == 0 else 2), msg
 
 
+def _format_import_summary(hub: Path, diff_paths: List[Path]) -> str:
+    summary_lines = []
+    summary_lines.append("Import fertig.")
+    summary_lines.append("Hub: {}".format(hub))
+    if diff_paths:
+        summary_lines.append(
+            "Diff-Berichte ({}):".format(len(diff_paths))
+        )
+        for p in diff_paths:
+            summary_lines.append("  - {}".format(p))
+    else:
+        summary_lines.append("Keine Diff-Berichte erzeugt.")
+    return "\n".join(summary_lines)
+
+
 def main() -> int:
     import argparse
     parser = argparse.ArgumentParser(description="repolens-extractor-v2: Import ZIPs to hub.")
@@ -1157,19 +1172,7 @@ def main() -> int:
         except Exception as e:
             print("Fehler bei {}: {}".format(zp, e), file=sys.stderr)
 
-    summary_lines = []
-    summary_lines.append("Import fertig.")
-    summary_lines.append("Hub: {}".format(hub))
-    if diff_paths:
-        summary_lines.append(
-            "Diff-Berichte ({}):".format(len(diff_paths))
-        )
-        for p in diff_paths:
-            summary_lines.append("  - {}".format(p))
-    else:
-        summary_lines.append("Keine Diff-Berichte erzeugt.")
-
-    summary = "\n".join(summary_lines)
+    summary = _format_import_summary(hub, diff_paths)
     print(summary)
 
     if console:

--- a/merger/repoground/tests/test_extractor_logic.py
+++ b/merger/repoground/tests/test_extractor_logic.py
@@ -98,3 +98,71 @@ def test_make_entry_logic_with_errors(tmp_path, monkeypatch):
     assert entry.get("sha256") is None
     # ensure no sha256_error_class (deprecated/removed in favor of status)
     assert "sha256_error_class" not in entry
+
+
+def _prepare_extractor_main(monkeypatch, tmp_path, outcomes):
+    hub = tmp_path / "hub"
+    hub.mkdir()
+    merges_dir = tmp_path / "merges"
+    calls = []
+
+    for name in outcomes:
+        (hub / name).write_bytes(b"zip")
+
+    def fake_import_zip_wrapper(zip_path, observed_hub, observed_merges_dir):
+        calls.append((zip_path.name, observed_hub, observed_merges_dir))
+        return outcomes[zip_path.name]
+
+    monkeypatch.setattr(extractor.sys, "argv", ["extractor", "--hub", str(hub)])
+    monkeypatch.setattr(extractor, "detect_hub_dir", lambda *_: hub)
+    monkeypatch.setattr(extractor, "get_merges_dir", lambda _: merges_dir)
+    monkeypatch.setattr(extractor, "import_zip_wrapper", fake_import_zip_wrapper)
+    monkeypatch.setattr(extractor, "console", None)
+    return hub, merges_dir, calls
+
+
+def test_main_reports_diff_paths_in_sorted_zip_order(tmp_path, monkeypatch, capsys):
+    outcomes = {
+        "b.zip": tmp_path / "b-diff.md",
+        "a.zip": tmp_path / "a-diff.md",
+    }
+    hub, merges_dir, calls = _prepare_extractor_main(monkeypatch, tmp_path, outcomes)
+
+    result = extractor.main()
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert calls == [
+        ("a.zip", hub, merges_dir),
+        ("b.zip", hub, merges_dir),
+    ]
+    assert captured.err == ""
+    assert captured.out == (
+        f"RepoGround extractor – Hub: {hub}\n"
+        "Import fertig.\n"
+        f"Hub: {hub}\n"
+        "Diff-Berichte (2):\n"
+        f"  - {outcomes['a.zip']}\n"
+        f"  - {outcomes['b.zip']}\n"
+    )
+
+
+def test_main_reports_when_processed_zips_create_no_diffs(tmp_path, monkeypatch, capsys):
+    outcomes = {"b.zip": None, "a.zip": None}
+    hub, merges_dir, calls = _prepare_extractor_main(monkeypatch, tmp_path, outcomes)
+
+    result = extractor.main()
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert calls == [
+        ("a.zip", hub, merges_dir),
+        ("b.zip", hub, merges_dir),
+    ]
+    assert captured.err == ""
+    assert captured.out == (
+        f"RepoGround extractor – Hub: {hub}\n"
+        "Import fertig.\n"
+        f"Hub: {hub}\n"
+        "Keine Diff-Berichte erzeugt.\n"
+    )


### PR DESCRIPTION
Closes #1239.

## What changed
- added direct characterization tests for current extractor `main()` output and sorted ZIP processing before production refactoring;
- extracted only post-import summary rendering into `_format_import_summary`;
- hub detection, ZIP discovery/import, exception handling, console alerts and return codes remain unchanged.

## Evidence
- baseline extractor logic tests: 4/4 passed;
- characterization tests against unchanged production code: 6/6 passed;
- final focused extractor logic tests: 6/6 passed;
- broader extractor/schema tests: 13/13 passed;
- direct old-vs-new summary equivalence: 8/8 list-size cases exact;
- C901: `extractor.main` 11 -> clean; repository maintainability 169 -> 168, `new_count=0`, `excess_total=2180`, `current_max=138`;
- Ruff excluding existing legacy C901s on the two changed files: pass;
- py_compile: pass;
- git diff --check: pass.

One C901 target only. Reviewed implementation head: `71accfa81d89e761bb9b7279cf65f7659b2a385a`.