### PR TITLE
refactor(context): reduce compile plan complexity

### DIFF
--- a/merger/repoground/core/context_compiler.py
+++ b/merger/repoground/core/context_compiler.py
@@ -1080,6 +1080,64 @@ def _prepare_context_selection_inputs(
     )
 
 
+def _context_plan_diagnostics(
+    status: Mapping[str, Any],
+    required_resolution: Mapping[str, Any],
+) -> tuple[
+    dict[str, Any],
+    list[dict[str, Any]],
+    dict[str, Any],
+    Any,
+    Any,
+]:
+    required_value = required_resolution.get("required_reading")
+    required = required_value if isinstance(required_value, dict) else {}
+    gaps: list[dict[str, Any]] = []
+    if required.get("status") in {"fail", "not_applicable"}:
+        gaps.append(
+            {
+                "source": "required_reading",
+                "status": required.get("status"),
+                "missing_required": required.get("missing_required"),
+                "reason": "required reading is not fully available",
+            }
+        )
+    elif required.get("missing_recommended"):
+        gaps.append(
+            {
+                "source": "required_reading",
+                "status": "warn",
+                "missing_recommended": required.get("missing_recommended"),
+                "reason": "recommended reading is not fully available",
+            }
+        )
+
+    availability_value = status.get("availability_model")
+    availability = availability_value if isinstance(availability_value, dict) else {}
+    freshness = availability.get("freshness")
+    graph_availability = availability.get("graph_availability")
+    if isinstance(freshness, dict) and freshness.get("status") not in {
+        "fresh",
+        "not_comparable",
+    }:
+        gaps.append(
+            {
+                "source": "freshness",
+                "status": freshness.get("status"),
+                "reason": freshness.get("reason"),
+            }
+        )
+    if (
+        isinstance(graph_availability, dict)
+        and graph_availability.get("status") != "available"
+    ):
+        gaps.append(
+            graph_gap_from_availability("graph_availability", graph_availability)
+        )
+
+    return required, gaps, availability, freshness, graph_availability
+
+
 def compile_context_plan(
     bundle_manifest: str | Path,
     *,
@@ -1151,62 +1209,9 @@ def compile_context_plan(
             context_budget_tokens=context_budget_tokens,
         )
 
-    required = (
-        required_resolution.get("required_reading")
-        if isinstance(required_resolution.get("required_reading"), dict)
-        else {}
+    required, gaps, availability, freshness, graph_availability = (
+        _context_plan_diagnostics(status, required_resolution)
     )
-    gaps: list[dict[str, Any]] = []
-    if required.get("status") in {"fail", "not_applicable"}:
-        gaps.append(
-            {
-            "source": "required_reading",
-            "status": required.get("status"),
-            "missing_required": required.get("missing_required"),
-            "reason": "required reading is not fully available",
-            }
-        )
-    elif required.get("missing_recommended"):
-        gaps.append(
-            {
-            "source": "required_reading",
-            "status": "warn",
-            "missing_recommended": required.get("missing_recommended"),
-            "reason": "recommended reading is not fully available",
-            }
-        )
-
-    availability = (
-        status.get("availability_model")
-        if isinstance(status.get("availability_model"), dict)
-        else {}
-    )
-    freshness = (
-        availability.get("freshness") if isinstance(availability, dict) else None
-    )
-    graph_availability = (
-        availability.get("graph_availability")
-        if isinstance(availability, dict)
-        else None
-    )
-    if isinstance(freshness, dict) and freshness.get("status") not in {
-        "fresh",
-        "not_comparable",
-    }:
-        gaps.append(
-            {
-                "source": "freshness",
-                "status": freshness.get("status"),
-                "reason": freshness.get("reason"),
-            }
-        )
-    if (
-        isinstance(graph_availability, dict)
-        and graph_availability.get("status") != "available"
-    ):
-        gaps.append(
-            graph_gap_from_availability("graph_availability", graph_availability)
-        )
 
     retrieval_candidates, retrieval_signal, retrieval_gaps = _retrieval_candidates(
         manifest_path,

--- a/merger/repoground/tests/test_context_compiler.py
+++ b/merger/repoground/tests/test_context_compiler.py
@@ -527,6 +527,33 @@ def test_compile_context_plan_rejects_invalid_utf8_after_relation_hit(tmp_path, 
     assert not any(item["source"] == "relation_cards_jsonl" for item in plan["selected_context"])
 
 
+def test_compile_context_plan_preserves_required_and_availability_diagnostics(tmp_path):
+    manifest = _write_complete_bundle(tmp_path)
+
+    plan = compile_context_plan(
+        manifest,
+        task="Explain the context compiler",
+        task_profile="basic_repo_question",
+        query="context compiler",
+        context_budget_tokens=120,
+        bytes_per_token=4.0,
+    )
+
+    required = plan["signals"]["required_reading"]
+    availability = plan["signals"]["availability"]
+    assert required["status"] == "warn"
+    assert required["missing_recommended"] == ["snapshot_plan_json"]
+    assert availability["status"] == "fail"
+    assert availability["freshness"]["status"] == "unknown"
+    assert availability["freshness"]["reason"] == "blocked_by_missing_provenance"
+    assert availability["graph_availability"]["status"] == "not_generated"
+    assert [gap["source"] for gap in plan["gaps"][:3]] == [
+        "required_reading",
+        "freshness",
+        "graph_availability",
+    ]
+
+
 def test_compile_context_plan_falls_back_to_required_reading_when_signals_missing(tmp_path):
     manifest = _write_fallback_bundle(tmp_path)
 


### PR DESCRIPTION
## Scope

Reduce only the Ruff C901 finding in `compile_context_plan` by extracting the existing required-reading/freshness/graph diagnostic assembly into a private helper. No public signature, result schema, ranking, candidate generation, or budget semantics change.

Bureau source: `REPOGROUND-LEGACY-RECONCILIATION-V1-T004`

## Characterization

- pre-change context compiler suite: 19 passed
- new diagnostic characterization test passes against the pre-refactor behavior
- preserves required-reading, freshness, graph-availability values and gap order

## Validation

- `ruff check --select C901 .../context_compiler.py`: pass; target finding removed
- `ruff check` on changed files: pass
- `python -m pytest -q --disable-warnings .../test_context_compiler.py`: 20 passed
- `python -m py_compile` on changed files: pass
- `git diff --check`: pass

`ruff format --check` would reformat both whole files on unmodified main as well, so this slice intentionally does not introduce an unrelated whole-file formatting diff.