### PR TITLE
refactor(doc-freshness): reduce classification complexity

### DIFF
--- a/merger/repoground/core/doc_freshness.py
+++ b/merger/repoground/core/doc_freshness.py
@@ -284,6 +284,50 @@ def _hard_dangling(results: Iterable[EvidenceResult]) -> list[EvidenceResult]:
     ]
 
 
+def _classify_partial(
+    results: list[EvidenceResult], dangling: list[EvidenceResult]
+) -> tuple[str, str, str]:
+    # Owner-asserted mixed state (v1 done / rest open). Never auto-flag as
+    # under/overstated; only a vanished hard evidence ref is a real problem.
+    if dangling:
+        return (
+            "regressed",
+            "error",
+            "partial claim cites evidence that no longer exists: "
+            + "; ".join(d.detail for d in dangling),
+        )
+    missing_open = _missing_open_markers(results)
+    if missing_open:
+        return (
+            "partial_maybe_resolved",
+            "warning",
+            "partial claim's open marker(s) are gone; implementation may be "
+            "complete — either promote to done, mark stale, or verify: "
+            + "; ".join(m.detail for m in missing_open),
+        )
+    return "partial_ok", "ok", "partial (mixed state asserted by owner)"
+
+
+def _classify_done(
+    dangling: list[EvidenceResult], stale_markers: list[EvidenceResult]
+) -> tuple[str, str, str]:
+    if dangling:
+        return (
+            "regressed",
+            "error",
+            "doc claims done, but cited evidence is missing: "
+            + "; ".join(d.detail for d in dangling),
+        )
+    if stale_markers:
+        return (
+            "stale_marker_present",
+            "warning",
+            "doc claims done, but still literally contains the stale/TODO "
+            "marker: " + "; ".join(m.detail for m in stale_markers),
+        )
+    return "consistent", "ok", "done and evidence verified"
+
+
 def classify_entry(
     status: str, results: list[EvidenceResult]
 ) -> tuple[str, str, str]:
@@ -311,42 +355,10 @@ def classify_entry(
         return "consistent", "ok", "no completion evidence; matches 'none'"
 
     if status == "partial":
-        # Owner-asserted mixed state (v1 done / rest open). Never auto-flag as
-        # under/overstated; only a vanished hard evidence ref is a real problem.
-        if dangling:
-            return (
-                "regressed",
-                "error",
-                "partial claim cites evidence that no longer exists: "
-                + "; ".join(d.detail for d in dangling),
-            )
-        missing_open = _missing_open_markers(results)
-        if missing_open:
-            return (
-                "partial_maybe_resolved",
-                "warning",
-                "partial claim's open marker(s) are gone; implementation may be "
-                "complete — either promote to done, mark stale, or verify: "
-                + "; ".join(m.detail for m in missing_open),
-            )
-        return "partial_ok", "ok", "partial (mixed state asserted by owner)"
+        return _classify_partial(results, dangling)
 
     if status == "done":
-        if dangling:
-            return (
-                "regressed",
-                "error",
-                "doc claims done, but cited evidence is missing: "
-                + "; ".join(d.detail for d in dangling),
-            )
-        if stale_markers:
-            return (
-                "stale_marker_present",
-                "warning",
-                "doc claims done, but still literally contains the stale/TODO "
-                "marker: " + "; ".join(m.detail for m in stale_markers),
-            )
-        return "consistent", "ok", "done and evidence verified"
+        return _classify_done(dangling, stale_markers)
 
     if status == "stale":
         # A known, *declared* drift (mirrors C2.9 declared_upgrades). Valid only


### PR DESCRIPTION
## Scope

Reduce only the Ruff C901 finding in `core.doc_freshness.classify_entry` by extracting the existing `partial` and `done` status classifiers into private pure helpers. Evidence derivation, status dispatch order, exact classification/severity/message outputs, stale/none/historical behavior, and unknown-status handling remain unchanged.

Bureau source: `REPOGROUND-LEGACY-RECONCILIATION-V1-T004`

## Behavior evidence

- `test_doc_freshness.py`: 39/39 pass before and after
- `test_claim_evidence_map.py`: 8/8 pass after
- old/new output identical across 13 status/evidence combinations covering historical, none, partial, done, stale, and unknown status paths

## Validation

- `classify_entry` C901: 1 -> 0
- raw RepoGround C901 findings: 126 -> 125
- full-file Ruff: pass
- Python compile: pass
- `git diff --check`: pass

`ruff format --check` already reports this file as needing formatting on unchanged `main`; this slice does not reformat unrelated historical lines.