### PR TITLE
refactor(index): reduce CLI complexity

### DIFF
--- a/merger/repoground/cli/cmd_index.py
+++ b/merger/repoground/cli/cmd_index.py
@@ -3,14 +3,35 @@ import sys
 from pathlib import Path
 from merger.repoground.retrieval import index_db
 
+
+def _resolve_index_output_path(args: argparse.Namespace, chunk_path: Path) -> Path:
+    if args.out:
+        return Path(args.out)
+    return chunk_path.with_suffix(".index.sqlite")
+
+
+def _build_index_config_payload(
+    args: argparse.Namespace, dump_path: Path
+) -> dict[str, object]:
+    config_payload: dict[str, object] = {"cli_args": str(args)}
+    if dump_path.exists():
+        import json
+
+        try:
+            dump_data = json.loads(dump_path.read_text(encoding="utf-8"))
+            generator = dump_data.get("generator", {})
+            config_payload["config_sha256"] = generator.get("config_sha256", "")
+            config_payload["lenskit_version"] = generator.get("version", "unknown")
+        except Exception:
+            pass
+    return config_payload
+
+
 def run_index(args: argparse.Namespace) -> int:
     dump_path = Path(args.dump)
     chunk_path = Path(args.chunk_index)
 
-    if args.out:
-        out_path = Path(args.out)
-    else:
-        out_path = chunk_path.with_suffix(".index.sqlite")
+    out_path = _resolve_index_output_path(args, chunk_path)
 
     if not dump_path.exists():
         print(f"Error: Dump file not found: {dump_path}", file=sys.stderr)
@@ -38,21 +59,10 @@ def run_index(args: argparse.Namespace) -> int:
 
     print(f"Building index from {chunk_path.name}...")
     try:
-        config_payload = {
-            "cli_args": str(args),
-        }
-        # Attempt to extract config_sha256 and lenskit_version from dump manifest if available
-        if dump_path.exists():
-            import json
-            try:
-                dump_data = json.loads(dump_path.read_text(encoding="utf-8"))
-                generator = dump_data.get("generator", {})
-                config_payload["config_sha256"] = generator.get("config_sha256", "")
-                config_payload["lenskit_version"] = generator.get("version", "unknown")
-            except Exception:
-                pass
-
-        index_db.build_index(dump_path, chunk_path, out_path, config_payload=config_payload)
+        config_payload = _build_index_config_payload(args, dump_path)
+        index_db.build_index(
+            dump_path, chunk_path, out_path, config_payload=config_payload
+        )
         print(f"✅ Index built successfully: {out_path}")
         return 0
     except Exception as e:


### PR DESCRIPTION
## Scope

Reduce only the Ruff C901 finding in `cli.cmd_index.run_index` by extracting two deterministic private concerns: output-path resolution and optional dump-generator metadata parsing. No CLI arguments, output strings, return codes, index build contract, verify/rebuild logic, or failure cleanup semantics change.

Bureau source: `REPOGROUND-LEGACY-RECONCILIATION-V1-T004`

## Behavior evidence

- valid manifest + explicit output: old/new canonical result identical
- valid manifest + derived output: old/new canonical result identical
- invalid manifest + explicit output: old/new canonical result identical
- retrieval stack integration: pass before and after

## Validation

- `cmd_index.py` C901: 1 finding -> 0
- raw RepoGround C901 findings: 129 -> 128
- Ruff full-file check: pass
- Ruff formatter: pass
- Python compile: pass
- `test_retrieval_stack_integration.py`: pass
- `git diff --check`: pass

A first SSE candidate was separately disproven as a valid ratchet because removing nested guards only exposed the outer `stream_logs` C901 finding; that no-change lane was reverted and closed without commit or push.