### PR TITLE
refactor(jobstore): reduce remove job complexity

### DIFF
--- a/merger/repoground/service/jobstore.py
+++ b/merger/repoground/service/jobstore.py
@@ -169,22 +169,19 @@ class JobStore:
             self._save_jobs()
             self._save_artifacts()
 
-    def _remove_job_internal(self, job_id: str):
-        job = self._jobs_cache.get(job_id)
-        if not job:
+    @staticmethod
+    def _safe_unlink_artifact_file(base: Path, rel: str) -> None:
+        if not rel or os.path.isabs(rel):
             return
+        try:
+            target = (base / rel).resolve()
+            target.relative_to(base.resolve())
+            if target.exists():
+                target.unlink()
+        except Exception as exc:
+            logger.warning("Failed to delete artifact file %s relative to %s: %s", rel, base, exc)
 
-        def _safe_unlink(base: Path, rel: str) -> None:
-            if not rel or os.path.isabs(rel):
-                return
-            try:
-                target = (base / rel).resolve()
-                target.relative_to(base.resolve())
-                if target.exists():
-                    target.unlink()
-            except Exception as exc:
-                logger.warning("Failed to delete artifact file %s relative to %s: %s", rel, base, exc)
-
+    def _remove_job_artifacts(self, job_id: str, job: Job) -> None:
         for art_id in job.artifact_ids:
             art = self._artifacts_cache.get(art_id)
             if art:
@@ -196,11 +193,17 @@ class JobStore:
                     )
                     if merges_dir.exists():
                         for fname in art.paths.values():
-                            _safe_unlink(merges_dir, fname)
+                            self._safe_unlink_artifact_file(merges_dir, fname)
                 except Exception as exc:
                     logger.warning("Failed to clean up artifact %s for job %s: %s", art_id, job_id, exc)
                 del self._artifacts_cache[art_id]
 
+    def _remove_job_internal(self, job_id: str):
+        job = self._jobs_cache.get(job_id)
+        if not job:
+            return
+
+        self._remove_job_artifacts(job_id, job)
         self._remove_source_snapshot_for_job(job_id)
 
         log_p = self.logs_dir / f"{job_id}.log"


### PR DESCRIPTION
## Summary
- extract artifact unlink and artifact-cache cleanup from `_remove_job_internal` into private helpers
- preserve containment checks, custom/default merges-dir resolution, warning text and artifact-cache deletion behavior
- leave source-snapshot, log, SSE subscriber and job-cache closeout ordering unchanged

## Validation
- exact base: `38bc346645665922d7258c79e5d795866522e3f9`
- exact head: `048410381cc60f5460dfdede4b06fb1a93933952`
- `_remove_job_internal` C901 removed; `jobstore.py` now has no C901 findings
- repo-wide C901: 144 -> 143 (+ 3 known intentional invalid-syntax fixture findings)
- GC/hardening/SSE tests: 23 passed
- direct old-vs-new matrix: 7/7 exact for missing job, no artifacts, valid artifact, traversal, missing artifact id, custom merges dir and absolute path; includes cache/file/snapshot/log/subscriber effects
- full file Ruff: pass
- `git diff --check`: pass

Closes #1285