### PR TITLE
refactor(readonly): reduce adapter config complexity

### DIFF
--- a/merger/repoground/core/readonly_adapter.py
+++ b/merger/repoground/core/readonly_adapter.py
@@ -143,6 +143,20 @@ def _resolve_config_path(base: Path, raw: Any, *, label: str) -> Path:
     return candidate.resolve()
 
 
+def _resolve_allowed_roots(base: Path, raw_roots: Any) -> tuple[Path, ...]:
+    if not isinstance(raw_roots, list) or not raw_roots:
+        raise RepoGroundReadonlyAdapterError("allowed_roots must be a non-empty array")
+    roots = tuple(
+        _resolve_config_path(base, value, label="allowed root") for value in raw_roots
+    )
+    for root in roots:
+        if not root.is_dir():
+            raise RepoGroundReadonlyAdapterError(
+                f"allowed root does not exist or is not a directory: {root}"
+            )
+    return roots
+
+
 def _validate_manifest(path: Path) -> None:
     if not path.is_file() or not path.name.endswith(".bundle.manifest.json"):
         raise RepoGroundReadonlyAdapterError(
@@ -202,17 +216,7 @@ class RepoGroundReadonlyAdapter:
                 f"adapter config must be {CONFIG_KIND} version {CONFIG_VERSION}"
             )
         base = path.parent
-        raw_roots = document.get("allowed_roots")
-        if not isinstance(raw_roots, list) or not raw_roots:
-            raise RepoGroundReadonlyAdapterError("allowed_roots must be a non-empty array")
-        roots = tuple(
-            _resolve_config_path(base, value, label="allowed root") for value in raw_roots
-        )
-        for root in roots:
-            if not root.is_dir():
-                raise RepoGroundReadonlyAdapterError(
-                    f"allowed root does not exist or is not a directory: {root}"
-                )
+        roots = _resolve_allowed_roots(base, document.get("allowed_roots"))
 
         raw_snapshots = document.get("snapshots")
         if not isinstance(raw_snapshots, list) or not raw_snapshots:

--- a/merger/repoground/tests/test_readonly_adapter.py
+++ b/merger/repoground/tests/test_readonly_adapter.py
@@ -139,6 +139,47 @@ def test_adapter_lists_only_explicit_snapshots(tmp_path: Path) -> None:
     assert str(other) not in json.dumps(result)
 
 
+def test_adapter_rejects_empty_allowed_roots(tmp_path: Path) -> None:
+    config = tmp_path / "adapter.json"
+    config.write_text(
+        json.dumps(
+            {
+                "kind": "repobrief.readonly_adapter_config",
+                "version": "1.0",
+                "allowed_roots": [],
+                "snapshots": [{"id": "demo", "manifest": "missing.json"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        RepoGroundReadonlyAdapterError, match="allowed_roots must be a non-empty array"
+    ):
+        RepoGroundReadonlyAdapter.from_config(config)
+
+
+def test_adapter_rejects_missing_allowed_root(tmp_path: Path) -> None:
+    config = tmp_path / "adapter.json"
+    config.write_text(
+        json.dumps(
+            {
+                "kind": "repobrief.readonly_adapter_config",
+                "version": "1.0",
+                "allowed_roots": ["missing-root"],
+                "snapshots": [{"id": "demo", "manifest": "missing.json"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        RepoGroundReadonlyAdapterError,
+        match="allowed root does not exist or is not a directory",
+    ):
+        RepoGroundReadonlyAdapter.from_config(config)
+
+
 def test_adapter_rejects_manifest_outside_allowed_root(tmp_path: Path) -> None:
     root = tmp_path / "allowed"
     root.mkdir()


### PR DESCRIPTION
Closes #1241.

## What changed
- added direct characterization tests for empty and missing `allowed_roots` before production refactoring;
- extracted only allowed-root resolution/existence validation into `_resolve_allowed_roots`;
- snapshot registration, duplicate-id handling, manifest root-boundary validation, manifest validation and read-only semantics remain unchanged.

## Evidence
- baseline readonly-adapter tests: 12/12 passed;
- characterization tests against unchanged production code: 14/14 passed;
- final focused readonly-adapter tests: 14/14 passed;
- direct old-vs-new allowed-root equivalence: 8/8 cases exact, including exception type/message;
- `from_config` C901 11 -> clean; repository maintainability 168 -> 167, `new_count=0`, `excess_total=2179`, `current_max=138`;
- Ruff excluding the two pre-existing unrelated C901 findings in the same file: pass;
- py_compile: pass;
- git diff --check: pass.

One C901 target only. Reviewed implementation head: `3029507ef51b5a6644115ad74d46e28a5a8bd1f0`.