### PR TITLE
refactor(workbench): reduce goldset validation complexity

### DIFF
--- a/merger/repoground/core/workbench_usefulness.py
+++ b/merger/repoground/core/workbench_usefulness.py
@@ -163,6 +163,33 @@ def _source_identity(manifest_path: Path) -> dict[str, Any]:
     }
 
 
+def _validate_goldset_question(
+    raw: Any, seen: set[str]
+) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise ValueError("goldset question must be an object")
+    question_id = raw.get("id")
+    query = raw.get("query")
+    expected_paths = raw.get("expected_paths")
+    expected_symbols = raw.get("expected_symbols")
+    if not isinstance(question_id, str) or not question_id:
+        raise ValueError("goldset question id must be a non-empty string")
+    if question_id in seen:
+        raise ValueError(f"duplicate goldset question id: {question_id}")
+    if not isinstance(query, str) or not query:
+        raise ValueError(f"question {question_id} query must be non-empty")
+    if not isinstance(expected_paths, list) or not expected_paths:
+        raise ValueError(f"question {question_id} expected_paths must be non-empty")
+    if not isinstance(expected_symbols, list) or not expected_symbols:
+        raise ValueError(f"question {question_id} expected_symbols must be non-empty")
+    if not all(isinstance(item, str) and item for item in expected_paths):
+        raise ValueError(f"question {question_id} expected_paths are invalid")
+    if not all(isinstance(item, str) and item for item in expected_symbols):
+        raise ValueError(f"question {question_id} expected_symbols are invalid")
+    seen.add(question_id)
+    return raw
+
+
 def _validate_goldset(goldset: dict[str, Any]) -> list[dict[str, Any]]:
     if (
         goldset.get("kind") != GOLDSET_KIND
@@ -177,28 +204,7 @@ def _validate_goldset(goldset: dict[str, Any]) -> list[dict[str, Any]]:
     seen: set[str] = set()
     validated: list[dict[str, Any]] = []
     for raw in questions:
-        if not isinstance(raw, dict):
-            raise ValueError("goldset question must be an object")
-        question_id = raw.get("id")
-        query = raw.get("query")
-        expected_paths = raw.get("expected_paths")
-        expected_symbols = raw.get("expected_symbols")
-        if not isinstance(question_id, str) or not question_id:
-            raise ValueError("goldset question id must be a non-empty string")
-        if question_id in seen:
-            raise ValueError(f"duplicate goldset question id: {question_id}")
-        if not isinstance(query, str) or not query:
-            raise ValueError(f"question {question_id} query must be non-empty")
-        if not isinstance(expected_paths, list) or not expected_paths:
-            raise ValueError(f"question {question_id} expected_paths must be non-empty")
-        if not isinstance(expected_symbols, list) or not expected_symbols:
-            raise ValueError(f"question {question_id} expected_symbols must be non-empty")
-        if not all(isinstance(item, str) and item for item in expected_paths):
-            raise ValueError(f"question {question_id} expected_paths are invalid")
-        if not all(isinstance(item, str) and item for item in expected_symbols):
-            raise ValueError(f"question {question_id} expected_symbols are invalid")
-        seen.add(question_id)
-        validated.append(raw)
+        validated.append(_validate_goldset_question(raw, seen))
     return validated
 
 

--- a/merger/repoground/tests/test_workbench_usefulness.py
+++ b/merger/repoground/tests/test_workbench_usefulness.py
@@ -9,6 +9,7 @@ import pytest
 from merger.repoground.cli.main import main
 from merger.repoground.core.workbench_usefulness import (
     _baseline_guardrails_visible,
+    _validate_goldset,
     evaluate_workbench_usefulness,
 )
 from merger.repoground.tests.test_readonly_adapter import _adapter
@@ -96,6 +97,41 @@ def test_repository_goldset_questions_do_not_describe_retired_products_as_curren
                         )
 
     assert offenders == [], "retired product name found in active goldset question: " + "; ".join(offenders)
+
+
+def test_validate_goldset_preserves_question_validation_order() -> None:
+    def question(question_id: str, **overrides):
+        value = {
+            "id": question_id,
+            "query": "hello",
+            "expected_paths": ["brief.md"],
+            "expected_symbols": ["hello_adapter"],
+        }
+        value.update(overrides)
+        return value
+
+    cases = [
+        (0, "not-an-object", "goldset question must be an object"),
+        (0, question("", query="", expected_paths=[], expected_symbols=[]), "goldset question id must be a non-empty string"),
+        (1, question("demo-0", query=""), "duplicate goldset question id: demo-0"),
+        (0, question("demo-0", query="", expected_paths=[], expected_symbols=[]), "question demo-0 query must be non-empty"),
+        (0, question("demo-0", expected_paths=[], expected_symbols=[]), "question demo-0 expected_paths must be non-empty"),
+        (0, question("demo-0", expected_symbols=[]), "question demo-0 expected_symbols must be non-empty"),
+        (0, question("demo-0", expected_paths=["", "brief.md"], expected_symbols=[""]), "question demo-0 expected_paths are invalid"),
+        (0, question("demo-0", expected_symbols=["", "hello_adapter"]), "question demo-0 expected_symbols are invalid"),
+    ]
+
+    for index, replacement, expected_message in cases:
+        questions = [question(f"demo-{ordinal}") for ordinal in range(5)]
+        questions[index] = replacement
+        goldset = {
+            "kind": "repobrief.workbench_usefulness_goldset",
+            "version": "1.0",
+            "questions": questions,
+        }
+        with pytest.raises(ValueError) as exc_info:
+            _validate_goldset(goldset)
+        assert str(exc_info.value) == expected_message
 
 
 def test_eval_measures_navigation_advantage_without_default_promotion(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #1261.

## What changed
- added a direct characterization test for per-question goldset validation order before production refactoring;
- extracted only single-question validation into `_validate_goldset_question`;
- outer kind/version validation, minimum question count, iteration order and accepted raw object identity remain unchanged;
- no adapter, file, retrieval, scoring, network or report behavior changes.

## Evidence
- baseline workbench-usefulness suite: 6/6 passed;
- characterization test against unchanged production code: passed;
- final workbench-usefulness suite: 7/7 passed;
- direct old-vs-new single-question equivalence: 18/18 exact, including error messages, `seen` mutation timing and raw object identity;
- target `_validate_goldset` C901 12 -> clean; repository maintainability 157 -> 156, `new_count=0`, `excess_total=2058`, `current_max=138`;
- Ruff excluding unrelated pre-existing C901: pass;
- py_compile: pass;
- git diff --check: pass.

One C901 target only. Reviewed implementation head: `4c06b4195b03f38a13c4dc8df9e7d5285b4ec0d1`.