### PR TITLE
refactor(service-client): reduce profile-config validation complexity

### DIFF
--- a/merger/repoground/cli/cmd_service_client.py
+++ b/merger/repoground/cli/cmd_service_client.py
@@ -27,6 +27,21 @@ _PROFILE_ALLOWED_KEYS = frozenset({"base_url", "token_env"})
 _PROFILE_FORBIDDEN_KEYS = frozenset({"token", "secret"})
 
 
+def _validate_profile_keys(name: str, profile: dict) -> None:
+    forbidden = _PROFILE_FORBIDDEN_KEYS.intersection(profile.keys())
+    if forbidden:
+        raise ValueError(
+            f"Profile {name!r} contains forbidden key(s) {sorted(forbidden)}; "
+            "secrets must come from env (token_env) or --token, never from config"
+        )
+    unknown = set(profile.keys()) - _PROFILE_ALLOWED_KEYS
+    if unknown:
+        raise ValueError(
+            f"Profile {name!r} has unknown key(s) {sorted(unknown)}; "
+            f"allowed: {sorted(_PROFILE_ALLOWED_KEYS)}"
+        )
+
+
 def _validate_profile_config(data: Any, path: pathlib.Path) -> dict:
     if not isinstance(data, dict):
         raise ValueError(f"Profile config root must be a JSON object ({path})")
@@ -40,18 +55,7 @@ def _validate_profile_config(data: Any, path: pathlib.Path) -> dict:
     for name, profile in (profiles or {}).items():
         if not isinstance(profile, dict):
             raise ValueError(f"Profile {name!r} must be a JSON object")
-        forbidden = _PROFILE_FORBIDDEN_KEYS.intersection(profile.keys())
-        if forbidden:
-            raise ValueError(
-                f"Profile {name!r} contains forbidden key(s) {sorted(forbidden)}; "
-                "secrets must come from env (token_env) or --token, never from config"
-            )
-        unknown = set(profile.keys()) - _PROFILE_ALLOWED_KEYS
-        if unknown:
-            raise ValueError(
-                f"Profile {name!r} has unknown key(s) {sorted(unknown)}; "
-                f"allowed: {sorted(_PROFILE_ALLOWED_KEYS)}"
-            )
+        _validate_profile_keys(name, profile)
         base_url = profile.get("base_url")
         if base_url is not None and not isinstance(base_url, str):
             raise ValueError(f"Profile {name!r} 'base_url' must be a string")

--- a/merger/repoground/tests/test_service_client.py
+++ b/merger/repoground/tests/test_service_client.py
@@ -1849,6 +1849,29 @@ def test_service_client_invalid_profile_config_with_base_url_override_is_config_
     assert "garbage" in parsed["message"]
 
 
+def test_profile_config_forbidden_keys_precede_unknown_keys() -> None:
+    data = {
+        "profiles": {
+            "bad": {
+                "base_url": "http://x:8787",
+                "token": "super-secret",
+                "garbage": "x",
+            }
+        }
+    }
+
+    with pytest.raises(ValueError) as exc_info:
+        _mod._validate_profile_config(data, pathlib.Path("profiles.json"))
+
+    message = str(exc_info.value)
+    assert message == (
+        "Profile 'bad' contains forbidden key(s) ['token']; "
+        "secrets must come from env (token_env) or --token, never from config"
+    )
+    assert "garbage" not in message
+    assert "super-secret" not in message
+
+
 def test_service_client_profile_with_token_field_rejected(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: pathlib.Path,


### PR DESCRIPTION
Closes #1258.

## What changed
- continues the RepoGround C901 reduction after the exact-11 frontier was exhausted by the parallel Pythonista slices;
- added a direct characterization test for profile-key validation precedence before production refactoring;
- extracted only forbidden/unknown profile-key validation into `_validate_profile_keys`;
- root/profiles/default_profile validation, profile iteration, profile object validation, base_url parsing, token_env validation and all network fail-closed behavior remain unchanged.

## Security evidence
- baseline full service-client suite: 101/101 passed;
- characterization test against unchanged production code: passed;
- final full service-client suite on the rebased/current-main tree: 102/102 passed;
- direct old-vs-new key-helper equivalence after rebase: 9/9 exact, including `token + garbage`, both forbidden keys, allowed keys and exact exception messages;
- forbidden keys still win over unknown keys, and secret values never appear in errors;
- current main after parallel PR #1259: C901 total 158; candidate tree: 157, `new_count=0`, `excess_total=2060`, `current_max=138`;
- target `_validate_profile_config` C901 12 -> clean (<=10);
- Ruff excluding unrelated pre-existing C901: pass;
- py_compile: pass;
- git diff --check: pass.

## Main-drift reconciliation
- original reviewed head `84ecd8cde6fadea2e4fb0ac3e9ff6e49bdea106c` became behind when #1259 merged;
- local rebase onto main `ba48e0633819905611d40cefd829bf682492c3ad` produced tested head `319a06b791c861e4ef792ba54d1270dbcd5cec86`;
- GitHub update-branch CAS produced current PR head `c72e45be50e46e22c75cd2e9329bbfec727a8cc2`;
- tested rebase head and current PR head have the identical Git tree `5a95bd8b1482a062fa5b68a42187be8ad367e707`.

One C901 target only. Current exact implementation head: `c72e45be50e46e22c75cd2e9329bbfec727a8cc2`.