### PR TITLE
refactor(source): reduce source mode validation complexity

### DIFF
--- a/merger/repoground/service/source_acquisition.py
+++ b/merger/repoground/service/source_acquisition.py
@@ -468,6 +468,22 @@ class SourceModeConflictError(ValueError):
     """
 
 
+def _validate_local_remote_selection(
+    *,
+    has_remote_ref: bool,
+    non_default_policy: bool,
+) -> None:
+    if has_remote_ref:
+        raise SourceModeConflictError(
+            "remote_ref is only valid with repo_source_mode='remote_snapshot'."
+        )
+    if non_default_policy:
+        raise SourceModeConflictError(
+            "a non-default remote_ref_policy is only valid with "
+            "repo_source_mode='remote_snapshot'."
+        )
+
+
 def validate_source_mode_request(
     *,
     repo_source_mode: Optional[str],
@@ -507,15 +523,10 @@ def validate_source_mode_request(
 
     # Every non-remote mode (local_current, local_ff, or the legacy None default):
     # remote ref selection must not be smuggled in where it has no effect.
-    if has_remote_ref:
-        raise SourceModeConflictError(
-            "remote_ref is only valid with repo_source_mode='remote_snapshot'."
-        )
-    if non_default_policy:
-        raise SourceModeConflictError(
-            "a non-default remote_ref_policy is only valid with "
-            "repo_source_mode='remote_snapshot'."
-        )
+    _validate_local_remote_selection(
+        has_remote_ref=has_remote_ref,
+        non_default_policy=non_default_policy,
+    )
 
     if repo_source_mode == "local_current":
         if pre_pull is True:

--- a/merger/repoground/tests/test_source_acquisition.py
+++ b/merger/repoground/tests/test_source_acquisition.py
@@ -137,6 +137,71 @@ def test_effective_source_mode_rejects_explicit_contradictions():
         resolve_effective_source_mode(_Req(repo_source_mode="wat"))
 
 
+SOURCE_MODE_ERRORS = {
+    "unknown": "unknown repo_source_mode: 'wat'",
+    "remote_snapshot_pre_pull": (
+        "remote_snapshot never mutates the local repo; pre_pull must not be true. "
+        "Use local_ff for a fast-forward pre-pull."
+    ),
+    "remote_ref": "remote_ref is only valid with repo_source_mode='remote_snapshot'.",
+    "remote_policy": (
+        "a non-default remote_ref_policy is only valid with "
+        "repo_source_mode='remote_snapshot'."
+    ),
+    "local_current_pre_pull": (
+        "local_current scans the working tree as-is and does not fast-forward; "
+        "pre_pull must not be true."
+    ),
+    "local_ff_pre_pull": "local_ff implies a fast-forward pre-pull; pre_pull must not be false.",
+    "local_ff_plan_only": (
+        "local_ff cannot be combined with plan_only: local_ff would fast-forward "
+        "the local repo, but plan_only must not cause any local mutation. "
+        "Use local_current for plan-only, or remote_snapshot for a non-mutating remote check."
+    ),
+}
+
+
+@pytest.mark.parametrize(
+    ("repo_source_mode", "pre_pull", "plan_only", "remote_ref", "remote_ref_policy", "expected_error"),
+    [
+        (None, None, False, None, None, None),
+        ("local_current", False, True, "   ", "upstream", None),
+        ("local_ff", True, False, None, "upstream", None),
+        ("remote_snapshot", False, True, "origin/main", "default_branch", None),
+        ("wat", None, False, "origin/main", "default_branch", SOURCE_MODE_ERRORS["unknown"]),
+        ("remote_snapshot", True, False, None, None, SOURCE_MODE_ERRORS["remote_snapshot_pre_pull"]),
+        ("local_current", None, False, "origin/main", None, SOURCE_MODE_ERRORS["remote_ref"]),
+        ("local_ff", True, True, "origin/main", "default_branch", SOURCE_MODE_ERRORS["remote_ref"]),
+        ("local_current", None, False, None, "default_branch", SOURCE_MODE_ERRORS["remote_policy"]),
+        ("local_current", True, False, None, None, SOURCE_MODE_ERRORS["local_current_pre_pull"]),
+        ("local_ff", False, False, None, None, SOURCE_MODE_ERRORS["local_ff_pre_pull"]),
+        ("local_ff", True, True, None, None, SOURCE_MODE_ERRORS["local_ff_plan_only"]),
+    ],
+)
+def test_source_mode_validator_contract(
+    repo_source_mode,
+    pre_pull,
+    plan_only,
+    remote_ref,
+    remote_ref_policy,
+    expected_error,
+):
+    kwargs = {
+        "repo_source_mode": repo_source_mode,
+        "pre_pull": pre_pull,
+        "plan_only": plan_only,
+        "remote_ref": remote_ref,
+        "remote_ref_policy": remote_ref_policy,
+    }
+    if expected_error is None:
+        assert sa.validate_source_mode_request(**kwargs) is None
+        return
+
+    with pytest.raises(SourceModeConflictError) as exc_info:
+        sa.validate_source_mode_request(**kwargs)
+    assert str(exc_info.value) == expected_error
+
+
 # --- 1. default_branch on a no-upstream local branch -----------------------
 
 def test_remote_snapshot_passes_seekable_archive_stream_to_extractor(


### PR DESCRIPTION
Closes #1243.

## What changed
- added a direct table-driven characterization contract for coherent source modes and every conflict class before production refactoring;
- extracted only the two non-remote `remote_ref` / non-default-policy conflict checks into `_validate_local_remote_selection`;
- `has_remote_ref` and `non_default_policy` are still computed at the same point before the `remote_snapshot` branch, preserving evaluation order;
- all remaining mode, pre_pull and plan_only rules are untouched.

## Evidence
- baseline source-acquisition tests: 49/49 passed;
- baseline service-reuse tests: 20/20 passed;
- characterization contract against unchanged production code: source suite 61/61 passed;
- final source suite: 61/61 passed;
- final source + service-reuse suites: 81/81 passed;
- direct old-vs-new matrix: 360/360 combinations exact return/exception type/message match;
- custom remote-ref probe preserves evaluation order `bool -> str`;
- target `validate_source_mode_request` C901 11 -> clean; repository maintainability 167 -> 166, `new_count=0`, `excess_total=2178`, `current_max=138`;
- Ruff excluding pre-existing unrelated legacy C901s in the same file: pass;
- py_compile: pass;
- git diff --check: pass.

One C901 target only. Reviewed implementation head: `083c5ff1812e18b2012c1027b2a0d16a1b38fe3a`.