### PR TITLE
refactor(merge): reduce repository-role inference complexity

### DIFF
--- a/merger/repoground/core/merge.py
+++ b/merger/repoground/core/merge.py
@@ -1834,23 +1834,35 @@ def save_hub_path(script_path: Path, hub_dir: Path) -> bool:
         return False
 
 
+def _infer_repo_roles_from_name(root: str) -> List[str]:
+    roles = []
+    if "tool" in root or "merger" in root:
+        roles.append("tooling")
+    if "contract" in root or "schema" in root:
+        roles.append("contracts")
+    if "meta" in root:
+        roles.append("governance")
+    if "lern" in root:
+        roles.append("education")
+    if "geist" in root:
+        roles.append("knowledge-base")
+    if "haus" in root:
+        roles.append("logic-core")
+    if "sensor" in root:
+        roles.append("ingestion")
+    if "ui" in root or "app" in root or "leitstand" in root:
+        roles.append("ui")
+    if "wgx" in root:
+        roles.append("fleet-management")
+    return roles
+
+
 def infer_repo_role(root_label: str, files: List["FileInfo"]) -> str:
     """
     Infers the high-level semantic role of the repository within the organism.
     """
-    roles = []
     root = root_label.lower()
-
-    # Name-based heuristics
-    if "tool" in root or "merger" in root: roles.append("tooling")
-    if "contract" in root or "schema" in root: roles.append("contracts")
-    if "meta" in root: roles.append("governance")
-    if "lern" in root: roles.append("education")
-    if "geist" in root: roles.append("knowledge-base")
-    if "haus" in root: roles.append("logic-core")
-    if "sensor" in root: roles.append("ingestion")
-    if "ui" in root or "app" in root or "leitstand" in root: roles.append("ui")
-    if "wgx" in root: roles.append("fleet-management")
+    roles = _infer_repo_roles_from_name(root)
 
     # Content-based heuristics
     has_contracts = any(f.category == "contract" for f in files)

--- a/merger/repoground/tests/test_merge_core.py
+++ b/merger/repoground/tests/test_merge_core.py
@@ -20,6 +20,7 @@ from merger.repoground.core.merge import (
     make_output_filename,
     determine_inclusion_status,
     iter_report_blocks,
+    infer_repo_role,
     FileInfo
 )
 
@@ -78,6 +79,38 @@ class TestMergeCore(unittest.TestCase):
         cat, tags = classify_file_v2(Path("scripts/deploy.sh"), ".sh")
         self.assertEqual(cat, "source")
         self.assertIn("script", tags)
+
+    def test_infer_repo_role_preserves_name_order_and_contract_fallback(self):
+        class FakeFile:
+            def __init__(self, category):
+                self.category = category
+
+        cases = [
+            ("", [], "service"),
+            ("plain", [], "service"),
+            ("TOOL-APP", [], "tooling / ui"),
+            (
+                "tool-schema-meta-ui-wgx",
+                [],
+                "tooling / contracts / governance / ui / fleet-management",
+            ),
+            (
+                "lern-geist-haus-sensor-app",
+                [],
+                "education / knowledge-base / logic-core / ingestion / ui",
+            ),
+            ("schema", [FakeFile("contract")], "contracts"),
+            ("plain", [FakeFile("source"), FakeFile("contract")], "contracts"),
+            ("plain", [FakeFile("source")], "service"),
+            (
+                "merger-contract-meta-lern-geist-haus-sensor-leitstand-wgx",
+                [],
+                "tooling / contracts / governance / education / knowledge-base / logic-core / ingestion / ui / fleet-management",
+            ),
+        ]
+
+        for root_label, files, expected in cases:
+            self.assertEqual(infer_repo_role(root_label, files), expected)
 
     def test_generate_run_id(self):
         # Basic determinism


### PR DESCRIPTION
Closes #1266.

## What changed
- added a characterization test for repository-role ordering/fallback behavior before production refactoring;
- extracted only name-based role heuristics into `_infer_repo_roles_from_name`;
- lowercasing, content-based contract detection/deduplication, default `service` fallback and return formatting remain unchanged.

## Evidence
- baseline `test_merge_core.py`: 19/19 passed;
- characterization test against unchanged production: passed;
- final `test_merge_core.py`: 20/20 passed;
- report/semantic consumer suites: 70/70 passed;
- direct old-vs-new name-helper equivalence: 21/21 exact;
- target `infer_repo_role` C901 12 -> clean; maintainability 154 -> 153, new_count 0, excess_total 2040;
- Ruff, py_compile and diff-check passed.

Reviewed implementation head: `40e0f3ff48034778c632dd365e5c3c52daa69575`.