### PR TITLE
refactor(retrieval): reduce context-bundle provenance complexity

### DIFF
--- a/merger/repoground/retrieval/query_core.py
+++ b/merger/repoground/retrieval/query_core.py
@@ -1215,6 +1215,21 @@ def _expand_context(db_conn: sqlite3.Connection, chunk_id: str, file_path: str, 
 
     return None
 
+def _context_hit_provenance(hit: Dict[str, Any]):
+    """Return the existing provenance class, source refs, and derived ref for one hit."""
+    prov_type = "explicit" if "range_ref" in hit else "derived"
+
+    refs = []
+    if "range_ref" in hit and hit["range_ref"]:
+        refs.append(hit["range_ref"].get("file_path", hit.get("path")))
+    elif "derived_range_ref" in hit and hit["derived_range_ref"]:
+        refs.append(hit["derived_range_ref"].get("file_path", hit.get("path")))
+    else:
+        refs.append(hit.get("path", ""))
+
+    return prov_type, refs, hit.get("derived_range_ref")
+
+
 def build_context_bundle(query_text: str, results: List[Dict[str, Any]], raw_contents: Dict[str, str], db_conn: sqlite3.Connection, context_mode: str = "exact", context_window_lines: int = 0) -> Dict[str, Any]:
     """
     Builds a query_context_bundle_json compliant structure from a list of hits.
@@ -1226,20 +1241,8 @@ def build_context_bundle(query_text: str, results: List[Dict[str, Any]], raw_con
     }
 
     for idx, hit in enumerate(results):
-        # Extract explicit vs derived provenance
-        prov_type = "derived"
-        if "range_ref" in hit:
-            prov_type = "explicit"
-
-        refs = []
-        if "range_ref" in hit and hit["range_ref"]:
-            refs.append(hit["range_ref"].get("file_path", hit.get("path")))
-        elif "derived_range_ref" in hit and hit["derived_range_ref"]:
-            refs.append(hit["derived_range_ref"].get("file_path", hit.get("path")))
-        else:
-            refs.append(hit.get("path", ""))
-
-        derived_ref = hit.get("derived_range_ref")
+        # Extract explicit vs derived provenance.
+        prov_type, refs, derived_ref = _context_hit_provenance(hit)
 
         hit_ctx = {
             "hit_identity": hit.get("chunk_id", f"hit_{idx}"),

--- a/merger/repoground/tests/test_context_bundle.py
+++ b/merger/repoground/tests/test_context_bundle.py
@@ -126,6 +126,38 @@ def test_context_bundle_preserves_provenance(tmp_path):
     assert "merged.md" in hit["bundle_source_references"]
 
 
+def test_context_bundle_preserves_falsy_explicit_range_ref_precedence():
+    import sqlite3
+
+    hit = {
+        "chunk_id": "c-falsy-explicit",
+        "repo_id": "r1",
+        "path": "src/original.py",
+        "range": "L1-L2",
+        "score": 0.75,
+        "why": {},
+        "range_ref": None,
+        "derived_range_ref": {"file_path": "src/derived.py", "start_byte": 10},
+    }
+
+    with sqlite3.connect(":memory:") as conn:
+        bundle = query_core.build_context_bundle(
+            "needle", [hit], {"c-falsy-explicit": "body"}, conn, context_mode="exact"
+        )
+
+    projected = bundle["hits"][0]
+    assert projected["provenance_type"] == "explicit"
+    assert projected["bundle_source_references"] == ["src/derived.py"]
+    assert projected["epistemics"]["resolver_status"] == "resolved_explicit"
+    assert projected["epistemics"]["interpolation"] == {
+        "used": True,
+        "reason": "derived_from_source",
+    }
+    assert "range_ref" in projected
+    assert projected["range_ref"] is None
+    assert "derived_range_ref" not in projected
+
+
 def test_context_expansion_exact_vs_block_vs_window(mini_index):
     # exact
     res_exact = query_core.execute_query(mini_index, query_text="hello", build_context=True, context_mode="exact")


### PR DESCRIPTION
Closes #1251.

## What changed
- added a direct characterization test for the legacy falsy-`range_ref` precedence case before production refactoring;
- extracted only provenance classification, `bundle_source_references` selection and `derived_ref` lookup into `_context_hit_provenance`;
- SQLite context expansion, hit ordering, scores, explain/graph fields, raw snippets, epistemic status construction, range attachment precedence, context-risk payload, ranking and retrieval routing remain unchanged.

## Evidence
- baseline focused contract suite: 14/14 passed;
- characterization test against unchanged production code: passed;
- final context-bundle + eval + API-query suites: 43/43 passed;
- direct old-vs-new helper equivalence: 8/8 exact, including truthy/falsy explicit refs, derived fallback, missing paths and derived-ref object identity;
- target `build_context_bundle` C901 11 -> clean; repository maintainability 163 -> 162, `new_count=0`, `excess_total=2174`, `current_max=138`;
- Ruff excluding unrelated pre-existing C901: pass;
- py_compile: pass;
- git diff --check: pass.

One C901 target only. Reviewed implementation head: `c560fd35a77c0b46513676cf55f26d1c87590e85`.