### PR TITLE
refactor(atlas): reduce search snapshot-selection complexity

### DIFF
--- a/merger/repoground/atlas/search.py
+++ b/merger/repoground/atlas/search.py
@@ -79,6 +79,17 @@ def _content_match(root_value: str, item: Dict[str, Any], content_query_lower: s
     return False, None
 
 
+def _latest_snapshots_per_root(
+    snapshots: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    latest_snapshots: Dict[str, Dict[str, Any]] = {}
+    for snapshot in snapshots:
+        root_id = snapshot['root_id']
+        if root_id not in latest_snapshots:
+            latest_snapshots[root_id] = snapshot
+    return list(latest_snapshots.values())
+
+
 class AtlasSearch:
     def __init__(self, registry_db_path: Path):
         self.registry_db_path = registry_db_path
@@ -114,11 +125,7 @@ class AtlasSearch:
 
         if not snapshot_id and not all_snapshots:
             # Keep only the latest snapshot per root (DESC order => first wins).
-            latest_snapshots = {}
-            for s in snapshots:
-                if s['root_id'] not in latest_snapshots:
-                    latest_snapshots[s['root_id']] = s
-            snapshots = list(latest_snapshots.values())
+            snapshots = _latest_snapshots_per_root(snapshots)
 
         # Parse date filters once (shared by both paths).
         after_dt = None

--- a/merger/repoground/tests/test_atlas_index.py
+++ b/merger/repoground/tests/test_atlas_index.py
@@ -2,6 +2,7 @@ import json
 
 from merger.repoground.atlas.registry import AtlasRegistry
 from merger.repoground.atlas.index import AtlasFTSIndex
+from merger.repoground.atlas import search as search_module
 from merger.repoground.atlas.search import AtlasSearch
 from merger.repoground.atlas.paths import resolve_index_db_path, resolve_atlas_base_dir
 
@@ -135,6 +136,56 @@ def test_all_snapshots_returns_history(tmp_path):
     assert len(searcher.search()) == 4
     # historical: s1(2) + s2(3) + s3(1) = 6
     assert len(searcher.search(all_snapshots=True)) == 6
+
+
+def test_search_latest_snapshot_selection_keeps_first_per_root(
+    tmp_path, monkeypatch
+):
+    snapshots = [
+        {"snapshot_id": "r1-new", "root_id": "r1"},
+        {"snapshot_id": "r2-new", "root_id": "r2"},
+        {"snapshot_id": "r1-old", "root_id": "r1"},
+        {"snapshot_id": "r3-new", "root_id": "r3"},
+        {"snapshot_id": "r2-old", "root_id": "r2"},
+    ]
+
+    class FakeRegistry:
+        def __init__(self, _path):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def list_complete_snapshots(self, **kwargs):
+            assert kwargs == {
+                "machine_id": None,
+                "root_id": None,
+                "snapshot_id": None,
+            }
+            return snapshots
+
+        def list_roots(self):
+            return [{"root_id": root_id} for root_id in ("r1", "r2", "r3")]
+
+    observed = {}
+    monkeypatch.setattr(search_module, "AtlasRegistry", FakeRegistry)
+    searcher = AtlasSearch(tmp_path / "registry.sqlite")
+
+    def capture_linear(selected_snapshots, roots_cache, *args):
+        observed["snapshot_ids"] = [item["snapshot_id"] for item in selected_snapshots]
+        observed["root_ids"] = list(roots_cache)
+        return []
+
+    monkeypatch.setattr(searcher, "_search_linear", capture_linear)
+
+    assert searcher.search(use_index=False) == []
+    assert observed == {
+        "snapshot_ids": ["r1-new", "r2-new", "r3-new"],
+        "root_ids": ["r1", "r2", "r3"],
+    }
 
 
 def test_latest_resolution(tmp_path):


### PR DESCRIPTION
Closes #1247.

## What changed
- added a direct characterization test for latest-only snapshot selection before production refactoring;
- extracted only the in-memory `first snapshot per root wins` block into `_latest_snapshots_per_root`;
- registry reads, date parsing, extension normalization, index-vs-linear routing, index fallback, content matching and result shaping remain unchanged.

## Evidence
- baseline Atlas search/index suites: 19/19 passed;
- characterization test against unchanged production code: passed;
- final Atlas search/index suites: 20/20 passed;
- direct old-vs-new helper equivalence: 6/6 exact, including order, object identity and KeyError behavior;
- target `AtlasSearch.search` C901 11 -> clean; repository maintainability 165 -> 164, `new_count=0`, `excess_total=2176`, `current_max=138`;
- Ruff excluding unrelated pre-existing Atlas C901 findings: pass;
- py_compile: pass;
- git diff --check: pass.

One C901 target only. Reviewed implementation head: `fa0ce8fd2eb0f10955ab0644ab9537b42a378abc`.