### PR TITLE
refactor(atlas): reduce markdown renderer complexity

### DIFF
--- a/merger/repoground/adapters/atlas.py
+++ b/merger/repoground/adapters/atlas.py
@@ -1204,15 +1204,7 @@ class AtlasScanner:
             "truncated": limit_hit_reason
         }
 
-def render_atlas_md(atlas_data: Dict[str, Any]) -> str:
-    stats = atlas_data["stats"]
-    root = atlas_data.get("root", "Unknown")
-
-    lines = []
-    lines.append(f"# 🗺️ Atlas: {root}")
-    lines.append(f"Generated: {stats.get('end_time')} (Duration: {stats.get('duration_seconds'):.2f}s)")
-    lines.append("")
-
+def _append_atlas_scan_metadata(lines: List[str], stats: Dict[str, Any]) -> None:
     if stats.get("inventory_file"):
         lines.append(f"**Inventory (Files):** `{Path(stats.get('inventory_file')).name}`")
     if stats.get("dirs_inventory_file"):
@@ -1238,6 +1230,18 @@ def render_atlas_md(atlas_data: Dict[str, Any]) -> str:
         for ex in sorted(stats["active_excludes"]):
             lines.append(f"- `{ex}`")
         lines.append("")
+
+
+def render_atlas_md(atlas_data: Dict[str, Any]) -> str:
+    stats = atlas_data["stats"]
+    root = atlas_data.get("root", "Unknown")
+
+    lines = []
+    lines.append(f"# 🗺️ Atlas: {root}")
+    lines.append(f"Generated: {stats.get('end_time')} (Duration: {stats.get('duration_seconds'):.2f}s)")
+    lines.append("")
+
+    _append_atlas_scan_metadata(lines, stats)
 
     lines.append("## 📊 Overview")
     lines.append(f"- **Total Directories:** {stats.get('total_dirs')}")


### PR DESCRIPTION
## Summary
- extract the existing Atlas scan-metadata Markdown block into `_append_atlas_scan_metadata`
- keep every rendered Markdown line, ordering rule, default value, and exception behavior unchanged
- no scan control, persistence, retrieval, source-mode, security, or Atlas registry changes

## Evidence
- baseline adjacent Atlas tests: 19/19 passed
- complete Atlas test family after change: 149/149 passed
- old-vs-new byte-equivalence matrix: 1,088 cases with identical Markdown output or identical exception type/message
- Ruff 0.16.3: `render_atlas_md` no longer reports C901; remaining C901 findings in `atlas.py` are pre-existing and out of scope
- repo C901: 150 -> 149
- new_count: 0
- excess_total: 2034 -> 2032
- current_max: 138 unchanged
- non-C901 Ruff for the touched file: pass
- `git diff --check`: pass

Base: `41e8e532518e03634cfd0bc9377570ded37c0282`
Head: `5503a030620b4b2b3d9cd8765c4d54ed08e323e2`

Closes #1274