### PR TITLE
refactor(adapters): reduce diagnostics rebuild complexity

### DIFF
--- a/merger/repoground/adapters/diagnostics.py
+++ b/merger/repoground/adapters/diagnostics.py
@@ -9,6 +9,46 @@ logger = logging.getLogger(__name__)
 SCHEMA_VERSION = "diagnostics.snapshot.v1"
 TTL_HOURS = 24
 
+
+def _collect_repo_diagnostics(hub_path: Path, repos: Dict[str, Any]) -> Dict[str, Any]:
+    results = {}
+
+    # 2. Iterate Fleet Repos and check local state
+    for repo_name, meta in repos.items():
+        repo_path = hub_path / repo_name
+
+        # Check existence
+        if not repo_path.is_dir():
+            results[repo_name] = {
+                "status": "missing",
+                "checks": []
+            }
+            continue
+
+        checks = []
+
+        # Profile Expectation
+        wgx = meta.get("wgx") if isinstance(meta.get("wgx"), dict) else {}
+        expected = wgx.get("profile_expected")
+        if expected is True:
+            profile_path = repo_path / ".wgx" / "profile.yml"
+            if not profile_path.exists():
+                checks.append({
+                    "code": "missing_wgx_profile",
+                    "severity": "warn",
+                    "message": ".wgx/profile.yml expected but missing"
+                })
+
+        results[repo_name] = {
+            "status": "ok" if not checks else "issue",
+            "checks": checks,
+            # Pass through role for convenience
+            "role": meta.get("role", "unknown")
+        }
+
+    return results
+
+
 def rebuild(hub_path: Path) -> Dict[str, Any]:
     """
     Rebuilds diagnostics snapshot based on fleet.snapshot.json expectations.
@@ -73,40 +113,7 @@ def rebuild(hub_path: Path) -> Dict[str, Any]:
             pass
 
     repos = fleet_data.get("data", {}).get("repos", {})
-    results = {}
-
-    # 2. Iterate Fleet Repos and check local state
-    for repo_name, meta in repos.items():
-        repo_path = hub_path / repo_name
-
-        # Check existence
-        if not repo_path.is_dir():
-            results[repo_name] = {
-                "status": "missing",
-                "checks": []
-            }
-            continue
-
-        checks = []
-
-        # Profile Expectation
-        wgx = meta.get("wgx") if isinstance(meta.get("wgx"), dict) else {}
-        expected = wgx.get("profile_expected")
-        if expected is True:
-            profile_path = repo_path / ".wgx" / "profile.yml"
-            if not profile_path.exists():
-                checks.append({
-                    "code": "missing_wgx_profile",
-                    "severity": "warn",
-                    "message": ".wgx/profile.yml expected but missing"
-                })
-
-        results[repo_name] = {
-            "status": "ok" if not checks else "issue",
-            "checks": checks,
-            # Pass through role for convenience
-            "role": meta.get("role", "unknown")
-        }
+    results = _collect_repo_diagnostics(hub_path, repos)
 
     # P3: Summary & Issues Total
     summary = {


### PR DESCRIPTION
## Summary
- extract the existing per-repository diagnostics loop into `_collect_repo_diagnostics`
- keep fleet loading/error snapshots, TTL handling, summary calculation, persisted payloads, and return values unchanged
- no API, schema, retrieval, security, persistence-policy, or default-routing changes

## Evidence
- exact base: `cf50690b427aaa60eeb73d449d394706c2dd89fc`
- head: `b55542adf4ba7d0a0676dd57ceb3ab1ae7a058ba`
- Ruff 0.15.13 file-local C901: `rebuild` `12 > 10` -> pass
- full Ruff check for `diagnostics.py`: pass
- repo C901 count: `151 -> 150`; no new C901 finding
- old-vs-new behavior matrix: 5/5 normalized cases identical (missing snapshot, invalid JSON, fleet error, mixed repo states, stale TTL)
- `test_diagnostics_lookup.py`: 15/15 passed
- `test_service_router_closeout.py`: 8/8 passed
- `git diff --check`: pass

The repo-wide Ruff statistics command also surfaces three pre-existing invalid-syntax fixtures; this slice neither adds nor touches them.

Closes #1272