### PR TITLE
refactor(merge): reduce file-offset extraction complexity

### DIFF
--- a/merger/repoground/core/merge.py
+++ b/merger/repoground/core/merge.py
@@ -5725,6 +5725,25 @@ def build_derived_artifacts(dump_index_path, chunk_path, base_name_func, run_id,
     return derived_paths
 
 
+def _advance_file_offset_marker(
+    line_str: str, current_id: Optional[str]
+) -> Tuple[Optional[str], Optional[str], bool]:
+    """Advance the legacy code-zone marker state for one decoded line."""
+    if "<!-- zone:begin" in line_str and re.search(r'type="?code"?', line_str):
+        # Dual-read: extract id regardless of quotes.
+        # Handles id="FILE:..." or id=FILE:...
+        # Tighter regex ensures we don't grab the trailing -->
+        match = re.search(r'id=(?:"([^"]+)"|([a-zA-Z0-9._:-]+))', line_str)
+        if match:
+            return match.group(1) or match.group(2), None, False
+        return current_id, None, False
+    if current_id and line_str.strip().startswith("```"):
+        return None, current_id, False
+    if current_id and "<!-- zone:end" in line_str:
+        return None, None, True
+    return current_id, None, False
+
+
 def extract_file_offsets(md_paths: List[Path], debug: bool = False) -> Dict[str, Tuple[str, int]]:
     offsets = {}
     for md_path in md_paths:
@@ -5742,21 +5761,14 @@ def extract_file_offsets(md_paths: List[Path], debug: bool = False) -> Dict[str,
 
                     line_len = len(line)
                     line_str = line.decode("utf-8", errors="ignore")
+                    current_id, captured_id, malformed_zone = _advance_file_offset_marker(
+                        line_str, current_id
+                    )
 
-                    if "<!-- zone:begin" in line_str and re.search(r'type="?code"?', line_str):
-                        # Dual-read: extract id regardless of quotes.
-                        # Handles id="FILE:..." or id=FILE:...
-                        # Tighter regex ensures we don't grab the trailing -->
-                        m = re.search(r'id=(?:"([^"]+)"|([a-zA-Z0-9._:-]+))', line_str)
-                        if m:
-                            current_id = m.group(1) or m.group(2)
-                    elif current_id and line_str.strip().startswith("```"):
-                        offsets[current_id] = (md_path.name, pos + line_len)
-                        current_id = None
-                    elif current_id and "<!-- zone:end" in line_str:
-                        if debug:
-                            print(f"warning: malformed zone marker in {md_path.name}", file=sys.stderr)
-                        current_id = None
+                    if captured_id is not None:
+                        offsets[captured_id] = (md_path.name, pos + line_len)
+                    if malformed_zone and debug:
+                        print(f"warning: malformed zone marker in {md_path.name}", file=sys.stderr)
 
                     pos += line_len
         except Exception as e:

--- a/merger/repoground/tests/test_offset_parser_handles_marker_variations.py
+++ b/merger/repoground/tests/test_offset_parser_handles_marker_variations.py
@@ -108,3 +108,20 @@ def test_offset_parser_handles_marker_variations(tmp_path: Path):
     assert "FILE:test6" not in offsets
     assert "FILE:test7" in offsets
     assert offsets["FILE:test7"][0] == "f6.md"
+
+
+def test_offset_parser_preserves_open_id_across_idless_code_begin(tmp_path: Path):
+    path = tmp_path / "idless-begin.md"
+    payload = (
+        "<!-- zone:begin type=code id=FILE:original -->\n"
+        "<!-- zone:begin type=code lang=python -->\n"
+        "```python\n"
+        "value = 1\n"
+        "```\n"
+    ).encode("utf-8")
+    path.write_bytes(payload)
+
+    offsets = extract_file_offsets([path], debug=False)
+
+    fence_end = payload.index(b"```python\n") + len(b"```python\n")
+    assert offsets == {"FILE:original": (path.name, fence_end)}


### PR DESCRIPTION
## Summary
- characterize the legacy idless nested code-zone begin behavior before refactoring
- extract per-line marker state handling from `extract_file_offsets`
- preserve byte offsets, malformed-zone handling, decoding, debug behavior, and downstream canonical range semantics

## Validation
- 7/7 focused offset/report parsing tests
- 13/13 chunk-index / split-mode / range-propagation consumer tests
- 20/20 direct legacy/new marker-state equivalence cases
- graph maintainability ratchet: 153 -> 152 C901, new_count=0, excess_total=2038
- Ruff excluding legacy C901: pass
- py_compile: pass
- git diff --check: pass

Closes #1268