### PR TITLE
refactor(graph): reduce index compiler complexity

### DIFF
--- a/merger/repoground/architecture/graph_index.py
+++ b/merger/repoground/architecture/graph_index.py
@@ -132,6 +132,29 @@ def _infer_bundle_provenance(
     return run_id, digest
 
 
+def _build_graph_lookups(
+    graph: Dict[str, Any],
+) -> tuple[dict[str, list[str]], dict[str, str], dict[str, dict[str, Any]]]:
+    adjacency: dict[str, list[str]] = {}
+    nodes_by_path: dict[str, str] = {}
+    node_meta_by_id: dict[str, dict[str, Any]] = {}
+
+    for node in graph["nodes"]:
+        node_id = node["node_id"]
+        adjacency[node_id] = []
+        node_meta_by_id[node_id] = node
+        if node.get("path"):
+            nodes_by_path[node["path"]] = node_id
+
+    for edge in graph["edges"]:
+        if edge["src"] in adjacency:
+            adjacency[edge["src"]].append(edge["dst"])
+    for neighbors in adjacency.values():
+        neighbors.sort()
+
+    return adjacency, nodes_by_path, node_meta_by_id
+
+
 def compile_graph_index(
     graph_path: Path,
     entrypoints_path: Path,
@@ -175,22 +198,7 @@ def compile_graph_index(
             "unreachable_nodes": 0,
         },
     }
-    adjacency: dict[str, list[str]] = {}
-    nodes_by_path: dict[str, str] = {}
-    node_meta_by_id: dict[str, dict[str, Any]] = {}
-
-    for node in graph["nodes"]:
-        node_id = node["node_id"]
-        adjacency[node_id] = []
-        node_meta_by_id[node_id] = node
-        if node.get("path"):
-            nodes_by_path[node["path"]] = node_id
-
-    for edge in graph["edges"]:
-        if edge["src"] in adjacency:
-            adjacency[edge["src"]].append(edge["dst"])
-    for neighbors in adjacency.values():
-        neighbors.sort()
+    adjacency, nodes_by_path, node_meta_by_id = _build_graph_lookups(graph)
 
     entrypoint_nodes = {
         nodes_by_path[item["path"]]


### PR DESCRIPTION
## Scope

Reduce only the Ruff C901 finding in `architecture.graph_index.compile_graph_index` by extracting deterministic graph lookup construction into a private helper. Provenance validation, entrypoint selection, BFS distance calculation, path aliases, metrics, and output schema remain unchanged.

Bureau source: `REPOGROUND-LEGACY-RECONCILIATION-V1-T004`

## Behavior evidence

- graph compiler/index tests + graph E2E: 21/21 pass before and after
- old/new canonical output identical for baseline graph
- old/new canonical output identical with an isolated node
- old/new canonical output identical when the declared entrypoint is absent from graph nodes

## Validation

- `graph_index.py` C901: 1 -> 0
- raw RepoGround C901 findings: 128 -> 127
- full-file Ruff: pass
- Python compile: pass
- `git diff --check`: pass

`ruff format --check` already fails on unchanged `main` for an old line in `load_graph_index`; this slice does not reformat that unrelated line.