### PR TITLE
refactor(atlas): reduce index-search content-resolution complexity

### DIFF
--- a/merger/repoground/atlas/search.py
+++ b/merger/repoground/atlas/search.py
@@ -90,6 +90,21 @@ def _latest_snapshots_per_root(
     return list(latest_snapshots.values())
 
 
+def _indexed_content_match(
+    row,
+    item: Dict[str, Any],
+    snap_by_id: Dict[str, Dict[str, Any]],
+    roots_cache: Dict[str, Dict[str, Any]],
+    content_query_lower: str,
+) -> Tuple[bool, Optional[str]]:
+    snap = snap_by_id.get(row['snapshot_id'])
+    root = roots_cache.get(snap['root_id']) if snap else None
+    root_val = root.get('root_value') if root else None
+    if not root_val:
+        return False, None
+    return _content_match(root_val, item, content_query_lower)
+
+
 class AtlasSearch:
     def __init__(self, registry_db_path: Path):
         self.registry_db_path = registry_db_path
@@ -212,12 +227,9 @@ class AtlasSearch:
                 continue
 
             if content_query:
-                snap = snap_by_id.get(row['snapshot_id'])
-                root = roots_cache.get(snap['root_id']) if snap else None
-                root_val = root.get('root_value') if root else None
-                if not root_val:
-                    continue
-                matched, snippet = _content_match(root_val, item, content_query_lower)
+                matched, snippet = _indexed_content_match(
+                    row, item, snap_by_id, roots_cache, content_query_lower
+                )
                 if not matched:
                     continue
                 if snippet:

--- a/merger/repoground/tests/test_atlas_index.py
+++ b/merger/repoground/tests/test_atlas_index.py
@@ -338,6 +338,27 @@ def _content_keys(rows):
     return sorted((r["snapshot_id"], r["rel_path"]) for r in rows)
 
 
+def test_index_content_confirmation_resolves_snapshot_root_value(
+    tmp_path, monkeypatch
+):
+    searcher, _ = _build_content_index(tmp_path, {"a.txt": "alpha beta"})
+    observed = []
+
+    def capture_content_match(root_value, item, content_query_lower):
+        observed.append((root_value, item["rel_path"], content_query_lower))
+        return True, "captured snippet"
+
+    monkeypatch.setattr(search_module, "_content_match", capture_content_match)
+
+    rows = searcher.search(use_index=True, content_query="Needle")
+
+    assert _content_keys(rows) == [("s1", "a.txt")]
+    assert rows[0]["content_snippet"] == "captured snippet"
+    assert observed == [
+        (str(tmp_path / "content_root"), "a.txt", "needle"),
+    ]
+
+
 # --- Regression: the index-backed content search must never lose a hit that
 # --- the linear (live-filesystem substring) path would find (ADR-009 invariant).
 


### PR DESCRIPTION
Closes #1249.

## What changed
- added a direct characterization test against the real Atlas index path before production refactoring;
- extracted only index-row -> snapshot -> root -> `root_value` resolution into `_indexed_content_match`;
- the existing live `_content_match` remains authoritative, and snippet mutation/result shaping stay in `_try_index_search`;
- index existence, coverage, metadata query, fallback warnings, name filters and result ordering are untouched.

## Evidence
- characterization test against unchanged production code: pass;
- final Atlas search/index suites: 21/21 passed;
- direct old-vs-new helper equivalence: 8/8 exact including missing/falsy snapshot/root and KeyError behavior plus identical `_content_match` call traces;
- target `_try_index_search` C901 11 -> clean; repository maintainability 164 -> 163, `new_count=0`, `excess_total=2175`, `current_max=138`;
- Ruff excluding unrelated pre-existing Atlas C901s: pass;
- py_compile: pass;
- git diff --check: pass.

One C901 target only. Reviewed implementation head: `96c9cbaf53c6031f0746fcf33d64564ee261c4d4`.