### PR TITLE
refactor(snapshot): reduce manifest-role cleanup complexity

### DIFF
--- a/merger/repoground/cli/cmd_ground.py
+++ b/merger/repoground/cli/cmd_ground.py
@@ -1641,6 +1641,19 @@ def run_snapshot_create(args: argparse.Namespace) -> int:
     return 0 if result.get("status") == "ok" else 1
 
 
+def _manifest_deletion_candidate(
+    bundle_dir: Path, root: Path, raw_path: object
+) -> Path | None:
+    if not isinstance(raw_path, str) or not raw_path:
+        return None
+    candidate = (bundle_dir / raw_path).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return None
+    return candidate
+
+
 def _drop_manifest_role(bundle_manifest: Path, role: str) -> list[Path]:
     data = json.loads(bundle_manifest.read_text(encoding="utf-8"))
     artifacts = data.get("artifacts", [])
@@ -1653,15 +1666,11 @@ def _drop_manifest_role(bundle_manifest: Path, role: str) -> list[Path]:
         if not isinstance(artifact, dict) or artifact.get("role") != role:
             kept.append(artifact)
             continue
-        raw_path = artifact.get("path")
-        if isinstance(raw_path, str) and raw_path:
-            candidate = (bundle_manifest.parent / raw_path).resolve()
-            try:
-                candidate.relative_to(root)
-            except ValueError:
-                pass
-            else:
-                dropped.append(candidate)
+        candidate = _manifest_deletion_candidate(
+            bundle_manifest.parent, root, artifact.get("path")
+        )
+        if candidate is not None:
+            dropped.append(candidate)
     data["artifacts"] = kept
     if role == "sqlite_index":
         capabilities = data.setdefault("capabilities", {})

--- a/merger/repoground/tests/test_ground_snapshot_cli.py
+++ b/merger/repoground/tests/test_ground_snapshot_cli.py
@@ -330,6 +330,49 @@ def test_public_share_removes_profile_excluded_sqlite(monkeypatch, tmp_path, cap
     assert manifest_data["capabilities"]["fts5_bm25"] is False
 
 
+def test_drop_manifest_role_keeps_external_targets_outside_bundle(tmp_path):
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    manifest = bundle_dir / "bundle.manifest.json"
+    inside = bundle_dir / "inside.sqlite"
+    outside = tmp_path / "outside.sqlite"
+    linked = bundle_dir / "linked.sqlite"
+    missing = bundle_dir / "missing.sqlite"
+
+    inside.write_bytes(b"inside")
+    outside.write_bytes(b"outside")
+    linked.symlink_to(outside)
+    manifest.write_text(
+        json.dumps(
+            {
+                "artifacts": [
+                    {"role": "sqlite_index", "path": inside.name},
+                    {"role": "sqlite_index", "path": "../outside.sqlite"},
+                    {"role": "sqlite_index", "path": linked.name},
+                    {"role": "sqlite_index", "path": missing.name},
+                    {"role": "canonical_md", "path": "brief.md"},
+                    "opaque-artifact-entry",
+                ],
+                "capabilities": {"fts5_bm25": True},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    dropped = cmd_ground._drop_manifest_role(manifest, "sqlite_index")
+
+    assert dropped == [inside.resolve(), missing.resolve()]
+    assert not inside.exists()
+    assert outside.read_bytes() == b"outside"
+    assert linked.is_symlink()
+    manifest_data = json.loads(manifest.read_text(encoding="utf-8"))
+    assert manifest_data["artifacts"] == [
+        {"role": "canonical_md", "path": "brief.md"},
+        "opaque-artifact-entry",
+    ]
+    assert manifest_data["capabilities"]["fts5_bm25"] is False
+
+
 def test_snapshot_create_graph_index_is_not_verified_as_primary_json(tmp_path, capsys):
     repo = tmp_path / "repo"
     repo.mkdir()


### PR DESCRIPTION
Closes #1253.

## What changed
- added a direct characterization test for the manifest cleanup filesystem boundary before production refactoring;
- extracted only raw manifest path -> safe in-bundle deletion candidate resolution into `_manifest_deletion_candidate`;
- manifest filtering/order, sqlite capability downgrade, atomic manifest write timing, actual `unlink()` calls, returned dropped paths and `FileNotFoundError` tolerance remain unchanged.

## Safety evidence
- baseline snapshot CLI suite: 39/39 passed;
- new characterization test against unchanged production code: passed;
- the test proves an in-bundle file is deleted, `../outside.sqlite` is not, a symlink resolving outside is not, and an absent in-bundle target remains a returned safe candidate;
- final snapshot CLI + publication surface + symbol-index consumer suites: 54/54 passed;
- direct old-vs-new path helper equivalence: 10/10 exact, including relative/absolute inside/outside paths, symlink, missing path, `.`, empty value and non-string input;
- target `_drop_manifest_role` C901 11 -> clean; repository maintainability 162 -> 161, `new_count=0`, `excess_total=2173`, `current_max=138`;
- Ruff excluding unrelated pre-existing C901: pass;
- py_compile: pass;
- git diff --check: pass.

One C901 target only. Reviewed implementation head: `bc9acf68c2498c7954f2a63e8dba0a6464bd4889`.