### PR TITLE
refactor(pythonista): split prescan pool viewer

### DIFF
--- a/merger/repoground/frontends/pythonista/merger_ui_prescan.py
+++ b/merger/repoground/frontends/pythonista/merger_ui_prescan.py
@@ -338,6 +338,111 @@ def _update_prescan_pool(
     sheet.close()
 
 
+def _format_pool_info(data):
+    if not data or not isinstance(data, dict):
+        return "Invalid state"
+    raw = data.get("raw")
+    compressed = data.get("compressed")
+    if raw is None and compressed is None:
+        return "ALL"
+    raw_count = len(raw) if raw else 0
+    compressed_count = len(compressed) if compressed else 0
+    return f"Partial: {raw_count} files / {compressed_count} rules"
+
+
+def _pool_viewer_items(pool):
+    items = [
+        {"repo": repo, "info": _format_pool_info(data)}
+        for repo, data in pool.items()
+    ]
+    items.sort(key=lambda item: item["repo"])
+    return items
+
+
+def _pool_inspector_message(repo, entry):
+    raw = entry.get("raw")
+    compressed = entry.get("compressed")
+    message = f"Repo: {repo}\n\n"
+    if raw is None and compressed is None:
+        return message + "State: ALL files included."
+
+    raw_count = len(raw) if raw else 0
+    compressed_count = len(compressed) if compressed else 0
+    message += (
+        f"State: Partial\nFiles: {raw_count}\nRules: {compressed_count}\n\n"
+    )
+    if not compressed:
+        return message
+
+    message += "Rules (Compressed):\n"
+    for rule in compressed[:15]:
+        message += f"- {rule}\n"
+    if len(compressed) > 15:
+        message += f"... and {len(compressed) - 15} more"
+    return message
+
+
+def _show_pool_inspector(pool, repo, console_module, ui_module):
+    entry = pool.get(repo)
+    if not entry or not isinstance(entry, dict):
+        return
+    message = _pool_inspector_message(repo, entry)
+    if console_module:
+        console_module.alert(
+            "Pool Details", message, "OK", hide_cancel_button=True
+        )
+    elif ui_module:
+        ui_module.alert("Pool Details", message, "OK")
+
+
+def _add_empty_pool_label(sheet, ui_module):
+    label = ui_module.Label(frame=(0, 0, 500, 600))
+    label.text = "Pool is empty."
+    label.alignment = ui_module.ALIGN_CENTER
+    label.text_color = "gray"
+    sheet.add_subview(label)
+
+
+def _create_pool_viewer_table(parent, pool, ui_module, console_module):
+    table = ui_module.TableView()
+    table.frame = (0, 0, 500, 540)
+    table.flex = "WH"
+    table.background_color = "#111111"
+    table.separator_color = "#333333"
+    data_source = _PoolViewerDataSource(
+        parent, pool, _pool_viewer_items(pool), ui_module, console_module
+    )
+    table.data_source = data_source
+    table.delegate = data_source
+    return table
+
+
+def _clear_pool_from_viewer(parent, pool, sheet, console_module):
+    pool.clear()
+    parent.save_last_state()
+    parent._update_repo_info()
+    sheet.close()
+    if console_module:
+        console_module.hud_alert("Pool cleared")
+
+
+def _add_pool_viewer_clear_bar(parent, pool, sheet, ui_module, console_module):
+    bar = ui_module.View(frame=(0, 540, 500, 60))
+    bar.flex = "WT"
+    bar.background_color = "#222222"
+
+    button = ui_module.Button(title="Clear Pool")
+    button.frame = (10, 10, 100, 40)
+    button.background_color = "#ff3b30"
+    button.tint_color = "white"
+    button.corner_radius = 6
+    button.action = lambda sender: _clear_pool_from_viewer(
+        parent, pool, sheet, console_module
+    )
+    bar.add_subview(button)
+    sheet.add_subview(bar)
+
+
 class MergerUIPrescanMixin:
     def show_prescan_sheet(self, sender):
         """
@@ -471,149 +576,63 @@ class MergerUIPrescanMixin:
     def show_pool_viewer(self, sender):
         """Shows the current Selection Pool content."""
         pool = self.saved_prescan_selections
-
         sheet = ui.View()
         sheet.name = "Selection Pool"
         sheet.background_color = "#111111"
         sheet.frame = (0, 0, 500, 600)
 
         if not pool:
-            lbl = ui.Label(frame=(0, 0, 500, 600))
-            lbl.text = "Pool is empty."
-            lbl.alignment = ui.ALIGN_CENTER
-            lbl.text_color = "gray"
-            sheet.add_subview(lbl)
+            _add_empty_pool_label(sheet, ui)
         else:
-            tv = ui.TableView()
-            tv.frame = (0, 0, 500, 540)
-            tv.flex = "WH"
-            tv.background_color = "#111111"
-            tv.separator_color = "#333333"
-
-            # Helper to format info
-            def format_pool_info(data):
-                if not data or not isinstance(data, dict):
-                    return "Invalid state"
-
-                # Check for ALL state (both None)
-                raw = data.get("raw")
-                compressed = data.get("compressed")
-
-                if raw is None and compressed is None:
-                    return "ALL"
-
-                # Partial state
-                raw_count = len(raw) if raw else 0
-                compressed_count = len(compressed) if compressed else 0
-                return f"Partial: {raw_count} files / {compressed_count} rules"
-
-            # Convert pool to list
-            items = []
-            for repo, data in pool.items():
-                info = format_pool_info(data)
-                items.append({"repo": repo, "info": info})
-
-            items.sort(key=lambda x: x["repo"])
-
-            class PoolDS(object):
-                def __init__(self, parent_ui):
-                    self.parent = parent_ui
-
-                def tableview_number_of_rows(self, tv, section):
-                    return len(items)
-
-                def tableview_cell_for_row(self, tv, section, row):
-                    item = items[row]
-                    cell = ui.TableViewCell('value1')
-                    cell.text_label.text = item["repo"]
-                    cell.detail_text_label.text = item["info"]
-                    cell.text_label.text_color = "white"
-                    cell.detail_text_label.text_color = "#888888"
-                    cell.background_color = "#111111"
-                    cell.accessory_type = 'detail_button'
-                    return cell
-
-                def tableview_accessory_button_tapped(self, tv, section, row):
-                    self.show_inspector(row)
-
-                def tableview_did_select(self, tv, section, row):
-                    self.show_inspector(row)
-
-                def show_inspector(self, row):
-                    item = items[row]
-                    repo = item["repo"]
-                    entry = pool.get(repo)
-
-                    if not entry or not isinstance(entry, dict):
-                        return
-
-                    raw = entry.get("raw")
-                    compressed = entry.get("compressed")
-
-                    msg = f"Repo: {repo}\n\n"
-
-                    if raw is None and compressed is None:
-                        msg += "State: ALL files included."
-                    else:
-                        r_count = len(raw) if raw else 0
-                        c_count = len(compressed) if compressed else 0
-                        msg += f"State: Partial\nFiles: {r_count}\nRules: {c_count}\n\n"
-
-                        if compressed:
-                            msg += "Rules (Compressed):\n"
-                            # Limit display
-                            display_rules = compressed[:15]
-                            for r in display_rules:
-                                msg += f"- {r}\n"
-                            if len(compressed) > 15:
-                                msg += f"... and {len(compressed)-15} more"
-
-                    if console:
-                        console.alert("Pool Details", msg, "OK", hide_cancel_button=True)
-                    elif ui:
-                        ui.alert("Pool Details", msg, "OK")
-
-                def tableview_can_edit(self, tv, section, row):
-                    return True
-
-                def tableview_delete(self, tv, section, row):
-                    repo = items[row]["repo"]
-                    if repo in pool:
-                        del pool[repo]
-                        # Persist immediately using parent reference
-                        self.parent.save_last_state()
-                        self.parent._update_repo_info()
-
-                    items.pop(row)
-                    tv.delete_rows([row])
-
-            ds = PoolDS(self)
-            tv.data_source = ds
-            tv.delegate = ds
-            sheet.add_subview(tv)
-
-            # Bottom Bar
-            bar = ui.View(frame=(0, 540, 500, 60))
-            bar.flex = "WT"
-            bar.background_color = "#222222"
-
-            btn_clear = ui.Button(title="Clear Pool")
-            btn_clear.frame = (10, 10, 100, 40)
-            btn_clear.background_color = "#ff3b30"
-            btn_clear.tint_color = "white"
-            btn_clear.corner_radius = 6
-            def clear_action(sender):
-                pool.clear()
-                self.save_last_state()
-                self._update_repo_info()
-                sheet.close()
-                if console: console.hud_alert("Pool cleared")
-            btn_clear.action = clear_action
-            bar.add_subview(btn_clear)
-
-            sheet.add_subview(bar)
+            sheet.add_subview(_create_pool_viewer_table(self, pool, ui, console))
+            _add_pool_viewer_clear_bar(self, pool, sheet, ui, console)
 
         sheet.present("sheet")
+
+
+class _PoolViewerDataSource:
+    def __init__(self, parent, pool, items, ui_module, console_module):
+        self.parent = parent
+        self.pool = pool
+        self.items = items
+        self.ui = ui_module
+        self.console = console_module
+
+    def tableview_number_of_rows(self, tv, section):
+        return len(self.items)
+
+    def tableview_cell_for_row(self, tv, section, row):
+        item = self.items[row]
+        cell = self.ui.TableViewCell("value1")
+        cell.text_label.text = item["repo"]
+        cell.detail_text_label.text = item["info"]
+        cell.text_label.text_color = "white"
+        cell.detail_text_label.text_color = "#888888"
+        cell.background_color = "#111111"
+        cell.accessory_type = "detail_button"
+        return cell
+
+    def tableview_accessory_button_tapped(self, tv, section, row):
+        self.show_inspector(row)
+
+    def tableview_did_select(self, tv, section, row):
+        self.show_inspector(row)
+
+    def show_inspector(self, row):
+        repo = self.items[row]["repo"]
+        _show_pool_inspector(self.pool, repo, self.console, self.ui)
+
+    def tableview_can_edit(self, tv, section, row):
+        return True
+
+    def tableview_delete(self, tv, section, row):
+        repo = self.items[row]["repo"]
+        if repo in self.pool:
+            del self.pool[repo]
+            self.parent.save_last_state()
+            self.parent._update_repo_info()
+        self.items.pop(row)
+        tv.delete_rows([row])
 
 
 class _PrescanDataSource:

--- a/merger/repoground/tests/test_pythonista_prescan_sheet.py
+++ b/merger/repoground/tests/test_pythonista_prescan_sheet.py
@@ -21,6 +21,9 @@ class _Console:
     def hide_activity(self, *args: object) -> None:
         self.calls.append(("hide_activity", *args))
 
+    def alert(self, *args: object, **kwargs: object) -> None:
+        self.calls.append(("alert", *args, kwargs))
+
 
 class _View(prescan_ui.MergerUIPrescanMixin):
     def __init__(self, selected: list[str]) -> None:
@@ -165,6 +168,9 @@ class _FakeTableView(_Widget):
     def reload_data(self) -> None:
         self.reload_count += 1
 
+    def delete_rows(self, rows) -> None:
+        self.deleted_rows = list(rows)
+
 
 class _FakeTableViewCell:
     def __init__(self, style=None) -> None:
@@ -181,6 +187,12 @@ class _FakeUI:
     Button = _FakeButton
     TableView = _FakeTableView
     TableViewCell = _FakeTableViewCell
+    ALIGN_CENTER = "center"
+    alert_calls = []
+
+    @staticmethod
+    def alert(*args) -> None:
+        _FakeUI.alert_calls.append(args)
 
 
 def _prescan_tree():
@@ -417,3 +429,129 @@ def test_present_prescan_ui_append_unions_and_recompresses_partial(monkeypatch) 
     assert view.saved_state_calls == 1
     assert view._prescan_active is False
     assert sheet.closed is True
+
+
+def _presented_pool_viewer(monkeypatch, pool, *, use_console=True):
+    monkeypatch.setattr(prescan_ui, "ui", _FakeUI, raising=False)
+    console = _Console() if use_console else None
+    monkeypatch.setattr(prescan_ui, "console", console, raising=False)
+    view = _View([])
+    view.saved_prescan_selections = pool
+    view.saved_state_calls = 0
+    view.repo_info_calls = 0
+    view.save_last_state = lambda: setattr(
+        view, "saved_state_calls", view.saved_state_calls + 1
+    )
+    view._update_repo_info = lambda: setattr(
+        view, "repo_info_calls", view.repo_info_calls + 1
+    )
+    _FakeUI.last_presented = None
+    _FakeUI.alert_calls = []
+    view.show_pool_viewer(None)
+    return view, _FakeUI.last_presented, console
+
+
+def _pool_table(sheet):
+    return next(widget for widget in sheet.subviews if isinstance(widget, _FakeTableView))
+
+
+def test_show_pool_viewer_empty_pool_presents_empty_label(monkeypatch) -> None:
+    _, sheet, _ = _presented_pool_viewer(monkeypatch, {})
+
+    assert sheet.name == "Selection Pool"
+    assert sheet.presented == "sheet"
+    labels = [widget for widget in sheet.subviews if isinstance(widget, _FakeLabel)]
+    assert len(labels) == 1
+    assert labels[0].text == "Pool is empty."
+    assert labels[0].alignment == _FakeUI.ALIGN_CENTER
+    assert labels[0].text_color == "gray"
+
+
+def test_show_pool_viewer_sorts_and_formats_rows(monkeypatch) -> None:
+    pool = {
+        "z-invalid": "legacy",
+        "m-partial": {"raw": ["a", "b"], "compressed": ["src"]},
+        "a-all": {"raw": None, "compressed": None},
+    }
+    _, sheet, _ = _presented_pool_viewer(monkeypatch, pool)
+    table = _pool_table(sheet)
+    ds = table.data_source
+
+    cells = [
+        ds.tableview_cell_for_row(table, 0, row)
+        for row in range(ds.tableview_number_of_rows(table, 0))
+    ]
+    assert [(cell.text_label.text, cell.detail_text_label.text) for cell in cells] == [
+        ("a-all", "ALL"),
+        ("m-partial", "Partial: 2 files / 1 rules"),
+        ("z-invalid", "Invalid state"),
+    ]
+    assert all(cell.accessory_type == "detail_button" for cell in cells)
+
+
+def test_show_pool_viewer_inspector_limits_compressed_rules(monkeypatch) -> None:
+    rules = [f"rule-{index:02d}" for index in range(16)]
+    pool = {"repo-a": {"raw": ["a", "b"], "compressed": rules}}
+    _, sheet, console = _presented_pool_viewer(monkeypatch, pool)
+    table = _pool_table(sheet)
+
+    table.data_source.tableview_did_select(table, 0, 0)
+
+    assert console.calls[-1][0:3] == ("alert", "Pool Details", console.calls[-1][2])
+    message = console.calls[-1][2]
+    assert message.startswith("Repo: repo-a\n\nState: Partial\nFiles: 2\nRules: 16\n\nRules (Compressed):\n")
+    assert "- rule-14\n" in message
+    assert "rule-15" not in message
+    assert message.endswith("... and 1 more")
+    assert console.calls[-1][3] == "OK"
+    assert console.calls[-1][4] == {"hide_cancel_button": True}
+
+
+def test_show_pool_viewer_inspector_falls_back_to_ui_alert(monkeypatch) -> None:
+    pool = {"repo-a": {"raw": None, "compressed": None}}
+    _, sheet, _ = _presented_pool_viewer(monkeypatch, pool, use_console=False)
+    table = _pool_table(sheet)
+
+    table.data_source.tableview_accessory_button_tapped(table, 0, 0)
+
+    assert _FakeUI.alert_calls == [
+        ("Pool Details", "Repo: repo-a\n\nState: ALL files included.", "OK")
+    ]
+
+
+def test_show_pool_viewer_delete_persists_and_updates_info(monkeypatch) -> None:
+    pool = {
+        "repo-a": {"raw": None, "compressed": None},
+        "repo-b": {"raw": ["x"], "compressed": ["x"]},
+    }
+    view, sheet, _ = _presented_pool_viewer(monkeypatch, pool)
+    table = _pool_table(sheet)
+    ds = table.data_source
+
+    assert ds.tableview_can_edit(table, 0, 0) is True
+    ds.tableview_delete(table, 0, 0)
+
+    assert view.saved_prescan_selections == {
+        "repo-b": {"raw": ["x"], "compressed": ["x"]}
+    }
+    assert view.saved_state_calls == 1
+    assert view.repo_info_calls == 1
+    assert table.deleted_rows == [0]
+    assert ds.tableview_number_of_rows(table, 0) == 1
+
+
+def test_show_pool_viewer_clear_pool_persists_updates_and_closes(monkeypatch) -> None:
+    pool = {"repo-a": {"raw": None, "compressed": None}}
+    view, sheet, console = _presented_pool_viewer(monkeypatch, pool)
+    clear_button = next(
+        widget for container in sheet.subviews for widget in getattr(container, "subviews", [])
+        if getattr(widget, "title", None) == "Clear Pool"
+    )
+
+    clear_button.action(clear_button)
+
+    assert view.saved_prescan_selections == {}
+    assert view.saved_state_calls == 1
+    assert view.repo_info_calls == 1
+    assert sheet.closed is True
+    assert console.calls[-1] == ("hud_alert", "Pool cleared")


### PR DESCRIPTION
## T024 Slice 3

Zerlegt ausschließlich `MergerUIPrescanMixin.show_pool_viewer`; die bereits abgeschlossenen Prescan-Presentation-/Pool-Update-Slices bleiben unverändert.

### Charakterisierung vor Produktionsänderung
- Prescan-Suite vor Refactor: 18/18 grün.
- Neu gebunden: leerer Pool, sortierte ALL/PARTIAL/invalid-Zeilen, Inspector mit 15-Regeln-Limit, UI-Alert-Fallback, Zeilenlöschung mit Persistenz/Repo-Info-Refresh sowie Clear-Pool mit Persistenz/Refresh/Close/HUD.

### Ergebnis
- `show_pool_viewer`: C901 24 -> unter Schwelle
- gesamte `merger_ui_prescan.py`: kein C901-Fund mehr
- isolierter Repo-Effekt gegen `main` 73dfd2b0: Findings 157 -> 156; Excess 2060 -> 2046; `new_count=0`

### Validierung
- Prescan-/Mixin-Vertrag: 21/21 grün
- Pythonista-Scope: 86/86 grün
- Parity-Guard: pass
- Graph maintainability ratchet: pass
- Ruff: pass
- py_compile: pass
- git diff --check: pass
- revisionsgebundener Self-Review ohne Finding

Exact reviewed head: `474ef301eb813bdce2ecc1ddf8aa55d0b81c0ddd`.