### PR TITLE
refactor(retrieval): reduce miss-classification complexity

### DIFF
--- a/merger/repoground/retrieval/eval_core.py
+++ b/merger/repoground/retrieval/eval_core.py
@@ -11,6 +11,16 @@ WHY_FAIL_QUERY_EXECUTION = "query execution failed"
 WHY_FAIL_MISSING_EXPLAIN = "missing explain from query execution"
 
 
+def _has_expected_path_match(
+    expected_paths: List[str], top_results: List[str]
+) -> bool:
+    for result_path in top_results:
+        for exp_pattern in expected_paths:
+            if exp_pattern in result_path:
+                return True
+    return False
+
+
 def classify_miss(query_case: Dict[str, Any], expected_paths: List[str], is_relevant: bool, found_count: int, top_results: List[str]) -> Tuple[List[str], Optional[str]]:
     """
     Classify a retrieval miss mechanically.
@@ -40,16 +50,7 @@ def classify_miss(query_case: Dict[str, Any], expected_paths: List[str], is_rele
     # Expected paths provided but not in results: expected not in top-k
     elif expected_paths and top_results:
         # Check if any expected path substring is in top results
-        found_expected = False
-        for result_path in top_results:
-            for exp_pattern in expected_paths:
-                if exp_pattern in result_path:
-                    found_expected = True
-                    break
-            if found_expected:
-                break
-        
-        if not found_expected:
+        if not _has_expected_path_match(expected_paths, top_results):
             miss_types.append("expected_not_in_top_k")
     # Missing metadata for classification
     elif not expected_paths:

--- a/merger/repoground/tests/test_retrieval_eval.py
+++ b/merger/repoground/tests/test_retrieval_eval.py
@@ -788,6 +788,28 @@ def test_classify_miss_found_expected_pattern_in_results_but_not_relevant():
     assert miss_types == ["unknown"]
 
 
+def test_classify_miss_expected_path_substring_matching_contract():
+    case = {"query": "test"}
+    cases = [
+        (["expected.py"], ["src/expected.py"], ["unknown"]),
+        (["src/expected.py"], ["expected.py"], ["expected_not_in_top_k"]),
+        ([""], ["anything.py"], ["unknown"]),
+        (["expected.py"], ["other.py", "nested/expected.py"], ["unknown"]),
+        ([""], [""], ["unknown"]),
+    ]
+
+    for expected_paths, top_results, expected_miss_types in cases:
+        miss_types, primary = eval_core.classify_miss(
+            case,
+            expected_paths=expected_paths,
+            is_relevant=False,
+            found_count=len(top_results),
+            top_results=top_results,
+        )
+        assert miss_types == expected_miss_types
+        assert primary == expected_miss_types[0]
+
+
 def test_miss_taxonomy_expected_not_in_top_k_integration(mini_index_for_eval, tmp_path):
     """Integration-level check: do_eval emits expected_not_in_top_k on a real miss with returned results."""
     queries_json = tmp_path / "eval_queries.json"


### PR DESCRIPTION
Closes #1264.

## What changed
- added a characterization test for expected-path substring matching before production refactoring;
- extracted only the nested expected-path/top-result matching loop into `_has_expected_path_match`;
- query-error precedence, relevance handling, zero-results, missing-metadata and unknown fallback remain unchanged.

## Evidence
- direct classify_miss baseline: 6/6 passed;
- characterization test against unchanged production: passed;
- direct classify_miss final: 7/7 passed;
- full retrieval-eval module: 41/41 passed;
- direct old-vs-new helper equivalence: 10/10 exact plus identical short-circuit probe trace;
- target classify_miss C901 12 -> clean; maintainability 156 -> 155, new_count 0, excess_total 2056;
- Ruff, py_compile and diff-check passed.

Reviewed implementation head: `647ab517bb7e1519a18ce8003e89ca778f4fd1d5`.