### PR TITLE
fix(pythonista): align fallback source mode validation

### DIFF
--- a/merger/repoground/frontends/pythonista/build.py
+++ b/merger/repoground/frontends/pythonista/build.py
@@ -345,6 +345,21 @@ except ImportError:
         class SourceModeConflictError(ValueError):  # type: ignore[no-redef]
             """Local fallback mirroring service.source_acquisition.SourceModeConflictError."""
 
+        def _validate_local_remote_selection(
+            *,
+            has_remote_ref,
+            non_default_policy,
+        ):
+            if has_remote_ref:
+                raise SourceModeConflictError(
+                    "remote_ref is only valid with repo_source_mode='remote_snapshot'."
+                )
+            if non_default_policy:
+                raise SourceModeConflictError(
+                    "a non-default remote_ref_policy is only valid with "
+                    "repo_source_mode='remote_snapshot'."
+                )
+
         def validate_source_mode_request(  # type: ignore[no-redef]
             *,
             repo_source_mode,
@@ -368,19 +383,15 @@ except ImportError:
             if repo_source_mode == "remote_snapshot":
                 if pre_pull is True:
                     raise SourceModeConflictError(
-                        "remote_snapshot never mutates the local repo; pre_pull must not be true."
+                        "remote_snapshot never mutates the local repo; pre_pull must not be true. "
+                        "Use local_ff for a fast-forward pre-pull."
                     )
                 return None
 
-            if has_remote_ref:
-                raise SourceModeConflictError(
-                    "remote_ref is only valid with repo_source_mode='remote_snapshot'."
-                )
-            if non_default_policy:
-                raise SourceModeConflictError(
-                    "a non-default remote_ref_policy is only valid with "
-                    "repo_source_mode='remote_snapshot'."
-                )
+            _validate_local_remote_selection(
+                has_remote_ref=has_remote_ref,
+                non_default_policy=non_default_policy,
+            )
 
             if repo_source_mode == "local_current":
                 if pre_pull is True:
@@ -398,7 +409,8 @@ except ImportError:
                 if plan_only:
                     raise SourceModeConflictError(
                         "local_ff cannot be combined with plan_only: local_ff would fast-forward "
-                        "the local repo, but plan_only must not cause any local mutation."
+                        "the local repo, but plan_only must not cause any local mutation. "
+                        "Use local_current for plan-only, or remote_snapshot for a non-mutating remote check."
                     )
                 return None
 

--- a/merger/repoground/tests/test_pythonista_pre_pull.py
+++ b/merger/repoground/tests/test_pythonista_pre_pull.py
@@ -187,6 +187,58 @@ def test_headless_source_mode_control_plane_conflicts(monkeypatch, argv):
     assert exc.value.code == 2
 
 
+def test_repo_ground_fallback_validator_matches_service_contract(monkeypatch):
+    """The dependency-free Pythonista fallback must exactly mirror the service validator."""
+    import importlib
+    import itertools
+
+    from merger.repoground.service.source_acquisition import (
+        validate_source_mode_request as central_validator,
+    )
+
+    def outcome(validator, kwargs):
+        try:
+            return ("return", validator(**kwargs))
+        except Exception as exc:
+            return ("raise", exc.__class__.__name__, str(exc))
+
+    monkeypatch.setitem(sys.modules, "merger.repoground.service.source_acquisition", None)
+    monkeypatch.setitem(sys.modules, "repoground.service.source_acquisition", None)
+    try:
+        importlib.reload(repo_ground)
+        fallback_validator = repo_ground.validate_source_mode_request
+        mismatches = []
+        dimensions = (
+            [None, "local_current", "local_ff", "remote_snapshot", "wat"],
+            [None, False, True],
+            [False, True],
+            [None, "", "   ", "origin/main"],
+            [None, "upstream", "default_branch"],
+        )
+        names = (
+            "repo_source_mode",
+            "pre_pull",
+            "plan_only",
+            "remote_ref",
+            "remote_ref_policy",
+        )
+        for values in itertools.product(*dimensions):
+            kwargs = dict(zip(names, values))
+            central = outcome(central_validator, kwargs)
+            fallback = outcome(fallback_validator, kwargs)
+            if central != fallback:
+                mismatches.append((kwargs, central, fallback))
+
+        assert not mismatches, (
+            f"fallback validator drifted in {len(mismatches)} of 360 cases: "
+            f"{mismatches[:2]}"
+        )
+    finally:
+        sys.modules.pop("merger.repoground.service.source_acquisition", None)
+        sys.modules.pop("repoground.service.source_acquisition", None)
+        importlib.reload(repo_ground)
+
+
 def test_repo_ground_falls_closed_when_service_validator_unavailable(monkeypatch):
     """If the service package cannot be imported, repoLens must not fail open.
 


### PR DESCRIPTION
Closes #1245.

## What changed
- added an exact fallback-vs-service regression over all 360 source-mode combinations;
- the regression was proven red before production changes with 36/360 mismatches across exactly two stale fallback message classes;
- aligned those two Pythonista fallback messages with the central service validator;
- extracted only the two non-remote remote-selection checks into `_validate_local_remote_selection`, reducing the fallback validator's C901 complexity;
- allow/deny decisions, validation order, remote-ref evaluation order and fail-closed behavior remain unchanged.

## Evidence
- baseline Pythonista suite: 35/35 passed;
- pre-fix parity regression: failed as intended with 36/360 mismatches (24 remote_snapshot/pre_pull, 12 local_ff/plan_only);
- post-fix parity regression: 0/360 mismatches;
- final Pythonista suite: 36/36 passed;
- final Pythonista + central source-acquisition suites: 97/97 passed;
- custom remote-ref probe preserves evaluation order `bool -> str`;
- target fallback `validate_source_mode_request` C901 11 -> clean; repository maintainability 166 -> 165, `new_count=0`, `excess_total=2177`, `current_max=138`;
- full Ruff on both changed files: pass;
- py_compile: pass;
- git diff --check: pass.

This intentionally changes only the two stale fallback error strings so the documented Pythonista fallback contract is again exactly aligned with the central service validator. Reviewed implementation head: `c689cc376a6e6bbfcdccf18bf426a264e45ca601`.