### PR TITLE
refactor(pythonista): split prescan presentation setup

### DIFF
--- a/merger/repoground/frontends/pythonista/merger_ui_prescan.py
+++ b/merger/repoground/frontends/pythonista/merger_ui_prescan.py
@@ -24,6 +24,141 @@ def _selected_prescan_repo_path(view):
     return True, view.hub / selected[0]
 
 
+def _append_prescan_item(flat_items, node, depth, root_name):
+    name = node["path"].split("/")[-1]
+    if node["path"] == ".":
+        name = root_name
+    icon = "📁" if node["type"] == "dir" else "📄"
+    flat_items.append(
+        {
+            "path": node["path"],
+            "display": f"{'  ' * depth}{icon} {name}",
+            "type": node["type"],
+            "depth": depth,
+            "orig": node,
+            "selected": False,
+        }
+    )
+    children = node.get("children") or []
+    dirs = sorted((child for child in children if child["type"] == "dir"), key=lambda child: child["path"])
+    files = sorted((child for child in children if child["type"] == "file"), key=lambda child: child["path"])
+    for child in dirs + files:
+        _append_prescan_item(flat_items, child, depth + 1, root_name)
+
+
+def _flatten_prescan_items(root_node, root_name):
+    flat_items = []
+    _append_prescan_item(flat_items, root_node, 0, root_name)
+    return flat_items
+
+
+def _recommended_prescan_path(path_str):
+    path = path_str.lower()
+    if "readme" in path or path.endswith(".ai-context.yml"):
+        return True
+    parts = path.split("/")
+    return ("src" in parts or "contracts" in parts or "docs" in parts) and "test" not in path
+
+
+def _pool_selects_path(path, pool_set, normalize_path_fn):
+    normalized = normalize_path_fn(path)
+    if normalized in pool_set:
+        return True
+    parts = normalized.split("/")
+    return any("/".join(parts[: index + 1]) in pool_set for index in range(len(parts)))
+
+
+def _initialize_prescan_selection(flat_items, existing_pool_entry, normalize_path_fn):
+    if existing_pool_entry and isinstance(existing_pool_entry, dict):
+        raw = existing_pool_entry.get("raw")
+        if raw is None:
+            for item in flat_items:
+                item["selected"] = True
+            return
+        if isinstance(raw, list):
+            pool_set = {normalize_path_fn(path) for path in raw}
+            for item in flat_items:
+                item["selected"] = _pool_selects_path(item["path"], pool_set, normalize_path_fn)
+        return
+    if not existing_pool_entry:
+        for item in flat_items:
+            item["selected"] = item["type"] == "file" and _recommended_prescan_path(item["path"])
+
+
+def _initial_prescan_selection_state(flat_items, existing_pool_entry):
+    is_all = (
+        isinstance(existing_pool_entry, dict)
+        and existing_pool_entry.get("raw") is None
+        and existing_pool_entry.get("compressed") is None
+    )
+    if is_all:
+        return {"mode": "all"}
+    if not any(item["selected"] for item in flat_items):
+        return {"mode": "none"}
+    return {"mode": "partial"}
+
+
+def _make_prescan_sheet(owner, root_name, ui_module):
+    class PrescanSheet(ui_module.View):
+        def __init__(self, parent):
+            super().__init__()
+            self._parent = parent
+            self.name = f"Prescan: {root_name}"
+            self.background_color = "#111111"
+            self.frame = (0, 0, 600, 800)
+
+        def will_close(self):
+            if self._parent._prescan_active:
+                self._parent._prescan_active = False
+
+    return PrescanSheet(owner)
+
+
+def _add_prescan_stats(sheet, prescan_data, ui_module, parse_human_size_fn):
+    stats_lbl = ui_module.Label(frame=(10, 10, 580, 20))
+    stats_lbl.text = (
+        f"{prescan_data['file_count']} files • "
+        f"{parse_human_size_fn(str(prescan_data['total_bytes']))} bytes total"
+    )
+    stats_lbl.text_color = "gray"
+    stats_lbl.font = ("<System>", 12)
+    sheet.add_subview(stats_lbl)
+
+
+def _toggle_prescan_all(flat_items, selection_state, table_view, value):
+    for item in flat_items:
+        item["selected"] = value
+    selection_state["mode"] = "all" if value else "none"
+    table_view.reload_data()
+
+
+def _add_prescan_select_buttons(sheet, flat_items, selection_state, table_view, ui_module):
+    button_specs = (("All", 10, True), ("None", 100, False))
+    for title, x, value in button_specs:
+        button = ui_module.Button(title=title)
+        button.frame = (x, 40, 80, 30)
+        button.background_color = "#333333"
+        button.tint_color = "white"
+        button.corner_radius = 4
+        button.action = lambda sender, selected=value: _toggle_prescan_all(
+            flat_items, selection_state, table_view, selected
+        )
+        sheet.add_subview(button)
+
+
+def _create_prescan_table(sheet, flat_items, selection_state, ui_module):
+    table_view = ui_module.TableView()
+    table_view.frame = (0, 80, sheet.width, sheet.height - 140)
+    table_view.flex = "WH"
+    table_view.background_color = "#111111"
+    table_view.separator_color = "#333333"
+    table_view.allows_multiple_selection = False
+    data_source = _PrescanDataSource(flat_items, selection_state, ui_module)
+    table_view.data_source = data_source
+    table_view.delegate = data_source
+    return table_view
+
+
 class MergerUIPrescanMixin:
     def show_prescan_sheet(self, sender):
         """
@@ -81,261 +216,22 @@ class MergerUIPrescanMixin:
         t.start()
 
     def _present_prescan_ui(self, prescan_data):
-        """
-        Displays the prescan tree in a Sheet.
-        Allows selection of files/folders.
-        """
+        """Displays the prescan tree in a selection-only Sheet."""
         root_node = prescan_data["tree"]
         root_name = prescan_data["root"]
-
-        # Flatten tree for table view (simple indentation approach)
-        flat_items = []
-
-        def traverse(node, depth):
-            # Item struct: { path, display, type, depth, node_ref }
-            name = node["path"].split("/")[-1]
-            if node["path"] == ".": name = root_name
-
-            icon = "📁" if node["type"] == "dir" else "📄"
-            indent = "  " * depth
-            display = f"{indent}{icon} {name}"
-
-            flat_items.append({
-                "path": node["path"],
-                "display": display,
-                "type": node["type"],
-                "depth": depth,
-                "orig": node,
-                "selected": False # Default state
-            })
-
-            if node.get("children"):
-                # Sort: Dirs first, then files
-                dirs = [c for c in node["children"] if c["type"] == "dir"]
-                files = [c for c in node["children"] if c["type"] == "file"]
-
-                dirs.sort(key=lambda x: x["path"])
-                files.sort(key=lambda x: x["path"])
-
-                for c in dirs + files:
-                    traverse(c, depth + 1)
-
-        traverse(root_node, 0)
-
-        # Initially select based on Recommended heuristic
-        # Start with None, then run heuristic
-        for item in flat_items:
-            item["selected"] = False
-
-        # Load existing selection from pool if available
-        # This supports the "Append" workflow by initializing with previous state
+        flat_items = _flatten_prescan_items(root_node, root_name)
         existing_pool_entry = self.saved_prescan_selections.get(root_name)
+        _initialize_prescan_selection(flat_items, existing_pool_entry, normalize_path)
+        selection_state = _initial_prescan_selection_state(flat_items, existing_pool_entry)
 
-        # Logic:
-        # - If pool has entry (dict):
-        #   - If raw is None: ALL state - select everything
-        #   - If raw is list: Use raw for UI truth (not compressed)
-        # - If no pool entry:
-        #   - Run Heuristic (Recommended).
-
-        if existing_pool_entry:
-            if isinstance(existing_pool_entry, dict):
-                raw = existing_pool_entry.get("raw")
-                if raw is None:
-                    # ALL state - select everything
-                    for item in flat_items:
-                        item["selected"] = True
-                elif isinstance(raw, list):
-                    # Partial selection from pool - use raw for UI truth
-                    # Normalize paths for consistent matching
-                    pool_set = set(normalize_path(p) for p in raw)
-                    for item in flat_items:
-                        normalized_item_path = normalize_path(item["path"])
-                        # Direct match
-                        if normalized_item_path in pool_set:
-                            item["selected"] = True
-                        else:
-                            # Check if parent dir is in pool (for compressed paths)
-                            parts = normalized_item_path.split('/')
-                            for i in range(len(parts)):
-                                sub = "/".join(parts[:i+1])
-                                if sub in pool_set:
-                                    item["selected"] = True
-                                    break
-            else:
-                # Legacy format - shouldn't happen after migration
-                # Run heuristic as fallback
-                pass
-        else:
-            # No existing selection -> Heuristic
-            # Run heuristic logic (same as prescanRecommended)
-            def is_recommended(path_str):
-                path = path_str.lower()
-                # Critical
-                if "readme" in path or path.endswith(".ai-context.yml"):
-                    return True
-                # Code
-                parts = path.split('/')
-                if "src" in parts or "contracts" in parts or "docs" in parts:
-                    if "test" not in path:
-                         return True
-                return False
-
-            for item in flat_items:
-                if item["type"] == "file":
-                    if is_recommended(item["path"]):
-                        item["selected"] = True
-
-        # Create Sheet with reliable close handling
-        # ARCHITECTURE NOTE: Prescan → Selection Pool (modify only)
-        # Merge → Explicit action from main view (never triggered from prescan)
-        class PrescanSheet(ui.View):
-            """
-            Custom View subclass.
-            Note: We avoid relying solely on will_close() for critical state reset due to
-            potential delegate limitations/bugs in some Pythonista versions.
-            State is reset explicitly in action handlers.
-            """
-            def __init__(self, parent):
-                super().__init__()
-                self._parent = parent
-                self.name = f"Prescan: {root_name}"
-                self.background_color = "#111111"
-                self.frame = (0, 0, 600, 800)
-
-            def will_close(self):
-                # Fallback safety net
-                if self._parent._prescan_active:
-                     self._parent._prescan_active = False
-
-        sheet = PrescanSheet(self)
+        sheet = _make_prescan_sheet(self, root_name, ui)
+        _add_prescan_stats(sheet, prescan_data, ui, parse_human_size)
+        tv = _create_prescan_table(sheet, flat_items, selection_state, ui)
+        _add_prescan_select_buttons(sheet, flat_items, selection_state, tv, ui)
+        sheet.add_subview(tv)
 
         def reset_guard():
             self._prescan_active = False
-
-        # Track selection mode explicitly for better state management
-        # This helps prevent crashes when transitioning between ALL/PARTIAL/NONE states
-        selection_state = {
-            'mode': 'partial'  # 'all', 'partial', or 'none'
-        }
-
-        # Initialize selection mode based on current selection
-        # Check if existing pool entry is in ALL state (both raw and compressed are None)
-        is_all = (isinstance(existing_pool_entry, dict) and
-                  existing_pool_entry.get("raw") is None and
-                  existing_pool_entry.get("compressed") is None)
-
-        if is_all:
-            selection_state['mode'] = 'all'
-        elif not any(item["selected"] for item in flat_items):
-            selection_state['mode'] = 'none'
-        else:
-            selection_state['mode'] = 'partial'
-
-        # Header Stats
-        stats_lbl = ui.Label(frame=(10, 10, 580, 20))
-        stats_lbl.text = f"{prescan_data['file_count']} files • {parse_human_size(str(prescan_data['total_bytes']))} bytes total" # approximate
-        stats_lbl.text_color = "gray"
-        stats_lbl.font = ("<System>", 12)
-        sheet.add_subview(stats_lbl)
-
-        # Buttons: Select All / None / Recommended
-        btn_y = 40
-        btn_w = 80
-        btn_h = 30
-
-        def toggle_all(val):
-            for i in flat_items: i["selected"] = val
-            # Update selection mode
-            if val:
-                selection_state['mode'] = 'all'
-            else:
-                selection_state['mode'] = 'none'
-            tv.reload_data()
-
-        btn_all = ui.Button(title="All")
-        btn_all.frame = (10, btn_y, btn_w, btn_h)
-        btn_all.background_color = "#333333"
-        btn_all.tint_color = "white"
-        btn_all.corner_radius = 4
-        btn_all.action = lambda s: toggle_all(True)
-        sheet.add_subview(btn_all)
-
-        btn_none = ui.Button(title="None")
-        btn_none.frame = (100, btn_y, btn_w, btn_h)
-        btn_none.background_color = "#333333"
-        btn_none.tint_color = "white"
-        btn_none.corner_radius = 4
-        btn_none.action = lambda s: toggle_all(False)
-        sheet.add_subview(btn_none)
-
-        # TableView
-        tv_y = 80
-        tv_h = sheet.height - tv_y - 60 # space for bottom bar
-        tv = ui.TableView()
-        tv.frame = (0, tv_y, sheet.width, tv_h)
-        tv.flex = "WH"
-        tv.background_color = "#111111"
-        tv.separator_color = "#333333"
-        tv.allows_multiple_selection = False # We handle selection manually
-
-        class PrescanDS(object):
-            def tableview_number_of_rows(self, tv, section):
-                return len(flat_items)
-
-            def tableview_cell_for_row(self, tv, section, row):
-                item = flat_items[row]
-                cell = ui.TableViewCell()
-                cell.text_label.text = item["display"]
-                cell.text_label.font = ("<Mono>", 12)
-                cell.background_color = "#111111"
-                cell.text_label.text_color = "white" if item["type"] == "file" else "#88ccff"
-
-                if item["selected"]:
-                    cell.accessory_type = "checkmark"
-                else:
-                    cell.accessory_type = "none"
-                return cell
-
-            def tableview_did_select(self, tv, section, row):
-                # Toggle logic
-                item = flat_items[row]
-                new_state = not item["selected"]
-
-                # Handle ALL state transition
-                if selection_state['mode'] == 'all' and not new_state:
-                    # Deselecting from ALL state - switch to partial selection mode
-                    selection_state['mode'] = 'partial'
-
-                self._set_selected_recursive(item, new_state)
-
-                # Update selection mode after change
-                if all(i["selected"] for i in flat_items):
-                    selection_state['mode'] = 'all'
-                elif not any(i["selected"] for i in flat_items):
-                    selection_state['mode'] = 'none'
-                else:
-                    selection_state['mode'] = 'partial'
-
-                tv.reload_data()
-
-            def _set_selected_recursive(self, item, state):
-                item["selected"] = state
-                # If dir, find children in flat list and toggle
-                if item["type"] == "dir":
-                    # Naive: scan following items with depth > item.depth
-                    # Since it is a flat list from traversal, children are immediately following.
-                    idx = flat_items.index(item)
-                    for i in range(idx + 1, len(flat_items)):
-                        child = flat_items[i]
-                        if child["depth"] <= item["depth"]:
-                            break
-                        child["selected"] = state
-
-        ds = PrescanDS()
-        tv.data_source = ds
-        tv.delegate = ds
-        sheet.add_subview(tv)
 
         # Bottom Bar: Remove / Cancel / Replace / Append
         bar_y = sheet.height - 50
@@ -747,3 +643,50 @@ class MergerUIPrescanMixin:
             sheet.add_subview(bar)
 
         sheet.present("sheet")
+
+
+class _PrescanDataSource:
+    def __init__(self, flat_items, selection_state, ui_module):
+        self.flat_items = flat_items
+        self.selection_state = selection_state
+        self.ui = ui_module
+
+    def tableview_number_of_rows(self, tv, section):
+        return len(self.flat_items)
+
+    def tableview_cell_for_row(self, tv, section, row):
+        item = self.flat_items[row]
+        cell = self.ui.TableViewCell()
+        cell.text_label.text = item["display"]
+        cell.text_label.font = ("<Mono>", 12)
+        cell.background_color = "#111111"
+        cell.text_label.text_color = "white" if item["type"] == "file" else "#88ccff"
+        cell.accessory_type = "checkmark" if item["selected"] else "none"
+        return cell
+
+    def tableview_did_select(self, tv, section, row):
+        item = self.flat_items[row]
+        new_state = not item["selected"]
+        if self.selection_state["mode"] == "all" and not new_state:
+            self.selection_state["mode"] = "partial"
+        self._set_selected_recursive(item, new_state)
+        self._refresh_selection_mode()
+        tv.reload_data()
+
+    def _refresh_selection_mode(self):
+        if all(item["selected"] for item in self.flat_items):
+            self.selection_state["mode"] = "all"
+        elif not any(item["selected"] for item in self.flat_items):
+            self.selection_state["mode"] = "none"
+        else:
+            self.selection_state["mode"] = "partial"
+
+    def _set_selected_recursive(self, item, state):
+        item["selected"] = state
+        if item["type"] != "dir":
+            return
+        index = self.flat_items.index(item)
+        for child in self.flat_items[index + 1 :]:
+            if child["depth"] <= item["depth"]:
+                break
+            child["selected"] = state

--- a/merger/repoground/tests/test_pythonista_prescan_sheet.py
+++ b/merger/repoground/tests/test_pythonista_prescan_sheet.py
@@ -95,3 +95,223 @@ def test_show_prescan_sheet_scans_selected_repo_and_schedules_ui(monkeypatch) ->
     assert len(delayed) == 1
     assert delayed[0][1] == 0
     assert console.calls[-1] == ("hide_activity",)
+
+
+class _TextLabel:
+    def __init__(self) -> None:
+        self.text = None
+        self.font = None
+        self.text_color = None
+
+
+class _Widget:
+    def __init__(self, frame=None) -> None:
+        self.subviews = []
+        self._frame = (0, 0, 0, 0)
+        self.width = 0
+        self.height = 0
+        self.closed = False
+        self.presented = None
+        if frame is not None:
+            self.frame = frame
+
+    @property
+    def frame(self):
+        return self._frame
+
+    @frame.setter
+    def frame(self, value) -> None:
+        self._frame = value
+        self.width = value[2]
+        self.height = value[3]
+
+    def add_subview(self, view) -> None:
+        self.subviews.append(view)
+
+    def present(self, style) -> None:
+        self.presented = style
+        _FakeUI.last_presented = self
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeView(_Widget):
+    pass
+
+
+class _FakeLabel(_Widget):
+    def __init__(self, frame=None) -> None:
+        super().__init__(frame)
+        self.text = None
+        self.text_color = None
+        self.font = None
+
+
+class _FakeButton(_Widget):
+    def __init__(self, title=None) -> None:
+        super().__init__()
+        self.title = title
+        self.action = None
+
+
+class _FakeTableView(_Widget):
+    def __init__(self) -> None:
+        super().__init__()
+        self.data_source = None
+        self.delegate = None
+        self.reload_count = 0
+
+    def reload_data(self) -> None:
+        self.reload_count += 1
+
+
+class _FakeTableViewCell:
+    def __init__(self, style=None) -> None:
+        self.style = style
+        self.text_label = _TextLabel()
+        self.detail_text_label = _TextLabel()
+        self.background_color = None
+        self.accessory_type = None
+
+
+class _FakeUI:
+    View = _FakeView
+    Label = _FakeLabel
+    Button = _FakeButton
+    TableView = _FakeTableView
+    TableViewCell = _FakeTableViewCell
+
+
+def _prescan_tree():
+    return {
+        "path": ".",
+        "type": "dir",
+        "children": [
+            {"path": "tests/test_x.py", "type": "file"},
+            {
+                "path": "src",
+                "type": "dir",
+                "children": [
+                    {"path": "src/b.py", "type": "file"},
+                    {"path": "src/a.py", "type": "file"},
+                ],
+            },
+            {"path": "README.md", "type": "file"},
+            {
+                "path": "docs",
+                "type": "dir",
+                "children": [{"path": "docs/guide.md", "type": "file"}],
+            },
+        ],
+    }
+
+
+def _presented_prescan(monkeypatch, *, pool=None):
+    monkeypatch.setattr(prescan_ui, "ui", _FakeUI, raising=False)
+    monkeypatch.setattr(prescan_ui, "console", _Console(), raising=False)
+    monkeypatch.setattr(prescan_ui, "normalize_path", lambda value: value, raising=False)
+    monkeypatch.setattr(prescan_ui, "parse_human_size", lambda value: value, raising=False)
+    view = _View(["repo-a"])
+    view.saved_prescan_selections = {} if pool is None else {"repo-a": pool}
+    view.saved_state_calls = 0
+    view.save_last_state = lambda: setattr(view, "saved_state_calls", view.saved_state_calls + 1)
+    view._prescan_active = True
+    data = {
+        "tree": _prescan_tree(),
+        "root": "repo-a",
+        "file_count": 5,
+        "total_bytes": 2048,
+    }
+    _FakeUI.last_presented = None
+    prescan_ui.MergerUIPrescanMixin._present_prescan_ui(view, data)
+    return view, _FakeUI.last_presented
+
+
+def _table_cells(sheet):
+    table = next(widget for widget in sheet.subviews if isinstance(widget, _FakeTableView))
+    ds = table.data_source
+    return table, [ds.tableview_cell_for_row(table, 0, row) for row in range(ds.tableview_number_of_rows(table, 0))]
+
+
+def test_present_prescan_ui_recommended_selection_and_sorted_tree(monkeypatch) -> None:
+    view, sheet = _presented_prescan(monkeypatch)
+
+    assert sheet.name == "Prescan: repo-a"
+    assert sheet.presented == "sheet"
+    table, cells = _table_cells(sheet)
+    assert [cell.text_label.text.strip() for cell in cells] == [
+        "📁 repo-a",
+        "📁 docs",
+        "📄 guide.md",
+        "📁 src",
+        "📄 a.py",
+        "📄 b.py",
+        "📄 README.md",
+        "📄 test_x.py",
+    ]
+    assert [cell.accessory_type for cell in cells] == [
+        "none",
+        "none",
+        "checkmark",
+        "none",
+        "checkmark",
+        "checkmark",
+        "checkmark",
+        "none",
+    ]
+    assert table.reload_count == 0
+    assert view._prescan_active is True
+
+
+def test_present_prescan_ui_restores_directory_selection_from_pool(monkeypatch) -> None:
+    _, sheet = _presented_prescan(
+        monkeypatch, pool={"raw": ["src"], "compressed": ["src"]}
+    )
+
+    _, cells = _table_cells(sheet)
+    selected = {
+        cell.text_label.text.strip()
+        for cell in cells
+        if cell.accessory_type == "checkmark"
+    }
+    assert selected == {"📁 src", "📄 a.py", "📄 b.py"}
+
+
+def test_present_prescan_ui_none_then_replace_clears_all_pool_state(monkeypatch) -> None:
+    view, sheet = _presented_prescan(
+        monkeypatch, pool={"raw": None, "compressed": None}
+    )
+    table, cells = _table_cells(sheet)
+    assert all(cell.accessory_type == "checkmark" for cell in cells)
+
+    none_button = next(widget for widget in sheet.subviews if getattr(widget, "title", None) == "None")
+    none_button.action(none_button)
+    assert table.reload_count == 1
+
+    replace_button = next(
+        widget for widget in sheet.subviews if getattr(widget, "title", None) == "Store (Replace)"
+    )
+    replace_button.action(replace_button)
+
+    assert view.saved_prescan_selections == {}
+    assert view.saved_state_calls == 1
+    assert view._prescan_active is False
+    assert sheet.closed is True
+
+
+def test_present_prescan_ui_directory_toggle_updates_descendants(monkeypatch) -> None:
+    _, sheet = _presented_prescan(monkeypatch)
+    table, _ = _table_cells(sheet)
+    data_source = table.data_source
+
+    data_source.tableview_did_select(table, 0, 3)
+
+    _, cells = _table_cells(sheet)
+    selected = {
+        cell.text_label.text.strip()
+        for cell in cells
+        if cell.accessory_type == "checkmark"
+    }
+    assert {"📁 src", "📄 a.py", "📄 b.py"} <= selected
+    assert table.reload_count == 1


### PR DESCRIPTION
## T024 Slice 1

Reduziert ausschließlich die Komplexität von `MergerUIPrescanMixin._present_prescan_ui`, ohne `_pool_update` oder `show_pool_viewer` semantisch umzubauen.

### Änderung
- Tree-Flattening, Recommended-/Pool-Initialauswahl, Selection-State, Sheet-/Stats-/Button-Aufbau und TableView-Delegate in begrenzte Helfer zerlegt.
- `_pool_update` bleibt als eigener verschachtelter Block unverändert komplex und ist ausdrücklich der nächste separate T024-Slice.
- Pythonista-Mixin-Globalvertrag bleibt unverändert.

### Charakterisierung vor Produktionsänderung
- bestehende 3 Prescan-Tests + 3 neue UI-Charakterisierungstests: 6/6 grün;
- Sortierung/Recommended-Auswahl, Pool-Wiederherstellung und ALL → None → Replace mit Persistenz/Guard/Close waren gebunden.
- zusätzlich ist der ausgelagerte rekursive Directory-Toggle direkt regressionsgetestet.

### Ergebnis
- `_present_prescan_ui`: C901 86 -> 46
- `_pool_update`: C901 44 -> 44
- `show_pool_viewer`: C901 24 -> 24
- Repo-Findingzahl: 160 -> 160
- Excess-Mass: 2172 -> 2132
- `new_count=0`

### Validierung
- Pythonista-Scope: 75/75 Tests grün
- Parity-Guard: pass
- Graph maintainability ratchet: pass
- Ruff außerhalb bestehender C901: pass
- py_compile: pass
- git diff --check: pass

Exact reviewed head: `41949518`.