### PR TITLE
refactor(service): reduce create job complexity

### DIFF
--- a/merger/repoground/service/job_router.py
+++ b/merger/repoground/service/job_router.py
@@ -28,6 +28,24 @@ def _cleanup_source_snapshots_after_gc() -> None:
     if snapshot_cleanup.get("status") == "blocked":
         logger.warning("Source snapshot cleanup blocked: %s", snapshot_cleanup)
 
+
+def _reuse_succeeded_job(existing: Job, request: JobRequest) -> bool:
+    effective_source_mode = resolve_effective_source_mode(request)
+    if effective_source_mode == "local_ff":
+        logger.info(
+            "Not reusing succeeded job %s because local_ff requires a fresh repo-sync check.",
+            existing.id,
+        )
+        return False
+    if effective_source_mode == "remote_snapshot":
+        logger.info(
+            "Not reusing succeeded job %s because remote_snapshot requires fresh remote resolution.",
+            existing.id,
+        )
+        return False
+    logger.info("Reusing existing succeeded job %s", existing.id)
+    return True
+
 @router.post('/api/jobs', response_model=Job, dependencies=[Depends(verify_token)])
 def create_job(request: JobRequest):
     # Validate Hub in request
@@ -79,23 +97,8 @@ def create_job(request: JobRequest):
         # A succeeded remote_snapshot job is likewise never reused: moving ref
         # names are not content-stable, so the cached result may no longer match
         # the current remote. (See rlens-source-acquisition-blueprint.md.)
-        if existing.status == "succeeded":
-            effective_source_mode = resolve_effective_source_mode(request)
-            effective_local_ff = effective_source_mode == "local_ff"
-            effective_remote_snapshot = effective_source_mode == "remote_snapshot"
-            if effective_local_ff:
-                logger.info(
-                    "Not reusing succeeded job %s because local_ff requires a fresh repo-sync check.",
-                    existing.id,
-                )
-            elif effective_remote_snapshot:
-                logger.info(
-                    "Not reusing succeeded job %s because remote_snapshot requires fresh remote resolution.",
-                    existing.id,
-                )
-            else:
-                logger.info("Reusing existing succeeded job %s", existing.id)
-                return existing
+        if existing.status == "succeeded" and _reuse_succeeded_job(existing, request):
+            return existing
 
     job = Job.create(request, content_hash=content_hash)
     job.hub_resolved = resolved_hub_str


### PR DESCRIPTION
## Summary
- extract succeeded-job reuse policy from `create_job` into a private helper
- preserve active-job reuse, `local_ff`/`remote_snapshot` fresh-job behavior, force-new behavior and exact logging
- leave request normalization, strict include validation, hashing, GC, store writes and runner submission unchanged

## Validation
- exact base: `7a8ed47831805db156b8634caa721d73e200df4a`
- exact head: `c99ed1b3d6bf865065d63c09406da5ca87687ceb`
- target C901 removed; `job_router.py` retains only the pre-existing SSE C901 findings
- repo-wide C901: 146 -> 145 (+ 3 known intentional invalid-syntax fixture findings)
- `test_service_reuse.py` + `test_service_hardening.py`: 33 passed
- `test_service_integration.py`: 2 passed, 1 skipped
- direct old-vs-new matrix: 7/7 exact for active, succeeded local_current/local_ff/remote_snapshot, failed, missing and force_new cases including GC/store/runner side effects
- full file Ruff: pass
- `git diff --check`: pass

Closes #1282